### PR TITLE
[prometheus] Use `panelId` and `target.refId` for requestId

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -77,7 +77,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
       var query: any = {};
       query.expr = templateSrv.replace(target.expr, options.scopedVars, self.interpolateQueryExpr);
-      query.requestId = target.expr;
+      query.requestId = options.panelId + target.refId;
 
       var interval = target.interval || options.interval;
       var intervalFactor = target.intervalFactor || 1;


### PR DESCRIPTION
Addresses https://github.com/grafana/grafana/issues/5459

Using these two values ties requests to a
particular query position within a panel, ensuring
that requests are canceled if:
- Duplicate requests with the same query are sent
- Requests from the same query position (but a
  different query) are sent

The last point is important as it identifies
queries by a physical location in the dashboard
instead of with the query expression.  If a
different query from the same position in a panel
is sent, the previous request should be canceled.
