### PR TITLE
added limitation on exploreQueries

### DIFF
--- a/public/app/plugins/datasource/influxdb/queryBuilder.js
+++ b/public/app/plugins/datasource/influxdb/queryBuilder.js
@@ -89,6 +89,8 @@ function (_) {
       }
     }
 
+    query += 'LIMIT 50';
+
     return query;
   };
 


### PR DESCRIPTION
If you have a lot of tables in your InfluxDB, the browser could hang some time due to clicking on the "FROM" field, when there is nothing typed in, or the selection is too less.
