### PR TITLE
Set home dashboard per user per org #3214

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -160,7 +160,12 @@ func Register(r *macaron.Macaron) {
 			r.Delete("/:id", wrap(DeleteApiKey))
 		}, reqOrgAdmin)
 
-		r.Combo("/preferences").Get(GetPreferences).Put(bind(m.SavePreferencesCommand{}), wrap(SavePreferences))
+    // Preferences
+    r.Group("/preferences", func() {
+		  r.Get("/", wrap(GetPreferences))
+      r.Put("/", bind(m.SavePreferencesCommand{}), wrap(SavePreferences))
+      r.Post("/set-home-dash", bind(m.SavePreferencesCommand{}), wrap(SetHomeDashboard))
+    })
 
 		// Data sources
 		r.Group("/datasources", func() {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -162,7 +162,7 @@ func Register(r *macaron.Macaron) {
 
 		// Preferences
 		r.Group("/preferences", func() {
-			r.Get("/", wrap(GetPreferences))
+			r.Get("/", GetPreferences)
 			r.Put("/", bind(m.SavePreferencesCommand{}), wrap(SavePreferences))
 			r.Post("/set-home-dash", bind(m.SavePreferencesCommand{}), wrap(SetHomeDashboard))
 		})

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,6 +200,7 @@ func Register(r *macaron.Macaron) {
 			r.Get("/home", GetHomeDashboard)
 			r.Get("/tags", GetDashboardTags)
 			r.Post("/import", bind(dtos.ImportDashboardCommand{}), wrap(ImportDashboard))
+			r.Get("/id/:id", GetDashboardSlugById)
 		})
 
 		// Dashboard snapshots

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -160,12 +160,12 @@ func Register(r *macaron.Macaron) {
 			r.Delete("/:id", wrap(DeleteApiKey))
 		}, reqOrgAdmin)
 
-    // Preferences
-    r.Group("/preferences", func() {
-		  r.Get("/", wrap(GetPreferences))
-      r.Put("/", bind(m.SavePreferencesCommand{}), wrap(SavePreferences))
-      r.Post("/set-home-dash", bind(m.SavePreferencesCommand{}), wrap(SetHomeDashboard))
-    })
+		// Preferences
+		r.Group("/preferences", func() {
+			r.Get("/", wrap(GetPreferences))
+			r.Put("/", bind(m.SavePreferencesCommand{}), wrap(SavePreferences))
+			r.Post("/set-home-dash", bind(m.SavePreferencesCommand{}), wrap(SetHomeDashboard))
+		})
 
 		// Data sources
 		r.Group("/datasources", func() {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,7 +200,6 @@ func Register(r *macaron.Macaron) {
 			r.Get("/home", GetHomeDashboard)
 			r.Get("/tags", GetDashboardTags)
 			r.Post("/import", bind(dtos.ImportDashboardCommand{}), wrap(ImportDashboard))
-			r.Get("/id/:id", GetDashboardSlugById)
 		})
 
 		// Dashboard snapshots

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -204,3 +204,17 @@ func GetDashboardTags(c *middleware.Context) {
 
 	c.JSON(200, query.Result)
 }
+
+func GetDashboardSlugById(c *middleware.Context) {
+	dashId := c.ParamsInt64(":id")
+	query := m.GetDashboardSlugByIdQuery{Id: dashId}
+	err := bus.Dispatch(&query)
+	if err != nil {
+		c.JsonApiErr(500, "Failed to get slug from database", err)
+		return
+	}
+
+	slug := dtos.DashboardSlug{Slug: query.Result}
+
+	c.JSON(200, &slug)
+}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -159,6 +159,28 @@ func canEditDashboard(role m.RoleType) bool {
 }
 
 func GetHomeDashboard(c *middleware.Context) {
+
+	// Checking if there is any preference set for home dashboard
+	query := m.GetPreferencesQuery{UserId: c.UserId, OrgId: c.OrgId}
+
+	if err := bus.Dispatch(&query); err != nil {
+		c.JsonApiErr(500, "Failed to get preferences", err)
+	}
+
+	if query.Result.HomeDashboardId != 0 {
+		query := m.GetDashboardSlugByIdQuery{Id: query.Result.HomeDashboardId}
+		err := bus.Dispatch(&query)
+		if err != nil {
+			c.JsonApiErr(500, "Failed to get slug from database", err)
+			return
+		}
+
+		slug := dtos.DashboardSlug{Slug: query.Result}
+
+		c.JSON(200, &slug)
+		return
+	}
+
 	filePath := path.Join(setting.StaticRootPath, "dashboards/home.json")
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -203,18 +225,4 @@ func GetDashboardTags(c *middleware.Context) {
 	}
 
 	c.JSON(200, query.Result)
-}
-
-func GetDashboardSlugById(c *middleware.Context) {
-	dashId := c.ParamsInt64(":id")
-	query := m.GetDashboardSlugByIdQuery{Id: dashId}
-	err := bus.Dispatch(&query)
-	if err != nil {
-		c.JsonApiErr(500, "Failed to get slug from database", err)
-		return
-	}
-
-	slug := dtos.DashboardSlug{Slug: query.Result}
-
-	c.JSON(200, &slug)
 }

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -57,6 +57,10 @@ type DashboardFullWithMeta struct {
 	Dashboard *simplejson.Json `json:"dashboard"`
 }
 
+type DashboardSlug struct {
+	Slug string `json:"slug"`
+}
+
 type DataSource struct {
 	Id                int64            `json:"id"`
 	OrgId             int64            `json:"orgId"`

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -7,7 +7,7 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-// PUT /api/user/prefs
+// PUT /api/preferences
 func SavePreferences(c *middleware.Context, cmd m.SavePreferencesCommand) Response {
 
 	cmd.UserId = c.UserId
@@ -21,7 +21,7 @@ func SavePreferences(c *middleware.Context, cmd m.SavePreferencesCommand) Respon
 
 }
 
-// GET /api/user/prefs
+// GET /api/preferences
 func GetPreferences(c *middleware.Context) {
 
 	query := m.GetPreferencesQuery{UserId: c.UserId, OrgId: c.OrgId}
@@ -37,4 +37,18 @@ func GetPreferences(c *middleware.Context) {
 	}
 
 	c.JSON(200, dto)
+}
+
+// POST /api/preferences/set-home-dash
+func SetHomeDashboard(c *middleware.Context, cmd m.SavePreferencesCommand) Response {
+
+  cmd.UserId = c.UserId
+  cmd.OrgId = c.OrgId
+
+  if err := bus.Dispatch(&cmd); err != nil {
+    return ApiError(500, "Failed to set home dashboard", err)
+  }
+
+  return ApiSuccess("Home dashboard set")
+
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -42,13 +42,13 @@ func GetPreferences(c *middleware.Context) {
 // POST /api/preferences/set-home-dash
 func SetHomeDashboard(c *middleware.Context, cmd m.SavePreferencesCommand) Response {
 
-  cmd.UserId = c.UserId
-  cmd.OrgId = c.OrgId
+	cmd.UserId = c.UserId
+	cmd.OrgId = c.OrgId
 
-  if err := bus.Dispatch(&cmd); err != nil {
-    return ApiError(500, "Failed to set home dashboard", err)
-  }
+	if err := bus.Dispatch(&cmd); err != nil {
+		return ApiError(500, "Failed to set home dashboard", err)
+	}
 
-  return ApiSuccess("Home dashboard set")
+	return ApiSuccess("Home dashboard set")
 
 }

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -148,3 +148,8 @@ type GetDashboardsQuery struct {
 	DashboardIds []int64
 	Result       *[]Dashboard
 }
+
+type GetDashboardSlugByIdQuery struct {
+	Id     int64
+	Result string
+}

--- a/pkg/models/preferences.go
+++ b/pkg/models/preferences.go
@@ -39,7 +39,7 @@ type SavePreferencesCommand struct {
 	UserId int64
 	OrgId  int64
 
-	HomeDashboardId int64
-	Timezone        string
-	Theme           string
+	HomeDashboardId int64   `json:"dashboardId"`
+	Timezone        string  `json:"timezone"`
+	Theme           string  `json:"theme"`
 }

--- a/pkg/models/preferences.go
+++ b/pkg/models/preferences.go
@@ -39,7 +39,7 @@ type SavePreferencesCommand struct {
 	UserId int64
 	OrgId  int64
 
-	HomeDashboardId int64   `json:"dashboardId"`
-	Timezone        string  `json:"timezone"`
-	Theme           string  `json:"theme"`
+	HomeDashboardId int64  `json:"homeDashboardId"`
+	Timezone        string `json:"timezone"`
+	Theme           string `json:"theme"`
 }

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -18,6 +18,7 @@ func init() {
 	bus.AddHandler("sql", DeleteDashboard)
 	bus.AddHandler("sql", SearchDashboards)
 	bus.AddHandler("sql", GetDashboardTags)
+	bus.AddHandler("sql", GetDashboardSlugById)
 }
 
 func SaveDashboard(cmd *m.SaveDashboardCommand) error {
@@ -251,6 +252,20 @@ func GetDashboards(query *m.GetDashboardsQuery) error {
 
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func GetDashboardSlugById(query *m.GetDashboardSlugByIdQuery) error {
+	dashboard := m.Dashboard{Id: query.Id}
+	has, err := x.Get(&dashboard)
+	query.Result = dashboard.Slug
+
+	if err != nil {
+		return err
+	} else if has == false {
+		return m.ErrDashboardNotFound
 	}
 
 	return nil

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+  "time"
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -41,6 +42,8 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 				HomeDashboardId: cmd.HomeDashboardId,
 				Timezone:        cmd.Timezone,
 				Theme:           cmd.Theme,
+        Created:         time.Now(),
+        Updated:         time.Now(),
 			}
 			_, err = sess.Insert(&prefs)
 			return err
@@ -48,6 +51,8 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 			prefs.HomeDashboardId = cmd.HomeDashboardId
 			prefs.Timezone = cmd.Timezone
 			prefs.Theme = cmd.Theme
+      prefs.Updated = time.Now()
+      prefs.Version += 1
 			_, err = sess.Id(prefs.Id).Update(&prefs)
 			return err
 		}

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -1,9 +1,9 @@
 package sqlstore
 
 import (
-  "time"
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+	"time"
 )
 
 func init() {
@@ -42,8 +42,8 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 				HomeDashboardId: cmd.HomeDashboardId,
 				Timezone:        cmd.Timezone,
 				Theme:           cmd.Theme,
-        Created:         time.Now(),
-        Updated:         time.Now(),
+				Created:         time.Now(),
+				Updated:         time.Now(),
 			}
 			_, err = sess.Insert(&prefs)
 			return err
@@ -51,8 +51,8 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 			prefs.HomeDashboardId = cmd.HomeDashboardId
 			prefs.Timezone = cmd.Timezone
 			prefs.Theme = cmd.Theme
-      prefs.Updated = time.Now()
-      prefs.Version += 1
+			prefs.Updated = time.Now()
+			prefs.Version += 1
 			_, err = sess.Id(prefs.Id).Update(&prefs)
 			return err
 		}

--- a/public/app/core/routes/dashboard_loaders.js
+++ b/public/app/core/routes/dashboard_loaders.js
@@ -7,25 +7,19 @@ function (coreModule) {
   coreModule.default.controller('LoadDashboardCtrl', function($scope, $routeParams, dashboardLoaderSrv, backendSrv) {
 
     if (!$routeParams.slug) {
-
-      backendSrv.get('/api/preferences').then(function(preferences) {
-        if (preferences !== null && preferences.homeDashboardId !== 0) {
-          backendSrv.get('/api/dashboards/id/' + preferences.homeDashboardId).then(function(dashSlug) {
-            $routeParams.type = 'db';
-            $routeParams.slug = dashSlug.slug;
-            dashboardLoaderSrv.loadDashboard($routeParams.type, $routeParams.slug).then(function(result) {
-              $scope.initDashboard(result, $scope);
-            });
-          });
+      backendSrv.get('/api/dashboards/home').then(function(result) {
+        if (result.slug == null) {
+          var meta = result.meta;
+          meta.canSave = meta.canShare = meta.canStar = false;
+          $scope.initDashboard(result, $scope);
         } else {
-          backendSrv.get('/api/dashboards/home').then(function(result) {
-            var meta = result.meta;
-            meta.canSave = meta.canShare = meta.canStar = false;
+          $routeParams.type = 'db';
+          $routeParams.slug = result.slug;
+          dashboardLoaderSrv.loadDashboard($routeParams.type, $routeParams.slug).then(function(result) {
             $scope.initDashboard(result, $scope);
           });
         }
       });
-
       return;
     }
 

--- a/public/app/core/routes/dashboard_loaders.js
+++ b/public/app/core/routes/dashboard_loaders.js
@@ -7,11 +7,25 @@ function (coreModule) {
   coreModule.default.controller('LoadDashboardCtrl', function($scope, $routeParams, dashboardLoaderSrv, backendSrv) {
 
     if (!$routeParams.slug) {
-      backendSrv.get('/api/dashboards/home').then(function(result) {
-        var meta = result.meta;
-        meta.canSave = meta.canShare = meta.canStar = false;
-        $scope.initDashboard(result, $scope);
+
+      backendSrv.get('/api/preferences').then(function(preferences) {
+        if (preferences !== null && preferences.homeDashboardId !== 0) {
+          backendSrv.get('/api/dashboards/id/' + preferences.homeDashboardId).then(function(dashSlug) {
+            $routeParams.type = 'db';
+            $routeParams.slug = dashSlug.slug;
+            dashboardLoaderSrv.loadDashboard($routeParams.type, $routeParams.slug).then(function(result) {
+              $scope.initDashboard(result, $scope);
+            });
+          });
+        } else {
+          backendSrv.get('/api/dashboards/home').then(function(result) {
+            var meta = result.meta;
+            meta.canSave = meta.canShare = meta.canStar = false;
+            $scope.initDashboard(result, $scope);
+          });
+        }
       });
+
       return;
     }
 

--- a/public/app/features/dashboard/dashnav/dashnav.ts
+++ b/public/app/features/dashboard/dashnav/dashnav.ts
@@ -106,7 +106,7 @@ export class DashNavCtrl {
     $scope.saveDashboardAsHome = function() {
       // TODO: this backend method needs to be implemented
       backendSrv.post('/api/preferences/set-home-dash', {
-        dashboardId: $scope.dashboard.id
+        homeDashboardId: $scope.dashboard.id
       });
     };
 


### PR DESCRIPTION
Now a user can set the home dashboard per org as per his/her preference.

2 comments:
- Instead of storing dashboard_id , we can store dashboard_slug so that we can avoid an extra call api to get dashboard slug.
- Tests need to be written for this PR. (Will write it once this PR is reviewed :) )
