### PR TITLE
Allow [[..]] filter notation in text panels.

### DIFF
--- a/src/app/panels/text/module.html
+++ b/src/app/panels/text/module.html
@@ -5,6 +5,6 @@
   </markdown>
   <p ng-show="panel.mode == 'text'" ng-style='panel.style' ng-bind-html-unsafe="panel.content | striphtml | newlines">
   </p>
-  <p ng-show="panel.mode == 'html'" ng-bind-html-unsafe="panel.content">
+  <p ng-show="panel.mode == 'html'" ng-bind-html-unsafe="panel.content | applyfilters">
   </p>
 </div>

--- a/src/app/panels/text/module.js
+++ b/src/app/panels/text/module.js
@@ -102,7 +102,7 @@ function (angular, app, _, require) {
 
   module.filter('applyfilters', function(filterSrv){
     return function (input) {
-      return filterSrv.applyFilterToTarget(input)
+      return filterSrv.applyFilterToTarget(input);
     };
   });
 });

--- a/src/app/panels/text/module.js
+++ b/src/app/panels/text/module.js
@@ -14,7 +14,8 @@ define([
   'angular',
   'app',
   'underscore',
-  'require'
+  'require',
+  'services/filterSrv'
 ],
 function (angular, app, _, require) {
   'use strict';
@@ -96,6 +97,12 @@ function (angular, app, _, require) {
         .replace(/&/g, '&amp;')
         .replace(/>/g, '&gt;')
         .replace(/</g, '&lt;');
+    };
+  });
+
+  module.filter('applyfilters', function(filterSrv){
+    return function (input) {
+      return filterSrv.applyFilterToTarget(input)
     };
   });
 });


### PR DESCRIPTION
Adds a new "applyfilters" module filter for text panels, allowing the the values of any defined grafana filters to be interpolated within panels.  Currently only html panels have this filter enabled, but it can be added to plain text or markdown panels if required.

We're using this in conjunction with an "application-name" grafana filter, to insert an HTML iframe showing the relevant nagios servicegroup page for that application; the source of our text panel is something like:

```
<iframe src="https://nagios/nagios/cgi-bin/status.cgi?servicegroup=[[application-name]]&style=detail" width="100%" />
```
