### PR TITLE
Issue 3461: Session table is now created automatically

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -19,6 +19,7 @@ func AddMigrations(mg *Migrator) {
 	addDashboardSnapshotMigrations(mg)
 	addQuotaMigration(mg)
 	addPluginBundleMigration(mg)
+	addSessionMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/session_mig.go
+++ b/pkg/services/sqlstore/migrations/session_mig.go
@@ -1,0 +1,16 @@
+package migrations
+
+import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func addSessionMigration(mg *Migrator) {
+	var sessionV1 = Table{
+		Name: "session",
+		Columns: []*Column{
+			{Name: "key", Type: DB_Char, IsPrimaryKey: true, Length: 16},
+			{Name: "data", Type: DB_Blob},
+			{Name: "expiry", Type: DB_Integer, Length: 255, Nullable: false},
+		},
+	}
+
+	mg.AddMigration("create session table", NewAddTableMigration(sessionV1))
+}


### PR DESCRIPTION
Resolves #3461.  This adds a migration step for managing the session table in the main mysql/postgresql database.  I decided not to check the session provider configuration because there is no pattern in place to handle schema migrations in a separate datastore.  So, for example, if the user wants to keep main data in mysql and sessions in postgres, this PR will not help them.
