### PR TITLE
Cross build support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ grunt karma:dev
 
 ### Run tests for backend assets before commit
 ```
-test -z "$(gofmt -s -l . | grep -v vendor/src/ | tee /dev/stderr)"
+test -z "$(gofmt -s -l . | grep -v -E 'vendor/(github.com|golang.org|gopkg.in)' | tee /dev/stderr)"
 ```
 
 ### Run tests for frontend assets before commit

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,13 +9,16 @@ module.exports = function (grunt) {
     genDir: 'public_gen',
     destDir: 'dist',
     tempDir: 'tmp',
-    arch: os.arch(),
     platform: process.platform.replace('win32', 'windows'),
   };
 
   if (process.platform.match(/^win/)) {
     config.arch = process.env.hasOwnProperty('ProgramFiles(x86)') ? 'x64' : 'x86';
   }
+
+  config.arch = grunt.option('arch') || os.arch();
+
+  config.phjs = grunt.option('phjsToRelease');
 
   config.pkg.version = grunt.option('pkgVer') || config.pkg.version;
   console.log('Version', config.pkg.version);

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ easily the grafana repository you want to build.
 ```bash
 go get github.com/*your_account*/grafana
 mkdir $GOPATH/src/github.com/grafana
-ln -s  github.com/*your_account*/grafana $GOPATH/src/github.com/grafana/grafana
+ln -s  $GOPATH/src/github.com/*your_account*/grafana $GOPATH/src/github.com/grafana/grafana
 ```
 
 ### Building the backend

--- a/tasks/build_task.js
+++ b/tasks/build_task.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
     });
     grunt.config('copy.backend_files', {
       expand: true,
-      src: ['conf/defaults.ini', 'conf/sample.ini', 'vendor/**/*', 'scripts/*'],
+      src: ['conf/defaults.ini', 'conf/sample.ini', 'vendor/phantomjs/*', 'scripts/*'],
       options: { mode: true},
       dest: '<%= tempDir %>'
     });

--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -1,38 +1,33 @@
 module.exports = function(config,grunt) {
   'use strict';
 
-  grunt.registerTask('phantomjs', 'Copy phantomjs binary from node', function() {
+  grunt.registerTask('phantomjs', 'Copy phantomjs binary to vendor/', function() {
 
     var dest = './vendor/phantomjs/phantomjs';
     var confDir = './node_modules/phantomjs-prebuilt/lib/';
 
-    if (!grunt.file.exists(dest)){
+    src = config.phjs
 
-      src = config.phjs
+    if (!src){
+      var m=grunt.file.read(confDir+"location.js")
+      var src=/= \"([^\"]*)\"/.exec(m)[1];
 
-      if (!src){
-        var m=grunt.file.read(confDir+"location.js")
-        var src=/= \"([^\"]*)\"/.exec(m)[1];
-
-        if (!grunt.file.isPathAbsolute(src)) {
-          src = confDir+src;
-        }
+      if (!grunt.file.isPathAbsolute(src)) {
+        src = confDir+src;
       }
-
-      try {
-        grunt.config('copy.phantom_bin', {
-          src: src,
-          dest: dest,
-          options: { mode: true},
-        });
-        grunt.task.run('copy:phantom_bin');
-      } catch (err) {
-        grunt.verbose.writeln(err);
-        grunt.fail.warn('No working Phantomjs binary available')
-      }
-
-    } else {
-      grunt.log.writeln('Phantomjs already imported from node');
     }
+
+    try {
+      grunt.config('copy.phantom_bin', {
+        src: src,
+        dest: dest,
+        options: { mode: true},
+      });
+      grunt.task.run('copy:phantom_bin');
+    } catch (err) {
+      grunt.verbose.writeln(err);
+      grunt.fail.warn('No working Phantomjs binary available')
+    }
+
   });
 };

--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -8,11 +8,15 @@ module.exports = function(config,grunt) {
 
     if (!grunt.file.exists(dest)){
 
-      var m=grunt.file.read(confDir+"location.js")
-      var src=/= \"([^\"]*)\"/.exec(m)[1];
+      src = config.phjs
 
-      if (!grunt.file.isPathAbsolute(src)) {
-        src = confDir+src;
+      if (!src){
+        var m=grunt.file.read(confDir+"location.js")
+        var src=/= \"([^\"]*)\"/.exec(m)[1];
+
+        if (!grunt.file.isPathAbsolute(src)) {
+          src = confDir+src;
+        }
       }
 
       try {


### PR DESCRIPTION
This PR deals with issue #6067 and is a step forward to #5156. It intends to support cross build of grafana binary and packages.

It adds options to `build.go` build system :

```
Version: 4.0.0-pre1, Linux Version: 4.0.0, Package Iteration: 1474193119pre1
Usage of /tmp/go-build428128758/command-line-arguments/_obj/exe/build:
  -cc string
        CC
  -cgo-enabled string
        CGO_ENABLED
  -cxx string
        CXX
  -goarch string
        GOARCH (default "amd64")
  -goos string
        GOOS (default "linux")
  -phjs string
        PhantomJS binary
  -pkg-arch string
        PKG ARCH
  -race
        Use race detector
exit status 2
```
- `-cc`, `-cgo-enabled`, `-cxx` are here to support the cross build tool chain needed for `sqlite3`.
- `-pkg-arch` is here to help `fpm` select the right arch. Otherwise, it uses the default host arch. We cannot use easily `goarch` for this purpose (eg `-goarch arm` would lead to a package unusable on armhf)
- `-phjs` is here to allow to ship a working `phantomjs` binary with the packages. Otherwise, we would end up with the binary setup by `phantomjs-prebuild` for the host arch.

It also adds options to `grunt` :
- `--arch`, since `grunt` is used to produce the tarball, this is needed to have the right arch in the tarball name (and not the host arch) 
- `--phjsToRelease`, since `grunt` is responsible for copying `PhantomJS` binary to `vendor`.

In the end, we can do

```
go run build.go -goarch=armv7 -cgo-enabled=1 -cc=arm-linux-gnueabihf-gcc -cxx=arm-linux-gnueabihf-g++ -pkg-arch=armhf -phjs=./phantomjs build pkg-deb
```

and produce the right packages.

Remark: Nothing related to cross build, but I made a change to avoid copying go dependencies from `vendor/` during release. I made no changes for `tmp/public` but it contains a lot of files that could probably be removed (eg. .sass and .ts) for release.
