### PR TITLE
feat(graph): adds fixed height option for legend

### DIFF
--- a/public/app/plugins/panels/graph/axisEditor.html
+++ b/public/app/plugins/panels/graph/axisEditor.html
@@ -181,10 +181,21 @@
 				<li class="tight-form-item">
 					<editor-checkbox text="Right side" model="panel.legend.rightSide" change="render()"></editor-checkbox>
 				</li>
-				<li ng-if="panel.legend.rightSide" class="tight-form-item">
-					Side width
+			</ul>
+			<div class="clearfix"></div>
+		</div>
+		<div class="tight-form" ng-if="panel.legend.rightSide">
+			<ul class="tight-form-list">
+				<li class="tight-form-item" style="width: 80px">
+					<i class="fa fa-remove invisible"></i>
 				</li>
-				<li ng-if="panel.legend.rightSide" style="width: 105px">
+				<li class="tight-form-item">
+					<editor-checkbox text="Fixed legend height" model="panel.legend.fixedLegendHeight" change="get_data()"></editor-checkbox>
+				</li>
+				<li  class="tight-form-item">
+					Legend side width
+				</li>
+				<li  style="width: 105px">
 					<input type="number" class="input-small tight-form-input" placeholder="250" bs-tooltip="'Set a min-width for the legend side table/block'" data-placement="right"
 					ng-model="panel.legend.sideWidth" ng-change="render()" ng-model-onblur>
 				</li>

--- a/public/app/plugins/panels/graph/graph.js
+++ b/public/app/plugins/panels/graph/graph.js
@@ -86,7 +86,6 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             graphHeight -= scope.panel.title ? 24 : 9; // subtract panel title bar
 
             graphHeight = graphHeight - getLegendHeight(graphHeight); // subtract one line legend
-
             elem.css('height', graphHeight + 'px');
 
             return true;

--- a/public/app/plugins/panels/graph/legend.js
+++ b/public/app/plugins/panels/graph/legend.js
@@ -89,6 +89,15 @@ function (angular, _, $) {
         }
 
         function render() {
+          if (panel.legend.rightSide && scope.panel.legend.fixedLegendHeight) {
+            var panelheight = scope.height || scope.panel.height || scope.row.height;
+            $container.css("height", panelheight);
+            $container.toggleClass('graph-legend-fixed-height', true);
+          } else {
+            $container.toggleClass('graph-legend-fixed-height', false);
+            $container.css("height", "");
+          }
+
           if (firstRender) {
             elem.append($container);
             $container.on('click', '.graph-legend-icon', openColorSelector);

--- a/public/less/panel_graph.less
+++ b/public/less/panel_graph.less
@@ -60,7 +60,6 @@
 }
 
 .graph-legend-table {
-  display: table;
   width: 100%;
   margin: 0;
 
@@ -182,6 +181,10 @@
   .editor-row {
     padding: 5px;
   }
+}
+
+.graph-legend-fixed-height {
+  overflow-y: scroll;
 }
 
 .annotation-tags {


### PR DESCRIPTION
Makes it possible to limit the height of the right side legend to the size of the panel.
This gives the user more control of the panel layout.

closes #1277 
