### PR TITLE
WIP: OpenTSDB aggregation support with templating + Bosun as metadata source

### DIFF
--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -11,6 +11,7 @@ const (
 	DS_INFLUXDB_08   = "influxdb_08"
 	DS_ES            = "elasticsearch"
 	DS_OPENTSDB      = "opentsdb"
+	DS_BOSUN         = "bosun"
 	DS_ACCESS_DIRECT = "direct"
 	DS_ACCESS_PROXY  = "proxy"
 )

--- a/public/app/directives/valueSelectDropdown.js
+++ b/public/app/directives/valueSelectDropdown.js
@@ -141,7 +141,7 @@ function (angular, app, _) {
           option.selected = true;
         }
 
-        if (option.text === 'All' || excludeOthers) {
+        if (option.text === 'All' || option.text === 'Aggr' || excludeOthers) {
           setAllExceptCurrentTo(false);
           commitChange = true;
         }
@@ -160,7 +160,7 @@ function (angular, app, _) {
         vm.selectedValues = _.filter(vm.options, {selected: true});
 
         if (vm.selectedValues.length > 1 && vm.selectedValues.length !== vm.options.length) {
-          if (vm.selectedValues[0].text === 'All') {
+          if (vm.selectedValues[0].text === 'All' || vm.selectedValues[0].text === 'Aggr') {
             vm.selectedValues[0].selected = false;
             vm.selectedValues = vm.selectedValues.slice(1, vm.selectedValues.length);
           }

--- a/public/app/features/dashboard/submenuCtrl.js
+++ b/public/app/features/dashboard/submenuCtrl.js
@@ -29,7 +29,7 @@ function (angular) {
         dynamicDashboardSrv.update($scope.dashboard);
         $rootScope.$emit('template-variable-value-updated');
         $rootScope.$broadcast('refresh');
-      });
+      })
     };
 
     $scope.init();

--- a/public/app/features/dashboard/submenuCtrl.js
+++ b/public/app/features/dashboard/submenuCtrl.js
@@ -29,7 +29,7 @@ function (angular) {
         dynamicDashboardSrv.update($scope.dashboard);
         $rootScope.$emit('template-variable-value-updated');
         $rootScope.$broadcast('refresh');
-      })
+      });
     };
 
     $scope.init();

