### PR TITLE
Added metadata fields under Settings tab

### DIFF
--- a/docs/sources/reference/http_api.md
+++ b/docs/sources/reference/http_api.md
@@ -70,13 +70,15 @@ Creates a new dashboard or updates an existing dashboard.
         "schemaVersion": 6,
         "version": 0
       },
-      "overwrite": false
+      "overwrite": false,
+      "userId:": 3
     }
 
 JSON Body schema:
 
-- **dashboard** – The complete dashboard model, id = null to create a new dashboard
+- **dashboard** – The complete dashboard model, id = null to create a new dashboard.
 - **overwrite** – Set to true if you want to overwrite existing dashboard with newer version or with same dashboard title.
+- **userId** - Set userId if you want to record who created or updated a dashboard.
 
 **Example Response**:
 

--- a/docs/sources/reference/http_api.md
+++ b/docs/sources/reference/http_api.md
@@ -70,15 +70,13 @@ Creates a new dashboard or updates an existing dashboard.
         "schemaVersion": 6,
         "version": 0
       },
-      "overwrite": false,
-      "userId:": 3
+      "overwrite": false
     }
 
 JSON Body schema:
 
 - **dashboard** – The complete dashboard model, id = null to create a new dashboard.
 - **overwrite** – Set to true if you want to overwrite existing dashboard with newer version or with same dashboard title.
-- **userId** - Set userId if you want to record who created or updated a dashboard.
 
 **Example Response**:
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -52,11 +52,11 @@ func GetDashboard(c *middleware.Context) {
 	// Finding the last creator and updater of the dashboard
 	updater, creator := "Anonymous", "Anonymous"
 	if dash.UpdatedBy > 0 {
-	  updater = getUserLogin(dash.UpdatedBy)
-  }
-  if dash.CreatedBy > 0 {
-    creator = getUserLogin(dash.CreatedBy)
-  }
+		updater = getUserLogin(dash.UpdatedBy)
+	}
+	if dash.CreatedBy > 0 {
+		creator = getUserLogin(dash.CreatedBy)
+	}
 
 	dto := dtos.DashboardFullWithMeta{
 		Dashboard: dash.Data,
@@ -70,7 +70,7 @@ func GetDashboard(c *middleware.Context) {
 			Created:   dash.Created,
 			Updated:   dash.Updated,
 			UpdatedBy: updater,
-      CreatedBy: creator,
+			CreatedBy: creator,
 		},
 	}
 
