### PR TITLE
OpenTSDB: consistent options for http requests

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -199,11 +199,21 @@ function (angular, _, dateMath) {
     };
 
     this._get = function(relativeUrl, params) {
-      return backendSrv.datasourceRequest({
+      var options = {
         method: 'GET',
         url: this.url + relativeUrl,
         params: params,
-      });
+      };
+
+      if (this.basicAuth || this.withCredentials) {
+        options.withCredentials = true;
+      }
+
+      if (this.basicAuth) {
+        options.headers = {"Authorization": this.basicAuth};
+      }
+
+      return backendSrv.datasourceRequest(options);
     };
 
     this.metricFindQuery = function(query) {

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -128,13 +128,7 @@ function (angular, _, dateMath) {
         data: reqBody
       };
 
-      if (this.basicAuth || this.withCredentials) {
-        options.withCredentials = true;
-      }
-
-      if (this.basicAuth) {
-        options.headers = {"Authorization": this.basicAuth};
-      }
+      this._addCredentialOptions(options);
 
       // In case the backend is 3rd-party hosted and does not suport OPTIONS, urlencoded requests
       // go as POST rather than OPTIONS+POST
@@ -205,15 +199,18 @@ function (angular, _, dateMath) {
         params: params,
       };
 
+      this._addCredentialOptions(options);
+
+      return backendSrv.datasourceRequest(options);
+    };
+
+    this._addCredentialOptions = function(options) {
       if (this.basicAuth || this.withCredentials) {
         options.withCredentials = true;
       }
-
       if (this.basicAuth) {
         options.headers = {"Authorization": this.basicAuth};
       }
-
-      return backendSrv.datasourceRequest(options);
     };
 
     this.metricFindQuery = function(query) {
@@ -437,7 +434,6 @@ function (angular, _, dateMath) {
       date = dateMath.parse(date, roundUp);
       return date.valueOf();
     }
-
   }
 
   return {


### PR DESCRIPTION
The OpenTSDB datasource.js applies withCredentials / basicAuth to HTTP requests made from the performTimeSeriesQuery function, but not to requests made from the_get function that's used for suggest, search, aggregator and filter api calls. 

This patch adds those options to HTTP requests made from the _get function
