### PR TITLE
add override options to allow multiple stacks

### DIFF
--- a/src/app/panels/graph/seriesOverridesCtrl.js
+++ b/src/app/panels/graph/seriesOverridesCtrl.js
@@ -70,7 +70,7 @@ define([
     $scope.addOverrideOption('Staircase line', 'steppedLine', [true, false]);
     $scope.addOverrideOption('Points', 'points', [true, false]);
     $scope.addOverrideOption('Points Radius', 'pointradius', [1,2,3,4,5]);
-    $scope.addOverrideOption('Stack', 'stack', [true, false]);
+    $scope.addOverrideOption('Stack', 'stack', [true, false, 2, 3, 4, 5]);
     $scope.addOverrideOption('Y-axis', 'yaxis', [1, 2]);
     $scope.addOverrideOption('Z-index', 'zindex', [-1,-2,-3,0,1,2,3]);
     $scope.updateCurrentOverrides();


### PR DESCRIPTION
Flot allows to group series in multiple stacks by setting their _stack_ value to the same key (_true_, number or string, see https://github.com/flot/flot/blob/master/jquery.flot.stack.js#L13 for reference).

Unfortunately I don't have a Graphite instance available to test the PNG graphs, so this is only tested with the Flot backend.
