### PR TITLE
Add missing peer dependency: phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-phantomjs-launcher": "0.2.1",
     "load-grunt-tasks": "3.4.0",
     "mocha": "2.3.4",
+    "phantomjs": "^1.9.19",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "systemjs": "0.19.6",


### PR DESCRIPTION
phantomjs is a needed devdependency but with recent npm peer dependencies are not automagically installed
