### PR TITLE
add support for external server for serving the static assets

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -44,6 +44,9 @@ enforce_domain = false
 # The full public facing url
 root_url = %(protocol)s://%(domain)s:%(http_port)s/
 
+# The public facing url for static assets
+# static_url = <calculated according to root_url>
+
 # Log web requests
 router_logging = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -46,6 +46,10 @@
 # If you use reverse proxy and sub path specify full url (with sub path)
 ;root_url = http://localhost:3000
 
+# The public facing url where static assets are stored. This is the "public" directory
+# from the grafana release (dont forget to setup CORS!)
+;static_url = http://my-cdn.com/grafana/public
+
 # Log web requests
 ;router_logging = false
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -114,6 +114,23 @@ callback URL to be correct).
 > in front of Grafana that exposes it through a subpath. In that
 > case add the subpath to the end of this URL setting.
 
+### static_url
+
+The url where the front end files (HTML, JS, and CSS
+files) are accessible. By default grafana is serving those in the same server.
+For optimization you can put those files on a host optimized for serving static
+files (like a CDN or S3 like server).
+
+> **Note**  You will need to setup CORS headers on your static server to make this work
+
+CORS settings example for Apache:
+
+    Header set Access-Control-Allow-Origin "*"
+
+CORS settings example for Nginx:
+
+   add_header Access-Control-Allow-Origin "*";
+
 ### static_root_path
 
 The path to the directory where the front end files (HTML, JS, and CSS

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -121,15 +121,9 @@ files) are accessible. By default grafana is serving those in the same server.
 For optimization you can put those files on a host optimized for serving static
 files (like a CDN or S3 like server).
 
-> **Note**  You will need to setup CORS headers on your static server to make this work
+> **Note** This setting only works for core application and plugins.
+> External plugins will still be served by the main application server.
 
