### PR TITLE
Set custom type for templating variables (#4941)

### DIFF
--- a/public/dashboards/scripted_templated.js
+++ b/public/dashboards/scripted_templated.js
@@ -47,6 +47,7 @@ dashboard.templating = {
       refresh: true,
       options: [],
       current: null,
+      type: 'custom'
     },
     {
       name: 'test2',
@@ -54,6 +55,7 @@ dashboard.templating = {
       refresh: true,
       options: [],
       current: null,
+      type: 'custom'
     }
   ]
 };


### PR DESCRIPTION
Explicitly set the example template variable's type to `custom` (default is `query`) so that on dashboard initialization, the variable is properly handled and does not result in the error: `Template variables could not be initialized: datasource.metricFindQuery is not a function` (called for query types).

Custom types are handled correctly in the Grafana code. This. dashboard just needs to set the type.

Fixes #4941.
