### PR TITLE
Fix missing downsampling name in kairos plugin

### DIFF
--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -284,6 +284,10 @@ function (angular, _, dateMath, kbn) {
       query.aggregators = [];
 
       if (target.downsampling !== '(NONE)') {
+        if (target.downsampling === undefined) {
+          target.downsampling = 'avg';
+          target.sampling = '10s';
+        }
         query.aggregators.push({
           name: target.downsampling,
           align_sampling: true,


### PR DESCRIPTION
Theoretical fix to #2894. I undoubtedly did this wrong... but it also seems to work for my use case. @torkelo if you can provide guidance I'm happy to fix this in a better way!
