### PR TITLE
Addresses #1853, redact session provider secrets

### DIFF
--- a/pkg/api/admin_settings.go
+++ b/pkg/api/admin_settings.go
@@ -17,7 +17,7 @@ func AdminGetSettings(c *middleware.Context) {
 		for _, key := range section.Keys() {
 			keyName := key.Name()
 			value := key.Value()
-			if strings.Contains(keyName, "secret") || strings.Contains(keyName, "password") || (strings.Contains(keyName, "provider_config") && strings.Contains(value, "@"))  {
+			if strings.Contains(keyName, "secret") || strings.Contains(keyName, "password") || (strings.Contains(keyName, "provider_config") && strings.Contains(value, "@")) {
 				value = "************"
 			}
 

--- a/pkg/api/admin_settings.go
+++ b/pkg/api/admin_settings.go
@@ -17,7 +17,7 @@ func AdminGetSettings(c *middleware.Context) {
 		for _, key := range section.Keys() {
 			keyName := key.Name()
 			value := key.Value()
-			if strings.Contains(keyName, "secret") || strings.Contains(keyName, "password") {
+			if strings.Contains(keyName, "secret") || strings.Contains(keyName, "password") || (strings.Contains(keyName, "provider_config") && strings.Contains(value, "@"))  {
 				value = "************"
 			}
 


### PR DESCRIPTION
In cases where a database is used for session storage, redact the
session_provider config value. I assumed "@" as the marker for a
database vs file/memory.
