### PR TITLE
Fixes when panel repeat is removed by clearing the templating variables

### DIFF
--- a/public/app/features/dashboard/dynamicDashboardSrv.js
+++ b/public/app/features/dashboard/dynamicDashboardSrv.js
@@ -31,7 +31,6 @@ function (angular, _) {
       var i, j, row, panel;
       for (i = 0; i < this.dashboard.rows.length; i++) {
         row = this.dashboard.rows[i];
-
         // handle row repeats
         if (row.repeat) {
           this.repeatRow(row, i);
@@ -40,6 +39,7 @@ function (angular, _) {
         else if (row.repeatRowId && row.repeatIteration !== this.iteration) {
           this.dashboard.rows.splice(i, 1);
           i = i - 1;
+          continue;
         }
 
         // repeat panels
@@ -52,6 +52,8 @@ function (angular, _) {
           else if (panel.repeatPanelId && panel.repeatIteration !== this.iteration) {
             row.panels = _.without(row.panels, panel);
             j = j - 1;
+          } else if (!_.isEmpty(panel.scopedVars) && panel.repeatIteration !== this.iteration) {
+            panel.scopedVars = {};
           }
         }
       }
@@ -116,8 +118,9 @@ function (angular, _) {
           panel = copy.panels[i];
           panel.scopedVars = {};
           panel.scopedVars[variable.name] = option;
+          panel.repeatIteration = this.iteration;
         }
-      });
+      }, this);
     };
 
     this.getPanelClone = function(sourcePanel, row, index) {

--- a/public/test/specs/dynamicDashboardSrv-specs.js
+++ b/public/test/specs/dynamicDashboardSrv-specs.js
@@ -41,18 +41,20 @@ define([
       dash.templating.list.push({
         name: 'apps',
         current: {
-          text: 'se1, se2',
-          value: ['se1', 'se2']
+          text: 'se1, se2, se3',
+          value: ['se1', 'se2', 'se3']
         },
         options: [
           {text: 'se1', value: 'se1', selected: true},
           {text: 'se2', value: 'se2', selected: true},
+          {text: 'se3', value: 'se3', selected: true},
+          {text: 'se4', value: 'se4', selected: false}
         ]
       });
     });
 
     it('should repeat panel one time', function() {
-      expect(ctx.rows[0].panels.length).to.be(2);
+      expect(ctx.rows[0].panels.length).to.be(3);
     });
 
     it('should mark panel repeated', function() {
@@ -63,6 +65,7 @@ define([
     it('should set scopedVars on panels', function() {
       expect(ctx.rows[0].panels[0].scopedVars.apps.value).to.be('se1');
       expect(ctx.rows[0].panels[1].scopedVars.apps.value).to.be('se2');
+      expect(ctx.rows[0].panels[2].scopedVars.apps.value).to.be('se3');
     });
 
     describe('After a second iteration', function() {
@@ -83,18 +86,34 @@ define([
       });
 
       it('should have same panel count', function() {
-        expect(ctx.rows[0].panels.length).to.be(2);
+        expect(ctx.rows[0].panels.length).to.be(3);
       });
     });
 
     describe('After a second iteration and selected values reduced', function() {
       beforeEach(function() {
         ctx.dash.templating.list[0].options[1].selected = false;
+        
+        ctx.dynamicDashboardSrv.update(ctx.dash);
+      });
+
+      it('should clean up repeated panel', function() {
+        expect(ctx.rows[0].panels.length).to.be(2);
+      });
+    });
+
+    describe('After a second iteration and panel repeat is turned off', function() {
+      beforeEach(function() {
+        ctx.rows[0].panels[0].repeat = null;
         ctx.dynamicDashboardSrv.update(ctx.dash);
       });
 
       it('should clean up repeated panel', function() {
         expect(ctx.rows[0].panels.length).to.be(1);
+      });
+
+      it('should remove scoped vars from reused panel', function() {
+        expect(ctx.rows[0].panels[0].scopedVars).to.be.empty();
       });
     });
 


### PR DESCRIPTION
The original panel should clear all the templating variables and
look like it did before repeat was selected. Fixes #3831.

Also cleans up after a row repeat is removed.
