### PR TITLE
Add allow_sign_up setting for auth.google/github.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -143,6 +143,7 @@ auth_url = https://github.com/login/oauth/authorize
 token_url = https://github.com/login/oauth/access_token
 api_url = https://api.github.com/user
 allowed_domains =
+allow_sign_up = false
 
 #################################### Google Auth ##########################
 [auth.google]
@@ -154,6 +155,7 @@ auth_url = https://accounts.google.com/o/oauth2/auth
 token_url = https://accounts.google.com/o/oauth2/token
 api_url = https://www.googleapis.com/oauth2/v1/userinfo
 allowed_domains =
+allow_sign_up = false
 
 #################################### Logging ##########################
 [log]

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -181,9 +181,13 @@ Client ID and a Client Secret. Specify these in the grafana config file. Example
     scopes = user:email
     auth_url = https://github.com/login/oauth/authorize
     token_url = https://github.com/login/oauth/access_token
+    allow_sign_up = false
 
 Restart the grafana backend. You should now see a github login button on the login page. You can
 now login or signup with your github accounts.
+
+You may allow users to sign-up via github auth by setting allow_sign_up to true. When this option is
+set to true, any user successfully authenticating via github auth will be automatically signed up.
 
 ## [auth.google]
 You need to create a google project. You can do this in the [Google Developer Console](https://console.developers.google.com/project).
@@ -203,9 +207,13 @@ Client ID and a Client Secret. Specify these in the grafana config file. Example
     auth_url = https://accounts.google.com/o/oauth2/auth
     token_url = https://accounts.google.com/o/oauth2/token
     allowed_domains = mycompany.com
+    allow_sign_up = false
 
 Restart the grafana backend. You should now see a google login button on the login page. You can
 now login or signup with your google accounts. `allowed_domains` option is optional.
+
+You may allow users to sign-up via google auth by setting allow_sign_up to true. When this option is
+set to true, any user successfully authenticating via google auth will be automatically signed up.
 
 <hr>
 ## [session]

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -63,7 +63,7 @@ func OAuthLogin(ctx *middleware.Context) {
 
 	// create account if missing
 	if err == m.ErrUserNotFound {
-		if !setting.AllowUserSignUp {
+		if !connect.IsSignupAllowed() {
 			ctx.Redirect(setting.AppSubUrl + "/login")
 			return
 		}

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -7,6 +7,7 @@ type OAuthInfo struct {
 	Enabled                bool
 	AllowedDomains         []string
 	ApiUrl                 string
+	AllowSignup            bool
 }
 
 type OAuther struct {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -25,6 +25,7 @@ type SocialConnector interface {
 	Type() int
 	UserInfo(token *oauth2.Token) (*BasicUserInfo, error)
 	IsEmailAllowed(email string) bool
+	IsSignupAllowed() bool
 
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
 	Exchange(ctx context.Context, code string) (*oauth2.Token, error)
@@ -52,6 +53,7 @@ func NewOAuthService() {
 			ApiUrl:         sec.Key("api_url").String(),
 			Enabled:        sec.Key("enabled").MustBool(),
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
+			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 		}
 
 		if !info.Enabled {
@@ -73,13 +75,13 @@ func NewOAuthService() {
 		// GitHub.
 		if name == "github" {
 			setting.OAuthService.GitHub = true
-			SocialMap["github"] = &SocialGithub{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl}
+			SocialMap["github"] = &SocialGithub{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl, allowSignup: info.AllowSignup}
 		}
 
 		// Google.
 		if name == "google" {
 			setting.OAuthService.Google = true
-			SocialMap["google"] = &SocialGoogle{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl}
+			SocialMap["google"] = &SocialGoogle{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl, allowSignup: info.AllowSignup}
 		}
 	}
 }
@@ -102,6 +104,7 @@ type SocialGithub struct {
 	*oauth2.Config
 	allowedDomains []string
 	ApiUrl         string
+	allowSignup    bool
 }
 
 func (s *SocialGithub) Type() int {
@@ -110,6 +113,10 @@ func (s *SocialGithub) Type() int {
 
 func (s *SocialGithub) IsEmailAllowed(email string) bool {
 	return isEmailAllowed(email, s.allowedDomains)
+}
+
+func (s *SocialGithub) IsSignupAllowed() bool {
+	return s.allowSignup
 }
 
 func (s *SocialGithub) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
@@ -150,6 +157,7 @@ type SocialGoogle struct {
 	*oauth2.Config
 	allowedDomains []string
 	ApiUrl         string
+	allowSignup    bool
 }
 
 func (s *SocialGoogle) Type() int {
@@ -158,6 +166,10 @@ func (s *SocialGoogle) Type() int {
 
 func (s *SocialGoogle) IsEmailAllowed(email string) bool {
 	return isEmailAllowed(email, s.allowedDomains)
+}
+
+func (s *SocialGoogle) IsSignupAllowed() bool {
+	return s.allowSignup
 }
 
 func (s *SocialGoogle) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {


### PR DESCRIPTION
Setting this option to 'true' on github or google auth will cause any successful logins through those services to automatically sign up.

Note that I removed the [user] allow_sign_up logic check for oauth services, as I didn't want to introduce a confusing override situation. I'd be happy to adjust this if desired.
