### PR TITLE
WIP: auto-complete support in Prometheus query editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -5,6 +5,7 @@ define([
   'app/core/utils/datemath',
   './directives',
   './query_ctrl',
+  './func_editor',
 ],
 function (angular, _, moment, dateMath) {
   'use strict';

--- a/public/app/plugins/datasource/prometheus/func_editor.js
+++ b/public/app/plugins/datasource/prometheus/func_editor.js
@@ -1,0 +1,164 @@
+define([
+  'angular',
+  'lodash',
+  'jquery',
+],
+function (angular, _, $) {
+  'use strict';
+
+  angular
+    .module('grafana.directives')
+    .directive('prometheusFuncEditor', function($compile) {
+
+      var exprTemplate = '<input type="text" class="input-xxlarge tight-form-input"' +
+                         'placeholder="query expression"></input>';
+
+      return {
+        restrict: 'A',
+        link: function postLink($scope, elem) {
+          function inputBlur() {
+            /* jshint validthis:true */
+            var $input = $(this);
+            $scope.target.expr = $input.val();
+            $scope.$apply($scope.refreshMetricData);
+          }
+
+          function inputKeyPress(e) {
+            /* jshint validthis:true */
+            if (e.which === 13) {
+              inputBlur.call(this);
+            }
+          }
+
+          // Returns true if the character at "pos" in the expression string "str" looks
+          // like it could be a metric name (if it's not in a string, a label matchers
+          // section, or a range specification).
+          function isPotentialMetric(str, pos) {
+            var quote = null;
+            var inMatchersOrRange = false;
+
+            for (var i = 0; i < pos; i++) {
+              var ch = str[i];
+
+              // Skip over escaped characters (quotes or otherwise) in strings.
+              if (quote !== null && ch === "\\") {
+                i += 1;
+                continue;
+              }
+
+              // Track if we are entering or leaving a string.
+              switch (ch) {
+              case quote:
+                quote = null;
+                break;
+              case '"':
+              case "'":
+                quote = ch;
+                break;
+              }
+
+              // Ignore curly braces and square brackets in strings.
+              if (quote) {
+                continue;
+              }
+
+              // Track whether we are in curly braces (label matchers).
+              switch (ch) {
+              case "{":
+              case "[":
+                inMatchersOrRange = true;
+                break;
+              case "}":
+              case "]":
+                inMatchersOrRange = false;
+                break;
+              }
+            }
+
+            return !inMatchersOrRange && quote === null;
+          }
+
+          // Returns the current word under the cursor position in $input.
+          function currentWord($input) {
+            var wordRE = new RegExp("[a-zA-Z0-9:_]");
+            var pos = $input.prop("selectionStart");
+            var str = $input.val();
+            var len = str.length;
+            var start = pos;
+            var end = pos;
+
+            while (start > 0 && str[start-1].match(wordRE)) {
+              start--;
+            }
+            while (end < len && str[end].match(wordRE)) {
+              end++;
+            }
+
+            return {
+              start: start,
+              end: end,
+              word: $input.val().substring(start, end)
+            };
+          }
+
+          function addTypeahead($input) {
+            $scope.datasource.performSuggestQuery('')
+            .then(function(allMetricName) {
+              // For the typeahead autocompletion, we need to remember where to put
+              // the cursor after inserting an autocompleted word (we want to put it
+              // after that word, not at the end of the entire input string).
+              var afterUpdatePos = null;
+
+              $input.typeahead({
+                // Needs to return true for autocomplete items that should be matched
+                // by the current input.
+                matcher: function(item) {
+                  var cw = currentWord($input);
+                  if (cw.word.length !== 0 &&
+                    item.toLowerCase().indexOf(cw.word.toLowerCase()) > -1 &&
+                    isPotentialMetric($input.val(), cw.start)) {
+                    return true;
+                  }
+                  return false;
+                },
+                // Returns the entire string to which the input field should be set
+                // upon selecting an item from the autocomplete list.
+                updater: function(item) {
+                  var str = $input.val();
+                  var cw = currentWord($input);
+                  afterUpdatePos = cw.start + item.length;
+                  setTimeout(function() {
+                    // after input update, move cursor correct place
+                    $input.prop("selectionStart", afterUpdatePos);
+                    $input.prop("selectionEnd", afterUpdatePos);
+                  }, 0);
+                  return str.substring(0, cw.start) + item + str.substring(cw.end, str.length);
+                },
+                source: allMetricName,
+                items: 30
+              });
+            });
+          }
+
+          function addElementsAndCompile() {
+            var $input = $(exprTemplate);
+            $input.val($scope.target.expr);
+            $input.blur(inputBlur);
+            $input.keypress(inputKeyPress);
+            $input.appendTo(elem);
+            addTypeahead($input);
+            $compile(elem.contents())($scope);
+          }
+
+          function relink() {
+            elem.children().remove();
+            addElementsAndCompile();
+          }
+
+          relink();
+        }
+      };
+
+    });
+
+});

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -41,26 +41,8 @@
       Query
     </li>
     <li>
-      <input type="text"
-             class="input-xxlarge tight-form-input"
-             ng-model="target.expr"
-             spellcheck='false'
-             placeholder="query expression"
-             data-min-length=0 data-items=100
-             ng-model-onblur
-             ng-change="refreshMetricData()">
-    </li>
-    <li class="tight-form-item">
-      Metric
-    </li>
-    <li>
-      <input type="text"
-             class="input-medium tight-form-input"
-             ng-model="target.metric"
-             spellcheck='false'
-             bs-typeahead="suggestMetrics"
-             placeholder="metric name"
-             data-min-length=0 data-items=100>
+      <span prometheus-func-editor>
+      </span>
     </li>
   </ul>
 

--- a/public/app/plugins/datasource/prometheus/query_ctrl.js
+++ b/public/app/plugins/datasource/prometheus/query_ctrl.js
@@ -38,12 +38,6 @@ function (angular, _) {
       $scope.metric = '';
     };
 
-    $scope.suggestMetrics = function(query, callback) {
-      $scope.datasource
-        .performSuggestQuery(query)
-        .then(callback);
-    };
-
     $scope.linkToPrometheus = function() {
       var range = Math.ceil(($scope.range.to.valueOf() - $scope.range.from.valueOf()) / 1000);
       var endTime = $scope.range.to.utc().format('YYYY-MM-DD HH:MM');


### PR DESCRIPTION
Just porting this commit.
https://github.com/prometheus/prometheus/commit/15c58c0f3ea575b855135977e590c6918e8ba9e5

Now, we can use typeahead in Query field directly.
When leaving the field or pressing Enter, call Prometheus API and draw graph. 
![prometheus_typeahead](https://cloud.githubusercontent.com/assets/224552/10711090/196a96dc-7aac-11e5-9b93-e64b80b98bce.jpg)
