### PR TITLE
Fix https - cert and key need separate files

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -198,7 +198,7 @@ func NewConfigContext(config string) {
 	if server.Key("protocol").MustString("http") == "https" {
 		Protocol = HTTPS
 		CertFile = server.Key("cert_file").String()
-		KeyFile = server.Key("cert_file").String()
+		KeyFile = server.Key("cert_key_file").String()
 	}
 
 	Domain = server.Key("domain").MustString("localhost")


### PR DESCRIPTION
This change was needed to make the protocol = https work
