### PR TITLE
docs(configuration): set `allow_sign_up` to `true` for gerneric OAuth

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -394,7 +394,7 @@ browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
     token_url =
     api_url =
     allowed_domains = mycompany.com mycompany.org
-    allow_sign_up = false
+    allow_sign_up = true
 
 Set api_url to the resource that returns basic user info.
 


### PR DESCRIPTION
Update documentation for Generic OAuth to enable Grafana to accept new users authenticated through OAuth. Without `allow_sign_up` set to `true` only previously authenticated users may log in.