### PR TITLE
Add 'Last 2 days' option to quick ranges

### DIFF
--- a/public/app/core/utils/rangeutil.ts
+++ b/public/app/core/utils/rangeutil.ts
@@ -38,6 +38,7 @@ var rangeOptions = [
   { from: 'now-12h',  to: 'now',      display: 'Last 12 hours',         section: 3 },
   { from: 'now-24h',  to: 'now',      display: 'Last 24 hours',         section: 3 },
 
+  { from: 'now-2d',   to: 'now',      display: 'Last 2 days',           section: 0 },
   { from: 'now-7d',   to: 'now',      display: 'Last 7 days',           section: 0 },
   { from: 'now-30d',  to: 'now',      display: 'Last 30 days',          section: 0 },
   { from: 'now-60d',  to: 'now',      display: 'Last 60 days',          section: 0 },


### PR DESCRIPTION
"Last 2 days" is very useful to compare trends between current and last day, it was included in previous versions of Grafana, but it's currently missing in Grafana 4.
