### PR TITLE
Add input for color picker palette (fix #5061)

### DIFF
--- a/public/app/core/directives/spectrum_picker.js
+++ b/public/app/core/directives/spectrum_picker.js
@@ -18,6 +18,7 @@ function (angular, coreModule) {
         var options = angular.extend({
           showAlpha: true,
           showButtons: false,
+          showInput: true,
           color: ngModel.$viewValue,
           change: function(color) {
             scope.$apply(function() {

--- a/public/sass/components/_color_picker.scss
+++ b/public/sass/components/_color_picker.scss
@@ -35,3 +35,17 @@
   float: left;
   z-index: 0;
 }
+
+.sp-input {
+  padding: $input-padding-y $input-padding-x;
+  margin-right: $gf-form-margin;
+  font-size: $font-size-base;
+  line-height: $input-line-height;
+  color: $input-color;
+  background-color: $input-bg;
+  background-image: none;
+  background-clip: padding-box;
+  border: $input-btn-border-width solid $input-border-color;
+  @include border-radius($input-border-radius-sm);
+  @include box-shadow($input-box-shadow);
+}


### PR DESCRIPTION
See https://github.com/grafana/grafana/issues/5061

---

This commit enables free form typing for the color picker through
Spectrum's `showInput` option. It also applies Grafana specific
styles to the palette input.

This will allow us to set more consistent colors across
thresholds in our graphs, and address potential accessibility
issues as highlighted in #5061.
