### PR TITLE
(prometheus) add step option for annotation

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -171,9 +171,14 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
       return $q.reject(err);
     }
 
+    var step = '60s';
+    if (annotation.step) {
+        step = templateSrv.replace(annotation.step);
+    }
+
     var query = {
       expr: interpolated,
-      step: '60s'
+      step: step
     };
 
     var start = this.getPrometheusTime(options.range.from, false);

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -1,8 +1,11 @@
-
-<h5 class="section-heading">Search expression</h6>
 <div class="gf-form-group">
 	<div class="gf-form">
+		<span class="gf-form-label width-10">Search expression</span>
 		<input type="text" class="gf-form-input" ng-model='ctrl.annotation.expr' placeholder="ALERTS"></input>
+	</div>
+	<div class="gf-form">
+		<span class="gf-form-label width-10">step</span>
+		<input type="text" class="gf-form-input max-width-6" ng-model='ctrl.annotation.step' placeholder="60s"></input>
 	</div>
 </div>
 


### PR DESCRIPTION
By adding step option, user can control the density of annotation line.

before:
![before](https://cloud.githubusercontent.com/assets/224552/19020106/f5f7d740-88d9-11e6-9e50-c233113bdade.png)

after:
![after](https://cloud.githubusercontent.com/assets/224552/19020115/48cb6cf2-88da-11e6-909c-9c9844e18e52.png)
