### PR TITLE
Added plugin mode to text panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 web.config
 config.js
 *.sublime-workspace
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 - Added rounding for graphites from and to time range filters
   for very short absolute ranges (Issue #320)
+- Added plugin mode to text panel
 
 # 1.5.3 (2014-04-17)
 - Add support for async scripted dashboards (Issue #274)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A beautiful, easy to use and feature rich Graphite dashboard replacement and gra
 - [Scripted dashboards](https://github.com/torkelo/grafana/wiki/Scripted-dashboards) (generate from js script and url parameters)
 - Flexible [time range controls](https://github.com/torkelo/grafana/wiki/Time-range-controls)
 - [Dashboard playlists](https://github.com/torkelo/grafana/wiki/Dashboard-playlist)
+- Write plug-ins inside the dashboard to augment grafana's functionality (see src/app/dashboards/plugin.json for a simple example)
 
 ### InfluxDB
 - [Use InfluxDB](https://github.com/torkelo/grafana/wiki/InfluxDB) as metric datasource

--- a/src/app/dashboards/plugin.json
+++ b/src/app/dashboards/plugin.json
@@ -1,0 +1,102 @@
+{
+  "title": "Welcome to Grafana!",
+  "services": {
+    "filter": {
+      "list": [],
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      }
+    }
+  },
+  "rows": [
+    {
+      "title": "Welcome to Grafana",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "text",
+          "loadingEditor": false,
+          "mode": "plugin",
+          "content": "<h5>This panel is using an controller and an angular.js HTML template that are defined inside this panel!</h5>\n\n<div ng-controller=\"Controller\">\n  {{name}}\n</div>",
+          "script": "angular.module(\"kibana.panels.text\").controller(\"Controller\", [\"$scope\", function($scope) { \n   $scope.name = \"Max Karl Ernst Ludwig Planck (April 23, 1858 – October 4, 1947)\";\n}]);",
+          "style": {},
+          "title": "Welcome to Grafana"
+        }
+      ],
+      "notice": false
+    }
+  ],
+  "editable": true,
+  "failover": false,
+  "panel_hints": true,
+  "style": "dark",
+  "pulldowns": [
+    {
+      "type": "filtering",
+      "collapse": false,
+      "notice": false,
+      "enable": false
+    },
+    {
+      "type": "annotations",
+      "enable": false
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "now": true
+    }
+  ],
+  "loader": {
+    "save_gist": false,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "30d",
+    "load_gist": false,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": false,
+    "hide": false
+  },
+  "refresh": false,
+  "tags": [],
+  "timezone": "browser"
+}

--- a/src/app/panels/text/editor.html
+++ b/src/app/panels/text/editor.html
@@ -1,16 +1,25 @@
 <div>
   <div class="row-fluid">
     <div class="span4">
-      <label class="small">Mode</label> <select class="input-medium" ng-model="panel.mode" ng-options="f for f in ['html','markdown','text']"></select>
+      <label class="small">Mode</label> <select class="input-medium" ng-model="panel.mode" ng-options="f for f in ['html','markdown','text', 'plugin']"></select>
     </div>
     <div class="span2" ng-show="panel.mode == 'text'">
       <label class="small">Font Size</label> <select class="input-mini" ng-model="panel.style['font-size']" ng-options="f for f in ['6pt','7pt','8pt','10pt','12pt','14pt','16pt','18pt','20pt','24pt','28pt','32pt','36pt','42pt','48pt','52pt','60pt','72pt']"></select>
     </div>
   </div>
 
+  <label ng-show="panel.mode == 'plugin'" class=small>Script
+    <span>(Define new angular.js components in this area)</span>
+  </label>
+
+  <textarea ng-show="panel.mode == 'plugin'" ng-model="panel.script" rows="6" style="width:95%" ng-change="render()" ng-model-onblur
+            placeholder="var module = angular.module('kibana.panels.text');">
+  </textarea>
+
   <label class=small>Content
-    <span ng-show="panel.mode == 'html'">(This area uses HTML sanitized via AngularJS's <a href='http://docs.angularjs.org/api/ngSanitize.$sanitize'>$sanitize</a> service)</span>
+    <span ng-show="panel.mode == 'html'">(This area uses HTML)</span>
     <span ng-show="panel.mode == 'markdown'">(This area uses <a target="_blank" href="http://en.wikipedia.org/wiki/Markdown">Markdown</a>. HTML is not supported)</span>
+    <span ng-show="panel.mode == 'plugin'">(This area uses angular.js HTML templates. You can reference the above defined components.)</span>
   </label>
 
   <textarea ng-model="panel.content" rows="6" style="width:95%" ng-change="render()" ng-model-onblur>

--- a/src/app/panels/text/module.html
+++ b/src/app/panels/text/module.html
@@ -7,4 +7,6 @@
   </p>
   <p ng-show="panel.mode == 'html'" ng-bind-html-unsafe="panel.content">
   </p>
+  <p ng-show="panel.mode == 'plugin'" compile-data script="{{panel.script}}" template="{{panel.content}}">
+  </p>
 </div>

--- a/src/app/panels/text/module.js
+++ b/src/app/panels/text/module.js
@@ -6,8 +6,8 @@
  * == text
  * Status: *Stable*
  *
- * The text panel is used for displaying static text formated as markdown, sanitized html or as plain
- * text.
+ * The text panel is used for displaying static text formated as markdown, html as plain
+ * text or for writing grafana plug-ins.
  *
  */
 define([
@@ -19,18 +19,25 @@ define([
 function (angular, app, _, require) {
   'use strict';
 
-  var module = angular.module('kibana.panels.text', []);
+  var providers = {};
+  var module = angular.module('kibana.panels.text', [], function($controllerProvider, $compileProvider, $provide) {
+    providers = {
+      $controllerProvider: $controllerProvider,
+      $compileProvider: $compileProvider,
+      $provide: $provide
+    };
+  });
   app.useModule(module);
 
   module.controller('text', function($scope) {
 
     $scope.panelMeta = {
-      description : "A static text panel that can use plain text, markdown, or (sanitized) HTML"
+      description : "A static text panel that can use plain text, markdown, or HTML. Additionally, it is possible to write grafana plug-ins."
     };
 
     // Set and populate defaults
     var _d = {
-      mode    : "markdown", // 'html', 'markdown', 'text'
+      mode    : "markdown", // 'html', 'markdown', 'text', 'plugin'
       content : "",
       style: {},
     };
@@ -98,4 +105,49 @@ function (angular, app, _, require) {
         .replace(/</g, '&lt;');
     };
   });
+
+  // thx to Maxim Shoustin
+  // (http://stackoverflow.com/questions/19096239/ng-click-do-not-work-when-a-template-bound-using-ng-bind-html-unsafe#answer-19096506)
+  module.directive( 'compileData', function ( $compile ) {
+    return {
+      scope: true,
+      link: function ( scope, element, attrs ) {
+
+        // thx to Jussi Kosunen
+        // (http://stackoverflow.com/questions/15250644/angularjs-loading-a-controller-dynamically#answer-15292441)
+        attrs.$observe( 'script', function ( script ) {
+          // Store our _invokeQueue length before loading our controllers/directives/services
+          // This is just so we don't re-register anything
+          var queueLengthBefore = angular.module('kibana.panels.text')._invokeQueue.length;
+          /*jshint -W061 */
+          eval(script);
+          dynamicallyRegisterComponents(queueLengthBefore);
+        });
+
+        var elmnt;
+        attrs.$observe( 'template', function ( myTemplate ) {
+          if ( angular.isDefined( myTemplate ) ) {
+            // compile the provided template against the current scope
+            elmnt = $compile( myTemplate )( scope );
+            element.html(""); // dummy "clear"
+            element.append( elmnt );
+          }
+        });
+      }
+    };
+  });
+
+  function dynamicallyRegisterComponents( queueLengthBefore ) {
+    // Register the controls/directives/services we just loaded
+    var queue = angular.module('kibana.panels.text')._invokeQueue;
+    for (var i = queueLengthBefore; i < queue.length; i++) {
+      var call = queue[i];
+      // call is in the form [providerName, providerFunc, providerArguments]
+      var provider = providers[call[0]];
+      if (provider) {
+        // e.g. $controllerProvider.register("Ctrl", function() { ... })
+        provider[call[1]].apply(provider, call[2]);
+      }
+    }
+  }
 });

--- a/src/app/panels/text/module.js
+++ b/src/app/panels/text/module.js
@@ -32,7 +32,8 @@ function (angular, app, _, require) {
   module.controller('text', function($scope) {
 
     $scope.panelMeta = {
-      description : "A static text panel that can use plain text, markdown, or HTML. Additionally, it is possible to write grafana plug-ins."
+      description : "A static text panel that can use plain text, markdown, or HTML. " +
+        "Additionally, it is possible to write grafana plug-ins."
     };
 
     // Set and populate defaults

--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -245,7 +245,10 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
 
     var renderTemplate = function(json,params) {
       var _r;
-      _.templateSettings = {interpolate : /\{\{(.+?)\}\}/g};
+      /* iterpolate with 3 curly braces so that it doesn't conflict with angular.js HTML placeholders
+       * (2 curly braces) when using the plugin mode of the text panel.
+       */
+      _.templateSettings = {interpolate : /\{\{\{(.+?)\}\}\}/g};
       var template = _.template(json);
       var rendered = template({ARGS:params});
       try {


### PR DESCRIPTION
A bit of background:
I'm currently working on an open source monitoring system for java based (web) applications.
- Backend: Graphite
- Frontend: Grafana
- Custom collector agent, including a profiler

My problem is, that I have requirements that are too specific to include them in grafana like displaying call stacks collected by the profiler. So I added a plugin mode to the text panel that solves this problem.
## 

The plugin mode offers two textareas. The first one can be used to implement additional controllers, directives and filters. In the second one you can enter angular.js HTML templates that reference the new components. This way it is easy to augment grafana with specific functionality within a dashboard itself and without maintaining an own fork of the project.

I hope you find this useful
