### PR TITLE
Fixes broken default plugin path on Windows

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -461,7 +461,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 
 	Env = Cfg.Section("").Key("app_mode").MustString("development")
 	InstanceName = Cfg.Section("").Key("instance_name").MustString("unknown_instance_name")
-	PluginsPath = Cfg.Section("paths").Key("plugins").String()
+	PluginsPath = makeAbsolute(Cfg.Section("paths").Key("plugins").String(), HomePath)
 
 	server := Cfg.Section("server")
 	AppUrl, AppSubUrl = parseAppUrlAndSubUrl(server)


### PR DESCRIPTION
Grafana-server didnt load ../data/plugins as default but instead created a data/plugins folder in the bin directory.

Grafana-cli on the other hand downloaded plugins into ../data/plugins which made it very confusing to install plugins.
