### PR TITLE
Openidconnect

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -218,6 +218,7 @@ allow_sign_up = false
 client_id = some_client_id
 client_secret = some_client_secret
 scopes = openid profile email
+provider_name = Google
 provider = https://accounts.google.com/
 auth_url =
 token_url =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -220,6 +220,7 @@ client_secret = some_client_secret
 scopes = openid profile email
 provider_name = Google
 provider = https://accounts.google.com/
+provider_icon = fa-openid
 auth_url =
 token_url =
 api_url =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -211,6 +211,19 @@ token_url = https://accounts.google.com/o/oauth2/token
 api_url = https://www.googleapis.com/oauth2/v1/userinfo
 allowed_domains =
 
+#################################### OpenID Connect Auth ##########################
+[auth.openidc]
+enabled = false
+allow_sign_up = false
+client_id = some_client_id
+client_secret = some_client_secret
+scopes = openid profile email
+provider = https://accounts.google.com/
+auth_url =
+token_url =
+api_url =
+allowed_domains =
+
 #################################### Basic Auth ##########################
 [auth.basic]
 enabled = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -203,6 +203,7 @@ check_for_updates = true
 ;scopes = openid profile email
 ;allowed_domains =
 ;provider = https://accounts.google.com/
+;provider_name = Google
 # next three are fetched from openid connect discovery document if not given here
 ;auth_url = https://accounts.google.com/o/oauth2/auth
 ;token_url = https://accounts.google.com/o/oauth2/token

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -204,6 +204,7 @@ check_for_updates = true
 ;allowed_domains =
 ;provider = https://accounts.google.com/
 ;provider_name = Google
+;provider_icon = fa-google
 # next three are fetched from openid connect discovery document if not given here
 ;auth_url = https://accounts.google.com/o/oauth2/auth
 ;token_url = https://accounts.google.com/o/oauth2/token

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -194,6 +194,20 @@ check_for_updates = true
 ;api_url = https://www.googleapis.com/oauth2/v1/userinfo
 ;allowed_domains =
 
