### PR TITLE
Escape html chararcters in singlestat renderer

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -188,7 +188,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       if (_.isString(lastValue)) {
         data.value = 0;
-        data.valueFormated = lastValue;
+        data.valueFormated = _.escape(lastValue);
         data.valueRounded = 0;
       } else {
         data.value = this.series[0].stats[this.panel.valueName];


### PR DESCRIPTION
SingleStat panel does not escape string data. So if data contains any special HTML character (eg. < >), nothing will show up.
