### PR TITLE
Hex units

### DIFF
--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -388,7 +388,6 @@ function($, _, moment) {
     return "0x" + hexString;
   };
 
-
   // Currencies
   kbn.valueFormats.currencyUSD = kbn.formatBuilders.currency('$');
   kbn.valueFormats.currencyGBP = kbn.formatBuilders.currency('£');

--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -373,9 +373,6 @@ function($, _, moment) {
 
   kbn.valueFormats.hex = function(value, decimals) {
     if (value == null) { return ""; }
-    if (decimals === 0) {
-      return Math.floor(value).toString(16).toUpperCase();
-    }
     return parseFloat(kbn.toFixed(value, decimals)).toString(16).toUpperCase();
   };
 
@@ -383,7 +380,7 @@ function($, _, moment) {
     if (value == null) { return ""; }
     var hexString = kbn.valueFormats.hex(value, decimals);
     if (hexString.substring(0,1) === "-") {
-      return "-0x" + hexString.substring(1, -1);
+      return "-0x" + hexString.substring(1);
     }
     return "0x" + hexString;
   };

--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -368,6 +368,27 @@ function($, _, moment) {
     return kbn.toFixed(100*size, decimals) + '%';
   };
 
+  /* Formats the value to hex. Uses float if specified decimals are not 0.
+   * There are two options, one with 0x, and one without */
+
+  kbn.valueFormats.hex = function(value, decimals) {
+    if (value == null) { return ""; }
+    if (decimals === 0) {
+      return Math.floor(value).toString(16).toUpperCase();
+    }
+    return parseFloat(kbn.toFixed(value, decimals)).toString(16).toUpperCase();
+  };
+
+  kbn.valueFormats.hex0x = function(value, decimals) {
+    if (value == null) { return ""; }
+    var hexString = kbn.valueFormats.hex(value, decimals);
+    if (hexString.substring(0,1) === "-") {
+      return "-0x" + hexString.substring(1, -1);
+    }
+    return "0x" + hexString;
+  };
+
+
   // Currencies
   kbn.valueFormats.currencyUSD = kbn.formatBuilders.currency('$');
   kbn.valueFormats.currencyGBP = kbn.formatBuilders.currency('£');
@@ -617,6 +638,8 @@ function($, _, moment) {
           {text: 'Humidity (%H)',     value: 'humidity'   },
           {text: 'ppm',               value: 'ppm'        },
           {text: 'decibel',           value: 'dB'         },
+          {text: 'hexadecimal (0x)',  value: 'hex0x'      },
+          {text: 'hexadecimal',       value: 'hex'        },
         ]
       },
       {

--- a/public/test/core/utils/kbn_specs.js
+++ b/public/test/core/utils/kbn_specs.js
@@ -161,4 +161,50 @@ define([
       expect(str).to.be('15ms');
     });
   });
+
+  describe('hex', function() {
+      it('positive integer', function() {
+	var str = kbn.valueFormats.hex(100, 0);
+	expect(str).to.be('64');
+      });
+      it('negative integer', function() {
+	var str = kbn.valueFormats.hex(-100, 0);
+	expect(str).to.be('-64');
+      });
+      it('null', function() {
+	var str = kbn.valueFormats.hex(null, 0);
+	expect(str).to.be('');
+      });
+      it('positive float', function() {
+	var str = kbn.valueFormats.hex(50.52, 1);
+	expect(str).to.be('32.828F5C28F5C2');
+      }); 
+      it('negative float', function() {
+	var str = kbn.valueFormats.hex(-50.333, 2);
+	expect(str).to.be('-32.547AE147AE14');
+      });
+  });
+
+  describe('hex 0x', function() {
+    it('positive integeter', function() {
+      var str = kbn.valueFormats.hex0x(7999,0);
+      expect(str).to.be('0x1F3F');
+    });
+    it('negative integer', function() {
+      var str = kbn.valueFormats.hex0x(-584,0);
+      expect(str).to.be('-0x248');
+    });
+    it('null', function() {
+      var str = kbn.valueFormats.hex0x(null, 0);
+      expect(str).to.be('');
+    });
+    it('positive float', function() {
+      var str = kbn.valueFormats.hex0x(74.443, 3);
+      expect(str).to.be('0x4A.716872B020C4');
+    });
+    it('negative float', function() {
+      var str = kbn.valueFormats.hex0x(-65.458, 1);
+      expect(str).to.be('-0x41.8');
+    });
+  });
 });

--- a/public/test/core/utils/kbn_specs.js
+++ b/public/test/core/utils/kbn_specs.js
@@ -177,7 +177,7 @@ define([
       });
       it('positive float', function() {
 	var str = kbn.valueFormats.hex(50.52, 1);
-	expect(str).to.be('32.828F5C28F5C2');
+	expect(str).to.be('32.8');
       }); 
       it('negative float', function() {
 	var str = kbn.valueFormats.hex(-50.333, 2);


### PR DESCRIPTION
Adds hex units to the column style formatter in the table panel. This is a continuation of my previous PR: [#5474](https://github.com/grafana/grafana/pull/5474)
