### PR TITLE
Fixed an exception when adding a graphite function.

### DIFF
--- a/src/app/controllers/graphiteTarget.js
+++ b/src/app/controllers/graphiteTarget.js
@@ -234,7 +234,7 @@ function (angular, _, config, gfunc, Parser) {
       $scope.moveAliasFuncLast();
       $scope.smartlyHandleNewAliasByNode(newFunc);
 
-      if (!funcDef.params.length && newFunc.added) {
+      if (!newFunc.params.length && newFunc.added) {
         $scope.targetChanged();
       }
     };


### PR DESCRIPTION
The error was that funcDef is just a string parsed from an event
like onMouseDown or something like that. This event is turned
into a function instance, and the function instance has
expected parameters and so forth. However, the number of
parameters was actually checked on the funcDef.
