### PR TITLE
Fix issue #4533: InfluxDB 0.11.1+ Multiple queries

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -61,6 +61,13 @@ export class GrafanaApp {
         };
         return $delegate;
       }]);
+
+      $provide.decorator('$httpBackend', function($delegate) {
+        return function(method, url, post, callback, headers, timeout, withCredentials, responseType) {
+          url = url.replace(';', '%3B');
+          $delegate(method, url, post, callback, headers, timeout, withCredentials, responseType);
+        };
+      });
     });
 
     this.ngModuleDependencies = [

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -55,7 +55,7 @@ export default class InfluxDatasource {
       query = query.replace(/\$interval/g, (target.interval || options.interval));
       return query;
 
-    }).join("\n");
+    }).join(";\n");
 
     // replace grafana variables
     allQueries = allQueries.replace(/\$timeFilter/g, timeFilter);

--- a/public/vendor/angular/angular.js
+++ b/public/vendor/angular/angular.js
@@ -1437,7 +1437,6 @@ function encodeUriQuery(val, pctEncodeSpaces) {
              replace(/%3A/gi, ':').
              replace(/%24/g, '$').
              replace(/%2C/gi, ',').
-             replace(/%3B/gi, ';').
              replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
 }
 

--- a/public/vendor/angular/angular.js
+++ b/public/vendor/angular/angular.js
@@ -1437,6 +1437,7 @@ function encodeUriQuery(val, pctEncodeSpaces) {
              replace(/%3A/gi, ':').
              replace(/%24/g, '$').
              replace(/%2C/gi, ',').
+             replace(/%3B/gi, ';').
              replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
 }
 


### PR DESCRIPTION
InfluxDB supports now properly semi-colons and throws an error if
semi-colon is missing (https://github.com/influxdata/influxdb/pull/6004)

Grafana in process of joining multiple queries was using only "\n" as a
separator between queries.

My patch fixes this and adding semi-colons between queries.

As a side effect I hit a bug with angular.js and not correct urlencode
semi-colons (there is a longer discussion about it:
https://github.com/angular/angular.js/issues/9224).

I hope it's ok to remove that regex and keep semi-colon encoded in URL.

Tested with InfluxDB 0.10, 0.11 and 0.12 (don't have any 0.9).
