### PR TITLE
Add client side scaling for opentsdb datasource

### DIFF
--- a/src/app/partials/opentsdb/editor.html
+++ b/src/app/partials/opentsdb/editor.html
@@ -118,13 +118,25 @@
           <li class="grafana-target-segment">
             Alias:
           </li>
-					<li>
-						<input type="text"
+          <li>
+            <input type="text"
                    class="grafana-target-segment-input input-medium"
                    ng-model="target.alias"
                    spellcheck='false'
                    placeholder="series alias"
                    data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                   />
+          </li>
+          <li class="grafana-target-segment">
+            Scale:
+          </li>
+		  <li>
+		    <input type="text"
+                   class="grafana-target-segment-input input-medium"
+                   ng-model="target.scale"
+                   spellcheck='false'
+                   placeholder="Scale value by"
                    ng-blur="targetBlur()"
                    />
           </li>

--- a/src/app/services/opentsdb/opentsdbDatasource.js
+++ b/src/app/services/opentsdb/opentsdbDatasource.js
@@ -97,11 +97,21 @@ function (angular, _, kbn) {
 
       metricLabel = createMetricLabel(md.metric, tagData, options);
 
-      // TSDB returns datapoints has a hash of ts => value.
-      // Can't use _.pairs(invert()) because it stringifies keys/values
-      _.each(md.dps, function (v, k) {
-        dps.push([v, k * 1000]);
-      });
+      // TSDB doesn't support scaling, so allow it client side
+      var scale = parseFloat(options.scale);
+      if (!isNaN(scale) && scale !== 1){
+        _.each(md.dps, function (v, k) {
+          dps.push([v * scale, k * 1000]);
+        });
+      }
+      else
+      {
+        // TSDB returns datapoints has a hash of ts => value.
+        // Can't use _.pairs(invert()) because it stringifies keys/values
+        _.each(md.dps, function (v, k) {
+          dps.push([v, k * 1000]);
+        });
+      }
 
       return { target: metricLabel, datapoints: dps };
     }


### PR DESCRIPTION
OpenTSDB api doesn't have an option to scale values by a constant. This commit adds this functionaliy client side. For example internet traffic graphs are commonly in bits per second, but counters are in octets(bytes). 
