### PR TITLE
Added nanosecond y-scale formatting

### DIFF
--- a/src/app/components/kbn.js
+++ b/src/app/components/kbn.js
@@ -574,6 +574,10 @@ function($, _, moment) {
       return function(val) {
         return kbn.microsFormat(val, decimals);
       };
+    case 'ns':
+      return function(val) {
+        return kbn.nanosFormat(val, decimals);
+      };
     default:
       return function(val) {
         return val % 1 === 0 ? val : val.toFixed(decimals);
@@ -614,6 +618,24 @@ function($, _, moment) {
     }
     else {
       return (size / 1000000).toFixed(decimals) + " s";
+    }
+  };
+
+  kbn.nanosFormat = function(size, decimals) {
+    if (size < 1000) {
+      return size.toFixed(0) + " ns";
+    }
+    else if (size < 1000000) {
+      return (size / 1000).toFixed(decimals) + " µs";
+    }
+    else if (size < 1000000000) {
+      return (size / 1000000).toFixed(decimals) + " ms";
+    }
+    else if (size < 60000000000){
+      return (size / 1000000000).toFixed(decimals) + " s";
+    }
+    else {
+      return (size / 60000000000).toFixed(decimals) + " m";
     }
   };
 

--- a/src/app/panels/graphite/axisEditor.html
+++ b/src/app/panels/graphite/axisEditor.html
@@ -10,11 +10,11 @@
     </div>
     <div class="editor-option">
       <label class="small">Left Y Format <tip>Y-axis formatting</tip></label>
-      <select class="input-small" ng-model="panel.y_formats[0]" ng-options="f for f in ['none','short','bytes', 'bits', 'ms', 'µs']" ng-change="render()"></select>
+      <select class="input-small" ng-model="panel.y_formats[0]" ng-options="f for f in ['none','short','bytes', 'bits', 'ms', 'µs', 'ns']" ng-change="render()"></select>
     </div>
     <div class="editor-option">
       <label class="small">Right Y Format <tip>Y-axis formatting</tip></label>
-      <select class="input-small" ng-model="panel.y_formats[1]" ng-options="f for f in ['none','short','bytes', 'bits', 'ms', 'µs']" ng-change="render()"></select>
+      <select class="input-small" ng-model="panel.y_formats[1]" ng-options="f for f in ['none','short','bytes', 'bits', 'ms', 'µs', 'ns']" ng-change="render()"></select>
     </div>
 
     <div class="editor-option">

--- a/src/test/specs/kbn-format-specs.js
+++ b/src/test/specs/kbn-format-specs.js
@@ -21,4 +21,33 @@ define([
     });
 
   });
+
+  describe('nanosecond formatting', function () {
+
+    it('should translate 25 to 25 ns', function () {
+      var str = kbn.nanosFormat(25, 2);
+      expect(str).to.be("25 ns");
+    });
+
+    it('should translate 2558 to 2.56 µs', function () {
+      var str = kbn.nanosFormat(2558, 2);
+      expect(str).to.be("2.56 µs");
+    });
+
+    it('should translate 2558000 to 2.56 ms', function () {
+      var str = kbn.nanosFormat(2558000, 2);
+      expect(str).to.be("2.56 ms");
+    });
+
+    it('should translate 2019962000 to 2.02 s', function () {
+      var str = kbn.nanosFormat(2049962000, 2);
+      expect(str).to.be("2.05 s");
+    });
+
+    it('should translate 95199620000 to 1.59 m', function () {
+      var str = kbn.nanosFormat(95199620000, 2);
+      expect(str).to.be("1.59 m");
+    });
+
+  });
 });


### PR DESCRIPTION
Hello devs,
We've recently started using Grafana and really like it (kudos!).

Some of our metrics though are reported in _nanoseconds_ - which are not available by default in the y-scale selection, so I've added `ns` to the available formatters. It would be very cool if this got merged, so we don't have to maintain our own branch with this formatter added :-)

Let me know what you think about this - thanks in advance!
