### PR TITLE
Added support for TLS client auth for datasource proxies (#5801)

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -17,14 +17,27 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-var dataProxyTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	Proxy:           http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).Dial,
-	TLSHandshakeTimeout: 10 * time.Second,
+func dataProxyTransport(ds *m.DataSource) (*http.Transport, error) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+
+	if ds.TlsAuth {
+		cert, err := tls.LoadX509KeyPair(ds.TlsClientCert, ds.TlsClientKey)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
+	}
+	return transport, nil
 }
 
 func NewReverseProxy(ds *m.DataSource, proxyPath string, targetUrl *url.URL) *httputil.ReverseProxy {
@@ -105,7 +118,11 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 
 	proxyPath := c.Params("*")
 	proxy := NewReverseProxy(ds, proxyPath, targetUrl)
-	proxy.Transport = dataProxyTransport
+	proxy.Transport, err = dataProxyTransport(ds)
+	if err != nil {
+		c.JsonApiErr(400, "Unable to load TLS certificate", err)
+		return
+	}
 	proxy.ServeHTTP(c.Resp, c.Req.Request)
 	c.Resp.Header().Del("Set-Cookie")
 }

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -34,6 +34,7 @@ func GetDataSources(c *middleware.Context) {
 			Database:  ds.Database,
 			User:      ds.User,
 			BasicAuth: ds.BasicAuth,
+			TlsAuth:   ds.TlsAuth,
 			IsDefault: ds.IsDefault,
 		}
 
