### PR TITLE
Change InfluxDB SQL generation template to wrap column names in quoutes

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -62,7 +62,7 @@ function (angular, _, kbn) {
           query = queryElements.join(" ");
         }
         else {
-          var template = "select [[func]]([[column]]) as [[column]]_[[func]] from [[series]] " +
+          var template = "select [[func]](\"[[column]]\") as \"[[column]]_[[func]]\" from [[series]] " +
                          "where  [[timeFilter]] [[condition_add]] [[condition_key]] [[condition_op]] [[condition_value]] " +
                          "group by time([[interval]]) order asc";
 


### PR DESCRIPTION
Since column names can contain dots or dashes, which will give syntax errors from InfluxDB API, [unless wrapped in quotes](https://github.com/influxdb/influxdb/issues/481).
