### PR TITLE
Add: tag_values_constrained() func to search for more specific tagvs

### DIFF
--- a/public/app/plugins/datasource/opennms/datasource.js
+++ b/public/app/plugins/datasource/opennms/datasource.js
@@ -1,0 +1,266 @@
+define([
+    'angular',
+    'lodash',
+    'kbn',
+    'moment',
+    './directives',
+    './queryCtrl',
+    './modalCtrl'
+  ],
+function (angular, _, kbn) {
+    'use strict';
+
+    var module = angular.module('grafana.services');
+
+    module.factory('OpenNMSDatasource', function ($q, $http) {
+
+      function OpenNMSDatasource(datasource) {
+        this.type = 'opennms';
+        this.url = datasource.url;
+        this.name = datasource.name;
+        this.basicAuth = datasource.basicAuth;
+        this.withCredentials = datasource.withCredentials;
+        this.searchLimit = 25;
+
+        this.supportMetrics = true;
+        this.editorSrc = 'app/features/opennms/partials/query.editor.html';
+      }
+
+      // Called once per panel (graph)
+      OpenNMSDatasource.prototype.query = function (options) {
+        var _this = this;
+
+        // Build the query
+        var query = _this._buildQuery(options);
+
+        // Make the request
+        var request;
+        if (query.source.length > 0) {
+          // Only make the request if there is at lease one source
+          request = this._onmsRequest('POST', '/rest/measurements', query);
+        } else {
+          // Otherwise return an empty set of measurements
+          request = $q.defer();
+          request.resolve({measurements: []});
+        }
+
+        // Process the results
+        return $q.when(request).then(function (response) {
+          return _this._processResponse(response);
+        });
+      };
+
+      /**
+       * Combines all the targets in the panel in a single query,
+       * this allows us to make a single round-trip, and take advantage of compression.
+       */
+      OpenNMSDatasource.prototype._buildQuery = function (options) {
+        var _this = this;
+
+        var query = {
+          "start": convertToTimestamp(options.range.from),
+          "end": convertToTimestamp(options.range.to),
+          "step": Math.max(kbn.interval_to_ms(options.interval), 1),
+          "maxrows": options.maxDataPoints,
+          "source": [],
+          "expression": []
+        };
+
+        _.each(options.targets, function (target) {
+          var transient = "false";
+          if (target.hide) {
+            transient = true;
+          }
+
+          if (target.type === "attribute") {
+            if (!((target.nodeId && target.resourceId && target.attribute))) {
+              return;
+            }
+
+            var label = target.label;
+            if (label === undefined) {
+              label = target.attribute;
+            }
+
+            query.source.push({
+              "aggregation": target.aggregation,
+              "attribute": target.attribute,
+              "label": label,
+              "resourceId": _this._getRemoteResourceId(target.nodeId, target.resourceId),
+              "transient": transient
+            });
+          } else if (target.type === "expression") {
+            if (!((target.label && target.expression))) {
+              return;
+            }
+
+            query.expression.push({
+              "label": target.label,
+              "value": target.expression,
+              "transient": transient
+            });
+          }
+        });
+
+        return query;
+      };
+
+      OpenNMSDatasource.prototype._processResponse = function (response) {
+        var labels = response.labels;
+        var columns = response.columns;
+        var timestamps = response.timestamps;
+        var series = [];
+        var i, j, nRows, nCols, datapoints;
+
+        if (timestamps !== undefined) {
+          nRows = timestamps.length;
+          nCols = columns.length;
+
+          for (i = 0; i < nCols; i++) {
+            datapoints = [];
+            for (j = 0; j < nRows; j++) {
+              // Skip rows that are out-of-ranges - this can happen with RRD data in narrow time spans
+              if (timestamps[j] < response.start || timestamps[j] > response.end) {
+                continue;
+              }
+
+              datapoints.push([columns[i].values[j], timestamps[j]]);
+            }
+
+            series.push({
+              target: labels[i],
+              datapoints: datapoints
+            });
+          }
+        }
+
+        return {data: series };
+      };
+
+      function retry(deferred, callback, delay) {
+        return callback().then(undefined, function (reason) {
+          if (reason.status !== 0 || reason.status >= 300) {
+            reason.message = 'OpenNMS Error: <br/>' + reason.data;
+            deferred.reject(reason);
+          }
+          else {
+            setTimeout(function () {
+              return retry(deferred, callback, Math.min(delay * 2, 30000));
+            }, delay);
+          }
+        });
+      }
+
+      OpenNMSDatasource.prototype._onmsRequest = function (method, url, data) {
+        var _this = this;
+
+        var deferred = $q.defer();
+
+        retry(deferred, function () {
+          var params = {};
+
+          if (method === 'GET') {
+            _.extend(params, data);
+            data = null;
+          }
+
+          var options = {
+            method: method,
+            url: _this.url + url,
+            params: params,
+            data: data
+          };
+
+          if (_this.basicAuth || _this.withCredentials) {
+            options.withCredentials = true;
+          }
+          if (_this.basicAuth) {
+            options.headers = options.headers || {};
+            options.headers.Authorization = _this.basicAuth;
+          }
+
+          return $http(options).success(function (data) {
+            deferred.resolve(data);
+          });
+        }, 10);
+
+        return deferred.promise;
+      };
+
+      function flattenResourcesWithAttributes(resources, resourcesWithAttributes) {
+        _.each(resources, function (resource) {
+          if (resource.rrdGraphAttributes !== undefined && Object.keys(resource.rrdGraphAttributes).length > 0) {
+            resourcesWithAttributes.push(resource);
+          }
+          if (resource.children !== undefined && resource.children.resource.length > 0) {
+            flattenResourcesWithAttributes(resource.children.resource, resourcesWithAttributes);
+          }
+        });
+        return resourcesWithAttributes;
+      }
+
+      OpenNMSDatasource.prototype.getResourcesWithAttributesForNode = function (nodeId) {
+        return this._onmsRequest('GET', '/rest/resources/fornode/' + encodeURIComponent(nodeId), {
+          depth: -1
+        }).then(function (root) {
+          return flattenResourcesWithAttributes([root], []);
+        });
+      };
+
+      OpenNMSDatasource.prototype._getRemoteResourceId = function (nodeId, resourceId) {
+        var prefix = "";
+        if (nodeId.indexOf(":") > 0) {
+          prefix = "nodeSource[";
+        } else {
+          prefix = "node[";
+        }
+        return prefix + nodeId + "]." + resourceId;
+      };
+
+      OpenNMSDatasource.prototype.suggestAttributes = function (nodeId, resourceId, query) {
+        return this._onmsRequest('GET', '/rest/resources/' + encodeURIComponent(this._getRemoteResourceId(nodeId, resourceId)), {
+          depth: -1
+        }).then(function (data) {
+          query = query.toLowerCase();
+
+          var attributes = [];
+          _.each(data.rrdGraphAttributes, function (value, key) {
+            if (key.toLowerCase().indexOf(query) >= 0) {
+              attributes.push(key);
+            }
+          });
+          attributes.sort();
+
+          return attributes;
+        });
+      };
+
+      OpenNMSDatasource.prototype.searchForNodes = function (query) {
+        var _this = this;
+        return this._onmsRequest('GET', '/rest/nodes', {
+          limit: _this.searchLimit,
+          match: 'any',
+          comparator: 'ilike',
+          orderBy: 'id',
+          order: 'asc',
+          label: '%' + query + '%',
+          sysName: '%' + query + '%',
+          'ipInterface.ipAddress': '%' + query + '%',
+          'ipInterface.ipHostName': '%' + query + '%',
+          'foreignId': query + '%' // doesn't support leading '%'
+        });
+      };
+
+      function convertToTimestamp(date) {
+        if (date === 'now') {
+          date = new Date();
+        } else {
+          date = kbn.parseDate(date);
+        }
+        return date.getTime();
+      }
+
+      return OpenNMSDatasource;
+    });
+
+  });

