### PR TITLE
(prometheus) fix template variable expansion in legend

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -257,7 +257,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       return this.getOriginalMetricName(labelData);
     }
 
-    return this.renderTemplate(options.legendFormat, labelData) || '{}';
+    return this.renderTemplate(templateSrv.replace(options.legendFormat), labelData) || '{}';
   };
 
   this.renderTemplate = function(aliasPattern, aliasData) {


### PR DESCRIPTION
I accidentally break the function.
Fix it by this PR.
