### PR TITLE
Adds 95th Percentile to Graph's Legend.

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -18,6 +18,18 @@ function translateFillOption(fill) {
   return fill === 0 ? 0.001 : fill/10;
 }
 
+function sortNumber(a,b) {
+  return a - b;
+}
+
+function percentile(arr, percent) {
+  if (arr.length == 0 )
+	  return false;
+  k = ( arr.length - 1 ) * percent;
+  f = Math.floor( k )
+  return arr[f];
+}
+
 export default class TimeSeries {
   datapoints: any;
   id: string;
@@ -98,6 +110,7 @@ export default class TimeSeries {
     this.stats.max = -Number.MAX_VALUE;
     this.stats.min = Number.MAX_VALUE;
     this.stats.avg = null;
+    this.stats.p95 = null;
     this.stats.current = null;
     this.allIsNull = true;
     this.allIsZero = true;
@@ -107,6 +120,7 @@ export default class TimeSeries {
     var currentTime;
     var currentValue;
     var nonNulls = 0;
+    var p95_array = [];
 
     for (var i = 0; i < this.datapoints.length; i++) {
       currentValue = this.datapoints[i][0];
@@ -124,6 +138,7 @@ export default class TimeSeries {
           this.stats.total += currentValue;
           this.allIsNull = false;
           nonNulls++;
+	  p95_array.push (currentValue);
         }
 
         if (currentValue > this.stats.max) {
@@ -150,6 +165,9 @@ export default class TimeSeries {
     if (this.stats.min === Number.MAX_VALUE) { this.stats.min = null; }
 
     if (result.length) {
+      p95_array.sort(sortNumber);
+      this.stats.p95 = percentile(p95_array, 0.95);
+      console.log(p95_array);
       this.stats.avg = (this.stats.total / nonNulls);
       this.stats.current = result[result.length-1][1];
       if (this.stats.current === null && result.length > 1) {

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -131,6 +131,7 @@ function (angular, _, $) {
               header += getTableHeaderHtml('min');
               header += getTableHeaderHtml('max');
               header += getTableHeaderHtml('avg');
+              header += getTableHeaderHtml('p95');
               header += getTableHeaderHtml('current');
               header += getTableHeaderHtml('total');
             }
@@ -167,6 +168,7 @@ function (angular, _, $) {
 
             if (panel.legend.values) {
               var avg = series.formatValue(series.stats.avg);
+              var p95 = series.formatValue(series.stats.p95);
               var current = series.formatValue(series.stats.current);
               var min = series.formatValue(series.stats.min);
               var max = series.formatValue(series.stats.max);
@@ -175,6 +177,7 @@ function (angular, _, $) {
               if (panel.legend.min) { html += '<div class="graph-legend-value min">' + min + '</div>'; }
               if (panel.legend.max) { html += '<div class="graph-legend-value max">' + max + '</div>'; }
               if (panel.legend.avg) { html += '<div class="graph-legend-value avg">' + avg + '</div>'; }
+              if (panel.legend.p95) { html += '<div class="graph-legend-value p95">' + p95 + '</div>'; }
               if (panel.legend.current) { html += '<div class="graph-legend-value current">' + current + '</div>'; }
               if (panel.legend.total) { html += '<div class="graph-legend-value total">' + total + '</div>'; }
             }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -80,6 +80,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       current: false,
       total: false,
       avg: false
+      p95: false
     },
     // how null points should be handled
     nullPointMode : 'connected',
@@ -318,7 +319,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   legendValuesOptionChanged() {
     var legend = this.panel.legend;
-    legend.values = legend.min || legend.max || legend.avg || legend.current || legend.total;
+    legend.values = legend.min || legend.max || legend.avg || legend.p95 || legend.current || legend.total;
     this.render();
   }
 

--- a/public/app/plugins/panel/graph/tab_legend.html
+++ b/public/app/plugins/panel/graph/tab_legend.html
@@ -48,6 +48,14 @@
 
 		<div class="gf-form-inline">
 			<gf-form-switch class="gf-form"
+				label="95th percentile" label-class="width-4"
+				checked="ctrl.panel.legend.p95" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+		</div>
+
+
+		<div class="gf-form-inline">
+			<gf-form-switch class="gf-form"
 				label="Total" label-class="width-4"
 				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>


### PR DESCRIPTION
Issue discussing this: #6053

This patch adds 95th percentile calculation to the legend. This is
useful for calculating on the fly this metric on a given dataset.

We added a new line on the legend table for this, leaving some room to add (if you think this is interesting) a 99th percentile calculation as well.

Here's an image of what this looks like:

![p95](https://cloud.githubusercontent.com/assets/547142/18566724/55e033e0-7b6b-11e6-8427-c68b52e4808b.png)

Please let me know what you guys think.

Since we use this metric a lot (and it's useful to calculate this on the fly for any given graph zoom in/out), we thought we share this so everyone else can use it too!
