### PR TITLE
Cloudwatch params.InstanceIDs => params.InstanceIds so it builds

### DIFF
--- a/pkg/api/cloudwatch/cloudwatch.go
+++ b/pkg/api/cloudwatch/cloudwatch.go
@@ -112,7 +112,7 @@ func handleDescribeInstances(req *cwRequest, c *middleware.Context) {
 		params.Filters = reqParam.Parameters.Filters
 	}
 	if len(reqParam.Parameters.InstanceIds) > 0 {
-		params.InstanceIDs = reqParam.Parameters.InstanceIds
+		params.InstanceIds = reqParam.Parameters.InstanceIds
 	}
 
 	resp, err := svc.DescribeInstances(params)


### PR DESCRIPTION
Signed-off-by: Alex Bligh alex@alex.org.uk

This change is necessary to build here. Perhaps the upstream package has changed the parameter name or something.

Without it:

```
nimrod:grafana amb$ go get
# github.com/grafana/grafana/pkg/api/cloudwatch
pkg/api/cloudwatch/cloudwatch.go:115: params.InstanceIDs undefined (type *ec2.DescribeInstancesInput has no field or method InstanceIDs)
```
