### PR TITLE
Remove duplicate link for LICENSE

### DIFF
--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -32,7 +32,7 @@ If you wish to get paid support please [contact us](mailto:contact@grafana.org).
 
 ## License
 
-Grafana is licensed under Apache 2.0. See [LICENSE](https://github.com/grafana/grafana/blob/master/LICENSE.mdhttps://github.com/grafana/grafana/blob/master/LICENSE.md)
+Grafana is licensed under Apache 2.0. See [LICENSE](https://github.com/grafana/grafana/blob/master/LICENSE.md)
 for full license text.
 
 


### PR DESCRIPTION
The LICENSE link had a bogus URL which appears to have been duplicated, remove one of the duplicates so the link works as expected.
