### PR TITLE
Fixed bug that wasn't showing the StaticRootPath when validation failed

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -386,7 +386,7 @@ func validateStaticRootPath() error {
 		return nil
 	}
 
-	return errors.New("Failed to detect generated css or javascript files in static root (%s), have you executed default grunt task?")
+	return fmt.Errorf("Failed to detect generated css or javascript files in static root (%s), have you executed default grunt task?", StaticRootPath)
 }
 
 func NewConfigContext(args *CommandLineArgs) error {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -6,7 +6,6 @@ package setting
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"


### PR DESCRIPTION
Pretty simple fix.
