### PR TITLE
(templating) set time from/to variable in "custom templating"

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -138,6 +138,10 @@
 					<span class="gf-form-label width-13">Values seperated by comma</span>
 					<input type="text" class="gf-form-input" ng-model='current.query' ng-blur="runQuery()" placeholder="1, 10, 20, myvalue"></input>
 				</div>
+				<div class="gf-form">
+					<span class="gf-form-label width-13">Expand option</span>
+					<editor-checkbox text="Enable" model="current.expand" change="runQuery()"></editor-checkbox>
+				</div>
 			</div>
 
 			<div ng-show="current.type === 'query'" class="gf-form-group">

--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -25,7 +25,7 @@ function (angular, _, kbn) {
       // update variables with refresh === 2
       var promises = self.variables
         .filter(function(variable) {
-          return variable.refresh === 2;
+          return variable.refresh === 2 || variable.expand;
         }).map(function(variable) {
           return self.updateOptions(variable);
         });
@@ -158,8 +158,23 @@ function (angular, _, kbn) {
     };
 
     this._updateNonQueryVariable = function(variable) {
+      var query = variable.query;
+      if (variable.type === 'custom' && variable.expand) {
+        var range = timeSrv.timeRange();
+        try {
+          query = _.template(templateSrv.replace(query), {
+            range: {
+              from: range.from,
+              to: range.to
+            }
+          }, { variable: 'g' });
+        } catch (e) {
+          query = '';
+        }
+      }
+
       // extract options in comma seperated string
-      variable.options = _.map(variable.query.split(/[,]+/), function(text) {
+      variable.options = _.map(query.split(/[,]+/), function(text) {
         return { text: text.trim(), value: text.trim() };
       });
 


### PR DESCRIPTION
This is a proposal to enable time from/to templating.
I achieve that by allow underscore.js templating, and provide Grafana's time range as template data.
- Link the PR to an issue for new features
  - https://github.com/grafana/grafana/issues/1909
  - https://github.com/grafana/grafana/issues/3346

![template_template](https://cloud.githubusercontent.com/assets/224552/13659634/bbd1741e-e6c6-11e5-973a-6fefec381091.png)
