### PR TITLE
Remove exit 0 at the end of init.d script

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -144,5 +144,3 @@ case "$1" in
     exit 1
     ;;
 esac
-
-exit 0


### PR DESCRIPTION
Details:

```
19:32:56 default-centos-66.vagrantup.com ~$ /etc/init.d/grafana-server status && echo $?
grafana-server is stopped
0

19:33:01 default-centos-66.vagrantup.com ~$ sh -x /etc/init.d/grafana-server status
...
+ echo 'grafana-server is stopped'
grafana-server is stopped
+ return 3
+ exit 0
```

This must be fixed, because it does not return actual status. As an example, chef's service resource will not work, because of incorrect return status.
