### PR TITLE
Ldap EscapeFilter

### DIFF
--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -290,7 +290,7 @@ func (a *ldapAuther) searchForUser(username string) (*ldapUserInfo, error) {
 				a.server.Attr.Name,
 				a.server.Attr.MemberOf,
 			},
-			Filter: strings.Replace(a.server.SearchFilter, "%s", username, -1),
+			Filter: strings.Replace(a.server.SearchFilter, "%s", ldap.EscapeFilter(username), -1),
 		}
 
 		searchResult, err = a.conn.Search(&searchReq)
@@ -323,7 +323,7 @@ func (a *ldapAuther) searchForUser(username string) (*ldapUserInfo, error) {
 			if a.server.GroupSearchFilterUserAttribute == "" {
 				filter_replace = getLdapAttr(a.server.Attr.Username, searchResult)
 			}
-			filter := strings.Replace(a.server.GroupSearchFilter, "%s", filter_replace, -1)
+			filter := strings.Replace(a.server.GroupSearchFilter, "%s", ldap.EscapeFilter(filter_replace), -1)
 
 			if ldapCfg.VerboseLogging {
 				log.Info("LDAP: Searching for user's groups: %s", filter)


### PR DESCRIPTION
Addresses issue #5121 - escapes user entered text (i.e. username) using ldap.EscapeFilter.
