### PR TITLE
[Fix] Import of dashboards will not migrate the dashboards correct

### DIFF
--- a/public/app/features/dashboard/dashboardSrv.js
+++ b/public/app/features/dashboard/dashboardSrv.js
@@ -16,7 +16,7 @@ function (angular, $, _, moment) {
         data = {};
       }
 
-      if (!data.id && data.version) {
+      if (!data.id && data.version && !data.schemaVersion) {
         data.schemaVersion = data.version;
       }
 


### PR DESCRIPTION
Hi,

while importing a dashboard from json file the version is resetted to 'null'. Later on there is a check if there is an 'id' and 'version' present. If not the 'version' is used as 'schemaVersion'.

```
if (!data.id && data.version) {
    data.schemaVersion = data.version;
}
```

Now if you import an dashboard from another grafana installation with updates, the update count becomes the 'schemaVersion' and the migration will not be executed. 

The small fix adds an additional check for an existing 'schemaVersion' to prevent this error.

```
if (!data.id && data.version && !data.schemaVersion) {
  data.schemaVersion = data.version;
}
```

Thanks,
Kristian

---

added check for existing schemaVersion.
if this check is missing the import of a dashboard fails if there is a version reflecting the update version
