### PR TITLE
Fixed broken tags search

### DIFF
--- a/public/app/core/components/search/search.html
+++ b/public/app/core/components/search/search.html
@@ -16,7 +16,7 @@
 			<span ng-if="ctrl.query.tag.length">
 				|
 				<span ng-repeat="tagName in ctrl.query.tag">
-					<a ng-click="ctrl.removeTag(tagName, $event)" tag-color-from-name="ctrl.tagName" class="label label-tag">
+					<a ng-click="ctrl.removeTag(tagName, $event)" tag-color-from-name="tagName" class="label label-tag">
 						<i class="fa fa-remove"></i>
 						{{tagName}}
 					</a>
@@ -28,7 +28,7 @@
 	<div class="search-results-container" ng-if="ctrl.tagsMode">
 		<div class="row">
 			<div class="span6 offset1">
-				<div ng-repeat="tag in results" class="pointer" style="width: 180px; float: left;"
+				<div ng-repeat="tag in ctrl.results" class="pointer" style="width: 180px; float: left;"
 					ng-class="{'selected': $index === selectedIndex }"
 					ng-click="ctrl.filterByTag(tag.term, $event)">
 					<a class="search-result-tag label label-tag" tag-color-from-name="tag.term">

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -108,9 +108,12 @@ export class SearchCtrl {
 
   getTags() {
     return this.backendSrv.get('/api/dashboards/tags').then((results) => {
-      this.tagsMode = true;
+      this.tagsMode = !this.tagsMode;
       this.results = results;
       this.giveSearchFocus = this.giveSearchFocus + 1;
+      if ( !this.tagsMode ) {
+        this.search();
+      }
     });
   };
 


### PR DESCRIPTION
@torkelo / @bergquist 

Following things are broken in Grafana master:
1. Tags search [ Clicking on "tags" in dashboard search ]
2. Coloring of selected tags

Following thing is broken in Grafana 2.6:
1. Remove Tags search

All the three bugs are fixed in PR. Please review/merge. Thanks.
