### PR TITLE
cloudwatch: add support for defining AWS profile for CloudWatch datasource

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -18,6 +18,7 @@ function (angular, _) {
       this.supportMetrics = true;
       this.proxyUrl = datasource.url;
       this.defaultRegion = datasource.jsonData.defaultRegion;
+      this.profile = datasource.jsonData.profile;
     }
 
     CloudWatchDatasource.prototype.query = function(options) {
@@ -73,6 +74,7 @@ function (angular, _) {
     CloudWatchDatasource.prototype.performTimeSeriesQuery = function(query, start, end) {
       return this.awsRequest({
         region: query.region,
+        profile: this.profile,
         action: 'GetMetricStatistics',
         parameters:  {
           namespace: query.namespace,
@@ -115,6 +117,7 @@ function (angular, _) {
     CloudWatchDatasource.prototype.getDimensionValues = function(region, namespace, metricName, dimensions) {
       var request = {
         region: templateSrv.replace(region),
+        profile: this.profile,
         action: 'ListMetrics',
         parameters: {
           namespace: templateSrv.replace(namespace),

--- a/public/app/plugins/datasource/cloudwatch/partials/config.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/config.html
@@ -12,6 +12,17 @@
   </ul>
   <div class="clearfix"></div>
 </div>
+<div class="tight-form last">
+  <ul class="tight-form-list">
+    <li class="tight-form-item" style="width: 160px">
+      AWS Profile
+    </li>
+    <li>
+      <input type="text" class="tight-form-input input-xlarge" ng-model='current.jsonData.profile' placeholder="default" required></input>
+    </li>
+  </ul>
+  <div class="clearfix"></div>
+</div>
 
 <!-- <div class="tight&#45;form" ng&#45;show="current.jsonData.access === 'direct'"> -->
 <!--   <ul class="tight&#45;form&#45;list"> -->


### PR DESCRIPTION
Add support for defining AWS profile for CloudWatch datasource to support
pulling information from multiple different AWS accounts to single dashboard.

With this change, it is possible to define multiple AWS credentials in
~/.aws/credentials file and connect different data sources to different
AWS accounts.
