### PR TITLE
Add optional tooltip ordering

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -81,9 +81,9 @@ function ($) {
           // Stacked series can increase its length on each new stacked serie if null points found,
           // to speed the index search we begin always on the last found hoverIndex.
           var newhoverIndex = this.findHoverIndexFromDataPoints(pos.x, series, hoverIndex);
-          results.push({ value: value, hoverIndex: newhoverIndex });
+          results.push({ value: value, hoverIndex: newhoverIndex, color: series.color, label: series.label });
         } else {
-          results.push({ value: value, hoverIndex: hoverIndex });
+          results.push({ value: value, hoverIndex: hoverIndex, color: series.color, label: series.label });
         }
       }
 
@@ -133,6 +133,18 @@ function ($) {
 
         absoluteTime = dashboard.formatDate(seriesHoverInfo.time, tooltipFormat);
 
+        // Dynamically reorder the hovercard for the current time point if the
+        // option is enabled.
+        if (panel.tooltip.ordering === 'decreasing') {
+          seriesHoverInfo.sort(function(a, b) {
+            return parseFloat(b.value) - parseFloat(a.value);
+          });
+        } else if (panel.tooltip.ordering === 'increasing') {
+          seriesHoverInfo.sort(function(a, b) {
+            return parseFloat(a.value) - parseFloat(b.value);
+          });
+        }
+
         for (i = 0; i < seriesHoverInfo.length; i++) {
           hoverInfo = seriesHoverInfo[i];
 
@@ -150,7 +162,7 @@ function ($) {
           value = series.formatValue(hoverInfo.value);
 
           seriesHtml += '<div class="graph-tooltip-list-item ' + highlightClass + '"><div class="graph-tooltip-series-name">';
-          seriesHtml += '<i class="fa fa-minus" style="color:' + series.color +';"></i> ' + series.label + ':</div>';
+          seriesHtml += '<i class="fa fa-minus" style="color:' + hoverInfo.color +';"></i> ' + hoverInfo.label + ':</div>';
           seriesHtml += '<div class="graph-tooltip-value">' + value + '</div></div>';
           plot.highlight(i, hoverInfo.hoverIndex);
         }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -92,6 +92,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     tooltip       : {
       value_type: 'cumulative',
       shared: true,
+      ordering: 'alphabetical',
       msResolution: false,
     },
     // time overrides

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -42,21 +42,27 @@
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Misc options</h5>
 		<div class="gf-form">
-			<label class="gf-form-label width-7">Null value</label>
+			<label class="gf-form-label width-9">Null value</label>
 			<div class="gf-form-select-wrapper">
 				<select class="gf-form-input max-width-8" ng-model="ctrl.panel.nullPointMode" ng-options="f for f in ['connected', 'null', 'null as zero']" ng-change="ctrl.render()"></select>
 			</div>
 		</div>
 		<div class="gf-form">
-			<label class="gf-form-label width-7">Renderer</label>
+			<label class="gf-form-label width-9">Renderer</label>
 			<div class="gf-form-select-wrapper max-width-8">
 				<select class="gf-form-input" ng-model="ctrl.panel.renderer" ng-options="f for f in ['flot', 'png']" ng-change="ctrl.render()"></select>
 			</div>
 		</div>
 		<div class="gf-form">
-			<label class="gf-form-label width-7">Tooltip mode</label>
+			<label class="gf-form-label width-9">Tooltip mode</label>
 			<div class="gf-form-select-wrapper max-width-8">
 				<select class="gf-form-input" ng-model="ctrl.panel.tooltip.shared" ng-options="f.value as f.text for f in [{text: 'All series', value: true}, {text: 'Single', value: false}]" ng-change="ctrl.render()"></select>
+			</div>
+		</div>
+		<div class="gf-form">
+			<label class="gf-form-label width-9">Tooltip ordering<tip>The ordering from top to bottom</tip></label>
+			<div class="gf-form-select-wrapper max-width-8">
+				<select class="gf-form-input" ng-model="ctrl.panel.tooltip.ordering" ng-options="f.value as f.text for f in [{text: 'Alphabetical', value: 'alphabetical'}, {text: 'Increasing', value: 'increasing'}, {text: 'Decreasing', value: 'decreasing'}]" ng-change="ctrl.render()"></select>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
After the issue #1189 asking for sorted tooltips, a PR was submitted (#3165) and merged. It was roll-backed because the feature was not optional and just made inspecting series values as you hover impossible as they keep jumping around.

Thus, this PR takes the code of @hcooper and makes it optional. It creates a new select in Misc Options, taking 3 values "Aplhabetical" (default, which is the "name" of current behavior if I am not mistaking), "Increasing" and "Decreasing". The default is the current behavior.
For graphical homogeneity, it also increases the width of the misc options keys to 9 instead of 7.

![default](https://cloud.githubusercontent.com/assets/534945/14939223/f2e27698-0f3d-11e6-8699-a1c65ebffcfe.png)
![incr](https://cloud.githubusercontent.com/assets/534945/14939224/f70dbdf4-0f3d-11e6-8230-2bceb63b562f.png)
![decreasing](https://cloud.githubusercontent.com/assets/534945/14939227/1e288612-0f3e-11e6-85ff-9432c1d63ce1.png)
