### PR TITLE
Add TLS for mysql

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -63,8 +63,14 @@ name = grafana
 user = root
 password =
 
-# For "postgres" only, either "disable", "require" or "verify-full"
+# For "postgres", use either "disable", "require" or "verify-full"
+# For "mysql", use either "true", "false", or "skip-verify".
 ssl_mode = disable
+
+ca_cert_path =
+client_key_path =
+client_cert_path =
+server_cert_name =
 
 # For "sqlite3" only, path relative to data_path setting
 path = grafana.db

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -156,7 +156,24 @@ The database user's password (not applicable for `sqlite3`).
 
 ### ssl_mode
 
-For `postgres` only, either `disable`, `require` or `verify-full`.
+For Postgres, use either `disable`, `require` or `verify-full`.
+For MySQL, use either `true`, `false`, or `skip-verify`.
+
+### ca_cert_path 
+
+(MySQL only) The path to the CA certificate to use. On many linux systems, certs can be found in `/etc/ssl/certs`.
+
+### client_key_path 
+
+(MySQL only) The path to the client key. Only if server requires client authentication.
+
+### client_cert_path 
+
+(MySQL only) The path to the client cert. Only if server requires client authentication.
+
+### server_cert_name 
+
+(MySQL only) The common name field of the certificate used by the `mysql` server. Not necessary if `ssl_mode` is set to `skip-verify`.
 
 <hr />
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -14,16 +14,16 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 
+	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/go-xorm/xorm"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/go-sql-driver/mysql"
 )
 
 type MySQLConfig struct {
-	SslMode string
-	CaCertPath string
+	SslMode        string
+	CaCertPath     string
 	ClientKeyPath  string
 	ClientCertPath string
 	ServerCertName string

--- a/pkg/services/sqlstore/tls_mysql.go
+++ b/pkg/services/sqlstore/tls_mysql.go
@@ -1,0 +1,41 @@
+package sqlstore
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func makeCert(tlsPoolName string, config MySQLConfig) (*tls.Config, error) {
+	rootCertPool := x509.NewCertPool()
+	pem, err := ioutil.ReadFile(config.CaCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read DB CA Cert path: %v", config.CaCertPath)
+	}
+	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+		return nil, err
+	}
+	clientCert := make([]tls.Certificate, 0, 1)
+	if (config.ClientCertPath != "" && config.ClientKeyPath != "") {
+
+		certs, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		clientCert = append(clientCert, certs)
+	}
+	tlsConfig := &tls.Config{
+		RootCAs:      rootCertPool,
+		Certificates: clientCert,
+	}
+	tlsConfig.ServerName = config.ServerCertName
+	if config.SslMode == "skip-verify" {
+		tlsConfig.InsecureSkipVerify = true
+	}
+	// Return more meaningful error before it is too late
+	if config.ServerCertName == "" && !tlsConfig.InsecureSkipVerify{
+		return nil, fmt.Errorf("server_cert_name is missing. Consider using ssl_mode = skip-verify.")
+	}
+	return tlsConfig, nil
+}

--- a/pkg/services/sqlstore/tls_mysql.go
+++ b/pkg/services/sqlstore/tls_mysql.go
@@ -17,7 +17,7 @@ func makeCert(tlsPoolName string, config MySQLConfig) (*tls.Config, error) {
 		return nil, err
 	}
 	clientCert := make([]tls.Certificate, 0, 1)
-	if (config.ClientCertPath != "" && config.ClientKeyPath != "") {
+	if config.ClientCertPath != "" && config.ClientKeyPath != "" {
 
 		certs, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientKeyPath)
 		if err != nil {
@@ -34,7 +34,7 @@ func makeCert(tlsPoolName string, config MySQLConfig) (*tls.Config, error) {
 		tlsConfig.InsecureSkipVerify = true
 	}
 	// Return more meaningful error before it is too late
-	if config.ServerCertName == "" && !tlsConfig.InsecureSkipVerify{
+	if config.ServerCertName == "" && !tlsConfig.InsecureSkipVerify {
 		return nil, fmt.Errorf("server_cert_name is missing. Consider using ssl_mode = skip-verify.")
 	}
 	return tlsConfig, nil


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/2998

Use ssl_mode for mysql and add docs for the new parameters in config
Tolerate ssl_mode without client authentication. Client cert is not necessary for a SSL connection. So we tolerate failure if client cert is not provided.
