### PR TITLE
Fixes #2818.  Adds support for mysql backends via unix sockets

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -81,7 +81,7 @@ provider = file
 # postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
 # mysql: go-sql-driver/mysql dsn config string, examples:
 #         `user:password@tcp(127.0.0.1:3306)/database_name`
-#         `user:password@unix(1/var/run/mysqld/mysqld.sock)/database_name`
+#         `user:password@unix(/var/run/mysqld/mysqld.sock)/database_name`
 # memcache: 127.0.0.1:11211
 
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -79,7 +79,9 @@ provider = file
 # file: session dir path, is relative to grafana data_path
 # redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
 # postgres: user=a password=b host=localhost port=5432 dbname=c sslmode=disable
-# mysql: go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
+# mysql: go-sql-driver/mysql dsn config string, examples:
+#         `user:password@tcp(127.0.0.1:3306)/database_name`
+#         `user:password@unix(1/var/run/mysqld/mysqld.sock)/database_name`
 # memcache: 127.0.0.1:11211
 
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -113,8 +113,13 @@ func getEngine() (*xorm.Engine, error) {
 	cnnstr := ""
 	switch DbCfg.Type {
 	case "mysql":
-		cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8",
-			DbCfg.User, DbCfg.Pwd, DbCfg.Host, DbCfg.Name)
+		protocol := "tcp"
+		if strings.HasPrefix(DbCfg.Host, "/") {
+			protocol = "unix"
+		}
+
+		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?charset=utf8",
+			DbCfg.User, DbCfg.Pwd, protocol, DbCfg.Host, DbCfg.Name)
 	case "postgres":
 		var host, port = "127.0.0.1", "5432"
 		fields := strings.Split(DbCfg.Host, ":")


### PR DESCRIPTION
Fixes #2818. For mysql, sqlstore now assumes a unix socket if the host value begins with /.  This was the easiest way to support the feature and mirrors behavior in graphite/django (https://docs.djangoproject.com/en/dev/ref/settings/#host).
