### PR TITLE
Update kbn.js - correct typo for megabits/sec

### DIFF
--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -595,7 +595,7 @@ function($, _) {
           {text: 'bytes/sec',   value: 'Bps'},
           {text: 'kilobites/sec', value: 'Kbits'},
           {text: 'kilobytes/sec',    value: 'KBs'},
-          {text: 'megabites/sec', value: 'Mbits'},
+          {text: 'megabits/sec', value: 'Mbits'},
           {text: 'megabytes/sec',    value: 'MBs'},
           {text: 'gigabytes/sec',   value: 'GBs'},
           {text: 'gigabites/sec',   value: 'Gbits'},

--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -593,12 +593,12 @@ function($, _) {
           {text: 'packets/sec', value: 'pps'},
           {text: 'bits/sec',    value: 'bps'},
           {text: 'bytes/sec',   value: 'Bps'},
-          {text: 'kilobites/sec', value: 'Kbits'},
+          {text: 'kilobits/sec', value: 'Kbits'},
           {text: 'kilobytes/sec',    value: 'KBs'},
           {text: 'megabits/sec', value: 'Mbits'},
           {text: 'megabytes/sec',    value: 'MBs'},
           {text: 'gigabytes/sec',   value: 'GBs'},
-          {text: 'gigabites/sec',   value: 'Gbits'},
+          {text: 'gigabits/sec',   value: 'Gbits'},
         ]
       },
       {


### PR DESCRIPTION
data rate for Mbits has typo - should be megabits/sec - not megabites/sec
