### PR TITLE
Fixed Annotations with InfluxDb9 Datasources

### DIFF
--- a/public/app/plugins/datasource/influxdb/influxSeries.js
+++ b/public/app/plugins/datasource/influxdb/influxSeries.js
@@ -5,7 +5,8 @@ function (_) {
   'use strict';
 
   function InfluxSeries(options) {
-    this.seriesList = options.seriesList;
+    this.seriesList = options.seriesList && options.seriesList.results && options.seriesList.results.length > 0
+      ? options.seriesList.results[0].series || [] : [];
     this.alias = options.alias;
     this.annotation = options.annotation;
   }
@@ -17,11 +18,9 @@ function (_) {
     var self = this;
 
     console.log(self.seriesList);
-    if (!self.seriesList || !self.seriesList.results || !self.seriesList.results[0]) {
+    if (self.seriesList.length === 0) {
       return output;
     }
-
-    this.seriesList = self.seriesList.results[0].series;
 
     _.each(self.seriesList, function(series) {
       var datapoints = [];
@@ -63,18 +62,14 @@ function (_) {
         if (column === self.annotation.textColumn) { textCol = index; return; }
       });
 
-      _.each(series.points, function (point) {
+      _.each(series.values, function (value) {
         var data = {
           annotation: self.annotation,
-          time: point[timeCol],
-          title: point[titleCol],
-          tags: point[tagsCol],
-          text: point[textCol]
+          time: + new Date(value[timeCol]),
+          title: value[titleCol],
+          tags: value[tagsCol],
+          text: value[textCol]
         };
-
-        if (tagsCol) {
-          data.tags = point[tagsCol];
-        }
 
         list.push(data);
       });

--- a/public/app/plugins/datasource/influxdb/plugin.json
+++ b/public/app/plugins/datasource/influxdb/plugin.json
@@ -13,5 +13,6 @@
     "annotations": "app/plugins/datasource/influxdb/partials/annotations.editor.html"
   },
 
-  "metrics": true
+  "metrics": true,
+  "annotations": true
 }


### PR DESCRIPTION
Prior to this fix, annotations were broken when using Influxdb9 as a datasource.
Below you can see a screenshot of the now working changes:

![screen shot 2015-04-28 at 4 36 14 pm](https://cloud.githubusercontent.com/assets/10675565/7379705/b78c2db4-edc4-11e4-80ea-a6fca4208bf4.png)
