### PR TITLE
Adding bps unit type for network gear

### DIFF
--- a/src/app/components/kbn.js
+++ b/src/app/components/kbn.js
@@ -396,6 +396,53 @@ function($, _, moment) {
     return (size.toFixed(decimals) + ext);
   };
 
+  kbn.bpsFormat = function(size, decimals) {
+    var ext, steps = 0;
+
+    if(_.isUndefined(decimals)) {
+      decimals = 2;
+    } else if (decimals === 0) {
+      decimals = undefined;
+    }
+
+    while (Math.abs(size) >= 1000) {
+      steps++;
+      size /= 1000;
+    }
+
+    switch (steps) {
+    case 0:
+      ext = " bps";
+      break;
+    case 1:
+      ext = " Kbps";
+      break;
+    case 2:
+      ext = " Mbps";
+      break;
+    case 3:
+      ext = " Gbps";
+      break;
+    case 4:
+      ext = " Tbps";
+      break;
+    case 5:
+      ext = " Pbps";
+      break;
+    case 6:
+      ext = " Ebps";
+      break;
+    case 7:
+      ext = " Zbps";
+      break;
+    case 8:
+      ext = " Ybps";
+      break;
+    }
+
+    return (size.toFixed(decimals) + ext);
+  };
+
   kbn.shortFormat = function(size, decimals) {
     var ext, steps = 0;
 
@@ -456,6 +503,10 @@ function($, _, moment) {
     case 'bits':
       return function(val) {
         return kbn.bitFormat(val, decimals);
+      };
+    case 'bps':
+      return function(val) {
+        return kbn.bpsFormat(val, decimals);
       };
     case 's':
       return function(val) {

--- a/src/app/directives/grafanaGraph.js
+++ b/src/app/directives/grafanaGraph.js
@@ -367,6 +367,9 @@ function (angular, $, kbn, moment, _) {
           case 'bits':
             url += '&yUnitSystem=binary';
             break;
+          case 'bps':
+            url += '&yUnitSystem=si';
+            break;
           case 'short':
             url += '&yUnitSystem=si';
             break;

--- a/src/app/panels/graph/axisEditor.html
+++ b/src/app/panels/graph/axisEditor.html
@@ -4,7 +4,7 @@
     <h5>Left Y Axis</h5>
        <div class="editor-option">
         <label class="small">Format <tip>Y-axis formatting</tip></label>
-        <select class="input-small" ng-model="panel.y_formats[0]" ng-options="f for f in ['none','short','bytes', 'bits', 's', 'ms', 'µs', 'ns']" ng-change="render()"></select>
+        <select class="input-small" ng-model="panel.y_formats[0]" ng-options="f for f in ['none','short','bytes', 'bits', 'bps', 's', 'ms', 'µs', 'ns']" ng-change="render()"></select>
       </div>
       <div class="editor-option">
         <label class="small">Min / <a ng-click="toggleGridMinMax('leftMin')">Auto <i class="icon-star" ng-show="_.isNull(panel.grid.leftMin)"></i></a></label>
@@ -23,7 +23,7 @@
     <h5>Right Y Axis</h5>
        <div class="editor-option">
         <label class="small">Format <tip>Y-axis formatting</tip></label>
-        <select class="input-small" ng-model="panel.y_formats[1]" ng-options="f for f in ['none','short','bytes', 'bits', 's', 'ms', 'µs', 'ns']" ng-change="render()"></select>
+        <select class="input-small" ng-model="panel.y_formats[1]" ng-options="f for f in ['none','short','bytes', 'bits', 'bps', 's', 'ms', 'µs', 'ns']" ng-change="render()"></select>
       </div>
       <div class="editor-option">
         <label class="small">Min / <a ng-click="toggleGridMinMax('rightMin')">Auto <i class="icon-star" ng-show="_.isNull(panel.grid.rightMin)"></i></a></label>

--- a/src/app/panels/graph/module.js
+++ b/src/app/panels/graph/module.js
@@ -86,7 +86,7 @@ function (angular, app, $, _, kbn, moment, timeSeries) {
        */
       scale         : 1,
       /** @scratch /panels/histogram/3
-       * y_formats :: 'none','bytes','bits','short', 's', 'ms'
+       * y_formats :: 'none','bytes','bits','bps','short', 's', 'ms'
        */
       y_formats    : ['short', 'short'],
       /** @scratch /panels/histogram/5


### PR DESCRIPTION
Currently there is no way to accurately plot network bps statistics, as network 'bits' are an SI unit type (steps of 1000), versus storage 'bits' which are binary (steps of 1024).  This change adds a 'bps' unit type to the axis labels, which is nearly identical to bits but uses 1000 to calculate the units instead of 1024 (along with different exts).  This is my first ever pull request so be gentle :)
