### PR TITLE
wrap the title of a panel and dashboard search results. fixes #7203

### DIFF
--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -68,9 +68,9 @@
   }
 
   .search-item {
+    word-wrap: break-word;
     display: block;
     padding: 3px 10px;
-    white-space: nowrap;
     background-color: $grafanaListBackground;
     margin-bottom: 4px;
 

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -57,6 +57,7 @@ div.flot-text {
   min-height: 9px;
   padding-top: 4px;
   cursor: pointer;
+  word-wrap: break-word;
 }
 
 .panel-title {


### PR DESCRIPTION
![2017-01-10-221325_1920x1080_scrot](https://cloud.githubusercontent.com/assets/6697261/21834333/58aa3f08-d782-11e6-8940-201ab5aba8c5.png)
