### PR TITLE
Added dashboard and panel descriptions

### DIFF
--- a/src/app/directives/panelMenu.js
+++ b/src/app/directives/panelMenu.js
@@ -11,7 +11,9 @@ function (angular, $, _) {
     .directive('panelMenu', function($compile, linkSrv) {
       var linkTemplate =
           '<span class="panel-title drag-handle pointer">' +
-            '<span class="panel-title-text drag-handle">{{panel.title | interpolateTemplateVars}}</span>' +
+            '<span class="panel-title-text drag-handle">{{panel.title | interpolateTemplateVars}}' +
+            '<span ng-show="panel.description !== null && panel.description.length">'+
+            '<tip icon="info-sign" place="bottom">{{panel.description}}</tip></span></span>' +
             '<span class="panel-links-icon"></span>' +
           '</span>';
 

--- a/src/app/directives/tip.js
+++ b/src/app/directives/tip.js
@@ -11,8 +11,8 @@ function (angular, kbn) {
       return {
         restrict: 'E',
         link: function(scope, elem, attrs) {
-          var _t = '<i class="grafana-tip icon-'+(attrs.icon||'question-sign')+'" bs-tooltip="\''+
-            kbn.addslashes(elem.text())+'\'"></i>';
+          var _t = '<i class="grafana-tip icon-'+(attrs.icon||'question-sign')+'" data-placement='+(attrs.place||'top')+' bs-tooltip="\''+
+                     kbn.addslashes(elem.text())+'\'"></i>';
           elem.replaceWith($compile(angular.element(_t))(scope));
         }
       };

--- a/src/app/partials/dashboard_topnav.html
+++ b/src/app/partials/dashboard_topnav.html
@@ -3,10 +3,9 @@
 		<div class="container-fluid">
 			<span class="brand">
 				<img class="logo-icon" src="img/fav32.png" bs-tooltip="'Grafana'" data-placement="bottom"></img>
-				<span class="page-title">{{dashboard.title}}</span>
+				<span class="page-title" >{{dashboard.title}} <span ng-show="dashboard.description !== null && dashboard.description.length"><tip place="bottom" icon="info-sign">{{dashboard.description}}</tip></span> </span>
 			</span>
 			<ul class="nav pull-right" ng-controller='DashboardNavCtrl' ng-init="init()">
-
 				<li ng-show="dashboardViewState.fullscreen">
 					<a ng-click="exitFullscreen()">
 						Back to dashboard

--- a/src/app/partials/dasheditor.html
+++ b/src/app/partials/dasheditor.html
@@ -39,6 +39,9 @@
 						</bootstrap-tagsinput>
 						<tip>Press enter to a add tag</tip>
 					</div>
+					<div class="editor-option">
+                               			<label class="small">Description</label><textarea cols="60" rows="5"  ng-model='dashboard.description'></textarea>
+                        		</div>
 				</div>
 			</div>
 		</div>

--- a/src/app/partials/panelgeneral.html
+++ b/src/app/partials/panelgeneral.html
@@ -7,8 +7,11 @@
     <div class="editor-option">
       <label class="small">Span</label> <select class="input-mini" ng-model="panel.span" ng-options="f for f in [0,1,2,3,4,5,6,7,8,9,10,11,12]"></select>
     </div>
-		<div class="editor-option">
+    <div class="editor-option">
       <label class="small">Height</label><input type="text" class="input-small" ng-model='panel.height'></select>
+    </div>
+    <div class="editor-option">
+      <label class="small">Description</label><textarea type="text" class="input-small" ng-model='panel.description'></textarea>
     </div>
   </div>
 </div>

--- a/src/app/services/dashboard/dashboardSrv.js
+++ b/src/app/services/dashboard/dashboardSrv.js
@@ -21,6 +21,7 @@ function (angular, $, kbn, _, moment) {
 
       this.id = data.id || null;
       this.title = data.title || 'No Title';
+      this.description = data.description;
       this.originalTitle = this.title;
       this.tags = data.tags || [];
       this.style = data.style || "dark";


### PR DESCRIPTION
I have added the functionality of add descriptions to the dashboards and the graph panels.

This is for the dashboard:

![image](https://cloud.githubusercontent.com/assets/8693668/5452287/6ed177c8-8519-11e4-8465-63d5aa5a9821.png)

And this one for each panel.

![image](https://cloud.githubusercontent.com/assets/8693668/5452265/31bcb8f2-8519-11e4-8cbe-728da3915c52.png)
