### PR TITLE
RabbitMQ Notifier

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,7 +49,7 @@ var (
 	M_Alerting_Notification_Sent_OpsGenie  Counter
 	M_Aws_CloudWatch_GetMetricStatistics   Counter
 	M_Aws_CloudWatch_ListMetrics           Counter
-
+  M_Alerting_Notification_Sent_RabbitMQ  Counter
 	// Timers
 	M_DataSource_ProxyReq_Timer Timer
 	M_Alerting_Execution_Time   Timer
@@ -114,6 +114,7 @@ func initMetricVars(settings *MetricSettings) {
 	M_Alerting_Notification_Sent_PagerDuty = RegCounter("alerting.notifications_sent", "type", "pagerduty")
 	M_Alerting_Notification_Sent_Victorops = RegCounter("alerting.notifications_sent", "type", "victorops")
 	M_Alerting_Notification_Sent_OpsGenie = RegCounter("alerting.notifications_sent", "type", "opsgenie")
+  M_Alerting_Notification_Sent_RabbitMQ = RegCounter("alerting.notifications_sent", "type", "rabbitmq")
 
 	M_Aws_CloudWatch_GetMetricStatistics = RegCounter("aws.cloudwatch.get_metric_statistics")
 	M_Aws_CloudWatch_ListMetrics = RegCounter("aws.cloudwatch.list_metrics")

--- a/pkg/services/alerting/notifiers/rabbitmq.go
+++ b/pkg/services/alerting/notifiers/rabbitmq.go
@@ -25,11 +25,16 @@ type RabbitMQNotifier struct {
 }
 
 func NewRabbitMQNotifier(model *m.AlertNotification) (alerting.Notifier, error) {
+  if model.Settings == nil {
+    return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
+  }
+
   hostAddress := model.Settings.Get("hostaddress").MustString()
   username := model.Settings.Get("username").MustString()
   password := model.Settings.Get("password").MustString()
   vhost := model.Settings.Get("vhost").MustString()
   exchange := model.Settings.Get("exchange").MustString()
+
 
   if hostAddress == "" {
     return nil, alerting.ValidationError{Reason: "Could not find host address in settings"}

--- a/pkg/services/alerting/notifiers/rabbitmq.go
+++ b/pkg/services/alerting/notifiers/rabbitmq.go
@@ -1,0 +1,121 @@
+package notifiers
+
+import (
+  "fmt"
+  "github.com/grafana/grafana/pkg/bus"
+  "github.com/grafana/grafana/pkg/log"
+  "github.com/grafana/grafana/pkg/metrics"
+  m "github.com/grafana/grafana/pkg/models"
+  "github.com/grafana/grafana/pkg/services/alerting"
+  "github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+func init() {
+  alerting.RegisterNotifier("rabbitmq", NewRabbitMQNotifier)
+}
+
+type RabbitMQNotifier struct {
+  NotifierBase
+  HostAddress string
+  Username    string
+  Password    string
+  VHost       string
+  Exchange    string
+  log       log.Logger
+}
+
+func NewRabbitMQNotifier(model *m.AlertNotification) (alerting.Notifier, error) {
+  hostAddress := model.Settings.Get("hostaddress").MustString()
+  username := model.Settings.Get("username").MustString()
+  password := model.Settings.Get("password").MustString()
+  vhost := model.Settings.Get("vhost").MustString()
+  exchange := model.Settings.Get("exchange").MustString()
+
+  if hostAddress == "" {
+    return nil, alerting.ValidationError{Reason: "Could not find host address in settings"}
+  }
+
+  if username == "" {
+    return nil, alerting.ValidationError{Reason: "Could not find host username in settings"}
+  }
+
+  if password == "" {
+    return nil, alerting.ValidationError{Reason: "Could not find host password in settings"}
+  }
+
+  if vhost == "" {
+    return nil, alerting.ValidationError{Reason: "Could not find host vhost in settings"}
+  }
+
+  if exchange == "" {
+    return nil, alerting.ValidationError{Reason: "Could not find host exchange in settings"}
+  }
+
+    return &RabbitMQNotifier{
+    NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
+    HostAddress:    hostAddress,
+      Username: username,
+      Password: password,
+      VHost: vhost,
+      Exchange: exchange,
+    log:          log.New("alerting.notifier.rabbitmq"),
+  }, nil
+}
+
+func (this *RabbitMQNotifier) Notify(evalContext *alerting.EvalContext) error {
+  this.log.Info("Sending alert notification to", "host", this.HostAddress)
+  this.log.Info("Sending alert notification to", "username", this.Username)
+  this.log.Info("Sending alert notification to", "password", this.Password)
+  this.log.Info("Sending alert notification to", "vhost", this.VHost)
+  this.log.Info("Sending alert notification to", "exchange", this.Exchange)
+  metrics.M_Alerting_Notification_Sent_RabbitMQ.Inc(1)
+
+  bodyJSON := simplejson.New()
+  bodyJSON.Set("title", evalContext.GetNotificationTitle())
+  bodyJSON.Set("ruleId", evalContext.Rule.Id)
+  bodyJSON.Set("ruleName", evalContext.Rule.Name)
+  bodyJSON.Set("state", evalContext.Rule.State)
+  bodyJSON.Set("evalMatches", evalContext.EvalMatches)
+
+  ruleUrl, err := evalContext.GetRuleUrl()
+  if err == nil {
+    bodyJSON.Set("ruleUrl", ruleUrl)
+  }
+
+  if evalContext.Rule.Message != "" {
+    bodyJSON.Set("message", evalContext.Rule.Message)
+  }
+
+
+
+  url := fmt.Sprintf("http://%s:%s@%s:15672/api/exchanges/%s/%s/publish", this.Username, this.Password, this.HostAddress, this.VHost, this.Exchange)
+  body, _ := bodyJSON.MarshalJSON()
+  props := make([]string, 0)
+
+  messageJson := simplejson.New()
+  messageJson.Set("properties",  props)
+  messageJson.Set("vhost", this.VHost)
+  messageJson.Set("name", this.Exchange)
+  messageJson.Set("routing_key", this.Exchange)
+  messageJson.Set("delivery_mode","1")
+  messageJson.Set("payload", string(body))
+  messageJson.Set("payload_encoding", "string");
+
+  message, _ := messageJson.MarshalJSON()
+
+  cmd := &m.SendWebhookSync{
+    Url:        url,
+    User:       this.Username,
+    Password:   this.Password,
+    Body:       string(message),
+    HttpMethod: "POST",
+  }
+
+  if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
+    this.log.Error("Failed to send webhook", "error", err, "webhook", this.Name)
+    return err
+  }
+
+  return nil
+
+}

--- a/pkg/services/alerting/notifiers/rabbitmq_test.go
+++ b/pkg/services/alerting/notifiers/rabbitmq_test.go
@@ -32,7 +32,7 @@ func TestRabbitMQNotifier(t *testing.T) {
           "hostaddress": "rabbitmq",
           "username":"guest",
           "password":"guest",
-          "vhost":"Live"
+          "vhost":"Live",
           "exchange":"alerts"
 				}`
 
@@ -48,7 +48,7 @@ func TestRabbitMQNotifier(t *testing.T) {
 
         So(err, ShouldBeNil)
         So(rabbitmqNotifier.Name, ShouldEqual, "ops")
-        So(rabbitmqNotifier.Type, ShouldEqual, "email")
+        So(rabbitmqNotifier.Type, ShouldEqual, "rabbitmq")
         So(rabbitmqNotifier.HostAddress, ShouldEqual, "rabbitmq")
         So(rabbitmqNotifier.Username, ShouldEqual, "guest")
         So(rabbitmqNotifier.Password, ShouldEqual, "guest")

--- a/pkg/services/alerting/notifiers/rabbitmq_test.go
+++ b/pkg/services/alerting/notifiers/rabbitmq_test.go
@@ -1,0 +1,60 @@
+package notifiers
+
+import (
+  "testing"
+
+  "github.com/grafana/grafana/pkg/components/simplejson"
+  m "github.com/grafana/grafana/pkg/models"
+  . "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRabbitMQNotifier(t *testing.T) {
+  Convey("RabbitMQ notifier tests", t, func() {
+
+    Convey("Parsing alert notification from settings", func() {
+      Convey("empty settings should return error", func() {
+        json := `{ }`
+
+        settingsJSON, _ := simplejson.NewJson([]byte(json))
+        model := &m.AlertNotification{
+          Name:     "ops",
+          Type:     "rabbitmq",
+          Settings: settingsJSON,
+        }
+
+        _, err := NewRabbitMQNotifier(model)
+        So(err, ShouldNotBeNil)
+      })
+
+      Convey("from settings", func() {
+        json := `
+				{
+          "hostaddress": "rabbitmq",
+          "username":"guest",
+          "password":"guest",
+          "vhost":"Live"
+          "exchange":"alerts"
+				}`
+
+        settingsJSON, _ := simplejson.NewJson([]byte(json))
+        model := &m.AlertNotification{
+          Name:     "ops",
+          Type:     "rabbitmq",
+          Settings: settingsJSON,
+        }
+
+        not, err := NewRabbitMQNotifier(model)
+        rabbitmqNotifier := not.(*RabbitMQNotifier)
+
+        So(err, ShouldBeNil)
+        So(rabbitmqNotifier.Name, ShouldEqual, "ops")
+        So(rabbitmqNotifier.Type, ShouldEqual, "email")
+        So(rabbitmqNotifier.HostAddress, ShouldEqual, "rabbitmq")
+        So(rabbitmqNotifier.Username, ShouldEqual, "guest")
+        So(rabbitmqNotifier.Password, ShouldEqual, "guest")
+        So(rabbitmqNotifier.Exchange, ShouldEqual, "alerts")
+        So(rabbitmqNotifier.VHost, ShouldEqual, "Live")
+      })
+    })
+  })
+}

--- a/public/app/features/alerting/partials/notification_edit.html
+++ b/public/app/features/alerting/partials/notification_edit.html
@@ -19,7 +19,7 @@
       <div class="gf-form">
         <span class="gf-form-label width-12">Type</span>
         <div class="gf-form-select-wrapper width-15">
-          <select class="gf-form-input" ng-model="ctrl.model.type" ng-options="t for t in ['webhook', 'email', 'slack', 'pagerduty', 'victorops', 'opsgenie']" ng-change="ctrl.typeChanged(notification, $index)">
+          <select class="gf-form-input" ng-model="ctrl.model.type" ng-options="t for t in ['webhook', 'email', 'slack', 'pagerduty', 'victorops', 'opsgenie', 'rabbitmq']" ng-change="ctrl.typeChanged(notification, $index)">
           </select>
         </div>
       </div>
@@ -136,6 +136,53 @@
            checked="ctrl.model.settings.autoClose"
            tooltip="Automatically close alerts in OpseGenie once the alert goes back to ok.">
         </gf-form-switch>
+      </div>
+    </div>
+
+    <div class="gf-form-group section" ng-if="ctrl.model.type === 'rabbitmq'">
+      <h3 class="page-heading">RabbitMQ Settings</h3>
+      <div class="gf-form">
+        <span class="gf-form-label width-12">Host Address</span>
+        <input type="text"
+               class="gf-form-input width-15"
+               ng-model="ctrl.model.settings.hostaddress"
+               data-placement="right">
+        </input>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-12">Username</span>
+        <input type="text"
+               class="gf-form-input width-15"
+               ng-model="ctrl.model.settings.username"
+               data-placement="right">
+        </input>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-12">Password</span>
+        <input type="text"
+               class="gf-form-input width-15"
+               ng-model="ctrl.model.settings.password"
+               data-placement="right">
+        </input>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-12">Virtual Host</span>
+        <input type="text"
+               class="gf-form-input width-15"
+               ng-model="ctrl.model.settings.vhost"
+               data-placement="right">
+        </input>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-12">Exchange</span>
+        <input type="text"
+               class="gf-form-input width-15"
+               ng-model="ctrl.model.settings.exchange"
+               data-placement="right">
+        </input>
+      </div>
+      <div class="gf-form">
+        <span>The RabbitMQ server needs to have the REST API enabled for this notifier to work.</span>
       </div>
     </div>
 


### PR DESCRIPTION
Added a new RabbitMQ notifier which will publish the notification for alerts to a specified exchange. 

Added UI for configuration of the notifier which allows the RabbitMQ Host, Username, Password, VHost and Exchange to be specified.

The notifier requires the RabbitMQ REST API to be enabled and uses SendWebhookSync internall to post to RabbitMQ. 

Tests are provided for the configuration options required by the notifier.
