### PR TITLE
Slash escape regex

### DIFF
--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -35,7 +35,7 @@ function (angular, _) {
     };
 
     function regexEscape(value) {
-      return value.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+      return value.replace(/[\\^$*+?.()|[\]{}\/]/g, '\\$&');
     }
 
     function luceneEscape(value) {

--- a/public/test/specs/templateSrv-specs.js
+++ b/public/test/specs/templateSrv-specs.js
@@ -135,6 +135,11 @@ define([
         expect(result).to.be('test|test2');
       });
 
+      it('slash should be properly escaped in regex format', function() {
+         var result = _templateSrv.formatValue('Gi3/14', 'regex');
+         expect(result).to.be('Gi3\\/14');
+      });
+
     });
 
     describe('can check if variable exists', function() {


### PR DESCRIPTION
Slash symbol "/" wasn't escaped when we chose variable from template dropdown, so we couldn't choose interface names like Gi9/10 when querying from influxdb.
