### PR TITLE
Add github organizations support

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -153,6 +153,7 @@ token_url = https://github.com/login/oauth/access_token
 api_url = https://api.github.com/user
 team_ids =
 allowed_domains =
+allowed_organizations =
 
 #################################### Google Auth ##########################
 [auth.google]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -146,12 +146,13 @@
 ;allow_sign_up = false
 ;client_id = some_id
 ;client_secret = some_secret
-;scopes = user:email
+;scopes = user:email,read:org
 ;auth_url = https://github.com/login/oauth/authorize
 ;token_url = https://github.com/login/oauth/access_token
 ;api_url = https://api.github.com/user
 ;team_ids =
 ;allowed_domains =
+;allowed_organizations =
 
 #################################### Google Auth ##########################
 [auth.google]

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -48,6 +48,8 @@ func OAuthLogin(ctx *middleware.Context) {
 	if err != nil {
 		if err == social.ErrMissingTeamMembership {
 			ctx.Redirect(setting.AppSubUrl + "/login?failedMsg=" + url.QueryEscape("Required Github team membership not fulfilled"))
+		} else if err == social.ErrMissingOrganizationMembership {
+			ctx.Redirect(setting.AppSubUrl + "/login?failedMsg=" + url.QueryEscape("Required Github organization membership not fulfilled"))
 		} else {
 			ctx.Handle(500, fmt.Sprintf("login.OAuthLogin(get info from %s)", name), err)
 		}


### PR DESCRIPTION
Now you can add

```
allowed_organizations = grafana
```

which only allows to log in people that are part of the `grafana` organization in the GitHub.

// This is my first contribution in the go language
