### PR TITLE
Fixes "no datapoints" from InfluxDB 0.9.1 data source

### DIFF
--- a/public/app/plugins/datasource/influxdb/queryBuilder.js
+++ b/public/app/plugins/datasource/influxdb/queryBuilder.js
@@ -112,7 +112,6 @@ function (_) {
       query += ' fill(' + target.fill + ')';
     }
 
-    query += " ORDER BY asc";
     target.query = query;
 
     return query;

--- a/public/test/specs/influx09-querybuilder-specs.js
+++ b/public/test/specs/influx09-querybuilder-specs.js
@@ -13,7 +13,7 @@ define([
       var query = builder.build();
 
       it('should generate correct query', function() {
-        expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE $timeFilter GROUP BY time($interval) ORDER BY asc');
+        expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE $timeFilter GROUP BY time($interval)');
       });
 
     });
@@ -28,13 +28,13 @@ define([
 
       it('should generate correct query', function() {
         expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE "hostname" = \'server1\' AND $timeFilter'
-                            + ' GROUP BY time($interval) ORDER BY asc');
+                            + ' GROUP BY time($interval)');
       });
 
       it('should switch regex operator with tag value is regex', function() {
         var builder = new InfluxQueryBuilder({measurement: 'cpu', tags: [{key: 'app', value: '/e.*/'}]});
         var query = builder.build();
-        expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE "app" =~ /e.*/ AND $timeFilter GROUP BY time($interval) ORDER BY asc');
+        expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE "app" =~ /e.*/ AND $timeFilter GROUP BY time($interval)');
       });
     });
 
@@ -48,7 +48,7 @@ define([
       var query = builder.build();
 
       it('should generate correct query', function() {
-        expect(query).to.be('SELECT sum(tx_in), mean(tx_out) FROM "cpu" WHERE $timeFilter GROUP BY time($interval) ORDER BY asc');
+        expect(query).to.be('SELECT sum(tx_in), mean(tx_out) FROM "cpu" WHERE $timeFilter GROUP BY time($interval)');
       });
     });
 
@@ -62,7 +62,7 @@ define([
 
       it('should generate correct query', function() {
         expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE "hostname" = \'server1\' AND "app" = \'email\' AND ' +
-                            '$timeFilter GROUP BY time($interval) ORDER BY asc');
+                            '$timeFilter GROUP BY time($interval)');
       });
     });
 
@@ -76,7 +76,7 @@ define([
 
       it('should generate correct query', function() {
         expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE "hostname" = \'server1\' OR "hostname" = \'server2\' AND ' +
-                            '$timeFilter GROUP BY time($interval) ORDER BY asc');
+                            '$timeFilter GROUP BY time($interval)');
       });
     });
 
@@ -90,7 +90,7 @@ define([
 
         var query = builder.build();
         expect(query).to.be('SELECT mean(value) FROM "cpu" WHERE $timeFilter ' +
-          'GROUP BY time($interval), "host" ORDER BY asc');
+          'GROUP BY time($interval), "host"');
       });
     });
 


### PR DESCRIPTION
This removes usage of the `ORDER BY` clause for InfluxDB 0.9.x data
sources, which is currently not supported in the latest InfluxDB master
(0.9.1).
