### PR TITLE
Refactor timspan default in scripted examples.

### DIFF
--- a/src/app/dashboards/scripted.js
+++ b/src/app/dashboards/scripted.js
@@ -23,7 +23,7 @@ var dashboard, timspan;
 var ARGS;
 
 // Set a default timespan if one isn't specified
-timspan = '1d';
+timspan = ARGS.from || 'now-1d';
 
 // Intialize a skeleton with nothing but a rows array and service object
 dashboard = {
@@ -33,7 +33,7 @@ dashboard = {
 // Set a title
 dashboard.title = 'Scripted dash';
 dashboard.time = {
-  from: "now-" + (ARGS.from || timspan),
+  from: timspan,
   to: "now"
 };
 

--- a/src/app/dashboards/scripted_async.js
+++ b/src/app/dashboards/scripted_async.js
@@ -25,7 +25,7 @@ return function(callback) {
   var dashboard, timspan;
 
   // Set a default timespan if one isn't specified
-  timspan = '1d';
+  timspan = ARGS.from || 'now-1d';
 
   // Intialize a skeleton with nothing but a rows array and service object
   dashboard = {
@@ -36,7 +36,7 @@ return function(callback) {
   // Set a title
   dashboard.title = 'Scripted dash';
   dashboard.time = {
-    from: "now-" + (ARGS.from || timspan),
+    from: timspan,
     to: "now"
   };
 

--- a/src/app/dashboards/scripted_templated.js
+++ b/src/app/dashboards/scripted_templated.js
@@ -23,7 +23,7 @@ var dashboard, timspan;
 var ARGS;
 
 // Set a default timespan if one isn't specified
-timspan = '1d';
+timspan = ARGS.from || 'now-1d';
 
 // Intialize a skeleton with nothing but a rows array and service object
 dashboard = {
@@ -33,7 +33,7 @@ dashboard = {
 // Set a title
 dashboard.title = 'Scripted dash';
 dashboard.time = {
-  from: "now-" + (ARGS.from || timspan),
+  from: timspan,
   to: "now"
 };
 dashboard.templating = {


### PR DESCRIPTION
Before this PR, setting `from=now-6h` would lead to `dashboard.time.from = "now-now-6h"`, which appears to work but is misleading.

These changes should more clearly express the intent and format of `ARGS.from`.
