### PR TITLE
Modified initscript

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -17,6 +17,12 @@
 # Short-Description: start and stop grafana-server
 ### END INIT INFO
 
+# init.d / servicectl compatibility (openSUSE)
+if [ -f /etc/rc.status ]; then
+    . /etc/rc.status
+    rc_reset
+fi
+
 # Source function library
 . /etc/rc.d/init.d/functions
 
@@ -35,16 +41,16 @@ MAX_OPEN_FILES=10000
 
 PID_FILE=/var/run/$PROG.pid
 PID_FILE_TIMEOUT=10
-
 DAEMON=/usr/sbin/$PROG
-DAEMON_OPTS="--pidfile=${PID_FILE} --config=${CONF_FILE} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
 
 lockfile=/var/lock/subsys/$PROG
 
-# Source the default environment file
+# Source the default Grafana environment file
 if [ -f "/etc/sysconfig/$PROG" ]; then
     . /etc/sysconfig/$PROG
 fi
+
+DAEMON_OPTS="--pidfile=${PID_FILE} --config=${CONF_FILE} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
 
 if [ "$EUID" != "0" ]; then
     echo "You need root privileges to run this script."

--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -1,155 +1,130 @@
-#! /usr/bin/env bash
-
+#!/bin/bash
+#
+# grafana-server        Startup script for Grafana
+#
 # chkconfig: 2345 80 05
-# description: Grafana web server & backend
+# description: Grafana web server and backend
 # processname: grafana
 # config: /etc/grafana/grafana.ini
 # pidfile: /var/run/grafana.pid
-
+#
 ### BEGIN INIT INFO
 # Provides:          grafana
 # Required-Start:    $all
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start grafana at boot time
+# Short-Description: start and stop grafana-server
 ### END INIT INFO
 
-#  tested on
-#  1. New lsb that define start-stop-daemon
-#  3. Centos with initscripts package installed
+# Source function library
+. /etc/rc.d/init.d/functions
 
+# Set the default values for grafana-server variables
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
-NAME=grafana-server
-DESC="Grafana Server"
-
+PROG=grafana-server
 GRAFANA_USER=grafana
 GRAFANA_GROUP=grafana
 GRAFANA_HOME=/usr/share/grafana
 CONF_DIR=/etc/grafana
-WORK_DIR=$GRAFANA_HOME
 DATA_DIR=/var/lib/grafana
 PLUGINS_DIR=/var/lib/grafana/plugins
 LOG_DIR=/var/log/grafana
 CONF_FILE=$CONF_DIR/grafana.ini
 MAX_OPEN_FILES=10000
-PID_FILE=/var/run/$NAME.pid
-DAEMON=/usr/sbin/$NAME
 
-if [ `id -u` -ne 0 ]; then
-  echo "You need root privileges to run this script"
-  exit 4
-fi
+PID_FILE=/var/run/$PROG.pid
+PID_FILE_TIMEOUT=10
 
-if [ ! -x $DAEMON ]; then
-  echo "Program not installed or not executable"
-  exit 5
-fi
-
-#
-# init.d / servicectl compatibility (openSUSE)
-#
-if [ -f /etc/rc.status ]; then
-    . /etc/rc.status
-    rc_reset
-fi
-
-#
-# Source function library.
-#
-if [ -f /etc/rc.d/init.d/functions ]; then
-    . /etc/rc.d/init.d/functions
-fi
-
-# overwrite settings from default file
-[ -e /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
-
+DAEMON=/usr/sbin/$PROG
 DAEMON_OPTS="--pidfile=${PID_FILE} --config=${CONF_FILE} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
 
-function isRunning() {
-  status -p $PID_FILE $NAME > /dev/null 2>&1
-}
+lockfile=/var/lock/subsys/$PROG
 
-case "$1" in
-  start)
-    echo -n $"Starting $DESC: .... "
+# Source the default environment file
+if [ -f "/etc/sysconfig/$PROG" ]; then
+    . /etc/sysconfig/$PROG
+fi
 
-    isRunning
-    if [ $? -eq 0 ]; then
-      echo "Already running."
-      exit 0
-    fi
+if [ "$EUID" != "0" ]; then
+    echo "You need root privileges to run this script."
+    exit 4
+fi
 
