### PR TITLE
fix(metricsegment): Fix cached options (and custom == 'false' behavior)

### DIFF
--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -205,7 +205,7 @@ function (_, $, coreModule) {
 
           $scope.onSegmentChange = function() {
             if (cachedOptions) {
-              var option = _.find(cachedOptions, {text: $scope.segment.value});
+              var option = _.find(cachedOptions, {value: $scope.segment.value});
               if (option && option.value !== $scope.property) {
                 $scope.property = option.value;
               } else if (attrs.custom !== 'false') {


### PR DESCRIPTION
This fixes an issue that cached options were ignored on segment change because the code searches for a field 'text' in the cached metrics but the relevant field is called 'value'.

When custom is set to 'false', a selected metric is only accepted if it was found in the option cache. Due to the issue above metrics were ignored if they had custom set to 'false'.

The change has been tested with the sun and moon datasource plugin where it fixes https://github.com/fetzerch/grafana-sunandmoon-datasource/issues/6 and the simple json datasource plugin (as an example for a plugin that uses custom == 'true').

The issue was introduced in https://github.com/grafana/grafana/commit/918481909c2e53994d907b39923da5c4711f1456