### PR TITLE
Enable scaling down seconds unit s > ms > µs > ns

### DIFF
--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -500,6 +500,19 @@ function($, _, moment) {
   kbn.valueFormats.s = function(size, decimals, scaledDecimals) {
     if (size === null) { return ""; }
 
+    // Less than 1 µs, devide in ns
+    if (Math.abs(size) < 0.000001) {
+      return kbn.toFixedScaled(size * 1.e9, decimals, scaledDecimals - decimals, -9, " ns");
+    }
+    // Less than 1 ms, devide in µs
+    if (Math.abs(size) < 0.001) {
+      return kbn.toFixedScaled(size * 1.e6, decimals, scaledDecimals - decimals, -6, " µs");
+    }
+    // Less than 1 second, devide in ms
+    if (Math.abs(size) < 1) {
+      return kbn.toFixedScaled(size * 1.e3, decimals, scaledDecimals - decimals, -3, " ms");
+    }
+
     if (Math.abs(size) < 60) {
       return kbn.toFixed(size, decimals) + " s";
     }

--- a/public/test/core/utils/kbn_specs.js
+++ b/public/test/core/utils/kbn_specs.js
@@ -68,6 +68,11 @@ define([
   describeValueFormat('wps', 789000000, 1000000, -1, '789M wps');
   describeValueFormat('iops', 11000000000, 1000000000, -1, '11B iops');
 
+  describeValueFormat('s', 1.23456789e-7, 1e-10, 8, '123.5 ns');
+  describeValueFormat('s', 1.23456789e-4, 1e-7, 5, '123.5 µs');
+  describeValueFormat('s', 1.23456789e-3, 1e-6, 4, '1.235 ms');
+  describeValueFormat('s', 1.23456789e-2, 1e-5, 3, '12.35 ms');
+  describeValueFormat('s', 1.23456789e-1, 1e-4, 2, '123.5 ms');
   describeValueFormat('s', 24, 1, 0, '24 s');
   describeValueFormat('s', 246, 1, 0, '4.1 min');
   describeValueFormat('s', 24567, 100, 0, '6.82 hour');


### PR DESCRIPTION
Units currently scale to bigger units. For exemple s > m > h...
It could also be usefull to scale them to smaller units : s > ms > µs > ns.
In this PR, it has been enabled only for 'seconds' unit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafana/grafana/5642)

<!-- Reviewable:end -->
