### PR TITLE
Fixed schema elasticsearch

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -19,6 +19,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
     this.name = instanceSettings.name;
     this.index = instanceSettings.index;
     this.timeField = instanceSettings.jsonData.timeField;
+    this.fixedSchema = instanceSettings.jsonData.fixedSchema || false;
     this.esVersion = instanceSettings.jsonData.esVersion;
     this.indexPattern = new IndexPattern(instanceSettings.index, instanceSettings.jsonData.interval);
     this.interval = instanceSettings.jsonData.timeInterval;

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -18,7 +18,8 @@ function (angular, _, queryDef) {
         index: "=",
         onChange: "&",
         getFields: "&",
-        esVersion: '='
+        esVersion: '=',
+        fixedSchema: '='
       }
     };
   });

--- a/public/app/plugins/datasource/elasticsearch/partials/config.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/config.html
@@ -24,6 +24,7 @@
 	<div class="gf-form">
 		<span class="gf-form-label width-9">Version</span>
 		<select class="gf-form-input gf-size-auto" ng-model="ctrl.current.jsonData.esVersion" ng-options="f.value as f.name for f in ctrl.esVersions"></select>
+		<editor-checkbox text="Fixed Schema" tip="Autocomplete will consider each metric to be stored within an elasticsearch type" model="ctrl.current.jsonData.fixedSchema"></editor-checkbox>
 	</div>
 
 </div>

--- a/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
@@ -16,9 +16,10 @@
 <div ng-repeat="agg in ctrl.target.metrics">
 	<elastic-metric-agg
 		target="ctrl.target" index="$index"
-		get-fields="ctrl.getFields($fieldType)"
+		get-fields="ctrl.getMetrics($fieldType)"
 		on-change="ctrl.queryUpdated()"
-		es-version="ctrl.esVersion">
+		es-version="ctrl.esVersion"
+		fixed-schema="ctrl.fixedSchema">
 	</elastic-metric-agg>
 </div>
 

--- a/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
@@ -39,8 +39,9 @@ export class ElasticQueryCtrl extends QueryCtrl {
   }
 
   getFields(type) {
-      /* When using the fixed schema options, the metrics names are the
-         elasticsearch types within the index */
+      /* When using the fixed schema options, the metrics tags are the fields
+         defined within the elasticsearch index associated to (arbitrarilly)
+         the first metric. */
       var data;
       if (this.fixedSchema) {
           var data = this.datasource.getTags(this.target.metrics[0]['field']);


### PR DESCRIPTION
This PR implements the suggestion done at #3767

Forking the elasticsearch database to add the suggested option was a nightmare, since the code base of Grafana is changing too fast, and I could not maintain it.

Only 2 functions are affected:
- the function retrieving the metrics names
- the function retrieving the tags associated to a metric,

To test the modifications, one can use the following script to populate an elasticsearch with some data. One will need first to configure the template (it is explained in the documentation included in the PR).

https://github.com/Gueust/elasticsearch-metrics-tools/blob/master/es_injectors/inject_bogus_metrics.py

When using the Fixed Schema option, the auto-completion for tags is done only for the first metric. It does not have sense to aggregate two metrics not sharing tags.

I'm open to any improvement or suggestions. I really want to push this feature, because willing to use Grafana with elastic in a production environment, I can guarantee that such a feature is necessary.
