### PR TITLE
Add elasticsearch as annotations source

### DIFF
--- a/src/app/panels/annotations/editor.html
+++ b/src/app/panels/annotations/editor.html
@@ -76,6 +76,8 @@
       <label class="small">Elasticsearch query</label>
       <input type="text" ng-model='currentAnnnotation.query' placeholder=""></input>
     </div>
+  </div>
+  <div class="editor-row" ng-if="currentAnnnotation.type === 'es annotations'">
     <div class="editor-option">
       <label class="small">Elasticsearch timestamp field</label>
       <input type="text" ng-model='currentAnnnotation.timestampField' placeholder="@timestamp"></input>

--- a/src/app/panels/annotations/editor.html
+++ b/src/app/panels/annotations/editor.html
@@ -76,6 +76,18 @@
       <label class="small">Elasticsearch query</label>
       <input type="text" ng-model='currentAnnnotation.query' placeholder=""></input>
     </div>
+    <div class="editor-option">
+      <label class="small">Elasticsearch timestamp field</label>
+      <input type="text" ng-model='currentAnnnotation.timestampField' placeholder="@timestamp"></input>
+    </div>
+    <div class="editor-option">
+      <label class="small">Elasticsearch message field</label>
+      <input type="text" ng-model='currentAnnnotation.messageField' placeholder="message"></input>
+    </div>
+    <div class="editor-option">
+      <label class="small">Elasticsearch max results</label>
+      <input type="text" ng-model='currentAnnnotation.maxResults' placeholder="100"></input>
+    </div>
   </div>
 
 </div>

--- a/src/app/panels/annotations/editor.html
+++ b/src/app/panels/annotations/editor.html
@@ -33,7 +33,7 @@
     </div>
     <div class="editor-option">
       <label class="small">Type</label>
-      <select ng-model="currentAnnnotation.type" ng-options="f for f in ['graphite metric', 'graphite events']"></select>
+      <select ng-model="currentAnnnotation.type" ng-options="f for f in ['graphite metric', 'graphite events', 'es annotations']"></select>
     </div>
     <div class="editor-option">
       <label class="small">Icon color</label>
@@ -64,6 +64,17 @@
     <div class="editor-option">
       <label class="small">Graphite event tags</label>
       <input type="text" ng-model='currentAnnnotation.tags' placeholder=""></input>
+    </div>
+  </div>
+
+  <div class="editor-row" ng-if="currentAnnnotation.type === 'es annotations'">
+    <div class="editor-option">
+      <label class="small">Elasticsearch index</label>
+      <input type="text" ng-model='currentAnnnotation.index' placeholder=""></input>
+    </div>
+    <div class="editor-option">
+      <label class="small">Elasticsearch query</label>
+      <input type="text" ng-model='currentAnnnotation.query' placeholder=""></input>
     </div>
   </div>
 

