### PR TITLE
Register new queries available in InfluxDB - Holt Winters

### DIFF
--- a/pkg/tsdb/influxdb/query_part.go
+++ b/pkg/tsdb/influxdb/query_part.go
@@ -33,6 +33,15 @@ func init() {
 	renders["median"] = QueryDefinition{Renderer: functionRenderer}
 	renders["sum"] = QueryDefinition{Renderer: functionRenderer}
 
+  renders["holt_winters"] = QueryDefinition{
+    Renderer: functionRenderer,
+    Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
+  }
+  renders["holt_winters_with_fit"] = QueryDefinition{
+    Renderer: functionRenderer,
+    Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
+  }
+  
 	renders["derivative"] = QueryDefinition{
 		Renderer: functionRenderer,
 		Params:   []DefinitionParameters{{Name: "duration", Type: "interval"}},

--- a/pkg/tsdb/influxdb/query_part.go
+++ b/pkg/tsdb/influxdb/query_part.go
@@ -33,15 +33,15 @@ func init() {
 	renders["median"] = QueryDefinition{Renderer: functionRenderer}
 	renders["sum"] = QueryDefinition{Renderer: functionRenderer}
 
-  renders["holt_winters"] = QueryDefinition{
-    Renderer: functionRenderer,
-    Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
-  }
-  renders["holt_winters_with_fit"] = QueryDefinition{
-    Renderer: functionRenderer,
-    Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
-  }
-  
+	renders["holt_winters"] = QueryDefinition{
+		Renderer: functionRenderer,
+		Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
+	}
+	renders["holt_winters_with_fit"] = QueryDefinition{
+		Renderer: functionRenderer,
+		Params:   []DefinitionParameters{{Name: "number", Type: "number"}, {Name: "season", Type: "number"}},
+	}
+
 	renders["derivative"] = QueryDefinition{
 		Renderer: functionRenderer,
 		Params:   []DefinitionParameters{{Name: "duration", Type: "interval"}},
@@ -59,7 +59,7 @@ func init() {
 	renders["stddev"] = QueryDefinition{Renderer: functionRenderer}
 	renders["time"] = QueryDefinition{
 		Renderer: functionRenderer,
-		Params:   []DefinitionParameters{{Name: "interval", Type: "time"}},
+		Params:   []DefinitionParameters{{Name: "interval", Type: "time"}, {Name: "offset", Type: "time"}},
 	}
 	renders["fill"] = QueryDefinition{
 		Renderer: functionRenderer,

--- a/public/app/plugins/datasource/influxdb/query_part.ts
+++ b/public/app/plugins/datasource/influxdb/query_part.ts
@@ -15,6 +15,7 @@ var categories = {
   Aggregations: [],
   Selectors: [],
   Transformations: [],
+  Predictions: [],
   Math: [],
   Aliasing: [],
   Fields: [],

--- a/public/app/plugins/datasource/influxdb/query_part.ts
+++ b/public/app/plugins/datasource/influxdb/query_part.ts
@@ -241,8 +241,9 @@ register({
 register({
   type: 'time',
   category: groupByTimeFunctions,
-  params: [{ name: "interval", type: "time", options: ['auto', '1s', '10s', '1m', '5m', '10m', '15m', '1h'] }],
-  defaultParams: ['auto'],
+  params: [{ name: "interval", type: "time", options: ['auto', '1s', '10s', '1m', '5m', '10m', '15m', '1h'] },
+    { name: "offset", type: "time", options: ['auto', '1s', '10s', '1m', '5m', '10m', '15m', '1h'] }],
+  defaultParams: ['auto', 'auto'],
   renderer: functionRenderer,
 });
 
@@ -260,6 +261,25 @@ register({
   category: categories.Transformations,
   params: [{ name: "duration", type: "interval", options: ['1s', '10s', '1m', '5m', '10m', '15m', '1h']}],
   defaultParams: ['10s'],
+  renderer: functionRenderer,
+});
+
+// predictions
+register({
+  type: 'holt_winters',
+  addStrategy: addTransformationStrategy,
+  category: categories.Predictions,
+  params: [{ name: "number", type: "number", options: [5, 10, 20, 30, 40]}, { name: "season", type: "number", options: [0, 1, 2, 5, 10]}],
+  defaultParams: [10, 2],
+  renderer: functionRenderer,
+});
+
+register({
+  type: 'holt_winters_with_fit',
+  addStrategy: addTransformationStrategy,
+  category: categories.Predictions,
+  params: [{ name: "number", type: "number", options: [5, 10, 20, 30, 40]}, { name: "season", type: "number", options: [0, 1, 2, 5, 10]}],
+  defaultParams: [10, 2],
   renderer: functionRenderer,
 });
 

--- a/public/app/plugins/datasource/influxdb/specs/influx_query_specs.ts
+++ b/public/app/plugins/datasource/influxdb/specs/influx_query_specs.ts
@@ -124,7 +124,7 @@ describe('InfluxQuery', function() {
 
       var queryText = query.render();
       expect(queryText).to.be('SELECT mean("value") FROM "cpu" WHERE $timeFilter ' +
-                          'GROUP BY time($interval), "host"');
+                          'GROUP BY time($interval, $interval), "host"');
     });
   });
 
@@ -148,7 +148,7 @@ describe('InfluxQuery', function() {
         groupBy: [{type: 'time'}, {type: 'fill', params: ['0']}],
       }, templateSrv, {});
       var queryText = query.render();
-      expect(queryText).to.be('SELECT "value" FROM "cpu" WHERE $timeFilter GROUP BY time($interval) fill(0)');
+      expect(queryText).to.be('SELECT "value" FROM "cpu" WHERE $timeFilter GROUP BY time($interval, $interval) fill(0)');
     });
   });
 


### PR DESCRIPTION
For correct data fill on holt winters predictions, the time function needed modification to allow a 2nd param for offset, as per [documentation].(https://docs.influxdata.com/influxdb/v1.0/query_language/data_exploration/#advanced-group-by-time-syntax)

I couldn't see a way to add a param to time() as optional though, from my testing having both interval and offset set to $interval or 'auto' works perfectly well and all the grunt tests pass.

#5619 refers