### PR TITLE
annotation on a single panel

### DIFF
--- a/public/app/partials/panelgeneral.html
+++ b/public/app/partials/panelgeneral.html
@@ -28,6 +28,10 @@
 				<option value=""></option>
 			</select>
 		</div>
+		<div class="gf-form max-width-26">
+			<span class="gf-form-label width-8">Annotation</span>
+			<input type="text" class="gf-form-input" ng-model='ctrl.panel.annotationFilter.tag' on-change="ctrl.render()"></input>
+		</div>
 	</div>
 </div>
 


### PR DESCRIPTION
Fix https://github.com/grafana/grafana/issues/717.

To filter annotations I use annotation "tag" and match by regex.
It works well with templating variable with multiple selection and panel repeat.

By this feature, user can filter out extra annotation what is not related to graph.
(user can filter alert annotation by server id or something.)
