### PR TITLE
(cloudwatch) percentile support

### DIFF
--- a/pkg/api/cloudwatch/cloudwatch.go
+++ b/pkg/api/cloudwatch/cloudwatch.go
@@ -143,25 +143,33 @@ func handleGetMetricStatistics(req *cwRequest, c *middleware.Context) {
 
 	reqParam := &struct {
 		Parameters struct {
-			Namespace  string                  `json:"namespace"`
-			MetricName string                  `json:"metricName"`
-			Dimensions []*cloudwatch.Dimension `json:"dimensions"`
-			Statistics []*string               `json:"statistics"`
-			StartTime  int64                   `json:"startTime"`
-			EndTime    int64                   `json:"endTime"`
-			Period     int64                   `json:"period"`
+			Namespace          string                  `json:"namespace"`
+			MetricName         string                  `json:"metricName"`
+			Dimensions         []*cloudwatch.Dimension `json:"dimensions"`
+			Statistics         []*string               `json:"statistics"`
+			ExtendedStatistics []*string               `json:"extendedStatistics"`
+			StartTime          int64                   `json:"startTime"`
+			EndTime            int64                   `json:"endTime"`
+			Period             int64                   `json:"period"`
 		} `json:"parameters"`
 	}{}
 	json.Unmarshal(req.Body, reqParam)
 
 	params := &cloudwatch.GetMetricStatisticsInput{
-		Namespace:  aws.String(reqParam.Parameters.Namespace),
-		MetricName: aws.String(reqParam.Parameters.MetricName),
-		Dimensions: reqParam.Parameters.Dimensions,
-		Statistics: reqParam.Parameters.Statistics,
-		StartTime:  aws.Time(time.Unix(reqParam.Parameters.StartTime, 0)),
-		EndTime:    aws.Time(time.Unix(reqParam.Parameters.EndTime, 0)),
-		Period:     aws.Int64(reqParam.Parameters.Period),
+		Namespace:          aws.String(reqParam.Parameters.Namespace),
+		MetricName:         aws.String(reqParam.Parameters.MetricName),
+		Dimensions:         reqParam.Parameters.Dimensions,
+		Statistics:         reqParam.Parameters.Statistics,
+		ExtendedStatistics: reqParam.Parameters.ExtendedStatistics,
+		StartTime:          aws.Time(time.Unix(reqParam.Parameters.StartTime, 0)),
+		EndTime:            aws.Time(time.Unix(reqParam.Parameters.EndTime, 0)),
+		Period:             aws.Int64(reqParam.Parameters.Period),
+	}
+	if len(reqParam.Parameters.Statistics) != 0 {
+		params.Statistics = reqParam.Parameters.Statistics
+	}
+	if len(reqParam.Parameters.ExtendedStatistics) != 0 {
+		params.ExtendedStatistics = reqParam.Parameters.ExtendedStatistics
 	}
 
 	resp, err := svc.GetMetricStatistics(params)
@@ -254,11 +262,12 @@ func handleDescribeAlarmsForMetric(req *cwRequest, c *middleware.Context) {
 
 	reqParam := &struct {
 		Parameters struct {
-			Namespace  string                  `json:"namespace"`
-			MetricName string                  `json:"metricName"`
-			Dimensions []*cloudwatch.Dimension `json:"dimensions"`
-			Statistic  string                  `json:"statistic"`
-			Period     int64                   `json:"period"`
+			Namespace         string                  `json:"namespace"`
+			MetricName        string                  `json:"metricName"`
+			Dimensions        []*cloudwatch.Dimension `json:"dimensions"`
+			Statistic         string                  `json:"statistic"`
+			ExtendedStatistic string                  `json:"extendedStatistic"`
+			Period            int64                   `json:"period"`
 		} `json:"parameters"`
 	}{}
 	json.Unmarshal(req.Body, reqParam)
@@ -273,6 +282,9 @@ func handleDescribeAlarmsForMetric(req *cwRequest, c *middleware.Context) {
 	}
 	if reqParam.Parameters.Statistic != "" {
 		params.Statistic = aws.String(reqParam.Parameters.Statistic)
+	}
+	if reqParam.Parameters.ExtendedStatistic != "" {
+		params.ExtendedStatistic = aws.String(reqParam.Parameters.ExtendedStatistic)
 	}
 
 	resp, err := svc.DescribeAlarmsForMetric(params)

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -357,6 +357,7 @@ function (angular, _, moment, dateMath, kbn, CloudWatchAnnotationQuery) {
       var periodMs = options.period * 1000;
 
       return _.map(options.statistics, function(stat) {
+        var extended = !_.includes(self.standardStatistics, stat);
         var dps = [];
         var lastTimestamp = null;
         _.chain(md.Datapoints)
@@ -369,7 +370,11 @@ function (angular, _, moment, dateMath, kbn, CloudWatchAnnotationQuery) {
             dps.push([null, lastTimestamp + periodMs]);
           }
           lastTimestamp = timestamp;
-          dps.push([dp[stat], timestamp]);
+          if (!extended) {
+            dps.push([dp[stat], timestamp]);
+          } else {
+            dps.push([dp.ExtendedStatistics[stat], timestamp]);
+          }
         })
         .value();
 

--- a/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.js
+++ b/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.js
@@ -61,14 +61,13 @@ function (angular, _) {
     };
 
     $scope.getStatSegments = function() {
-      return $q.when([
+      return $q.when(_.flatten([
         angular.copy($scope.removeStatSegment),
-        uiSegmentSrv.getSegmentForValue('Average'),
-        uiSegmentSrv.getSegmentForValue('Maximum'),
-        uiSegmentSrv.getSegmentForValue('Minimum'),
-        uiSegmentSrv.getSegmentForValue('Sum'),
-        uiSegmentSrv.getSegmentForValue('SampleCount'),
-      ]);
+        _.map($scope.datasource.standardStatistics, function(s) {
+          return uiSegmentSrv.getSegmentForValue(s);
+        }),
+        uiSegmentSrv.getSegmentForValue('pNN.NN'),
+      ]));
     };
 
     $scope.statSegmentChanged = function(segment, index) {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -161,6 +161,67 @@ describe('CloudWatchDatasource', function() {
     });
   });
 
+  describe('When performing CloudWatch query for extended statistics', function() {
+    var requestParams;
+
+    var query = {
+      range: { from: 'now-1h', to: 'now' },
+      targets: [
+        {
+          region: 'us-east-1',
+          namespace: 'AWS/ApplicationELB',
+          metricName: 'TargetResponseTime',
+          dimensions: {
+            LoadBalancer: 'lb',
+            TargetGroup: 'tg'
+          },
+          statistics: ['p90.00'],
+          period: 300
+        }
+      ]
+    };
+
+    var response = {
+      Datapoints: [
+        {
+          ExtendedStatistics: {
+            'p90.00': 1
+          },
+          Timestamp: 'Wed Dec 31 1969 16:00:00 GMT-0800 (PST)'
+        },
+        {
+          ExtendedStatistics: {
+            'p90.00': 2
+          },
+          Timestamp: 'Wed Dec 31 1969 16:05:00 GMT-0800 (PST)'
+        },
+        {
+          ExtendedStatistics: {
+            'p90.00': 5
+          },
+          Timestamp: 'Wed Dec 31 1969 16:15:00 GMT-0800 (PST)'
+        }
+      ],
+      Label: 'TargetResponseTime'
+    };
+
+    beforeEach(function() {
+      ctx.backendSrv.datasourceRequest = function(params) {
+        requestParams = params;
+        return ctx.$q.when({data: response});
+      };
+    });
+
+    it('should return series list', function(done) {
+      ctx.ds.query(query).then(function(result) {
+        expect(result.data[0].target).to.be('TargetResponseTime_p90.00');
+        expect(result.data[0].datapoints[0][0]).to.be(response.Datapoints[0].ExtendedStatistics['p90.00']);
+        done();
+      });
+      ctx.$rootScope.$apply();
+    });
+  });
+
   function describeMetricFindQuery(query, func) {
     describe('metricFindQuery ' + query, () => {
       let scenario: any = {};


### PR DESCRIPTION
This is a new feature.
https://aws.amazon.com/blogs/aws/amazon-cloudwatch-update-percentile-statistics-and-new-dashboard-widgets/

http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Statistic
> The value of the specified percentile. You can specify any percentile, using up to two decimal places (for example, p95.45). For more information, see Percentiles.

Percentile statistics can take "pNN.NN" form.
Current query editor doesn't mainly consider such free editing format.
But user can specify arbitrary statistics by direct input.
This PR add just a "hint".

Currently, it is not available in some region. I'll try it later.
```
% aws cloudwatch get-metric-statistics --namespace AWS/EC2 --metric-name CPUUtilization --dimensions Name=InstanceId,Value=i-xxxxxxxx --statistics Average --period 300 --start-time 2016-11-18T00:00:00 --end-time 2016-11-18T01:00:00 | head
{
    "Datapoints": [
        {
            "Timestamp": "2016-11-18T00:20:00Z",
            "Average": 2.226,
            "Unit": "Percent"
        },
        {
            "Timestamp": "2016-11-18T00:30:00Z",
            "Average": 2.134,
% aws cloudwatch get-metric-statistics --namespace AWS/EC2 --metric-name CPUUtilization --dimensions Name=InstanceId,Value=i-xxxxxxxx --statistics p90.00 --period 300 --start-time 2016-11-18T00:00:00 --end-time 2016-11-18T01:00:00 | head

An error occurred (InvalidParameterValue) when calling the GetMetricStatistics operation: The parameter Statistics.member.1 must be a value in the set [ Minimum, Maximum, Average, SampleCount, Sum ].
```