### PR TITLE
Display milliseconds in the chart (InfluxDB)

### DIFF
--- a/src/app/components/timeSeries.js
+++ b/src/app/components/timeSeries.js
@@ -92,7 +92,7 @@ function (_, kbn) {
         this.info.min = currentValue;
       }
 
-      result.push([currentTime * 1000, currentValue]);
+      result.push([currentTime, currentValue]);
     }
 
     if (result.length > 2) {

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -140,7 +140,7 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
     InfluxDatasource.prototype._seriesQuery = function(query) {
       return this._influxRequest('GET', '/series', {
         q: query,
-        time_precision: 's',
+        time_precision: 'ms',
       });
     };
 
@@ -347,7 +347,7 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
     }
 
     function to_utc_epoch_seconds(date) {
-      return (date.getTime() / 1000).toFixed(0) + 's';
+      return (date.getTime()).toFixed(0) + 'ms';
     }
 
     return InfluxDatasource;


### PR DESCRIPTION
Hi! I fixed a bug. Now the chart displays the millisecond. I had to edit files "influxdbDatasource.js" and "timeSeries.js". @torkelo was almost right when he suggested solution - https://github.com/grafana/grafana/issues/728#issuecomment-53535201. You have to be careful, as the corrected file "timeSeries.js" may affect the work with other databases (Graphite and OpenTSDB).
