### PR TITLE
Fixes regex InfluxDB queries intoduced in 1.6.0

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -68,7 +68,7 @@ function (angular, _, kbn) {
         }
         else {
 
-          var template = "select [[group]][[group_comma]] [[func]](\"[[column]]\") as \"[[column]]_[[func]]\" from \"[[series]]\" " +
+          var template = "select [[group]][[group_comma]] [[func]](\"[[column]]\") as \"[[column]]_[[func]]\" from [[series]] " +
                          "where  [[timeFilter]] [[condition_add]] [[condition_key]] [[condition_op]] [[condition_value]] " +
                          "group by time([[interval]])[[group_comma]] [[group]] order asc";
 
@@ -85,6 +85,10 @@ function (angular, _, kbn) {
             group_comma: target.groupby_field_add && target.groupby_field ? ',' : '',
             group: target.groupby_field_add ? target.groupby_field : '',
           };
+
+          if(!templateData.series.match('^/.*/')) {
+                  templateData.series = '"' + templateData.series + '"';
+          }
 
           query = _.template(template, templateData, this.templateSettings);
           query = filterSrv.applyTemplateToTarget(query);
@@ -112,12 +116,11 @@ function (angular, _, kbn) {
     };
 
     InfluxDatasource.prototype.listColumns = function(seriesName) {
-      return this.doInfluxRequest('select * from "' + seriesName + '" limit 1').then(function(data) {
+      return this.doInfluxRequest('select * from /' + seriesName + '/ limit 1').then(function(data) {
         if (!data) {
           return [];
         }
 
-        return data[0].columns;
       });
     };
 
@@ -229,7 +232,7 @@ function (angular, _, kbn) {
             datapoints[i] = [metricValue, groupPoints[i][timeCol]];
           }
 
-          seriesName = alias ? alias : key;
+          seriesName = alias ? alias : series.name;
 
           // if mulitple groups append key to alias
           if (alias && groupByField) {


### PR DESCRIPTION
Do not encapsulate regex with quotes in query string

Fix the way series names are displayed, do not use column name but rather series names, this was original and more useful behaviour
