### PR TITLE
Increase the height of the spark lines

### DIFF
--- a/public/app/plugins/panels/singlestat/singleStatPanel.js
+++ b/public/app/plugins/panels/singlestat/singleStatPanel.js
@@ -97,7 +97,7 @@ function (angular, app, _, $) {
             plotCss.bottom = '5px';
             plotCss.left = '-5px';
             plotCss.width = (width - 10) + 'px';
-            plotCss.height = (height - 45) + 'px';
+            plotCss.height = (height - 5) + 'px';
           }
           else {
             plotCss.bottom = "0px";


### PR DESCRIPTION
Simple change to increase the canvas height to allow better space usage for small panels in background mode. I think it looks much neater and makes the changes more visible.

**After change:**

![image](https://cloud.githubusercontent.com/assets/14072681/11880941/9dfe3376-a4fb-11e5-972f-f973e1ac5635.png)
