### PR TITLE
fixes #1481.  correctly escape api_key.key column name

### DIFF
--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -66,7 +66,7 @@ func UpdateApiKey(cmd *m.UpdateApiKeyCommand) error {
 
 func GetApiKeyByKey(query *m.GetApiKeyByKeyQuery) error {
 	var apikey m.ApiKey
-	has, err := x.Where("key=?", query.Key).Get(&apikey)
+	has, err := x.Where("`key`=?", query.Key).Get(&apikey)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
'key' is a reserved word in mysql. So when building a query,
the api-key.key column name needs to be escaped
