### PR TITLE
Add an option to disable loading icon

### DIFF
--- a/src/app/features/dashboard/dashboardSrv.js
+++ b/src/app/features/dashboard/dashboardSrv.js
@@ -27,6 +27,7 @@ function (angular, $, kbn, _, moment) {
       this.editable = data.editable === false ? false : true;
       this.hideControls = data.hideControls || false;
       this.sharedCrosshair = data.sharedCrosshair || false;
+      this.disableLoadingIcon = data.disableLoadingIcon || false;
       this.rows = data.rows || [];
       this.nav = data.nav || [];
       this.time = data.time || { from: 'now-6h', to: 'now' };

--- a/src/app/features/dashboard/panelSrv.js
+++ b/src/app/features/dashboard/panelSrv.js
@@ -99,7 +99,9 @@ function (angular, _) {
           if ($scope.otherPanelInFullscreenMode()) { return; }
 
           delete $scope.panelMeta.error;
-          $scope.panelMeta.loading = true;
+          if (!$scope.dashboard.disableLoadingIcon) {
+            $scope.panelMeta.loading = true;
+          }
 
           panel_get_data();
         };

--- a/src/app/partials/dasheditor.html
+++ b/src/app/partials/dasheditor.html
@@ -75,6 +75,7 @@
 						<label for="pulldown{{pulldown.type}}" class="cr1"></label>
 					</div>
           <editor-opt-bool text="Shared Crosshair (CTRL+O)" model="dashboard.sharedCrosshair"></editor-opt-bool>
+          <editor-opt-bool text="Disable loading icon" model="dashboard.disableLoadingIcon"></editor-opt-bool>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
When autorefresh interval has a small value (less than 5-10s), panel loading icons blink just too much (especially if the dashboard contains many panels).
