### PR TITLE
Add dashboards:export CLI command

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 		cmd.ListOrgs,
 		cmd.CreateOrg,
 		cmd.DeleteOrg,
+		cmd.ExportDashboard,
 		cmd.ImportDashboard,
 		cmd.ListDataSources,
 		cmd.CreateDataSource,


### PR DESCRIPTION
Allows exporting all dashboards to a --dir or filtering dashboards
by title.  If no --dir is specified, a single dashboard must be
found and it will be sent to stdout which can be piped to a file.

Fixes #1498
