### PR TITLE
docs(): Fix changelog link in whats-new-in-v2-1

### DIFF
--- a/docs/sources/guides/whats-new-in-v2-1.md
+++ b/docs/sources/guides/whats-new-in-v2-1.md
@@ -126,5 +126,5 @@ string values.
 
 ### Changelog
 For a detailed list and link to github issues for everything included in the 2.1 release please
-view the [CHANGELOG.md]("https://github.com/grafana/grafana/blob/master/CHANGELOG.md") file.
+view the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md) file.
 


### PR DESCRIPTION
The quotes turn the value into a title attribute rather than href attribute, thus on http://docs.grafana.org/guides/whats-new-in-v2-1/ this link was rendered as `<a href title="https://github.com/...">CHANGELOG.md</a>` which when clicked goes back to itself (not to GitHub).
