### PR TITLE
Feature/data proxy audit log

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -47,8 +47,8 @@ root_url = %(protocol)s://%(domain)s:%(http_port)s/
 # Log web requests
 router_logging = false
 
-# This enables query request audit logging, output at warn level, default is false
-audit_logging = false
+# This enables data proxy logging, default is false
+data_proxy_logging = false
 
 # the path relative working path
 static_root_path = public

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -47,6 +47,9 @@ root_url = %(protocol)s://%(domain)s:%(http_port)s/
 # Log web requests
 router_logging = false
 
+# This enables query request audit logging, output at warn level, default is false
+audit_logging = false
+
 # the path relative working path
 static_root_path = public
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -50,7 +50,7 @@
 ;router_logging = false
 
 # This enables query request audit logging, output at warn level, default is false
-audit_logging = false
+;data_proxy_logging = false
 
 # the path relative working path
 ;static_root_path = public

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -49,6 +49,9 @@
 # Log web requests
 ;router_logging = false
 
+# This enables query request audit logging, output at warn level, default is false
+audit_logging = false
+
 # the path relative working path
 ;static_root_path = public
 

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -143,6 +143,7 @@ with Grafana admin permission.
         "protocol":"http",
         "root_url":"%(protocol)s://%(domain)s:%(http_port)s/",
         "router_logging":"true",
+        "audit_logging":"true",
         "static_root_path":"public"
       },
       "session":{

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -143,7 +143,7 @@ with Grafana admin permission.
         "protocol":"http",
         "root_url":"%(protocol)s://%(domain)s:%(http_port)s/",
         "router_logging":"true",
-        "audit_logging":"true",
+        "data_proxy_logging":"true",
         "static_root_path":"public"
       },
       "session":{

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
@@ -133,17 +132,14 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 }
 
 func outputToAuditLog(dataSourceType string, c *middleware.Context) {
-	auditLogger := log.New("data-proxy-audit", "userId", c.UserId, "orgId", c.OrgId, "uname", c.Login)
+	auditLogger := log.New("data-proxy-audit", "userid", c.UserId, "orgid", c.OrgId, "username", c.Login)
 
-	bodyString := ""
+	var body string
 	if c.Req.Request.Body != nil {
-		reqBody := c.Req.Request.Body
-		buffer, _ := ioutil.ReadAll(reqBody)
-
+		buffer, _ := ioutil.ReadAll(c.Req.Request.Body)
 		c.Req.Request.Body = ioutil.NopCloser(bytes.NewBuffer(buffer))
-		bodyString = string(buffer)
+		body = string(buffer)
 	}
 
-	logFormat := "Datasource: %s, URI: %s, Method: %s, Body: %s"
-	auditLogger.Info(fmt.Sprintf(logFormat, dataSourceType, c.Req.RequestURI, c.Req.Request.Method, bodyString))
+	auditLogger.Info("Proxying incoming request", "datasource", dataSourceType, "uri", c.Req.RequestURI, "method", c.Req.Request.Method, "body", body)
 }

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -125,15 +125,15 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 		return
 	}
 
-	auditLog(ds.Type, c)
+	proxyLog(ds.Type, c)
 
 	proxy.ServeHTTP(c.Resp, c.Req.Request)
 	c.Resp.Header().Del("Set-Cookie")
 }
 
