### PR TITLE
Make axis and graph labels values precision depend on graph range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [Issue #634](https://github.com/grafana/grafana/issues/634). Dashboard: Dashboard tags now in different colors (from fixed palette) determined by tag name.
 - [Issue #685](https://github.com/grafana/grafana/issues/685). Dashboard: New config.js option to change/remove window title prefix.
 - [Issue #781](https://github.com/grafana/grafana/issues/781). Dashboard: Title URL is now slugified for greater URL readability, works with both ES & InfluxDB storage, is backward compatible
+- [Issue #785](https://github.com/grafana/grafana/issues/785). Elasticsearch: Support for full elasticsearch lucene search grammar when searching for dashboards, better async search
 
 **Fixes**
 - [Issue #696](https://github.com/grafana/grafana/issues/696). Graph: Fix for y-axis format 'none' when values are in scientific notation (ex 2.3e-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [Issue #685](https://github.com/grafana/grafana/issues/685). Dashboard: New config.js option to change/remove window title prefix.
 - [Issue #781](https://github.com/grafana/grafana/issues/781). Dashboard: Title URL is now slugified for greater URL readability, works with both ES & InfluxDB storage, is backward compatible
 - [Issue #785](https://github.com/grafana/grafana/issues/785). Elasticsearch: Support for full elasticsearch lucene search grammar when searching for dashboards, better async search
+- [Issue #787](https://github.com/grafana/grafana/issues/787). Dashboard: time range can now be read from URL parameters, will override dashboard saved time range
 
 **Fixes**
 - [Issue #696](https://github.com/grafana/grafana/issues/696). Graph: Fix for y-axis format 'none' when values are in scientific notation (ex 2.3e-13)

--- a/src/app/components/kbn.js
+++ b/src/app/components/kbn.js
@@ -8,6 +8,25 @@ function($, _, moment) {
 
   var kbn = {};
 
+  function round(value, diff) {
+    if(value === 0) {
+      return '0';
+    }
+
+    if(String(value).indexOf('e') !== -1) {
+      return String(value);
+    }
+
+    var x;
+    if(typeof diff === 'undefined') {
+      x = 2 - Math.log(value > 0 ? value : -value) / Math.LN10;
+    }
+    else {
+      x = Math.log(diff) / Math.LN10;
+    }
+    return value.toFixed(2 - x > 0 ? 2 - x : 0);
+  }
+
    /**
      * Calculate a graph interval
      *
@@ -306,14 +325,8 @@ function($, _, moment) {
     ].join(';') + '"></div>';
   };
 
-  kbn.byteFormat = function(size, decimals) {
+  kbn.byteFormat = function(size, diff) {
     var ext, steps = 0;
-
-    if(_.isUndefined(decimals)) {
-      decimals = 2;
-    } else if (decimals === 0) {
-      decimals = undefined;
-    }
 
     while (Math.abs(size) >= 1024) {
       steps++;
@@ -350,17 +363,11 @@ function($, _, moment) {
       break;
     }
 
-    return (size.toFixed(decimals) + ext);
+    return round(size, diff) + ext;
   };
 
-  kbn.bitFormat = function(size, decimals) {
+  kbn.bitFormat = function(size, diff) {
     var ext, steps = 0;
-
-    if(_.isUndefined(decimals)) {
-      decimals = 2;
-    } else if (decimals === 0) {
-      decimals = undefined;
-    }
 
     while (Math.abs(size) >= 1024) {
       steps++;
@@ -397,17 +404,11 @@ function($, _, moment) {
       break;
     }
 
-    return (size.toFixed(decimals) + ext);
+    return round(size, diff) + ext;
   };
 
-  kbn.bpsFormat = function(size, decimals) {
+  kbn.bpsFormat = function(size, diff) {
     var ext, steps = 0;
-
-    if(_.isUndefined(decimals)) {
-      decimals = 2;
-    } else if (decimals === 0) {
-      decimals = undefined;
-    }
 
     while (Math.abs(size) >= 1000) {
       steps++;
@@ -444,17 +445,11 @@ function($, _, moment) {
       break;
     }
 
-    return (size.toFixed(decimals) + ext);
+    return round(size, diff) + ext;
   };
 
-  kbn.shortFormat = function(size, decimals) {
+  kbn.shortFormat = function(size, diff) {
     var ext, steps = 0;
-
-    if(_.isUndefined(decimals)) {
-      decimals = 2;
-    } else if (decimals === 0) {
-      decimals = undefined;
-    }
 
     while (Math.abs(size) >= 1000) {
       steps++;
@@ -491,164 +486,138 @@ function($, _, moment) {
       break;
     }
 
-    return (size.toFixed(decimals) + ext);
+    return round(size, diff) + ext;
   };
 
-  kbn.getFormatFunction = function(formatName, decimals) {
+  kbn.getFormatFunction = function(formatName, diff) {
     switch(formatName) {
     case 'short':
       return function(val) {
-        return kbn.shortFormat(val, decimals);
+        return kbn.shortFormat(val, diff);
       };
     case 'bytes':
       return function(val) {
-        return kbn.byteFormat(val, decimals);
+        return kbn.byteFormat(val, diff);
       };
     case 'bits':
       return function(val) {
-        return kbn.bitFormat(val, decimals);
+        return kbn.bitFormat(val, diff);
       };
     case 'bps':
       return function(val) {
-        return kbn.bpsFormat(val, decimals);
+        return kbn.bpsFormat(val, diff);
       };
     case 's':
       return function(val) {
-        return kbn.sFormat(val, decimals);
+        return kbn.sFormat(val, diff);
       };
     case 'ms':
       return function(val) {
-        return kbn.msFormat(val, decimals);
+        return kbn.msFormat(val, diff);
       };
     case 'µs':
       return function(val) {
-        return kbn.microsFormat(val, decimals);
+        return kbn.microsFormat(val, diff);
       };
     case 'ns':
       return function(val) {
-        return kbn.nanosFormat(val, decimals);
+        return kbn.nanosFormat(val, diff);
       };
     default:
-      return function(val, axis) {
-        return kbn.noneFormat(val, axis ? axis.tickDecimals : null);
+      return function(val) {
+        return round(val, diff);
       };
     }
   };
 
-  kbn.noneFormat = function(value, decimals) {
-    var factor = decimals ? Math.pow(10, decimals) : 1;
-    var formatted = String(Math.round(value * factor) / factor);
-
-    // if exponent return directly
-    if (formatted.indexOf('e') !== -1 || value === 0) {
-      return formatted;
-    }
-
-    // If tickDecimals was specified, ensure that we have exactly that
-    // much precision; otherwise default to the value's own precision.
-
-    if (decimals != null) {
-      var decimalPos = formatted.indexOf(".");
-      var precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
-      if (precision < decimals) {
-        return (precision ? formatted : formatted + ".") + (String(factor)).substr(1, decimals - precision);
-      }
-    }
-
-    return formatted;
-  };
-
-  kbn.msFormat = function(size, decimals) {
+  kbn.msFormat = function(size, diff) {
     // Less than 1 milli, downscale to micro
     if (Math.abs(size) < 1) {
-      return kbn.microsFormat(size * 1000,decimals);
+      return kbn.microsFormat(size * 1000, diff);
     }
     else if (Math.abs(size) < 1000) {
-      return size.toFixed(decimals) + " ms";
+      return round(size, diff) + " ms";
     }
     // Less than 1 min
     else if (Math.abs(size) < 60000) {
-      return (size / 1000).toFixed(decimals) + " s";
+      return round(size / 1000, diff) + " s";
     }
     // Less than 1 hour, devide in minutes
     else if (Math.abs(size) < 3600000) {
-      return (size / 60000).toFixed(decimals) + " min";
+      return round(size / 60000, diff) + " min";
     }
     // Less than one day, devide in hours
     else if (Math.abs(size) < 86400000) {
-      return (size / 3600000).toFixed(decimals) + " hour";
+      return round(size / 3600000, diff) + " hour";
     }
     // Less than one year, devide in days
     else if (Math.abs(size) < 31536000000) {
-      return (size / 86400000).toFixed(decimals) + " day";
+      return round(size / 86400000, diff) + " day";
     }
 
-    return (size / 31536000000).toFixed(decimals) + " year";
+    return round(size / 31536000000, diff) + " year";
   };
 
-  kbn.sFormat = function(size, decimals) {
+  kbn.sFormat = function(size, diff) {
     // Less than 1 sec, downscale to milli
     if (Math.abs(size) < 1) {
-      return kbn.msFormat(size * 1000, decimals);
+      return kbn.msFormat(size * 1000, diff);
     }
     // Less than 10 min, use seconds
     else if (Math.abs(size) < 600) {
-      return size.toFixed(decimals) + " s";
+      return round(size, diff) + " s";
     }
     // Less than 1 hour, devide in minutes
     else if (Math.abs(size) < 3600) {
-      return (size / 60).toFixed(decimals) + " min";
+      return round(size / 60, diff) + " min";
     }
     // Less than one day, devide in hours
     else if (Math.abs(size) < 86400) {
-      return (size / 3600).toFixed(decimals) + " hour";
+      return round(size / 3600, diff) + " hour";
     }
     // Less than one week, devide in days
     else if (Math.abs(size) < 604800) {
-      return (size / 86400).toFixed(decimals) + " day";
+      return round(size / 86400, diff) + " day";
     }
     // Less than one year, devide in week
     else if (Math.abs(size) < 31536000) {
-      return (size / 604800).toFixed(decimals) + " week";
+      return round(size / 604800, diff) + " week";
     }
 
-    return (size / 3.15569e7).toFixed(decimals) + " year";
+    return round(size / 3.15569e7, diff) + " year";
   };
 
-  kbn.microsFormat = function(size, decimals) {
+  kbn.microsFormat = function(size, diff) {
     // Less than 1 micro, downscale to nano
     if (Math.abs(size) < 1) {
-      return kbn.nanosFormat(size * 1000, decimals);
+      return kbn.nanosFormat(size * 1000, diff);
     }
     else if (Math.abs(size) < 1000) {
-      return size.toFixed(decimals) + " µs";
+      return round(size, diff) + " µs";
     }
     else if (Math.abs(size) < 1000000) {
-      return (size / 1000).toFixed(decimals) + " ms";
+      return round(size / 1000, diff) + " ms";
     }
     else {
-      return (size / 1000000).toFixed(decimals) + " s";
+      return round(size / 1000000, diff) + " s";
     }
   };
 
-  kbn.nanosFormat = function(size, decimals) {
-    if (Math.abs(size) < 1) {
-      return size.toFixed(decimals) + " ns";
-    }
-    else if (Math.abs(size) < 1000) {
-      return size.toFixed(0) + " ns";
+  kbn.nanosFormat = function(size, diff) {
+    if (Math.abs(size) < 1000) {
+      return round(size, diff) + " ns";
     }
     else if (Math.abs(size) < 1000000) {
-      return (size / 1000).toFixed(decimals) + " µs";
+      return round(size / 1000, diff) + " µs";
     }
     else if (Math.abs(size) < 1000000000) {
-      return (size / 1000000).toFixed(decimals) + " ms";
+      return round(size / 1000000, diff) + " ms";
     }
     else if (Math.abs(size) < 60000000000){
-      return (size / 1000000000).toFixed(decimals) + " s";
+      return round(size / 1000000000, diff) + " s";
     }
     else {
-      return (size / 60000000000).toFixed(decimals) + " m";
+      return round(size / 60000000000, diff) + " m";
     }
   };
 

--- a/src/app/components/kbn.js
+++ b/src/app/components/kbn.js
@@ -353,6 +353,7 @@ function($, _, moment) {
     while (Math.abs(size) >= 1024) {
       steps++;
       size /= 1024;
+      diff /= 1024;
     }
 
     switch (steps) {
@@ -394,6 +395,7 @@ function($, _, moment) {
     while (Math.abs(size) >= 1024) {
       steps++;
       size /= 1024;
+      diff /= 1024;
     }
 
     switch (steps) {
@@ -435,6 +437,7 @@ function($, _, moment) {
     while (Math.abs(size) >= 1000) {
       steps++;
       size /= 1000;
+      diff /= 1000;
     }
 
     switch (steps) {
@@ -476,6 +479,7 @@ function($, _, moment) {
     while (Math.abs(size) >= 1000) {
       steps++;
       size /= 1000;
+      diff /= 1000;
     }
 
     switch (steps) {

--- a/src/app/dashboards/default.json
+++ b/src/app/dashboards/default.json
@@ -9,6 +9,7 @@
       "title": "New row",
       "height": "150px",
       "collapse": false,
+      "editable": true,
       "panels": [
         {
           "id": 1,
@@ -26,6 +27,7 @@
       "title": "Welcome to Grafana",
       "height": "210px",
       "collapse": false,
+      "editable": true,
       "panels": [
         {
           "id": 2,
@@ -50,6 +52,7 @@
     {
       "title": "test",
       "height": "250px",
+      "editable": true,
       "collapse": false,
       "panels": [
         {

--- a/src/app/directives/grafanaGraph.js
+++ b/src/app/directives/grafanaGraph.js
@@ -154,6 +154,19 @@ function (angular, $, kbn, moment, _) {
             series.data = series.getFlotPairs(panel.nullPointMode, panel.y_formats);
           }
 
+          var values = data[0].data;
+          data.min = Number.MAX_VALUE;
+          data.max = Number.MIN_VALUE;
+
+          for(var j = 0; j < values.length; j++) {
+            if(values[j][1] < data.min) {
+              data.min = values[j][1];
+            }
+            if(values[j][1] > data.max) {
+              data.max = values[j][1];
+            }
+          }
+
           if (data.length && data[0].info.timeStep) {
             options.series.bars.barWidth = data[0].info.timeStep / 1.5;
           }
@@ -305,7 +318,7 @@ function (angular, $, kbn, moment, _) {
         }
 
         function configureAxisMode(axis, format) {
-          axis.tickFormatter = kbn.getFormatFunction(format, 1);
+          axis.tickFormatter = kbn.getFormatFunction(format, data.max - data.min);
         }
 
         function time_format(interval, ticks, min, max) {
@@ -355,7 +368,7 @@ function (angular, $, kbn, moment, _) {
               value = item.datapoint[1];
             }
 
-            value = kbn.getFormatFunction(format, 2)(value, item.series.yaxis);
+            value = kbn.getFormatFunction(format, data.max - data.min)(value);
             timestamp = dashboard.formatDate(item.datapoint[0]);
 
             $tooltip.html(group + value + " @ " + timestamp).place_tt(pos.pageX, pos.pageY);

--- a/src/app/services/elasticsearch/es-datasource.js
+++ b/src/app/services/elasticsearch/es-datasource.js
@@ -215,15 +215,15 @@ function (angular, _, config, kbn, moment) {
         for (var i=0; i<string.length; i++) {
           character = string[i];
 
-          if (character == opener) {
+          if (character === opener) {
             count++;
-          } else if (character == closer) {
+          } else if (character === closer) {
             count--;
           }
         }
 
         return count > 0;
-      }
+      };
 
       var tagsOnly = queryString.indexOf('tags!:') === 0;
       if (tagsOnly) {

--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -68,7 +68,14 @@ function (_) {
   addFuncDef({
     name: 'diffSeries',
     params: optionalSeriesRefArgs,
-    defaultParams: ['#B'],
+    defaultParams: ['#A'],
+    category: categories.Calculate,
+  });
+
+  addFuncDef({
+    name: 'divideSeries',
+    params: optionalSeriesRefArgs,
+    defaultParams: ['#A'],
     category: categories.Calculate,
   });
 

--- a/src/app/services/templateValuesSrv.js
+++ b/src/app/services/templateValuesSrv.js
@@ -70,9 +70,7 @@ function (angular, _, kbn) {
         if (otherVariable === updatedVariable) {
           return;
         }
-        console.log("value");
         if (templateSrv.containsVariable(otherVariable.query, updatedVariable.name)) {
-          console.log("valuei2");
           return self.updateOptions(otherVariable);
         }
       });

--- a/src/test/specs/kbn-format-specs.js
+++ b/src/test/specs/kbn-format-specs.js
@@ -48,7 +48,6 @@ define([
     it('should translate 2558000 to 2.558 ms', function () {
       var str = kbn.nanosFormat(2558000, 0.011);
       expect(str).to.be("2.558 ms");
-<<<<<<< HEAD
     });
 
     it('should translate 2019962000 to 2.0500 s', function () {

--- a/src/test/specs/kbn-format-specs.js
+++ b/src/test/specs/kbn-format-specs.js
@@ -5,19 +5,19 @@ define([
 
   describe('millisecond formating', function() {
 
-    it('should translate 4378634603 as 1.67 years', function() {
-      var str = kbn.msFormat(4378634603, 2);
+    it('should translate 4378634603 as 50.68 day', function() {
+      var str = kbn.msFormat(4378634603, 0.23);
       expect(str).to.be('50.68 day');
     });
 
     it('should translate 3654454 as 1.02 hour', function() {
-      var str = kbn.msFormat(3654454, 2);
+      var str = kbn.msFormat(3654454, 0.11);
       expect(str).to.be('1.02 hour');
     });
 
-    it('should translate 365445 as 6.09 min', function() {
-      var str = kbn.msFormat(365445, 2);
-      expect(str).to.be('6.09 min');
+    it('should translate 365445 as 6.091 min', function() {
+      var str = kbn.msFormat(365445, 0.022);
+      expect(str).to.be('6.091 min');
     });
 
   });
@@ -33,37 +33,31 @@ define([
     });
   });
 
-  describe('none format tests', function() {
-    it('should translate 2 as 2.0000 if axis decimals is 4', function() {
-      var str = kbn.getFormatFunction('')(2, { tickDecimals: 4 });
-      expect(str).to.be('2.0000');
-    });
-  });
-
   describe('nanosecond formatting', function () {
-    it('should translate 25 to 25 ns', function () {
-      var str = kbn.nanosFormat(25, 2);
-      expect(str).to.be("25 ns");
+
+    it('should translate 25 to 25.0 ns', function () {
+      var str = kbn.nanosFormat(25, 5);
+      expect(str).to.be("25.0 ns");
     });
 
     it('should translate 2558 to 2.56 µs', function () {
-      var str = kbn.nanosFormat(2558, 2);
+      var str = kbn.nanosFormat(2558, 0.44);
       expect(str).to.be("2.56 µs");
     });
 
-    it('should translate 2558000 to 2.56 ms', function () {
-      var str = kbn.nanosFormat(2558000, 2);
-      expect(str).to.be("2.56 ms");
+    it('should translate 2558000 to 2.558 ms', function () {
+      var str = kbn.nanosFormat(2558000, 0.011);
+      expect(str).to.be("2.558 ms");
     });
 
-    it('should translate 2019962000 to 2.02 s', function () {
-      var str = kbn.nanosFormat(2049962000, 2);
-      expect(str).to.be("2.05 s");
+    it('should translate 2019962000 to 2.0500 s', function () {
+      var str = kbn.nanosFormat(2049962000, 0.0077);
+      expect(str).to.be("2.0500 s");
     });
 
-    it('should translate 95199620000 to 1.59 m', function () {
-      var str = kbn.nanosFormat(95199620000, 2);
-      expect(str).to.be("1.59 m");
+    it('should translate 95199620000 to 1.58666 m', function () {
+      var str = kbn.nanosFormat(95199620000, 0.0005);
+      expect(str).to.be("1.58666 m");
     });
 
   });

--- a/src/test/specs/kbn-format-specs.js
+++ b/src/test/specs/kbn-format-specs.js
@@ -5,19 +5,19 @@ define([
 
   describe('millisecond formating', function() {
 
-    it('should translate 4378634603 as 1.67 years', function() {
-      var str = kbn.msFormat(4378634603, 2);
+    it('should translate 4378634603 as 50.68 day', function() {
+      var str = kbn.msFormat(4378634603, 0.23);
       expect(str).to.be('50.68 day');
     });
 
     it('should translate 3654454 as 1.02 hour', function() {
-      var str = kbn.msFormat(3654454, 2);
+      var str = kbn.msFormat(3654454, 0.11);
       expect(str).to.be('1.02 hour');
     });
 
-    it('should translate 365445 as 6.09 min', function() {
-      var str = kbn.msFormat(365445, 2);
-      expect(str).to.be('6.09 min');
+    it('should translate 365445 as 6.091 min', function() {
+      var str = kbn.msFormat(365445, 0.022);
+      expect(str).to.be('6.091 min');
     });
 
   });
@@ -33,38 +33,31 @@ define([
     });
   });
 
-  describe('none format tests', function() {
-    it('should translate 2 as 2.0000 if axis decimals is 4', function() {
-      var str = kbn.getFormatFunction('')(2, { tickDecimals: 4 });
-      expect(str).to.be('2.0000');
-    });
-  });
-
   describe('nanosecond formatting', function () {
 
-    it('should translate 25 to 25 ns', function () {
-      var str = kbn.nanosFormat(25, 2);
-      expect(str).to.be("25 ns");
+    it('should translate 25 to 25.0 ns', function () {
+      var str = kbn.nanosFormat(25, 5);
+      expect(str).to.be("25.0 ns");
     });
 
     it('should translate 2558 to 2.56 µs', function () {
-      var str = kbn.nanosFormat(2558, 2);
+      var str = kbn.nanosFormat(2558, 0.44);
       expect(str).to.be("2.56 µs");
     });
 
-    it('should translate 2558000 to 2.56 ms', function () {
-      var str = kbn.nanosFormat(2558000, 2);
-      expect(str).to.be("2.56 ms");
+    it('should translate 2558000 to 2.558 ms', function () {
+      var str = kbn.nanosFormat(2558000, 0.011);
+      expect(str).to.be("2.558 ms");
     });
 
-    it('should translate 2019962000 to 2.02 s', function () {
-      var str = kbn.nanosFormat(2049962000, 2);
-      expect(str).to.be("2.05 s");
+    it('should translate 2019962000 to 2.0500 s', function () {
+      var str = kbn.nanosFormat(2049962000, 0.0077);
+      expect(str).to.be("2.0500 s");
     });
 
-    it('should translate 95199620000 to 1.59 m', function () {
-      var str = kbn.nanosFormat(95199620000, 2);
-      expect(str).to.be("1.59 m");
+    it('should translate 95199620000 to 1.58666 m', function () {
+      var str = kbn.nanosFormat(95199620000, 0.0005);
+      expect(str).to.be("1.58666 m");
     });
 
   });

--- a/src/test/specs/timeSrv-specs.js
+++ b/src/test/specs/timeSrv-specs.js
@@ -11,7 +11,7 @@ define([
     var _dashboard;
 
     beforeEach(module('grafana.services'));
-    beforeEach(ctx.providePhase());
+    beforeEach(ctx.providePhase(['$routeParams']));
     beforeEach(ctx.createService('timeSrv'));
 
     beforeEach(function() {
@@ -33,6 +33,45 @@ define([
         expect(_.isDate(time.from)).to.be(true);
         expect(_.isDate(time.to)).to.be(true);
       });
+    });
+
+    describe('init time from url', function() {
+      it('should handle relative times', function() {
+        ctx.$routeParams.from = 'now-2d';
+        ctx.$routeParams.to = 'now';
+        ctx.service.init(_dashboard);
+        var time = ctx.service.timeRange(false);
+        expect(time.from).to.be('now-2d');
+        expect(time.to).to.be('now');
+      });
+
+      it('should handle formated dates', function() {
+        ctx.$routeParams.from = '20140410T052010';
+        ctx.$routeParams.to = '20140520T031022';
+        ctx.service.init(_dashboard);
+        var time = ctx.service.timeRange(true);
+        expect(time.from.getTime()).to.equal(new Date("2014-04-10T05:20:10Z").getTime());
+        expect(time.to.getTime()).to.equal(new Date("2014-05-20T03:10:22Z").getTime());
+      });
+
+      it('should handle formated dates without time', function() {
+        ctx.$routeParams.from = '20140410';
+        ctx.$routeParams.to = '20140520';
+        ctx.service.init(_dashboard);
+        var time = ctx.service.timeRange(true);
+        expect(time.from.getTime()).to.equal(new Date("2014-04-10T00:00:00Z").getTime());
+        expect(time.to.getTime()).to.equal(new Date("2014-05-20T00:00:00Z").getTime());
+      });
+
+      it('should handle epochs', function() {
+        ctx.$routeParams.from = '1410337646373';
+        ctx.$routeParams.to = '1410337665699';
+        ctx.service.init(_dashboard);
+        var time = ctx.service.timeRange(true);
+        expect(time.from.getTime()).to.equal(1410337646373);
+        expect(time.to.getTime()).to.equal(1410337665699);
+      });
+
     });
 
     describe('setTime', function() {


### PR DESCRIPTION
Another attempt of making axis and labels values precision depend on graph range (https://github.com/grafana/grafana/pull/637). It changes the precision dynamically while zooming the graph in or out. In addition to previous attempt I added a protection from scientific notation values. It still needs some tests in real environment - it would be good to check if different data types (seconds, kBytes etc.) are viewed correctly in graphs with real data source.
