### PR TITLE
Cleanup KairosDB Plugin

### DIFF
--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -29,8 +29,9 @@ function (angular, _, kbn) {
       var queries = _.compact(_.map(options.targets, _.partial(convertTargetToQuery, options)));
       var plotParams = _.compact(_.map(options.targets, function(target) {
         var alias = target.alias;
-        if (typeof target.alias == 'undefined' || target.alias == "")
+        if (typeof target.alias === 'undefined' || target.alias === "") {
           alias = target.metric;
+        }
         return !target.hide
             ?  {alias: alias,
                 exouter: target.exOuter}
@@ -171,8 +172,9 @@ function (angular, _, kbn) {
             }
           });
           details+= ") ";
-          if (details != " ( ) ")
+          if (details !== " ( ) ") {
             target += details;
+          }
           var datapoints = [];
 
           for (var i = 0; i < result.values.length; i++) {
@@ -180,8 +182,9 @@ function (angular, _, kbn) {
             var v = result.values[i][1];
             datapoints[i] = [v, t];
           }
-          if (plotParams[index].exouter)
-            datapoints = PeakFilter(datapoints, 10);
+          if (plotParams[index].exouter) {
+            datapoints = new PeakFilter(datapoints, 10);
+          }
           output.push({ target: target, datapoints: datapoints });
         });
         index ++;
@@ -387,27 +390,31 @@ function (angular, _, kbn) {
     function PeakFilter(dataIn, limit) {
       var datapoints = dataIn;
       var arrLength = datapoints.length;
-      if (arrLength <= 3)
+      if (arrLength <= 3) {
         return datapoints;
+      }
       var LastIndx = arrLength - 1;
 
       // Check first point
       var prvDelta = Math.abs((datapoints[1][0] - datapoints[0][0]) / datapoints[0][0]);
       var nxtDelta = Math.abs((datapoints[1][0] - datapoints[2][0]) / datapoints[2][0]);
-      if (prvDelta >= limit && nxtDelta < limit)
+      if (prvDelta >= limit && nxtDelta < limit) {
         datapoints[0][0] = datapoints[1][0];
+      }
 
       // Check last point
       prvDelta = Math.abs((datapoints[LastIndx - 1][0] - datapoints[LastIndx - 2][0]) / datapoints[LastIndx - 2][0]);
       nxtDelta = Math.abs((datapoints[LastIndx - 1][0] - datapoints[LastIndx][0]) / datapoints[LastIndx][0]);
-      if (prvDelta >= limit && nxtDelta < limit)
+      if (prvDelta >= limit && nxtDelta < limit) {
         datapoints[LastIndx][0] = datapoints[LastIndx - 1][0];
+      }
 
       for (var i = 1; i < arrLength - 1; i++) {
         prvDelta = Math.abs((datapoints[i][0] - datapoints[i - 1][0]) / datapoints[i - 1][0]);
         nxtDelta = Math.abs((datapoints[i][0] - datapoints[i + 1][0]) / datapoints[i + 1][0]);
-        if (prvDelta >= limit && nxtDelta >= limit)
+        if (prvDelta >= limit && nxtDelta >= limit) {
           datapoints[i][0] = (datapoints[i-1][0] + datapoints[i+1][0]) / 2;
+        }
       }
 
       return datapoints;

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -86,7 +86,7 @@ function (angular, _, kbn) {
     };
 
     KairosDBDatasource.prototype.performTagSuggestQuery = function(metricname,range,type,keyValue) {
-      if(tagList && (metricname === tagList.metricName) && (range.from === tagList.range.from) &&
+      if (tagList && (metricname === tagList.metricName) && (range.from === tagList.range.from) &&
         (range.to === tagList.range.to)) {
         return getTagListFromResponse(tagList.results,type,keyValue);
       }
@@ -119,10 +119,10 @@ function (angular, _, kbn) {
       if (!results.data) {
         return [];
       }
-      if(type==="key") {
+      if (type==="key") {
         return _.keys(results.data.queries[0].results[0].tags);
       }
-      else if(type==="value" && _.has(results.data.queries[0].results[0].tags,keyValue)) {
+      else if (type==="value" && _.has(results.data.queries[0].results[0].tags,keyValue)) {
         return results.data.queries[0].results[0].tags[keyValue];
       }
       return [];
@@ -134,13 +134,13 @@ function (angular, _, kbn) {
      * @returns {*}
      */
     function handleQueryError(results) {
-      if(results.data.errors && !_.isEmpty(results.data.errors)) {
+      if (results.data.errors && !_.isEmpty(results.data.errors)) {
         var errors = {
           message: results.data.errors[0]
         };
         return $q.reject(errors);
       }
-      else{
+      else {
         return $q.reject(results);
       }
     }
@@ -158,15 +158,15 @@ function (angular, _, kbn) {
           var target = plotParams[index].alias;
           var details = " ( ";
           _.each(result.group_by,function(element) {
-            if(element.name==="tag") {
+            if (element.name==="tag") {
               _.each(element.group,function(value, key) {
                 details+= key+"="+value+" ";
               });
             }
-            else if(element.name==="value") {
+            else if (element.name==="value") {
               details+= 'value_group='+element.group.group_number+" ";
             }
-            else if(element.name==="time") {
+            else if (element.name==="time") {
               details+= 'time_group='+element.group.group_number+" ";
             }
           });
@@ -201,7 +201,7 @@ function (angular, _, kbn) {
       };
 
       query.aggregators = [];
-      if(target.downsampling!=='(NONE)') {
+      if (target.downsampling!=='(NONE)') {
         query.aggregators.push({
           name: target.downsampling,
           align_sampling: true,
@@ -209,46 +209,46 @@ function (angular, _, kbn) {
           sampling: KairosDBDatasource.prototype.convertToKairosInterval(target.sampling || options.interval)
         });
       }
-      if(target.horizontalAggregators) {
+      if (target.horizontalAggregators) {
         _.each(target.horizontalAggregators,function(chosenAggregator) {
           var returnedAggregator = {
             name:chosenAggregator.name
           };
-          if(chosenAggregator.sampling_rate) {
+          if (chosenAggregator.sampling_rate) {
             returnedAggregator.sampling = KairosDBDatasource.prototype.convertToKairosInterval(chosenAggregator.sampling_rate);
             returnedAggregator.align_sampling = true;
             returnedAggregator.align_start_time =true;
           }
-          if(chosenAggregator.unit) {
+          if (chosenAggregator.unit) {
             returnedAggregator.unit = chosenAggregator.unit+'s';
           }
-          if(chosenAggregator.factor && chosenAggregator.name==='div') {
+          if (chosenAggregator.factor && chosenAggregator.name==='div') {
             returnedAggregator.divisor = chosenAggregator.factor;
           }
-          else if(chosenAggregator.factor && chosenAggregator.name==='scale') {
+          else if (chosenAggregator.factor && chosenAggregator.name==='scale') {
             returnedAggregator.factor  = chosenAggregator.factor;
           }
-          if(chosenAggregator.percentile) {
+          if (chosenAggregator.percentile) {
             returnedAggregator.percentile = chosenAggregator.percentile;
           }
           query.aggregators.push(returnedAggregator);
         });
       }
-      if(_.isEmpty(query.aggregators)) {
+      if (_.isEmpty(query.aggregators)) {
         delete query.aggregators;
       }
 
-      if(target.tags) {
+      if (target.tags) {
         query.tags = angular.copy(target.tags);
       }
 
-      if(target.groupByTags || target.nonTagGroupBys) {
+      if (target.groupByTags || target.nonTagGroupBys) {
         query.group_by = [];
-        if(target.groupByTags) {query.group_by.push({name: "tag", tags: angular.copy(target.groupByTags)});}
-        if(target.nonTagGroupBys) {
+        if (target.groupByTags) {query.group_by.push({name: "tag", tags: angular.copy(target.groupByTags)});}
+        if (target.nonTagGroupBys) {
           _.each(target.nonTagGroupBys,function(rawGroupBy) {
             var formattedGroupBy = angular.copy(rawGroupBy);
-            if(formattedGroupBy.name==='time') {
+            if (formattedGroupBy.name==='time') {
               formattedGroupBy.range_size=KairosDBDatasource.prototype.convertToKairosInterval(formattedGroupBy.range_size);
             }
             query.group_by.push(formattedGroupBy);
@@ -266,7 +266,7 @@ function (angular, _, kbn) {
       var interval_regex = /(\d+(?:\.\d+)?)([Mwdhmsy])/;
       var interval_regex_ms = /(\d+(?:\.\d+)?)(ms)/;
       var matches = intervalString.match(interval_regex_ms);
-      if(!matches) {
+      if (!matches) {
         matches = intervalString.match(interval_regex);
       }
       if (!matches) {
@@ -276,12 +276,12 @@ function (angular, _, kbn) {
       var value = matches[1];
       var unit = matches[2];
       if (value%1!==0) {
-        if(unit==='ms') {throw new Error('Invalid interval value, cannot be smaller than the millisecond');}
+        if (unit==='ms') {throw new Error('Invalid interval value, cannot be smaller than the millisecond');}
         value = Math.round(kbn.intervals_in_seconds[unit]*value*1000);
         unit = 'ms';
 
       }
-      switch(unit) {
+      switch (unit) {
         case 'ms':
           unit = 'milliseconds';
           break;
@@ -334,7 +334,7 @@ function (angular, _, kbn) {
           if (result) {
             var value = result[1];
             var unit = result[2];
-            switch(unit) {
+            switch (unit) {
               case 'ms':
                 unit = 'milliseconds';
                 break;
@@ -375,7 +375,7 @@ function (angular, _, kbn) {
         date = kbn.parseDate(date);
       }
 
-      if(_.isDate(date)) {
+      if (_.isDate(date)) {
         name = start_stop_name + "_absolute";
         response_obj[name] = date.getTime();
         return;
@@ -403,7 +403,7 @@ function (angular, _, kbn) {
       if (prvDelta >= limit && nxtDelta < limit)
         datapoints[LastIndx][0] = datapoints[LastIndx - 1][0];
 
-      for (var i = 1; i < arrLength - 1; i++){
+      for (var i = 1; i < arrLength - 1; i++) {
         prvDelta = Math.abs((datapoints[i][0] - datapoints[i - 1][0]) / datapoints[i - 1][0]);
         nxtDelta = Math.abs((datapoints[i][0] - datapoints[i + 1][0]) / datapoints[i + 1][0]);
         if (prvDelta >= limit && nxtDelta >= limit)

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -55,7 +55,7 @@ function (angular, _, kbn) {
       var reqBody = {
         metrics: queries
       };
-      reqBody.cache_time=0;
+      reqBody.cache_time = 0;
       convertToKairosTime(start,reqBody,'start');
       convertToKairosTime(end,reqBody,'end');
       var options = {
@@ -120,10 +120,10 @@ function (angular, _, kbn) {
       if (!results.data) {
         return [];
       }
-      if (type==="key") {
+      if (type === "key") {
         return _.keys(results.data.queries[0].results[0].tags);
       }
-      else if (type==="value" && _.has(results.data.queries[0].results[0].tags,keyValue)) {
+      else if (type === "value" && _.has(results.data.queries[0].results[0].tags,keyValue)) {
         return results.data.queries[0].results[0].tags[keyValue];
       }
       return [];
@@ -159,19 +159,19 @@ function (angular, _, kbn) {
           var target = plotParams[index].alias;
           var details = " ( ";
           _.each(result.group_by,function(element) {
-            if (element.name==="tag") {
+            if (element.name === "tag") {
               _.each(element.group,function(value, key) {
-                details+= key+"="+value+" ";
+                details += key + "=" + value + " ";
               });
             }
-            else if (element.name==="value") {
-              details+= 'value_group='+element.group.group_number+" ";
+            else if (element.name === "value") {
+              details += 'value_group=' + element.group.group_number + " ";
             }
-            else if (element.name==="time") {
-              details+= 'time_group='+element.group.group_number+" ";
+            else if (element.name === "time") {
+              details += 'time_group=' + element.group.group_number + " ";
             }
           });
-          details+= ") ";
+          details += ") ";
           if (details !== " ( ) ") {
             target += details;
           }
@@ -204,7 +204,7 @@ function (angular, _, kbn) {
       };
 
       query.aggregators = [];
-      if (target.downsampling!=='(NONE)') {
+      if (target.downsampling !== '(NONE)') {
         query.aggregators.push({
           name: target.downsampling,
           align_sampling: true,
@@ -223,13 +223,13 @@ function (angular, _, kbn) {
             returnedAggregator.align_start_time =true;
           }
           if (chosenAggregator.unit) {
-            returnedAggregator.unit = chosenAggregator.unit+'s';
+            returnedAggregator.unit = chosenAggregator.unit + 's';
           }
-          if (chosenAggregator.factor && chosenAggregator.name==='div') {
+          if (chosenAggregator.factor && chosenAggregator.name === 'div') {
             returnedAggregator.divisor = chosenAggregator.factor;
           }
-          else if (chosenAggregator.factor && chosenAggregator.name==='scale') {
-            returnedAggregator.factor  = chosenAggregator.factor;
+          else if (chosenAggregator.factor && chosenAggregator.name === 'scale') {
+            returnedAggregator.factor = chosenAggregator.factor;
           }
           if (chosenAggregator.percentile) {
             returnedAggregator.percentile = chosenAggregator.percentile;
@@ -249,10 +249,10 @@ function (angular, _, kbn) {
         query.group_by = [];
         if (target.groupByTags) {query.group_by.push({name: "tag", tags: angular.copy(target.groupByTags)});}
         if (target.nonTagGroupBys) {
-          _.each(target.nonTagGroupBys,function(rawGroupBy) {
+          _.each(target.nonTagGroupBys, function(rawGroupBy) {
             var formattedGroupBy = angular.copy(rawGroupBy);
-            if (formattedGroupBy.name==='time') {
-              formattedGroupBy.range_size=KairosDBDatasource.prototype.convertToKairosInterval(formattedGroupBy.range_size);
+            if (formattedGroupBy.name === 'time') {
+              formattedGroupBy.range_size = KairosDBDatasource.prototype.convertToKairosInterval(formattedGroupBy.range_size);
             }
             query.group_by.push(formattedGroupBy);
           });
@@ -278,9 +278,9 @@ function (angular, _, kbn) {
 
       var value = matches[1];
       var unit = matches[2];
-      if (value%1!==0) {
-        if (unit==='ms') {throw new Error('Invalid interval value, cannot be smaller than the millisecond');}
-        value = Math.round(kbn.intervals_in_seconds[unit]*value*1000);
+      if (value%1 !== 0) {
+        if (unit === 'ms') {throw new Error('Invalid interval value, cannot be smaller than the millisecond');}
+        value = Math.round(kbn.intervals_in_seconds[unit] * value * 1000);
         unit = 'ms';
 
       }
@@ -413,7 +413,7 @@ function (angular, _, kbn) {
         prvDelta = Math.abs((datapoints[i][0] - datapoints[i - 1][0]) / datapoints[i - 1][0]);
         nxtDelta = Math.abs((datapoints[i][0] - datapoints[i + 1][0]) / datapoints[i + 1][0]);
         if (prvDelta >= limit && nxtDelta >= limit) {
-          datapoints[i][0] = (datapoints[i-1][0] + datapoints[i+1][0]) / 2;
+          datapoints[i][0] = (datapoints[i - 1][0] + datapoints[i + 1][0]) / 2;
         }
       }
 

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -27,7 +27,7 @@ function (angular, _, kbn) {
       var end = options.range.to;
 
       var queries = _.compact(_.map(options.targets, _.partial(convertTargetToQuery, options)));
-      var plotParams = _.compact(_.map(options.targets, function(target){
+      var plotParams = _.compact(_.map(options.targets, function(target) {
         var alias = target.alias;
         if (typeof target.alias == 'undefined' || target.alias == "")
           alias = target.metric;

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -149,18 +149,18 @@ function (angular, _, kbn) {
     function handleKairosDBQueryResponse(plotParams, results) {
       var output = [];
       var index = 0;
-      _.each(results.data.queries, function (series) {
+      _.each(results.data.queries, function(series) {
         var sample_size = series.sample_size;
         console.log("sample_size:" + sample_size + " samples");
 
-        _.each(series.results, function (result) {
+        _.each(series.results, function(result) {
 
           //var target = result.name;
           var target = plotParams[index].alias;
           var details = " ( ";
-          _.each(result.group_by,function(element) {
+          _.each(result.group_by, function(element) {
             if (element.name === "tag") {
-              _.each(element.group,function(value, key) {
+              _.each(element.group, function(value, key) {
                 details += key + "=" + value + " ";
               });
             }
@@ -213,7 +213,7 @@ function (angular, _, kbn) {
         });
       }
       if (target.horizontalAggregators) {
-        _.each(target.horizontalAggregators,function(chosenAggregator) {
+        _.each(target.horizontalAggregators, function(chosenAggregator) {
           var returnedAggregator = {
             name:chosenAggregator.name
           };

--- a/public/app/plugins/datasource/kairosdb/queryCtrl.js
+++ b/public/app/plugins/datasource/kairosdb/queryCtrl.js
@@ -108,7 +108,7 @@ function (angular, _) {
 
     $scope.removeFilterTag = function(key) {
       delete $scope.target.tags[key];
-      if (_.size($scope.target.tags)===0) {
+      if (_.size($scope.target.tags) === 0) {
         $scope.target.tags = null;
       }
       $scope.targetBlur();
@@ -171,7 +171,7 @@ function (angular, _) {
 
     $scope.removeGroupByTag = function(index) {
       $scope.target.groupByTags.splice(index, 1);
-      if (_.size($scope.target.groupByTags)===0) {
+      if (_.size($scope.target.groupByTags) === 0) {
         $scope.target.groupByTags = null;
       }
       $scope.targetBlur();
@@ -179,16 +179,16 @@ function (angular, _) {
 
     $scope.removeNonTagGroupBy = function(index) {
       $scope.target.nonTagGroupBys.splice(index, 1);
-      if (_.size($scope.target.nonTagGroupBys)===0) {
+      if (_.size($scope.target.nonTagGroupBys) === 0) {
         $scope.target.nonTagGroupBys = null;
       }
       $scope.targetBlur();
     };
 
     $scope.changeGroupByInput = function() {
-      $scope.isTagGroupBy = $scope.target.currentGroupByType==='tag';
-      $scope.isValueGroupBy = $scope.target.currentGroupByType==='value';
-      $scope.isTimeGroupBy = $scope.target.currentGroupByType==='time';
+      $scope.isTagGroupBy = $scope.target.currentGroupByType === 'tag';
+      $scope.isValueGroupBy = $scope.target.currentGroupByType === 'value';
+      $scope.isTimeGroupBy = $scope.target.currentGroupByType === 'time';
       $scope.validateGroupBy();
     };
 
@@ -270,7 +270,7 @@ function (angular, _) {
 
     $scope.removeHorizontalAggregator = function(index) {
       $scope.target.horizontalAggregators.splice(index, 1);
-      if (_.size($scope.target.horizontalAggregators)===0) {
+      if (_.size($scope.target.horizontalAggregators) === 0) {
         $scope.target.horizontalAggregators = null;
       }
 
@@ -282,7 +282,7 @@ function (angular, _) {
         $scope.target.currentHorizontalAggregatorName);
       $scope.hasUnit = _.contains(['sampler','rate'], $scope.target.currentHorizontalAggregatorName);
       $scope.hasFactor = _.contains(['div','scale'], $scope.target.currentHorizontalAggregatorName);
-      $scope.hasPercentile = 'percentile'===$scope.target.currentHorizontalAggregatorName;
+      $scope.hasPercentile = 'percentile' === $scope.target.currentHorizontalAggregatorName;
       $scope.validateHorizontalAggregator();
     };
 
@@ -303,7 +303,7 @@ function (angular, _) {
           errors.factor = 'You must supply a numeric value for this aggregator';
           $scope.isAggregatorValid = false;
         }
-        else if (parseInt($scope.target.horAggregator.factor)===0 && $scope.target.currentHorizontalAggregatorName==='div') {
+        else if (parseInt($scope.target.horAggregator.factor) === 0 && $scope.target.currentHorizontalAggregatorName === 'div') {
           errors.factor = 'Cannot divide by 0';
           $scope.isAggregatorValid = false;
         }

--- a/public/app/plugins/datasource/kairosdb/queryCtrl.js
+++ b/public/app/plugins/datasource/kairosdb/queryCtrl.js
@@ -94,7 +94,7 @@ function (angular, _) {
 
       $scope.validateFilterTag();
       if (!$scope.target.errors.tags) {
-        if(!_.has($scope.target.tags,$scope.target.currentTagKey)) {
+        if (!_.has($scope.target.tags,$scope.target.currentTagKey)) {
           $scope.target.tags[$scope.target.currentTagKey] = [];
         }
         $scope.target.tags[$scope.target.currentTagKey].push($scope.target.currentTagValue);
@@ -108,7 +108,7 @@ function (angular, _) {
 
     $scope.removeFilterTag = function(key) {
       delete $scope.target.tags[key];
-      if(_.size($scope.target.tags)===0) {
+      if (_.size($scope.target.tags)===0) {
         $scope.target.tags = null;
       }
       $scope.targetBlur();
@@ -116,7 +116,7 @@ function (angular, _) {
 
     $scope.validateFilterTag = function() {
       $scope.target.errors.tags = null;
-      if(!$scope.target.currentTagKey || !$scope.target.currentTagValue) {
+      if (!$scope.target.currentTagKey || !$scope.target.currentTagValue) {
         $scope.target.errors.tags = "You must specify a tag name and value.";
       }
     };
@@ -136,7 +136,7 @@ function (angular, _) {
       $scope.validateGroupBy();
       // nb: if error is found, means that user clicked on cross : cancels input
       if (_.isEmpty($scope.target.errors.groupBy)) {
-        if($scope.isTagGroupBy) {
+        if ($scope.isTagGroupBy) {
           if (!$scope.target.groupByTags) {
             $scope.target.groupByTags = [];
           }
@@ -147,15 +147,15 @@ function (angular, _) {
           }
           $scope.target.groupBy.tagKey = '';
         }
-        else  {
+        else {
           if (!$scope.target.nonTagGroupBys) {
             $scope.target.nonTagGroupBys = [];
           }
           var groupBy = {
             name: $scope.target.currentGroupByType
           };
-          if($scope.isValueGroupBy) {groupBy.range_size = $scope.target.groupBy.valueRange;}
-          else if($scope.isTimeGroupBy) {
+          if ($scope.isValueGroupBy) {groupBy.range_size = $scope.target.groupBy.valueRange;}
+          else if ($scope.isTimeGroupBy) {
             groupBy.range_size = $scope.target.groupBy.timeInterval;
             groupBy.group_count = $scope.target.groupBy.groupCount;
           }
@@ -171,7 +171,7 @@ function (angular, _) {
 
     $scope.removeGroupByTag = function(index) {
       $scope.target.groupByTags.splice(index, 1);
-      if(_.size($scope.target.groupByTags)===0) {
+      if (_.size($scope.target.groupByTags)===0) {
         $scope.target.groupByTags = null;
       }
       $scope.targetBlur();
@@ -179,7 +179,7 @@ function (angular, _) {
 
     $scope.removeNonTagGroupBy = function(index) {
       $scope.target.nonTagGroupBys.splice(index, 1);
-      if(_.size($scope.target.nonTagGroupBys)===0) {
+      if (_.size($scope.target.nonTagGroupBys)===0) {
         $scope.target.nonTagGroupBys = null;
       }
       $scope.targetBlur();
@@ -196,32 +196,32 @@ function (angular, _) {
       delete $scope.target.errors.groupBy;
       var errors = {};
       $scope.isGroupByValid = true;
-      if($scope.isTagGroupBy) {
-        if(!$scope.target.groupBy.tagKey) {
+      if ($scope.isTagGroupBy) {
+        if (!$scope.target.groupBy.tagKey) {
           $scope.isGroupByValid = false;
           errors.tagKey = 'You must supply a tag name';
         }
       }
-      if($scope.isValueGroupBy) {
-        if(!$scope.target.groupBy.valueRange || !isInt($scope.target.groupBy.valueRange)) {
+      if ($scope.isValueGroupBy) {
+        if (!$scope.target.groupBy.valueRange || !isInt($scope.target.groupBy.valueRange)) {
           errors.valueRange = "Range must be an integer";
           $scope.isGroupByValid = false;
         }
       }
-      if($scope.isTimeGroupBy) {
+      if ($scope.isTimeGroupBy) {
         try {
           $scope.datasource.convertToKairosInterval($scope.target.groupBy.timeInterval);
-        } catch(err) {
+        } catch (err) {
           errors.timeInterval = err.message;
           $scope.isGroupByValid = false;
         }
-        if(!$scope.target.groupBy.groupCount || !isInt($scope.target.groupBy.groupCount)) {
+        if (!$scope.target.groupBy.groupCount || !isInt($scope.target.groupBy.groupCount)) {
           errors.groupCount = "Group count must be an integer";
           $scope.isGroupByValid = false;
         }
       }
 
-      if(!_.isEmpty(errors)) {
+      if (!_.isEmpty(errors)) {
         $scope.target.errors.groupBy = errors;
       }
     };
@@ -245,17 +245,17 @@ function (angular, _) {
 
       $scope.validateHorizontalAggregator();
       // nb: if error is found, means that user clicked on cross : cancels input
-      if(_.isEmpty($scope.target.errors.horAggregator)) {
+      if (_.isEmpty($scope.target.errors.horAggregator)) {
         if (!$scope.target.horizontalAggregators) {
           $scope.target.horizontalAggregators = [];
         }
         var aggregator = {
           name:$scope.target.currentHorizontalAggregatorName
         };
-        if($scope.hasSamplingRate) {aggregator.sampling_rate = $scope.target.horAggregator.samplingRate;}
-        if($scope.hasUnit) {aggregator.unit = $scope.target.horAggregator.unit;}
-        if($scope.hasFactor) {aggregator.factor = $scope.target.horAggregator.factor;}
-        if($scope.hasPercentile) {aggregator.percentile = $scope.target.horAggregator.percentile;}
+        if ($scope.hasSamplingRate) {aggregator.sampling_rate = $scope.target.horAggregator.samplingRate;}
+        if ($scope.hasUnit) {aggregator.unit = $scope.target.horAggregator.unit;}
+        if ($scope.hasFactor) {aggregator.factor = $scope.target.horAggregator.factor;}
+        if ($scope.hasPercentile) {aggregator.percentile = $scope.target.horAggregator.percentile;}
         $scope.target.horizontalAggregators.push(aggregator);
         $scope.targetBlur();
       }
@@ -270,7 +270,7 @@ function (angular, _) {
 
     $scope.removeHorizontalAggregator = function(index) {
       $scope.target.horizontalAggregators.splice(index, 1);
-      if(_.size($scope.target.horizontalAggregators)===0) {
+      if (_.size($scope.target.horizontalAggregators)===0) {
         $scope.target.horizontalAggregators = null;
       }
 
@@ -290,26 +290,26 @@ function (angular, _) {
       delete $scope.target.errors.horAggregator;
       var errors = {};
       $scope.isAggregatorValid = true;
-      if($scope.hasSamplingRate) {
+      if ($scope.hasSamplingRate) {
         try {
           $scope.datasource.convertToKairosInterval($scope.target.horAggregator.samplingRate);
-        } catch(err) {
+        } catch (err) {
           errors.samplingRate = err.message;
           $scope.isAggregatorValid = false;
         }
       }
-      if($scope.hasFactor) {
-        if(!$scope.target.horAggregator.factor) {
+      if ($scope.hasFactor) {
+        if (!$scope.target.horAggregator.factor) {
           errors.factor = 'You must supply a numeric value for this aggregator';
           $scope.isAggregatorValid = false;
         }
-        else if(parseInt($scope.target.horAggregator.factor)===0 && $scope.target.currentHorizontalAggregatorName==='div') {
+        else if (parseInt($scope.target.horAggregator.factor)===0 && $scope.target.currentHorizontalAggregatorName==='div') {
           errors.factor = 'Cannot divide by 0';
           $scope.isAggregatorValid = false;
         }
       }
-      if($scope.hasPercentile) {
-        if(!$scope.target.horAggregator.percentile ||
+      if ($scope.hasPercentile) {
+        if (!$scope.target.horAggregator.percentile ||
           $scope.target.horAggregator.percentile<=0 ||
           $scope.target.horAggregator.percentile>1) {
           errors.percentile = 'Percentile must be between 0 and 1';
@@ -317,7 +317,7 @@ function (angular, _) {
         }
       }
 
-      if(!_.isEmpty(errors)) {
+      if (!_.isEmpty(errors)) {
         $scope.target.errors.horAggregator = errors;
       }
     };
@@ -335,10 +335,10 @@ function (angular, _) {
       for (var i =0;i < MetricList.length; i++) {
         Metric = MetricList[i];
         MetricArray = Metric.split('.');
-        if(!result.hasOwnProperty(MetricArray[0])) {
+        if (!result.hasOwnProperty(MetricArray[0])) {
           result[MetricArray[0]] = {};
         }
-        if(!result[MetricArray[0]].hasOwnProperty(MetricArray[1])) {
+        if (!result[MetricArray[0]].hasOwnProperty(MetricArray[1])) {
           result[MetricArray[0]][MetricArray[1]] = [];
         }
         result[MetricArray[0]][MetricArray[1]].push(MetricArray[2]);
@@ -357,7 +357,7 @@ function (angular, _) {
         if (target.sampling) {
           $scope.datasource.convertToKairosInterval(target.sampling);
         }
-      } catch(err) {
+      } catch (err) {
         errs.sampling = err.message;
       }
 

--- a/public/app/plugins/datasource/kairosdb/queryCtrl.js
+++ b/public/app/plugins/datasource/kairosdb/queryCtrl.js
@@ -327,25 +327,6 @@ function (angular, _) {
     };
 
     // Validation
-    function MetricListToObject(MetricList) {
-      var result = {};
-      var Metric;
-      var MetricArray = [];
-      var MetricCnt = 0;
-      for (var i =0;i < MetricList.length; i++) {
-        Metric = MetricList[i];
-        MetricArray = Metric.split('.');
-        if (!result.hasOwnProperty(MetricArray[0])) {
-          result[MetricArray[0]] = {};
-        }
-        if (!result[MetricArray[0]].hasOwnProperty(MetricArray[1])) {
-          result[MetricArray[0]][MetricArray[1]] = [];
-        }
-        result[MetricArray[0]][MetricArray[1]].push(MetricArray[2]);
-      }
-      return result;
-    }
-
     function validateTarget(target) {
       var errs = {};
 


### PR DESCRIPTION
- Fix styles of KairosDB Plugin to pass `grunt test`.
- I checked styles of KairosDB Plugin with below additional settings of JSCS. I prefer those rules, but those are not following the styles of Grafana, please tell me. I'll fix it.

```
    "requireSpaceBeforeBinaryOperators": [
      "=",
      "+",
      "-",
      "/",
      "*",
      "==",
      "===",
      "!=",
      "!=="
    ],
    "requireSpaceAfterKeywords": [
      "for",
      "if",
      "else",
      "switch",
      "case",
      "try",
      "catch",
      "while",
    ],
    "requireSpaceBeforeKeywords": [
      "else",
      "while",
      "catch"
    ]
```
