### PR TITLE
Update postinst

### DIFF
--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -6,6 +6,7 @@ set -e
 
 startGrafana() {
   if [ -x /bin/systemctl ] ; then
+    /bin/systemctl daemon-reload
 		/bin/systemctl start grafana-server.service
 	elif [ -x /etc/init.d/grafana-server ] ; then
 		/etc/init.d/grafana-server start


### PR DESCRIPTION
With present postinst script on Centos 7, restart after upgrade is not working with Warning: grafana-server.service changed on disk. Run 'systemctl daemon-reload' to reload units.

So i added systemctl daemon-reload.

* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**
