### PR TITLE
feat(computedfield): add computed field to graph plugin

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -19,7 +19,7 @@ func GetTestMetrics(c *middleware.Context) Response {
 	stepInSeconds := (to - from) / maxDataPoints
 
 	result := dtos.MetricQueryResultDto{}
-	result.Data = make([]dtos.MetricQueryResultDataDto, 1)
+	result.Data = make([]dtos.MetricQueryResultDataDto, 2)
 
 	for seriesIndex := range result.Data {
 		points := make([][2]float64, maxDataPoints)

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -77,6 +77,14 @@
 		</div>
 	</div>
 
+	<div class="section gf-form-group">
+		<h5 class="section-heading">Computed Field</h5>
+		<div class="gf-form">
+			<label class="gf-form-label width-7">Computation</label>
+			<input type="text" class="gf-form-input max-width-30" ng-model="ctrl.panel.computation" ng-change="ctrl.redoComputation()" ng-model-onblur>
+		</div>
+	</div>
+
 </div>
 
 <div class="editor-row">


### PR DESCRIPTION
A computed field allows the user to create an ad-hoc expression across
any metrics. This is useful when you are recording two metrics
separately and want to do calculations like A per B.

Here we start with two series (random fake data for this example).
![](https://www.dropbox.com/s/rkpnki4mrptd1li/Screenshot%202016-06-25%2021.37.06.png?dl=1)

I have added a new field to the `Display` tab which allows the user to enter the calculation between the two queries. This runs the function against each data point from the series and turns the panel into a single graph of the results of the calculation.
![](https://www.dropbox.com/s/2g4zn52qjgj7ht4/Screenshot%202016-06-25%2021.43.41.png?dl=1)

This is obviously just a proof of concept to get some feedback about the general usefulness and acceptability of this feature to the graph panel. This feature was developed with the specific described need above. I am recording metrics in ways which require us to actually do a "post processing" calculation between two queries. Using this approach, I can plot this metric (i.e. A per B occurrences).

If there is a better way to accomplish this I would also like to hear that! For reference, I am using elasticsearch as the data store but this approach would work across queries from multiple data stores.
