### PR TITLE
Fixing exposed username and password in InfluxDB query string

### DIFF
--- a/pkg/api/dataproxy_test.go
+++ b/pkg/api/dataproxy_test.go
@@ -27,7 +27,7 @@ func TestDataSourceProxy(t *testing.T) {
 		})
 	})
 
-	Convey("When getting influxdb datasource proxy", t, func() {
+	Convey("When getting influxdb datasource proxy (08)", t, func() {
 		ds := m.DataSource{
 			Type:     m.DS_INFLUXDB_08,
 			Url:      "http://influxdb:8083",
@@ -51,6 +51,32 @@ func TestDataSourceProxy(t *testing.T) {
 			queryVals := req.URL.Query()
 			So(queryVals["u"][0], ShouldEqual, "user")
 			So(queryVals["p"][0], ShouldEqual, "password")
+		})
+
+	})
+
+	Convey("When getting influxdb datasource proxy", t, func() {
+		ds := m.DataSource{
+			Type:     m.DS_INFLUXDB,
+			Url:      "http://influxdb:8083",
+			Database: "site",
+		}
+
+		proxy := NewReverseProxy(&ds, "")
+
+		requestUrl, _ := url.Parse("http://grafana.com/sub")
+		req := http.Request{URL: requestUrl}
+
+		proxy.Director(&req)
+
+		Convey("Should not add db to url", func() {
+			So(req.URL.Path, ShouldEqual, "/")
+		})
+
+		Convey("Should add username and password", func() {
+			queryVals := req.URL.Query()
+			So(queryVals["u"], ShouldBeNil)
+			So(queryVals["p"], ShouldBeNil)
 		})
 
 	})


### PR DESCRIPTION
This will need to be followed up by a UI change, but this dataproxy change will make it so that username and password are not passed in the URL query string if they don't need to be (specifically for the InfluxDB data sources).

We're seeing a problem where, when we enable logging at a certain level, usernames and passwords (which are in the query string) are being logged. Since it's possible to authenticate to InfluxDB using HTTP basic auth instead of passing these parameters as strings, we should support that mode.

Also added a bit of code coverage and a test to ensure that if the username and password are absent from the `DataSource`, they don't get passed as parameters.
