### PR TITLE
Minor nav fix

### DIFF
--- a/public/app/features/plugins/partials/edit.html
+++ b/public/app/features/plugins/partials/edit.html
@@ -1,5 +1,5 @@
 <navbar title="Plugins" title-url="plugins" icon="icon-gf icon-gf-apps">
-<a href="plugins" class="navbar-page-btn">
+<a href="plugins/{{ctrl.model.pluginId}}/edit" class="navbar-page-btn">
   {{ctrl.model.name}}
 </a>
 </navbar>


### PR DESCRIPTION
Bug: On any plugin's edit page, clicking on the name of the plugin was taking me back to the list of plugins.

Fix: Clicking on the name of plugin should either do nothing and redirect me to the same page.
