### PR TITLE
don't calculate cumulative value if series overrides stack to false

### DIFF
--- a/public/app/panels/graph/graph.tooltip.js
+++ b/public/app/panels/graph/graph.tooltip.js
@@ -58,6 +58,8 @@ function ($) {
         if (scope.panel.stack) {
           if (scope.panel.tooltip.value_type === 'individual') {
             value = series.data[hoverIndex][1];
+          } else if (!series.stack) {
+            value = series.data[hoverIndex][1];
           } else {
             last_value += series.data[hoverIndex][1];
             value = last_value;

--- a/public/test/specs/graph-tooltip-specs.js
+++ b/public/test/specs/graph-tooltip-specs.js
@@ -73,8 +73,8 @@ define([
   describeSharedTooltip("steppedLine false, stack true, individual false", function(ctx) {
     ctx.setup(function() {
       ctx.data = [
-        { data: [[10, 15], [12, 20]], },
-        { data: [[10, 2], [12, 3]], }
+        { data: [[10, 15], [12, 20]], stack: true },
+        { data: [[10, 2], [12, 3]], stack: true }
       ];
       ctx.scope.panel.stack = true;
       ctx.pos = { x: 11 };
@@ -82,6 +82,22 @@ define([
 
     it('should show stacked value', function() {
       expect(ctx.results[1].value).to.be(17);
+    });
+
+  });
+
+  describeSharedTooltip("steppedLine false, stack true, individual false, series stack false", function(ctx) {
+    ctx.setup(function() {
+      ctx.data = [
+        { data: [[10, 15], [12, 20]], stack: true },
+        { data: [[10, 2], [12, 3]], stack: false }
+      ];
+      ctx.scope.panel.stack = true;
+      ctx.pos = { x: 11 };
+    });
+
+    it('should not show stacked value', function() {
+      expect(ctx.results[1].value).to.be(2);
     });
 
   });


### PR DESCRIPTION
When I create memory usage graph, and stack series except "Total Memory"
The tooltip value seems to be wrong value.

The total memory only has 1GB, but the tooltip show about 1.6GB.
![memory](https://cloud.githubusercontent.com/assets/224552/9242618/363377b4-41bf-11e5-8ecd-e5fcae9e771a.png)

So, I think the tooltip should care about series stack option to calculate the value.
