### PR TITLE
Issue with templating latest InfluxDB v0.11.0, force query to lowercase

### DIFF
--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -15,7 +15,7 @@ export default class ResponseParser {
     var series = influxResults.series[0];
     return _.map(series.values, (value) => {
       if (_.isArray(value)) {
-        if (query.indexOf('SHOW TAG VALUES') >= 0) {
+        if (query.toLowerCase().indexOf('show tag values') >= 0) {
           return { text: (value[1] || value[0]) };
         } else {
           return { text: value[0] };


### PR DESCRIPTION
After upgrading InfluxDB to v0.11.0 coupled with grafana v3.0.0-pre1, noticed that templating was not working as expected when using tag values queries. Turns out as of 03/23/16 a fix was made to check for SHOW TAG VALUES in the query, but if using lowercase this gets skipped and only the key is returned with the new layout.

This fix forces the query to lowercase and checks for 'show tag values' to return the needful.

```
2016/03/26 06:25:57 [I] Starting Grafana
2016/03/26 06:25:57 [I] Version: 3.0.0-pre1, Commit: v2.6.0-1091-g30f3b55, Build date: 2016-02-25 03:26:07 -0600 CST
2016/03/26 06:25:57 [I] Configuration Info
Config files:
  [0]: /usr/local/grafana/grafana-3.0.0-pre1/share/conf/defaults.ini
  [1]: /etc/grafana/grafana.ini
Command lines overrides:
  [0]: default.paths.data=/usr/local/grafana/lib
  [1]: default.paths.logs=/var/log/grafana
Paths:
  home: /usr/local/grafana/grafana-3.0.0-pre1/share
  data: /usr/local/grafana/lib
  logs: /var/log/grafana
  plugins: /usr/local/grafana/plugins

2016/03/26 06:25:57 [I] Database: mysql
2016/03/26 06:25:57 [I] Migrator: Starting DB migration
2016/03/26 06:25:58 [I] Login: Ldap enabled, reading config file: /etc/grafana/ldap.toml
2016/03/26 06:25:58 [I] Plugins: Scan starting
2016/03/26 06:25:58 [I] Plugins: Scaning dir /usr/local/grafana/grafana-3.0.0-pre1/share/public/app/plugins
2016/03/26 06:25:58 [I] Plugins: Scaning dir /usr/local/grafana/plugins
2016/03/26 06:25:58 [I] Listen: http://0.0.0.0:3000
```
