### PR TITLE
unbind resize event during slideshow

### DIFF
--- a/src/app/services/playlistSrv.js
+++ b/src/app/services/playlistSrv.js
@@ -67,6 +67,7 @@ function (angular, _, kbn) {
 
       timerInstance = setInterval(function() {
         $rootScope.$apply(function() {
+          angular.element(window).unbind('resize');
           $location.path(dashboards[index % dashboards.length].url);
           index++;
         });


### PR DESCRIPTION
There was a memory leak during slideshows due to event handlers piling up in jquery. I was able to squash it by unbinding the resize event before loading the new dashboard. 
