### PR TITLE
Workaround a recent behavior modification

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -26,7 +26,7 @@ function (angular, $, _, appLevelRequire) {
     // features if we define them after boot time
     register_fns = {};
 
-  // This stores the Kibana revision number, @REV@ is replaced by grunt.
+  // // This stores the Kibana revision number, @REV@ is replaced by grunt.
   app.constant('grafanaVersion',"@grafanaVersion@");
 
   // Use this for cache busting partials


### PR DESCRIPTION
A fresh `npm install` seems to break the `build` task. It used to work fine on my laptop but broke after a reset of `node_modules`.

```
$ grunt build
[ snip ]
>> Uglifying source "dist/app/app.js" failed.
Warning: Uglification failed.
Unexpected token: name (stores). 
Line 61327 in dist/app/app.js
 Use --force to continue.

Aborted due to warnings.
```

The offending line is https://github.com/torkelo/grafana/blob/master/src/app/app.js#L29, which has been uncommented by a previous task, hence the error.

My fix is quite naive, there must be a better way… I haven't found the 3rd-party library version change that caused the issue though.

Here's my `npm list`: https://gist.github.com/brutasse/e1d158792531db2c00cb
