### PR TITLE
specify date format in elastic search query

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -10,7 +10,7 @@ function (angular) {
 
   ElasticQueryBuilder.prototype.getRangeFilter = function() {
     var filter = {};
-    filter[this.timeField] = {"gte": "$timeFrom", "lte": "$timeTo"};
+    filter[this.timeField] = {"gte": "$timeFrom", "lte": "$timeTo", "format": "epoch_millis"};
     return filter;
   };
 
@@ -127,6 +127,7 @@ function (angular) {
             "interval": this.getInterval(aggDef),
             "field": this.timeField,
             "min_doc_count": 0,
+            "format": "epoch_millis",
             "extended_bounds": { "min": "$timeFrom", "max": "$timeTo" }
           };
           break;


### PR DESCRIPTION
I'm using grafana 2.5.0 and elastichsearch 2.0.0, I've run into the issue reported here: https://github.com/grafana/grafana/issues/3236

For me this patch has fixed the issue, although I don't have an older version of elasticsearch available to test it there as well.
