### PR TITLE
Fix broken link in Debian installation guide

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -88,7 +88,7 @@ this database before upgrades. You can also use mysql or postgres as the Grafana
 
 ## Configuration
 
-The configuration file is located at `/etc/grafana/grafana.ini`.  Go the [Configuration](configuration) page for details
+The configuration file is located at `/etc/grafana/grafana.ini`.  Go the [Configuration](/installation/configuration) page for details
 on all those options.
 
 ### Adding data sources


### PR DESCRIPTION
Link to the Configuration page 404's
