### PR TITLE
Add notes about godep and npm install -g

### DIFF
--- a/docs/sources/project/building_from_source.md
+++ b/docs/sources/project/building_from_source.md
@@ -28,6 +28,11 @@ godep restore                    (will pull down all golang lib dependecies in y
 go build .
 ```
 
+If you do not have `godep`  already, you will need to install it first:
+```
+go get github.com/kr/godep
+```
+You should also ensure that `$GOPATH\bin` is in your `$PATH`.
 # Building on Windows
 The Grafana backend includes Sqlite3 which requires GCC to compile. So in order to compile Grafana on windows you need
 to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download).
@@ -42,7 +47,7 @@ npm install
 npm install -g grunt-cli
 grunt
 ```
-
+_Please note that depending on how you have installed Node, `npm install -g` may need to be run as `root`._
 ## Recompile backend on source change
 To rebuild on source change (requires that you executed godep restore)
 ```


### PR DESCRIPTION
Godep will need to be installed first (and available in path) - possibly obvious to Go programmers, but not so obvious to people for whom Grafana may be their first exposure to Go.

`npm install -g` will need write access to wherever your node packages are installed - if you've installed via your distro's package manager, this will probably require root access.
