### PR TITLE
fix(prometheus): use time independent API to list metrics and labels names

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -148,20 +148,13 @@ function (angular, _, moment, dateMath) {
             });
           });
         } else {
-          var metric_query = 'count(' + label_values_query[1] + ') by (' +
-                             label_values_query[2]  + ')';
-          url = '/api/v1/query?query=' + encodeURIComponent(metric_query) +
-                    '&time=' + (moment().valueOf() / 1000);
+          url = '/api/v1/series?match[]=' + encodeURIComponent(label_values_query[1]);
 
           return this._request('GET', url)
             .then(function(result) {
-              if (result.data.data.result.length === 0 ||
-                  _.keys(result.data.data.result[0].metric).length === 0) {
-                return [];
-              }
-              return _.map(result.data.data.result, function(metricValue) {
+              return _.map(result.data.data, function(metric) {
                 return {
-                  text: metricValue.metric[label_values_query[2]],
+                  text: metric[label_values_query[2]],
                   expandable: true
                 };
               });
@@ -190,14 +183,13 @@ function (angular, _, moment, dateMath) {
           });
       } else {
         // if query contains full metric name, return metric name and label list
-        url = '/api/v1/query?query=' + encodeURIComponent(interpolated) +
-              '&time=' + (moment().valueOf() / 1000);
+        url = '/api/v1/series?match[]=' + encodeURIComponent(interpolated);
 
         return this._request('GET', url)
           .then(function(result) {
-            return _.map(result.data.data.result, function(metricData) {
+            return _.map(result.data.data, function(metric) {
               return {
-                text: getOriginalMetricName(metricData.metric),
+                text: getOriginalMetricName(metric),
                 expandable: true
               };
             });

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -59,19 +59,16 @@ describe('PrometheusDatasource', function() {
       ctx.$rootScope.$apply();
       expect(results.length).to.be(3);
     });
-    it('label_values(metric, resource) should generate count metric query', function() {
+    it('label_values(metric, resource) should generate series query', function() {
       response = {
         status: "success",
-        data: {
-          resultType: "vector",
-          result: [
-            {metric: {resource: "value1"}, value: []},
-            {metric: {resource: "value2"}, value: []},
-            {metric: {resource: "value3"}, value: []}
-          ]
-        }
+        data: [
+          {__name__: "metric", resource: "value1"},
+          {__name__: "metric", resource: "value2"},
+          {__name__: "metric", resource: "value3"}
+        ]
       };
-      ctx.$httpBackend.expect('GET', /proxied\/api\/v1\/query\?query=count\(metric\)%20by%20\(resource\)&time=.*/).respond(response);
+      ctx.$httpBackend.expect('GET', 'proxied/api/v1/series?match[]=metric').respond(response);
       ctx.ds.metricFindQuery('label_values(metric, resource)').then(function(data) { results = data; });
       ctx.$httpBackend.flush();
       ctx.$rootScope.$apply();
@@ -90,4 +87,3 @@ describe('PrometheusDatasource', function() {
     });
   });
 });
-


### PR DESCRIPTION
Currently if one uses prometheus data source with a template variable, in some cases (except when _label_values_ "function" is called with one argument or when _metrics_ "function" is called) the metrics names or labels results can exclude some metric/label combination (called series by prometheus) simply because it is not currently available (a.k.a. does not have a value in the current moment), note that the current moment is _not_ related to the dashboard/graph from..to timestamps.

This pull request tries to solve to problem by calling prometheus endpoint that does not have this constraint. Another possible approach could be to figure it out the "best" _time_ to get the "right" labels, but this would make template variables time dependent and I don't think it is a reasonable solution.

More info on the commit message.
