### PR TITLE
Fix auto_assign_org_role = Read Only Editor docs

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -248,7 +248,10 @@ organization to be created for that new user.
 
 The role new users will be assigned for the main organization (if the
 above setting is set to true).  Defaults to `Viewer`, other valid
-options are `Admin` and `Editor` and `Read-Only Editor`.
+options are `Admin` and `Editor` and `Read Only Editor`. e.g. :
+
+`auto_assign_org_role = Read Only Editor`
+
 
 <hr>
 


### PR DESCRIPTION
`auto_assign_org_role` should be `Read Only Editor` rather than `Read-Only Editor`
