### PR TITLE
Add missing closing " in Docker README

### DIFF
--- a/docker/production/README.md
+++ b/docker/production/README.md
@@ -23,7 +23,7 @@ All options defined in conf/grafana.ini can be overridden using environment vari
 ```
 docker run -i -p 3000:3000 \
   -e "GF_SERVER_ROOT_URL=http://grafana.server.name"  \
-  -e "GF_SECURITY_ADMIN_PASSWORD=secret  \
+  -e "GF_SECURITY_ADMIN_PASSWORD=secret"  \
   grafana/grafana:develop
 ```
 


### PR DESCRIPTION
This PR adds a missing closing `"` in the Docker README.md file.
