### PR TITLE
(prometheus) align query time range

### DIFF
--- a/public/app/features/dashboard/timeSrv.js
+++ b/public/app/features/dashboard/timeSrv.js
@@ -85,6 +85,10 @@ define([
       }
     };
 
+    this.getRefreshInterval = function () {
+      return this.dashboard.refresh;
+    };
+
     this.refreshDashboard = function() {
       $rootScope.$broadcast('refresh');
     };

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -285,11 +285,14 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
   this.alignTime = function(time, range) {
     var refreshInterval = timeSrv.getRefreshInterval();
-    var unitTime = 60;
-    if (!refreshInterval || range < unitTime) {
-      return time;
+    if (refreshInterval) {
+      var m = refreshInterval.match(durationSplitRegexp);
+      var unitTime = Math.min(moment.duration(parseInt(m[1]), m[2]).asSeconds(), 60);
+      if (range >= unitTime) {
+        time -= (time % unitTime);
+      }
     }
-    return time - (time % unitTime);
+    return time;
   };
 
   this.getPrometheusTime = function(date, roundUp) {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -64,6 +64,8 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     var self = this;
     var start = this.getPrometheusTime(options.range.from, false);
     var end = this.getPrometheusTime(options.range.to, true);
+    start = this.alignTime(start, end - start);
+    end = this.alignTime(end, end - start);
 
     var queries = [];
     var activeTargets = [];
@@ -174,6 +176,8 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
 
     var start = this.getPrometheusTime(options.range.from, false);
     var end = this.getPrometheusTime(options.range.to, true);
+    start = this.alignTime(start, end - start);
+    end = this.alignTime(end, end - start);
     var self = this;
 
     return this.performTimeSeriesQuery(query, start, end).then(function(results) {
@@ -277,6 +281,14 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       return label[0] + '="' + label[1] + '"';
     }).join(',');
     return metricName + '{' + labelPart + '}';
+  };
+
+  this.alignTime = function(time, range) {
+    var unitTime = 60;
+    if (range < unitTime) {
+      return time;
+    }
+    return time - (time % unitTime);
   };
 
   this.getPrometheusTime = function(date, roundUp) {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -284,8 +284,9 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   };
 
   this.alignTime = function(time, range) {
+    var refreshInterval = timeSrv.getRefreshInterval();
     var unitTime = 60;
-    if (range < unitTime) {
+    if (!refreshInterval || range < unitTime) {
       return time;
     }
     return time - (time % unitTime);

--- a/public/app/plugins/datasource/prometheus/metric_find_query.js
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.js
@@ -53,6 +53,8 @@ function (_) {
     } else {
       var start = this.datasource.getPrometheusTime(this.range.from, false);
       var end = this.datasource.getPrometheusTime(this.range.to, true);
+      start = this.datasource.alignTime(start, end - start);
+      end = this.datasource.alignTime(end, end - start);
       url = '/api/v1/series?match[]=' + encodeURIComponent(metric)
         + '&start=' + start
         + '&end=' + end;
@@ -114,6 +116,8 @@ function (_) {
   PrometheusMetricFindQuery.prototype.metricNameAndLabelsQuery = function(query) {
     var start = this.datasource.getPrometheusTime(this.range.from, false);
     var end = this.datasource.getPrometheusTime(this.range.to, true);
+    start = this.datasource.alignTime(start, end - start);
+    end = this.datasource.alignTime(end, end - start);
     var url = '/api/v1/series?match[]=' + encodeURIComponent(query)
       + '&start=' + start
       + '&end=' + end;

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -13,7 +13,7 @@ describe('PrometheusDatasource', function() {
     ctx.$q = $q;
     ctx.$httpBackend =  $httpBackend;
     ctx.$rootScope = $rootScope;
-    ctx.ds = $injector.instantiate(PrometheusDatasource, {instanceSettings: instanceSettings});
+    ctx.ds = $injector.instantiate(PrometheusDatasource, {instanceSettings: instanceSettings, timeSrv: ctx.timeSrv});
     $httpBackend.when('GET', /\.html$/).respond('');
   }));
 

--- a/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
@@ -15,7 +15,7 @@ describe('PrometheusMetricFindQuery', function() {
     ctx.$q = $q;
     ctx.$httpBackend =  $httpBackend;
     ctx.$rootScope = $rootScope;
-    ctx.ds = $injector.instantiate(PrometheusDatasource, {instanceSettings: instanceSettings});
+    ctx.ds = $injector.instantiate(PrometheusDatasource, {instanceSettings: instanceSettings, timeSrv: ctx.timeSrv});
     $httpBackend.when('GET', /\.html$/).respond('');
   }));
 

--- a/public/test/specs/helpers.js
+++ b/public/test/specs/helpers.js
@@ -142,6 +142,10 @@ define([
     this.setTime = function(time) {
       this.time = time;
     };
+
+    this.getRefreshInterval = function() {
+      return undefined;
+    };
   }
 
   function ContextSrvStub() {


### PR DESCRIPTION
By this changes, Prometheus query time range is always align 1 minutes when time range is longer than 1 minutes.

I use nginx as frontend of Prometheus, and cache query result for short time to reduce Prometheus load.

This PR is very useful for some situation.
The situation is "many user look same dashboard, and set auto refresh".
In such situation, too many query is executed by Prometheus simultaneously when refreshing dashboard.
(see https://github.com/grafana/grafana/pull/4220 )

The time range is set like "now-1h" - "now", so the actual query time range for Prometheus is get from Browser time, so the time range could be slightly differ.
The cache key of nginx is "query request url", these query doesn't use cache...
