### PR TITLE
(cloudwatch) make Scripted Dashboard friendly

### DIFF
--- a/pkg/api/cloudwatch/metrics.go
+++ b/pkg/api/cloudwatch/metrics.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var metricsMap map[string][]string
@@ -76,27 +75,17 @@ func handleGetRegions(req *cwRequest, c *middleware.Context) {
 		"eu-central-1", "eu-west-1", "sa-east-1", "us-east-1", "us-west-1", "us-west-2",
 	}
 
-	result := []interface{}{}
-	for _, region := range regions {
-		result = append(result, util.DynMap{"text": region, "value": region})
-	}
-
-	c.JSON(200, result)
+	c.JSON(200, regions)
 }
 
 func handleGetNamespaces(req *cwRequest, c *middleware.Context) {
-	keys := []string{}
+	var keys []string
 	for key := range metricsMap {
 		keys = append(keys, key)
 	}
 	sort.Sort(sort.StringSlice(keys))
 
-	result := []interface{}{}
-	for _, key := range keys {
-		result = append(result, util.DynMap{"text": key, "value": key})
-	}
-
-	c.JSON(200, result)
+	c.JSON(200, keys)
 }
 
 func handleGetMetrics(req *cwRequest, c *middleware.Context) {
@@ -114,9 +103,9 @@ func handleGetMetrics(req *cwRequest, c *middleware.Context) {
 		return
 	}
 
-	result := []interface{}{}
+	var result []string
 	for _, name := range namespaceMetrics {
-		result = append(result, util.DynMap{"text": name, "value": name})
+		result = append(result, name)
 	}
 
 	c.JSON(200, result)
@@ -137,9 +126,9 @@ func handleGetDimensions(req *cwRequest, c *middleware.Context) {
 		return
 	}
 
-	result := []interface{}{}
+	var result []string
 	for _, name := range dimensionValues {
-		result = append(result, util.DynMap{"text": name, "value": name})
+		result = append(result, name)
 	}
 
 	c.JSON(200, result)

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -150,28 +150,36 @@ function (angular, _) {
 
       var transformSuggestData = function(suggestData) {
         return _.map(suggestData, function(v) {
-          return { text: v };
+          return { text: v, value: v };
         });
       };
 
       var regionQuery = query.match(/^regions\(\)/);
       if (regionQuery) {
-        return this.getRegions();
+        return this.getRegions().then(function(result) {
+          return transformSuggestData(result);
+        });
       }
 
       var namespaceQuery = query.match(/^namespaces\(\)/);
       if (namespaceQuery) {
-        return this.getNamespaces();
+        return this.getNamespaces().then(function(result) {
+          return transformSuggestData(result);
+        });
       }
 
       var metricNameQuery = query.match(/^metrics\(([^\)]+?)\)/);
       if (metricNameQuery) {
-        return this.getMetrics(metricNameQuery[1]);
+        return this.getMetrics(metricNameQuery[1]).then(function(result) {
+          return transformSuggestData(result);
+        });
       }
 
       var dimensionKeysQuery = query.match(/^dimension_keys\(([^\)]+?)\)/);
       if (dimensionKeysQuery) {
-        return this.getDimensionKeys(dimensionKeysQuery[1]);
+        return this.getDimensionKeys(dimensionKeysQuery[1]).then(function(result) {
+          return transformSuggestData(result);
+        });
       }
 
       var dimensionValuesQuery = query.match(/^dimension_values\(([^,]+?),\s?([^,]+?),\s?([^,]+?)(,\s?([^)]*))?\)/);


### PR DESCRIPTION
Current datasource API is not friendly for Scripted Dashboard.
The format of return values are Templated Dashboard format.
Make them Scripted Dashboard friendly.
