### PR TITLE
Update render.js to render from a bounded box around the div containi…

### DIFF
--- a/vendor/phantomjs/render.js
+++ b/vendor/phantomjs/render.js
@@ -41,6 +41,15 @@ page.open(params.url, function (status) {
     });
 
     if (canvas || tries === 1000) {
+      var bb = page.evaluate(function () { 
+         return document.getElementsByClassName("sidemenu-canvas")[0].getBoundingClientRect(); 
+      });
+      page.clipRect = {
+         top:    bb.top,
+         left:   bb.left,
+         width:  bb.width,
+         height: bb.height
+      };
       page.render(params.png);
       phantom.exit();
     }


### PR DESCRIPTION
…ng the graph to prevent clipping

The original code chopped the bottom off the graph if the graph legend was over two lines.
Rendering just the contents of the div tag ensures that the full graph is rendered, not just whats available in the viewport window.
We render the div tag by locating the bounded box around the div containing the graph, and using a clipRect() to limit the render to just the div.
