### PR TITLE
added bucket script implementation with simple tests

### DIFF
--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -167,6 +167,7 @@ function (_, $, coreModule) {
         options: "=",
         getOptions: "&",
         onChange: "&",
+        custom: "@"
       },
       link: {
         pre: function postLink($scope, elem, attrs) {
@@ -176,7 +177,7 @@ function (_, $, coreModule) {
             var option = _.find($scope.options, {value: value});
             var segment = {
               cssClass: attrs.cssClass,
-              custom: attrs.custom,
+              custom: $scope.custom,
               value: option ? option.text : value,
               selectMode: attrs.selectMode,
             };
@@ -208,7 +209,7 @@ function (_, $, coreModule) {
               var option = _.find(cachedOptions, {text: $scope.segment.value});
               if (option && option.value !== $scope.property) {
                 $scope.property = option.value;
-              } else if (attrs.custom !== 'false') {
+              } else if ($scope.custom !== 'false') {
                 $scope.property = $scope.segment.value;
               }
             } else {

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -38,7 +38,11 @@ function (angular, _, queryDef) {
     };
 
     $scope.updatePipelineAggOptions = function() {
-      $scope.pipelineAggOptions = queryDef.getPipelineAggOptions($scope.target);
+      if (queryDef.isBucketScriptAgg($scope.agg.type)) {
+        $scope.pipelineAggOptions = [];
+      } else {
+        $scope.pipelineAggOptions = queryDef.getPipelineAggOptions($scope.target);
+      }
     };
 
     $rootScope.onAppEvent('elastic-query-updated', function() {
@@ -54,7 +58,8 @@ function (angular, _, queryDef) {
       $scope.aggDef = _.find($scope.metricAggTypes, {value: $scope.agg.type});
 
       if (queryDef.isPipelineAgg($scope.agg.type)) {
-        $scope.agg.pipelineAgg = $scope.agg.pipelineAgg || 'select metric';
+        var default_text = queryDef.isBucketScriptAgg($scope.agg.type) ? 'metric name':'select metric';
+        $scope.agg.pipelineAgg = $scope.agg.pipelineAgg || default_text;
         $scope.agg.field = $scope.agg.pipelineAgg;
 
         var pipelineOptions = queryDef.getPipelineOptions($scope.agg);

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -13,7 +13,7 @@
 	<div class="gf-form">
 		<metric-segment-model property="agg.type" options="metricAggTypes" on-change="onTypeChange()" custom="false" css-class="width-10"></metric-segment-model>
 		<metric-segment-model ng-if="aggDef.requiresField" property="agg.field" get-options="getFieldsInternal()" on-change="onChange()" css-class="width-12"></metric-segment-model>
-		<metric-segment-model ng-if="aggDef.isPipelineAgg" property="agg.pipelineAgg" options="pipelineAggOptions" on-change="onChangeInternal()" custom="false" css-class="width-12"></metric-segment-model>
+		<metric-segment-model ng-if="aggDef.isPipelineAgg" property="agg.pipelineAgg" options="pipelineAggOptions" on-change="onChangeInternal()" custom="{{aggDef.customName}}" css-class="width-12"></metric-segment-model>
 	</div>
 
 	<div class="gf-form gf-form--grow">
@@ -37,6 +37,12 @@
 </div>
 
 <div class="gf-form-group" ng-if="showOptions">
+
+	<div class="gf-form offset-width-7" ng-if="agg.type === 'bucket_script'">
+		<label class="gf-form-label width-10">Script</label>
+		<input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.script" ng-blur="onChangeInternal()" spellcheck='false'>
+	</div>
+
 	<div class="gf-form offset-width-7" ng-if="agg.type === 'derivative'">
 		<label class="gf-form-label width-10">Unit</label>
 		<input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.unit" ng-blur="onChangeInternal()" spellcheck='false'>

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -204,6 +204,15 @@ function (queryDef) {
       if (queryDef.isPipelineAgg(metric.type)) {
         if (metric.pipelineAgg && /^\d*$/.test(metric.pipelineAgg)) {
           metricAgg = { buckets_path: metric.pipelineAgg };
+        } else if (queryDef.isBucketScriptAgg(metric.type)) {
+          metricAgg = {buckets_path: {}};
+          for (var j = 0; j < target.metrics.length; j++) {
+            var the_metric = target.metrics[j];
+            if (the_metric.type !== 'count' && !queryDef.isPipelineAgg(the_metric.type)) {
+              var key = the_metric.field.replace(/[^A-Za-z0-9]/gi, '');
+              metricAgg['buckets_path'][key] = the_metric.id;
+            }
+          }
         } else {
           continue;
         }

--- a/public/app/plugins/datasource/elasticsearch/query_def.js
+++ b/public/app/plugins/datasource/elasticsearch/query_def.js
@@ -14,8 +14,9 @@ function (_) {
       {text: "Extended Stats",  value: 'extended_stats', requiresField: true, supportsMissing: true, supportsInlineScript: true},
       {text: "Percentiles",  value: 'percentiles', requiresField: true, supportsMissing: true, supportsInlineScript: true},
       {text: "Unique Count", value: "cardinality", requiresField: true, supportsMissing: true},
-      {text: "Moving Average",  value: 'moving_avg', requiresField: false, isPipelineAgg: true, minVersion: 2},
-      {text: "Derivative",  value: 'derivative', requiresField: false, isPipelineAgg: true, minVersion: 2 },
+      {text: "Moving Average",  value: 'moving_avg', requiresField: false, isPipelineAgg: true, customName: false, minVersion: 2},
+      {text: "Derivative",  value: 'derivative', requiresField: false, isPipelineAgg: true, customName: false, minVersion: 2 },
+      {text: "Bucket Script",  value: 'bucket_script', requiresField: false, isPipelineAgg: true, customName: true, minVersion: 2},
       {text: "Raw Document", value: "raw_document", requiresField: false}
     ],
 
@@ -86,6 +87,9 @@ function (_) {
       ],
       'derivative': [
         {text: 'unit', default: undefined},
+      ],
+      'bucket_script': [
+        {text: 'script', default: '0'},
       ]
     },
 
@@ -134,6 +138,10 @@ function (_) {
       return false;
     },
 
+    isBucketScriptAgg: function(metricType) {
+      return this.isPipelineAgg(metricType) && metricType === 'bucket_script';
+    },
+
     getPipelineAggOptions: function(targets) {
       var self = this;
       var result = [];
@@ -142,7 +150,6 @@ function (_) {
           result.push({text: self.describeMetric(metric), value: metric.id });
         }
       });
-
       return result;
     },
 

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def_specs.ts
@@ -92,13 +92,13 @@ describe('ElasticQueryDef', function() {
 
       describe('using esversion 2', function() {
           it('should get pipeline aggs', function() {
-              expect(queryDef.getMetricAggTypes(2).length).to.be(11);
+              expect(queryDef.getMetricAggTypes(2).length).to.be(12);
           });
       });
 
       describe('using esversion 5', function() {
           it('should get pipeline aggs', function() {
-              expect(queryDef.getMetricAggTypes(5).length).to.be(11);
+              expect(queryDef.getMetricAggTypes(5).length).to.be(12);
           });
       });
   });


### PR DESCRIPTION
This pull request addresses indirectly https://github.com/grafana/grafana/issues/3163 as it adds ability for custom aggregations, yet without the problems of a full custom query. Directly solves https://github.com/grafana/grafana/issues/5968

With this addition, basically every field becomes available for bucket_script aggregation and arithmetic operations are possible after adding a "Bucket Script" type metric.

Only problem I see so far with this is there's no easy way to validate the script before executing the query, however a bad script will basically result in an error, being an obvious indication there's something wrong with it. There's definitely room for improvement there, though.

<img width="1409" alt="screen shot 2016-08-27 at 4 51 25 pm" src="https://cloud.githubusercontent.com/assets/379148/18030303/98760742-6c76-11e6-93e6-abd2a31c294b.png">
