### PR TITLE
added explicitly setting token as Bearer Type

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -96,7 +96,7 @@ func OAuthLogin(ctx *middleware.Context) {
 		}
 		sslcli := &http.Client{Transport: tr}
 
-		oauthCtx = context.TODO()
+		oauthCtx = context.Background()
 		oauthCtx = context.WithValue(oauthCtx, oauth2.HTTPClient, sslcli)
 	}
 
@@ -106,6 +106,8 @@ func OAuthLogin(ctx *middleware.Context) {
 		ctx.Handle(500, "login.OAuthLogin(NewTransportWithCode)", err)
 		return
 	}
+	// token.TokenType was defaulting to "bearer", which is out of spec, so we explicitly set to "Bearer"
+	token.TokenType = "Bearer"
 
 	ctx.Logger.Debug("OAuthLogin Got token")
 


### PR DESCRIPTION
@DanCech @torkelo sorry for the long cycle on follow up, I was on vacation

This is following up on my original PR #6209 implementing the only thing I found missing from #6226 when implementing the v4.0.0-beta1 tagged release (my oauth2 API implementing service also validates Auth Headers which were being improperly formatted without the tokenType explicitly set)