### PR TITLE
always allow manual refresh

### DIFF
--- a/src/app/panels/timepicker/module.html
+++ b/src/app/panels/timepicker/module.html
@@ -48,7 +48,7 @@
         </ul>
 
       </li>
-      <li ng-show="!dashboard.refresh" class="grafana-menu-refresh">
+      <li class="grafana-menu-refresh">
         <a ng-click="timeSrv.refreshDashboard()"><i class="fa fa-refresh"></i></a>
       </li>
     </ul>


### PR DESCRIPTION
Keep the manual refresh button visible even if auto-refresh is enabled on a dashboard.

I often find myself wanting to refresh manually sooner than the set auto-refresh interval and not being able to do so is annoying. It's also an odd difference from Kibana 3 which Grafana's UI is largely modeled after.

This is #1208 rebased to current master.
