### PR TITLE
Single stat panel throws warning on multiple series result.

### DIFF
--- a/public/app/panels/singlestat/module.js
+++ b/public/app/panels/singlestat/module.js
@@ -171,6 +171,12 @@ function (angular, app, _, kbn, TimeSeries, PanelMeta) {
     $scope.render = function() {
       var data = {};
 
+      if($scope.series.length > 1) {
+        $scope.appEvent('alert-warning', ['Multiple Series Error', 'Metric query returns ' +
+        $scope.series.length + ' series. Single Stat Panel expects a single series.']);
+        $scope.series = [];
+      }
+
       $scope.setValues(data);
 
       data.thresholds = $scope.panel.thresholds.split(',').map(function(strVale) {
@@ -185,7 +191,6 @@ function (angular, app, _, kbn, TimeSeries, PanelMeta) {
 
     $scope.setValues = function(data) {
       data.flotpairs = [];
-
       if ($scope.series && $scope.series.length > 0) {
         var lastPoint = _.last($scope.series[0].datapoints);
         var lastValue = _.isArray(lastPoint) ? lastPoint[0] : null;

--- a/public/app/panels/singlestat/module.js
+++ b/public/app/panels/singlestat/module.js
@@ -171,12 +171,6 @@ function (angular, app, _, kbn, TimeSeries, PanelMeta) {
     $scope.render = function() {
       var data = {};
 
-      if($scope.series.length > 1) {
-        $scope.appEvent('alert-warning', ['Multiple Series Error', 'Metric query returns ' +
-        $scope.series.length + ' series. Single Stat Panel expects a single series.']);
-        $scope.series = [];
-      }
-
       $scope.setValues(data);
 
       data.thresholds = $scope.panel.thresholds.split(',').map(function(strVale) {
@@ -191,6 +185,15 @@ function (angular, app, _, kbn, TimeSeries, PanelMeta) {
 
     $scope.setValues = function(data) {
       data.flotpairs = [];
+
+      if($scope.series.length > 1) {
+        $scope.inspector.error = new Error();
+        $scope.inspector.error.message = 'Multiple Series Error';
+        $scope.inspector.error.data = 'Metric query returns ' + $scope.series.length +
+        ' series. Single Stat Panel expects a single series.\n\nResponse:\n'+JSON.stringify($scope.series);
+        throw $scope.inspector.error;
+      }
+
       if ($scope.series && $scope.series.length > 0) {
         var lastPoint = _.last($scope.series[0].datapoints);
         var lastValue = _.isArray(lastPoint) ? lastPoint[0] : null;


### PR DESCRIPTION
As the first step to notify user that Single Stat panel expects a single series as a result of the metric query, this PR implemented a warning alert. So, the user has to make sure that the query returns a single series.
