### PR TITLE
Adds opentsdb chart label field

### DIFF
--- a/src/app/partials/opentsdb/editor.html
+++ b/src/app/partials/opentsdb/editor.html
@@ -43,7 +43,7 @@
         <ul class="grafana-segment-list" role="menu">
           <li>
             <input type="text"
-                   class="input-xxlarge grafana-target-segment-input"
+                   class="grafana-target-segment-input"
                    ng-model="target.metric"
                    spellcheck='false'
                    bs-typeahead="suggestMetrics"
@@ -56,6 +56,16 @@
                ng-show="target.errors.metric">
               <i class="icon-warning-sign"></i>
             </a>
+          </li>
+          <li>
+            <input type="text"
+                   class="grafana-target-segment-input"
+                   ng-model="target.chartLabel"
+                   spellcheck='false'
+                   placeholder="chart label(optional)"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                   />
           </li>
           <li class="grafana-target-segment">
             Aggregator

--- a/src/app/services/opentsdb/opentsdbDatasource.js
+++ b/src/app/services/opentsdb/opentsdbDatasource.js
@@ -38,12 +38,12 @@ function (angular, _, kbn) {
       });
 
       return this.performTimeSeriesQuery(queries, start, end)
-        .then(function(response) {
-          var result = _.map(response.data, function(metricData) {
-            return transformMetricData(metricData, groupByTags);
-          });
+        .then(_.bind(function(response) {
+          var result = _.map(response.data, _.bind(function(metricData, index) {
+            return transformMetricData(metricData, groupByTags, this.targets[index]);
+          }, this));
           return { data: result };
-        });
+        }, options));
     };
 
     OpenTSDBDatasource.prototype.performTimeSeriesQuery = function(queries, start, end) {
@@ -80,8 +80,20 @@ function (angular, _, kbn) {
       });
     };
 
-    function transformMetricData(md, groupByTags) {
-      var dps = [];
+    function transformMetricData(md, groupByTags, options) {
+      var dps = [],
+          tagData = [],
+          metricLabel = null;
+
+      if (!_.isEmpty(md.tags)) {
+        _.each(_.pairs(md.tags), function(tag) {
+          if (_.has(groupByTags, tag[0])) {
+            tagData.push(tag[0] + "=" + tag[1]);
+          }
+        });
+      }
+
+      metricLabel = createMetricLabel(md.metric, tagData, options);
 
       // TSDB returns datapoints has a hash of ts => value.
       // Can't use _.pairs(invert()) because it stringifies keys/values
@@ -89,22 +101,19 @@ function (angular, _, kbn) {
         dps.push([v, k]);
       });
 
-      var target = md.metric;
-      if (!_.isEmpty(md.tags)) {
-        var tagData = [];
+      return { target: metricLabel, datapoints: dps };
+    }
 
-        _.each(_.pairs(md.tags), function(tag) {
-          if (_.has(groupByTags, tag[0])) {
-            tagData.push(tag[0] + "=" + tag[1]);
-          }
-        });
-
-        if (!_.isEmpty(tagData)) {
-          target = target + "{" + tagData.join(", ") + "}";
-        }
+    function createMetricLabel(metric, tagData, options) {
+      if (options.chartLabel) {
+        return options.chartLabel;
       }
 
-      return { target: target, datapoints: dps };
+      if (!_.isEmpty(tagData)) {
+        metric += "{" + tagData.join(", ") + "}";
+      }
+
+      return metric;
     }
 
     function convertTargetToQuery(target) {


### PR DESCRIPTION
Hi,

There are cases where opentsdb has multiple queries with the same metric name. So, the chart readability turns harder, since we have to compare tag by tag.

I implemented a new field called "chart label". I didn't write any validation since the default value is "interface{tag list}" and the new field is not required.

Cheers!
