### PR TITLE
second parameter of groupByNode() should be 0 indexed

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -193,7 +193,7 @@ function (_) {
       {
         name: "node",
         type: "int",
-        options: [1,2,3,4,5,6,7,8,9,10,12]
+        options: [0,1,2,3,4,5,6,7,8,9,10,12]
       },
       {
         name: "function",


### PR DESCRIPTION
Graphite docs state that the second parameter of groupByNode() is 0 indexed.

https://graphite.readthedocs.org/en/latest/functions.html#graphite.render.functions.groupByNode
