### PR TITLE
fix config flag

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -18,7 +18,7 @@ specified in a `.ini` configuration file or specified using environment variable
 > **Note.** If you have installed Grafana using the `deb` or `rpm`
 > packages, then your configuration file is located at
 > `/etc/grafana/grafana.ini`. This path is specified in the Grafana
-> init.d script using `--config` file parameter.
+> init.d script using `-config` file parameter.
 
 ## Using environment variables
 


### PR DESCRIPTION
```
root@f452fb19c1cc:/go/src/github.com/raintank/grafana# ./bin/grafana-server --help
Usage of ./bin/grafana-server:
  -config="": path to config file
  -homepath="": path to grafana install/home path, defaults to working directory
  -pidfile="": path to pid file
```
