### PR TITLE
Allow to show multiple tags with annotations with InfluxDB datasource

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -89,7 +89,7 @@ function (_, TableModel) {
         if (column === 'sequence_number') { return; }
         if (!titleCol) { titleCol = index; }
         if (column === self.annotation.titleColumn) { titleCol = index; return; }
-        if (self.annotation.tagsColumn.includes(column)) { tagsCol.push(index); return; }
+        if (_.contains(tagsColumn.split(","), column)) { tagsCol.push(index); return; }
         if (column === self.annotation.textColumn) { textCol = index; return; }
       });
 

--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -81,7 +81,7 @@ function (_, TableModel) {
     _.each(this.series, function (series) {
       var titleCol = null;
       var timeCol = null;
-      var tagsCol = null;
+      var tagsCol = [];
       var textCol = null;
 
       _.each(series.columns, function(column, index) {
@@ -89,7 +89,7 @@ function (_, TableModel) {
         if (column === 'sequence_number') { return; }
         if (!titleCol) { titleCol = index; }
         if (column === self.annotation.titleColumn) { titleCol = index; return; }
-        if (column === self.annotation.tagsColumn) { tagsCol = index; return; }
+        if (self.annotation.tagsColumn.includes(column)) { tagsCol.push(index); return; }
         if (column === self.annotation.textColumn) { textCol = index; return; }
       });
 
@@ -98,7 +98,7 @@ function (_, TableModel) {
           annotation: self.annotation,
           time: + new Date(value[timeCol]),
           title: value[titleCol],
-          tags: value[tagsCol],
+          tags: tagsCol.map(function(t) { return value[t]; }),
           text: value[textCol]
         };
 


### PR DESCRIPTION
Fix the problem when using InfluxDB as backend that selecting multiple tags for annotations were not working.
![influx multiple tags annotations](https://cloud.githubusercontent.com/assets/3237784/14252366/4e0c5258-fa87-11e5-859f-4afdc5c3e367.png)
