### PR TITLE
Restricted suggestions

### DIFF
--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -73,9 +73,7 @@ function (angular, _, kbn) {
     };
 
     OpenTSDBDatasource.prototype.performSuggestQuery = function(query, type, target) {
-
       var that = this;
-      var url = this.url;
       var options = {
         method: 'GET',
         url: this.url + '/api/suggest',
@@ -86,48 +84,51 @@ function (angular, _, kbn) {
 
         }
       };
-      return $http(options).then( function(result) {
+      return $http(options).then(function(result) {
         result.data.sort();
 
-        if ((type == 'metrics' || !target.metric) && _.isEmpty(target.tags))
+        if ((type === 'metrics' || !target.metric) && _.isEmpty(target.tags)) {
           return result.data;
+        }
 
-          return that.performSearchLookup(type, target).then(function(lookupResults) {
-            var output = intersect_safe(that.lastLookupResults, result.data);
-  //        console.log("Lookup Results: " + JSON.stringify(that.lastLookupResults));
-            console.log("Suggest Results: " + JSON.stringify(result.data));
-            console.log("Merged Results: " + JSON.stringify(output));
-            return output;
-          }, function(error) {
-            console.log("Could not performSuggestQuery...");
-            return null;
-          });
+        return that.performSearchLookup(type, target).then(function(lookupResults) {
+          // var output = intersect_safe(that.lastLookupResults, result.data);
+          var output = intersect_safe(lookupResults, result.data);
+          // console.log("Lookup Results: " + JSON.stringify(that.lastLookupResults));
+          // console.log("Suggest Results: " + JSON.stringify(result.data));
+          // console.log("Merged Results: " + JSON.stringify(output));
+          return output;
+        });
       });
     };
-
 
     OpenTSDBDatasource.prototype.performSearchLookup = function(type, target) {
       var that = this;
       var searchTags = [];
       if (!_.isEmpty(target.tags)) {
         _.each(_.pairs(target.tags), function(tag) {
-          searchTags.push(''+ tag[0] + '=' + tag[1]);
+          searchTags.push(tag[0] + '=' + tag[1]);
         });
       }
-      if (type == 'tagv')
-        if (target.currentTagKey)
-          searchTags.push(''+target.currentTagKey+'=*');
-      else if (type == 'tagk')
-        if (target.currentTagValue)
+      if (type === 'tagv') {
+        if (target.currentTagKey) {
+          searchTags.push(target.currentTagKey+'=*');
+        }
+      } else if (type === 'tagk') {
+        if (target.currentTagValue) {
           searchTags.push('*='+target.currentTagValue);
+        }
+      }
 
       var search = '';
-      if (type != 'metrics')
+      if (type !== 'metrics') {
         search += target.metric;
+      }
       search += '{' + searchTags.join(',') + '}';
 
-      if ((type == this.lastLookupType) && (this.lastLookupQuery == search))
+      if ((type === this.lastLookupType) && (this.lastLookupQuery === search)) {
         return this.lastLookupResults;
+      }
       this.lastLookupQuery = search;
       this.lastLookupType = type;
 
@@ -138,28 +139,37 @@ function (angular, _, kbn) {
           m: search
         },
       };
-      console.log(JSON.stringify(options));
+      // console.log(JSON.stringify(options));
 
       return $http(options).then(function(result) {
         // iterate through the results and find all the available/matching tags & values
         var resultSet = new Set();
         _.each(result.data.results, function(lookupResults) {
-          if (type == 'metrics') {
+          if (type === 'metrics') {
             resultSet.add(lookupResults.metric);
           } else {
             _.each(_.pairs(lookupResults.tags), function(tag) {
-              if (type == 'tagk') {
-                if (!target.currentTagValue || (target.currentTagValue == tag[1]))
+              if (type === 'tagk') {
+                if (!target.currentTagValue || (target.currentTagValue === tag[1])) {
                   resultSet.add(tag[0]);
+                }
               } else {
-                if (!target.currentTagKey || (target.currentTagKey == tag[0]))
+                if (!target.currentTagKey || (target.currentTagKey === tag[0])) {
                   resultSet.add(tag[1]);
+                }
               }
-            })
+            });
           }
         });
-        var resultsOut = [v for (v of resultSet)].sort();
-        console.log("Lookup Results: " + JSON.stringify(resultsOut));
+        // Grunt doesn't like this, I guess because its ECMAScript 6?
+        // var resultsOut = [v for (v of resultSet)].sort();
+        var resultsOut = [];
+        resultSet.forEach(function(k,v) {
+          resultsOut.add(v);
+        });
+        resultsOut.sort();
+
+        // console.log("Lookup Results: " + JSON.stringify(resultsOut));
         that.lastLookupResults = resultsOut;
         return resultsOut;
       });
@@ -254,21 +264,21 @@ function (angular, _, kbn) {
       return date.getTime();
     }
 
-    function intersect_safe(a, b)
-    {
+    function intersect_safe(a, b) {
       var ai = 0;
       var bi = 0;
       var result = [];
 
-      while( ai < a.length && bi < b.length ){
-         if      (a[ai] < b[bi] ){ ai++; }
-         else if (a[ai] > b[bi] ){ bi++; }
-         else /* they're equal */
-         {
-           result.push(a[ai]);
-           ai++;
-           bi++;
-         }
+      while(ai < a.length && bi < b.length) {
+        if (a[ai] < b[bi]) {
+          ai++;
+        } else if (a[ai] > b[bi]) {
+          bi++;
+        } else { /* they're equal */
+          result.push(a[ai]);
+          ai++;
+          bi++;
+        }
       }
 
       return result;

--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -175,7 +175,7 @@ function (angular, _, kbn) {
       var match;
       try {
         var parts = expandedQuery.split(/[{}]/);
-        var match = parts[0];
+        match = parts[0];
         if (match.indexOf('*')) {
           // search/lookup doesn't support wildcards, its either a specific metric, or all metrics
           // if there is a wildcard, strip the metric search from the query, but keep it for matching
@@ -202,25 +202,25 @@ function (angular, _, kbn) {
         var resultSet = new Set();
         _.each(searchResult.data.results, function(item) {
           if (type === 'metric') {
-              if ((match === '') || (match === '*')) {
-                resultSet.add(item.metric);
-              } else {
-                var wildPos = match.indexOf('*');
-                if (wildPos != 0) {
-                  var startMatch = match.substring(0, match.indexOf('*'));
-                  var endMatch = match.substring(match.indexOf('*')+1, match.length);
+            if ((match === '') || (match === '*')) {
+              resultSet.add(item.metric);
+            } else {
+              var wildPos = match.indexOf('*');
+              if (wildPos !== 0) {
+                var startMatch = match.substring(0, match.indexOf('*'));
+                var endMatch = match.substring(match.indexOf('*')+1, match.length);
 
-                  var startsWith = (item.metric.indexOf(startMatch) == 0);
-                  var endsWith = (item.metric.indexOf(endMatch, item.metric.length - endMatch.length) !== -1);
-                  if (startsWith && endsWith) {
-                    resultSet.add(item.metric);
-                  }
-                } else if (item.metric === match) {
-                  // this matches only a specific metric name, which isn't very useful
+                var startsWith = (item.metric.indexOf(startMatch) === 0);
+                var endsWith = (item.metric.indexOf(endMatch, item.metric.length - endMatch.length) !== -1);
+                if (startsWith && endsWith) {
                   resultSet.add(item.metric);
                 }
-                // ignore everything else
+              } else if (item.metric === match) {
+                // this matches only a specific metric name, which isn't very useful
+                resultSet.add(item.metric);
               }
+              // ignore everything else
+            }
           } else {
             _.each(_.pairs(item.tags), function(tag) {
               if ((type === 'tagk') && (match === tag[1])) {
@@ -233,19 +233,22 @@ function (angular, _, kbn) {
         });
         // Grunt doesn't like this, I guess because its ECMAScript 6?
         // var resultsOut = [v for (v of resultSet)].sort();
-        return _.map([...resultSet], function(name) {
-          return {
-            text: name,
+        // return _.map([...resultSet], function(name) {
+        var resultsOut = [];
+        resultSet.sort(); // we sort first, because its more work to sort the dict.text property
+        resultSet.forEach(function(k,v) {
+          resultsOut.push({
+            text: v,
             expandable: false
-          };
+          });
         });
+        return resultsOut;
       });
     };
 
     OpenTSDBDatasource.prototype.doSearchLookup = function(type, query, handler) {
       this.lastLookupQuery = query;
       this.lastLookupType = type;
-      var that = this;
 
       var options = {
         method: 'GET',
@@ -254,7 +257,6 @@ function (angular, _, kbn) {
           m: query
         },
       };
-      // console.log(JSON.stringify(options));
 
       return $http(options).then(handler);
     };

--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -235,13 +235,13 @@ function (angular, _, kbn) {
         // var resultsOut = [v for (v of resultSet)].sort();
         // return _.map([...resultSet], function(name) {
         var resultsOut = [];
-        resultSet.sort(); // we sort first, because its more work to sort the dict.text property
         resultSet.forEach(function(k,v) {
           resultsOut.push({
             text: v,
             expandable: false
           });
         });
+        resultsOut.sort();
         return resultsOut;
       });
     };

--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -94,9 +94,10 @@ function (angular, _, kbn) {
         return that.performSearchLookup(type, target).then(function(lookupResults) {
           // var output = intersect_safe(that.lastLookupResults, result.data);
           var output = intersect_safe(lookupResults, result.data);
-          // console.log("Lookup Results: " + JSON.stringify(that.lastLookupResults));
-          // console.log("Suggest Results: " + JSON.stringify(result.data));
-          // console.log("Merged Results: " + JSON.stringify(output));
+          //console.log("lookupResults: " + JSON.stringify(lookupResults));
+          //console.log("that.lastLookupResults: " + JSON.stringify(that.lastLookupResults));
+          //console.log("result.data: " + JSON.stringify(result.data));
+          //console.log("output: " + JSON.stringify(output));
           return output;
         });
       });
@@ -126,22 +127,15 @@ function (angular, _, kbn) {
       }
       search += '{' + searchTags.join(',') + '}';
 
+      // /api/search/lookup can be an expensive operation, so we cache our most recent results and re-use them is possible
       if ((type === this.lastLookupType) && (this.lastLookupQuery === search)) {
-        return this.lastLookupResults;
+        // goofy promise stuff... so we need to wrap up the result in the promise
+        return $q(function(resolve) {
+          resolve(that.lastLookupResults);
+        });
       }
-      this.lastLookupQuery = search;
-      this.lastLookupType = type;
 
-      var options = {
-        method: 'GET',
-        url: this.url + '/api/search/lookup',
-        params: {
-          m: search
-        },
-      };
-      // console.log(JSON.stringify(options));
-
-      return $http(options).then(function(result) {
+      return this.doSearchLookup(type, search, function(result) {
         // iterate through the results and find all the available/matching tags & values
         var resultSet = new Set();
         _.each(result.data.results, function(lookupResults) {
@@ -165,7 +159,7 @@ function (angular, _, kbn) {
         // var resultsOut = [v for (v of resultSet)].sort();
         var resultsOut = [];
         resultSet.forEach(function(k,v) {
-          resultsOut.add(v);
+          resultsOut.push(v);
         });
         resultsOut.sort();
 
@@ -173,6 +167,96 @@ function (angular, _, kbn) {
         that.lastLookupResults = resultsOut;
         return resultsOut;
       });
+    };
+
+    OpenTSDBDatasource.prototype.metricFindQuery = function(query) {
+      var type = 'metric';
+      var expandedQuery = templateSrv.replace(query);
+      var match;
+      try {
+        var parts = expandedQuery.split(/[{}]/);
+        var match = parts[0];
+        if (match.indexOf('*')) {
+          // search/lookup doesn't support wildcards, its either a specific metric, or all metrics
+          // if there is a wildcard, strip the metric search from the query, but keep it for matching
+          expandedQuery='{'+parts[1]+'}';
+        }
+        var tagString = parts[1];
+        tagString.replace(/(\b[^=]+)=(\b[^,]+|\*)/g, function ($0, key, val) {
+          if (val === '*') {
+            match = key;
+            type = 'tagv';
+          } else if (key === '*') {
+            match = val;
+            type = 'tagk';
+          }
+        });
+      }
+      catch (err) {
+        return $q.reject(err);
+      }
+
+      return this.doSearchLookup(type, expandedQuery, function(searchResult) {
+        // iterate through the results and find all the available/matching tags & values
+
+        var resultSet = new Set();
+        _.each(searchResult.data.results, function(item) {
+          if (type === 'metric') {
+              if ((match === '') || (match === '*')) {
+                resultSet.add(item.metric);
+              } else {
+                var wildPos = match.indexOf('*');
+                if (wildPos != 0) {
+                  var startMatch = match.substring(0, match.indexOf('*'));
+                  var endMatch = match.substring(match.indexOf('*')+1, match.length);
+
+                  var startsWith = (item.metric.indexOf(startMatch) == 0);
+                  var endsWith = (item.metric.indexOf(endMatch, item.metric.length - endMatch.length) !== -1);
+                  if (startsWith && endsWith) {
+                    resultSet.add(item.metric);
+                  }
+                } else if (item.metric === match) {
+                  // this matches only a specific metric name, which isn't very useful
+                  resultSet.add(item.metric);
+                }
+                // ignore everything else
+              }
+          } else {
+            _.each(_.pairs(item.tags), function(tag) {
+              if ((type === 'tagk') && (match === tag[1])) {
+                resultSet.add(tag[0]);
+              } else if ((type === 'tagv') && (match === tag[0])) {
+                resultSet.add(tag[1]);
+              }
+            });
+          }
+        });
+        // Grunt doesn't like this, I guess because its ECMAScript 6?
+        // var resultsOut = [v for (v of resultSet)].sort();
+        return _.map([...resultSet], function(name) {
+          return {
+            text: name,
+            expandable: false
+          };
+        });
+      });
+    };
+
+    OpenTSDBDatasource.prototype.doSearchLookup = function(type, query, handler) {
+      this.lastLookupQuery = query;
+      this.lastLookupType = type;
+      var that = this;
+
+      var options = {
+        method: 'GET',
+        url: this.url + '/api/search/lookup',
+        params: {
+          m: query
+        },
+      };
+      // console.log(JSON.stringify(options));
+
+      return $http(options).then(handler);
     };
 
     function transformMetricData(md, groupByTags, options) {

--- a/src/app/features/opentsdb/queryCtrl.js
+++ b/src/app/features/opentsdb/queryCtrl.js
@@ -44,19 +44,19 @@ function (angular, _, kbn) {
 
     $scope.suggestMetrics = function(query, callback) {
       $scope.datasource
-        .performSuggestQuery(query, 'metrics')
+        .performSuggestQuery(query, 'metrics', $scope.$parent.target)
         .then(callback);
     };
 
     $scope.suggestTagKeys = function(query, callback) {
       $scope.datasource
-        .performSuggestQuery(query, 'tagk')
+        .performSuggestQuery(query, 'tagk', $scope.$parent.target)
         .then(callback);
     };
 
     $scope.suggestTagValues = function(query, callback) {
       $scope.datasource
-        .performSuggestQuery(query, 'tagv')
+        .performSuggestQuery(query, 'tagv', $scope.$parent.target)
         .then(callback);
     };
 


### PR DESCRIPTION
Limits the dropdown suggestions for metrics, tag keys, and tag values based on the current metric and 'committed' set of tags.  Additionally, this branch also provides support for templating from OpenTSDB.  Queries look like: [metric]{<tags>}  There can be only ONE wildcard '_' character used for EITHER metric, OR tags which will be used for the populated values.  Ie, *{host=server01} will return all metrics with a tag of 'host' matching 'server01'.  mysql.Connections{host=_} will return a list of hosts which contain the metric 'mysql.Connections'.  Globbing is supported, so 'mysql._' will return all metrics which contain 'mysql.' at the start of the string.  Globbing will also match trailing characters, '_.bytesIn'.
