### PR TITLE
CLI commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,13 @@ func main() {
 	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
 		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
 		cmd.ListDataSources}
-	app.Flags = append(app.Flags, []cli.Flag{}...)
+	app.Flags = append(app.Flags, []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Value: "grafana.ini",
+			Usage: "path to config file",
+		},
+	}...)
 	app.Run(os.Args)
 
 	log.Close()

--- a/main.go
+++ b/main.go
@@ -31,8 +31,8 @@ func main() {
 	app.Name = "Grafana Backend"
 	app.Usage = "grafana web"
 	app.Version = version
-	app.Commands = []cli.Command{cmd.CmdWeb, cmd.CmdImportJson,
-		cmd.CmdListAccounts, cmd.CmdCreateAccount, cmd.CmdDeleteAccount}
+	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
+		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,8 @@ func main() {
 	app.Name = "Grafana Backend"
 	app.Usage = "grafana web"
 	app.Version = version
-	app.Commands = []cli.Command{cmd.CmdWeb, cmd.CmdImportJson}
+	app.Commands = []cli.Command{cmd.CmdWeb, cmd.CmdImportJson,
+		cmd.CmdListAccounts}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)
 

--- a/main.go
+++ b/main.go
@@ -31,9 +31,11 @@ func main() {
 	app.Name = "Grafana Backend"
 	app.Usage = "grafana web"
 	app.Version = version
-	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
+	app.Commands = []cli.Command{
 		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
-		cmd.ListDataSources, cmd.CreateDataSource, cmd.DescribeDataSource, cmd.DeleteDataSource}
+		cmd.ImportDashboard,
+		cmd.ListDataSources, cmd.CreateDataSource, cmd.DescribeDataSource, cmd.DeleteDataSource,
+		cmd.Web}
 	app.Flags = append(app.Flags, []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	app.Version = version
 	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
 		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
-		cmd.ListDataSources, cmd.DescribeDataSource}
+		cmd.ListDataSources, cmd.CreateDataSource, cmd.DescribeDataSource}
 	app.Flags = append(app.Flags, []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	app.Version = version
 	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
 		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
-		cmd.ListDataSources, cmd.CreateDataSource, cmd.DescribeDataSource}
+		cmd.ListDataSources, cmd.CreateDataSource, cmd.DescribeDataSource, cmd.DeleteDataSource}
 	app.Flags = append(app.Flags, []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	app.Version = version
 	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
 		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
-		cmd.ListDataSources}
+		cmd.ListDataSources, cmd.DescribeDataSource}
 	app.Flags = append(app.Flags, []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	app.Usage = "grafana web"
 	app.Version = version
 	app.Commands = []cli.Command{cmd.CmdWeb, cmd.CmdImportJson,
-		cmd.CmdListAccounts}
+		cmd.CmdListAccounts, cmd.CmdCreateAccount}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)
 

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ func main() {
 	app.Flags = append(app.Flags, []cli.Flag{
 		cli.StringFlag{
 			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
+			Usage: "path to grafana.ini config file",
 		},
 	}...)
 	app.Run(os.Args)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ func main() {
 	app.Usage = "grafana web"
 	app.Version = version
 	app.Commands = []cli.Command{cmd.Web, cmd.ImportJson,
-		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount}
+		cmd.ListAccounts, cmd.CreateAccount, cmd.DeleteAccount,
+		cmd.ListDataSources}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	app.Usage = "grafana web"
 	app.Version = version
 	app.Commands = []cli.Command{cmd.CmdWeb, cmd.CmdImportJson,
-		cmd.CmdListAccounts, cmd.CmdCreateAccount}
+		cmd.CmdListAccounts, cmd.CmdCreateAccount, cmd.CmdDeleteAccount}
 	app.Flags = append(app.Flags, []cli.Flag{}...)
 	app.Run(os.Args)
 

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -12,7 +12,7 @@ import (
 	"text/tabwriter"
 )
 
