### PR TITLE
When get_data fails the legend should be cleared

### DIFF
--- a/src/app/panels/graph/module.js
+++ b/src/app/panels/graph/module.js
@@ -203,6 +203,7 @@ function (angular, app, $, _, kbn, moment, TimeSeries) {
           $scope.panelMeta.loading = false;
           $scope.panelMeta.error = err.message || "Timeseries data request error";
           $scope.inspector.error = err;
+          $scope.legend = [];
           $scope.render([]);
         });
     };

--- a/src/test/specs/graph-ctrl-specs.js
+++ b/src/test/specs/graph-ctrl-specs.js
@@ -36,6 +36,20 @@ define([
         var data = ctx.scope.render.getCall(0).args[0];
         expect(data.length).to.be(2);
       });
+
+      describe('get_data failure following success', function() {
+        beforeEach(function() {
+          ctx.datasource.query = sinon.stub().returns(ctx.$q.reject('Datasource Error'));
+          ctx.scope.get_data();
+          ctx.scope.$digest();
+        });
+
+        it('should clear the legend data', function() {
+          expect(ctx.scope.legend).to.eql([]);
+        });
+
+      });
+
     });
 
   });


### PR DESCRIPTION
This fixes what is probably an uncommon edge case I ran into it today:

We have some dashboards that display a bunch of graphs based on a template value, some graphs for some template values don't have any data (the series doesn't even exist in the data source). Currently when switching between template values and landing on one of these situations the graph updates to be empty and displays the error indicator as expected but the legend from the previous template value persists. This can be a bit confusing to the user as they may see current/average/etc values in the legend but a blank and errored graph. This commit clears $scope.legend when get_data fails.

Side note: the same thing happens with annotations as well, the graph errors and goes black but annotations persist, I poked at that code a bit but it seems that annotations are cached in the graph directive so there wasn't a clean path to clear them out from the controller. It's also probably not as much of an issue that the annotation persist as they are still 'correct'.
