### PR TITLE
Fixed some minor typos in docs

### DIFF
--- a/docs/sources/plugins/developing_plugins.md
+++ b/docs/sources/plugins/developing_plugins.md
@@ -42,6 +42,6 @@ This makes it possible to have both built and src content in the same plugin fol
 ## Boilerplate
 We currently have three different examples that you can fork/download to get started developing your grafana plugin.
 
- - [simple-json-datasource](https://github.com/grafana/simple-json-datasource) (small datasource plugin for quering json data from backends)
+ - [simple-json-datasource](https://github.com/grafana/simple-json-datasource) (small datasource plugin for querying json data from backends)
  - [piechart-panel](https://github.com/grafana/piechart-panel)
  - [example-app](https://github.com/grafana/example-app)

--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -11,7 +11,7 @@ page_keywords: grafana, plugins, documentation
 The easiest way to install plugins is by using the CLI tool grafana-cli which is bundled with grafana. Before any modification take place after modifying plugins, grafana-server needs to be restarted.
 
 ### Grafana plugin directory
-On Linux systems the grafana-cli will assume that the grafana plugin directory is "/var/lib/grafana/plugins". It's possible to override the directory which grafana-cli will operate on by specifing the --path flag. On Windows systems this parameter have to be specified for every call.
+On Linux systems the grafana-cli will assume that the grafana plugin directory is "/var/lib/grafana/plugins". It's possible to override the directory which grafana-cli will operate on by specifying the --path flag. On Windows systems this parameter have to be specified for every call.
 
 ### Grafana-cli commands
 


### PR DESCRIPTION
While reading docs for plugins, found couple of typos. Fixing them in this PR.
