### PR TITLE
Add new parameter to config: default_theme.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -172,6 +172,9 @@ verify_email_enabled = false
 # Background text for the user field on the login page
 login_hint = email or username
 
+# Default UI theme ("dark" or "light")
+default_theme = dark
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -155,6 +155,9 @@ check_for_updates = true
 # Background text for the user field on the login page
 ;login_hint = email or username
 
+# Default UI theme ("dark" or "light")
+;default_theme = dark
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func init() {
@@ -26,7 +28,7 @@ func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error 
 	}
 
 	res := &m.Preferences{
-		Theme:           "dark",
+		Theme:           setting.DefaultTheme,
 		Timezone:        "browser",
 		HomeDashboardId: 0,
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -88,6 +88,7 @@ var (
 	AutoAssignOrgRole  string
 	VerifyEmailEnabled bool
 	LoginHint          string
+	DefaultTheme       string
 
 	// Http auth
 	AdminUser     string
@@ -454,6 +455,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Read Only Editor", "Viewer"})
 	VerifyEmailEnabled = users.Key("verify_email_enabled").MustBool(false)
 	LoginHint = users.Key("login_hint").String()
+	DefaultTheme = users.Key("default_theme").String()
 
 	// anonymous access
 	AnonymousEnabled = Cfg.Section("auth.anonymous").Key("enabled").MustBool(false)


### PR DESCRIPTION
New config parameter default_theme. Allow to set UI default theme globally.

What is done:
- Hard code in pkg/services/sqlstore/preferences.go:29 has been removed
- New setting "default_theme" has been added.
- Default value is "dark". No changes here.
