### PR TITLE
Softened the color a bit by mixing in the panel-bg.

### DIFF
--- a/public/sass/components/_modals.scss
+++ b/public/sass/components/_modals.scss
@@ -67,6 +67,7 @@
 
 .modal-content {
   padding: $spacer*2;
+  min-height: $spacer*15;
 }
 
 // Remove bottom margin if need be

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -90,7 +90,7 @@ div.flot-text {
 }
 
 .panel-info-corner {
-  color: $text-color;
+  color: $text-muted;
   cursor: pointer;
   position: absolute;
   display: none;
@@ -102,14 +102,14 @@ div.flot-text {
 
   .fa {
     position: relative;
-    top: -2px;
+    top: -4px;
     left: -5px;
-    font-size: 90%;
+    font-size: 75%;
   }
 
   &--info {
     display: block;
-    background: $blue-dark;
+    background: mix($panel-bg, $body-bg, 35%);
     .fa:before {
       content: "\f129";
     }
@@ -117,7 +117,7 @@ div.flot-text {
 
   &--links {
     display: block;
-    background: $blue-dark;
+    background: mix($panel-bg, $body-bg, 35%);
     .fa {
       left: -3px;
     }

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -103,13 +103,13 @@ div.flot-text {
   .fa {
     position: relative;
     top: -4px;
-    left: -5px;
+    left: -6px;
     font-size: 75%;
   }
 
   &--info {
     display: block;
-    background: mix($panel-bg, $body-bg, 35%);
+    background: lighten($panel-bg, 4%);
     .fa:before {
       content: "\f129";
     }
@@ -117,9 +117,9 @@ div.flot-text {
 
   &--links {
     display: block;
-    background: mix($panel-bg, $body-bg, 35%);
+    background: lighten($panel-bg, 4%);
     .fa {
-      left: -3px;
+      left: -5px;
     }
     .fa:before {
       content: "\f08e";
@@ -128,6 +128,7 @@ div.flot-text {
 
   &--error {
     display: block;
+    color: $text-color;
     background: $errorBackground !important;
     .fa:before {
       content: "\f12a";


### PR DESCRIPTION
Softened the color a bit by mixing in the panel-bg, so it's not introducing any new variables. Was too stark as pure body-bg. 

I think it sits much nicer in the dashboard now when there are many info items. We want to encourage folks to enter these details, and I dont want to visually punish them if every panel had info. 

<img width="1232" alt="screenshot 2016-12-16 12 13 35" src="https://cloud.githubusercontent.com/assets/2886187/21271458/13ef95d2-c389-11e6-9d2d-60524ea180d3.png">

The light theme is fine, on-par with the rest of the light theme. But that really needs some love and contrast overall. 

Added a min-height for modal-body container. It was too small and awkward when the message was only a line or two. 
