### PR TITLE
Documented units for timepicker

### DIFF
--- a/docs/sources/reference/timerange.md
+++ b/docs/sources/reference/timerange.md
@@ -24,7 +24,7 @@ All of this applies to all Panels in the Dashboard (except those with Panel Time
 
 It's possible to customize the options displayed for relative time and the auto-refresh options. 
 
-From Dashboard setttings, click the Timepicker tab. From here you can specify the relative and auto refresh intervals. The Timepicker tab settings are saved on a per Dashboard basis.
+From Dashboard setttings, click the Timepicker tab. From here you can specify the relative and auto refresh intervals. The Timepicker tab settings are saved on a per Dashboard basis.  Entries are comma seperated and accept a number followed by one of the following units: s (seconds), m (minutes), h (hours), d (days), w (weeks), M (months), y (years).
 
 ![](/img/v1/timepicker_editor.png)
 


### PR DESCRIPTION
Timepicker units (like s, m, M, etc) were not in the documentation so I have added them.
