### PR TITLE
Ability to map ranges to text in Singlestat panel

### DIFF
--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -192,35 +192,3 @@
 		</div>
 	</div>
 </div>
-
-<div class="editor-row">
-	<div class="section" style="margin-bottom: 20px">
-		<div class="tight-form last">
-			<ul class="tight-form-list">
-				<li class="tight-form-item">
-					<strong>Value to text mapping</strong>
-				</li>
-				<li class="tight-form-item"  ng-repeat-start="map in ctrl.panel.valueMaps">
-					<i class="fa fa-remove pointer" ng-click="ctrl.removeValueMap(map)"></i>
-				</li>
-				<li>
-					<input type="text" ng-model="map.value" placeholder="value" class="input-mini tight-form-input" ng-blur="ctrl.render()">
-				</li>
-				<li class="tight-form-item">
-					<i class="fa fa-arrow-right"></i>
-				</li>
-				<li ng-repeat-end>
-					<input type="text" placeholder="text" ng-model="map.text" class="input-mini tight-form-input" ng-blur="ctrl.render()">
-				</li>
-
-				<li>
-					<a class="pointer tight-form-item last" ng-click="ctrl.addValueMap();">
-						<i class="fa fa-plus"></i>
-					</a>
-				</li>
-
-			</ul>
-			<div class="clearfix"></div>
-		</div>
-	</div>
-</div>

--- a/public/app/plugins/panel/singlestat/mappings.html
+++ b/public/app/plugins/panel/singlestat/mappings.html
@@ -52,7 +52,7 @@
                         <div class="tight-form" ng-repeat="rangeMap in ctrl.panel.rangeMaps">
                                 <ul class="tight-form-list">
                                         <li class="tight-form-item">
-                                                <i class="fa fa-remove pointer" ng-click="ctrl.panel.removeRangeMap(rangeMap)"></i>
+                                                <i class="fa fa-remove pointer" ng-click="ctrl.removeRangeMap(rangeMap)"></i>
                                         </li>
                                         <li class="tight-form-item">
                                                 From

--- a/public/app/plugins/panel/singlestat/mappings.html
+++ b/public/app/plugins/panel/singlestat/mappings.html
@@ -1,0 +1,84 @@
+<div class="editor-row">
+        <div class="section tight-form-container" style="margin-bottom: 20px">
+                <div class="tight-form">
+                        <ul class="tight-form-list">
+                                <li class="tight-form-item">
+                                        Type
+                                </li>
+                                <li>
+                                        <select class="input-medium tight-form-input" ng-model="ctrl.panel.mappingType"
+					ng-options="f.value as f.name for f in ctrl.panel.mappingTypes" ng-change="ctrl.render()"></select>
+                                </li>
+                        </ul>
+                        <div class="clearfix"></div>
+                </div>
+	</div>
+</div>
+<div class="editor-row" ng-if="ctrl.panel.mappingType==1">
+	<div class="section" style="margin-bottom: 20px">
+		<div class="tight-form last">
+			<ul class="tight-form-list">
+				<li class="tight-form-item">
+					<strong>Value to text mapping</strong>
+				</li>
+				<li class="tight-form-item"  ng-repeat-start="map in ctrl.panel.valueMaps">
+					<i class="fa fa-remove pointer" ng-click="ctrl.removeValueMap(map)"></i>
+				</li>
+				<li>
+					<input type="text" ng-model="map.value" placeholder="value" class="input-mini tight-form-input" ng-blur="ctrl.render()">
+				</li>
+				<li class="tight-form-item">
+					<i class="fa fa-arrow-right"></i>
+				</li>
+				<li ng-repeat-end>
+					<input type="text" placeholder="text" ng-model="map.text" class="input-mini tight-form-input" ng-blur="ctrl.render()">
+				</li>
+
+				<li>
+					<a class="pointer tight-form-item last" ng-click="ctrl.addValueMap();">
+						<i class="fa fa-plus"></i>
+					</a>
+				</li>
+
+			</ul>
+			<div class="clearfix"></div>
+		</div>
+	</div>
+</div>
+<div class="editor-row" ng-if="ctrl.panel.mappingType==2">
+        <h5>Set range mappings</h5>
+        <div class="section gf-form-group">
+                <div class="tight-form-container">
+                        <div class="tight-form" ng-repeat="rangeMap in ctrl.panel.rangeMaps">
+                                <ul class="tight-form-list">
+                                        <li class="tight-form-item">
+                                                <i class="fa fa-remove pointer" ng-click="ctrl.panel.removeRangeMap(rangeMap)"></i>
+                                        </li>
+                                        <li class="tight-form-item">
+                                                From
+                                        </li>
+                                        <li>
+                                                <input type="text" ng-model="rangeMap.from" class="input-mini tight-form-input" ng-blur="ctrl.render()">
+                                        </li>
+					<li class="tight-form-item">
+                                                To
+                                        </li>
+                                        <li>
+                                                <input type="text" ng-model="rangeMap.to" class="input-mini tight-form-input" ng-blur="ctrl.render()">
+                                        </li>
+					<li class="tight-form-item">
+                                                Text
+                                        </li>
+                                        <li>
+                                                <input type="text" ng-model="rangeMap.text" class="input-mini tight-form-input" ng-blur="ctrl.render()">
+                                        </li>
+                                </ul>
+                                <div class="clearfix"></div>
+                        </div>
+                </div>
+
+                <button class="btn btn-inverse" style="margin-top: 20px" ng-click="ctrl.addRangeMap()">
+                        Add a range mapping
+                </button>
+        </div>
+</div>

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -34,6 +34,14 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     valueMaps: [
       { value: 'null', op: '=', text: 'N/A' }
     ],
