### PR TITLE
Improve tooltip performance

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -181,8 +181,8 @@ function ($, core) {
       // get pageX from position on x axis and pageY from relative position in original panel
       if (pos.panelRelY) {
         var pointOffset = plot.pointOffset({x: pos.x});
-        if (Number.isNaN(pointOffset.left) || pointOffset.left < 0) {
-          $tooltip.detach();
+        if (Number.isNaN(pointOffset.left) || pointOffset.left < 0 || pointOffset.left > elem.width()) {
+          self.clear(plot);
           return;
         }
         pos.pageX = elem.offset().left + pointOffset.left;

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -165,6 +165,7 @@ function ($, core) {
     this.clear = function(plot) {
       $tooltip.detach();
       plot.clearCrosshair();
+      plot.unhighlight();
     };
 
     this.show = function(pos, item) {

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -177,6 +177,11 @@ function ($, core) {
         }
         pos.pageX = elem.offset().left + pointOffset.left;
         pos.pageY = elem.offset().top + elem.height() * pos.panelRelY;
+        var isVisible = pos.pageY >= $(window).scrollTop() && pos.pageY <= $(window).innerHeight() + $(window).scrollTop();
+        if (!isVisible) {
+          self.clear(plot);
+          return;
+        }
         plot.setCrosshair(pos);
         allSeriesMode = true;
 

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -34,13 +34,22 @@ function ($, core) {
     };
 
     this.findHoverIndexFromData = function(posX, series) {
-      var len = series.data.length;
-      for (var j = 0; j < len; j++) {
-        if (series.data[j][0] > posX) {
-          return Math.max(j - 1,  0);
+      var lower = 0;
+      var upper = series.data.length - 1;
+      var middle;
+      while (true) {
+        if (lower > upper) {
+          return Math.max(upper, 0);
+        }
+        middle = Math.floor((lower + upper) / 2);
+        if (series.data[middle][0] === posX) {
+          return middle;
+        } else if (series.data[middle][0] < posX) {
+          lower = middle + 1;
+        } else { //if (series.data[middle][0] > posX) {
+          upper = middle - 1;
         }
       }
-      return j - 1;
     };
 
     this.renderAndShow = function(absoluteTime, innerHtml, pos, xMode) {

--- a/public/app/plugins/panel/graph/specs/tooltip_specs.ts
+++ b/public/app/plugins/panel/graph/specs/tooltip_specs.ts
@@ -40,6 +40,31 @@ function describeSharedTooltip(desc, fn) {
   });
 }
 
+describe("findHoverIndexFromData", function() {
+  var tooltip = new GraphTooltip(elem, dashboard, scope);
+  var series = { data: [[100, 0], [101, 0], [102, 0], [103, 0], [104, 0], [105, 0], [106, 0], [107, 0]] };
+
+  it("should return 0 if posX out of lower bounds", function() {
+    var posX = 99;
+    expect(tooltip.findHoverIndexFromData(posX, series)).to.be(0);
+  });
+
+  it("should return n - 1 if posX out of upper bounds", function() {
+    var posX = 108;
+    expect(tooltip.findHoverIndexFromData(posX, series)).to.be(series.data.length - 1);
+  });
+
+  it("should return i if posX in series", function() {
+    var posX = 104;
+    expect(tooltip.findHoverIndexFromData(posX, series)).to.be(4);
+  });
+
+  it("should return i if posX not in series and i + 1 > posX", function() {
+    var posX = 104.9;
+    expect(tooltip.findHoverIndexFromData(posX, series)).to.be(4);
+  });
+});
+
 describeSharedTooltip("steppedLine false, stack false", function(ctx) {
   ctx.setup(function() {
     ctx.data = [
@@ -168,6 +193,3 @@ describeSharedTooltip("steppedLine false, stack true, individual true", function
     expect(ctx.results[1].value).to.be(2);
   });
 });
-
-
-


### PR DESCRIPTION
Tooltips aren't that performant and it's even worse when there are many.
I replaced the linear search in findHoverIndexFromData with binary search, which is faster in my benchmarks:
```
1000 data points
random posX, not necessarily in array
new, 1000000 calls, 125ms
old, 1000000 calls, 1772ms
posX in array
new, 1000000 calls, 103ms
old, 1000000 calls, 1405ms
```

Tooltips are only shown if they are in the browsers viewport.
![tooltip](https://cloud.githubusercontent.com/assets/6831775/22102325/604d59d2-de37-11e6-83f3-df0cab8c702d.gif)

I can't tell if they are actually faster now or if it's just placebo.
