### PR TITLE
Kairos downsampling: better fix, works with multi-source charts

### DIFF
--- a/public/app/plugins/datasource/kairosdb/datasource.js
+++ b/public/app/plugins/datasource/kairosdb/datasource.js
@@ -283,11 +283,7 @@ function (angular, _, dateMath, kbn) {
 
       query.aggregators = [];
 
-      if (target.downsampling !== '(NONE)') {
-        if (target.downsampling === undefined) {
-          target.downsampling = 'avg';
-          target.sampling = '10s';
-        }
+      if (target.downsampling !== '(NONE)' && target.downsampling !== undefined) {
         query.aggregators.push({
           name: target.downsampling,
           align_sampling: true,


### PR DESCRIPTION
This is a followup to pull/2898 and #2894. We should not enforce a 10s avg aggregation if the downsampling is undefined. For example, if you want to do a count on a multi data source chart, this breaks it entirely.

Instead, we add a check that, if the downsampling aggregation name is undefined, we do nothing. i.e., the default empty select box behaves just like selecting (NONE) now.
