### PR TITLE
Log bad alert config and fixed alert message typo

### DIFF
--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -104,7 +104,7 @@ func (e *DashAlertExtractor) GetAlerts() ([]*m.Alert, error) {
 				panelQuery := findPanelQueryByRefId(panel, queryRefId)
 
 				if panelQuery == nil {
-					return nil, ValidationError{Reason: "Alert refes to query that cannot be found"}
+					return nil, ValidationError{Reason: "Alert refers to query that cannot be found"}
 				}
 
 				dsName := ""

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -104,6 +104,7 @@ func (e *DashAlertExtractor) GetAlerts() ([]*m.Alert, error) {
 				panelQuery := findPanelQueryByRefId(panel, queryRefId)
 
 				if panelQuery == nil {
+					e.log.Error("Query not found", "panel", alert.PanelId, "queryRefId", queryRefId)
 					return nil, ValidationError{Reason: "Alert refers to query that cannot be found"}
 				}
 


### PR DESCRIPTION
If I have 10 alerts configured on a dashboard and one of them has a bad config, its super hard to find which one is the bad one and I cannot save anymore alerts on the dashboard without fixing the wrong alert. :|