### PR TITLE
export sorted dashboard json

### DIFF
--- a/public/app/core/utils/sort_by_keys.ts
+++ b/public/app/core/utils/sort_by_keys.ts
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+
+export default function sortByKeys(input) {
+  if (_.isArray(input)) {
+    var newArray = [];
+    _.forEach(
+      input,
+      function(item) { newArray.push(sortByKeys(item)); }
+    );
+    return newArray;
+  }
+
+  if (_.isPlainObject(input)) {
+    var sortedObject = {};
+    _.forEach(
+      _.keys(input).sort(),
+      function(key) { sortedObject[key] = sortByKeys(input[key]); }
+    );
+    return sortedObject;
+  }
+
+  return input;
+}

--- a/public/app/features/dashboard/export/exporter.ts
+++ b/public/app/features/dashboard/export/exporter.ts
@@ -3,6 +3,7 @@
 import config from 'app/core/config';
 import angular from 'angular';
 import _ from 'lodash';
+import sortByKeys from 'app/core/utils/sort_by_keys';
 
 import {DynamicDashboardSrv} from '../dynamic_dashboard_srv';
 
@@ -145,18 +146,14 @@ export class DashboardExporter {
         }
       }
 
-      requires = _.map(requires, req =>  {
-        return req;
-      });
-
       // make inputs and requires a top thing
       var newObj = {};
       newObj["__inputs"] = inputs;
-      newObj["__requires"] = requires;
+      newObj["__requires"] = _.sortBy(requires, ['id']);
 
       _.defaults(newObj, saveModel);
 
-      return newObj;
+      return sortByKeys(newObj);
     }).catch(err => {
       console.log('Export failed:', err);
       return {


### PR DESCRIPTION
This implements #7092 by recursively sorting all objects in the dashboard json by key.  It doesn't modify the order of arrays since the order is meaningful in the majority of cases.
