### PR TITLE
allow multiple params for sumSeriesWithWildcards

### DIFF
--- a/src/app/services/graphite/gfunc.js
+++ b/src/app/services/graphite/gfunc.js
@@ -157,7 +157,12 @@ function (_) {
   addFuncDef({
     name: 'sumSeriesWithWildcards',
     category: categories.Combine,
-    params: [{ name: "node", type: "int" }],
+    params: [
+      { name: "node", type: "int" },
+      { name: "node", type: "int", optional: true },
+      { name: "node", type: "int", optional: true },
+      { name: "node", type: "int", optional: true }
+    ],
     defaultParams: [3]
   });
 


### PR DESCRIPTION
sumSeriesWithWildcards can take multiple position arguments (http://graphite.readthedocs.org/en/latest/functions.html#graphite.render.functions.sumSeriesWithWildcards).
