### PR TITLE
Added allow_sign_up setting to auth.ldap to be able to disable automatic user creation for LDAP logins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -267,6 +267,7 @@ auto_sign_up = true
 [auth.ldap]
 enabled = false
 config_file = /etc/grafana/ldap.toml
+allow_sign_up = true
 
 #################################### SMTP / Emailing #####################
 [smtp]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -252,6 +252,7 @@
 [auth.ldap]
 ;enabled = false
 ;config_file = /etc/grafana/ldap.toml
+;allow_sign_up = true
 
 #################################### SMTP / Emailing ##########################
 [smtp]

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type ldapAuther struct {
@@ -132,8 +133,10 @@ func (a *ldapAuther) getGrafanaUserFor(ldapUser *ldapUserInfo) (*m.User, error) 
 	// get user from grafana db
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: ldapUser.Username}
 	if err := bus.Dispatch(&userQuery); err != nil {
-		if err == m.ErrUserNotFound {
+		if err == m.ErrUserNotFound && setting.LdapAllowSignup {
 			return a.createGrafanaUser(ldapUser)
+		} else if err == m.ErrUserNotFound {
+			return nil, ErrInvalidCredentials
 		} else {
 			return nil, err
 		}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -134,8 +134,9 @@ var (
 	GoogleTagManagerId string
 
 	// LDAP
-	LdapEnabled    bool
-	LdapConfigFile string
+	LdapEnabled     bool
+	LdapConfigFile  string
+	LdapAllowSignup bool = true
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -551,6 +552,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	ldapSec := Cfg.Section("auth.ldap")
 	LdapEnabled = ldapSec.Key("enabled").MustBool(false)
 	LdapConfigFile = ldapSec.Key("config_file").String()
+	LdapAllowSignup = ldapSec.Key("allow_sign_up").MustBool(true)
 
 	alerting := Cfg.Section("alerting")
 	AlertingEnabled = alerting.Key("enabled").MustBool(false)


### PR DESCRIPTION
There seemed to be no way to prevent Grafana from automatically creating user accounts if the user supplied valid LDAP credentials. I've added an 'allow_sign_up' setting to the auth.ldap settings, similar to the setting in auth.github and auth.google, which enables automatic user account creation to be turned off for LDAP authentication. 
