### PR TITLE
Allow script directory to be configurable.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -355,6 +355,10 @@ exchange = grafana_events
 enabled = false
 path = /var/lib/grafana/dashboards
 
+#################################### Scripted Dashboard JS files ################
+[dashboards.scripts]
+path = public/dashboards
+
 #################################### Usage Quotas ########################
 [quota]
 enabled = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -334,10 +334,14 @@
 ;rabbitmq_url = amqp://localhost/
 ;exchange = grafana_events
 
-;#################################### Dashboard JSON files ##########################
+#################################### Dashboard JSON files ##########################
 [dashboards.json]
 ;enabled = false
 ;path = /var/lib/grafana/dashboards
+
+#################################### Scripted Dashboard JS files ################
+[dashboards.scripts]
+;path = public/dashboards
 
 #################################### Alerting ######################################
 [alerting]

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -84,6 +84,9 @@ with Grafana admin permission.
         "enabled":"false",
         "path":"/var/lib/grafana/dashboards"
       },
+      "dashboards.scripts":{
+        "path":"public/dashboards"
+      },
       "database":{
         "host":"127.0.0.1:0000",
         "name":"grafana",

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -506,6 +506,14 @@ Grafana backend index those json dashboards which will make them appear in regul
 ### path
 The full path to a directory containing your json dashboards.
 
+## [dashboards.scripts]
+
+If you have a system that automatically builds scripted dashboards as js files you can enable this feature to have the
+Grafana backend index those scripted dashboards so they are available to use.
+
+### path
+The full path to a directory containing your dashboard scripts.
+
 ## [smtp]
 Email server settings.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -222,6 +222,7 @@ func Register(r *macaron.Macaron) {
 			r.Combo("/db/:slug").Get(GetDashboard).Delete(DeleteDashboard)
 			r.Post("/db", reqEditorRole, bind(m.SaveDashboardCommand{}), wrap(PostDashboard))
 			r.Get("/file/:file", GetDashboardFromJsonFile)
+			r.Get("/script/:file", GetDashboardScriptFromFile)
 			r.Get("/home", wrap(GetHomeDashboard))
 			r.Get("/tags", GetDashboardTags)
 			r.Post("/import", bind(dtos.ImportDashboardCommand{}), wrap(ImportDashboard))

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -237,6 +238,24 @@ func addGettingStartedPanelToHomeDashboard(dash *simplejson.Json) {
 	panels := row.Get("panels").MustArray()
 	panels = append(panels, newpanel)
 	row.Set("panels", panels)
+}
+
+func GetDashboardScriptFromFile(c *middleware.Context) {
+	file := c.Params(":file")
+
+	script := search.GetDashboardScriptFromFile(file)
+	if script == nil {
+		c.JsonApiErr(404, "Dashboard script not found", nil)
+		return
+	}
+
+	data, err := ioutil.ReadFile(script.Path)
+	if err != nil {
+		c.JsonApiErr(404, "Could not load script file", nil)
+		return
+	}
+
+	c.RawData(200, data)
 }
 
 func GetDashboardFromJsonFile(c *middleware.Context) {

--- a/pkg/services/search/script_index.go
+++ b/pkg/services/search/script_index.go
@@ -1,0 +1,86 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/log"
+)
+
+type DashboardScriptIndex struct {
+	path  string
+	items []*DashboardScript
+}
+
+type DashboardScript struct {
+	Name string
+	Path string
+}
+
+func (s *DashboardScript) String() string {
+	return "name=" + s.Name + ";path=" + s.Path
+}
+
+func NewDashboardScriptIndex(path string) *DashboardScriptIndex {
+	log.Info("Creating scripted dashboard index for path: %v", path)
+
+	index := DashboardScriptIndex{}
+	index.path = path
+	index.updateIndex()
+	return &index
+}
+
+func (index *DashboardScriptIndex) updateLoop() {
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+			if err := index.updateIndex(); err != nil {
+				log.Error(3, "Failed to update dashboard json index %v", err)
+			}
+		}
+	}
+}
+
+func (index *DashboardScriptIndex) GetScript(name string) *DashboardScript {
+	for _, item := range index.items {
+		if item.Name == name {
+			return item
+		}
+	}
+
+	return nil
+}
+
+func (index *DashboardScriptIndex) updateIndex() error {
+	var items = make([]*DashboardScript, 0)
+
+	visitor := func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if f.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(f.Name(), ".js") {
+			stat, _ := os.Stat(path)
+
+			item := &DashboardScript{}
+			item.Name = stat.Name()
+			item.Path = path
+			items = append(items, item)
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(index.path, visitor); err != nil {
+		return err
+	}
+
+	index.items = items
+	return nil
+}

--- a/pkg/services/search/script_index_test.go
+++ b/pkg/services/search/script_index_test.go
@@ -1,0 +1,28 @@
+package search
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestScriptIndex(t *testing.T) {
+
+	Convey("Given the json dash index", t, func() {
+		index := NewDashboardScriptIndex("../../../public/dashboards/")
+
+		Convey("Should be able to update index", func() {
+			err := index.updateIndex()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Should get a script by its name", func() {
+			res := index.GetScript("scripted.js")
+			So(res, ShouldNotBeNil)
+
+			So(res.Name, ShouldEqual, "scripted.js")
+			So(res.Path, ShouldEqual, "../../../public/dashboards/scripted.js")
+		})
+
+	})
+}

--- a/public/app/features/dashboard/dashboardLoaderSrv.js
+++ b/public/app/features/dashboard/dashboardLoaderSrv.js
@@ -59,7 +59,7 @@ function (angular, moment, _, $, kbn, dateMath, impressionStore) {
     };
 
     this._loadScriptedDashboard = function(file) {
-      var url = 'public/dashboards/'+file.replace(/\.(?!js)/,"/") + '?' + new Date().getTime();
+      var url = 'api/dashboards/script/'+file.replace(/\.(?!js)/,"/") + '?' + new Date().getTime();
 
       return $http({ url: url, method: "GET" })
       .then(this._executeScript).then(function(result) {


### PR DESCRIPTION
This would resolve https://github.com/grafana/grafana/issues/3809

This change allows for the script directory to be configurable the same way the json dashboard directory is. This works by adding an indexing task that runs once per minute to index all of the js files and store them in an index. At load time the index is queried and the api dynamically returns the contents of the requests javascript file. The dashboard then processes this javascript the same way it did before. One difference between this and the json index is that this will always be on and defaults to public/dashboards which provides the same functionality out of the box that you get now. 