### PR TITLE
Make the disclosion of build/version information configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -125,6 +125,9 @@ disable_gravatar = false
 # data source proxy whitelist (ip_or_domain:port seperated by spaces)
 data_source_proxy_whitelist =
 
+# set to false if you don't want to disclose version info
+show_build_info = true
+
 #################################### Users ####################################
 [users]
 # disable user signup / registration

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -106,16 +106,24 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 		defaultDatasource = "-- Grafana --"
 	}
 
+	buildInfo := map[string]interface{}{
+		"version":    "",
+		"commit":     "",
+		"buildstamp": 0,
+	}
+
+	if setting.ShowBuildInfo == true {
+		buildInfo["version"] = setting.BuildVersion
+		buildInfo["commit"] = setting.BuildCommit
+		buildInfo["buildstamp"] = setting.BuildStamp
+	}
+
 	jsonObj := map[string]interface{}{
 		"defaultDatasource": defaultDatasource,
 		"datasources":       datasources,
 		"appSubUrl":         setting.AppSubUrl,
 		"allowOrgCreate":    (setting.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
-		"buildInfo": map[string]interface{}{
-			"version":    setting.BuildVersion,
-			"commit":     setting.BuildCommit,
-			"buildstamp": setting.BuildStamp,
-		},
+		"buildInfo":         buildInfo,
 	}
 
 	return jsonObj, nil

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -28,6 +28,7 @@ func LoginView(c *middleware.Context) {
 	settings["googleAuthEnabled"] = setting.OAuthService.Google
 	settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	settings["disableUserSignUp"] = !setting.AllowUserSignUp
+	settings["showBuildInfo"] = setting.ShowBuildInfo
 
 	if !tryLoginUsingRememberCookie(c) {
 		c.HTML(200, VIEW_INDEX)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -75,6 +75,7 @@ var (
 	DisableGravatar       bool
 	EmailCodeValidMinutes int
 	DataProxyWhiteList    map[string]bool
+	ShowBuildInfo         bool
 
 	// User settings
 	AllowUserSignUp    bool
@@ -419,6 +420,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	CookieUserName = security.Key("cookie_username").String()
 	CookieRememberName = security.Key("cookie_remember_name").String()
 	DisableGravatar = security.Key("disable_gravatar").MustBool(true)
+	ShowBuildInfo = security.Key("show_build_info").MustBool(true)
 
 	//  read data source proxy white list
 	DataProxyWhiteList = make(map[string]bool)

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -18,6 +18,7 @@ function (angular, coreModule, config) {
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
+    $scope.showBuildInfo     = config.showBuildInfo;
 
     $scope.loginMode = true;
     $scope.submitBtnText = 'Log in';
@@ -34,11 +35,13 @@ function (angular, coreModule, config) {
     };
 
     // build info view model
-    $scope.buildInfo = {
-      version: config.buildInfo.version,
-      commit: config.buildInfo.commit,
-      buildstamp: new Date(config.buildInfo.buildstamp * 1000)
-    };
+    if (config.showBuildInfo) {
+      $scope.buildInfo = {
+        version: config.buildInfo.version,
+        commit: config.buildInfo.commit,
+        buildstamp: new Date(config.buildInfo.buildstamp * 1000)
+      };
+    }
 
     $scope.submit = function() {
       if ($scope.loginMode) {

--- a/public/app/features/profile/partials/select_org.html
+++ b/public/app/features/profile/partials/select_org.html
@@ -40,7 +40,7 @@
 
 
 		<div class="row" style="margin-top: 50px">
-			<div class="version-footer text-center small">
+			<div class="version-footer text-center small" ng-if="showBuildInfo">
 				Grafana version: {{buildInfo.version}}, commit: {{buildInfo.commit}},
 				build date: {{buildInfo.buildstamp | date: 'yyyy-MM-dd HH:mm:ss' }}
 			</div>

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -85,7 +85,7 @@
 		</div>
 
 		<div class="row" style="margin-top: 50px">
-			<div class="version-footer text-center small">
+			<div class="version-footer text-center small" ng-if="showBuildInfo">
 				Grafana version: {{buildInfo.version}}, commit: {{buildInfo.commit}},
 				build date: {{buildInfo.buildstamp | date: 'yyyy-MM-dd HH:mm:ss' }}
 			</div>

--- a/public/app/partials/signup_invited.html
+++ b/public/app/partials/signup_invited.html
@@ -82,7 +82,7 @@
 		</div>
 
 		<div class="row" style="margin-top: 50px">
-			<div class="version-footer text-center small">
+			<div class="version-footer text-center small" ng-if="showBuildInfo">
 				Grafana version: {{buildInfo.version}}, commit: {{buildInfo.commit}},
 				build date: {{buildInfo.buildstamp | date: 'yyyy-MM-dd HH:mm:ss' }}
 			</div>

--- a/public/app/partials/signup_step2.html
+++ b/public/app/partials/signup_step2.html
@@ -100,7 +100,7 @@
 		</div>
 
 		<div class="row" style="margin-top: 50px">
-			<div class="version-footer text-center small">
+			<div class="version-footer text-center small" ng-if="showBuildInfo">
 				Grafana version: {{buildInfo.version}}, commit: {{buildInfo.commit}},
 				build date: {{buildInfo.buildstamp | date: 'yyyy-MM-dd HH:mm:ss' }}
 			</div>


### PR DESCRIPTION
Hide version information on public pages to make the corporate security officers happy. 
Security claims that showing version makes it easier to find known security exploits.
