### PR TITLE
Allow change dashboard to Editable state without using Save as

### DIFF
--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -52,7 +52,8 @@ function (angular, _) {
     };
 
     $scope.saveDashboard = function(options) {
-      if ($scope.dashboardMeta.canSave === false) {
+      if ($scope.dashboardMeta.canSave === false && $scope.dashboard.editable === false) {
+        $scope.appEvent('alert-warning', ['Not Editable', 'Cannot save ' + $scope.dashboard.title]);
         return;
       }
 

--- a/public/app/features/dashboard/partials/dashboardTopNav.html
+++ b/public/app/features/dashboard/partials/dashboardTopNav.html
@@ -26,13 +26,13 @@
 				<li ng-show="dashboardMeta.canShare">
 					<a class="pointer" ng-click="shareDashboard()" bs-tooltip="'Share dashboard'" data-placement="bottom"><i class="fa fa-share-square-o"></i></a>
 				</li>
-				<li ng-show="dashboardMeta.canSave">
+				<li ng-show="dashboardMeta.canSave || contextSrv.isEditor">
 					<a ng-click="saveDashboard()" bs-tooltip="'Save dashboard'" data-placement="bottom"><i class="fa fa-save"></i></a>
 				</li>
 				<li class="dropdown">
 					<a class="pointer" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
 					<ul class="dropdown-menu">
-						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>
+						<li ng-if="dashboardMeta.canEdit || contextSrv.isEditor"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('annotations');">Annotations</a></li>
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('templating');">Templating</a></li>
 						<li><a class="pointer" ng-click="exportDashboard();">Export</a></li>


### PR DESCRIPTION
This should improve the issue [#2554](https://github.com/grafana/grafana/issues/2554)
It allows the editor to access the settings and change the Editable checkbox.
Small side effect is the fact that the save button is always there, but there is a warning message if you try to save when it's not Editable.
