### PR TITLE
restart grafana after upgrade

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -7,7 +7,7 @@ set -e
 startGrafana() {
   if [ -x /bin/systemctl ]; then
     /bin/systemctl daemon-reload
-    /bin/systemctl start grafana-server
+    /bin/systemctl restart grafana-server
 	elif [ -x "/etc/init.d/grafana-server" ]; then
 		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
 			invoke-rc.d grafana-server restart || true

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -10,9 +10,9 @@ startGrafana() {
     /bin/systemctl start grafana-server
 	elif [ -x "/etc/init.d/grafana-server" ]; then
 		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-			invoke-rc.d grafana-server start || true
+			invoke-rc.d grafana-server restart || true
 		else
-			/etc/init.d/grafana-server start || true
+			/etc/init.d/grafana-server restart || true
 		fi
 	fi
 }


### PR DESCRIPTION
The current debian post install script only tries to start the already running grafana process after an upgrade. This leads to errors ( blank site with {{alert.title}} ) due to changed js and css hashes while grafana is delivering the old ones. To load the new sources we need to restart grafana after an upgrade.
