### PR TITLE
Hide the reset password link if using LDAP Auth

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -28,6 +28,7 @@ func LoginView(c *middleware.Context) {
 	settings["googleAuthEnabled"] = setting.OAuthService.Google
 	settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	settings["disableUserSignUp"] = !setting.AllowUserSignUp
+  settings["ldapEnabled"]       = setting.LdapEnabled
 
 	if !tryLoginUsingRememberCookie(c) {
 		c.HTML(200, VIEW_INDEX)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -28,7 +28,7 @@ func LoginView(c *middleware.Context) {
 	settings["googleAuthEnabled"] = setting.OAuthService.Google
 	settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	settings["disableUserSignUp"] = !setting.AllowUserSignUp
-  settings["ldapEnabled"]       = setting.LdapEnabled
+	settings["ldapEnabled"] = setting.LdapEnabled
 
 	if !tryLoginUsingRememberCookie(c) {
 		c.HTML(200, VIEW_INDEX)

--- a/public/app/controllers/loginCtrl.js
+++ b/public/app/controllers/loginCtrl.js
@@ -19,6 +19,7 @@ function (angular, config) {
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
+    $scope.ldapEnabled       = config.ldapEnabled;
 
     $scope.loginMode = true;
     $scope.submitBtnText = 'Log in';

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -94,7 +94,7 @@
 		</div>
 
 		<div class="row" style="margin-top: 40px">
-			<div class="text-center">
+			<div class="text-center" nf-if="LdapEnabled == false">
 				<a href="user/password/send-reset-email">
 					Forgot your password?
 				</a>


### PR DESCRIPTION
Addresses #2495 

Should also provide a pattern for disabling password reset for other auth methods.
