### PR TITLE
Limit ElasticSearch to return only title and tags for dashboard search

### DIFF
--- a/src/app/features/elasticsearch/datasource.js
+++ b/src/app/features/elasticsearch/datasource.js
@@ -270,7 +270,8 @@ function (angular, _, config, kbn, moment) {
         query: { query_string: { query: queryString } },
         facets: { tags: { terms: { field: "tags", order: "term", size: 50 } } },
         size: this.searchMaxResults,
-        sort: ["_uid"]
+        sort: ["_uid"],
+        fields: ["title", "tags"]
       };
 
       return this._post('/dashboard/_search', query)
@@ -286,8 +287,8 @@ function (angular, _, config, kbn, moment) {
             var hit = resultsHits[i];
             displayHits.dashboards.push({
               id: hit._id,
-              title: hit._source.title,
-              tags: hit._source.tags
+              title: hit.fields.title,
+              tags: hit.fields.tags
             });
           }
 


### PR DESCRIPTION
Right now ElasticSearch will return the whole dashboard for every result in the search. In our case this returns up to several MBs of documents. This takes a lot of time on slower connections (even on our office WiFi it's quite noticeable) and it'll take a lot of time to parse all this stuff even though only title and tags are used.
This change limits search to return fields title and tags only.

Below is a comparison in the search time and size (left old code, right new code) for the same search

![search_time](https://cloud.githubusercontent.com/assets/273236/6801691/67fa5736-d22a-11e4-835f-e63c00f44531.png)
