### PR TITLE
(cloudwatch) fix null point mode

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -263,7 +263,7 @@ function (angular, _) {
         })
         .each(function(dp) {
           var timestamp = new Date(dp.Timestamp).getTime();
-          if (lastTimestamp && (timestamp - lastTimestamp) > periodMs * 2) {
+          if (lastTimestamp && (timestamp - lastTimestamp) > periodMs) {
             dps.push([null, lastTimestamp + periodMs]);
           }
           lastTimestamp = timestamp;

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -55,7 +55,7 @@ describe('CloudWatchDatasource', function() {
         },
         {
           Average: 5,
-          Timestamp: 'Wed Dec 31 1969 16:20:00 GMT-0800 (PST)'
+          Timestamp: 'Wed Dec 31 1969 16:15:00 GMT-0800 (PST)'
         }
       ],
       Label: 'CPUUtilization'


### PR DESCRIPTION
Sorry, the minimum scale of timestamp is second, twice of period is too long.
