### PR TITLE
Fix elasticsearch hourly indexes

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/index_pattern.js
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.js
@@ -11,7 +11,7 @@ function (_, moment) {
   }
 
   IndexPattern.intervalMap = {
-    "Hours":   { startOf: 'hour',     amount: 'hours'},
+    "Hourly":   { startOf: 'hour',     amount: 'hours'},
     "Daily":   { startOf: 'day',      amount: 'days'},
     "Weekly":  { startOf: 'isoWeek',  amount: 'weeks'},
     "Monthly": { startOf: 'month',    amount: 'months'},


### PR DESCRIPTION
Graphing elasticsearch hourly indexes is currently broken. When configuring the Data Source, the select option is "Hourly". So when Grafana determine which indexes to use, it fails because the index pattern is for "Hours", not "Hourly".

Stack trace is

```
TypeError: Cannot read property 'startOf' of undefined
    at c.getIndexList (:3000/public/app/plugins/datasource/elasticsearch/index_pattern.js?bust=1452208439354:4)
    at k.getQueryHeader (:3000/public/app/plugins/datasource/elasticsearch/datasource.js?bust=1452208439354:4)
    at k.query (:3000/public/app/plugins/datasource/elasticsearch/datasource.js?bust=1452208439354:4)
    at issueMetricQuery (app.b4b243aa.js:34)
    at n.a.refreshData (app.b4b243aa.js:44)
    at app.b4b243aa.js:34
    at i (app.b4b243aa.js:13)
    at app.b4b243aa.js:13
    at n.$eval (app.b4b243aa.js:13)
    at n.$digest (app.b4b243aa.js:13)
```
