### PR TITLE
InfluxDB Filters

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -60,6 +60,7 @@ function (angular, _, kbn) {
           }
 
           query = queryElements.join(" ");
+          query = filterSrv.applyFilterToTarget(query);
         }
         else {
           var template = "select [[func]](\"[[column]]\") as \"[[column]]_[[func]]\" from [[series]] " +
@@ -79,6 +80,7 @@ function (angular, _, kbn) {
           };
 
           query = _.template(template, templateData, this.templateSettings);
+          query = filterSrv.applyFilterToTarget(query);
           target.query = query;
         }
 


### PR DESCRIPTION
refs #334 - Allow using filters in InfluxDB queries

You can create new filter using InfluxDB query syntax:

![screen shot 2014-05-01 at 00 41 38](https://cloud.githubusercontent.com/assets/43941/2848205/8a0dc6be-d0b9-11e3-8ee0-a39295dc20ec.png)

then you can see the filters result:

![screen shot 2014-05-01 at 00 41 27](https://cloud.githubusercontent.com/assets/43941/2848211/a1ddc9ec-d0b9-11e3-82bd-1772b016066e.png)

You can use the templating system in query (and raw query):

![screen shot 2014-05-01 at 00 42 36](https://cloud.githubusercontent.com/assets/43941/2848215/b0ab60d8-d0b9-11e3-9981-ebca49f950e0.png)

And you can see different result using different filters:

![screen shot 2014-05-01 at 00 42 21](https://cloud.githubusercontent.com/assets/43941/2848220/c1e8e924-d0b9-11e3-83ca-1afb6ba77e5f.png)

![screen shot 2014-05-01 at 00 50 52](https://cloud.githubusercontent.com/assets/43941/2848226/eca62b22-d0b9-11e3-8d7c-ec572838289b.png)
