### PR TITLE
Adjusted the active state to fix the faint line showing.

### DIFF
--- a/public/sass/components/_tabs.scss
+++ b/public/sass/components/_tabs.scss
@@ -65,6 +65,6 @@
     border-bottom: 2px solid $panel-bg;
     color: $link-color;
     position: relative;
-    top: 2px;
+    top: 1px;
   }
 }


### PR DESCRIPTION
Probably related to the font change in 4.0. 