### PR TITLE
Ability to use simple scripts in ElasticSearch metrics

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -189,6 +189,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         return $q.when([]);
       }
 
+      payload = payload.replace(/\$intervalMs/g, options.interval ? kbn.interval_to_ms(options.interval) : "1");
       payload = payload.replace(/\$interval/g, options.interval);
       payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
       payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -61,6 +61,29 @@ function (angular, _, queryDef) {
           $scope.target.bucketAggs = [];
         }
       }
+
+      // Metric scripts
+      if ($scope.aggDef.allowsScript) {
+        if ($scope.settingsLinkText.length > 0) {
+          $scope.settingsLinkText += ", ";
+        }
+
+        $scope.settingsLinkText += "Script: ";
+        if($scope.agg.script && $scope.agg.script.script && $scope.agg.script.script.length) {
+          var script = { script: $scope.agg.script.script };
+          $scope.agg.settings.script = script;
+
+          if ($scope.agg.script.lang) {
+            script.lang = $scope.agg.script.lang;
+          }
+
+          $scope.settingsLinkText += '"' + $scope.agg.script.script + '"';
+        }
+        else {
+          delete $scope.agg.settings.script;
+          $scope.settingsLinkText += "none";
+        }
+      }
     };
 
     $scope.toggleOptions = function() {
@@ -70,6 +93,7 @@ function (angular, _, queryDef) {
     $scope.onTypeChange = function() {
       $scope.agg.settings = {};
       $scope.agg.meta = {};
+      $scope.agg.script = {};
       $scope.showOptions = false;
       $scope.onChange();
     };

--- a/public/app/plugins/datasource/elasticsearch/partials/metricAgg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metricAgg.html
@@ -10,7 +10,11 @@
 			<metric-segment-model property="agg.field" get-options="getFieldsInternal()" on-change="onChange()" css-class="tight-form-item-xxlarge"></metric-segment>
 		</li>
 		<li class="tight-form-item last" ng-if="settingsLinkText">
-			<a ng-click="toggleOptions()">{{settingsLinkText}}</a>
+			<a ng-click="toggleOptions()">
+				<i class="fa fa-caret-down" ng-show="showOptions"></i>
+				<i class="fa fa-caret-right" ng-hide="showOptions"></i>
+				{{settingsLinkText}}
+			</a>
 		</li>
 	</ul>
 
@@ -27,7 +31,7 @@
 
 <div class="tight-form" ng-if="showOptions">
 	<div class="tight-form-inner-box">
-		<div class="tight-form last" ng-if="agg.type === 'percentiles'">
+		<div class="tight-form" ng-if="agg.type === 'percentiles'">
 			<ul class="tight-form-list">
 				<li class="tight-form-item">
 					Percentiles
@@ -51,7 +55,7 @@
 				<div class="clearfix"></div>
 			</div>
 		</div>
-		<div class="tight-form last" ng-if="agg.type === 'extended_stats'">
+		<div class="tight-form" ng-if="agg.type === 'extended_stats'">
 			<ul class="tight-form-list">
 				<li class="tight-form-item" style="width: 100px">
 					Sigma
@@ -61,6 +65,30 @@
 				</li>
 			</ul>
 			<div class="clearfix"></div>
+		</div>
+		<div ng-if="aggDef.allowsScript">
+			<div class="tight-form">
+				<ul class="tight-form-list">
+					<li class="tight-form-item" style="width: 100px">
+						Script
+					</li>
+					<li>
+						<input type="text" class="input-xlarge tight-form-input last" ng-model="agg.script.script" placeholder="_value * _value / $intervalMs" ng-blur="onChange()"></input>
+					</li>
+				</ul>
+				<div class="clearfix"></div>
+			</div>
+			<div class="tight-form last">
+				<ul class="tight-form-list">
+					<li class="tight-form-item" style="width: 100px">
+						Language
+					</li>
+					<li>
+						<input type="text" class="input-xlarge tight-form-input last" ng-model="agg.script.lang" placeholder="expression" ng-blur="onChange()"></input>
+					</li>
+				</ul>
+				<div class="clearfix"></div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/public/app/plugins/datasource/elasticsearch/query_def.js
+++ b/public/app/plugins/datasource/elasticsearch/query_def.js
@@ -6,15 +6,15 @@ function (_) {
 
   return {
     metricAggTypes: [
-      {text: "Count",   value: 'count', requiresField: false},
-      {text: "Average",  value: 'avg', requiresField: true},
-      {text: "Sum",  value: 'sum', requiresField: true},
-      {text: "Max",  value: 'max', requiresField: true},
-      {text: "Min",  value: 'min', requiresField: true},
-      {text: "Extended Stats",  value: 'extended_stats', requiresField: true},
-      {text: "Percentiles",  value: 'percentiles', requiresField: true},
-      {text: "Unique Count", value: "cardinality", requiresField: true},
-      {text: "Raw Document", value: "raw_document", requiresField: false}
+      {text: "Count",   value: 'count', requiresField: false, allowsScript: false},
+      {text: "Average",  value: 'avg', requiresField: true, allowsScript: true},
+      {text: "Sum",  value: 'sum', requiresField: true, allowsScript: true},
+      {text: "Max",  value: 'max', requiresField: true, allowsScript: true},
+      {text: "Min",  value: 'min', requiresField: true, allowsScript: true},
+      {text: "Extended Stats",  value: 'extended_stats', requiresField: true, allowsScript: true},
+      {text: "Percentiles",  value: 'percentiles', requiresField: true, allowsScript: true},
+      {text: "Unique Count", value: "cardinality", requiresField: true, allowsScript: true},
+      {text: "Raw Document", value: "raw_document", requiresField: false, allowsScript: false}
     ],
 
     bucketAggTypes: [


### PR DESCRIPTION
This change allows one to use simple scripts in ElasticSearch metrics.

With the added `$intervalMs` variable you can do interval dependent adjustments to get the correct value of interval sums.

![Example](http://i.imgur.com/pND6czC.png)
