### PR TITLE
add default value for fill policy

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -276,7 +276,7 @@ function (angular, _, dateMath) {
 
         query.downsample = interval + "-" + target.downsampleAggregator;
 
-        if (target.downsampleFillPolicy !== "none") {
+        if (target.downsampleFillPolicy && target.downsampleFillPolicy !== "none") {
           query.downsample += "-" + target.downsampleFillPolicy;
         }
       }


### PR DESCRIPTION
Avoid breaking existing dashboards by using a default fill policy (none) in OpenTSDB 2.2.
Fixes #3877 
