### PR TITLE
(singlestat) add support alias expansion

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -201,10 +201,18 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       }
     }
 
+    var self = this;
+    var replaceAlias = function(map) {
+      var replacedMap = angular.copy(map);
+      replacedMap.text = replacedMap.text.replace(/{{alias}}/, self.series[0].alias);
+      return replacedMap;
+    };
+    var valueMaps = this.panel.valueMaps.map(replaceAlias);
+    var rangeMaps = this.panel.rangeMaps.map(replaceAlias);
     // check value to text mappings if its enabled
     if (this.panel.mappingType === 1) {
-      for (var i = 0; i < this.panel.valueMaps.length; i++) {
-        var map = this.panel.valueMaps[i];
+      for (var i = 0; i < valueMaps.length; i++) {
+        var map = valueMaps[i];
         // special null case
         if (map.value === 'null') {
           if (data.value === null || data.value === void 0) {
@@ -222,8 +230,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
         }
       }
     } else if (this.panel.mappingType === 2) {
-      for (var i = 0; i < this.panel.rangeMaps.length; i++) {
-        var map = this.panel.rangeMaps[i];
+      for (var i = 0; i < rangeMaps.length; i++) {
+        var map = rangeMaps[i];
         // special null case
         if (map.from === 'null' && map.to === 'null') {
           if (data.value === null || data.value === void 0) {


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/5094

Not sure what is the best.
But one of the easy way to support it is this.
Set range map enough wide, and set mapping text to "{{alias}}", and change the alias by datasource plugin legend format.
