### PR TITLE
Adding custom "All format" templating.

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -163,7 +163,7 @@
                   All format
                 </li>
                 <li ng-show="current.includeAll">
-                  <select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe']"></select>
+                  <select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe', 'custom']"></select>
                 </li>
               </ul>
               <div class="clearfix"></div>
@@ -208,7 +208,7 @@
 									All format
 								</li>
 								<li ng-show="current.includeAll">
-									<select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe']"></select>
+									<select class="input-medium tight-form-input last" ng-model="current.allFormat" ng-change="runQuery()" ng-options="f for f in ['glob', 'wildcard', 'regex wildcard', 'regex values', 'lucene', 'pipe', 'custom']"></select>
 								</li>
 							</ul>
 							<div class="clearfix"></div>

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -180,9 +180,13 @@ function (angular, _, kbn) {
 
     this.updateOptionsFromMetricFindQuery = function(variable, datasource) {
       return datasource.metricFindQuery(variable.query).then(function (results) {
+        var currentAllValue = '';
+        if (variable.options) {
+          currentAllValue = variable.options[0].value;
+        }
         variable.options = self.metricNamesToVariableValues(variable, results);
         if (variable.includeAll) {
-          self.addAllOption(variable);
+          self.addAllOption(variable, currentAllValue);
         }
         if (!variable.options.length) {
           variable.options.push(getNoneOption());
@@ -244,9 +248,13 @@ function (angular, _, kbn) {
       return value.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&');
     };
 
-    this.addAllOption = function(variable) {
+    this.addAllOption = function(variable, currentAllValue) {
       var allValue = '';
       switch(variable.allFormat) {
+        case 'custom': {
+          allValue = currentAllValue;
+          break;
+        }
         case 'wildcard': {
           allValue = '*';
           break;

--- a/public/test/specs/templateValuesSrv-specs.js
+++ b/public/test/specs/templateValuesSrv-specs.js
@@ -360,6 +360,24 @@ define([
       });
     });
 
+    describeUpdateVariable('with include all and custom value', function(scenario) {
+      scenario.setup(function() {
+        scenario.variable = {
+          type: 'query',
+          query: 'apps.*',
+          name: 'test',
+          includeAll: true,
+          allFormat: 'custom',
+          options: [{text: "All", value: "frontend-.*"}]
+        };
+        scenario.queryResult = [{text: 'frontend-01'}, {text: 'frontend-02'}, { text: 'backend-01'}];
+      });
+
+      it('should add the all value untouched', function() {
+        expect(scenario.variable.options[0].value).to.be('frontend-.*');
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This change allows users to input a custom "All value" for their queries.

![image](https://cloud.githubusercontent.com/assets/1591461/12375234/b3726a2a-bc97-11e5-80b5-6b2787934ed0.png)

This PR fixes #2713. As stated in the mentioned issue, having this gives the user greater flexibility when defining variables.

This works by adding a new "all format" option that takes the value in the "all value" text field and uses that as "all value".
