### PR TITLE
added support for 'less is worse' thresholds

### DIFF
--- a/src/app/directives/grafanaGraph.js
+++ b/src/app/directives/grafanaGraph.js
@@ -141,7 +141,12 @@ function (angular, $, kbn, moment, _) {
             });
 
             if (panel.grid.threshold2) {
-              var limit2 = panel.grid.thresholdLine ? panel.grid.threshold2 : null;
+              var limit2;
+              if (panel.grid.thresholdLine) {
+                limit2 = panel.grid.threshold2;
+              } else {
+                limit2 = panel.grid.threshold1 > panel.grid.threshold2 ?  -Infinity : +Infinity;
+              }
               options.grid.markings.push({
                 yaxis: { from: panel.grid.threshold2, to: limit2 },
                 color: panel.grid.threshold2Color


### PR DESCRIPTION
Sometimes you want to express 'less is worse' thresholds. That means setting the error threshold below the warning threshold. The problem was, that the error marking always went up to +Infinity. Concerns 16599a07a936569bfaabbcc57cf8087a01132cfa.
