### PR TITLE
Added a checkbox to templates that refreshes template values on time range change

### DIFF
--- a/public/app/features/dashboard/dashboardSrv.js
+++ b/public/app/features/dashboard/dashboardSrv.js
@@ -229,9 +229,9 @@ function (angular, $, _, moment) {
       var i, j, k;
       var oldVersion = this.schemaVersion;
       var panelUpgrades = [];
-      this.schemaVersion = 8;
+      this.schemaVersion = 9;
 
-      if (oldVersion === 8) {
+      if (oldVersion === 9) {
         return;
       }
 
@@ -383,6 +383,15 @@ function (angular, $, _, moment) {
             }
           });
         });
+      }
+
+      if (oldVersion < 9) {
+        // update template variables
+        for (i = 0 ; i < this.templating.list.length; i++) {
+          var templateVariable = this.templating.list[i];
+          if (templateVariable.refresh) { templateVariable.refresh = 'On Dashboard Load'; }
+          if (!templateVariable.refresh) { templateVariable.refresh = 'Never'; }
+        }
       }
 
       if (panelUpgrades.length === 0) {

--- a/public/app/features/templating/editorCtrl.js
+++ b/public/app/features/templating/editorCtrl.js
@@ -13,6 +13,7 @@ function (angular, _) {
       type: 'query',
       datasource: null,
       refresh: false,
+      refreshOnTimeChange: false,
       name: '',
       options: [],
       includeAll: false,

--- a/public/app/features/templating/editorCtrl.js
+++ b/public/app/features/templating/editorCtrl.js
@@ -12,8 +12,7 @@ function (angular, _) {
     var replacementDefaults = {
       type: 'query',
       datasource: null,
-      refresh: false,
-      refreshOnTimeChange: false,
+      refresh: 'Never',
       name: '',
       options: [],
       includeAll: false,

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -214,11 +214,20 @@
 							<div class="clearfix"></div>
 						</div>
 
-						<div class="tight-form last">
+						<div class="tight-form">
 							<ul class="tight-form-list">
 								<li class="tight-form-item last">
 									<editor-checkbox text="Refresh on load" model="current.refresh"></editor-checkbox>
 									<tip>Check if you want values to be updated on dashboard load, will slow down dashboard load time</tip>
+								</li>
+							</ul>
+							<div class="clearfix"></div>
+						</div>
+						<div class="tight-form last">
+							<ul class="tight-form-list">
+								<li class="tight-form-item last">
+									<editor-checkbox text="Refresh on time range change" model="current.refreshOnTimeChange"></editor-checkbox>
+									<tip>Check if you want values to be updated on time range change, will slow down time range change and dashboard load time</tip>
 								</li>
 							</ul>
 							<div class="clearfix"></div>

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -214,20 +214,14 @@
 							<div class="clearfix"></div>
 						</div>
 
-						<div class="tight-form">
-							<ul class="tight-form-list">
-								<li class="tight-form-item last">
-									<editor-checkbox text="Refresh on load" model="current.refresh"></editor-checkbox>
-									<tip>Check if you want values to be updated on dashboard load, will slow down dashboard load time</tip>
-								</li>
-							</ul>
-							<div class="clearfix"></div>
-						</div>
 						<div class="tight-form last">
 							<ul class="tight-form-list">
-								<li class="tight-form-item last">
-									<editor-checkbox text="Refresh on time range change" model="current.refreshOnTimeChange"></editor-checkbox>
-									<tip>Check if you want values to be updated on time range change, will slow down time range change and dashboard load time</tip>
+								<li class="tight-form-item" style="width: 100px;">
+									Refresh
+									<tip>When to update the values of this template, will slow down dashboard load / time change</tip>
+								</li>
+								<li>
+									<select class="input-large tight-form-input" ng-model="current.refresh" ng-options="f for f in ['Never', 'On Dashboard Load', 'On Time Change']"></select>
 								</li>
 							</ul>
 							<div class="clearfix"></div>

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -20,6 +20,17 @@ function (angular, _, kbn) {
       }
     }, $rootScope);
 
+    $rootScope.onAppEvent('refresh', function() {
+      var promises = [];
+      for (var i = 0; i < self.variables.length; i++) {
+        var variable = self.variables[i];
+        if (variable.refreshOnTimeChange) {
+          promises.push(self.updateOptions(variable));
+        }
+      }
+      return $q.all(promises);
+    }, $rootScope);
+
     this.init = function(dashboard) {
       this.variables = dashboard.templating.list;
       templateSrv.init(this.variables);

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -24,7 +24,7 @@ function (angular, _, kbn) {
       var promises = [];
       for (var i = 0; i < self.variables.length; i++) {
         var variable = self.variables[i];
-        if (variable.refreshOnTimeChange) {
+        if (variable.refresh === 'On Time Change') {
           promises.push(self.updateOptions(variable));
         }
       }
@@ -44,7 +44,7 @@ function (angular, _, kbn) {
         if (urlValue !== void 0) {
           promises.push(this.setVariableFromUrl(variable, urlValue));
         }
-        else if (variable.refresh) {
+        else if (variable.refresh === 'On Dashboard Load' || variable.refresh === 'On Time Change') {
           promises.push(this.updateOptions(variable));
         }
         else if (variable.type === 'interval') {

--- a/public/dashboards/template_vars.json
+++ b/public/dashboards/template_vars.json
@@ -259,5 +259,6 @@
     "enable": false
   },
   "refresh": false,
+  "refreshOnTimeChange": false,
   "version": 6
 }

--- a/public/dashboards/template_vars.json
+++ b/public/dashboards/template_vars.json
@@ -258,7 +258,6 @@
   "annotations": {
     "enable": false
   },
-  "refresh": false,
-  "refreshOnTimeChange": false,
+  "refresh": "Never",
   "version": 6
 }

--- a/public/test/specs/dashboardSrv-specs.js
+++ b/public/test/specs/dashboardSrv-specs.js
@@ -204,7 +204,7 @@ define([
       });
 
       it('dashboard schema version should be set to latest', function() {
-        expect(model.schemaVersion).to.be(8);
+        expect(model.schemaVersion).to.be(9);
       });
 
     });


### PR DESCRIPTION
If the checkbox is selected, the query for the values of the template is re-run whenever the refresh button is clicked, or the time range changes.

Ui Changes:
![template](https://cloud.githubusercontent.com/assets/8438951/11762518/594a7836-a0b7-11e5-800a-c7396ea37737.png)

This closes #3427 
