### PR TITLE
fix(influxdb) autocomplete measurement while typing, fixes #4278

### DIFF
--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -76,10 +76,8 @@ function (_, $, coreModule) {
         };
 
         $scope.source = function(query, callback) {
-          if (options) { return options; }
-
           $scope.$apply(function() {
-            $scope.getOptions().then(function(altSegments) {
+            $scope.getOptions({ measurementFilter: query }).then(function(altSegments) {
               $scope.altSegments = altSegments;
               options = _.map($scope.altSegments, function(alt) { return alt.value; });
 

--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -11,7 +11,7 @@
 				<label class="gf-form-label query-keyword width-7">FROM</label>
 
 				<metric-segment segment="ctrl.policySegment" get-options="ctrl.getPolicySegments()" on-change="ctrl.policyChanged()"></metric-segment>
-				<metric-segment segment="ctrl.measurementSegment" get-options="ctrl.getMeasurements()" on-change="ctrl.measurementChanged()"></metric-segment>
+				<metric-segment segment="ctrl.measurementSegment" get-options="ctrl.getMeasurements(measurementFilter)" on-change="ctrl.measurementChanged()"></metric-segment>
 			</div>
 
 			<div class="gf-form">

--- a/public/app/plugins/datasource/influxdb/query_builder.js
+++ b/public/app/plugins/datasource/influxdb/query_builder.js
@@ -39,7 +39,7 @@ function (_) {
     return this.target.rawQuery ? this._modifyRawQuery() : this._buildQuery();
   };
 
-  p.buildExploreQuery = function(type, withKey) {
+  p.buildExploreQuery = function(type, withKey, withMeasurementFilter) {
     var query;
     var measurement;
 
@@ -51,6 +51,10 @@ function (_) {
       measurement = this.target.measurement;
     } else if (type === 'MEASUREMENTS') {
       query = 'SHOW MEASUREMENTS';
+      if (withMeasurementFilter)
+      {
+        query += ' WITH MEASUREMENT =~ /' + withMeasurementFilter +'/';
+      }
     } else if (type === 'FIELDS') {
       query = 'SHOW FIELD KEYS FROM "' + this.target.measurement + '"';
       return query;

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -191,8 +191,8 @@ export class InfluxQueryCtrl extends QueryCtrl {
     this.target.rawQuery = !this.target.rawQuery;
   }
 
-  getMeasurements() {
-    var query = this.queryBuilder.buildExploreQuery('MEASUREMENTS');
+  getMeasurements(measurementFilter) {
+    var query = this.queryBuilder.buildExploreQuery('MEASUREMENTS', undefined, measurementFilter);
     return this.datasource.metricFindQuery(query)
       .then(this.transformToSegments(true))
       .catch(this.handleQueryError.bind(this));

--- a/public/app/plugins/datasource/influxdb/specs/query_builder_specs.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder_specs.ts
@@ -37,6 +37,24 @@ describe('InfluxQueryBuilder', function() {
       expect(query).to.be('SHOW MEASUREMENTS');
     });
 
+    it('should have no conditions in measurement query for query with no tags and empty query', function() {
+      var builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
+      var query = builder.buildExploreQuery('MEASUREMENTS', undefined, '');
+      expect(query).to.be('SHOW MEASUREMENTS');
+    });
+
+    it('should have WITH MEASUREMENT in measurement query for non-empty query with no tags', function() {
+      var builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
+      var query = builder.buildExploreQuery('MEASUREMENTS', undefined, 'something');
+      expect(query).to.be('SHOW MEASUREMENTS WITH MEASUREMENT =~ /something/');
+    });
+
+    it('should have WITH MEASUREMENT WHERE in measurement query for non-empty query with tags', function() {
+          var builder = new InfluxQueryBuilder({ measurement: '', tags: [{key: 'app', value: 'email'}] });
+          var query = builder.buildExploreQuery('MEASUREMENTS', undefined, 'something');
+          expect(query).to.be("SHOW MEASUREMENTS WITH MEASUREMENT =~ /something/ WHERE \"app\" = 'email'");
+    });
+
     it('should have where condition in measurement query for query with tags', function() {
       var builder = new InfluxQueryBuilder({measurement: '', tags: [{key: 'app', value: 'email'}]});
       var query = builder.buildExploreQuery('MEASUREMENTS');


### PR DESCRIPTION
Here is my attempt at using the influxdb "WITH MEASUREMENT =~" while adding or editing a measurement in the query editor.
