### PR TITLE
Render panel images with any SSL protocol

### DIFF
--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -26,7 +26,7 @@ func RenderToPng(params *RenderOpts) (string, error) {
 	pngPath, _ := filepath.Abs(filepath.Join(setting.ImagesDir, util.GetRandomString(20)))
 	pngPath = pngPath + ".png"
 
-	cmd := exec.Command(binPath, "--ignore-ssl-errors=true", scriptPath, "url="+params.Url, "width="+params.Width,
+	cmd := exec.Command(binPath, "--ignore-ssl-errors=true", "--ssl-protocol=any", scriptPath, "url="+params.Url, "width="+params.Width,
 		"height="+params.Height, "png="+pngPath, "cookiename="+setting.SessionOptions.CookieName,
 		"domain="+setting.Domain, "sessionid="+params.SessionId)
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
When reverse proxying Grafana behind an SSL web server without SSLv3 support, panel PNGs fail to render.  The resulting PNG is just a large transparent PNG with no data.

Phantomjs defaults to SSLv3.  It's common practice these days to disable SSLv3 due to the POODLE vulnerability.

This PR allows phantomjs to use any available SSL protocol (including TLSv1).  Non-SSL connections are unaffected by this change.

Another fix would be to upgrade phantomjs to 1.9.8 or greater ([which uses TLSv1 as the default](https://github.com/ariya/phantomjs/issues/12655)).
