### PR TITLE
Interpolate the query in an annotation

### DIFF
--- a/public/app/features/annotations/annotations_srv.js
+++ b/public/app/features/annotations/annotations_srv.js
@@ -7,7 +7,7 @@ define([
 
   var module = angular.module('grafana.services');
 
-  module.service('annotationsSrv', function($rootScope, $q, datasourceSrv, alertSrv, timeSrv) {
+  module.service('annotationsSrv', function($rootScope, $q, datasourceSrv, alertSrv, timeSrv, templateSrv) {
     var promiseCached;
     var list = [];
     var self = this;
@@ -43,6 +43,7 @@ define([
           return;
         }
         return datasourceSrv.get(annotation.datasource).then(function(datasource) {
+          annotation.query = templateSrv.replace(annotation.query);
           var query = {range: range, rangeRaw: rangeRaw, annotation: annotation};
           return datasource.annotationQuery(query)
             .then(self.receiveAnnotationResults)


### PR DESCRIPTION
Many of our users would like to interpolate variables into the annotations query. There are many different variable options, and two extra arguments to `templateSrv.replace()`, but this seems to cover our basic use case.

If there's a better option to do this please let me know, I'm happy to fix it.
