### PR TITLE
Add drilldown dashboard link

### DIFF
--- a/src/app/partials/panelgeneral.html
+++ b/src/app/partials/panelgeneral.html
@@ -10,5 +10,11 @@
 		<div class="editor-option">
       <label class="small">Height</label><input type="text" class="input-small" ng-model='panel.height'></select>
     </div>
-  </div>
+    <h5>Drilldown dashboard</h5>
+    <div class="editor-option">
+      <label class="small">Dashboard name</label><input type="text" class="input-medium" ng-model='panel.drillDown'></input>
+    </div>
+    <div class="editor-option">
+      <label class="small">Extra variables (key=value,key=value)</label><input type="text" class="input-medium" ng-model='panel.drillDownVariables'></input>
+    </div>
 </div>

--- a/src/app/partials/panelgeneral.html
+++ b/src/app/partials/panelgeneral.html
@@ -7,7 +7,7 @@
     <div class="editor-option">
       <label class="small">Span</label> <select class="input-mini" ng-model="panel.span" ng-options="f for f in [0,1,2,3,4,5,6,7,8,9,10,11,12]"></select>
     </div>
-		<div class="editor-option">
+    <div class="editor-option">
       <label class="small">Height</label><input type="text" class="input-small" ng-model='panel.height'></select>
     </div>
     <h5>Drilldown dashboard</h5>
@@ -17,4 +17,5 @@
     <div class="editor-option">
       <label class="small">Extra variables (key=value,key=value)</label><input type="text" class="input-medium" ng-model='panel.drillDownVariables'></input>
     </div>
+  </div>
 </div>

--- a/src/app/services/panelSrv.js
+++ b/src/app/services/panelSrv.js
@@ -15,6 +15,7 @@ function (angular, _) {
         {
           text: "view",
           icon: "icon-eye-open",
+        },
         {
           text: 'Drill down',
           click: 'drillDown(panel.drillDown)',

--- a/src/app/services/panelSrv.js
+++ b/src/app/services/panelSrv.js
@@ -69,6 +69,7 @@ function (angular, _) {
           src: './app/partials/share-panel.html',
           scope: $scope.$new()
         });
+      };
 
       $scope.drillDown = function(dashboard) {
         var variables = {};

--- a/src/app/services/panelSrv.js
+++ b/src/app/services/panelSrv.js
@@ -6,7 +6,7 @@ function (angular, _) {
   'use strict';
 
   var module = angular.module('grafana.services');
-  module.service('panelSrv', function($rootScope, $timeout, datasourceSrv) {
+  module.service('panelSrv', function($rootScope, $timeout, datasourceSrv, $location) {
 
     this.init = function($scope) {
       if (!$scope.panel.span) { $scope.panel.span = 12; }
@@ -15,6 +15,13 @@ function (angular, _) {
         {
           text: "view",
           icon: "icon-eye-open",
+        {
+          text: 'Drill down',
+          click: 'drillDown(panel.drillDown)',
+          condition: true
+        },
+        {
+          text: "Fullscreen",
           click: 'toggleFullscreen(false)',
           condition: $scope.panelMeta.fullscreenView
         },
@@ -61,6 +68,22 @@ function (angular, _) {
           src: './app/partials/share-panel.html',
           scope: $scope.$new()
         });
+
+      $scope.drillDown = function(dashboard) {
+        var variables = {};
+
+        if (dashboard == null) { return; }
+        _.each($scope.dashboard.templating.list, function(variable) {
+          variables['var-' + variable.name] = variable.current.value;
+        });
+
+        if ($scope.panel.drillDownVariables != null) {
+          _.each($scope.panel.drillDownVariables.split(','), function(token) {
+            variables['var-' + token.split('=')[0]] = token.split('=')[1];
+          });
+        }
+
+        $location.path("/dashboard/db/" + dashboard).search(variables);
       };
 
       $scope.editPanelJson = function() {


### PR DESCRIPTION
Implemented "Drill down" dashboard link on a panel. It lets you add a link to the dashboard and pass any extra variables (filters) while automatically passing current filters. 

Comments/suggestions/etc welcomed.

Github Issue: https://github.com/grafana/grafana/issues/530
