### PR TITLE
Axis Y value display mode

### DIFF
--- a/public/app/plugins/panel/graph/axisEditor.html
+++ b/public/app/plugins/panel/graph/axisEditor.html
@@ -51,6 +51,12 @@
 					empty-to-null ng-model="ctrl.panel.grid.leftMin"
 					ng-change="ctrl.render()" ng-model-onblur>
 				</li>
+				<li class="tight-form-item">
+					Value
+				</li>
+				<li>
+					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.leftValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
+				</li>
 				</ul>
 			<div class="clearfix"></div>
 		</div>
@@ -103,6 +109,12 @@
 					<input type="number" class="input-small tight-form-input" placeholder="auto" style="width: 113px;"
 					empty-to-null ng-model="ctrl.panel.grid.rightMin"
 					ng-change="ctrl.render()" ng-model-onblur>
+				</li>
+				<li class="tight-form-item">
+					Value
+				</li>
+				<li>
+					<select class="input-small tight-form-input" style="width: 113px" ng-model="ctrl.panel.grid.rightValue" ng-options="f for f in ['raw','absolute']" ng-change="ctrl.render()"></select>
 				</li>
 			</ul>
 			<div class="clearfix"></div>

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -363,11 +363,13 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             options.yaxes.push(secondY);
 
             applyLogScale(options.yaxes[1], data);
-            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1]);
+            configureAxisMode(options.yaxes[1], panel.percentage && panel.stack ? "percent" : panel.y_formats[1],
+                panel.grid.rightValue === 'absolute');
           }
 
           applyLogScale(options.yaxes[0], data);
-          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0]);
+          configureAxisMode(options.yaxes[0], panel.percentage && panel.stack ? "percent" : panel.y_formats[0],
+                panel.grid.leftValue === 'absolute');
         }
 
         function applyLogScale(axis, data) {
@@ -413,9 +415,9 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           }
         }
 
-        function configureAxisMode(axis, format) {
+        function configureAxisMode(axis, format, absolute) {
           axis.tickFormatter = function(val, axis) {
-            return kbn.valueFormats[format](val, axis.tickDecimals, axis.scaledDecimals);
+            return kbn.valueFormats[format](absolute?Math.abs(val):val, axis.tickDecimals, axis.scaledDecimals);
           };
         }
 


### PR DESCRIPTION
I suggest a new feature: the display mode of the values on the Y axis (raw or absolute). It looks better for the network speed. Default: raw.

![raw](https://cloud.githubusercontent.com/assets/936530/13869016/1f61ea24-ecf1-11e5-85f8-db06ae3ddb6d.jpg)

![abs](https://cloud.githubusercontent.com/assets/936530/13869019/2344733c-ecf1-11e5-8937-7a37c3d70613.jpg)
