### PR TITLE
Adding Ansible role for Grafana v2.x

### DIFF
--- a/docs/sources/installation/provisioning.md
+++ b/docs/sources/installation/provisioning.md
@@ -17,6 +17,7 @@ system. These are not maintained by any core Grafana team member and might be ou
 
 * [github.com/bobrik/ansible-grafana](https://github.com/bobrik/ansible-grafana)
 * [github.com/bitmazk/ansible-digitalocean-influxdb-grafana](https://github.com/bitmazk/ansible-digitalocean-influxdb-grafana)
+* [github.com/picotrading/ansible-grafana](https://github.com/picotrading/ansible-grafana)
 
 ## Docker
 


### PR DESCRIPTION
Adding Ansible role which is compatible with Grafana v2.x.
