### PR TITLE
Add URL hashing balancing

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -19,7 +19,6 @@ function (angular, _, kbn) {
       this.username = datasource.username;
       this.password = datasource.password;
       this.name = datasource.name;
-      
       this.templateSettings = {
         interpolate : /\[\[([\s\S]+?)\]\]/g,
       };
@@ -82,7 +81,6 @@ function (angular, _, kbn) {
           query = _.template(template, templateData, this.templateSettings);
           target.query = query;
         }
-
 	return this.doInfluxRequest(query, target.alias).then(handleInfluxQueryResponse);
       }, this);
 
@@ -187,6 +185,7 @@ function (angular, _, kbn) {
           output.push({ target:target, datapoints:datapoints });
         });
       });
+
       return output;
     }
 

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -19,7 +19,6 @@ function (angular, _, kbn) {
       this.username = datasource.username;
       this.password = datasource.password;
       this.name = datasource.name;
-      this.avoid_empty_data = datasource.avoid_empty_data;
       
       this.templateSettings = {
         interpolate : /\[\[([\s\S]+?)\]\]/g,
@@ -122,7 +121,7 @@ function (angular, _, kbn) {
       });
     }
 
-    InfluxDatasource.prototype.doInfluxRequest = function(query, alias, influxUrl) {
+    InfluxDatasource.prototype.doInfluxRequest = function(query, alias) {
       var _this = this;
       var deferred = $q.defer();
 
@@ -163,7 +162,6 @@ function (angular, _, kbn) {
           deferred.resolve(data);
         });
       }, 10);
-
 
       return deferred.promise;
     };

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -14,7 +14,8 @@ function (angular, _, kbn) {
       this.type = 'influxDB';
       this.editorSrc = 'app/partials/influxdb/editor.html';
       this.urls = datasource.urls;
-      this.urls_lb = datasource.urls;
+      this.urls_rr_lb = datasource.urls;
+      this.urls_hash_lb = datasource.lb_hashing;
       this.username = datasource.username;
       this.password = datasource.password;
       this.name = datasource.name;
@@ -83,25 +84,7 @@ function (angular, _, kbn) {
           target.query = query;
         }
 
-	if (this.avoid_empty_data) {
-		var lastResponse   = null;
-		var influxResponse = null;
-		for(var i = 0; i < this.urls.length; i++) {
-			var url 	   = this.urls[i];
-			var totalResults   = 0;
-			influxResponse = this.doInfluxRequest(query, target.alias, url).then(handleInfluxQueryResponse).then(function(data) {
-					totalResults = data.length;
-					lastResponse = data;
-					return data;
-					});
-			if (totalResults > 0) {
-				return influxResponse;
-			}
-		}
-		return influxResponse;
-	} else {
-		return this.doInfluxRequest(query, target.alias).then(handleInfluxQueryResponse);
-	}
+	return this.doInfluxRequest(query, target.alias).then(handleInfluxQueryResponse);
       }, this);
 
       return $q.all(promises).then(function(results) {
@@ -145,11 +128,22 @@ function (angular, _, kbn) {
 
       retry(deferred, function() {
 	var currentUrl = null;
-	if (influxUrl) {
-		currentUrl = influxUrl;
-	} else {
-		currentUrl = _this.urls_lb.shift();
-		_this.urls_lb.push(currentUrl);
+	/* Should we use RR load-balancing or hashing? */
+	if (_this.urls_hash_lb) {
+		for (var i=0; i<_this.urls_hash_lb.length; i++) {
+			var matches = query.match(_this.urls_hash_lb[i].regexp);
+			if (matches) {
+				var index = _this.urls_hash_lb[i].url_index;
+				currentUrl = _this.urls[index];
+				if (currentUrl) {
+					break;
+				}
+			}
+		}
+	}
+	if (!currentUrl) {
+		currentUrl = _this.urls_rr_lb.shift();
+		_this.urls_rr_lb.push(currentUrl);
 	}
         var params = {
           u: _this.username,
@@ -169,6 +163,7 @@ function (angular, _, kbn) {
           deferred.resolve(data);
         });
       }, 10);
+
 
       return deferred.promise;
     };


### PR DESCRIPTION
Currently grafana does round-robing balancing when a list of URLs are set. This pull request adds support for URL hashing, that means that users can also opt to select which URLs to use based on a pattern (regexp) that would be ran against the query.

For example:

```
influx: {
         default: true,
         url: 'http://datacenter.XYZ.example.com:8086/db/foo,http://datacenter.ABC.example.com/db/foo',
         lb_hashing: [
                { regexp: /XYZ/, url_index: 0 },
                { regexp: /ABC/, url_index: 1 },
         ],
         type: 'influxdb',
         username: 'test',
         password: 'test',
},
```

So if a user has a panel with the following queries:
- select mean(value) from table WHERE datacenter = 'XYZ'
- select mean(value) from table WHERE datacenter = 'ABC'

Then the query of XYZ would match:

```
                { regexp: /XYZ/, url_index: 0 },
```

And thus use the first URL (http://datacenter.XYZ.example.com:8086/db/foo).

This is very helpful if you are using InfluxDB and have multiple datacenters (and multiple masters/leaders, or don't have replication, etc), because now in your graphs you can show data from all your datacenters with a single influx datasource.

Let me know if syntax (tabs/spaces) are right, been a while since I did javascript so my vim may be a bit more customized for other languages :)

Thanks!
