### PR TITLE
HTML titles

### DIFF
--- a/public/app/features/panel/panel_menu.js
+++ b/public/app/features/panel/panel_menu.js
@@ -12,7 +12,7 @@ function (angular, $, _, Tether) {
     .directive('panelMenu', function($compile, linkSrv) {
       var linkTemplate =
           '<span class="panel-title drag-handle pointer">' +
-            '<span class="panel-title-text drag-handle">{{ctrl.panel.title | interpolateTemplateVars:this}}</span>' +
+            '<span class="panel-title-text drag-handle" ng-bind-html="ctrl.panel.title"></span>' +
             '<span class="panel-links-btn"><i class="fa fa-external-link"></i></span>' +
             '<span class="panel-time-info" ng-show="ctrl.timeInfo"><i class="fa fa-clock-o"></i> {{ctrl.timeInfo}}</span>' +
           '</span>';


### PR DESCRIPTION
_(Note this is needs work to be finalized)_

I have a need for HTML in titles and axes labels (think super/subscripts, glypicons, and images).  I was able to track down where the panel title is, but was not sure how to go about preserving the call to the `interpolateTemplateVars` while also using `ng-bind-html` for HTML rendering.

Any pointers would be great and I an finish this up.

Thank you!
