### PR TITLE
Support for threshold colouring of zero / negative values.

### DIFF
--- a/src/app/panels/singlestat/singleStatPanel.js
+++ b/src/app/panels/singlestat/singleStatPanel.js
@@ -148,7 +148,7 @@ function (angular, app, _, $) {
 
           var body = getBigValueHtml();
 
-          if (panel.colorBackground && data.mainValue) {
+          if (panel.colorBackground && !isNaN(data.mainValue)) {
             var color = getColorForValue(data.mainValue);
             if (color) {
               $panelContainer.css('background-color', color);


### PR DESCRIPTION
Supporting negative thresholds allows end-users to configure single stat panels with thresholds == 0 etc.
