### PR TITLE
[5443] Check if title is empty before save a new dashboard

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -121,6 +121,10 @@ func PostDashboard(c *middleware.Context, cmd m.SaveDashboardCommand) Response {
 	}
 
 	dash := cmd.GetDashboardModel()
+	// Check if Title is empty
+	if dash.Title == "" {
+		return ApiError(400, m.ErrDashboardTitleEmpty.Error(), nil)
+	}
 	if dash.Id == 0 {
 		limitReached, err := middleware.QuotaReached(c, "dashboard")
 		if err != nil {

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -15,6 +15,7 @@ var (
 	ErrDashboardSnapshotNotFound   = errors.New("Dashboard snapshot not found")
 	ErrDashboardWithSameNameExists = errors.New("A dashboard with the same name already exists")
 	ErrDashboardVersionMismatch    = errors.New("The dashboard has been changed by someone else")
+	ErrDashboardTitleEmpty         = errors.New("Dashboard title cannot be empty")
 )
 
 type UpdatePluginDashboardError struct {


### PR DESCRIPTION
This commit attempts to fix the following issue https://github.com/grafana/grafana/issues/5443 . The problem is due to the fact that the binding below doesn't correctly validate against the content of the pointer field but only checks if the "dashboard" field exists. 

```
type SaveDashboardCommand struct {
	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
        [...]
```

Thus, if the user provide an empty title eg. `{"dashboard": {"title":""}}` the `NewDashboard()` will attempt to create a new slug from an empty string. Eventually this will produce a new dashboard entry with no title for reference.