### PR TITLE
Fixing issue of escaping tag values in Prometheus

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -76,7 +76,12 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       activeTargets.push(target);
 
       var query: any = {};
-      query.expr = templateSrv.replace(target.expr, options.scopedVars, self.interpolateQueryExpr);
+      if (target.expr.indexOf("!==") !== -1 ||  target.expr.indexOf("=~") !== -1 || target.expr.indexOf("!~") !== -1) {
+        query.expr = templateSrv.replace(target.expr, options.scopedVars, self.interpolateQueryExpr);
+      } else {
+        query.expr = templateSrv.replace(target.expr, options.scopedVars, "pipe");
+      }
+
       query.requestId = options.panelId + target.refId;
 
       var interval = templateSrv.replace(target.interval, options.scopedVars) || options.interval;


### PR DESCRIPTION
Today when a dashboard uses Prometheus as a data store, when there is a template that is being used that has either ALL or multi-value then, by default regex escape is carried out and this breaks queries when tag value is a hostname like "google.com". This PR tries to avoid regex escape when tags are of "=" operation where regexes can not be applied as per prometheus documentation:
https://prometheus.io/docs/querying/basics/#time-series-selectors

Please provide feedback if this wouldn't work on all scenarios.
