### PR TITLE
[influxdb] [ui] "Make continuous query" button

### DIFF
--- a/src/app/controllers/influxTargetCtrl.js
+++ b/src/app/controllers/influxTargetCtrl.js
@@ -53,6 +53,23 @@ function (angular) {
       $scope.target.rawQuery = false;
     };
 
+    $scope.continuousQuery = function () {
+      $scope.target.cq_name = $scope.datasource.continuousQueryName($scope.target);
+      $scope.$watch('target.cq_name', function () {
+        $scope.target.cq_query = $scope.datasource.continuousQuery($scope.target, false);
+      });
+    };
+
+    $scope.makeContinuousQuery = function () {
+      $scope.datasource.makeContinuousQuery($scope.target).then(function() {
+        var clone = angular.copy($scope.target);
+        clone.series = $scope.target.cq_name;
+        $scope.target.hide = true;
+        $scope.panel.targets.push(clone);
+        $scope.get_data();
+      });
+    };
+
     // Cannot use typeahead and ng-change on blur at the same time
     $scope.seriesBlur = function() {
       if ($scope.oldSeries !== $scope.target.series) {

--- a/src/app/partials/influxdb/editor.html
+++ b/src/app/partials/influxdb/editor.html
@@ -20,6 +20,7 @@
                 <a tabindex="1" ng-click="duplicate()">Duplicate</a>
                 <a tabindex="2" ng-click="showQuery()" ng-hide="target.rawQuery">Raw query mode</a>
                 <a tabindex="2" ng-click="hideQuery()" ng-show="target.rawQuery">Query editor mode</a>
+                <a tabindex="3" ng-click="continuousQuery()" config-modal="app/partials/influxdb/makeContinuousQuery.html">Make continuous query</a>
               </li>
            </ul>
           </li>

--- a/src/app/partials/influxdb/makeContinuousQuery.html
+++ b/src/app/partials/influxdb/makeContinuousQuery.html
@@ -1,0 +1,14 @@
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+</div>
+<div class="modal-body">
+  <h5> Some text about continuous queries and our naming convention... </h5>
+  <label>Continuous query name:</label>
+  <input ng-model='target.cq_name' type="text" style="width:70%" onclick="this.select()" onfocus="this.select()">
+  <label>Continuous query:</label>
+  <input ng-model='target.cq_query' type="text" style="width:70%" onclick="this.select()" onfocus="this.select()"> into {{target.cq_name}}
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-success" ng-click="dismiss();">Close</button>
+  <button type="button" class="btn btn-success" ng-click="makeContinuousQuery();dismiss();">Make continuous query</button>
+</div>


### PR DESCRIPTION
This change adds a button "Make continuous query" in influxdb editor that creates continuous query based on the given query.

Let's say we have query like this: `SELECT B, F(A) from N group by time(T), B where $condition`
We'd like to have an almost one-click way to create and run in influx a continuous query like this:
`SELECT B, F(A) as A from N group by time(T), B into cq.N.F_A.B.T.$retentionPolicyMarker` 

This code is probably not very generic.. It forces our CQ naming convention and a way we define the retention policy, but it might be a good point to start a discussion about such a feature. 

PS. It's also written basing on 1.7 grafana version and then just rebased to the 1.8, so I noticed that templating the query was replaced by InfluxQueryBuilder... 
