### PR TITLE
fixed scoping issue with certPool variable

### DIFF
--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -30,7 +30,7 @@ func (a *ldapAuther) Dial() error {
 	var err error
 	var certPool *x509.CertPool
 	if a.server.RootCACert != "" {
-		certPool := x509.NewCertPool()
+		certPool = x509.NewCertPool()
 		for _, caCertFile := range strings.Split(a.server.RootCACert, " ") {
 			if pem, err := ioutil.ReadFile(caCertFile); err != nil {
 				return err


### PR DESCRIPTION
This PR addresses issue #6260 and enables the root_ca_cert setting to work.  Until this fix is adopted and in a release, a workaround is to add the CA certificate to systems global certificate store.
