### PR TITLE
Fixed datasources icon

### DIFF
--- a/public/app/features/panel/metrics_ds_selector.ts
+++ b/public/app/features/panel/metrics_ds_selector.ts
@@ -10,7 +10,7 @@ var template = `
   <div class="gf-form-inline">
     <div class="gf-form">
       <label class="gf-form-label">
-        <i class="icon-gf icon-gf-datasource"></i>
+        <i class="icon-gf icon-gf-datasources"></i>
       </label>
       <label class="gf-form-label">
         Panel data source


### PR DESCRIPTION
Datasource icon wasn't appearing in the query editor. It was missing an "s" at the end.
