### PR TITLE
Make API key usage example meaningfully runable

### DIFF
--- a/public/app/features/org/orgApiKeysCtrl.js
+++ b/public/app/features/org/orgApiKeysCtrl.js
@@ -30,6 +30,7 @@ function (angular) {
 
         var modalScope = $scope.$new(true);
         modalScope.key = result.key;
+        modalScope.rootPath = window.location.origin + $scope.$root.appSubUrl;
 
         $scope.appEvent('show-modal', {
           src: 'public/app/features/org/partials/apikeyModal.html',

--- a/public/app/features/org/partials/apikeyModal.html
+++ b/public/app/features/org/partials/apikeyModal.html
@@ -27,7 +27,7 @@
 			<br>
 			<br>
 			<pre class="small">
-curl -H "Authorization: Bearer your_key_above" http://your.grafana.com/api/dashboards/db/mydash
+curl -H "Authorization: Bearer {{key}}" {{rootPath}}/api/dashboards/home
 			</pre>
 		</div>
 


### PR DESCRIPTION
Hey 👋 

I was looking at the API key modal dialog that appears on successful creation, the one with the usage example, and thought that it would be nice if the example would be something you can copy and run without doing any changes to it. Right now it has placeholders in it, making it only useful as a template.

The actual changes:
* API key is interpolated right into the example
* the URL now points to where your actual Grafana API is
* GETing the home dashboard instead of a very likely non-existing dashboard, and therefore the call will return something meaningful

The result looks like this:
<img width="787" alt="screen shot 2017-01-12 at 23 34 41" src="https://cloud.githubusercontent.com/assets/206971/21909244/bb863e30-d91f-11e6-83ce-e7a9607e6f44.png">

Do you think this is a useful thing to have?

Concerns:
* `window.location.origin` seems to be [not entirely well supported](http://www.w3schools.com/jsref/prop_loc_origin.asp), there are [ways](http://tosbourn.com/a-fix-for-window-location-origin-in-internet-explorer/) to full-proof it. What's the best way of going about this?