### PR TITLE
LDAP: Warn user if there are no mappings

### DIFF
--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -164,6 +164,7 @@ func (a *ldapAuther) syncUserInfo(user *m.User, ldapUser *ldapUserInfo) error {
 
 func (a *ldapAuther) syncOrgRoles(user *m.User, ldapUser *ldapUserInfo) error {
 	if len(a.server.LdapGroups) == 0 {
+		log.Warn("Ldap: no group mappings defined")
 		return nil
 	}
 


### PR DESCRIPTION
#5245

I had a problem generating the ldap.toml file, accidentally it had two [[servers]] sections, so mappings weren't defined.

This line would have been very useful.
