### PR TITLE
(performance) cache panel/label width

### DIFF
--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -31,6 +31,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
         var sortedSeries;
         var legendSideLastValue = null;
         var rootScope = scope.$root;
+        var panelWidth = 0;
 
         rootScope.onAppEvent('setCrosshair', function(event, info) {
           // do not need to to this if event is from this panel
@@ -104,7 +105,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
             return true;
           }
 
-          if (elem.width() === 0) {
+          if (panelWidth === 0) {
             return true;
           }
         }
@@ -159,6 +160,16 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
 
         // Function for rendering panel
         function render_panel() {
+          if (!rootScope.panelWidthCache) {
+            rootScope.panelWidthCache = {};
+          }
+          if (rootScope.panelWidthCache[panel.span]) {
+            panelWidth = rootScope.panelWidthCache[panel.span];
+          } else {
+            panelWidth = elem.width();
+            rootScope.panelWidthCache[panel.span] = panelWidth;
+          }
+
           if (shouldAbortRender()) {
             return;
           }
@@ -276,7 +287,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
         }
 
         function addTimeAxis(options) {
-          var ticks = elem.width() / 100;
+          var ticks = panelWidth / 100;
           var min = _.isUndefined(ctrl.range.from) ? null : ctrl.range.from.valueOf();
           var max = _.isUndefined(ctrl.range.to) ? null : ctrl.range.to.valueOf();
 
@@ -444,7 +455,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
         }
 
         function render_panel_as_graphite_png(url) {
-          url += '&width=' + elem.width();
+          url += '&width=' + panelWidth;
           url += '&height=' + elem.css('height').replace('px', '');
           url += '&bgcolor=1f1f1f'; // @grayDarker & @grafanaPanelBackground
           url += '&fgcolor=BBBFC2'; // @textColor & @grayLighter

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -110,6 +110,23 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           }
         }
 
+        function getLabelWidth(type, text, elem) {
+          var labelWidth = 0;
+          if (!rootScope.labelWidthCache) {
+            rootScope.labelWidthCache = {};
+          }
+          if (!rootScope.labelWidthCache[type]) {
+            rootScope.labelWidthCache[type] = {};
+          }
+          if (rootScope.labelWidthCache[type][text]) {
+            labelWidth = rootScope.labelWidthCache[type][text];
+          } else {
+            labelWidth = elem.width();
+            rootScope.labelWidthCache[type][text] = labelWidth;
+          }
+          return labelWidth;
+        }
+
         function drawHook(plot) {
           // Update legend values
           var yaxis = plot.getYAxes();
@@ -138,7 +155,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
               .text(panel.yaxes[0].label)
               .appendTo(elem);
 
-            yaxisLabel.css("margin-top", yaxisLabel.width() / 2);
+            yaxisLabel[0].style.marginTop = (getLabelWidth('left', panel.yaxes[0].label, yaxisLabel) / 2) + 'px';
           }
 
           // add right axis labels
@@ -147,7 +164,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
               .text(panel.yaxes[1].label)
               .appendTo(elem);
 
-            rightLabel.css("margin-top", rightLabel.width() / 2);
+            rightLabel[0].style.marginTop = (getLabelWidth('right', panel.yaxes[1].label, rightLabel) / 2) + 'px';
           }
         }
 


### PR DESCRIPTION
elem.width() cause "force reflow".
Cache the result reduce "force reflow" and make page loading faster.
