### PR TITLE
Fix context dependency

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -11,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/prometheus/client_golang/api/prometheus"
+	"golang.org/x/net/context"
 	pmodel "github.com/prometheus/common/model"
 )
 


### PR DESCRIPTION
The context dependency in `pkg/tsdb/prometheus/prometheus.go` is breaking `go run build.go setup`:

```
mst@mst-ThinkPad-X1-Carbon-3rd:~/documents/code/grafana/grafana/src/github.com/grafana/grafana$ go run build.go setup
Version: 4.0.0-pre1, Linux Version: 4.0.0, Package Iteration: 1474576557pre1
go get -v github.com/kardianos/govendor
go install -v ./pkg/cmd/grafana-server
pkg/tsdb/prometheus/prometheus.go:4:2: cannot find package "context" in any of:
    /home/mst/documents/code/grafana/grafana/src/github.com/grafana/grafana/vendor/context (vendor tree)
    /usr/lib/go/src/context (from $GOROOT)
    /home/mst/documents/code/grafana/grafana/src/context (from $GOPATH)
exit status 1
exit status 1
```

After this change it builds again:

```
mst@mst-ThinkPad-X1-Carbon-3rd:~/documents/code/grafana/grafana/src/github.com/grafana/grafana$ go run build.go setup
Version: 4.0.0-pre1, Linux Version: 4.0.0, Package Iteration: 1474576652pre1
go get -v github.com/kardianos/govendor
go install -v ./pkg/cmd/grafana-server
github.com/grafana/grafana/pkg/tsdb/prometheus
github.com/grafana/grafana/pkg/services/alerting/init
github.com/grafana/grafana/pkg/cmd/grafana-server
mst@mst-ThinkPad-X1-Carbon-3rd:~/documents/code/grafana/grafana/src/github.com/grafana/grafana$
```
