### PR TITLE
Added datemath rounding for integer quantities other than 1

### DIFF
--- a/public/app/core/utils/datemath.ts
+++ b/public/app/core/utils/datemath.ts
@@ -91,8 +91,8 @@ function parseDateMath(mathString, time, roundUp?) {
     }
 
     if (type === 0) {
-      // rounding is only allowed on whole, single, units (eg M or 1M, not 0.5M or 2M)
-      if (num !== 1) {
+      // rounding is only allowed on whole units (eg M or 1M, not 0.5M or 2M)
+      if (num % 1 !== 0) {
         return undefined;
       }
     }
@@ -104,9 +104,11 @@ function parseDateMath(mathString, time, roundUp?) {
       if (type === 0) {
         if (roundUp) {
           dateTime.endOf(unit);
+          dateTime.set(unit, Math.ceil(dateTime.get(unit) / num) * num);
         }
         else {
           dateTime.startOf(unit);
+          dateTime.set(unit, Math.floor(dateTime.get(unit) / num) * num);
         }
       } else if (type === 1) {
         dateTime.add(num, unit);

--- a/public/test/core/utils/datemath_specs.ts
+++ b/public/test/core/utils/datemath_specs.ts
@@ -24,8 +24,8 @@ describe("DateMath", () => {
       expect(dateMath.parse('now+5f')).to.be(undefined);
     });
 
-    it('should return undefined if rounding unit is not 1', () => {
-      expect(dateMath.parse('now/2y')).to.be(undefined);
+    it('should return undefined if rounding unit is not an intiger', () => {
+      expect(dateMath.parse('now/1.9y')).to.be(undefined);
       expect(dateMath.parse('now/0.5y')).to.be(undefined);
     });
 
@@ -42,8 +42,31 @@ describe("DateMath", () => {
     expected.setSeconds(0);
     expected.setMilliseconds(0);
 
-    var startOfDay = dateMath.parse('now/d', false).valueOf()
+    var startOfDay = dateMath.parse('now/d', false).valueOf();
     expect(startOfDay).to.be(expected.getTime());
+  });
+
+  it("now/2m should set to the closest (preceding) even minute", () => {
+    var expected = new Date();
+    var min = expected.getMinutes();
+    min = Math.floor(min / 2) * 2;
+    expected.setMinutes(min);
+    expected.setSeconds(0);
+    expected.setMilliseconds(0);
+
+    var evenMinute = dateMath.parse('now/2m', false).valueOf();
+    expect(evenMinute).to.be(expected.getTime());
+  });
+
+  it("now/10s should set to start of current 10s interval", () => {
+    var expected = new Date();
+    var sec = expected.getSeconds();
+    sec = Math.floor(sec / 10) * 10;
+    expected.setSeconds(sec);
+    expected.setMilliseconds(0);
+
+    var interval10s = dateMath.parse('now/10s', false).valueOf();
+    expect(interval10s).to.be(expected.getTime());
   });
 
   describe('subtraction', () => {


### PR DESCRIPTION
Allows users to use more flexible rounding of date offsets.
For example round to even minutes (`/2m`) or to 10 second intervals (`/10s`).

![Example](http://i.imgur.com/vLT9bxO.png)
