### PR TITLE
Bug fix: seal the timeline at the legend on the right

### DIFF
--- a/public/app/plugins/panel/graph/axisEditor.html
+++ b/public/app/plugins/panel/graph/axisEditor.html
@@ -51,12 +51,6 @@
 					empty-to-null ng-model="ctrl.panel.grid.leftMin"
 					ng-change="ctrl.render()" ng-model-onblur>
 				</li>
-				<li class="tight-form-item">
-					Value
-				</li>
-				<li>
-					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.leftValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
-				</li>
 				</ul>
 			<div class="clearfix"></div>
 		</div>
@@ -109,12 +103,6 @@
 					<input type="number" class="input-small tight-form-input" placeholder="auto" style="width: 113px;"
 					empty-to-null ng-model="ctrl.panel.grid.rightMin"
 					ng-change="ctrl.render()" ng-model-onblur>
-				</li>
-				<li class="tight-form-item">
-					Value
-				</li>
-				<li>
-					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.rightValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
 				</li>
 			</ul>
 			<div class="clearfix"></div>

--- a/public/app/plugins/panel/graph/axisEditor.html
+++ b/public/app/plugins/panel/graph/axisEditor.html
@@ -51,6 +51,12 @@
 					empty-to-null ng-model="ctrl.panel.grid.leftMin"
 					ng-change="ctrl.render()" ng-model-onblur>
 				</li>
+				<li class="tight-form-item">
+					Value
+				</li>
+				<li>
+					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.leftValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
+				</li>
 				</ul>
 			<div class="clearfix"></div>
 		</div>
@@ -103,6 +109,12 @@
 					<input type="number" class="input-small tight-form-input" placeholder="auto" style="width: 113px;"
 					empty-to-null ng-model="ctrl.panel.grid.rightMin"
 					ng-change="ctrl.render()" ng-model-onblur>
+				</li>
+				<li class="tight-form-item">
+					Value
+				</li>
+				<li>
+					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.rightValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
 				</li>
 			</ul>
 			<div class="clearfix"></div>

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -363,11 +363,11 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             options.yaxes.push(secondY);
 
             applyLogScale(options.yaxes[1], data);
-            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1]);
+            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1], panel.grid.rightValue == 'absolute');
           }
 
           applyLogScale(options.yaxes[0], data);
-          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0]);
+          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0], panel.grid.leftValue == 'absolute');
         }
 
         function applyLogScale(axis, data) {
@@ -413,9 +413,9 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           }
         }
 
-        function configureAxisMode(axis, format) {
+        function configureAxisMode(axis, format, absolute) {
           axis.tickFormatter = function(val, axis) {
-            return kbn.valueFormats[format](val, axis.tickDecimals, axis.scaledDecimals);
+            return kbn.valueFormats[format](absolute?Math.abs(val):val, axis.tickDecimals, axis.scaledDecimals);
           };
         }
 

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -256,7 +256,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           if (shouldDelayDraw(panel)) {
             // temp fix for legends on the side, need to render twice to get dimensions right
             callPlot(false);
-            setTimeout(function() { callPlot(true); }, 50);
+            setTimeout(function() { addTimeAxis(options); callPlot(true); }, 50);
             legendSideLastValue = panel.legend.rightSide;
           }
           else {

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -363,11 +363,11 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             options.yaxes.push(secondY);
 
             applyLogScale(options.yaxes[1], data);
-            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1], panel.grid.rightValue == 'absolute');
+            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1]);
           }
 
           applyLogScale(options.yaxes[0], data);
-          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0], panel.grid.leftValue == 'absolute');
+          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0]);
         }
 
         function applyLogScale(axis, data) {
@@ -413,9 +413,9 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           }
         }
 
-        function configureAxisMode(axis, format, absolute) {
+        function configureAxisMode(axis, format) {
           axis.tickFormatter = function(val, axis) {
-            return kbn.valueFormats[format](absolute?Math.abs(val):val, axis.tickDecimals, axis.scaledDecimals);
+            return kbn.valueFormats[format](val, axis.tickDecimals, axis.scaledDecimals);
           };
         }
 


### PR DESCRIPTION
Steps of render graph with legend:
1. render diagram on full width
![01](https://cloud.githubusercontent.com/assets/936530/13868842/04ae99fe-ecef-11e5-938b-13cc10eb6381.jpg)
2. render legend over the diagram
![02](https://cloud.githubusercontent.com/assets/936530/13868846/0b93474c-ecef-11e5-93e2-0e13d8c18346.jpg)
3. resize diagram (after delay 50 milliseconds)
![03](https://cloud.githubusercontent.com/assets/936530/13868851/1196b192-ecef-11e5-9912-70080617cc00.jpg)

After this patch time axis will be recalculated before redraw diagram.
![04](https://cloud.githubusercontent.com/assets/936530/13868855/1ccd77bc-ecef-11e5-8fe3-3a75cbf622cd.jpg)

Especially the bug manifests snapshot. Snapshot before patch 
![test-dashboard-copy-failed](https://cloud.githubusercontent.com/assets/936530/13868857/26c0fd84-ecef-11e5-8f70-e766d0c30c99.png)
and after
![test-dashboard-copy-ok](https://cloud.githubusercontent.com/assets/936530/13868859/2c326cda-ecef-11e5-8c02-3f4d073a6495.png)
