### PR TITLE
Fix dataproxy_test.go tests

### DIFF
--- a/pkg/api/dataproxy_test.go
+++ b/pkg/api/dataproxy_test.go
@@ -14,7 +14,8 @@ func TestDataSourceProxy(t *testing.T) {
 
 	Convey("When getting graphite datasource proxy", t, func() {
 		ds := m.DataSource{Url: "htttp://graphite:8080", Type: m.DS_GRAPHITE}
-		proxy := NewReverseProxy(&ds, "/render")
+		targetUrl, _ := url.Parse(ds.Url)
+		proxy := NewReverseProxy(&ds, "/render", targetUrl)
 
 		requestUrl, _ := url.Parse("http://grafana.com/sub")
 		req := http.Request{URL: requestUrl}
@@ -36,7 +37,8 @@ func TestDataSourceProxy(t *testing.T) {
 			Password: "password",
 		}
 
-		proxy := NewReverseProxy(&ds, "")
+		targetUrl, _ := url.Parse(ds.Url)
+		proxy := NewReverseProxy(&ds, "", targetUrl)
 
 		requestUrl, _ := url.Parse("http://grafana.com/sub")
 		req := http.Request{URL: requestUrl}


### PR DESCRIPTION
Hi,

This change fix dataproxy_test.go tests that was failing with:

pkg/api/dataproxy_test.go:17: not enough arguments in call to NewReverseProxy
pkg/api/dataproxy_test.go:39: not enough arguments in call to NewReverseProxy
FAIL    _/home/ubuntu/grafana/pkg/api [build failed]

Cheers
