### PR TITLE
Ldap login hints

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -131,6 +131,9 @@ auto_assign_org = true
 # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
 auto_assign_org_role = Viewer
 
+# Background text for the user field on the login page
+login_hint = email or username
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -130,6 +130,9 @@
 # Default role new users will be automatically assigned (if disabled above is set to true)
 ;auto_assign_org_role = Viewer
 
+# Background text for the user field on the login page
+;login_hint = email or username
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -28,6 +28,7 @@ func LoginView(c *middleware.Context) {
 	settings["googleAuthEnabled"] = setting.OAuthService.Google
 	settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	settings["disableUserSignUp"] = !setting.AllowUserSignUp
+	settings["loginHint"] = setting.LoginHint
 
 	if !tryLoginUsingRememberCookie(c) {
 		c.HTML(200, VIEW_INDEX)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -79,6 +79,7 @@ var (
 	AllowUserOrgCreate bool
 	AutoAssignOrg      bool
 	AutoAssignOrgRole  string
+	LoginHint          string
 
 	// Http auth
 	AdminUser     string
@@ -392,6 +393,7 @@ func NewConfigContext(args *CommandLineArgs) {
 	AllowUserOrgCreate = users.Key("allow_org_create").MustBool(true)
 	AutoAssignOrg = users.Key("auto_assign_org").MustBool(true)
 	AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Read Only Editor", "Viewer"})
+	LoginHint = users.Key("login_hint").String()
 
 	// anonymous access
 	AnonymousEnabled = Cfg.Section("auth.anonymous").Key("enabled").MustBool(false)

--- a/public/app/controllers/loginCtrl.js
+++ b/public/app/controllers/loginCtrl.js
@@ -19,6 +19,7 @@ function (angular, config) {
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
+    $scope.loginHint     = config.loginHint;
 
     $scope.loginMode = true;
     $scope.submitBtnText = 'Log in';

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -26,7 +26,7 @@
 								<strong>User</strong>
 							</li>
 							<li>
-								<input type="text" name="username" class="tight-form-input last" required ng-model='formModel.user' placeholder="email or username" style="width: 253px">
+								<input type="text" name="username" class="tight-form-input last" required ng-model='formModel.user' placeholder={{loginHint}} style="width: 253px">
 							</li>
 						</ul>
 						<div class="clearfix"></div>


### PR DESCRIPTION
This will allow users to set a custom string for the background in the "user" text field instead of the hardcoded "email or username". For example, you could set:
login_hint = LANID@example.com
or
login_hint = username

Addresses #2494 
