### PR TITLE
Fix dashboard/panel link in Scripted Dashboard

### DIFF
--- a/public/app/features/dashlinks/module.js
+++ b/public/app/features/dashlinks/module.js
@@ -114,7 +114,7 @@ function (angular, _) {
           title: linkDef.title,
           icon: iconMap[linkDef.icon],
           tooltip: linkDef.tooltip,
-          target: linkDef.targetBlank ? "_blank" : "",
+          target: linkDef.targetBlank ? "_blank" : "_self",
           keepTime: linkDef.keepTime,
           includeVars: linkDef.includeVars,
         }]);

--- a/public/app/features/panellinks/linkSrv.js
+++ b/public/app/features/panellinks/linkSrv.js
@@ -62,7 +62,7 @@ function (angular, kbn, _) {
       this.getPanelLinkAnchorInfo = function(link) {
         var info = {};
         if (link.type === 'absolute') {
-          info.target = link.targetBlank ? '_blank' : '';
+          info.target = link.targetBlank ? '_blank' : '_self';
           info.href = templateSrv.replace(link.url || '');
           info.title = templateSrv.replace(link.title || '');
           info.href += '?';


### PR DESCRIPTION
When I create dashboard/panel link in scripted dashboard, some links seems to be not working.
I want to create link to change ARGS for scripted dashboard, absolute link is only way to do this, I create link like "/dashboard/script/foo.js?bar=baz".
But such links seems to be not working.

I guess the reason is empty anchor target attribute, so I set "_self", it works.

This is test scripted dashboard, please place this to "<grafana dir>/public/dashboards/test.js" to reproduce.

``` javascript
'use strict';
var window, document, ARGS, $, jQuery, moment, kbn;

var title = ARGS.title || 'none';
var dashboard = {
  title: title,
  time: {
    from: "now-6h",
    to: "now"
  },
  rows : [
    {
      title: title,
      showTitle: true,
      panels: [
        {
          title: title,
          span: 12,
          type: 'text',
          mode: 'text',
          content: '',
          links: [
            {
              name: 'Drilldown dashboard',
              title: 'Test Panel Link',
              type: 'absolute',
              url: '/dashboard/script/test.js',
              params: 'title=foo'
            }
          ]
        }
      ]
    }
  ],
  links: [
    {
      type: 'link',
      icon: 'external link',
      tags: [],
      title: 'Test Dashboard Link',
      url: '/dashboard/script/test.js?title=foo',
      tooltip: 'Test Dashboard Tooltip',
      keepTime: false
    }
  ],
};
return dashboard;
```
