### PR TITLE
Fix: Add validation to timepicker input fields to prevent saving invalid values

### DIFF
--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -5,6 +5,7 @@ import angular from 'angular';
 import moment from 'moment';
 
 import * as rangeUtil from 'app/core/utils/rangeutil';
+import * as dateMath from 'app/core/utils/datemath';
 
 export class TimePickerCtrl {
 

--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -26,7 +26,7 @@ export class TimePickerCtrl {
   isUtc: boolean;
 
   /** @ngInject */
-  constructor(private $scope, private $rootScope, private timeSrv) {
+  constructor(private $scope, private $rootScope, private timeSrv, private alertSrv) {
     $scope.ctrl = this;
 
     $rootScope.onAppEvent('zoom-out', () => this.zoom(2), $scope);
@@ -111,8 +111,14 @@ export class TimePickerCtrl {
     if (this.refresh.value !== this.dashboard.refresh) {
       this.timeSrv.setAutoRefresh(this.refresh.value);
     }
-
-    this.timeSrv.setTime(this.timeRaw, true);
+    if (dateMath.parse(this.timeRaw.from, false) !== undefined
+      && dateMath.parse(this.timeRaw.to, true) !== undefined) {
+        this.timeSrv.setTime(this.timeRaw, true);
+    } else {
+      var data = { message: "Selected time range is invalid." };
+      this.alertSrv.set("Error", data.message, "warning", 2000);
+      throw data;
+    }
     this.$rootScope.appEvent('hide-dash-editor');
   }
 


### PR DESCRIPTION
Pushed upstream from our own hosted Grafana service @ [hostedgraphite.com](http://www.hostedgraphite.com/), fixes #4254.
