### PR TITLE
set mode 0640 and group grafana on /etc/grafana/grafana.ini

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -43,9 +43,9 @@ case "$1" in
 	chmod 755 /var/log/grafana /var/lib/grafana
 
 	# configuration files should not be modifiable by grafana user, as this can be a security issue
-	chown -Rh root:root /etc/grafana/*
+	chown -Rh root:$GRAFANA_GROUP /etc/grafana/*
 	chmod 755 /etc/grafana
-	find /etc/grafana -type f -exec chmod 644 {} ';'
+	find /etc/grafana -type f -exec chmod 640 {} ';'
 	find /etc/grafana -type d -exec chmod 755 {} ';'
 
 	# if $2 is set, this is an upgrade

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -43,9 +43,9 @@ if [ $1 -eq 1 ] ; then
 	chmod 755 /var/log/grafana /var/lib/grafana
 
 	# configuration files should not be modifiable by grafana user, as this can be a security issue
-	chown -Rh root:root /etc/grafana/*
+	chown -Rh root:$GRAFANA_GROUP /etc/grafana/*
 	chmod 755 /etc/grafana
-	find /etc/grafana -type f -exec chmod 644 {} ';'
+	find /etc/grafana -type f -exec chmod 640 {} ';'
 	find /etc/grafana -type d -exec chmod 755 {} ';'
 
   if [ -x /bin/systemctl ] ; then


### PR DESCRIPTION
A quick fix for issue #2126. Sets files in `/etc/grafana` to mode `0640` and group ownership to `grafana`.
