### PR TITLE
Add Android 5 theme colour

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
+    <meta name="theme-color" content="#000">
 
     <title>Grafana</title>
 


### PR DESCRIPTION
This makes the "chrome" on Google Chrome for Android black.  More info [here](http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android)
