### PR TITLE
Mac grafana wrapper script

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -24,4 +24,17 @@ brew update
 brew reinstall grafana
 ```
 
+-------------
 
+You can also install the latest unstable grafana from git:
+
+
+```
+brew install --HEAD grafana/grafana/grafana
+```
+
+To upgrade grafana if you've installed from HEAD:
+
+```
+brew reinstall --HEAD grafana/grafana/grafana
+```

--- a/packaging/mac/bin/grafana
+++ b/packaging/mac/bin/grafana
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+DAEMON=grafana-server
+EXECUTABLE=/usr/local/bin/grafana-server
+CONFIG=/usr/local/etc/grafana/grafana.ini
+HOMEPATH=/usr/local/share/grafana
+LOGPATH=/usr/local/var/log/grafana
+DATAPATH=/usr/local/var/lib/grafana
+PLUGINPATH=/usr/local/var/lib/grafana/plugins
+
+case "$1" in
+start)
+  $EXECUTABLE --config=$CONFIG --homepath=$HOMEPATH cfg:default.paths.logs=$LOGPATH cfg:default.paths.data=$DATAPATH cfg:default.paths.plugins=$PLUGINPATH 2> /dev/null &
+  [ $? -eq 0 ] && echo "$DAEMON started"
+;;
+stop)
+  killall $DAEMON
+  [ $? -eq 0 ] && echo "$DAEMON stopped"
+;;
+restart)
+  $0 stop
+  $0 start
+;;
+*)
+  echo "Usage: $0 (start|stop|restart)"
+;;
+esac


### PR DESCRIPTION
One of the homebrew folks first asked for a wrapper script to make launching grafana easier. Later I was asked to remove it and submit it upstream, so here it is. I also added instructions for installing grafana HEAD from git with homebrew back into the mac installation docs.
