### PR TITLE
[WIP] Add shared Orgs

### DIFF
--- a/pkg/api/dtos/org.go
+++ b/pkg/api/dtos/org.go
@@ -1,7 +1,8 @@
 package dtos
 
 type UpdateOrgForm struct {
-	Name string `json:"name" binding:"Required"`
+	Name   string `json:"name" binding:"Required"`
+	Shared bool   `json:"shared" binding:"Required"`
 }
 
 type UpdateOrgAddressForm struct {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -60,6 +60,7 @@ type OrgUpdated struct {
 	Timestamp time.Time `json:"timestamp"`
 	Id        int64     `json:"id"`
 	Name      string    `json:"name"`
+	Shared    bool      `json:"shared"`
 }
 
 type UserCreated struct {

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -43,8 +43,9 @@ type DeleteOrgCommand struct {
 }
 
 type UpdateOrgCommand struct {
-	Name  string
-	OrgId int64
+	Name   string
+	Shared bool
+	OrgId  int64
 }
 
 type UpdateOrgAddressCommand struct {

--- a/public/app/features/org/orgDetailsCtrl.js
+++ b/public/app/features/org/orgDetailsCtrl.js
@@ -17,12 +17,13 @@ function (angular) {
         $scope.org = org;
         $scope.address = org.address;
         contextSrv.user.orgName = org.name;
+        contextSrv.user.shared = org.shared;
       });
     };
 
     $scope.update = function() {
       if (!$scope.orgForm.$valid) { return; }
-      var data = {name: $scope.org.name};
+      var data = {name: $scope.org.name, shared: $scope.org.shared};
       backendSrv.put('/api/org', data).then($scope.getOrgInfo);
     };
 

--- a/public/app/features/org/partials/orgDetails.html
+++ b/public/app/features/org/partials/orgDetails.html
@@ -25,6 +25,10 @@
 					<div class="clearfix"></div>
 				</div>
 
+				<label>Shared
+					<input type="checkbox" ng-model="org.shared" class="tight-form-input">
+				</label>
+
 				<br>
 				<button type="submit" class="pull-right btn btn-success" ng-click="update()">Update</button>
 			</form>
@@ -94,5 +98,3 @@
 
 	</div>
 </div>
-
-


### PR DESCRIPTION
I really want to solve the #2033 

My solution is:
- Add a radio button in Org settings which marks the org as `shared`. After settings are updated we have all users as viewers (a role may be optional) in the Org.
- Add callback which called when new user is signed up, the callback should adds user for all Orgs which has `shared` flag. (_Not implemented yet_)

So what you think about such approach?
