### PR TITLE
(cloudwatch) add "Divide Sum By Period" option

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -330,6 +330,9 @@ function (angular, _, moment, dateMath) {
             dps.push([null, lastTimestamp + periodMs]);
           }
           lastTimestamp = timestamp;
+          if (options.divideSumByPeriod && stat === 'Sum') {
+            dp[stat] = dp[stat] / options.period;
+          }
           dps.push([dp[stat], timestamp]);
         });
 

--- a/public/app/plugins/datasource/cloudwatch/partials/query.parameter.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/query.parameter.html
@@ -52,6 +52,9 @@
 		<li>
 			<input type="text" class="input-xlarge tight-form-input"  ng-model="target.alias" spellcheck='false' ng-model-onblur ng-change="onChange()">
 		</li>
+		<li class="tight-form-item query-keyword">
+			Sum / Period <editor-checkbox text="" model="target.divideSumByPeriod" change="onChange()"></editor-checkbox>
+		</li>
 	</ul>
 	<div class="clearfix"></div>
 </div>

--- a/public/app/plugins/datasource/cloudwatch/query_ctrl.js
+++ b/public/app/plugins/datasource/cloudwatch/query_ctrl.js
@@ -10,6 +10,7 @@ function (angular, _) {
   module.controller('CloudWatchQueryCtrl', function($scope) {
 
     $scope.init = function() {
+      $scope.target.divideSumByPeriod = $scope.target.divideSumByPeriod || false;
       $scope.aliasSyntax = '{{metric}} {{stat}} {{namespace}} {{region}} {{<dimension name>}}';
     };
 


### PR DESCRIPTION
Another approach to fix https://github.com/grafana/grafana/issues/3187 .
There are not so much exceptional cases which we need to calculate in Grafana side.
And the expression is only "Sum / Period", so I simply add checkbox to use the expression.

These are exceptional cases what I found.

DynamoDB: ConsumedReadCapacityUnits, ConsumedWriteCapacityUnits
https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/dynamo-metricscollected.html

EBS: VolumeReadBytes, VolumeWriteBytes, VolumeReadOps, VolumeWriteOps
https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ebs-metricscollected.html

EC2: DiskReadOps, DiskWriteOps
https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ec2-metricscollected.html
