### PR TITLE
Fix templating error dialog for Prometheus

### DIFF
--- a/public/app/services/backendSrv.js
+++ b/public/app/services/backendSrv.js
@@ -106,6 +106,11 @@ function (angular, _, config) {
           });
         }
 
+        // for Prometheus
+        if (!err.data.message && _.isString(err.data.error)) {
+          err.data.message = err.data.error;
+        }
+
         throw err;
       });
     };


### PR DESCRIPTION
Fix part of issue https://github.com/grafana/grafana/issues/3183.
I can't get datasource type in backendSrv, so I simply copy data.error to data.message.

I don't know other datasource would case this issue. I only fix for Prometheus.
