### PR TITLE
Allow kbn.secondsToHms() to return result in milliseconds (influxdb 0.9)

### DIFF
--- a/public/app/components/kbn.js
+++ b/public/app/components/kbn.js
@@ -81,11 +81,16 @@ function($, _, moment) {
     if(numminutes){
       return numminutes + 'm';
     }
-    var numseconds = (((seconds % 31536000) % 86400) % 3600) % 60;
+    var numseconds = Math.floor((((seconds % 31536000) % 86400) % 3600) % 60);
     if(numseconds){
       return numseconds + 's';
     }
-    return 'less then a second'; //'just now' //or other string you like;
+    var nummilliseconds = Math.floor(seconds * 1000.0);
+    if(nummilliseconds){
+      return nummilliseconds + 'ms';
+    }
+
+    return 'less then a millisecond'; //'just now' //or other string you like;
   };
 
   kbn.to_percent = function(number,outof) {

--- a/public/test/specs/kbn-format-specs.js
+++ b/public/test/specs/kbn-format-specs.js
@@ -63,7 +63,7 @@ define([
     it('10m 1600 resolution', function() {
       var range = { from: kbn.parseDate('now-10m'), to: kbn.parseDate('now') };
       var str = kbn.calculateInterval(range, 1600, null);
-      expect(str).to.be('0.1s');
+      expect(str).to.be('100ms');
     });
 
     it('fixed user interval', function() {


### PR DESCRIPTION
When using influxdb 0.9 as source it's not possible to zoom beyond a certain threshold. This is due to the function `kbn.secondsToHms()` returning float results for the interval between 0 and 1 second. This threshold is dependent on the range viewed and the width of the graph. On my desktop Grafana fails with a 15 minute range when viewed in full screen.

This PR adds a millisecond case to `kbn.secondsToHms()` to avoid results like "0.1s" by returning "100ms" instead.

This fixes zoom when using the influxdb 0.9 data source.

Please note that the default return value of 'less then a millisecond' will never be used - with or without this PR. `kbn.secondsToHms()` is only called from `kbn.calculateInterval()`, which sets a lower limit of 1ms. Current master will return "0.001s", this PR will return "1ms" when called with the lower limit as argument.
