### PR TITLE
Allow the use of auth and credentials in opentsdb

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -73,7 +73,6 @@ function (angular, _, dateMath) {
         url: this.url + '/api/query',
         data: reqBody
       };
-      
       if (this.basicAuth || this.withCredentials) {
         options.withCredentials = true;
       }

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -13,6 +13,8 @@ function (angular, _, dateMath) {
     this.type = 'opentsdb';
     this.url = instanceSettings.url;
     this.name = instanceSettings.name;
+    this.withCredentials = instanceSettings.withCredentials;
+    this.basicAuth = instanceSettings.basicAuth;
     this.supportMetrics = true;
 
     // Called once per panel (graph)
@@ -71,6 +73,15 @@ function (angular, _, dateMath) {
         url: this.url + '/api/query',
         data: reqBody
       };
+      
+      if (this.basicAuth || this.withCredentials) {
+        options.withCredentials = true;
+      }
+      if (this.basicAuth) {
+        options.headers = {
+          "Authorization": this.basicAuth
+        };
+      }
 
       // In case the backend is 3rd-party hosted and does not suport OPTIONS, urlencoded requests
       // go as POST rather than OPTIONS+POST


### PR DESCRIPTION
I had a local hack that was adding credentials to requests but then I tried the nightly build and noted the credentials were still not getting sent even if I selected "With Credentials". It seems that opentsdb is just obviously not sending it after comparing the code with other datasources.

This PR will set withCredentials and auth (if used) to the request. 
