### PR TITLE
Wait for all panels to render in PhantomJS

### DIFF
--- a/vendor/phantomjs/render.js
+++ b/vendor/phantomjs/render.js
@@ -36,7 +36,8 @@ page.open(params.url, function (status) {
     var canvas = page.evaluate(function() {
       var body = angular.element(document.body);   // 1
       var rootScope = body.scope().$root;
-      return rootScope.performance.panelsRendered > 0;
+      var panels = angular.element('div.panel').length;
+      return rootScope.performance.panelsRendered >= panels;
     });
 
     if (canvas || tries === 1000) {


### PR DESCRIPTION
Fixes #2085

We want to set up physical displays (mounted TVs) to show dashboards in Grafana, driven by a RaspberryPI. The problem we encountered is that the raspberry has to load all the client-side code and data, even though no one will be interacting with the display. Instead, it'd be much faster to have the server render the dashboard and just serve up the image on the display.

This changes the PhantomJS rendering script to wait for at least the number of panel elements on the page to render, rather than waiting for only one of them. I've tested locally and both single-panel and dashboard rendering works as expected.

cc @cyc @jamesob
