### PR TITLE
Add optional maximum value parameter to perSecond.

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -42,7 +42,7 @@ function (_) {
   addFuncDef({
     name: 'perSecond',
     category: categories.Transform,
-    params: [],
+    params: [{ name: "max value", type: "int", optional: true }],
     defaultParams: [],
   });
 


### PR DESCRIPTION
The perSecond function takes an optional parameter to specify a maximum
value. See http://graphite.readthedocs.org/en/latest/functions.html#graphite.render.functions.perSecond.
