### PR TITLE
Username restriction

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -175,14 +175,14 @@ allow_sign_up = true
 # Allow non admin users to create organizations
 allow_org_create = true
 
-# Allow a user to set their username as an email address
-allow_email_username = true
-
 # Set to true to automatically assign new users to the default organization (id 1)
 auto_assign_org = true
 
 # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
 auto_assign_org_role = Viewer
+
+# Allow a user to set their username as an email address
+allow_email_username = true
 
 # Require email validation before sign up completes
 verify_email_enabled = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -175,6 +175,9 @@ allow_sign_up = true
 # Allow non admin users to create organizations
 allow_org_create = true
 
+# Allow a user to set their username as an email address
+allow_email_username = true
+
 # Set to true to automatically assign new users to the default organization (id 1)
 auto_assign_org = true
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -169,6 +169,9 @@
 # Default role new users will be automatically assigned (if disabled above is set to true)
 ;auto_assign_org_role = Viewer
 
+# Allow a user to set their username as an email address
+;allow_email_username = true
+
 # Background text for the user field on the login page
 ;login_hint = email or username
 

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -73,6 +73,11 @@ func SignUpStep2(c *middleware.Context, form dtos.SignUpStep2Form) Response {
 		createUserCmd.EmailVerified = true
 	}
 
+	// check for valid username
+	if util.IsEmail(form.Login) {
+		return ApiError(400, "Cannot set email as login name", nil);
+	}
+
 	// check if user exists
 	existing := m.GetUserByLoginQuery{LoginOrEmail: form.Email}
 	if err := bus.Dispatch(&existing); err == nil {

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -74,7 +74,7 @@ func SignUpStep2(c *middleware.Context, form dtos.SignUpStep2Form) Response {
 	}
 
 	// check for valid username
-	if util.IsEmail(form.Login) {
+	if util.IsEmail(createUserCmd.Login) {
 		return ApiError(400, "Cannot set email as login name", nil);
 	}
 

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -74,7 +74,7 @@ func SignUpStep2(c *middleware.Context, form dtos.SignUpStep2Form) Response {
 	}
 
 	// check for valid username
-	if util.IsEmail(createUserCmd.Login) {
+	if !setting.AllowEmailAsLogin && util.IsEmail(createUserCmd.Login) {
 		return ApiError(400, "Cannot set email as login name", nil);
 	}
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -59,6 +59,11 @@ func UpdateUserActiveOrg(c *middleware.Context) Response {
 }
 
 func handleUpdateUser(cmd m.UpdateUserCommand) Response {
+	// check for valid username
+	if util.IsEmail(cmd.Login) {
+		return ApiError(400, "Cannot set email as login name", nil);
+	}
+
 	if len(cmd.Login) == 0 {
 		cmd.Login = cmd.Email
 		if len(cmd.Login) == 0 {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -60,7 +60,7 @@ func UpdateUserActiveOrg(c *middleware.Context) Response {
 
 func handleUpdateUser(cmd m.UpdateUserCommand) Response {
 	// check for valid username
-	if util.IsEmail(cmd.Login) {
+	if !setting.AllowEmailAsLogin && util.IsEmail(cmd.Login) {
 		return ApiError(400, "Cannot set email as login name", nil);
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -87,6 +87,7 @@ var (
 	// User settings
 	AllowUserSignUp    bool
 	AllowUserOrgCreate bool
+	AllowEmailAsLogin  bool
 	AutoAssignOrg      bool
 	AutoAssignOrgRole  string
 	VerifyEmailEnabled bool
@@ -514,6 +515,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	users := Cfg.Section("users")
 	AllowUserSignUp = users.Key("allow_sign_up").MustBool(true)
 	AllowUserOrgCreate = users.Key("allow_org_create").MustBool(true)
+	AllowEmailAsLogin = users.Key("allow_email_username").MustBool(false)
 	AutoAssignOrg = users.Key("auto_assign_org").MustBool(true)
 	AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Read Only Editor", "Viewer"})
 	VerifyEmailEnabled = users.Key("verify_email_enabled").MustBool(false)

--- a/public/app/core/controllers/signup_ctrl.ts
+++ b/public/app/core/controllers/signup_ctrl.ts
@@ -20,7 +20,7 @@ export class SignUpCtrl {
     var params = $location.search();
     $scope.formModel.orgName = params.email;
     $scope.formModel.email = params.email;
-    $scope.formModel.username = params.email;
+    $scope.formModel.username = "";
     $scope.formModel.code = params.code;
 
     $scope.verifyEmailEnabled = false;


### PR DESCRIPTION
Created user name restriction during sign up and update to fix exploit introduced by PR https://github.com/grafana/grafana/pull/6330

_ISSUE_
Oauth Login will by be checked by email only now and in the case of Google, the Login value will be set to the users email by default.

_FIX_
Users creating new accounts and updating their profile info cannot set an email as their username. This will make it so email type username's are reserved for OAuth user creation only to create a cleaner workflow and prevent ugly server error from duplicate key issue if another user sets their username to a different email that attempts to authenticate from Google or other source.
