### PR TITLE
Allow copy & paste panels

### DIFF
--- a/public/app/core/panelclipboard.js
+++ b/public/app/core/panelclipboard.js
@@ -1,0 +1,30 @@
+define([
+  'app/core/store',
+  'angular',
+],
+function (store, angular) {
+  'use strict';
+
+  return {
+    get: function() {
+      var json = store.get("copiedPanel");
+      var panel = null;
+      try {
+        panel = JSON.parse(json);
+      } catch(err) {
+        this.clear();
+      }
+      return panel;
+    },
+    set: function(panel, namePrefix) {
+      var copy = angular.copy(panel);
+      copy.title = namePrefix + copy.title;
+      delete copy["id"];
+      delete copy["span"];
+      store.set("copiedPanel", JSON.stringify(copy));
+    },
+    clear: function() {
+      store.delete("copiedPanel");
+    }
+  };
+});

--- a/public/app/features/dashboard/dashboardCtrl.js
+++ b/public/app/features/dashboard/dashboardCtrl.js
@@ -3,8 +3,9 @@ define([
   'jquery',
   'app/core/config',
   'moment',
+  'app/core/panelclipboard',
 ],
-function (angular, $, config, moment) {
+function (angular, $, config, moment, panelclipboard) {
   "use strict";
 
   var module = angular.module('grafana.controllers');
@@ -88,6 +89,22 @@ function (angular, $, config, moment) {
       $scope.resetRow();
       $scope.row.title = 'New row';
       $scope.addRow($scope.dashboard, $scope.row);
+    };
+
+    $scope.pasteInNewRow = function() {
+      var panel = panelclipboard.get();
+      if (panel != null) {
+        $scope.resetRow();
+        panel["span"] = 12;
+
+        $scope.row.title = panel.title;
+        $scope.row.panels = [];
+
+        $scope.addRow($scope.dashboard, $scope.row);
+        $scope.dashboard.addPanel(panel, $scope.row);
+      } else {
+        $scope.appEvent('alert-error', ["Clipboard error", "The clipboard doesn't contain a valid panel"]);
+      }
     };
 
     $scope.resetRow = function() {

--- a/public/app/features/dashboard/rowCtrl.js
+++ b/public/app/features/dashboard/rowCtrl.js
@@ -1,9 +1,10 @@
 define([
   'angular',
   'lodash',
-  'app/core/config'
+  'app/core/config',
+  'app/core/panelclipboard'
 ],
-function (angular, _, config) {
+function (angular, _, config, panelclipboard) {
   'use strict';
 
   var module = angular.module('grafana.controllers');
@@ -112,6 +113,20 @@ function (angular, _, config) {
       $timeout(function() {
         $scope.dashboardViewState.update({fullscreen: true, edit: true, panelId: panel.id });
       });
+    };
+
+    $scope.pastePanel = function() {
+      var panel = panelclipboard.get();
+      if (panel != null) {
+        panel.span = 12;
+        $scope.addPanel(panel);
+
+        $timeout(function() {
+          $scope.$broadcast('render');
+        });
+      } else {
+        $scope.appEvent('alert-error', ["Clipboard error", "The clipboard doesn't contain a valid panel"]);
+      }
     };
 
     $scope.setHeight = function(height) {

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -1,6 +1,7 @@
 ///<reference path="../../headers/common.d.ts" />
 
 import config from 'app/core/config';
+import panelclipboard from 'app/core/panelclipboard';
 import _ from 'lodash';
 import angular from 'angular';
 import $ from 'jquery';
@@ -81,6 +82,10 @@ export class PanelCtrl {
     this.changeView(true, true);
   }
 
+  copyPanel() {
+    panelclipboard.set(this.panel, this.dashboard.title + ": ");
+  }
+
   exitFullscreen() {
     this.changeView(false, false);
   }
@@ -111,6 +116,7 @@ export class PanelCtrl {
     let menu = [];
     menu.push({text: 'View', click: 'ctrl.viewPanel(); dismiss();'});
     menu.push({text: 'Edit', click: 'ctrl.editPanel(); dismiss();', role: 'Editor'});
+    menu.push({text: 'Copy', click: 'ctrl.copyPanel(); dismiss();'});
     if (!this.fullscreen) { //  duplication is not supported in fullscreen mode
       menu.push({ text: 'Duplicate', click: 'ctrl.duplicate()', role: 'Editor' });
     }

--- a/public/app/headers/common.d.ts
+++ b/public/app/headers/common.d.ts
@@ -38,6 +38,11 @@ declare module 'app/core/store' {
   export default store;
 }
 
+declare module 'app/core/panelclipboard' {
+  var panelclipboard: any;
+  export default panelclipboard;
+}
+
 declare module 'tether' {
   var config: any;
   export default config;

--- a/public/app/partials/dashboard.html
+++ b/public/app/partials/dashboard.html
@@ -37,6 +37,9 @@
 										<li bindonce ng-repeat="(key, value) in panels">
 											<a ng-click="addPanelDefault(key)" bo-text="value.name"></a>
 										</li>
+										<li>
+											<a ng-click="pastePanel()">Paste panel</a>
+										</li>
 									</ul>
 								</li>
 								<li class="dropdown-submenu">
@@ -102,6 +105,9 @@
 			<div class="span12" style="text-align:right;">
 				<span style="margin-right: 10px;" ng-click="addRowDefault()" class="pointer btn btn-secondary btn-small">
 					<span><i class="fa fa-plus"></i> ADD ROW</span>
+				</span>
+				<span style="margin-right: 10px;" ng-click="pasteInNewRow()" class="pointer btn btn-secondary btn-small">
+					<span><i class="fa fa-plus"></i> PASTE IN NEW ROW</span>
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
We use this mainly to diagnose problems we're having with our production site - while we have a lot of different dashboards,  sometimes it's very useful to quickly combine graphs from different dashboard to see all of them one after the other.
This makes it very easy to correlate different events.

I'm using the localStorage as a clipboard. To paste panels you can either add them to an existing row or create a new row with just this panel (what we're using mainly).

I don't have much experience with angular or javascript in general, so please let me know if anything's really weird or incorrect.

![image](https://cloud.githubusercontent.com/assets/273236/7417689/17d1ecb4-ef68-11e4-8af0-b499ed426664.png)

![image](https://cloud.githubusercontent.com/assets/273236/7417690/1e2a4106-ef68-11e4-9273-13941adf57c7.png)

![image](https://cloud.githubusercontent.com/assets/273236/7417692/218836be-ef68-11e4-90f2-e3c1eb4f41c4.png)
