### PR TITLE
[RenderToPng fix]

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ go get github.com/grafana/grafana
 ```
 
 ### Building the backend
-Replace X.Y.Z by actual version number.
 ```bash
 cd $GOPATH/src/github.com/grafana/grafana
 go run build.go setup            (only needed once to install godep)

--- a/build.go
+++ b/build.go
@@ -136,7 +136,7 @@ func readVersionFromPackageJson() {
 			// add timestamp to iteration
 			linuxPackageIteration = fmt.Sprintf("%s%v", linuxPackageIteration, time.Now().Unix())
 		}
-		log.Println(fmt.Sprintf("teration %v", linuxPackageIteration))
+		log.Println(fmt.Sprintf("Iteration %v", linuxPackageIteration))
 	}
 }
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -248,7 +248,7 @@ mode = console, file
 # Buffer length of channel, keep it as it is if you don't know what it is.
 buffer_len = 10000
 
-# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
+# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
 level = Info
 
 # For "console" mode only

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -230,7 +230,7 @@ check_for_updates = true
 # Buffer length of channel, keep it as it is if you don't know what it is.
 ;buffer_len = 10000
 
-# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Trace"
+# Either "Trace", "Debug", "Info", "Warn", "Error", "Critical", default is "Info"
 ;level = Info
 
 # For "console" mode only

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -31,7 +31,7 @@ func RenderToPng(c *middleware.Context) {
 		Width:     queryReader.Get("width", "800"),
 		Height:    queryReader.Get("height", "400"),
 		SessionId: c.Session.ID(),
-		Timeout:   queryReader.Get("timeout", "15"),
+		Timeout:   queryReader.Get("timeout", "30"),
 	}
 
 	renderOpts.Url = setting.ToAbsUrl(renderOpts.Url)

--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -72,6 +73,7 @@ func RenderToPng(params *RenderOpts) (string, error) {
 		if err := cmd.Process.Kill(); err != nil {
 			log.Error(4, "failed to kill: %v", err)
 		}
+		return "", fmt.Errorf("PhantomRenderer::renderToPng timeout (>%vs)",timeout)
 	case <-done:
 	}
 

--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -73,7 +73,7 @@ func RenderToPng(params *RenderOpts) (string, error) {
 		if err := cmd.Process.Kill(); err != nil {
 			log.Error(4, "failed to kill: %v", err)
 		}
-		return "", fmt.Errorf("PhantomRenderer::renderToPng timeout (>%vs)",timeout)
+		return "", fmt.Errorf("PhantomRenderer::renderToPng timeout (>%vs)", timeout)
 	case <-done:
 	}
 

--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -15,8 +15,6 @@ module.exports = function(config,grunt) {
         src = confDir+src;
       }
 
-      var exec = require('child_process').execFileSync;
-
       try {
         grunt.config('copy.phantom_bin', {
           src: src,


### PR DESCRIPTION
This is a pull request for the feature #4900
It returns a more explicit diagnosis when `RenderToPng()` timeouts and extend the time before timeout (was 15s, it is 30s in this pull request).
Also some minor typo fix here and there, and some useless code removal.
