### PR TITLE
Influxdb operators

### DIFF
--- a/public/app/plugins/datasource/influxdb/queryBuilder.js
+++ b/public/app/plugins/datasource/influxdb/queryBuilder.js
@@ -10,14 +10,16 @@ function (_) {
 
   function renderTagCondition (tag, index) {
     var str = "";
+    var operator = (tag.operator || '=');
     if (index > 0) {
       str = (tag.condition || 'AND') + ' ';
     }
 
-    if (tag.value && tag.value[0] === '/' && tag.value[tag.value.length - 1] === '/') {
-      return str + '"' +tag.key + '"' + ' =~ ' + tag.value;
+    if (tag.value && (operator === '=~' || operator === '!~') && /^\/.*\/$/.test(tag.value)) {
+       return str + '"' + tag.key + '"' + ' ' + operator + ' ' + tag.value;
     }
-    return str + '"' + tag.key + '"' + " = '" + tag.value + "'";
+
+    return str + '"' + tag.key + '" ' + operator + " '" + tag.value + "'";
   }
 
   var p = InfluxQueryBuilder.prototype;
@@ -127,3 +129,4 @@ function (_) {
 
   return InfluxQueryBuilder;
 });
+

--- a/public/app/plugins/datasource/influxdb/queryBuilder.js
+++ b/public/app/plugins/datasource/influxdb/queryBuilder.js
@@ -16,7 +16,7 @@ function (_) {
     }
 
     if (tag.value && (operator === '=~' || operator === '!~') && /^\/.*\/$/.test(tag.value)) {
-       return str + '"' + tag.key + '"' + ' ' + operator + ' ' + tag.value;
+      return str + '"' + tag.key + '"' + ' ' + operator + ' ' + tag.value;
     }
 
     return str + '"' + tag.key + '" ' + operator + " '" + tag.value + "'";
@@ -129,4 +129,3 @@ function (_) {
 
   return InfluxQueryBuilder;
 });
-

--- a/public/app/plugins/datasource/influxdb/queryBuilder.js
+++ b/public/app/plugins/datasource/influxdb/queryBuilder.js
@@ -17,6 +17,8 @@ function (_) {
 
     if (tag.value && (operator === '=~' || operator === '!~') && /^\/.*\/$/.test(tag.value)) {
       return str + '"' + tag.key + '"' + ' ' + operator + ' ' + tag.value;
+    } else if (tag.value && /^\/.*\/$/.test(tag.value)) {
+      return str + '"' + tag.key + '"' + ' =~ ' + tag.value;
     }
 
     return str + '"' + tag.key + '" ' + operator + " '" + tag.value + "'";

--- a/public/app/plugins/datasource/influxdb/queryCtrl.js
+++ b/public/app/plugins/datasource/influxdb/queryCtrl.js
@@ -35,7 +35,13 @@ function (angular, _, InfluxQueryBuilder) {
           $scope.tagSegments.push(MetricSegment.newCondition(tag.condition));
         }
         $scope.tagSegments.push(new MetricSegment({value: tag.key, type: 'key', cssClass: 'query-segment-key' }));
-        $scope.tagSegments.push(MetricSegment.newOperator(tag.operator));
+        if (tag.operator) {
+          $scope.tagSegments.push(MetricSegment.newOperator(tag.operator));
+        } else if (/^\/.*\/$/.test(tag.value)) {
+          $scope.tagSegments.push(MetricSegment.newOperator('=~'));
+        } else {
+          $scope.tagSegments.push(MetricSegment.newOperator('='));
+        }
         $scope.tagSegments.push(new MetricSegment({value: tag.value, type: 'value', cssClass: 'query-segment-value'}));
       });
 

--- a/public/app/plugins/datasource/influxdb/queryCtrl.js
+++ b/public/app/plugins/datasource/influxdb/queryCtrl.js
@@ -251,7 +251,7 @@ function (angular, _, InfluxQueryBuilder) {
           tags[tagIndex].key = segment2.value;
         }
         else if (segment2.type === 'value') {
-          tagOperator = $scope.getTagValueOperator(segment2.value, tags[tagIndex].operator)
+          tagOperator = $scope.getTagValueOperator(segment2.value, tags[tagIndex].operator);
           if (tagOperator) {
             $scope.tagSegments[index-1] = MetricSegment.newOperator(tagOperator);
             tags[tagIndex].operator = tagOperator;
@@ -330,4 +330,3 @@ function (angular, _, InfluxQueryBuilder) {
   });
 
 });
-

--- a/public/app/plugins/datasource/influxdb/queryCtrl.js
+++ b/public/app/plugins/datasource/influxdb/queryCtrl.js
@@ -161,7 +161,7 @@ function (angular, _, InfluxQueryBuilder) {
                         MetricSegment.newOperator('<'), MetricSegment.newOperator('>')]);
 
       } else if (segment.type === 'operator' && /^\/.*\/$/.test($scope.tagSegments[index+1].value)) {
-        return $q.when([ MetricSegment.newOperator('=~'), MetricSegment.newOperator('!~')]);
+        return $q.when([MetricSegment.newOperator('=~'), MetricSegment.newOperator('!~')]);
       }
       else  {
         return $q.when([]);

--- a/public/app/plugins/datasource/influxdb/queryCtrl.js
+++ b/public/app/plugins/datasource/influxdb/queryCtrl.js
@@ -156,10 +156,12 @@ function (angular, _, InfluxQueryBuilder) {
         query = $scope.queryBuilder.buildExploreQuery('TAG_VALUES', $scope.tagSegments[index-2].value);
       } else if (segment.type === 'condition') {
         return $q.when([new MetricSegment('AND'), new MetricSegment('OR')]);
-      } else if (segment.type === 'operator') {
+      } else if (segment.type === 'operator' && /^(?!\/.*\/$)/.test($scope.tagSegments[index+1].value)) {
         return $q.when([MetricSegment.newOperator('='), MetricSegment.newOperator('<>'),
-                        MetricSegment.newOperator('<'), MetricSegment.newOperator('>'),
-                        MetricSegment.newOperator('=~'), MetricSegment.newOperator('!~')]);
+                        MetricSegment.newOperator('<'), MetricSegment.newOperator('>')]);
+
+      } else if (segment.type === 'operator' && /^\/.*\/$/.test($scope.tagSegments[index+1].value)) {
+        return $q.when([ MetricSegment.newOperator('=~'), MetricSegment.newOperator('!~')]);
       }
       else  {
         return $q.when([]);


### PR DESCRIPTION
This patch includes some missing comparators/operators for influxdb:
`>  - greater than`
`<  - less than`
`<> - not equal`
`!~ - doesn't match against`

It includes the tag.operator fields to facilitate identification of the operators on the segments.
It keeps the logic for the regex syntax; although it changes the way to validate it
 to handle the new operators use case.
