### PR TITLE
fix(graph): fix X axis value selection.

### DIFF
--- a/public/app/plugins/panel/graph/axes_editor.ts
+++ b/public/app/plugins/panel/graph/axes_editor.ts
@@ -58,7 +58,9 @@ export class AxesEditorCtrl {
   }
 
   xAxisOptionChanged()  {
-    this.panelCtrl.processor.setPanelDefaultsForNewXAxisMode();
+    if (!this.panel.xaxis.values || !this.panel.xaxis.values[0]){
+      this.panelCtrl.processor.setPanelDefaultsForNewXAxisMode();
+    }
     this.panelCtrl.onDataReceived(this.panelCtrl.dataList);
   }
 


### PR DESCRIPTION
This PR fixes bug with new non time series X axis mode: when you change value from default _total_ to another, nothing happens.
