### PR TITLE
Fix issue 4333: correct stacked values on legend and tooltips.

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -69,10 +69,10 @@ function ($) {
           } else if (!series.stack) {
             value = series.data[hoverIndex][1];
           } else {
-            var stack_index = series.stack == 'A'?1:
-                series.stack == 'B'?2:
-                series.stack == 'C'?3:
-                series.stack == 'D'?4:0;
+            var stack_index = series.stack === 'A'?1:
+                series.stack === 'B'?2:
+                series.stack === 'C'?3:
+                series.stack === 'D'?4:0;
             last_value[stack_index] += series.data[hoverIndex][1];
             value = last_value[stack_index];
           }

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -45,7 +45,7 @@ function ($) {
       var results = [];
 
       //now we know the current X (j) position for X and Y values
-      var last_value = 0; //needed for stacked values
+      var last_value = [0, 0, 0, 0, 0]; //needed for stacked values
 
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];
@@ -69,8 +69,12 @@ function ($) {
           } else if (!series.stack) {
             value = series.data[hoverIndex][1];
           } else {
-            last_value += series.data[hoverIndex][1];
-            value = last_value;
+            var stack_index = series.stack == 'A'?1:
+                series.stack == 'B'?2:
+                series.stack == 'C'?3:
+                series.stack == 'D'?4:0;
+            last_value[stack_index] += series.data[hoverIndex][1];
+            value = last_value[stack_index];
           }
         } else {
           value = series.data[hoverIndex][1];

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -100,6 +100,26 @@ function (angular, _, $) {
           return html + '</th>';
         }
 
+        function getStackValue(series, panel, value, stack) {
+            var stack_index =
+                    (series.stack == 'A'?1:
+                    series.stack == 'B'?2:
+                    series.stack == 'C'?3:
+                    series.stack == 'D'?4:
+                    0),
+                result = 0;
+
+            series.stack?
+                "individual" === panel.tooltip.value_type?
+                    result = value:
+                    series.stack?
+                        (stack[stack_index] += value, result = stack[stack_index]):
+                        result = value:
+                result = value;
+
+            return result;
+        }
+
         function render() {
           if (firstRender) {
             elem.append($container);
@@ -133,6 +153,12 @@ function (angular, _, $) {
             $container.append($(header));
           }
 
+          var stack_avg = [0, 0, 0, 0, 0],
+            stack_current = [0, 0, 0, 0, 0],
+            stack_min = [0, 0, 0, 0, 0],
+            stack_max = [0, 0, 0, 0, 0],
+            stack_total = [0, 0, 0, 0, 0];
+
           if (panel.legend.sort) {
             seriesList = _.sortBy(seriesList, function(series) {
               return series.stats[panel.legend.sort];
@@ -145,6 +171,11 @@ function (angular, _, $) {
           var seriesShown = 0;
           for (i = 0; i < seriesList.length; i++) {
             var series = seriesList[i];
+            var avg = series.formatValue(getStackValue(series, panel, series.stats.avg, stack_avg));
+            var current = series.formatValue(getStackValue(series, panel, series.stats.current, stack_current));
+            var min = series.formatValue(getStackValue(series, panel, series.stats.min, stack_min));
+            var max = series.formatValue(getStackValue(series, panel, series.stats.max, stack_max));
+            var total = series.formatValue(getStackValue(series, panel, series.stats.total, stack_total));
 
             if (series.hideFromLegend(panel.legend)) {
               continue;
@@ -161,12 +192,6 @@ function (angular, _, $) {
             html += '<a class="graph-legend-alias pointer">' + _.escape(series.label) + '</a>';
 
             if (panel.legend.values) {
-              var avg = series.formatValue(series.stats.avg);
-              var current = series.formatValue(series.stats.current);
-              var min = series.formatValue(series.stats.min);
-              var max = series.formatValue(series.stats.max);
-              var total = series.formatValue(series.stats.total);
-
               if (panel.legend.min) { html += '<div class="graph-legend-value min">' + min + '</div>'; }
               if (panel.legend.max) { html += '<div class="graph-legend-value max">' + max + '</div>'; }
               if (panel.legend.avg) { html += '<div class="graph-legend-value avg">' + avg + '</div>'; }

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -102,10 +102,10 @@ function (angular, _, $) {
 
         function getStackValue(series, panel, value, stack) {
             var stack_index =
-                    (series.stack == 'A'?1:
-                    series.stack == 'B'?2:
-                    series.stack == 'C'?3:
-                    series.stack == 'D'?4:
+                    (series.stack === 'A'?1:
+                    series.stack === 'B'?2:
+                    series.stack === 'C'?3:
+                    series.stack === 'D'?4:
                     0),
                 result = 0;
 

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -101,23 +101,20 @@ function (angular, _, $) {
         }
 
         function getStackValue(series, panel, value, stack) {
-            var stack_index =
-                    (series.stack === 'A'?1:
-                    series.stack === 'B'?2:
-                    series.stack === 'C'?3:
-                    series.stack === 'D'?4:
-                    0),
-                result = 0;
+          var stack_index = (series.stack === 'A')?1:
+            (series.stack === 'B')?2:
+            (series.stack === 'C')?3:
+            (series.stack === 'D')?4:0;
+          var result = 0;
 
-            series.stack?
-                "individual" === panel.tooltip.value_type?
-                    result = value:
-                    series.stack?
-                        (stack[stack_index] += value, result = stack[stack_index]):
-                        result = value:
-                result = value;
-
-            return result;
+          series.stack?
+            "individual" === panel.tooltip.value_type?
+              result = value:
+              series.stack?
+                (stack[stack_index] += value, result = stack[stack_index]):
+                result = value:
+            result = value;
+          return result;
         }
 
         function render() {


### PR DESCRIPTION
To issue #4333

For example: We have two network link. We must show them and the total traffic. Created 6 metrics: RX1, RX2, RX, TX1, TX2, TX. RX2 = RX, TX2 = TX. Configure series specifics as in the screenshot.
![stack01](https://cloud.githubusercontent.com/assets/936530/13875812/e8dd7104-ed21-11e5-9b45-71ca3a23b5c5.jpg)
Although that option "Stacked Values" is set to "cumulative", min/max value of RX/TX are copy of RX2/TX2. On series tooltips wrong cumulative values for TX1 and TX.

After corrections.
![stack02](https://cloud.githubusercontent.com/assets/936530/13875818/ec97a864-ed21-11e5-806c-38193f8b9415.jpg)
