### PR TITLE
fix template url for prometheus annotation editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -6,7 +6,7 @@ class PrometheusConfigCtrl {
 }
 
 class PrometheusAnnotationsQueryCtrl {
-  static templateUrl = 'annotations.editor.html';
+  static templateUrl = 'partials/annotations.editor.html';
 }
 
 export {


### PR DESCRIPTION
might be broken by recent change,
https://github.com/grafana/grafana/commit/8784be9a14cb4cc46e488ac01991fec001e6773e
