### PR TITLE
Suppress redrawing when Shared Crosshair is disabled

### DIFF
--- a/public/app/panels/graph/graph.tooltip.js
+++ b/public/app/panels/graph/graph.tooltip.js
@@ -82,13 +82,16 @@ function ($) {
     };
 
     elem.mouseleave(function () {
-      if (scope.panel.tooltip.shared || dashboard.sharedCrosshair) {
+      if (scope.panel.tooltip.shared) {
         var plot = elem.data().plot;
         if (plot) {
           $tooltip.detach();
           plot.unhighlight();
-          scope.appEvent('clearCrosshair');
         }
+      }
+
+      if (dashboard.sharedCrosshair) {
+        scope.appEvent('clearCrosshair');
       }
     });
 


### PR DESCRIPTION
I found that Shared Tooltip cause redrawing all graphs in dashboard when mouse leaves from graph.
It might be better to suppress redrawing all graphs when Shared Crosshair is disabled, because the cost of redrawing becomes too big if dashboard has many graphs.
