### PR TITLE
Add spinner to search & give feedback on search errors

### DIFF
--- a/src/app/controllers/search.js
+++ b/src/app/controllers/search.js
@@ -83,7 +83,7 @@ function (angular, _, config, $) {
       // bookeeping for determining stale search requests
       var searchId = $scope.currentSearchId + 1;
       $scope.currentSearchId = searchId > $scope.currentSearchId ? searchId : $scope.currentSearchId;
-
+      $scope.searchLoading=true;
       return $scope.db.searchDashboards(queryString)
         .then(function(results) {
           // since searches are async, it's possible that these results are not for the latest search. throw
@@ -91,6 +91,7 @@ function (angular, _, config, $) {
           if (searchId < $scope.currentSearchId) {
             return;
           }
+          $scope.searchLoading=false;
 
           $scope.tagsOnly = results.tagsOnly;
           $scope.results.dashboards = results.dashboards;

--- a/src/app/features/elasticsearch/datasource.js
+++ b/src/app/features/elasticsearch/datasource.js
@@ -294,7 +294,7 @@ function (angular, _, config, kbn, moment) {
           displayHits.tagsOnly = tagsOnly;
           return displayHits;
         },
-        function(reason) {return {dashboards: [], tags: []}});
+        function() {return {dashboards: [], tags: []};});
     };
 
     return ElasticDatasource;

--- a/src/app/features/elasticsearch/datasource.js
+++ b/src/app/features/elasticsearch/datasource.js
@@ -293,7 +293,8 @@ function (angular, _, config, kbn, moment) {
 
           displayHits.tagsOnly = tagsOnly;
           return displayHits;
-        });
+        },
+        function(reason) {return {dashboards: [], tags: []}});
     };
 
     return ElasticDatasource;

--- a/src/app/partials/search.html
+++ b/src/app/partials/search.html
@@ -2,7 +2,10 @@
 
 	<div class="dashboard-editor-header">
 		<div class="dashboard-editor-title" style="border: 0; line-height: 41px;">
-			<i class="fa fa-search"></i>
+			<span class="fa">
+				<i class="fa fa-spinner fa-spin" ng-show="searchLoading == true"></i>
+				<i class="fa fa-search" ng-show="searchLoading == false"></i>
+			</span>
 			Search
 		</div>
 


### PR DESCRIPTION
Change the looking glass of the search to a spinner while search is being performed.
Add callback to show empty result set when an error occurs during the search.

![image](https://cloud.githubusercontent.com/assets/273236/6801315/d46d1128-d226-11e4-840f-acd42283cf5f.png)
