### PR TITLE
AWS Elasticsearch Service Dimensions

### DIFF
--- a/pkg/api/cloudwatch/metrics.go
+++ b/pkg/api/cloudwatch/metrics.go
@@ -86,7 +86,7 @@ func init() {
 		"AWS/EC2":              {"AutoScalingGroupName", "ImageId", "InstanceId", "InstanceType"},
 		"AWS/ELB":              {"LoadBalancerName", "AvailabilityZone"},
 		"AWS/ElasticMapReduce": {"ClusterId", "JobFlowId", "JobId"},
-		"AWS/ES":               {},
+		"AWS/ES":               {"ClientId", "DomainName"},
 		"AWS/Events":           {"RuleName"},
 		"AWS/Kinesis":          {"StreamName", "ShardID"},
 		"AWS/Lambda":           {"FunctionName"},


### PR DESCRIPTION
This PR adds CloudWatch dimensions for AWS ES: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/es-metricscollected.html#es-metric-dimensions
