### PR TITLE
Updated condition for basic auth so that the context exits also if the auth proxy is enabled.

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -131,7 +131,7 @@ func initContextWithApiKey(ctx *Context) bool {
 }
 
 func initContextWithBasicAuth(ctx *Context) bool {
-	if !setting.BasicAuthEnabled {
+	if !setting.BasicAuthEnabled || setting.AuthProxyEnabled {
 		return false
 	}
 


### PR DESCRIPTION
Added the extra setting to verify if the auth proxy is enabled as if there's already a proxy handling authorization, it should be the only layer taking care of authentication.  Otherwise, having auth proxy enabled and basic auth enabled will cause an authorization error unless the same user/password combination is also present in the grafana user database.
