### PR TITLE
ElasticSearch histogram setting to ignore the first and last datapoints

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.js
@@ -96,6 +96,9 @@ function (angular, _, queryDef) {
           $scope.agg.field = $scope.target.timeField;
           settingsLinkText = 'Interval: ' + settings.interval;
           settingsLinkText += ', Min Doc Count: ' + settings.min_doc_count;
+          if (settings.dropFirstLast) {
+            settingsLinkText += ', Drop first & last value';
+          }
         }
       }
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -10,8 +10,9 @@ function (_, queryDef) {
     this.response = response;
   }
 
-  ElasticResponse.prototype.processMetrics = function(esAgg, target, seriesList, props) {
+  ElasticResponse.prototype.processMetrics = function(esAgg, target, seriesList, props, dropFirstLast) {
     var metric, y, i, newSeries, bucket, value;
+    dropFirstLast = dropFirstLast ? 1 : 0;
 
     for (y = 0; y < target.metrics.length; y++) {
       metric = target.metrics[y];
@@ -22,7 +23,7 @@ function (_, queryDef) {
       switch(metric.type) {
         case 'count': {
           newSeries = { datapoints: [], metric: 'count', props: props};
-          for (i = 0; i < esAgg.buckets.length; i++) {
+          for (i = dropFirstLast; i < esAgg.buckets.length - dropFirstLast; i++) {
             bucket = esAgg.buckets[i];
             value = bucket.doc_count;
             newSeries.datapoints.push([value, bucket.key]);
@@ -31,17 +32,17 @@ function (_, queryDef) {
           break;
         }
         case 'percentiles': {
-          if (esAgg.buckets.length === 0) {
+          if (esAgg.buckets.length - dropFirstLast * 2 <= 0) {
             break;
           }
 
-          var firstBucket = esAgg.buckets[0];
+          var firstBucket = esAgg.buckets[dropFirstLast];
           var percentiles = firstBucket[metric.id].values;
 
           for (var percentileName in percentiles) {
             newSeries = {datapoints: [], metric: 'p' + percentileName, props: props, field: metric.field};
 
-            for (i = 0; i < esAgg.buckets.length; i++) {
+            for (i = dropFirstLast; i < esAgg.buckets.length - dropFirstLast; i++) {
               bucket = esAgg.buckets[i];
               var values = bucket[metric.id].values;
               newSeries.datapoints.push([values[percentileName], bucket.key]);
@@ -59,7 +60,7 @@ function (_, queryDef) {
 
             newSeries = {datapoints: [], metric: statName, props: props, field: metric.field};
 
-            for (i = 0; i < esAgg.buckets.length; i++) {
+            for (i = dropFirstLast; i < esAgg.buckets.length - dropFirstLast; i++) {
               bucket = esAgg.buckets[i];
               var stats = bucket[metric.id];
 
@@ -77,7 +78,7 @@ function (_, queryDef) {
         }
         default: {
           newSeries = { datapoints: [], metric: metric.type, field: metric.field, props: props};
-          for (i = 0; i < esAgg.buckets.length; i++) {
+          for (i = dropFirstLast; i < esAgg.buckets.length - dropFirstLast; i++) {
             bucket = esAgg.buckets[i];
 
             value = bucket[metric.id];
@@ -158,7 +159,7 @@ function (_, queryDef) {
 
       if (depth === maxDepth) {
         if (aggDef.type === 'date_histogram')  {
-          this.processMetrics(esAgg, target, seriesList, props);
+          this.processMetrics(esAgg, target, seriesList, props, aggDef.settings && aggDef.settings.dropFirstLast);
         } else {
           this.processAggregationDocs(esAgg, aggDef, target, docs, props);
         }

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -37,7 +37,7 @@
 	<div class="tight-form-inner-box" ng-if="agg.type === 'date_histogram'">
 		<div class="tight-form">
 			<ul class="tight-form-list">
-				<li class="tight-form-item" style="width: 94px">
+				<li class="tight-form-item" style="width: 140px">
 					Interval
 				</li>
 				<li>
@@ -46,13 +46,29 @@
 			</ul>
 			<div class="clearfix"></div>
 		</div>
-		<div class="tight-form last">
+		<div class="tight-form">
 			<ul class="tight-form-list">
-				<li class="tight-form-item" style="width: 94px">
+				<li class="tight-form-item" style="width: 140px">
 					Min Doc Count
 				</li>
 				<li>
-					<input type="number" class="tight-form-input" ng-model="agg.settings.min_doc_count" ng-blur="onChangeInternal()"></input>
+					<input type="number" class="tight-form-input" ng-model="agg.settings.min_doc_count" ng-blur="onChangeInternal()">
+				</li>
+			</ul>
+			<div class="clearfix"></div>
+		</div>
+		<div class="tight-form last">
+			<ul class="tight-form-list">
+				<li class="tight-form-item" style="width: 140px">
+					Drop first &amp; last value
+				</li>
+				<li class="tight-form-item">
+					<input class="cr1" type="checkbox" id="agg[{{agg.id}}].settings.dropFirstLast"
+					ng-model="agg.settings.dropFirstLast" ng-checked="agg.settings.dropFirstLast" ng-change="onChangeInternal()">
+					<label for="agg[{{agg.id}}].settings.dropFirstLast" class="cr1"></label>
+				</li>
+				<li class="tight-form-item last">
+					<i class="fa fa-question-circle" bs-tooltip="'Ignore the first and last values of the dataset'" data-placement="right"></i>
 				</li>
 			</ul>
 			<div class="clearfix"></div>


### PR DESCRIPTION
### Summary

For some interval histogram queries on data like that which is produced by [Elastic topbeat](https://www.elastic.co/products/beats/topbeat) the inexact spread and offset of the data leads to the first and last histogram buckets having undesired and incorrect values.

This option ignores the first and last buckets, so that only the correct data is shown. Especially useful for current data/table values, single metrics, etc.

![The option](http://i.imgur.com/QXje0hq.png)
### Further description

When using topbeat the per process data is reported every 10 seconds, and every process gets an entry in the ES database. But the timestamps for these processes are a bit spread out around the 10 second interval.

In such scenarios getting the per process CPU usage, or count number of processes, some times shows incorrect results for the first and last buckets/datapoints:

![Incorrect data](http://i.imgur.com/7rlODHg.png)

With this option set you can see that the "current" value is correct:

![Correct](http://i.imgur.com/b9chHXz.png)
