### PR TITLE
Fix panel layout

### DIFF
--- a/public/css/less/panel.less
+++ b/public/css/less/panel.less
@@ -1,6 +1,6 @@
 .panel {
   display: inline-block;
-  float: left;
+  *float: left;
   vertical-align: top;
   position: relative;
 }


### PR DESCRIPTION
When I create a dashboard, that has two or more column graphs, the layout is broken.
(I use Google Chrome.)

broken layout:
![grafana_panel_layout_broken](https://cloud.githubusercontent.com/assets/224552/8256862/cbafe30a-16e4-11e5-85ec-7a957c0c219c.png)

expected layout:
![grafana_panel_layout](https://cloud.githubusercontent.com/assets/224552/8256871/d30c1b32-16e4-11e5-8234-a0f79302e005.png)

The "float" style may be specified for IE, I add "*" as prefix of "float".
