### PR TITLE
Bug fixes for flexible Y-Min and Y-Max settings

### DIFF
--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -354,7 +354,7 @@ function (angular, $, moment, _, kbn, GraphTooltip, thresholdManExports) {
 
         function parseThresholdExpr(expr) {
           var match, operator, value, precision;
-          match = expr.match(/\s*([<=>~]*)\W*(\d+(\.\d+)?)/);
+          match = expr.match(/\s*([<=>~]*)\s*(\-?\d+(\.\d+)?)/);
           if (match) {
             operator = match[1];
             value = parseFloat(match[2]);

--- a/public/app/plugins/panel/graph/graph.js
+++ b/public/app/plugins/panel/graph/graph.js
@@ -354,6 +354,7 @@ function (angular, $, moment, _, kbn, GraphTooltip, thresholdManExports) {
 
         function parseThresholdExpr(expr) {
           var match, operator, value, precision;
+          expr = String(expr);
           match = expr.match(/\s*([<=>~]*)\s*(\-?\d+(\.\d+)?)/);
           if (match) {
             operator = match[1];

--- a/public/app/plugins/panel/graph/specs/graph_specs.ts
+++ b/public/app/plugins/panel/graph/specs/graph_specs.ts
@@ -328,4 +328,36 @@ describe('grafanaGraph', function() {
       });
     });
   });
+  graphScenario('when using Y-Min and Y-Max settings stored as number', function(ctx) {
+    describe('and Y-Min is 0 and Y-Max is 100', function() {
+      ctx.setup(function(ctrl, data) {
+        ctrl.panel.yaxes[0].min = 0;
+        ctrl.panel.yaxes[0].max = 100;
+        data[0] = new TimeSeries({
+          datapoints: [[120,10],[160,20]],
+          alias: 'series1',
+        });
+      });
+
+      it('should set min to 0 and max to 100', function() {
+         expect(ctx.plotOptions.yaxes[0].min).to.be(0);
+         expect(ctx.plotOptions.yaxes[0].max).to.be(100);
+      });
+    });
+    describe('and Y-Min is -100 and Y-Max is -10.5', function() {
+      ctx.setup(function(ctrl, data) {
+        ctrl.panel.yaxes[0].min = -100;
+        ctrl.panel.yaxes[0].max = -10.5;
+        data[0] = new TimeSeries({
+          datapoints: [[120,10],[160,20]],
+          alias: 'series1',
+        });
+      });
+
+      it('should set min to -100 and max to -10.5', function() {
+         expect(ctx.plotOptions.yaxes[0].min).to.be(-100);
+         expect(ctx.plotOptions.yaxes[0].max).to.be(-10.5);
+      });
+    });
+  });
 });

--- a/public/app/plugins/panel/graph/specs/graph_specs.ts
+++ b/public/app/plugins/panel/graph/specs/graph_specs.ts
@@ -312,5 +312,20 @@ describe('grafanaGraph', function() {
          expect(ctx.plotOptions.yaxes[0].max).to.be(0);
       });
     });
+    describe('and negative values used', function() {
+      ctx.setup(function(ctrl, data) {
+        ctrl.panel.yaxes[0].min = '-10';
+        ctrl.panel.yaxes[0].max = '-13.14';
+        data[0] = new TimeSeries({
+          datapoints: [[120,10],[160,20]],
+          alias: 'series1',
+        });
+      });
+
+      it('should set min and max to negative', function() {
+         expect(ctx.plotOptions.yaxes[0].min).to.be(-10);
+         expect(ctx.plotOptions.yaxes[0].max).to.be(-13.14);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR fixes some issues described in #6051:
- [x] a) plain negative numbers for limits don't seem to work anymore
- [ ] b) I am not able to set ymax in a way so that it defaults to e.g. 150 but will scale up if data becomes too large
- [ ] c) I cannot define ymax for multiple graphs from a template

**Important:** please, don't merge until all bugs are fixed.
