### PR TITLE
append windows phantomjs with .exe

### DIFF
--- a/tasks/options/phantomjs.js
+++ b/tasks/options/phantomjs.js
@@ -6,6 +6,10 @@ module.exports = function(config,grunt) {
     var dest = './vendor/phantomjs/phantomjs';
     var confDir = './node_modules/phantomjs-prebuilt/lib/';
 
+    if (process.platform === "win32") {
+      dest += ".exe";
+    }
+
     src = config.phjs
 
     if (!src){


### PR DESCRIPTION
The windows phantomjs ships without .exe, so it does not work out-of-the-box

This just renames it, see #6738 