### PR TITLE
Format seconds metric by week if needed

### DIFF
--- a/src/app/components/kbn.js
+++ b/src/app/components/kbn.js
@@ -521,6 +521,10 @@ function($, _, moment) {
     else if (size < 604800) {
       return (size / 86400).toFixed(decimals) + " day";
     }
+    // Less than one year, devide in week
+    else if (size < 31536000) {
+      return (size / 604800).toFixed(decimals) + " week";
+    }
 
     return (size / 3.15569e7).toFixed(decimals) + " year";
   };


### PR DESCRIPTION
We graph for example the our consumer uptime in seconds.
So right now, it display something like "0.0" year.
It's not so useful. So now, it displays uptimes in days,
then in weeks, and then in years ;)

(Thanks for this amazing dashboard !!!)
