### PR TITLE
Form adjustments for app work

### DIFF
--- a/public/sass/components/_gf-form.scss
+++ b/public/sass/components/_gf-form.scss
@@ -50,6 +50,12 @@ $gf-form-label-margin: 0.25rem;
   @include border-radius($label-border-radius-sm);
 }
 
+.gf-form-label--textarea {
+  line-height: $input-line-height * 2;
+  padding-top: 0px;
+  padding-bottom: 16px; // $spacer (1rem) was slightly too short.
+}
+
 .gf-form-checkbox {
   flex-shrink: 0;
   padding: $input-padding-y $input-padding-x;
@@ -67,6 +73,7 @@ $gf-form-label-margin: 0.25rem;
   display: block;
   width: 100%;
   padding: $input-padding-y $input-padding-x;
+  margin-right: $gf-form-label-margin;
   font-size: $font-size-base;
   line-height: $input-line-height;
   color: $input-color;
@@ -111,6 +118,7 @@ $gf-form-label-margin: 0.25rem;
 .gf-form-select-wrapper {
   position: relative;
   background-color: $input-bg;
+  margin-right: $gf-form-label-margin;
 
   select.gf-form-input {
     text-indent: .01px;
@@ -139,8 +147,15 @@ $gf-form-label-margin: 0.25rem;
   }
 }
 
-.gf-form-select-wrapper + .gf-form-select-wrapper { 
-  margin-left: $gf-form-label-margin; 
+.gf-form--textarea {
+  align-items: flex-start;
+}
+
+input[type="number"].gf-natural-language-form {
+  font-size: $font-size-base;
+  line-height: $input-line-height;
+  margin: -6px -5px 0 5px;
+  padding: $input-padding-y/2 $input-padding-x/2;
 }
 
 .gf-form-btn {


### PR DESCRIPTION
@torkelo I wasnt able to find where you added the right margin, so i added it here and removed the `.gf-form-select-wrapper + .gf-form-select-wrapper` that was still in master. 

I also want to talk about adding a class to support an adjustable margin-right (like offset in a grid) for in-line form elements. 

And on line 53, I know that's a hacky way to approach it, so would love some brainstorming on a better approach. It helps accommodate a 2 line text area by default, but it also allows the label to remain at flex-start when the text area grows:

![gf-form-textarea](https://cloud.githubusercontent.com/assets/2886187/13970308/4ea4f1c6-f05e-11e5-8d6f-b2202a128545.gif)
