### PR TITLE
Removed green border from OK alerts.

### DIFF
--- a/public/sass/pages/_alerting.scss
+++ b/public/sass/pages/_alerting.scss
@@ -61,7 +61,6 @@
   }
 
   &--ok {
-    box-shadow: 0 0 5px rgba(0,200,0,10.8);
     .panel-alert-icon:before {
       color: $online;
       content: "\e611";


### PR DESCRIPTION
Makes dashboards too busy, competes for attention where action is unnecessary.