--- a/src/app/services/all.js
+++ b/src/app/services/all.js
@@ -6,6 +6,7 @@ define([
   './timer',
   './panelMove',
   './keyboardManager',
+  './elasticSrv',
   './annotationsSrv',
   './playlistSrv',
   './unsavedChangesSrv',

--- a/src/app/services/annotationsSrv.js
+++ b/src/app/services/annotationsSrv.js
@@ -83,7 +83,7 @@ define([
       });
     };
 
-    this.getESAnnotations = function() {
+    this.getESAnnotations = function(rangeUnparsed) {
       var annotations = this.getAnnotationsByType('es annotations');
       if (annotations.length === 0) {
         return [];
@@ -91,7 +91,8 @@ define([
       var promises = _.map(annotations, function(annotation) {
         var esQuery = {
           index: annotation.index,
-          query: annotation.query
+          query: annotation.query,
+          range: rangeUnparsed
         };
 
         var receiveFunc = _.partial(receiveESMetrics, annotation);

--- a/src/app/services/annotationsSrv.js
+++ b/src/app/services/annotationsSrv.js
@@ -7,7 +7,7 @@ define([
 
   var module = angular.module('kibana.services');
 
-  module.service('annotationsSrv', function(dashboard, datasourceSrv, $q, alertSrv, $rootScope) {
+  module.service('annotationsSrv', function(dashboard, datasourceSrv, elasticSrv, $q, alertSrv, $rootScope) {
     var promiseCached;
     var annotationPanel;
     var list = [];
@@ -40,7 +40,9 @@ define([
       var graphiteMetrics = this.getGraphiteMetrics(filterSrv, rangeUnparsed);
       var graphiteEvents = this.getGraphiteEvents(rangeUnparsed);
 
-      promiseCached = $q.all(graphiteMetrics.concat(graphiteEvents))
+      var esAnnotations = this.getESAnnotations(rangeUnparsed);
+
+      promiseCached = $q.all(graphiteMetrics.concat(graphiteEvents).concat(esAnnotations))
         .then(function() {
           return list;
         });
@@ -80,6 +82,38 @@ define([
         enable: true
       });
     };
+
+    this.getESAnnotations = function() {
+      var annotations = this.getAnnotationsByType('es annotations');
+      if (annotations.length === 0) {
+        return [];
+      }
+      var promises = _.map(annotations, function(annotation) {
+        var esQuery = {
+          index: annotation.index,
+          query: annotation.query
+        };
+
+        var receiveFunc = _.partial(receiveESMetrics, annotation);
+        return elasticSrv.query(esQuery)
+        .then(receiveFunc)
+        .then(null, errorHandler);
+      });
+
+      return promises;
+    };
+
+    function receiveESMetrics(annotation, results) {
+      results['data']['hits']['hits'].forEach (function(result) {
+        var source = result['_source'];
+        //TODO make fields configurable
+        addAnnotation({
+          annotation: annotation,
+          time: moment(source['@timestamp']).valueOf(),
+          description: source['message']
+        });
+      });
+    }
 
     this.getGraphiteMetrics = function(filterSrv, rangeUnparsed) {
       var annotations = this.getAnnotationsByType('graphite metric');

--- a/src/app/services/elasticSrv.js
+++ b/src/app/services/elasticSrv.js
@@ -17,22 +17,36 @@ function (angular, $, kbn, _, config) {
       //TODO be smart on size parameter
     this.query = function(esQuery) {
       var url = config.elasticsearch + "/" + esQuery.index + "/_search";
-      var data = {
-        "query": {
-          "filtered": {
-            "query": {
-              "bool": {
-                "should": [{
-                  "query_string": {
-                    "query": esQuery.query
-                  }
-                }]
+      var filter = {
+        "bool": {
+          "must": [{
+            "range": {
+              "@timestamp": {
+                "from": esQuery.range.from,
+                "to": esQuery.range.to
               }
             }
+          }]
+        }
+      };
+      var query = {
+        "bool": {
+          "should": [{
+            "query_string": {
+              "query": esQuery.query
+            }
+          }]
+        }
+      };
+      var data = {
+        "query" : {
+          "filtered": {
+            "query" : query,
+            "filter": filter
           }
         },
-        "size": 100
-      }
+        "size" : 100
+      };
       var options = {
       };
       if (config.elasticsearchBasicAuth) {

--- a/src/app/services/elasticSrv.js
+++ b/src/app/services/elasticSrv.js
@@ -17,15 +17,15 @@ function (angular, $, kbn, _, config) {
       //TODO be smart on size parameter
     this.query = function(esQuery) {
       var url = config.elasticsearch + "/" + esQuery.index + "/_search";
+      var range = {};
+      range[esQuery.timestampField] = {
+        "from": esQuery.range.from,
+        "to": esQuery.range.to
+      };
       var filter = {
         "bool": {
           "must": [{
-            "range": {
-              "@timestamp": {
-                "from": esQuery.range.from,
-                "to": esQuery.range.to
-              }
-            }
+            "range": range
           }]
         }
       };
@@ -45,7 +45,7 @@ function (angular, $, kbn, _, config) {
             "filter": filter
           }
         },
-        "size" : 100
+        "size" : esQuery.maxResults
       };
       var options = {
       };

--- a/src/app/services/elasticSrv.js
+++ b/src/app/services/elasticSrv.js
@@ -1,0 +1,46 @@
+define([
+  'angular',
+  'jquery',
+  'kbn',
+  'underscore',
+  'config'
+],
+function (angular, $, kbn, _, config) {
+  'use strict';
+
+  var module = angular.module('kibana.services');
+  module.service('elasticSrv', function(
+    $routeParams, $http, $rootScope, $injector, $location, $timeout,
+    ejsResource, timer, alertSrv
+  ) {
+      // An elasticJS client to use TODO use it instead of direct $http
+      //var ejs = ejsResource(config.elasticsearch, config.elasticsearchBasicAuth);
+
+      //TODO be smart on size parameter
+    this.query = function(esQuery) {
+      var options = {
+        url: config.elasticsearch + "/" + esQuery.index + "/_search?q=" + esQuery.query + "&size=100",
+        method: "GET"
+      };
+      if (config.elasticsearchBasicAuth) {
+        options.withCredentials = true;
+        options.headers = {
+          "Authorization": "Basic " + config.elasticsearchBasicAuth
+        };
+      }
+      return $http(options)
+    .error(function(data, status) {
+      if(status === 0) {
+        alertSrv.set('Error',"Could not contact Elasticsearch at "+config.elasticsearch+
+          ". Please ensure that Elasticsearch is reachable from your system." ,'error');
+      } else {
+        alertSrv.set('Error',"Could not search for "+ esQuery.query +". If you"+
+          " are using a proxy, ensure it is configured correctly",'error');
+      }
+      return false;
+    }).success(function() {
+      //console.log(data);
+    });
+    };
+  });
+});


### PR DESCRIPTION
Support for elasticsearch as annotation source.
Current feature:
- allow to search against any index ("toto", "_all", "toto,titi")
- allow any query (using query_string syntax)

Limitation: cannot use the classic "logstash" index name pattern since the index is fixed.
I probably won't fix it in this PR since people can use aliases in the beginning

Fix #201
