### PR TITLE
redact provider_config from log or console

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -190,7 +190,7 @@ func ToAbsUrl(relativeUrl string) string {
 
 func shouldRedactKey(s string) bool {
 	uppercased := strings.ToUpper(s)
-	return strings.Contains(uppercased, "PASSWORD") || strings.Contains(uppercased, "SECRET")
+	return strings.Contains(uppercased, "PASSWORD") || strings.Contains(uppercased, "SECRET") || strings.Contains(uppercased, "PROVIDER_CONFIG")
 }
 
 func shouldRedactURLKey(s string) bool {


### PR DESCRIPTION
PROVIDER_CONFIG is presented in plain text to log or console if overriden via environment variable, while 'admin > server settings' shows it redacted.
