### PR TITLE
Generic SQL Datasource [WIP]

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/cloudwatch"
+	"github.com/grafana/grafana/pkg/api/sqlds"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
@@ -98,6 +99,8 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 
 	if ds.Type == m.DS_CLOUDWATCH {
 		cloudwatch.HandleRequest(c, ds)
+	} else if ds.Type == m.DS_GENERIC_SQL {
+		sqlds.HandleRequest(c, ds)
 	} else {
 		proxyPath := c.Params("*")
 		proxy := NewReverseProxy(ds, proxyPath, targetUrl)

--- a/pkg/api/sqlds/sqlds.go
+++ b/pkg/api/sqlds/sqlds.go
@@ -1,0 +1,250 @@
+// Copyright 2016 Foursquare Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlds
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/middleware"
+	m "github.com/grafana/grafana/pkg/models"
+	// "github.com/grafana/grafana/pkg/util"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-xorm/core"
+	"github.com/go-xorm/xorm"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type sqlDataRequest struct {
+	Query string `json:"query"`
+	From  int64  `json:"from"`
+	To    int64  `json:"to"`
+	Body  []byte `json:"-"`
+}
+
+func getEngine(ds *m.DataSource) (*xorm.Engine, error) {
+	dbTypeRaw, ok1 := ds.JsonData["sqlDBType"]
+	if !ok1 {
+		return nil, errors.New("Cannot deserialize sqlDBType")
+	}
+	dbType, ok2 := dbTypeRaw.(string)
+	if !ok2 {
+		return nil, errors.New("Cannot convert sqlDBType")
+	}
+
+	hostPortRaw, ok3 := ds.JsonData["sqlHost"]
+	if !ok3 {
+		return nil, errors.New("Cannot deserialize sqlHost")
+	}
+	hostPort, ok4 := hostPortRaw.(string)
+	if !ok4 {
+		return nil, errors.New("Cannot convert sqlHost")
+	}
+
+	cnnstr := ""
+	switch dbType {
+	case "mysql":
+		cnnstr = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8",
+			ds.User, ds.Password, hostPort, ds.Database)
+
+	case "postgres":
+		var host, port = "127.0.0.1", "5432"
+		fields := strings.Split(hostPort, ":")
+		if len(fields) > 0 && len(strings.TrimSpace(fields[0])) > 0 {
+			host = fields[0]
+		}
+		if len(fields) > 1 && len(strings.TrimSpace(fields[1])) > 0 {
+			port = fields[1]
+		}
+		cnnstr = fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s",
+			ds.User, ds.Password, host, port, ds.Database, "disable")
+
+	default:
+		return nil, fmt.Errorf("Unknown database type: %s", dbType)
+	}
+
+	return xorm.NewEngine(dbType, cnnstr)
+}
+
+type datapointStruct struct {
+	Timestamp time.Time
+	Value     float64
+	IsNull    bool
+}
+
+type timeseriesStruct struct {
+	Name       string
+	Datapoints []datapointStruct
+}
+
+func decodeTimestamp(rawTimestamp interface{}) (time.Time, error) {
+	if rawTimestamp == nil {
+		return time.Unix(0, 0), errors.New("Timestamp must not be NULL")
+	}
+
+	switch rawTimestamp.(type) {
+	case time.Time:
+		return rawTimestamp.(time.Time), nil
+
+	case int64:
+		return time.Unix(rawTimestamp.(int64), 0), nil
+
+	case float64:
+		return time.Unix(int64(rawTimestamp.(float64)), 0), nil
+
+	default:
+		return time.Unix(0, 0), fmt.Errorf("Invalid type for timestamp: %v", reflect.TypeOf(rawTimestamp))
+	}
+}
+
+func decodeValue(rawValue interface{}) (float64, bool, error) {
+	if rawValue == nil {
+		return 0, false, nil
+	}
+
+	switch rawValue.(type) {
+	case float64:
+		return rawValue.(float64), true, nil
+
+	case int64:
+		return float64(rawValue.(int64)), true, nil
+
+	default:
+		return 0.0, false, errors.New("Invalid value format")
+	}
+
+}
+
+func query(db *core.DB, sql string, from int64, to int64) ([]timeseriesStruct, error) {
+	rawRows, err := db.Query(sql, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rawRows.Close()
+
+	columnNames, err := rawRows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(columnNames) <= 1 {
+		return nil, errors.New("The query only returned a single column.")
+	}
+
+	allTimeseries := make([]timeseriesStruct, len(columnNames)-1)
+	for i, _ := range allTimeseries {
+		allTimeseries[i].Name = columnNames[i+1]
+		allTimeseries[i].Datapoints = make([]datapointStruct, 0)
+	}
+
+	var count = 0
+	fields := make([]interface{}, len(columnNames))
+
+	for rawRows.Next() {
+		count += 1
+
+		err = rawRows.ScanSlice(&fields)
+		if err != nil {
+			return nil, err
+		}
+
+		var timestamp time.Time
+		timestamp, err = decodeTimestamp(fields[0])
+		if err != nil {
+			return nil, err
+		}
+
+		for i, _ := range allTimeseries {
+			var value float64
+			var isSet bool
+
+			value, isSet, err = decodeValue(fields[i+1])
+			if err != nil {
+				return nil, err
+			}
+
+			if isSet {
+				datapoint := datapointStruct{timestamp, value, false}
+				allTimeseries[i].Datapoints = append(allTimeseries[i].Datapoints, datapoint)
+			} else {
+				datapoint := datapointStruct{timestamp, 0.0, true}
+				allTimeseries[i].Datapoints = append(allTimeseries[i].Datapoints, datapoint)
+			}
+		}
+	}
+
+	log.Info("Found %d rows.", count)
+
+	return allTimeseries, nil
+}
+
+type convertedTimeseriesStruct struct {
+	Target     string        `json:"target"`
+	Datapoints []interface{} `json:"datapoints"`
+}
+
+func HandleRequest(c *middleware.Context, ds *m.DataSource) {
+	var req sqlDataRequest
+	req.Body, _ = ioutil.ReadAll(c.Req.Request.Body)
+	json.Unmarshal(req.Body, &req)
+
+	log.Info("SQL request: query='%v', from=%v, to=%v", req.Query, req.From, req.To)
+
+	engine, err := getEngine(ds)
+	if err != nil {
+		c.JsonApiErr(500, "Unable to open SQL connection", err)
+		return
+	}
+	defer engine.Close()
+
+	session := engine.NewSession()
+	defer session.Close()
+
+	db := session.DB()
+
+	allTimeseries, err := query(db, req.Query, req.From, req.To)
+	if err != nil {
+		c.JsonApiErr(500, fmt.Sprintf("Data error: %v", err.Error()), err)
+		return
+	}
+
+	// Convert the timeseries into the JSON form required by the Grafana frontend.
+	convertedAllTimeseries := make([]convertedTimeseriesStruct, 0)
+	for _, timeseries := range allTimeseries {
+		convertedTimeseries := convertedTimeseriesStruct{}
+		convertedTimeseries.Target = timeseries.Name
+		convertedTimeseries.Datapoints = make([]interface{}, 0)
+		for _, datapoint := range timeseries.Datapoints {
+			timestamp := datapoint.Timestamp.UnixNano() / 1000.0 / 1000.0
+			if datapoint.IsNull {
+				convertedTimeseries.Datapoints = append(convertedTimeseries.Datapoints, []interface{}{nil, timestamp})
+			} else {
+				convertedTimeseries.Datapoints = append(convertedTimeseries.Datapoints, []interface{}{datapoint.Value, timestamp})
+			}
+		}
+
+		convertedAllTimeseries = append(convertedAllTimeseries, convertedTimeseries)
+	}
+
+	c.JSON(200, convertedAllTimeseries)
+}

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -14,6 +14,7 @@ const (
 	DS_CLOUDWATCH    = "cloudwatch"
 	DS_KAIROSDB      = "kairosdb"
 	DS_PROMETHEUS    = "prometheus"
+	DS_GENERIC_SQL   = "generic_sql"
 	DS_ACCESS_DIRECT = "direct"
 	DS_ACCESS_PROXY  = "proxy"
 )
@@ -57,11 +58,12 @@ var knownDatasourcePlugins map[string]bool = map[string]bool{
 	DS_CLOUDWATCH:  true,
 	DS_PROMETHEUS:  true,
 	DS_OPENTSDB:    true,
+	DS_GENERIC_SQL: true,
 	"opennms":      true,
 	"druid":        true,
 	"dalmatinerdb": true,
 	"gnocci":       true,
-	"zabbix":       true,
+	"zabbix":       true,	
 }
 
 func IsKnownDataSourcePlugin(dsType string) bool {

--- a/public/app/plugins/datasource/generic_sql/datasource.ts
+++ b/public/app/plugins/datasource/generic_sql/datasource.ts
@@ -1,0 +1,62 @@
+///<reference path="../../../headers/common.d.ts" />
+
+// Copyright 2016 Foursquare Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import angular from 'angular';
+import _ from 'lodash';
+
+/** @ngInject */
+export function SqlDatasource(instanceSettings, $q, backendSrv) {
+  this.url = instanceSettings.url;
+
+  this._request = function(options) {
+    options.url = this.url + options.url;
+    options.method = options.method || 'GET';
+    options.inspect = { 'type': 'generic_sql' };
+
+    return backendSrv.datasourceRequest(options);
+  };
+
+  this.query = function(queryOptions) {
+    var self = this;
+
+    var targetPromises = _(queryOptions.targets)
+      .filter(function(target) { return target.target && !target.hide; })
+      .map(function(target) {
+        var requestOptions = {
+          url: '/sqldata',
+          method: 'POST',
+          data: {
+            query: target.target,
+            from: queryOptions.range.from.unix(),
+            to: queryOptions.range.to.unix(),
+          }
+        };
+
+        return self._request(requestOptions);
+      })
+      .value();
+
+    return $q.all(targetPromises).then(function(responses) {
+      var result = {
+        data: _.map(responses, function(response) {
+          return response.data;
+        })
+      };
+      result.data = _.flatten(result.data);
+      return result;
+    });
+  };
+}

--- a/public/app/plugins/datasource/generic_sql/module.ts
+++ b/public/app/plugins/datasource/generic_sql/module.ts
@@ -1,0 +1,28 @@
+///<reference path="../../../headers/common.d.ts" />
+
+// Copyright 2016 Foursquare Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {SqlDatasource} from './datasource';
+import {SqlDatasourceQueryCtrl} from './query_ctrl';
+
+class SqlDatasourceConfigCtrl {
+  static templateUrl = 'public/app/plugins/datasource/generic_sql/partials/config.html';
+}
+
+export {
+  SqlDatasource as Datasource,
+  SqlDatasourceQueryCtrl as QueryCtrl,
+  SqlDatasourceConfigCtrl as ConfigCtrl,
+};

--- a/public/app/plugins/datasource/generic_sql/partials/config.html
+++ b/public/app/plugins/datasource/generic_sql/partials/config.html
@@ -1,0 +1,53 @@
+<h2>SQL Options</h2>
+
+<div class="tight-form">
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="width: 80px">
+			DB Type
+		</li>
+		<li>
+			<select class="input-medium tight-form-input" ng-model="ctrl.current.jsonData.sqlDBType" ng-options="f for f in ['mysql', 'postgres']"></select>
+		</li>
+		<li class="tight-form-item" style="width: 80px">
+			Host
+		</li>
+		<li>
+			<input type="text" class="tight-form-input input-medium" ng-model='ctrl.current.jsonData.sqlHost' placeholder="localhost:3306">
+		</li>
+		<li class="tight-form-item" ng-if="ctrl.current.jsonData.sqlDBType === 'postgres'">
+			SSL&nbsp;
+			<input class="cr1" id="jsonData.sqlSsl" type="checkbox" ng-model="current.jsonData.sqlSsl" ng-checked="ctrl.current.jsonData.sqlSsl">
+			<label for="jsonData.sqlSsl" class="cr1"></label>
+		</li>
+	</ul>
+	<div class="clearfix"></div>
+</div>
+<div class="tight-form">
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="width: 80px">
+			Database
+		</li>
+		<li>
+			<input type="text" class="tight-form-input input-medium" ng-model='ctrl.current.database' placeholder="">
+		</li>
+	</ul>
+	<div class="clearfix"></div>
+</div>
+<div class="tight-form">
+	<ul class="tight-form-list">
+		<li class="tight-form-item" style="width: 80px">
+			User
+		</li>
+		<li>
+			<input type="text" class="tight-form-input input-medium" ng-model='ctrl.current.user' placeholder="">
+		</li>
+		<li class="tight-form-item" style="width: 80px">
+			Password
+		</li>
+		<li>
+			<input type="password" class="tight-form-input input-medium" ng-model='ctrl.current.password' placeholder="">
+		</li>
+	</ul>
+	<div class="clearfix"></div>
+</div>
+

--- a/public/app/plugins/datasource/generic_sql/partials/query.editor.html
+++ b/public/app/plugins/datasource/generic_sql/partials/query.editor.html
@@ -1,0 +1,5 @@
+<query-editor-row ctrl="ctrl">
+	<li class="tight-form-flex-wrapper">
+		<input type="text" class="tight-form-clear-input" style="width: 100%;" ng-model="ctrl.target.target" spellcheck='false'></input>
+	</li>
+</query-editor-row>

--- a/public/app/plugins/datasource/generic_sql/plugin.json
+++ b/public/app/plugins/datasource/generic_sql/plugin.json
@@ -1,0 +1,10 @@
+{
+  "type": "datasource",
+  "name": "Generic SQL",
+  "id": "generic_sql",
+
+  "module": "plugins/generic_sql/module",
+  "staticRoot": ".",
+
+  "metrics": true
+}

--- a/public/app/plugins/datasource/generic_sql/query_ctrl.ts
+++ b/public/app/plugins/datasource/generic_sql/query_ctrl.ts
@@ -1,0 +1,27 @@
+///<reference path="../../../headers/common.d.ts" />
+
+// Copyright 2016 Foursquare Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import {QueryCtrl} from 'app/plugins/sdk';
+
+export class SqlDatasourceQueryCtrl extends QueryCtrl {
+  static templateUrl = 'public/app/plugins/datasource/generic_sql/partials/query.editor.html';
+
+  /** @ngInject **/
+  constructor($scope, $injector) {
+    super($scope, $injector);
+  }
+}


### PR DESCRIPTION
This is datasource that will send arbitrary SQL queries to either PostgreSQL or
MySQL using the xorm library in the backend. It is a work in progress. I'm making the PR in order to get early comments on the approach.

SQL results use the first column for the timestamp (datetime or integer/float as
number of seconds since UTC epoch), and the remaining columns for the timeseries
value(s) associated with that timestamp.

The query has $1 and $2 replacements for the `from` and `to` times. Currently,
the number of seconds since the UTC epoch is set as the values for those
replacements.

The timeseries name is determined by the alias of the applicable column.

Limitations:
1. No connection pooling: A connection to the SQL server is opened for every request
   to the backend.
2. The datasource config should allow the specification of a SQL type to be used
   for the `from` and `to` times. E.g., datetime, integer (seconds since epoch),
   integer (milliseconds since epoch), float (seconds since epoch), and
   float (milliseconds since epoch).
3. The datasource config should allow specification of any of the integer/float
   time formats for decoding timestamp values. Currently, the datasource assumes
   seconds since UTC epoch.
4. The datasource should allow the definition of arbitrary template variables.
   This would put the SQL query into the datasource config and not into the
   metric query editor. [Some work is done here in a Generic HTTP datasource that
   I am working on, and needs to be integrated.]

This has only been tested with PostgrSQL 9.5.0.
