### PR TITLE
Update systemd unit's description to be more understandable

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Starts and stops a single grafana instance on this system
+Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Starts and stops a single grafana instance on this system
+Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target


### PR DESCRIPTION
I use top for server maintenance, but I found the description being shown is a bit confusing, I think it's better to tell users like `X instance`, or `X server`.

I don't know how to describe grafana precisely, so just leaving its name as is with `instance` appended.
