### PR TITLE
Change default values for linewidth and fill.

### DIFF
--- a/public/app/panels/graph/module.js
+++ b/public/app/panels/graph/module.js
@@ -67,9 +67,9 @@ function (angular, app, $, _, kbn, moment, TimeSeries, PanelMeta) {
       // show/hide lines
       lines         : true,
       // fill factor
-      fill          : 0,
+      fill          : 1,
       // line width in pixels
-      linewidth     : 1,
+      linewidth     : 2,
       // show hide points
       points        : false,
       // point radius in pixels


### PR DESCRIPTION
Every time I create a new graph i change line fill to 1 and line width to 2.
I think those settings make the graphs looks much better. Lets make the world more beautiful by settings those as default :)

current default:
![default_0_1](https://cloud.githubusercontent.com/assets/618863/7247402/687ac336-e809-11e4-85ab-d7c9f9a93dd4.PNG)

with linefill 1 and line width 1
![default_1_1](https://cloud.githubusercontent.com/assets/618863/7247406/6d5e0124-e809-11e4-879f-b344f189f979.PNG)

with linefill 1 and line width 2
![default_1_2](https://cloud.githubusercontent.com/assets/618863/7247409/7069eaea-e809-11e4-88a3-191d3fc003ec.PNG)
