### PR TITLE
Implement filters for Prometheus legend labels

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import * as dateMath from 'app/core/utils/datemath';
 import PrometheusMetricFindQuery from './metric_find_query';
+import * as promTemplate from './template';
 
 var durationSplitRegexp = /(\d+)(ms|s|m|h|d|w|M|y)/;
 
@@ -269,13 +270,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
   };
 
   this.renderTemplate = function(aliasPattern, aliasData) {
-    var aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
-    return aliasPattern.replace(aliasRegex, function(match, g1) {
-      if (aliasData[g1]) {
-        return aliasData[g1];
-      }
-      return g1;
-    });
+    return promTemplate.renderTemplate(aliasPattern, aliasData);
   };
 
   this.getOriginalMetricName = function(labelData) {

--- a/public/app/plugins/datasource/prometheus/template.ts
+++ b/public/app/plugins/datasource/prometheus/template.ts
@@ -1,8 +1,72 @@
 ///<reference path="../../../headers/common.d.ts" />
 
+const tStr = '(?:"([^"]*)")';
+const tVar = '([_a-zA-Z0-9]+)';
+const tExpr = '(?:' + tStr + '|' + tVar + ')';
+const tArgList = tExpr + '(?:\\s*,\\s*' + tExpr + ')*';
+const tPipe = '\\s*\\|\\s*(\\w+)\\s*\\(\\s*(' + tArgList + ')?\\s*,?\\s*\\)\\s*';
+
+const functions = {
+  replace: function(val, what, to) {
+    return val.replace(new RegExp(what, 'g'), to);
+  },
+  toPercent: function(val) {
+    return Math.round(parseFloat(val)*100) + '%';
+  },
+};
+
+function expand(val, aliasData) {
+  const ma = val.match(tStr);
+  if (ma) {
+    return ma[1];
+  }
+
+  if (aliasData[val]) {
+    return aliasData[val];
+  }
+
+  return val;
+}
+
+function splitArgs(input) {
+  var matches;
+  const regex = new RegExp('(' + tExpr + ')\s*,?\s*', 'g');
+  var ret = [];
+  while ((matches = regex.exec(input)) !== null) {
+    ret.push(matches[1]);
+  }
+  return ret;
+}
+
+function renderPipe(pipe, aliasData) {
+  var result = expand(pipe[1], aliasData);
+  const inputExpression = pipe[0];
+  const regex = new RegExp(tPipe, 'g');
+  var matches;
+  while ((matches = regex.exec(inputExpression)) !== null) {
+    const functionName = matches[1];
+    const args = splitArgs(matches[2]);
+    var forFunc = [ result ];
+    for (const arg of args) {
+      forFunc.push(expand(arg, aliasData));
+    }
+
+    const func = functions[functionName];
+    result = func.apply(func, forFunc);
+  }
+  return result;
+}
+
 export function renderTemplate(aliasPattern, aliasData) {
+  const pipeRegex = '^(' + tExpr + ')(?:' + tPipe + ')*$';
+
   var aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
   return aliasPattern.replace(aliasRegex, function(match, g1) {
+    const asPipe = g1.match(pipeRegex);
+    if (asPipe) {
+      return renderPipe(asPipe, aliasData);
+    }
+
     if (aliasData[g1]) {
       return aliasData[g1];
     }

--- a/public/app/plugins/datasource/prometheus/template.ts
+++ b/public/app/plugins/datasource/prometheus/template.ts
@@ -1,0 +1,12 @@
+///<reference path="../../../headers/common.d.ts" />
+
+export function renderTemplate(aliasPattern, aliasData) {
+  var aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
+  return aliasPattern.replace(aliasRegex, function(match, g1) {
+    if (aliasData[g1]) {
+      return aliasData[g1];
+    }
+    return g1;
+  });
+}
+

--- a/public/test/specs/prom_template_specs.js
+++ b/public/test/specs/prom_template_specs.js
@@ -1,0 +1,30 @@
+define([
+  'app/plugins/datasource/prometheus/template'
+], function(template) {
+  'use strict';
+
+  var one = function(templ) {
+    return template.renderTemplate(templ, {
+      'foo': 'bar',
+      'baz': 'quux',
+      'before': '  right',
+      'after': 'left  ',
+    });
+  };
+
+  describe('promTemplate', function() {
+    describe('renderTemplate', function() {
+      it('has the 3.1 behaviour', function() {
+        expect(one('foo')).to.be('foo');
+        expect(one('{{ foo }}')).to.be('bar');
+        expect(one('{{ foo }} {{ baz }}')).to.be('bar quux');
+        expect(one('{{ foo }} is {{ baz }}')).to.be('bar is quux');
+        var s = 'replace whoopdee "doo \'';
+        expect(one(s)).to.be(s);
+
+        expect(one('{{ downright invalid }}')).to.be('downright invalid');
+        expect(one('{{ unrecognised }}')).to.be('unrecognised');
+      });
+    });
+  });
+});

--- a/public/test/specs/prom_template_specs.js
+++ b/public/test/specs/prom_template_specs.js
@@ -9,6 +9,8 @@ define([
       'baz': 'quux',
       'before': '  right',
       'after': 'left  ',
+      'host': 'foo.west-coast',
+      'cluster': 'west-coast',
     });
   };
 
@@ -24,6 +26,27 @@ define([
 
         expect(one('{{ downright invalid }}')).to.be('downright invalid');
         expect(one('{{ unrecognised }}')).to.be('unrecognised');
+      });
+
+      it('can do a simple replace', function() {
+        expect(one('{{ foo | replace("a", "ee") }}')).to.be('beer');
+        expect(one('{{ "foo" | replace("oo", "d") }}')).to.be('fd');
+      });
+
+      it('can do a chained replace', function() {
+        expect(one(
+            '{{ foo | replace("a", "ee") | replace("er", "an") }}'))
+            .to.be('bean');
+      });
+
+      it('can do a replace with vars', function() {
+        expect(one('{{ host | replace(cluster, "ee") }}'))
+            .to.be('foo.ee');
+      });
+
+
+      it('can do percentages', function() {
+        expect(one('{{ "0.5" | toPercent() }}')).to.be('50%');
       });
     });
   });


### PR DESCRIPTION
Fix #3545.

This allows replacements in labels in legends for the Prometheus data source. e.g.

```
{{ foo | replace("bar", "baz") }}
```

I also implemented the `toPercent()` function as an example. Other functions should be easy to add. I omitted the hostname parsing functions as they are pretty complex, but would be great to add as another PR. Personally, I care most about the `replace()` functionality.

There are various things I consider bugs in the old parser, which I have maintained, e.g. `{{ this could never work }}` expands to `this could never work`.

I stuck with a regex-based parser as:

* the existing code was broken specifically so it could use a simple regex based solution
* Angular's `$parse` can't be used, as it's not safe for arbitrary inputs (like the previous code).
* I couldn't find any reasonable JS libraries for this.

