### PR TITLE
Add missing option `Read-Only Editor` to auto_assign_org_role descrip…

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -226,7 +226,7 @@ organization to be created for that new user.
 
 The role new users will be assigned for the main organization (if the
 above setting is set to true).  Defaults to `Viewer`, other valid
-options are `Admin` and `Editor`.
+options are `Admin` and `Editor` and `Read-Only Editor`.
 
 <hr>
 


### PR DESCRIPTION
Commit adds missing option `Read-Only Editor` to `auto_assign_org_role` description.
