### PR TITLE
Allow multiple org_ids in ldap toml configuration

### DIFF
--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -74,6 +74,7 @@ group_dn = "cn=admins,dc=grafana,dc=org"
 org_role = "Admin"
 # The Grafana organization database id, optional, if left out the default org (id 1) will be used
 # org_id = 1
+# org_ids = [ 1, 2 ]
 
 [[servers.group_mappings]]
 group_dn = "cn=users,dc=grafana,dc=org"

--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -75,6 +75,8 @@ group_dn = "cn=admins,dc=grafana,dc=org"
 org_role = "Admin"
 # The Grafana organization database id, optional, if left out the default org (id 1) will be used
 # org_id = 1
+# Multiple org ids are allowed too
+# org_ids = [ 1, 2 ]
 
 [[servers.group_mappings]]
 group_dn = "cn=users,dc=grafana,dc=org"

--- a/pkg/login/settings.go
+++ b/pkg/login/settings.go
@@ -46,6 +46,7 @@ type LdapAttributeMap struct {
 type LdapGroupToOrgRole struct {
 	GroupDN string     `toml:"group_dn"`
 	OrgId   int64      `toml:"org_id"`
+	OrgIds  []int64    `toml:"org_ids"`
 	OrgRole m.RoleType `toml:"org_role"`
 }
 


### PR DESCRIPTION
This PR add a new `org_ids` field in ldap.toml configuration file.
For each id in org_ids, the org_role will be affected to this organization for the user.
Related Issue : https://github.com/grafana/grafana/issues/2608