### PR TITLE
Added percent values in the tooltip and legend for stacked series

### DIFF
--- a/public/app/panels/graph/axisEditor.html
+++ b/public/app/panels/graph/axisEditor.html
@@ -217,6 +217,9 @@
 					<editor-checkbox text="Current" model="panel.legend.current" change="legendValuesOptionChanged()"></editor-checkbox>
 				</li>
 				<li class="tight-form-item">
+					<editor-checkbox text="Percent" model="panel.legend.percent" change="legendValuesOptionChanged()"></editor-checkbox>
+				</li>
+				<li class="tight-form-item">
 					<editor-checkbox text="Total" model="panel.legend.total" change="legendValuesOptionChanged()"></editor-checkbox>
 				</li>
 				<li class="tight-form-item">

--- a/public/app/panels/graph/module.js
+++ b/public/app/panels/graph/module.js
@@ -85,6 +85,7 @@ function (angular, _, moment, kbn, TimeSeries, PanelMeta) {
         min: false,
         max: false,
         current: false,
+        percent: false,
         total: false,
         avg: false
       },
@@ -281,7 +282,7 @@ function (angular, _, moment, kbn, TimeSeries, PanelMeta) {
 
     $scope.legendValuesOptionChanged = function() {
       var legend = $scope.panel.legend;
-      legend.values = legend.min || legend.max || legend.avg || legend.current || legend.total;
+      legend.values = legend.min || legend.max || legend.avg || legend.current || legend.percent || legend.total;
       $scope.render();
     };
 

--- a/public/app/panels/graph/styleEditor.html
+++ b/public/app/panels/graph/styleEditor.html
@@ -52,10 +52,14 @@
 			text="All series" model="panel.tooltip.shared" change="render()"
 			tip="Show all series on same tooltip and a x croshair to help follow all series">
 		</editor-opt-bool>
-		<div class="editor-option" ng-show="panel.stack">
+		<div class="editor-option" ng-show="panel.stack && panel.tooltip.shared">
       <label class="small">Stacked Values <tip>How should the values in stacked charts to be calculated?</tip></label>
       <select class="input-small" ng-model="panel.tooltip.value_type" ng-options="f for f in ['cumulative','individual']" ng-change="render()"></select>
     </div>
+    <editor-opt-bool
+			text="Show Percent Values" model="panel.tooltip.percent_vals" showIf="panel.stack && panel.tooltip.shared" change="render()"
+			tip="Show percent values for all stacked series in the tooltip">
+		</editor-opt-bool>   
   </div>
 </div>
 

--- a/public/less/panel_graph.less
+++ b/public/less/panel_graph.less
@@ -40,6 +40,9 @@
   &.avg:before {
     content: "Avg: "
   }
+  &.percent:before {
+    content: "Percent: "
+  }
 }
 
 .graph-legend-icon .fa {
@@ -105,7 +108,7 @@
   }
 
   .graph-legend-value {
-    &.current, &.max, &.min, &.total, &.avg {
+    &.current, &.max, &.min, &.total, &.avg, &.percent {
       &:before {
         content: '';
       }
@@ -271,5 +274,3 @@
   text-align: center;
   font-size: 12px;
 }
-
-

--- a/public/test/specs/graph-tooltip-specs.js
+++ b/public/test/specs/graph-tooltip-specs.js
@@ -166,6 +166,42 @@ define([
 
   });
 
-});
+  describeSharedTooltip("steppedLine false, stack true, individual true, stacked value percent true ", function(ctx) {
+    ctx.setup(function() {
+      ctx.data = [
+        {
+          data: [[10, 8], [12, 20]],
+          lines: {},
+          datapoints: {
+            pointsize: 2,
+            points: [[10, 8], [12, 20]],
+          },
+          stack: true
+        },
+        {
+          data: [[10, 2], [12, 3]],
+          lines: {},
+          datapoints: {
+            pointsize: 2,
+            points: [[10, 2], [12, 3]],
+          },
+          stack: true
+        }
+      ];
+      ctx.scope.panel.stack = true;
+      ctx.scope.panel.tooltip.value_type = 'individual';
+      ctx.scope.panel.tooltip.percent_vals = true;
+      ctx.pos = { x: 11 };
+    });
 
+    it('should not show stacked value', function() {
+      expect(ctx.results[1].value).to.be(2);
+      expect(ctx.results[0].value).to.be(8);
+      expect(ctx.results[1].percent_val).to.be(20);
+      expect(ctx.results[0].percent_val).to.be(80);
+    });
+
+  });
+
+});
 


### PR DESCRIPTION
With this PR you can see the percent of each series to the total stacked series by only move the mouse over the graph.

Useful to see in one view how big is a measurement and it's relative amount against other measurements and the total stacked

![image](https://cloud.githubusercontent.com/assets/5883405/11450362/d8504770-959d-11e5-8099-5db2cb700736.png)

A new checkbox enable/disable this new feature.

![image](https://cloud.githubusercontent.com/assets/5883405/11450379/0654ac42-959e-11e5-82b2-4233ed9f937e.png)

You can disable this feature for individual series by only overriding the stack

![image](https://cloud.githubusercontent.com/assets/5883405/11450387/38e9324a-959e-11e5-893c-0541b5dbd896.png)

This is the full editor

![image](https://cloud.githubusercontent.com/assets/5883405/11450360/a480299c-959d-11e5-8eb4-722c544bd537.png)
