### PR TITLE
set useApplyAsync for $http

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -41,10 +41,11 @@ export class GrafanaApp {
     var app = angular.module('grafana', []);
     app.constant('grafanaVersion', "@grafanaVersion@");
 
-    app.config(($locationProvider, $controllerProvider, $compileProvider, $filterProvider, $provide) => {
+    app.config(($locationProvider, $controllerProvider, $compileProvider, $filterProvider, $httpProvider, $provide) => {
       if (config.buildInfo.env !== 'development') {
         $compileProvider.debugInfoEnabled(false);
       }
+      $httpProvider.useApplyAsync(true);
 
       this.registerFunctions.controller = $controllerProvider.register;
       this.registerFunctions.directive  = $compileProvider.directive;


### PR DESCRIPTION
According to following document, this option is useful if the application call many HTTP request.

> Configure $http service to combine processing of multiple http responses received at around the same time via $rootScope.$applyAsync. This can result in significant performance improvement for bigger applications that make many HTTP requests concurrently (common during application bootstrap).

https://docs.angularjs.org/api/ng/provider/$httpProvider

I test this and I confirm that $scope.digest calling count is significantly reduced.
