### PR TITLE
Do not align refresh time

### DIFF
--- a/public/app/features/dashboard/timeSrv.js
+++ b/public/app/features/dashboard/timeSrv.js
@@ -77,12 +77,11 @@ define([
     this.setAutoRefresh = function (interval) {
       this.dashboard.refresh = interval;
       if (interval) {
-        var _i = kbn.interval_to_ms(interval);
-        var wait_ms = _i - (Date.now() % _i);
+        var interval_ms = kbn.interval_to_ms(interval);
         $timeout(function () {
-          self.start_scheduled_refresh(_i);
+          self.start_scheduled_refresh(interval_ms);
           self.refreshDashboard();
-        }, wait_ms);
+        }, interval_ms);
       } else {
         this.cancel_scheduled_refresh();
       }


### PR DESCRIPTION
 When you have a lot of dashboards, all of them end up refreshing their dashboards at the exact same time, which isn't particulary good for your TSDB backend.
