### PR TITLE
Ignore nulls unless 'null as zero' for series.stats.avg

### DIFF
--- a/public/app/core/time_series.ts
+++ b/public/app/core/time_series.ts
@@ -98,6 +98,7 @@ class TimeSeries {
     var nullAsZero = fillStyle === 'null as zero';
     var currentTime;
     var currentValue;
+    var nonNulls = 0;
 
     for (var i = 0; i < this.datapoints.length; i++) {
       currentValue = this.datapoints[i][0];
@@ -114,6 +115,7 @@ class TimeSeries {
         if (_.isNumber(currentValue)) {
           this.stats.total += currentValue;
           this.allIsNull = false;
+          nonNulls++;
         }
 
         if (currentValue > this.stats.max) {
@@ -136,7 +138,7 @@ class TimeSeries {
     if (this.stats.min === Number.MAX_VALUE) { this.stats.min = null; }
 
     if (result.length) {
-      this.stats.avg = (this.stats.total / result.length);
+      this.stats.avg = (this.stats.total / nonNulls);
       this.stats.current = result[result.length-1][1];
       if (this.stats.current === null && result.length > 1) {
         this.stats.current = result[result.length-2][1];

--- a/public/test/core/time_series_specs.js
+++ b/public/test/core/time_series_specs.js
@@ -43,6 +43,17 @@ define([
         expect(series.stats.max).to.be(-4);
       });
 
+      it('average value should ignore nulls', function() {
+        series = new TimeSeries(testData);
+        series.getFlotPairs('null', yAxisFormats);
+        expect(series.stats.avg).to.be(6.333333333333333);
+      });
+
+      it('with null as zero style, average value should treat nulls as 0', function() {
+        series = new TimeSeries(testData);
+        series.getFlotPairs('null as zero', yAxisFormats);
+        expect(series.stats.avg).to.be(4.75);
+      });
     });
 
     describe('series overrides', function() {


### PR DESCRIPTION
Fixes #3244 

Not sure if this is what maintainers would like to do, but it seems obvious to me. The legend values are really handy, but average is useless for stats with nulls IMHO.

For instance, latencies reported from collectd to graphite rely on null as a very important distinction from zero. Zero means the latency for that data point was 0. Null means there were no events for that data point. Average should only concern itself with actual events, in my humble opinion :).

Thanks!
