### PR TITLE
auth_proxy: Populate all fields when creating user

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -175,7 +175,10 @@ enabled = true
 #################################### Auth Proxy ##########################
 [auth.proxy]
 enabled = false
-header_name = X-WEBAUTH-USER
+header_username = X-WEBAUTH-USER
+header_email = X-WEBAUTH-EMAIL
+header_name = X-WEBAUTH-NAME
+header_company = X-WEBAUTH-COMPANY
 header_property = username
 auto_sign_up = true
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -170,7 +170,10 @@
 #################################### Auth Proxy ##########################
 [auth.proxy]
 ;enabled = false
-;header_name = X-WEBAUTH-USER
+;header_username = X-WEBAUTH-USER
+;header_email = X-WEBAUTH-EMAIL
+;header_name = X-WEBAUTH-NAME
+;header_company = X-WEBAUTH-COMPANY
 ;header_property = username
 ;auto_sign_up = true
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -340,8 +340,17 @@ This feature allows you to handle authentication in a http reverse proxy.
 ### enabled
 Defaults to `false`
 
-### header_name
+### header_username
 Defaults to X-WEBAUTH-USER
+
+### header_email
+Defaults to X-WEBAUTH-EMAIL
+
+### header_name
+Defaults to X-WEBAUTH-NAME
+
+### header_company
+Defaults to X-WEBAUTH-COMPANY
 
 #### header_property
 Defaults to username but can also be set to email

--- a/docs/sources/reference/http_api.md
+++ b/docs/sources/reference/http_api.md
@@ -1270,7 +1270,10 @@ Keys:
 			"auth.proxy":{
 				"auto_sign_up":"true",
 				"enabled":"false",
-				"header_name":"X-WEBAUTH-USER",
+				"header_username":"X-WEBAUTH-USER",
+				"header_email":"X-WEBAUTH-EMAIL",
+				"header_name":"X-WEBAUTH-NAME",
+				"header_company":"X-WEBAUTH-COMPANY",
 				"header_property":"username"
 			},
 			"dashboards.json":{

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -157,7 +157,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 		middlewareScenario("When auth_proxy is enabled enabled and user exists", func(sc *scenarioContext) {
 			setting.AuthProxyEnabled = true
-			setting.AuthProxyHeaderName = "X-WEBAUTH-USER"
+			setting.AuthProxyUsernameHeaderName = "X-WEBAUTH-USER"
 			setting.AuthProxyHeaderProperty = "username"
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
@@ -178,7 +178,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 		middlewareScenario("When auth_proxy is enabled enabled and user does not exists", func(sc *scenarioContext) {
 			setting.AuthProxyEnabled = true
-			setting.AuthProxyHeaderName = "X-WEBAUTH-USER"
+			setting.AuthProxyUsernameHeaderName = "X-WEBAUTH-USER"
 			setting.AuthProxyHeaderProperty = "username"
 			setting.AuthProxyAutoSignUp = true
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -89,10 +89,14 @@ var (
 	AnonymousOrgRole string
 
 	// Auth proxy settings
-	AuthProxyEnabled        bool
-	AuthProxyHeaderName     string
-	AuthProxyHeaderProperty string
-	AuthProxyAutoSignUp     bool
+	AuthProxyEnabled            bool
+	AuthProxyHeaderProperty     string
+	AuthProxyEmailHeaderName    string
+	AuthProxyUsernameHeaderName string
+	AuthProxyNameHeaderName     string
+	AuthProxyCompanyHeaderName  string
+
+	AuthProxyAutoSignUp bool
 
 	// Basic Auth
 	BasicAuthEnabled bool
@@ -401,8 +405,11 @@ func NewConfigContext(args *CommandLineArgs) {
 	// auth proxy
 	authProxy := Cfg.Section("auth.proxy")
 	AuthProxyEnabled = authProxy.Key("enabled").MustBool(false)
-	AuthProxyHeaderName = authProxy.Key("header_name").String()
 	AuthProxyHeaderProperty = authProxy.Key("header_property").String()
+	AuthProxyEmailHeaderName = authProxy.Key("header_email").String()
+	AuthProxyUsernameHeaderName = authProxy.Key("header_username").String()
+	AuthProxyNameHeaderName = authProxy.Key("header_name").String()
+	AuthProxyCompanyHeaderName = authProxy.Key("header_company").String()
 	AuthProxyAutoSignUp = authProxy.Key("auto_sign_up").MustBool(true)
 
 	authBasic := Cfg.Section("auth.basic")


### PR DESCRIPTION
In our environment, we get many more information than just the `login` or `email` address when a user authenticates on the reverse-proxy in front of Grafana.

This pull request aims to populate all available fields that we get when a user logs in and pass them to the new user created if we have `auto_sign_up = true`
