### PR TITLE
fix mac.md for incorrect href

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -7,7 +7,7 @@ page_keywords: grafana, installation, mac, osx, guide
 # Installing on Mac
 
 There is currently no binary build for Mac. But read the [build from
-source](../project/building_from_source) page for instructions on how to
+source](/project/building_from_source) page for instructions on how to
 build it yourself.
 
 


### PR DESCRIPTION
The link points to http://docs.grafana.org/installation/project/building_from_source , but should be http://docs.grafana.org/project/building_from_source
