### PR TITLE
Bugfix for Basic Auth: strip auth from url before using

### DIFF
--- a/src/app/services/graphite/graphiteDatasource.js
+++ b/src/app/services/graphite/graphiteDatasource.js
@@ -14,7 +14,15 @@ function (angular, _, $, config, kbn, moment) {
   module.factory('GraphiteDatasource', function(dashboard, $q, filterSrv, $http) {
 
     function GraphiteDatasource(datasource) {
-      this.url = datasource.url;
+      var passwordEnd = datasource.url.indexOf('@');
+      if(passwordEnd > 0) {
+        var userStart = datasource.url.indexOf('//') + 2;
+        var urlHead = datasource.url.substring(0,userStart);
+        this.url = urlHead + datasource.url.substring(passwordEnd);
+      }
+      else {
+        this.url = datasource.url;
+      }
       this.type = 'graphite';
       this.basicAuth = datasource.basicAuth;
     }


### PR DESCRIPTION
This fixes the Basic Auth not working issue (issue#16) further, by
removing the auth string from the URL before grafana attempts to use
it. Some js doesn't handle it properly I think, and tries to include the auth
string in dns lookups(?), so the request never even hits the graphite
server when an auth string is present (at least in my attempts). Adding this bit of code to strip out the username:password@ got it to both send the request to the graphite server as well as login via basic auth as expected.
