### PR TITLE
fix z-index order in Series Overrides

### DIFF
--- a/public/app/plugins/panel/graph/series_overrides_ctrl.js
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.js
@@ -105,7 +105,7 @@ define([
     $scope.addOverrideOption('Stack', 'stack', [true, false, 'A', 'B', 'C', 'D']);
     $scope.addOverrideOption('Color', 'color', ['change']);
     $scope.addOverrideOption('Y-axis', 'yaxis', [1, 2]);
-    $scope.addOverrideOption('Z-index', 'zindex', [-1,-2,-3,0,1,2,3]);
+    $scope.addOverrideOption('Z-index', 'zindex', [-3,-2,-1,0,1,2,3]);
     $scope.addOverrideOption('Transform', 'transform', ['negative-Y']);
     $scope.addOverrideOption('Legend', 'legend', [true, false]);
     $scope.updateCurrentOverrides();


### PR DESCRIPTION
Unless I'm misunderstanding something, this order seems more logical.
