### PR TITLE
Bring back threshold line mode

### DIFF
--- a/public/app/plugins/panel/graph/tab_axes.html
+++ b/public/app/plugins/panel/graph/tab_axes.html
@@ -68,5 +68,6 @@
         </div>
       </div>
     </div>
+    <gf-form-switch class="gf-form" label="Line Mode" label-class="width-10" checked="ctrl.panel.grid.thresholdLine" on-change="ctrl.render()"></gf-form-switch>
   </div>
 </div>


### PR DESCRIPTION
Threshold line mode was somehow discarded from the HTML in the ui redesign, this brings it back
