### PR TITLE
Fixes #219: Change filter selection to use typeahead

### DIFF
--- a/src/app/panels/filtering/module.html
+++ b/src/app/panels/filtering/module.html
@@ -5,21 +5,23 @@
     <div ng-repeat="filter in filter.templateParameters" class="small filter-panel-filter">
       <div>
         <i class="filter-action pointer icon-remove" bs-tooltip="'Remove'" ng-click="remove(filter)"></i>
-        <i class="filter-action pointer icon-edit" ng-hide="filter.editing" bs-tooltip="'Edit'" ng-click="filter.editing = true"></i>
+        <i class="filter-action pointer icon-edit" ng-hide="filter.editing" bs-tooltip="'Edit'" ng-click="filter.editing = true; filter.picking=false"></i>
       </div>
 
       <div ng-hide="filter.editing" style="margin-right: 45px;">
         <ul class="unstyled">
           <li ng-if="filter.name" class="dropdown">
-            {{filter.name}} :
-            <a class="dropdown-toggle" data-toggle="dropdown">
-              {{filter.current.text}}
-            </a>
-              <ul class="dropdown-menu">
-                <li ng-repeat="option in filter.options">
-                  <a ng-click="filterOptionSelected(filter, option)">{{option.text}}</a>
-                </li>
-              </ul>
+            {{filter.name}}:
+            <a ng-hide="filter.picking" ng-click="filterPick(filter, $event)">{{filter.current.text}}</a>
+            <span ng-show="filter.picking">
+              <input type="text" class="filter-small" autocomplete="off" spellcheck="false" data-items="30" min-length="0" ng-model="selectedFilter" bs-typeahead="textFilter($index)" focus-me="filter.picking" ng-keypress="$event.keyCode == 13 ? filterApply(filter, selectedFilter) : null" />
+              <button type="button" class="btn btn-success btn-micro" ng-click="filterApply(filter, selectedFilter);selectedFilter=''">
+                <span class="icon-play"></span>
+              </button>
+              <button type="button" class="btn btn-info btn-micro" ng-click="filterPick(filter);selectedFilter=''">
+                <span class="icon-remove"></span>
+              </button>
+            </span>
           </li>
         </ul>
       </div>

--- a/src/app/panels/filtering/module.js
+++ b/src/app/panels/filtering/module.js
@@ -1,6 +1,6 @@
 /*
 
-  ## filtering
+## filtering
 
 */
 define([
@@ -14,6 +14,18 @@ function (angular, app, _) {
   var module = angular.module('kibana.panels.filtering', []);
   app.useModule(module);
 
+  app.directive('focusMe', function() {
+    return {
+      link: function(scope, element, attrs) {
+        scope.$watch(attrs.focusMe, function(value) {
+          if(value === true) {
+            element[0].focus();
+          }
+        });
+      }
+    };
+  });
+
   module.controller('filtering', function($scope, datasourceSrv, $rootScope, $timeout, $q) {
 
     $scope.panelMeta = {
@@ -25,6 +37,7 @@ function (angular, app, _) {
     var _d = {
     };
     _.defaults($scope.panel,_d);
+    _.each($scope.filter.templateParameters, function(param) { param.picking = false; });
 
     $scope.init = function() {
       // empty. Don't know if I need the function then.
@@ -34,21 +47,26 @@ function (angular, app, _) {
       $scope.filter.removeTemplateParameter(templateParameter);
     };
 
-    $scope.filterOptionSelected = function(templateParameter, option, recursive) {
-      templateParameter.current = option;
+    $scope.filterOptionSelected = function(templateParameter, selectedFilter, recursive) {
+      var filter = _.find(templateParameter.options, function(opt) { return opt.text === selectedFilter; });
 
-      $scope.filter.updateTemplateData();
+      if (filter != null) {
+        templateParameter.current = filter;
 
-      return $scope.applyFilterToOtherFilters(templateParameter)
-        .then(function() {
-          // only refresh in the outermost call
-          if (!recursive) {
-            $scope.dashboard.refresh();
-          }
-        });
+        $scope.filter.updateTemplateData();
+
+        return $scope.applyFilterToOtherFilters(templateParameter)
+          .then(function() {
+            // only refresh in the outermost call
+            if (!recursive) {
+              $scope.dashboard.refresh();
+            }
+          });
+      }
     };
 
     $scope.applyFilterToOtherFilters = function(updatedTemplatedParam) {
+      cachedFilters = {};
       var promises = _.map($scope.filter.templateParameters, function(templateParam) {
         if (templateParam === updatedTemplatedParam) {
           return;
@@ -83,12 +101,30 @@ function (angular, app, _) {
           if (templateParam.current) {
             var currentExists = _.findWhere(templateParam.options, { value: templateParam.current.value });
             if (currentExists) {
-              return $scope.filterOptionSelected(templateParam, templateParam.current, true);
+              return $scope.filterOptionSelected(templateParam, templateParam.current.text, true);
             }
           }
 
-          return $scope.filterOptionSelected(templateParam, templateParam.options[0], true);
+          return $scope.filterOptionSelected(templateParam, templateParam.options[0].text, true);
         });
+    };
+
+    var cachedFilters = {};
+    $scope.textFilter = function(filterIndex) {
+      if (!cachedFilters[filterIndex]) {
+        var opts = $scope.filter.templateParameters[filterIndex].options;
+        cachedFilters[filterIndex] = _.map(opts, function(option) { return option.text;});
+      }
+      return cachedFilters[filterIndex];
+    };
+
+    $scope.filterPick = function(filter) {
+      filter.picking=!filter.picking;
+    };
+
+    $scope.filterApply = function(filter, selectedFilter) {
+      $scope.filterOptionSelected(filter, selectedFilter);
+      $scope.filterPick(filter);
     };
 
     $scope.add = function() {

--- a/src/css/less/submenu.less
+++ b/src/css/less/submenu.less
@@ -78,7 +78,7 @@
 .filter-panel-filter {
   display:inline-block;
   vertical-align: top;
-  padding: 4px 10px 3px 10px;
+  padding: 3px 10px 3px 10px;
   border-right: 1px solid @submenuBorder;
 }
 
@@ -115,4 +115,16 @@
 
 .filter-apply {
   float:right;
+}
+
+input.filter-small[type="text"] {
+  height: 75%;
+  font-size: 12px;
+  line-height: 75%;
+  margin: 0px 0px;
+  padding: 2px 6px;
+}
+
+.btn-micro {
+	padding: 1px 6px;
 }


### PR DESCRIPTION
Updated the filter dropdown to use the included bootstrap typeahead control. Upgrading to the current versions of the javascript libraries would decrease the custom code that was required for this functionality, and increase the usability.
