### PR TITLE
Added exporting graph data to CSV with series.alias as columns.

### DIFF
--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -14,6 +14,41 @@ export function exportSeriesListToCsv(seriesList) {
     saveSaveBlob(text, 'grafana_data_export.csv');
 };
 
+export function exportSeriesListToCsvColumns(seriesList) {
+    var text = 'Time;';
+    // add header
+    _.each(seriesList, function(series) {
+        text += series.alias + ';';
+    });
+    text = text.substring(0,text.length-1);
+    text += '\n';
+
+    // process data
+    var dataArr = [[]];
+    var sIndex = 1;
+    _.each(seriesList, function(series) {
+        var cIndex = 0;
+        dataArr.push([]);
+        _.each(series.datapoints, function(dp) {
+            dataArr[0][cIndex] = new Date(dp[1]).toISOString();
+            dataArr[sIndex][cIndex] = dp[0];
+            cIndex++;
+        });
+        sIndex++;
+    });
+
+    // make text
+    for (var i = 0; i < dataArr[0].length; i++) {
+        text += dataArr[0][i] + ';';
+        for (var j = 1; j < dataArr.length; j++) {
+            text += dataArr[j][i] + ';';
+        }
+        text = text.substring(0,text.length-1);
+        text += '\n';
+    }
+    saveSaveBlob(text, 'grafana_data_export.csv');
+};
+
 export function exportTableDataToCsv(table) {
     var text = '';
     // add header

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -126,6 +126,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   getExtendedMenu() {
     var menu = super.getExtendedMenu();
     menu.push({text: 'Export CSV', click: 'ctrl.exportCsv()'});
+    menu.push({text: 'Export CSV (series2columns)', click: 'ctrl.exportCsvColumns()'});
     menu.push({text: 'Toggle legend', click: 'ctrl.toggleLegend()'});
     return menu;
   }
@@ -294,6 +295,10 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   exportCsv() {
     fileExport.exportSeriesListToCsv(this.seriesList);
+  }
+
+  exportCsvColumns() {
+    fileExport.exportSeriesListToCsvColumns(this.seriesList);
   }
 }
 


### PR DESCRIPTION
When exporting data as CSV from the extended menu, the series data is placed in a sequence in the first column. This PR implements getting the timestamp in the first column and series.alias in the following columns. 

The result is this:

```
Time;valA;valB
2015-06-11T11:50:00.000Z;1.1;2.0
2015-06-11T11:51:00.000Z;1.2;2.3
2015-06-11T11:52:00.000Z;1.2;2.31
2015-06-11T11:53:00.000Z;1.1;1.15
2015-06-11T11:54:00.000Z;1.11;1.1
2015-06-11T11:55:00.000Z;1.13;1.16
2015-06-11T11:56:00.000Z;1.13;1.8
2015-06-11T11:57:00.000Z;0.8;1.5
```

whereas the old behavior is this:

```
Series;Time;Value
valA;2015-06-11T11:50:00.000Z;1.1
valA;2015-06-11T11:51:00.000Z;1.2
valA;2015-06-11T11:52:00.000Z;1.2
valA;2015-06-11T11:53:00.000Z;1.1
valA;2015-06-11T11:54:00.000Z;1.11
valA;2015-06-11T11:55:00.000Z;1.13
valA;2015-06-11T11:56:00.000Z;1.13
valA;2015-06-11T11:57:00.000Z;0.8
valB;2015-06-11T11:50:00.000Z;2.0
valB;2015-06-11T11:51:00.000Z;2.3
valB;2015-06-11T11:52:00.000Z;2.31
valB;2015-06-11T11:53:00.000Z;1.15
valB;2015-06-11T11:54:00.000Z;1.1
valB;2015-06-11T11:55:00.000Z;1.16
valB;2015-06-11T11:56:00.000Z;1.8
valB;2015-06-11T11:57:00.000Z;1.5
```

I added this functionality as an extra Export CSV-choice when clicking the extended menu for a graph panel:

![image](https://cloud.githubusercontent.com/assets/590304/13061339/c7f8e43a-d437-11e5-87f7-d7c6839d4509.png)
