### PR TITLE
Export CSV in the same format as presented in Table panel.

### DIFF
--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -139,7 +139,8 @@ class TablePanelCtrl extends MetricsPanelCtrl {
   }
 
   exportCsv() {
-    FileExport.exportTableDataToCsv(this.table);
+    var renderer = new TableRenderer(this.panel, this.table, this.dashboard.isTimezoneUtc());
+    FileExport.exportTableDataToCsv(renderer.render_values());
   }
 
   link(scope, elem, attrs, ctrl) {

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -141,4 +141,21 @@ export class TableRenderer {
 
     return html;
   }
+
+  render_values() {
+    let rows = [];
+
+    for (var y = 0; y < this.table.rows.length; y++) {
+      let row = this.table.rows[y];
+      let new_row = [];
+      for (var i = 0; i < this.table.columns.length; i++) {
+        new_row.push(this.formatColumnValue(i, row[i]));
+      }
+      rows.push(new_row);
+    }
+    return {
+        columns: this.table.columns,
+        rows: rows,
+    };
+  }
 }


### PR DESCRIPTION
This fixes issue https://github.com/grafana/grafana/issues/5372.

The data is exported in the same exact format as presented in the table panel. This is achieved by using the same renderer as the UI uses.
