### PR TITLE
Allow for plugin testing.

### DIFF
--- a/src/test/specs/graph-ctrl-specs.js
+++ b/src/test/specs/graph-ctrl-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'panels/graph/module'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/graph-specs.js
+++ b/src/test/specs/graph-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'angular',
   'jquery',
   'components/timeSeries',

--- a/src/test/specs/graphiteDatasource-specs.js
+++ b/src/test/specs/graphiteDatasource-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'services/graphite/graphiteDatasource'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/graphiteTargetCtrl-specs.js
+++ b/src/test/specs/graphiteTargetCtrl-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'services/graphite/gfunc',
   'controllers/graphiteTarget'
 ], function(helpers, gfunc) {

--- a/src/test/specs/influxdb-datasource-specs.js
+++ b/src/test/specs/influxdb-datasource-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'services/influxdb/influxdbDatasource'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/row-ctrl-specs.js
+++ b/src/test/specs/row-ctrl-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'controllers/row'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/seriesOverridesCtrl-specs.js
+++ b/src/test/specs/seriesOverridesCtrl-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'panels/graph/seriesOverridesCtrl'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/sharePanelCtrl-specs.js
+++ b/src/test/specs/sharePanelCtrl-specs.js
@@ -1,5 +1,5 @@
 define([
-  './helpers',
+  'helpers',
   'controllers/sharePanelCtrl'
 ], function(helpers) {
   'use strict';

--- a/src/test/specs/templateValuesSrv-specs.js
+++ b/src/test/specs/templateValuesSrv-specs.js
@@ -1,6 +1,6 @@
 define([
   'mocks/dashboard-mock',
-  './helpers',
+  'helpers',
   'moment',
   'services/templateValuesSrv'
 ], function(dashboardMock, helpers, moment) {

--- a/src/test/specs/timeSrv-specs.js
+++ b/src/test/specs/timeSrv-specs.js
@@ -1,6 +1,6 @@
 define([
   'mocks/dashboard-mock',
-  './helpers',
+  'helpers',
   'lodash',
   'services/timeSrv'
 ], function(dashboardMock, helpers, _) {

--- a/src/test/test-main.js
+++ b/src/test/test-main.js
@@ -4,7 +4,8 @@ require.config({
   paths: {
     specs:                 '../test/specs',
     mocks:                 '../test/mocks',
-    config:                '../config.sample',
+    helpers:               '../test/specs/helpers',
+    config:                ['../config', '../config.sample'],
     kbn:                   'components/kbn',
     store:                 'components/store',
 
@@ -96,9 +97,10 @@ require.config({
 
 require([
   'angular',
+  'config',
   'angularMocks',
   'app',
-], function(angular) {
+], function(angular, config) {
   'use strict';
 
   for (var file in window.__karma__.files) {
@@ -113,7 +115,7 @@ require([
   angular.module('grafana.panels', []);
   angular.module('grafana.filters', []);
 
-  require([
+  var specs = [
     'specs/lexer-specs',
     'specs/parser-specs',
     'specs/gfunc-specs',
@@ -135,9 +137,14 @@ require([
     'specs/kbn-format-specs',
     'specs/dashboardSrv-specs',
     'specs/dashboardViewStateSrv-specs'
-  ], function () {
-    window.__karma__.start();
+  ];
+
+  var pluginSpecs = (config.plugins.specs || []).map(function (spec) {
+    return '../plugins/' + spec;
   });
 
+  require(specs.concat(pluginSpecs), function () {
+    window.__karma__.start();
+  });
 });
 

--- a/tasks/options/jscs.js
+++ b/tasks/options/jscs.js
@@ -3,6 +3,7 @@ module.exports = function(config) {
     src: [
       'Gruntfile.js',
       '<%= srcDir %>/app/**/*.js',
+      '<%= srcDir %>/plugins/**/*.js',
       '!<%= srcDir %>/app/panels/*/{lib,leaflet}/*',
       '!<%= srcDir %>/app/dashboards/*'
     ],


### PR DESCRIPTION
With this change in place you can include plugin specs in `grunt test` by creating a `src/config.js` like that includes something like this:

``` js
      plugins: {
        // list of plugin panels
        panels: [],
        // requirejs modules in plugins folder that should be loaded
        // for example custom datasources
        dependencies: ['grafana-plugins/atlas.Datasource'],
        specs: ['grafana-plugins/specs/atlasDatasource-specs']
      }
```
