### PR TITLE
(cloudwatch) support null point mode

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -25,6 +25,7 @@ function (angular, _) {
       var end = convertToCloudWatchTime(options.range.to);
 
       var queries = [];
+      options = _.clone(options);
       _.each(options.targets, _.bind(function(target) {
         if (target.hide || !target.namespace || !target.metricName || _.isEmpty(target.statistics)) {
           return;
@@ -38,11 +39,11 @@ function (angular, _) {
         query.statistics = target.statistics;
 
         var range = end - start;
-        query.period = parseInt(target.period, 10) || 60;
-
+        query.period = parseInt(target.period, 10) || (query.namespace === 'AWS/EC2' ? 300 : 60);
         if (range / query.period >= 1440) {
           query.period = Math.ceil(range / 1440 / 60) * 60;
         }
+        target.period = query.period;
 
         queries.push(query);
       }, this));
@@ -252,13 +253,22 @@ function (angular, _) {
       };
       _.extend(aliasData, options.dimensions);
 
+      var periodMs = options.period * 1000;
       return _.map(options.statistics, function(stat) {
-        var dps = _.chain(md.Datapoints).map(function(dp) {
-          return [dp[stat], new Date(dp.Timestamp).getTime()];
-        })
+        var dps = [];
+        var lastTimestamp = null;
+        _.chain(md.Datapoints)
         .sortBy(function(dp) {
-          return dp[1];
-        }).value();
+          return dp.Timestamp;
+        })
+        .each(function(dp) {
+          var timestamp = new Date(dp.Timestamp).getTime();
+          if (lastTimestamp && (timestamp - lastTimestamp) > periodMs * 2) {
+            dps.push([null, lastTimestamp + periodMs]);
+          }
+          lastTimestamp = timestamp;
+          dps.push([dp[stat], timestamp]);
+        });
 
         aliasData.stat = stat;
         var seriesName = aliasPattern.replace(aliasRegex, function(match, g1) {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -48,6 +48,14 @@ describe('CloudWatchDatasource', function() {
         {
           Average: 1,
           Timestamp: 'Wed Dec 31 1969 16:00:00 GMT-0800 (PST)'
+        },
+        {
+          Average: 2,
+          Timestamp: 'Wed Dec 31 1969 16:05:00 GMT-0800 (PST)'
+        },
+        {
+          Average: 5,
+          Timestamp: 'Wed Dec 31 1969 16:20:00 GMT-0800 (PST)'
         }
       ],
       Label: 'CPUUtilization'
@@ -78,6 +86,14 @@ describe('CloudWatchDatasource', function() {
       ctx.ds.query(query).then(function(result) {
         expect(result.data[0].target).to.be('CPUUtilization_Average');
         expect(result.data[0].datapoints[0][0]).to.be(response.Datapoints[0]['Average']);
+        done();
+      });
+      ctx.$rootScope.$apply();
+    });
+
+    it('should return null for missing data point', function(done) {
+      ctx.ds.query(query).then(function(result) {
+        expect(result.data[0].datapoints[2][0]).to.be(null);
         done();
       });
       ctx.$rootScope.$apply();


### PR DESCRIPTION
Currently, the Grafana graph lines are always connected even though the instance is stopped.

When I stopped instance from 18:30 to 19:50, the graph becomes like below.
![connected](https://cloud.githubusercontent.com/assets/224552/11180648/c038ec48-8c9f-11e5-9ace-75494f5add01.png)

I expect to the line is disconnected while instance stopped.
So, I add null to datapoints to make gap.
![add_null](https://cloud.githubusercontent.com/assets/224552/11180667/fcec826c-8c9f-11e5-9f47-e4596655eddf.png)

The interval of CloudWatch metrics emission should be 60 seconds. (for EC2, 300 seconds).
When there is no datapoint in twice of the interval, we can safely add null to there.
