### PR TITLE
Send OpenTSDB POST request as urlencoded

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -72,6 +72,9 @@ function (angular, _, dateMath) {
         data: reqBody
       };
 
+      // In case the backend is 3rd-party hosted and does not suport OPTIONS, urlencoded requests
+      // go as POST rather than OPTIONS+POST
+      options.headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
       return backendSrv.datasourceRequest(options);
     };
 


### PR DESCRIPTION
More details here: https://github.com/grafana/grafana/issues/3748

But basically, it happens that OpenTSDB can be hosted behind SSO (OpenTSDB is usually used by mid/big companies so there are lot of teams involved) and it is very frequent that SSO wont support OPTIONS so if you are using credentials and SSO, sending the request as OPTIONS will make the request fail.

This is to change the request to urlencoded which curiously is already happening on other datasources (like influxdb since it uses credentials).
