### PR TITLE
Prometheus annotation support

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -295,6 +295,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   }
 
   function renderTemplate(format, data) {
+    var originalSettings = _.templateSettings;
     _.templateSettings = {
       interpolate: /\{\{(.+?)\}\}/g
     };

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -200,8 +200,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     var interpolated;
     try {
       interpolated = templateSrv.replace(expr);
-    }
-    catch (err) {
+    } catch (err) {
       return $q.reject(err);
     }
 

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -5,8 +5,13 @@ class PrometheusConfigCtrl {
   static templateUrl = 'public/app/plugins/datasource/prometheus/partials/config.html';
 }
 
+class PrometheusAnnotationsQueryCtrl {
+  static templateUrl = 'public/app/plugins/datasource/prometheus/partials/annotations.editor.html';
+}
+
 export {
   PrometheusDatasource as Datasource,
   PrometheusQueryCtrl as QueryCtrl,
-  PrometheusConfigCtrl as ConfigCtrl
+  PrometheusConfigCtrl as ConfigCtrl,
+  PrometheusAnnotationsQueryCtrl as AnnotationsQueryCtrl,
 };

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -1,0 +1,28 @@
+<div class="editor-row">
+	<div class="section">
+		<h5>Search expression</h5>
+		<div class="editor-option">
+			<input type="text" class="span6" ng-model='currentAnnotation.expr' placeholder="ALERTS"></input>
+		</div>
+	</div>
+</div>
+
+<div class="editor-row">
+  <div class="section">
+		<h5>Field formats</h5>
+		<div class="editor-option">
+			<label class="small">Title</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.titleFormat' placeholder="alertname"></input>
+		</div>
+
+		<div class="editor-option">
+			<label class="small">Tags</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.tagKeys' placeholder="label1,label2"></input>
+		</div>
+
+		<div class="editor-option">
+			<label class="small">Text</label>
+			<input type="text" class="input-small" ng-model='currentAnnotation.textFormat' placeholder="instance"></input>
+		</div>
+	</div>
+</div>

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -2,7 +2,7 @@
 	<div class="section">
 		<h5>Search expression</h5>
 		<div class="editor-option">
-			<input type="text" class="span6" ng-model='currentAnnotation.expr' placeholder="ALERTS"></input>
+			<input type="text" class="span6" ng-model='annotation.expr' placeholder="ALERTS"></input>
 		</div>
 	</div>
 </div>
@@ -12,17 +12,17 @@
 		<h5>Field formats</h5>
 		<div class="editor-option">
 			<label class="small">Title</label>
-			<input type="text" class="input-small" ng-model='currentAnnotation.titleFormat' placeholder="alertname"></input>
+			<input type="text" class="input-small" ng-model='annotation.titleFormat' placeholder="alertname"></input>
 		</div>
 
 		<div class="editor-option">
 			<label class="small">Tags</label>
-			<input type="text" class="input-small" ng-model='currentAnnotation.tagKeys' placeholder="label1,label2"></input>
+			<input type="text" class="input-small" ng-model='annotation.tagKeys' placeholder="label1,label2"></input>
 		</div>
 
 		<div class="editor-option">
 			<label class="small">Text</label>
-			<input type="text" class="input-small" ng-model='currentAnnotation.textFormat' placeholder="instance"></input>
+			<input type="text" class="input-small" ng-model='annotation.textFormat' placeholder="instance"></input>
 		</div>
 	</div>
 </div>

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -2,7 +2,7 @@
 	<div class="section">
 		<h5>Search expression</h5>
 		<div class="editor-option">
-			<input type="text" class="span6" ng-model='annotation.expr' placeholder="ALERTS"></input>
+			<input type="text" class="span6" ng-model='ctrl.annotation.expr' placeholder="ALERTS"></input>
 		</div>
 	</div>
 </div>
@@ -12,17 +12,17 @@
 		<h5>Field formats</h5>
 		<div class="editor-option">
 			<label class="small">Title</label>
-			<input type="text" class="input-small" ng-model='annotation.titleFormat' placeholder="alertname"></input>
+			<input type="text" class="input-small" ng-model='ctrl.annotation.titleFormat' placeholder="alertname"></input>
 		</div>
 
 		<div class="editor-option">
 			<label class="small">Tags</label>
-			<input type="text" class="input-small" ng-model='annotation.tagKeys' placeholder="label1,label2"></input>
+			<input type="text" class="input-small" ng-model='ctrl.annotation.tagKeys' placeholder="label1,label2"></input>
 		</div>
 
 		<div class="editor-option">
 			<label class="small">Text</label>
-			<input type="text" class="input-small" ng-model='annotation.textFormat' placeholder="instance"></input>
+			<input type="text" class="input-small" ng-model='ctrl.annotation.textFormat' placeholder="instance"></input>
 		</div>
 	</div>
 </div>

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -3,5 +3,6 @@
   "name": "Prometheus",
   "id": "prometheus",
 
-  "metrics": true
+  "metrics": true,
+  "annotations": true
 }

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -162,11 +162,17 @@ describe('PrometheusDatasource', function() {
     var urlExpected = 'proxied/api/v1/query_range?query=' +
                       encodeURIComponent('ALERTS{alertstate="firing"}') +
                       '&start=1443438675&end=1443460275&step=60s';
-    var annotation = {
-      expr: 'ALERTS{alertstate="firing"}',
-      tagKeys: 'job',
-      titleFormat: '{{alertname}}',
-      textFormat: '{{instance}}'
+    var options = {
+      annotation: {
+        expr: 'ALERTS{alertstate="firing"}',
+        tagKeys: 'job',
+        titleFormat: '{{alertname}}',
+        textFormat: '{{instance}}'
+      },
+      range: {
+        from: moment(1443438674760),
+        to: moment(1443460274760)
+      }
     };
     var response = {
       status: "success",
@@ -180,7 +186,7 @@ describe('PrometheusDatasource', function() {
     };
     beforeEach(function() {
       ctx.$httpBackend.expect('GET', urlExpected).respond(response);
-      ctx.ds.annotationQuery(annotation, {from: moment(1443438674760), to: moment(1443460274760)}).then(function(data) { results = data; });
+      ctx.ds.annotationQuery(options).then(function(data) { results = data; });
       ctx.$httpBackend.flush();
     });
     it('should return annotation list', function() {

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -157,4 +157,39 @@ describe('PrometheusDatasource', function() {
       expect(results.length).to.be(3);
     });
   });
+  describe('When performing annotationQuery', function() {
+    var results;
+    var urlExpected = 'proxied/api/v1/query_range?query=' +
+                      encodeURIComponent('ALERTS{alertstate="firing"}') +
+                      '&start=1443438675&end=1443460275&step=60s';
+    var annotation = {
+      expr: 'ALERTS{alertstate="firing"}',
+      tagKeys: 'job',
+      titleFormat: '{{alertname}}',
+      textFormat: '{{instance}}'
+    };
+    var response = {
+      status: "success",
+      data: {
+        resultType: "matrix",
+        result: [{
+          metric: {"__name__": "ALERTS", alertname: "InstanceDown", alertstate: "firing", instance: "testinstance", job: "testjob"},
+          values: [[1443454528, "1"]]
+        }]
+      }
+    };
+    beforeEach(function() {
+      ctx.$httpBackend.expect('GET', urlExpected).respond(response);
+      ctx.ds.annotationQuery(annotation, {from: moment(1443438674760), to: moment(1443460274760)}).then(function(data) { results = data; });
+      ctx.$httpBackend.flush();
+    });
+    it('should return annotation list', function() {
+      ctx.$rootScope.$apply();
+      expect(results.length).to.be(1);
+      expect(results[0].tags).to.contain('testjob');
+      expect(results[0].title).to.be('InstanceDown');
+      expect(results[0].text).to.be('testinstance');
+      expect(results[0].time).to.be(1443454528 * 1000);
+    });
+  });
 });


### PR DESCRIPTION
I suggest to use Prometheus metric to annotation data source.
If we can annotate ALERT or something in each instance graph, it might be useful.
![prometheus_annotation](https://cloud.githubusercontent.com/assets/224552/10245551/8e9cb068-6943-11e5-9d1d-318f15b3f692.png)

Query example

Annotate ALERT

> ALERTS{alertstate="firing"}

Annotate process restart

> changes(process_start_time_seconds[1m]) >= bool 1
