### PR TITLE
Better support for elasticsearch search grammar + async search request fix

### DIFF
--- a/src/app/services/elasticsearch/es-datasource.js
+++ b/src/app/services/elasticsearch/es-datasource.js
@@ -215,15 +215,15 @@ function (angular, _, config, kbn, moment) {
         for (var i=0; i<string.length; i++) {
           character = string[i];
 
-          if (character == opener) {
+          if (character === opener) {
             count++;
-          } else if (character == closer) {
+          } else if (character === closer) {
             count--;
           }
         }
 
         return count > 0;
-      }
+      };
 
       var tagsOnly = queryString.indexOf('tags!:') === 0;
       if (tagsOnly) {


### PR DESCRIPTION
Two issues are being addressed in this pull request: async search results trampling each other and partial searches not adhering to elasticsearch grammar.
## async search results

Since the partial searches can return out of order, the displayed search results will often be for an older partial search.  This is especially noticeable as your number of dashboards increases and elasticsearch slows down for the more general initial partial searches.

The fix is just to keep a global counter that we compare with the local one to see if we are on the latest search query.  If not, throw the results away.  This fix is datasource agnostic.
## elasticsearch grammar

Previously, the code would blindly add a \* to the end of the querystring in order to make it partial.  This pretty much breaks all the more complex features of the elasticsearch grammar and makes many searches impossible.  It was also previously calling toLower() on everything and then attempting to fix one reserved word (AND) but only doing that for the first occurrence.

The proposed fix attempts to leave the search box as close to direct elasticsearch grammar as possible. As such, it no longer auto-lowercases things for you.  It will also now check for basic grammar constructs before appending the *. 

See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax
