### PR TITLE
Added string thresholds for singlestat and table panel

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -195,7 +195,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
         data.valueRounded = 0;
         data.valueFormated = this.series[0].alias;
         this.panel.isString = true;
-      } else if (_.isString(lastValue)) {
+      } else if (_.isString !== void 0 && _.isString(lastValue)) {
         data.value = 0;
         data.valueFormated = _.escape(lastValue);
         data.valueRounded = 0;
@@ -505,6 +505,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       setElementHeight();
 
       var body = panel.gauge.show ? '' : getBigValueHtml();
+
+      console.log(data.valueRounded);
 
       if (panel.colorBackground && !isNaN(data.valueRounded)) {
         var color = getColorForValue(data, panel.isString ? data.valueFormated : data.valueRounded);

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -494,7 +494,11 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       // get thresholds
       data.thresholds = panel.thresholds.split(',').map(function(strVale) {
-        return Number(strVale.trim());
+        if (strVale.trim().charAt(0) === '/') {
+          return kbn.stringToJsRegex(strVale.trim());
+        } else {
+          return Number(strVale.trim());
+        }
       });
       data.colorMap = panel.colors;
 
@@ -598,7 +602,7 @@ function getColorForValue(data, value) {
     }
   }
   if (colorIndices.length > 0) {
-    return data.colorMap[_.last(colorIndices)];
+    return data.colorMap[_.first(colorIndices)];
   } else {
     return _.first(data.colorMap);
   }

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -591,21 +591,13 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 function getColorForValue(data, value) {
   var colorIndices = [];
   for (var i = data.thresholds.length; i > 0; i--) {
-    if (_.isNumber(value)) {
-      if (value >= data.thresholds[i-1]) {
-        colorIndices.push(i);
-      }
-    } else if (_.isString(value)) {
-      if (value.match(data.thresholds[i-1])) {
-        colorIndices.push(i);
-      }
+    if (_.isNumber(value) && value >= data.thresholds[i-1]) {
+      return data.colorMap[i];
+    } else if (_.isString(value) && value.match(data.thresholds[i-1])) {
+      return data.colorMap[i];
     }
   }
-  if (colorIndices.length > 0) {
-    return data.colorMap[_.first(colorIndices)];
-  } else {
-    return _.first(data.colorMap);
-  }
+  return _.first(data.colorMap);
 }
 
 export {

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -589,7 +589,6 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 }
 
 function getColorForValue(data, value) {
-  var colorIndices = [];
   for (var i = data.thresholds.length; i > 0; i--) {
     if (_.isNumber(value) && value >= data.thresholds[i-1]) {
       return data.colorMap[i];

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -585,12 +585,23 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 }
 
 function getColorForValue(data, value) {
+  var colorIndices = [];
   for (var i = data.thresholds.length; i > 0; i--) {
-    if (value >= data.thresholds[i-1]) {
-      return data.colorMap[i];
+    if (_.isNumber(value)) {
+      if (value >= data.thresholds[i-1]) {
+        colorIndices.push(i);
+      }
+    } else if (_.isString(value)) {
+      if (value.match(data.thresholds[i-1])) {
+        colorIndices.push(i);
+      }
     }
   }
-  return _.first(data.colorMap);
+  if (colorIndices.length > 0) {
+    return data.colorMap[_.last(colorIndices)];
+  } else {
+    return _.first(data.colorMap);
+  }
 }
 
 export {

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -67,7 +67,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       maxValue: 100,
       thresholdMarkers: true,
       thresholdLabels: false
-    }
+    },
+    isString : false
   };
 
   /** @ngInject */
@@ -193,11 +194,14 @@ class SingleStatCtrl extends MetricsPanelCtrl {
         data.value = 0;
         data.valueRounded = 0;
         data.valueFormated = this.series[0].alias;
+        this.panel.isString = true;
       } else if (_.isString(lastValue)) {
         data.value = 0;
         data.valueFormated = _.escape(lastValue);
         data.valueRounded = 0;
+        this.panel.isString = true;
       } else {
+        this.panel.isString = false;
         data.value = this.series[0].stats[this.panel.valueName];
         data.flotpairs = this.series[0].flotpairs;
 
@@ -301,7 +305,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
         return valueString;
       }
 
-      var color = getColorForValue(data, value);
+      var color = getColorForValue(data, panel.isString ? valueString : value);
       if (color) {
         return '<span style="color:' + color + '">'+ valueString + '</span>';
       }
@@ -407,7 +411,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
               width: thresholdMarkersWidth,
             },
             value: {
-              color: panel.colorValue ? getColorForValue(data, data.valueRounded) : null,
+              color: panel.colorValue ? getColorForValue(data, this.panel.isString ? data.valueFormated : data.valueRounded) : null,
               formatter: function() { return getValueText(); },
               font: { size: fontSize, family: '"Helvetica Neue", Helvetica, Arial, sans-serif' }
             },
@@ -499,7 +503,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       var body = panel.gauge.show ? '' : getBigValueHtml();
 
       if (panel.colorBackground && !isNaN(data.valueRounded)) {
-        var color = getColorForValue(data, data.valueRounded);
+        var color = getColorForValue(data, panel.isString ? data.valueFormated : data.valueRounded);
         if (color) {
           $panelContainer.css('background-color', color);
           if (scope.fullscreen) {

--- a/public/app/plugins/panel/singlestat/specs/singlestat_panel_spec.ts
+++ b/public/app/plugins/panel/singlestat/specs/singlestat_panel_spec.ts
@@ -49,8 +49,46 @@ describe('grafanaSingleStat', function() {
       thresholds: [-27, 20]
     };
 
-    it('-30 should return green', () => {
+    it('-26 should return yellow', () => {
       expect(getColorForValue(data, -26)).to.be('yellow');
+    });
+  });
+
+  describe('string thresholds', () => {
+    var data: any = {
+      colorMap : ['green', 'yellow', 'red'],
+      thresholds : [/value1/, /value2/]
+    };
+
+    it('"other" should be green', () => {
+      expect(getColorForValue(data, 'other')).to.be('green');
+    });
+
+    it('"value1" should be yellow', () => {
+      expect(getColorForValue(data, 'value1')).to.be('yellow');
+    });
+
+    it('"value2" should be red', () => {
+      expect(getColorForValue(data, 'value2')).to.be('red');
+    });
+  });
+
+  describe('string thresholds with multiple matches', () => {
+    var data: any = {
+      colorMap : ['green', 'yellow', 'red'],
+      thresholds : [/val/, /v.*/]
+    };
+
+    it('"other" should be green', () => {
+      expect(getColorForValue(data, 'other')).to.be('green');
+    });
+
+    it('"value1" should be red', () => {
+      expect(getColorForValue(data, 'value1')).to.be('red');
+    });
+
+    it('"victor" should be red', () => {
+      expect(getColorForValue(data, 'victor')).to.be('red');
     });
   });
 });

--- a/public/app/plugins/panel/singlestat/specs/singlestat_panel_spec.ts
+++ b/public/app/plugins/panel/singlestat/specs/singlestat_panel_spec.ts
@@ -76,19 +76,19 @@ describe('grafanaSingleStat', function() {
   describe('string thresholds with multiple matches', () => {
     var data: any = {
       colorMap : ['green', 'yellow', 'red'],
-      thresholds : [/val/, /v.*/]
+      thresholds : [/val/, /v.*[^e]$/]
     };
 
     it('"other" should be green', () => {
       expect(getColorForValue(data, 'other')).to.be('green');
     });
 
-    it('"value1" should be red', () => {
-      expect(getColorForValue(data, 'value1')).to.be('red');
+    it('"value" should be red', () => {
+      expect(getColorForValue(data, 'value')).to.be('yellow');
     });
 
-    it('"victor" should be red', () => {
-      expect(getColorForValue(data, 'victor')).to.be('red');
+    it('"val" should be red', () => {
+      expect(getColorForValue(data, 'val')).to.be('red');
     });
   });
 });

--- a/public/app/plugins/panel/table/editor.html
+++ b/public/app/plugins/panel/table/editor.html
@@ -110,7 +110,7 @@
 				</ul>
 				<div class="clearfix"></div>
 			</div>
-			<div class="tight-form" ng-if="style.type === 'number'">
+			<div class="tight-form" ng-if="style.type !== 'date'">
 				<ul class="tight-form-list">
 					<li class="tight-form-item text-right" style="width: 93px">
 						Coloring

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -15,9 +15,14 @@ export class TableRenderer {
 
   getColorForValue(value, style) {
     if (!style.thresholds) { return null; }
-
+    _.each(style.thresholds, function(r) {
+        console.log(r.source);
+    });
+    console.log(value);
     for (var i = style.thresholds.length; i > 0; i--) {
-      if (value >= style.thresholds[i - 1]) {
+      if (_.isNumber(value) && value >= style.thresholds[i - 1]) {
+        return style.colors[i];
+      } else if (_.isString(value) && value.match(style.thresholds[i-1])) {
         return style.colors[i];
       }
     }
@@ -73,6 +78,20 @@ export class TableRenderer {
         }
 
         return valueFormater(v, style.decimals, null);
+      };
+    }
+
+    if (style.type === 'string') {
+      return v => {
+        if (style.colorMode) {
+          var stringStyle = _.merge({}, style);
+          console.log(stringStyle.thresholds);
+          stringStyle.thresholds = _.map(stringStyle.thresholds, function(str) {
+            return kbn.stringToJsRegex(str.trim());
+          });
+          this.colorState[stringStyle.colorModel] = this.getColorForValue(v, stringStyle);
+        }
+        return this.defaultCellFormater(v, stringStyle);
       };
     }
 

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -1,4 +1,4 @@
-///<reference path="../../../headers/common.d.ts" />
+//<reference path="../../../headers/common.d.ts" />
 
 import _ from 'lodash';
 import moment from 'moment';
@@ -15,10 +15,7 @@ export class TableRenderer {
 
   getColorForValue(value, style) {
     if (!style.thresholds) { return null; }
-    _.each(style.thresholds, function(r) {
-        console.log(r.source);
-    });
-    console.log(value);
+
     for (var i = style.thresholds.length; i > 0; i--) {
       if (_.isNumber(value) && value >= style.thresholds[i - 1]) {
         return style.colors[i];
@@ -83,13 +80,12 @@ export class TableRenderer {
 
     if (style.type === 'string') {
       return v => {
+        var stringStyle = _.merge({}, style);
         if (style.colorMode) {
-          var stringStyle = _.merge({}, style);
-          console.log(stringStyle.thresholds);
           stringStyle.thresholds = _.map(stringStyle.thresholds, function(str) {
             return kbn.stringToJsRegex(str.trim());
           });
-          this.colorState[stringStyle.colorModel] = this.getColorForValue(v, stringStyle);
+          this.colorState[stringStyle.colorMode] = this.getColorForValue(v, stringStyle);
         }
         return this.defaultCellFormater(v, stringStyle);
       };
@@ -137,7 +133,6 @@ export class TableRenderer {
     if (addWidthHack) {
       widthHack = '<div class="table-panel-width-hack">' + this.table.columns[columnIndex].text + '</div>';
     }
-
     return '<td' + style + '>' + value + widthHack + '</td>';
   }
 

--- a/public/app/plugins/panel/table/specs/renderer_specs.ts
+++ b/public/app/plugins/panel/table/specs/renderer_specs.ts
@@ -14,6 +14,7 @@ describe('when rendering table', () => {
       {text: 'String'},
       {text: 'United', unit: 'bps'},
       {text: 'Sanitized'},
+      {text: 'StringColored'}
     ];
 
     var panel = {
@@ -53,7 +54,14 @@ describe('when rendering table', () => {
           pattern: 'Sanitized',
           type: 'string',
           sanitize: true,
-        }
+        },
+        {
+          pattern: 'StringColored',
+          type: 'string',
+          colorMode: 'value',
+          thresholds: ["/val/", "/v.*[^e]$/"],
+          colors: ['green', 'orange', 'red']
+         }
       ]
     };
 
@@ -121,6 +129,21 @@ describe('when rendering table', () => {
     it('sanitized value should render as', () => {
       var html = renderer.renderCell(6, 'text <a href="http://google.com">link</a>');
       expect(html).to.be('<td>sanitized</td>');
+    });
+
+    it('"other" should be colored green', () => {
+      var html = renderer.renderCell(7, 'other');
+      expect(html).to.be('<td style="color:green">other</td>');
+    });
+
+    it('"value" should be colored orange', () => {
+      var html = renderer.renderCell(7, 'value');
+      expect(html).to.be('<td style="color:orange">value</td>');
+    });
+
+    it('"val" should be colored red', () => {
+      var html = renderer.renderCell(7, 'val');
+      expect(html).to.be('<td style="color:red">val</td>');
     });
   });
 });


### PR DESCRIPTION
Related issue/feature request: [#3601](https://github.com/grafana/grafana/issues/3601)

This will allow you to input regex for threshold values in both the singlestat and table panels.
The regex works like this: Enter regex, seperated by commas for more regex. Make sure the regex starts with a forward slash, so it can determine between a number and regex. Anything that does not match a regex, will be mapped to the first color, this is similar to how the thresholds with numbers work, where anything <= the first number is mapped to the first color.

The getColorForValue function seems redundant to be in both the table panel and singlestat, I am considering moving it to somewhere common, like /public/app/core/utils/kbn.js . However, this would break the current tests for singlestat, requiring that they be moved to kbn_specs. The file singlestat_panel_specs.ts would then be useless and have to be removed, not sure how that works with a pull request.
