### PR TITLE
fix #660 by checking if options is undefined

### DIFF
--- a/src/app/services/opentsdb/opentsdbDatasource.js
+++ b/src/app/services/opentsdb/opentsdbDatasource.js
@@ -106,7 +106,7 @@ function (angular, _, kbn) {
     }
 
     function createMetricLabel(metric, tagData, options) {
-      if (options.alias) {
+      if (!_.isUndefined(options) && options.alias) {
         return options.alias;
       }
 


### PR DESCRIPTION
- a complete fix with a consistent support of alias in all use cases is not obvious (see #660 for explanations)
