### PR TITLE
Dynamically reorder hovercard

### DIFF
--- a/public/app/panels/graph/graph.tooltip.js
+++ b/public/app/panels/graph/graph.tooltip.js
@@ -74,9 +74,9 @@ function ($) {
           // Stacked series can increase its length on each new stacked serie if null points found,
           // to speed the index search we begin always on the last found hoverIndex.
           var newhoverIndex = this.findHoverIndexFromDataPoints(pos.x, series, hoverIndex);
-          results.push({ value: value, hoverIndex: newhoverIndex});
+          results.push({ value: value, hoverIndex: newhoverIndex, color: series.color, label: series.label });
         } else {
-          results.push({ value: value, hoverIndex: hoverIndex});
+          results.push({ value: value, hoverIndex: hoverIndex, color: series.color, label: series.label });
         }
       }
 
@@ -119,6 +119,11 @@ function ($) {
         seriesHtml = '';
         timestamp = dashboard.formatDate(seriesHoverInfo.time);
 
+	// Dynamically reorder the hovercard for the current time point.
+        seriesHoverInfo.sort(function(a, b) {
+          return parseFloat(b.value) - parseFloat(a.value);
+        });
+
         for (i = 0; i < seriesHoverInfo.length; i++) {
           hoverInfo = seriesHoverInfo[i];
 
@@ -130,7 +135,7 @@ function ($) {
           value = series.formatValue(hoverInfo.value);
 
           seriesHtml += '<div class="graph-tooltip-list-item"><div class="graph-tooltip-series-name">';
-          seriesHtml += '<i class="fa fa-minus" style="color:' + series.color +';"></i> ' + series.label + ':</div>';
+          seriesHtml += '<i class="fa fa-minus" style="color:' + hoverInfo.color +';"></i> ' + hoverInfo.label + ':</div>';
           seriesHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';
           plot.highlight(i, hoverInfo.hoverIndex);
         }


### PR DESCRIPTION
(This replaces #3117, after I moved branches around).

As requested in #3106 and #1189, this PR reorders the hovercard to reflect the order of the values.

Previously, rendering the hovercard used two arrays (`seriesList` and `seriesHoverInfo`) that are presumed to be in the same order. Therefore simply sorting by `value` would reorder the values correctly but not the colors and labels array.

To make sorting easier, this PR modifies `getMultiSeriesPlotHoverInfo()` to also return the `color` and `label` values (which were previously fetched from `getSeriesFn()`).

I've tested this on a single series, multi series, and stacked series. Let me know if there are other cases that need testing.

Here's an example showing the reordering:

![selection_008](https://cloud.githubusercontent.com/assets/131580/10867092/c9b19b1a-800d-11e5-8da4-4bb4e2927749.png)

![selection_010](https://cloud.githubusercontent.com/assets/131580/10867091/c7bff982-800d-11e5-90a5-34c7b34733c1.png)
