### PR TITLE
add metrics search page

### DIFF
--- a/public/app/core/controllers/search_ctrl.js
+++ b/public/app/core/controllers/search_ctrl.js
@@ -120,6 +120,9 @@ function (angular, _, coreModule, config) {
 
     $scope.newDashboard = function() {
       $location.url('dashboard/new');
+
+      var search = _.extend($location.search(),{editview:'settings'});
+      $location.search(search);
     };
 
   });

--- a/public/app/core/controllers/sidemenu_ctrl.js
+++ b/public/app/core/controllers/sidemenu_ctrl.js
@@ -28,6 +28,12 @@ function (angular, _, $, coreModule, config) {
           href: $scope.getUrl("/datasources"),
         });
       }
+
+      $scope.mainLinks.push({
+        text: "Metrics",
+        icon: "fa fa-fw fa-search",
+        href: $scope.getUrl("/dashboard/metrics"),
+      });
     };
 
     $scope.loadOrgs = function() {

--- a/public/app/core/routes/all.js
+++ b/public/app/core/routes/all.js
@@ -36,6 +36,11 @@ define([
         controller : 'NewDashboardCtrl',
         reloadOnSearch: false,
       })
+      .when('/dashboard/metrics',{
+        templateUrl: 'app/partials/dashboard.html',
+        controller : 'MetricsCtrl',
+        reloadOnSearch: true,
+      })
       .when('/import/dashboard', {
         templateUrl: 'app/features/dashboard/partials/import.html',
         controller : 'DashboardImportCtrl',

--- a/public/app/core/routes/dashboard_loaders.js
+++ b/public/app/core/routes/dashboard_loaders.js
@@ -43,4 +43,15 @@ function (coreModule) {
     }, $scope);
   });
 
+  coreModule.controller('MetricsCtrl', function($scope) {
+    var dashboard = {
+      title: " ",
+      rows: [{height: '250px', panels: []}]
+    };
+    $scope.initDashboard({
+      meta: {canStar: false, canShare: false},
+      dashboard: dashboard
+    }, $scope);
+  });
+
 });

--- a/public/app/features/dashboard/dashboardNavCtrl.js
+++ b/public/app/features/dashboard/dashboardNavCtrl.js
@@ -54,6 +54,11 @@ function (angular, _) {
         return;
       }
 
+      if(_.isEmpty($scope.dashboard.title)){
+        $scope.appEvent('alert-warning', ['Dashboard save failed', 'Title must not be empty']);
+        return ;
+      }
+
       var clone = $scope.dashboard.getSaveModelClone();
 
       backendSrv.saveDashboard(clone, options).then(function(data) {

--- a/public/app/features/dashboard/partials/dashboardTopNav.html
+++ b/public/app/features/dashboard/partials/dashboardTopNav.html
@@ -8,7 +8,7 @@
 					<i class="fa fa-bars"></i>
 				</a>
 
-				<div class="top-nav-dashboards-btn">
+				<div class="top-nav-dashboards-btn" ng-show="!dashboardMeta.topNavHidden">
 					<a class="pointer" ng-click="openSearch()">
 						<i class="fa fa-th-large"></i>
 						<span class="dashboard-title">{{dashboard.title}}</span>
@@ -29,7 +29,7 @@
 				<li ng-show="dashboardMeta.canSave">
 					<a ng-click="saveDashboard()" bs-tooltip="'Save dashboard'" data-placement="bottom"><i class="fa fa-save"></i></a>
 				</li>
-				<li class="dropdown">
+				<li class="dropdown" ng-show="dashboardMeta.canSave">
 					<a class="pointer" ng-click="hideTooltip($event)" bs-tooltip="'Manage dashboard'" data-placement="bottom" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
 					<ul class="dropdown-menu">
 						<li ng-if="dashboardMeta.canEdit"><a class="pointer" ng-click="openEditView('settings');">Settings</a></li>

--- a/public/app/features/dashboard/partials/settings.html
+++ b/public/app/features/dashboard/partials/settings.html
@@ -25,7 +25,7 @@
 							Title
 						</li>
 						<li>
-							<input type="text" class="input-xlarge tight-form-input" ng-model='dashboard.title'></input>
+							<input type="text" class="input-xlarge tight-form-input" ng-model='dashboard.title' autofocus="autofocus"/>
 						</li>
 						<li class="tight-form-item">
 							Tags

--- a/public/app/features/dashboard/rowCtrl.js
+++ b/public/app/features/dashboard/rowCtrl.js
@@ -8,7 +8,7 @@ function (angular, _, config) {
 
   var module = angular.module('grafana.controllers');
 
-  module.controller('RowCtrl', function($scope, $rootScope, $timeout) {
+  module.controller('RowCtrl', function($scope, $rootScope, $timeout, $location) {
     var _d = {
       title: "Row",
       height: "150px",
@@ -21,6 +21,27 @@ function (angular, _, config) {
 
     $scope.init = function() {
       $scope.editor = {index: 0};
+      if ($location.path() === '/dashboard/metrics') {
+        var defaultSpan = 12;
+        var _as = 12 - $scope.dashboard.rowSpan($scope.row);
+
+        var panel = {
+          title: config.new_panel_title,
+          error: false,
+          span: _as < defaultSpan && _as > 0 ? _as : defaultSpan,
+          editable: true,
+          type: 'graph'
+        };
+
+        $scope.addPanel(panel);
+
+        $scope.dashboardViewState.update({fullscreen: true, edit: panel, panelId: 1});
+        $scope.dashboardMeta.canEdit = true;
+        $scope.dashboardMeta.canShare = false;
+        $scope.dashboardMeta.canSave = false;
+        $scope.dashboardMeta.canStar = false;
+        $scope.dashboardMeta.topNavHidden = true;
+      }
     };
 
     $scope.togglePanelMenu = function(posX) {

--- a/public/app/features/panel/partials/panel.html
+++ b/public/app/features/panel/partials/panel.html
@@ -10,7 +10,7 @@
 			<i class="fa fa-spinner fa-spin"></i>
 		</span>
 
-		<div class="panel-title-container drag-handle" panel-menu></div>
+		<div class="panel-title-container drag-handle" panel-menu ng-if="dashboardMeta.canSave"></div>
 	</div>
 
 	<div class="panel-content">
@@ -32,7 +32,7 @@
 				</div>
 			</div>
 
-			<button class="gf-box-header-close-btn" ng-click="exitFullscreen();">
+			<button ng-show='dashboardMeta.canSave' class="gf-box-header-close-btn" ng-click="exitFullscreen();">
 				Back to dashboard
 			</button>
 		</div>


### PR DESCRIPTION
sometimes, we just want to search some metrics, or just use the graph temporarily. If we use dashboard to find a metric, must clicks: "Home" => "New" => "Add Panel" => "Graph". It's too complicated for just get a metric result temporarily. 

metrics search page like below:

![Image](https://github.com/godfreyhe/t/blob/master/pics/1.jpg)

just click "Metrics" on left for search
