### PR TITLE
Allow multiple LDAP servers; Allow root CA file to be specified; Allow POSIX LDAP schema

### DIFF
--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -2,7 +2,7 @@
 verbose_logging = false
 
 [[servers]]
-# Ldap server host
+# Ldap server host (specify multiple hosts space separated)
 host = "127.0.0.1"
 # Default port is 389 or 636 if use_ssl = true
 port = 389

--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -18,10 +18,31 @@ bind_dn = "cn=admin,dc=grafana,dc=org"
 # Search user bind password
 bind_password = 'grafana'
 
+# Schema's supporting memberOf
+
 # Search filter, for example "(cn=%s)" or "(sAMAccountName=%s)"
 search_filter = "(cn=%s)"
 # An array of base dns to search through
 search_base_dns = ["dc=grafana,dc=org"]
+
+# Uncomment this section (and comment out the previous 2 entries) to use POSIX schema.
+# In POSIX LDAP schemas, querying the people 'ou' gives you entries that do not have a
+# memberOf attribute, so a secondary query must be made for groups. This is done by
+# enabling group_search_filter below. You must also set
+#    member_of = "cn"
+# in [servers.attributes] below.
+#
+# Search filter, used to retrieve the user
+# search_filter = "(uid=%s)"
+#
+# An array of the base DNs to search through for users. Typically uses ou=people.
+# search_base_dns = ["ou=people,dc=grafana,dc=org"]
+#
+# Group search filter, to retrieve the groups of which the user is a member
+# group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+#
+# An array of the base DNs to search through for groups. Typically uses ou=groups
+# group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
 
 # Specify names of the ldap attributes your ldap uses
 [servers.attributes]

--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -10,6 +10,8 @@ port = 389
 use_ssl = false
 # set to true if you want to skip ssl cert validation
 ssl_skip_verify = false
+# set to the path to your root CA certificate or leave unset to use system defaults
+# root_ca_cert = /path/to/certificate.crt
 
 # Search user bind dn
 bind_dn = "cn=admin,dc=grafana,dc=org"

--- a/pkg/login/settings.go
+++ b/pkg/login/settings.go
@@ -27,6 +27,9 @@ type LdapServerConf struct {
 	SearchFilter  string   `toml:"search_filter"`
 	SearchBaseDNs []string `toml:"search_base_dns"`
 
+	GroupSearchFilter  string   `toml:"group_search_filter"`
+	GroupSearchBaseDNs []string `toml:"group_search_base_dns"`
+
 	LdapGroups []*LdapGroupToOrgRole `toml:"group_mappings"`
 }
 

--- a/pkg/login/settings.go
+++ b/pkg/login/settings.go
@@ -19,6 +19,7 @@ type LdapServerConf struct {
 	Port          int              `toml:"port"`
 	UseSSL        bool             `toml:"use_ssl"`
 	SkipVerifySSL bool             `toml:"ssl_skip_verify"`
+	RootCACert    string           `toml:"root_ca_cert"`
 	BindDN        string           `toml:"bind_dn"`
 	BindPassword  string           `toml:"bind_password"`
 	Attr          LdapAttributeMap `toml:"attributes"`


### PR DESCRIPTION
This pull request contains a couple of enhancements to LDAP:
- Allow multiple LDAP servers to be specified
- Allow a root CA to be specified (e.g. for when a company has its own CA and does not use public CAs)
- Allow POSIX schema for LDAP (where groups are not in a `memberOf` attribute)

I've tested all of these now in our environment. Note that the  third of these I've only tested with our simple schema (default openLDAP POSIX schema) but it should work elsewhere.
