### PR TITLE
(cloudwatch) expand multi select template variable

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -23,7 +23,7 @@ function (angular, _, moment, dateMath, CloudWatchAnnotationQuery) {
 
       var queries = [];
       options = angular.copy(options);
-      options.targets = this.expandTemplateVariable(options.targets);
+      options.targets = this.expandTemplateVariable(options.targets, templateSrv);
       _.each(options.targets, _.bind(function(target) {
         if (target.hide || !target.namespace || !target.metricName || _.isEmpty(target.statistics)) {
           return;
@@ -333,7 +333,7 @@ function (angular, _, moment, dateMath, CloudWatchAnnotationQuery) {
       });
     }
 
-    this.expandTemplateVariable = function(targets) {
+    this.expandTemplateVariable = function(targets, templateSrv) {
       return _.chain(targets)
       .map(function(target) {
         var dimensionKey = null;

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -23,6 +23,7 @@ function (angular, _, moment, dateMath, CloudWatchAnnotationQuery) {
 
       var queries = [];
       options = angular.copy(options);
+      options.targets = this.expandTemplateVariable(options.targets);
       _.each(options.targets, _.bind(function(target) {
         if (target.hide || !target.namespace || !target.metricName || _.isEmpty(target.statistics)) {
           return;
@@ -331,6 +332,36 @@ function (angular, _, moment, dateMath, CloudWatchAnnotationQuery) {
         return {target: seriesName, datapoints: dps};
       });
     }
+
+    this.expandTemplateVariable = function(targets) {
+      return _.chain(targets)
+      .map(function(target) {
+        var dimensionKey = null;
+        var variableName = null;
+        _.each(target.dimensions, function(v, k) {
+          if (templateSrv.variableExists(v)) {
+            dimensionKey = k;
+            variableName = v;
+          }
+        });
+        if (dimensionKey) {
+          var variable = _.find(templateSrv.variables, function(variable) {
+            return templateSrv.containsVariable(variableName, variable.name);
+          });
+          return _.chain(variable.options)
+          .filter(function(v) {
+            return v.selected;
+          })
+          .map(function(v) {
+            var t = angular.copy(target);
+            t.dimensions[dimensionKey] = v.value;
+            return t;
+          }).value();
+        } else {
+          return [target];
+        }
+      }).flatten().value();
+    };
 
     this.convertToCloudWatchTime = function(date, roundUp) {
       if (_.isString(date)) {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -98,6 +98,38 @@ describe('CloudWatchDatasource', function() {
       });
       ctx.$rootScope.$apply();
     });
+
+    it('should generate the correct targets by expanding template variables', function() {
+      var templateSrv = {
+        variables: [
+          {
+            name: 'instance_id',
+            options: [
+              { value: 'i-23456789', selected: false },
+              { value: 'i-34567890', selected: true }
+            ]
+          }
+        ],
+        variableExists: function (e) { return true; },
+        containsVariable: function (str, variableName) { return str.indexOf('$' + variableName) !== -1; }
+      };
+
+      var targets = [
+        {
+          region: 'us-east-1',
+          namespace: 'AWS/EC2',
+          metricName: 'CPUUtilization',
+          dimensions: {
+            InstanceId: '$instance_id'
+          },
+          statistics: ['Average'],
+          period: 300
+        }
+      ];
+
+      var result = ctx.ds.expandTemplateVariable(targets, templateSrv);
+      expect(result[0].dimensions.InstanceId).to.be('i-34567890');
+    });
   });
 
   function describeMetricFindQuery(query, func) {


### PR DESCRIPTION
CloudWatch query doesn't support mutiple query target itself.
So, expand template variable in datasource plugin side.
