### PR TITLE
Oauth2 Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,28 @@
 all: deps build
 
-deps:
+deps-go:
 	go run build.go setup
+
+deps-js:
 	npm install
 
-build:
+deps: deps-go deps-js
+
+build-go:
 	go run build.go build
+
+build-js:
 	npm run build
 
-test:
+build: build-go build-js
+
+test-go:
 	go test -v ./pkg/...
+
+test-js:
 	npm test
+
+test: test-go test-js
 
 run:
 	./bin/grafana-server

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -27,7 +27,7 @@ func LoginView(c *middleware.Context) {
 
 	enabledOAuths := make(map[string]interface{})
 	for key, oauth := range setting.OAuthService.OAuthInfos {
-		enabledOAuths[key] = map[string]string{"name": oauth.Name}
+		enabledOAuths[key] = map[string]string{"name": oauth.DisplayName}
 	}
 
 	viewData.Settings["oauth"] = enabledOAuths

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -27,7 +27,7 @@ func LoginView(c *middleware.Context) {
 
 	enabledOAuths := make(map[string]interface{})
 	for key, oauth := range setting.OAuthService.OAuthInfos {
-		enabledOAuths[key] = map[string]string{"name": oauth.DisplayName}
+		enabledOAuths[key] = map[string]string{"name": oauth.Name}
 	}
 
 	viewData.Settings["oauth"] = enabledOAuths

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -149,7 +149,7 @@ func OAuthLogin(ctx *middleware.Context) {
 			return
 		}
 		cmd := m.CreateUserCommand{
-			Login:          userInfo.Email,
+			Login:          userInfo.Login,
 			Email:          userInfo.Email,
 			Name:           userInfo.Name,
 			Company:        userInfo.Company,

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -35,6 +35,14 @@ func OAuthLogin(ctx *middleware.Context) {
 		return
 	}
 
+	error := ctx.Query("error")
+	if error != "" {
+		errorDesc := ctx.Query("error_description")
+		ctx.Logger.Info("OAuthLogin Failed", "error", error, "errorDesc", errorDesc)
+		ctx.Redirect(setting.AppSubUrl + "/login?failCode=1003")
+		return
+	}
+
 	code := ctx.Query("code")
 	if code == "" {
 		state := GenStateString()

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -82,14 +82,7 @@ func OAuthLogin(ctx *middleware.Context) {
 
 	ctx.Logger.Debug("OAuthLogin got user info", "userInfo", userInfo)
 
-	// validate that the email is allowed to login to grafana
-	if !connect.IsEmailAllowed(userInfo.Email) {
-		ctx.Logger.Info("OAuth login attempt with unallowed email", "email", userInfo.Email)
-		ctx.Redirect(setting.AppSubUrl + "/login?failCode=1002")
-		return
-	}
-
-	userQuery := m.GetUserByLoginQuery{LoginOrEmail: userInfo.Email}
+	userQuery := m.GetUserByLoginQuery{LoginOrEmail: userInfo.Name}
 	err = bus.Dispatch(&userQuery)
 
 	// create account if missing
@@ -108,8 +101,8 @@ func OAuthLogin(ctx *middleware.Context) {
 			return
 		}
 		cmd := m.CreateUserCommand{
-			Login:          userInfo.Email,
-			Email:          userInfo.Email,
+			Login:          userInfo.Identity,
+			Email:          userInfo.Identity,
 			Name:           userInfo.Name,
 			Company:        userInfo.Company,
 			DefaultOrgRole: userInfo.Role,

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -9,7 +9,9 @@ type OAuthInfo struct {
 	ApiUrl                 string
 	AllowSignup            bool
 	Name                   string
-	DisplayName            string
+	TlsClientCert          string
+	TlsClientKey           string
+	TlsClientCa            string
 }
 
 type OAuther struct {

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -9,6 +9,7 @@ type OAuthInfo struct {
 	ApiUrl                 string
 	AllowSignup            bool
 	Name                   string
+	DisplayName            string
 }
 
 type OAuther struct {

--- a/pkg/social/generic_oauth.go
+++ b/pkg/social/generic_oauth.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -162,9 +161,11 @@ func (s *GenericOAuth) FetchOrganizations(client *http.Client) ([]string, error)
 
 func (s *GenericOAuth) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
-		Id    int    `json:"id"`
-		Name  string `json:"login"`
-		Email string `json:"email"`
+		Name       string              `json:"name"`
+		Login      string              `json:"login"`
+		Username   string              `json:"username"`
+		Email      string              `json:"email"`
+		Attributes map[string][]string `json:"attributes"`
 	}
 
 	var err error
@@ -180,9 +181,28 @@ func (s *GenericOAuth) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	}
 
 	userInfo := &BasicUserInfo{
-		Identity: strconv.Itoa(data.Id),
 		Name:     data.Name,
+		Login:    data.Login,
 		Email:    data.Email,
+	}
+
+	if (userInfo.Email == "" && data.Attributes["email:primary"] != nil) {
+		userInfo.Email = data.Attributes["email:primary"][0]
+	}
+
+	if userInfo.Email == "" {
+		userInfo.Email, err = s.FetchPrivateEmail(client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if (userInfo.Login == "" && data.Username != "") {
+		userInfo.Login = data.Username
+	}
+
+	if (userInfo.Login == "") {
+		userInfo.Login = data.Email
 	}
 
 	if !s.IsTeamMember(client) {
@@ -191,13 +211,6 @@ func (s *GenericOAuth) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 
 	if !s.IsOrganizationMember(client) {
 		return nil, errors.New("User not a member of one of the required organizations")
-	}
-
-	if userInfo.Email == "" {
-		userInfo.Email, err = s.FetchPrivateEmail(client)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return userInfo, nil

--- a/pkg/social/generic_oauth.go
+++ b/pkg/social/generic_oauth.go
@@ -2,10 +2,6 @@ package social
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -25,146 +21,14 @@ func (s *GenericOAuth) Type() int {
 	return int(models.GENERIC)
 }
 
-func (s *GenericOAuth) IsEmailAllowed(email string) bool {
-	return isEmailAllowed(email, s.allowedDomains)
-}
-
 func (s *GenericOAuth) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
-func (s *GenericOAuth) IsTeamMember(client *http.Client) bool {
-	if len(s.teamIds) == 0 {
-		return true
-	}
-
-	teamMemberships, err := s.FetchTeamMemberships(client)
-	if err != nil {
-		return false
-	}
-
-	for _, teamId := range s.teamIds {
-		for _, membershipId := range teamMemberships {
-			if teamId == membershipId {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func (s *GenericOAuth) IsOrganizationMember(client *http.Client) bool {
-	if len(s.allowedOrganizations) == 0 {
-		return true
-	}
-
-	organizations, err := s.FetchOrganizations(client)
-	if err != nil {
-		return false
-	}
-
-	for _, allowedOrganization := range s.allowedOrganizations {
-		for _, organization := range organizations {
-			if organization == allowedOrganization {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func (s *GenericOAuth) FetchPrivateEmail(client *http.Client) (string, error) {
-	type Record struct {
-		Email    string `json:"email"`
-		Primary  bool   `json:"primary"`
-		Verified bool   `json:"verified"`
-	}
-
-	emailsUrl := fmt.Sprintf(s.apiUrl + "/emails")
-	r, err := client.Get(emailsUrl)
-	if err != nil {
-		return "", err
-	}
-
-	defer r.Body.Close()
-
-	var records []Record
-
-	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
-		return "", err
-	}
-
-	var email = ""
-	for _, record := range records {
-		if record.Primary {
-			email = record.Email
-		}
-	}
-
-	return email, nil
-}
-
-func (s *GenericOAuth) FetchTeamMemberships(client *http.Client) ([]int, error) {
-	type Record struct {
-		Id int `json:"id"`
-	}
-
-	membershipUrl := fmt.Sprintf(s.apiUrl + "/teams")
-	r, err := client.Get(membershipUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	defer r.Body.Close()
-
-	var records []Record
-
-	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
-		return nil, err
-	}
-
-	var ids = make([]int, len(records))
-	for i, record := range records {
-		ids[i] = record.Id
-	}
-
-	return ids, nil
-}
-
-func (s *GenericOAuth) FetchOrganizations(client *http.Client) ([]string, error) {
-	type Record struct {
-		Login string `json:"login"`
-	}
-
-	url := fmt.Sprintf(s.apiUrl + "/orgs")
-	r, err := client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	defer r.Body.Close()
-
-	var records []Record
-
-	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
-		return nil, err
-	}
-
-	var logins = make([]string, len(records))
-	for i, record := range records {
-		logins[i] = record.Login
-	}
-
-	return logins, nil
-}
-
 func (s *GenericOAuth) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
-		Id    int    `json:"id"`
-		Name  string `json:"login"`
-		Email string `json:"email"`
+		Id    string `json:"id"`
+		Name  string `json:"username"`
 	}
 
 	var err error
@@ -181,24 +45,8 @@ func (s *GenericOAuth) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	}
 
 	userInfo := &BasicUserInfo{
-		Identity: strconv.Itoa(data.Id),
+		Identity: data.Id,
 		Name:     data.Name,
-		Email:    data.Email,
-	}
-
-	if !s.IsTeamMember(client) {
-		return nil, errors.New("User not a member of one of the required teams")
-	}
-
-	if !s.IsOrganizationMember(client) {
-		return nil, errors.New("User not a member of one of the required organizations")
-	}
-
-	if userInfo.Email == "" {
-		userInfo.Email, err = s.FetchPrivateEmail(client)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return userInfo, nil

--- a/pkg/social/generic_oauth.go
+++ b/pkg/social/generic_oauth.go
@@ -2,6 +2,10 @@ package social
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -21,18 +25,149 @@ func (s *GenericOAuth) Type() int {
 	return int(models.GENERIC)
 }
 
+func (s *GenericOAuth) IsEmailAllowed(email string) bool {
+	return isEmailAllowed(email, s.allowedDomains)
+}
+
 func (s *GenericOAuth) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
-func (s *GenericOAuth) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
+func (s *GenericOAuth) IsTeamMember(client *http.Client) bool {
+	if len(s.teamIds) == 0 {
+		return true
+	}
+
+	teamMemberships, err := s.FetchTeamMemberships(client)
+	if err != nil {
+		return false
+	}
+
+	for _, teamId := range s.teamIds {
+		for _, membershipId := range teamMemberships {
+			if teamId == membershipId {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (s *GenericOAuth) IsOrganizationMember(client *http.Client) bool {
+	if len(s.allowedOrganizations) == 0 {
+		return true
+	}
+
+	organizations, err := s.FetchOrganizations(client)
+	if err != nil {
+		return false
+	}
+
+	for _, allowedOrganization := range s.allowedOrganizations {
+		for _, organization := range organizations {
+			if organization == allowedOrganization {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (s *GenericOAuth) FetchPrivateEmail(client *http.Client) (string, error) {
+	type Record struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+
+	emailsUrl := fmt.Sprintf(s.apiUrl + "/emails")
+	r, err := client.Get(emailsUrl)
+	if err != nil {
+		return "", err
+	}
+
+	defer r.Body.Close()
+
+	var records []Record
+
+	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
+		return "", err
+	}
+
+	var email = ""
+	for _, record := range records {
+		if record.Primary {
+			email = record.Email
+		}
+	}
+
+	return email, nil
+}
+
+func (s *GenericOAuth) FetchTeamMemberships(client *http.Client) ([]int, error) {
+	type Record struct {
+		Id int `json:"id"`
+	}
+
+	membershipUrl := fmt.Sprintf(s.apiUrl + "/teams")
+	r, err := client.Get(membershipUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	var records []Record
+
+	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
+		return nil, err
+	}
+
+	var ids = make([]int, len(records))
+	for i, record := range records {
+		ids[i] = record.Id
+	}
+
+	return ids, nil
+}
+
+func (s *GenericOAuth) FetchOrganizations(client *http.Client) ([]string, error) {
+	type Record struct {
+		Login string `json:"login"`
+	}
+
+	url := fmt.Sprintf(s.apiUrl + "/orgs")
+	r, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	var records []Record
+
+	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
+		return nil, err
+	}
+
+	var logins = make([]string, len(records))
+	for i, record := range records {
+		logins[i] = record.Login
+	}
+
+	return logins, nil
+}
+
+func (s *GenericOAuth) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
-		Id    string `json:"id"`
-		Name  string `json:"username"`
+		Id    int    `json:"id"`
+		Name  string `json:"login"`
+		Email string `json:"email"`
 	}
 
 	var err error
-	client := s.Client(oauth2.NoContext, token)
 	r, err := client.Get(s.apiUrl)
 	if err != nil {
 		return nil, err
@@ -45,8 +180,24 @@ func (s *GenericOAuth) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	}
 
 	userInfo := &BasicUserInfo{
-		Identity: data.Id,
+		Identity: strconv.Itoa(data.Id),
 		Name:     data.Name,
+		Email:    data.Email,
+	}
+
+	if !s.IsTeamMember(client) {
+		return nil, errors.New("User not a member of one of the required teams")
+	}
+
+	if !s.IsOrganizationMember(client) {
+		return nil, errors.New("User not a member of one of the required organizations")
+	}
+
+	if userInfo.Email == "" {
+		userInfo.Email, err = s.FetchPrivateEmail(client)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return userInfo, nil

--- a/pkg/social/github_oauth.go
+++ b/pkg/social/github_oauth.go
@@ -168,7 +168,7 @@ func (s *SocialGithub) FetchOrganizations(client *http.Client) ([]string, error)
 	return logins, nil
 }
 
-func (s *SocialGithub) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
+func (s *SocialGithub) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int    `json:"id"`
 		Name  string `json:"login"`
@@ -176,7 +176,6 @@ func (s *SocialGithub) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	}
 
 	var err error
-	client := s.Client(oauth2.NoContext, token)
 	r, err := client.Get(s.apiUrl)
 	if err != nil {
 		return nil, err

--- a/pkg/social/github_oauth.go
+++ b/pkg/social/github_oauth.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -171,7 +170,7 @@ func (s *SocialGithub) FetchOrganizations(client *http.Client) ([]string, error)
 func (s *SocialGithub) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int    `json:"id"`
-		Name  string `json:"login"`
+		Login string `json:"login"`
 		Email string `json:"email"`
 	}
 
@@ -188,8 +187,8 @@ func (s *SocialGithub) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	}
 
 	userInfo := &BasicUserInfo{
-		Identity: strconv.Itoa(data.Id),
-		Name:     data.Name,
+		Name:     data.Login,
+		Login:    data.Login,
 		Email:    data.Email,
 	}
 

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -30,7 +30,6 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 
 func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
-		Id    string `json:"id"`
 		Name  string `json:"name"`
 		Email string `json:"email"`
 	}
@@ -45,7 +44,6 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 		return nil, err
 	}
 	return &BasicUserInfo{
-		Identity: data.Id,
 		Name:     data.Name,
 		Email:    data.Email,
 	}, nil

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -27,7 +28,7 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
-func (s *SocialGoogle) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
+func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
 		Id    string `json:"id"`
 		Name  string `json:"name"`
@@ -35,7 +36,6 @@ func (s *SocialGoogle) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	}
 	var err error
 
-	client := s.Client(oauth2.NoContext, token)
 	r, err := client.Get(s.apiUrl)
 	if err != nil {
 		return nil, err

--- a/pkg/social/grafananet_oauth.go
+++ b/pkg/social/grafananet_oauth.go
@@ -2,8 +2,6 @@ package social
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -18,6 +16,10 @@ type SocialGrafanaNet struct {
 	allowSignup          bool
 }
 
+type OrgRecord struct {
+	Login string `json:"login"`
+}
+
 func (s *SocialGrafanaNet) Type() int {
 	return int(models.GRAFANANET)
 }
@@ -30,19 +32,14 @@ func (s *SocialGrafanaNet) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
-func (s *SocialGrafanaNet) IsOrganizationMember(client *http.Client) bool {
+func (s *SocialGrafanaNet) IsOrganizationMember(organizations []OrgRecord) bool {
 	if len(s.allowedOrganizations) == 0 {
 		return true
 	}
 
-	organizations, err := s.FetchOrganizations(client)
-	if err != nil {
-		return false
-	}
-
 	for _, allowedOrganization := range s.allowedOrganizations {
 		for _, organization := range organizations {
-			if organization == allowedOrganization {
+			if organization.Login == allowedOrganization {
 				return true
 			}
 		}
@@ -51,39 +48,13 @@ func (s *SocialGrafanaNet) IsOrganizationMember(client *http.Client) bool {
 	return false
 }
 
-func (s *SocialGrafanaNet) FetchOrganizations(client *http.Client) ([]string, error) {
-	type Record struct {
-		Login string `json:"login"`
-	}
-
-	url := fmt.Sprintf(s.url + "/api/oauth2/user/orgs")
-	r, err := client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	defer r.Body.Close()
-
-	var records []Record
-
-	if err = json.NewDecoder(r.Body).Decode(&records); err != nil {
-		return nil, err
-	}
-
-	var logins = make([]string, len(records))
-	for i, record := range records {
-		logins[i] = record.Login
-	}
-
-	return logins, nil
-}
-
 func (s *SocialGrafanaNet) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int    `json:"id"`
 		Name  string `json:"login"`
 		Email string `json:"email"`
 		Role  string `json:"role"`
+		Orgs  []OrgRecord `json:"orgs"`
 	}
 
 	var err error
@@ -106,7 +77,7 @@ func (s *SocialGrafanaNet) UserInfo(token *oauth2.Token) (*BasicUserInfo, error)
 		Role:     data.Role,
 	}
 
-	if !s.IsOrganizationMember(client) {
+	if !s.IsOrganizationMember(data.Orgs) {
 		return nil, ErrMissingOrganizationMembership
 	}
 

--- a/pkg/social/grafananet_oauth.go
+++ b/pkg/social/grafananet_oauth.go
@@ -3,7 +3,6 @@ package social
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 
@@ -51,8 +50,8 @@ func (s *SocialGrafanaNet) IsOrganizationMember(organizations []OrgRecord) bool 
 
 func (s *SocialGrafanaNet) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
-		Id    int    `json:"id"`
-		Name  string `json:"login"`
+		Name  string `json:"name"`
+		Login string `json:"username"`
 		Email string `json:"email"`
 		Role  string `json:"role"`
 		Orgs  []OrgRecord `json:"orgs"`
@@ -71,8 +70,8 @@ func (s *SocialGrafanaNet) UserInfo(client *http.Client) (*BasicUserInfo, error)
 	}
 
 	userInfo := &BasicUserInfo{
-		Identity: strconv.Itoa(data.Id),
 		Name:     data.Name,
+		Login:    data.Login,
 		Email:    data.Email,
 		Role:     data.Role,
 	}

--- a/pkg/social/grafananet_oauth.go
+++ b/pkg/social/grafananet_oauth.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"encoding/json"
+	"net/http"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -48,7 +49,7 @@ func (s *SocialGrafanaNet) IsOrganizationMember(organizations []OrgRecord) bool 
 	return false
 }
 
-func (s *SocialGrafanaNet) UserInfo(token *oauth2.Token) (*BasicUserInfo, error) {
+func (s *SocialGrafanaNet) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int    `json:"id"`
 		Name  string `json:"login"`
@@ -58,7 +59,6 @@ func (s *SocialGrafanaNet) UserInfo(token *oauth2.Token) (*BasicUserInfo, error)
 	}
 
 	var err error
-	client := s.Client(oauth2.NoContext, token)
 	r, err := client.Get(s.url + "/api/oauth2/user")
 	if err != nil {
 		return nil, err

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -1,12 +1,13 @@
 package social
 
 import (
+	"net/http"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"golang.org/x/net/context"
-
 	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type BasicUserInfo struct {
@@ -20,12 +21,13 @@ type BasicUserInfo struct {
 
 type SocialConnector interface {
 	Type() int
-	UserInfo(token *oauth2.Token) (*BasicUserInfo, error)
+	UserInfo(client *http.Client) (*BasicUserInfo, error)
 	IsEmailAllowed(email string) bool
 	IsSignupAllowed() bool
 
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
 	Exchange(ctx context.Context, code string) (*oauth2.Token, error)
+	Client(ctx context.Context, t *oauth2.Token) *http.Client
 }
 
 var (
@@ -52,7 +54,9 @@ func NewOAuthService() {
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 			Name:           sec.Key("name").MustString(name),
-			DisplayName:    sec.Key("display_name").String(),
+			TlsClientCert:  sec.Key("tls_client_cert").String(),
+			TlsClientKey:   sec.Key("tls_client_key").String(),
+			TlsClientCa:    sec.Key("tls_client_ca").String(),
 		}
 
 		if !info.Enabled {
@@ -60,6 +64,7 @@ func NewOAuthService() {
 		}
 
 		setting.OAuthService.OAuthInfos[name] = info
+
 		config := oauth2.Config{
 			ClientID:     info.ClientId,
 			ClientSecret: info.ClientSecret,
@@ -86,9 +91,10 @@ func NewOAuthService() {
 		// Google.
 		if name == "google" {
 			SocialMap["google"] = &SocialGoogle{
-				Config: &config, allowedDomains: info.AllowedDomains,
-				apiUrl:      info.ApiUrl,
-				allowSignup: info.AllowSignup,
+				Config:               &config,
+				allowedDomains:       info.AllowedDomains,
+				apiUrl:               info.ApiUrl,
+				allowSignup:          info.AllowSignup,
 			}
 		}
 
@@ -105,15 +111,15 @@ func NewOAuthService() {
 		}
 
 		if name == "grafananet" {
-			config := oauth2.Config{
+			config = oauth2.Config{
 				ClientID:     info.ClientId,
 				ClientSecret: info.ClientSecret,
-				Endpoint: oauth2.Endpoint{
-					AuthURL:  setting.GrafanaNetUrl + "/oauth2/authorize",
-					TokenURL: setting.GrafanaNetUrl + "/api/oauth2/token",
+				Endpoint:     oauth2.Endpoint{
+					AuthURL:      setting.GrafanaNetUrl + "/oauth2/authorize",
+					TokenURL:     setting.GrafanaNetUrl + "/api/oauth2/token",
 				},
-				RedirectURL: strings.TrimSuffix(setting.AppUrl, "/") + SocialBaseUrl + name,
-				Scopes:      info.Scopes,
+				RedirectURL:  strings.TrimSuffix(setting.AppUrl, "/") + SocialBaseUrl + name,
+				Scopes:       info.Scopes,
 			}
 
 			SocialMap["grafananet"] = &SocialGrafanaNet{

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -11,7 +11,6 @@ import (
 )
 
 type BasicUserInfo struct {
-	Identity string
 	Name     string
 	Email    string
 	Login    string

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -52,6 +52,7 @@ func NewOAuthService() {
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 			Name:           sec.Key("name").MustString(name),
+			DisplayName:    sec.Key("display_name").String(),
 		}
 
 		if !info.Enabled {

--- a/public/app/core/controllers/login_ctrl.js
+++ b/public/app/core/controllers/login_ctrl.js
@@ -11,6 +11,7 @@ function (angular, _, coreModule, config) {
     "1000": "Required team membership not fulfilled",
     "1001": "Required organization membership not fulfilled",
     "1002": "Required email domain not fulfilled",
+    "1003": "Login provider denied login request",
   };
 
   coreModule.default.controller('LoginCtrl', function($scope, backendSrv, contextSrv, $location) {


### PR DESCRIPTION
This PR streamlines the OAuth2 support, and builds on the work done in #6209 

It removes 1 API call from the grafana.net login flow, adds support for client certificates, and makes it easier for login modules to define how new user accounts will be set up.
