### PR TITLE
Make Slack Logo link to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Website](http://grafana.org) |
 [Twitter](https://twitter.com/grafana) |
 [IRC](https://webchat.freenode.net/?channels=grafana) |
-![](https://brandfolder.com/api/favicon/icon?size=16&domain=www.slack.com)
+[![Slack](https://brandfolder.com/api/favicon/icon?size=16&domain=www.slack.com)](http://slack.raintank.io)
 [Slack](http://slack.raintank.io) |
 [Email](mailto:contact@grafana.org)
 


### PR DESCRIPTION
Right now the Slack logo links to an image of the slack logo. This PR is a _minor_ edit to the Readme to fix the link.
