### PR TITLE
Wrong accessor for InstanceIds

### DIFF
--- a/pkg/api/cloudwatch/cloudwatch.go
+++ b/pkg/api/cloudwatch/cloudwatch.go
@@ -112,7 +112,7 @@ func handleDescribeInstances(req *cwRequest, c *middleware.Context) {
 		params.Filters = reqParam.Parameters.Filters
 	}
 	if len(reqParam.Parameters.InstanceIds) > 0 {
-		params.InstanceIDs = reqParam.Parameters.InstanceIds
+		params.InstanceIds = reqParam.Parameters.InstanceIds
 	}
 
 	resp, err := svc.DescribeInstances(params)


### PR DESCRIPTION
When I attempt to go get the package I get the following error. It looks like the aws api is using InstanceIds instead.

```
MBP:golang nickrobinson$ go get github.com/grafana/grafana
# github.com/grafana/grafana/pkg/api/cloudwatch
../../go/src/github.com/grafana/grafana/pkg/api/cloudwatch/cloudwatch.go:115: params.InstanceIDs undefined (type *ec2.DescribeInstancesInput has no field or method InstanceIDs, but does have InstanceIds)
```
