### PR TITLE
Elasticsearch derivative queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -76,7 +76,7 @@ function (_, queryDef) {
           newSeries = { datapoints: [], metric: metric.type, field: metric.field, props: props};
           for (i = 0; i < esAgg.buckets.length; i++) {
             bucket = esAgg.buckets[i];
-            if (typeof bucket[metric.id] != 'undefined') {
+            if (typeof bucket[metric.id] !== 'undefined') {
               value = bucket[metric.id].value;
               newSeries.datapoints.push([value, bucket.key]);
             }

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -76,12 +76,10 @@ function (_, queryDef) {
           newSeries = { datapoints: [], metric: metric.type, field: metric.field, props: props};
           for (i = 0; i < esAgg.buckets.length; i++) {
             bucket = esAgg.buckets[i];
-            if (typeof bucket[metric.id] == 'undefined') {
-              value = 0;
-            } else {
+            if (typeof bucket[metric.id] != 'undefined') {
               value = bucket[metric.id].value;
+              newSeries.datapoints.push([value, bucket.key]);
             }
-            newSeries.datapoints.push([value, bucket.key]);
           }
           seriesList.push(newSeries);
           break;

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -76,7 +76,11 @@ function (_, queryDef) {
           newSeries = { datapoints: [], metric: metric.type, field: metric.field, props: props};
           for (i = 0; i < esAgg.buckets.length; i++) {
             bucket = esAgg.buckets[i];
-            value = bucket[metric.id].value;
+            if (typeof bucket[metric.id] == 'undefined') {
+              value = 0;
+            } else {
+              value = bucket[metric.id].value;
+            }
             newSeries.datapoints.push([value, bucket.key]);
           }
           seriesList.push(newSeries);


### PR DESCRIPTION
Hi,

When using a derivative query in elasticsearch the first result is null and this is causing errors in elastic_response.js.  This patch lets it skip the null entry and draw the graph.  I have tested this using the following query :

```
{
  "size": 0,
  "query": {
    "filtered": {
      "query": {
        "query_string": {
          "query": "$lucene_query"
        }
      },
      "filter": {
        "bool": {
          "must": [
            {
              "range": {
                "@timestamp": {
                  "gte": "$timeFrom",
                  "lte": "$timeTo"
                }
              }
            }
          ]
        }
      }
    }
  },
  "aggs": {
    "2": {
      "date_histogram": {
        "interval": "$interval",
        "field": "@timestamp",
        "min_doc_count": 0,
        "extended_bounds": {
          "min": "$timeFrom",
          "max": "$timeTo"
        }
      },
      "aggs": {
        "3": {
          "max": {
            "field": "rx"
          }
        }, 
        "1": {
          "derivative": {
            "buckets_path": "3"
          }
        }
      }
    }
  }
}
```
