### PR TITLE
Purge timspan variable from scripted templates.

### DIFF
--- a/src/app/dashboards/scripted.js
+++ b/src/app/dashboards/scripted.js
@@ -17,7 +17,7 @@
 var window, document, ARGS, $, jQuery, moment, kbn;
 
 // Setup some variables
-var dashboard, timspan;
+var dashboard;
 
 // All url parameters are available via the ARGS object
 var ARGS;
@@ -30,11 +30,11 @@ dashboard = {
 // Set a title
 dashboard.title = 'Scripted dash';
 
-// set default time
+// Set default time
 // time can be overriden in the url using from/to parameteres, but this is
 // handled automatically in grafana core during dashboard initialization
 dashboard.time = {
-  from: 'now-6h',
+  from: "now-6h",
   to: "now"
 };
 

--- a/src/app/dashboards/scripted_async.js
+++ b/src/app/dashboards/scripted_async.js
@@ -22,10 +22,7 @@ var window, document, ARGS, $, jQuery, moment, kbn;
 return function(callback) {
 
   // Setup some variables
-  var dashboard, timspan;
-
-  // Set a default timespan if one isn't specified
-  timspan = ARGS.from || 'now-1d';
+  var dashboard;
 
   // Intialize a skeleton with nothing but a rows array and service object
   dashboard = {
@@ -35,9 +32,13 @@ return function(callback) {
 
   // Set a title
   dashboard.title = 'Scripted dash';
+
+  // Set default time
+  // time can be overriden in the url using from/to parameteres, but this is
+  // handled automatically in grafana core during dashboard initialization
   dashboard.time = {
-    from: timspan,
-    to: "now"
+      from: "now-6h",
+      to: "now"
   };
 
   var rows = 1;

--- a/src/app/dashboards/scripted_templated.js
+++ b/src/app/dashboards/scripted_templated.js
@@ -17,13 +17,10 @@
 var window, document, ARGS, $, jQuery, moment, kbn;
 
 // Setup some variables
-var dashboard, timspan;
+var dashboard;
 
 // All url parameters are available via the ARGS object
 var ARGS;
-
-// Set a default timespan if one isn't specified
-timspan = ARGS.from || 'now-1d';
 
 // Intialize a skeleton with nothing but a rows array and service object
 dashboard = {
@@ -31,11 +28,16 @@ dashboard = {
 };
 
 // Set a title
-dashboard.title = 'Scripted dash';
+dashboard.title = 'Scripted and templated dash';
+
+// Set default time
+// time can be overriden in the url using from/to parameteres, but this is
+// handled automatically in grafana core during dashboard initialization
 dashboard.time = {
-  from: timspan,
+  from: "now-6h",
   to: "now"
 };
+
 dashboard.templating = {
   enable: true,
   list: [


### PR DESCRIPTION
Following @torkelo's improvements to https://github.com/grafana/grafana/pull/1086, this PR removes the declaration and use of the `timspan` variable in all scripted dashboard examples.
