### PR TITLE
Fix npm 3 build failure in phantomjs task

### DIFF
--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -6,6 +6,11 @@ module.exports = function(config,grunt) {
     var dest = './vendor/phantomjs/phantomjs';
     var confDir = './node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/'
 
+    if (!grunt.file.exists(confDir)) {
+      // npm 3 or npm 2 with dedupe
+      confDir = './node_modules/phantomjs/lib/';
+    }
+
     if (!grunt.file.exists(dest)){
 
       var m=grunt.file.read(confDir+"location.js")


### PR DESCRIPTION
npm v3.0+ by default dedupes node modules and stores them in a flat tree, which means the hardcoded path to the location.js will no longer be nested under the karma-phantomjs-launcher module.

This fixes issue #2999.
