### PR TITLE
Add the datasource of RDBMS (PostgreSQL and MySQL)

### DIFF
--- a/pkg/api/sqldb/sqldb.go
+++ b/pkg/api/sqldb/sqldb.go
@@ -85,7 +85,7 @@ func getData(db *core.DB, req *sqlDataRequest) (interface{}, error) {
 	data.Results = make([]resultsStruct, 1)
 	data.Results[0].Series = make([]seriesStruct, 0)
 
-	for i, _ := range queries {
+	for i := range queries {
 		if queries[i] == "" {
 			continue
 		}
@@ -123,7 +123,7 @@ func arrangeResult(rows *core.Rows, name string) (interface{}, error) {
 		}
 
 		// bytes -> string
-		for i, _ := range columnValues {
+		for i := range columnValues {
 			switch columnValues[i].(type) {
 			case []byte:
 				columnValues[i] = fmt.Sprintf("%s", columnValues[i])

--- a/pkg/api/sqldb/sqldb.go
+++ b/pkg/api/sqldb/sqldb.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
-	// "github.com/grafana/grafana/pkg/util"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/go-xorm/core"

--- a/pkg/api/sqldb/sqldb.go
+++ b/pkg/api/sqldb/sqldb.go
@@ -1,0 +1,165 @@
+package sqldb
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/middleware"
+	m "github.com/grafana/grafana/pkg/models"
+	// "github.com/grafana/grafana/pkg/util"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-xorm/core"
+	"github.com/go-xorm/xorm"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type sqlDataRequest struct {
+	Query string `json:"query"`
+	Body  []byte `json:"-"`
+}
+
+type seriesStruct struct {
+	Columns []string        `json:"columns"`
+	Name    string          `json:"name"`
+	Values  [][]interface{} `json:"values"`
+}
+
+type resultsStruct struct {
+	Series []seriesStruct `json:"series"`
+}
+
+type dataStruct struct {
+	Results []resultsStruct `json:"results"`
+}
+
+func getEngine(ds *m.DataSource) (*xorm.Engine, error) {
+	dbms, err := ds.JsonData.Get("dbms").String()
+	if err != nil {
+		return nil, errors.New("Invalid DBMS")
+	}
+
+	host, err := ds.JsonData.Get("host").String()
+	if err != nil {
+		return nil, errors.New("Invalid host")
+	}
+
+	port, err := ds.JsonData.Get("port").String()
+	if err != nil {
+		return nil, errors.New("Invalid port")
+	}
+
+	constr := ""
+
+	switch dbms {
+	case "mysql":
+		constr = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8",
+			ds.User, ds.Password, host, port, ds.Database)
+
+	case "postgres":
+		sslEnabled, _ := ds.JsonData.Get("ssl").Bool()
+		sslMode := "disable"
+		if sslEnabled {
+			sslMode = "require"
+		}
+
+		constr = fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s",
+			ds.User, ds.Password, host, port, ds.Database, sslMode)
+
+	default:
+		return nil, fmt.Errorf("Unknown DBMS: %s", dbms)
+	}
+
+	return xorm.NewEngine(dbms, constr)
+}
+
+func getData(db *core.DB, req *sqlDataRequest) (interface{}, error) {
+	queries := strings.Split(req.Query, ";")
+
+	data := dataStruct{}
+	data.Results = make([]resultsStruct, 1)
+	data.Results[0].Series = make([]seriesStruct, 0)
+
+	for i, _ := range queries {
+		if queries[i] == "" {
+			continue
+		}
+
+		rows, err := db.Query(queries[i])
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		name := fmt.Sprintf("table_%d", i+1)
+		series, err := arrangeResult(rows, name)
+		if err != nil {
+			return nil, err
+		}
+		data.Results[0].Series = append(data.Results[0].Series, series.(seriesStruct))
+	}
+
+	return data, nil
+}
+
+func arrangeResult(rows *core.Rows, name string) (interface{}, error) {
+	columnNames, err := rows.Columns()
+
+	series := seriesStruct{}
+	series.Columns = columnNames
+	series.Name = name
+
+	for rows.Next() {
+		columnValues := make([]interface{}, len(columnNames))
+
+		err = rows.ScanSlice(&columnValues)
+		if err != nil {
+			return nil, err
+		}
+
+		// bytes -> string
+		for i, _ := range columnValues {
+			switch columnValues[i].(type) {
+			case []byte:
+				columnValues[i] = fmt.Sprintf("%s", columnValues[i])
+			}
+		}
+
+		series.Values = append(series.Values, columnValues)
+	}
+
+	return series, err
+}
+
+func HandleRequest(c *middleware.Context, ds *m.DataSource) {
+	var req sqlDataRequest
+	req.Body, _ = ioutil.ReadAll(c.Req.Request.Body)
+	json.Unmarshal(req.Body, &req)
+
+	log.Debug("SQL request: query='%v'", req.Query)
+
+	engine, err := getEngine(ds)
+	if err != nil {
+		c.JsonApiErr(500, "Unable to open SQL connection", err)
+		return
+	}
+	defer engine.Close()
+
+	session := engine.NewSession()
+	defer session.Close()
+
+	db := session.DB()
+
+	result, err := getData(db, &req)
+	if err != nil {
+		c.JsonApiErr(500, fmt.Sprintf("Data error: %v, Query: %s", err.Error(), req.Query), err)
+		return
+	}
+
+	c.JSON(200, result)
+}

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -16,6 +16,7 @@ const (
 	DS_CLOUDWATCH    = "cloudwatch"
 	DS_KAIROSDB      = "kairosdb"
 	DS_PROMETHEUS    = "prometheus"
+	DS_SQLDB         = "sqldb"
 	DS_ACCESS_DIRECT = "direct"
 	DS_ACCESS_PROXY  = "proxy"
 )
@@ -59,6 +60,7 @@ var knownDatasourcePlugins map[string]bool = map[string]bool{
 	DS_CLOUDWATCH:  true,
 	DS_PROMETHEUS:  true,
 	DS_OPENTSDB:    true,
+	DS_SQLDB:       true,
 	"opennms":      true,
 	"druid":        true,
 	"dalmatinerdb": true,

--- a/public/app/plugins/datasource/sqldb/datasource.ts
+++ b/public/app/plugins/datasource/sqldb/datasource.ts
@@ -266,7 +266,7 @@ export default class SqlDatasource {
             's': 'SECOND',
             'w': 'WEEK',
           };
-          rtn = 'DATE_SUB(CURDATE(), INTERVAL ' + amount + ' ' + units[unit] + ')';
+          rtn = 'DATE_SUB(CURRENT_TIMESTAMP(), INTERVAL ' + amount + ' ' + units[unit] + ')';
           break;
 
         default:

--- a/public/app/plugins/datasource/sqldb/datasource.ts
+++ b/public/app/plugins/datasource/sqldb/datasource.ts
@@ -405,6 +405,7 @@ export default class SqlDatasource {
     case 'timestamp':
     case 'timestamptz':
     case 'datetime':
+    case 'date':
       return 'timestamp';
 
     case 'numeric':

--- a/public/app/plugins/datasource/sqldb/datasource.ts
+++ b/public/app/plugins/datasource/sqldb/datasource.ts
@@ -1,0 +1,439 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import angular from 'angular';
+import _ from 'lodash';
+
+import * as dateMath from 'app/core/utils/datemath';
+import SqlSeries from './sql_series';
+import SqlQuery from './sql_query';
+import ResponseParser from './response_parser';
+import SqlQueryBuilder from './query_builder';
+
+export default class SqlDatasource {
+  type: string;
+  username: string;
+  password: string;
+  name: string;
+  database: any;
+  interval: any;
+  supportAnnotations: boolean;
+  supportMetrics: boolean;
+  responseParser: any;
+  url: string;
+  dbms: string;
+
+  /** @ngInject */
+  constructor(instanceSettings, private $q, private backendSrv, private templateSrv) {
+    this.type = 'sqldb';
+
+    this.username = instanceSettings.username;
+    this.password = instanceSettings.password;
+    this.name = instanceSettings.name;
+    this.database = instanceSettings.database;
+    this.interval = (instanceSettings.jsonData || {}).timeInterval;
+    this.supportAnnotations = true;
+    this.supportMetrics = true;
+    this.responseParser = new ResponseParser();
+    this.url = instanceSettings.url;
+    this.dbms = (instanceSettings.jsonData || {}).dbms;
+  }
+
+  query(options) {
+    var queryTargets = [];
+    var i, y;
+
+    var allQueries = _.map(options.targets, (target) => {
+      if (target.hide) { return []; }
+      if (target.timeColDataType === undefined) { return []; }
+
+      queryTargets.push(target);
+      var arr = target.timeColDataType.split(':');
+      target.timeCol = arr[0].trim();
+      target.timeDataType = arr[1].trim();
+
+      var queryModel = new SqlQuery(target, this.templateSrv, options.scopedVars);
+      queryModel.dbms = this.dbms;
+      var query =  queryModel.render(true);
+      query = this._replaceQueryVars(query, options, target);
+
+      return query;
+
+    }).join(";");
+
+    allQueries = this.templateSrv.replace(allQueries, options.scopedVars);
+
+    return this._seriesQuery(allQueries).then((data): any => {
+      if (!data || !data.results) {
+        return [];
+      }
+
+      var seriesList = [];
+      for (i = 0; i < data.results.length; i++) {
+        var result = data.results[i];
+        if (!result || !result.series) { continue; }
+
+        var target = queryTargets[i];
+        var alias = target.alias;
+        if (alias) {
+          alias = this.templateSrv.replace(target.alias, options.scopedVars);
+        }
+
+        var sqlSeries = new SqlSeries({ series: data.results[i].series, table: target.table, alias: alias });
+
+        switch (target.resultFormat) {
+          case 'table': {
+            seriesList.push(sqlSeries.getTable());
+            break;
+          }
+          default: {
+            var timeSeries = sqlSeries.getTimeSeries();
+            for (y = 0; y < timeSeries.length; y++) {
+              seriesList.push(timeSeries[y]);
+            }
+            break;
+          }
+        }
+      }
+
+      return { data: seriesList };
+    });
+  };
+
+  annotationQuery(options) {
+    var timeDataType = options.annotation.timeDataType;
+
+    if (!options.annotation.query || options.annotation.query === '') {
+      var castTimeCol = '';
+      if (this._abstractDataType(timeDataType) === 'timestamp') {
+        castTimeCol = this._ts2Num('$timeColumn', timeDataType);
+      } else {
+        castTimeCol = '$timeColumn';
+      }
+      castTimeCol += ' * 1000';
+
+      options.annotation.query =
+          'SELECT ' +
+          castTimeCol + ' AS "time", ' +
+          (options.annotation.tags || 'NULL') + ' AS "tags", ' +
+          (options.annotation.title || 'NULL') + ' AS "title", ' +
+          (options.annotation.text || 'NULL') + ' AS "text" ' +
+          'FROM ' + options.annotation.schema + '.' + options.annotation.table + ' ' +
+          'WHERE $timeFilter';
+    }
+
+    var query = options.annotation.query;
+
+    query = this._replaceQueryVars(query, options, options.annotation);
+    query = this.templateSrv.replace(query, null, 'regex');
+
+    return this._seriesQuery(query).then(data => {
+      if (!data || !data.results || !data.results[0]) {
+        throw { message: 'No results in response from SqlDB' };
+      }
+      return new SqlSeries({series: data.results[0].series, annotation: options.annotation}).getAnnotations();
+    });
+  };
+
+  metricFindQuery(query) {
+    var interpolated;
+    try {
+      interpolated = this.templateSrv.replace(query, null, 'regex');
+    } catch (err) {
+      return this.$q.reject(err);
+    }
+
+    return this._seriesQuery(interpolated)
+      .then(_.curry(this.responseParser.parse)(query));
+  };
+
+  _seriesQuery(query) {
+    return this._sqlRequest('POST', '/query', {query: query, epoch: 'ms'});
+  }
+
+
+  serializeParams(params) {
+    if (!params) { return '';}
+
+    return _.reduce(params, (memo, value, key) => {
+      if (value === null || value === undefined) { return memo; }
+      memo.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+      return memo;
+    }, []).join("&");
+  }
+
+  testDatasource() {
+    return this.metricFindQuery('SELECT 1 AS num').then(() => {
+      return { status: "success", message: "Data source is working", title: "Success" };
+    });
+  }
+
+  _sqlRequest(method, url, data) {
+    var self = this;
+
+    var options: any = {
+      method: method,
+      url:    this.url + url,
+      data:   data,
+      precision: "ms",
+      inspect: { type: 'sqldb' },
+      paramSerializer: this.serializeParams,
+    };
+
+    return this.backendSrv.datasourceRequest(options).then(result => {
+      return result.data;
+    }, function(err) {
+      if (err.status !== 0 || err.status >= 300) {
+        if (err.data && err.data.error) {
+          throw { message: 'SqlDB Error Response: ' + err.data.error, data: err.data, config: err.config };
+        } else {
+          throw { message: 'SqlDB Error: ' + err.message, data: err.data, config: err.config };
+        }
+      }
+    });
+  };
+
+  _replaceQueryVars(query, options, target) {
+      var from = this._getSubTimestamp(options.rangeRaw.from, target.timeDataType, false);
+      var to = this._getSubTimestamp(options.rangeRaw.to, target.timeDataType, true);
+      var isToNow = (options.rangeRaw.to === 'now');
+
+      var timeFilter = this._getTimeFilter(isToNow);
+      query = query.replace(/\$timeFilter/g, timeFilter);
+
+      query = query.replace(/\$from/g, from);
+      query = query.replace(/\$to/g, to);
+
+      from = this._getSubTimestamp(options.rangeRaw.from, 'numeric', false);
+      to = this._getSubTimestamp(options.rangeRaw.to, 'numeric', true);
+      query = query.replace(/\$unixFrom/g, from);
+      query = query.replace(/\$unixTo/g, to);
+
+      from = this._getSubTimestamp(options.rangeRaw.from, 'timestamp with time zone', false);
+      to = this._getSubTimestamp(options.rangeRaw.to, 'timestamp with time zone', true);
+      query = query.replace(/\$timeFrom/g, from);
+      query = query.replace(/\$timeTo/g, to);
+
+      var unixtimeColumn = this._getRoundUnixTime(target);
+      query = query.replace(/\$unixtimeColumn/g, unixtimeColumn);
+
+      query = query.replace(/\$timeColumn/g, target.timeCol);
+
+      var autoIntervalNum = this._getIntervalNum(target.interval || options.interval);
+      query = query.replace(/\$interval/g, autoIntervalNum);
+
+      return query;
+  }
+
+  _getTimeFilter(isToNow) {
+    if (isToNow) {
+      return '$timeColumn > $from';
+
+    } else {
+      return '$timeColumn > $from AND $timeColumn < $to';
+    }
+  }
+
+  _getSubTimestamp(date, toDataType, roundUp) {
+    var rtn = null;
+
+    if (_.isString(date)) {
+      if (date === 'now') {
+        switch (this._abstractDataType(toDataType)) {
+        case 'timestamp':
+          return this._num2Ts('now()');
+
+        case 'numeric':
+          return this._ts2Num('now()', 'timestamp with time zone');
+        }
+      }
+
+      var parts = /^now-(\d+)([d|h|m|s])$/.exec(date);
+
+      if (parts) {
+        var amount = parseInt(parts[1]);
+        var unit = parts[2];
+
+        switch (this.dbms) {
+        case 'postgres':
+          rtn = '(now() - \'' + amount + unit + '\'::interval)';
+          break;
+
+        case "mysql":
+          var units = {
+            'd': 'DAY',
+            'h': 'HOUR',
+            'm': 'MINUTE',
+            's': 'SECOND',
+            'w': 'WEEK',
+          };
+          rtn = 'DATE_SUB(CURDATE(), INTERVAL ' + amount + ' ' + units[unit] + ')';
+          break;
+
+        default:
+          break;
+        }
+
+      } else {
+        date = dateMath.parse(date, roundUp);
+      }
+    }
+
+    var isNumericDate = false;
+    if (rtn == null) {
+      rtn = (date.valueOf() / 1000).toFixed(0);
+      isNumericDate = true;
+    }
+
+    switch (this._abstractDataType(toDataType)) {
+    case 'timestamp':
+      if (isNumericDate) {
+        rtn = this._num2Ts(rtn);
+      }
+      break;
+
+    case 'numeric':
+      if (! isNumericDate) {
+        rtn = this._ts2Num(rtn, 'timestamp with time zone');
+      }
+      break;
+    }
+
+    return rtn;
+  }
+
+  _getRoundUnixTime(target) {
+    var col = '$timeColumn';
+
+    if (this._abstractDataType(target.timeDataType) === 'timestamp') {
+       col = this._ts2Num(col, 'timestamp with time zone');
+    }
+
+    var rtn = col;
+    if (target.groupBy && target.groupBy.length > 0) {
+      var interval = this._getIntervalNum(target.groupBy[0].params[0]);
+      switch (this.dbms) {
+      case "postgres":
+        rtn = 'round(' + col + ' / ' + interval + ') * ' + interval;
+        break;
+
+      case "mysql":
+        rtn = '(' + col + ' DIV ' + interval + ') * ' + interval;
+        break;
+      }
+    }
+
+    return rtn;
+  }
+
+  _num2Ts(str) {
+    if (str === 'now()') {
+      return str;
+
+    } else {
+      switch (this.dbms) {
+      case 'postgres':
+        return 'to_timestamp(' + str + ')';
+
+      case 'mysql':
+        return 'FROM_UNIXTIME(' + str + ')';
+
+      default:
+        return str;
+      }
+    }
+  }
+
+  _ts2Num(str, toDataType) {
+    switch (this.dbms) {
+    case 'postgres':
+      return 'extract(epoch from ' + str + '::' + this._pgShortTs(toDataType) + ')';
+
+    case 'mysql':
+      return 'UNIX_TIMESTAMP(' + str + ')';
+
+    default:
+      return str;
+    }
+  }
+
+  _getIntervalNum(str) {
+    var rtn = str;
+
+    if (str === 'auto') {
+      return '$interval';
+    }
+
+    var parts = /^(\d+)([a-z]*)$/.exec(str);
+    if (parts) {
+      var amount = parseInt(parts[1]);
+      var unit = parts[2];
+
+      // cast to seconds
+      switch (unit) {
+        case 'ms':
+          rtn = amount / 1000;
+          break;
+
+        case 'm':
+          rtn = amount * 60;
+          break;
+
+        case 'h':
+          rtn = amount * 60 * 12;
+          break;
+
+        case 'd':
+          rtn = amount * 60 * 12 * 24;
+          break;
+
+        case 'w':
+          rtn = amount * 60 * 12 * 24 * 7;
+          break;
+
+        default: // "s"
+          rtn = amount;
+      }
+    }
+
+    return rtn;
+  }
+
+  _abstractDataType(datatype) {
+    switch (datatype) {
+    case 'timestamp with time zone':
+    case 'timestamp without time zone':
+    case 'timestamp':
+    case 'timestamptz':
+    case 'datetime':
+      return 'timestamp';
+
+    case 'numeric':
+    case 'decimal':
+    case 'bigint':
+    case 'integer':
+    case 'real':
+    case 'float':
+    case 'double':
+    case 'double precision':
+      return 'numeric';
+
+    default:
+      return datatype;
+    }
+  }
+
+  _pgShortTs(str) {
+    switch (str) {
+    case 'timestamptz':
+    case 'timestamp with time zone':
+      return 'timestamptz';
+
+    case 'timestamp':
+    case 'timestamp without time zone':
+      return 'timestamp';
+
+    default:
+      return str;
+    };
+  }
+}

--- a/public/app/plugins/datasource/sqldb/module.ts
+++ b/public/app/plugins/datasource/sqldb/module.ts
@@ -1,0 +1,24 @@
+import SqlDatasource from './datasource';
+import {SqlQueryCtrl} from './query_ctrl';
+
+class SqlConfigCtrl {
+  static templateUrl = 'partials/config.html';
+}
+
+class SqlQueryOptionsCtrl {
+  static templateUrl = 'partials/query.options.html';
+}
+
+class SqlAnnotationsQueryCtrl {
+  static templateUrl = 'partials/annotations.editor.html';
+}
+
+export {
+  SqlDatasource as Datasource,
+  SqlQueryCtrl as QueryCtrl,
+  SqlConfigCtrl as ConfigCtrl,
+  SqlQueryOptionsCtrl as QueryOptionsCtrl,
+  SqlAnnotationsQueryCtrl as AnnotationsQueryCtrl,
+};
+
+

--- a/public/app/plugins/datasource/sqldb/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/sqldb/partials/annotations.editor.html
@@ -1,0 +1,57 @@
+
+<h5 class="section-heading">Query
+	<tip>You can use some variables to specify the condition about span:
+		 (ex1) $timeColumn &gt; $timeFrom AND $timeColumn &lt; $timeTo
+		 (ex2) $timeColumn &gt; $unixFrom AND $timeColumn &lt; $unixTo
+		 (ex3) $timeFileter
+	</tip>
+</h5>
+<div class="gf-form-group">
+	<div class="gf-form">
+		<input type="text" class="gf-form-input" ng-model='ctrl.annotation.query' placeholder="select text from events where $timeFilter"></input>
+	</div>
+</div>
+
+<h5 class="section-heading">Query parts</h5>
+<div class="gf-form-group">
+	<div class="gf-form-inline">
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Schema</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.schema' placeholder=""></input>
+		</div>
+
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Table</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.table' placeholder=""></input>
+		</div>
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Time</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.timeCol' placeholder=""></input>
+		</div>
+
+		<div class="gf-form">
+			<span class="gf-form-label width-7">Type of Time</span>
+            <select type="text" class="gf-form-input max-width-20" ng-model='ctrl.annotation.timeDataType' ng-options="f for f in ['timestamp without time zone', 'timestamp with time zone', 'numeric']"></select>
+		</div>
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Tags</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.tags' placeholder=""></input>
+		</div>
+
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Title</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.title' placeholder=""></input>
+		</div>
+
+		<div class="gf-form">
+			<span class="gf-form-label width-5">Text</span>
+			<input type="text" class="gf-form-input max-width-10" ng-model='ctrl.annotation.text' placeholder=""></input>
+		</div>
+	</div>
+</div>

--- a/public/app/plugins/datasource/sqldb/partials/config.html
+++ b/public/app/plugins/datasource/sqldb/partials/config.html
@@ -1,0 +1,53 @@
+<h3 class="page-heading">SqlDB Details</h3>
+
+<div class="gf-form-group">
+	<div class="gf-form-inline">
+		<div class="gf-form max-width-15">
+			<span class="gf-form-label width-7">DBMS</span>
+			<select class="input-medium tight-form-input" ng-model="ctrl.current.jsonData.dbms" ng-options="f for f in ['postgres', 'mysql']"></select>
+		</div>
+		<div class="gf-form max-width-15" ng-if="ctrl.current.jsonData.dbms === 'postgres'">
+			<span class="gf-form-label width-7">SSL</span>
+			<input class="cr1" id="jsonData.ssl" type="checkbox" value="on" ng-model="ctrl.current.jsonData.ssl" ng-checked="ctrl.current.jsonData.ssl">
+			<label for="jsonData.ssl" class="cr1"></label>
+		</div>
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form max-width-30">
+			<span class="gf-form-label width-7">Host</span>
+			<input type="text" class="gf-form-input" ng-model='ctrl.current.jsonData.host' placeholder="localhost" required></input>
+		</div>
+		<div class="gf-form max-width-30">
+			<span class="gf-form-label width-7">Port</span>
+			<input type="text" class="gf-form-input" ng-model='ctrl.current.jsonData.port' placeholder="5432" required></input>
+		</div>
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form max-width-30">
+			<span class="gf-form-label width-7">Database</span>
+			<input type="text" class="gf-form-input" ng-model='ctrl.current.database' placeholder="" required></input>
+		</div>
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form max-width-30">
+			<span class="gf-form-label width-7">User</span>
+			<input type="text" class="gf-form-input" ng-model='ctrl.current.user' placeholder="" required></input>
+		</div>
+		<div class="gf-form max-width-30">
+			<span class="gf-form-label width-7">Password</span>
+			<input type="password" class="gf-form-input" ng-model='ctrl.current.password' placeholder="" required></input>
+		</div>
+	</div>
+</div>
+
+<div class="gf-form-group">
+	<div class="gf-form max-width-21">
+		<span class="gf-form-label">Default group by time</span>
+		<input type="text" class="gf-form-input width-6" ng-model="ctrl.current.jsonData.timeInterval"
+		spellcheck='false' placeholder="example: >10s"></input>
+		<i class="fa fa-question-circle" bs-tooltip="'Set a low limit by having a greater sign: example: >10s'" data-placement="right"></i>
+	</div>
+</div>

--- a/public/app/plugins/datasource/sqldb/partials/query.editor.html
+++ b/public/app/plugins/datasource/sqldb/partials/query.editor.html
@@ -1,0 +1,112 @@
+<query-editor-row query-ctrl="ctrl" can-collapse="true" has-text-edit-mode="true">
+
+	<div class="gf-form" ng-if="ctrl.target.rawQuery">
+		<input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.refresh()"></input>
+	</div>
+
+	<div ng-if="!ctrl.target.rawQuery">
+
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword width-7">FROM</label>
+
+				<metric-segment segment="ctrl.schemaSegment" get-options="ctrl.getSchemaSegments()" on-change="ctrl.schemaChanged()"></metric-segment>
+				<metric-segment segment="ctrl.tableSegment" get-options="ctrl.getTableSegments()" on-change="ctrl.tableChanged()"></metric-segment>
+			</div>
+
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword">WHERE</label>
+			</div>
+
+			<div class="gf-form" ng-repeat="segment in ctrl.tagSegments">
+				<metric-segment segment="segment" get-options="ctrl.getTagsOrValues(segment, $index)" on-change="ctrl.tagSegmentUpdated(segment, $index)"></metric-segment>
+			</div>
+
+			<div class="gf-form gf-form--grow">
+				<div class="gf-form-label gf-form-label--grow"></div>
+			</div>
+		</div>
+
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword width-7">
+					<span>TIME : TYPE</span>
+				</label>
+			</div>
+
+			<div class="gf-form">
+				<metric-segment segment="ctrl.timeColDataTypeSegment" get-options="ctrl.getTimeColDataTypeSegments()" on-change="ctrl.timeColDataTypeChanged()"></metric-segment>
+			</div>
+
+			<div class="gf-form gf-form--grow">
+				<div class="gf-form-label gf-form-label--grow"></div>
+			</div>
+		</div>
+
+		<div class="gf-form-inline" ng-repeat="selectParts in ctrl.queryModel.selectModels">
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword width-7">
+					<span ng-show="$index === 0">SELECT</span>
+				</label>
+			</div>
+
+			<div class="gf-form" ng-repeat="part in selectParts">
+				<sql-query-part-editor
+														class="gf-form-label query-part"
+														part="part"
+														remove-action="ctrl.removeSelectPart(selectParts, part)"
+														part-updated="ctrl.selectPartUpdated(selectParts, part)"
+														get-options="ctrl.getPartOptions(part)">
+				</sql-query-part-editor>
+			</div>
+
+			<div class="gf-form">
+				<label class="dropdown"
+								dropdown-typeahead="ctrl.selectMenu"
+								dropdown-typeahead-on-select="ctrl.addSelectPart(selectParts, $item, $subItem)">
+				</label>
+			</div>
+
+			<div class="gf-form gf-form--grow">
+				<div class="gf-form-label gf-form-label--grow"></div>
+			</div>
+		</div>
+
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<label class="gf-form-label query-keyword width-7">
+					<span>GROUP BY</span>
+				</label>
+
+				<sql-query-part-editor
+								ng-repeat="part in ctrl.queryModel.groupByParts"
+								part="part"
+								class="gf-form-label query-part"
+								remove-action="ctrl.removeGroupByPart(part, $index)" part-updated="ctrl.refresh();" get-options="ctrl.getPartOptions(part)">
+				</sql-query-part-editor>
+			</div>
+
+			<div class="gf-form gf-form--grow">
+				<div class="gf-form-label gf-form-label--grow"></div>
+			</div>
+		</div>
+
+	</div>
+
+	<div class="gf-form-inline">
+		<div class="gf-form max-width-30">
+			<label class="gf-form-label query-keyword width-7">ALIAS BY</label>
+			<input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
+		</div>
+		<div class="gf-form">
+			<label class="gf-form-label">Format as</label>
+			<div class="gf-form-select-wrapper">
+				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.resultFormat" ng-options="f.value as f.text for f in ctrl.resultFormats" ng-change="ctrl.refresh()"></select>
+			</div>
+		</div>
+		<div class="gf-form gf-form--grow">
+			<div class="gf-form-label gf-form-label--grow"></div>
+		</div>
+	</div>
+
+</query-editor-row>

--- a/public/app/plugins/datasource/sqldb/partials/query.options.html
+++ b/public/app/plugins/datasource/sqldb/partials/query.options.html
@@ -1,0 +1,75 @@
+<section class="grafana-metric-options">
+	<div class="gf-form-group">
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<span class="gf-form-label"><i class="fa fa-wrench"></i></span>
+				<span class="gf-form-label width-11">Group by time interval</span>
+				<input type="text" class="gf-form-input" ng-model="ctrl.panelCtrl.panel.interval" ng-blur="ctrl.panelCtrl.refresh();"
+				spellcheck='false' placeholder="example: >10s">
+				<span class="gf-form-label"><i class="fa fa-question-circle" bs-tooltip="'Set a low limit by having a greater sign: example: >60s'" data-placement="right"></i></span>
+			</div>
+		</div>
+		<div class="gf-form-inline">
+			<div class="gf-form">
+				<!--span class="gf-form-label">
+					<i class="fa fa-info-circle"></i>
+				</span-->
+				<span class="gf-form-label width-10">
+					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(1)" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+						<i class="fa fa-info-circle"></i>
+						&nbsp;alias patterns
+					</a>
+				</span>
+				<span class="gf-form-label width-10">
+					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(2)" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+					<i class="fa fa-info-circle"></i>
+						&nbsp;stacking
+					</a>
+				</span>
+				<span class="gf-form-label width-10">
+					<a ng-click="ctrl.panelCtrl.toggleEditorHelp(3)" bs-tooltip="'click to show helpful info'" data-placement="bottom">
+					<i class="fa fa-info-circle"></i>
+						&nbsp;group by time
+					</a>
+				</span>
+			</div>
+		</div>
+	</div>
+</section>
+
+<div class="editor-row">
+	<div class="pull-left">
+
+		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 1">
+			<h5>Alias patterns</h5>
+			<ul>
+				<li>$t = replaced with table name</li>
+				<li>$table = replaced with table name</li>
+				<li>$col = replaced with column name</li>
+			</ul>
+		</div>
+
+		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 2">
+			<h5>Stacking</h5>
+			<ul>
+				<li>When stacking is enabled it important that points align</li>
+				<li>If there are missing points for one series it can cause gaps or missing bars</li>
+				<li>Use the group by time option below your queries and specify for example &gt;10s if your metrics are written every 10 seconds</li>
+				<li>This will insert zeros for series that are missing tables and will make stacking work properly</li>
+			</ul>
+		</div>
+
+		<div class="grafana-info-box span6" ng-if="ctrl.panelCtrl.editorHelpIndex === 3">
+			<h5>Group by time</h5>
+			<ul>
+				<li>Group by time is important, otherwise the query could return many thousands of datapoints that will slow down Grafana</li>
+				<li>Leave the group by time field empty for each query and it will be calculated based on time range and pixel width of the graph</li>
+				<li>The low limit can only be set in the group by time option below your queries</li>
+				<li>You set a low limit by adding a greater sign before the interval</li>
+				<li>Example: &gt;60s if you write metrics to RDB every 60 seconds</li>
+			</ul>
+		</div>
+	</div>
+</div>
+
+

--- a/public/app/plugins/datasource/sqldb/partials/query_part.html
+++ b/public/app/plugins/datasource/sqldb/partials/query_part.html
@@ -1,0 +1,5 @@
+<div class="tight-form-func-controls">
+	<span class="pointer fa fa-remove" ng-click="removeActionInternal()" ></span>
+</div>
+
+<a ng-click="toggleControls()" class="query-part-name">{{part.def.type}}</a><span>(</span><span class="query-part-parameters"></span><span>)</span>

--- a/public/app/plugins/datasource/sqldb/plugin.json
+++ b/public/app/plugins/datasource/sqldb/plugin.json
@@ -1,0 +1,16 @@
+{
+  "type": "datasource",
+  "name": "SqlDB",
+  "id": "sqldb",
+
+  "defaultMatchFormat": "regex values",
+  "metrics": true,
+  "annotations": true,
+
+  "info": {
+    "author": {
+      "name": "Grafana Project",
+      "url": "http://grafana.org"
+    }
+  }
+}

--- a/public/app/plugins/datasource/sqldb/query_builder.d.ts
+++ b/public/app/plugins/datasource/sqldb/query_builder.d.ts
@@ -1,0 +1,2 @@
+declare var test: any;
+export default test;

--- a/public/app/plugins/datasource/sqldb/query_builder.js
+++ b/public/app/plugins/datasource/sqldb/query_builder.js
@@ -1,0 +1,116 @@
+define([
+  'lodash'
+],
+function (_) {
+  'use strict';
+
+  function SqlQueryBuilder(target) {
+    this.target = target;
+  }
+
+  function renderTagCondition (tag, index) {
+    var str = "";
+    var operator = tag.operator;
+    var value = tag.value;
+    if (index > 0) {
+      str = (tag.condition || 'AND') + ' ';
+    }
+
+    // quote value unless regex or number
+    if (isNaN(+value)) {
+      value = "'" + value + "'";
+    }
+
+    return str + '"' + tag.key + '" ' + operator + ' ' + value;
+  }
+
+  var p = SqlQueryBuilder.prototype;
+
+  p.build = function() {
+    return this.target.rawQuery ? this._modifyRawQuery() : this._buildQuery();
+  };
+
+  p.buildExploreQuery = function(type, withKey) {
+    var query;
+    var table;
+
+    if (type === 'TAG_KEYS') {
+      query = 'SELECT column_name ' +
+              'FROM information_schema.columns ' +
+              'WHERE table_schema = \'' + this.target.schema + '\' AND ' +
+                    'table_name = \'' + this.target.table + '\' ' +
+              'ORDER BY ordinal_position';
+      return query;
+
+    } else if (type === 'TAG_VALUES') {
+      query = 'SELECT distinct(' + withKey + ') ' +
+              'FROM "' + this.target.schema + '"."' + this.target.table + '" ' +
+              'ORDER BY ' + withKey;
+      return query;
+
+    } else if (type === 'TABLES') {
+      query = 'SELECT table_name ' +
+              'FROM information_schema.tables ' +
+              'WHERE table_schema = \'' + this.target.schema + '\' ' +
+              'ORDER BY table_name';
+      return query;
+
+    } else if (type === 'FIELDS') {
+      query = 'SELECT concat(column_name, \' : \', data_type)' +
+              'FROM information_schema.columns ' +
+              'WHERE table_schema = \'' + this.target.schema + '\' AND ' +
+                    'table_name = \'' + this.target.table + '\' ' +
+              'ORDER BY ordinal_position';
+      return query;
+
+    } else if (type === 'SCHEMA') {
+      query = 'SELECT schema_name ' +
+              'FROM information_schema.schemata ' +
+              'ORDER BY schema_name';
+      return query;
+
+    } else if (type === 'SET_DEFAULT') {
+      var exceptSchemaArr = "'information_schema', 'pg_catalog'";
+      var numericTypes = "'numeric', 'decimal', 'bigint', 'integer', " +
+                         "'double', 'double precision', 'float'";
+
+      query = 'SELECT table_schema, table_name, ' +
+                     'concat(column_name, \' : \', data_type) ' +
+              'FROM information_schema.columns ' +
+              'WHERE table_schema NOT IN (' + exceptSchemaArr + ') ' +
+              'ORDER BY (data_type LIKE \'timestamp%\') desc, ' +
+                       '(data_type = \'datetime\') desc, ' +
+                       'table_schema, table_name, ' +
+                       '(data_type IN (' + numericTypes + ')) desc, ' +
+                       'ordinal_position ' +
+              'LIMIT 1';
+      return query;
+    }
+
+    if (table) {
+      if (!table.match('^/.*/') && !table.match(/^merge\(.*\)/)) {
+        table = '"' + table+ '"';
+      }
+      query += ' FROM ' + table;
+    }
+
+    if (this.target.tags && this.target.tags.length > 0) {
+      var whereConditions = _.reduce(this.target.tags, function(memo, tag) {
+        // do not add a condition for the key we want to explore for
+        if (tag.key === withKey) {
+          return memo;
+        }
+        memo.push(renderTagCondition(tag, memo.length));
+        return memo;
+      }, []);
+
+      if (whereConditions.length > 0) {
+        query +=  ' WHERE ' + whereConditions.join(' ');
+      }
+    }
+
+    return query;
+  };
+
+  return SqlQueryBuilder;
+});

--- a/public/app/plugins/datasource/sqldb/query_builder.js
+++ b/public/app/plugins/datasource/sqldb/query_builder.js
@@ -64,9 +64,9 @@ function (_) {
       return query;
 
     } else if (type === 'SCHEMA') {
-      query = 'SELECT schema_name ' +
-              'FROM information_schema.schemata ' +
-              'ORDER BY schema_name';
+      query = 'SELECT DISTINCT(table_schema) AS table_schema ' +
+              'FROM information_schema.columns ' +
+              'ORDER BY table_schema';
       return query;
 
     } else if (type === 'SET_DEFAULT') {

--- a/public/app/plugins/datasource/sqldb/query_ctrl.ts
+++ b/public/app/plugins/datasource/sqldb/query_ctrl.ts
@@ -1,0 +1,354 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import './query_part_editor';
+
+import angular from 'angular';
+import _ from 'lodash';
+import SqlQueryBuilder from './query_builder';
+import SqlQuery from './sql_query';
+import queryPart from './query_part';
+import {QueryCtrl} from 'app/plugins/sdk';
+
+export class SqlQueryCtrl extends QueryCtrl {
+  static templateUrl = 'partials/query.editor.html';
+
+  queryModel: SqlQuery;
+  queryBuilder: any;
+  groupBySegment: any;
+  resultFormats: any[];
+  schemaSegment: any;
+  timeColDataTypeSegment: any;
+  tagSegments: any[];
+  selectMenu: any;
+  tableSegment: any;
+  removeTagFilterSegment: any;
+  matchOperators: any;
+
+  /** @ngInject **/
+  constructor($scope, $injector, private templateSrv, private $q, private uiSegmentSrv) {
+    super($scope, $injector);
+
+    this.target = this.target;
+
+    this.matchOperators = queryPart.getMatchOperators(this.datasource.dbms);
+
+    this.queryModel = new SqlQuery(this.target, templateSrv, this.panel.scopedVars);
+    this.queryBuilder = new SqlQueryBuilder(this.target, { matchOperators: this.matchOperators });
+
+    this.resultFormats = [
+      {text: 'Time series', value: 'time_series'},
+      {text: 'Table', value: 'table'},
+    ];
+
+    this.schemaSegment = uiSegmentSrv.newSegment(this.target.schema);
+
+    if (!this.target.table) {
+      this.tableSegment = uiSegmentSrv.newSelectMeasurement();
+    } else {
+      this.tableSegment = uiSegmentSrv.newSegment(this.target.table);
+    }
+
+    this.timeColDataTypeSegment = uiSegmentSrv.newSegment(this.target.timeColDataType);
+
+    this.tagSegments = [];
+    for (let tag of this.target.tags) {
+      if (!tag.operator) {
+        if (/^\/.*\/$/.test(tag.value)) {
+          tag.operator = this.matchOperators.match;
+        } else {
+          tag.operator = '=';
+        }
+      }
+
+      if (tag.condition) {
+        this.tagSegments.push(uiSegmentSrv.newCondition(tag.condition));
+      }
+
+      this.tagSegments.push(uiSegmentSrv.newKey(tag.key));
+      this.tagSegments.push(uiSegmentSrv.newOperator(tag.operator));
+      this.tagSegments.push(uiSegmentSrv.newKeyValue(tag.value));
+    }
+
+    this.fixTagSegments();
+    this.buildSelectMenu();
+    this.removeTagFilterSegment = uiSegmentSrv.newSegment({fake: true, value: '-- remove tag filter --'});
+
+    /*
+     TODO:
+     This doen't work well when trying to change a parameter from the default value put by setDefault().
+    if (this.target.isNew) {
+      this.setDefault();
+    }
+    */
+  }
+
+  setDefault() {
+    var query = this.queryBuilder.buildExploreQuery('SET_DEFAULT');
+    this.datasource._seriesQuery(query).then(data => {
+      if (!data.results[0].series[0].values) { return; }
+      var result = data.results[0].series[0].values[0];
+      this.target.schema          = result[0];
+      this.target.table           = result[1];
+      this.target.timeColDataType = result[2];
+
+      this.schemaSegment = this.uiSegmentSrv.newSegment(this.target.schema);
+      this.tableSegment = this.uiSegmentSrv.newSegment(this.target.table);
+      this.timeColDataTypeSegment = this.uiSegmentSrv.newSegment(this.target.timeColDataType);
+    });
+  }
+
+  buildSelectMenu() {
+    var categories = queryPart.getCategories();
+    this.selectMenu = _.reduce(categories, function(memo, cat, key) {
+      var menu = {
+        text: key,
+        submenu: cat.map(item => {
+         return {text: item.type, value: item.type};
+        }),
+      };
+      memo.push(menu);
+      return memo;
+    }, []);
+  }
+
+  groupByAction() {
+    this.panelCtrl.refresh();
+  }
+
+  removeGroupByPart(part, index) {
+    this.queryModel.removeGroupByPart(part, index);
+    this.panelCtrl.refresh();
+  }
+
+  addSelectPart(selectParts, cat, subitem) {
+    this.queryModel.addSelectPart(selectParts, subitem.value);
+    this.panelCtrl.refresh();
+  }
+
+  removeSelectPart(selectParts, part) {
+    this.queryModel.removeSelectPart(selectParts, part);
+    this.panelCtrl.refresh();
+  }
+
+  selectPartUpdated() {
+    this.panelCtrl.refresh();
+  }
+
+  fixTagSegments() {
+    var count = this.tagSegments.length;
+    var lastSegment = this.tagSegments[Math.max(count-1, 0)];
+
+    if (!lastSegment || lastSegment.type !== 'plus-button') {
+      this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+    }
+  }
+
+  tableChanged() {
+    this.target.table = this.tableSegment.value;
+    this.panelCtrl.refresh();
+  }
+
+  getSchemaSegments() {
+    var schemasQuery = this.queryBuilder.buildExploreQuery('SCHEMA');
+    return this.datasource.metricFindQuery(schemasQuery)
+    .then(this.transformToSegments(false))
+    .catch(this.handleQueryError.bind(this));
+  }
+
+  schemaChanged() {
+    this.target.schema = this.schemaSegment.value;
+    this.panelCtrl.refresh();
+  }
+
+  getTimeColDataTypeSegments() {
+    var timeColQuery = this.queryBuilder.buildExploreQuery('FIELDS');
+    return this.datasource.metricFindQuery(timeColQuery)
+    .then(this.transformToSegments(false))
+    .catch(this.handleQueryError.bind(this));
+  }
+
+  timeColDataTypeChanged() {
+    this.target.timeColDataType = this.timeColDataTypeSegment.value;
+    this.panelCtrl.refresh();
+  }
+
+  toggleEditorMode() {
+    try {
+      this.target.query = this.queryModel.render(false);
+    } catch (err) {
+      console.log('query render error');
+    }
+    this.target.rawQuery = !this.target.rawQuery;
+  }
+
+  getTableSegments() {
+    var query = this.queryBuilder.buildExploreQuery('TABLES');
+    return this.datasource.metricFindQuery(query)
+      .then(this.transformToSegments(true))
+      .catch(this.handleQueryError.bind(this));
+  }
+
+  getPartOptions(part) {
+    if (part.def.type === 'field') {
+      var fieldsQuery = this.queryBuilder.buildExploreQuery('TAG_KEYS');
+      return this.datasource.metricFindQuery(fieldsQuery)
+      .then(this.transformToSegments(true))
+      .catch(this.handleQueryError.bind(this));
+    }
+  }
+
+  handleQueryError(err) {
+    this.error = err.message || 'Failed to issue metric query';
+    return [];
+  }
+
+  transformToSegments(addTemplateVars) {
+    return (results) => {
+      var segments = _.map(results, segment => {
+        return this.uiSegmentSrv.newSegment({ value: segment.text, expandable: segment.expandable });
+      });
+
+      if (addTemplateVars) {
+        for (let variable of this.templateSrv.variables) {
+          segments.unshift(this.uiSegmentSrv.newSegment({
+            type: 'template', value: '/^$' + variable.name + '$/', expandable: true
+          }));
+          segments.unshift(this.uiSegmentSrv.newSegment({
+            type: 'template', value: '$' + variable.name, expandable: true
+          }));
+        }
+      }
+
+      return segments;
+    };
+  }
+
+  getTagsOrValues(segment, index) {
+    if (segment.type === 'condition') {
+      return this.$q.when([
+        this.uiSegmentSrv.newSegment('AND'), this.uiSegmentSrv.newSegment('OR')
+      ]);
+    }
+    if (segment.type === 'operator') {
+      var nextValue = this.tagSegments[index+1].value;
+      if (/^\/.*\/$/.test(nextValue)) {
+        return this.$q.when(this.uiSegmentSrv.newOperators([
+          this.matchOperators.match, this.matchOperators.not
+        ]));
+      } else {
+        return this.$q.when(this.uiSegmentSrv.newOperators([
+          '=', '<>', '<', '>'
+        ]));
+      }
+    }
+
+    var query, addTemplateVars;
+    if (segment.type === 'key' || segment.type === 'plus-button') {
+      query = this.queryBuilder.buildExploreQuery('TAG_KEYS');
+      addTemplateVars = false;
+    } else if (segment.type === 'value')  {
+      query = this.queryBuilder.buildExploreQuery('TAG_VALUES', this.tagSegments[index-2].value);
+      addTemplateVars = true;
+    }
+
+    return this.datasource.metricFindQuery(query)
+    .then(this.transformToSegments(addTemplateVars))
+    .then(results => {
+      if (segment.type === 'key') {
+        results.splice(0, 0, angular.copy(this.removeTagFilterSegment));
+      }
+      return results;
+    })
+    .catch(this.handleQueryError.bind(this));
+  }
+
+  getFieldSegments() {
+    var fieldsQuery = this.queryBuilder.buildExploreQuery('TAG_KEYS');
+    return this.datasource.metricFindQuery(fieldsQuery)
+    .then(this.transformToSegments(false))
+    .catch(this.handleQueryError);
+  }
+
+  tagSegmentUpdated(segment, index) {
+    this.tagSegments[index] = segment;
+
+    // handle remove tag condition
+    if (segment.value === this.removeTagFilterSegment.value) {
+      this.tagSegments.splice(index, 3);
+      if (this.tagSegments.length === 0) {
+        this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+      } else if (this.tagSegments.length > 2) {
+        this.tagSegments.splice(Math.max(index-1, 0), 1);
+        if (this.tagSegments[this.tagSegments.length-1].type !== 'plus-button') {
+          this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+        }
+      }
+    } else {
+      if (segment.type === 'plus-button') {
+        if (index > 2) {
+          this.tagSegments.splice(index, 0, this.uiSegmentSrv.newCondition('AND'));
+        }
+        this.tagSegments.push(this.uiSegmentSrv.newOperator('='));
+        this.tagSegments.push(this.uiSegmentSrv.newFake(
+          'select tag value', 'value', 'query-segment-value'
+        ));
+        segment.type = 'key';
+        segment.cssClass = 'query-segment-key';
+      }
+
+      if ((index+1) === this.tagSegments.length) {
+        this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+      }
+    }
+
+    this.rebuildTargetTagConditions();
+  }
+
+  rebuildTargetTagConditions() {
+    var tags = [];
+    var tagIndex = 0;
+    var tagOperator = "";
+
+    _.each(this.tagSegments, (segment2, index) => {
+      if (segment2.type === 'key') {
+        if (tags.length === 0) {
+          tags.push({});
+        }
+        tags[tagIndex].key = segment2.value;
+      } else if (segment2.type === 'value') {
+        tagOperator = this.getTagValueOperator(segment2.value, tags[tagIndex].operator);
+        if (tagOperator) {
+          this.tagSegments[index-1] = this.uiSegmentSrv.newOperator(tagOperator);
+          tags[tagIndex].operator = tagOperator;
+        }
+        tags[tagIndex].value = segment2.value;
+      } else if (segment2.type === 'condition') {
+        tags.push({ condition: segment2.value });
+        tagIndex += 1;
+      } else if (segment2.type === 'operator') {
+        tags[tagIndex].operator = segment2.value;
+      }
+    });
+
+    this.target.tags = tags;
+    this.panelCtrl.refresh();
+  }
+
+  getTagValueOperator(tagValue, tagOperator) {
+    if (tagOperator !== this.matchOperators.match &&
+        tagOperator !== this.matchOperators.not &&
+        /^\/.*\/$/.test(tagValue)) {
+      return this.matchOperators.match;
+
+    } else if ((tagOperator === this.matchOperators.match ||
+                tagOperator === this.matchOperators.not) &&
+               /^(?!\/.*\/$)/.test(tagValue)) {
+      return '=';
+    }
+  }
+
+  getCollapsedText() {
+    return this.queryModel.render(false);
+  }
+}
+

--- a/public/app/plugins/datasource/sqldb/query_part.ts
+++ b/public/app/plugins/datasource/sqldb/query_part.ts
@@ -1,0 +1,321 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import _ from 'lodash';
+
+var index = [];
+var categories = {
+  Aggregations: [],
+  Selectors: [],
+  Math: [],
+  Aliasing: [],
+  Fields: [],
+};
+
+var groupByTimeFunctions = [];
+
+class QueryPartDef {
+  type: string;
+  params: any[];
+  defaultParams: any[];
+  renderer: any;
+  category: any;
+  addStrategy: any;
+
+  constructor(options: any) {
+    this.type = options.type;
+    this.params = options.params;
+    this.defaultParams = options.defaultParams;
+    this.renderer = options.renderer;
+    this.category = options.category;
+    this.addStrategy = options.addStrategy;
+  }
+
+  static register(options: any) {
+    index[options.type] = new QueryPartDef(options);
+    options.category.push(index[options.type]);
+  }
+}
+
+function functionRenderer(part, innerExpr) {
+  var str = part.def.type + '(';
+  var parameters = _.map(part.params, (value, index) => {
+    var paramType = part.def.params[index];
+    if (paramType.type === 'time') {
+      if (value === 'auto') {
+        value = '$interval';
+      }
+    }
+    if (paramType.quote === 'single') {
+      return "'" + value + "'";
+    } else if (paramType.quote === 'double') {
+      return '"' + value + '"';
+    }
+    return value;
+  });
+
+  if (innerExpr) {
+    parameters.unshift(innerExpr);
+  }
+  return str + parameters.join(', ') + ')';
+}
+
+function aliasRenderer(part, innerExpr) {
+  return innerExpr + ' AS ' + '"' + part.params[0] + '"';
+}
+
+function suffixRenderer(part, innerExpr) {
+  return innerExpr + ' ' + part.params[0];
+}
+
+function identityRenderer(part, innerExpr) {
+  return part.params[0];
+}
+
+function quotedIdentityRenderer(part, innerExpr) {
+  return '"' + part.params[0] + '"';
+}
+
+function fieldRenderer(part, innerExpr) {
+  return part.params[0];
+}
+
+function replaceAggregationAddStrategy(selectParts, partModel) {
+  // look for existing aggregation
+  for (var i = 0; i < selectParts.length; i++) {
+    var part = selectParts[i];
+    if (part.def.category === categories.Aggregations) {
+      selectParts[i] = partModel;
+      return;
+    }
+    if (part.def.category === categories.Selectors) {
+      selectParts[i] = partModel;
+      return;
+    }
+  }
+
+  selectParts.splice(1, 0, partModel);
+}
+
+function addMathStrategy(selectParts, partModel) {
+  var partCount = selectParts.length;
+  if (partCount > 0) {
+    // if last is math, replace it
+    if (selectParts[partCount-1].def.type === 'math') {
+      selectParts[partCount-1] = partModel;
+      return;
+    }
+    // if next to last is math, replace it
+    if (selectParts[partCount-2].def.type === 'math') {
+      selectParts[partCount-2] = partModel;
+      return;
+    } else if (selectParts[partCount-1].def.type === 'alias') { // if last is alias add it before
+      selectParts.splice(partCount-1, 0, partModel);
+      return;
+    }
+  }
+  selectParts.push(partModel);
+}
+
+function addAliasStrategy(selectParts, partModel) {
+  var partCount = selectParts.length;
+  if (partCount > 0) {
+    // if last is alias, replace it
+    if (selectParts[partCount-1].def.type === 'alias') {
+      selectParts[partCount-1] = partModel;
+      return;
+    }
+  }
+  selectParts.push(partModel);
+}
+
+function addFieldStrategy(selectParts, partModel, query) {
+  // copy all parts
+  var parts = _.map(selectParts, function(part: any) {
+    return new QueryPart({type: part.def.type, params: _.clone(part.params)});
+  });
+
+  query.selectModels.push(parts);
+}
+
+QueryPartDef.register({
+  type: 'field',
+  addStrategy: addFieldStrategy,
+  category: categories.Fields,
+  params: [{type: 'field', dynamicLookup: true}],
+  defaultParams: ['value'],
+  renderer: fieldRenderer,
+});
+
+// Aggregations
+QueryPartDef.register({
+  type: 'count',
+  addStrategy: replaceAggregationAddStrategy,
+  category: categories.Aggregations,
+  params: [],
+  defaultParams: [],
+  renderer: functionRenderer,
+});
+
+QueryPartDef.register({
+  type: 'avg',
+  addStrategy: replaceAggregationAddStrategy,
+  category: categories.Aggregations,
+  params: [],
+  defaultParams: [],
+  renderer: functionRenderer,
+});
+
+QueryPartDef.register({
+  type: 'sum',
+  addStrategy: replaceAggregationAddStrategy,
+  category: categories.Aggregations,
+  params: [],
+  defaultParams: [],
+  renderer: functionRenderer,
+});
+
+// transformations
+
+QueryPartDef.register({
+  type: 'time',
+  category: groupByTimeFunctions,
+  params: [{ name: "interval", type: "time", options: ['auto', '1s', '10s', '1m', '5m', '10m', '15m', '1h'] }],
+  defaultParams: ['auto'],
+  renderer: functionRenderer,
+});
+
+// Selectors
+
+QueryPartDef.register({
+  type: 'max',
+  addStrategy: replaceAggregationAddStrategy,
+  category: categories.Selectors,
+  params: [],
+  defaultParams: [],
+  renderer: functionRenderer,
+});
+
+QueryPartDef.register({
+  type: 'min',
+  addStrategy: replaceAggregationAddStrategy,
+  category: categories.Selectors,
+  params: [],
+  defaultParams: [],
+  renderer: functionRenderer,
+});
+
+QueryPartDef.register({
+  type: 'tag',
+  category: groupByTimeFunctions,
+  params: [{name: 'tag', type: 'string', dynamicLookup: true}],
+  defaultParams: ['tag'],
+  renderer: fieldRenderer,
+});
+
+QueryPartDef.register({
+  type: 'math',
+  addStrategy: addMathStrategy,
+  category: categories.Math,
+  params: [{ name: "expr", type: "string"}],
+  defaultParams: [' / 100'],
+  renderer: suffixRenderer,
+});
+
+QueryPartDef.register({
+  type: 'alias',
+  addStrategy: addAliasStrategy,
+  category: categories.Aliasing,
+  params: [{ name: "name", type: "string", quote: 'double'}],
+  defaultParams: ['alias'],
+  renderMode: 'suffix',
+  renderer: aliasRenderer,
+});
+
+class QueryPart {
+  part: any;
+  def: QueryPartDef;
+  params: any[];
+  text: string;
+
+  constructor(part: any) {
+    this.part = part;
+    this.def = index[part.type];
+    if (!this.def) {
+      throw {message: 'Could not find query part ' + part.type};
+    }
+
+    part.params = part.params || _.clone(this.def.defaultParams);
+    this.params = part.params;
+    this.updateText();
+  }
+
+  render(innerExpr: string) {
+    return this.def.renderer(this, innerExpr);
+  }
+
+  hasMultipleParamsInString (strValue, index) {
+    if (strValue.indexOf(',') === -1) {
+      return false;
+    }
+
+    return this.def.params[index + 1] && this.def.params[index + 1].optional;
+  }
+
+  updateParam (strValue, index) {
+    // handle optional parameters
+    // if string contains ',' and next param is optional, split and update both
+    if (this.hasMultipleParamsInString(strValue, index)) {
+      _.each(strValue.split(','), function(partVal: string, idx) {
+        this.updateParam(partVal.trim(), idx);
+      }, this);
+      return;
+    }
+
+    if (strValue === '' && this.def.params[index].optional) {
+      this.params.splice(index, 1);
+    } else {
+      this.params[index] = strValue;
+    }
+
+    this.part.params = this.params;
+    this.updateText();
+  }
+
+  updateText() {
+    if (this.params.length === 0) {
+      this.text = this.def.type + '()';
+      return;
+    }
+
+    var text = this.def.type + '(';
+    text += this.params.join(', ');
+    text += ')';
+    this.text = text;
+  }
+}
+
+export default {
+  create: function(part): any {
+    return new QueryPart(part);
+  },
+
+  getCategories: function() {
+    return categories;
+  },
+
+  getMatchOperators: function(dbms) {
+    var rtn = null;
+    switch (dbms) {
+      case 'postgres':
+        rtn = { 'match': '~*', 'not': '!~*' };
+        break;
+      case 'mysql':
+        rtn = { 'match': 'REGEXP', 'not': 'NOT REGEXP' };
+        break;
+      default:
+        break;
+    };
+
+    return rtn;
+  },
+};

--- a/public/app/plugins/datasource/sqldb/query_part_editor.js
+++ b/public/app/plugins/datasource/sqldb/query_part_editor.js
@@ -1,0 +1,178 @@
+define([
+  'angular',
+  'lodash',
+  'jquery',
+],
+function (angular, _, $) {
+  'use strict';
+
+  angular
+    .module('grafana.directives')
+    .directive('sqlQueryPartEditor', function($compile, templateSrv) {
+
+      var paramTemplate = '<input type="text" style="display:none"' +
+                          ' class="input-mini tight-form-func-param"></input>';
+      return {
+        restrict: 'E',
+        templateUrl: 'public/app/plugins/datasource/sqldb/partials/query_part.html',
+        scope: {
+          part: "=",
+          removeAction: "&",
+          partUpdated: "&",
+          getOptions: "&",
+        },
+        link: function postLink($scope, elem) {
+          var part = $scope.part;
+          var partDef = part.def;
+          var $paramsContainer = elem.find('.query-part-parameters');
+          var $controlsContainer = elem.find('.tight-form-func-controls');
+
+          function clickFuncParam(paramIndex) {
+            /*jshint validthis:true */
+            var $link = $(this);
+            var $input = $link.next();
+
+            $input.val(part.params[paramIndex]);
+            $input.css('width', ($link.width() + 16) + 'px');
+
+            $link.hide();
+            $input.show();
+            $input.focus();
+            $input.select();
+
+            var typeahead = $input.data('typeahead');
+            if (typeahead) {
+              $input.val('');
+              typeahead.lookup();
+            }
+          }
+
+          function inputBlur(paramIndex) {
+            /*jshint validthis:true */
+            var $input = $(this);
+            var $link = $input.prev();
+            var newValue = $input.val();
+
+            if (newValue !== '' || part.def.params[paramIndex].optional) {
+              $link.html(templateSrv.highlightVariablesAsHtml(newValue));
+
+              part.updateParam($input.val(), paramIndex);
+              $scope.$apply($scope.partUpdated);
+            }
+
+            $input.hide();
+            $link.show();
+          }
+
+          function inputKeyPress(paramIndex, e) {
+            /*jshint validthis:true */
+            if(e.which === 13) {
+              inputBlur.call(this, paramIndex);
+            }
+          }
+
+          function inputKeyDown() {
+            /*jshint validthis:true */
+            this.style.width = (3 + this.value.length) * 8 + 'px';
+          }
+
+          function addTypeahead($input, param, paramIndex) {
+            if (!param.options && !param.dynamicLookup) {
+              return;
+            }
+
+            var typeaheadSource = function (query, callback) {
+              if (param.options) { return param.options; }
+
+              $scope.$apply(function() {
+                $scope.getOptions().then(function(result) {
+                  var dynamicOptions = _.map(result, function(op) { return op.value; });
+                  callback(dynamicOptions);
+                });
+              });
+            };
+
+            $input.attr('data-provide', 'typeahead');
+            var options = param.options;
+            if (param.type === 'int') {
+              options = _.map(options, function(val) { return val.toString(); });
+            }
+
+            $input.typeahead({
+              source: typeaheadSource,
+              minLength: 0,
+              items: 1000,
+              updater: function (value) {
+                setTimeout(function() {
+                  inputBlur.call($input[0], paramIndex);
+                }, 0);
+                return value;
+              }
+            });
+
+            var typeahead = $input.data('typeahead');
+            typeahead.lookup = function () {
+              this.query = this.$element.val() || '';
+              var items = this.source(this.query, $.proxy(this.process, this));
+              return items ? this.process(items) : items;
+            };
+          }
+
+          $scope.toggleControls = function() {
+            var targetDiv = elem.closest('.tight-form');
+
+            if (elem.hasClass('show-function-controls')) {
+              elem.removeClass('show-function-controls');
+              targetDiv.removeClass('has-open-function');
+              $controlsContainer.hide();
+              return;
+            }
+
+            elem.addClass('show-function-controls');
+            targetDiv.addClass('has-open-function');
+            $controlsContainer.show();
+          };
+
+          $scope.removeActionInternal = function() {
+            $scope.toggleControls();
+            $scope.removeAction();
+          };
+
+          function addElementsAndCompile() {
+            _.each(partDef.params, function(param, index) {
+              if (param.optional && part.params.length <= index) {
+                return;
+              }
+
+              if (index > 0) {
+                $('<span>, </span>').appendTo($paramsContainer);
+              }
+
+              var paramValue = templateSrv.highlightVariablesAsHtml(part.params[index]);
+              var $paramLink = $('<a class="graphite-func-param-link pointer">' + paramValue + '</a>');
+              var $input = $(paramTemplate);
+
+              $paramLink.appendTo($paramsContainer);
+              $input.appendTo($paramsContainer);
+
+              $input.blur(_.partial(inputBlur, index));
+              $input.keyup(inputKeyDown);
+              $input.keypress(_.partial(inputKeyPress, index));
+              $paramLink.click(_.partial(clickFuncParam, index));
+
+              addTypeahead($input, param, index);
+            });
+          }
+
+          function relink() {
+            $paramsContainer.empty();
+            addElementsAndCompile();
+          }
+
+          relink();
+        }
+      };
+
+    });
+
+});

--- a/public/app/plugins/datasource/sqldb/response_parser.ts
+++ b/public/app/plugins/datasource/sqldb/response_parser.ts
@@ -1,0 +1,34 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import _ from 'lodash';
+
+export default class ResponseParser {
+
+  parse(query, results) {
+    if (!results || results.results.length === 0) { return []; }
+
+    var sqlResults = results.results[0];
+    if (!sqlResults.series) {
+      return [];
+    }
+
+    var res = {};
+    _.each(sqlResults.series, serie => {
+      _.each(serie.values, value => {
+        if (_.isArray(value)) {
+          addUnique(res, value[0]);
+        } else {
+          addUnique(res, value);
+        }
+      });
+    });
+
+    return _.map(res, value => {
+      return { text: value};
+    });
+  }
+}
+
+function addUnique(arr, value) {
+  arr[value] = value;
+}

--- a/public/app/plugins/datasource/sqldb/sql_query.ts
+++ b/public/app/plugins/datasource/sqldb/sql_query.ts
@@ -1,0 +1,225 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import _ from 'lodash';
+import queryPart from './query_part';
+
+export default class SqlQuery {
+  dbms: string;
+  target: any;
+  selectModels: any[];
+  queryBuilder: any;
+  groupByParts: any;
+  templateSrv: any;
+  scopedVars: any;
+
+  /** @ngInject */
+  constructor(target, templateSrv?, scopedVars?) {
+    this.dbms = null;
+    this.target = target;
+    this.templateSrv = templateSrv;
+    this.scopedVars = scopedVars;
+
+    target.schema = target.schema || 'default';
+    target.dsType = 'sqldb';
+    target.timeColDataType = target.timeColDataType || 'time : type';
+    target.resultFormat = target.resultFormat || 'time_series';
+    target.tags = target.tags || [];
+    target.groupBy = target.groupBy || [
+      {type: 'time', params: ['$interval']},
+    ];
+    target.targetLists = target.targetLists || [[
+      {type: 'field', params: ['*']},
+      {type: 'count', params: []},
+    ]];
+    target.alias = target.alias || '$t.$col';
+
+    this.updateProjection();
+  }
+
+  updateProjection() {
+    this.selectModels = _.map(this.target.targetLists, function(parts: any) {
+      return _.map(parts, queryPart.create);
+    });
+    this.groupByParts = _.map(this.target.groupBy, queryPart.create);
+  }
+
+  updatePersistedParts() {
+    this.target.targetLists = _.map(this.selectModels, function(selectParts) {
+      return _.map(selectParts, function(part: any) {
+        return {type: part.def.type, params: part.params};
+      });
+    });
+  }
+
+  hasGroupByTime() {
+    return _.find(this.target.groupBy, (g: any) => g.type === 'time');
+  }
+
+  addGroupBy(value) {
+    var stringParts = value.match(/^(\w+)\((.*)\)$/);
+    var typePart = stringParts[1];
+    var arg = stringParts[2];
+    var partModel = queryPart.create({type: typePart, params: [arg]});
+    var partCount = this.target.groupBy.length;
+
+    if (partCount === 0) {
+      this.target.groupBy.push(partModel.part);
+    } else if (typePart === 'time') {
+      this.target.groupBy.splice(0, 0, partModel.part);
+    } else {
+      this.target.groupBy.push(partModel.part);
+    }
+
+    this.updateProjection();
+  }
+
+  removeGroupByPart(part, index) {
+    var categories = queryPart.getCategories();
+
+    if (part.def.type === 'time') {
+      // remove aggregations
+      this.target.targetLists = _.map(this.target.targetLists, (s: any) => {
+        return _.filter(s, (part: any) => {
+          var partModel = queryPart.create(part);
+          if (partModel.def.category === categories.Aggregations) {
+            return false;
+          }
+          if (partModel.def.category === categories.Selectors) {
+            return false;
+          }
+          return true;
+        });
+      });
+    }
+
+    this.target.groupBy.splice(index, 1);
+    this.updateProjection();
+  }
+
+  removeSelect(index: number) {
+    this.target.targetLists.splice(index, 1);
+    this.updateProjection();
+  }
+
+  removeSelectPart(selectParts, part) {
+    // if we remove the field remove the whole statement
+    if (part.def.type === 'field') {
+      if (this.selectModels.length > 1) {
+        var modelsIndex = _.indexOf(this.selectModels, selectParts);
+        this.selectModels.splice(modelsIndex, 1);
+      }
+    } else {
+      var partIndex = _.indexOf(selectParts, part);
+      selectParts.splice(partIndex, 1);
+    }
+
+    this.updatePersistedParts();
+  }
+
+  addSelectPart(selectParts, type) {
+    var partModel = queryPart.create({type: type});
+    partModel.def.addStrategy(selectParts, partModel, this);
+    this.updatePersistedParts();
+  }
+
+  private renderTagCondition(tag, index, interpolate) {
+    var str = "";
+    var operator = tag.operator;
+    var value = tag.value;
+    if (index > 0) {
+      str = (tag.condition || 'AND') + ' ';
+    }
+
+    if (!operator) {
+      if (/^\/.*\/$/.test(value)) {
+        operator = '=~';
+      } else {
+        operator = '=';
+      }
+    }
+
+    // quote value unless regex
+    var matchOperators = queryPart.getMatchOperators(this.dbms);
+    if (!matchOperators || (operator !== matchOperators.match && operator !== matchOperators.not)) {
+      if (interpolate) {
+        value = this.templateSrv.replace(value, this.scopedVars);
+      }
+      if (operator !== '>' && operator !== '<') {
+        value = "'" + value.replace('\\', '\\\\') + "'";
+      }
+    } else if (interpolate){
+      value = this.templateSrv.replace(value, this.scopedVars, 'regex');
+      value = "'" + value.replace(/^\//, '').replace(/\/$/, '') + "'";
+    }
+
+    return str + tag.key + ' ' + operator + ' ' + value;
+  }
+
+  gettableAndSchema(interpolate) {
+    var schema = this.target.schema;
+    var table = this.target.table || 'table';
+
+    if (!table.match('^/.*/')) {
+      table = table;
+    } else if (interpolate) {
+      table = this.templateSrv.replace(table, this.scopedVars, 'regex');
+    }
+
+    if (schema !== 'default') {
+      schema = this.target.schema + '.';
+    } else {
+      schema = "";
+    }
+
+    var rtn = schema + table;
+
+    return rtn;
+  }
+
+  render(interpolate?) {
+    var target = this.target;
+
+    if (target.rawQuery) {
+      if (interpolate) {
+        return this.templateSrv.replace(target.query, this.scopedVars, 'regex');
+      } else {
+        return target.query;
+      }
+    }
+
+    var query = 'SELECT ';
+
+    query += '$unixtimeColumn * 1000 AS time_msec, ';
+
+    var i, y;
+    for (i = 0; i < this.selectModels.length; i++) {
+      let parts = this.selectModels[i];
+      var selectText = "";
+      for (y = 0; y < parts.length; y++) {
+        let part = parts[y];
+        selectText = part.render(selectText);
+      }
+
+      if (i > 0) {
+        query += ', ';
+      }
+      query += selectText;
+    }
+
+    query += ' FROM ' + this.gettableAndSchema(interpolate) + ' WHERE ';
+    var conditions = _.map(target.tags, (tag, index) => {
+      return this.renderTagCondition(tag, index, interpolate);
+    });
+
+    query += conditions.join(' ');
+    query += (conditions.length > 0 ? ' AND ' : '') + '$timeFilter';
+
+    if (target.groupBy.length !== 0) {
+      query += ' GROUP BY $unixtimeColumn';
+    }
+
+    query += ' ORDER BY $unixtimeColumn';
+
+    return query;
+  }
+}

--- a/public/app/plugins/datasource/sqldb/sql_series.d.ts
+++ b/public/app/plugins/datasource/sqldb/sql_series.d.ts
@@ -1,0 +1,2 @@
+declare var test: any;
+export default test;

--- a/public/app/plugins/datasource/sqldb/sql_series.js
+++ b/public/app/plugins/datasource/sqldb/sql_series.js
@@ -1,0 +1,158 @@
+define([
+  'lodash',
+  'app/core/table_model',
+],
+function (_, TableModel) {
+  'use strict';
+
+  function SqlSeries(options) {
+    this.series = options.series;
+    this.table = options.table;
+    this.alias = options.alias;
+    this.annotation = options.annotation;
+  }
+
+  var p = SqlSeries.prototype;
+
+  p.getTimeSeries = function() {
+    var output = [];
+    var self = this;
+    var i, j;
+
+    if (self.series.length === 0) {
+      return output;
+    }
+
+    _.each(self.series, function(series) {
+      var columns = series.columns.length;
+      var tags = _.map(series.tags, function(value, key) {
+        return key + ': ' + value;
+      });
+
+      for (j = 1; j < columns; j++) {
+        var seriesName = self.table;
+        var columnName = series.columns[j];
+        if (columnName !== 'value') {
+          seriesName = seriesName + '.' + columnName;
+        }
+
+        if (self.alias) {
+          seriesName = self._getSeriesName(series, j);
+        } else if (series.tags) {
+          seriesName = seriesName + ' {' + tags.join(', ') + '}';
+        }
+
+        var datapoints = [];
+        if (series.values) {
+          for (i = 0; i < series.values.length; i++) {
+            var sample = Number(series.values[i][j]);
+            var ts = parseFloat(series.values[i][0]);
+
+            if (isNaN(sample)) {
+              datapoints[i] = [series.values[i][j], ts];
+            } else {
+              datapoints[i] = [sample, ts];
+            }
+          }
+        }
+
+        output.push({ target: seriesName, datapoints: datapoints});
+      }
+    });
+
+    return output;
+  };
+
+  p._getSeriesName = function(series, index) {
+    var self = this;
+    var regex = /\$(\w+)|\[\[([\s\S]+?)\]\]/g;
+
+    return this.alias.replace(regex, function(match, g1, g2) {
+      var group = g1 || g2;
+
+      if (group === 't' || group === 'table') { return self.table || series.name; }
+      if (group === 'col') { return series.columns[index]; }
+
+      return match;
+    });
+  };
+
+  p.getAnnotations = function () {
+    var list = [];
+    var self = this;
+
+    _.each(this.series, function (series) {
+      var titleCol = null;
+      var timeCol = null;
+      var tagsCol = null;
+      var textCol = null;
+
+      _.each(series.columns, function(column, index) {
+        if (column === 'time') { timeCol = index; return; }
+        if (column === 'tags') { tagsCol = index; return; }
+        if (column === 'title') { titleCol = index; return; }
+        if (column === 'text') { textCol = index; return; }
+        if (!titleCol) { titleCol = index; }
+      });
+
+      _.each(series.values, function (value) {
+        var data = {
+          annotation: self.annotation,
+          time: + new Date(parseFloat(value[timeCol])),
+          title: value[titleCol],
+          tags: value[tagsCol],
+          text: value[textCol]
+        };
+
+        list.push(data);
+      });
+    });
+
+    return list;
+  };
+
+  p.getTable = function() {
+    var table = new TableModel.default();
+    var self = this;
+    var i, j;
+
+    if (self.series.length === 0) {
+      return table;
+    }
+
+    _.each(self.series, function(series, seriesIndex) {
+
+      if (seriesIndex === 0) {
+        table.columns.push({text: 'Time', type: 'time'});
+        _.each(_.keys(series.tags), function(key) {
+          table.columns.push({text: key});
+        });
+        for (j = 1; j < series.columns.length; j++) {
+          table.columns.push({text: series.columns[j]});
+        }
+      }
+
+      if (series.values) {
+        for (i = 0; i < series.values.length; i++) {
+          var values = series.values[i];
+          var reordered = [parseFloat(values[0])];
+          if (series.tags) {
+            for (var key in series.tags) {
+              if (series.tags.hasOwnProperty(key)) {
+                reordered.push(series.tags[key]);
+              }
+            }
+          }
+          for (j = 1; j < values.length; j++) {
+            reordered.push(values[j]);
+          }
+          table.rows.push(reordered);
+        }
+      }
+    });
+
+    return table;
+  };
+
+  return SqlSeries;
+});

--- a/public/app/plugins/datasource/sqldb/sql_series.js
+++ b/public/app/plugins/datasource/sqldb/sql_series.js
@@ -143,8 +143,15 @@ function (_, TableModel) {
               }
             }
           }
+
+          var float_v = null;
           for (j = 1; j < values.length; j++) {
-            reordered.push(parseFloat(values[j]));
+            float_v = parseFloat(values[j]);
+            if (isNaN(float_v)) {
+              reordered.push(values[j]);
+            } else {
+              reordered.push(float_v);
+            }
           }
           table.rows.push(reordered);
         }

--- a/public/app/plugins/datasource/sqldb/sql_series.js
+++ b/public/app/plugins/datasource/sqldb/sql_series.js
@@ -144,7 +144,7 @@ function (_, TableModel) {
             }
           }
           for (j = 1; j < values.length; j++) {
-            reordered.push(values[j]);
+            reordered.push(parseFloat(values[j]));
           }
           table.rows.push(reordered);
         }


### PR DESCRIPTION
I added the datasource of RDBMS named "SQL DB". This plugin supports PostgreSQL and MySQL.
- This datasource is implemented refering to the one of influxDB. So the all features with influxDB are also supported in SQL DB datasource. You can use query editor, defining raw query, templating, annotation, mixed queries, search condition with regex, and so on.
- The panel interface of frontend is very similar to influxDB datasource.
- SQL DB datasource needs the backend to connect databases of RDBMS, because we cannot connect RDBMS via HTTP.
  The backend listens HTTP POSTs from the frontend, connects databases and execute queries, and returns the results to the frontend.
  In this plugin, the backend uses xorm to connect RDBMS.
- SQL DB datasource needs users to specify which column has timestamp data.

Here is the detail about the fearures of SQL DB datasource.
https://github.com/anzai/grafana/wiki/SQL-DB-plugin-%28datasource%29