+    mappingTypes: [
+      {name: 'value to text', value: 1},
+      {name: 'range to text', value: 2},
+    ],
+    rangeMaps: [
+      { from: 'null', to: 'null', text: 'N/A' }
+    ],
+    mappingType: 1,
     nullPointMode: 'connected',
     valueName: 'avg',
     prefixFontSize: '50%',
@@ -71,6 +79,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   onInitEditMode() {
     this.fontSizes = ['20%', '30%','50%','70%','80%','100%', '110%', '120%', '150%', '170%', '200%'];
     this.addEditorTab('Options', 'public/app/plugins/panel/singlestat/editor.html', 2);
+    this.addEditorTab('Mappings', 'public/app/plugins/panel/singlestat/mappings.html', 3);
     this.unitFormats = kbn.getUnitFormats();
   }
 
@@ -195,23 +204,45 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       }
     }
 
-    // check value to text mappings
-    for (var i = 0; i < this.panel.valueMaps.length; i++) {
-      var map = this.panel.valueMaps[i];
-      // special null case
-      if (map.value === 'null') {
-        if (data.value === null || data.value === void 0) {
+    // check value to text mappings if its enabled
+    if (this.panel.mappingType === 1) {
+      for (var i = 0; i < this.panel.valueMaps.length; i++) {
+        var map = this.panel.valueMaps[i];
+        // special null case
+        if (map.value === 'null') {
+          if (data.value === null || data.value === void 0) {
+            data.valueFormated = map.text;
+            return;
+          }
+          continue;
+        }
+
+        // value/number to text mapping
+        var value = parseFloat(map.value);
+        if (value === data.valueRounded) {
           data.valueFormated = map.text;
           return;
         }
-        continue;
       }
+    } else if (this.panel.mappingType === 2) {
+      for (var i = 0; i < this.panel.rangeMaps.length; i++) {
+        var map = this.panel.rangeMaps[i];
+        // special null case
+        if (map.from === 'null' && map.to === 'null') {
+          if (data.value === null || data.value === void 0) {
+            data.valueFormated = map.text;
+            return;
+          }
+          continue;
+        }
 
-      // value/number to text mapping
-      var value = parseFloat(map.value);
-      if (value === data.valueRounded) {
-        data.valueFormated = map.text;
-        return;
+        // value/number to range mapping
+        var from = parseFloat(map.from);
+        var to = parseFloat(map.to);
+        if (to >= data.valueRounded && from <= data.valueRounded) {
+          data.valueFormated = map.text;
+          return;
+        }
       }
     }
 
@@ -228,6 +259,16 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
   addValueMap() {
     this.panel.valueMaps.push({value: '', op: '=', text: '' });
+  }
+
+  removeRangeMap(rangeMap) {
+    var index = _.indexOf(this.panel.rangeMaps, rangeMap);
+    this.panel.rangeMaps.splice(index, 1);
+    this.render();
+  };
+
+  addRangeMap() {
+    this.panel.rangeMaps.push({from: '', to: '', text: ''});
   }
 
   link(scope, elem, attrs, ctrl) {

--- a/public/app/plugins/panel/singlestat/specs/singlestat-specs.ts
+++ b/public/app/plugins/panel/singlestat/specs/singlestat-specs.ts
@@ -84,4 +84,29 @@ describe('SingleStatCtrl', function() {
       expect(ctx.data.valueFormated).to.be('OK');
     });
   });
+
+  singleStatScenario('When range to text mapping is specifiedfor first range', function(ctx) {
+    ctx.setup(function() {
+      ctx.datapoints = [[41,50]];
+      ctx.ctrl.panel.mappingType = 2;
+      ctx.ctrl.panel.rangeMaps = [{from: '10', to: '50', text: 'OK'},{from: '51', to: '100', text: 'NOT OK'}];
+    });
+
+    it('Should replace value with text OK', function() {
+      expect(ctx.data.valueFormated).to.be('OK');
+    });
+  });
+
+  singleStatScenario('When range to text mapping is specified for other ranges', function(ctx) {
+    ctx.setup(function() {
+      ctx.datapoints = [[65,75]];
+      ctx.ctrl.panel.mappingType = 2;
+      ctx.ctrl.panel.rangeMaps = [{from: '10', to: '50', text: 'OK'},{from: '51', to: '100', text: 'NOT OK'}];
+    });
+
+    it('Should replace value with text NOT OK', function() {
+      expect(ctx.data.valueFormated).to.be('NOT OK');
+    });
+  });
+
 });


### PR DESCRIPTION
Resolves issue #1319 

Key points:
1. Smooth upgrade, **NO** need to change existing value to text mappings.
2. But you can only choose either of the two, either value to text mapping or range to text mapping but not both at the same time.

Here are some screenshots of Singlestat panel editor:

**Value to text mappings removed from Options tab**
<img width="1269" alt="screen shot 2016-04-10 at 11 25 55 pm" src="https://cloud.githubusercontent.com/assets/1019609/14418474/ba9e7d1a-ff73-11e5-828b-7c45dc3b605a.png">

**Moved the value to text mappings to Mappings tab**
<img width="1269" alt="screen shot 2016-04-10 at 11 26 03 pm" src="https://cloud.githubusercontent.com/assets/1019609/14418486/d3acd5d6-ff73-11e5-9bf4-0c0964ed1e10.png">

**Range to text mapping functionality**
<img width="1260" alt="screen shot 2016-04-10 at 11 26 09 pm" src="https://cloud.githubusercontent.com/assets/1019609/14418537/2b531ba6-ff74-11e5-84bd-34a994b1c70b.png">
