### PR TITLE
add variable $intervalSecond

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -219,6 +219,38 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         return $q.when([]);
       }
 
+      // convert interval string to milliseconds
+      var intervalToSecond = function (intervalString) {
+        if (!intervalString) {
+          return 1;
+        } else {
+          var interval = parseInt(intervalString);
+          if (isNaN(interval)) {
+            return 1;
+          } else  {
+            var lastIndex = intervalString.length - 1;
+            var unit = intervalString.slice(lastIndex);
+            var scale = 1;
+            switch (unit) {
+              case 'd':
+                scale = 86400;
+                break;
+              case 'h':
+                scale = 3600;
+                break;
+              case 'm':
+                scale = 60;
+                break;
+              default:
+                scale = 1;
+            }
+            return interval * scale;
+          }
+        }
+      };
+
+      // intervalSecond: interval in seconds
+      payload = payload.replace(/\$intervalSecond/g, intervalToSecond(options.interval));
       payload = payload.replace(/\$interval/g, options.interval);
       payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
       payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());

--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -219,38 +219,9 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         return $q.when([]);
       }
 
-      // convert interval string to milliseconds
-      var intervalToSecond = function (intervalString) {
-        if (!intervalString) {
-          return 1;
-        } else {
-          var interval = parseInt(intervalString);
-          if (isNaN(interval)) {
-            return 1;
-          } else  {
-            var lastIndex = intervalString.length - 1;
-            var unit = intervalString.slice(lastIndex);
-            var scale = 1;
-            switch (unit) {
-              case 'd':
-                scale = 86400;
-                break;
-              case 'h':
-                scale = 3600;
-                break;
-              case 'm':
-                scale = 60;
-                break;
-              default:
-                scale = 1;
-            }
-            return interval * scale;
-          }
-        }
-      };
-
-      // intervalSecond: interval in seconds
-      payload = payload.replace(/\$intervalSecond/g, intervalToSecond(options.interval));
+      // intervalSec: interval in seconds
+      payload = payload.replace(/\$intervalSec/g, kbn.interval_to_seconds(options.interval));
+      payload = payload.replace(/\$intervalMs/g, kbn.interval_to_ms(options.interval));
       payload = payload.replace(/\$interval/g, options.interval);
       payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
       payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());

--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -220,8 +220,10 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
       }
 
       // intervalSec: interval in seconds
-      payload = payload.replace(/\$intervalSec/g, kbn.interval_to_seconds(options.interval));
-      payload = payload.replace(/\$intervalMs/g, kbn.interval_to_ms(options.interval));
+      if (options.interval && options.interval.match(kbn.interval_regex)) {
+        payload = payload.replace(/\$intervalSec/g, kbn.interval_to_seconds(options.interval));
+        payload = payload.replace(/\$intervalMs/g, kbn.interval_to_ms(options.interval));
+      }
       payload = payload.replace(/\$interval/g, options.interval);
       payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
       payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());


### PR DESCRIPTION
Add a templated variable `$intervalSecond` for the data source of Elasticsearch.

### Issue:
#3773 

### Usage:

When I want to calculate the QPS from PV
```
_value / $intervalSecond
```