### PR TITLE
handle wrong responses coming from  datasource backend requests

### DIFF
--- a/public/app/services/backendSrv.js
+++ b/public/app/services/backendSrv.js
@@ -111,7 +111,7 @@ function (angular, _, config) {
           $window.location.href = location;
           deferred.reject();
         } else {
-            deferred.resolve(data);
+          deferred.resolve(data);
         }
       }, function(err) {
         // handle unauthorized for backend requests


### PR DESCRIPTION
Hi,

we're currently faced the situation where our backend (we are using a proxy in front of Grafana installation) accidently returns a redirect to a login page (HTTP response 403/200) and not a 401 HTTP response code when the user session timed out.
What happens is that the dashboard will show errors and the client tries again and again to get data but will never have success.... because the session in timed out.
In our cause the user has left the office and will return next morning... so there are lot of requests like this especially when it is a big dashboard ;-)

So, this patch will catch the response and check if it is a HTML response or not.

Not sure if this is also important to the "normal" Grafana installation but this might help others and does not harm the normal workflow.

Thanks,
Kristian
