### PR TITLE
Prometheus: Interval/Step changes

### DIFF
--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -133,7 +133,7 @@ function($, _) {
     return str;
   };
 
-  kbn.interval_regex = /(\d+(?:\.\d+)?)([Mwdhmsy])/;
+  kbn.interval_regex = /(\d+(?:\.\d+)?)(ms|[Mwdhmsy])/;
 
   // histogram & trends
   kbn.intervals_in_seconds = {
@@ -143,7 +143,8 @@ function($, _) {
     d: 86400,
     h: 3600,
     m: 60,
-    s: 1
+    s: 1,
+    ms: 0.001,
   };
 
   kbn.calculateInterval = function(range, resolution, userInterval) {

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -176,7 +176,7 @@
 				</div>
 			</div>
 
-			<div class="gf-form-group" >
+			<div class="gf-form-group" ng-if="current.type !== 'interval'">
 				<h5 class="section-heading">Selection Options</h5>
 				<div class="gf-form">
 					<span class="gf-form-label width-10">Multi-value</span>

--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -32,6 +32,14 @@ function (angular, _) {
         }
         this._index[variable.name] = variable;
       }
+
+      // add system interval variable if
+      // user has not added it
+      if (!this._index['interval']) {
+        this._index['interval'] = {
+          current: {value: ''}
+        };
+      }
     };
 
     function regexEscape(value) {

--- a/public/app/plugins/datasource/influxdb/partials/query.options.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.options.html
@@ -2,7 +2,6 @@
 	<div class="gf-form-group">
 		<div class="gf-form-inline">
 			<div class="gf-form">
-				<span class="gf-form-label"><i class="fa fa-wrench"></i></span>
 				<span class="gf-form-label width-11">Group by time interval</span>
 				<input type="text" class="gf-form-input" ng-model="ctrl.panelCtrl.panel.interval" ng-blur="ctrl.panelCtrl.refresh();"
 				spellcheck='false' placeholder="example: >10s">
@@ -11,9 +10,6 @@
 		</div>
 		<div class="gf-form-inline">
 			<div class="gf-form">
-				<!--span class="gf-form-label">
-					<i class="fa fa-info-circle"></i>
-				</span-->
 				<span class="gf-form-label width-10">
 					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(1);" bs-tooltip="'click to show helpful info'" data-placement="bottom">
 						<i class="fa fa-info-circle"></i>
@@ -38,7 +34,7 @@
 </section>
 
 <div class="editor-row">
-	<div class="pull-left" style="margin-top: 30px;">
+	<div class="pull-left">
 
 		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 1">
 			<h5>Alias patterns</h5>

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -5,9 +5,8 @@ import _ from 'lodash';
 import moment from 'moment';
 
 import * as dateMath from 'app/core/utils/datemath';
+import kbn from 'app/core/utils/kbn';
 import PrometheusMetricFindQuery from './metric_find_query';
-
-var durationSplitRegexp = /(\d+)(ms|s|m|h|d|w|M|y)/;
 
 /** @ngInject */
 export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateSrv) {
@@ -62,28 +61,27 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     var start = getPrometheusTime(options.range.from, false);
     var end = getPrometheusTime(options.range.to, true);
 
-    var queries = [];
-    options = _.clone(options);
-    _.each(options.targets, _.bind(function(target) {
+    var queries = _.map(options.targets, target => {
       if (!target.expr || target.hide) {
         return;
       }
 
       var query: any = {};
-      query.expr = templateSrv.replace(target.expr, options.scopedVars, interpolateQueryExpr);
+      var interval = templateSrv.replace(target.interval || options.interval);
+      query.step = this.calculateStep(interval);
 
-      var interval = target.interval || options.interval;
-      var intervalFactor = target.intervalFactor || 1;
-      target.step = query.step = this.calculateInterval(interval, intervalFactor);
       var range = Math.ceil(end - start);
       // Prometheus drop query if range/step > 11000
       // calibrate step if it is too big
-      if (query.step !== 0 && range / query.step > 11000) {
-        target.step = query.step = Math.ceil(range / 11000);
+      if (range / query.step > 11000) {
+        query.step = Math.ceil(range / 11000);
       }
 
-      queries.push(query);
-    }, this));
+      var scopedVars = _.extend({"interval": {value: interval}, "intervalMs": {value: query.step}}, options.scopedVars);
+      query.expr = templateSrv.replace(target.expr, scopedVars, interpolateQueryExpr);
+
+      return query;
+    });
 
     // No valid targets, return the empty result to save a round trip.
     if (_.isEmpty(queries)) {
@@ -204,15 +202,12 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     });
   };
 
