### PR TITLE
[RFC] Don't quote everything in InfluxQL.

### DIFF
--- a/public/app/core/components/query_part/query_part.ts
+++ b/public/app/core/components/query_part/query_part.ts
@@ -92,11 +92,11 @@ export function functionRenderer(part, innerExpr) {
         value = '$interval';
       }
     }
-    if (paramType.quote === 'single') {
-      return "'" + value + "'";
-    } else if (paramType.quote === 'double') {
-      return '"' + value + '"';
-    }
+    //if (paramType.quote === 'single') {
+    //  return "'" + value + "'";
+    //} else if (paramType.quote === 'double') {
+    //  return '"' + value + '"';
+    //}
 
     return value;
   });
@@ -117,7 +117,8 @@ export function identityRenderer(part, innerExpr) {
 }
 
 export function quotedIdentityRenderer(part, innerExpr) {
-  return '"' + part.params[0] + '"';
+  //return '"' + part.params[0] + '"';
+  return part.params[0];
 }
 
 

--- a/public/app/plugins/datasource/influxdb/influx_query.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query.ts
@@ -154,27 +154,35 @@ export default class InfluxQuery {
         value = this.templateSrv.replace(value, this.scopedVars);
       }
       if (operator !== '>' && operator !== '<') {
-        value = "'" + value.replace(/\\/g, '\\\\') + "'";
+        //value = "'" + value.replace(/\\/g, '\\\\') + "'";
+        value = value.replace(/\\/g, '\\\\');
       }
     } else if (interpolate) {
-      value = this.templateSrv.replace(value, this.scopedVars, 'regex');
+      //value = this.templateSrv.replace(value, this.scopedVars, 'regex');
+      value = this.templateSrv.replace(value, this.scopedVars, 'glob');
     }
 
-    return str + '"' + tag.key + '" ' + operator + ' ' + value;
+    //return str + '"' + tag.key + '" ' + operator + ' ' + value;
+    return str + tag.key + ' ' + operator + ' ' + value;
   }
 
   getMeasurementAndPolicy(interpolate) {
     var policy = this.target.policy;
     var measurement = this.target.measurement || 'measurement';
 
-    if (!measurement.match('^/.*/')) {
-      measurement = '"' + measurement+ '"';
-    } else if (interpolate) {
-      measurement = this.templateSrv.replace(measurement, this.scopedVars, 'regex');
+    //if (!measurement.match('^/.*/')) {
+    //  measurement = '"' + measurement+ '"';
+    //} else if (interpolate) {
+    //  measurement = this.templateSrv.replace(measurement, this.scopedVars, 'regex');
+    //}
+
+    if (interpolate) {
+      measurement = this.templateSrv.replace(measurement, this.scopedVars, 'glob');
     }
 
     if (policy !== 'default') {
-      policy = '"' + this.target.policy + '".';
+      //policy = '"' + this.target.policy + '".';
+      policy = this.target.policy + '.';
     } else {
       policy = "";
     }
@@ -193,7 +201,8 @@ export default class InfluxQuery {
     }
 
     var escapedValues = _.map(value, kbn.regexEscape);
-    return escapedValues.join('|');
+    //return escapedValues.join('|');
+    return escapedValues.join(',');
   };
 
   render(interpolate?) {

--- a/public/app/plugins/datasource/influxdb/query_builder.js
+++ b/public/app/plugins/datasource/influxdb/query_builder.js
@@ -25,12 +25,13 @@ function (_) {
       }
     }
 
-    // quote value unless regex or number
-    if (operator !== '=~' && operator !== '!~' && isNaN(+value)) {
-      value = "'" + value + "'";
-    }
+    //// quote value unless regex or number
+    //if (operator !== '=~' && operator !== '!~' && isNaN(+value)) {
+    //  value = "'" + value + "'";
+    //}
 
-    return str + '"' + tag.key + '" ' + operator + ' ' + value;
+    //return str + '"' + tag.key + '" ' + operator + ' ' + value;
+    return str + tag.key + ' ' + operator + ' ' + value;
   }
 
   var p = InfluxQueryBuilder.prototype;
@@ -59,19 +60,21 @@ function (_) {
       query = 'SHOW FIELD KEYS FROM "' + this.target.measurement + '"';
       return query;
     } else if (type === 'RETENTION POLICIES') {
-      query = 'SHOW RETENTION POLICIES on "' + this.database + '"';
+      //query = 'SHOW RETENTION POLICIES on "' + this.database + '"';
+      query = 'SHOW RETENTION POLICIES on ' + this.database;
       return query;
     }
 
     if (measurement) {
-      if (!measurement.match('^/.*/') && !measurement.match(/^merge\(.*\)/)) {
-        measurement = '"' + measurement+ '"';
-      }
+      //if (!measurement.match('^/.*/') && !measurement.match(/^merge\(.*\)/)) {
+      //  measurement = '"' + measurement+ '"';
+      //}
       query += ' FROM ' + measurement;
     }
 
     if (withKey) {
-      query += ' WITH KEY = "' + withKey + '"';
+      //query += ' WITH KEY = "' + withKey + '"';
+      query += ' WITH KEY = ' + withKey;
     }
 
     if (this.target.tags && this.target.tags.length > 0) {

--- a/public/app/plugins/datasource/influxdb/query_part.ts
+++ b/public/app/plugins/datasource/influxdb/query_part.ts
@@ -37,14 +37,16 @@ function register(options: any) {
 var groupByTimeFunctions = [];
 
 function aliasRenderer(part, innerExpr) {
-  return innerExpr + ' AS ' + '"' + part.params[0] + '"';
+  //return innerExpr + ' AS ' + '"' + part.params[0] + '"';
+  return innerExpr + ' AS ' + part.params[0];
 }
 
 function fieldRenderer(part, innerExpr) {
   if (part.params[0] === '*')  {
     return '*';
   }
-  return '"' + part.params[0] + '"';
+  //return '"' + part.params[0] + '"';
+  return part.params[0];
 }
 
 function replaceAggregationAddStrategy(selectParts, partModel) {


### PR DESCRIPTION
This allows Grafana to support my InfluxDB-to-MySQL protocol converter, https://github.com/philip-wernersbach/influx-mysql.

This is necessary because InfluxQL statements can literally have everything quoted (column names, integers, literals, etc.), and InfluxDB will parse the statement and then convert the quoted strings into the proper types. SQL databases will happily accept these statements, but the behavior is undefined when you do SQL comparisons with the quoted strings and the properly typed database columns.

This probably isn't good enough to be merged into Grafana as-is, but I'm hoping to get feedback so I can refine this and get it included into Grafana.