-func auditLog(dataSourceType string, c *middleware.Context) {
-	if setting.AuditLogging {
-		auditLogger := log.New("data-proxy-audit", "userid", c.UserId, "orgid", c.OrgId, "username", c.Login)
+func proxyLog(dataSourceType string, c *middleware.Context) {
+	if setting.DataProxyLogging {
+		auditLogger := log.New("data-proxy-log", "userid", c.UserId, "orgid", c.OrgId, "username", c.Login)
 
 		var body string
 		if c.Req.Request.Body != nil {
@@ -142,6 +142,6 @@ func auditLog(dataSourceType string, c *middleware.Context) {
 			body = string(buffer)
 		}
 
-		auditLogger.Warn("Proxying incoming request", "datasource", dataSourceType, "uri", c.Req.RequestURI, "method", c.Req.Request.Method, "body", body)
+		auditLogger.Info("Proxying incoming request", "datasource", dataSourceType, "uri", c.Req.RequestURI, "method", c.Req.Request.Method, "body", body)
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -65,7 +65,7 @@ var (
 	SshPort            int
 	CertFile, KeyFile  string
 	RouterLogging      bool
-	AuditLogging       bool
+	DataProxyLogging       bool
 	StaticRootPath     string
 	EnableGzip         bool
 	EnforceDomain      bool
@@ -491,7 +491,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	HttpAddr = server.Key("http_addr").MustString(DEFAULT_HTTP_ADDR)
 	HttpPort = server.Key("http_port").MustString("3000")
 	RouterLogging = server.Key("router_logging").MustBool(false)
-	AuditLogging = server.Key("audit_logging").MustBool(false)
+	DataProxyLogging = server.Key("data_proxy_logging").MustBool(false)
 	EnableGzip = server.Key("enable_gzip").MustBool(false)
 	EnforceDomain = server.Key("enforce_domain").MustBool(false)
 	StaticRootPath = makeAbsolute(server.Key("static_root_path").String(), HomePath)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -65,6 +65,7 @@ var (
 	SshPort            int
 	CertFile, KeyFile  string
 	RouterLogging      bool
+	AuditLogging       bool
 	StaticRootPath     string
 	EnableGzip         bool
 	EnforceDomain      bool
@@ -490,6 +491,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	HttpAddr = server.Key("http_addr").MustString(DEFAULT_HTTP_ADDR)
 	HttpPort = server.Key("http_port").MustString("3000")
 	RouterLogging = server.Key("router_logging").MustBool(false)
+	AuditLogging = server.Key("audit_logging").MustBool(false)
 	EnableGzip = server.Key("enable_gzip").MustBool(false)
 	EnforceDomain = server.Key("enforce_domain").MustBool(false)
 	StaticRootPath = makeAbsolute(server.Key("static_root_path").String(), HomePath)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -65,7 +65,7 @@ var (
 	SshPort            int
 	CertFile, KeyFile  string
 	RouterLogging      bool
-	DataProxyLogging       bool
+	DataProxyLogging   bool
 	StaticRootPath     string
 	EnableGzip         bool
 	EnforceDomain      bool


### PR DESCRIPTION
I need to have a basic audit log set up for info security purposes so we can tell who may have accessed what data in the event of a data leak. This PR targets a small data proxy change to add logging to this as a single point of access for our data sources. We can lock down access to these datasources to only occur through Grafana so this should be sufficient. 

We use ES and InfluxDB so this has been particularly developed targeting those, of note is that I need to pull the RequestBody from the incoming proxied request to get more information about which source is being hit in ES. 

So far, I have tested this in a local dev setup and confirmed that output logs have the information I'm looking for at the data proxy level, and that the RequestBody was not consumed. Working on more effective testing where we have real data sources configured as well, but I don't see anything that would suggest this doesn't work as expected right now. Logs output to grafana.log in default setup and for Influx they look like: 

`t=2017-01-10T11:39:20-0800 lvl=info msg="Proxying incoming request" logger=data-proxy-audit userid=1 orgid=1 username=admin datasource=influxdb uri="/api/datasources/proxy/1/query?db=database&q=SELECT%20mean(%22value%22)%20FROM%20%22measurement%22%20WHERE%20time%20%3E%20now()%20-%206h%20GROUP%20BY%20time(10s)%20fill(null)&epoch=ms" method=GET body=`

and for ES they look like: 

```t=2017-01-10T11:39:46-0800 lvl=info msg="Proxying incoming request" logger=data-proxy-audit userid=1 orgid=1 username=admin datasource=elasticsearch uri=/api/datasources/proxy/2/_msearch method=POST body="{\"search_type\":\"query_then_fetch\",\"ignore_unavailable\":true,\"index\":\"index\"}\n{\"size\":0,\"query\":{\"bool\":{\"must\":[{\"range\":{\"@timestamp\":{\"gte\":\"1484055586660\",\"lte\":\"1484077186660\",\"format\":\"epoch_millis\"}}},{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}]}},\"aggs\":{\"2\":{\"date_histogram\":{\"interval\":\"10s\",\"field\":\"@timestamp\",\"min_doc_count\":0,\"extended_bounds\":{\"min\":\"1484055586660\",\"max\":\"1484077186660\"},\"format\":\"epoch_millis\"},\"aggs\":{}}}}\n"```

Thanks for taking a look! Let me know if anything seems strange :). 