### PR TITLE
Cancel in flight repeated requests

### DIFF
--- a/public/app/core/services/backend_srv.js
+++ b/public/app/core/services/backend_srv.js
@@ -96,18 +96,18 @@ function (angular, _, coreModule, config) {
     this.datasourceRequest = function(options) {
       options.retry = options.retry || 0;
 
-      // A cacheKey is provided by the datasource as a unique identifier for a
-      // particular query. If the cacheKey exists, the promise it is keyed to
+      // A requestID is provided by the datasource as a unique identifier for a
+      // particular query. If the requestID exists, the promise it is keyed to
       // is canceled, canceling the previous datasource request if it is still
       // in-flight.
       var canceler;
-      if (options.cacheKey) {
-        if (canceler = datasourceInFlightRequests[options.cacheKey]) {
+      if (options.requestID) {
+        if (canceler = datasourceInFlightRequests[options.requestID]) {
           canceler.resolve();
         }
         canceler = $q.defer();
         options.timeout = canceler.promise;
-        datasourceInFlightRequests[options.cacheKey] = canceler;
+        datasourceInFlightRequests[options.requestID] = canceler;
       }
 
       var requestIsLocal = options.url.indexOf('/') === 0;

--- a/public/app/core/services/backend_srv.js
+++ b/public/app/core/services/backend_srv.js
@@ -120,21 +120,15 @@ function (angular, _, coreModule, config) {
 
       return $http(options).then(null, function(err) {
         if (err.status === HTTP_REQUEST_ABORTED) {
-          // Need to return the right data structure so it has no effect on
-          // iterating over returned data in datasource.ts#115
-          // TODO: Hitting another refresh cancels the "loading" animation on
-          // panes. Figure out how to keep it going.
-          return {
-            data: {
-              data: {
-                result: []
-              }
-            }
-          };
+          // TODO: Hitting refresh before the original request returns cancels
+          // the "loading" animation on the panes, but it should continue to be
+          // visible.
+          err.statusText = "request aborted";
+          return err;
         }
 
         // handle unauthorized for backend requests
-        if (requestIsLocal && firstAttempt  && err.status === 401) {
+        if (requestIsLocal && firstAttempt && err.status === 401) {
           return self.loginPing().then(function() {
             options.retry = 1;
             canceler.resolve();

--- a/public/app/core/services/backend_srv.js
+++ b/public/app/core/services/backend_srv.js
@@ -131,7 +131,9 @@ function (angular, _, coreModule, config) {
         if (requestIsLocal && firstAttempt && err.status === 401) {
           return self.loginPing().then(function() {
             options.retry = 1;
-            canceler.resolve();
+            if (canceler) {
+              canceler.resolve();
+            }
             return self.datasourceRequest(options);
           });
         }

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -183,7 +183,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     };
 
     metricsQuery.targets.forEach(function(target) {
-      target.exprID = target.expr + target.refId + metricsQuery.panelId;
+      target.exprID = target.refId + metricsQuery.panelId;
     });
 
     return datasource.query(metricsQuery);

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -183,7 +183,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     };
 
     metricsQuery.targets.forEach(function(target) {
-      target.cacheKey = target.expr + target.refId + metricsQuery.panelId;
+      target.exprID = target.expr + target.refId + metricsQuery.panelId;
     });
 
     return datasource.query(metricsQuery);

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -182,6 +182,10 @@ class MetricsPanelCtrl extends PanelCtrl {
       cacheTimeout: this.panel.cacheTimeout
     };
 
+    metricsQuery.targets.forEach(function(target) {
+      target.cacheKey = target.expr + target.refId + metricsQuery.panelId;
+    });
+
     return datasource.query(metricsQuery);
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -21,11 +21,11 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   this.withCredentials = instanceSettings.withCredentials;
   this.lastErrors = {};
 
-  this._request = function(method, url, cacheKey) {
+  this._request = function(method, url, requestID) {
     var options: any = {
       url: this.url + url,
       method: method,
-      cacheKey: cacheKey,
+      requestID: requestID,
     };
 
     if (this.basicAuth || this.withCredentials) {
@@ -77,7 +77,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
       var query: any = {};
       query.expr = templateSrv.replace(target.expr, options.scopedVars, self.interpolateQueryExpr);
-      query.cacheKey = target.cacheKey;
+      query.requestID = target.exprID;
 
       var interval = target.interval || options.interval;
       var intervalFactor = target.intervalFactor || 1;
@@ -128,7 +128,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
   this.performTimeSeriesQuery = function(query, start, end) {
     var url = '/api/v1/query_range?query=' + encodeURIComponent(query.expr) + '&start=' + start + '&end=' + end + '&step=' + query.step;
-    return this._request('GET', url, query.cacheKey);
+    return this._request('GET', url, query.requestID);
   };
 
   this.performSuggestQuery = function(query) {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -58,6 +58,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     return escapedValues.join('|');
   };
 
+  var HTTP_REQUEST_ABORTED = -1;
   // Called once per panel (graph)
   this.query = function(options) {
     var self = this;
@@ -107,6 +108,9 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       var result = [];
 
       _.each(allResponse, function(response, index) {
+        if (response.status === HTTP_REQUEST_ABORTED) {
+          return;
+        }
         if (response.status === 'error') {
           self.lastErrors.query = response.error;
           throw response.error;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -25,7 +25,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     var options: any = {
       url: this.url + url,
       method: method,
-      cacheKey: cacheKey
+      cacheKey: cacheKey,
     };
 
     if (this.basicAuth || this.withCredentials) {
@@ -76,6 +76,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
       var query: any = {};
       query.expr = templateSrv.replace(target.expr, options.scopedVars, self.interpolateQueryExpr);
+      query.cacheKey = target.cacheKey;
 
       var interval = target.interval || options.interval;
       var intervalFactor = target.intervalFactor || 1;
@@ -123,7 +124,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
   this.performTimeSeriesQuery = function(query, start, end) {
     var url = '/api/v1/query_range?query=' + encodeURIComponent(query.expr) + '&start=' + start + '&end=' + end + '&step=' + query.step;
-    return this._request('GET', url, query.expr.toString());
+    return this._request('GET', url, query.cacheKey);
   };
 
   this.performSuggestQuery = function(query) {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -21,10 +21,11 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   this.withCredentials = instanceSettings.withCredentials;
   this.lastErrors = {};
 
-  this._request = function(method, url) {
+  this._request = function(method, url, cacheKey) {
     var options: any = {
       url: this.url + url,
-      method: method
+      method: method,
+      cacheKey: cacheKey
     };
 
     if (this.basicAuth || this.withCredentials) {
@@ -122,7 +123,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
   this.performTimeSeriesQuery = function(query, start, end) {
     var url = '/api/v1/query_range?query=' + encodeURIComponent(query.expr) + '&start=' + start + '&end=' + end + '&step=' + query.step;
-    return this._request('GET', url);
+    return this._request('GET', url, query.expr.toString());
   };
 
   this.performSuggestQuery = function(query) {


### PR DESCRIPTION
- Requested in #2501
- Pass a unique query-request identifier that can cancel in-flight requests if an additional request is issued from the same pane/query combination before the first returns.

I can see two ways of generating the unique key:
1. Leave it entirely up to the datasource to find a way to uniquely identify requests and pass that value on to the map implemented in `backend_srv.js`
2. What I did here, which is to attempt to make it easier on the datasources that send an individual request per time series by creating the key in `metrics_panel_ctrl.ts`.

Let me know which you prefer.

Regardless of the choice above, the datasource then needs to pass the key through to `backendSrv.datasourceRequest` and handle the error status `-1` appropriately. A Prometheus example is added in this PR.
