### PR TITLE
add now_delay_minutes setting

### DIFF
--- a/src/app/components/settings.js
+++ b/src/app/components/settings.js
@@ -27,7 +27,8 @@ function (_, crypto) {
       elasticsearch_all_disabled    : false,
       timezoneOffset                : null,
       playlist_timespan             : "1m",
-      unsaved_changes_warning       : true
+      unsaved_changes_warning       : true,
+      now_delay_minutes             : 0
     };
 
     // This initializes a new hash on purpose, to avoid adding parameters to

--- a/src/app/services/graphite/graphiteDatasource.js
+++ b/src/app/services/graphite/graphiteDatasource.js
@@ -75,7 +75,12 @@ function (angular, _, $, config, kbn, moment) {
     GraphiteDatasource.prototype.translateTime = function(date, rounding) {
       if (_.isString(date)) {
         if (date === 'now') {
-          return 'now';
+          if (config.now_delay_minutes > 0) {
+            return '-' + config.now_delay_minutes + 'minutes';
+          }
+          else {
+            return 'now';
+          }
         }
         else if (date.indexOf('now') >= 0) {
           date = date.substring(3);

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -1,10 +1,11 @@
 define([
   'angular',
   'underscore',
+  'config',
   'kbn',
   './influxSeries'
 ],
-function (angular, _, kbn, InfluxSeries) {
+function (angular, _, config, kbn, InfluxSeries) {
   'use strict';
 
   var module = angular.module('kibana.services');
@@ -219,7 +220,12 @@ function (angular, _, kbn, InfluxSeries) {
     function getInfluxTime(date) {
       if (_.isString(date)) {
         if (date === 'now') {
-          return 'now()';
+          if (config.now_delay_minutes > 0) {
+            return 'now() - ' + config.now_delay_minutes + 'm';
+          }
+          else {
+            return 'now()';
+          }
         }
         else if (date.indexOf('now') >= 0) {
           return date.substring(4);


### PR DESCRIPTION
I have some aggregate metrics that take a while to fill, so when I run graphs until actual now() they are inaccurate for a certain amount of time until all the nodes have checked in. I added a setting to globally delay now by x amount of minutes to give the metrics a chance to hear from all the nodes before displaying. 
