### PR TITLE
Enable image rendering to use browser time offset

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -14,11 +14,12 @@ func RenderToPng(c *middleware.Context) {
 	queryParams := fmt.Sprintf("?%s", c.Req.URL.RawQuery)
 
 	renderOpts := &renderer.RenderOpts{
-		Path:    c.Params("*") + queryParams,
-		Width:   queryReader.Get("width", "800"),
-		Height:  queryReader.Get("height", "400"),
-		OrgId:   c.OrgId,
-		Timeout: queryReader.Get("timeout", "30"),
+		Path:       c.Params("*") + queryParams,
+		Width:      queryReader.Get("width", "800"),
+		Height:     queryReader.Get("height", "400"),
+		OrgId:      c.OrgId,
+		Timeout:    queryReader.Get("timeout", "30"),
+		TimeOffset: queryReader.Get("timeOffset", ""),
 	}
 
 	pngPath, err := renderer.RenderToPng(renderOpts)

--- a/public/app/features/dashboard/partials/shareModal.html
+++ b/public/app/features/dashboard/partials/shareModal.html
@@ -69,6 +69,15 @@
 	</div>
 </script>
 
+<script type="text/ng-template" id="renderImageOptions.html">
+	<div class="gf-form-group">
+		<gf-form-switch class="gf-form"
+			label="Use browser time offset in image" label-class="width-18" switch-class="max-width-6"
+			checked="options.browserTimeOffset" on-change="buildUrl()">
+		</gf-form-switch>
+	</div>
+</script>
+
 <script type="text/ng-template" id="shareLink.html">
 	<div class="share-modal-header">
 		<div class="share-modal-big-icon">
@@ -91,6 +100,7 @@
 					</div>
 				</div>
 			</div>
+			<div ng-include src="'renderImageOptions.html'"></div>
 			<div class="gf-form" ng-show="modeSharePanel">
 				<a href="{{imageUrl}}" target="_blank"><i class="fa fa-camera"></i> Direct link rendered image</a>
 			</div>

--- a/public/app/features/dashboard/shareModalCtrl.js
+++ b/public/app/features/dashboard/shareModalCtrl.js
@@ -10,7 +10,7 @@ function (angular, _, require, config) {
 
   module.controller('ShareModalCtrl', function($scope, $rootScope, $location, $timeout, timeSrv, templateSrv, linkSrv) {
 
-    $scope.options = { forCurrent: true, includeTemplateVars: true, theme: 'current' };
+    $scope.options = { forCurrent: true, includeTemplateVars: true, browserTimeOffset: false, theme: 'current' };
     $scope.editor = { index: $scope.tabIndex || 0};
 
     $scope.init = function() {
@@ -82,6 +82,13 @@ function (angular, _, require, config) {
       $scope.imageUrl = soloUrl.replace(config.appSubUrl + '/dashboard-solo/', config.appSubUrl + '/render/dashboard-solo/');
       $scope.imageUrl += '&width=1000';
       $scope.imageUrl += '&height=500';
+      if ($scope.options.browserTimeOffset) {
+        var offsetMinutes = new Date().getTimezoneOffset(); // Negative if ahead of UTC
+        var sign = offsetMinutes < 0 ? '+' : '-';
+        var hours = ('0' + Math.abs(offsetMinutes) / 60).slice(-2);
+        var minutes = ('0' + Math.abs(offsetMinutes) % 60).slice(-2);
+        $scope.imageUrl += '&timeOffset=' + encodeURIComponent(sign + hours + minutes);
+      }
     };
 
   });


### PR DESCRIPTION
Implements https://github.com/grafana/grafana/issues/5670.

The current implementation just use the present browser time offset and doesn't consider DST. That is, the present time offset is simply used regardless of whether the target image contains data of times when DST was in effect.

That's why I added a switch to specify whether to use this feature and made the default false.

In spite of this limitation, I believe there are a lot of cases in which this feature is useful.