### PR TITLE
allow data sources to add items to a panel's extended menu

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -81,10 +81,8 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 			dsMap["index"] = ds.Database
 		}
 
-		if ds.Type == m.DS_PROMETHEUS {
-			// add unproxied server URL for link to Prometheus web UI
-			dsMap["directUrl"] = ds.Url
-		}
+		// Add unproxied server URL for uses such as links to Prometheus web UI and Graphite Composer.
+		dsMap["directUrl"] = ds.Url
 
 		datasources[ds.Name] = dsMap
 	}

--- a/public/app/core/directives/misc.js
+++ b/public/app/core/directives/misc.js
@@ -1,9 +1,10 @@
 define([
   'angular',
+  'lodash',
   '../core_module',
   'app/core/utils/kbn',
 ],
-function (angular, coreModule, kbn) {
+function (angular, _, coreModule, kbn) {
   'use strict';
 
   coreModule.directive('tip', function($compile) {
@@ -87,7 +88,7 @@ function (angular, coreModule, kbn) {
         }
 
         var li = '<li' + (item.submenu && item.submenu.length ? ' class="dropdown-submenu"' : '') + '>' +
-          '<a tabindex="-1" ng-href="' + (item.href || '') + '"' + (item.click ? ' ng-click="' + item.click + '"' : '') +
+          '<a tabindex="-1" ng-href="' + (item.href || '') + '"' + (item.click ? ' ng-click="' + _.escape(item.click) + '"' : '') +
           (item.target ? ' target="' + item.target + '"' : '') + (item.method ? ' data-method="' + item.method + '"' : '') +
           (item.configModal ? ' dash-editor-link="' + item.configModal + '"' : "") +
           '>' + (item.text || '') + '</a>';

--- a/public/app/features/panel/panel_menu.js
+++ b/public/app/features/panel/panel_menu.js
@@ -28,6 +28,7 @@ function (angular, $, _) {
         }
         return template;
       }
+
       function createMenuTemplate($scope) {
         var template = '<div class="panel-menu small">';
 
@@ -51,7 +52,7 @@ function (angular, $, _) {
           }
 
           template += '<a class="panel-menu-link" ';
-          if (item.click) { template += ' ng-click="' + item.click + '"'; }
+          if (item.click) { template += ' ng-click="' + _.escape(item.click) + '"'; }
           if (item.editorLink) { template += ' dash-editor-link="' + item.editorLink + '"'; }
           template += '>';
           template += item.text + '</a>';
@@ -65,6 +66,22 @@ function (angular, $, _) {
 
       function getExtendedMenu($scope) {
         var menu = angular.copy($scope.panelMeta.extendedMenu);
+
+        // Determine the datasource for the panel.
+        var datasource = $scope.panel.datasource;
+        if (datasource == null) {
+          datasource = $scope.datasource;
+        }
+        if (datasource != null && datasource.getPanelExtendedMenuItems) {
+          var links = datasource.getPanelExtendedMenuItems($scope.panel);
+          if (links && links.length > 0) {
+            menu.push({ divider: true });
+            _.each(links, function(link) {
+              menu.push(link);
+            });
+          }
+        }
+
         return menu;
       }
 

--- a/public/app/panels/graph/module.js
+++ b/public/app/panels/graph/module.js
@@ -289,6 +289,11 @@ function (angular, _, moment, kbn, TimeSeries, PanelMeta) {
       kbn.exportSeriesListToCsv($scope.seriesList);
     };
 
+    // Called from panel menu.
+    $scope.openUrlInNewWindow = function(url) {
+      return window.open(url, '_blank');
+    };
+
     panelSrv.init($scope);
 
   });

--- a/public/app/plugins/datasource/graphite/datasource.js
+++ b/public/app/plugins/datasource/graphite/datasource.js
@@ -19,6 +19,7 @@ function (angular, _, $, config, dateMath) {
     function GraphiteDatasource(datasource) {
       this.basicAuth = datasource.basicAuth;
       this.url = datasource.url;
+      this.directUrl = datasource.directUrl;
       this.name = datasource.name;
       this.cacheTimeout = datasource.cacheTimeout;
       this.withCredentials = datasource.withCredentials;
@@ -193,6 +194,24 @@ function (angular, _, $, config, dateMath) {
           };
         });
       });
+    };
+
+    GraphiteDatasource.prototype.getPanelExtendedMenuItems = function(options) {
+      var graphOptions = {
+        targets: options.targets,
+        cacheTimeout: options.cacheTimeout || this.cacheTimeout,
+        maxDataPoints: options.maxDataPoints,
+      };
+
+      var params = this.buildGraphiteParams(graphOptions, options.scopedVars);
+      params = _.filter(params, function(param) { return !param.startsWith('format'); });
+
+      var composerUrl = this.directUrl + '/composer?' + params.join('&');
+
+      return [{
+        text: 'Graphite Composer',
+        click: 'openUrlInNewWindow("' + composerUrl + '")',
+      }];
     };
 
     GraphiteDatasource.prototype.testDatasource = function() {


### PR DESCRIPTION
Data sources should implement the new `getPanelExtendedMenuItems` method. It should return a list of menu items in the format expected by the gfDropdown directive.

As a first use, add a "Graphite Composer" link to panels using the Graphite data source, which opens the panel's targets in the Graphite Composer.
