### PR TITLE
Support for Atlas as a datasource

### DIFF
--- a/src/app/services/atlas/atlasDatasource.js
+++ b/src/app/services/atlas/atlasDatasource.js
@@ -1,66 +1,65 @@
 define([
-    'angular',
-    'lodash'
-  ],
-  function (angular, _) {
-    'use strict';
+  'angular',
+  'lodash'
+],
+function (angular, _) {
+  'use strict';
 
-    var module = angular.module('grafana.services');
+  var module = angular.module('grafana.services');
 
-    module.factory('AtlasDatasource', function($q, $http) {
+  module.factory('AtlasDatasource', function($q, $http) {
 
-      function AtlasDatasource(datasource) {
-        this.type = 'atlas';
-        this.url = datasource.url;
-        this.supportMetrics = true;
-      }
+    function AtlasDatasource(datasource) {
+      this.type = 'atlas';
+      this.url = datasource.url;
+      this.supportMetrics = true;
+    }
 
-      AtlasDatasource.prototype.query = function(options) {
-        var deferred = $q.defer();
+    AtlasDatasource.prototype.query = function(options) {
+      var deferred = $q.defer();
 
-        // Atlas can take multiple concatenated stack queries
-        var fullQuery = _.pluck(options.targets, 'query').join(',');
+      // Atlas can take multiple concatenated stack queries
+      var fullQuery = _.pluck(options.targets, 'query').join(',');
 
-        var params = {
-          q: fullQuery,
-          step: options.interval,
-          s: options.range.from,
-          e: options.range.to,
-          format: 'json'
-        };
-
-        var httpOptions = {
-          method: 'GET',
-          url:    this.url + '/api/v1/graph',
-          params: params,
-          inspect: { type: 'atlas' }
-        };
-
-        $http(httpOptions).success(function (data) {
-          deferred.resolve({
-            data: makeTimeSeries(data)
-          });
-        });
-
-        return deferred.promise;
+      var params = {
+        q: fullQuery,
+        step: options.interval,
+        s: options.range.from,
+        e: options.range.to,
+        format: 'json'
       };
 
-      function makeTimeSeries (result) {
-        return _.map(result.legend, function (legend, index) {
-          var series = {target: legend, datapoints: []};
-          var values = _.pluck(result.values, index);
+      var httpOptions = {
+        method: 'GET',
+        url:    this.url + '/api/v1/graph',
+        params: params,
+        inspect: { type: 'atlas' }
+      };
 
-          for (var i = 0; i < values.length; i++) {
-            var value = values[i];
-            var timestamp = result.start + (i * result.step);
-            series.datapoints.push([value, timestamp]);
-          }
-
-          return series;
+      $http(httpOptions).success(function (data) {
+        deferred.resolve({
+          data: makeTimeSeries(data)
         });
-      }
+      });
 
-      return AtlasDatasource;
-    });
+      return deferred.promise;
+    };
 
+    function makeTimeSeries (result) {
+      return _.map(result.legend, function (legend, index) {
+        var series = {target: legend, datapoints: []};
+        var values = _.pluck(result.values, index);
+
+        for (var i = 0; i < values.length; i++) {
+          var value = values[i];
+          var timestamp = result.start + (i * result.step);
+          series.datapoints.push([value, timestamp]);
+        }
+
+        return series;
+      });
+    }
+
+    return AtlasDatasource;
   });
+});

--- a/src/app/services/atlas/atlasDatasource.js
+++ b/src/app/services/atlas/atlasDatasource.js
@@ -1,0 +1,66 @@
+define([
+    'angular',
+    'lodash'
+  ],
+  function (angular, _) {
+    'use strict';
+
+    var module = angular.module('grafana.services');
+
+    module.factory('AtlasDatasource', function($q, $http) {
+
+      function AtlasDatasource(datasource) {
+        this.type = 'atlas';
+        this.url = datasource.url;
+        this.supportMetrics = true;
+      }
+
+      AtlasDatasource.prototype.query = function(options) {
+        var deferred = $q.defer();
+
+        // Atlas can take multiple concatenated stack queries
+        var fullQuery = _.pluck(options.targets, 'query').join(',');
+
+        var params = {
+          q: fullQuery,
+          step: options.interval,
+          s: options.range.from,
+          e: options.range.to,
+          format: 'json'
+        };
+
+        var httpOptions = {
+          method: 'GET',
+          url:    this.url + '/api/v1/graph',
+          params: params,
+          inspect: { type: 'atlas' }
+        };
+
+        $http(httpOptions).success(function (data) {
+          deferred.resolve({
+            data: makeTimeSeries(data)
+          });
+        });
+
+        return deferred.promise;
+      };
+
+      function makeTimeSeries (result) {
+        return _.map(result.legend, function (legend, index) {
+          var series = {target: legend, datapoints: []};
+          var values = _.pluck(result.values, index);
+
+          for (var i = 0; i < values.length; i++) {
+            var value = values[i];
+            var timestamp = result.start + (i * result.step);
+            series.datapoints.push([value, timestamp]);
+          }
+
+          return series;
+        });
+      }
+
+      return AtlasDatasource;
+    });
+
+  });

--- a/src/app/services/datasourceSrv.js
+++ b/src/app/services/datasourceSrv.js
@@ -6,6 +6,7 @@ define([
   './influxdb/influxdbDatasource',
   './opentsdb/opentsdbDatasource',
   './elasticsearch/es-datasource',
+  './atlas/atlasDatasource',
 ],
 function (angular, _, config) {
   'use strict';
@@ -69,6 +70,9 @@ function (angular, _, config) {
         break;
       case 'elasticsearch':
         Datasource = $injector.get('ElasticDatasource');
+        break;
+      case 'atlas':
+        Datasource = $injector.get('AtlasDatasource');
         break;
       default:
         Datasource = $injector.get(ds.type);

--- a/src/test/specs/atlasDatasource-specs.js
+++ b/src/test/specs/atlasDatasource-specs.js
@@ -52,7 +52,7 @@ define([
         ctx.$httpBackend.verifyNoOutstandingExpectation();
       });
 
-      it.only('should return series list', function() {
+      it('should return series list', function() {
         expect(results.data.length).to.be(2);
         expect(results.data[0].target).to.be('atlas.legacy=epic, name=sps, nf.app=nccp');
         expect(results.data[0].datapoints[0]).to.eql([604930.164776, 1419312000000]);

--- a/src/test/specs/atlasDatasource-specs.js
+++ b/src/test/specs/atlasDatasource-specs.js
@@ -1,0 +1,64 @@
+define([
+  './helpers',
+  'services/atlas/atlasDatasource'
+], function(helpers) {
+  'use strict';
+
+  describe('AtlasDatasource', function() {
+    var ctx = new helpers.ServiceTestContext();
+
+    beforeEach(module('grafana.services'));
+    beforeEach(ctx.providePhase(['templateSrv']));
+    beforeEach(ctx.createService('AtlasDatasource'));
+    beforeEach(function() {
+      ctx.ds = new ctx.service({ url: [''] });
+    });
+
+    describe('When querying atlas with multiple stack query targets', function() {
+      var results;
+      var urlExpected = "/api/v1/graph?e=now&format=json&q=name,sps,:eq,:sum,name,ssCpuUser,:eq,:sum&s=now-1h&step=10m";
+      var query = {
+        range: { from: 'now-1h', to: 'now' },
+        targets: [
+          { query: 'name,sps,:eq,:sum' },
+          { query: 'name,ssCpuUser,:eq,:sum' }
+        ],
+        interval: '10m'
+      };
+
+      var response = {
+        start: 1419312000000,
+        step: 600000,
+        legend: [
+          "atlas.legacy=epic, name=sps, nf.app=nccp",
+          "atlas.legacy=epic, name=ssCpuUser, nf.app=alerttest, nf.asg=alerttest-v042, nf.cluster=alerttest, nf.node=alert1"
+        ],
+        metrics: [{}],
+        values:[
+          [604930.164776, 18.537333],
+          [593086.155587, 20.939233],
+          [605539.831071, 20.855982]
+        ],
+        notices: []
+      };
+
+      beforeEach(function() {
+        ctx.$httpBackend.expect('GET', urlExpected).respond(response);
+        ctx.ds.query(query).then(function(data) { results = data; });
+        ctx.$httpBackend.flush();
+      });
+
+      it('should generate the correct query', function() {
+        ctx.$httpBackend.verifyNoOutstandingExpectation();
+      });
+
+      it.only('should return series list', function() {
+        expect(results.data.length).to.be(2);
+        expect(results.data[0].target).to.be('atlas.legacy=epic, name=sps, nf.app=nccp');
+        expect(results.data[0].datapoints[0]).to.eql([604930.164776, 1419312000000]);
+        expect(results.data[0].datapoints[1]).to.eql([593086.155587, 1419312000000 + 600000]);
+      });
+    });
+  });
+});
+

--- a/src/test/test-main.js
+++ b/src/test/test-main.js
@@ -124,6 +124,7 @@ require([
     'specs/influxSeries-specs',
     'specs/influxQueryBuilder-specs',
     'specs/influxdb-datasource-specs',
+    'specs/atlasDatasource-specs',
     'specs/graph-ctrl-specs',
     'specs/graph-specs',
     'specs/graph-tooltip-specs',


### PR DESCRIPTION
This is still a rough cut but at least the default dashboard loads. Time shifting and multiple lines seem to work as well.

Config spec looks like this:

``` js
atlas: {
  type: 'atlas',
  url: "http://localhost:7101"
}
```

Default targets definition looks like this:

``` json
"targets": [
  {
    "query": "(,0h,1w,),(,name,sps,:eq,nf.cluster,nccp-silverlight,:eq,:and,:sum,:swap,:offset,$(name) $(atlas.offset),:legend,),:each"
  }
],
```

See https://github.com/Netflix/atlas for info on Atlas.

Some things to sort out:
- [ ] Data source dropdown goes blank
- [ ] Metrics editor goes blank
- [ ] Test WoW legend support
- [ ] 5m window defaults to 0.1s step size which Atlas doesn't support
- [ ] PNG display