@@ -160,6 +161,9 @@ func convertModelToDtos(ds *m.DataSource) dtos.DataSource {
 		BasicAuth:         ds.BasicAuth,
 		BasicAuthUser:     ds.BasicAuthUser,
 		BasicAuthPassword: ds.BasicAuthPassword,
+		TlsAuth:           ds.TlsAuth,
+		TlsClientCert:     ds.TlsClientCert,
+		TlsClientKey:      ds.TlsClientKey,
 		WithCredentials:   ds.WithCredentials,
 		IsDefault:         ds.IsDefault,
 		JsonData:          ds.JsonData,

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -77,6 +77,9 @@ type DataSource struct {
 	BasicAuth         bool             `json:"basicAuth"`
 	BasicAuthUser     string           `json:"basicAuthUser"`
 	BasicAuthPassword string           `json:"basicAuthPassword"`
+	TlsAuth           bool             `json:"tlsAuth"`
+	TlsClientCert     string           `json:"tlsClientCert"`
+	TlsClientKey      string           `json:"tlsClientKey"`
 	WithCredentials   bool             `json:"withCredentials"`
 	IsDefault         bool             `json:"isDefault"`
 	JsonData          *simplejson.Json `json:"jsonData,omitempty"`

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -42,6 +42,9 @@ type DataSource struct {
 	BasicAuth         bool
 	BasicAuthUser     string
 	BasicAuthPassword string
+	TlsAuth           bool
+	TlsClientCert     string
+	TlsClientKey      string
 	WithCredentials   bool
 	IsDefault         bool
 	JsonData          *simplejson.Json
@@ -86,6 +89,9 @@ type AddDataSourceCommand struct {
 	BasicAuth         bool             `json:"basicAuth"`
 	BasicAuthUser     string           `json:"basicAuthUser"`
 	BasicAuthPassword string           `json:"basicAuthPassword"`
+	TlsAuth           bool             `json:"tlsAuth"`
+	TlsClientCert     string           `json:"tlsClientCert"`
+	TlsClientKey      string           `json:"tlsClientKey"`
 	WithCredentials   bool             `json:"withCredentials"`
 	IsDefault         bool             `json:"isDefault"`
 	JsonData          *simplejson.Json `json:"jsonData"`
@@ -107,6 +113,9 @@ type UpdateDataSourceCommand struct {
 	BasicAuth         bool             `json:"basicAuth"`
 	BasicAuthUser     string           `json:"basicAuthUser"`
 	BasicAuthPassword string           `json:"basicAuthPassword"`
+	TlsAuth           bool             `json:"tlsAuth"`
+	TlsClientCert     string           `json:"tlsClientCert"`
+	TlsClientKey      string           `json:"tlsClientKey"`
 	WithCredentials   bool             `json:"withCredentials"`
 	IsDefault         bool             `json:"isDefault"`
 	JsonData          *simplejson.Json `json:"jsonData"`

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -73,6 +73,9 @@ func AddDataSource(cmd *m.AddDataSourceCommand) error {
 			BasicAuth:         cmd.BasicAuth,
 			BasicAuthUser:     cmd.BasicAuthUser,
 			BasicAuthPassword: cmd.BasicAuthPassword,
+			TlsAuth:           cmd.TlsAuth,
+			TlsClientCert:     cmd.TlsClientCert,
+			TlsClientKey:      cmd.TlsClientKey,
 			WithCredentials:   cmd.WithCredentials,
 			JsonData:          cmd.JsonData,
 			Created:           time.Now(),
@@ -119,6 +122,9 @@ func UpdateDataSource(cmd *m.UpdateDataSourceCommand) error {
 			BasicAuth:         cmd.BasicAuth,
 			BasicAuthUser:     cmd.BasicAuthUser,
 			BasicAuthPassword: cmd.BasicAuthPassword,
+			TlsAuth:           cmd.TlsAuth,
+			TlsClientCert:     cmd.TlsClientCert,
+			TlsClientKey:      cmd.TlsClientKey,
 			WithCredentials:   cmd.WithCredentials,
 			JsonData:          cmd.JsonData,
 			Updated:           time.Now(),
@@ -126,6 +132,7 @@ func UpdateDataSource(cmd *m.UpdateDataSourceCommand) error {
 
 		sess.UseBool("is_default")
 		sess.UseBool("basic_auth")
+		sess.UseBool("tls_auth")
 		sess.UseBool("with_credentials")
 
 		_, err := sess.Where("id=? and org_id=?", ds.Id, ds.OrgId).Update(ds)

--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -101,4 +101,15 @@ func addDataSourceMigration(mg *Migrator) {
 	mg.AddMigration("Add column with_credentials", NewAddColumnMigration(tableV2, &Column{
 		Name: "with_credentials", Type: DB_Bool, Nullable: false, Default: "0",
 	}))
+
+	// add columns to activate TLS client auth option
+	mg.AddMigration("Add column tls_auth", NewAddColumnMigration(tableV2, &Column{
+		Name: "tls_auth", Type: DB_Bool, Nullable: false, Default: "0",
+	}))
+	mg.AddMigration("Add column tls_client_cert", NewAddColumnMigration(tableV2, &Column{
+		Name: "tls_client_cert", Type: DB_NVarchar, Length: 255, Nullable: true,
+	}))
+	mg.AddMigration("Add column tls_client_key", NewAddColumnMigration(tableV2, &Column{
+		Name: "tls_client_key", Type: DB_NVarchar, Length: 255, Nullable: true,
+	}))
 }

--- a/public/app/features/plugins/partials/ds_http_settings.html
+++ b/public/app/features/plugins/partials/ds_http_settings.html
@@ -49,6 +49,10 @@
 									label="With Credentials"
 				 checked="current.withCredentials" switch-class="max-width-6">
 		</gf-form-switch>
+		<gf-form-switch class="gf-form" ng-if="current.access=='proxy'"
+									label="TLS Client Auth"
+				 checked="current.tlsAuth" switch-class="max-width-6">
+		</gf-form-switch>
 	</div>
 
 	<div class="gf-form" ng-if="current.basicAuth">
@@ -63,6 +67,20 @@
 			Password
 		</span>
 		<input class="gf-form-input max-width-21" type="password" ng-model='current.basicAuthPassword' placeholder="password" required></input>
+	</div>
+
+	<div class="gf-form" ng-if="current.tlsAuth && current.access=='proxy'">
+		<span class="gf-form-label width-7">
+			Client Cert
+		</span>
+		<input class="gf-form-input max-width-23" type="text"  ng-model='current.tlsClientCert' placeholder="cert path" required></input>
+	</div>
+
+	<div class="gf-form" ng-if="current.tlsAuth && current.access=='proxy'">
+		<span class="gf-form-label width-7">
+			Client Key
+		</span>
+		<input class="gf-form-input max-width-23" type="text" ng-model='current.tlsClientKey' placeholder="key path" required></input>
 	</div>
 </div>
 


### PR DESCRIPTION
Fixes #5801 (and #2316)

The basic functionality is now there to add client cert and key paths (local to the grafana server) to the data source HTTP auth configuration when using proxy access. I thought about adding another boolean for TLS server verification (its currently hardcoded to skip server verification), but I wanted to submit a small checkpoint to make sure I'm on the right track.

Any comments or questions? Is there any preference for the layout of the new form fields on the datasource edit screen? I kind of just took a stab at it.