@@ -78,14 +78,14 @@ func GetDashboard(c *middleware.Context) {
 }
 
 func getUserLogin(userId int64) string {
-  query := m.GetUserByIdQuery{Id: userId}
-  err := bus.Dispatch(&query)
-    if err != nil {
-      return "Anonymous"
-    } else {
-      user := query.Result
-      return user.Login
-    }
+	query := m.GetUserByIdQuery{Id: userId}
+	err := bus.Dispatch(&query)
+	if err != nil {
+		return "Anonymous"
+	} else {
+		user := query.Result
+		return user.Login
+	}
 }
 
 func DeleteDashboard(c *middleware.Context) {
@@ -114,8 +114,8 @@ func PostDashboard(c *middleware.Context, cmd m.SaveDashboardCommand) {
 	if !c.IsSignedIn {
 		cmd.UserId = -1
 	} else {
-    cmd.UserId = c.UserId
-  }
+		cmd.UserId = c.UserId
+	}
 
 	dash := cmd.GetDashboardModel()
 	if dash.Id == 0 {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -42,7 +42,7 @@ type DashboardMeta struct {
 	Created    time.Time `json:"created"`
 	Updated    time.Time `json:"updated"`
 	UpdatedBy  string    `json:"updatedBy"`
-  CreatedBy  string    `json:"createdBy"`
+	CreatedBy  string    `json:"createdBy"`
 }
 
 type DashboardFullWithMeta struct {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -30,19 +30,23 @@ type CurrentUser struct {
 }
 
 type DashboardMeta struct {
-	IsStarred  bool      `json:"isStarred,omitempty"`
-	IsHome     bool      `json:"isHome,omitempty"`
-	IsSnapshot bool      `json:"isSnapshot,omitempty"`
-	Type       string    `json:"type,omitempty"`
-	CanSave    bool      `json:"canSave"`
-	CanEdit    bool      `json:"canEdit"`
-	CanStar    bool      `json:"canStar"`
-	Slug       string    `json:"slug"`
-	Expires    time.Time `json:"expires"`
-	Created    time.Time `json:"created"`
-	Updated    time.Time `json:"updated"`
-	UpdatedBy  string    `json:"updatedBy"`
-	CreatedBy  string    `json:"createdBy"`
+	IsStarred    bool      `json:"isStarred,omitempty"`
+	IsHome       bool      `json:"isHome,omitempty"`
+	IsSnapshot   bool      `json:"isSnapshot,omitempty"`
+	Type         string    `json:"type,omitempty"`
+	CanSave      bool      `json:"canSave"`
+	CanEdit      bool      `json:"canEdit"`
+	CanStar      bool      `json:"canStar"`
+	Slug         string    `json:"slug"`
+	Expires      time.Time `json:"expires"`
+	Created      time.Time `json:"created"`
+	Updated      time.Time `json:"updated"`
+	UpdatedBy    string    `json:"updatedBy"`
+	CreatedBy    string    `json:"createdBy"`
+  TotalRows    int64     `json:"totalRows"`
+  TotalPanels  int64     `json:"totalPanels"`
+  TotalQueries int64     `json:"totalQueries"`
+  Version      int       `json:"version"`
 }
 
 type DashboardFullWithMeta struct {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -43,10 +43,10 @@ type DashboardMeta struct {
 	Updated      time.Time `json:"updated"`
 	UpdatedBy    string    `json:"updatedBy"`
 	CreatedBy    string    `json:"createdBy"`
-  TotalRows    int64     `json:"totalRows"`
-  TotalPanels  int64     `json:"totalPanels"`
-  TotalQueries int64     `json:"totalQueries"`
-  Version      int       `json:"version"`
+	TotalRows    int       `json:"totalRows"`
+	TotalPanels  int       `json:"totalPanels"`
+	TotalQueries int       `json:"totalQueries"`
+	Version      int       `json:"version"`
 }
 
 type DashboardFullWithMeta struct {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -42,6 +42,7 @@ type DashboardMeta struct {
 	Created    time.Time `json:"created"`
 	Updated    time.Time `json:"updated"`
 	UpdatedBy  string    `json:"updatedBy"`
+  CreatedBy  string    `json:"createdBy"`
 }
 
 type DashboardFullWithMeta struct {

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -34,7 +34,7 @@ type Dashboard struct {
 	Updated time.Time
 
 	UpdatedBy int64
-  CreatedBy int64
+	CreatedBy int64
 
 	Title string
 	Data  map[string]interface{}
@@ -67,7 +67,7 @@ func (dash *Dashboard) GetTags() []string {
 	return b
 }
 
-func NewDashboardFromJson(data map[string]interface {}) *Dashboard {
+func NewDashboardFromJson(data map[string]interface{}) *Dashboard {
 	dash := &Dashboard{}
 	dash.Data = data
 	dash.Title = dash.Data["title"].(string)
@@ -93,10 +93,10 @@ func NewDashboardFromJson(data map[string]interface {}) *Dashboard {
 func (cmd *SaveDashboardCommand) GetDashboardModel() *Dashboard {
 	dash := NewDashboardFromJson(cmd.Dashboard)
 	if dash.Data["version"] == 0 {
-    dash.CreatedBy = cmd.UserId
-  }
-  dash.UpdatedBy = cmd.UserId
-  dash.OrgId = cmd.OrgId
+		dash.CreatedBy = cmd.UserId
+	}
+	dash.UpdatedBy = cmd.UserId
+	dash.OrgId = cmd.OrgId
 	dash.UpdateSlug()
 	return dash
 }
@@ -118,9 +118,9 @@ func (dash *Dashboard) UpdateSlug() {
 
 type SaveDashboardCommand struct {
 	Dashboard map[string]interface{} `json:"dashboard" binding:"Required"`
-  UserId    int64                  `json:"userId"`
+	UserId    int64                  `json:"userId"`
 	OrgId     int64                  `json:"-"`
-  Overwrite bool                   `json:"overwrite"`
+	Overwrite bool                   `json:"overwrite"`
 
 	Result *Dashboard
 }

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -34,6 +34,7 @@ type Dashboard struct {
 	Updated time.Time
 
 	UpdatedBy int64
+  CreatedBy int64
 
 	Title string
 	Data  map[string]interface{}
@@ -66,7 +67,7 @@ func (dash *Dashboard) GetTags() []string {
 	return b
 }
 
-func NewDashboardFromJson(data map[string]interface{}) *Dashboard {
+func NewDashboardFromJson(data map[string]interface {}) *Dashboard {
 	dash := &Dashboard{}
 	dash.Data = data
 	dash.Title = dash.Data["title"].(string)
@@ -91,8 +92,11 @@ func NewDashboardFromJson(data map[string]interface{}) *Dashboard {
 // GetDashboardModel turns the command into the savable model
 func (cmd *SaveDashboardCommand) GetDashboardModel() *Dashboard {
 	dash := NewDashboardFromJson(cmd.Dashboard)
-	dash.OrgId = cmd.OrgId
-	dash.UpdatedBy = cmd.UpdatedBy
+	if dash.Data["version"] == 0 {
+    dash.CreatedBy = cmd.UserId
+  }
+  dash.UpdatedBy = cmd.UserId
+  dash.OrgId = cmd.OrgId
 	dash.UpdateSlug()
 	return dash
 }
@@ -114,9 +118,9 @@ func (dash *Dashboard) UpdateSlug() {
 
 type SaveDashboardCommand struct {
 	Dashboard map[string]interface{} `json:"dashboard" binding:"Required"`
-	Overwrite bool                   `json:"overwrite"`
+  UserId    int64                  `json:"userId"`
 	OrgId     int64                  `json:"-"`
-	UpdatedBy int64                  `json:"-"`
+  Overwrite bool                   `json:"overwrite"`
 
 	Result *Dashboard
 }

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -98,8 +98,8 @@ func addDashboardMigration(mg *Migrator) {
 		Name: "updated_by", Type: DB_Int, Nullable: true,
 	}))
 
-  // add column to store creator of a dashboard
-  mg.AddMigration("Add column created_by in dashboard - v2", NewAddColumnMigration(dashboardV2, &Column{
-    Name: "created_by", Type: DB_Int, Nullable: true,
-  }))
+	// add column to store creator of a dashboard
+	mg.AddMigration("Add column created_by in dashboard - v2", NewAddColumnMigration(dashboardV2, &Column{
+		Name: "created_by", Type: DB_Int, Nullable: true,
+	}))
 }

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -97,4 +97,9 @@ func addDashboardMigration(mg *Migrator) {
 	mg.AddMigration("Add column updated_by in dashboard - v2", NewAddColumnMigration(dashboardV2, &Column{
 		Name: "updated_by", Type: DB_Int, Nullable: true,
 	}))
+
+  // add column to store creator of a dashboard
+  mg.AddMigration("Add column created_by in dashboard - v2", NewAddColumnMigration(dashboardV2, &Column{
+    Name: "created_by", Type: DB_Int, Nullable: true,
+  }))
 }

--- a/public/app/features/dashboard/partials/settings.html
+++ b/public/app/features/dashboard/partials/settings.html
@@ -151,6 +151,17 @@
           </ul>
           <div class="clearfix"></div>
         </div>
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Created by:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{dashboardMeta.createdBy}}
+           </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div>
       </div>
     </div>
   </div>

--- a/public/app/features/dashboard/partials/settings.html
+++ b/public/app/features/dashboard/partials/settings.html
@@ -115,9 +115,9 @@
 	</div>
 
   <div ng-if="editor.index == 4">
-    <div class="editor-row">
-      <div class="tight-form-section">
-        <h5>Dashboard info</h5>
+    <div class="row">
+      <h5>Dashboard info</h5>
+      <div class="pull-left tight-form">
         <div class="tight-form">
           <ul class="tight-form-list">
             <li class="tight-form-item" style="width: 120px">
@@ -132,21 +132,21 @@
         <div class="tight-form">
           <ul class="tight-form-list">
             <li class="tight-form-item" style="width: 120px">
-              Created at:
-            </li>
-            <li class="tight-form-item" style="width: 180px">
-              {{formatDate(dashboardMeta.created)}}
-           </li>
-          </ul>
-          <div class="clearfix"></div>
-        </div>
-        <div class="tight-form last">
-          <ul class="tight-form-list">
-            <li class="tight-form-item" style="width: 120px">
               Last updated by:
             </li>
             <li class="tight-form-item" style="width: 180px">
               {{dashboardMeta.updatedBy}}
+            </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div> 
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Created at:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{formatDate(dashboardMeta.created)}}
             </li>
           </ul>
           <div class="clearfix"></div>
@@ -158,7 +158,53 @@
             </li>
             <li class="tight-form-item" style="width: 180px">
               {{dashboardMeta.createdBy}}
-           </li>
+            </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div>
+      </div>
+      <div class="pull-left tight-form">
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Total rows:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{dashboardMeta.totalRows}}
+            </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div>
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Total panels:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{dashboardMeta.totalPanels}}
+            </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div>
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Total queries:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{dashboardMeta.totalQueries}}
+            </li>
+          </ul>
+          <div class="clearfix"></div>
+        </div>
+        <div class="tight-form">
+          <ul class="tight-form-list">
+            <li class="tight-form-item" style="width: 120px">
+              Version:
+            </li>
+            <li class="tight-form-item" style="width: 180px">
+              {{dashboardMeta.version}}
+            </li>
           </ul>
           <div class="clearfix"></div>
         </div>


### PR DESCRIPTION
Changes in this PR:
1. Create/Update dashboard http api has userId parameter now, which is completely optional to maintain backward compatibility.
2. Under "Manage dashboard" > "Settings" > "Metadata", now "Created by:" details are displayed too.

Fixing 1 part out of 3 from #3841 
