### PR TITLE
get rid of weird line breaks and use action

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -72,8 +72,6 @@ function isRunning() {
 
 case "$1" in
   start)
-    echo -n $"Starting $DESC: .... "
-
     isRunning
     if [ $? -eq 0 ]; then
       echo "Already running."
@@ -90,7 +88,7 @@ case "$1" in
 
     # Start Daemon
     cd $GRAFANA_HOME
-    su -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 3>&1 &" $GRAFANA_USER 2> /dev/null
+    action $"Starting $DESC: ..." su -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 3>&1 &" $GRAFANA_USER 2> /dev/null
     return=$?
     if [ $return -eq 0 ]
     then
@@ -114,7 +112,6 @@ case "$1" in
       done
     fi
 
-    echo "OK"
     exit $return
     ;;
   stop)
@@ -123,17 +120,17 @@ case "$1" in
     if [ -f "$PID_FILE" ]; then
       killproc -p $PID_FILE -d 20 $NAME
       if [ $? -eq 1 ]; then
-        echo -n "$DESC is not running but pid file exists, cleaning up"
+        echo  "$DESC is not running but pid file exists, cleaning up"
       elif [ $? -eq 3 ]; then
         PID="`cat $PID_FILE`"
-        echo -n "Failed to stop $DESC (pid $PID)"
+        echo  "Failed to stop $DESC (pid $PID)"
         exit 1
       fi
       rm -f "$PID_FILE"
-      echo "OK"
+      echo  ""
       exit 0
     else
-      echo -n "(not running)"
+      echo  "(not running)"
     fi
     exit 0
     ;;

--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -115,7 +115,7 @@ case "$1" in
     exit $return
     ;;
   stop)
-    echo -n "Stopping $DESC ..."
+    echo -n "Stopping $DESC: ..."
 
     if [ -f "$PID_FILE" ]; then
       killproc -p $PID_FILE -d 20 $NAME


### PR DESCRIPTION
- Link the PR to an issue for new features
- Rebase your PR if it gets out of sync with master
  When using restarts/stops/starts you'd get weird output sometimes, Strange line breaks 'OK' status overlapping the next lines etc...
  This fixes those moves OK to the right place and colorizes them correctly.
