### PR TITLE
Diff aggregate on singlestat panel

### DIFF
--- a/docs/sources/reference/singlestat.md
+++ b/docs/sources/reference/singlestat.md
@@ -31,6 +31,7 @@ The singlestat panel has a normal query editor to allow you define your exact me
    * `total` - The sum of all the non-null values in the series
    * `first` - The first value in the series
    * `delta` - The total incremental increase (of a counter) in the series. An attempt is made to account for counter resets, but this will only be accurate for single instance metrics. Used to show total counter increase in time series.
+   * `diff` - The difference betwen 'current' (last value) and 'first'.
    * `range` - The difference between 'min' and 'max'. Useful the show the range of change for a gauge.
 4. `Postfixes`: The Postfix fields let you define a custom label and font-size (as a %) to appear *after* the value
 5. `Units`: Units are appended to the the Singlestat  within the panel, and will respect the color and threshold settings for the value.

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -104,6 +104,7 @@ export default class TimeSeries {
     this.stats.current = null;
     this.stats.first = null;
     this.stats.delta = 0;
+    this.stats.diff = null;
     this.stats.range = null;
     this.stats.timeStep = Number.MAX_VALUE;
     this.allIsNull = true;
@@ -192,6 +193,9 @@ export default class TimeSeries {
     }
     if (this.stats.max !== null && this.stats.min !== null) {
       this.stats.range = this.stats.max - this.stats.min;
+    }
+    if (this.stats.current !== null && this.stats.first !== null) {
+      this.stats.diff = this.stats.current - this.stats.first;
     }
 
     this.stats.count = result.length;

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -21,7 +21,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   invalidGaugeRange: boolean;
   panel: any;
   events: any;
-  valueNameOptions: any[] = ['min','max','avg', 'current', 'total', 'name', 'first', 'delta', 'range'];
+  valueNameOptions: any[] = ['min','max','avg', 'current', 'total', 'name', 'first', 'delta', 'diff', 'range'];
 
   // Set and populate defaults
   panelDefaults = {


### PR DESCRIPTION
Implements https://github.com/grafana/grafana/issues/7234 (and completes https://github.com/grafana/grafana/pull/6740)

> `diff` aggregate (which would be `current - first`) for gauges (which may go up and down)

---

Should I also implement some tests for this new aggregate ?