### PR TITLE
Display tag values whenever a tag is part of the query (opentsdb)

### DIFF
--- a/src/app/services/opentsdb/opentsdbDatasource.js
+++ b/src/app/services/opentsdb/opentsdbDatasource.js
@@ -33,9 +33,7 @@ function (angular, _, kbn) {
       var groupByTags = {};
       _.each(queries, function(query) {
         _.each(query.tags, function(val, key) {
-          if (val === "*") {
-            groupByTags[key] = true;
-          }
+          groupByTags[key] = true;
         });
       });
 


### PR DESCRIPTION
Currently, the tag values associated with a _timeserie_ is only displayed if the query was specify using _tagname_=_*_.
Actually, whenever a tag is specified (and the query is valid for the opentsdb backend), the _tag_key=tag_value_ should be displayed because they are full part of the timeserie definition
