### PR TITLE
Override time range period

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -154,6 +154,19 @@ class MetricsPanelCtrl extends PanelCtrl {
       this.rangeRaw = this.range;
     }
 
+    if (this.panel.timePeriod) {
+      var timePeriodInterpolated = this.templateSrv.replace(this.panel.timePeriod, this.panel.scopedVars);
+      var timePeriodInfo = rangeUtil.describeTextRange(timePeriodInterpolated);
+      if (timePeriodInfo.invalid) {
+        this.timeInfo = 'invalid period';
+        return;
+      }
+
+      var timePeriod = '+' + timePeriodInterpolated;
+      this.timeInfo += ' timePeriod ' + timePeriod;
+      this.range.to = dateMath.parseDateMath(timePeriod, this.range.from.clone(), true);
+    }
+
     if (this.panel.hideTimeOverride) {
       this.timeInfo = '';
     }

--- a/public/app/features/panel/partials/panelTime.html
+++ b/public/app/features/panel/partials/panelTime.html
@@ -27,6 +27,17 @@
 		<span class="gf-form-label">
 			<i class="fa fa-clock-o"></i>
 		</span>
+		<span class="gf-form-label width-12">Override time period</span>
+		<span class="gf-form-label width-6">Period</span>
+		<input type="text" class="gf-form-input max-width-8" placeholder="1h"
+			empty-to-null ng-model="ctrl.panel.timePeriod" valid-time-span
+			ng-change="ctrl.refresh()" ng-model-onblur>
+	</div>
+
+	<div class="gf-form">
+		<span class="gf-form-label">
+			<i class="fa fa-clock-o"></i>
+		</span>
 		<editor-checkbox text="Hide time override info" model="ctrl.panel.hideTimeOverride" change="ctrl.refresh()"></editor-checkbox>
 	</div>
 </div>


### PR DESCRIPTION
Support override time range period.
By this PR, user can mix different time range length graph (e.g. 1 day and 1 week) in a dashboard.
