### PR TITLE
Enable user to define their own OAuth Provider with customizable button

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -27,6 +27,8 @@ func LoginView(c *middleware.Context) {
 
 	viewData.Settings["googleAuthEnabled"] = setting.OAuthService.Google
 	viewData.Settings["githubAuthEnabled"] = setting.OAuthService.GitHub
+	viewData.Settings["genericOAuthEnabled"] = setting.OAuthService.Generic
+	viewData.Settings["oauthProviderName"] = setting.OAuthService.OAuthProviderName
 	viewData.Settings["disableUserSignUp"] = !setting.AllowUserSignUp
 	viewData.Settings["loginHint"] = setting.LoginHint
 	viewData.Settings["allowUserPassLogin"] = setting.AllowUserPassLogin

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -11,8 +11,9 @@ type OAuthInfo struct {
 }
 
 type OAuther struct {
-	GitHub, Google, Twitter bool
-	OAuthInfos              map[string]*OAuthInfo
+	GitHub, Google, Twitter, Generic bool
+	OAuthInfos                       map[string]*OAuthInfo
+	OAuthProviderName                string
 }
 
 var OAuthService *OAuther

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -42,7 +42,7 @@ func NewOAuthService() {
 	setting.OAuthService = &setting.OAuther{}
 	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
 
-	allOauthes := []string{"github", "google"}
+	allOauthes := []string{"github", "google", "generic-oauth"}
 
 	for _, name := range allOauthes {
 		sec := setting.Cfg.Section("auth." + name)
@@ -96,6 +96,22 @@ func NewOAuthService() {
 				Config: &config, allowedDomains: info.AllowedDomains,
 				apiUrl:      info.ApiUrl,
 				allowSignup: info.AllowSignup,
+			}
+		}
+
+		// Generic - Uses the same scheme as Github.
+		if name == "generic-oauth" {
+			setting.OAuthService.Generic = true
+			setting.OAuthService.OAuthProviderName = sec.Key("oauth_provider_name").String()
+			teamIds := sec.Key("team_ids").Ints(",")
+			allowedOrganizations := sec.Key("allowed_organizations").Strings(" ")
+			SocialMap["generic-oauth"] = &SocialGithub{
+				Config:               &config,
+				allowedDomains:       info.AllowedDomains,
+				apiUrl:               info.ApiUrl,
+				allowSignup:          info.AllowSignup,
+				teamIds:              teamIds,
+				allowedOrganizations: allowedOrganizations,
 			}
 		}
 	}

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -42,7 +42,7 @@ func NewOAuthService() {
 	setting.OAuthService = &setting.OAuther{}
 	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
 
-	allOauthes := []string{"github", "google", "generic-oauth"}
+	allOauthes := []string{"github", "google", "generic_oauth"}
 
 	for _, name := range allOauthes {
 		sec := setting.Cfg.Section("auth." + name)
@@ -100,12 +100,12 @@ func NewOAuthService() {
 		}
 
 		// Generic - Uses the same scheme as Github.
-		if name == "generic-oauth" {
+		if name == "generic_oauth" {
 			setting.OAuthService.Generic = true
 			setting.OAuthService.OAuthProviderName = sec.Key("oauth_provider_name").String()
 			teamIds := sec.Key("team_ids").Ints(",")
 			allowedOrganizations := sec.Key("allowed_organizations").Strings(" ")
-			SocialMap["generic-oauth"] = &SocialGithub{
+			SocialMap["generic_oauth"] = &SocialGithub{
 				Config:               &config,
 				allowedDomains:       info.AllowedDomains,
 				apiUrl:               info.ApiUrl,

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -17,8 +17,10 @@ function (angular, coreModule, config) {
 
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
-    $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled;
+    $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled || config.genericOAuthEnabled;
     $scope.allowUserPassLogin = config.allowUserPassLogin;
+    $scope.genericOAuthEnabled = config.genericOAuthEnabled;
+    $scope.oauthProviderName = config.oauthProviderName;
     $scope.disableUserSignUp = config.disableUserSignUp;
     $scope.loginHint     = config.loginHint;
 

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -59,6 +59,10 @@
 						<i class="fa fa-github"></i>
 						with Github
 					</a>
+					<a class="btn btn-large btn-generic-oauth" href="login/generic-oauth" target="_self" ng-if="genericOAuthEnabled">
+						<i class="fa fa-gear"></i>
+            with {{oauthProviderName || "OAuth 2"}}
+          </a>
 				</div>
 			</div>
 

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -59,7 +59,7 @@
 						<i class="fa fa-github"></i>
 						with Github
 					</a>
-					<a class="btn btn-large btn-generic-oauth" href="login/generic-oauth" target="_self" ng-if="genericOAuthEnabled">
+					<a class="btn btn-large btn-generic-oauth" href="login/generic_oauth" target="_self" ng-if="genericOAuthEnabled">
 						<i class="fa fa-gear"></i>
             with {{oauthProviderName || "OAuth 2"}}
           </a>


### PR DESCRIPTION
For folks that would like to use their own OAuth Provider instead of using GitHub or Google,
with this PR they can now use the [auth.generic_oauth] config option. If enabled, Grafana 
will attempt to connect exactly the same as to GitHub. 

This does leave the responsibility to the user to create a Users API endpoint that returns
JSON. At the very least, this endpoint must provide an email for the user. e.g.:

**GET /your/api/path/user**
`{ "email": "user@domain.com" }`

In my application, I used the [doorkeeper gem](https://github.com/doorkeeper-gem/doorkeeper) 
which is compatible with the GitHub OAuth integration.

When you set the `oauth_provider_name`, to your company name the button to auth will read 
"with Your Company Name" instead of "with Github."

An Example Configuration looks like:

```
[auth.generic_oauth]
enabled = true
allow_sign_up = true
client_id = 123abc
client_secret = 987xyz
scopes = user:email
auth_url = http://localhost:5000/oauth/authorize
token_url = http://localhost:5000/oauth/token
api_url = http://localhost:5000/api/v1/user
oauth_provider_name = Your Company Here
```
