### PR TITLE
Opentsdb queries fixed without alias but with tags/filters

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -332,7 +332,8 @@ function (angular, _, dateMath) {
       var tagData = [];
 
       if (!_.isEmpty(md.tags)) {
-        _.each(_.pairs(md.tags), function(tag) {
+        _.each(_.toPairs(md.tags), function(tag) {
+          console.log(tag);
           if (_.has(groupByTags, tag[0])) {
             tagData.push(tag[0] + "=" + tag[1]);
           }

--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -333,7 +333,6 @@ function (angular, _, dateMath) {
 
       if (!_.isEmpty(md.tags)) {
         _.each(_.toPairs(md.tags), function(tag) {
-          console.log(tag);
           if (_.has(groupByTags, tag[0])) {
             tagData.push(tag[0] + "=" + tag[1]);
           }


### PR DESCRIPTION
- Link the PR to an issue for new features
- Rebase your PR if it gets out of sync with master

In lodash 4.0, _.pairs is renamed to _.toPairs (https://github.com/lodash/lodash/wiki/Changelog)
