### PR TITLE
fix appending query strings in linkSrv

### DIFF
--- a/public/app/features/panellinks/linkSrv.js
+++ b/public/app/features/panellinks/linkSrv.js
@@ -48,8 +48,22 @@ function (angular, kbn, _) {
           return url;
         }
 
-        url += (url.indexOf('?') !== -1 ? '&' : '?');
-        return url + paramsArray.join('&');
+        return this.appendToQueryString(url, paramsArray.join('&'));
+      };
+
+      this.appendToQueryString = function(url, stringToAppend) {
+        if (!_.isUndefined(stringToAppend) && stringToAppend !== null && stringToAppend !== '') {
+          var pos = url.indexOf('?');
+          if (pos !== -1) {
+            if (url.length - pos > 1) {
+              url += '&';
+            }
+          } else {
+            url += '?';
+          }
+          url += stringToAppend;
+        }
+        return url;
       };
 
       this.getAnchorInfo = function(link) {
@@ -65,7 +79,6 @@ function (angular, kbn, _) {
           info.target = link.targetBlank ? '_blank' : '_self';
           info.href = templateSrv.replace(link.url || '', scopedVars);
           info.title = templateSrv.replace(link.title || '', scopedVars);
-          info.href += '?';
         }
         else if (link.dashUri) {
           info.href = 'dashboard/' + link.dashUri + '?';
@@ -91,8 +104,9 @@ function (angular, kbn, _) {
         }
 
         info.href = this.addParamsToUrl(info.href, params);
+
         if (link.params) {
-          info.href += "&" + templateSrv.replace(link.params, scopedVars);
+          info.href = this.appendToQueryString(info.href, templateSrv.replace(link.params, scopedVars));
         }
 
         return info;

--- a/public/test/specs/linkSrv-specs.js
+++ b/public/test/specs/linkSrv-specs.js
@@ -1,0 +1,50 @@
+define([
+  'lodash',
+  'app/features/panellinks/linkSrv'
+], function(_) {
+  'use strict';
+
+  describe('linkSrv', function() {
+    var _linkSrv;
+
+    beforeEach(module('grafana.services'));
+
+    beforeEach(inject(function(linkSrv) {
+      _linkSrv = linkSrv;
+    }));
+
+    describe('when appending query strings', function() {
+
+      it('add ? to URL if not present', function() {
+        var url = _linkSrv.appendToQueryString('http://example.com', 'foo=bar');
+        expect(url).to.be('http://example.com?foo=bar');
+      });
+
+      it('do not add & to URL if ? is present but query string is empty', function() {
+        var url = _linkSrv.appendToQueryString('http://example.com?', 'foo=bar');
+        expect(url).to.be('http://example.com?foo=bar');
+      });
+
+      it('add & to URL if query string is present', function() {
+        var url = _linkSrv.appendToQueryString('http://example.com?foo=bar', 'hello=world');
+        expect(url).to.be('http://example.com?foo=bar&hello=world');
+      });
+
+      it('do not change the URL if there is nothing to append', function() {
+        _.each(['', undefined, null], function(toAppend) {
+          var url1 = _linkSrv.appendToQueryString('http://example.com', toAppend);
+          expect(url1).to.be('http://example.com');
+
+          var url2 = _linkSrv.appendToQueryString('http://example.com?', toAppend);
+          expect(url2).to.be('http://example.com?');
+
+          var url3 = _linkSrv.appendToQueryString('http://example.com?foo=bar', toAppend);
+          expect(url3).to.be('http://example.com?foo=bar');
+        });
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
When linkSrv appends parameters to a URL's query string, it would blindly add a ? to the URL even if the URL already contained a ? or the string to add was empty. This change fixes that behavior and some other edge cases.

Includes a unit test to verify expected behavior.
