### PR TITLE
Option to hide time options on dashboard

### DIFF
--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -125,6 +125,7 @@ function (angular, _) {
       newScope.clone = $scope.dashboard.getSaveModelClone();
       newScope.clone.editable = true;
       newScope.clone.hideControls = false;
+      newScope.clone.hideTimeOptions = false;
 
       $scope.appEvent('show-modal', {
         src: './app/features/dashboard/partials/saveDashboardAs.html',

--- a/public/app/features/dashboard/dashboardSrv.js
+++ b/public/app/features/dashboard/dashboardSrv.js
@@ -29,6 +29,7 @@ function (angular, $, kbn, _, moment) {
       this.timezone = data.timezone || 'browser';
       this.editable = data.editable === false ? false : true;
       this.hideControls = data.hideControls || false;
+      this.hideTimeOptions = data.hideTimeOptions || false;
       this.sharedCrosshair = data.sharedCrosshair || false;
       this.rows = data.rows || [];
       this.nav = data.nav || [];

--- a/public/app/features/dashboard/partials/settings.html
+++ b/public/app/features/dashboard/partials/settings.html
@@ -68,6 +68,9 @@
 						<li class="tight-form-item">
 							<editor-checkbox text="Shared Crosshair (CTRL+O)" model="dashboard.sharedCrosshair"></editor-checkbox>
 						</li>
+						<li class="tight-form-item">
+							<editor-checkbox text="Hide Time Options" model="dashboard.hideTimeOptions"></editor-checkbox>
+						</li>
 					</ul>
 					<div class="clearfix"></div>
 				</div>

--- a/public/app/panels/timepicker/module.html
+++ b/public/app/panels/timepicker/module.html
@@ -1,4 +1,4 @@
-<div ng-controller='timepicker' ng-init="init()">
+<div ng-controller='timepicker' ng-init="init()" ng-show="!dashboard.hideTimeOptions">
   <style>
     .timepicker-timestring {
       font-weight: normal;
@@ -54,4 +54,14 @@
       </li>
     </ul>
   </form>
+</div>
+<div ng-controller='timepicker' ng-init="init()" ng-show="dashboard.hideTimeOptions && dashboard.refresh">
+        <ul class="nav">
+            <li class="dropdown">
+                <a bs-tooltip="time.tooltip" data-placement="bottom">
+                    <i class="fa fa-clock-o"></i>
+                    <span ng-show="dashboard.refresh" class="text-warning">Refreshed every {{dashboard.refresh}} </span>
+                </a>
+          </li>
+    </ul>
 </div>

--- a/public/dashboards/template_vars.json
+++ b/public/dashboards/template_vars.json
@@ -10,6 +10,7 @@
   "timezone": "browser",
   "editable": true,
   "hideControls": false,
+  "hideTimeOptions": false,
   "rows": [
     {
       "title": "Row1",


### PR DESCRIPTION
This should fix the [#2013](https://github.com/grafana/grafana/issues/2013).
Basically it creates a new option dashboard.hideTimeOptions; and hide the time option when true.
It keeps the informational part for the refresh if it's activated.
