### PR TITLE
round up maxDataPoints to nearest integer in request. graphite 0.9.x and...

### DIFF
--- a/src/app/panels/graphite/module.js
+++ b/src/app/panels/graphite/module.js
@@ -230,7 +230,7 @@ function (angular, app, $, _, kbn, moment, timeSeries) {
     $scope.updateTimeRange = function () {
       $scope.range = filterSrv.timeRange();
       $scope.rangeUnparsed = filterSrv.timeRange(false);
-      $scope.resolution = ($(window).width() * ($scope.panel.span / 12)) / 2;
+      $scope.resolution = Math.ceil(($(window).width() * ($scope.panel.span / 12)) / 2);
       $scope.interval = '10m';
 
       if ($scope.range) {


### PR DESCRIPTION
... 0.9.12 seem to treat decimal maxDataPoints badly returning enourmous amounts of data.

I was messing around with using the 30day dashboard time range and noticed that it was exceedingly slow. After some digging I found that if you pass a decimal to graphite for maxDataPoints it returns a massive time range, seemingly all the data for that range at the smallest resolution.
Although this seems like a graphite issue, the client side fix is quite simple so I figured I'd contribute.
