### PR TITLE
Do not pass Authorization header in Grafana.net proxy

### DIFF
--- a/pkg/api/gnetproxy.go
+++ b/pkg/api/gnetproxy.go
@@ -36,6 +36,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 		// clear cookie headers
 		req.Header.Del("Cookie")
 		req.Header.Del("Set-Cookie")
+		req.Header.Del("Authorization")
 	}
 
 	return &httputil.ReverseProxy{Director: director}


### PR DESCRIPTION
This fixes https://github.com/grafana/grafana/issues/6240.
