### PR TITLE
Fixed variable name for annotations

### DIFF
--- a/public/app/plugins/datasource/influxdb/influxSeries.js
+++ b/public/app/plugins/datasource/influxdb/influxSeries.js
@@ -48,7 +48,7 @@ function (_) {
     var list = [];
     var self = this;
 
-    _.each(this.seriesList, function (series) {
+    _.each(this.series, function (series) {
       var titleCol = null;
       var timeCol = null;
       var tagsCol = null;


### PR DESCRIPTION
This is why dynamically typed languages are inherently inferior. Someone changed the variable name and forgot to update it in all of the locations.
