### PR TITLE
added little workraround for graphites timezones/DST failures

### DIFF
--- a/src/app/components/settings.js
+++ b/src/app/components/settings.js
@@ -24,7 +24,7 @@ function (_, crypto) {
       default_route                 : '/dashboard/file/default.json',
       grafana_index                 : 'grafana-dash',
       elasticsearch_all_disabled    : false,
-      timezoneOffset                : null,
+      timezoneOffset                : 'auto',
     };
 
     // This initializes a new hash on purpose, to avoid adding parameters to
@@ -57,6 +57,16 @@ function (_, crypto) {
           default: true
         }
       };
+    }
+
+    if (settings.timezoneOffset === 'auto' )
+    {
+      //this hack is to deal with graphites poor tz support. It doesn't like
+      // DST, so we're gonna make a january (non-dst) date and get its offset
+      var nonDSTDate = new Date(new Date().getFullYear(),0,1);
+
+      //given "Tue Apr 08 2014 08:24:50 GMT-0400 (EDT)", get "-0400"
+      settings.timezoneOffset = nonDSTDate.toString().split(' ')[5].substring(3);
     }
 
     _.each(settings.datasources, function(datasource, key) {

--- a/src/config.sample.js
+++ b/src/config.sample.js
@@ -38,6 +38,7 @@ function (Settings) {
     /**
      * If your graphite server has another timezone than you & users browsers specify the offset here
      * Example: "-0500" (for UTC - 5 hours)
+     * If your graphite server runs UTC, you can set this to "auto" and it will pick the right timezone for you
      */
     timezoneOffset: null,
 


### PR DESCRIPTION
We have users in several timezones and run all our servers and graphite in UTC. In order to enable us all to use zoom correctly, I added an "auto" feature to timezoneOffset that determines your non-DST offset from UTC automatically. I think it works pretty well, even if it is a bit of a hack. 
