### PR TITLE
'list series' instead of 'select * from /.*/ limit 1'

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -126,7 +126,7 @@ function (angular, _, kbn, InfluxSeries) {
     };
 
     InfluxDatasource.prototype.listSeries = function() {
-      return this.doInfluxRequest('select * from /.*/ limit 1').then(function(data) {
+      return this.doInfluxRequest('list series').then(function(data) {
         return _.map(data, function(series) {
           return series.name;
         });


### PR DESCRIPTION
'list series' response is much faster than 'select \* from /.*/ limit 1' for the auto-complete option. Especially noticeable on large datasets.
