### PR TITLE
no unbound recursion in publish()

### DIFF
--- a/pkg/services/eventpublisher/eventpublisher.go
+++ b/pkg/services/eventpublisher/eventpublisher.go
@@ -109,25 +109,26 @@ func Setup() error {
 }
 
 func publish(routingKey string, msgString []byte) {
-	err := channel.Publish(
-		exchange,   //exchange
-		routingKey, // routing key
-		false,      // mandatory
-		false,      // immediate
-		amqp.Publishing{
-			ContentType: "application/json",
-			Body:        msgString,
-		},
-	)
-	if err != nil {
+	for {
+		err := channel.Publish(
+			exchange,   //exchange
+			routingKey, // routing key
+			false,      // mandatory
+			false,      // immediate
+			amqp.Publishing{
+				ContentType: "application/json",
+				Body:        msgString,
+			},
+		)
+		if err == nil {
+			return
+		}
 		// failures are most likely because the connection was lost.
 		// the connection will be re-established, so just keep
 		// retrying every 2seconds until we successfully publish.
 		time.Sleep(2 * time.Second)
 		fmt.Println("publish failed, retrying.")
-		publish(routingKey, msgString)
 	}
-	return
 }
 
 func eventListener(event interface{}) error {


### PR DESCRIPTION
unbound recursion approach can blow up call stack,
and - I think - allocate memory unboundedly as well.

We can simply loop until err != nil

I didn't actually test this live, though tests succeed
