### PR TITLE
Issues/6317 empty google login

### DIFF
--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -46,5 +46,6 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	return &BasicUserInfo{
 		Name:     data.Name,
 		Email:    data.Email,
+        Login:    data.Email
 	}, nil
 }

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -46,6 +46,6 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	return &BasicUserInfo{
 		Name:     data.Name,
 		Email:    data.Email,
-    Login:    data.Email
+    Login:    data.Email,
 	}, nil
 }

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -46,6 +46,6 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	return &BasicUserInfo{
 		Name:     data.Name,
 		Email:    data.Email,
-        Login:    data.Email
+    Login:    data.Email
 	}, nil
 }

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -46,6 +46,6 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 	return &BasicUserInfo{
 		Name:     data.Name,
 		Email:    data.Email,
-    Login:    data.Email,
+		Login:    data.Email,
 	}, nil
 }


### PR DESCRIPTION
- Link the PR to an issue for new features
  https://github.com/grafana/grafana/issues/6317

This PR is to address an issue with empty login for Google OAuth. It assigns Login to data.Email by default. This will ensure uniq logins across domains and make sure that the uniq columne `login` does not get a duplicate key error if a user fails to set a custom username.
