### PR TITLE
added consolidation selector for each metric

### DIFF
--- a/src/app/partials/graphite/editor.html
+++ b/src/app/partials/graphite/editor.html
@@ -13,11 +13,49 @@
             <i class="icon icon-warning-sign"></i>
           </a>
         </li>
+        <li class="dropdown">
+          <a  class="pointer dropdown-toggle"
+              data-toggle="dropdown"
+              tabindex="1">
+              <span graphite-func-editor class="grafana-metric-consolidation grafana-target-function">
+              <tip>notifies Grafana  how to compute consolidation or summarization process when needed</tip>
+              C[ <b> {{target.consolidationFunc == null ? 'avg':target.consolidationFunc }} </b> ]
+             </span>
+            <!--div class="grafana-metric-consolidation-mode"></div-->
+          </a>
+          <ul class="dropdown-menu pull-right" role="menu">
+           <li role="menuitem">
+              <a  tabindex="1"
+                  ng-click="target.consolidationFunc='avg'">
+                avg
+              </a>
+           </li>
+           <li role="menuitem">
+              <a  tabindex="2"
+                  ng-click="target.consolidationFunc='sum'">
+                sum
+              </a>
+            </li>
+            <li role="menuitem">
+              <a  tabindex="3"
+                  ng-click="target.consolidationFunc='max'">
+                max
+              </a>
+            </li>
+            <li role="menuitem">
+               <a  tabindex="4"
+                  ng-click="target.consolidationFunc='min'">
+                min
+              </a>
+            </li>
+          </ul>    
+        </li>
         <li>
           <a class="pointer" tabindex="1" ng-click="showTextEditor = !showTextEditor">
             <i class="icon icon-pencil"></i>
           </a>
         </li>
+        
         <li class="dropdown">
           <a  class="pointer dropdown-toggle"
               data-toggle="dropdown"
@@ -30,8 +68,10 @@
                   ng-click="duplicate()">
                 Duplicate
               </a>
-          </ul>
+            </li>
+          </ul>  
         </li>
+
         <li>
           <a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
             <i class="icon icon-remove"></i>

--- a/src/app/services/graphite/graphiteDatasource.js
+++ b/src/app/services/graphite/graphiteDatasource.js
@@ -255,7 +255,11 @@ function (angular, _, $, config, kbn, moment) {
 
         targetValue = targets[this._seriesRefLetters[i]];
         targetValue = targetValue.replace(regex, nestedSeriesRegexReplacer);
-
+        if(target.consolidationFunc && target.consolidationFunc !== 'avg') {
+          targetValue= 'aliasSub(consolidateBy(' + targetValue +
+                       ',"' + target.consolidationFunc +'"),"consolidateBy\\((.*),.'+
+                       target.consolidationFunc+'.\\)$","\\1")';
+        }
         clean_options.push("target=" + encodeURIComponent(targetValue));
       }
 

--- a/src/css/less/grafana.less
+++ b/src/css/less/grafana.less
@@ -173,6 +173,19 @@
   margin-top: 35px;
 }
 
+
+.grafana-metric-consolidation{
+padding: 8px 7px;
+font-weight: normal;
+border-right: 1px solid #dad9d9;
+border-left: 1px solid #dad9d9;
+color: #666;
+display: inline-block;
+font-size: 0.75em;
+
+}
+
+
 // fix for fixed positioned panel & scrolling
 .grafana-segment-dropdown-menu {
   margin-bottom: 70px;


### PR DESCRIPTION
When doing large time window request ,grafana uses maxDataPoints to reduce the received data and graphite server computes a "consolidated" version of the real data, else it can be impossible to plot in real time on the client side .

The problem of this method is that graphite ( if not changed by hand ) consolidates by averaging data, and sometimes  dependant on the metric nature this could  be  erroneous ( by example when counting hits).

Graphite give us the option to change the consolidation method with function consolidateBy(), this PR enables the automatic change of consolidation method when needed.By adding a consolidation selector on each metric row. 

In the next picture you can see the exactly the same metric ploted with each consolidation option (avg,sum,max,min). 

![image](https://cloud.githubusercontent.com/assets/5883405/4623864/62f6a26e-5357-11e4-91f5-a0a3f056671c.png)

YES !!! is the same metric !! queried with maxDataPoints !! this example could give us the importance of maintain visible for user the consolidation method that grafana will use.
