### PR TITLE
[WIP] live reload

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,13 +5,14 @@ import (
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/live"
+	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"gopkg.in/macaron.v1"
 )
 
 // Register adds http routes
-func Register(r *macaron.Macaron) {
+func Register(r *macaron.Macaron, restartChan chan struct{}) {
 	reqSignedIn := middleware.Auth(&middleware.AuthOptions{ReqSignedIn: true})
 	reqGrafanaAdmin := middleware.Auth(&middleware.AuthOptions{ReqSignedIn: true, ReqGrafanaAdmin: true})
 	reqEditorRole := middleware.RoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
@@ -248,6 +249,17 @@ func Register(r *macaron.Macaron) {
 		r.Get("/users/:id/quotas", wrap(GetUserQuotas))
 		r.Put("/users/:id/quotas/:target", bind(m.UpdateUserQuotaCmd{}), wrap(UpdateUserQuota))
 		r.Get("/stats", AdminGetStats)
+		r.Put("/restart", func(c *middleware.Context) {
+			select {
+			case restartChan <- struct{}{}:
+				// restart sent.
+				log.Info("restart event emitted.")
+			default:
+				// restart already pending.
+				log.Info("restart channel full.")
+			}
+			c.JSON(200, "OK")
+		})
 	}, reqGrafanaAdmin)
 
 	// rendering

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/eventpublisher"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/search"
@@ -63,7 +62,6 @@ func main() {
 	login.Init()
 	social.NewOAuthService()
 	eventpublisher.Init()
-	plugins.Init()
 
 	if err := notifications.Init(); err != nil {
 		log.Fatal(3, "Notification service failed to initialize", err)


### PR DESCRIPTION
issue #4843 

This commit allows for a live reload of plugins without needing
to terminate the grafana-server binary.  Plugins can added/removed
in the plugins_dir and then a restart triggered by sending a PUT
request to /api/admin/restart.
