### PR TITLE
Made Opentsdb query editor UI consistent

### DIFF
--- a/public/app/plugins/datasource/opentsdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/opentsdb/partials/query.editor.html
@@ -81,6 +81,7 @@
 
 		<gf-form-switch class="gf-form"
 										label="Disable downsampling"
+                    label-class="query-keyword"
 										checked="ctrl.target.disableDownsampling"
 										on-change="ctrl.targetBlur()">
 		</gf-form-switch>
@@ -125,7 +126,7 @@
 			</div>
 
 			<div class="gf-form">
-				<label class="gf-form-label">Type</label>
+				<label class="gf-form-label query-keyword">Type</label>
 				<div class="gf-form-select-wrapper">
 					<select ng-model="ctrl.target.currentFilterType" class="gf-form-input" ng-options="filType for filType in ctrl.filterTypes">
 					</select>
@@ -137,7 +138,11 @@
 				</input>
 			</div>
 
-			<gf-form-switch class="gf-form" label="Group by" checked="ctrl.target.currentFilterGroupBy" on-change="ctrl.targetBlur()">
+      <gf-form-switch class="gf-form"
+                    label="Group by" 
+                    label-class="query-keyword"
+                    checked="ctrl.target.currentFilterGroupBy"
+                    on-change="ctrl.targetBlur()">
 			</gf-form-switch>
 
 			<div class="gf-form" ng-show="ctrl.addFilterMode">
@@ -146,7 +151,6 @@
 						<i class="fa fa-warning"></i>
 					</a>
 				</label>
-
 				<label class="gf-form-label">
 					<a ng-click="ctrl.addFilter()" ng-hide="ctrl.errors.filters">add filter</a>
 					<a ng-click="ctrl.closeAddFilterMode()">
@@ -223,12 +227,12 @@
 		</gf-form-switch>
 
 		<gf-form-switch ng-hide="!ctrl.target.shouldComputeRate"
-										class="gf-form" label="Counter" checked="ctrl.target.isCounter" on-change="ctrl.targetBlur()">
+										class="gf-form" label="Counter" label-class="query-keyword" checked="ctrl.target.isCounter" on-change="ctrl.targetBlur()">
 		</gf-form-switch>
 
 
 		<div class="gf-form" ng-hide="!ctrl.target.isCounter || !ctrl.target.shouldComputeRate">
-			<label class="gf-form-label">Counter Max</label>
+			<label class="gf-form-label query-keyword">Counter Max</label>
 			<input type="text" class="gf-form-input"
 					 	 ng-disabled="!ctrl.target.shouldComputeRate"
 						 ng-model="ctrl.target.counterMax" spellcheck='false'
@@ -236,7 +240,7 @@
 						 ng-blur="ctrl.targetBlur()">
 			</input>
 
-			<label class="gf-form-label">Reset Value</label>
+			<label class="gf-form-label query-keyword">Reset Value</label>
 			<input type="text" class="tight-form-input input-small"
 					   ng-disabled="!ctrl.target.shouldComputeRate"
 						 ng-model="ctrl.target.counterResetValue" spellcheck='false'


### PR DESCRIPTION
Some fields in the editor were in blue and some in white, so made the UI of the Opentsdb query editor fields consistent.
