### PR TITLE
(cloudwatch) null check of dimension

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -129,7 +129,7 @@ function (angular, _) {
         .pluck('Dimensions')
         .flatten()
         .filter(function(dimension) {
-          return dimension.Name === dimensionKey;
+          return dimension !== null && dimension.Name === dimensionKey;
         })
         .pluck('Value')
         .uniq()


### PR DESCRIPTION
ListMetrics result could have null dimension.
Need to check null.

@torkelo Sorry, I found a bug. please review and merge this.
