### PR TITLE
Correct timeStep in case of missing values

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -115,6 +115,8 @@ export default class TimeSeries {
       currentValue = this.datapoints[i][0];
       currentTime = this.datapoints[i][1];
 
+      // Due to missing values we could have different timeStep all along the series
+      // so we have to find the minimum one (could occur with aggregators such as ZimSum)
       if (i>0) {
         var previousTime = this.datapoints[i-1][1];
         if (!this.stats.timeStep || currentTime - previousTime < this.stats.timeStep) {

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -115,6 +115,13 @@ export default class TimeSeries {
       currentValue = this.datapoints[i][0];
       currentTime = this.datapoints[i][1];
 
+      if (i>0) {
+        var previousTime = this.datapoints[i-1][1];
+        if (!this.stats.timeStep || currentTime - previousTime < this.stats.timeStep) {
+          this.stats.timeStep = currentTime - previousTime;
+        }
+      }
+
       if (currentValue === null) {
         if (ignoreNulls) { continue; }
         if (nullAsZero) {
@@ -143,10 +150,6 @@ export default class TimeSeries {
       }
 
       result.push([currentTime, currentValue]);
-    }
-
-    if (this.datapoints.length >= 2) {
-      this.stats.timeStep = this.datapoints[1][1] - this.datapoints[0][1];
     }
 
     if (this.stats.max === -Number.MAX_VALUE) { this.stats.max = null; }


### PR DESCRIPTION
Hello,

This PR correctly calculates timeStep in case of series with missing values.
Due to missing values we could have different timeStep all along the series, so we have to compute the minimum timeStep found for each series.

Thank you 👍 

Ben