### PR TITLE
Removed spurious `</div>`, fixes Edge on Windows

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -41,7 +41,6 @@
 			</div>
 
 			<div ng-view class="main-view"></div>
-			</div>
 
 		</div>
 


### PR DESCRIPTION
This spurious `</div>` causes Windows to freak out and not run the following `<script>` tag, breaking grafana.
