### PR TITLE
Serialize an elasticsearch error previously printed as 'Object'

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -146,7 +146,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         return { status: "success", message: "Data source is working", title: "Success" };
       }, function(err) {
         if (err.data && err.data.error) {
-          return { status: "error", message: err.data.error, title: "Error" };
+          return { status: "error", message: angular.toJson(err.data.error), title: "Error" };
         } else {
           return { status: "error", message: err.status, title: "Error" };
         }


### PR DESCRIPTION
The err.data.error being an object, the error printed was : [object Object]

We now serialize the object to at least display its content. The result is then the json sent back by elasticsearch.

For instance it can be: 

```
{"root_cause":[{"type":"index_not_found_exception","reason":"no such index","index":"test-metricsd","resource.type":"index_or_alias","resource.id":"test-metricsd"}],"type":"index_not_found_exception","reason":"no such index","index":"test-metricsd","resource.type":"index_or_alias","resource.id":"test-metricsd"}
```

when trying to do requests to a non-existing index.

Edit: oops, I misspelled elasticsearch in the branch name.
