### PR TITLE
Triggers grafana packer CircleCI build after successful build of master branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,3 +27,10 @@ test:
      # js tests
      - ./node_modules/grunt-cli/bin/grunt test
      - npm run coveralls
+
+deployment:
+  master:
+    branch: master
+    owner: grafana
+    commands: 
+      - ./trigger_grafana_packer.sh ${TRIGGER_GRAFANA_PACKER_CIRCLECI_TOKEN}

--- a/trigger_grafana_packer.sh
+++ b/trigger_grafana_packer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+_circle_token=$1
+
+trigger_build_url=https://circleci.com/api/v1/project/grafana/grafana-packer/tree/master?circle-token=${_circle_token}
+
+curl \
+--header "Accept: application/json" \
+--header "Content-Type: application/json" \
+--request POST ${trigger_build_url}


### PR DESCRIPTION
Only triggers for main grafana repo (not forks) and when the master branch is built. That means if the circleci yml file is correct it should not trigger the grafana packer circleci build when this PR is created.
