### PR TITLE
default sidemenu to open #54

### DIFF
--- a/public/app/controllers/loginCtrl.js
+++ b/public/app/controllers/loginCtrl.js
@@ -14,7 +14,7 @@ function (angular, config) {
       password: '',
     };
 
-    contextSrv.setSideMenuState(false);
+    contextSrv.sidemenu = false;
 
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;

--- a/public/app/routes/dashLoadControllers.js
+++ b/public/app/routes/dashLoadControllers.js
@@ -36,7 +36,9 @@ function (angular, _, kbn, moment, $) {
 
   });
 
-  module.controller('DashFromSnapshotCtrl', function($scope, $routeParams, backendSrv) {
+  module.controller('DashFromSnapshotCtrl', function($scope, $routeParams, backendSrv, contextSrv) {
+    //don't show the sidemenu in snapshots.
+    contextSrv.sidemenu = false;
     backendSrv.get('/api/snapshots/' + $routeParams.key).then(function(result) {
       $scope.initDashboard(result, $scope);
     }, function() {

--- a/public/app/services/contextSrv.js
+++ b/public/app/services/contextSrv.js
@@ -45,7 +45,19 @@ function (angular, _, store, config) {
     this.user = new User();
     this.isSignedIn = this.user.isSignedIn;
     this.isGrafanaAdmin = this.user.isGrafanaAdmin;
-    this.sidemenu = store.getBool('grafana.sidemenu', true);
+    var sidemenuDefault = false;
+    if (this.hasRole('Admin')) {
+      sidemenuDefault = true;
+    }
+    this.sidemenu = store.getBool('grafana.sidemenu', sidemenuDefault);
+    if (this.isSignedIn && !store.exists('grafana.sidemenu')) {
+      // If the sidemnu has never been set before, set it to false.
+      // This will result in this.sidemenu and the localStorage grafana.sidemenu
+      // to be out of sync if the user has an admin role.  But this is 
+      // intentional and results in the user seeing the sidemenu only on
+      // their first login.
+      store.set('grafana.sidemenu', false);
+    }
     this.isEditor = this.hasRole('Editor') || this.hasRole('Admin');
   });
 });

--- a/public/app/services/contextSrv.js
+++ b/public/app/services/contextSrv.js
@@ -45,7 +45,7 @@ function (angular, _, store, config) {
     this.user = new User();
     this.isSignedIn = this.user.isSignedIn;
     this.isGrafanaAdmin = this.user.isGrafanaAdmin;
-    this.sidemenu = store.getBool('grafana.sidemenu');
+    this.sidemenu = store.getBool('grafana.sidemenu', true);
     this.isEditor = this.hasRole('Editor') || this.hasRole('Admin');
   });
 });

--- a/public/app/services/contextSrv.js
+++ b/public/app/services/contextSrv.js
@@ -53,7 +53,7 @@ function (angular, _, store, config) {
     if (this.isSignedIn && !store.exists('grafana.sidemenu')) {
       // If the sidemnu has never been set before, set it to false.
       // This will result in this.sidemenu and the localStorage grafana.sidemenu
-      // to be out of sync if the user has an admin role.  But this is 
+      // to be out of sync if the user has an admin role.  But this is
       // intentional and results in the user seeing the sidemenu only on
       // their first login.
       store.set('grafana.sidemenu', false);


### PR DESCRIPTION
If the grafana.sidemenu setting is not present in a users browser local storage, then default to setting it to true.
