### PR TITLE
Tooltip detatch too soon on mobile click

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -538,7 +538,9 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       elem.mouseleave(function() {
         if (panel.links.length === 0) { return;}
-        drilldownTooltip.detach();
+        $(timeout(function() {
+          drilldownTooltip.detach();
+        });
       });
 
       elem.click(function(evt) {

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -538,7 +538,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       elem.mouseleave(function() {
         if (panel.links.length === 0) { return;}
-        $(timeout(function() {
+        $timeout(function() {
           drilldownTooltip.detach();
         });
       });


### PR DESCRIPTION
This resolves an issue for mobile browsers where the mouseleave event fires before the click event. See issue #5597 for further details
