### PR TITLE
Fix "Link to Prometheus" button for proxied Prometheus sources.

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -81,6 +81,11 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 			dsMap["index"] = ds.Database
 		}
 
+		if ds.Type == m.DS_PROMETHEUS {
+			// add unproxied server URL for link to Prometheus web UI
+			dsMap["directUrl"] = ds.Url
+		}
+
 		datasources[ds.Name] = dsMap
 	}
 

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -12,6 +12,7 @@ const (
 	DS_ES            = "elasticsearch"
 	DS_OPENTSDB      = "opentsdb"
 	DS_CLOUDWATCH    = "cloudwatch"
+	DS_PROMETHEUS    = "prometheus"
 	DS_ACCESS_DIRECT = "direct"
 	DS_ACCESS_PROXY  = "proxy"
 )

--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -21,12 +21,8 @@ function (angular, _, moment, dateMath) {
       this.name = datasource.name;
       this.supportMetrics = true;
 
-      var url = datasource.url;
-      if (url[url.length-1] === '/') {
-        // remove trailing slash
-        url = url.substr(0, url.length - 1);
-      }
-      this.url = url;
+      this.url = datasource.url.replace(/\/$/g, '');
+      this.directUrl = datasource.directUrl.replace(/\/$/g, '');
       this.basicAuth = datasource.basicAuth;
       this.lastErrors = {};
     }

--- a/public/app/plugins/datasource/prometheus/queryCtrl.js
+++ b/public/app/plugins/datasource/prometheus/queryCtrl.js
@@ -111,7 +111,7 @@ function (angular, _, kbn, dateMath) {
       };
 
       var hash = encodeURIComponent(JSON.stringify([expr]));
-      return $scope.datasource.url + '/graph#' + hash;
+      return $scope.datasource.directUrl + '/graph#' + hash;
     };
 
     $scope.calculateInterval = function() {

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -10,11 +10,11 @@ describe('PrometheusDatasource', function() {
   beforeEach(angularMocks.module('grafana.services'));
   beforeEach(ctx.createService('PrometheusDatasource'));
   beforeEach(function() {
-    ctx.ds = new ctx.service({ url: '', user: 'test', password: 'mupp' });
+    ctx.ds = new ctx.service({ url: 'proxied', directUrl: 'direct', user: 'test', password: 'mupp' });
   });
   describe('When querying prometheus with one target using query editor target spec', function() {
     var results;
-    var urlExpected = '/api/v1/query_range?query=' +
+    var urlExpected = 'proxied/api/v1/query_range?query=' +
                       encodeURIComponent('test{job="testjob"}') +
                       '&start=1443438675&end=1443460275&step=60s';
     var query = {
@@ -53,7 +53,7 @@ describe('PrometheusDatasource', function() {
         status: "success",
         data: ["value1", "value2", "value3"]
       };
-      ctx.$httpBackend.expect('GET', '/api/v1/label/resource/values').respond(response);
+      ctx.$httpBackend.expect('GET', 'proxied/api/v1/label/resource/values').respond(response);
       ctx.ds.metricFindQuery('label_values(resource)').then(function(data) { results = data; });
       ctx.$httpBackend.flush();
       ctx.$rootScope.$apply();
@@ -71,7 +71,7 @@ describe('PrometheusDatasource', function() {
           ]
         }
       };
-      ctx.$httpBackend.expect('GET', /\/api\/v1\/query\?query=count\(metric\)%20by%20\(resource\)&time=.*/).respond(response);
+      ctx.$httpBackend.expect('GET', /proxied\/api\/v1\/query\?query=count\(metric\)%20by%20\(resource\)&time=.*/).respond(response);
       ctx.ds.metricFindQuery('label_values(metric, resource)').then(function(data) { results = data; });
       ctx.$httpBackend.flush();
       ctx.$rootScope.$apply();
@@ -82,7 +82,7 @@ describe('PrometheusDatasource', function() {
         status: "success",
         data: ["metric1","metric2","metric3","nomatch"]
       };
-      ctx.$httpBackend.expect('GET', '/api/v1/label/__name__/values').respond(response);
+      ctx.$httpBackend.expect('GET', 'proxied/api/v1/label/__name__/values').respond(response);
       ctx.ds.metricFindQuery('metrics(metric.*)').then(function(data) { results = data; });
       ctx.$httpBackend.flush();
       ctx.$rootScope.$apply();


### PR DESCRIPTION
@torkelo The question here is whether the unproxied datasource URL is ever considered confidential for a proxied datasource. If that's the case, we could also decide to disable the "Link to Prometheus" button in proxied mode, though that would be unfortunate for users that _can_ actually access the direct server link even if it's proxied in Grafana (like when wall screen devices have more restrictive VPN settings than a developer's workstation). That link is very useful, from experience with it in PromDash :)
