### PR TITLE
make status command exit with proper code

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -138,6 +138,7 @@ case "$1" in
     ;;
   status)
     status -p $PID_FILE $NAME
+    exit $?
     ;;
   restart|force-reload)
     if [ -f "$PID_FILE" ]; then


### PR DESCRIPTION
This makes `service grafana-server status` exit with the proper code and allows the chef `service` provider to start it properly.

In particular, when the service isn't running, the `status` command should exit with `3`, but it was always exiting with `0`
