### PR TITLE
Add VictorOps alert notification capability

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,42 +9,43 @@ func init() {
 }
 
 var (
-	M_Instance_Start                     Counter
-	M_Page_Status_200                    Counter
-	M_Page_Status_500                    Counter
-	M_Page_Status_404                    Counter
-	M_Page_Status_Unknown                Counter
-	M_Api_Status_200                     Counter
-	M_Api_Status_404                     Counter
-	M_Api_Status_500                     Counter
-	M_Api_Status_Unknown                 Counter
-	M_Proxy_Status_200                   Counter
-	M_Proxy_Status_404                   Counter
-	M_Proxy_Status_500                   Counter
-	M_Proxy_Status_Unknown               Counter
-	M_Api_User_SignUpStarted             Counter
-	M_Api_User_SignUpCompleted           Counter
-	M_Api_User_SignUpInvite              Counter
-	M_Api_Dashboard_Save                 Timer
-	M_Api_Dashboard_Get                  Timer
-	M_Api_Dashboard_Search               Timer
-	M_Api_Admin_User_Create              Counter
-	M_Api_Login_Post                     Counter
-	M_Api_Login_OAuth                    Counter
-	M_Api_Org_Create                     Counter
-	M_Api_Dashboard_Snapshot_Create      Counter
-	M_Api_Dashboard_Snapshot_External    Counter
-	M_Api_Dashboard_Snapshot_Get         Counter
-	M_Models_Dashboard_Insert            Counter
-	M_Alerting_Result_State_Alerting     Counter
-	M_Alerting_Result_State_Ok           Counter
-	M_Alerting_Result_State_Paused       Counter
-	M_Alerting_Result_State_NoData       Counter
-	M_Alerting_Result_State_ExecError    Counter
-	M_Alerting_Active_Alerts             Counter
-	M_Alerting_Notification_Sent_Slack   Counter
-	M_Alerting_Notification_Sent_Email   Counter
-	M_Alerting_Notification_Sent_Webhook Counter
+	M_Instance_Start                       Counter
+	M_Page_Status_200                      Counter
+	M_Page_Status_500                      Counter
+	M_Page_Status_404                      Counter
+	M_Page_Status_Unknown                  Counter
+	M_Api_Status_200                       Counter
+	M_Api_Status_404                       Counter
+	M_Api_Status_500                       Counter
+	M_Api_Status_Unknown                   Counter
+	M_Proxy_Status_200                     Counter
+	M_Proxy_Status_404                     Counter
+	M_Proxy_Status_500                     Counter
+	M_Proxy_Status_Unknown                 Counter
+	M_Api_User_SignUpStarted               Counter
+	M_Api_User_SignUpCompleted             Counter
+	M_Api_User_SignUpInvite                Counter
+	M_Api_Dashboard_Save                   Timer
+	M_Api_Dashboard_Get                    Timer
+	M_Api_Dashboard_Search                 Timer
+	M_Api_Admin_User_Create                Counter
+	M_Api_Login_Post                       Counter
+	M_Api_Login_OAuth                      Counter
+	M_Api_Org_Create                       Counter
+	M_Api_Dashboard_Snapshot_Create        Counter
+	M_Api_Dashboard_Snapshot_External      Counter
+	M_Api_Dashboard_Snapshot_Get           Counter
+	M_Models_Dashboard_Insert              Counter
+	M_Alerting_Result_State_Alerting       Counter
+	M_Alerting_Result_State_Ok             Counter
+	M_Alerting_Result_State_Paused         Counter
+	M_Alerting_Result_State_NoData         Counter
+	M_Alerting_Result_State_ExecError      Counter
+	M_Alerting_Active_Alerts               Counter
+	M_Alerting_Notification_Sent_Slack     Counter
+	M_Alerting_Notification_Sent_Victorops Counter
+	M_Alerting_Notification_Sent_Email     Counter
+	M_Alerting_Notification_Sent_Webhook   Counter
 
 	// Timers
 	M_DataSource_ProxyReq_Timer Timer
@@ -105,6 +106,7 @@ func initMetricVars(settings *MetricSettings) {
 
 	M_Alerting_Active_Alerts = RegCounter("alerting.active_alerts")
 	M_Alerting_Notification_Sent_Slack = RegCounter("alerting.notifications_sent", "type", "slack")
+	M_Alerting_Notification_Sent_Victorops = RegCounter("alerting.notifications_sent", "type", "victorops")
 	M_Alerting_Notification_Sent_Email = RegCounter("alerting.notifications_sent", "type", "email")
 	M_Alerting_Notification_Sent_Webhook = RegCounter("alerting.notifications_sent", "type", "webhook")
 

--- a/pkg/services/alerting/notifiers/victorops.go
+++ b/pkg/services/alerting/notifiers/victorops.go
@@ -1,0 +1,94 @@
+package notifiers
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/metrics"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// AlertStateCritical - Victorops uses "CRITICAL" string to indicate "Alerting" state
+const AlertStateCritical = "CRITICAL"
+
+func init() {
+	alerting.RegisterNotifier("victorops", NewVictoropsNotifier)
+}
+
+// NewVictoropsNotifier creates an instance of VictoropsNotifier that
+// handles posting notifications to Victorops REST API
+func NewVictoropsNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	url := model.Settings.Get("url").MustString()
+	if url == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find victorops url property in settings"}
+	}
+
+	return &VictoropsNotifier{
+		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
+		URL:          url,
+		log:          log.New("alerting.notifier.victorops"),
+	}, nil
+}
+
+// VictoropsNotifier defines URL property for Victorops REST API
+// and handles notification process by formatting POST body according to
+// Victorops specifications (http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)
+type VictoropsNotifier struct {
+	NotifierBase
+	URL string
+	log log.Logger
+}
+
+// Notify sends notification to Victorops via POST to URL endpoint
+func (this *VictoropsNotifier) Notify(evalContext *alerting.EvalContext) error {
+	this.log.Info("Executing victorops notification", "ruleId", evalContext.Rule.Id, "notification", this.Name)
+	metrics.M_Alerting_Notification_Sent_Victorops.Inc(1)
+
+	fields := make([]map[string]interface{}, 0)
+	fieldLimitCount := 4
+	for index, evt := range evalContext.EvalMatches {
+		fields = append(fields, map[string]interface{}{
+			"title": evt.Metric,
+			"value": evt.Value,
+			"short": true,
+		})
+		if index > fieldLimitCount {
+			break
+		}
+	}
+
+	if evalContext.Error != nil {
+		fields = append(fields, map[string]interface{}{
+			"title": "Error message",
+			"value": evalContext.Error.Error(),
+			"short": false,
+		})
+	}
+
+	messageType := evalContext.Rule.State
+	if evalContext.Rule.State == models.AlertStateAlerting { // translate 'Alerting' to 'CRITICAL' (Victorops analog)
+		messageType = AlertStateCritical
+	}
+
+	body := map[string]interface{}{
+		"message_type":     messageType,
+		"entity_id":        evalContext.Rule.Name,
+		"timestamp":        time.Now().Unix(),
+		"state_start_time": evalContext.StartTime.Unix(),
+		"state_message":    evalContext.Rule.Message,
+		"monitoring_tool":  "Grafana v" + setting.BuildVersion,
+	}
+
+	data, _ := json.Marshal(&body)
+	cmd := &models.SendWebhook{Url: this.URL, Body: string(data)}
+
+	if err := bus.Dispatch(cmd); err != nil {
+		this.log.Error("Failed to send victorops notification", "error", err, "webhook", this.Name)
+	}
+
+	return nil
+}

