### PR TITLE
datasource_mig: set json_data column non-nullable

### DIFF
--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -59,7 +59,7 @@ func addDataSourceMigration(mg *Migrator) {
 			{Name: "basic_auth_user", Type: DB_NVarchar, Length: 255, Nullable: true},
 			{Name: "basic_auth_password", Type: DB_NVarchar, Length: 255, Nullable: true},
 			{Name: "is_default", Type: DB_Bool, Nullable: false},
-			{Name: "json_data", Type: DB_Text, Nullable: true},
+			{Name: "json_data", Type: DB_Text, Nullable: false},
 			{Name: "created", Type: DB_DateTime, Nullable: false},
 			{Name: "updated", Type: DB_DateTime, Nullable: false},
 		},


### PR DESCRIPTION
Hello! The json_data column of the data_source SQL table is not Nullable as it's not supported by current code. This patch should avoid a late panic but may not fix the original issue. Indeed after 2.5 to 3-beta1 migration, we ended up with a NULL json_data value in MariaDB for our only data_source table row (graphite).

The code doesn't support a null json_data, it crashed at:

```
[Macaron] PANIC: runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:423 (0x4c3189)
/usr/local/go/src/runtime/panic.go:42 (0x4c1849)
/usr/local/go/src/runtime/sigpanic_unix.go:24 (0x4d81fa)
/go/src/github.com/grafana/grafana/pkg/components/simplejson/simplejson.go:299 (0x741300)
/go/src/github.com/grafana/grafana/pkg/api/frontendsettings.go:62 (0x615af7)
/go/src/github.com/grafana/grafana/pkg/api/index.go:12 (0x616915)
/go/src/github.com/grafana/grafana/pkg/api/index.go:141 (0x61936b)
/usr/local/go/src/runtime/asm_amd64.s:437 (0x4f32ee)
/usr/local/go/src/reflect/value.go:432 (0x65775a)
/usr/local/go/src/reflect/value.go:300 (0x656421)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/github.com/go-macaron/inject/inject.go:117 (0x932c02)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:113 (0x5ea3a7)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:104 (0x5ea28c)
/go/src/github.com/grafana/grafana/pkg/middleware/session.go:71 (0x63f4f7)
/usr/local/go/src/runtime/asm_amd64.s:437 (0x4f32ee)
/usr/local/go/src/reflect/value.go:432 (0x65775a)
/usr/local/go/src/reflect/value.go:300 (0x656421)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/github.com/go-macaron/inject/inject.go:117 (0x932c02)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:113 (0x5ea3a7)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:104 (0x5ea28c)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/recovery.go:161 (0x5fd222)
/usr/local/go/src/runtime/asm_amd64.s:437 (0x4f32ee)
/usr/local/go/src/reflect/value.go:432 (0x65775a)
/usr/local/go/src/reflect/value.go:300 (0x656421)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/github.com/go-macaron/inject/inject.go:117 (0x932c02)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:113 (0x5ea3a7)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:104 (0x5ea28c)
/go/src/github.com/grafana/grafana/pkg/middleware/logger.go:38 (0x63e47a)
/usr/local/go/src/runtime/asm_amd64.s:437 (0x4f32ee)
/usr/local/go/src/reflect/value.go:432 (0x65775a)
/usr/local/go/src/reflect/value.go:300 (0x656421)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/github.com/go-macaron/inject/inject.go:117 (0x932c02)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/context.go:113 (0x5ea3a7)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/router.go:184 (0x5fe994)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/router.go:286 (0x5f777d)
/go/src/github.com/grafana/grafana/Godeps/_workspace/src/gopkg.in/macaron.v1/macaron.go:175 (0x5ef70a)
/usr/local/go/src/net/http/server.go:1862 (0x5c9e7e)
/usr/local/go/src/net/http/server.go:1361 (0x5c76ce)
/usr/local/go/src/runtime/asm_amd64.s:1696 (0x4f5611)
2016/04/02 19:44:27 [I] Completed a.b.c.d admin "GET / HTTP/1.1" 500 Internal Server Error 0 bytes in 5222us
```

We fixed the issue with:

``` sql
MariaDB [grafana]> update data_source set json_data="{}";
```
