### PR TITLE
Elasticsearch 5.x support

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
@@ -24,6 +24,7 @@ export class ElasticConfigCtrl {
   esVersions = [
     {name: '1.x', value: 1},
     {name: '2.x', value: 2},
+    {name: '5.x', value: 5},
   ];
 
   indexPatternTypeChanged() {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -76,11 +76,9 @@ function (queryDef) {
     for (var i = 0; i < aggDef.settings.filters.length; i++) {
       var query = aggDef.settings.filters[i].query;
       filterObj[query] = {
-        query: {
-          query_string: {
-            query: query,
-            analyze_wildcard: true
-          }
+        query_string: {
+          query: query,
+          analyze_wildcard: true
         }
       };
     }

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
@@ -138,8 +138,8 @@ describe('ElasticQueryBuilder', function() {
       ],
     });
 
-    expect(query.aggs["2"].filters.filters["@metric:cpu"].query.query_string.query).to.be("@metric:cpu");
-    expect(query.aggs["2"].filters.filters["@metric:logins.count"].query.query_string.query).to.be("@metric:logins.count");
+    expect(query.aggs["2"].filters.filters["@metric:cpu"].query_string.query).to.be("@metric:cpu");
+    expect(query.aggs["2"].filters.filters["@metric:logins.count"].query_string.query).to.be("@metric:logins.count");
     expect(query.aggs["2"].aggs["4"].date_histogram.field).to.be("@timestamp");
   });
 


### PR DESCRIPTION
Hello,

I fixed the queries and the search types which were deprecated since Elasticsearch 2.0.0 and removed with Elasticsearch 5.0.

If you need to play around, here's a test instance : https://metrics.dissidence.ovh/dashboard/db/concorde (Default user/pass). The elasticsearch instance isn't directly open, but you can access it through Kibana at https://kibana.dissidence.ovh/. It is being fed data from Metricbeat through Logstash.

Should fix #5740.

Have a good day !
