### PR TITLE
Changed redis provider_options example in configuration.md to reflex correct usage

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -428,7 +428,7 @@ session provider you have configured.
 - **mysql:** go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
 - **postgres:** ex:  user=a password=b host=localhost port=5432 dbname=c sslmode=disable
 - **memcache:** ex:  127.0.0.1:11211
-- **redis:** ex: `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+- **redis:** ex: `addr=127.0.0.1:6379,pool_size=100,prefix=grafana`
 
 If you use MySQL or Postgres as the session store you need to create the
 session table manually.


### PR DESCRIPTION
The 'db'  provider_options for redis should be a interger, `grafana` is should be the `prefix`.  Altered the documentation to reflect this. 
