### PR TITLE
register non-builtin mixed type datasource plugins 

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
@@ -110,9 +111,14 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 	}
 
 	// add mixed backend data source
-	datasources["-- Mixed --"] = map[string]interface{}{
-		"type": "mixed",
-		"meta": plugins.DataSources["mixed"],
+	for _, ds := range plugins.DataSources {
+		if !ds.Mixed {
+			continue
+		}
+		datasources["-- "+strings.Title(ds.Id)+" --"] = map[string]interface{}{
+			"type": "mixed",
+			"meta": plugins.DataSources[ds.Id],
+		}
 	}
 
 	if defaultDatasource == "" {


### PR DESCRIPTION
I really impressed this comment, https://github.com/grafana/grafana/issues/3677#issuecomment-262543040.
But, current Grafana backend only register builtin "mixed" datasource.
I want to change the behavior.