### PR TITLE
Missing carriage return in init script when displaying usage

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -148,7 +148,7 @@ case "$1" in
     $0 start
     ;;
   *)
-    echo -n "Usage: $0 {start|stop|restart|force-reload|status}"
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
     exit 3
     ;;
 esac


### PR DESCRIPTION
A carriage return is missing, so the next shell line starts after the gafana usage instead of at the beginning on the next line.
