### PR TITLE
singlestat/module.ts onDataError was calling onDataReceived incorrectly

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -82,7 +82,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   }
 
   onDataError(err) {
-    this.onDataReceived({data: []});
+    this.onDataReceived([]);
   }
 
   onDataReceived(dataList) {


### PR DESCRIPTION
onDataError was calling onDataReceived with {data : []} which breaks at the first line since object has no map function.
The correct form is probably just []
