### PR TITLE
Rough Authorization Code Example

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -5,6 +5,11 @@
 		"./pkg/..."
 	],
 	"Deps": [
+                {
+			"ImportPath": "github.com/influxdata/influxdb",
+			"Comment": "v0.10.3",
+			"Rev": "f55169eaca706f78e2d66edb0b8e62861712a747"
+		},
 		{
 			"ImportPath": "github.com/BurntSushi/toml",
 			"Comment": "v0.1.0-21-g056c9bc",

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -111,13 +111,19 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 					return
 				}
 				for _, query := range strings.Split(strings.Replace(queries,";","\n",-1),"\n"){
-					if strings.HasPrefix(query, "SELECT"){
-						if !strings.Contains(query,fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
+					if strings.Contains(strings.ToUpper(query), "INTO") || strings.Contains(query, ","){
+						c.JsonApiErr(403, "Unauthorized Query", nil)
+						return
+					}else if strings.HasPrefix(strings.ToUpper(query), "SELECT"){
+						if !strings.Contains(strings.ToUpper(query),fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
 							c.JsonApiErr(403, "Unauthorized Query", nil)
 							return
 						}
-					}else{
+					}else if strings.HasPrefix(strings.ToUpper(query), "SHOW"){
 						log.Info("Metadata Query: %#v",query)
+					}else{
+						c.JsonApiErr(403, "Unauthorized Query", nil)
+						return
 					}
 				}
 			}else{

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -111,11 +111,10 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 					return
 				}
 				for _, query := range strings.Split(strings.Replace(queries,";","\n",-1),"\n"){
-					if strings.Contains(strings.ToUpper(query), "INTO") || strings.Contains(query, ","){
-						c.JsonApiErr(403, "Unauthorized Query", nil)
-						return
-					}else if strings.HasPrefix(strings.ToUpper(query), "SELECT"){
-						if !strings.Contains(strings.ToUpper(query),fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
+					if strings.HasPrefix(strings.ToUpper(query), "SELECT"){
+						if strings.Contains(strings.ToUpper(query), "INTO")
+						|| strings.ContainsAny(query, ",~/")
+						|| !strings.Contains(strings.ToUpper(query),fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
 							c.JsonApiErr(403, "Unauthorized Query", nil)
 							return
 						}

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -112,9 +112,9 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 				}
 				for _, query := range strings.Split(strings.Replace(queries,";","\n",-1),"\n"){
 					if strings.HasPrefix(strings.ToUpper(query), "SELECT"){
-						if strings.Contains(strings.ToUpper(query), "INTO")
-						|| strings.ContainsAny(query, ",~/")
-						|| !strings.Contains(strings.ToUpper(query),fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
+						if strings.Contains(strings.ToUpper(query), "INTO") ||
+							strings.ContainsAny(query, ",~/") ||
+							!strings.Contains(strings.ToUpper(query),fmt.Sprintf("FROM \"P%d.",c.SignedInUser.OrgId)){
 							c.JsonApiErr(403, "Unauthorized Query", nil)
 							return
 						}

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -174,8 +174,9 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 							return
 						}
 						for indx,source := range stmt.SourceNames() {
-							regex := stmt.Sources[indx].(*influxql.Measurement).Regex.Val
+							regex := stmt.Sources[indx].(*influxql.Measurement).Regex
 							if regex != nil {
+								regex := regex.Val
 								if len(measurements) == 0 {
 									measurements,err = getMeasurements(ds,proxyPath)
 									if err != nil{


### PR DESCRIPTION
I'm putting this up here for the benefit of anyone who wants to implement a metric/measurement level authorization scheme. Since shield for Elasticsearch has added document & field level security I didn't feel it necessary to try and cover the entire ES query language, but I do double check that the datasource being queried belongs to the org of the logged in user.

For Influxdb and opentsdb I check that the measurement/metric starts with P followed by the org of the logged in user and then a period after which the rest of the name can be anything. It's hard coded because I'm lazy and don't need anything more but it could be generalized to take a pattern from the datasource definition if someone wanted to do the front-end work.

A note for anyone who uses this though, opentsdb 2.3 is going to introduce expressions and I haven't covered that here because v2.3 isn't even in beta yet. And I believe that influxdb before 0.9 had joins and other query features that could circumvent my checks.
