### PR TITLE
[prometheus] Fix step calibration

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.js
+++ b/public/app/plugins/datasource/prometheus/datasource.js
@@ -212,7 +212,7 @@ function (angular, _, moment, dateMath) {
         sec = 1;
       }
 
-      return Math.ceil(sec * intervalFactor) + 's';
+      return Math.ceil(sec * intervalFactor);
     };
 
     function transformMetricData(md, options) {

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -19,7 +19,7 @@ describe('PrometheusDatasource', function() {
     var results;
     var urlExpected = 'proxied/api/v1/query_range?query=' +
                       encodeURIComponent('test{job="testjob"}') +
-                      '&start=1443438675&end=1443460275&step=60s';
+                      '&start=1443438675&end=1443460275&step=60';
     var query = {
       range: { from: moment(1443438674760), to: moment(1443460274760) },
       targets: [{ expr: 'test{job="testjob"}' }],


### PR DESCRIPTION
The step interval is (correctly) being converted to seconds, but the
unit of measure suffixed onto the end is preventing the subsequent
step calibration. Because the query upstream defaults to seconds as
the unit of measure, the suffix can simply be removed and everything
works as intended.