--- a/public/app/plugins/datasource/opennms/datasource.js
+++ b/public/app/plugins/datasource/opennms/datasource.js
@@ -1,0 +1,265 @@
+define([
+    'angular',
+    'lodash',
+    'kbn',
+    'moment',
+    './queryCtrl',
+    './modalCtrl'
+  ],
+function (angular, _, kbn) {
+    'use strict';
+
+    var module = angular.module('grafana.services');
+
+    module.factory('OpenNMSDatasource', function ($q, $http) {
+
+      function OpenNMSDatasource(datasource) {
+        this.type = 'opennms';
+        this.url = datasource.url;
+        this.name = datasource.name;
+        this.basicAuth = datasource.basicAuth;
+        this.withCredentials = datasource.withCredentials;
+        this.searchLimit = 25;
+
+        this.supportMetrics = true;
+        this.editorSrc = 'app/features/opennms/partials/query.editor.html';
+      }
+
+      // Called once per panel (graph)
+      OpenNMSDatasource.prototype.query = function (options) {
+        var _this = this;
+
+        // Build the query
+        var query = _this._buildQuery(options);
+
+        // Make the request
+        var request;
+        if (query.source.length > 0) {
+          // Only make the request if there is at lease one source
+          request = this._onmsRequest('POST', '/rest/measurements', query);
+        } else {
+          // Otherwise return an empty set of measurements
+          request = $q.defer();
+          request.resolve({measurements: []});
+        }
+
+        // Process the results
+        return $q.when(request).then(function (response) {
+          return _this._processResponse(response);
+        });
+      };
+
+      /**
+       * Combines all the targets in the panel in a single query,
+       * this allows us to make a single round-trip, and take advantage of compression.
+       */
+      OpenNMSDatasource.prototype._buildQuery = function (options) {
+        var _this = this;
+
+        var query = {
+          "start": convertToTimestamp(options.range.from),
+          "end": convertToTimestamp(options.range.to),
+          "step": Math.max(kbn.interval_to_ms(options.interval), 1),
+          "maxrows": options.maxDataPoints,
+          "source": [],
+          "expression": []
+        };
+
+        _.each(options.targets, function (target) {
+          var transient = "false";
+          if (target.hide) {
+            transient = true;
+          }
+
+          if (target.type === "attribute") {
+            if (!((target.nodeId && target.resourceId && target.attribute))) {
+              return;
+            }
+
+            var label = target.label;
+            if (label === undefined) {
+              label = target.attribute;
+            }
+
+            query.source.push({
+              "aggregation": target.aggregation,
+              "attribute": target.attribute,
+              "label": label,
+              "resourceId": _this._getRemoteResourceId(target.nodeId, target.resourceId),
+              "transient": transient
+            });
+          } else if (target.type === "expression") {
+            if (!((target.label && target.expression))) {
+              return;
+            }
+
+            query.expression.push({
+              "label": target.label,
+              "value": target.expression,
+              "transient": transient
+            });
+          }
+        });
+
+        return query;
+      };
+
+      OpenNMSDatasource.prototype._processResponse = function (response) {
+        var labels = response.labels;
+        var columns = response.columns;
+        var timestamps = response.timestamps;
+        var series = [];
+        var i, j, nRows, nCols, datapoints;
+
+        if (timestamps !== undefined) {
+          nRows = timestamps.length;
+          nCols = columns.length;
+
+          for (i = 0; i < nCols; i++) {
+            datapoints = [];
+            for (j = 0; j < nRows; j++) {
+              // Skip rows that are out-of-ranges - this can happen with RRD data in narrow time spans
+              if (timestamps[j] < response.start || timestamps[j] > response.end) {
+                continue;
+              }
+
+              datapoints.push([columns[i].values[j], timestamps[j]]);
+            }
+
+            series.push({
+              target: labels[i],
+              datapoints: datapoints
+            });
+          }
+        }
+
+        return {data: series };
+      };
+
+      function retry(deferred, callback, delay) {
+        return callback().then(undefined, function (reason) {
+          if (reason.status !== 0 || reason.status >= 300) {
+            reason.message = 'OpenNMS Error: <br/>' + reason.data;
+            deferred.reject(reason);
+          }
+          else {
+            setTimeout(function () {
+              return retry(deferred, callback, Math.min(delay * 2, 30000));
+            }, delay);
+          }
+        });
+      }
+
+      OpenNMSDatasource.prototype._onmsRequest = function (method, url, data) {
+        var _this = this;
+
+        var deferred = $q.defer();
+
+        retry(deferred, function () {
+          var params = {};
+
+          if (method === 'GET') {
+            _.extend(params, data);
+            data = null;
+          }
+
+          var options = {
+            method: method,
+            url: _this.url + url,
+            params: params,
+            data: data
+          };
+
+          if (_this.basicAuth || _this.withCredentials) {
+            options.withCredentials = true;
+          }
+          if (_this.basicAuth) {
+            options.headers = options.headers || {};
+            options.headers.Authorization = _this.basicAuth;
+          }
+
+          return $http(options).success(function (data) {
+            deferred.resolve(data);
+          });
+        }, 10);
+
+        return deferred.promise;
+      };
+
+      function flattenResourcesWithAttributes(resources, resourcesWithAttributes) {
+        _.each(resources, function (resource) {
+          if (resource.rrdGraphAttributes !== undefined && Object.keys(resource.rrdGraphAttributes).length > 0) {
+            resourcesWithAttributes.push(resource);
+          }
+          if (resource.children !== undefined && resource.children.resource.length > 0) {
+            flattenResourcesWithAttributes(resource.children.resource, resourcesWithAttributes);
+          }
+        });
+        return resourcesWithAttributes;
+      }
+
+      OpenNMSDatasource.prototype.getResourcesWithAttributesForNode = function (nodeId) {
+        return this._onmsRequest('GET', '/rest/resources/fornode/' + encodeURIComponent(nodeId), {
+          depth: -1
+        }).then(function (root) {
+          return flattenResourcesWithAttributes([root], []);
+        });
+      };
+
+      OpenNMSDatasource.prototype._getRemoteResourceId = function (nodeId, resourceId) {
+        var prefix = "";
+        if (nodeId.indexOf(":") > 0) {
+          prefix = "nodeSource[";
+        } else {
+          prefix = "node[";
+        }
+        return prefix + nodeId + "]." + resourceId;
+      };
+
+      OpenNMSDatasource.prototype.suggestAttributes = function (nodeId, resourceId, query) {
+        return this._onmsRequest('GET', '/rest/resources/' + encodeURIComponent(this._getRemoteResourceId(nodeId, resourceId)), {
+          depth: -1
+        }).then(function (data) {
+          query = query.toLowerCase();
+
+          var attributes = [];
+          _.each(data.rrdGraphAttributes, function (value, key) {
+            if (key.toLowerCase().indexOf(query) >= 0) {
+              attributes.push(key);
+            }
+          });
+          attributes.sort();
+
+          return attributes;
+        });
+      };
+
+      OpenNMSDatasource.prototype.searchForNodes = function (query) {
+        var _this = this;
+        return this._onmsRequest('GET', '/rest/nodes', {
+          limit: _this.searchLimit,
+          match: 'any',
+          comparator: 'ilike',
+          orderBy: 'id',
+          order: 'asc',
+          label: '%' + query + '%',
+          sysName: '%' + query + '%',
+          'ipInterface.ipAddress': '%' + query + '%',
+          'ipInterface.ipHostName': '%' + query + '%',
+          'foreignId': query + '%' // doesn't support leading '%'
+        });
+      };
+
+      function convertToTimestamp(date) {
+        if (date === 'now') {
+          date = new Date();
+        } else {
+          date = kbn.parseDate(date);
+        }
+        return date.getTime();
+      }
+
+      return OpenNMSDatasource;
+    });
+
+  });

