### PR TITLE
added global page title prefix setting

### DIFF
--- a/src/app/components/settings.js
+++ b/src/app/components/settings.js
@@ -14,6 +14,7 @@ function (_, crypto) {
      */
     var defaults = {
       datasources                   : {},
+      title                         : 'Grafana - ',
       panels                        : ['graph', 'text'],
       plugins                       : {},
       default_route                 : '/dashboard/file/default.json',

--- a/src/app/controllers/dash.js
+++ b/src/app/controllers/dash.js
@@ -40,7 +40,7 @@ function (angular, $, config, _) {
       $scope.panelMoveOver = panelMove.onOver;
       $scope.panelMoveOut = panelMove.onOut;
 
-      window.document.title = 'Grafana - ' + $scope.dashboard.title;
+      window.document.title = (config.title ? config.title : '') + $scope.dashboard.title;
 
       // start auto refresh
       if($scope.dashboard.refresh) {

--- a/src/config.sample.js
+++ b/src/config.sample.js
@@ -73,6 +73,17 @@ function (Settings) {
     * ========================================================
     */
 
+    /* title:
+    * The global page title prefix that is prepended before the specific dashboard titles.
+    * Defaults to 'Grafana - '.
+    *
+    * title: undefined, // default prefix, page title = 'Grafana - <dashboard title>'
+    * title: null, // no prefix, page title = <dashboard title>
+    * title: '', // no prefix, page title = <dashboard title>
+    * title: 'Custom | ', // custom prefix, page title = 'Custom | <dashboard title>'
+    */
+    title: undefined,
+
     // specify the limit for dashboard search results
     search: {
       max_results: 20


### PR DESCRIPTION
Hello there,

I added this setting to be able to clear the 'Grafana - ' global page title prefix to improve readability in our setup with many Grafana tabs being open concurrently. I think this may be handy for others as well.

The behavior is documented in the `config.sample.js`. Please let me know your thoughts on this or what else is needed for this to get included, thanks.