--- a/public/app/features/alerting/alert_tab_ctrl.ts
+++ b/public/app/features/alerting/alert_tab_ctrl.ts
@@ -87,6 +87,7 @@ export class AlertTabCtrl {
     switch (type) {
       case "email": return "fa fa-envelope";
       case "slack": return "fa fa-slack";
+      case "victorops": return "fa fa-exclamation-triangle";
       case "webhook": return "fa fa-cubes";
     }
   }

--- a/public/app/features/alerting/partials/notification_edit.html
+++ b/public/app/features/alerting/partials/notification_edit.html
@@ -66,7 +66,7 @@
     </div>
 
     <div class="gf-form-group" ng-if="ctrl.model.type === 'victorops'">
-      <h3 class="page-heading">Victorops settings</h3>
+      <h3 class="page-heading">VictorOps settings</h3>
       <div class="gf-form">
         <span class="gf-form-label width-6">Url</span>
         <input type="text" required class="gf-form-input max-width-30" ng-model="ctrl.model.settings.url" placeholder="Victorops url"></input>

--- a/public/app/features/alerting/partials/notification_edit.html
+++ b/public/app/features/alerting/partials/notification_edit.html
@@ -19,7 +19,7 @@
       <div class="gf-form">
         <span class="gf-form-label width-12">Type</span>
         <div class="gf-form-select-wrapper width-15">
-          <select class="gf-form-input" ng-model="ctrl.model.type" ng-options="t for t in ['webhook', 'email', 'slack']" ng-change="ctrl.typeChanged(notification, $index)">
+          <select class="gf-form-input" ng-model="ctrl.model.type" ng-options="t for t in ['webhook', 'email', 'slack', 'victorops']" ng-change="ctrl.typeChanged(notification, $index)">
           </select>
         </div>
       </div>
@@ -62,6 +62,14 @@
       <div class="gf-form">
         <span class="gf-form-label width-6">Url</span>
         <input type="text" required class="gf-form-input max-width-30" ng-model="ctrl.model.settings.url" placeholder="Slack incoming webhook url"></input>
+      </div>
+    </div>
+
+    <div class="gf-form-group" ng-if="ctrl.model.type === 'victorops'">
+      <h3 class="page-heading">Victorops settings</h3>
+      <div class="gf-form">
+        <span class="gf-form-label width-6">Url</span>
+        <input type="text" required class="gf-form-input max-width-30" ng-model="ctrl.model.settings.url" placeholder="Victorops url"></input>
       </div>
     </div>
 


### PR DESCRIPTION
### Overview

VictorOps is a hub for centralizing the flow of information throughout the incident lifecycle. Driven by IT and DevOps system data, VictorOps provides a unified platform for real-time alerting, collaboration, and documentation (https://victorops.com/)

This PR adds functionality to `POST` alert notifications to VictorOps via [REST API](http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/)

Feature Request [#6411](https://github.com/grafana/grafana/issues/6411)

![image](https://cloud.githubusercontent.com/assets/324803/19783227/ee7a192c-9c45-11e6-9320-752f5f3c62ed.png)
