### PR TITLE
Use dateMath in ScriptedDashboard

### DIFF
--- a/public/app/features/dashboard/dashboardLoaderSrv.js
+++ b/public/app/features/dashboard/dashboardLoaderSrv.js
@@ -4,8 +4,9 @@ define([
   'lodash',
   'jquery',
   'kbn',
+  'app/core/utils/datemath',
 ],
-function (angular, moment, _, $, kbn) {
+function (angular, moment, _, $, kbn, dateMath) {
   'use strict';
 
   var module = angular.module('grafana.services');
@@ -59,8 +60,8 @@ function (angular, moment, _, $, kbn) {
       };
 
       /*jshint -W054 */
-      var script_func = new Function('ARGS','kbn','_','moment','window','document','$','jQuery', 'services', result.data);
-      var script_result = script_func($routeParams, kbn, _ , moment, window, document, $, $, services);
+      var script_func = new Function('ARGS','kbn','dateMath','_','moment','window','document','$','jQuery', 'services', result.data);
+      var script_result = script_func($routeParams, kbn, dateMath, _ , moment, window, document, $, $, services);
 
       // Handle async dashboard scripts
       if (_.isFunction(script_result)) {


### PR DESCRIPTION
I want to parse time string, 'now-6h', in ScriptedDashboard.
So, pass dateMath to ScriptedDashboard.
(Not sure, this is correct. If there is any other way, please tell me...)
