### PR TITLE
Add support for regex based series merging in InfluxDB

### DIFF
--- a/src/app/services/influxdb/influxQueryBuilder.js
+++ b/src/app/services/influxdb/influxQueryBuilder.js
@@ -18,7 +18,7 @@ function () {
     var query = 'select ';
     var seriesName = target.series;
 
-    if(!seriesName.match('^/.*/')) {
+    if(!seriesName.match('^/.*/') && !seriesName.match(/^merge\(.*\)/)) {
       seriesName = '"' + seriesName+ '"';
     }
 

--- a/src/test/specs/influxQueryBuilder-specs.js
+++ b/src/test/specs/influxQueryBuilder-specs.js
@@ -44,6 +44,35 @@ define([
 
     });
 
+    describe('merge function detection', function() {
+      it('should not quote wrap regex merged series', function() {
+        var builder = new InfluxQueryBuilder({
+          series: 'merge(/^google.test/)',
+          column: 'value',
+          function: 'mean'
+        });
+
+        var query = builder.build();
+
+        expect(query).to.be('select mean(value) from merge(/^google.test/) where $timeFilter ' +
+          'group by time($interval) order asc');
+      });
+
+      it('should quote wrap series names that start with "merge"', function() {
+        var builder = new InfluxQueryBuilder({
+          series: 'merge.google.test',
+          column: 'value',
+          function: 'mean'
+        });
+
+        var query = builder.build();
+
+        expect(query).to.be('select mean(value) from "merge.google.test" where $timeFilter ' +
+          'group by time($interval) order asc'); 
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
This feature was added in InfluxDB 0.8.4. 

The change needed to Grafana is to skip wrapping the series with `"` when the merge function is used.
