### PR TITLE
removed autoupdate on variabe refresh,  fix #2722

### DIFF
--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -45,17 +45,6 @@ function (angular, _, kbn) {
     };
 
     this.setVariableFromUrl = function(variable, urlValue) {
-      if (variable.refresh) {
-        var self = this;
-        //refresh the list of options before setting the value
-        return this.updateOptions(variable).then(function() {
-          var option = _.findWhere(variable.options, { text: urlValue });
-          option = option || { text: urlValue, value: urlValue };
-
-          self.updateAutoInterval(variable);
-          return self.setVariableValue(variable, option);
-        });
-      }
       var option = _.findWhere(variable.options, { text: urlValue });
       option = option || { text: urlValue, value: urlValue };
 


### PR DESCRIPTION
As discussed previously in https://github.com/grafana/grafana/issues/2722 . This autoUpdate  is not needed if either:

a) reload full URL with all variables
b) you are working interactively with template variables.
c) you need render with phantomjs images from templated dashboard passing all variables in the URL.

tested in the three last cases , this PR fix https://github.com/grafana/grafana/issues/2722, 
