### PR TITLE
Fixing snapshot templating bug

### DIFF
--- a/public/app/features/dashboard/shareSnapshotCtrl.js
+++ b/public/app/features/dashboard/shareSnapshotCtrl.js
@@ -117,7 +117,7 @@ function (angular, _) {
       // remove template queries
       _.each(dash.templating.list, function(variable) {
         variable.query = "";
-        variable.options = [];
+        variable.options = variable.current;
         variable.refresh = false;
       });
 


### PR DESCRIPTION
This fix perfectly resolves #3660 as in snapshot only the current value is shown. Also, when there is also one value in the dropdown menu, it won't open up for selection. 
