### PR TITLE
Added a new template option to enable and disable auto dashboard refresh on variable change

### DIFF
--- a/public/app/core/filters/filters.ts
+++ b/public/app/core/filters/filters.ts
@@ -60,11 +60,15 @@ coreModule.filter('noXml', function() {
 
 coreModule.filter('interpolateTemplateVars', function (templateSrv) {
   var filterFunc : any = function (text, scope) {
-    if (scope.panel) {
-      return templateSrv.replaceWithText(text, scope.panel.scopedVars);
-    } else {
-      return templateSrv.replaceWithText(text, scope.row.scopedVars);
+    if (!templateSrv.dashboard_autoupdate && scope.lastValidTitle !== '') {
+     return scope.lastValidTitle;
     }
+    if (scope.panel) {
+      scope.lastValidTitle = templateSrv.replaceWithText(text, scope.panel.scopedVars);
+    } else {
+      scope.lastValidTitle = templateSrv.replaceWithText(text, scope.row.scopedVars);
+    }
+    return scope.lastValidTitle;
   };
 
   filterFunc.$stateful = true;

--- a/public/app/features/dashboard/dashboardSrv.js
+++ b/public/app/features/dashboard/dashboardSrv.js
@@ -33,6 +33,10 @@ function (angular, $, _, moment) {
       this.time = data.time || { from: 'now-6h', to: 'now' };
       this.timepicker = data.timepicker || {};
       this.templating = this._ensureListExist(data.templating);
+      if (typeof this.templating.dashboard_autoupdate === 'undefined') {
+        //old dashboard version without autoupdate option
+        this.templating.dashboard_autoupdate=true;
+      }
       this.annotations = this._ensureListExist(data.annotations);
       this.refresh = data.refresh;
       this.snapshot = data.snapshot;

--- a/public/app/features/dashboard/submenuCtrl.js
+++ b/public/app/features/dashboard/submenuCtrl.js
@@ -6,13 +6,15 @@ function (angular) {
 
   var module = angular.module('grafana.controllers');
 
-  module.controller('SubmenuCtrl', function($scope, $q, $rootScope, templateValuesSrv, dynamicDashboardSrv) {
+  module.controller('SubmenuCtrl', function($scope, $q, $rootScope, templateValuesSrv, templateSrv, dynamicDashboardSrv) {
 
     $scope.init = function() {
       $scope.panel = $scope.pulldown;
       $scope.row = $scope.pulldown;
       $scope.annotations = $scope.dashboard.templating.list;
       $scope.variables = $scope.dashboard.templating.list;
+      $scope.dashboard_autoupdate = templateSrv.dashboard_autoupdate;
+      $scope.must_reload = !templateSrv.dashboard_autoupdate;
     };
 
     $scope.disableAnnotation = function (annotation) {
@@ -25,13 +27,25 @@ function (angular) {
     };
 
     $scope.variableUpdated = function(variable) {
+      $scope.dashboard_autoupdate=templateSrv.dashboard_autoupdate;
+      if(!$scope.dashboard_autoupdate){
+        $scope.must_reload=true;
+      }
       templateValuesSrv.variableUpdated(variable).then(function() {
-        dynamicDashboardSrv.update($scope.dashboard);
-        $rootScope.$emit('template-variable-value-updated');
-        $rootScope.$broadcast('refresh');
+        if(templateSrv.dashboard_autoupdate) {
+          dynamicDashboardSrv.update($scope.dashboard);
+          $rootScope.$emit('template-variable-value-updated');
+          $rootScope.$broadcast('refresh');
+        }
+        else {
+          $rootScope.$emit('template-variable-value-updated');
+        }
       });
     };
-
+    $scope.refreshDashboard = function () {
+      $rootScope.$broadcast('refresh');
+      $scope.must_reload=false;
+    };
     $scope.init();
 
   });

--- a/public/app/features/panel/panel_srv.js
+++ b/public/app/features/panel/panel_srv.js
@@ -11,6 +11,8 @@ function (angular, _, config) {
   module.service('panelSrv', function($rootScope, $timeout, datasourceSrv, $q) {
 
     this.init = function($scope) {
+      //memory for the last valid Title after variable reload
+      $scope.lastValidTitle='';
 
       if (!$scope.panel.span) { $scope.panel.span = 12; }
 
@@ -115,6 +117,8 @@ function (angular, _, config) {
       };
 
       $scope.get_data = function() {
+        //resel panel last title
+        $scope.lastValidTitle='';
         if ($scope.otherPanelInFullscreenMode()) { return; }
 
         if ($scope.panel.snapshotData) {
@@ -151,7 +155,7 @@ function (angular, _, config) {
       $scope.dashboardViewState.registerPanel($scope);
       $scope.datasources = datasourceSrv.getMetricSources();
 
-      if (!$scope.skipDataOnInit) {
+      if (!$scope.skipDataOnInit && $scope.dashboard.templating.dashboard_autoupdate) {
         $timeout(function() {
           $scope.get_data();
         }, 30);

--- a/public/app/features/templating/editorCtrl.js
+++ b/public/app/features/templating/editorCtrl.js
@@ -23,6 +23,7 @@ function (angular, _) {
 
     $scope.init = function() {
       $scope.mode = 'list';
+      $scope.dashboard_autoupdate = templateSrv.dashboard_autoupdate;
 
       $scope.datasources = _.filter(datasourceSrv.getMetricSources(), function(ds) {
         return !ds.meta.builtIn;
@@ -82,6 +83,11 @@ function (angular, _) {
         if (err.data && err.data.message) { err.message = err.data.message; }
         $scope.appEvent("alert-error", ['Templating', 'Template variables could not be initialized: ' + err.message]);
       });
+    };
+
+    $scope.toggleDashboardAutoUpdate = function() {
+      $scope.dashboard_autoupdate=!$scope.dashboard_autoupdate;
+      templateSrv.dashboard_autoupdate= !templateSrv.dashboard_autoupdate;
     };
 
     $scope.edit = function(variable) {

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -7,6 +7,11 @@
 
 		<div class="tabs">
 			<ul class="nav nav-tabs">
+				<li ng-class="{active: mode === 'globalops'}">
+					<a ng-click="mode = 'globalops';">
+						Global Options
+					</a>
+				</li>
 				<li ng-class="{active: mode === 'list'}">
 					<a ng-click="mode = 'list';">
 						Variables
@@ -35,6 +40,23 @@
 	</div>
 
 	<div class="gf-box-body">
+	
+		<div ng-if="mode === 'globalops'">
+			<div class="editor-row">
+				<div class="tight-form-section">
+					<h5>Dashboard Options</h5>
+					<div class="tight-form last">
+						<ul class="tight-form-list">
+							<li class="tight-form-item last">
+									<editor-checkbox text="Refresh Dashboard on each variable Change" model="dashboard_autoupdate" change="toggleDashboardAutoUpdate()"></editor-checkbox>
+									<tip>Check if you want dashboard auto refresh on each variable change, this will add unnecessari overload to the metric backend if you have several variables to choose before reloadng dashboard </tip>
+							</li>
+						</ul>
+						<div class="clearfix"></div>
+					</div>
+				</div>
+      </div>
+		</div>
 
 		<div ng-if="mode === 'list'">
 

--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -1,4 +1,4 @@
-define([
+  define([
   'angular',
   'lodash',
   './editorCtrl',
@@ -17,11 +17,11 @@ function (angular, _) {
     this._texts = {};
     this._grafanaVariables = {};
 
-    this.init = function(variables) {
-      this.variables = variables;
+    this.init = function(templating) {
+      this.variables = templating.list;
+      this.dashboard_autoupdate = templating.dashboard_autoupdate ;
       this.updateTemplateData();
     };
-
     this.updateTemplateData = function() {
       this._values = {};
       this._texts = {};

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -22,7 +22,7 @@ function (angular, _, kbn) {
 
     this.init = function(dashboard) {
       this.variables = dashboard.templating.list;
-      templateSrv.init(this.variables);
+      templateSrv.init(dashboard.templating);
 
       var queryParams = $location.search();
       var promises = [];

--- a/public/app/partials/submenu.html
+++ b/public/app/partials/submenu.html
@@ -8,6 +8,11 @@
 				</span>
 				<value-select-dropdown variable="variable" on-updated="variableUpdated(variable)" get-values-for-tag="getValuesForTag(variable, tagKey)"></value-select-dropdown>
 			</li>
+      <li class="submenu-item"  ng-if="must_reload">
+        <button type="button" class="btn btn-success btn-reload" ng-click="refreshDashboard();">
+         Reload Dashboard  <i class="fa fa-refresh"></i>
+        </button>
+      </li>
 		</ul>
 
 		<ul class="tight-form-list" ng-if="dashboard.annotations.list.length > 0">

--- a/public/less/submenu.less
+++ b/public/less/submenu.less
@@ -131,3 +131,11 @@
   display: inline-block;
   color: @textColor;
 }
+
+.btn-reload {
+  color: #fff;
+  padding: 8px 7px;
+  background-color: #9E4A0E;
+  border-color: #eea236;
+  font-size: 16px !important;
+}

--- a/public/test/specs/templateSrv-specs.js
+++ b/public/test/specs/templateSrv-specs.js
@@ -20,7 +20,7 @@ define([
 
     describe('init', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'oogle' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'oogle' } }], dashboard_autoupdate: true });
       });
 
       it('should initialize template data', function() {
@@ -31,7 +31,7 @@ define([
 
     describe('replace can pass scoped vars', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'oogle' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'oogle' } }],dashboard_autoupdate: true });
       });
 
       it('should replace $test with scoped value', function() {
@@ -95,7 +95,7 @@ define([
 
     describe('can check if variable exists', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'oogle' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'oogle' } }], dashboard_autoupdate: true });
       });
 
       it('should return true if exists', function() {
@@ -106,7 +106,7 @@ define([
 
     describe('can hightlight variables in string', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'oogle' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'oogle' } }], dashboard_autoupdate: true });
       });
 
       it('should insert html', function() {
@@ -128,7 +128,7 @@ define([
 
     describe('when checking if a string contains a variable', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'muuuu' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'muuuu' } }], dashboard_autoupdate: true });
       });
 
       it('should find it with $var syntax', function() {
@@ -145,7 +145,7 @@ define([
 
     describe('updateTemplateData with simple value', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: 'muuuu' } }]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: 'muuuu' } }], dashboard_autoupdate: true });
       });
 
       it('should set current value and update template data', function() {
@@ -156,7 +156,7 @@ define([
 
     describe('fillVariableValuesForUrl with multi value', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: ['val1', 'val2'] }}]);
+        _templateSrv.init({ list : [{ name: 'test', current: { value: ['val1', 'val2'] }}], dashboard_autoupdate: true });
       });
 
       it('should set multiple url params', function() {
@@ -168,7 +168,7 @@ define([
 
     describe('fillVariableValuesForUrl with multi value and scopedVars', function() {
       beforeEach(function() {
-        _templateSrv.init([{ name: 'test', current: { value: ['val1', 'val2'] }}]);
+        _templateSrv.init({ list: [{ name: 'test', current: { value: ['val1', 'val2'] }}], dashboard_autoupdate: true });
       });
 
       it('should set multiple url params', function() {
@@ -180,10 +180,10 @@ define([
 
     describe('replaceWithText', function() {
       beforeEach(function() {
-        _templateSrv.init([
+        _templateSrv.init({ list :[
           { name: 'server', current: { value: '{asd,asd2}', text: 'All' } },
           { name: 'period', current: { value: '$__auto_interval', text: 'auto' } }
-        ]);
+        ],  dashboard_autoupdate: true });
         _templateSrv.setGrafanaVariable('$__auto_interval', '13m');
         _templateSrv.updateTemplateData();
       });


### PR DESCRIPTION
Adds new feature in https://github.com/grafana/grafana/issues/1445

The main goal is avoid extra load in the data backends while selecting variables.

Now will exist a new template "global" parameter to enable and disable it.

![image](https://cloud.githubusercontent.com/assets/5883405/11338060/0f04ada6-91f2-11e5-8153-ae106c39faaf.png)

If enabled auto-refresh ( by default) it will work as ussualy . If don't  it apears a reload button on each variable change , suggesting reload if you need to view new data. 

![image](https://cloud.githubusercontent.com/assets/5883405/11338101/652ad9da-91f2-11e5-98c2-0752774cce91.png)

 It doesn't change the normal behavior of the top "auto refresh " config.

![image](https://cloud.githubusercontent.com/assets/5883405/11338148/ac7a9bf4-91f2-11e5-8226-cc194b4271f3.png)

if auto refresh is reached then the dashboard reloads with current selected variables if the reload button has not been pressed.
