### PR TITLE
Add empty default options for constant templates

### DIFF
--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -16,6 +16,7 @@ export class ConstantVariable implements Variable {
     label: '',
     query: '',
     current: {},
+    options: [],
   };
 
   /** @ngInject **/


### PR DESCRIPTION
Adds an empty default options for constant templates, fixing a bug preventing users from changing the value.

* Bug Report: [https://github.com/grafana/grafana/issues/6459](url)