### PR TITLE
3854 head response, fixes #3854

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/live"
 	"github.com/grafana/grafana/pkg/middleware"
-	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/models"
 	"gopkg.in/macaron.v1"
 )
 
@@ -18,6 +18,9 @@ func Register(r *macaron.Macaron) {
 	reqOrgAdmin := middleware.RoleAuth(m.ROLE_ADMIN)
 	quota := middleware.Quota
 	bind := binding.Bind
+
+	// automatically set HEAD for every GET
+	r.SetAutoHead(true)
 
 	// not logged in views
 	r.Get("/", reqSignedIn, Index)

--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -113,7 +113,7 @@ function (_, $, coreModule) {
           if (str[0] === '/') { str = str.substring(1); }
           if (str[str.length - 1] === '/') { str = str.substring(0, str.length-1); }
           try {
-            return item.toLowerCase().match(str);
+            return item.toLowerCase().match(str.toLowerCase());
           } catch(e) {
             return false;
           }


### PR DESCRIPTION
Found in macaron there is a convenient "SetAutoHead" which returns a HEAD on every request. It now turns any HEAD -> 404 to the correct HEAD response.
