### PR TITLE
add proxy_url

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -32,6 +32,9 @@ domain = localhost
 # The full public facing url
 root_url = %(protocol)s://%(domain)s:%(http_port)s/
 
+proxy = false
+proxy_url = %(protocol)s://%(domain)s/
+
 # Log web requests
 router_logging = false
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -42,6 +42,10 @@ var (
 	AppUrl    string
 	AppSubUrl string
 
+	// Proxy settings.
+	Proxy     bool
+	ProxyUrl  string
+
 	// build
 	BuildVersion string
 	BuildCommit  string
@@ -132,6 +136,15 @@ func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
 	appSubUrl := strings.TrimSuffix(url.Path, "/")
 
 	return appUrl, appSubUrl
+}
+
+func parseProxyUrl(section *ini.Section) (string) {
+	proxyUrl := section.Key("proxy_url").MustString("http://localhost:3000/")
+	if proxyUrl[len(proxyUrl)-1] != '/' {
+		proxyUrl += "/"
+	}
+
+	return proxyUrl
 }
 
 func ToAbsUrl(relativeUrl string) string {
@@ -344,6 +357,9 @@ func NewConfigContext(args *CommandLineArgs) {
 		CertFile = server.Key("cert_file").String()
 		KeyFile = server.Key("cert_key").String()
 	}
+	//proxy
+	ProxyUrl = parseProxyUrl(server)
+	Proxy = server.Key("proxy").MustBool(false)
 
 	Domain = server.Key("domain").MustString("localhost")
 	HttpAddr = server.Key("http_addr").MustString("0.0.0.0")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -43,8 +43,8 @@ var (
 	AppSubUrl string
 
 	// Proxy settings.
-	Proxy     bool
-	ProxyUrl  string
+	Proxy    bool
+	ProxyUrl string
 
 	// build
 	BuildVersion string
@@ -138,7 +138,7 @@ func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
 	return appUrl, appSubUrl
 }
 
-func parseProxyUrl(section *ini.Section) (string) {
+func parseProxyUrl(section *ini.Section) string {
 	proxyUrl := section.Key("proxy_url").MustString("http://localhost:3000/")
 	if proxyUrl[len(proxyUrl)-1] != '/' {
 		proxyUrl += "/"

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -60,6 +60,11 @@ func NewOAuthService() {
 			continue
 		}
 
+		redirectUrl := setting.AppUrl
+		if setting.Proxy {
+			redirectUrl = setting.ProxyUrl
+		}
+
 		setting.OAuthService.OAuthInfos[name] = info
 		config := oauth2.Config{
 			ClientID:     info.ClientId,
@@ -68,7 +73,7 @@ func NewOAuthService() {
 				AuthURL:  info.AuthUrl,
 				TokenURL: info.TokenUrl,
 			},
-			RedirectURL: strings.TrimSuffix(setting.AppUrl, "/") + SocialBaseUrl + name,
+			RedirectURL: strings.TrimSuffix(redirectUrl, "/") + SocialBaseUrl + name,
 			Scopes:      info.Scopes,
 		}
 


### PR DESCRIPTION
If behind a proxy, send proxy_url as OAuth2 redirect_uri.

I have grafana sitting behind apache, this flag allows me to modify the redirect_uri to an externally accessible resource.
