### PR TITLE
Add support for templated data source names

### DIFF
--- a/public/app/features/panel/panelSrv.js
+++ b/public/app/features/panel/panelSrv.js
@@ -103,10 +103,6 @@ function (angular, _, config) {
       };
 
       $scope.getCurrentDatasource = function() {
-        if ($scope.datasource) {
-          return $q.when($scope.datasource);
-        }
-
         return datasourceSrv.get($scope.panel.datasource);
       };
 

--- a/public/app/services/datasourceSrv.js
+++ b/public/app/services/datasourceSrv.js
@@ -8,7 +8,7 @@ function (angular, _, config) {
 
   var module = angular.module('grafana.services');
 
-  module.service('datasourceSrv', function($q, $injector, $rootScope) {
+  module.service('datasourceSrv', function($q, $injector, $rootScope, templateSrv) {
     var self = this;
 
     this.init = function() {
@@ -44,6 +44,8 @@ function (angular, _, config) {
       if (!name) {
         return this.get(config.defaultDatasource);
       }
+
+      name = templateSrv.replaceWithText(name);
 
       if (this.datasources[name]) {
         return $q.when(this.datasources[name]);


### PR DESCRIPTION
This adds support for changing the datasource name to something like `$env-metrics`.

I removed the read-through cache support in `panelSrv.getCurrentDatasource` to keep the code DRY. It didn't seem to have an affect on anything, but if it's necessary I can add the `templateSrv.replaceWithText` line there as well.
