### PR TITLE
use influxdb aliases to distinguish between multiple columns

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -30,7 +30,8 @@ function (angular, _, kbn) {
           return [];
         }
 
-        var template = "select [[func]]([[column]]) as [[column]]_[[func]] from [[series]] where [[timeFilter]] group by time([[interval]]) order asc";
+        var template = "select [[func]]([[column]]) as [[column]]_[[func]] from [[series]] where [[timeFilter]]" + 
+          " group by time([[interval]]) order asc";
 
         var templateData = {
           series: target.series,

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -30,7 +30,7 @@ function (angular, _, kbn) {
           return [];
         }
 
-        var template = "select [[func]]([[column]]) from [[series]] where [[timeFilter]] group by time([[interval]]) order asc";
+        var template = "select [[func]]([[column]]) as [[column]]_[[func]] from [[series]] where [[timeFilter]] group by time([[interval]]) order asc";
 
         var templateData = {
           series: target.series,


### PR DESCRIPTION
Currently if you have multiple values in a single series, grafana will use the aggregation function for the series name due to the default way influxdb returns column names. This PR alters the InfluxDB query (in a non-backwards compatible fashion sadly, requires InfluxDB 0.5.0rc3 or greater for column aliasing) to return the column name as [[column]]_[[func]] so the columns can be distinguished from each other if using the same aggregation function.
