### PR TITLE
Send UTC + offset to graphite, rather than local + offset

### DIFF
--- a/src/app/services/graphite/graphiteDatasource.js
+++ b/src/app/services/graphite/graphiteDatasource.js
@@ -85,10 +85,6 @@ function (angular, _, $, config, kbn, moment) {
 
       date = moment.utc(date);
 
-      if (dashboard.current.timezone === 'browser') {
-        date = date.local();
-      }
-
       if (config.timezoneOffset) {
         date = date.zone(config.timezoneOffset);
       }


### PR DESCRIPTION
Remove the conversion to local time when sending absolute to/from parameters to graphite.  Note that this retains the ability for users to set a separate timezoneOffset if they're connecting to a graphite server that isn't using UTC.
