### PR TITLE
add support for screenshots in plugins.

### DIFF
--- a/pkg/plugins/frontend_plugin.go
+++ b/pkg/plugins/frontend_plugin.go
@@ -24,6 +24,9 @@ func (fp *FrontendPluginBase) initFrontendPlugin() {
 
 	fp.Info.Logos.Small = evalRelativePluginUrlPath(fp.Info.Logos.Small, fp.Id)
 	fp.Info.Logos.Large = evalRelativePluginUrlPath(fp.Info.Logos.Large, fp.Id)
+	for i := -0; i < len(fp.Info.Screenshots); i++ {
+		fp.Info.Screenshots[i].Path = evalRelativePluginUrlPath(fp.Info.Screenshots[i].Path, fp.Id)
+	}
 	fp.handleModuleDefaults()
 }
 

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -19,12 +19,13 @@ type PluginBase struct {
 }
 
 type PluginInfo struct {
-	Author      PluginInfoLink   `json:"author"`
-	Description string           `json:"description"`
-	Links       []PluginInfoLink `json:"links"`
-	Logos       PluginLogos      `json:"logos"`
-	Version     string           `json:"version"`
-	Updated     string           `json:"updated"`
+	Author      PluginInfoLink      `json:"author"`
+	Description string              `json:"description"`
+	Links       []PluginInfoLink    `json:"links"`
+	Logos       PluginLogos         `json:"logos"`
+	Screenshots []PluginScreenshots `json:"screenshots"`
+	Version     string              `json:"version"`
+	Updated     string              `json:"updated"`
 }
 
 type PluginInfoLink struct {
@@ -35,6 +36,11 @@ type PluginInfoLink struct {
 type PluginLogos struct {
 	Small string `json:"small"`
 	Large string `json:"large"`
+}
+
+type PluginScreenshots struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
 }
 
 type PluginStaticRoute struct {

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -34,6 +34,7 @@ func TestPluginScans(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(len(Apps), ShouldBeGreaterThan, 0)
 		So(Apps["app-example"].Info.Logos.Large, ShouldEqual, "public/plugins/app-example/img/logo_large.png")
+		So(Apps["app-example"].Info.Screenshots[1].Path, ShouldEqual, "public/plugins/app-example/img/screenshot2.png")
 	})
 
 }

--- a/tests/app-plugin-json/plugin.json
+++ b/tests/app-plugin-json/plugin.json
@@ -26,6 +26,10 @@
       "small": "img/logo_small.png",
       "large": "img/logo_large.png"
     },
+    "screenshots": [
+      {"name": "img1", "path": "img/screenshot1.png"},
+      {"name": "img2", "path": "img/screenshot2.png"}
+    ],
     "links": [
       {"name": "Project site", "url": "http://project.com"},
       {"name": "License & Terms", "url": "http://license.com"}


### PR DESCRIPTION
Allow plugin creators to include screenshots of their plugin
in action. Primarily for use in Grafana.net info pages.
