### PR TITLE
Added an option to hide the custom time range

### DIFF
--- a/public/app/features/dashboard/dashboardSrv.js
+++ b/public/app/features/dashboard/dashboardSrv.js
@@ -59,6 +59,7 @@ function (angular, $, kbn, _, moment) {
 
       if (contextSrv.hasRole('Viewer')) {
         meta.canSave = false;
+        meta.canEdit = false;
       }
 
       if (meta.isSnapshot) {

--- a/public/app/panels/timepicker/editor.html
+++ b/public/app/panels/timepicker/editor.html
@@ -38,6 +38,21 @@
 				</ul>
 				<div class="clearfix"></div>
 			</div>
+      
+			<div class="tight-form">
+				<ul class="tight-form-list">
+					<li class="tight-form-item" style="width: 148px">
+						<strong>Enable custom time range</strong>
+					</li>
+					<li>
+						<input id="panel.custom_time_range_enabled" type="checkbox" class="cr1"
+							ng-model="panel.custom_time_range_enabled">
+                        <label for="panel.custom_time_range_enabled" class="cr1"></label>
+				  </li>
+				</ul>
+				<div class="clearfix"></div>
+			</div>
+      
 			</div>
 
 			<p>

--- a/public/app/panels/timepicker/module.html
+++ b/public/app/panels/timepicker/module.html
@@ -45,7 +45,7 @@
               </li>
             </ul>
           </li>
-          <li><a ng-click="customTime()">Custom</a></li>
+          <li ng-show="panel.custom_time_range_enabled"><a ng-click="customTime()">Custom</a></li>
         </ul>
 
       </li>

--- a/public/app/panels/timepicker/module.js
+++ b/public/app/panels/timepicker/module.js
@@ -37,6 +37,7 @@ function (angular, app, _, moment, kbn) {
       status        : "Stable",
       time_options  : ['5m','15m','1h','6h','12h','24h','2d','7d','30d'],
       refresh_intervals : ['5s','10s','30s','1m','5m','15m','30m','1h','2h','1d'],
+      custom_time_range_enabled : true
     };
 
     _.defaults($scope.panel,_d);


### PR DESCRIPTION
Hi,

we like to hide the custom time range selection option in some situations for some panels. 
This is a patch for adding this option to the editor and accordingly hide the entry in the module.

Thanks,
Kristian
