### PR TITLE
Avoid to request influxdb when query is hidden

### DIFF
--- a/public/app/features/panel/partials/query_editor_row.html
+++ b/public/app/features/panel/partials/query_editor_row.html
@@ -45,7 +45,7 @@
 			</ul>
 		</label>
     <label class="gf-form-label">
-			<a ng-click="ctrl.toggleHideQuery()" role="menuitem">
+			<a ng-click="ctrl.toggleHideQuery()" ng-class="{hidden: ctrl.target.hide}" role="menuitem">
 				<i class="fa fa-eye"></i>
 			</a>
 		</label>

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -134,6 +134,8 @@ export default class InfluxDatasource {
   };
 
   _seriesQuery(query) {
+    if (!query) { return this.$q.when({results: []}); }
+
     return this._influxRequest('GET', '/query', {q: query, epoch: 'ms'});
   }
 

--- a/public/sass/components/_query_editor.scss
+++ b/public/sass/components/_query_editor.scss
@@ -24,6 +24,10 @@
   .gf-form,
   .gf-form-filler {
     margin-bottom: 2px;
+
+    a.hidden {
+      color: $gray-3;
+    }
   }
 
   .gf-form-switch,


### PR DESCRIPTION
When hiding an influxdb query a request is still made to the datasource without any data (parameter `q` is empty in the request).

This PR aims also show if a query is hidden or not :
![hide-button](https://cloud.githubusercontent.com/assets/2076632/16232657/bf419bfa-37cb-11e6-8652-4fc4b8ecd144.gif)
