### PR TITLE
Fix Graphana not able to use fields from nested objects with annotations pulled from Elasticsearch

### DIFF
--- a/src/app/services/elasticsearch/es-datasource.js
+++ b/src/app/services/elasticsearch/es-datasource.js
@@ -86,7 +86,23 @@ function (angular, _, config, kbn, moment) {
         var list = [];
         var hits = results.data.hits.hits;
 
+        var getFieldFromSource = function(source, fieldName) {
+          var fieldValue;
+          if (fieldName) {
+            var fieldNames = fieldName.split('.');
+            fieldValue = source;
+            for (var i = 0; i < fieldNames.length; i++) {
+              fieldValue = fieldValue[fieldNames[i]];
+            }
+            if (_.isArray(fieldValue)) {
+              fieldValue = fieldValue.join(',');
+            }
+          }
+          return fieldValue;
+        };
+
         for (var i = 0; i < hits.length; i++) {
+          console.log('annotationQuery', hits[i]);
           var source = hits[i]._source;
           var fields = hits[i].fields;
           var time = source[timeField];
@@ -98,20 +114,10 @@ function (angular, _, config, kbn, moment) {
           var event = {
             annotation: annotation,
             time: moment.utc(time).valueOf(),
-            title: source[titleField],
+            title: getFieldFromSource(source, titleField),
+            tags: getFieldFromSource(source, tagsField),
+            text: getFieldFromSource(source, textField)
           };
-
-          if (source[tagsField]) {
-            if (_.isArray(source[tagsField])) {
-              event.tags = source[tagsField].join(', ');
-            }
-            else {
-              event.tags = source[tagsField];
-            }
-          }
-          if (textField && source[textField]) {
-            event.text = source[textField];
-          }
 
           list.push(event);
         }

--- a/src/css/less/grafana.less
+++ b/src/css/less/grafana.less
@@ -435,6 +435,9 @@ select.grafana-target-segment-input {
   background-color: rgb(58, 57, 57);
   border-radius: 5px;
   z-index: 9999;
+  max-width: 800px;
+  max-height: 600px;
+  overflow: hidden;
 }
 
 .tooltip.in {


### PR DESCRIPTION
This adds support for title and text fields like "@fields.my_value" which are returned by Elastichsearch as nested objects. Fixes issue #829
