### PR TITLE
fixing #2021

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -94,6 +94,7 @@ func Register(r *macaron.Macaron) {
 
 		r.Get("/frontend/settings/", GetFrontendSettings)
 		r.Any("/datasources/proxy/:id/*", reqSignedIn, ProxyDataSourceRequest)
+		r.Any("/datasources/proxy/:id", reqSignedIn, ProxyDataSourceRequest)
 
 		// Dashboard
 		r.Group("/dashboards", func() {


### PR DESCRIPTION
This tiny commit fixes a routing problem for proxy requests. The
router was expecting a url path behind the proxy id, if none was
given (read: the service proxied was at the root of a host) then
the router would return a 404. With this patch it now propperly
uses ProxyDataSourceRequest.
