### PR TITLE
use new plugin-specific repo route when installing or updating a single plugin

### DIFF
--- a/pkg/cmd/grafana-cli/commands/upgrade_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"github.com/fatih/color"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/log"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 )
 
@@ -14,20 +16,17 @@ func upgradeCommand(c CommandLine) error {
 		return err
 	}
 
-	remotePlugins, err2 := s.ListAllPlugins(c.GlobalString("repo"))
+	v, err2 := s.GetPlugin(localPlugin.Id, c.GlobalString("repo"))
 
 	if err2 != nil {
 		return err2
 	}
 
-	for _, v := range remotePlugins.Plugins {
-		if localPlugin.Id == v.Id {
-			if ShouldUpgrade(localPlugin.Info.Version, v) {
-				s.RemoveInstalledPlugin(pluginsDir, pluginName)
-				return InstallPlugin(localPlugin.Id, "", c)
-			}
-		}
+	if ShouldUpgrade(localPlugin.Info.Version, v) {
+		s.RemoveInstalledPlugin(pluginsDir, pluginName)
+		return InstallPlugin(localPlugin.Id, "", c)
 	}
 
+	log.Infof("%s %s is up to date \n", color.GreenString("✔"), localPlugin.Id)
 	return nil
 }


### PR DESCRIPTION
This update improves efficiency when installing or updating a specific plugin by only requesting the details of that plugin from the repo.

It also improves the error message when a plugin isn't found locally, and adds a message when attempting to update a plugin that's already up to date.
