### PR TITLE
Ensure Promtheus step interval is always < 11000

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -99,11 +99,11 @@ function (angular, _, moment, dateMath) {
       var url = '/api/v1/query_range?query=' + encodeURIComponent(query.expr) + '&start=' + start + '&end=' + end;
 
       var step = query.step;
-      var range = Math.floor(end - start);
+      var range = Math.ceil(end - start);
       // Prometheus drop query if range/step > 11000
       // calibrate step if it is too big
       if (step !== 0 && range / step > 11000) {
-        step = Math.floor(range / 11000);
+        step = Math.ceil(range / 11000);
       }
       url += '&step=' + step;
 
@@ -212,7 +212,7 @@ function (angular, _, moment, dateMath) {
         sec = 1;
       }
 
-      return Math.floor(sec * intervalFactor) + 's';
+      return Math.ceil(sec * intervalFactor) + 's';
     };
 
     function transformMetricData(md, options) {


### PR DESCRIPTION
Using a 2 week window (1209600 seconds) and a 60s step, Math.floor()
recalculates a step of 109 and results in 11097 data points in the
Prometheus query (> the 11000 max set by Prometheus). Math.ceil()
returns a step of 110 and 10996 data points.
