### PR TITLE
ES: Change bool queries to use 'filter' clause

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -87,7 +87,7 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
       var queryInterpolated = templateSrv.replace(queryString, {}, 'lucene');
       var query = {
         "bool": {
-          "must": [
+          "filter": [
             { "range": range },
             {
               "query_string": {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -117,7 +117,7 @@ function (queryDef) {
       filter = adhocFilters[i];
       condition = {};
       condition[filter.key] = filter.value;
-      query.query.bool.must.push({"term": condition});
+      query.query.bool.filter.push({"term": condition});
     }
   };
 
@@ -133,7 +133,7 @@ function (queryDef) {
       "size": 0,
       "query": {
         "bool": {
-          "must": [
+          "filter": [
             {"range": this.getRangeFilter()},
             {
               "query_string": {
@@ -226,13 +226,13 @@ function (queryDef) {
       "size": 0,
       "query": {
         "bool": {
-          "must": [{"range": this.getRangeFilter()}]
+          "filter": [{"range": this.getRangeFilter()}]
         }
       }
     };
 
     if (queryDef.query) {
-      query.query.bool.must.push({
+      query.query.bool.filter.push({
         "query_string": {
           "analyze_wildcard": true,
           "query": queryDef.query,

--- a/public/app/plugins/datasource/elasticsearch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/datasource_specs.ts
@@ -77,7 +77,7 @@ describe('ElasticDatasource', function() {
 
     it('should json escape lucene query', function() {
       var body = angular.fromJson(parts[1]);
-      expect(body.query.bool.must[1].query_string.query).to.be('escape\\:test');
+      expect(body.query.bool.filter[1].query_string.query).to.be('escape\\:test');
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
@@ -16,7 +16,7 @@ describe('ElasticQueryBuilder', function() {
       bucketAggs: [{type: 'date_histogram', field: '@timestamp', id: '1'}],
     });
 
-    expect(query.query.bool.must[0].range["@timestamp"].gte).to.be("$timeFrom");
+    expect(query.query.bool.filter[0].range["@timestamp"].gte).to.be("$timeFrom");
     expect(query.aggs["1"].date_histogram.extended_bounds.min).to.be("$timeFrom");
   });
 
@@ -32,7 +32,7 @@ describe('ElasticQueryBuilder', function() {
       bucketAggs: [{type: 'date_histogram', field: '@timestamp', id: '1'}],
     });
 
-    expect(query.query.bool.must[0].range["@timestamp"].gte).to.be("$timeFrom");
+    expect(query.query.bool.filter[0].range["@timestamp"].gte).to.be("$timeFrom");
     expect(query.aggs["1"].date_histogram.extended_bounds.min).to.be("$timeFrom");
   });
 
@@ -258,6 +258,6 @@ describe('ElasticQueryBuilder', function() {
       {key: 'key1', operator: '=', value: 'value1'}
     ]);
 
-    expect(query.query.bool.must[2].term["key1"]).to.be("value1");
+    expect(query.query.bool.filter[2].term["key1"]).to.be("value1");
   });
 });


### PR DESCRIPTION
This changes all bool queries to use 'filter' clause instead of 'must' for better performance as ES considers the clauses for caching.

https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-bool-query.html