### PR TITLE
Add github api_url to github auth docs

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -268,6 +268,7 @@ example:
     scopes = user:email
     auth_url = https://github.com/login/oauth/authorize
     token_url = https://github.com/login/oauth/access_token
+    api_url = https://api.github.com
     allow_sign_up = false
     team_ids =
 


### PR DESCRIPTION
This adds `api_url` to the github auth configuration documentation.
