### PR TITLE
Minor update to documentation for MySQL sessions

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -327,7 +327,7 @@ This option should be configured differently depending on what type of
 session provider you have configured.
 
 - **file:** session file path, e.g. `data/sessions`
-- **mysql:** go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1)/database_name`
+- **mysql:** go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
 - **postgres:** ex:  user=a password=b host=localhost port=5432 dbname=c sslmode=disable
 
 If you use MySQL or Postgres as the session store you need to create the


### PR DESCRIPTION
Just a minor clarification to the documentation with regards to configuration of the MySQL driver for sessions.

In the current documentation, there's no mention of the TCP port in the dsn config string (I'm not familiar with go-sql-driver/mysql at all). I falsely assumed that it'd default to port 3306 but it doesn't appear to and Grafana silently fails. Hoping this will save somebody else a few minutes of their life. The lack of TCP port in the dsn config string might also be cause of issues in the later comments of issue #1861.
