### PR TITLE
Backward and forward arrows for time shift

### DIFF
--- a/public/app/features/dashboard/keybindings.js
+++ b/public/app/features/dashboard/keybindings.js
@@ -60,6 +60,14 @@ function(angular, $) {
         scope.appEvent('zoom-out', evt);
       }, { inputDisabled: true });
 
+      keyboardManager.bind('left', function(evt) {
+        scope.appEvent('shift-time-backward', evt);
+      }, { inputDisabled: true });
+
+      keyboardManager.bind('right', function(evt) {
+        scope.appEvent('shift-time-forward', evt);
+      }, { inputDisabled: true });
+
       keyboardManager.bind('ctrl+e', function(evt) {
         scope.appEvent('export-dashboard', evt);
       }, { inputDisabled: true });

--- a/public/app/features/dashboard/timepicker/timepicker.html
+++ b/public/app/features/dashboard/timepicker/timepicker.html
@@ -1,6 +1,16 @@
 <ul class="nav gf-timepicker-nav">
 
 	<li class="dashnav-zoom-out" style="padding-top: 2px">
+                <a class='small' ng-click='ctrl.move(-1)'>
+                        &lt;
+                </a>
+        </li>
+	<li class="dashnav-zoom-out" style="padding-top: 2px">
+                <a class='small' ng-click='ctrl.move(1)'>
+                        &gt; 
+                </a>
+        </li>
+	<li class="dashnav-zoom-out" style="padding-top: 2px">
 		<a class='small' ng-click='ctrl.zoom(2)'>
 			Zoom Out
 		</a>

--- a/public/app/features/dashboard/timepicker/timepicker.html
+++ b/public/app/features/dashboard/timepicker/timepicker.html
@@ -2,12 +2,12 @@
 
 	<li class="dashnav-zoom-out" style="padding-top: 2px">
                 <a class='small' ng-click='ctrl.move(-1)'>
-                        &lt;
+                        <i class="fa fa-arrow-left"></i>
                 </a>
         </li>
 	<li class="dashnav-zoom-out" style="padding-top: 2px">
                 <a class='small' ng-click='ctrl.move(1)'>
-                        &gt; 
+                        <i class="fa fa-arrow-right"></i> 
                 </a>
         </li>
 	<li class="dashnav-zoom-out" style="padding-top: 2px">

--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -30,6 +30,8 @@ export class TimePickerCtrl {
     $scope.ctrl = this;
 
     $rootScope.onAppEvent('zoom-out', () => this.zoom(2), $scope);
+    $rootScope.onAppEvent('shift-time-forward', () => this.move(1), $scope);
+    $rootScope.onAppEvent('shift-time-backward', () => this.move(-1), $scope);
     $rootScope.onAppEvent('refresh', () => this.init(), $scope);
     $rootScope.onAppEvent('dash-editor-hidden', () => this.isOpen = false, $scope);
 
@@ -85,6 +87,30 @@ export class TimePickerCtrl {
     }
 
     this.timeSrv.setTime({from: moment.utc(from), to: moment.utc(to) });
+  }
+
+  move(direction) {
+    var range = this.timeSrv.timeRange();
+
+    var timespan = (range.to.valueOf() - range.from.valueOf());
+    var to, from;
+    if (direction === -1) {
+      to = range.to.valueOf() - timespan;
+      from = range.from.valueOf() - timespan;
+    } else if (direction === 1) {
+      to = range.to.valueOf() + timespan;
+      from = range.from.valueOf() + timespan;
+      if (to > Date.now() && range.to < Date.now()) {
+        to = Date.now();
+        from = range.from.valueOf();
+      }
+    } else {
+      to = range.to.valueOf();
+      from = range.from.valueOf();
+    }
+
+    this.timeSrv.setTime({from: moment.utc(from), to: moment.utc(to) });
+
   }
 
   openDropdown() {

--- a/public/app/partials/help_modal.html
+++ b/public/app/partials/help_modal.html
@@ -29,6 +29,14 @@
 				<td>Refresh (Fetches new data and rerenders panels)</td>
 			</tr>
 			<tr>
+                                <td><span class="label label-info">&lt;</span></td>
+                                <td>Shift time backward</td>
+                        </tr>
+			<tr>
+                                <td><span class="label label-info">&gt;</span></td>
+                                <td>Shift time forward</td>
+                        </tr>
+			<tr>
 				<td><span class="label label-info">CTRL+S</span></td>
 				<td>Save dashboard</td>
 			</tr>


### PR DESCRIPTION
Resolves #119 

Key points:
1. Arrows on the nav bar to move backward and forward in time.
2. Simple keyboard binding with left and right arrows to move backward and forward in time.
3. Moves according to the timespan selected on the dashboard.

Screenshot:
**Near `Zoom Out` button**
<img width="1267" alt="screen shot 2016-04-07 at 1 33 29 am" src="https://cloud.githubusercontent.com/assets/1019609/14345247/c4567a94-fc60-11e5-90ce-710da8b1f180.png">
