### PR TITLE
ui(dashboard): delete empty rows without confirmation

### DIFF
--- a/public/app/features/dashboard/rowCtrl.js
+++ b/public/app/features/dashboard/rowCtrl.js
@@ -43,12 +43,21 @@ function (angular, app, _, config) {
     };
 
     $scope.delete_row = function() {
+      function delete_row() {
+        $scope.dashboard.rows = _.without($scope.dashboard.rows, $scope.row);
+      }
+
+      if (!$scope.row.panels.length) {
+        delete_row();
+        return;
+      }
+
       $scope.appEvent('confirm-modal', {
         title: 'Are you sure you want to delete this row?',
         icon: 'fa-trash',
         yesText: 'Delete',
         onConfirm: function() {
-          $scope.dashboard.rows = _.without($scope.dashboard.rows, $scope.row);
+          delete_row();
         }
       });
     };

--- a/public/test/specs/row-ctrl-specs.js
+++ b/public/test/specs/row-ctrl-specs.js
@@ -12,7 +12,24 @@ define([
     beforeEach(ctx.providePhase());
     beforeEach(ctx.createControllerPhase('RowCtrl'));
 
+    describe('delete_row', function () {
+      describe('when row is empty (has no panels)', function () {
+        beforeEach(function () {
+          ctx.scope.dashboard.rows = [{id: 1, panels: []}];
+          ctx.scope.row = ctx.scope.dashboard.rows[0];
+          ctx.scope.appEvent = sinon.spy();
+
+          ctx.scope.delete_row();
+        });
+
+        it('should NOT ask for confirmation', function () {
+          expect(ctx.scope.appEvent.called).to.be(false);
+        });
+
+        it('should delete row', function () {
+          expect(ctx.scope.dashboard.rows).to.not.contain(ctx.scope.row);
+        });
+      });
+    });
   });
-
 });
-


### PR DESCRIPTION
It's quite annoying IMHO to ask for confirmation when deleting an empty row with no panels attached, especially when you add one by mistake or trying to arrange things.
