### PR TITLE
Including more special options for fill

### DIFF
--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -138,8 +138,10 @@
 					</a>
 					<ul class="dropdown-menu">
 						<li><a ng-click="target.fill = ''">no fill</a></li>
-						<li><a ng-click="target.fill = 'null'">fill (null)</a></li>
 						<li><a ng-click="target.fill = '0'">fill (0)</a></li>
+						<li><a ng-click="target.fill = 'null'">fill (null)</a></li>
+						<li><a ng-click="target.fill = 'none'">fill (none)</a></li>
+						<li><a ng-click="target.fill = 'previous'">fill (previous)</a></li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
Included "previous" and "none" as possible values for fill.
From the influxdb documentation:
- "previous" means the values of the previous window is used.
- "none" means that all null values are removed.
