### PR TITLE
Default username for InfluxDB is root, not admin

### DIFF
--- a/src/config.sample.js
+++ b/src/config.sample.js
@@ -22,14 +22,14 @@ define(['settings'], function(Settings) {
         influxdb: {
           type: 'influxdb',
           url: "http://my_influxdb_server:8086/db/database_name",
-          username: 'admin',
-          password: 'admin',
+          username: 'root',
+          password: 'root',
         },
         grafana: {
           type: 'influxdb',
           url: "http://my_influxdb_server:8086/db/grafana",
-          username: 'admin',
-          password: 'admin',
+          username: 'root',
+          password: 'root',
           grafanaDB: true
         },
       },


### PR DESCRIPTION
Reduce friction for first time users. The sample config specifies admin/admin to connect to InfluxDB, this doesn't work for a default InfluxDB install:

http://influxdb.com/docs/v0.8/introduction/getting_started.html
