### PR TITLE
Issues/5960 google oauth hd param

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -229,6 +229,7 @@ auth_url = https://accounts.google.com/o/oauth2/auth
 token_url = https://accounts.google.com/o/oauth2/token
 api_url = https://www.googleapis.com/oauth2/v1/userinfo
 allowed_domains =
+hosted_domain =
 
 #################################### Grafana.net Auth ####################
 [auth.grafananet]

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -53,7 +53,11 @@ func OAuthLogin(ctx *middleware.Context) {
 	if code == "" {
 		state := GenStateString()
 		ctx.Session.Set(middleware.SESS_KEY_OAUTH_STATE, state)
-		ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
+		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
+			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
+		}else{
+			ctx.Redirect(connect.AuthCodeURL(state, oauth2.SetParam("hd", setting.OAuthService.OAuthInfos[name].HostedDomain, oauth2.AccessTypeOnline));
+		}
 		return
 	}
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -56,7 +56,7 @@ func OAuthLogin(ctx *middleware.Context) {
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
 			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
 		}else{
-			ctx.Redirect(connect.AuthCodeURL(state, oauth2.SetParam("hd", setting.OAuthService.OAuthInfos[name].HostedDomain, oauth2.AccessTypeOnline));
+			ctx.Redirect(connect.AuthCodeURL(state, oauth2.SetParam("hd", setting.OAuthService.OAuthInfos[name].HostedDomain), oauth2.AccessTypeOnline));
 		}
 		return
 	}

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -6,7 +6,7 @@ type OAuthInfo struct {
 	AuthUrl, TokenUrl      string
 	Enabled                bool
 	AllowedDomains         []string
-    HostedDomain           []string
+	HostedDomain           string
 	ApiUrl                 string
 	AllowSignup            bool
 	Name                   string

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -6,6 +6,7 @@ type OAuthInfo struct {
 	AuthUrl, TokenUrl      string
 	Enabled                bool
 	AllowedDomains         []string
+    HostedDomain           []string
 	ApiUrl                 string
 	AllowSignup            bool
 	Name                   string

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -12,6 +12,7 @@ import (
 type SocialGoogle struct {
 	*oauth2.Config
 	allowedDomains []string
+	hostedDomain   string
 	apiUrl         string
 	allowSignup    bool
 }

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -51,7 +51,7 @@ func NewOAuthService() {
 			ApiUrl:         sec.Key("api_url").String(),
 			Enabled:        sec.Key("enabled").MustBool(),
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
-            Hd:             sec.Key("hosted_domain").String(),
+			HostedDomain:   sec.Key("hosted_domain").String(),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 			Name:           sec.Key("name").MustString(name),
 			TlsClientCert:  sec.Key("tls_client_cert").String(),
@@ -93,7 +93,7 @@ func NewOAuthService() {
 			SocialMap["google"] = &SocialGoogle{
 				Config:               &config,
 				allowedDomains:       info.AllowedDomains,
-                Hd:                   info.HostedDomain,
+				hostedDomain:         info.HostedDomain,
 				apiUrl:               info.ApiUrl,
 				allowSignup:          info.AllowSignup,
 			}

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -51,6 +51,7 @@ func NewOAuthService() {
 			ApiUrl:         sec.Key("api_url").String(),
 			Enabled:        sec.Key("enabled").MustBool(),
 			AllowedDomains: sec.Key("allowed_domains").Strings(" "),
+            Hd:             sec.Key("hosted_domain").String(),
 			AllowSignup:    sec.Key("allow_sign_up").MustBool(),
 			Name:           sec.Key("name").MustString(name),
 			TlsClientCert:  sec.Key("tls_client_cert").String(),
@@ -92,6 +93,7 @@ func NewOAuthService() {
 			SocialMap["google"] = &SocialGoogle{
 				Config:               &config,
 				allowedDomains:       info.AllowedDomains,
+                Hd:                   info.HostedDomain,
 				apiUrl:               info.ApiUrl,
 				allowSignup:          info.AllowSignup,
 			}


### PR DESCRIPTION
This PR adds support for the Google Hosted Domain hint discussed in Issue https://github.com/grafana/grafana/issues/5960

Configureable from .ini [auth.google].hosted_domain param
