### PR TITLE
(fix)elasticsearch: IP addresses don't survive terms aggregation (#4393)

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -171,6 +171,9 @@ function (_, queryDef) {
           } else {
             props["filter"] = nameIndex;
           }
+          if (bucket.key_as_string) {
+            props[aggDef.field] = bucket.key_as_string;
+          }
           this.processBuckets(bucket, target, seriesList, docs, props, depth+1);
         }
       }


### PR DESCRIPTION
Hello,

this should fix issue [#4393](https://github.com/grafana/grafana/issues/4393).

![image](https://cloud.githubusercontent.com/assets/20045868/19304280/451edc76-906c-11e6-9bd3-fa3f3e8cbe18.png)

I created this PR so I can get some feed back if this is an ok solution. It is working for me, but I would realy like some feed back and/or guidance. :)

Thank you and kind regards,
Uros
