### PR TITLE
add option pkg-rpm and pkg-deb to create separately both packages #3407

### DIFF
--- a/build.go
+++ b/build.go
@@ -76,6 +76,14 @@ func main() {
 			grunt("release")
 			createLinuxPackages()
 
+		case "pkg-rpm":
+			grunt("release")
+			createRpmPackages()
+      
+		case "pkg-deb":
+			grunt("release")
+			createDebPackages()
+
 		case "latest":
 			makeLatestDistCopies()
 
@@ -146,8 +154,7 @@ type linuxPackageOptions struct {
 
 	depends []string
 }
-
-func createLinuxPackages() {
+func createDebPackages() {
 	createPackage(linuxPackageOptions{
 		packageType:            "deb",
 		homeDir:                "/usr/share/grafana",
@@ -167,7 +174,9 @@ func createLinuxPackages() {
 
 		depends: []string{"adduser", "libfontconfig"},
 	})
+}
 
+func createRpmPackages() {
 	createPackage(linuxPackageOptions{
 		packageType:            "rpm",
 		homeDir:                "/usr/share/grafana",
@@ -187,6 +196,11 @@ func createLinuxPackages() {
 
 		depends: []string{"initscripts", "fontconfig"},
 	})
+}
+
+func createLinuxPackages() {
+	createDebPackages()
+	createRpmPackages()
 }
 
 func createPackage(options linuxPackageOptions) {

--- a/build.go
+++ b/build.go
@@ -79,7 +79,7 @@ func main() {
 		case "pkg-rpm":
 			grunt("release")
 			createRpmPackages()
-      
+
 		case "pkg-deb":
 			grunt("release")
 			createDebPackages()
@@ -154,6 +154,7 @@ type linuxPackageOptions struct {
 
 	depends []string
 }
+
 func createDebPackages() {
 	createPackage(linuxPackageOptions{
 		packageType:            "deb",


### PR DESCRIPTION
Now you can create only rpm or only deb by only  execute 

```
#go run build.go build pkg-rpm

#go run build.go build pkg-deb
```
