### PR TITLE
Update datasource.js

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -76,7 +76,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
 
       var queryInterpolated = templateSrv.replace(queryString);
       var filter = { "bool": { "must": [{ "range": range }] } };
-      var query = { "bool": { "should": [{ "query_string": { "query": queryInterpolated } }] } };
+      var query = { "bool": { "should": [{ "query_string": { "query": queryInterpolated, "lowercase_expanded_terms": false } }] } };
       var data = {
         "fields": [timeField, "_source"],
         "query" : { "filtered": { "query" : query, "filter": filter } },


### PR DESCRIPTION
When you make query string queries, this parameter defaults to true: `lowercase_expanded_terms`

What this does is auto lowercase your searched-for terms. With fields that are unanalyzed, case must match.  When part of these strings are upper case, it will cause a failure to match the wildcarded query. You can test in sense with this:

```
GET /index/query_string1/_search
{
    "query" : {
        "query_string": {
           "query": "name.raw:server-histogram.RFC100QueryContract.*.response-duration.*",
           "lowercase_expanded_terms": false
        }

    }
```
