### PR TITLE
Add documentation on the build system for occasional contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the latest master builds [here](http://grafana.org/download/builds)
 ### Dependencies
 
 - Go 1.5
-- NodeJS
+- NodeJS v0.12.0
 - [Godep](https://github.com/tools/godep)
 
 ### Get Code
@@ -110,7 +110,7 @@ go run build.go build
 
 ### Building frontend assets
 
-To build less to css for the frontend you will need a recent version of of node (v0.12.0),
+To build less to css for the frontend you will need a recent version of of **node (v0.12.0)**,
 npm (v2.5.0) and grunt (v0.4.5). Run the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ the latest master builds [here](http://grafana.org/download/builds)
 go get github.com/grafana/grafana
 ```
 
+Since imports of dependencies use the absolute path github.com/grafana/grafana within the $GOPATH,
+you will need to put your version of the code in $GOPATH/src/github.com/grafana/grafana to be able
+to develop and build grafana on a cloned repository. To do so, you can clone your forked repository
+directly to $GOPATH/src/github.com/grafana or you can create a symbolic link from your version
+of the code to $GOPATH/src/github.com/grafana/grafana. The last options makes it possible to change
+easily the grafana repository you want to build.
+```bash
+go get github.com/*your_account*/grafana
+mkdir $GOPATH/src/github.com/grafana
+ln -s  github.com/*your_account*/grafana $GOPATH/src/github.com/grafana/grafana
+```
+
 ### Building the backend
 Replace X.Y.Z by actual version number.
 ```bash
@@ -104,6 +116,13 @@ npm (v2.5.0) and grunt (v0.4.5). Run the following:
 ```bash
 npm install
 npm run build
+```
+
+To build the frontend assets only on changes:
+
+```bash
+sudo npm install -g grunt-cli # to do only once to install grunt command line interface
+grunt watch
 ```
 
 ### Recompile backend on source change


### PR DESCRIPTION
Add the documentation suggested by the issue #4866 on how to build one's fork repository using the strange go dependencies system.

It also states the node JS version in the Dependencies paragraph, since this dependency has to been installed manually, and having contributed, I know I made a mistake at that point.

It also adds a doc to explain how to build the frontend on changes using grunt watch. torkelo gave me that advice by email on the mailing list, and I'm sure it can be of help to some other that have programming experience like myself, but not javascript experience.
