### PR TITLE
Update dashboard.md

### DIFF
--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -96,7 +96,7 @@ Will return the dashboard given the dashboard slug. Slug is the url friendly ver
         "isStarred": false,
         "slug": "production-overview"
       },
-      "model": {
+      "dashboard": {
         "id": null,
         "title": "Production Overview",
         "tags": [ "templated" ],


### PR DESCRIPTION
The key returned by `GET /api/dashboards/db/:slug` is "dashboard" (not "model").
