### PR TITLE
Added fix for template variables when no options are available to select

### DIFF
--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -27,7 +27,7 @@ function (angular, _) {
       this._texts = {};
 
       _.each(this.variables, function(variable) {
-        if (!variable.current || !variable.current.value) { return; }
+        if (!variable.current || !variable.current.isNone && !variable.current.value) { return; }
 
         this._values[variable.name] = this.renderVariableValue(variable);
         this._texts[variable.name] = variable.current.text;

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -10,6 +10,7 @@ function (angular, _, kbn) {
 
   module.service('templateValuesSrv', function($q, $rootScope, datasourceSrv, $location, templateSrv, timeSrv) {
     var self = this;
+    function getNoneOption() { return { text: 'None', value: '', isNone: true }; }
 
     $rootScope.onAppEvent('time-range-changed', function()  {
       var variable = _.findWhere(self.variables, { type: 'interval' });
@@ -174,6 +175,9 @@ function (angular, _, kbn) {
         variable.options = self.metricNamesToVariableValues(variable, results);
         if (variable.includeAll) {
           self.addAllOption(variable);
+        }
+        if (!variable.options.length) {
+          variable.options.push(getNoneOption());
         }
         return datasource;
       });

--- a/public/test/specs/templateValuesSrv-specs.js
+++ b/public/test/specs/templateValuesSrv-specs.js
@@ -224,8 +224,9 @@ define([
         scenario.queryResult = [{text: 'apps.backend.backend_01.counters.req'}, {text: 'apps.backend.backend_02.counters.req'}];
       });
 
-      it('should not add non matching items', function() {
-        expect(scenario.variable.options.length).to.be(0);
+      it('should not add non matching items, None option should be added instead', function() {
+        expect(scenario.variable.options.length).to.be(1);
+        expect(scenario.variable.options[0].isNone).to.be(true);
       });
     });
 


### PR DESCRIPTION
When template variable queries return 0 results and a user attempts to click on the variable dropdown, an error occurs. 

The changes in this pull request resolve this issue by adding a **None** option to the results if nothing is available.
