### PR TITLE
[grafana-cli]: Added list-versions. Added help for specific plugin version.

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -27,12 +27,16 @@ func runCommand(command func(commandLine CommandLine) error) func(context *cli.C
 var pluginCommands = []cli.Command{
 	{
 		Name:   "install",
-		Usage:  "install <plugin id>",
+		Usage:  "install <plugin id> <plugin version (optional)>",
 		Action: runCommand(installCommand),
 	}, {
 		Name:   "list-remote",
 		Usage:  "list remote available plugins",
 		Action: runCommand(listremoteCommand),
+	}, {
+		Name:   "list-versions",
+		Usage:  "list-versions <plugin id>",
+		Action: runCommand(listversionsCommand),
 	}, {
 		Name:    "update",
 		Usage:   "update <plugin id>",

--- a/pkg/cmd/grafana-cli/commands/listversions_command.go
+++ b/pkg/cmd/grafana-cli/commands/listversions_command.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"errors"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+)
+
+func validateVersionInput(c CommandLine) error {
+	arg := c.Args().First()
+	if arg == "" {
+		return errors.New("please specify plugin to list versions for")
+	}
+
+	return nil
+}
+
+func listversionsCommand(c CommandLine) error {
+	if err := validateVersionInput(c); err != nil {
+		return err
+	}
+
+	pluginToList := c.Args().First()
+
+	plugin, err := s.GetPlugin(pluginToList, c.GlobalString("repo"))
+	if err != nil {
+		return err
+	}
+
+	for _, i := range plugin.Versions {
+		logger.Infof("%v\n", i.Version)
+	}
+
+	return nil
+}


### PR DESCRIPTION
I went to add the functionality I requested in #5533, but found that this functionality was already present in `grafana-cli` (yay) so I have added command-line help that indicates you can optionally specify a plugin version.

To compliment this, have added a new `grafana-cli` function of `plugins list-versions <plugin id>` (e.g. `grafana-cli plugins list-versions bosun-app`), so that you can discover the valid, published versions of a given plugin.
