### PR TITLE
fix(elasticsearch): Query editor allows to remove last group by (#5692)

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -23,7 +23,7 @@
 		<label class="gf-form-label" ng-if="isFirst">
 			<a class="pointer" ng-click="addBucketAgg()"><i class="fa fa-plus"></i></a>
 		</label>
-		<label class="gf-form-label">
+		<label class="gf-form-label" ng-if="!isFirst">
 			<a class="pointer" ng-click="removeBucketAgg()"><i class="fa fa-minus"></i></a>
 		</label>
 	</div>


### PR DESCRIPTION
Hello,

this should fix issue [#5692](https://github.com/grafana/grafana/issues/5692).

I recreated the PR because I kinda broke my fork with all the git wizardry on the command line. Sorry, I don't know what I'm doing with git sometimes.

Hopefully now it will be ok.

Kind regards, 

Uros
