### PR TITLE
enable withCredentials in elasticsearch basic auth

### DIFF
--- a/src/app/services/elasticsearch/es-datasource.js
+++ b/src/app/services/elasticsearch/es-datasource.js
@@ -37,6 +37,7 @@ function (angular, _, config, kbn, moment) {
       };
 
       if (this.basicAuth) {
+        options.withCredentials = true;
         options.headers = {
           "Authorization": "Basic " + this.basicAuth
         };


### PR DESCRIPTION
Currently cookies are passed in requests to graphite and not passed to elasticsearch. The reason is that `withCredentials` is set to `true` in graphite datasource (see [here](https://github.com/grafana/grafana/blob/master/src/app/services/graphite/graphiteDatasource.js#L202)), but not set in ES datasource.

This pull request fixes the behavior.
