### PR TITLE
Support Multiple Fields in InfluxDB 0.9+

### DIFF
--- a/public/app/plugins/datasource/influxdb/influxSeries.js
+++ b/public/app/plugins/datasource/influxdb/influxSeries.js
@@ -20,25 +20,39 @@ function (_) {
       return output;
     }
 
+    var field_datapoints = function(datapoints, column_index) {
+      return _.map(datapoints, function(datapoint) {
+        return [datapoint[column_index - 1], _.last(datapoint)];
+      });
+    };
+
     _.each(self.series, function(series) {
       var datapoints = [];
+      var columns = series.columns.length;
       for (var i = 0; i < series.values.length; i++) {
-        datapoints[i] = [series.values[i][1], new Date(series.values[i][0]).getTime()];
+        datapoints[i] = series.values[i].slice(1);
+        datapoints[i].push(new Date(series.values[i][0]).getTime());
       }
 
-      var seriesName = series.name;
+      for (var j = 1; j < columns; j++) {
+        var seriesName = series.name;
+        var columnName = series.columns[j];
 
-      if (self.alias) {
-        seriesName = self._getSeriesName(series);
-      } else if (series.tags) {
-        var tags = _.map(series.tags, function(value, key) {
-          return key + ': ' + value;
-        });
+        if (self.alias) {
+          seriesName = self._getSeriesName(series);
+        } else if (series.tags) {
+          var tags = _.map(series.tags, function(value, key) {
+            return key + ': ' + value;
+          });
+          if (columnName === 'value') {
+            seriesName = seriesName + ' {' + tags.join(', ') + '}';
+          } else {
+            seriesName = seriesName + '.' + columnName + ' {' + tags.join(', ') + '}';
+          }
+        }
 
-        seriesName = seriesName + ' {' + tags.join(', ') + '}';
+        output.push({ target: seriesName, datapoints: field_datapoints(datapoints, j)});
       }
-
-      output.push({ target: seriesName, datapoints: datapoints });
     });
 
     return output;

--- a/public/test/specs/influxSeries-specs.js
+++ b/public/test/specs/influxSeries-specs.js
@@ -5,6 +5,96 @@ define([
 
   describe('when generating timeseries from influxdb response', function() {
 
+    describe('given multiple fields for series', function() {
+      var options = { series: [
+        {
+          name: 'cpu',
+          tags:  {app: 'test', server: 'server1'},
+          columns: ['time', 'mean', 'max', 'min'],
+          values: [["2015-05-18T10:57:05Z", 10, 11, 9], ["2015-05-18T10:57:06Z", 20, 21, 19]]
+        }
+      ]};
+      describe('and no alias', function() {
+        it('should generate multiple datapoints for each column', function() {
+          var series = new InfluxSeries(options);
+          var result = series.getTimeSeries();
+
+          expect(result.length).to.be(3);
+          expect(result[0].target).to.be('cpu.mean {app: test, server: server1}');
+          expect(result[0].datapoints[0][0]).to.be(10);
+          expect(result[0].datapoints[0][1]).to.be(1431946625000);
+          expect(result[0].datapoints[1][0]).to.be(20);
+          expect(result[0].datapoints[1][1]).to.be(1431946626000);
+
+          expect(result[1].target).to.be('cpu.max {app: test, server: server1}');
+          expect(result[1].datapoints[0][0]).to.be(11);
+          expect(result[1].datapoints[0][1]).to.be(1431946625000);
+          expect(result[1].datapoints[1][0]).to.be(21);
+          expect(result[1].datapoints[1][1]).to.be(1431946626000);
+
+          expect(result[2].target).to.be('cpu.min {app: test, server: server1}');
+          expect(result[2].datapoints[0][0]).to.be(9);
+          expect(result[2].datapoints[0][1]).to.be(1431946625000);
+          expect(result[2].datapoints[1][0]).to.be(19);
+          expect(result[2].datapoints[1][1]).to.be(1431946626000);
+
+        });
+      });
+
+      describe('and simple alias', function() {
+        it('should use alias', function() {
+          options.alias = 'new series';
+          var series = new InfluxSeries(options);
+          var result = series.getTimeSeries();
+
+          expect(result[0].target).to.be('new series');
+          expect(result[1].target).to.be('new series');
+          expect(result[2].target).to.be('new series');
+        });
+
+      });
+
+      describe('and alias patterns', function() {
+        it('should replace patterns', function() {
+          options.alias = 'alias: $m -> $tag_server ([[measurement]])';
+          var series = new InfluxSeries(options);
+          var result = series.getTimeSeries();
+
+          expect(result[0].target).to.be('alias: cpu -> server1 (cpu)');
+          expect(result[1].target).to.be('alias: cpu -> server1 (cpu)');
+          expect(result[2].target).to.be('alias: cpu -> server1 (cpu)');
+        });
+
+      });
+    });
+    describe('given measurement with default fieldname', function() {
+      var options = { series: [
+        {
+          name: 'cpu',
+          tags:  {app: 'test', server: 'server1'},
+          columns: ['time', 'value'],
+          values: [["2015-05-18T10:57:05Z", 10], ["2015-05-18T10:57:06Z", 12]]
+        },
+        {
+          name: 'cpu',
+          tags:  {app: 'test2', server: 'server2'},
+          columns: ['time', 'value'],
+          values: [["2015-05-18T10:57:05Z", 15], ["2015-05-18T10:57:06Z", 16]]
+        }
+      ]};
+
+      describe('and no alias', function() {
+
+        it('should generate label with no field', function() {
+          var series = new InfluxSeries(options);
+          var result = series.getTimeSeries();
+
+          expect(result[0].target).to.be('cpu {app: test, server: server1}');
+          expect(result[1].target).to.be('cpu {app: test2, server: server2}');
+        });
+      });
+
+    });
     describe('given two series', function() {
       var options = { series: [
         {
@@ -28,13 +118,13 @@ define([
           var result = series.getTimeSeries();
 
           expect(result.length).to.be(2);
-          expect(result[0].target).to.be('cpu {app: test, server: server1}');
+          expect(result[0].target).to.be('cpu.mean {app: test, server: server1}');
           expect(result[0].datapoints[0][0]).to.be(10);
           expect(result[0].datapoints[0][1]).to.be(1431946625000);
           expect(result[0].datapoints[1][0]).to.be(12);
           expect(result[0].datapoints[1][1]).to.be(1431946626000);
 
-          expect(result[1].target).to.be('cpu {app: test2, server: server2}');
+          expect(result[1].target).to.be('cpu.mean {app: test2, server: server2}');
           expect(result[1].datapoints[0][0]).to.be(15);
           expect(result[1].datapoints[0][1]).to.be(1431946625000);
           expect(result[1].datapoints[1][0]).to.be(16);


### PR DESCRIPTION
- Update influxdb 0.9 plugin to iterate thru fields returned by InfluxDB
  and output ea. field metric separately
- Updates default label to include Field Name

example query that now returns all fields as separate datapoints instead of just the first one:

`select field1, field2 from sample_measurement ...`

Awesome!
