### PR TITLE
fixes rendering issue when dashboard contains multiple panels.

### DIFF
--- a/vendor/phantomjs/render.js
+++ b/vendor/phantomjs/render.js
@@ -55,7 +55,8 @@
 
         var rootScope = body.injector().get('$rootScope');
         if (!rootScope) {return false;}
-        return rootScope.panelsRendered;
+        var panelsToLoad = window.angular.element('div.panel').length;
+        return rootScope.panelsRendered >= panelsToLoad;
       });
 
       if (panelsRendered || tries === 1000) {


### PR DESCRIPTION
#5889

Multi-panel dashboard rendering waits for profiler.ts:renderingCompleted
to set the this.$rootScope.panelsRendered to have value greater or equal
to number of panels in the dashboard.
