### PR TITLE
Added an option to set a min-width for the graphs side table/area.

### DIFF
--- a/public/app/panels/graph/axisEditor.html
+++ b/public/app/panels/graph/axisEditor.html
@@ -181,6 +181,13 @@
 				<li class="tight-form-item">
 					<editor-checkbox text="Right side" model="panel.legend.rightSide" change="render()"></editor-checkbox>
 				</li>
+				<li ng-if="panel.legend.rightSide" class="tight-form-item">
+					Side width
+				</li>
+				<li ng-if="panel.legend.rightSide" style="width: 105px">
+					<input type="number" class="input-small tight-form-input" placeholder="250" bs-tooltip="'Set a min-width for the legend side table/block'" data-placement="right"
+					ng-model="panel.legend.sideWidth" ng-change="render()" ng-model-onblur>
+				</li>
 			</ul>
 			<div class="clearfix"></div>
 		</div>

--- a/public/app/panels/graph/legend.js
+++ b/public/app/panels/graph/legend.js
@@ -101,6 +101,10 @@ function (angular, _, $) {
 
           $container.empty();
 
+          // Set min-width if side style and there is a value, otherwise remove the CSS propery
+          var width = panel.legend.rightSide && panel.legend.sideWidth ? panel.legend.sideWidth + "px" : "";
+          $container.css("min-width", width);
+
           $container.toggleClass('graph-legend-table', panel.legend.alignAsTable === true);
 
           if (panel.legend.alignAsTable) {


### PR DESCRIPTION
Added an option to set a min-width for the graphs side table/area.

Useful for a couple of reasons:
- Get the timelines of vertically stacked graphs aligned when right side content differs
- Set a sane width when not using table with the "right side" setting

The setting is only shown when "Right side" is checked, so it shouldn't be in the way.

![Example](http://i.imgur.com/rossGOP.png)
