### PR TITLE
add support for optionally showing legend in full screen

### DIFF
--- a/src/app/panels/graph/axisEditor.html
+++ b/src/app/panels/graph/axisEditor.html
@@ -41,6 +41,7 @@
   <div class="section">
     <h5>Legend styles</h5>
 		<editor-opt-bool text="Show" model="panel.legend.show" change="get_data();"></editor-opt-bool>
+		<editor-opt-bool text="Full screen only" model="panel.legend.fullscreen"></editor-opt-bool>
 		<editor-opt-bool text="Values" model="panel.legend.values" change="render()"></editor-opt-bool>
 		<editor-opt-bool text="Table" model="panel.legend.alignAsTable" change="render()"></editor-opt-bool>
 		<editor-opt-bool text="Right side" model="panel.legend.rightSide" change="render()"></editor-opt-bool>

--- a/src/app/panels/graph/module.html
+++ b/src/app/panels/graph/module.html
@@ -15,7 +15,7 @@
 
 		</div>
 
-		<div class="graph-legend-wrapper" ng-if="panel.legend.show" graph-legend></div>
+		<div class="graph-legend-wrapper" ng-if="panel.legend.show || (panel.legend.fullscreen && dashboardViewState.fullscreen && !editMode)" graph-legend></div>
 	</div>
 
 	<div class="clearfix"></div>

--- a/src/app/panels/graph/module.js
+++ b/src/app/panels/graph/module.js
@@ -75,6 +75,7 @@ function (angular, app, $, _, kbn, moment, TimeSeries, PanelMeta) {
       // legend options
       legend: {
         show: true, // disable/enable legend
+        fullscreen: true, // disable/enable legend in fullscreen
         values: false, // disable/enable legend values
         min: false,
         max: false,

--- a/src/app/services/dashboard/dashboardViewStateSrv.js
+++ b/src/app/services/dashboard/dashboardViewStateSrv.js
@@ -137,6 +137,8 @@ function (angular, _, $) {
 
       panelScope.fullscreen = true;
 
+      panelScope.get_data();
+
       $timeout(function() {
         panelScope.$emit('render');
       });


### PR DESCRIPTION
This pull request adds a toggle in graph settings to only show the legend in full screen mode. The rationale is that I do not want legends cluttering up my dashboards consisting of many graphs but they are often useful to see in full screen mode due to the min/max/avg/total statistics. 
