### PR TITLE
Bring panel alert to front and move tooltip to top.

### DIFF
--- a/src/app/directives/grafanaPanel.js
+++ b/src/app/directives/grafanaPanel.js
@@ -18,7 +18,7 @@ function (angular, $, config) {
       '<div class="panel-header">'+
           '<span class="alert-error panel-error small pointer"' +
                 'config-modal="app/partials/inspector.html" ng-if="panelMeta.error">' +
-            '<span data-placement="right" bs-tooltip="panelMeta.error">' +
+            '<span data-placement="top" bs-tooltip="panelMeta.error">' +
             '<i class="icon-exclamation-sign"></i><span class="panel-error-arrow"></span>' +
             '</span>' +
           '</span>' +

--- a/src/css/less/panel.less
+++ b/src/css/less/panel.less
@@ -62,6 +62,7 @@
   left: 0;
   padding: 0px 17px 6px 5px;
   top: 0;
+  z-index: 10;
   i {
     position: relative;
     top: -2px;


### PR DESCRIPTION
This makes the panel a lot easier to mouse over without odd visual effects.

So instead of this:
![bad](https://cloud.githubusercontent.com/assets/690/5545218/8f785cb4-8ad0-11e4-8916-6f2cfc97057c.gif)

You get this:
![good](https://cloud.githubusercontent.com/assets/690/5545219/93e7cdc0-8ad0-11e4-8d01-6e4fcb30f6f8.gif)
