### PR TITLE
Add config option to strip (most) colors from console logs

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -224,6 +224,8 @@ level = Info
 # For "console" mode only
 [log.console]
 level =
+# Set formatting to "false" to disable color formatting of console logs
+formatting = true
 
 # For "file" mode only
 [log.file]

--- a/pkg/log/console.go
+++ b/pkg/log/console.go
@@ -45,15 +45,17 @@ var (
 
 // ConsoleWriter implements LoggerInterface and writes messages to terminal.
 type ConsoleWriter struct {
-	lg    *log.Logger
-	Level int `json:"level"`
+	lg         *log.Logger
+	Level      int  `json:"level"`
+	Formatting bool `json:"formatting"`
 }
 
 // create ConsoleWriter returning as LoggerInterface.
 func NewConsole() LoggerInterface {
 	return &ConsoleWriter{
-		lg:    log.New(os.Stderr, "", log.Ldate|log.Ltime),
-		Level: TRACE,
+		lg:         log.New(os.Stderr, "", log.Ldate|log.Ltime),
+		Level:      TRACE,
+		Formatting: true,
 	}
 }
 
@@ -65,7 +67,7 @@ func (cw *ConsoleWriter) WriteMsg(msg string, skip, level int) error {
 	if cw.Level > level {
 		return nil
 	}
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || !cw.Formatting {
 		cw.lg.Println(msg)
 	} else {
 		cw.lg.Println(colors[level](msg))

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -140,7 +140,7 @@ type CommandLineArgs struct {
 
 func init() {
 	IsWindows = runtime.GOOS == "windows"
-	log.NewLogger(0, "console", `{"level": 0}`)
+	log.NewLogger(0, "console", `{"level": 0, "formatting":true}`)
 }
 
 func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
@@ -527,7 +527,11 @@ func initLogging(args *CommandLineArgs) {
 		// Generate log configuration.
 		switch mode {
 		case "console":
-			LogConfigs[i] = util.DynMap{"level": level}
+			formatting := sec.Key("formatting").MustBool(true)
+			LogConfigs[i] = util.DynMap{
+				"level":      level,
+				"formatting": formatting,
+			}
 		case "file":
 			logPath := sec.Key("file_name").MustString(filepath.Join(LogsPath, "grafana.log"))
 			os.MkdirAll(filepath.Dir(logPath), os.ModePerm)


### PR DESCRIPTION
This adds an option in the config file to strip the colors from the console logs. There is an additional source of colors in the logs (but this seems to affect all logs, console or otherwise), in the middleware, where logging urls served has color codes. That does not have access to the configuration settings, though, so I'm leaving it be for the time being.
