### PR TITLE
Included $col as an option for the "Alias pattern" on influxdb

### DIFF
--- a/docs/sources/datasources/influxdb.md
+++ b/docs/sources/datasources/influxdb.md
@@ -62,6 +62,7 @@ You can switch to raw query mode by pressing the pen icon.
 
 - $m = replaced with measurement name
 - $measurement = replaced with measurement name
+- $col = replaced with column name
 - $tag_hostname = replaced with the value of the hostname tag
 - You can also use [[tag_hostname]] pattern replacement syntax
 

--- a/public/app/plugins/datasource/influxdb/influxSeries.js
+++ b/public/app/plugins/datasource/influxdb/influxSeries.js
@@ -35,7 +35,7 @@ function (_) {
         }
 
         if (self.alias) {
-          seriesName = self._getSeriesName(series);
+          seriesName = self._getSeriesName(series, j);
         } else if (series.tags) {
           seriesName = seriesName + ' {' + tags.join(', ') + '}';
         }
@@ -54,13 +54,14 @@ function (_) {
     return output;
   };
 
-  p._getSeriesName = function(series) {
+  p._getSeriesName = function(series, index) {
     var regex = /\$(\w+)|\[\[([\s\S]+?)\]\]/g;
 
     return this.alias.replace(regex, function(match, g1, g2) {
       var group = g1 || g2;
 
       if (group === 'm' || group === 'measurement') { return series.name; }
+      if (group === 'col') { return series.columns[index]; }
       if (group.indexOf('tag_') !== 0) { return match; }
 
       var tag = group.replace('tag_', '');

--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -210,6 +210,7 @@
 			<ul>
 				<li>$m = replaced with measurement name</li>
 				<li>$measurement = replaced with measurement name</li>
+				<li>$col = replaced with column name</li>
 				<li>$tag_hostname = replaced with the value of the hostname tag</li>
 				<li>You can also use [[tag_hostname]] pattern replacement syntax</li>
 			</ul>


### PR DESCRIPTION
With this patch it's possible to use the column name as an identifier.
This can help when we have multiple columns as it would be possible to automatic generate a legend.
Also this would help in future when grafana could support the "AS" in the query builder.
