### PR TITLE
Pass flag to query continuous

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -181,7 +181,8 @@ class MetricsPanelCtrl extends PanelCtrl {
       format: this.panel.renderer === 'png' ? 'png' : 'json',
       maxDataPoints: this.resolution,
       scopedVars: this.panel.scopedVars,
-      cacheTimeout: this.panel.cacheTimeout
+      cacheTimeout: this.panel.cacheTimeout,
+      continuous: this.panel.continuous || false
     };
 
     return datasource.query(metricsQuery);

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -172,6 +172,11 @@ class MetricsPanelCtrl extends PanelCtrl {
       return this.$q.when([]);
     }
 
+    var self = this;
+    _.each(this.panel.targets, function(target) {
+      target.continuous = self.panel.continuous || false;
+    });
+
     var metricsQuery = {
       panelId: this.panel.id,
       range: this.range,
@@ -181,8 +186,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       format: this.panel.renderer === 'png' ? 'png' : 'json',
       maxDataPoints: this.resolution,
       scopedVars: this.panel.scopedVars,
-      cacheTimeout: this.panel.cacheTimeout,
-      continuous: this.panel.continuous || false
+      cacheTimeout: this.panel.cacheTimeout
     };
 
     return datasource.query(metricsQuery);


### PR DESCRIPTION
Current snap datasource cache past metrics data and return all data.
https://github.com/raintank/snap-app/blob/d4bf396ee9e0463d1c68bcaa0ec2e06c1db1f110/src/datasource/stream_handler.js#L71-L93

It is required to work with existing Graph panel.
But, if panel plugin has cache for metrics data too (like Epoch), it is inefficient.

So, I want to change this behavior like,
If panel support realtime chart (like Epoch), pass the flag, and datasource return only new metrics data.

http://epochjs.github.io/epoch/real-time/
