### PR TITLE
(prometheus) check time range

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -123,6 +123,10 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   };
 
   this.performTimeSeriesQuery = function(query, start, end) {
+    if (start > end) {
+      throw { message: 'Invalid time range' };
+    }
+
     var url = '/api/v1/query_range?query=' + encodeURIComponent(query.expr) + '&start=' + start + '&end=' + end + '&step=' + query.step;
     return this._request('GET', url, query.requestId);
   };


### PR DESCRIPTION
When I specify invalid time range to Prometheus query, Prometheus output a lot of error log.

```
time="2016-09-28T18:05:29+09:00" level=error msg="http: panic serving 127.0.0.1:46123: runtime error: makeslice: cap out of range\ngoroutine 2532905 ....
```

The query response doesn't contain information about invalid time range, so need to check datasource plugin side.
