### PR TITLE
Fixing permission issues for new installations

### DIFF
--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -36,6 +36,8 @@ MAX_OPEN_FILES=10000
 PID_FILE=/var/run/$NAME.pid
 DAEMON=/usr/sbin/$NAME
 
+umask 0027
+
 if [ `id -u` -ne 0 ]; then
 	echo "You need root privileges to run this script"
 	exit 4

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -17,6 +17,7 @@ ExecStart=/usr/sbin/grafana-server                                \
                             cfg:default.paths.data=${DATA_DIR}    \
 LimitNOFILE=10000
 TimeoutStopSec=20
+UMask=0027
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The umask as 0027 will generates permissions like:
0640 - for files
0750 - for directories

This should solve the grafana.db being accesable by any user for new installations.
[#2126](https://github.com/grafana/grafana/issues/2126)
