### PR TITLE
Support `$`-replacements in KairosDB like the InfluxDB datasource.

### DIFF
--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -222,21 +222,21 @@ function (angular, _, kbn) {
 
           _.each(result.group_by, function(element) {
             if (element.name === "tag") {
-              _.each(element.group, function(value, key) {
-                if (details != "") {
+              _.each(element.group, function(value) {
+                if (details !== "") {
                   details += ", ";
                 }
                 details += value;
               });
             }
             else if (element.name === "value") {
-              if (details != "") {
+              if (details !== "") {
                 details += ", ";
               }
               details += 'value_group=' + element.group.group_number;
             }
             else if (element.name === "time") {
-              if (details != "") {
+              if (details !== "") {
                 details += ", ";
               }
               details += 'time_group=' + element.group.group_number;

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -219,7 +219,7 @@ function (angular, _, kbn) {
           var segments = seriesName.split('.');
           var target = plotParams[index].alias;
           var details = "";
-          
+
           _.each(result.group_by, function(element) {
             if (element.name === "tag") {
               _.each(element.group, function(value, key) {


### PR DESCRIPTION
The InfluxDB 0.8 datasource let you add the following in your alias:
- `$g`, which gets replaced by the grouping value (here, if there are multiple group by columns, they're made into a comma-separated list).
- `$s`, replaced by the series name.
- `$<n>`, for integers `n`, gets replaced by the nth element of the series name, split by periods.

We are looking to add this so the KairosDB datasource has closer parity with the InfluxDB datasource, which we had been using before. We also don't like that you can't control what grouping labels get added to series names.