--- a/public/app/plugins/datasource/opennms/directives.js
+++ b/public/app/plugins/datasource/opennms/directives.js
@@ -1,0 +1,17 @@
+define([
+  'angular',
+],
+function (angular) {
+  'use strict';
+
+  var module = angular.module('grafana.directives');
+
+  module.directive('metricQueryEditorOpennms', function() {
+    return {
+      controller: 'OpenNMSQueryCtrl',
+      templateUrl: 'app/plugins/datasource/opennms/partials/query.editor.html',
+    };
+
+  });
+
+});

--- a/public/app/plugins/datasource/opennms/modalCtrl.js
+++ b/public/app/plugins/datasource/opennms/modalCtrl.js
@@ -1,0 +1,57 @@
+define([
+    'angular',
+    'lodash'
+  ],
+  function (angular) {
+    'use strict';
+
+    var module = angular.module('grafana.controllers');
+
+    module.controller('OpenNMSModalSelectionCtrl', function ($scope) {
+      $scope.searchForRows = function () {
+        $scope.searching = true;
+        $scope.search($scope.query)
+          .then(function (results) {
+            // Reset the selected row
+            $scope.selectedRow = null;
+            // Add the results to the scope
+            $scope.rows = results.rows;
+            $scope.count = results.count;
+            $scope.totalCount = results.totalCount;
+            // We're done
+            $scope.searching = false;
+          }, function () {
+            $scope.searching = false;
+          });
+      };
+
+      $scope.setClickedRow = function (index) {
+        if ($scope.selectedRow === index) {
+          $scope.selectedRow = null;
+        } else {
+          $scope.selectedRow = index;
+          // Keep a reference to the row when the selection is made
+          $scope.row = $scope.rows[$scope.selectedRow];
+        }
+      };
+
+      $scope.cancel = function () {
+        $scope.deferred.reject();
+      };
+
+      $scope.ok = function () {
+        if ($scope.selectedRow !== null) {
+          $scope.deferred.resolve($scope.row);
+        } else {
+          $scope.deferred.reject();
+        }
+      };
+
+      (function () {
+        $scope.query = "";
+        $scope.searchForRows();
+
+        $scope.selectedRow = null;
+      })();
+    });
+  });

