### PR TITLE
Add multi-value support for KairosDB

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -186,7 +186,7 @@
 									All format
 								</li>
 								<li ng-show="current.includeAll">
-									<select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe']"></select>
+									<select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe', 'native']"></select>
 								</li>
 							</ul>
 							<div class="clearfix"></div>
@@ -217,7 +217,7 @@
 								Multi format
 							</li>
 							<li ng-show="current.multi">
-								<select class="input-medium tight-form-input last" ng-model="current.multiFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'regex values', 'lucene', 'pipe']"></select>
+								<select class="input-medium tight-form-input last" ng-model="current.multiFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'regex values', 'lucene', 'pipe', 'native']"></select>
 							</li>
 						</ul>
 						<div class="clearfix"></div>

--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -49,6 +49,9 @@ function (angular, _) {
           case "pipe": {
             return value.join('|');
           }
+          case "native": {
+            return value;
+          }
           default:  {
             return '{' + value.join(',') + '}';
           }
@@ -91,7 +94,8 @@ function (angular, _) {
       var value;
       this._regex.lastIndex = 0;
 
-      return target.replace(this._regex, function(match, g1, g2) {
+      var native_array;
+      var regexed = target.replace(this._regex, function(match, g1, g2) {
         if (scopedVars) {
           value = scopedVars[g1 || g2];
           if (value) { return value.value; }
@@ -100,8 +104,13 @@ function (angular, _) {
         value = self._values[g1 || g2];
         if (!value) { return match; }
 
+        if (self._values[g1 || g2].constructor === Array) {
+          native_array = self._values[g1 || g2];
+        }
         return self._grafanaVariables[value] || value;
       });
+
+      return native_array || regexed;
     };
 
     this.replaceWithText = function(target, scopedVars) {

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -275,6 +275,10 @@ function (angular, _, kbn) {
           allValue = _.pluck(variable.options, 'text').join('|');
           break;
         }
+        case 'native': {
+          allValue = variable.options.map(function(o) { return o.text; });
+          break;
+        }
         default: {
           allValue = '{';
           allValue += _.pluck(variable.options, 'text').join(',');

--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -330,6 +330,9 @@ function (angular, _, dateMath, kbn) {
         query.tags = angular.copy(target.tags);
         _.forOwn(query.tags, function(value, key) {
           query.tags[key] = _.map(value, function(tag) { return templateSrv.replace(tag); });
+          if (query.tags[key].constructor === Array) {
+            query.tags[key] = query.tags[key][0];
+          }
         });
       }
 


### PR DESCRIPTION
KairosDB requires multie-value tags to be sent as separate elements of a JSON list (see [doc](https://kairosdb.github.io/kairosdocs/restapi/QueryMetrics.html#body)).

```
           "tags": {
               "host": ["foo", "foo2"],
               "customer": ["bar"]
           },
```

Grafana handles this correctly if the tag has several values set manually in the query. 

It is not compatible when using multi-values in templates. There doesn't seem to be any multi-format or all-format that support this. The variable replacement always returns a string using the various multi-format methods (e.g. `["{foo,foo2}"]`  for glob).

This pull request adds a `native` multi-format and all-format to handle this by returning an array instead of a string.

I don't write js very often, guidance/help/feedback is very welcome (specially if you have a different approach for the change in `public/app/features/templating/templateSrv.js`).
