### PR TITLE
Use correct domain in render.js

### DIFF
--- a/vendor/phantomjs/render.js
+++ b/vendor/phantomjs/render.js
@@ -22,7 +22,7 @@
   phantom.addCookie({
     'name': 'renderKey',
     'value': params.renderKey,
-    'domain': 'localhost',
+    'domain': params.domain,
   });
 
   page.viewportSize = {


### PR DESCRIPTION
* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master
Phantomjs is always rendering login page because domain is not considered. According to http://phantomjs.org/api/webpage/method/add-cookie.html a correct domain must be passed. Probably this change is now necessary due to https://github.com/grafana/grafana/issues/6660