### PR TITLE
Fix 'paranthesis' typo to 'parenthesis'

### DIFF
--- a/public/app/plugins/datasource/graphite/parser.js
+++ b/public/app/plugins/datasource/graphite/parser.js
@@ -142,13 +142,13 @@ define([
         name: this.consumeToken().value,
       };
 
-      // consume left paranthesis
+      // consume left parenthesis
       this.consumeToken();
 
       node.params = this.functionParameters();
 
       if (!this.match(')')) {
-        this.errorMark('Expected closing paranthesis');
+        this.errorMark('Expected closing parenthesis');
       }
 
       this.consumeToken();

--- a/public/test/specs/parser-specs.js
+++ b/public/test/specs/parser-specs.js
@@ -118,11 +118,11 @@ define([
       expect(rootNode.pos).to.be(19);
     });
 
-    it('invalid function expression missing closing paranthesis', function() {
+    it('invalid function expression missing closing parenthesis', function() {
       var parser = new Parser('sum(test');
       var rootNode = parser.getAst();
 
-      expect(rootNode.message).to.be('Expected closing paranthesis instead found end of string');
+      expect(rootNode.message).to.be('Expected closing parenthesis instead found end of string');
       expect(rootNode.pos).to.be(9);
     });
 

--- a/public/vendor/bootstrap/bootstrap.js
+++ b/public/vendor/bootstrap/bootstrap.js
@@ -2069,7 +2069,7 @@
   , move: function (e) {
       if (!this.shown) return
 
-      // grafana change, shift+left paranthesis
+      // grafana change, shift+left parenthesis
       if (e.shiftKey && e.keyCode === 40) {
         return;
       }


### PR DESCRIPTION
This typo is most noticable in the Graphite lexer error hint message.
