### PR TITLE
allow updates to secureJsonData.

### DIFF
--- a/pkg/services/sqlstore/plugin_setting.go
+++ b/pkg/services/sqlstore/plugin_setting.go
@@ -61,7 +61,6 @@ func UpdatePluginSetting(cmd *m.UpdatePluginSettingCmd) error {
 			for key, data := range cmd.SecureJsonData {
 				pluginSetting.SecureJsonData[key] = util.Encrypt([]byte(data), setting.SecretKey)
 			}
-			pluginSetting.SecureJsonData = cmd.GetEncryptedJsonData()
 			pluginSetting.Updated = time.Now()
 			pluginSetting.Enabled = cmd.Enabled
 			pluginSetting.JsonData = cmd.JsonData


### PR DESCRIPTION
- Link the PR to an issue for new features
- Rebase your PR if it gets out of sync with master
  SecureJsonData is stored as a json object in the DB. As the
  secureJsonData is never returned to the user they are unable
  to provide the full json object when performing updates instead
  the user can only provide the specific keys they wish to update.
  This commit ensures that only the provided keys are updated and
  existing keys in the secureJsonData object are left untouched.
