### PR TITLE
Disable load timeout in requirejs

### DIFF
--- a/tasks/options/requirejs.js
+++ b/tasks/options/requirejs.js
@@ -8,6 +8,7 @@ module.exports = function(config,grunt) {
       dir:  '<%= destDir %>',
       mainConfigFile: '<%= tempDir %>/app/components/require.config.js',
       baseUrl: './app',
+      waitSeconds: 0,
 
       modules: [], // populated below,
 


### PR DESCRIPTION
On slow platform (I'm running a RaspberryPI2 with a class 10 SDCard), requirejs may fail due to timeout (see comments on https://github.com/grafana/grafana/issues/2183)

This PR completly disable timeout, maybe it would be better to set a high value ?
