### PR TITLE
Enable sending dynamic interval to opentsdb

### DIFF
--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -28,10 +28,9 @@ function (angular, _, kbn) {
       if (options.interval.match(/\.[0-9]+s/)) {
         options.interval = parseFloat(options.interval)*1000 + "ms";
       }
-      _.each(options.targets, function(target){
+      _.each(options.targets, function(target) {
           qs.push(convertTargetToQuery(target, options.interval));
-        }
-        );
+      });
       var queries = _.compact(qs);
 
       // No valid targets, return the empty result to save a round trip.

--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -29,7 +29,7 @@ function (angular, _, kbn) {
         options.interval = parseFloat(options.interval)*1000 + "ms";
       }
       _.each(options.targets, function(target) {
-          qs.push(convertTargetToQuery(target, options.interval));
+        qs.push(convertTargetToQuery(target, options.interval));
       });
       var queries = _.compact(qs);
 

--- a/src/app/features/opentsdb/datasource.js
+++ b/src/app/features/opentsdb/datasource.js
@@ -24,9 +24,9 @@ function (angular, _, kbn) {
     OpenTSDBDatasource.prototype.query = function(options) {
       var start = convertToTSDBTime(options.range.from);
       var end = convertToTSDBTime(options.range.to);
-      var qs = Array();
+      var qs = [];
       if (options.interval.match(/\.[0-9]+s/)) {
-        options.interval = parseFloat(options.interval)*1000 + "ms"
+        options.interval = parseFloat(options.interval)*1000 + "ms";
       }
       _.each(options.targets, function(target){
           qs.push(convertTargetToQuery(target, options.interval));
@@ -157,7 +157,8 @@ function (angular, _, kbn) {
       }
 
       if (target.shouldDownsample) {
-        query.downsample = templateSrv.replace(target.downsampleInterval ? target.downsampleInterval : interval ) + "-" + target.downsampleAggregator;
+        var buf =  target.downsampleInterval || interval;
+        query.downsample = templateSrv.replace(buf) + "-" + target.downsampleAggregator;
       }
 
       query.tags = angular.copy(target.tags);


### PR DESCRIPTION
When opentsdb metric has downsample flag set and interval is left empty. Then interval calculated by grafana is used instead. Also opentsdb doesn't support float values, so I hacked around it.
