### PR TITLE
OpenTSDB: Restrict typeahead tag keys and values

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -90,6 +90,55 @@ function (angular, _, kbn) {
       });
     };
 
+    OpenTSDBDatasource.prototype.performMetricKeyValueLookup = function(metric, key) {
+      if(metric === "") {
+        throw "Metric not set.";
+      } else if(key === "") {
+        throw "Key not set.";
+      }
+      var m = metric + "{" + key + "=*}";
+      var options = {
+        method: 'GET',
+        url: this.url + '/api/search/lookup',
+        params: {
+          m: m,
+        }
+      };
+      return backendSrv.datasourceRequest(options).then(function(result) {
+        result = result.data.results;
+        var tagvs = [];
+        _.each(result, function(r) {
+          tagvs.push(r.tags[key]);
+        });
+        return tagvs;
+      });
+    };
+
+    OpenTSDBDatasource.prototype.performMetricKeyLookup = function(metric) {
+      if(metric === "") {
+        throw "Metric not set.";
+      }
+      var options = {
+        method: 'GET',
+        url: this.url + '/api/search/lookup',
+        params: {
+          m: metric,
+        }
+      };
+      return backendSrv.datasourceRequest(options).then(function(result) {
+        result = result.data.results;
+        var tagks = [];
+        _.each(result, function(r) {
+          _.each(r.tags, function(tagv, tagk) {
+            if(tagks.indexOf(tagk) === -1) {
+              tagks.push(tagk);
+            }
+          });
+        });
+        return tagks;
+      });
+    };
+
     OpenTSDBDatasource.prototype.testDatasource = function() {
       return this.performSuggestQuery('cpu', 'metrics').then(function () {
         return { status: "success", message: "Data source is working", title: "Success" };

--- a/public/app/plugins/datasource/opentsdb/queryCtrl.js
+++ b/public/app/plugins/datasource/opentsdb/queryCtrl.js
@@ -50,13 +50,13 @@ function (angular, _, kbn) {
 
     $scope.suggestTagKeys = function(query, callback) {
       $scope.datasource
-        .performSuggestQuery(query, 'tagk')
+        .performMetricKeyLookup($scope.target.metric)
         .then(callback);
     };
 
     $scope.suggestTagValues = function(query, callback) {
       $scope.datasource
-        .performSuggestQuery(query, 'tagv')
+        .performMetricKeyValueLookup($scope.target.metric, $scope.target.currentTagKey)
         .then(callback);
     };
 


### PR DESCRIPTION
WARNING: I do not know Javascript, or Angular.

When selecting metric tag keys, we only are interested in keys which are associated with this metric.  Likewise, when selecting a value for a certain key, we only want to consider values which apply to the given key and metric.

This follows up with the effort of https://github.com/grafana/grafana/pull/1433 to appropriately restrict tag keys and values. It differs in that it makes use of OpenTSDB's ['search/lookup'](http://opentsdb.net/docs/build/html/api_http/search/lookup.html) API endpoint to determine which keys or values are relevant in a given context.

This probably can't be merged as is, but hopefully provides a clear example of how that endpoint can be leveraged to make Grafana's OpenTSDB support better.
