### PR TITLE
correctly handle event being a ptr

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -32,7 +32,7 @@ type EventBase interface {
 }
 
 func ToOnWriteEvent(event interface{}) (*OnTheWireEvent, error) {
-	eventType := reflect.TypeOf(event)
+	eventType := reflect.TypeOf(event).Elem()
 
 	wireEvent := OnTheWireEvent{
 		Priority:  PRIO_INFO,
@@ -40,7 +40,7 @@ func ToOnWriteEvent(event interface{}) (*OnTheWireEvent, error) {
 		Payload:   event,
 	}
 
-	baseField := reflect.ValueOf(event).FieldByName("Timestamp")
+	baseField := reflect.Indirect(reflect.ValueOf(event)).FieldByName("Timestamp")
 	if baseField.IsValid() {
 		wireEvent.Timestamp = baseField.Interface().(time.Time)
 	} else {


### PR DESCRIPTION
Events are passed in as PTRs, so we need to de-reference when getting the type and value.
