### PR TITLE
docs(datasources/influxdb): Fix broken image link

### DIFF
--- a/docs/sources/datasources/influxdb.md
+++ b/docs/sources/datasources/influxdb.md
@@ -118,7 +118,7 @@ SHOW TAG VALUES WITH KEY = "hostname"  WHERE region =~ /$region/
 
 > Always you `regex values` or `regex wildcard` for All format or multi select format.
 
-![](img/docs/influxdb/templating_simple_ex1.png)
+![](/img/docs/influxdb/templating_simple_ex1.png)
 
 ## Annotations
 Annotations allows you to overlay rich event information on top of graphs.


### PR DESCRIPTION
Twas missing a leading `/`.