### PR TITLE
Added basic authorization for InfluxDB if needed

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -19,6 +19,7 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
       this.username = datasource.username;
       this.password = datasource.password;
       this.name = datasource.name;
+      this.basicAuth = datasource.basicAuth;
 
       this.saveTemp = _.isUndefined(datasource.save_temp) ? true : datasource.save_temp;
       this.saveTempTTL = _.isUndefined(datasource.save_temp_ttl) ? '30d' : datasource.save_temp_ttl;
@@ -169,6 +170,11 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
           data:   data,
           inspect: { type: 'influxdb' },
         };
+
+        options.headers = options.headers || {};
+        if (_this.basicAuth) {
+          options.headers.Authorization = 'Basic ' + _this.basicAuth;
+        }
 
         return $http(options).success(function (data) {
           deferred.resolve(data);


### PR DESCRIPTION
When using a web server with HTTP basic authentication on it (I used nginx for proxying requests to InfluxDB) the current version of Grafana simply doesn't send the credentials with the request.
I did notice that the Graphite data source does send the credentials, so I added the same basic logic for InfluxDB as well.
