### PR TITLE
updated some hard-coded colors to variables

### DIFF
--- a/public/css/less/gfbox.less
+++ b/public/css/less/gfbox.less
@@ -65,7 +65,7 @@
   margin: 15px;
   background: @grafanaPanelBackground;
   position: relative;
-  border: 1px solid @grayDark;
+  border: @grafanaPanelBorder;
   padding: 20px 20px 60px 49px;
 
   h2 {

--- a/public/css/less/grafana.less
+++ b/public/css/less/grafana.less
@@ -184,11 +184,11 @@
   position : absolute;
   top: -1000;
   left: 0;
-  color: #c8c8c8;
+  color: @tooltipColor;
   padding: 10px;
   font-size: 11pt;
   font-weight : 200;
-  background-color: rgb(58, 57, 57);
+  background-color: @tooltipBackground;
   border-radius: 5px;
   z-index: 9999;
   max-width: 800px;

--- a/public/css/less/variables.light.less
+++ b/public/css/less/variables.light.less
@@ -112,6 +112,7 @@
 @grafanaListMainLinkColor:     @textColor;
 
 
+
 // Tables
 // -------------------------
 @tableBackground:                   transparent; // overall background-color
@@ -145,8 +146,8 @@
 @btnDangerBackground:               lighten(@red, 5%);
 @btnDangerBackgroundHighlight:      darken(@red, 5%);
 
-@btnInverseBackground:              @gray;
-@btnInverseBackgroundHighlight:     darken(@gray, 10%);
+@btnInverseBackground:              @white;
+@btnInverseBackgroundHighlight:     darken(@grayLight, 15%);
 
 @iconContainerBackground:			      @white;
 @iconContainerBackgroundHighlight:	lighten(@white, 5%);
@@ -296,8 +297,8 @@
 
 // Tooltips and popovers
 // -------------------------
-@tooltipColor:            #fff;
-@tooltipBackground:       #333;
+@tooltipColor:            @grayDark;
+@tooltipBackground:        darken(@white,3%);
 @tooltipArrowWidth:       5px;
 @tooltipArrowColor:       @tooltipBackground;
 @tooltipLinkColor:        darken(@white,11%);


### PR DESCRIPTION
tooltips were hard-coded color, as well as panel borders. They looked great in dark theme, but broke in the light. These were converted to variables, which were set in the 2 variables.less files for each of use in the future. 

This PR should fix #2397 
