### PR TITLE
ApiPlugin custom header support

### DIFF
--- a/pkg/models/app_settings.go
+++ b/pkg/models/app_settings.go
@@ -1,6 +1,13 @@
 package models
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrAppSettingNotFound = errors.New("AppSetting not found")
+)
 
 type AppSettings struct {
 	Id       int64
@@ -32,4 +39,10 @@ type UpdateAppSettingsCmd struct {
 type GetAppSettingsQuery struct {
 	OrgId  int64
 	Result []*AppSettings
+}
+
+type GetAppSettingByAppIdQuery struct {
+	AppId  string
+	OrgId  int64
+	Result *AppSettings
 }

--- a/pkg/plugins/api_plugin.go
+++ b/pkg/plugins/api_plugin.go
@@ -31,6 +31,8 @@ func (app *ApiPlugin) Load(decoder *json.Decoder, pluginDir string) error {
 		return err
 	}
 
+	app.PluginDir = pluginDir
+
 	ApiPlugins[app.Id] = app
 	return nil
 }

--- a/pkg/plugins/api_plugin.go
+++ b/pkg/plugins/api_plugin.go
@@ -7,17 +7,23 @@ import (
 )
 
 type ApiPluginRoute struct {
-	Path            string          `json:"path"`
-	Method          string          `json:"method"`
-	ReqSignedIn     bool            `json:"reqSignedIn"`
-	ReqGrafanaAdmin bool            `json:"reqGrafanaAdmin"`
-	ReqRole         models.RoleType `json:"reqRole"`
-	Url             string          `json:"url"`
+	Path            string            `json:"path"`
+	Method          string            `json:"method"`
+	ReqSignedIn     bool              `json:"reqSignedIn"`
+	ReqGrafanaAdmin bool              `json:"reqGrafanaAdmin"`
+	ReqRole         models.RoleType   `json:"reqRole"`
+	Url             string            `json:"url"`
+	Headers         []ApiPluginHeader `json:"headers"`
 }
 
 type ApiPlugin struct {
 	PluginBase
 	Routes []*ApiPluginRoute `json:"routes"`
+}
+
+type ApiPluginHeader struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
 }
 
 func (app *ApiPlugin) Load(decoder *json.Decoder, pluginDir string) error {

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -59,6 +59,18 @@ func (app *AppPlugin) Load(decoder *json.Decoder, pluginDir string) error {
 		}
 	}
 
+	// check if we have child apiPlugins
+	for _, plugin := range ApiPlugins {
+		if strings.HasPrefix(plugin.PluginDir, app.PluginDir) {
+			plugin.IncludedInAppId = app.Id
+			app.Includes = append(app.Includes, AppIncludeInfo{
+				Name: plugin.Name,
+				Id:   plugin.Id,
+				Type: plugin.Type,
+			})
+		}
+	}
+
 	Apps[app.Id] = app
 	return nil
 }

--- a/pkg/services/sqlstore/app_settings.go
+++ b/pkg/services/sqlstore/app_settings.go
@@ -9,6 +9,7 @@ import (
 
 func init() {
 	bus.AddHandler("sql", GetAppSettings)
+	bus.AddHandler("sql", GetAppSettingByAppId)
 	bus.AddHandler("sql", UpdateAppSettings)
 }
 
@@ -17,6 +18,18 @@ func GetAppSettings(query *m.GetAppSettingsQuery) error {
 
 	query.Result = make([]*m.AppSettings, 0)
 	return sess.Find(&query.Result)
+}
+
+func GetAppSettingByAppId(query *m.GetAppSettingByAppIdQuery) error {
+	appSetting := m.AppSettings{OrgId: query.OrgId, AppId: query.AppId}
+	has, err := x.Get(&appSetting)
+	if err != nil {
+		return err
+	} else if has == false {
+		return m.ErrAppSettingNotFound
+	}
+	query.Result = &appSetting
+	return nil
 }
 
 func UpdateAppSettings(cmd *m.UpdateAppSettingsCmd) error {


### PR DESCRIPTION
This PR adds support for setting custom HTTP headers of proxied requests.

Each ApiPluginRoute can have 0 or more ApiPluginHeaders.  A header is comprised of a "Name" and "Content".  The name is static text, but the content is handled as a text/template document.   The only data passed to the template is the appSettings.JsonData of the associated IncludedInApp.  If the apiPlugin is not part of an appPlugin bundle then an empty map[string]interface is used.

This approach is used for the litmus-plugin, where the header is set to

```
{ "name": "Authorization", "content": "Bearer {{.apiKey}}"}
```

thus, when the litmus App saves the apiKey, requests can be made to the SaaS service.
