### PR TITLE
Fix typo in tags API documentation example request

### DIFF
--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -200,7 +200,7 @@ Get all tags of dashboards
 
 **Example Request**:
 
-    GET /api/dashboards/home HTTP/1.1
+    GET /api/dashboards/tags HTTP/1.1
     Accept: application/json
     Content-Type: application/json
     Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk


### PR DESCRIPTION
Hey 👋 

This fixes a typo in API docs, tags API request example has an incorrect path.

Thanks for Grafana, it's an excellent piece of software. 👍 