-  this.calculateInterval = function(interval, intervalFactor) {
-    var m = interval.match(durationSplitRegexp);
-    var dur = moment.duration(parseInt(m[1]), m[2]);
-    var sec = dur.asSeconds();
+  this.calculateStep = function(interval) {
+    var sec = kbn.interval_to_seconds(interval);
     if (sec < 1) {
       sec = 1;
     }
-
-    return Math.ceil(sec * intervalFactor);
+    return sec;
   };
 
   this.transformMetricData = function(md, options, start, end) {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -80,7 +80,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       var scopedVars = _.extend({"interval": {value: interval}, "intervalMs": {value: query.step}}, options.scopedVars);
       query.expr = templateSrv.replace(target.expr, scopedVars, interpolateQueryExpr);
 
-      queries.push(target);
+      queries.push(query);
     }
 
     // No valid targets, return the empty result to save a round trip.

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -9,9 +9,14 @@ class PrometheusAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
 }
 
+class PrometheusQueryOptionsCtrl {
+  static templateUrl = 'partials/query.options.html';
+}
+
 export {
   PrometheusDatasource as Datasource,
   PrometheusQueryCtrl as QueryCtrl,
   PrometheusConfigCtrl as ConfigCtrl,
+  PrometheusQueryOptionsCtrl as QueryOptionsCtrl,
   PrometheusAnnotationsQueryCtrl as AnnotationsQueryCtrl,
 };

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -29,7 +29,7 @@
 <div class="tight-form">
 	<ul class="tight-form-list" role="menu">
 		<li class="tight-form-item tight-form-align" style="width: 94px">
-			Legend format
+			Alias pattern
 		</li>
 		<li>
 			<input type="text" class="tight-form-input input-xxlarge" ng-model="ctrl.target.legendFormat"
@@ -45,10 +45,10 @@
 <div class="tight-form">
 	<ul class="tight-form-list" role="menu">
 		<li class="tight-form-item tight-form-align" style="width: 94px">
-			Step
+			Interval
 		</li>
 		<li>
-			<input type="text" class="input-mini tight-form-input" ng-model="ctrl.target.interval"
+			<input type="text" class="input-small tight-form-input" ng-model="ctrl.target.interval"
 			bs-tooltip="'Leave blank for auto handling based on time range and panel width'"
 			data-placement="right"
 			spellcheck='false'
@@ -60,15 +60,6 @@
 			</input>
 		</li>
 
-		<li class="tight-form-item">
-			Resolution
-		</li>
-		<li>
-			<select ng-model="ctrl.target.intervalFactor" class="tight-form-input input-mini"
-				ng-options="r.factor as r.label for r in ctrl.resolutions"
-				ng-change="ctrl.refreshMetricData()">
-			</select>
-		</li>
 		<li class="tight-form-item">
 			<a href="{{ctrl.linkToPrometheus}}" target="_blank" bs-tooltip="'Link to Graph in Prometheus'">
 				<i class="fa fa-share-square-o"></i>

--- a/public/app/plugins/datasource/prometheus/partials/query.options.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.options.html
@@ -2,21 +2,22 @@
 	<div class="gf-form-group">
 		<div class="gf-form-inline">
 			<div class="gf-form">
