### PR TITLE
Let xorm convert `False` into the right type

### DIFF
--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -89,8 +89,8 @@ func AddDataSource(cmd *m.AddDataSourceCommand) error {
 func updateIsDefaultFlag(ds *m.DataSource, sess *xorm.Session) error {
 	// Handle is default flag
 	if ds.IsDefault {
-		rawSql := "UPDATE data_source SET is_default = 0 WHERE org_id=? AND id <> ?"
-		if _, err := sess.Exec(rawSql, ds.OrgId, ds.Id); err != nil {
+		rawSql := "UPDATE data_source SET is_default=? WHERE org_id=? AND id <> ?"
+		if _, err := sess.Exec(rawSql, False, ds.OrgId, ds.Id); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
On a real database like Postgres, `bool` != `0`.

So this errors with:

```
2015/03/31 01:01:09 [datasources.go:93 AddDataSource()] [E] Failed to add datasource: pq: column "is_default" is of type boolean but expression is of type integer
```

I've never used xorm, so not 100% sure if this is correct, but it seems correct.