-var CmdListAccounts = cli.Command{
+var ListAccounts = cli.Command{
 	Name:        "account",
 	Usage:       "list accounts",
 	Description: "Lists the accounts in the system",
@@ -26,7 +26,7 @@ var CmdListAccounts = cli.Command{
 	},
 }
 
-var CmdCreateAccount = cli.Command{
+var CreateAccount = cli.Command{
 	Name:        "account:create",
 	Usage:       "create a new account",
 	Description: "Creates a new account",
@@ -40,7 +40,7 @@ var CmdCreateAccount = cli.Command{
 	},
 }
 
-var CmdDeleteAccount = cli.Command{
+var DeleteAccount = cli.Command{
 	Name:        "account:delete",
 	Usage:       "delete an existing account",
 	Description: "Deletes an existing account",

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -26,6 +26,20 @@ var CmdListAccounts = cli.Command{
 	},
 }
 
+var CmdCreateAccount = cli.Command{
+	Name:        "account:create",
+	Usage:       "create a new account",
+	Description: "Creates a new account",
+	Action:      createAccount,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Value: "grafana.ini",
+			Usage: "path to config file",
+		},
+	},
+}
+
 func listAccounts(c *cli.Context) {
 	setting.NewConfigContext()
 	sqlstore.NewEngine()
@@ -44,4 +58,33 @@ func listAccounts(c *cli.Context) {
 		fmt.Fprintf(w, "%d\t%s\n", account.Id, account.Name)
 	}
 	w.Flush()
+}
+
+func createAccount(c *cli.Context) {
+	setting.NewConfigContext()
+	sqlstore.NewEngine()
+	sqlstore.EnsureAdminUser()
+
+	if !c.Args().Present() {
+		fmt.Printf("Account name arg is required\n")
+		return
+	}
+
+	name := c.Args().First()
+
+	adminQuery := m.GetUserByLoginQuery{LoginOrEmail: setting.AdminUser}
+
+	if err := bus.Dispatch(&adminQuery); err == m.ErrUserNotFound {
+		log.Error(3, "Failed to find default admin user", err)
+		return
+	}
+
+	adminUser := adminQuery.Result
+
+	cmd := m.CreateAccountCommand{Name: name, UserId: adminUser.Id}
+	if err := bus.Dispatch(&cmd); err != nil {
+		log.Error(3, "Failed to create account", err)
+		return
+	}
+	fmt.Printf("Account %s created for admin user %s\n", name, adminUser.Email)
 }

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/codegangsta/cli"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"os"
+	"text/tabwriter"
+)
+
+var CmdListAccounts = cli.Command{
+	Name:        "account",
+	Usage:       "list accounts",
+	Description: "Lists the accounts in the system",
+	Action:      listAccounts,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Value: "grafana.ini",
+			Usage: "path to config file",
+		},
+	},
+}
+
+func listAccounts(c *cli.Context) {
+	setting.NewConfigContext()
+	sqlstore.NewEngine()
+	sqlstore.EnsureAdminUser()
+
+	accountsQuery := m.GetAccountsQuery{}
+	if err := bus.Dispatch(&accountsQuery); err != nil {
+		log.Error(3, "Failed to find accounts", err)
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+
+	fmt.Fprintf(w, "ID\tNAME\n")
+	for _, account := range accountsQuery.Result {
+		fmt.Fprintf(w, "%d\t%s\n", account.Id, account.Name)
+	}
+	w.Flush()
+}

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -43,7 +43,7 @@ func listAccounts(c *cli.Context) {
 		log.ConsoleFatalf("Failed to find accounts: %s", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 8, 1, 4, ' ', 0)
 
 	fmt.Fprintf(w, "ID\tNAME\n")
 	for _, account := range accountsQuery.Result {

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -17,13 +17,6 @@ var ListAccounts = cli.Command{
 	Usage:       "list accounts",
 	Description: "Lists the accounts in the system",
 	Action:      listAccounts,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
-	},
 }
 
 var CreateAccount = cli.Command{
@@ -31,13 +24,6 @@ var CreateAccount = cli.Command{
 	Usage:       "create a new account",
 	Description: "Creates a new account",
 	Action:      createAccount,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
-	},
 }
 
 var DeleteAccount = cli.Command{
@@ -45,13 +31,6 @@ var DeleteAccount = cli.Command{
 	Usage:       "delete an existing account",
 	Description: "Deletes an existing account",
 	Action:      deleteAccount,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
-	},
 }
 
 func listAccounts(c *cli.Context) {

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"os"
 	"text/tabwriter"
@@ -34,9 +33,7 @@ var DeleteAccount = cli.Command{
 }
 
 func listAccounts(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	accountsQuery := m.GetAccountsQuery{}
 	if err := bus.Dispatch(&accountsQuery); err != nil {
@@ -53,9 +50,7 @@ func listAccounts(c *cli.Context) {
 }
 
 func createAccount(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if !c.Args().Present() {
 		log.ConsoleFatal("Account name arg is required")
@@ -80,9 +75,7 @@ func createAccount(c *cli.Context) {
 }
 
 func deleteAccount(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if !c.Args().Present() {
 		log.ConsoleFatal("Account name arg is required")

--- a/pkg/cmd/accounts.go
+++ b/pkg/cmd/accounts.go
@@ -47,8 +47,7 @@ func listAccounts(c *cli.Context) {
 
 	accountsQuery := m.GetAccountsQuery{}
 	if err := bus.Dispatch(&accountsQuery); err != nil {
-		log.Error(3, "Failed to find accounts", err)
-		return
+		log.ConsoleFatalf("Failed to find accounts: %s", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
@@ -66,8 +65,7 @@ func createAccount(c *cli.Context) {
 	sqlstore.EnsureAdminUser()
 
 	if !c.Args().Present() {
-		fmt.Printf("Account name arg is required\n")
-		return
+		log.ConsoleFatal("Account name arg is required")
 	}
 
 	name := c.Args().First()
@@ -75,16 +73,15 @@ func createAccount(c *cli.Context) {
 	adminQuery := m.GetUserByLoginQuery{LoginOrEmail: setting.AdminUser}
 
 	if err := bus.Dispatch(&adminQuery); err == m.ErrUserNotFound {
-		log.Error(3, "Failed to find default admin user", err)
-		return
+		log.ConsoleFatalf("Failed to find default admin user: %s", err)
 	}
 
 	adminUser := adminQuery.Result
 
 	cmd := m.CreateAccountCommand{Name: name, UserId: adminUser.Id}
 	if err := bus.Dispatch(&cmd); err != nil {
-		log.Error(3, "Failed to create account", err)
-		return
+		log.ConsoleFatalf("Failed to create account: %s", err)
 	}
-	fmt.Printf("Account %s created for admin user %s\n", name, adminUser.Email)
+
+	log.ConsoleInfof("Account %s created for admin user %s\n", name, adminUser.Email)
 }

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"github.com/codegangsta/cli"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func initRuntime(c *cli.Context) {
+	setting.NewConfigContext(c.GlobalString("config"))
+	sqlstore.NewEngine()
+	sqlstore.EnsureAdminUser()
+}

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -24,10 +24,6 @@ var ImportJson = cli.Command{
 			Name:  "dir",
 			Usage: "path to folder containing json dashboards",
 		},
-		cli.StringFlag{
-			Name:  "account",
-			Usage: "Account name to save dashboards under",
-		},
 	},
 }
 
@@ -49,11 +45,11 @@ func runImport(c *cli.Context) {
 		return
 	}
 
-	accountName := c.String("account")
-	if len(accountName) == 0 {
-		log.Error(3, "Missing command flag --account")
-		return
+	if !c.Args().Present() {
+		log.ConsoleFatal("Account name arg is required")
 	}
+
+	accountName := c.Args().First()
 
 	setting.NewConfigContext()
 	sqlstore.NewEngine()

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -15,8 +15,8 @@ import (
 )
 
 var ImportJson = cli.Command{
-	Name:        "import-json",
-	Usage:       "grafana import",
+	Name:        "dashboard:import",
+	Usage:       "imports dashboards in JSON from a directory",
 	Description: "Starts Grafana import process",
 	Action:      runImport,
 	Flags: []cli.Flag{

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -10,8 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 var ImportDashboard = cli.Command{
@@ -48,9 +46,7 @@ func runImport(c *cli.Context) {
 
 	accountName := c.Args().First()
 
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	accountQuery := m.GetAccountByNameQuery{Name: accountName}
 	if err := bus.Dispatch(&accountQuery); err != nil {

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -30,19 +30,16 @@ var ImportJson = cli.Command{
 func runImport(c *cli.Context) {
 	dir := c.String("dir")
 	if len(dir) == 0 {
-		log.Error(3, "Missing command flag --dir")
-		return
+		log.ConsoleFatalf("Missing command flag --dir")
 	}
 
 	file, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		log.Error(3, "Directory does not exist: %v", dir)
-		return
+		log.ConsoleFatalf("Directory does not exist: %v", dir)
 	}
 
 	if !file.IsDir() {
-		log.Error(3, "%v is not a directory", dir)
-		return
+		log.ConsoleFatalf("%v is not a directory", dir)
 	}
 
 	if !c.Args().Present() {
@@ -57,8 +54,7 @@ func runImport(c *cli.Context) {
 
 	accountQuery := m.GetAccountByNameQuery{Name: accountName}
 	if err := bus.Dispatch(&accountQuery); err != nil {
-		log.Error(3, "Failed to find account", err)
-		return
+		log.ConsoleFatalf("Failed to find account", err)
 	}
 
 	accountId := accountQuery.Result.Id
@@ -72,19 +68,19 @@ func runImport(c *cli.Context) {
 		}
 		if strings.HasSuffix(f.Name(), ".json") {
 			if err := importDashboard(path, accountId); err != nil {
-				log.Error(3, "Failed to import dashboard file: %v,  err: %v", path, err)
+				log.ConsoleFatalf("Failed to import dashboard file: %v,  err: %v", path, err)
 			}
 		}
 		return nil
 	}
 
 	if err := filepath.Walk(dir, visitor); err != nil {
-		log.Error(3, "failed to scan dir for json files: %v", err)
+		log.ConsoleFatalf("Failed to scan dir for json files: %v", err)
 	}
 }
 
 func importDashboard(path string, accountId int64) error {
-	log.Info("Importing %v", path)
+	log.ConsoleInfof("Importing %v", path)
 
 	reader, err := os.Open(path)
 	if err != nil {

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var ImportJson = cli.Command{
+var ImportDashboard = cli.Command{
 	Name:        "dashboard:import",
 	Usage:       "imports dashboards in JSON from a directory",
 	Description: "Starts Grafana import process",

--- a/pkg/cmd/datasource.go
+++ b/pkg/cmd/datasource.go
@@ -49,7 +49,7 @@ func listDatasources(c *cli.Context) {
 		log.ConsoleFatalf("Failed to find datasources: %s", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 8, 1, 4, ' ', 0)
 
 	fmt.Fprintf(w, "ID\tNAME\tURL\tTYPE\tACCESS\tDEFAULT\n")
 	for _, ds := range query.Result {
@@ -84,7 +84,7 @@ func describeDataSource(c *cli.Context) {
 	}
 	datasource := query.Result
 
-	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 8, 1, 4, ' ', 0)
 	fmt.Fprintf(w, "NAME\t%s\n", datasource.Name)
 	fmt.Fprintf(w, "URL\t%s\n", datasource.Url)
 	fmt.Fprintf(w, "DEFAULT\t%t\n", datasource.IsDefault)

--- a/pkg/cmd/datasource.go
+++ b/pkg/cmd/datasource.go
@@ -12,12 +12,20 @@ import (
 	"text/tabwriter"
 )
 
-var ListDataSources = cli.Command{
-	Name:        "datasource",
-	Usage:       "list datasources",
-	Description: "Lists the datasources in the system",
-	Action:      listDatasources,
-}
+var (
+	ListDataSources = cli.Command{
+		Name:        "datasource",
+		Usage:       "list datasources",
+		Description: "Lists the datasources in the system",
+		Action:      listDatasources,
+	}
+	DescribeDataSource = cli.Command{
+		Name:        "datasource:info",
+		Usage:       "describe the details of a datasource",
+		Description: "Describes the details of a datasource",
+		Action:      describeDataSource,
+	}
+)
 
 func listDatasources(c *cli.Context) {
 	setting.NewConfigContext()
@@ -47,6 +55,49 @@ func listDatasources(c *cli.Context) {
 	for _, ds := range query.Result {
 		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%t\n", ds.Id, ds.Name, ds.Url, ds.Type,
 			ds.Access, ds.IsDefault)
+	}
+	w.Flush()
+}
+
+func describeDataSource(c *cli.Context) {
+	setting.NewConfigContext()
+	sqlstore.NewEngine()
+	sqlstore.EnsureAdminUser()
+
+	if len(c.Args()) != 2 {
+		log.ConsoleFatal("Account and datasource name args are required")
+	}
+
+	name := c.Args().First()
+	ds := c.Args()[1]
+
+	accountQuery := m.GetAccountByNameQuery{Name: name}
+	if err := bus.Dispatch(&accountQuery); err != nil {
+		log.ConsoleFatalf("Failed to find account: %s", err)
+	}
+
+	accountId := accountQuery.Result.Id
+
+	query := m.GetDataSourceByNameQuery{AccountId: accountId, Name: ds}
+	if err := bus.Dispatch(&query); err != nil {
+		log.ConsoleFatalf("Failed to find accounts: %s", err)
+	}
+	datasource := query.Result
+
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+	fmt.Fprintf(w, "NAME\t%s\n", datasource.Name)
+	fmt.Fprintf(w, "URL\t%s\n", datasource.Url)
+	fmt.Fprintf(w, "DEFAULT\t%t\n", datasource.IsDefault)
+	fmt.Fprintf(w, "ACCESS\t%s\n", datasource.Access)
+	fmt.Fprintf(w, "TYPE\t%s\n", datasource.Type)
+
+	switch datasource.Type {
+	case m.DS_INFLUXDB:
+		fmt.Fprintf(w, "DATABASE\t%s\n", datasource.Database)
+		fmt.Fprintf(w, "DB USER\t%s\n", datasource.User)
+		fmt.Fprintf(w, "DB PASSWORD\t%s\n", datasource.Password)
+	case m.DS_ES:
+		fmt.Fprintf(w, "INDEX\t%s\n", datasource.Database)
 	}
 	w.Flush()
 }

--- a/pkg/cmd/datasource.go
+++ b/pkg/cmd/datasource.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/codegangsta/cli"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"os"
+	"text/tabwriter"
+)
+
+var ListDataSources = cli.Command{
+	Name:        "datasource",
+	Usage:       "list datasources",
+	Description: "Lists the datasources in the system",
+	Action:      listDatasources,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "config",
+			Value: "grafana.ini",
+			Usage: "path to config file",
+		},
+	},
+}
+
+func listDatasources(c *cli.Context) {
+	setting.NewConfigContext()
+	sqlstore.NewEngine()
+	sqlstore.EnsureAdminUser()
+
+	if !c.Args().Present() {
+		log.ConsoleFatal("Account name arg is required")
+	}
+
+	name := c.Args().First()
+	accountQuery := m.GetAccountByNameQuery{Name: name}
+	if err := bus.Dispatch(&accountQuery); err != nil {
+		log.ConsoleFatalf("Failed to find account: %s", err)
+	}
+
+	accountId := accountQuery.Result.Id
+
+	query := m.GetDataSourcesQuery{AccountId: accountId}
+	if err := bus.Dispatch(&query); err != nil {
+		log.ConsoleFatalf("Failed to find datasources: %s", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 4, ' ', 0)
+
+	fmt.Fprintf(w, "ID\tNAME\tURL\tTYPE\tACCESS\tDEFAULT\n")
+	for _, ds := range query.Result {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%t\n", ds.Id, ds.Name, ds.Url, ds.Type,
+			ds.Access, ds.IsDefault)
+	}
+	w.Flush()
+}

--- a/pkg/cmd/datasource.go
+++ b/pkg/cmd/datasource.go
@@ -6,8 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 	"os"
 	"text/tabwriter"
 )
@@ -69,9 +67,7 @@ var (
 )
 
 func createDataSource(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if len(c.Args()) != 3 {
 		log.ConsoleFatal("Missing required arguments")
@@ -131,9 +127,7 @@ func createDataSource(c *cli.Context) {
 }
 
 func listDatasources(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if !c.Args().Present() {
 		log.ConsoleFatal("Account name arg is required")
@@ -163,9 +157,7 @@ func listDatasources(c *cli.Context) {
 }
 
 func describeDataSource(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if len(c.Args()) != 2 {
 		log.ConsoleFatal("Account and datasource name args are required")
@@ -206,9 +198,7 @@ func describeDataSource(c *cli.Context) {
 }
 
 func deleteDataSource(c *cli.Context) {
-	setting.NewConfigContext()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
+	initRuntime(c)
 
 	if len(c.Args()) != 2 {
 		log.ConsoleFatal("Account and datasource name args are required")

--- a/pkg/cmd/datasource.go
+++ b/pkg/cmd/datasource.go
@@ -17,13 +17,6 @@ var ListDataSources = cli.Command{
 	Usage:       "list datasources",
 	Description: "Lists the datasources in the system",
 	Action:      listDatasources,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
-	},
 }
 
 func listDatasources(c *cli.Context) {

--- a/pkg/cmd/import.go
+++ b/pkg/cmd/import.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var CmdImportJson = cli.Command{
+var ImportJson = cli.Command{
 	Name:        "import-json",
 	Usage:       "grafana import",
 	Description: "Starts Grafana import process",

--- a/pkg/cmd/import.go
+++ b/pkg/cmd/import.go
@@ -28,11 +28,6 @@ var ImportJson = cli.Command{
 			Name:  "account",
 			Usage: "Account name to save dashboards under",
 		},
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
 	},
 }
 

--- a/pkg/cmd/web.go
+++ b/pkg/cmd/web.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/services/eventpublisher"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
 )
@@ -71,10 +70,9 @@ func runWeb(c *cli.Context) {
 	log.Info("Starting Grafana")
 	log.Info("Version: %v, Commit: %v, Build date: %v", setting.BuildVersion, setting.BuildCommit, time.Unix(setting.BuildStamp, 0))
 
-	setting.NewConfigContext()
+	initRuntime(c)
+
 	social.NewOAuthService()
-	sqlstore.NewEngine()
-	sqlstore.EnsureAdminUser()
 	eventpublisher.Init()
 
 	var err error

--- a/pkg/cmd/web.go
+++ b/pkg/cmd/web.go
@@ -27,13 +27,6 @@ var Web = cli.Command{
 	Usage:       "grafana web",
 	Description: "Starts Grafana backend & web server",
 	Action:      runWeb,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "config",
-			Value: "grafana.ini",
-			Usage: "path to config file",
-		},
-	},
 }
 
 func newMacaron() *macaron.Macaron {

--- a/pkg/cmd/web.go
+++ b/pkg/cmd/web.go
@@ -22,7 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/social"
 )
 
-var CmdWeb = cli.Command{
+var Web = cli.Command{
 	Name:        "web",
 	Usage:       "grafana web",
 	Description: "Starts Grafana backend & web server",

--- a/pkg/log/console.go
+++ b/pkg/log/console.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"runtime"
@@ -21,15 +22,26 @@ func NewBrush(color string) Brush {
 	}
 }
 
-var colors = []Brush{
-	NewBrush("1;36"), // Trace      cyan
-	NewBrush("1;34"), // Debug      blue
-	NewBrush("1;32"), // Info       green
-	NewBrush("1;33"), // Warn       yellow
-	NewBrush("1;31"), // Error      red
-	NewBrush("1;35"), // Critical   purple
-	NewBrush("1;31"), // Fatal      red
-}
+var (
+	Red    = NewBrush("1;31")
+	Purple = NewBrush("1;35")
+	Yellow = NewBrush("1;33")
+	Green  = NewBrush("1;32")
+	Blue   = NewBrush("1;34")
+	Cyan   = NewBrush("1;36")
+
+	colors = []Brush{
+		Cyan,   // Trace      cyan
+		Blue,   // Debug      blue
+		Green,  // Info       green
+		Yellow, // Warn       yellow
+		Red,    // Error      red
+		Purple, // Critical   purple
+		Red,    // Fatal      red
+	}
+	consoleWriter = &ConsoleWriter{lg: log.New(os.Stdout, "", 0),
+		Level: TRACE}
+)
 
 // ConsoleWriter implements LoggerInterface and writes messages to terminal.
 type ConsoleWriter struct {
@@ -66,6 +78,76 @@ func (_ *ConsoleWriter) Flush() {
 }
 
 func (_ *ConsoleWriter) Destroy() {
+}
+
+func printConsole(level int, msg string) {
+	consoleWriter.WriteMsg(msg, 0, level)
+}
+
+func printfConsole(level int, format string, v ...interface{}) {
+	consoleWriter.WriteMsg(fmt.Sprintf(format, v...), 0, level)
+}
+
+// ConsoleTrace prints to stdout using TRACE colors
+func ConsoleTrace(s string) {
+	printConsole(TRACE, s)
+}
+
+// ConsoleTracef prints a formatted string to stdout using TRACE colors
+func ConsoleTracef(format string, v ...interface{}) {
+	printfConsole(TRACE, format, v...)
+}
+
+// ConsoleDebug prints to stdout using DEBUG colors
+func ConsoleDebug(s string) {
+	printConsole(DEBUG, s)
+}
+
+// ConsoleDebugf prints a formatted string to stdout using DEBUG colors
+func ConsoleDebugf(format string, v ...interface{}) {
+	printfConsole(DEBUG, format, v...)
+}
+
+// ConsoleInfo prints to stdout using INFO colors
+func ConsoleInfo(s string) {
+	printConsole(INFO, s)
+}
+
+// ConsoleInfof prints a formatted string to stdout using INFO colors
+func ConsoleInfof(format string, v ...interface{}) {
+	printfConsole(INFO, format, v...)
+}
+
+// ConsoleWarn prints to stdout using WARN colors
+func ConsoleWarn(s string) {
+	printConsole(WARN, s)
+}
+
+// ConsoleWarnf prints a formatted string to stdout using WARN colors
+func ConsoleWarnf(format string, v ...interface{}) {
+	printfConsole(WARN, format, v...)
+}
+
+// ConsoleError prints to stdout using ERROR colors
+func ConsoleError(s string) {
+	printConsole(ERROR, s)
+}
+
+// ConsoleErrorf prints a formatted string to stdout using ERROR colors
+func ConsoleErrorf(format string, v ...interface{}) {
+	printfConsole(ERROR, format, v...)
+}
+
+// ConsoleFatal prints to stdout using FATAL colors
+func ConsoleFatal(s string) {
+	printConsole(FATAL, s)
+	os.Exit(1)
+}
+
+// ConsoleFatalf prints a formatted string to stdout using FATAL colors
+func ConsoleFatalf(format string, v ...interface{}) {
+	printfConsole(FATAL, format, v...)
+	os.Exit(1)
 }
 
 func init() {

--- a/pkg/log/console.go
+++ b/pkg/log/console.go
@@ -40,7 +40,7 @@ type ConsoleWriter struct {
 // create ConsoleWriter returning as LoggerInterface.
 func NewConsole() LoggerInterface {
 	return &ConsoleWriter{
-		lg:    log.New(os.Stdout, "", log.Ldate|log.Ltime),
+		lg:    log.New(os.Stderr, "", log.Ldate|log.Ltime),
 		Level: TRACE,
 	}
 }

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -49,6 +49,10 @@ type GetAccountByNameQuery struct {
 	Result *Account
 }
 
+type GetAccountsQuery struct {
+	Result []*Account
+}
+
 type AccountDTO struct {
 	Id   int64  `json:"id"`
 	Name string `json:"name"`

--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -29,6 +29,10 @@ type CreateAccountCommand struct {
 	Result Account `json:"-"`
 }
 
+type DeleteAccountCommand struct {
+	Id int64
+}
+
 type UpdateAccountCommand struct {
 	Name      string `json:"name" binding:"Required"`
 	AccountId int64  `json:"-"`

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -93,6 +93,12 @@ type GetDataSourceByIdQuery struct {
 	Result    DataSource
 }
 
+type GetDataSourceByNameQuery struct {
+	Name      string
+	AccountId int64
+	Result    DataSource
+}
+
 // ---------------------
 // EVENTS
 type DataSourceCreatedEvent struct {

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -9,6 +9,7 @@ const (
 	DS_GRAPHITE      = "graphite"
 	DS_INFLUXDB      = "influxdb"
 	DS_ES            = "elasticsearch"
+	DS_OPENTSDB      = "opentsdb"
 	DS_ACCESS_DIRECT = "direct"
 	DS_ACCESS_PROXY  = "proxy"
 )

--- a/pkg/services/sqlstore/account.go
+++ b/pkg/services/sqlstore/account.go
@@ -14,6 +14,11 @@ func init() {
 	bus.AddHandler("sql", SetUsingAccount)
 	bus.AddHandler("sql", UpdateAccount)
 	bus.AddHandler("sql", GetAccountByName)
+	bus.AddHandler("sql", GetAccountsQuery)
+}
+
+func GetAccountsQuery(query *m.GetAccountsQuery) error {
+	return x.Find(&query.Result)
 }
 
 func GetAccountById(query *m.GetAccountByIdQuery) error {

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -15,10 +15,21 @@ func init() {
 	bus.AddHandler("sql", DeleteDataSource)
 	bus.AddHandler("sql", UpdateDataSource)
 	bus.AddHandler("sql", GetDataSourceById)
+	bus.AddHandler("sql", GetDataSourceByName)
 }
 
 func GetDataSourceById(query *m.GetDataSourceByIdQuery) error {
 	sess := x.Limit(100, 0).Where("account_id=? AND id=?", query.AccountId, query.Id)
+	has, err := sess.Get(&query.Result)
+
+	if !has {
+		return m.ErrDataSourceNotFound
+	}
+	return err
+}
+
+func GetDataSourceByName(query *m.GetDataSourceByNameQuery) error {
+	sess := x.Limit(100, 0).Where("account_id=? AND name=?", query.AccountId, query.Name)
 	has, err := sess.Get(&query.Result)
 
 	if !has {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -164,8 +164,12 @@ func loadEnvVariableOverrides() {
 	}
 }
 
-func NewConfigContext() {
+func NewConfigContext(config string) {
 	configFiles := findConfigFiles()
+
+	if config != "" {
+		configFiles = append(configFiles, config)
+	}
 
 	//log.Info("Loading config files: %v", configFiles)
 	var err error

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -15,7 +15,7 @@ func TestLoadingSettings(t *testing.T) {
 	Convey("Testing loading settings from ini file", t, func() {
 
 		Convey("Given the default ini files", func() {
-			NewConfigContext()
+			NewConfigContext("")
 
 			So(AppName, ShouldEqual, "Grafana")
 			So(AdminUser, ShouldEqual, "admin")
@@ -23,7 +23,7 @@ func TestLoadingSettings(t *testing.T) {
 
 		Convey("Should be able to override via environment variables", func() {
 			os.Setenv("GF_SECURITY_ADMIN_USER", "superduper")
-			NewConfigContext()
+			NewConfigContext("")
 
 			So(AdminUser, ShouldEqual, "superduper")
 		})


### PR DESCRIPTION
This PR adds some additional CLI commands for managing accounts and data sources which should make it easier to automate the setup of grafana when using configuration management tools.  It also adds some structure to the sub-commands that should make it easier to extend in a understandable manner.  The format is similar to the heroku CLI.

The following sub-commands are added:
- `account` - list accounts
- `account:create` - create a new account
- `account:delete` - delete an existing account
- `dashboard:import` - imports dashboards in JSON from a directory (rename of exising `import-json` command)
- `datasource` - list datasources
- `datasource:create` - creates a new datasource
- `datasource:info` - describe the details of a datasource
- `datasource:delete` - Deletes a datasource

```
```
