### PR TITLE
Add support for grep function to function editor

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -471,6 +471,13 @@ function (_) {
   });
 
   addFuncDef({
+    name: "grep",
+    category: categories.Filter,
+    params: [{ name: "grep", type: 'string' }],
+    defaultParams: ['grep']
+  });
+
+  addFuncDef({
     name: "exclude",
     category: categories.Filter,
     params: [{ name: "exclude", type: 'string' }],


### PR DESCRIPTION
Add support for the graphite `grep` function to the function editor. `grep` is the complement of `exclude`.
