### PR TITLE
(cloudwatch) basic expression support

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -262,12 +262,38 @@ function (angular, _) {
           return dp.Timestamp;
         })
         .each(function(dp) {
+          var value = dp[stat];
+          if (options.expressions.length > 0) {
+            value = _.reduce(options.expressions, function(memo, v) {
+              if (v === "") {
+                return; // skip
+              }
+
+              var e = v.split(' ');
+              if (e.length !== 2 || isNaN(e[1])) {
+                throw new Error('Invalid expression');
+              }
+              switch (e[0]) {
+              case '+':
+                return memo + e[1];
+              case '-':
+                return memo - e[1];
+              case '*':
+                return memo * e[1];
+              case '/':
+                return memo / e[1];
+              default:
+                throw new Error('Invalid expression');
+              }
+            }, value);
+          }
+
           var timestamp = new Date(dp.Timestamp).getTime();
           if (lastTimestamp && (timestamp - lastTimestamp) > periodMs) {
             dps.push([null, lastTimestamp + periodMs]);
           }
           lastTimestamp = timestamp;
-          dps.push([dp[stat], timestamp]);
+          dps.push([value, timestamp]);
         });
 
         aliasData.stat = stat;

--- a/public/app/plugins/datasource/cloudwatch/partials/query.editor.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/query.editor.html
@@ -85,6 +85,12 @@
 		<li>
 			<input type="text" class="input-mini tight-form-input" ng-model="target.period" spellcheck='false' placeholder="auto" ng-model-onblur ng-change="refreshMetricData()" />
 		</li>
+		<li class="tight-form-item query-keyword">
+			Expression
+		</li>
+		<li>
+			<input type="text" class="input-small tight-form-input" ng-model="target.expressions[0]" spellcheck='false' placeholder="expression" ng-model-onblur ng-change="refreshMetricData()" />
+		</li>
 
 	</ul>
 

--- a/public/app/plugins/datasource/cloudwatch/query_ctrl.js
+++ b/public/app/plugins/datasource/cloudwatch/query_ctrl.js
@@ -17,6 +17,7 @@ function (angular, _) {
       target.dimensions = target.dimensions || {};
       target.period = target.period || '';
       target.region = target.region || $scope.datasource.getDefaultRegion();
+      target.expressions = [];
 
       $scope.aliasSyntax = '{{metric}} {{stat}} {{namespace}} {{region}} {{<dimension name>}}';
 

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -38,7 +38,8 @@ describe('CloudWatchDatasource', function() {
             InstanceId: 'i-12345678'
           },
           statistics: ['Average'],
-          period: 300
+          period: 300,
+          expressions: []
         }
       ]
     };
@@ -94,6 +95,16 @@ describe('CloudWatchDatasource', function() {
     it('should return null for missing data point', function(done) {
       ctx.ds.query(query).then(function(result) {
         expect(result.data[0].datapoints[2][0]).to.be(null);
+        done();
+      });
+      ctx.$rootScope.$apply();
+    });
+
+    it('should return calculated series list', function(done) {
+      query.targets[0].expressions = ["* 100"];
+      ctx.ds.query(query).then(function(result) {
+        expect(result.data[0].target).to.be('CPUUtilization_Average');
+        expect(result.data[0].datapoints[0][0]).to.be(response.Datapoints[0]['Average'] * 100);
         done();
       });
       ctx.$rootScope.$apply();


### PR DESCRIPTION
We need to calculation to get correct metric value for some of the CloudWatch metrics.

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/MonitoringDynamoDB.html

> Use the Sum statistic to calculate the consumed throughput. For example, get the Sum value over a span of 1 minute, and divide it by the number of seconds in a minute (60) to calculate the average ConsumedReadCapacityUnits per second

This PR care about such situation.

![cloudwatch_expression](https://cloud.githubusercontent.com/assets/224552/10843884/0e51ba22-7f3f-11e5-9c6a-488ae5f12de0.png)
