### PR TITLE
Fix influxdb date range formatting

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -375,7 +375,7 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
       var fromIsAbsolute = from[from.length-1] === 's';
 
       if (until === 'now()' && !fromIsAbsolute) {
-        return 'time > now() - ' + from;
+        return 'time > ' + from;
       }
 
       return 'time > ' + from + ' and time < ' + until;
@@ -387,7 +387,7 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
           return 'now()';
         }
         else if (date.indexOf('now') >= 0) {
-          return date.substring(4);
+          return date.replace('now', 'now()');
         }
 
         date = kbn.parseDate(date);

--- a/src/test/specs/influxdb-datasource-specs.js
+++ b/src/test/specs/influxdb-datasource-specs.js
@@ -17,7 +17,7 @@ define([
     describe('When querying influxdb with one target using query editor target spec', function() {
       var results;
       var urlExpected = "/series?p=mupp&q=select+mean(value)+from+%22test%22"+
-                        "+where+time+%3E+now()+-+1h+group+by+time(1s)+order+asc";
+                        "+where+time+%3E+now()-1h+group+by+time(1s)+order+asc";
       var query = {
         range: { from: 'now-1h', to: 'now' },
         targets: [{ series: 'test', column: 'value', function: 'mean' }],
@@ -50,7 +50,7 @@ define([
     describe('When querying influxdb with one raw query', function() {
       var results;
       var urlExpected = "/series?p=mupp&q=select+value+from+series"+
-                        "+where+time+%3E+now()+-+1h";
+                        "+where+time+%3E+now()-1h";
       var query = {
         range: { from: 'now-1h', to: 'now' },
         targets: [{ query: "select value from series where $timeFilter", rawQuery: true }]
@@ -73,7 +73,7 @@ define([
     describe('When issuing annotation query', function() {
       var results;
       var urlExpected = "/series?p=mupp&q=select+title+from+events.backend_01"+
-                        "+where+time+%3E+now()+-+1h";
+                        "+where+time+%3E+now()-1h";
 
       var range = { from: 'now-1h', to: 'now' };
       var annotation = { query: 'select title from events.$server where $timeFilter' };


### PR DESCRIPTION
While tackling use case 'now-6h-1d', it seems better to use

`replace` instead of `substring(4)`

possible logic error this PR resolves:

`- 6h + now` -> substring(4) may generates wrong syntax
`now - 6h - 1d` -> substring(4) will create `- 6h - 1d`
`now-6h - 1d` -> substring(4) will create `6h - 1d`
