### PR TITLE
Docs: add example with filter in ES template

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -77,6 +77,11 @@ The Elasticsearch datasource supports two types of queries you can use to fill t
 {"find": "fields", "type": "string"}
 ```
 
+### Fields filtered by type, with filter
+```json
+{"find": "fields", "type": "string", "query": <lucene query>}
+```
+
 ### Multi format / All format
 Use lucene format.
 


### PR DESCRIPTION
I wanted to use the result of a first variable selection to filter the set of values for the second dropdown - my initial impression from the docs was that this wasn't possible, but after digging into the sources I found it was entirely straightforward. Hopefully this small doc change will make the feature more accessible to others who need it. 
