### PR TITLE
InfluxDB: Fix groupby selection

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -104,7 +104,7 @@ export function InfluxDatasource(instanceSettings, $q, backendSrv, templateSrv) 
   this.metricFindQuery = function (query) {
     var interpolated;
     try {
-      interpolated = templateSrv.replace(query);
+      interpolated = templateSrv.replace(query, null, 'regex');
     } catch (err) {
       return $q.reject(err);
     }


### PR DESCRIPTION
Default groupby selection for influxdb is escaped not like a regex, but as a glob. It works fine with one value in variable, but when you select multiple values, query is incorrect:

> SHOW TAG KEYS FROM "os.disk.fs.space_total" WHERE "host" =~ /{host-1,host-2}$/
