### PR TITLE
Update github auth docs

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -339,7 +339,7 @@ your Grafana instance. For example
     scopes = user:email,read:org
     auth_url = https://github.com/login/oauth/authorize
     token_url = https://github.com/login/oauth/access_token
-    allow_sign_up = false
+    allow_sign_up = true
     # space-delimited organization names
     allowed_organizations = github google
 


### PR DESCRIPTION
In Github's "allowed organizations" scenario, it makes sense to have
`allow_sign_up` to be `true` as most administrators will expect their
org's github users to be able to sign in without further steps like
creating a local user first.