### PR TITLE
(prometheus) support time parameter in query_result() query

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.js
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.js
@@ -13,7 +13,7 @@ function (_, moment) {
   PrometheusMetricFindQuery.prototype.process = function() {
     var label_values_regex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]+)\)$/;
     var metric_names_regex = /^metrics\((.+)\)$/;
-    var query_result_regex = /^query_result\((.+)\)$/;
+    var query_result_regex = /^query_result\((.+?)(?:,\s*([0-9]+))?\)$/;
 
     var label_values_query = this.query.match(label_values_regex);
     if (label_values_query) {
@@ -31,7 +31,7 @@ function (_, moment) {
 
     var query_result_query = this.query.match(query_result_regex);
     if (query_result_query) {
-      return this.queryResultQuery(query_result_query[1]);
+      return this.queryResultQuery(query_result_query[1], query_result_query[2]);
     }
 
     // if query contains full metric name, return metric name and label list
@@ -85,8 +85,9 @@ function (_, moment) {
     });
   };
 
-  PrometheusMetricFindQuery.prototype.queryResultQuery = function(query) {
-    var url = '/api/v1/query?query=' + encodeURIComponent(query) + '&time=' + (moment().valueOf() / 1000);
+  PrometheusMetricFindQuery.prototype.queryResultQuery = function(query, time) {
+    time = time || moment().valueOf();
+    var url = '/api/v1/query?query=' + encodeURIComponent(query) + '&time=' + (time / 1000);
 
     return this.datasource._request('GET', url)
     .then(function(result) {

--- a/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
@@ -97,5 +97,24 @@ describe('PrometheusMetricFindQuery', function() {
       expect(results.length).to.be(1);
       expect(results[0].text).to.be('metric{job="testjob"} 3846 1443454528000');
     });
+    it('query_result(metric, time) should generate metric name query', function() {
+      response = {
+        status: "success",
+        data: {
+          resultType: "vector",
+          result: [{
+            metric: {"__name__": "metric", job: "testjob"},
+            value: [1443454528.000, "3846"]
+          }]
+        }
+      };
+      ctx.$httpBackend.expect('GET', /proxied\/api\/v1\/query\?query=metric&time=.*/).respond(response);
+      var pm = new PrometheusMetricFindQuery(ctx.ds, 'query_result(metric, 1443454528000)');
+      pm.process().then(function(data) { results = data; });
+      ctx.$httpBackend.flush();
+      ctx.$rootScope.$apply();
+      expect(results.length).to.be(1);
+      expect(results[0].text).to.be('metric{job="testjob"} 3846 1443454528000');
+    });
   });
 });


### PR DESCRIPTION
Enable passing time parameter.
Use with https://github.com/grafana/grafana/pull/4348, this could be more useful.
