### PR TITLE
Including non_negative_derivative function on influxdb

### DIFF
--- a/public/app/plugins/datasource/influxdb/funcEditor.js
+++ b/public/app/plugins/datasource/influxdb/funcEditor.js
@@ -18,7 +18,7 @@ function (angular, _, $) {
 
       var functionList = [
         'count', 'mean', 'sum', 'min', 'max', 'mode', 'distinct', 'median',
-        'derivative', 'stddev', 'first', 'last', 'difference'
+        'derivative', 'non_negative_derivative', 'stddev', 'first', 'last', 'difference'
       ];
 
       var functionMenu = _.map(functionList, function(func) {


### PR DESCRIPTION
Since version 0.9.0 of influxdb the non_negative_derivative function
is merged, this small patch includes it as an option on grafana.
