### PR TITLE
Add continuous query in series results.

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -103,7 +103,7 @@ function (angular, _, kbn) {
     };
 
     InfluxDatasource.prototype.listSeries = function() {
-      return this.doInfluxRequest('list series').then(function(data) {
+      return this.doInfluxRequest('select * from /.*/ limit 1').then(function(data) {
         return _.map(data, function(series) {
           return series.name;
         });


### PR DESCRIPTION
InfluxDB have opportunity to create continuous query form series in database, but actually that are not exposed on query interface. This MR enable to display series and continuous query as series to query.

![screen shot 2014-07-13 at 19 58 54](https://cloud.githubusercontent.com/assets/43941/3565376/a57a3daa-0ab7-11e4-991e-9c1ca2e1e54b.png)

Change is in accord with [InfluxDB docs](http://influxdb.com/docs/v0.7/api/query_language.html#getting-a-list-of-time-series)
