### PR TITLE
Quote 'measurement' properly in getAltSegments() (influxdb 0.9)

### DIFF
--- a/public/app/plugins/datasource/influxdb/queryCtrl.js
+++ b/public/app/plugins/datasource/influxdb/queryCtrl.js
@@ -45,10 +45,10 @@ function (angular, _) {
         query = 'SHOW MEASUREMENTS';
       } else if (index % 2 === 1) {
         queryType = 'TAG_KEYS';
-        query = 'SHOW TAG KEYS FROM ' + measurement;
+        query = 'SHOW TAG KEYS FROM "' + measurement + '"';
       } else {
         queryType = 'TAG_VALUES';
-        query = "SHOW TAG VALUES FROM " + measurement + " WITH KEY = " + $scope.segments[$scope.segments.length - 2].value;
+        query = 'SHOW TAG VALUES FROM "' + measurement + '" WITH KEY = ' + $scope.segments[$scope.segments.length - 2].value;
       }
 
       console.log('getAltSegments: query' , query);


### PR DESCRIPTION
Grafana doesn't properly quote 'measurement' when requesting tag list and tag values. Influxdb 0.9 barks if there's a dot in the measurement identifier. This PR fixes that.
