### PR TITLE
Add lowercase_expanded_terms: false to elasticsearch query.

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -79,7 +79,8 @@ function (queryDef) {
         query: {
           query_string: {
             query: query,
-            analyze_wildcard: true
+            analyze_wildcard: true,
+            lowercase_expanded_terms: false
           }
         }
       };
@@ -113,6 +114,7 @@ function (queryDef) {
           "query": {
             "query_string": {
               "analyze_wildcard": true,
+              "lowercase_expanded_terms": false,
               "query": '$lucene_query',
             }
           },
@@ -203,6 +205,7 @@ function (queryDef) {
             "query_string": {
               "analyze_wildcard": true,
               "query": '$lucene_query',
+              "lowercase_expanded_terms": false,
             }
           },
           "filter": {


### PR DESCRIPTION
When using elasticsearch as a metric store, it's normal to disable analysis of strings as this is not meant for actual text search and all strings are generally identifiers. What this means is that a field like "server.MyService.method1.requests" is stored as is, with no lowercasing.

Unfortunately, elasticsearch queries default to lowercasing wildcard term matches, probably to support the text search use case more easily, but this breaks the ability to match case-sensitively on fields like the above - the index contains the non-analyzed mixed-case terms only, while the query only has lowercased terms. Disabling this lowercasing allows lucene queries like name:server.MyService.*.requests to work fine, for example to aggregate over all requests to a given service.

Perhaps this could be a configuration option, but I don't know if any grafana users would prefer this case-insensitive matching?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafana/grafana/4152)

<!-- Reviewable:end -->
