### PR TITLE
Typo fix in help_modal.html

### DIFF
--- a/public/app/partials/help_modal.html
+++ b/public/app/partials/help_modal.html
@@ -2,7 +2,7 @@
 	<div class="gf-box-header">
 		<div class="gf-box-title">
 			<i class="fa fa-keyboard-o"></i>
-			Keyboard shutcuts
+			Keyboard shortcuts
 		</div>
 
 		<button class="gf-box-header-close-btn" ng-click="dismiss();">


### PR DESCRIPTION
Fixed typo in header (Keyboard shutcuts -. Keyboard shortcuts)
