### PR TITLE
KairosDB: Update the template functionality to cohere with the very closely related OpenTSDB plugin

### DIFF
--- a/docs/sources/datasources/kairosdb.md
+++ b/docs/sources/datasources/kairosdb.md
@@ -36,12 +36,13 @@ KairosDB Datasource Plugin provides following functions in `Variables values que
 
 Name | Description
 ---- | ----
-`metrics(query)` | Returns a list of metric names. If nothing is given, returns a list of all metric names.
-`tag_names(query)` | Returns a list of tag names. If nothing is given, returns a list of all tag names.
-`tag_values(query)` | Returns a list of tag values. If nothing is given, returns a list of all tag values.
+`metrics(query)` | Returns a list of metric names matching `query`. If nothing is given, returns a list of all metric names.
+`tag_names(query)` | Returns a list of tag names matching `query`. If nothing is given, returns a list of all tag names.
+`tag_values(metric, tag)` | Returns a list of values for `tag` from the given `metric`.
 
 For details of `metric names`, `tag names`, and `tag values`, please refer to the KairosDB documentations.
 
 - [List Metric Names - KairosDB 0.9.4 documentation](http://kairosdb.github.io/kairosdocs/restapi/ListMetricNames.html)
 - [List Tag Names - KairosDB 0.9.4 documentation](http://kairosdb.github.io/kairosdocs/restapi/ListTagNames.html)
 - [List Tag Values - KairosDB 0.9.4 documentation](http://kairosdb.github.io/kairosdocs/restapi/ListTagValues.html)
+- [Query Metrics - KairosDB 0.9.4 documentation](http://kairosdb.github.io/kairosdocs/restapi/QueryMetrics.html).

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -78,8 +78,8 @@ function (angular, _, kbn) {
      */
     KairosDBDatasource.prototype._performMetricSuggestQuery = function(metric) {
       var options = {
-        url : this.url + '/api/v1/metricnames',
-        method : 'GET'
+        url: this.url + '/api/v1/metricnames',
+        method: 'GET'
       };
 
       return $http(options).then(function(response) {
@@ -103,8 +103,8 @@ function (angular, _, kbn) {
 	method: 'POST',
 	url: this.url + '/api/v1/datapoints/query/tags',
 	data: {
-          metrics : [{ name : metric }],
-          cache_time : 0,
+          metrics: [{ name: metric }],
+          cache_time: 0,
           start_absolute: 0
 	}
       };
@@ -132,8 +132,8 @@ function (angular, _, kbn) {
 	method: 'POST',
 	url: this.url + '/api/v1/datapoints/query/tags',
 	data: {
-          metrics : [{ name : metric }],
-          cache_time : 0,
+          metrics: [{ name: metric }],
+          cache_time: 0,
           start_absolute: 0
 	}
       };
@@ -148,11 +148,11 @@ function (angular, _, kbn) {
 
     KairosDBDatasource.prototype.performTagSuggestQuery = function(metric) {
       var options = {
-        url : this.url + '/api/v1/datapoints/query/tags',
-        method : 'POST',
-        data : {
-          metrics : [{ name : metric }],
-          cache_time : 0,
+        url: this.url + '/api/v1/datapoints/query/tags',
+        method: 'POST',
+        data: {
+          metrics: [{ name: metric }],
+          cache_time: 0,
           start_absolute: 0
         }
       };

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -100,13 +100,13 @@ function (angular, _, kbn) {
       if(!metric) { return $q.when([]); }
 
       var options = {
-	method: 'POST',
-	url: this.url + '/api/v1/datapoints/query/tags',
-	data: {
+        method: 'POST',
+        url: this.url + '/api/v1/datapoints/query/tags',
+        data: {
           metrics: [{ name: metric }],
           cache_time: 0,
           start_absolute: 0
-	}
+        }
       };
 
       return $http(options).then(function(result) {
@@ -129,13 +129,13 @@ function (angular, _, kbn) {
       }
 
       var options = {
-	method: 'POST',
-	url: this.url + '/api/v1/datapoints/query/tags',
-	data: {
+        method: 'POST',
+        url: this.url + '/api/v1/datapoints/query/tags',
+        data: {
           metrics: [{ name: metric }],
           cache_time: 0,
           start_absolute: 0
-	}
+        }
       };
 
       return $http(options).then(function(result) {

--- a/public/app/plugins/datasource/kairosdb/queryCtrl.js
+++ b/public/app/plugins/datasource/kairosdb/queryCtrl.js
@@ -53,7 +53,7 @@ function (angular, _) {
         return metricList;
       }
       else {
-        $scope.datasource.performMetricSuggestQuery().then(function(result) {
+        $scope.datasource._performMetricSuggestQuery().then(function(result) {
           metricList = result;
           callback(metricList);
         });
@@ -69,7 +69,7 @@ function (angular, _) {
         }
       }
 
-      $scope.datasource.performTagSuggestQuery($scope.target.metric).then(function(result) {
+      $scope.datasource._performTagSuggestQuery($scope.target.metric).then(function(result) {
         if (!_.isEmpty(result)) {
           tagList.push(result);
           callback(_.keys(result.tags));

--- a/public/app/plugins/datasource/kairosdb/queryCtrl.js
+++ b/public/app/plugins/datasource/kairosdb/queryCtrl.js
@@ -6,8 +6,6 @@ function (angular, _) {
   'use strict';
 
   var module = angular.module('grafana.controllers');
-  var metricList = [];
-  var tagList = [];
 
   module.controller('KairosDBQueryCtrl', function($scope) {
 
@@ -48,50 +46,26 @@ function (angular, _) {
       _.move($scope.panel.targets, fromIndex, toIndex);
     };
 
+    $scope.getTextValues = function(metricFindResult) {
+      return _.map(metricFindResult, function(value) { return value.text; });
+    };
+
     $scope.suggestMetrics = function(query, callback) {
-      if (!_.isEmpty(metricList)) {
-        return metricList;
-      }
-      else {
-        $scope.datasource._performMetricSuggestQuery().then(function(result) {
-          metricList = result;
-          callback(metricList);
-        });
-      }
+      $scope.datasource.metricFindQuery('metrics(' + query + ')')
+        .then($scope.getTextValues)
+        .then(callback);
     };
 
     $scope.suggestTagKeys = function(query, callback) {
-      if (!_.isEmpty(tagList)) {
-        var result = _.find(tagList, { name : $scope.target.metric });
-
-        if (!_.isEmpty(result)) {
-          return _.keys(result.tags);
-        }
-      }
-
-      $scope.datasource._performTagSuggestQuery($scope.target.metric).then(function(result) {
-        if (!_.isEmpty(result)) {
-          tagList.push(result);
-          callback(_.keys(result.tags));
-        }
-      });
+      $scope.datasource.metricFindQuery('tag_names(' + $scope.target.metric + ')')
+        .then($scope.getTextValues)
+        .then(callback);
     };
 
     $scope.suggestTagValues = function(query, callback) {
-      if (!_.isEmpty(tagList)) {
-        var result = _.find(tagList, { name : $scope.target.metric });
-
-        if (!_.isEmpty(result)) {
-          return result.tags[$scope.target.currentTagKey];
-        }
-      }
-
-      $scope.datasource.performTagSuggestQuery($scope.target.metric).then(function(result) {
-        if (!_.isEmpty(result)) {
-          tagList.push(result);
-          callback(result.tags[$scope.target.currentTagKey]);
-        }
-      });
+      $scope.datasource.metricFindQuery('tag_values(' + $scope.target.metric + ',' + $scope.target.currentTagKey + ')')
+        .then($scope.getTextValues)
+        .then(callback);
     };
 
     // Filter metric by tag


### PR DESCRIPTION
This changes the logic from @masaori335 where he is letting the template engine lookup all tags from the whole KairosDB, not just specific to one metric.

I have started to expand tag_values to take two parameters instead of one, namely "metric name" and "tag". This will list all possible tag values for that metric, and that tag. I feel this is closer to what the template engine does for eg. graphite where you do node1.\* to get all possible values of node2.

I might be using KairosDB and Grafana wrong, so Ill try to explain my use case:

I have several metrics, but for this example lets keep with one metric called "fping".
This "fping" metric have two tags, "target" and "host". The host tag is as you can imagine the hostname that is being "fpinged", and "target" (target is probably not a good name) is either "max", "min", "avg", "loss". 
Using this structure I want to eg. create a host template variable. Using the original logic I will get any value from any tag in kairosdb that contains the filter value. Eg. having a filter of "host" will get you things like "dead_hosts", "host_based_stuff" etc, but not the values of the tag "host".

I hope this makes sense, and if it does I can try and expand this functionality with error checking, documentation, etc.
