### PR TITLE
Moved ADD ROW to left to consolidate row actions

### DIFF
--- a/public/app/partials/dashboard.html
+++ b/public/app/partials/dashboard.html
@@ -15,8 +15,8 @@
 	</div>
 
 	<div ng-show='dashboardMeta.canEdit' class="row-fluid add-row-panel-hint">
-		<div class="span12" style="text-align:right;">
-			<span style="margin-right: 10px;" ng-click="addRowDefault()" class="pointer btn btn-inverse btn-small">
+		<div class="span12" style="text-align:left;">
+			<span style="margin-left: 12px;" ng-click="addRowDefault()" class="pointer btn btn-inverse btn-small">
 				<span><i class="fa fa-plus"></i> ADD ROW</span>
 			</span>
 		</div>


### PR DESCRIPTION
Proposing a small interface change that may seem unnecessary, but I believe it makes logical sense to couple these actions. 

Currently ADD ROW is still on the right. The more I use it, despite the muscle memory, it seemed odd to have a row action located all the way on the right, isolated from its other Row Action friends on the left side. 

![screenshot 2016-12-06 10 41 57](https://cloud.githubusercontent.com/assets/2886187/20931948/e1b40be2-bba0-11e6-8bf5-ea632fbbb69b.png)