### PR TITLE
Add support to Elasticsearch precision_threshold

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -68,6 +68,11 @@ function (angular, _, queryDef) {
       }
 
       switch($scope.agg.type) {
+        case 'cardinality': {
+          var precision_threshold = $scope.agg.settings.precision_threshold || '';
+          $scope.settingsLinkText = 'Precision threshold: ' + precision_threshold;
+          break;
+        }
         case 'percentiles': {
           $scope.agg.settings.percents = $scope.agg.settings.percents || [25,50,75,95,99];
           $scope.settingsLinkText = 'Values: ' + $scope.agg.settings.percents.join(',');

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -58,6 +58,11 @@
 		<input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.percents" array-join ng-blur="onChange()"></input>
 	</div>
 
+	<div class="gf-form offset-width-7" ng-if="agg.type === 'cardinality'">
+		<label class="gf-form-label width-10">Precision threshold</label>
+		<input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.precision_threshold" ng-blur="onChange()"></input>
+	</div>
+
 	<div ng-if="agg.type === 'extended_stats'">
 		<gf-form-switch ng-repeat="stat in extendedStats" class="gf-form offset-width-7" label="{{stat.text}}" label-class="width-10" checked="agg.meta[stat.value]" on-change="onChangeInternal()"></gf-form-switch>
 


### PR DESCRIPTION
Adds support to set a custom `precision_threshold` for unique counts (aka cardinality aggregations) in ElasticSearch.

Closes #4689 and #4231.

The chart below shows the same query using 3 different precision thresholds: default, 10 and 1000.
![precisions_comparision](https://cloud.githubusercontent.com/assets/2574399/14903708/72ed9546-0d79-11e6-9768-daa044e5ebd1.png)

And the image below shows how to set a custom threshold in the Query Editor:
![my_metric](https://cloud.githubusercontent.com/assets/2574399/14903717/8e8547cc-0d79-11e6-9aae-de386051a7a5.png)
