### PR TITLE
Allow special characters in column selection

### DIFF
--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -108,6 +108,10 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
             return series.name; // influxdb < 1.7
           });
         }
+      }).then(function(names) {
+        return names.map(function(name) {
+          return name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+        });
       });
     };
 

--- a/src/app/services/influxdb/influxdbDatasource.js
+++ b/src/app/services/influxdb/influxdbDatasource.js
@@ -81,7 +81,9 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
         if (!data) {
           return [];
         }
-        return data[0].columns;
+        return data[0].columns.map(function(item) {
+          return /^\w+$/.test(item) ? item : ('"' + item + '"');
+        });
       });
     };
 


### PR DESCRIPTION
The influxdb query editor is great.
The query editor currently does not propose column names when the series name contain a special character like a '/'.
Also the proposed column names are by this patch properly escaped by the editor.
