### PR TITLE
Changed font weight to look less muddy

### DIFF
--- a/public/css/less/grafana.less
+++ b/public/css/less/grafana.less
@@ -317,7 +317,7 @@
     margin: 10px 105px;
     strong {
       color: @headingsColor;
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 


### PR DESCRIPTION
Changed the font weight to look a bit less muddy. Any reason why we cant use a number instead of bold? It's a small change, but much more readable without sacrificing the highlight. 
### I'm proposing this:

![screenshot 2015-08-04 15 38 54](https://cloud.githubusercontent.com/assets/2886187/9070683/0ff2395c-3abf-11e5-85e4-aa9c46e0e49f.png)
### vs this:

![screenshot 2015-08-04 15 39 14](https://cloud.githubusercontent.com/assets/2886187/9070686/15f8bc72-3abf-11e5-9bcc-0fa8a95097bf.png)
