### PR TITLE
fix up sass lint warnings

### DIFF
--- a/public/sass/components/_gfbox.scss
+++ b/public/sass/components/_gfbox.scss
@@ -16,10 +16,10 @@
   background-color: transparent;
   border: none;
   padding: 8px;
+  color: $text-color;
   i {
     font-size: 120%;
   }
-  color: $text-color;
   &:hover {
     color: $white;
   }

--- a/public/sass/components/_row.scss
+++ b/public/sass/components/_row.scss
@@ -74,12 +74,11 @@
 .add-panel-panels-scroll {
   width: 100%;
   overflow: auto;
+  -ms-overflow-style: none;
 
   &::-webkit-scrollbar {
     display: none
   }
-
-  -ms-overflow-style: none;
 }
 
 .add-panel-panels {

--- a/public/sass/components/_shortcuts.scss
+++ b/public/sass/components/_shortcuts.scss
@@ -6,6 +6,8 @@
 }
 
 .shortcut-table {
+  margin-bottom: $spacer;
+
   .shortcut-table-category-header {
     font-weight: normal;
     font-size: $font-size-h6;
@@ -26,8 +28,6 @@
     text-align: right;
     color: $text-color;
   }
-
-  margin-bottom: $spacer;
 }
 
 .shortcut-table-key {

--- a/public/sass/components/_submenu.scss
+++ b/public/sass/components/_submenu.scss
@@ -7,11 +7,12 @@
 }
 
 .annotation-segment {
+  padding: 8px 7px;
+
   label.cr1 {
     margin-left: 5px;
     margin-top: 3px;
   }
-  padding: 8px 7px;
 }
 
 .submenu-item {
@@ -31,14 +32,14 @@
 
 .variable-value-link {
   padding-right: 10px;
-  .label-tag {
-    margin: 0 5px;
-  }
-
   padding: 8px 7px;
   box-sizing: content-box;
   display: inline-block;
   color: $text-color;
+
+  .label-tag {
+    margin: 0 5px;
+  }
 }
 
 .variable-link-wrapper  {

--- a/public/sass/components/_tabbed_view.scss
+++ b/public/sass/components/_tabbed_view.scss
@@ -38,10 +38,10 @@
   background-color: transparent;
   border: none;
   padding: ($tabs-padding-top + $tabs-top-margin) $spacer $tabs-padding-bottom;
+  color: $text-color;
   i {
     font-size: 120%;
   }
-  color: $text-color;
   &:hover {
     color: $white;
   }


### PR DESCRIPTION
clean up sass lint warnings:

```
Running "sasslint:target" (sasslint) task

public/sass/components/_gfbox.scss
  22:3  warning  Declarations should come before nestings  declarations-before-nesting

public/sass/components/_row.scss
  82:3  warning  Declarations should come before nestings  declarations-before-nesting

public/sass/components/_shortcuts.scss
  30:3  warning  Declarations should come before nestings  declarations-before-nesting

public/sass/components/_submenu.scss
  14:3  warning  Declarations should come before nestings  declarations-before-nesting
  38:3  warning  Declarations should come before nestings  declarations-before-nesting
  39:3  warning  Declarations should come before nestings  declarations-before-nesting
  40:3  warning  Declarations should come before nestings  declarations-before-nesting
  41:3  warning  Declarations should come before nestings  declarations-before-nesting

public/sass/components/_tabbed_view.scss
  44:3  warning  Declarations should come before nestings  declarations-before-nesting

✖ 9 problems (0 errors, 9 warnings)
```