### PR TITLE
Fix empty username in http log for /render calls

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -29,13 +29,13 @@ func Logger() macaron.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
 		start := time.Now()
 
-		rw := res.(macaron.ResponseWriter)
-		c.Next()
-
 		uname := c.GetCookie(setting.CookieUserName)
 		if len(uname) == 0 {
 			uname = "-"
 		}
+
+		rw := res.(macaron.ResponseWriter)
+		c.Next()
 
 		content := fmt.Sprintf("Completed %s %s \"%s %s %s\" %v %s %d bytes in %dus", c.RemoteAddr(), uname, req.Method, req.URL.Path, req.Proto, rw.Status(), http.StatusText(rw.Status()), rw.Size(), time.Since(start)/time.Microsecond)
 


### PR DESCRIPTION
Router logger did not show username in /render calls because cookies are cleared in these call. Now just get username before the call is executed. See #3405 for more info.