--- a/public/app/features/templating/editorCtrl.js
+++ b/public/app/features/templating/editorCtrl.js
@@ -16,6 +16,7 @@ function (angular, _) {
       name: '',
       options: [],
       includeAll: false,
+      includeAggr: false,
       allFormat: 'glob',
       multi: false,
       multiFormat: 'glob',

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -177,6 +177,16 @@
 
 						<div class="tight-form last">
 							<ul class="tight-form-list">
+								<li class="tight-form-item">
+									<editor-checkbox text="Aggregate option" model="current.includeAggr"></editor-checkbox>
+									<tip>Check if you want an additional option Aggr used to omit the value so it can be aggregated on.</tip>
+								</li>
+							</ul>
+							<div class="clearfix"></div>
+						</div>
+
+						<div class="tight-form last">
+							<ul class="tight-form-list">
 								<li class="tight-form-item last">
 									<editor-checkbox text="Refresh on load" model="current.refresh"></editor-checkbox>
 									<tip>Check if you want values to be updated on dashboard load, will slow down dashboard load time</tip>
@@ -184,6 +194,7 @@
 							</ul>
 							<div class="clearfix"></div>
 						</div>
+
 					</div>
 				</div>
 			</div>
@@ -200,7 +211,7 @@
 								Multi format
 							</li>
 							<li ng-show="current.multi">
-								<select class="input-small tight-form-input last" ng-model="current.multiFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'regex values']"></select>
+								<select class="input-small tight-form-input last" ng-model="current.multiFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'regex values', 'pipe delimited']"></select>
 							</li>
 						</ul>
 						<div class="clearfix"></div>

--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -41,6 +41,8 @@ function (angular, _) {
       } else {
         if (variable.multiFormat === 'regex values') {
           return '(' + value.join('|') + ')';
+        }else if (variable.multiFormat === 'pipe delimited') {
+          return value.join('|');
         }
         return '{' + value.join(',') + '}';
       }

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -187,11 +187,11 @@ function (angular, _, kbn) {
     this.updateOptionsFromMetricFindQuery = function(variable, datasource) {
       return datasource.metricFindQuery(variable.query).then(function (results) {
         variable.options = self.metricNamesToVariableValues(variable, results);
-        if (variable.includeAll) {
-          self.addAllOption(variable);
-        }
         if (variable.includeAggr) {
           self.addAggrOption(variable);
+        }
+        if (variable.includeAll) {
+          self.addAllOption(variable);
         }
         if (!variable.options.length) {
           variable.options.push(getNoneOption());
@@ -255,6 +255,12 @@ function (angular, _, kbn) {
 
     this.addAllOption = function(variable) {
       var allValue = '';
+
+      var cleanVariable = variable.options
+        .filter(function (s) {
+          return s.text !== "Aggr";
+        });
+
       switch(variable.allFormat) {
       case 'wildcard':
         allValue = '*';
@@ -263,13 +269,13 @@ function (angular, _, kbn) {
         allValue = '.*';
         break;
       case 'regex values':
-        allValue = '(' + _.map(variable.options, function(option) {
+        allValue = '(' + _.map(cleanVariable, function(option) {
           return self.regexEscape(option.text);
         }).join('|') + ')';
         break;
       default:
         allValue = '{';
-        allValue += _.pluck(variable.options, 'text').join(',');
+        allValue += _.pluck(cleanVariable, 'text').join(',');
         allValue += '}';
       }
 

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -190,6 +190,9 @@ function (angular, _, kbn) {
         if (variable.includeAll) {
           self.addAllOption(variable);
         }
+        if (variable.includeAggr) {
+          self.addAggrOption(variable);
+        }
         if (!variable.options.length) {
           variable.options.push(getNoneOption());
         }
@@ -271,6 +274,10 @@ function (angular, _, kbn) {
       }
 
       variable.options.unshift({text: 'All', value: allValue});
+    };
+
+    this.addAggrOption = function(variable) {
+      variable.options.unshift({text: 'Aggr', value: 'AGGR'});
     };
 
   });

--- a/public/app/plugins/datasource/bosun/datasource.js
+++ b/public/app/plugins/datasource/bosun/datasource.js
@@ -91,7 +91,7 @@ function (angular, _, kbn) {
         return $q.when([]);
       }
 
-      return this._get('/api/tagv/' + key + "/" + metric ).then(function(result) {
+      return this._get('/api/tagv/' + key + "/" + metric).then(function(result) {
         /*var tagvs = [];
         _.each(result.data, function(r) {
           tagvs.push(r.tags[key]);
@@ -105,14 +105,16 @@ function (angular, _, kbn) {
         return $q.when([]);
       }
 
-      var subtags_list = subtags.split(",")
-      var valid_subtags = subtags_list.filter(function (s) { return s.split("=")[1] != "*"
-                                                                 && s.split("=")[1] != "AGGR"
-                                                                 && s.split("=")[1].charAt(0) != "$"
-                                                                 && s.split("=")[1] != "" })
+      var subtags_list = subtags.split(",");
+      var valid_subtags = subtags_list.filter(function (s) {
+        return s.split("=")[1] !== "*"
+          && s.split("=")[1] !== "AGGR"
+          && s.split("=")[1].charAt(0) !== "$"
+          && s.split("=")[1] !== "";
+      });
       var params = valid_subtags.length > 0 ? "?" + valid_subtags.join("&") : "";
 
-      return this._get('/api/tagv/' + key + "/" + metric + params ).then(function(result) {
+      return this._get('/api/tagv/' + key + "/" + metric + params).then(function(result) {
         return result.data;
       });
     };
@@ -123,7 +125,7 @@ function (angular, _, kbn) {
       return this._get('/api/tagk/' + metric).then(function(result) {
         return result.data;
       });
-    }
+    };
 
     BosunDatasource.prototype._get = function(relativeUrl, params) {
       return backendSrv.datasourceRequest({
@@ -266,12 +268,12 @@ function (angular, _, kbn) {
       }
 
       var tags = angular.copy(target.tags);
-      query.tags = {}
+      query.tags = {};
       if(tags){
         for(var key in tags){
-          var tagv = templateSrv.replace(tags[key], options.scopedVars)
-          if (tagv.charAt(0) != "$" && tagv != "AGGR" ) {
-            query.tags[key] = tagv
+          var tagv = templateSrv.replace(tags[key], options.scopedVars);
+          if (tagv.charAt(0) !== "$" && tagv !== "AGGR") {
+            query.tags[key] = tagv;
           }
         }
       }

--- a/public/app/plugins/datasource/bosun/datasource.js
+++ b/public/app/plugins/datasource/bosun/datasource.js
@@ -11,17 +11,17 @@ function (angular, _, kbn) {
 
   var module = angular.module('grafana.services');
 
-  module.factory('OpenTSDBDatasource', function($q, backendSrv, templateSrv) {
+  module.factory('BosunDatasource', function($q, backendSrv, templateSrv) {
 
-    function OpenTSDBDatasource(datasource) {
-      this.type = 'opentsdb';
+    function BosunDatasource(datasource) {
+      this.type = 'bosun';
       this.url = datasource.url;
       this.name = datasource.name;
       this.supportMetrics = true;
     }
 
     // Called once per panel (graph)
-    OpenTSDBDatasource.prototype.query = function(options) {
+    BosunDatasource.prototype.query = function(options) {
       var start = convertToTSDBTime(options.range.from);
       var end = convertToTSDBTime(options.range.to);
       var qs = [];
@@ -60,7 +60,7 @@ function (angular, _, kbn) {
       });
     };
 
-    OpenTSDBDatasource.prototype.performTimeSeriesQuery = function(queries, start, end) {
+    BosunDatasource.prototype.performTimeSeriesQuery = function(queries, start, end) {
       var reqBody = {
         start: start,
         queries: queries
@@ -80,47 +80,27 @@ function (angular, _, kbn) {
       return backendSrv.datasourceRequest(options);
     };
 
-    OpenTSDBDatasource.prototype._performSuggestQuery = function(query) {
+    BosunDatasource.prototype._performSuggestQuery = function(query) {
       return this._get('/api/suggest', {type: 'metrics', q: query, max: 1000}).then(function(result) {
         return result.data;
       });
     };
 
-    OpenTSDBDatasource.prototype._performMetricKeyValueLookup = function(metric, key) {
+    BosunDatasource.prototype._performMetricKeyValueLookup = function(metric, key) {
       if(!metric || !key) {
         return $q.when([]);
       }
 
-      var m = metric + "{" + key + "=*}";
-
-      return this._get('/api/search/lookup', {m: m}).then(function(result) {
-        result = result.data.results;
-        var tagvs = [];
-        _.each(result, function(r) {
+      return this._get('/api/tagv/' + key + "/" + metric ).then(function(result) {
+        /*var tagvs = [];
+        _.each(result.data, function(r) {
           tagvs.push(r.tags[key]);
-        });
-        return tagvs;
+        });*/
+        return result.data;
       });
     };
 
-    OpenTSDBDatasource.prototype._performMetricKeyLookup = function(metric) {
-      if(!metric) { return $q.when([]); }
-
-      return this._get('/api/search/lookup', {m: metric, limit: 1000}).then(function(result) {
-        result = result.data.results;
-        var tagks = [];
-        _.each(result, function(r) {
-          _.each(r.tags, function(tagv, tagk) {
-            if(tagks.indexOf(tagk) === -1) {
-              tagks.push(tagk);
-            }
-          });
-        });
-        return tagks;
-      });
-    };
-
-    OpenTSDBDatasource.prototype._performMetricKeyValueWithSubtagsLookup = function(metric, key, subtags) {
+    BosunDatasource.prototype._performMetricKeyValueWithSubtagsLookup = function(metric, key, subtags) {
       if(!metric || !key || !subtags) {
         return $q.when([]);
       }
@@ -129,19 +109,15 @@ function (angular, _, kbn) {
       var valid_subtags = subtags_list.filter(function (s) { return s.split("=")[1] != "*"
                                                                  && s.split("=")[1] != "AGGR"
                                                                  && s.split("=")[1].charAt(0) != "$"
-                                                                 && s.split("=")[1] != "" });
-    
-     var params = "" 
-     if (valid_subtags.length > 0){
-       params = " AND (" + valid_subtags.join(" AND ") + ")"
-     }
+                                                                 && s.split("=")[1] != "" })
+      var params = valid_subtags.length > 0 ? "?" + valid_subtags.join("&") : "";
 
-      return this._get('/api/search/lookup' + key + params).then(function(result) {
+      return this._get('/api/tagv/' + key + "/" + metric + params ).then(function(result) {
         return result.data;
       });
     };
 
-    OpenTSDBDatasource.prototype._performMetricKeyLookup = function(metric) {
+    BosunDatasource.prototype._performMetricKeyLookup = function(metric) {
       if(!metric) { return $q.when([]); }
 
       return this._get('/api/tagk/' + metric).then(function(result) {
@@ -149,7 +125,7 @@ function (angular, _, kbn) {
       });
     }
 
-    OpenTSDBDatasource.prototype._get = function(relativeUrl, params) {
+    BosunDatasource.prototype._get = function(relativeUrl, params) {
       return backendSrv.datasourceRequest({
         method: 'GET',
         url: this.url + relativeUrl,
@@ -157,7 +133,7 @@ function (angular, _, kbn) {
       });
     };
 
-    OpenTSDBDatasource.prototype.metricFindQuery = function(query) {
+    BosunDatasource.prototype.metricFindQuery = function(query) {
       if (!query) { return $q.when([]); }
 
       var interpolated;
@@ -204,7 +180,7 @@ function (angular, _, kbn) {
       return $q.when([]);
     };
 
-    OpenTSDBDatasource.prototype.testDatasource = function() {
+    BosunDatasource.prototype.testDatasource = function() {
       return this._performSuggestQuery('cpu', 'metrics').then(function () {
         return { status: "success", message: "Data source is working", title: "Success" };
       });
@@ -326,7 +302,7 @@ function (angular, _, kbn) {
       return date.getTime();
     }
 
-    return OpenTSDBDatasource;
+    return BosunDatasource;
   });
 
 });

--- a/public/app/plugins/datasource/bosun/directives.js
+++ b/public/app/plugins/datasource/bosun/directives.js
@@ -1,0 +1,16 @@
+define([
+  'angular',
+],
+function (angular) {
+  'use strict';
+
+  var module = angular.module('grafana.directives');
+
+  module.directive('metricQueryEditorBosun', function() {
+    return {
+      controller: 'BosunQueryCtrl',
+      templateUrl: 'app/plugins/datasource/bosun/partials/query.editor.html',
+    };
+  });
+
+});

--- a/public/app/plugins/datasource/bosun/partials/config.html
+++ b/public/app/plugins/datasource/bosun/partials/config.html
@@ -1,17 +1,1 @@
 <div ng-include="httpConfigPartialSrc"></div>
-
-<br>
-<h5>OpenTSDB details</h5>
-
-<div class="tight-form last">
-    <ul class="tight-form-list">
-        <li class="tight-form-item" style="width: 80px">
-            Url
-        </li>
-        <li>
-            <input type="text" class="tight-form-input input-xlarge" ng-model='current.opentsdbUrl' placeholder="" required></input>
-        </li>
-    </ul>
-    <div class="clearfix"></div>
-</div>
-

--- a/public/app/plugins/datasource/bosun/partials/config.html
+++ b/public/app/plugins/datasource/bosun/partials/config.html
@@ -1,0 +1,17 @@
+<div ng-include="httpConfigPartialSrc"></div>
+
+<br>
+<h5>OpenTSDB details</h5>
+
+<div class="tight-form last">
+    <ul class="tight-form-list">
+        <li class="tight-form-item" style="width: 80px">
+            Url
+        </li>
+        <li>
+            <input type="text" class="tight-form-input input-xlarge" ng-model='current.opentsdbUrl' placeholder="" required></input>
+        </li>
+    </ul>
+    <div class="clearfix"></div>
+</div>
+

--- a/public/app/plugins/datasource/bosun/partials/query.editor.html
+++ b/public/app/plugins/datasource/bosun/partials/query.editor.html
@@ -1,0 +1,187 @@
+<div class="tight-form">
+	<ul class="tight-form-list pull-right">
+		<li class="tight-form-item small" ng-show="target.datasource">
+			<em>{{target.datasource}}</em>
+		</li>
+		<li class="tight-form-item">
+			<div class="dropdown">
+				<a class="pointer dropdown-toggle" data-toggle="dropdown" tabindex="1">
+					<i class="fa fa-bars"></i>
+				</a>
+				<ul class="dropdown-menu pull-right" role="menu">
+					<li role="menuitem"><a tabindex="1" ng-click="toggleQueryMode()">Switch editor mode</a></li>
+					<li role="menuitem"><a tabindex="1" ng-click="duplicateDataQuery(target)">Duplicate</a></li>
+					<li role="menuitem"><a tabindex="1" ng-click="moveDataQuery($index, $index-1)">Move up</a></li>
+					<li role="menuitem"><a tabindex="1" ng-click="moveDataQuery($index, $index+1)">Move down</a></li>
+				</ul>
+			</div>
+		</li>
+		<li class="tight-form-item last">
+			<a class="pointer" tabindex="1" ng-click="removeDataQuery(target)">
+				<i class="fa fa-remove"></i>
+			</a>
+		</li>
+	</ul>
+
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="min-width: 15px; text-align: center">
+			{{target.refId}}
+		</li>
+		<li>
+			<a  class="tight-form-item"
+				ng-click="target.hide = !target.hide; get_data();"
+				role="menuitem">
+				<i class="fa fa-eye"></i>
+			</a>
+		</li>
+	</ul>
+
+	<ul class="tight-form-list" role="menu">
+		<li class="tight-form-item" style="width: 86px">
+			Metric
+		</li>
+		<li>
+			<input type="text" class="input-large tight-form-input" ng-model="target.metric"
+			spellcheck='false' bs-typeahead="suggestMetrics" placeholder="metric name" data-min-length=0 data-items=100
+			ng-blur="targetBlur()">
+			</input>
+			<a bs-tooltip="target.errors.metric" style="color: rgb(229, 189, 28)" ng-show="target.errors.metric">
+				<i class="fa fa-warning"></i>
+			</a>
+		</li>
+		<li class="tight-form-item">
+			Aggregator
+		</li>
+		<li>
+			<select ng-model="target.aggregator" class="tight-form-input input-small"
+				ng-options="agg for agg in aggregators"
+				ng-change="targetBlur()">
+			</select>
+			<a bs-tooltip="target.errors.aggregator" style="color: rgb(229, 189, 28)" ng-show="target.errors.aggregator">
+				<i class="fa fa-warning"></i>
+			</a>
+		</li>
+
+		<li class="tight-form-item">
+			Alias:
+			<tip>Use patterns like $tag_tagname to replace part of the alias for a tag value</tip>
+		</li>
+		<li>
+			<input type="text" class="tight-form-input input-large"
+			ng-model="target.alias"
+			spellcheck='false'
+			placeholder="series alias"
+			data-min-length=0 data-items=100
+			ng-blur="targetBlur()"></input>
+		</li>
+	</ul>
+
+	<div class="clearfix"></div>
+</div>
+
+<div class="tight-form">
+	<ul class="tight-form-list" role="menu">
+		<li class="tight-form-item tight-form-align" style="width: 86px">
+			Down sample
+		</li>
+
+		<li>
+			<input type="text" class="input-large tight-form-input"
+			ng-model="target.downsampleInterval"
+			ng-model-onblur
+			ng-change="targetBlur()"
+			placeholder="interval (empty = auto)"></input>
+		</li>
+
+		<li class="tight-form-item">
+			Aggregator
+		</li>
+
+		<li>
+			<select ng-model="target.downsampleAggregator" class="tight-form-input input-small"
+				ng-options="agg for agg in aggregators"
+				ng-change="targetBlur()">
+			</select>
+		</li>
+
+		<li class="tight-form-item">
+			<editor-checkbox text="Disable downsampling" model="target.disableDownsampling" change="targetBlur()"></editor-checkbox>
+		</li>
+
+	</ul>
+	<div class="clearfix"></div>
+</div>
+
+<div class="tight-form">
+	<ul class="tight-form-list" role="menu">
+		<li class="tight-form-item tight-form-align" style="width: 86px">
+			Tags
+		</li>
+		<li ng-repeat="(key, value) in target.tags track by $index" class="tight-form-item">
+			{{key}}&nbsp;=&nbsp;{{value}}
+			<a ng-click="removeTag(key)">
+				<i class="fa fa-remove"></i>
+			</a>
+		</li>
+
+		<li class="tight-form-item" ng-hide="addTagMode">
+			<a ng-click="addTag()">
+				<i class="fa fa-plus"></i>
+			</a>
+		</li>
+
+		<li ng-show="addTagMode">
+			<input type="text" class="input-small tight-form-input" spellcheck='false'
+			bs-typeahead="suggestTagKeys" data-min-length=0 data-items=100
+			ng-model="target.currentTagKey" placeholder="key"></input>
+
+			<input type="text" class="input-small tight-form-input"
+			spellcheck='false' bs-typeahead="suggestTagValues"
+			data-min-length=0 data-items=100 ng-model="target.currentTagValue" placeholder="value">
+			</input>
+			<a ng-click="addTag()">
+				add tag
+			</a>
+			<a bs-tooltip="target.errors.tags"
+				style="color: rgb(229, 189, 28)"
+				ng-show="target.errors.tags">
+				<i class="fa fa-warning"></i>
+			</a>
+		</li>
+	</ul>
+	<div class="clearfix"></div>
+</div>
+
+<div class="tight-form">
+	<ul class="tight-form-list" role="menu">
+		<li class="tight-form-item tight-form-align" style="width: 86px">
+			<editor-checkbox text="Rate" model="target.shouldComputeRate" change="targetBlur()"></editor-checkbox>
+		</li>
+
+		<li class="tight-form-item" ng-hide="!target.shouldComputeRate">
+			<editor-checkbox text="Counter" model="target.isCounter" change="targetBlur()"></editor-checkbox>
+		</li>
+
+		<li class="tight-form-item" ng-hide="!target.isCounter">
+			Counter Max:
+		</li>
+
+		<li ng-hide="!target.isCounter">
+			<input type="text" class="tight-form-input input-small" ng-disabled="!target.shouldComputeRate"
+			ng-model="target.counterMax" spellcheck='false'
+			placeholder="max value" ng-model-onblur
+			ng-blur="targetBlur()"></input>
+		</li>
+		<li class="tight-form-item" ng-hide="!target.isCounter">
+			Reset Value:
+		</li>
+		<li ng-hide="!target.isCounter">
+			<input type="text" class="tight-form-input input-small" ng-disabled="!target.shouldComputeRate"
+			ng-model="target.counterResetValue" spellcheck='false'
+			placeholder="reset value" ng-model-onblur
+			ng-blur="targetBlur()"></input>
+		</li>
+	</ul>
+
+	<div class="clearfix"></div>
+</div>

--- a/public/app/plugins/datasource/bosun/plugin.json
+++ b/public/app/plugins/datasource/bosun/plugin.json
@@ -1,0 +1,15 @@
+{
+  "pluginType": "datasource",
+  "name": "Bosun",
+
+  "type": "bosun",
+  "serviceName": "BosunDatasource",
+
+  "module": "plugins/datasource/bosun/datasource",
+
+  "partials": {
+    "config": "app/plugins/datasource/bosun/partials/config.html"
+  },
+
+  "metrics": true
+}

--- a/public/app/plugins/datasource/bosun/queryCtrl.js
+++ b/public/app/plugins/datasource/bosun/queryCtrl.js
@@ -1,0 +1,110 @@
+define([
+  'angular',
+  'lodash',
+  'kbn'
+],
+function (angular, _, kbn) {
+  'use strict';
+
+  var module = angular.module('grafana.controllers');
+
+  module.controller('BosunQueryCtrl', function($scope) {
+
+    $scope.init = function() {
+      $scope.target.errors = validateTarget($scope.target);
+      $scope.aggregators = ['avg', 'sum', 'min', 'max', 'dev', 'zimsum', 'mimmin', 'mimmax'];
+
+      if (!$scope.target.aggregator) {
+        $scope.target.aggregator = 'sum';
+      }
+
+      if (!$scope.target.downsampleAggregator) {
+        $scope.target.downsampleAggregator = 'avg';
+      }
+    };
+
+    $scope.targetBlur = function() {
+      $scope.target.errors = validateTarget($scope.target);
+
+      // this does not work so good
+      if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
+        $scope.oldTarget = angular.copy($scope.target);
+        $scope.get_data();
+      }
+    };
+
+    $scope.getTextValues = function(metricFindResult) {
+      return _.map(metricFindResult, function(value) { return value.text; });
+    };
+
+    $scope.suggestMetrics = function(query, callback) {
+      $scope.datasource.metricFindQuery('metrics(' + query + ')')
+        .then($scope.getTextValues)
+        .then(callback);
+    };
+
+    $scope.suggestTagKeys = function(query, callback) {
+      $scope.datasource.metricFindQuery('tag_names(' + $scope.target.metric + ')')
+        .then($scope.getTextValues)
+        .then(callback);
+    };
+
+    $scope.suggestTagValues = function(query, callback) {
+      $scope.datasource.metricFindQuery('tag_values(' + $scope.target.metric + ',' + $scope.target.currentTagKey + ')')
+        .then($scope.getTextValues)
+        .then(callback);
+    };
+
+    $scope.addTag = function() {
+      if (!$scope.addTagMode) {
+        $scope.addTagMode = true;
+        return;
+      }
+
+      if (!$scope.target.tags) {
+        $scope.target.tags = {};
+      }
+
+      $scope.target.errors = validateTarget($scope.target);
+
+      if (!$scope.target.errors.tags) {
+        $scope.target.tags[$scope.target.currentTagKey] = $scope.target.currentTagValue;
+        $scope.target.currentTagKey = '';
+        $scope.target.currentTagValue = '';
+        $scope.targetBlur();
+      }
+
+      $scope.addTagMode = false;
+    };
+
+    $scope.removeTag = function(key) {
+      delete $scope.target.tags[key];
+      $scope.targetBlur();
+    };
+
+    function validateTarget(target) {
+      var errs = {};
+
+      if (target.shouldDownsample) {
+        try {
+          if (target.downsampleInterval) {
+            kbn.describe_interval(target.downsampleInterval);
+          } else {
+            errs.downsampleInterval = "You must supply a downsample interval (e.g. '1m' or '1h').";
+          }
+        } catch(err) {
+          errs.downsampleInterval = err.message;
+        }
+      }
+
+      if (target.tags && _.has(target.tags, target.currentTagKey)) {
+        errs.tags = "Duplicate tag key '" + target.currentTagKey + "'.";
+      }
+
+      return errs;
+    }
+
+    $scope.init();
+  });
+
+});

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -133,7 +133,7 @@ function (angular, _, kbn) {
           && s.split("=")[1] !== "";
       });
 
-      var params = ""
+      var params = "";
       if (valid_subtags.length > 0){
         params = " AND (" + valid_subtags.join(" AND ") + ")";
       }

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -125,16 +125,18 @@ function (angular, _, kbn) {
         return $q.when([]);
       }
 
-      var subtags_list = subtags.split(",")
-      var valid_subtags = subtags_list.filter(function (s) { return s.split("=")[1] != "*"
-                                                                 && s.split("=")[1] != "AGGR"
-                                                                 && s.split("=")[1].charAt(0) != "$"
-                                                                 && s.split("=")[1] != "" });
-    
-     var params = "" 
-     if (valid_subtags.length > 0){
-       params = " AND (" + valid_subtags.join(" AND ") + ")"
-     }
+      var subtags_list = subtags.split(",");
+      var valid_subtags = subtags_list.filter(function (s) {
+        return s.split("=")[1] !== "*"
+          && s.split("=")[1] !== "AGGR"
+          && s.split("=")[1].charAt(0) !== "$"
+          && s.split("=")[1] !== "";
+      });
+
+      var params = ""
+      if (valid_subtags.length > 0){
+        params = " AND (" + valid_subtags.join(" AND ") + ")";
+      }
 
       return this._get('/api/search/lookup' + key + params).then(function(result) {
         return result.data;
@@ -147,7 +149,7 @@ function (angular, _, kbn) {
       return this._get('/api/tagk/' + metric).then(function(result) {
         return result.data;
       });
-    }
+    };
 
     OpenTSDBDatasource.prototype._get = function(relativeUrl, params) {
       return backendSrv.datasourceRequest({
@@ -290,12 +292,12 @@ function (angular, _, kbn) {
       }
 
       var tags = angular.copy(target.tags);
-      query.tags = {}
+      query.tags = {};
       if(tags){
         for(var key in tags){
-          var tagv = templateSrv.replace(tags[key], options.scopedVars)
-          if (tagv.charAt(0) != "$" && tagv != "AGGR" ) {
-            query.tags[key] = tagv
+          var tagv = templateSrv.replace(tags[key], options.scopedVars);
+          if (tagv.charAt(0) !== "$" && tagv !== "AGGR") {
+            query.tags[key] = tagv;
           }
         }
       }

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -146,8 +146,17 @@ function (angular, _, kbn) {
     OpenTSDBDatasource.prototype._performMetricKeyLookup = function(metric) {
       if(!metric) { return $q.when([]); }
 
-      return this._get('/api/tagk/' + metric).then(function(result) {
-        return result.data;
+      return this._get('/api/search/lookup', {m: metric, limit: 1000}).then(function(result) {
+        result = result.data.results;
+        var tagks = [];
+        _.each(result, function(r) {
+          _.each(r.tags, function(tagv, tagk) {
+            if(tagks.indexOf(tagk) === -1) {
+              tagks.push(tagk);
+            }
+          });
+        });
+        return tagks;
       });
     };
 

--- a/public/test/specs/bosunDatasource-specs.js
+++ b/public/test/specs/bosunDatasource-specs.js
@@ -1,0 +1,52 @@
+define([
+  'helpers',
+  'plugins/datasource/bosun/datasource'
+], function(helpers) {
+  'use strict';
+
+  describe('bosun', function() {
+    var ctx = new helpers.ServiceTestContext();
+
+    beforeEach(module('grafana.services'));
+    beforeEach(ctx.providePhase(['backendSrv']));
+
+    beforeEach(ctx.createService('BosunDatasource'));
+    beforeEach(function() {
+      ctx.ds = new ctx.service({ url: [''] });
+    });
+
+    describe('When performing metricFindQuery', function() {
+      var results;
+      var requestOptions;
+
+      beforeEach(function() {
+        ctx.backendSrv.datasourceRequest = function(options) {
+          requestOptions = options;
+          return ctx.$q.when({data: [{ target: 'prod1.count', datapoints: [[10, 1], [12,1]] }]});
+        };
+      });
+
+      it('metrics() should generate api suggest query', function() {
+        ctx.ds.metricFindQuery('metrics()').then(function(data) { results = data; });
+        ctx.$rootScope.$apply();
+        expect(requestOptions.url).to.be('/api/suggest');
+      });
+
+      it('tag_names(cpu) should generate looku  query', function() {
+        ctx.ds.metricFindQuery('tag_names(cpu)').then(function(data) { results = data; });
+        ctx.$rootScope.$apply();
+        expect(requestOptions.url).to.be('/api/search/lookup');
+        expect(requestOptions.params.m).to.be('cpu');
+      });
+
+      it('tag_values(cpu, test) should generate looku  query', function() {
+        ctx.ds.metricFindQuery('tag_values(cpu, hostname)').then(function(data) { results = data; });
+        ctx.$rootScope.$apply();
+        expect(requestOptions.url).to.be('/api/search/lookup');
+        expect(requestOptions.params.m).to.be('cpu{hostname=*}');
+      });
+
+    });
+  });
+});
+

--- a/public/test/specs/templateSrv-specs.js
+++ b/public/test/specs/templateSrv-specs.js
@@ -71,6 +71,17 @@ define([
         expect(result).to.be('(test|test2)');
       });
 
+      it('multi value and pipe delimited format should render regex string', function() {
+        var result = _templateSrv.renderVariableValue({
+          multiFormat: 'pipe delimited',
+          current: {
+            value: ['test','test2'],
+          }
+        });
+        expect(result).to.be('test|test2');
+      });
+
+
     });
 
     describe('can check if variable exists', function() {


### PR DESCRIPTION
This is a work in progress but I'd very much like some feedback, I'm not a front-end guy. This adds a few things that are somewhat interconnected:
- Adds tag_values_with_subtags(metric,tag,subtag1,subtags2,...) to metricFindQuery() in OpenTSDB. This allows to filter down tags based on what other tags as present, as defined in the metadata API.
- Adds a special option "Aggr" as possible value for templating. When selected as tag it is simply omitted from the time serie query, allowing OpenTSDB to aggregate the multiple time series.
- Adds an additional datasource of type Bosun to make use as metadata source. In our environment OpenTSDB's metadata support can't be turned on without crushing our cluster. Bosun's works so might as well use it.

Where I think I'd need guidance:
- Aggr is implemented using the special value AGGR so it can be omitted if needed. There's probably as better way than a special string to do this.
- Bosun as datasource for timeseries works by putting a reverse proxy in front of it that forwards queries to /api/query and /api/suggest to OpenTSDB. Ideally I'd like to link an OpenTSDB datasource to the Bosun one so we can hit one or the other depending on the type of request I'm making. I'm not sure how to accomplish that with the way data sources are defined.
