### PR TITLE
fix(alert): alert test should return error when it failed to dispatch

### DIFF
--- a/pkg/services/alerting/notifiers/email.go
+++ b/pkg/services/alerting/notifiers/email.go
@@ -89,6 +89,7 @@ func (this *EmailNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if err != nil {
 		this.log.Error("Failed to send alert notification email", "error", err)
+		return err
 	}
 	return nil
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -112,6 +112,7 @@ func (this *OpsGenieNotifier) closeAlert(evalContext *alerting.EvalContext) erro
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 		this.log.Error("Failed to send notification to OpsGenie", "error", err, "body", string(body))
+		return err
 	}
 
 	return nil

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -89,6 +89,7 @@ func (this *PagerdutyNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 		this.log.Error("Failed to send notification to Pagerduty", "error", err, "body", string(body))
+		return err
 	}
 
 	return nil

--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -105,6 +105,7 @@ func (this *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 		this.log.Error("Failed to send slack notification", "error", err, "webhook", this.Name)
+		return err
 	}
 
 	return nil

--- a/pkg/services/alerting/notifiers/victorops.go
+++ b/pkg/services/alerting/notifiers/victorops.go
@@ -94,6 +94,7 @@ func (this *VictoropsNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 		this.log.Error("Failed to send victorops notification", "error", err, "webhook", this.Name)
+		return err
 	}
 
 	return nil

--- a/pkg/services/alerting/notifiers/webhook.go
+++ b/pkg/services/alerting/notifiers/webhook.go
@@ -74,6 +74,7 @@ func (this *WebhookNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 		this.log.Error("Failed to send webhook", "error", err, "webhook", this.Name)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Note that current localhost:6969 endpoint return 404. Users should notice that it fail when it actually failed.

### Before
![](https://i.gyazo.com/a2ee4521a5b2c72a28bdab927218708b.gif)

### After
![](https://i.gyazo.com/4858ac41412fcfe73810060d35a8c700.gif)