### PR TITLE
fixes 'derivate' function name - correct name is 'derivative'

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -138,7 +138,7 @@ function (_) {
   });
 
   addFuncDef({
-    name: 'derivate',
+    name: 'derivative',
     category: categories.Transform,
   });
 


### PR DESCRIPTION
see http://graphite.readthedocs.org/en/0.9.x/functions.html#graphite.render.functions.derivative
