### PR TITLE
Secure Elasticsearch datasources a bit

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -104,6 +104,22 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 	}
 
 	proxyPath := c.Params("*")
+
+	if ds.Type == m.DS_ES {
+		if c.Req.Request.Method == "DELETE" {
+			c.JsonApiErr(403, "Deletes not allowed on proxied Elasticsearch datasource", nil)
+			return
+		}
+		if c.Req.Request.Method == "PUT" {
+			c.JsonApiErr(403, "Puts not allowed on proxied Elasticsearch datasource", nil)
+			return
+		}
+		if c.Req.Request.Method == "POST" && proxyPath != "_msearch" {
+			c.JsonApiErr(403, "Posts not allowed on proxied Elasticsearch datasource except on /_msearch", nil)
+			return
+		}
+	}
+
 	proxy := NewReverseProxy(ds, proxyPath, targetUrl)
 	proxy.Transport = dataProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req.Request)


### PR DESCRIPTION
Instead of allowing users to access the entire cluster, apply some sane restrictions.

Tested locally with ES as a source of annotations.
