### PR TITLE
plugin/datasource/influxdb: added datasampling suffix

### DIFF
--- a/public/app/plugins/datasource/influxdb/partials/config.html
+++ b/public/app/plugins/datasource/influxdb/partials/config.html
@@ -31,3 +31,13 @@
 		<i class="fa fa-question-circle" bs-tooltip="'Set a low limit by having a greater sign: example: >10s'" data-placement="right"></i>
 	</div>
 </div>
+
+
+<div class="gf-form-group">
+	<div class="gf-form max-width-21">
+		<span class="gf-form-label">Downsample time suffix</span>
+		<input type="text" class="gf-form-input width-20" ng-model="ctrl.current.jsonData.downSampleGroup" spellcheck='false' placeholder="_1m;_1h;_1d"></input>
+		<input type="text" class="gf-form-input width-20" ng-model="ctrl.current.jsonData.downSampleRange" spellcheck='false' placeholder="3600;86400;10000"></input>
+		<i class="fa fa-question-circle" bs-tooltip="'Generate downsample suffix base on delta between from/until time: example: 86400 -> _1h -> cpu_1h'" data-placement="right"></i>
+	</div>
+</div>

--- a/public/app/plugins/datasource/influxdb/partials/query.options.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.options.html
@@ -49,6 +49,7 @@
 				<li>$col = replaced with column name</li>
 				<li>$tag_hostname = replaced with the value of the hostname tag</li>
 				<li>You can also use [[tag_hostname]] pattern replacement syntax</li>
+				<li>$downsample = replaced with your downsample range</li>
 			</ul>
 		</div>
 


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/420

now you can create downsampling groups and ranges and use pseudovariable $downsample for a suffix

i.e.:
groups: _1m;_1h;_1d
ranges:  300;3600;86400

i.e.
if the delta of a timerange is less than or equals to 86400 and greater than 300, then the suffix will be "_1h" and in your InfluxDB's query you can define:

SELECT mean("usage_system") FROM "cpu$downsampling" WHERE time > now() - 30m GROUP BY time(20s) fill(null);

and the query will be translated to:

SELECT mean("usage_system") FROM "cpu_1h" WHERE time > now() - 30m GROUP BY time(20s) fill(null);

any comments are welcome.
