### PR TITLE
(cloudwatch) fix period overwrite

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -25,7 +25,7 @@ function (angular, _) {
       var end = convertToCloudWatchTime(options.range.to);
 
       var queries = [];
-      options = _.clone(options);
+      options = angular.copy(options);
       _.each(options.targets, _.bind(function(target) {
         if (target.hide || !target.namespace || !target.metricName || _.isEmpty(target.statistics)) {
           return;


### PR DESCRIPTION
Underscore.js clone function is shallow copy, so this line accidentally overwrite Period parameter in query editor.
https://github.com/mtanda/grafana/blob/217d5df276cb24981aaeca03cbf0fa4ddb3d0201/public/app/plugins/datasource/cloudwatch/datasource.js#L46

If user expand their time range, Period becomes bigger value, and never becomes appropriate value in narrow time range.
By using angular copy (deep copy), fix this.
