### PR TITLE
Use percent-formatter for stack+percentage graph

### DIFF
--- a/public/app/panels/graph/graph.js
+++ b/public/app/panels/graph/graph.js
@@ -380,11 +380,11 @@ function (angular, $, kbn, moment, _, GraphTooltip) {
             options.yaxes.push(secondY);
 
             applyLogScale(options.yaxes[1], data);
-            configureAxisMode(options.yaxes[1], scope.panel.y_formats[1]);
+            configureAxisMode(options.yaxes[1], scope.panel.percentage && scope.panel.stack ? "percent" : scope.panel.y_formats[1]);
           }
 
           applyLogScale(options.yaxes[0], data);
-          configureAxisMode(options.yaxes[0], scope.panel.y_formats[0]);
+          configureAxisMode(options.yaxes[0], scope.panel.percentage && scope.panel.stack ? "percent" : scope.panel.y_formats[0]);
         }
 
         function applyLogScale(axis, data) {


### PR DESCRIPTION
Currently, if you check both "Stack" and "Percent" below "Display Styles", the Y axis still shows the configured unit, e.g. "s" for "seconds". However the graph actually shows percent values (0 .. 100) as configured.
Changing the unit to "percent" is wrong in this scenario as the legend table would show the wrong unit in that case then.

Hence this patch changes Y axis configuration to hard-coded "percent" if both checkboxes are set.
