### PR TITLE
Make ElasticSearch max results honor the global search.max_results setting.

### DIFF
--- a/src/app/services/elasticsearch/es-datasource.js
+++ b/src/app/services/elasticsearch/es-datasource.js
@@ -79,7 +79,7 @@ function (angular, _, config, kbn, moment) {
       var data = {
         "fields": [timeField, "_source"],
         "query" : { "filtered": { "query" : query, "filter": filter } },
-        "size": 100
+        "size": this.searchMaxResults
       };
 
       return this._request('POST', '/_search', annotation.index, data).then(function(results) {


### PR DESCRIPTION
The number of results returned was hard coded to 100.  Update this to honor the
global config search.max_results value, as is used in other parts of the code.
