### PR TITLE
fix pid creation fail on debian

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -38,9 +38,9 @@ case "$1" in
   fi
 
 	# Set user permissions on /var/log/grafana, /var/lib/grafana
-	mkdir -p /var/log/grafana /var/lib/grafana
-	chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
-	chmod 755 /var/log/grafana /var/lib/grafana
+	mkdir -p /var/log/grafana /var/lib/grafana /var/run/grafana-server
+	chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana /var/run/grafana-server
+	chmod 755 /var/log/grafana /var/lib/grafana /var/run/grafana-server
 
 	# configuration files should not be modifiable by grafana user, as this can be a security issue
 	chown -Rh root:$GRAFANA_GROUP /etc/grafana/*

--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -33,7 +33,8 @@ DATA_DIR=/var/lib/grafana
 LOG_DIR=/var/log/grafana
 CONF_FILE=$CONF_DIR/grafana.ini
 MAX_OPEN_FILES=10000
-PID_FILE=/var/run/$NAME.pid
+PID_DIR==/var/run/$NAME
+PID_FILE=$PID_DIR/$NAME.pid
 DAEMON=/usr/sbin/$NAME
 
 if [ `id -u` -ne 0 ]; then
@@ -72,7 +73,7 @@ case "$1" in
 	fi
 
 	# Prepare environment
-	mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$LOG_DIR" "$DATA_DIR"
+	mkdir -p "$LOG_DIR" "$DATA_DIR" "$PID_DIR" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$LOG_DIR" "$DATA_DIR"
 	touch "$PID_FILE" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$PID_FILE"
 
   if [ -n "$MAX_OPEN_FILES" ]; then

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -12,6 +12,7 @@ Type=simple
 WorkingDirectory=/usr/share/grafana
 ExecStart=/usr/sbin/grafana-server                                \
                             --config=${CONF_FILE}                 \
+                            --pidfile=${PID_FILE}                 \
                             cfg:default.paths.logs=${LOG_DIR}     \
                             cfg:default.paths.data=${DATA_DIR}    \
 LimitNOFILE=10000


### PR DESCRIPTION
No pid is created with systemd, this fix correct that issue. In addition
a specific folder is created to avoid permission issues.
