### PR TITLE
returns correct index

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -403,10 +403,7 @@ function (angular, _, dateMath) {
         } else {
           return _.findIndex(options.targets, function(target) {
             if (target.filters && target.filters.length > 0) {
-              return target.metric === metricData.metric &&
-              _.all(target.filters, function(filter) {
-                return filter.tagk === interpolatedTagValue === "*";
-              });
+              return target.metric === metricData.metric;
             } else {
               return target.metric === metricData.metric &&
               _.all(target.tags, function(tagV, tagK) {


### PR DESCRIPTION
Fixes #5273

`return filter.tagk === interpolatedTagValue === "*";` makes no sense as `interpolatedTagValue` is never set

cc @tkarshcmu @torkelo 
