### PR TITLE
Fix the kairosdb editor source file name

### DIFF
--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -13,7 +13,7 @@ function (angular, _, kbn) {
 
     function KairosDBDatasource(datasource) {
       this.type = datasource.type;
-      this.editorSrc = 'plugins/datasources/kairosdb/kairosdb.editor.html';
+      this.editorSrc = 'plugins/datasource/kairosdb/partials/query.editor.html';
       this.url = datasource.url;
       this.name = datasource.name;
       this.supportMetrics = true;


### PR DESCRIPTION
The editor html name in the kairosdb datasource script is incorrect.
