### PR TITLE
WIP: provide timeseries marking editor for backtesting

### DIFF
--- a/src/app/features/annotations/annotationsSrv.js
+++ b/src/app/features/annotations/annotationsSrv.js
@@ -10,18 +10,29 @@ define([
 
   module.service('annotationsSrv', function(datasourceSrv, $q, alertSrv, $rootScope, $sanitize) {
     var promiseCached;
-    var list = [];
+    var list = []; // for point in time annotations
+    var markings = []; // for regions
     var timezone;
     var self = this;
 
     this.init = function() {
       $rootScope.onAppEvent('refresh', this.clearCache);
       $rootScope.onAppEvent('setup-dashboard', this.clearCache);
+      $rootScope.onAppEvent('marked-region', this.saveAndAddMarking);
     };
 
     this.clearCache = function() {
       promiseCached = null;
       list = [];
+      markings = [];
+    };
+
+    this.saveAndAddMarking = function(marking) {
+      self.addMarking(marking);
+      dataSourceSrv.get("es").then(function(datasource) {
+          return datasource.saveMarking(marking)
+          .then(null, markingsErrorHandler);
+        }, this);
     };
 
     this.getAnnotations = function(rangeUnparsed, dashboard) {
@@ -44,6 +55,19 @@ define([
         }, this);
       });
 
+      var marking = {
+        datasource :"es"
+      }
+
+      promises.push(
+        dataSourceSrv.get(marking.datasource).then(function(datasource) {
+          return datasource.markingsQuery(marking, rangeUnparsed)
+          .then(self.receiveMarkingsResults)
+          .then(null, markingsErrorHandler);
+        }, this)
+      );
+
+
       promiseCached = $q.all(promises)
         .then(function() {
           return list;
@@ -57,11 +81,22 @@ define([
         addAnnotation(results[i]);
       }
     };
+    this.receiveMarkingsResults = function(results) {
+      for (var i = 0; i < results.length; i++) {
+        addMarking(results[i]);
+      }
+    };
 
     function errorHandler(err) {
       console.log('Annotation error: ', err);
       var message = err.message || "Annotation query failed";
       alertSrv.set('Annotations error', message,'error');
+    }
+
+    function markingsErrorHandler(err) {
+      console.log('Markings error: ', err);
+      var message = err.message || "Markings query failed";
+      alertSrv.set('Markings error', message,'error');
     }
 
     function addAnnotation(options) {
@@ -94,6 +129,21 @@ define([
         title: null,
         description: tooltip,
         score: 1
+      });
+    }
+
+    this.addMarking = function(options) {
+      var colors = {
+        ok: "#003300",
+        warn:"#B26B00",
+        crit: "#880000"
+      }
+      markings.push({
+        xaxis: {
+          from: options.from,
+          to:options.to
+        },
+        color: colors[options.state]
       });
     }
 

--- a/src/app/features/panel/panelMenu.js
+++ b/src/app/features/panel/panelMenu.js
@@ -14,7 +14,10 @@ function (angular, $, _) {
             '<span class="panel-title-text drag-handle">{{panel.title | interpolateTemplateVars}}</span>' +
             '<span class="panel-links-icon"></span>' +
             '<span class="panel-time-info" ng-show="panelMeta.timeInfo"><i class="fa fa-clock-o"></i> {{panelMeta.timeInfo}}</span>' +
-          '</span>';
+          '</span>' +
+            '<div id="panel-title-mark-ok" style="background-color:#003300;">mark-OK</div>' +
+            '<div id="panel-title-mark-warn" style="background-color:#B26B00;">mark-WARN</div>' +
+            '<div id="panel-title-mark-crit" style="background-color:#880000;">mark-CRIT</div>';
 
       function createMenuTemplate($scope) {
         var template = '<div class="panel-menu small">';

--- a/src/app/panels/graph/graph.js
+++ b/src/app/panels/graph/graph.js
@@ -153,6 +153,22 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
 
           var panel = scope.panel;
           var stack = panel.stack ? true : null;
+          var colors = {
+            ok: "#003300",
+            warn:"#B26B00",
+            crit: "#880000"
+          }
+          var markings = [];
+          for (i = 0; i <panel.grid.markings.length; i++) {
+            var m = panel.grid.markings[i];
+            markings.push({
+              xaxis: {
+                from: m.from,
+                to:m.to
+              },
+              color: colors[m.state]
+            });
+          }
 
           // Populate element
           var options = {
@@ -197,7 +213,7 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
               hoverable: true,
               color: '#c8c8c8',
               margin: { left: 0, right: 0 },
-              markings: panel.grid.markings
+              markings: markings
             },
             selection: {
               mode: "x",
@@ -454,16 +470,16 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
           return sortedSeries;
         });
         elem.bind("plotselected", function (event, ranges) {
-                var colors = {
-                ok: "#003300",
-                warn:"#B26B00",
-                crit: "#880000",
-              }
           scope.$apply(function() {
             if (ranges.mark ) {
-              scope.panel.grid.markings.push({xaxis: { from: ranges.xaxis.from, to:ranges.xaxis.to }, color: colors[ranges.mark]});
+              scope.panel.grid.markings.push({
+                from: ranges.xaxis.from,
+                to:ranges.xaxis.to,
+                state: ranges.mark
+              });
               scope.$broadcast("render");
-            } else {            timeSrv.setTime({
+            } else {
+              timeSrv.setTime({
               from  : moment.utc(ranges.xaxis.from).toDate(),
               to    : moment.utc(ranges.xaxis.to).toDate(),
             });

--- a/src/app/panels/graph/graph.js
+++ b/src/app/panels/graph/graph.js
@@ -197,6 +197,7 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
               hoverable: true,
               color: '#c8c8c8',
               margin: { left: 0, right: 0 },
+              markings: panel.grid.markings
             },
             selection: {
               mode: "x",
@@ -237,7 +238,6 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
               console.log('flotcharts error', e);
             }
           }
-
           if (shouldDelayDraw(panel)) {
             // temp fix for legends on the side, need to render twice to get dimensions right
             callPlot();
@@ -453,13 +453,21 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
         new GraphTooltip(elem, dashboard, scope, function() {
           return sortedSeries;
         });
-
         elem.bind("plotselected", function (event, ranges) {
+                var colors = {
+                ok: "#003300",
+                warn:"#B26B00",
+                crit: "#880000",
+              }
           scope.$apply(function() {
-            timeSrv.setTime({
+            if (ranges.mark ) {
+              scope.panel.grid.markings.push({xaxis: { from: ranges.xaxis.from, to:ranges.xaxis.to }, color: colors[ranges.mark]});
+              scope.$broadcast("render");
+            } else {            timeSrv.setTime({
               from  : moment.utc(ranges.xaxis.from).toDate(),
               to    : moment.utc(ranges.xaxis.to).toDate(),
             });
+          }
           });
         });
       }

--- a/src/app/panels/graph/graph.js
+++ b/src/app/panels/graph/graph.js
@@ -153,22 +153,6 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
 
           var panel = scope.panel;
           var stack = panel.stack ? true : null;
-          var colors = {
-            ok: "#003300",
-            warn:"#B26B00",
-            crit: "#880000"
-          }
-          var markings = [];
-          for (i = 0; i <panel.grid.markings.length; i++) {
-            var m = panel.grid.markings[i];
-            markings.push({
-              xaxis: {
-                from: m.from,
-                to:m.to
-              },
-              color: colors[m.state]
-            });
-          }
 
           // Populate element
           var options = {
@@ -213,7 +197,6 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
               hoverable: true,
               color: '#c8c8c8',
               margin: { left: 0, right: 0 },
-              markings: markings
             },
             selection: {
               mode: "x",
@@ -353,6 +336,18 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
             types: types
           };
         }
+         function addMarkings(options) {
+          if(!markings || markings.length === 0) {
+            return;
+          }
+          _.each(markings, function(event) {
+             options.grid.markings.push({
+                color: "green",
+                lineWidth: 1,
+                xaxis: { from: event.min, to: event.max }
+            });
+          });
+        }
 
         function configureAxisOptions(data, options) {
           var defaults = {
@@ -472,12 +467,11 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
         elem.bind("plotselected", function (event, ranges) {
           scope.$apply(function() {
             if (ranges.mark ) {
-              scope.panel.grid.markings.push({
+              scope.appEvent("marked-region", {
                 from: ranges.xaxis.from,
                 to:ranges.xaxis.to,
                 state: ranges.mark
               });
-              scope.$broadcast("render");
             } else {
               timeSrv.setTime({
               from  : moment.utc(ranges.xaxis.from).toDate(),

--- a/src/app/panels/graph/graph.tooltip.js
+++ b/src/app/panels/graph/graph.tooltip.js
@@ -96,7 +96,7 @@ function ($) {
       var plot = elem.data().plot;
       var plotData = plot.getData();
       var seriesList = getSeriesFn();
-      var group, value, timestamp, hoverInfo, i, series, seriesHtml;
+      var toolHtml, value, timestamp, hoverInfo, i, series;
 
       if(dashboard.sharedCrosshair){
         scope.appEvent('setCrosshair',  { pos: pos, scope: scope });
@@ -106,12 +106,13 @@ function ($) {
         return;
       }
 
+      toolHtml = '';
       if (scope.panel.tooltip.shared) {
         plot.unhighlight();
 
         var seriesHoverInfo = self.getMultiSeriesPlotHoverInfo(plotData, pos);
 
-        seriesHtml = '';
+
         timestamp = dashboard.formatDate(seriesHoverInfo.time);
 
         for (i = 0; i < seriesHoverInfo.length; i++) {
@@ -124,19 +125,20 @@ function ($) {
           series = seriesList[i];
           value = series.formatValue(hoverInfo.value);
 
-          seriesHtml += '<div class="graph-tooltip-list-item"><div class="graph-tooltip-series-name">';
-          seriesHtml += '<i class="fa fa-minus" style="color:' + series.color +';"></i> ' + series.label + ':</div>';
-          seriesHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';
+          toolHtml += '<div class="graph-tooltip-list-item"><div class="graph-tooltip-series-name">';
+          toolHtml += '<i class="fa fa-minus" style="color:' + series.color +';"></i> ' + series.label + ':</div>';
+          toolHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';
+
+
           plot.highlight(i, hoverInfo.hoverIndex);
         }
 
-        self.showTooltip(timestamp, seriesHtml, pos);
       }
       // single series tooltip
       else if (item) {
         series = seriesList[item.seriesIndex];
-        group = '<div class="graph-tooltip-list-item"><div class="graph-tooltip-series-name">';
-        group += '<i class="fa fa-minus" style="color:' + item.series.color +';"></i> ' + series.label + ':</div>';
+        toolHtml += '<div class="graph-tooltip-list-item"><div class="graph-tooltip-series-name">';
+        toolHtml += '<i class="fa fa-minus" style="color:' + item.series.color +';"></i> ' + series.label + ':</div>';
 
         if (scope.panel.stack && scope.panel.tooltip.value_type === 'individual') {
           value = item.datapoint[1] - item.datapoint[2];
@@ -147,14 +149,26 @@ function ($) {
 
         value = series.formatValue(value);
         timestamp = dashboard.formatDate(item.datapoint[0]);
-        group += '<div class="graph-tooltip-value">' + value + '</div>';
+        toolHtml += '<div class="graph-tooltip-value">' + value + '</div>';
+        toolHtml += '</div>';
 
-        self.showTooltip(timestamp, group, pos);
       }
-      // no hit
-      else {
-        $tooltip.detach();
+      if(toolHtml) {
+        toolHtml += '<br>Active markings:'
+
+        for(i = 0; i < scope.panel.grid.markings.length; i++) {
+        var m = scope.panel.grid.markings[i]
+        if (pos.x >= m.from && pos.x <= m.to) {
+          // should probably precompute the human friendly datetimes
+          toolHtml += '<br/>' + dashboard.formatDate(m.from) + " - " + dashboard.formatDate(m.to) + ": " + m.state + '<a href="del">delete</a>';
+        }
       }
+      self.showTooltip(timestamp, toolHtml, pos);
+                          // no hit
+                        } else {
+                          $tooltip.detach();
+                        }
+
     });
   }
 

--- a/src/app/panels/graph/module.js
+++ b/src/app/panels/graph/module.js
@@ -60,7 +60,8 @@ function (angular, app, $, _, kbn, moment, TimeSeries, PanelMeta) {
         threshold1: null,
         threshold2: null,
         threshold1Color: 'rgba(216, 200, 27, 0.27)',
-        threshold2Color: 'rgba(234, 112, 112, 0.22)'
+        threshold2Color: 'rgba(234, 112, 112, 0.22)',
+        markings: []
       },
       // show/hide lines
       lines         : true,

--- a/src/vendor/jquery/jquery.flot.selection.js
+++ b/src/vendor/jquery/jquery.flot.selection.js
@@ -143,10 +143,31 @@ The plugin allso adds the following methods to the plot object:
             // no more dragging
             selection.active = false;
             updateSelection(e);
+            function landedOn(ev, el) {
+                boundL = el.offset().left;
+                boundR = el.offset().left + el[0].offsetWidth;
+                boundT = el.offset().top;
+                boundB = el.offset().top + el[0].offsetHeight;
 
-            if (selectionIsSane())
-                triggerSelectedEvent();
-            else {
+                if (e.pageX >= boundL && e.pageX <= boundR && e.pageY >= boundT && e.pageY <= boundB) {
+                    return true;
+                }
+                return false;
+            }
+            // TODO: the coordinates are the ones from the actual mouseup, not from
+            // the on-graph selected area, which stops updating
+            // when you leave the graph. this difference can be confusing.
+            if (selectionIsSane()) {
+                mark = 0;
+                if (landedOn(e, $("#panel-title-mark-ok"))) {
+                    mark = "ok";
+                } else if (landedOn(e, $("#panel-title-mark-warn"))) {
+                    mark = "warn";
+                }else if (landedOn(e, $("#panel-title-mark-crit"))) {
+                    mark = "crit";
+                }
+                 triggerSelectedEvent(mark);
+            } else {
                 // this counts as a clear
                 plot.getPlaceholder().trigger("plotunselected", [ ]);
                 plot.getPlaceholder().trigger("plotselecting", [ null ]);
@@ -171,11 +192,11 @@ The plugin allso adds the following methods to the plot object:
             return r;
         }
 
-        function triggerSelectedEvent() {
+        function triggerSelectedEvent(mark) {
             var r = getSelection();
-
+            if(mark)
+                r.mark = mark;
             plot.getPlaceholder().trigger("plotselected", [ r ]);
-
             // backwards-compat stuff, to be removed in future
             if (r.xaxis && r.yaxis)
                 plot.getPlaceholder().trigger("selected", [ { x1: r.xaxis.from, y1: r.yaxis.from, x2: r.xaxis.to, y2: r.yaxis.to } ]);


### PR DESCRIPTION
the idea is to build a UX to easily annotate historical data as ok/warn/crit.
this means that software that does alerting, fault detection and machine learning can be validated against this historical data (backtesting).
we can even automatically score alerting logic by computing how well its output matches the annotated historical information.
here's a 45second video that quickly shows the UX idea in action:
https://vimeo.com/121497776
#### works :
- selecting frames, marking as warn/ok/... and retaining the state throughout zoom operations. i think i've been able to come up with a fairly elegant way to differentiate against zoom, and mark as ok/warn/crit (for the latter 3, the mouseup should be in the corresponding bar on top)

i'm a newcomer to the grafana codebase, and to UX, i know the current code is not great. i welcome feedback to make this better. in specific i'm currently trying to figure out:
#### next up:
- deleting or adjusting existing annotations (no idea yet how to do this)
- loading and saving annotations to/from ES (slowly reverse engineering codebase)
- currently the markings are saved in the dashboard definition, this is not good. they should only go in an external service such as ES.
- coming up with a way to build out this UX on a per-alerting rule basis (with 1 or more useful series), and leave other panels alone ;)
