### PR TITLE
Configure the OAuth redirectURL

### DIFF
--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -81,6 +81,7 @@ func NewOAuthService() {
 			TlsClientCa:                  sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:                sec.Key("tls_skip_verify_insecure").MustBool(),
 			SendClientCredentialsViaPost: sec.Key("send_client_credentials_via_post").MustBool(),
+			RedirectUrl:                  sec.Key("redirect_url").String(),
 		}
 
 		if !info.Enabled {
@@ -105,7 +106,7 @@ func NewOAuthService() {
 				AuthURL:  info.AuthUrl,
 				TokenURL: info.TokenUrl,
 			},
-			RedirectURL: strings.TrimSuffix(setting.AppUrl, "/") + SocialBaseUrl + name,
+			RedirectURL: info.RedirectUrl,
 			Scopes:      info.Scopes,
 		}
 
@@ -191,6 +192,10 @@ func NewOAuthService() {
 				allowSignup:          info.AllowSignup,
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
 			}
+		}
+
+		if len(config.RedirectURL) == 0 {
+			config.RedirectURL = strings.TrimSuffix(setting.AppUrl, "/") + SocialBaseUrl + name
 		}
 	}
 }

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -4,6 +4,7 @@ type OAuthInfo struct {
 	ClientId, ClientSecret       string
 	Scopes                       []string
 	AuthUrl, TokenUrl            string
+	RedirectUrl                  string
 	Enabled                      bool
 	EmailAttributeName           string
 	AllowedDomains               []string


### PR DESCRIPTION
While trying to enable Google authentication on my internal site, I hit a limitation of their service.

Google (and maybe others) don’t let you redirect to a private domain!

My solution was to make the redirect_url configurable, and point to a wildcard DNS service:

```
redirect_url = http://127.0.0.1.nip.io:3000/login/google
```



