### PR TITLE
Use SPDB license id

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test": "grunt test",
     "coveralls": "grunt karma:coveralls && rm -rf ./coverage"
   },
-  "license": "Apache License",
+  "license": "Apache-2.0",
   "dependencies": {
     "grunt-jscs": "~1.5.x",
     "karma-sinon": "^1.0.3",


### PR DESCRIPTION
This avoids an npm warning telling you to use such an id.
