### PR TITLE
Fix broken snapshots in grafana 2.6

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -21,6 +21,10 @@ func GetSharingOptions(c *middleware.Context) {
 }
 
 func CreateDashboardSnapshot(c *middleware.Context, cmd m.CreateDashboardSnapshotCommand) {
+	if cmd.Name == "" {
+		cmd.Name = "Unnamed snapshot"
+	}
+
 	if cmd.External {
 		// external snapshot ref requires key and delete key
 		if cmd.Key == "" || cmd.DeleteKey == "" {

--- a/pkg/models/dashboard_snapshot.go
+++ b/pkg/models/dashboard_snapshot.go
@@ -45,7 +45,7 @@ type DashboardSnapshotDTO struct {
 
 type CreateDashboardSnapshotCommand struct {
 	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
-	Name      string           `json:"name" binding:"Required"`
+	Name      string           `json:"name"`
 	Expires   int64            `json:"expires"`
 
 	// these are passed when storing an external snapshot ref


### PR DESCRIPTION
fixes #4778

3.0 made snapshots names required which is a breaking change since 2.6 don't support names.
I suggest that we add a default value for unnamed snapshots that.

Might be better ways to set a default value on the struct. 

This change needs to be deployed to snapshot.raintank.io
