### PR TITLE
fix(graph): narrow panels shows correct date format on x-axis

### DIFF
--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -296,7 +296,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             max: max,
             label: "Datetime",
             ticks: ticks,
-            timeformat: time_format(scope.interval, ticks, min, max),
+            timeformat: time_format(ticks, min, max),
           };
         }
 
@@ -436,20 +436,23 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           };
         }
 
-        function time_format(interval, ticks, min, max) {
+        function time_format(ticks, min, max) {
           if (min && max && ticks) {
-            var secPerTick = ((max - min) / ticks) / 1000;
+            var range = max - min;
+            var secPerTick = (range/ticks) / 1000;
+            var oneDay = 86400000;
+            var oneYear = 31536000000;
 
             if (secPerTick <= 45) {
               return "%H:%M:%S";
             }
-            if (secPerTick <= 7200) {
+            if (secPerTick <= 7200 || range <= oneDay) {
               return "%H:%M";
             }
             if (secPerTick <= 80000) {
               return "%m/%d %H:%M";
             }
-            if (secPerTick <= 2419200) {
+            if (secPerTick <= 2419200 || range <= oneYear) {
               return "%m/%d";
             }
             return "%Y-%m";


### PR DESCRIPTION
fixes #3852. The function that calculates the date format for the x-axis on a panel takes the panel width into account and can be wrong for certain date ranges if the panel is too narrow. E.g. can show dates in format m/d H:M when it should show it as H:M
