### PR TITLE
updating the limit of returned tagvs in a MetricKeyLookup

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -106,7 +106,7 @@ function (angular, _, kbn) {
     OpenTSDBDatasource.prototype._performMetricKeyLookup = function(metric) {
       if(!metric) { return $q.when([]); }
 
-      return this._get('/api/search/lookup', {m: metric}).then(function(result) {
+      return this._get('/api/search/lookup', {m: metric, limit: 1000}).then(function(result) {
         result = result.data.results;
         var tagks = [];
         _.each(result, function(r) {


### PR DESCRIPTION
OpenTSDB supports the 'limit' parameter in 2.1.0; prior versions seem to simply ignore it. This allows for 1000 tagvs to be returned from a metric/tagk lookup/