-    # Prepare environment
-    mkdir -p "$LOG_DIR" "$DATA_DIR" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$LOG_DIR" "$DATA_DIR"
-    touch "$PID_FILE" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$PID_FILE"
-
+start() {
     if [ -n "$MAX_OPEN_FILES" ]; then
       ulimit -n $MAX_OPEN_FILES
     fi
+    if [ -n $LOG_DIR ] && [ ! -e $LOG_DIR ]; then
+        mkdir -p "$LOG_DIR" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$LOG_DIR"
+    fi
+    if [ -n $DATA_DIR ] && [ ! -e $DATA_DIR ]; then
+        mkdir -p "$DATA_DIR" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR"
+    fi
+    if [ -n $PID_FILE ] && [ ! -e $PID_FILE ]; then
+        touch "$PID_FILE" && chown "$GRAFANA_USER":"$GRAFANA_GROUP" "$PID_FILE"
+    fi
 
-    # Start Daemon
     cd $GRAFANA_HOME
-    su -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 3>&1 &" $GRAFANA_USER 2> /dev/null
-    return=$?
-    if [ $return -eq 0 ]
-    then
-      sleep 1
-      # check if pid file has been written two
-      if ! [[ -s $PID_FILE ]]; then
-        echo "FAILED"
-        exit 1
-      fi
-      i=0
-      timeout=10
-      # Wait for the process to be properly started before exiting
-      until { cat "$PID_FILE" | xargs kill -0; } >/dev/null 2>&1
-      do
-        sleep 1
-        i=$(($i + 1))
-        if [ $i -gt $timeout ]; then
-          echo "FAILED"
-          exit 1
-        fi
-      done
+    echo -n $"Starting $PROG: "
+    su -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 2>&1 &" $GRAFANA_USER 2> /dev/null    
+    retval=$?
+    if [ $retval -eq 0 ]; then
+        timeout=0
+        while : ; do
+            [ ! -s $PID_FILE ] || break
+            if [ $timeout -ge $PID_FILE_TIMEOUT ]; then
+                retval=1
+                break
+            fi
+            sleep 1 && echo -n "."
+            timeout=$((timeout + 1))
+        done
     fi
+    [ $retval -eq 0 ] && touch $lockfile
+    [ $retval -eq 0 ] && echo_success
+    [ $retval -ne 0 ] && echo_failure
+    echo
+    return $retval
+}
 
-    echo "OK"
-    exit $return
-    ;;
-  stop)
-    echo -n "Stopping $DESC ..."
+stop() {
+    echo -n $"Stopping $PROG: "
+    killproc -p ${PID_FILE} ${NAME}
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
 
-    if [ -f "$PID_FILE" ]; then
-      killproc -p $PID_FILE -d 20 $NAME
-      if [ $? -eq 1 ]; then
-        echo -n "$DESC is not running but pid file exists, cleaning up"
-      elif [ $? -eq 3 ]; then
-        PID="`cat $PID_FILE`"
-        echo -n "Failed to stop $DESC (pid $PID)"
-        exit 1
-      fi
-      rm -f "$PID_FILE"
-      echo "OK"
-      exit 0
-    else
-      echo -n "(not running)"
-    fi
-    exit 0
-    ;;
-  status)
-    status -p $PID_FILE $NAME
-    exit $?
-    ;;
-  restart|force-reload)
-    if [ -f "$PID_FILE" ]; then
-      $0 stop
-      sleep 1
-    fi
-    $0 start
-    ;;
-  *)
-    echo "Usage: $0 {start|stop|restart|force-reload|status}"
-    exit 3
-    ;;
+rh_status() {
+    status -p $PID_FILE $PROG
+}
+
+rh_status_q() {
+    rh_status > /dev/null 2>&1
+}
+
+# See how we were called
+case $1 in
+    start)
+        rh_status_q && exit 0
+        start
+        ;;
+    stop)
+        rh_status_q || exit 0
+        stop
+        ;;
+    restart|force-reload)
+        stop
+        start
+        ;;
+    status)
+        rh_status
+        ;;
+    *)
+        echo $"Usage: $PROG {start|stop|restart|force-reload|status}"
+        exit 3
+        ;;
 esac
+exit $?


### PR DESCRIPTION
- Make better use of bash function library
- Use lockfile
- Break out start and stop into separate functions.

This also fixes the output during start|stop|restart on CentOS 6:

```
[root@localhost ~]# service grafana-server start
Starting Grafana Server: .... OK

[root@localhost ~]# service grafana-server restart
OKopping Grafana Server ...                                [  OK  ]
Starting Grafana Server: .... OK

[root@localhost ~]# service grafana-server stop
OKopping Grafana Server ...                                [  OK  ]
```
