### PR TITLE
Log to default log directory, only if custom configuration failed.

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -283,19 +283,19 @@ func evalConfigValues() {
 	}
 }
 
-func loadSpecifedConfigFile(configFile string) {
+func loadSpecifedConfigFile(configFile string) error {
 	if configFile == "" {
 		configFile = filepath.Join(HomePath, "conf/custom.ini")
 		// return without error if custom file does not exist
 		if !pathExists(configFile) {
-			return
+			return nil
 		}
 	}
 
 	userConfig, err := ini.Load(configFile)
 	userConfig.BlockMode = false
 	if err != nil {
-		log.Fatal(3, "Failed to parse %v, %v", configFile, err)
+		return fmt.Errorf("Failed to parse %v, %v", configFile, err)
 	}
 
 	for _, section := range userConfig.Sections() {
@@ -317,6 +317,7 @@ func loadSpecifedConfigFile(configFile string) {
 	}
 
 	configFiles = append(configFiles, configFile)
+	return nil
 }
 
 func loadConfiguration(args *CommandLineArgs) {
@@ -338,12 +339,12 @@ func loadConfiguration(args *CommandLineArgs) {
 	// load default overrides
 	applyCommandLineDefaultProperties(commandLineProps)
 
-	// init logging before specific config so we can log errors from here on
-	DataPath = makeAbsolute(Cfg.Section("paths").Key("data").String(), HomePath)
-	initLogging()
-
 	// load specified config file
-	loadSpecifedConfigFile(args.Config)
+	err = loadSpecifedConfigFile(args.Config)
+	if err != nil {
+		initLogging()
+		log.Fatal(3, err.Error())
+	}
 
 	// apply environment overrides
 	applyEnvVariableOverrides()


### PR DESCRIPTION
### Preface

Running grafana as non-root user fails (_by not owning default log directory_):
`[log.go:312 Error()] [E] Fail to set logger(file): open /usr/local/www/grafana3/data/log/grafana.log: permission denied`
### Details

This is because grafana reads `conf/defaults.ini` and takes `logs = data/log` and **before** reading custom configuration (_where logs directory could be re-defined to writable path_), opens `grafana.log` in write mode (_basically, creating file with 0 bytes size_), then reads custom configuration and re-opens log file in correct (_custom defined_) directory. Therefore, as grafana is being run as non-root and doesn't have permission to write to default `data` directory, it fails and simply exits. 

I see that this was implemented as a fix for #1992, to be able to see in default log file that custom configuration file has syntax or other errors. I understand why this was implemented, but I would strongly advise against such design.

This breaks several environments where user would want custom data/logs directory and default one isn't writable, either because of permissions or either because file-system (_where default data directory resides_) is mounted read-only. 

Of course, one could manually edit `defaults.ini` and change `logs` setting to something writable, but this would hurt distribution packaging and automation software. Therefore, I propose a simple fix for now.
### Pull request

This pull request doesn't change the logging design and fix for #1992 still applies. What it does - it only opens default log directory, if custom configuration has failed. If custom configuration is fine, it doesn't unnecessary open and write (i.e., create empty file) to default log file.
