### PR TITLE
Added '!=' option for where clause in the influx query builder

### DIFF
--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -212,7 +212,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
       if (/^\/.*\/$/.test(nextValue)) {
         return this.$q.when(this.uiSegmentSrv.newOperators(['=~', '!~']));
       } else {
-        return this.$q.when(this.uiSegmentSrv.newOperators(['=', '<>', '<', '>']));
+        return this.$q.when(this.uiSegmentSrv.newOperators(['=', '!=', '<>', '<', '>']));
       }
     }
 


### PR DESCRIPTION
This is for issue: [#5419](https://github.com/grafana/grafana/issues/5419)
