### PR TITLE
WIP: add Chart.js renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "Chart.Annotation.js": "^0.1.0",
     "chart.js": "2.1.6",
     "eventemitter3": "^1.2.0",
     "grunt-jscs": "~1.5.x",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "Chart.Annotation.js": "^0.1.0",
-    "chart.js": "2.1.6",
+    "chart.js": "2.2.0",
     "eventemitter3": "^1.2.0",
     "grunt-jscs": "~1.5.x",
     "grunt-sass-lint": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "chart.js": "2.1.5",
+    "chart.js": "2.1.6",
     "eventemitter3": "^1.2.0",
     "grunt-jscs": "~1.5.x",
     "grunt-sass-lint": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "chart.js": "2.1.5",
     "eventemitter3": "^1.2.0",
     "grunt-jscs": "~1.5.x",
     "grunt-sass-lint": "^0.2.0",

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -161,6 +161,76 @@ export default class TimeSeries {
     return result;
   }
 
+  getChartjsPairs(fillStyle) {
+    var result = [];
+
+    this.stats.total = 0;
+    this.stats.max = -Number.MAX_VALUE;
+    this.stats.min = Number.MAX_VALUE;
+    this.stats.avg = null;
+    this.stats.current = null;
+    this.allIsNull = true;
+    this.allIsZero = true;
+
+    var ignoreNulls = fillStyle === 'connected';
+    var nullAsZero = fillStyle === 'null as zero';
+    var currentTime;
+    var currentValue;
+    var nonNulls = 0;
+
+    for (var i = 0; i < this.datapoints.length; i++) {
+      currentValue = this.datapoints[i][0];
+      currentTime = this.datapoints[i][1];
+
+      if (currentValue === null) {
+        if (ignoreNulls) { continue; }
+        if (nullAsZero) {
+          currentValue = 0;
+        }
+      }
+
+      if (currentValue !== null) {
+        if (_.isNumber(currentValue)) {
+          this.stats.total += currentValue;
+          this.allIsNull = false;
+          nonNulls++;
+        }
+
+        if (currentValue > this.stats.max) {
+          this.stats.max = currentValue;
+        }
+
+        if (currentValue < this.stats.min) {
+          this.stats.min = currentValue;
+        }
+      }
+
+      if (currentValue !== 0) {
+        this.allIsZero = false;
+      }
+
+      result.push({ x: currentTime, y: currentValue });
+    }
+
+    if (this.datapoints.length >= 2) {
+      this.stats.timeStep = this.datapoints[1][1] - this.datapoints[0][1];
+    }
+
+    if (this.stats.max === -Number.MAX_VALUE) { this.stats.max = null; }
+    if (this.stats.min === Number.MAX_VALUE) { this.stats.min = null; }
+
+    if (result.length) {
+      this.stats.avg = (this.stats.total / nonNulls);
+      this.stats.current = result[result.length-1][1];
+      if (this.stats.current === null && result.length > 1) {
+        this.stats.current = result[result.length-2][1];
+      }
+    }
+
+    this.stats.count = result.length;
+    return result;
+  }
+
   updateLegendValues(formater, decimals, scaledDecimals) {
     this.valueFormater = formater;
     this.decimals = decimals;

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -259,6 +259,7 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
             // TODO
             sortedSeries = _.map(data, function(series) {
               series.borderColor = series.color;
+              series.backgroundColor = series.color;
               series.borderWidth = 2;
               series.pointRadius = 0;
               series.fill = (panel.fill > 0); // TODO

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -315,11 +315,23 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                             type: "time",
                             time: {
                               format: 'x',
-                            //  tooltipFormat: 'll HH:mm'
+                              displayFormats: {
+                                millisecond: 'HH:mm:ss',
+                                second: 'HH:mm:ss',
+                                minute: 'HH:mm',
+                                hour: 'HH:mm',
+                                day: 'HH:mm',
+                                week: 'M/D',
+                                month: 'M/D',
+                                quarter: 'M/D',
+                                year: 'YYYY-M'
+                              }
+                              //  tooltipFormat: 'll HH:mm'
                             },
                             gridLines: {
                               display: true,
-                              color: '#c8c8c8'
+                              color: 'rgba(200, 200, 200, 0.5)',
+                              drawBorder: false
                             },
                             scaleLabel: {
                               display: false,

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -279,6 +279,16 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                   canvas.height = elem.height();
                   elem.append($(canvas));
 
+                  var type = 'line';
+                  if (panel.lines) {
+                    type = 'line';
+                  } else if (panel.bars) {
+                    type = 'bar';
+                  } else if (panel.points) {
+                    type = '';
+                    // TODO
+                  }
+
                   var labels = [];
                   var ticks = Math.floor(panelWidth / 100);
                   var timediff = Math.floor((ctrl.range.to-ctrl.range.from) / ticks);
@@ -291,7 +301,7 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                   Chart.defaults.global.legend.display = false;
                   Chart.defaults.global.tooltips.enabled = false;
                   chart = new Chart(canvas, {
-                    type: 'line',
+                    type: type,
                     data: {
                       labels: labels,
                       datasets: data

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -259,6 +259,9 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
             // TODO
             sortedSeries = _.map(data, function(series) {
               series.borderColor = series.color;
+              series.borderWidth = 2;
+              series.pointRadius = 0;
+              series.fill = (panel.fill > 0); // TODO
               return series;
             });
           }
@@ -303,17 +306,23 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                               format: 'x',
                             //  tooltipFormat: 'll HH:mm'
                             },
-                            scaleLabel: {
+                            gridLines: {
                               display: true,
-                              labelString: 'Date'
+                              color: '#c8c8c8'
+                            },
+                            scaleLabel: {
+                              display: false,
                             }
                           }
                         ],
                         yAxes: [
                           {
-                            scaleLabel: {
+                            gridLines: {
                               display: true,
-                              labelString: 'value'
+                              color: '#c8c8c8'
+                            },
+                            scaleLabel: {
+                              display: false,
                             }
                           }
                         ]

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -283,10 +283,11 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                   if (panel.lines) {
                     type = 'line';
                   } else if (panel.bars) {
+                    // TODO
                     type = 'bar';
                   } else if (panel.points) {
-                    type = '';
                     // TODO
+                    type = '';
                   }
 
                   var labels = [];
@@ -327,6 +328,7 @@ function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
                         ],
                         yAxes: [
                           {
+                            stacked: panel.stack,
                             gridLines: {
                               display: true,
                               color: '#c8c8c8'

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -5,6 +5,7 @@ define([
   'lodash',
   'app/core/utils/kbn',
   './graph_tooltip',
+  'chart.js',
   'jquery.flot',
   'jquery.flot.selection',
   'jquery.flot.time',
@@ -14,7 +15,7 @@ define([
   'jquery.flot.crosshair',
   './jquery.flot.events',
 ],
-function (angular, $, moment, _, kbn, GraphTooltip) {
+function (angular, $, moment, _, kbn, GraphTooltip, Chart) {
   'use strict';
 
   var module = angular.module('grafana.directives');
@@ -33,6 +34,7 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
         var legendSideLastValue = null;
         var rootScope = scope.$root;
         var panelWidth = 0;
+        var chart = null;
 
         rootScope.onAppEvent('setCrosshair', function(event, info) {
           // do not need to to this if event is from this panel
@@ -228,7 +230,12 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
 
           for (var i = 0; i < data.length; i++) {
             var series = data[i];
-            series.data = series.getFlotPairs(series.nullPointMode || panel.nullPointMode);
+
+            if (panel.renderer === 'flot') {
+              series.data = series.getFlotPairs(series.nullPointMode || panel.nullPointMode);
+            } else if (panel.renderer === 'chart.js') {
+              series.data = series.getChartjsPairs(series.nullPointMode || panel.nullPointMode);
+            }
 
             // if hidden remove points and disable stack
             if (ctrl.hiddenSeries[series.alias]) {
@@ -244,15 +251,78 @@ function (angular, $, moment, _, kbn, GraphTooltip) {
           addTimeAxis(options);
           addGridThresholds(options, panel);
           addAnnotations(options);
-          configureAxisOptions(data, options);
 
-          sortedSeries = _.sortBy(data, function(series) { return series.zindex; });
+          if (panel.renderer === 'flot') {
+            configureAxisOptions(data, options);
+            sortedSeries = _.sortBy(data, function(series) { return series.zindex; });
+          } else if (panel.renderer === 'chart.js') {
+            // TODO
+            sortedSeries = _.map(data, function(series) {
+              series.borderColor = series.color;
+              return series;
+            });
+          }
 
           function callPlot(incrementRenderCounter) {
             try {
-              $.plot(elem, sortedSeries, options);
-              delete ctrl.error;
-              delete ctrl.inspector;
+              if (panel.renderer === 'flot') {
+                $.plot(elem, sortedSeries, options);
+                delete ctrl.error;
+                delete ctrl.inspector;
+              } else if (panel.renderer === 'chart.js') {
+                if (!chart) {
+                  var canvas = document.createElement('canvas');
+                  canvas.width = elem.width();
+                  canvas.height = elem.height();
+                  elem.append($(canvas));
+
+                  var labels = [];
+                  var ticks = Math.floor(panelWidth / 100);
+                  var timediff = Math.floor((ctrl.range.to-ctrl.range.from) / ticks);
+                  for (var n = 0; n < ticks; n++) {
+                    labels.push(moment(ctrl.range.from).add(timediff * n, 'ms').toDate());
+                  }
+
+                  Chart.defaults.global.animation.duration = 0;
+                  Chart.defaults.global.elements.line.tention = 0;
+                  Chart.defaults.global.legend.display = false;
+                  Chart.defaults.global.tooltips.enabled = false;
+                  chart = new Chart(canvas, {
+                    type: 'line',
+                    data: {
+                      labels: labels,
+                      datasets: data
+                    },
+                    options: {
+                      //responsive: true,
+                      scales: {
+                        xAxes: [
+                          {
+                            type: "time",
+                            time: {
+                              format: 'x',
+                            //  tooltipFormat: 'll HH:mm'
+                            },
+                            scaleLabel: {
+                              display: true,
+                              labelString: 'Date'
+                            }
+                          }
+                        ],
+                        yAxes: [
+                          {
+                            scaleLabel: {
+                              display: true,
+                              labelString: 'value'
+                            }
+                          }
+                        ]
+                      },
+                    }
+                  });
+                }
+                return chart;
+              }
             } catch (e) {
               console.log('flotcharts error', e);
               ctrl.error = e.message || "Render Error";

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -40,6 +40,12 @@
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Hover info</h5>
 		<div class="gf-form">
+			<label class="gf-form-label width-9">Renderer</label>
+			<div class="gf-form-select-wrapper max-width-8">
+				<select class="gf-form-input" ng-model="ctrl.panel.renderer" ng-options="f for f in ['flot', 'chart.js']" ng-change="ctrl.render()"></select>
+			</div>
+		</div>
+		<div class="gf-form">
 			<label class="gf-form-label width-9">Mode</label>
 			<div class="gf-form-select-wrapper max-width-8">
 				<select class="gf-form-input" ng-model="ctrl.panel.tooltip.shared" ng-options="f.value as f.text for f in [{text: 'All series', value: true}, {text: 'Single', value: false}]" ng-change="ctrl.render()"></select>

--- a/public/app/system.conf.js
+++ b/public/app/system.conf.js
@@ -28,7 +28,8 @@ System.config({
     "jquery.flot.time": "vendor/flot/jquery.flot.time",
     "jquery.flot.crosshair": "vendor/flot/jquery.flot.crosshair",
     "jquery.flot.fillbelow": "vendor/flot/jquery.flot.fillbelow",
-    "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge"
+    "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge",
+    "chart.js": "vendor/npm/chart.js/dist/Chart.bundle.min.js"
   },
 
   packages: {

--- a/public/test/test-main.js
+++ b/public/test/test-main.js
@@ -36,7 +36,8 @@
       "jquery.flot.time": "vendor/flot/jquery.flot.time",
       "jquery.flot.crosshair": "vendor/flot/jquery.flot.crosshair",
       "jquery.flot.fillbelow": "vendor/flot/jquery.flot.fillbelow",
-      "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge"
+      "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge",
+      "chart.js": "vendor/npm/chart.js/dist/Chart.bundle.min.js"
     },
 
     packages: {

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -31,6 +31,7 @@ module.exports = function(config) {
         'tether-drop/**/*',
         'tether-drop/**/*',
         'remarkable/dist/*',
+        'chart.js/**/*',
       ],
       dest: '<%= srcDir %>/vendor/npm'
     }


### PR DESCRIPTION
Just proposal.
The jQuery Flot is good graph plot library, but the development is stopped.
Grafana modify the Flot locally, but Grafana teams doesn't want to modify it so much.

I think if Grafana support another actively development library, we can add feature to the library, and make Grafana graph better.

So, I propose to support Chart.js renderer as second renderer.

The library is actively developed and have a lot of star.
https://github.com/chartjs/Chart.js

How do you think?
