### PR TITLE
When performing a metric find query, the InfluxDb9 datasource needs a qu...

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.js
+++ b/public/app/plugins/datasource/influxdb/datasource.js
@@ -105,6 +105,9 @@ function (angular, _, kbn, InfluxSeries, InfluxQueryBuilder) {
         case 'TAG_VALUES':
           var tagValues = _.flatten(series.values);
           return _.map(tagValues, function(tagValue) { return { text: tagValue, expandable: true }; });
+        default: // template values service does not pass in a a query type
+          var flattenedValues = _.flatten(series.values);
+          return _.map(flattenedValues, function(value) { return { text: value, expandable: true }; });
         }
       });
     };


### PR DESCRIPTION
With InfluxDb9, we are unable to perform a variable values query in templating. This is due to the fact that the influxdb9 datasource expects a parameter called queryType. Since this parameter is not needed by the other datasources, the datasource agnostic templating module never passes in the parameter as seen on line 108 of templateValuesSrv.js 
