### PR TITLE
Support auto grid min/max when using log scale

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -97,6 +97,7 @@ export default class TimeSeries {
     this.stats.total = 0;
     this.stats.max = -Number.MAX_VALUE;
     this.stats.min = Number.MAX_VALUE;
+    this.stats.logmin = Number.MAX_VALUE;
     this.stats.avg = null;
     this.stats.current = null;
     this.allIsNull = true;
@@ -133,6 +134,11 @@ export default class TimeSeries {
         if (currentValue < this.stats.min) {
           this.stats.min = currentValue;
         }
+
+        if (currentValue < this.stats.logmin && currentValue > 0) {
+          this.stats.logmin = currentValue;
+        }
+
       }
 
       if (currentValue !== 0) {

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -386,11 +386,12 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
               if (max === null || max < series.stats.max) {
                 max = series.stats.max;
               }
-              if (min === null || min > series.stats.min) {
-                min = series.stats.min;
+              if (min === null || min > series.stats.logmin) {
+                min = series.stats.logmin;
               }
             }
           }
+
           if (max === null && min === null) {
             max = Math.pow(axis.logBase,+2);
             min = Math.pow(axis.logBase,-2);
@@ -400,7 +401,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             min = max*Math.pow(axis.logBase,-4);
           }
 
-          axis.transform = function(v) { return Math.log(v) / Math.log(axis.logBase); };
+          axis.transform = function(v) { return (v < Number.MIN_VALUE) ? null : Math.log(v) / Math.log(axis.logBase); };
           axis.inverseTransform  = function (v) { return Math.pow(axis.logBase,v); };
 
           min = axis.inverseTransform(Math.floor(axis.transform(min)));

--- a/public/app/plugins/panel/graph/specs/graph_specs.ts
+++ b/public/app/plugins/panel/graph/specs/graph_specs.ts
@@ -172,9 +172,9 @@ describe('grafanaGraph', function() {
 
     it('should apply axis transform and ticks', function() {
       var axis = ctx.plotOptions.yaxes[0];
-      expect(axis.transform(100)).to.be(Math.log(100+0.1));
-      expect(axis.ticks[0]).to.be(0);
-      expect(axis.ticks[1]).to.be(1);
+      expect(axis.transform(100)).to.be(Math.log(100)/Math.log(10));
+      expect(axis.ticks[0]).to.be(0.01);
+      expect(axis.ticks[1]).to.be(0.1);
     });
   });
 

--- a/public/app/plugins/panel/graph/specs/graph_specs.ts
+++ b/public/app/plugins/panel/graph/specs/graph_specs.ts
@@ -166,15 +166,38 @@ describe('grafanaGraph', function() {
   });
 
   graphScenario('when logBase is log 10', function(ctx) {
-    ctx.setup(function(ctrl) {
+    ctx.setup(function(ctrl, data) {
       ctrl.panel.yaxes[0].logBase = 10;
+      data[0] = new TimeSeries({
+        datapoints: [[2000,1],[0.002,2],[0,3],[-1,4]],
+        alias: 'seriesAutoscale',
+      });
+      data[0].yaxis = 1;
+      ctrl.panel.yaxes[1].logBase = 10;
+      ctrl.panel.yaxes[1].min = 0.05;
+      ctrl.panel.yaxes[1].max = 1500;
+      data[1] = new TimeSeries({
+        datapoints: [[2000,1],[0.002,2],[0,3],[-1,4]],
+        alias: 'seriesFixedscale',
+      });
+      data[1].yaxis = 2;
     });
 
-    it('should apply axis transform and ticks', function() {
-      var axis = ctx.plotOptions.yaxes[0];
-      expect(axis.transform(100)).to.be(Math.log(100)/Math.log(10));
-      expect(axis.ticks[0]).to.be(0.01);
-      expect(axis.ticks[1]).to.be(0.1);
+    it('should apply axis transform, autoscaling (if necessary) and ticks', function() {
+      var axisAutoscale = ctx.plotOptions.yaxes[0];
+      expect(axisAutoscale.transform(100)).to.be(2);
+      expect(axisAutoscale.inverseTransform(-3)).to.be(0.001);
+      expect(axisAutoscale.min).to.be(0.001);
+      expect(axisAutoscale.max).to.be(10000);
+      expect(axisAutoscale.ticks.length).to.be(8);
+      expect(axisAutoscale.ticks[0]).to.be(0.001);
+      expect(axisAutoscale.ticks[7]).to.be(10000);
+      var axisFixedscale = ctx.plotOptions.yaxes[1];
+      expect(axisFixedscale.min).to.be(0.05);
+      expect(axisFixedscale.max).to.be(1500);
+      expect(axisFixedscale.ticks.length).to.be(5);
+      expect(axisFixedscale.ticks[0]).to.be(0.1);
+      expect(axisFixedscale.ticks[4]).to.be(1000);
     });
   });
 


### PR DESCRIPTION
Fixes [Issue #3090 ](https://github.com/grafana/grafana/issues/3090)

For a logarithmic axis, it determines the min and max of the graph data series and sets grid min and max accordingly - if they have not been set by the user.

A few notes:
- For the min it rounds down to the next lower logBase factor and for the max it rounds up to have ticks at both ends of the axis while displaying the full data range. 
- It ignores data values and axis values <= 0, as only positive values can be properly displayed on a logarithmic axis. (The previous implementation also displayed zero values, but allthough it might be nice to look at, that was not a real logarithmic axis - at least not a scientific one. Also, this prevents displaying small values - which is an important feature on a logarithmic scale - as they cannot be distinguished from zero.)
- It introduces stats.logmin to determine the smallest positive value (the min for the log axis) of a data series.
- If the axis has no data series, the axis range is set to logBase^-2 .. logBase^+2, thus creating 5 ticks. (This is similar to the axis range -1 .. +1 in steps of 0.5 for the linear axis without data series.)
- The graph_spec tests had to be adjusted to reflect the changes noted above.
- Limitation: the current string conversion of small numbers is lacking: 0.000001 is not very readable. For logarithmic scales exponential notation (1e-6) would make sense. But that would be another feature request...
