### PR TITLE
Allows datasource template variables to be dependent of other template variables.

### DIFF
--- a/public/app/features/templating/templateValuesSrv.js
+++ b/public/app/features/templating/templateValuesSrv.js
@@ -164,7 +164,9 @@ function (angular, _, $, kbn) {
         if (otherVariable === updatedVariable) {
           return;
         }
-        if (templateSrv.containsVariable(otherVariable.query, updatedVariable.name) ||
+        if ((otherVariable.type === "datasource" &&
+            templateSrv.containsVariable(otherVariable.regex, updatedVariable.name)) ||
+            templateSrv.containsVariable(otherVariable.query, updatedVariable.name) ||
             templateSrv.containsVariable(otherVariable.datasource, updatedVariable.name)) {
           return self.updateOptions(otherVariable);
         }


### PR DESCRIPTION
Fix for issue [#5716](https://github.com/grafana/grafana/issues/5716)

Datasource template variables were not being properly updated when their parent template variables were changed. This is because, the query property of ds template variables is set to their datasource type (e.g. influxdb), and they are given the property "regex", which actually contains the user entered query for the template variable. This PR changes the way a template variable is considered a child of another one, by adding a check for if the variable is a datasource type, and then checking if its regex field contains the variable in question.
