### PR TITLE
Grafana needs hideLegend=false in graphite urls when show legend is selected for Graphite PNG

### DIFF
--- a/src/app/directives/grafanaGraph.js
+++ b/src/app/directives/grafanaGraph.js
@@ -347,7 +347,7 @@ function (angular, $, kbn, moment, _) {
           url += scope.panel.stack ? '&areaMode=stacked' : '';
           url += scope.panel.fill !== 0 ? ('&areaAlpha=' + (scope.panel.fill/10).toFixed(1)) : '';
           url += scope.panel.linewidth !== 0 ? '&lineWidth=' + scope.panel.linewidth : '';
-          url += scope.panel.legend ? '' : '&hideLegend=true';
+          url += scope.panel.legend.show ? '&hideLegend=false' : '&hideLegend=true';
           url += scope.panel.grid.min !== null ? '&yMin=' + scope.panel.grid.min : '';
           url += scope.panel.grid.max !== null ? '&yMax=' + scope.panel.grid.max : '';
           url += scope.panel['x-axis'] ? '' : '&hideAxes=true';


### PR DESCRIPTION
Fix the graphite url generated to always obey the show legend option in grafana. Without hideLegend=false, grafana defaults to the graphite behavior of hiding the legend at (default 10) X+ number of series. Also the url generator should be checking scope.panel.legend.show.
