### PR TITLE
Added 'Manage dashboard' tooltip, hides on click.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,7 +30,6 @@
     "define": true,
     "require": true,
     "Chromath": false,
-    "setImmediate": true,
-    "$": false
+    "setImmediate": true
   }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -30,6 +30,7 @@
     "define": true,
     "require": true,
     "Chromath": false,
-    "setImmediate": true
+    "setImmediate": true,
+    "$": false
   }
 }

--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -51,8 +51,9 @@ function (angular, _) {
       $scope.exitFullscreen();
     };
 
-    $scope.removeToolTip = function() {
+    $scope.manageButtonClickAction = function() {
       $('.tooltip').not(this).hide();
+      $scope.appEvent('hide-dash-search');
     };
 
     $scope.saveDashboard = function(options) {

--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -52,7 +52,7 @@ function (angular, _) {
     };
 
     $scope.manageButtonClickAction = function() {
-      $('.tooltip').not(this).hide();
+      angular.element('#manageDashboardButton').tooltip('hide');
       $scope.appEvent('hide-dash-search');
     };
 

--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -52,7 +52,7 @@ function (angular, _) {
     };
 
     $scope.removeToolTip = function() {
-        $('.tooltip').not(this).hide();
+      $('.tooltip').not(this).hide();
     };
 
     $scope.saveDashboard = function(options) {

--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -51,6 +51,10 @@ function (angular, _) {
       $scope.exitFullscreen();
     };
 
+    $scope.removeToolTip = function() {
+        $('.tooltip').not(this).hide();
+    };
+
     $scope.saveDashboard = function(options) {
       if ($scope.dashboardMeta.canSave === false) {
         return;

--- a/public/app/features/dashboard/directives/dashSearchView.js
+++ b/public/app/features/dashboard/directives/dashSearchView.js
@@ -54,7 +54,14 @@ function (angular, $) {
             hookUpHideWhenClickedOutside();
           }
 
+          function hideSearch() {
+            if (editorScope) {
+              editorScope.dismiss();
+            }
+          }
+
           scope.onAppEvent('show-dash-search', showSearch);
+          scope.onAppEvent('hide-dash-search', hideSearch);
         }
       };
     });

--- a/public/app/features/dashboard/partials/dashboardTopNav.html
+++ b/public/app/features/dashboard/partials/dashboardTopNav.html
@@ -30,7 +30,7 @@
 					<a ng-click="saveDashboard()" bs-tooltip="'Save dashboard'" data-placement="bottom"><i class="fa fa-save"></i></a>
 				</li>
 				<li class="dropdown">
-					<a class="pointer" ng-click="removeToolTip()" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
+					<a class="pointer" ng-click="manageButtonClickAction()" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
 					<ul class="dropdown-menu">
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('annotations');">Annotations</a></li>

--- a/public/app/features/dashboard/partials/dashboardTopNav.html
+++ b/public/app/features/dashboard/partials/dashboardTopNav.html
@@ -30,7 +30,7 @@
 					<a ng-click="saveDashboard()" bs-tooltip="'Save dashboard'" data-placement="bottom"><i class="fa fa-save"></i></a>
 				</li>
 				<li class="dropdown">
-					<a class="pointer" ng-click="manageButtonClickAction()" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
+					<a id="manageDashboardButton" class="pointer" ng-click="manageButtonClickAction()" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
 					<ul class="dropdown-menu">
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('annotations');">Annotations</a></li>

--- a/public/app/features/dashboard/partials/dashboardTopNav.html
+++ b/public/app/features/dashboard/partials/dashboardTopNav.html
@@ -30,7 +30,7 @@
 					<a ng-click="saveDashboard()" bs-tooltip="'Save dashboard'" data-placement="bottom"><i class="fa fa-save"></i></a>
 				</li>
 				<li class="dropdown">
-					<a class="pointer" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
+					<a class="pointer" ng-click="removeToolTip()" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
 					<ul class="dropdown-menu">
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('annotations');">Annotations</a></li>


### PR DESCRIPTION
Added "Manage dashboard" Tooltip for the settings icon. Also, this tooltip hides when we click on the icon.

Here is the demo:

Hovering over the settings icon shows the following tooltip:
<img width="222" alt="screen shot 2015-09-18 at 12 55 43 am" src="https://cloud.githubusercontent.com/assets/1019609/9954739/4136184a-5da0-11e5-8fdb-f48e9a550431.png">

Clicking on the settings icon removes the tooltip and shows the dropdown menu.
<img width="304" alt="screen shot 2015-09-18 at 12 55 50 am" src="https://cloud.githubusercontent.com/assets/1019609/9954758/64bbbeaa-5da0-11e5-82b5-5595465cd71a.png">