-				<span class="gf-form-label width-9">Interval (step)</span>
-				<input type="text" class="gf-form-input max-width-9" ng-model="ctrl.panelCtrl.panel.interval" ng-blur="ctrl.panelCtrl.refresh();"
-				spellcheck='false' placeholder="example: >10s">
+				<span class="gf-form-label width-10">Interval (step)</span>
+				<input type="text" class="gf-form-input max-width-10" ng-model="ctrl.panelCtrl.panel.interval" ng-blur="ctrl.panelCtrl.refresh();" spellcheck='false' placeholder="example: >10s">
+			</div>
+			<div class="gf-form">
 				<span class="gf-form-label"><i class="fa fa-question-circle" bs-tooltip="'Set a low limit by having a greater sign: example: >60s'" data-placement="right"></i></span>
 			</div>
 		</div>
 		<div class="gf-form-inline">
 			<div class="gf-form">
-				<span class="gf-form-label width-9">
+				<span class="gf-form-label width-10">
 					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(1);" bs-tooltip="'click to show helpful info'" data-placement="bottom">
 						<i class="fa fa-info-circle"></i>
 						&nbsp;Alias patterns
 					</a>
 				</span>
-				<span class="gf-form-label width-9">
+				<span class="gf-form-label width-10">
 					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(2)" bs-tooltip="'click to show helpful info'" data-placement="bottom">
 					<i class="fa fa-info-circle"></i>
 						&nbsp;Interval

--- a/public/app/plugins/datasource/prometheus/partials/query.options.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.options.html
@@ -1,0 +1,49 @@
+<section class="grafana-metric-options">
+	<div class="gf-form-group">
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<span class="gf-form-label width-9">Interval (step)</span>
+				<input type="text" class="gf-form-input max-width-9" ng-model="ctrl.panelCtrl.panel.interval" ng-blur="ctrl.panelCtrl.refresh();"
+				spellcheck='false' placeholder="example: >10s">
+				<span class="gf-form-label"><i class="fa fa-question-circle" bs-tooltip="'Set a low limit by having a greater sign: example: >60s'" data-placement="right"></i></span>
+			</div>
+		</div>
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<span class="gf-form-label width-9">
+					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(1);" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+						<i class="fa fa-info-circle"></i>
+						&nbsp;Alias patterns
+					</a>
+				</span>
+				<span class="gf-form-label width-9">
+					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(2)" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+					<i class="fa fa-info-circle"></i>
+						&nbsp;Interval
+					</a>
+				</span>
+			</div>
+		</div>
+	</div>
+</section>
+
+<div class="editor-row">
+	<div class="pull-left">
+
+		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 1">
+			<h5>Alias patterns</h5>
+			<ul>
+				<li ng-non-bindable>{{&lt;label&gt;}} = replaced with label value</li>
+			</ul>
+		</div>
+
+		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 2">
+			<h5>Interval / step</h5>
+			<ul>
+			</ul>
+		</div>
+
+	</div>
+</div>
+
+

--- a/public/test/specs/templateSrv-specs.js
+++ b/public/test/specs/templateSrv-specs.js
@@ -43,6 +43,11 @@ define([
         var target = _templateSrv.replaceWithText('this.$test.filters', {'test': {value: 'mupp', text: 'asd'}});
         expect(target).to.be('this.asd.filters');
       });
+
+      it('should replace $test2 with scoped value', function() {
+        var target = _templateSrv.replace('this.[$test].filters', {'test2': {value: 'mupp', text: 'asd'}});
+        expect(target).to.be('this.[mupp].filters');
+      });
     });
 
     describe('replace can pass multi / all format', function() {


### PR DESCRIPTION
This PR / Branch Tries to make Prometheus more like the other data sources in terms of interval handling. 

This means that you can now set a interval lower limit on panel level (all queries), the panel has a `$interval` variable by default (meaning you can use this variable in your query even if you do not have a variable named interval). 

If you have a template variable named `interval` then that will be used. 

![image](https://cloud.githubusercontent.com/assets/10999/13534867/84e4fad6-e237-11e5-8108-3d3956a8ebbc.png)

Other changes:
- removed resolution, this parameter was very confusing as it override the step parameter and was just strange. 

TODO:
- fix alignment of time range to interval