+#################################### OpenID Connect Auth ##########################
+[auth.openidc]
+;enabled = false
+;allow_sign_up = false
+;client_id = some_client_id
+;client_secret = some_client_secret
+;scopes = openid profile email
+;allowed_domains =
+;provider = https://accounts.google.com/
+# next three are fetched from openid connect discovery document if not given here
+;auth_url = https://accounts.google.com/o/oauth2/auth
+;token_url = https://accounts.google.com/o/oauth2/token
+;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+
 #################################### Auth Proxy ##########################
 [auth.proxy]
 ;enabled = false

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -30,6 +30,7 @@ func LoginView(c *middleware.Context) {
 	viewData.Settings["openidcAuthEnabled"] = setting.OAuthService.Openidc
 	if setting.OAuthService.Openidc {
 		viewData.Settings["openidcProviderName"] = setting.OAuthService.OAuthInfos["openidc"].ProviderName
+		viewData.Settings["openidcProviderIcon"] = setting.OAuthService.OAuthInfos["openidc"].ProviderIcon
 	}
 	viewData.Settings["disableUserSignUp"] = !setting.AllowUserSignUp
 	viewData.Settings["loginHint"] = setting.LoginHint

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -28,6 +28,9 @@ func LoginView(c *middleware.Context) {
 	viewData.Settings["googleAuthEnabled"] = setting.OAuthService.Google
 	viewData.Settings["githubAuthEnabled"] = setting.OAuthService.GitHub
 	viewData.Settings["openidcAuthEnabled"] = setting.OAuthService.Openidc
+	if setting.OAuthService.Openidc {
+		viewData.Settings["openidcProviderName"] = setting.OAuthService.OAuthInfos["openidc"].ProviderName
+	}
 	viewData.Settings["disableUserSignUp"] = !setting.AllowUserSignUp
 	viewData.Settings["loginHint"] = setting.LoginHint
 

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -27,6 +27,7 @@ func LoginView(c *middleware.Context) {
 
 	viewData.Settings["googleAuthEnabled"] = setting.OAuthService.Google
 	viewData.Settings["githubAuthEnabled"] = setting.OAuthService.GitHub
+	viewData.Settings["openidcAuthEnabled"] = setting.OAuthService.Openidc
 	viewData.Settings["disableUserSignUp"] = !setting.AllowUserSignUp
 	viewData.Settings["loginHint"] = setting.LoginHint
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -6,4 +6,5 @@ const (
 	GITHUB OAuthType = iota + 1
 	GOOGLE
 	TWITTER
+	OPENIDC
 )

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -11,8 +11,8 @@ type OAuthInfo struct {
 }
 
 type OAuther struct {
-	GitHub, Google, Twitter bool
-	OAuthInfos              map[string]*OAuthInfo
+	GitHub, Google, Twitter, Openidc bool
+	OAuthInfos                       map[string]*OAuthInfo
 }
 
 var OAuthService *OAuther

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -8,6 +8,7 @@ type OAuthInfo struct {
 	AllowedDomains         []string
 	ApiUrl                 string
 	AllowSignup            bool
+	ProviderName           string
 }
 
 type OAuther struct {

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -9,6 +9,7 @@ type OAuthInfo struct {
 	ApiUrl                 string
 	AllowSignup            bool
 	ProviderName           string
+	ProviderIcon           string
 }
 
 type OAuther struct {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -56,6 +56,7 @@ func NewOAuthService() {
 			Enabled:        sec.Key("enabled").MustBool(),
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
+			ProviderName:   sec.Key("provider_name").String(),
 		}
 
 		if !info.Enabled {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -57,6 +57,7 @@ func NewOAuthService() {
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 			ProviderName:   sec.Key("provider_name").String(),
+			ProviderIcon:   sec.Key("provider_icon").String(),
 		}
 
 		if !info.Enabled {

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -17,7 +17,8 @@ function (angular, coreModule, config) {
 
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
-    $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled;
+    $scope.openidcAuthEnabled = config.openidcAuthEnabled;
+    $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled || config.openidcAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
     $scope.loginHint     = config.loginHint;
 

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -18,6 +18,7 @@ function (angular, coreModule, config) {
     $scope.googleAuthEnabled = config.googleAuthEnabled;
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.openidcAuthEnabled = config.openidcAuthEnabled;
+    $scope.openidcProviderName = config.openidcProviderName;
     $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled || config.openidcAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
     $scope.loginHint     = config.loginHint;

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -19,6 +19,7 @@ function (angular, coreModule, config) {
     $scope.githubAuthEnabled = config.githubAuthEnabled;
     $scope.openidcAuthEnabled = config.openidcAuthEnabled;
     $scope.openidcProviderName = config.openidcProviderName;
+    $scope.openidcProviderIcon = config.openidcProviderIcon;
     $scope.oauthEnabled = config.githubAuthEnabled || config.googleAuthEnabled || config.openidcAuthEnabled;
     $scope.disableUserSignUp = config.disableUserSignUp;
     $scope.loginHint     = config.loginHint;

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -52,7 +52,7 @@
 
 				<div class="login-oauth text-center" ng-if="oauthEnabled">
 					<a class="btn btn-large btn-google" href="login/openidc" target="_self" ng-if="openidcAuthEnabled">
-						<i class="fa fa-openid"></i>
+						<i class="fa {{openidcProviderIcon}}"></i>
 						with {{openidcProviderName}}
 					</a>
 					<a class="btn btn-large btn-google" href="login/google" target="_self" ng-if="googleAuthEnabled">

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -53,7 +53,7 @@
 				<div class="login-oauth text-center" ng-if="oauthEnabled">
 					<a class="btn btn-large btn-google" href="login/openidc" target="_self" ng-if="openidcAuthEnabled">
 						<i class="fa fa-openid"></i>
-						with OpenID Connect
+						with {{openidcProviderName}}
 					</a>
 					<a class="btn btn-large btn-google" href="login/google" target="_self" ng-if="googleAuthEnabled">
 						<i class="fa fa-google"></i>

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -51,6 +51,10 @@
 				<div class="clearfix"></div>
 
 				<div class="login-oauth text-center" ng-if="oauthEnabled">
+					<a class="btn btn-large btn-google" href="login/openidc" target="_self" ng-if="openidcAuthEnabled">
+						<i class="fa fa-openid"></i>
+						with OpenID Connect
+					</a>
 					<a class="btn btn-large btn-google" href="login/google" target="_self" ng-if="googleAuthEnabled">
 						<i class="fa fa-google"></i>
 						with Google


### PR DESCRIPTION
This pull request adds basic OpenID Connect authentication support based on the current google authentication. In fact the current google authentication can potentially be dropped in favor of this, since google is also an OpenID Connect provider. 

Here is a list of certified openid connect implementations. This should give an idea about which services that could be used for authentication with this feature: http://openid.net/certification/
