### PR TITLE
GitHub team membership requirement

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -140,6 +140,7 @@ enabled = false
 client_id = some_id
 client_secret = some_secret
 scopes = user:email
+team_ids =
 auth_url = https://github.com/login/oauth/authorize
 token_url = https://github.com/login/oauth/access_token
 api_url = https://api.github.com/user

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -179,6 +179,7 @@ Client ID and a Client Secret. Specify these in the grafana config file. Example
     client_id = YOUR_GITHUB_APP_CLIENT_ID
     client_secret = YOUR_GITHUB_APP_CLIENT_SECRET
     scopes = user:email
+    team_ids =
     auth_url = https://github.com/login/oauth/authorize
     token_url = https://github.com/login/oauth/access_token
     allow_sign_up = false
@@ -188,6 +189,21 @@ now login or signup with your github accounts.
 
 You may allow users to sign-up via github auth by setting allow_sign_up to true. When this option is
 set to true, any user successfully authenticating via github auth will be automatically signed up.
+
+### team_ids
+Require an active team membership for at least one of the given teams on GitHub.
+If the authenticated user isn't a member of at least one the teams they will not
+be able to register or authenticate with your Grafana instance. Example:
+
+    [auth.github]
+    enabled = true
+    client_id = YOUR_GITHUB_APP_CLIENT_ID
+    client_secret = YOUR_GITHUB_APP_CLIENT_SECRET
+    scopes = user:email
+    team_ids = 150,300
+    auth_url = https://github.com/login/oauth/authorize
+    token_url = https://github.com/login/oauth/access_token
+    allow_sign_up = false
 
 ## [auth.google]
 You need to create a google project. You can do this in the [Google Developer Console](https://console.developers.google.com/project).
@@ -257,5 +273,3 @@ enabled. Counters are sent every 24 hours. Default value is `true`.
 ### google_analytics_ua_id
 If you want to track Grafana usage via Google analytics specify *your* Univeral Analytics ID
 here. By defualt this feature is disabled.
-
-

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -45,7 +45,11 @@ func OAuthLogin(ctx *middleware.Context) {
 
 	userInfo, err := connect.UserInfo(token)
 	if err != nil {
-		ctx.Handle(500, fmt.Sprintf("login.OAuthLogin(get info from %s)", name), err)
+		if err == social.ErrMissingTeamMembership {
+			ctx.Redirect(setting.AppSubUrl + "/login?missing_team_membership=1")
+		} else {
+			ctx.Handle(500, fmt.Sprintf("login.OAuthLogin(get info from %s)", name), err)
+		}
 		return
 	}
 

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -75,7 +75,8 @@ func NewOAuthService() {
 		// GitHub.
 		if name == "github" {
 			setting.OAuthService.GitHub = true
-			SocialMap["github"] = &SocialGithub{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl, allowSignup: info.AllowSignup}
+			teamIds := sec.Key("team_ids").Ints(",")
+			SocialMap["github"] = &SocialGithub{Config: &config, allowedDomains: info.AllowedDomains, ApiUrl: info.ApiUrl, allowSignup: info.AllowSignup, teamIds: teamIds}
 		}
 
 		// Google.
@@ -105,6 +106,7 @@ type SocialGithub struct {
 	allowedDomains []string
 	ApiUrl         string
 	allowSignup    bool
+	teamIds        []int
 }
 
 func (s *SocialGithub) Type() int {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
@@ -108,6 +109,10 @@ type SocialGithub struct {
 	allowSignup    bool
 	teamIds        []int
 }
+
+var (
+	ErrMissingTeamMembership = errors.New("User not a member of one of the required teams")
+)
 
 func (s *SocialGithub) Type() int {
 	return int(models.GITHUB)

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
@@ -126,6 +127,28 @@ func (s *SocialGithub) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
+func (s *SocialGithub) IsTeamMember(client *http.Client, username string, teamId int) bool {
+	var data struct {
+		Url    string `json:"url"`
+		State  string `json:"state"`
+	}
+
+	membershipUrl := fmt.Sprintf("https://api.github.com/teams/%d/memberships/%s", teamId, username)
+	r, err := client.Get(membershipUrl)
+	if err != nil {
+		return false
+	}
+
+	defer r.Body.Close()
+
+	if err = json.NewDecoder(r.Body).Decode(&data); err != nil {
+		return false
+	}
+
+	active := data.State == "active"
+	return active
+}
+
 func (s *SocialGithub) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int    `json:"id"`
@@ -146,11 +169,23 @@ func (s *SocialGithub) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 		return nil, err
 	}
 
-	return &BasicUserInfo{
+	userInfo := &BasicUserInfo{
 		Identity: strconv.Itoa(data.Id),
 		Name:     data.Name,
 		Email:    data.Email,
-	}, nil
+	}
+
+	if len(s.teamIds) > 0 {
+		for _, teamId := range s.teamIds {
+			if s.IsTeamMember(client, data.Name, teamId) {
+				return userInfo, nil
+			}
+		}
+
+		return nil, ErrMissingTeamMembership
+	} else {
+		return userInfo, nil
+	}
 }
 
 //   ________                     .__


### PR DESCRIPTION
If the `team_ids` configuration option for `auth.github` section is present in an Grafana installation it will attempt to check for an active membership in _at least one_ of the specified teams. The user will be redirected back to the login page if there isn't an active team membership, otherwise they'll be able to authenticate like normal.

The teams will be looked in the order they are defined in the configuration file.

/cc grafana/grafana#1731 @torkelo @jssjr @mastahyeti
