### PR TITLE
Bugfix: org select btn was not working on profile

### DIFF
--- a/public/app/features/org/partials/profile.html
+++ b/public/app/features/org/partials/profile.html
@@ -51,7 +51,7 @@
 						<span class="btn btn-primary btn-mini" ng-show="org.orgId === contextSrv.user.orgId">
 							Current
 						</span>
-						<a ng-click="setUsingOrg(org)" class="btn btn-inverse btn-mini" ng-show="org.orgId !== contextSrv.user.orgId">
+						<a ng-click="ctrl.setUsingOrg(org)" class="btn btn-inverse btn-mini" ng-show="org.orgId !== contextSrv.user.orgId">
 							Select
 						</a>
 					</td>


### PR DESCRIPTION
Issue: [5290](https://github.com/grafana/grafana/issues/5290)
`setUsingOrg(org)` function was not referenced properly.
