### PR TITLE
feat(secuirty): Setting UMASK for grafana user running grafana-server

### DIFF
--- a/packaging/deb/default/grafana-server
+++ b/packaging/deb/default/grafana-server
@@ -17,3 +17,5 @@ CONF_FILE=/etc/grafana/grafana.ini
 RESTART_ON_UPGRADE=false
 
 PLUGINS_DIR=/var/lib/grafana/plugins
+
+UMASK=0027

--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -36,9 +36,9 @@ CONF_FILE=$CONF_DIR/grafana.ini
 MAX_OPEN_FILES=10000
 PID_FILE=/var/run/$NAME.pid
 DAEMON=/usr/sbin/$NAME
+UMASK=0027
 
-
-umask 0027
+umask $UMASK
 
 if [ `id -u` -ne 0 ]; then
 	echo "You need root privileges to run this script"
@@ -84,7 +84,7 @@ case "$1" in
 	fi
 
 	# Start Daemon
-	start-stop-daemon --start -b --chdir "$WORK_DIR" --user "$GRAFANA_USER" -c "$GRAFANA_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon --start -b --chdir "$WORK_DIR" --umask $UMASK --user "$GRAFANA_USER" -c "$GRAFANA_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
 	return=$?
 	if [ $return -eq 0 ]
 	then

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -9,6 +9,7 @@ EnvironmentFile=/etc/default/grafana-server
 User=grafana
 Group=grafana
 Type=simple
+UMask=${UMASK}
 Restart=on-failure
 WorkingDirectory=/usr/share/grafana
 ExecStart=/usr/sbin/grafana-server                                \

--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -35,6 +35,9 @@ CONF_FILE=$CONF_DIR/grafana.ini
 MAX_OPEN_FILES=10000
 PID_FILE=/var/run/$NAME.pid
 DAEMON=/usr/sbin/$NAME
+UMASK=0027
+
+umask $UMASK
 
 if [ `id -u` -ne 0 ]; then
   echo "You need root privileges to run this script"

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -8,6 +8,7 @@ After=network-online.target
 EnvironmentFile=/etc/sysconfig/grafana-server
 User=grafana
 Group=grafana
+UMask=${UMASK}
 Type=simple
 Restart=on-failure
 WorkingDirectory=/usr/share/grafana


### PR DESCRIPTION
Feedback on this would be great. 

Is this something that is common/expected to be handled in official rpm/deb packages? 

For the rpm init.d file that is using action & nohup I am not sure how to set umask, do not think just executing `umask $UMASK` has an effect in the process started by nohup. 

