### PR TITLE
Phantomjs

### DIFF
--- a/tasks/build_task.js
+++ b/tasks/build_task.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
     'copy:public_to_gen',
     'typescript:build',
     'karma:test',
+    'phantomjs',
     'css',
     'htmlmin:build',
     'ngtemplates',

--- a/tasks/default_task.js
+++ b/tasks/default_task.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
     'tslint',
     'clean:gen',
     'copy:public_to_gen',
+    'phantomjs',
     'css',
     'typescript:build'
   ]);

--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -1,11 +1,33 @@
 module.exports = function(config,grunt) {
   'use strict';
+
   grunt.registerTask('phantomjs', 'Copy phantomjs binary from node', function() {
-    var m=grunt.file.read("./node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/location.js")
-    var p=/= \"([^\"]*)\"/.exec(m);
-    if (grunt.file.exists(p[1])) {
-      grunt.log.writeln('Using '+ p[1]);
-      grunt.file.copy(p[1],'vendor/phantomjs/phantomjs');
+
+    var dest = './vendor/phantomjs/phantomjs';
+    var confDir = './node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/'
+
+    if (!grunt.file.exists(dest)){
+
+      var m=grunt.file.read(confDir+"location.js")
+      var src=/= \"([^\"]*)\"/.exec(m)[1];
+      
+      if (!grunt.file.isPathAbsolute(src)) {
+        src = confDir+src;
+      }
+
+      var exec = require('child_process').execFileSync;
+
+      try {
+        var ph=exec(src,['-v'], { stdio: 'ignore' });
+        grunt.verbose.writeln('Using '+ src);
+        grunt.file.copy(src, dest, { encoding: null });
+      } catch (err) {
+        grunt.verbose.writeln(err);
+        grunt.fail.warn('No working Phantomjs binary available')
+      }
+      
+    } else {
+       grunt.log.writeln('Phantomjs already imported from node');
     }
   });
 };

--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -1,0 +1,11 @@
+module.exports = function(config,grunt) {
+  'use strict';
+  grunt.registerTask('phantomjs', 'Copy phantomjs binary from node', function() {
+    var m=grunt.file.read("./node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/location.js")
+    var p=/= \"([^\"]*)\"/.exec(m);
+    if (grunt.file.exists(p[1])) {
+      grunt.log.writeln('Using '+ p[1]);
+      grunt.file.copy(p[1],'vendor/phantomjs/phantomjs');
+    }
+  });
+};


### PR DESCRIPTION
This a fix for #2683.
Nothing fancy : 
- phantomjs default binary is removed
- use `location.js` created during `npm install` to track the path of `phantomjs`
- if `phantomjs` was already copied to `vendor/phantomjs/`, do nothing
- check the binary (this mainly for phantomjs node module [#376](https://github.com/Medium/phantomjs/issues/376))
