### PR TITLE
Extend tooltip for drilldown link

### DIFF
--- a/src/app/features/panellinkeditor/module.html
+++ b/src/app/features/panellinkeditor/module.html
@@ -1,6 +1,6 @@
 <div class="editor-row">
   <div class="section">
-		<h5>Drilldown / detail link<tip>These links appear in the dropdown menu in the panel menu</tip></h5>
+		<h5>Drilldown / detail link<tip>These links appear in the dropdown menu in the panel menu. Use var-variableName=value in params to pass templating variables.</tip></h5>
 
 		<div class="grafana-target" ng-repeat="link in panel.links"j>
 			<div class="grafana-target-inner">


### PR DESCRIPTION
It took me a bit to find out that variables need to be passed with var-variableName. 
The behavior is not specific to the drilldown link but I couldn't find it in any documentation elsewhere and it might help others to have it documented right here.
