### PR TITLE
Add support for pre/post update hooks in the PluginEditCtrl.

### DIFF
--- a/public/app/features/plugins/edit_ctrl.ts
+++ b/public/app/features/plugins/edit_ctrl.ts
@@ -9,6 +9,8 @@ export class PluginEditCtrl {
   includedPanels: any;
   includedDatasources: any;
   tabIndex: number;
+  preUpdateHook: () => any;
+  postUpdateHook: () => any;
 
   /** @ngInject */
   constructor(private backendSrv: any, private $routeParams: any) {
@@ -24,18 +26,53 @@ export class PluginEditCtrl {
   }
 
   update() {
-    var updateCmd = _.extend({
-      pluginId: this.model.pluginId,
-      orgId: this.model.orgId,
-      enabled: this.model.enabled,
-      pinned: this.model.pinned,
-      jsonData: this.model.jsonData,
-      secureJsonData: this.model.secureJsonData,
-    }, {});
+    var chain = Promise.resolve();
+    var self = this;
+    // if set, handle the preUpdateHook. If this returns a promise,
+    // the next step of execution will block until the promise resolves.
+    // if the promise is rejected, this update will be aborted.
+    if (this.preUpdateHook != null) {
+      chain = chain.then(function() {
+        return Promise.resolve(self.preUpdateHook());
+      });
+    }
 
-    this.backendSrv.post(`/api/org/plugins/${this.pluginId}/settings`, updateCmd).then(function() {
+    // Perform the core update procedure
+    chain = chain.then(function() {
+      var updateCmd = _.extend({
+        pluginId: self.model.pluginId,
+        orgId: self.model.orgId,
+        enabled: self.model.enabled,
+        pinned: self.model.pinned,
+        jsonData: self.model.jsonData,
+        secureJsonData: self.model.secureJsonData,
+      }, {});
+
+      return self.backendSrv.post(`/api/org/plugins/${self.pluginId}/settings`, updateCmd);
+    });
+
+    // if set, performt he postUpdate hook. If a promise is returned it will block
+    // the final step of the update procedure (reloading the page) until the promise
+    // resolves.  If the promise is rejected the page will not be reloaded. 
+    if (this.postUpdateHook != null) {
+      chain = chain.then(function() {
+        return Promise.resolve(this.postUpdateHook());
+      });
+    }
+
+    // all stesp in the update procedure are complete, so reload the page to make changes
+    // take effect.
+    chain.then(function() {
       window.location.href = window.location.href;
     });
+  }
+
+  setPreUpdateHook(callback: () => any) {
+    this.preUpdateHook = callback;
+  }
+
+  setPOstUpdateHook(callback: () => any) {
+    this.postUpdateHook = callback;
   }
 
   toggleEnabled() {


### PR DESCRIPTION
This allows users to intercept the update procedure from their own
controller to modify the pluginSettings before they are saved and
perform additional tasks like syncing state via a third party API.
