### PR TITLE
ElasticSearch Terms & Date Histogram: Support 'missing' setting

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.js
@@ -27,6 +27,7 @@ function (angular, _, queryDef) {
 
     $scope.orderByOptions = [];
     $scope.bucketAggTypes = queryDef.bucketAggTypes;
+    $scope.bucketAggTypesHash = _.indexBy(queryDef.bucketAggTypes, 'value');
     $scope.orderOptions = queryDef.orderOptions;
     $scope.sizeOptions = queryDef.sizeOptions;
 

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -57,7 +57,7 @@
 			</ul>
 			<div class="clearfix"></div>
 		</div>
-		<div class="tight-form last">
+		<div class="tight-form">
 			<ul class="tight-form-list">
 				<li class="tight-form-item" style="width: 170px">
 					Trim edges points
@@ -71,11 +71,23 @@
 			</ul>
 			<div class="clearfix"></div>
 		</div>
+		<div class="tight-form last">
+			<ul class="tight-form-list">
+				<li class="tight-form-item" style="width: 170px;">
+					Missing
+					<tip>The missing parameter defines how documents that are missing a value should be treated. By default they will be ignored but it is also possible to treat them as if they had a value</tip>
+				</li>
+				<li>
+					<input type="text" class="tight-form-input last" empty-to-null ng-model="agg.settings.missing" ng-blur="onChangeInternal()" spellcheck='false'>
+				</li>
+			</ul>
+			<div class="clearfix"></div>
+		</div>
 	</div>
 	<div class="tight-form-inner-box" ng-if="agg.type === 'terms'">
 		<div class="tight-form">
 			<ul class="tight-form-list">
-				<li class="tight-form-item" style="width: 60px">
+				<li class="tight-form-item" style="width: 100px">
 					Order
 				</li>
 				<li>
@@ -86,7 +98,7 @@
 		</div>
 		<div class="tight-form">
 			<ul class="tight-form-list">
-				<li class="tight-form-item" style="width: 60px">
+				<li class="tight-form-item" style="width: 100px">
 					Size
 				</li>
 				<li>
@@ -95,13 +107,25 @@
 			</ul>
 			<div class="clearfix"></div>
 		</div>
-		<div class="tight-form last">
+		<div class="tight-form">
 			<ul class="tight-form-list">
-				<li class="tight-form-item" style="width: 60px">
+				<li class="tight-form-item" style="width: 100px">
 					Order By
 				</li>
 				<li>
 					<metric-segment-model property="agg.settings.orderBy" options="orderByOptions" on-change="onChangeInternal()" css-class="last"></metric-segment-model>
+				</li>
+			</ul>
+			<div class="clearfix"></div>
+		</div>
+		<div class="tight-form last">
+			<ul class="tight-form-list">
+				<li class="tight-form-item" style="width: 100px;">
+					Missing
+					<tip>The missing parameter defines how documents that are missing a value should be treated. By default they will be ignored but it is also possible to treat them as if they had a value</tip>
+				</li>
+				<li>
+					<input type="text" class="tight-form-input last" empty-to-null ng-model="agg.settings.missing" ng-blur="onChangeInternal()" spellcheck='false'>
 				</li>
 			</ul>
 			<div class="clearfix"></div>
@@ -129,5 +153,3 @@
 	</div>
 
 </div>
-
-

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -48,6 +48,10 @@ function (queryDef) {
       }
     }
 
+    if (aggDef.settings.missing) {
+      queryNode.terms.missing = aggDef.settings.missing;
+    }
+
     return queryNode;
   };
 
@@ -65,6 +69,10 @@ function (queryDef) {
 
     if (this.esVersion >= 2) {
       esAgg.format = "epoch_millis";
+    }
+
+    if (settings.missing) {
+      esAgg.missing = settings.missing;
     }
 
     return esAgg;

--- a/public/app/plugins/datasource/elasticsearch/query_def.js
+++ b/public/app/plugins/datasource/elasticsearch/query_def.js
@@ -20,9 +20,9 @@ function (_) {
     ],
 
     bucketAggTypes: [
-      {text: "Terms",           value: 'terms' },
+      {text: "Terms",           value: 'terms', supportsMissing: true },
       {text: "Filters",         value: 'filters' },
-      {text: "Date Histogram",  value: 'date_histogram' },
+      {text: "Date Histogram",  value: 'date_histogram', supportsMissing: true },
     ],
 
     orderByOptions: [


### PR DESCRIPTION
Hi.

I've added support in the missing setting in bucket aggregations (`terms` and `date histogram`) : 

![image](https://cloud.githubusercontent.com/assets/746471/13508623/75c276d4-e190-11e5-837a-9928ac7c1150.png)

Example for graph w/ the new setting : 

![image](https://cloud.githubusercontent.com/assets/746471/13508643/8b6a6b5e-e190-11e5-86e9-cfd831d6bf4b.png)
