### PR TITLE
Update kbn.js

### DIFF
--- a/public/app/components/kbn.js
+++ b/public/app/components/kbn.js
@@ -327,6 +327,10 @@ function($, _, moment) {
     return kbn.toFixed(size, decimals) + '%';
   };
 
+  kbn.valueFormats.HundredthOfAPercent = function(size, decimals) {
+    return kbn.toFixed(size/100, decimals) + '%';
+  };
+
   kbn.formatFuncCreator = function(factor, extArray) {
     return function(size, decimals, scaledDecimals) {
       if (size === null) {
@@ -542,6 +546,7 @@ function($, _, moment) {
           {text: 'none' , value: 'none'},
           {text: 'short', value: 'short'},
           {text: 'percent', value: 'percent'},
+          {text: 'Hundredth Percent', value: 'HundredthOfAPercent'},
           {text: 'ppm', value: 'ppm'},
           {text: 'dB', value: 'dB'},
         ]


### PR DESCRIPTION
VMware 5.5 CPU Usage (StatsFeeder) is now reported as hundredth of a percent (1 = 0.01%). A value between 0 and 10000. This change is to display the value back to percentage.
