### PR TITLE
Change bash linuxism so that it will work by default on FreeBSD

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. goimports     (https://github.com/bradfitz/goimports)


### PR DESCRIPTION
bash on FreeBSD is at /usr/local/bin/bash not at /bin/bash, /usr/bin/env works across the various Linux distro's, Darwin, and FreeBSD
