### PR TITLE
Enable the "limit" param in /api/search

### DIFF
--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -44,6 +44,7 @@ func searchHandler(query *Query) error {
 		IsStarred:    query.IsStarred,
 		OrgId:        query.OrgId,
 		DashboardIds: query.DashboardIds,
+		Limit:        query.Limit,
 	}
 
 	if err := bus.Dispatch(&dashQuery); err != nil {

--- a/pkg/services/search/models.go
+++ b/pkg/services/search/models.go
@@ -42,6 +42,7 @@ type FindPersistedDashboardsQuery struct {
 	UserId       int64
 	IsStarred    bool
 	DashboardIds []int
+	Limit        int
 
 	Result HitList
 }

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -123,6 +123,11 @@ type DashboardSearchProjection struct {
 }
 
 func SearchDashboards(query *search.FindPersistedDashboardsQuery) error {
+	limit := query.Limit
+	if limit == 0 {
+		limit = 1000
+	}
+
 	var sql bytes.Buffer
 	params := make([]interface{}, 0)
 
@@ -165,7 +170,8 @@ func SearchDashboards(query *search.FindPersistedDashboardsQuery) error {
 		params = append(params, "%"+query.Title+"%")
 	}
 
-	sql.WriteString(fmt.Sprintf(" ORDER BY dashboard.title ASC LIMIT 1000"))
+	sql.WriteString(fmt.Sprintf(" ORDER BY dashboard.title ASC LIMIT ?"))
+	params = append(params, limit)
 
 	var res []DashboardSearchProjection
 


### PR DESCRIPTION
Enable the use of the "limit" parameter when searching with /api/search.
hardcoded limit is now avoided for this feature.
It's usefull when you have more than 1000 dashboards.
