### PR TITLE
Prometheus annotation support

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -207,6 +207,57 @@ function (angular, _, moment, dateMath) {
       }
     };
 
+    PrometheusDatasource.prototype.annotationQuery = function(annotation, range) {
+      var expr = annotation.expr || '';
+      var tagKeys = annotation.tagKeys || '';
+      var titleFormat = annotation.titleFormat || '';
+      var textFormat = annotation.textFormat || '';
+
+      if (!expr) { return $q.when([]); }
+
+      var interpolated;
+      try {
+        interpolated = templateSrv.replace(expr);
+      }
+      catch (err) {
+        return $q.reject(err);
+      }
+
+      var query = {
+        expr: interpolated,
+        step: 60
+      };
+      var start = getPrometheusTime(range.from, false);
+      var end = getPrometheusTime(range.to, true);
+      return this.performTimeSeriesQuery(query, start, end).then(function(results) {
+        var eventList = [];
+        tagKeys = tagKeys.split(',');
+
+        _.each(results.data.data.result, function(series) {
+          var tags = _.chain(series.metric)
+          .filter(function(v, k) {
+            return _.contains(tagKeys, k);
+          }).value();
+
+          _.each(series.values, function(value) {
+            if (value[1] === '1') {
+              var event = {
+                annotation: annotation,
+                time: Math.floor(value[0]) * 1000,
+                title: renderTemplate(titleFormat, series.metric),
+                tags: tags,
+                text: renderTemplate(textFormat, series.metric)
+              };
+
+              eventList.push(event);
+            }
+          });
+        });
+
+        return eventList;
+      });
+    };
+
     PrometheusDatasource.prototype.testDatasource = function() {
       return this.metricFindQuery('metrics(.*)').then(function() {
         return { status: 'success', message: 'Data source is working', title: 'Success' };
@@ -242,22 +293,26 @@ function (angular, _, moment, dateMath) {
         return getOriginalMetricName(labelData);
       }
 
+      return renderTemplate(options.legendFormat, labelData) || '{}';
+    }
+
+    function renderTemplate(format, data) {
       var originalSettings = _.templateSettings;
       _.templateSettings = {
         interpolate: /\{\{(.+?)\}\}/g
       };
 
-      var template = _.template(templateSrv.replace(options.legendFormat));
-      var metricName;
+      var template = _.template(templateSrv.replace(format));
+      var result;
       try {
-        metricName = template(labelData);
+        result = template(data);
       } catch (e) {
-        metricName = '{}';
+        result = null;
       }
 
       _.templateSettings = originalSettings;
 
-      return metricName;
+      return result;
     }
 
     function getOriginalMetricName(labelData) {
@@ -271,12 +326,6 @@ function (angular, _, moment, dateMath) {
 
     function getPrometheusTime(date, roundUp) {
       if (_.isString(date)) {
-        if (date === 'now') {
-          return 'now()';
-        }
-        if (date.indexOf('now-') >= 0 && date.indexOf('/') === -1) {
-          return date.replace('now', 'now()').replace('-', ' - ');
-        }
         date = dateMath.parse(date, roundUp);
       }
       return (date.valueOf() / 1000).toFixed(0);

--- a/public/app/plugins/datasource/prometheus/directives.js
+++ b/public/app/plugins/datasource/prometheus/directives.js
@@ -10,4 +10,8 @@ function (angular) {
     return {controller: 'PrometheusQueryCtrl', templateUrl: 'app/plugins/datasource/prometheus/partials/query.editor.html'};
   });
 
+  module.directive('annotationsQueryEditorPrometheus', function() {
+    return {templateUrl: 'app/plugins/datasource/prometheus/partials/annotations.editor.html'};
+  });
+
 });

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -1,0 +1,28 @@
+<div class="editor-row">
+	<div class="section">
+		<h5>Search expression</h5>
+		<div class="editor-option">
+			<input type="text" class="span6" ng-model='currentAnnotation.expr' placeholder="ALERTS"></input>
+		</div>
+	</div>
+</div>
+
+<div class="editor-row">
+  <div class="section">
+		<h5>Field formats</h5>
+		<div class="editor-option">
+			<label class="small">Title</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.titleFormat' placeholder="alertname"></input>
+		</div>
+
+		<div class="editor-option">
+			<label class="small">Tags</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.tagKeys' placeholder="label1,label2"></input>
+		</div>
+
+		<div class="editor-option">
+			<label class="small">Text</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.textFormat' placeholder="instance"></input>
+		</div>
+	</div>
+</div>

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -11,5 +11,6 @@
     "config": "app/plugins/datasource/prometheus/partials/config.html"
   },
 
-  "metrics": true
+  "metrics": true,
+  "annotations": true
 }


### PR DESCRIPTION
I suggest to use Prometheus metric to annotation data source.
If we can annotate ALERT or something in each instance graph, it might be useful.
![prometheus_annotation](https://cloud.githubusercontent.com/assets/224552/10245551/8e9cb068-6943-11e5-9d1d-318f15b3f692.png)

Query example

Annotate ALERT

> ALERTS{alertstate="firing"}

Annotate process restart

> changes(process_start_time_seconds[1m]) >= bool 1
