### PR TITLE
external templating query source

### DIFF
--- a/public/app/plugins/datasource/templating_json/datasource.js
+++ b/public/app/plugins/datasource/templating_json/datasource.js
@@ -1,0 +1,76 @@
+define([
+  'angular',
+  'lodash',
+],
+function (angular, _) {
+  'use strict';
+
+  var module = angular.module('grafana.services');
+
+  module.factory('TemplatingJsonDatasource', function($q, backendSrv, templateSrv) {
+    function TemplatingJsonDatasource(datasource) {
+      this.type = 'templating_json';
+      this.name = datasource.name;
+      this.url = datasource.url;
+      this.basicAuth = datasource.basicAuth;
+      this.withCredentials = datasource.withCredentials;
+    }
+
+    TemplatingJsonDatasource.prototype._request = function(method, url) {
+      var options = {
+        url: url,
+        method: method
+      };
+
+      if (this.basicAuth || this.withCredentials) {
+        options.withCredentials = true;
+      }
+      if (this.basicAuth) {
+        options.headers = {
+          "Authorization": this.basicAuth
+        };
+      }
+
+      return backendSrv.datasourceRequest(options);
+    };
+
+    TemplatingJsonDatasource.prototype.metricFindQuery = function(query) {
+      if (!query) { return $q.when([]); }
+
+      try {
+        query = templateSrv.replace(query);
+      } catch (err) {
+        return $q.reject(err);
+      }
+
+      return this._request('GET', this.url).then(function(response) {
+        var result = response.data;
+        var keys = query.split('.');
+        keys.shift();
+
+        _.each(keys, function(key) {
+          if (!result[key]) {
+            throw new Error('invalid query');
+          }
+          result = result[key];
+        });
+
+        if (_.isString(result)) {
+          return [{ text: result }];
+        } else if (_.isArray(result)) {
+          return _.map(result, function(r) { return { text: r }; });
+        } else {
+          throw new Error('invalid data');
+        }
+      });
+    };
+
+    TemplatingJsonDatasource.prototype.testDatasource = function() {
+      return this._request('GET', this.url).then(function() {
+        return { status: 'success', message: 'Data source is working', title: 'Success' };
+      });
+    };
+
+    return TemplatingJsonDatasource;
+  });
+});

--- a/public/app/plugins/datasource/templating_json/partials/config.html
+++ b/public/app/plugins/datasource/templating_json/partials/config.html
@@ -1,0 +1,4 @@
+<div ng-include="httpConfigPartialSrc"></div>
+
+<br>
+

--- a/public/app/plugins/datasource/templating_json/plugin.json
+++ b/public/app/plugins/datasource/templating_json/plugin.json
@@ -1,0 +1,15 @@
+{
+  "pluginType": "datasource",
+  "name": "Templating_JSON",
+
+  "type": "templating_json",
+  "serviceName": "TemplatingJsonDatasource",
+
+  "module": "app/plugins/datasource/templating_json/datasource",
+
+  "partials": {
+    "config": "app/plugins/datasource/templating_json/partials/config.html"
+  },
+
+  "metrics": true
+}


### PR DESCRIPTION
This is my proposal to implement https://github.com/grafana/grafana/issues/2188 .
Add datasource for templating, and prepare metric find query for getting template source.

How to use.
1. prepare json file or endpoint which response json
2. set url of 1 to datasource
3. add template variable, and specify metric find query

If the query is ".foo", and responsed JSON is like below,

```
{
  "foo": [
    "foo1",
    "foo2",
    "foo3",
  ],
  "bar": [
    "bar1",
    "bar2",
    "bar3",
  ]
}
```

The result values becomes ["foo1", "foo2", "foo3"].

If it it acceptable to increase size of client js library code, I want to use jmespath to support more complex query.
http://jmespath.org/
