### PR TITLE
Update docstring for postgres session provider

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -67,7 +67,7 @@ path = grafana.db
 
 #################################### Session ####################################
 [session]
-# Either "memory", "file", "redis", "mysql", "postgresql", default is "file"
+# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
 provider = file
 
 # Provider config options

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -67,7 +67,7 @@
 
 #################################### Session ####################################
 [session]
-# Either "memory", "file", "redis", "mysql", "postgresql", default is "file"
+# Either "memory", "file", "redis", "mysql", "postgres", default is "file"
 ;provider = file
 
 # Provider config options


### PR DESCRIPTION
The postgres provider is named postgres and not postgresql. For somebody
configuring the server from the config file example, it is very easy to
write an invalid value into the file and accidentally use the "memory"
provider instead because of a typo.
