### PR TITLE
Fix variable name for graphite basic auth.

### DIFF
--- a/src/app/services/graphite/graphiteDatasource.js
+++ b/src/app/services/graphite/graphiteDatasource.js
@@ -129,7 +129,7 @@ function (angular, _, $, config, kbn, moment) {
       if (this.basicAuth) {
         options.withCredentials = true;
         options.headers = options.headers || {};
-        options.headers.Authorization = 'Basic ' + config.graphiteBasicAuth;
+        options.headers.Authorization = 'Basic ' + this.basicAuth;
       }
 
       options.url = this.url + options.url;


### PR DESCRIPTION
It looks like in the refactoring of PR #144 the variable name for graphite basic auth got changed d79dcb952d5519b3abbb151c0802177cdcb31358

This fixes that so HTTP auth works again on graphite.

I would assume that a similar change would need to be made on elasticsearch, but I do not have a running instance to test against, so I don't feel comfortable making that change.

References #152.
