### PR TITLE
Avoid to request influxdb when query is hidden 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,16 @@
 * **Scripts**: Use restart instead of start for deb package script, closes [#5282](https://github.com/grafana/grafana/pull/5282)
 * **Logging**: Moved to structured logging lib, and moved to component specific level filters via config file, closes [#4590](https://github.com/grafana/grafana/issues/4590)
 * **Search**: Add search limit query parameter, closes [#5292](https://github.com/grafana/grafana/pull/5292)
-* **OpenTSDB**: Support nested template variables in tag_values function, closes [4398](https://github.com/grafana/grafana/issues/4398)
-* **Datasource**: Pending data source requests are cancelled before new ones are issues (Graphite & Prometheus), closes [5321](https://github.com/grafana/grafana/issues/5321)
+* **OpenTSDB**: Support nested template variables in tag_values function, closes [#4398](https://github.com/grafana/grafana/issues/4398)
+* **Datasource**: Pending data source requests are cancelled before new ones are issues (Graphite & Prometheus), closes [#5321](https://github.com/grafana/grafana/issues/5321)
 
 ### Breaking changes
 * **Logging** : Changed default logging output format (now structured into message, and key value pairs, with logger key acting as component). You can also no change in config to json log ouput.
-* **Graphite** : The Graph panel no longer have a Graphite PNG option. closes #[5367](https://github.com/grafana/grafana/issues/5367)
+* **Graphite** : The Graph panel no longer have a Graphite PNG option. closes [#5367](https://github.com/grafana/grafana/issues/5367)
 
 ### Bug fixes
-* **PNG rendering**: Fixed phantomjs rendering and y-axis label rotation. fixes #[5220](https://github.com/grafana/grafana/issues/5220)
+* **PNG rendering**: Fixed phantomjs rendering and y-axis label rotation. fixes [#5220](https://github.com/grafana/grafana/issues/5220)
+* **CLI**: The cli tool now supports reading plugin.json from dist/plugin.json. fixes [#5410](https://github.com/grafana/grafana/issues/5410)
 
 # 3.0.4 Patch release (2016-05-25)
 * **Panel**: Fixed blank dashboard issue when switching to other dashboard while in fullscreen edit mode, fixes [#5163](https://github.com/grafana/grafana/pull/5163)

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -134,6 +134,8 @@ export default class InfluxDatasource {
   };
 
   _seriesQuery(query) {
+    if (!query) { return this.$q.when({results: []}); }
+
     return this._influxRequest('GET', '/query', {q: query, epoch: 'ms'});
   }
 

--- a/public/sass/_variables.light.scss
+++ b/public/sass/_variables.light.scss
@@ -60,7 +60,7 @@ $page-bg:  		  		    $white;
 $body-color:    		    $gray-1;
 $text-color:    		    $gray-1;
 $text-color-strong:	    $white;
-$text-color-weak: 	    $gray-1;
+$text-color-weak: 	    $gray-2;
 $text-color-faint:      $gray-3;
 $text-color-emphasis: 	$dark-5;
 


### PR DESCRIPTION
Different implementation of https://github.com/grafana/grafana/pull/5402

Merge to master once 3.1 is released.
