### PR TITLE
fix uglify TypeError

### DIFF
--- a/tasks/options/uglify.js
+++ b/tasks/options/uglify.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       cwd: '<%= destDir %>',
       options: {
         quite: true,
-        compress: true,
+        compress: {},
         preserveComments: false,
         banner: '<%= meta.banner %>'
       }


### PR DESCRIPTION
This patch fix the following uglify error:
`TypeError: Cannot assign to read only property 'warnings' of true`
Or we can upgrade grunt-contrib-uglify to latest v0.8.0 version which should also fix the issue.

This issue has been reported on grunt-contrib-uglify bug tracker:
https://github.com/gruntjs/grunt-contrib-uglify/issues/298