--- a/public/app/plugins/datasource/opennms/partials/attribute.selection.html
+++ b/public/app/plugins/datasource/opennms/partials/attribute.selection.html
@@ -1,0 +1,54 @@
+<div ng-controller="OpenNMSModalSelectionCtrl">
+    <div class="modal-header">
+        <ul class="tight-form-list" role="menu">
+            <li class="tight-form-item">
+                Search:
+            </li>
+            <li>
+                <input type="text"
+                       class="tight-form-input"
+                       ng-model="query"
+                       placeholder="query"
+                       ng-change="searchForRows()"
+                       data-min-length=0 data-items=100
+                        >
+            </li>
+        </ul>
+        <div class="clearfix"></div>
+    </div>
+
+    <div class="modal-body" style="display: block; height: 350px; overflow-y: scroll">
+        <div class="row-fluid">
+            <div ng-show="searching" class="text-center">
+                <i class="fa fa-spinner fa-4x fa-spin"></i>
+            </div>
+            <div ng-show="!searching">
+                <div ng-show="!rows.length">
+                    <h5 class="text-center">No results.</h5>
+                </div>
+                <table class="table table-condensed" ng-show="rows.length">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr ng-repeat="attribute in rows" ng-class="{'info':$index == selectedRow}"
+                        ng-click="setClickedRow($index)">
+                        <td>{{attribute}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        <p ng-show="!searching && rows.length" class="pull-left text-info">Showing <b>{{ count }}</b> of <b>{{
+            totalCount }}</b> attributes.</p>
+        <button type="button" class="btn btn-success" ng-click="cancel();dismiss()">Cancel</button>
+        <button type="button" class="btn btn-success" ng-click="ok();dismiss();" ng-disabled="selectedRow == null">
+            Select
+        </button>
+    </div>
+</div>

--- a/public/app/plugins/datasource/opennms/partials/config.html
+++ b/public/app/plugins/datasource/opennms/partials/config.html
@@ -1,0 +1,1 @@
+<div ng-include="httpConfigPartialSrc"></div>

--- a/public/app/plugins/datasource/opennms/partials/node.selection.html
+++ b/public/app/plugins/datasource/opennms/partials/node.selection.html
@@ -1,0 +1,60 @@
+<div ng-controller="OpenNMSModalSelectionCtrl">
+    <div class="modal-header">
+        <ul class="tight-form-list" role="menu">
+            <li class="tight-form-item">
+                Search:
+            </li>
+            <li>
+                <input type="text"
+                       class="tight-form-input input-xxlarge"
+                       ng-model="query"
+                       placeholder="query"
+                       ng-change="searchForRows()"
+                       data-min-length=0 data-items=100
+                        >
+            </li>
+        </ul>
+        <div class="clearfix"></div>
+    </div>
+
+    <div class="modal-body" style="display: block; height: 350px; overflow-y: scroll">
+        <div class="row-fluid">
+            <div ng-show="searching" class="text-center">
+                <i class="fa fa-spinner fa-4x fa-spin"></i>
+            </div>
+            <div ng-show="!searching">
+                <div ng-show="!rows.length">
+                    <h5 class="text-center">No results.</h5>
+                </div>
+                <table class="table table-condensed pre-scrollable" ng-show="rows.length">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Label</th>
+                        <th>Foreign Id</th>
+                        <th>sysName</th>
+                    </tr>
+                    </thead>
+                    <tbody style="height: 30px; overflow-y: scroll">
+                    <tr ng-repeat="node in rows" ng-class="{'info':$index == selectedRow}"
+                        ng-click="setClickedRow($index)">
+                        <th scope="row">{{node.id}}</th>
+                        <td>{{node.label}}</td>
+                        <td>{{node.foreignId}}</td>
+                        <td>{{node.sysName | limitTo: 48}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        <p ng-show="!searching && rows.length" class="pull-left text-info">Showing <b>{{ count }}</b> of <b>{{
+            totalCount }}</b> nodes.</p>
+        <button type="button" class="btn btn-success" ng-click="cancel();dismiss()">Cancel</button>
+        <button type="button" class="btn btn-success" ng-click="ok();dismiss();" ng-disabled="selectedRow == null">
+            Select
+        </button>
+    </div>
+</div>

--- a/public/app/plugins/datasource/opennms/partials/query.editor.html
+++ b/public/app/plugins/datasource/opennms/partials/query.editor.html
@@ -1,0 +1,175 @@
+<div class="tight-form">
+    <ul class="tight-form-list pull-right">
+        <li class="tight-form-item small" ng-show="target.datasource">
+            <em>{{target.datasource}}</em>
+        </li>
+        <li class="tight-form-item">
+            <a bs-tooltip="target.error"
+               style="color: rgb(229, 189, 28)"
+               ng-show="target.error">
+                <i class="fa fa-warning"></i>
+            </a>
+        </li>
+        <li class="tight-form-item">
+            <div class="dropdown">
+                <a class="pointer dropdown-toggle"
+                   data-toggle="dropdown"
+                   tabindex="1">
+                    <i class="fa fa-bars"></i>
+                </a>
+                <ul class="dropdown-menu pull-right" role="menu">
+                    <li role="menuitem">
+                        <a tabindex="1"
+                           ng-click="duplicate()">
+                            Duplicate
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+        <li class="tight-form-item last">
+            <a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
+                <i class="fa fa-remove"></i>
+            </a>
+        </li>
+    </ul>
+
+    <ul class="tight-form-list">
+        <li class="tight-form-item" style="min-width: 15px; text-align: center">
+            {{target.refId}}
+        </li>
+        <li>
+            <a class="tight-form-item"
+               ng-click="target.hide = !target.hide; get_data();"
+               role="menuitem">
+                <i class="fa fa-eye"></i>
+            </a>
+        </li>
+    </ul>
+
+    <ul class="tight-form-list" role="menu">
+        <li class="tight-form-item">
+            Type
+        </li>
+        <li>
+            <select class="tight-form-input"
+                    ng-model="target.type"
+                    ng-blur="targetBlur()">
+                <option value="attribute">Attribute</option>
+                <option value="expression">Expression</option>
+            </select>
+        </li>
+    </ul>
+
+    <ul class="tight-form-list" role="menu" ng-show="target.type === 'expression'">
+        <li class="tight-form-item">
+            Label <i class="fa fa-font"></i>
+        </li>
+        <li>
+            <input type="text"
+                   class="tight-form-input input-medium"
+                   ng-model="target.label"
+                   spellcheck='false'
+                   placeholder="series label"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                    />
+        </li>
+        <li class="tight-form-item">
+            Expression <i class="fa fa-calculator"></i>
+        </li>
+        <li>
+            <input type="text"
+                   class="tight-form-input input-xxlarge"
+                   ng-model="target.expression"
+                   spellcheck='false'
+                   placeholder="series expression"
+                   data-min-length=0 data-items=2048
+                   ng-blur="targetBlur()"
+                    />
+        </li>
+    </ul>
+
+    <ul class="tight-form-list" role="menu" ng-show="target.type === 'attribute'">
+        <li>
+            <a class="tight-form-item"
+               ng-click="openNodeSelectionModal();"
+               role="menuitem">
+                Node <i class="fa fa-tree"></i>
+            </a>
+        </li>
+        <li>
+            <input type="text"
+                   class="tight-form-input input-large"
+                   ng-model="target.nodeId"
+                   spellcheck='false'
+
+                   placeholder="node id"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                    >
+        </li>
+        <li ng-show="target.nodeId">
+            <a class="tight-form-item"
+               ng-click="openResourceSelectionModal();"
+               role="menuitem">
+                Resource <i class="fa fa-leaf"></i>
+            </a>
+        </li>
+        <li ng-show="target.nodeId">
+            <input type="text"
+                   class="tight-form-input input-xlarge"
+                   ng-model="target.resourceId"
+                   spellcheck='false'
+                   placeholder="resource id"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                    >
+        </li>
+        <li ng-show="target.resourceId">
+            <a class="tight-form-item"
+               ng-click="openAttributeSelectionModal();"
+               role="menuitem">
+                Attribute <i class="fa fa-tag"></i>
+            </a>
+        </li>
+        <li ng-show="target.resourceId">
+            <input type="text"
+                   class="tight-form-input"
+                   ng-model="target.attribute"
+                   spellcheck='false'
+                   placeholder="attribute"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                    >
+        </li>
+        <li class="tight-form-item" ng-show="target.attribute">
+            Label <i class="fa fa-font"></i>
+        </li>
+        <li ng-show="target.attribute">
+            <input type="text"
+                   class="tight-form-input input-medium"
+                   ng-model="target.label"
+                   spellcheck='false'
+                   placeholder="series label"
+                   data-min-length=0 data-items=100
+                   ng-blur="targetBlur()"
+                    />
+        </li>
+        <li class="tight-form-item" ng-show="target.attribute">
+            Aggregation <i class="fa fa-calculator"></i>
+        </li>
+        <li ng-show="target.attribute">
+            <select class="tight-form-input"
+                    ng-model="target.aggregation"
+                    ng-blur="targetBlur()">
+                <option value="AVERAGE">Average</option>
+                <option value="MIN">Min</option>
+                <option value="MAX">Max</option>
+                <option value="LAST">Last</option>
+            </select>
+        </li>
+    </ul>
+
+    <div class="clearfix"></div>
+</div>

--- a/public/app/plugins/datasource/opennms/partials/resource.selection.html
+++ b/public/app/plugins/datasource/opennms/partials/resource.selection.html
@@ -1,0 +1,59 @@
+<div ng-controller="OpenNMSModalSelectionCtrl">
+    <div class="modal-header">
+        <ul class="tight-form-list" role="menu">
+            <li class="tight-form-item">
+                Search:
+            </li>
+            <li>
+                <input type="text"
+                       class="tight-form-input input-xxlarge"
+                       ng-model="query"
+                       placeholder="query"
+                       ng-change="searchForRows()"
+                       data-min-length=0 data-items=100
+                        >
+            </li>
+        </ul>
+        <div class="clearfix"></div>
+    </div>
+
+    <div class="modal-body" style="display: block; height: 350px; overflow-y: scroll">
+        <div class="row-fluid">
+            <div ng-show="searching" class="text-center">
+                <i class="fa fa-spinner fa-4x fa-spin"></i>
+            </div>
+            <div ng-show="!searching">
+                <div ng-show="!rows.length">
+                    <h5 class="text-center">No results.</h5>
+                </div>
+                <table class="table table-condensed" ng-show="rows.length">
+                    <thead>
+                    <tr>
+                        <th>Label</th>
+                        <th>Name</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr ng-repeat="resource in rows" ng-class="{'info':$index == selectedRow}"
+                        ng-click="setClickedRow($index)">
+                        <td>{{resource.label}}</td>
+                        <td>{{resource.name}}</td>
+                        <td><a ng-show="resource.link.length > 0" href="{{ url }}/{{resource.link}}" target="_blank"><i
+                                class="fa fa-external-link"></i></a></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-footer">
+        <p ng-show="!searching && rows.length" class="pull-left text-info">Showing <b>{{ count }}</b> of <b>{{
+            totalCount }}</b> resources.</p>
+        <button type="button" class="btn btn-success" ng-click="cancel();dismiss()">Cancel</button>
+        <button type="button" class="btn btn-success" ng-click="ok();dismiss();" ng-disabled="selectedRow == null">
+            Select
+        </button>
+    </div>
+</div>

--- a/public/app/plugins/datasource/opennms/plugin.json
+++ b/public/app/plugins/datasource/opennms/plugin.json
@@ -1,0 +1,16 @@
+{
+  "pluginType": "datasource",
+  "name": "OpenNMS",
+
+  "type": "opennms",
+  "serviceName": "OpenNMSDatasource",
+
+  "module": "plugins/datasource/opennms/datasource",
+
+  "partials": {
+    "config": "app/plugins/datasource/opennms/partials/config.html",
+    "query": "app/plugins/datasource/opennms/partials/query.editor.html"
+  },
+
+  "metrics": true
+}

--- a/public/app/plugins/datasource/opennms/queryCtrl.js
+++ b/public/app/plugins/datasource/opennms/queryCtrl.js
@@ -1,0 +1,218 @@
+define([
+    'angular',
+    'lodash'
+  ],
+  function (angular, _) {
+    'use strict';
+
+    var module = angular.module('grafana.controllers');
+
+    module.controller('OpenNMSQueryCtrl', function ($scope, $q, $modal) {
+
+      $scope.init = function () {
+        $scope.aggregation = ['AVERAGE', 'MIN', 'MAX', 'LAST'];
+
+        if (!$scope.target.aggregation) {
+          $scope.target.aggregation = 'AVERAGE';
+        }
+
+        if (!$scope.target.type) {
+          $scope.target.type = 'attribute';
+        }
+
+        $scope.target.error = validateTarget($scope.target);
+      };
+
+      $scope.targetBlur = function () {
+        $scope.target.error = validateTarget($scope.target);
+
+        // this does not work so good
+        if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
+          $scope.oldTarget = angular.copy($scope.target);
+          $scope.get_data();
+        }
+      };
+
+      $scope.openNodeSelectionModal = function () {
+        var modalScope = $scope.$new(true);
+        modalScope.search = function (query) {
+          return $scope.datasource.searchForNodes(query)
+            .then(function (results) {
+              return {
+                'count': results.count,
+                'totalCount': results.totalCount,
+                'rows': results.node
+              };
+            });
+        };
+
+        modalScope.deferred = $q.defer();
+        modalScope.deferred.promise.then(function (node) {
+          if (!_.isUndefined(node.foreignId) && !_.isNull(node.foreignId)
+            && !_.isUndefined(node.foreignSource) && !_.isNull(node.foreignSource)) {
+            // Prefer fs:fid
+            $scope.target.nodeId = node.foreignSource + ":" + node.foreignId;
+          } else {
+            // Fallback to node id
+            $scope.target.nodeId = node.id;
+          }
+          $scope.targetBlur();
+        });
+
+        var nodeSelectionModal = $modal({
+          template: './app/plugins/datasource/opennms/partials/node.selection.html',
+          persist: true,
+          show: false,
+          scope: modalScope,
+          keyboard: false
+        });
+
+        $q.when(nodeSelectionModal).then(function (modalEl) {
+          modalEl.modal('show');
+        });
+      };
+
+      $scope.openResourceSelectionModal = function () {
+        var modalScope = $scope.$new(true);
+        modalScope.url = $scope.datasource.url;
+
+        function filterResources(resources, query) {
+          var filteredResources = resources;
+          if (query.length >= 1) {
+            query = query.toLowerCase();
+            filteredResources = _.filter(resources, function (resource) {
+              return resource.key.indexOf(query) >= 0;
+            });
+          }
+
+          // Limit the results - it takes along time to render if there are too many
+          var totalCount = filteredResources.length;
+          filteredResources = _.first(filteredResources, $scope.datasource.searchLimit);
+
+          return {
+            'count': filteredResources.length,
+            'totalCount': totalCount,
+            'rows': filteredResources
+          };
+        }
+
+        $scope.nodeResources = undefined;
+        modalScope.search = function (query) {
+          if ($scope.nodeResources !== undefined) {
+            var deferred = $q.defer();
+            deferred.resolve(filterResources($scope.nodeResources, query));
+            return deferred.promise;
+          }
+
+          return $scope.datasource.getResourcesWithAttributesForNode($scope.target.nodeId)
+            .then(function (resources) {
+              // Compute a key for more efficient searching
+              _.each(resources, function (resource) {
+                resource.key = resource.label.toLowerCase() + resource.name.toLowerCase();
+              });
+              // Sort the list once
+              $scope.nodeResources = _.sortBy(resources, function (resource) {
+                return resource.label;
+              });
+              // Filter
+              return filterResources(resources, query);
+            });
+        };
+
+        modalScope.deferred = $q.defer();
+        modalScope.deferred.promise.then(function (resource) {
+          // Exclude the node portion of the resource id
+          var re = /node(Source)?\[.*?]\.(.*)$/;
+          var match = re.exec(resource.id);
+          $scope.target.resourceId = match[2];
+          $scope.targetBlur();
+        });
+
+        var resourceSelectionModal = $modal({
+          template: './app/plugins/datasource/opennms/partials/resource.selection.html',
+          persist: true,
+          show: false,
+          scope: modalScope,
+          keyboard: false
+        });
+
+        $q.when(resourceSelectionModal).then(function (modalEl) {
+          modalEl.modal('show');
+        });
+      };
+
+      $scope.openAttributeSelectionModal = function () {
+        var modalScope = $scope.$new(true);
+        modalScope.search = function (query) {
+          // TODO: There's no need to keep going back to the server every time to get the list of attributes
+          return $scope.datasource
+            .suggestAttributes($scope.target.nodeId, $scope.target.resourceId, query)
+            .then(function (attributes) {
+              return {
+                'count': attributes.length,
+                'totalCount': attributes.length,
+                'rows': attributes
+              };
+            });
+        };
+
+        modalScope.deferred = $q.defer();
+        modalScope.deferred.promise.then(function (attribute) {
+          $scope.target.attribute = attribute;
+          $scope.targetBlur();
+        });
+
+        var attributeSelectionModal = $modal({
+          template: './app/plugins/datasource/opennms/partials/attribute.selection.html',
+          persist: true,
+          show: false,
+          scope: modalScope,
+          keyboard: false
+        });
+
+        $q.when(attributeSelectionModal).then(function (modalEl) {
+          modalEl.modal('show');
+        });
+      };
+
+      $scope.duplicate = function () {
+        var clone = angular.copy($scope.target);
+        $scope.panel.targets.push(clone);
+      };
+
+      $scope.suggestResourceIds = function (query, callback) {
+        $scope.datasource
+          .suggestResourceIds(query)
+          .then(callback);
+      };
+
+      $scope.suggestAttributes = function (query, callback) {
+        $scope.datasource
+          .suggestAttributes($scope.target.resourceid, query)
+          .then(callback);
+      };
+
+      function validateTarget(target) {
+        if (target.type === "attribute") {
+          if (!target.nodeId) {
+            return "You must supply a node id.";
+          } else if (!target.resourceId) {
+            return "You must supply a resource id.";
+          } else if (!target.attribute) {
+            return "You must supply an attribute.";
+          }
+        } else if (target.type === "expression") {
+          if (!target.label) {
+            return "You must supply a label.";
+          } else if (!target.expression) {
+            return "You must supply an expression.";
+          }
+        } else {
+          return "Invalid type.";
+        }
+
+        return undefined;
+      }
+    });
+
+  });

--- a/public/test/specs/opennmsDatasource-specs.js
+++ b/public/test/specs/opennmsDatasource-specs.js
@@ -1,0 +1,62 @@
+define([
+  'helpers',
+  'plugins/datasource/opennms/datasource'
+], function (helpers) {
+  'use strict';
+
+  describe('OpenNMSDatasource', function () {
+    var ctx = new helpers.ServiceTestContext();
+
+    beforeEach(module('grafana.services'));
+    beforeEach(ctx.providePhase(['templateSrv']));
+    beforeEach(ctx.createService('OpenNMSDatasource'));
+    beforeEach(function () {
+      ctx.ds = new ctx.service({url: [''], user: 'test', password: 'mupp'});
+    });
+
+    describe('When querying OpenNMS with one target', function () {
+      var results;
+
+      var query = {
+        range: {from: 'now-1h', to: 'now'},
+        targets: [{type:"attribute", nodeId: '1', resourceId: 'nodeSnmp[]', attribute: 'loadavg1', aggregation: 'AVERAGE'}],
+        interval: '1s'
+      };
+
+      var urlExpected = "/rest/measurements";
+      var response = {
+        "step": 300000,
+        "start": 1424211730000,
+        "end": 1424226130000,
+        "timestamps": [1424211730001],
+        "labels": ["loadavg1"],
+        "columns": [
+          {
+            "values": [5.0]
+          }
+        ]
+      };
+
+      beforeEach(function () {
+        ctx.$httpBackend.expect('POST', urlExpected).respond(response);
+        ctx.ds.query(query).then(function (data) {
+          results = data;
+        });
+        ctx.$httpBackend.flush();
+      });
+
+      it('should generate the correct query', function () {
+        ctx.$httpBackend.verifyNoOutstandingExpectation();
+      });
+
+      it('should return series list', function () {
+        expect(results.data.length).to.be(1);
+        expect(results.data[0].target).to.be('loadavg1');
+        expect(results.data[0].datapoints.length).to.be(1);
+      });
+
+    });
+
+  });
+
+});

--- a/public/test/specs/opentsdbDatasource-specs.js
+++ b/public/test/specs/opentsdbDatasource-specs.js
@@ -39,13 +39,19 @@ define([
         expect(requestOptions.params.m).to.be('cpu');
       });
 
-      it('tag_values(cpu, test) should generate looku  query', function() {
+      it('tag_values(cpu, test) should generate lookup query', function() {
         ctx.ds.metricFindQuery('tag_values(cpu, hostname)').then(function(data) { results = data; });
         ctx.$rootScope.$apply();
         expect(requestOptions.url).to.be('/api/search/lookup');
         expect(requestOptions.params.m).to.be('cpu{hostname=*}');
       });
 
+      it('tag_values_constrained(cpu, test, {tagk=tagv}) should generate lookup query', function() {
+        ctx.ds.metricFindQuery('tag_values_constrained(cpu, hostname, {tagk=tagv})').then(function(data) { results = data; });
+        ctx.$rootScope.$apply();
+        expect(requestOptions.url).to.be('/api/search/lookup');
+        expect(requestOptions.params.m).to.be('cpu{hostname=*,tagk=tagv}');
+      });
     });
   });
 });

--- a/public/test/test-main.js
+++ b/public/test/test-main.js
@@ -150,6 +150,7 @@ require([
     'specs/unsavedChangesSrv-specs',
     'specs/valueSelectDropdown-specs',
     'specs/opentsdbDatasource-specs',
+    'specs/opennmsDatasource-specs'
   ];
 
   var pluginSpecs = (config.plugins.specs || []).map(function (spec) {


### PR DESCRIPTION
Add: tag_values_constrained() function, to allow for an OpenTSDB-style query to be passed into a tagv lookup

ex: `tag_values_constrained(mysql.com_select,shard,{colo=NYC001})` would search for the tagvs of `shard` in the metric `mysql.com_select`, with a further qualifier of tagk `colo` being equal to tagv `NYC001`

The additional query terms must be enclosed in {}
