### PR TITLE
Add input fields for OpenTSDB counter max and reset values

### DIFF
--- a/src/app/partials/opentsdb/editor.html
+++ b/src/app/partials/opentsdb/editor.html
@@ -89,6 +89,20 @@
                    ng-model="target.isCounter"
                    ng-change="targetBlur()">
           </li>
+          <li class="grafana-target-segment-input" ng-hide="!target.isCounter">
+            Max:
+            <input type="number"
+                   class="grafana-target-segment-input input-small"
+                   ng-model="target.rateCounterMaxValue"
+                   ng-change="targetBlur()">
+          </li>
+          <li class="grafana-target-segment-input" ng-hide="!target.isCounter">
+            Reset:
+            <input type="number"
+                   class="grafana-target-segment-input input-small"
+                   ng-model="target.rateCounterResetValue"
+                   ng-change="targetBlur()">
+          </li>
           <li class="grafana-target-segment">
             Alias:
           </li>

--- a/src/app/services/opentsdb/opentsdbDatasource.js
+++ b/src/app/services/opentsdb/opentsdbDatasource.js
@@ -136,6 +136,12 @@ function (angular, _, kbn) {
         query.rateOptions = {
           counter: !!target.isCounter
         };
+        if (target.rateCounterMaxValue) {
+          query.rateOptions.counterMax = target.rateCounterMaxValue;
+        }
+        if (target.rateCounterResetValue) {
+          query.rateOptions.resetValue = target.rateCounterResetValue;
+        }
       }
 
       if (target.shouldDownsample) {


### PR DESCRIPTION
Adds support for the OpenTSDB counterMax and resetValue rate options. This is useful for instructing OpenTSDB to handle counter rollover and reset. The number input fields do not perfectly align. I'm no CSS expert and I couldn't get them them vertically centred. Would appreciate some help with that. Thanks!
