### PR TITLE
New graphite function: removeEmptySeries

### DIFF
--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -604,6 +604,11 @@ function (_, $) {
   });
 
   addFuncDef({
+    name: 'removeEmptySeries',
+    category: categories.Filter
+  });
+
+  addFuncDef({
     name: 'useSeriesAbove',
     category: categories.Filter,
     params: [


### PR DESCRIPTION
This patch adds the new graphite function `removeEmptySeries` to the function menu (below Filter)