-CORS settings example for Apache:
-
-    Header set Access-Control-Allow-Origin "*"
-
-CORS settings example for Nginx:
-
-   add_header Access-Control-Allow-Origin "*";
 
 ### static_root_path
 

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -5,6 +5,7 @@ type IndexViewData struct {
 	Settings                map[string]interface{}
 	AppUrl                  string
 	AppSubUrl               string
+	AppStaticUrl            string
 	GoogleAnalyticsId       string
 	GoogleTagManagerId      string
 	MainNavLinks            []*NavLink

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -135,6 +135,7 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 		"datasources":       datasources,
 		"panels":            panels,
 		"appSubUrl":         setting.AppSubUrl,
+		"appStaticUrl":         setting.AppStaticUrl,
 		"allowOrgCreate":    (setting.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
 		"authProxyEnabled":  setting.AuthProxyEnabled,
 		"buildInfo": map[string]interface{}{

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -35,12 +35,15 @@ func setIndexViewData(c *middleware.Context) (*dtos.IndexViewData, error) {
 
 	appUrl := setting.AppUrl
 	appSubUrl := setting.AppSubUrl
+	appStaticUrl := setting.AppStaticUrl
 
 	// special case when doing localhost call from phantomjs
 	if c.IsRenderCall {
 		appUrl = fmt.Sprintf("%s://localhost:%s", setting.Protocol, setting.HttpPort)
 		appSubUrl = ""
+		appStaticUrl = "public"
 		settings["appSubUrl"] = ""
+		settings["appStaticUrl"] = "public"
 	}
 
 	var data = dtos.IndexViewData{
@@ -62,6 +65,7 @@ func setIndexViewData(c *middleware.Context) (*dtos.IndexViewData, error) {
 		Settings:                settings,
 		AppUrl:                  appUrl,
 		AppSubUrl:               appSubUrl,
+		AppStaticUrl:            appStaticUrl,
 		GoogleAnalyticsId:       setting.GoogleAnalyticsId,
 		GoogleTagManagerId:      setting.GoogleTagManagerId,
 		BuildVersion:            setting.BuildVersion,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -467,7 +467,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	server := Cfg.Section("server")
 	AppUrl, AppSubUrl = parseAppUrlAndSubUrl(server)
 
-	appStaticUrl := server.Key("static_url").MustString(fmt.Sprintf("%s/public", appSubUrl))
+	appStaticUrl := server.Key("static_url").MustString(fmt.Sprintf("%s/public", AppSubUrl))
 
 	Protocol = HTTP
 	if server.Key("protocol").MustString("http") == "https" {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -39,6 +39,7 @@ var (
 	Env          string = DEV
 	AppUrl       string
 	AppSubUrl    string
+	AppStaticUrl string
 	InstanceName string
 
 	// build
@@ -172,7 +173,7 @@ func init() {
 	logger = log.New("settings")
 }
 
-func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
+func parseAppUrlAndSubUrl(section *ini.Section) (string, string, string) {
 	appUrl := section.Key("root_url").MustString("http://localhost:3000/")
 	if appUrl[len(appUrl)-1] != '/' {
 		appUrl += "/"
@@ -184,8 +185,9 @@ func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
 		log.Fatal(4, "Invalid root_url(%s): %s", appUrl, err)
 	}
 	appSubUrl := strings.TrimSuffix(url.Path, "/")
+	appStaticUrl := section.Key("static_url").MustString(fmt.Sprintf("%s/public", appSubUrl))
 
-	return appUrl, appSubUrl
+	return appUrl, appSubUrl, appStaticUrl
 }
 
 func ToAbsUrl(relativeUrl string) string {
@@ -464,7 +466,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	PluginsPath = makeAbsolute(Cfg.Section("paths").Key("plugins").String(), HomePath)
 
 	server := Cfg.Section("server")
-	AppUrl, AppSubUrl = parseAppUrlAndSubUrl(server)
+	AppUrl, AppSubUrl, AppStaticUrl = parseAppUrlAndSubUrl(server)
 
 	Protocol = HTTP
 	if server.Key("protocol").MustString("http") == "https" {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -173,7 +173,7 @@ func init() {
 	logger = log.New("settings")
 }
 
-func parseAppUrlAndSubUrl(section *ini.Section) (string, string, string) {
+func parseAppUrlAndSubUrl(section *ini.Section) (string, string) {
 	appUrl := section.Key("root_url").MustString("http://localhost:3000/")
 	if appUrl[len(appUrl)-1] != '/' {
 		appUrl += "/"
@@ -185,9 +185,8 @@ func parseAppUrlAndSubUrl(section *ini.Section) (string, string, string) {
 		log.Fatal(4, "Invalid root_url(%s): %s", appUrl, err)
 	}
 	appSubUrl := strings.TrimSuffix(url.Path, "/")
-	appStaticUrl := section.Key("static_url").MustString(fmt.Sprintf("%s/public", appSubUrl))
 
-	return appUrl, appSubUrl, appStaticUrl
+	return appUrl, appSubUrl
 }
 
 func ToAbsUrl(relativeUrl string) string {
@@ -466,7 +465,9 @@ func NewConfigContext(args *CommandLineArgs) error {
 	PluginsPath = makeAbsolute(Cfg.Section("paths").Key("plugins").String(), HomePath)
 
 	server := Cfg.Section("server")
-	AppUrl, AppSubUrl, AppStaticUrl = parseAppUrlAndSubUrl(server)
+	AppUrl, AppSubUrl = parseAppUrlAndSubUrl(server)
+
+	appStaticUrl := server.Key("static_url").MustString(fmt.Sprintf("%s/public", appSubUrl))
 
 	Protocol = HTTP
 	if server.Key("protocol").MustString("http") == "https" {

--- a/public/app/system.conf.js
+++ b/public/app/system.conf.js
@@ -1,15 +1,6 @@
-function getBaseURL() {
-  "use strict";
-  /* in the case of system.build, window is undefined
-     We should still pull the plugins from the CDN*/
-  if(typeof(window) === "undefined") {
-    return "public";
-  }
-  return window.grafanaBootData.settings.appStaticUrl || "public";
-}
 System.config({
   defaultJSExtenions: true,
-  baseURL: getBaseURL(),
+  baseURL: 'public',
   paths: {
     'remarkable': 'vendor/npm/remarkable/dist/remarkable.js',
     'tether': 'vendor/npm/tether/dist/js/tether.js',

--- a/public/app/system.conf.js
+++ b/public/app/system.conf.js
@@ -1,6 +1,15 @@
+function getBaseURL() {
+  "use strict";
+  /* in the case of system.build, window is undefined
+     We should still pull the plugins from the CDN*/
+  if(typeof(window) === "undefined") {
+    return "public";
+  }
+  return window.grafanaBootData.settings.appStaticUrl || "public";
+}
 System.config({
   defaultJSExtenions: true,
-  baseURL: 'public',
+  baseURL: getBaseURL(),
   paths: {
     'remarkable': 'vendor/npm/remarkable/dist/remarkable.js',
     'tether': 'vendor/npm/tether/dist/js/tether.js',

--- a/public/views/500.html
+++ b/public/views/500.html
@@ -7,8 +7,8 @@
 
     <title>Grafana</title>
 
-    <link rel="stylesheet" href="[[.AppSubUrl]]/public/css/grafana.dark.min.css" title="Dark">
-    <link rel="icon" type="image/png" href="[[.AppSubUrl]]/public/img/fav32.png">
+    <link rel="stylesheet" href="[[.AppStaticUrl]]/css/grafana.dark.min.css" title="Dark">
+    <link rel="icon" type="image/png" href="[[.AppStaticUrl]]/img/fav32.png">
 
   </head>
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -8,15 +8,15 @@
 
     <title>Grafana</title>
 
-		<link href='[[.AppSubUrl]]/public/css/fonts.min.css' rel='stylesheet' type='text/css'>
+		<link href='[[.AppStaticUrl]]/css/fonts.min.css' rel='stylesheet' type='text/css'>
 
 		[[if .User.LightTheme]]
-		  <link rel="stylesheet" href="[[.AppSubUrl]]/public/css/grafana.light.min.css">
+		  <link rel="stylesheet" href="[[.AppStaticUrl]]/css/grafana.light.min.css">
 		[[else]]
-		  <link rel="stylesheet" href="[[.AppSubUrl]]/public/css/grafana.dark.min.css">
+		  <link rel="stylesheet" href="[[.AppStaticUrl]]/css/grafana.dark.min.css">
 		[[end]]
 
-    <link rel="icon" type="image/png" href="[[.AppSubUrl]]/public/img/fav32.png">
+    <link rel="icon" type="image/png" href="[[.AppStaticUrl]]/img/fav32.png">
 		<base href="[[.AppSubUrl]]/" />
 
 	</head>
@@ -84,11 +84,11 @@
 		};
 	</script>
 
-	<!-- build:js [[.AppSubUrl]]/public/app/boot.js -->
-	<script src="[[.AppSubUrl]]/public/vendor/npm/es6-shim/es6-shim.js"></script>
-	<script src="[[.AppSubUrl]]/public/vendor/npm/systemjs/dist/system.src.js"></script>
-	<script src="[[.AppSubUrl]]/public/app/system.conf.js"></script>
-	<script src="[[.AppSubUrl]]/public/app/boot.js"></script>
+	<!-- build:js [[.AppStaticUrl]]/app/boot.js -->
+	<script src="[[.AppStaticUrl]]/vendor/npm/es6-shim/es6-shim.js"></script>
+	<script src="[[.AppStaticUrl]]/vendor/npm/systemjs/dist/system.src.js"></script>
+	<script src="[[.AppStaticUrl]]/app/system.conf.js"></script>
+	<script src="[[.AppStaticUrl]]/app/boot.js"></script>
 	<!-- endbuild -->
 
 	[[if .GoogleAnalyticsId]]

--- a/tasks/build_task.js
+++ b/tasks/build_task.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
     'uglify:genDir'
   ]);
 
-  // task to add [[.AppSubUrl]] to reved path
+  // task to add [[.AppStaticUrl]] to reved path
   grunt.registerTask('remapFilerev', function() {
     var root = grunt.config().genDir;
     var summary = grunt.filerev.summary;
@@ -34,8 +34,8 @@ module.exports = function(grunt) {
 
     for(var key in summary){
       if(summary.hasOwnProperty(key)){
-        var orig = key.replace(root, root+'/[[.AppSubUrl]]/public');
-        var revved = summary[key].replace(root, root+'/[[.AppSubUrl]]/public');
+        var orig = key.replace(root, root+'/[[.AppStaticUrl]]');
+        var revved = summary[key].replace(root, root+'/[[.AppStaticUrl]]');
         fixed[orig] = revved;
       }
     }


### PR DESCRIPTION
Implementation for #6307 

There is still the need to setup CORS in the static server as system.js is fetching
the scripts via xhr.

Using scriptLoad: true will not work here (yet) as it needs to have much more metadata.

This also adds a better approach for cacheBusting (using the git commit id, instead of Date.now())
