### PR TITLE
Updated rpm dependency to be compatible to SUSE and Redhat derivates

### DIFF
--- a/build.go
+++ b/build.go
@@ -222,7 +222,7 @@ func createRpmPackages() {
 		defaultFileSrc: "packaging/rpm/sysconfig/grafana-server",
 		systemdFileSrc: "packaging/rpm/systemd/grafana-server.service",
 
-		depends: []string{"initscripts", "fontconfig"},
+		depends: []string{"/sbin/service", "fontconfig"},
 	})
 }
 


### PR DESCRIPTION
The package installscripts does not exist on SUSE derivates. The most
compareable package for suse is aaa_base. The thing which is provided by
both packages and only by them is /sbin/service. RPM packages could also
depend to single provided files.

SLES12sp0:
 > rpm -q --whatprovides /sbin/service
 aaa_base-13.2+git20140911.61c1681-3.1.x86_64

SuSE 13.2:
  > rpm -q --whatprovides /sbin/service
  aaa_base-13.2+git20140911.61c1681-1.16.x86_64

Centos 7:
  > rpm -q --whatprovides /sbin/service
  initscripts-9.49.37-1.el7.x86_64

Centos 6:
 > rpm -q --whatprovides /sbin/service
  initscripts-9.03.46-1.el6.centos.x86_64

...

For SLES12 the service itself works as expected after installation.

* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**
