### PR TITLE
Disable username/password-based login

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -29,6 +29,7 @@ func LoginView(c *middleware.Context) {
 	viewData.Settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	viewData.Settings["disableUserSignUp"] = !setting.AllowUserSignUp
 	viewData.Settings["loginHint"] = setting.LoginHint
+	viewData.Settings["oauthOnly"] = setting.DisableUserPassLogin
 
 	if !tryLoginUsingRememberCookie(c) {
 		c.HTML(200, VIEW_INDEX, viewData)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -82,12 +82,13 @@ var (
 	ExternalEnabled      bool
 
 	// User settings
-	AllowUserSignUp    bool
-	AllowUserOrgCreate bool
-	AutoAssignOrg      bool
-	AutoAssignOrgRole  string
-	VerifyEmailEnabled bool
-	LoginHint          string
+	AllowUserSignUp      bool
+	AllowUserOrgCreate   bool
+	AutoAssignOrg        bool
+	AutoAssignOrgRole    string
+	VerifyEmailEnabled   bool
+	LoginHint            string
+	DisableUserPassLogin bool
 
 	// Http auth
 	AdminUser     string
@@ -454,6 +455,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Read Only Editor", "Viewer"})
 	VerifyEmailEnabled = users.Key("verify_email_enabled").MustBool(false)
 	LoginHint = users.Key("login_hint").String()
+	DisableUserPassLogin = users.Key("disable_user_pass_login").MustBool(false)
 
 	// anonymous access
 	AnonymousEnabled = Cfg.Section("auth.anonymous").Key("enabled").MustBool(false)

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -18,6 +18,7 @@ function (angular, coreModule, config) {
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled;
+    $scope.oauthOnly = config.oauthOnly;
     $scope.disableUserSignUp = config.disableUserSignUp;
     $scope.loginHint     = config.loginHint;
 

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -17,7 +17,7 @@
 				</button>
 			</div>
 
-      <form name="loginForm" class="login-form gf-form-group">
+      <form name="loginForm" class="login-form gf-form-group" ng-if="!oauthOnly">
 				<div class="gf-form" ng-if="loginMode">
 					<span class="gf-form-label width-7">User</span>
 					<input type="text" name="username" class="gf-form-input max-width-14" required ng-model='formModel.user' placeholder={{loginHint}}>
@@ -40,7 +40,7 @@
 			</form>
 
 			<div ng-if="loginMode">
-				<div class="text-center login-divider" ng-if="oauthEnabled">
+				<div class="text-center login-divider" ng-if="oauthEnabled && !oauthOnly">
 					<div class="login-divider-line">
 						<span class="login-divider-text">
 							Or login with
@@ -64,7 +64,7 @@
 
 			<div class="clearfix"></div>
 
-			<div class="text-center password-recovery">
+			<div class="text-center password-recovery" ng-if="!oauthOnly">
 				<div class="text-center">
 					<a href="user/password/send-reset-email">
 						Forgot your password?


### PR DESCRIPTION
FIXES #4674 , I needed a way to make OAuth the only login choice for my users. This PR proposes a configuration named `disable_user_pass_login` which when set to `true` removes the username and password form from the login page.

For example, the user might use the following configuration file on top of the defaults to only allow login via GitHub.

```
#################################### Users ####################################
[users]
# disable user signup / registration
allow_sign_up = false

# Allow non admin users to create organizations
allow_org_create = false

# Set to true to automatically assign new users to the default organization (id 1)
auto_assign_org = false

# Default role new users will be automatically assigned (if auto_assign_org above is set to true)
auto_assign_org_role = Editor

# Require email validation before sign up completes
verify_email_enabled = false

# Background text for the user field on the login page
login_hint = You shouldn't be seeing this

disable_user_pass_login = true

#################################### Anonymous Auth ##########################
[auth.anonymous]
# enable anonymous access
enabled = false

# specify organization name that should be used for unauthenticated users
org_name = Main Org.

# specify role for unauthenticated users
org_role = Viewer

#################################### Github Auth ##########################
[auth.github]
enabled = true
allow_sign_up = true
client_id = dd2ffbaf386380fd5756aee530afc8c798dae3069830a5b8ce56a9154e47af7b
client_secret = 7c77c4938842bd5fcc2a540605810adba5b37d2e9de36376bba036136e91ce5a
scopes = user:email
auth_url = http://localhost:5000/oauth/authorize
token_url = http://localhost:5000/oauth/token
api_url = http://localhost:5000/api/v1/user
team_ids =
allowed_organizations =

#################################### Google Auth ##########################
[auth.google]
enabled = false

```
