### PR TITLE
Labels and brackets for custom variables

### DIFF
--- a/src/app/features/templating/templateValuesSrv.js
+++ b/src/app/features/templating/templateValuesSrv.js
@@ -80,10 +80,19 @@ function (angular, _, kbn) {
     };
 
     this._updateNonQueryVariable = function(variable) {
-      // extract options in comma seperated string
-      variable.options = _.map(variable.query.split(/[,]+/), function(text) {
-        return { text: text.trim(), value: text.trim() };
-      });
+
+      variable.options = [];
+      var labels = variable.queryLabel ? variable.queryLabel.split(/,/) : [];
+      // split values on commas only if they are not between {}. It allows to create
+      // custom variables that, used on Graphite, can selectively switch groups of metrics
+      var values = variable.query ? variable.query.match(/(\{(?:[^\{]+)*\}|[^,]+)/g) : [];
+      for (var index = 0; index < values.length; index++) {
+        //undefined or empty labels must be filled with values
+        var label = (typeof labels[index] === 'undefined' || labels[index] === '') ?
+            values[index]:
+            labels[index];
+        variable.options.push({ text: label.trim(), value: values[index].trim() });
+      }
 
       if (variable.type === 'interval') {
         self.updateAutoInterval(variable);

--- a/src/app/features/templating/templateValuesSrv.js
+++ b/src/app/features/templating/templateValuesSrv.js
@@ -85,7 +85,7 @@ function (angular, _, kbn) {
       var labels = variable.queryLabel ? variable.queryLabel.split(/,/) : [];
       // split values on commas only if they are not between {}. It allows to create
       // custom variables that, used on Graphite, can selectively switch groups of metrics
-      var values = variable.query ? variable.query.match(/(\{(?:[^\{]+)*\}|[^,]+)/g) : [];
+      var values = variable.query ? variable.query.match(/(\{.*?\}|[^,]+)/g) : [];
       for (var index = 0; index < values.length; index++) {
         //undefined or empty labels must be filled with values
         var label = (typeof labels[index] === 'undefined' || labels[index] === '') ?

--- a/src/app/partials/templating_editor.html
+++ b/src/app/partials/templating_editor.html
@@ -94,6 +94,12 @@
 								<input type="text" class="input-xxlarge" ng-model='current.query' ng-blur="runQuery()" placeholder="1, 10, 20, myvalue"></input>
 							</div>
 						</div>
+						<div class="editor-row">
+							<div class="editor-option">
+								<label class="small">Labels seperated by comma (empty labels will be filled with values)</label>
+								<input type="text" class="input-xxlarge" ng-model='current.queryLabel' ng-blur="runQuery()" placeholder="label1, label10, label20"></input>
+							</div>
+						</div>
 					</div>
 
 					<div ng-show="current.type === 'query'">

--- a/src/test/specs/templateValuesSrv-specs.js
+++ b/src/test/specs/templateValuesSrv-specs.js
@@ -104,6 +104,20 @@ define([
       });
     });
 
+    describeUpdateVariable('update custom variable with brackets', function(scenario) {
+        scenario.setup(function(){
+            scenario.variable = { type: 'custom', query: '{a,b},c', queryLabel: 'login', name: 'test'};    
+        });
+
+        it('should update options array', function() {
+            expect(scenario.variable.options.length).to.be(2);
+            expect(scenario.variable.options[0].value).to.be('{a,b}');
+            expect(scenario.variable.options[0].text).to.be('login');
+            expect(scenario.variable.options[1].value).to.be('c');
+            expect(scenario.variable.options[1].text).to.be('c');
+        });
+    });
+
     describeUpdateVariable('basic query variable', function(scenario) {
       scenario.setup(function() {
         scenario.variable = { type: 'query', query: 'apps.*', name: 'test' };


### PR DESCRIPTION
This patch add two changes to templating:

1) the possibility to specify a label for each custom variables: this is useful when you want to give a meaningful name to a variable that, otherwise, would be dependant on the underling metric name (and sometimes it's too cryptic/context specifc to be easily understandable)

2) the possibility to specify custom variables with enclosed with {}: this is useful in graphite (i don't know about influx or opentsdb) because it allows to select an arbitrary number of metrics, grouping them together and switching them as a single custom variable

![screen shot 2015-02-12 at 12 13 29](https://cloud.githubusercontent.com/assets/5549635/6166648/377617a4-b2b2-11e4-8b5b-f63bdc247ba4.png)
