### PR TITLE
InfluxDB: Fix empty value tags and comma separated values

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -98,7 +98,8 @@ function (_, TableModel) {
           annotation: self.annotation,
           time: + new Date(value[timeCol]),
           title: value[titleCol],
-          tags: tagsCol.map(function(t) { return value[t]; }),
+          // Remove empty values, then split in different tags for comma separated values
+          tags: _.flatten(tagsCol.filter(function (t) { return value[t]; }).map(function(t) { return value[t].split(","); })),
           text: value[textCol]
         };
 


### PR DESCRIPTION
When a tag doesn't have a value it was showing a empty 'bubble'.
If value has several values separated by commas, make a 'bubble' for
each one.

https://github.com/grafana/grafana/issues/7267