### PR TITLE
Align step with interval passed to Prometheus query using rate()

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -53,7 +53,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       var query: any = {};
       query.expr = templateSrv.replace(target.expr, options.scopedVars);
 
-      var interval = target.interval || options.interval;
+      var interval = templateSrv.replace(target.interval, options.scopedVars) || options.interval;
       var intervalFactor = target.intervalFactor || 1;
       target.step = query.step = this.calculateInterval(interval, intervalFactor);
       var range = Math.ceil(end - start);

--- a/public/app/plugins/datasource/prometheus/query_ctrl.ts
+++ b/public/app/plugins/datasource/prometheus/query_ctrl.ts
@@ -63,7 +63,7 @@ class PrometheusQueryCtrl extends QueryCtrl {
       expr: this.templateSrv.replace(this.target.expr, this.panelCtrl.panel.scopedVars),
       range_input: rangeDiff + 's',
       end_input: endTime,
-      step_input: '',
+      step_input: this.target.step,
       stacked: this.panelCtrl.panel.stack,
       tab: 0
     };


### PR DESCRIPTION
Prometheus rate() function requires an interval. The way to pass a custom interval is using templated variable because hardcoding it to 5m is not correct for different step/resolution when trying to get the good zoomable dashboards.

However, there is no way to control Step rather than hardcode it in the Query Editor form for the graph. Say if I choose $interval as 5m or 1h, the Step is calculated automatically based on the period chosen. This is not correct. The step should be aligned with the interval passed despite what and how long period is chosen. Say if I choose "Last 12 hours", "Last 1 hour" periods, Grafana calculates the step automatically and it can't be passed as a variable to the query.

To align Step with the interval for rate() function, we can also use the same templated variable $interval. To achieve this, we need to support variables in the Step field (1st line change in the commit). So I can set `Step: $interval` and `Resolution: 1/1` and this will give me the exact true step of the value of $interval chosen being passed to both the query itself `rate(...)[$interval]` and Prometheus API request in the `step` param.

Also passing step to Prometheus via the link (2nd line change).
