### PR TITLE
Disable web-security for phantomjs rendering

### DIFF
--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -47,6 +47,7 @@ func RenderToPng(params *RenderOpts) (string, error) {
 
 	cmdArgs := []string{
 		"--ignore-ssl-errors=true",
+		"--web-security=false",
 		scriptPath,
 		"url=" + url,
 		"width=" + params.Width,


### PR DESCRIPTION
This PR adds "web-security=false" option to phantomjs graphs rendering. This might be useful when using direct connection to datasource (not proxied) and that datasource does not accept "localhost" as origin (CORS issues).