### PR TITLE
Implements dashed lines

### DIFF
--- a/src/app/components/require.config.js
+++ b/src/app/components/require.config.js
@@ -41,6 +41,7 @@ require.config({
     'jquery.flot.time':       '../vendor/jquery/jquery.flot.time',
     'jquery.flot.crosshair':  '../vendor/jquery/jquery.flot.crosshair',
     'jquery.flot.fillbelow':  '../vendor/jquery/jquery.flot.fillbelow',
+    'jquery.flot.dashes':     '../vendor/jquery/jquery.flot.dashes',
 
     modernizr:                '../vendor/modernizr-2.6.1',
 
@@ -85,6 +86,7 @@ require.config({
     'jquery.flot.time':     ['jquery', 'jquery.flot'],
     'jquery.flot.crosshair':['jquery', 'jquery.flot'],
     'jquery.flot.fillbelow':['jquery', 'jquery.flot'],
+    'jquery.flot.dashes':   ['jquery', 'jquery.flot'],
     'angular-cookies':      ['angular'],
     'angular-dragdrop':     ['jquery', 'angular'],
     'angular-loader':       ['angular'],

--- a/src/app/components/timeSeries.js
+++ b/src/app/components/timeSeries.js
@@ -31,6 +31,7 @@ function (_, kbn) {
 
   TimeSeries.prototype.applySeriesOverrides = function(overrides) {
     this.lines = {};
+    this.dashes = {};
     this.points = {};
     this.bars = {};
     this.info.yaxis = 1;
@@ -43,11 +44,16 @@ function (_, kbn) {
         continue;
       }
       if (override.lines !== void 0) { this.lines.show = override.lines; }
+      if (override.dashes !== void 0) { this.dashes.show = override.dashes; }
+      if (override.dashLength !== void 0) { this.dashes.dashLength = override.dashLength; }
       if (override.points !== void 0) { this.points.show = override.points; }
       if (override.bars !== void 0) { this.bars.show = override.bars; }
       if (override.fill !== void 0) { this.lines.fill = translateFillOption(override.fill); }
       if (override.stack !== void 0) { this.stack = override.stack; }
-      if (override.linewidth !== void 0) { this.lines.lineWidth = override.linewidth; }
+      if (override.linewidth !== void 0) {
+        this.dashes.lineWidth = override.linewidth;
+        this.lines.lineWidth = override.linewidth;
+      }
       if (override.pointradius !== void 0) { this.points.radius = override.pointradius; }
       if (override.steppedLine !== void 0) { this.lines.steps = override.steppedLine; }
       if (override.zindex !== void 0) { this.zindex = override.zindex; }

--- a/src/app/dashboards/default.json
+++ b/src/app/dashboards/default.json
@@ -82,6 +82,8 @@
           "lines": true,
           "fill": 1,
           "linewidth": 2,
+          "dashes": false,
+          "dashLength": 4,
           "points": false,
           "pointradius": 5,
           "bars": false,

--- a/src/app/dashboards/template_vars.json
+++ b/src/app/dashboards/template_vars.json
@@ -51,6 +51,8 @@
           "lines": true,
           "fill": 1,
           "linewidth": 1,
+          "dashes": false,
+          "dashLength": 4,
           "points": false,
           "pointradius": 5,
           "bars": false,

--- a/src/app/directives/grafanaGraph.js
+++ b/src/app/directives/grafanaGraph.js
@@ -129,6 +129,11 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
             hooks: { draw: [updateLegendValues] },
             legend: { show: false },
             series: {
+              dashes: {
+                show: panel.dashes,
+                lineWidth: panel.linewidth,
+                dashLength: panel.dashLength
+              },
               stackpercent: panel.stack ? panel.percentage : false,
               stack: panel.percentage ? null : stack,
               lines:  {
@@ -173,9 +178,24 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
             }
           };
 
+          // To have crosshairs working on dashed lines we display
+          // the lines with width 0
+          if(options.series.dashes.show === true) {
+            options.series.lines.show = true;
+            options.series.lines.lineWidth = 0;
+          }
+
           for (var i = 0; i < data.length; i++) {
             var series = data[i];
             series.applySeriesOverrides(panel.seriesOverrides);
+
+            if(series.dashes.show === true) {
+              series.lines.show = true;
+              series.lines.lineWidth = 0;
+            } else if(series.dashes.show === false) {
+              series.lines.lineWidth = panel.lineWidth;
+            }
+
             series.data = series.getFlotPairs(panel.nullPointMode, panel.y_formats);
 
             // if hidden remove points and disable stack

--- a/src/app/panels/graph/module.js
+++ b/src/app/panels/graph/module.js
@@ -17,6 +17,7 @@ define([
   'jquery.flot.stack',
   'jquery.flot.stackpercent',
   'jquery.flot.fillbelow',
+  'jquery.flot.dashes',
   'jquery.flot.crosshair'
 ],
 function (angular, app, $, _, kbn, moment, TimeSeries) {
@@ -342,8 +343,8 @@ function (angular, app, $, _, kbn, moment, TimeSeries) {
       $scope.render();
     };
 
-    $scope.addSeriesOverride = function(override) {
-      $scope.panel.seriesOverrides.push(override || {});
+    $scope.addSeriesOverride = function() {
+      $scope.panel.seriesOverrides.push({});
     };
 
     $scope.removeSeriesOverride = function(override) {

--- a/src/app/panels/graph/seriesOverridesCtrl.js
+++ b/src/app/panels/graph/seriesOverridesCtrl.js
@@ -73,6 +73,8 @@ define([
 
     $scope.addOverrideOption('Bars', 'bars', [true, false]);
     $scope.addOverrideOption('Lines', 'lines', [true, false]);
+    $scope.addOverrideOption('Dashed line', 'dashes', [true, false]);
+    $scope.addOverrideOption('Dash length', 'dashLength', [0,1,2,3,4,5,6,7,8,9,10]);
     $scope.addOverrideOption('Line fill', 'fill', [0,1,2,3,4,5,6,7,8,9,10]);
     $scope.addOverrideOption('Line width', 'linewidth', [0,1,2,3,4,5,6,7,8,9,10]);
     $scope.addOverrideOption('Fill below to', 'fillBelowTo', $scope.getSeriesNames());

--- a/src/app/panels/graph/styleEditor.html
+++ b/src/app/panels/graph/styleEditor.html
@@ -16,6 +16,10 @@
       <label class="small">Line Width</label>
       <select class="input-mini" ng-model="panel.linewidth" ng-options="f for f in [0,1,2,3,4,5,6,7,8,9,10]" ng-change="render()"></select>
     </div>
+    <div class="editor-option" ng-show="panel.dashes">
+      <label class="small">Dash Length</label>
+      <select class="input-mini" ng-model="panel.dashLength" ng-options="f for f in [0,1,2,3,4,5,6,7,8,9,10]" ng-change="render()"></select>
+    </div>
     <div class="editor-option" ng-show="panel.points">
       <label class="small">Point Radius</label>
       <select class="input-mini" ng-model="panel.pointradius" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10]" ng-change="render()"></select>
@@ -24,7 +28,7 @@
       <label class="small">Null point mode<tip>Define how null values should be drawn</tip></label>
       <select class="input-medium" ng-model="panel.nullPointMode" ng-options="f for f in ['connected', 'null', 'null as zero']" ng-change="render()"></select>
     </div>
-
+    <editor-opt-bool text="Dashed line" model="panel.dashes" change="render()"></editor-opt-bool>
 		<editor-opt-bool text="Staircase line" model="panel.steppedLine" change="render()"></editor-opt-bool>
   </div>
   <div class="section">

--- a/src/test/test-main.js
+++ b/src/test/test-main.js
@@ -43,6 +43,7 @@ require.config({
     'jquery.flot.time':       '../vendor/jquery/jquery.flot.time',
     'jquery.flot.crosshair':  '../vendor/jquery/jquery.flot.crosshair',
     'jquery.flot.fillbelow':  '../vendor/jquery/jquery.flot.fillbelow',
+    'jquery.flot.dashes':     '../vendor/jquery/jquery.flot.dashes',
 
     modernizr:                '../vendor/modernizr-2.6.1',
   },
@@ -69,6 +70,7 @@ require.config({
       exports: 'Crypto'
     },
 
+    'jquery-ui':            ['jquery'],
     'jquery.flot':          ['jquery'],
     'jquery.flot.pie':      ['jquery', 'jquery.flot'],
     'jquery.flot.events':   ['jquery', 'jquery.flot'],
@@ -78,6 +80,7 @@ require.config({
     'jquery.flot.time':     ['jquery', 'jquery.flot'],
     'jquery.flot.crosshair':['jquery', 'jquery.flot'],
     'jquery.flot.fillbelow':['jquery', 'jquery.flot'],
+    'jquery.flot.dashes':   ['jquery', 'jquery.flot'],
 
     'angular-route':        ['angular'],
     'angular-cookies':      ['angular'],

--- a/src/vendor/jquery/jquery.flot.dashes.js
+++ b/src/vendor/jquery/jquery.flot.dashes.js
@@ -1,0 +1,236 @@
+/*
+ * jQuery.flot.dashes
+ *
+ * options = {
+ *   series: {
+ *     dashes: {
+ *
+ *       // show
+ *       // default: false
+ *       // Whether to show dashes for the series.
+ *       show: <boolean>,
+ *
+ *       // lineWidth
+ *       // default: 2
+ *       // The width of the dashed line in pixels.
+ *       lineWidth: <number>,
+ *
+ *       // dashLength
+ *       // default: 10
+ *       // Controls the length of the individual dashes and the amount of
+ *       // space between them.
+ *       // If this is a number, the dashes and spaces will have that length.
+ *       // If this is an array, it is read as [ dashLength, spaceLength ]
+ *       dashLength: <number> or <array[2]>
+ *     }
+ *   }
+ * }
+ */
+(function($){
+
+  function init(plot) {
+
+    plot.hooks.processDatapoints.push(function(plot, series, datapoints) {
+
+      if (!series.dashes.show) return;
+
+      plot.hooks.draw.push(function(plot, ctx) {
+
+	var plotOffset = plot.getPlotOffset(),
+	    axisx = series.xaxis,
+	    axisy = series.yaxis;
+
+	function plotDashes(xoffset, yoffset) {
+
+	  var points = datapoints.points,
+	      ps = datapoints.pointsize,
+	      prevx = null,
+	      prevy = null,
+	      dashRemainder = 0,
+	      dashOn = true,
+	      dashOnLength,
+	      dashOffLength;
+
+	  if (series.dashes.dashLength[0]) {
+	    dashOnLength = series.dashes.dashLength[0];
+	    if (series.dashes.dashLength[1]) {
+	      dashOffLength = series.dashes.dashLength[1];
+	    } else {
+	      dashOffLength = dashOnLength;
+	    }
+	  } else {
+	    dashOffLength = dashOnLength = series.dashes.dashLength;
+	  }
+
+	  ctx.beginPath();
+
+	  for (var i = ps; i < points.length; i += ps) {
+
+	    var x1 = points[i - ps],
+		y1 = points[i - ps + 1],
+		x2 = points[i],
+		y2 = points[i + 1];
+
+	    if (x1 == null || x2 == null) continue;
+
+	    // clip with ymin
+	    if (y1 <= y2 && y1 < axisy.min) {
+	      if (y2 < axisy.min) continue;   // line segment is outside
+	      // compute new intersection point
+	      x1 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+	      y1 = axisy.min;
+	    } else if (y2 <= y1 && y2 < axisy.min) {
+	      if (y1 < axisy.min) continue;
+	      x2 = (axisy.min - y1) / (y2 - y1) * (x2 - x1) + x1;
+	      y2 = axisy.min;
+	    }
+
+	    // clip with ymax
+	    if (y1 >= y2 && y1 > axisy.max) {
+	      if (y2 > axisy.max) continue;
+	      x1 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+	      y1 = axisy.max;
+	    } else if (y2 >= y1 && y2 > axisy.max) {
+	      if (y1 > axisy.max) continue;
+	      x2 = (axisy.max - y1) / (y2 - y1) * (x2 - x1) + x1;
+	      y2 = axisy.max;
+	    }
+
+	    // clip with xmin
+	    if (x1 <= x2 && x1 < axisx.min) {
+	      if (x2 < axisx.min) continue;
+	      y1 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+	      x1 = axisx.min;
+	    } else if (x2 <= x1 && x2 < axisx.min) {
+	      if (x1 < axisx.min) continue;
+	      y2 = (axisx.min - x1) / (x2 - x1) * (y2 - y1) + y1;
+	      x2 = axisx.min;
+	    }
+
+	    // clip with xmax
+	    if (x1 >= x2 && x1 > axisx.max) {
+	      if (x2 > axisx.max) continue;
+	      y1 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+	      x1 = axisx.max;
+	    } else if (x2 >= x1 && x2 > axisx.max) {
+	      if (x1 > axisx.max) continue;
+	      y2 = (axisx.max - x1) / (x2 - x1) * (y2 - y1) + y1;
+	      x2 = axisx.max;
+	    }
+
+	    if (x1 != prevx || y1 != prevy) {
+	      ctx.moveTo(axisx.p2c(x1) + xoffset, axisy.p2c(y1) + yoffset);
+	    }
+
+	    var ax1 = axisx.p2c(x1) + xoffset,
+		ay1 = axisy.p2c(y1) + yoffset,
+		ax2 = axisx.p2c(x2) + xoffset,
+		ay2 = axisy.p2c(y2) + yoffset,
+		dashOffset;
+
+	    function lineSegmentOffset(segmentLength) {
+
+	      var c = Math.sqrt(Math.pow(ax2 - ax1, 2) + Math.pow(ay2 - ay1, 2));
+
+	      if (c <= segmentLength) {
+		return {
+		  deltaX: ax2 - ax1,
+		  deltaY: ay2 - ay1,
+		  distance: c,
+		  remainder: segmentLength - c
+		}
+	      } else {
+		var xsign = ax2 > ax1 ? 1 : -1,
+		    ysign = ay2 > ay1 ? 1 : -1;
+		return {
+		  deltaX: xsign * Math.sqrt(Math.pow(segmentLength, 2) / (1 + Math.pow((ay2 - ay1)/(ax2 - ax1), 2))),
+		  deltaY: ysign * Math.sqrt(Math.pow(segmentLength, 2) - Math.pow(segmentLength, 2) / (1 + Math.pow((ay2 - ay1)/(ax2 - ax1), 2))),
+		  distance: segmentLength,
+		  remainder: 0
+		};
+	      }
+	    }
+	    //-end lineSegmentOffset
+
+	    do {
+
+	      dashOffset = lineSegmentOffset(
+		  dashRemainder > 0 ? dashRemainder :
+		    dashOn ? dashOnLength : dashOffLength);
+
+	      if (dashOffset.deltaX != 0 || dashOffset.deltaY != 0) {
+		if (dashOn) {
+		  ctx.lineTo(ax1 + dashOffset.deltaX, ay1 + dashOffset.deltaY);
+		} else {
+		  ctx.moveTo(ax1 + dashOffset.deltaX, ay1 + dashOffset.deltaY);
+		}
+	      }
+
+	      dashOn = !dashOn;
+	      dashRemainder = dashOffset.remainder;
+	      ax1 += dashOffset.deltaX;
+	      ay1 += dashOffset.deltaY;
+
+	    } while (dashOffset.distance > 0);
+
+	    prevx = x2;
+	    prevy = y2;
+	  }
+
+	  ctx.stroke();
+	}
+	//-end plotDashes
+
+	ctx.save();
+	ctx.translate(plotOffset.left, plotOffset.top);
+	ctx.lineJoin = 'round';
+
+	var lw = series.dashes.lineWidth,
+	    sw = series.shadowSize;
+
+	// FIXME: consider another form of shadow when filling is turned on
+	if (lw > 0 && sw > 0) {
+	  // draw shadow as a thick and thin line with transparency
+	  ctx.lineWidth = sw;
+	  ctx.strokeStyle = "rgba(0,0,0,0.1)";
+	  // position shadow at angle from the mid of line
+	  var angle = Math.PI/18;
+	  plotDashes(Math.sin(angle) * (lw/2 + sw/2), Math.cos(angle) * (lw/2 + sw/2));
+	  ctx.lineWidth = sw/2;
+	  plotDashes(Math.sin(angle) * (lw/2 + sw/4), Math.cos(angle) * (lw/2 + sw/4));
+	}
+
+	ctx.lineWidth = lw;
+	ctx.strokeStyle = series.color;
+
+	if (lw > 0) {
+	  plotDashes(0, 0);
+	}
+
+	ctx.restore();
+
+      });
+      //-end draw hook
+
+    });
+    //-end processDatapoints hook
+
+  }
+  //-end init
+
+  $.plot.plugins.push({
+    init: init,
+    options: {
+      series: {
+	dashes: {
+	  show: false,
+	  lineWidth: 2,
+	  dashLength: 10
+	}
+      }
+    },
+    name: 'dashes',
+    version: '0.1'
+  });
+
+})(jQuery)


### PR DESCRIPTION
Adds support for dashed lines (#514) using jquery.flot.dashes.js, although, as mentioned on these two links
- https://code.google.com/p/flot/issues/detail?id=61
- http://stackoverflow.com/questions/24593077/does-jquery-flot-dashes-js-support-plothover-and-plotclick

I had to change a line in `jquery.flot.js` to be able to get the crosshair on the dotted lines. This is a first try at it and I must admit I never really touched Angular before, please therefore tell me what to change and I will do what I can.

Also, the `dashes` object gets the same linewidth as the global linewidth, these are two different plugins but I strongly feel that the user should not have a "Dashed line width" and a "Line width" selector side by side. Setting `dashes.show` to true also sets `lines.show` to false to be able to see the dashed line.

Screenshots below

![screenshot on 2014-10-15 at 02-59-38](https://cloud.githubusercontent.com/assets/937179/4637406/2cb83740-53ec-11e4-957c-ad0b2eeaaffe.png)
![screenshot on 2014-10-15 at 02-59-49](https://cloud.githubusercontent.com/assets/937179/4637411/335330b4-53ec-11e4-9e85-c21d95b40bbd.png)
