### PR TITLE
Update service file to start Grafana when PostgreSQL is ready

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Starts and stops a single grafana instance on this system
 Documentation=http://docs.grafana.org
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target postgresql.service
+After=network-online.target postgresql.service
 
 [Service]
 EnvironmentFile=/etc/default/grafana-server
@@ -18,6 +18,7 @@ ExecStart=/usr/sbin/grafana-server                                \
 LimitNOFILE=10000
 TimeoutStopSec=20
 UMask=0027
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Right now Grafana starts independently of PostgreSQL. If Grafana starts before Postgres it leads to errors like that:

```
[log.go:75 Fatal()] [E] fail to initialize orm engine: Sqlstore::Migration failed err: dial tcp 127.0.0.1:5432: connection refused
```

This change solves this issue. It also makes sure that Grafana will be restarted in case of crash.
