### PR TITLE
support regex expansion in templating "Regex" field

### DIFF
--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -96,7 +96,7 @@ export class QueryVariable implements Variable {
     options = [];
 
     if (this.regex) {
-      regex = kbn.stringToJsRegex(this.templateSrv.replace(this.regex));
+      regex = kbn.stringToJsRegex(this.templateSrv.replace(this.regex, {}, 'regex'));
     }
 
     for (i = 0; i < metricNames.length; i++) {


### PR DESCRIPTION
I want to expand multi selected template variable to "Regex" field.

* variable $a
  * values
    * foo (selected)
    * bar (selected)
* variable $b
  * values
    * baz (selected)
    * quux (selected)
* variable $c
  * Regex field
    * ($a$b)
  * values
    * foobar
    * foobaz (in this case, match this)