### PR TITLE
Table render method creates table object from scratch to apply all changes

### DIFF
--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -114,9 +114,13 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       }
     }
 
+    this.render();
+  }
+  
+  render() {
     this.table = transformDataToTable(this.dataRaw, this.panel);
     this.table.sort(this.panel.sort);
-    this.render(this.table);
+    super.render(this.table);
   }
 
   toggleColumnSort(col, colIndex) {


### PR DESCRIPTION
This solves #4544 

Render method should recreate the table and re-sort, otherwise most changes to options, including sorting are not applied until next refresh
