### PR TITLE
Add alignToFrom param to summarize

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -339,8 +339,12 @@ function (_) {
   addFuncDef({
     name: 'summarize',
     category: categories.Transform,
-    params: [{ name: "interval", type: "string" }, { name: "func", type: "select", options: ['sum', 'avg', 'min', 'max', 'last'] }],
-    defaultParams: ['1h', 'sum']
+    params: [
+      { name: "interval", type: "string" },
+      { name: "func", type: "select", options: ['sum', 'avg', 'min', 'max', 'last'] },
+      { name: "alignToFrom", type: "boolean", optional: true, options: ['false', 'true'] },
+    ],
+    defaultParams: ['1h', 'sum', 'false']
   });
 
   addFuncDef({
@@ -543,7 +547,7 @@ function (_) {
     var parameters = _.map(this.params, function(value, index) {
 
       var paramType = this.def.params[index].type;
-      if (paramType === 'int' || paramType === 'value_or_series') {
+      if (paramType === 'int' || paramType === 'value_or_series' || paramType === 'boolean') {
         return value;
       }
 

--- a/src/test/specs/gfunc-specs.js
+++ b/src/test/specs/gfunc-specs.js
@@ -79,7 +79,7 @@ define([
       var func = gfunc.createFuncInstance('summarize', { withDefaultParams: true });
       func.updateParam('1h', 0);
       expect(func.params[0]).to.be('1h');
-      expect(func.text).to.be('summarize(1h, sum)');
+      expect(func.text).to.be('summarize(1h, sum, false)');
     });
 
     it('should parse numbers as float', function() {


### PR DESCRIPTION
This adds support for the optional `alignToFrom` parameter of the `summarize` graphite function.
