### PR TITLE
Moving average support for all models along with additional settings

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -29,6 +29,7 @@ function (angular, _, queryDef) {
     $scope.metricAggTypes = queryDef.getMetricAggTypes($scope.esVersion);
     $scope.extendedStats = queryDef.extendedStats;
     $scope.pipelineAggOptions = [];
+    $scope.modelSettingsValues = {};
 
     $scope.init = function() {
       $scope.agg = metricAggs[$scope.index];
@@ -95,6 +96,12 @@ function (angular, _, queryDef) {
           $scope.settingsLinkText = 'Stats: ' + stats.join(', ');
           break;
         }
+        case 'moving_avg': {
+          $scope.movingAvgModelTypes = queryDef.movingAvgModelOptions;
+          $scope.modelSettings = queryDef.getMovingAvgSettings($scope.agg.settings.model, true);
+          $scope.updateMovingAvgModelSettings();
+          break;
+        }
         case 'raw_document': {
           $scope.target.metrics = [$scope.agg];
           $scope.target.bucketAggs = [];
@@ -124,6 +131,25 @@ function (angular, _, queryDef) {
     };
 
     $scope.onChangeInternal = function() {
+      $scope.onChange();
+    };
+
+    $scope.updateMovingAvgModelSettings = function () {
+      var modelSettingsKeys = [];
+      var modelSettings = queryDef.getMovingAvgSettings($scope.agg.settings.model, false);
+      for (var i=0; i < modelSettings.length; i++) {
+        modelSettingsKeys.push(modelSettings[i].value);
+      }
+
+      for (var key in $scope.agg.settings.settings) {
+        if (($scope.agg.settings.settings[key] === null) || (modelSettingsKeys.indexOf(key) === -1)) {
+          delete $scope.agg.settings.settings[key];
+        }
+      }
+    };
+
+    $scope.onChangeClearInternal = function() {
+      delete $scope.agg.settings.minimize;
       $scope.onChange();
     };
 

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -50,13 +50,23 @@
 
 	<div class="gf-form offset-width-7" ng-if="agg.type === 'moving_avg'">
 		<label class="gf-form-label width-10">Model</label>
-		<input type="text" class="gf-form-input max-width-12" ng-change="onChangeInternal()" ng-model="agg.settings.model" blur="onChange()" spellcheck='false'>
-	</div>
+                <metric-segment-model property="agg.settings.model" options="movingAvgModelTypes" on-change="onChangeClearInternal()" custom="false" css-class="width-12"></metric-segment-model>
+        </div>
 
 	<div class="gf-form offset-width-7" ng-if="agg.type === 'moving_avg'">
 		<label class="gf-form-label width-10">Predict</label>
 		<input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.predict" ng-blur="onChangeInternal()" spellcheck='false'>
 	</div>
+
+
+	<div class="gf-form offset-width-7" ng-if="agg.type === 'moving_avg'" ng-repeat="setting in modelSettings">
+		<label class="gf-form-label width-10">{{setting.text}}</label>
+		<input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.settings[setting.value]" ng-blur="onChangeInternal()" spellcheck='false'>
+        </div>
+
+	<gf-form-switch ng-if="agg.type === 'moving_avg' && agg.settings.model == 'holt_winters'" class="gf-form offset-width-7" label="Pad" label-class="width-10" checked="agg.settings.settings.pad" on-change="onChangeInternal()"></gf-form-switch>
+
+	<gf-form-switch ng-if="agg.type === 'moving_avg' && (agg.settings.model == 'ewma' || agg.settings.model == 'holt_winters' || agg.settings.model == 'holt')" class="gf-form offset-width-7" label="Minimize" label-class="width-10" checked="agg.settings.minimize" on-change="onChangeInternal()"></gf-form-switch>
 
 	<div class="gf-form offset-width-7" ng-if="agg.type === 'percentiles'">
 		<label class="gf-form-label width-10">Percentiles</label>

--- a/public/app/plugins/datasource/elasticsearch/query_def.js
+++ b/public/app/plugins/datasource/elasticsearch/query_def.js
@@ -69,15 +69,42 @@ function (_) {
       {text: '1d', value: '1d'},
     ],
 
+    movingAvgModelOptions: [
+      {text: 'Simple', value: 'simple'},
+      {text: 'Linear', value: 'linear'},
+      {text: 'Exponentially Weighted', value: 'ewma'},
+      {text: 'Holt Linear', value: 'holt'},
+      {text: 'Holt Winters', value: 'holt_winters'},
+    ],
+
     pipelineOptions: {
       'moving_avg' : [
         {text: 'window', default: 5},
         {text: 'model', default: 'simple'},
-        {text: 'predict', default: 0}
+        {text: 'minimize', default: false},
+        {text: 'predict', default: undefined}
       ],
       'derivative': [
         {text: 'unit', default: undefined},
       ]
+    },
+
+    movingAvgModelSettings: {
+      'simple' : [],
+      'linear' : [],
+      'ewma' : [
+        {text: "Alpha", value: "alpha", default: undefined}],
+      'holt' : [
+        {text: "Alpha", value: "alpha",  default: undefined},
+        {text: "Beta", value: "beta",  default: undefined},
+       ],
+      'holt_winters' : [
+        {text: "Alpha", value: "alpha", default: undefined},
+        {text: "Beta", value: "beta", default: undefined},
+        {text: "Gamma", value: "gamma", default: undefined},
+        {text: "Period", value: "period", default: undefined},
+        {text: "Pad", value: "pad", default: undefined, isCheckbox: true},
+       ],
     },
 
     getMetricAggTypes: function(esVersion) {
@@ -117,6 +144,19 @@ function (_) {
       });
 
       return result;
+    },
+
+    getMovingAvgSettings: function(model, filtered) {
+      var filteredResult = [];
+      if (filtered) {
+        _.each(this.movingAvgModelSettings[model], function(setting) {
+          if (!(setting.isCheckbox)) {
+            filteredResult.push(setting);
+          }
+        });
+        return filteredResult;
+      }
+      return this.movingAvgModelSettings[model];
     },
 
     getOrderByOptions: function(target) {


### PR DESCRIPTION
The issue-id for tracking the feature can be found here: https://github.com/grafana/grafana/issues/7153

```
ubuntu@vst-grafana-dev:~/dev/src/github.com/grafana/grafana$ grunt test
Version 4.1.0-beta1
Running "jscs:src" (jscs) task
>> 88 files without code style errors.

Running "jshint:source" (jshint) task

✔ No problems


Running "jshint:tests" (jshint) task

✔ No problems


Running "exec:tslint" (exec) task

Running "clean:gen" (clean) task
>> 1 path cleaned.

Running "copy:node_modules" (copy) task
Created 100 directories, copied 1596 files

Running "copy:public_to_gen" (copy) task
Created 322 directories, copied 2634 files

Running "phantomjs" task

Running "copy:phantom_bin" (copy) task
Copied 1 file

Running "sass:src" (sass) task

Running "concat:cssDark" (concat) task

Running "concat:cssLight" (concat) task

Running "concat:cssFonts" (concat) task

Running "styleguide" task

Running "sasslint:target" (sasslint) task

Running "postcss:dist" (postcss) task
>> 6 processed stylesheets created.
>> 6 sourcemaps created.

Running "exec:tscompile" (exec) task
Files:           238
Lines:         46254
Nodes:        216742
Identifiers:   65285
Symbols:       42859
Types:         19026
Memory used: 149503K
I/O read:      0.02s
I/O write:     0.07s
Parse time:    1.80s
Bind time:     0.77s
Check time:    2.62s
Emit time:     2.14s
Total time:    7.34s

Running "karma:test" (karma) task
05 01 2017 23:41:31.220:INFO [karma]: Karma v1.3.0 server started at http://localhost:9876/
05 01 2017 23:41:31.222:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
05 01 2017 23:41:31.229:INFO [launcher]: Starting browser PhantomJS
05 01 2017 23:41:31.524:INFO [PhantomJS 2.1.1 (Linux 0.0.0)]: Connected on socket /#259wrDS7EXutcwRaAAAA with id 85706365
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
.................
PhantomJS 2.1.1 (Linux 0.0.0): Executed 897 of 898 (skipped 1) SUCCESS (2.423 secs / 0.689 secs)

Running "no-only-tests" task

Done, without errors.
```

![screen shot 2017-01-05 at 3 28 29 pm](https://cloud.githubusercontent.com/assets/4401392/21701973/a99bbadc-d35d-11e6-83aa-a339110898b6.png)
