### PR TITLE
add kibana time format

### DIFF
--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -168,6 +168,19 @@ class TimeSrv {
     return range;
   }
 
+  timeRangeForKibanaUrl() {
+    var range = this.timeRange().raw;
+    var mode = "quick";
+
+    if (moment.isMoment(range.from) || moment.isMoment(range.to)) {
+      range.from = "'" + dateMath.parse(range.from, false).toJSON() + "'";
+      range.to = "'" + dateMath.parse(range.to, true).toJSON() + "'";
+      mode = "absolute";
+    }
+
+    return "(time:(from:" + range.from + ",mode:" + mode + ",to:" + range.to + "))";
+  }
+
   timeRange() {
     // make copies if they are moment  (do not want to return out internal moment, because they are mutable!)
     var raw = {

--- a/public/app/features/dashlinks/editor.html
+++ b/public/app/features/dashlinks/editor.html
@@ -65,6 +65,7 @@
 				<div class="gf-form">
 					<span class="gf-form-label width-6">Include</span>
 					<editor-checkbox text="Time range" model="link.keepTime" change="updated()"></editor-checkbox>
+          <editor-checkbox ng-show="link.keepTime" text="In Kibana format" model="link.kibanaFormat" change="updated()"></editor-checkbox>
 					<editor-checkbox text="Variable values" model="link.includeVars" change="updated()"></editor-checkbox>
 					<editor-checkbox text="Open in new tab " model="link.targetBlank" change="updated()"></editor-checkbox>
 				</div>

--- a/public/app/features/dashlinks/editor.html
+++ b/public/app/features/dashlinks/editor.html
@@ -65,7 +65,12 @@
 				<div class="gf-form">
 					<span class="gf-form-label width-6">Include</span>
 					<editor-checkbox text="Time range" model="link.keepTime" change="updated()"></editor-checkbox>
-          <editor-checkbox ng-show="link.keepTime" text="In Kibana format" model="link.kibanaFormat" change="updated()"></editor-checkbox>
+          <div class="gf-form" ng-show="link.keepTime">
+            <span class="gf-form-label width-10">Time format</span>
+            <div class="gf-form-select-wrapper gf-form--grow width-10">
+              <select class="gf-form-input" ng-model="link.timeFormat" ng-options="format for format in ['grafana','kibana']" ng-change="updated()"></select>
+            </div>
+          </div>
 					<editor-checkbox text="Variable values" model="link.includeVars" change="updated()"></editor-checkbox>
 					<editor-checkbox text="Open in new tab " model="link.targetBlank" change="updated()"></editor-checkbox>
 				</div>

--- a/public/app/features/dashlinks/editor.html
+++ b/public/app/features/dashlinks/editor.html
@@ -65,7 +65,7 @@
 				<div class="gf-form">
 					<span class="gf-form-label width-6">Include</span>
 					<editor-checkbox text="Time range" model="link.keepTime" change="updated()"></editor-checkbox>
-          <div class="gf-form" ng-show="link.keepTime">
+          <div class="gf-form" ng-show="link.keepTime && link.type == 'link'">
             <span class="gf-form-label width-10">Time format</span>
             <div class="gf-form-select-wrapper gf-form--grow width-10">
               <select class="gf-form-input" ng-model="link.timeFormat" ng-options="format for format in ['grafana','kibana']" ng-change="updated()"></select>

--- a/public/app/features/dashlinks/module.js
+++ b/public/app/features/dashlinks/module.js
@@ -101,6 +101,7 @@ function (angular, _) {
             title: linkDef.title,
             tags: linkDef.tags,
             keepTime: linkDef.keepTime,
+            kibanaFormat: linkDef.kibanaFormat,
             includeVars: linkDef.includeVars,
             icon: "fa fa-bars",
             asDropdown: true
@@ -118,6 +119,7 @@ function (angular, _) {
           tooltip: linkDef.tooltip,
           target: linkDef.targetBlank ? "_blank" : "_self",
           keepTime: linkDef.keepTime,
+          kibanaFormat: linkDef.kibanaFormat,
           includeVars: linkDef.includeVars,
         }]);
       }
@@ -143,6 +145,7 @@ function (angular, _) {
               url: 'dashboard/' + dash.uri,
               icon: 'fa fa-th-large',
               keepTime: link.keepTime,
+              kibanaFormat: link.kibanaFormat,
               includeVars: link.includeVars
             });
           }

--- a/public/app/features/dashlinks/module.js
+++ b/public/app/features/dashlinks/module.js
@@ -101,7 +101,7 @@ function (angular, _) {
             title: linkDef.title,
             tags: linkDef.tags,
             keepTime: linkDef.keepTime,
-            kibanaFormat: linkDef.kibanaFormat,
+            timeFormat: linkDef.timeFormat,
             includeVars: linkDef.includeVars,
             icon: "fa fa-bars",
             asDropdown: true
@@ -119,7 +119,7 @@ function (angular, _) {
           tooltip: linkDef.tooltip,
           target: linkDef.targetBlank ? "_blank" : "_self",
           keepTime: linkDef.keepTime,
-          kibanaFormat: linkDef.kibanaFormat,
+          timeFormat: linkDef.timeFormat,
           includeVars: linkDef.includeVars,
         }]);
       }
@@ -145,7 +145,7 @@ function (angular, _) {
               url: 'dashboard/' + dash.uri,
               icon: 'fa fa-th-large',
               keepTime: link.keepTime,
-              kibanaFormat: link.kibanaFormat,
+              timeFormat: link.timeFormat,
               includeVars: link.includeVars
             });
           }
@@ -173,7 +173,10 @@ function (angular, _) {
     $scope.dashboard.links = $scope.dashboard.links || [];
 
     $scope.addLink = function() {
-      $scope.dashboard.links.push({ type: 'dashboards', icon: 'external link' });
+      $scope.dashboard.links.push({
+        type: 'dashboards',
+        icon: 'external link',
+        timeFormat: 'grafana'});
       $scope.dashboard.updateSubmenuVisibility();
       $scope.updated();
     };

--- a/public/app/features/dashlinks/module.js
+++ b/public/app/features/dashlinks/module.js
@@ -101,12 +101,13 @@ function (angular, _) {
             title: linkDef.title,
             tags: linkDef.tags,
             keepTime: linkDef.keepTime,
-            timeFormat: linkDef.timeFormat,
             includeVars: linkDef.includeVars,
             icon: "fa fa-bars",
             asDropdown: true
           }]);
         }
+
+        linkDef.timeFormat = null;
 
         return $scope.searchDashboards(linkDef, 7);
       }

--- a/public/app/features/panellinks/linkSrv.js
+++ b/public/app/features/panellinks/linkSrv.js
@@ -15,9 +15,13 @@ function (angular, _, kbn) {
         var params = {};
 
         if (link.keepTime) {
-          var range = timeSrv.timeRangeForUrl();
-          params['from'] = range.from;
-          params['to'] = range.to;
+          if(link.kibanaFormat) {
+            params['_g'] = timeSrv.timeRangeForKibanaUrl();
+          } else {
+            var range = timeSrv.timeRangeForUrl();
+            params['from'] = range.from;
+            params['to'] = range.to;
+          }
         }
 
         if (link.includeVars) {
@@ -94,9 +98,13 @@ function (angular, _, kbn) {
         var params = {};
 
         if (link.keepTime) {
-          var range = timeSrv.timeRangeForUrl();
-          params['from'] = range.from;
-          params['to'] = range.to;
+          if(link.kibanaFormat) {
+            params['_g'] = timeSrv.timeRangeForKibanaUrl();
+          } else {
+            var range = timeSrv.timeRangeForUrl();
+            params['from'] = range.from;
+            params['to'] = range.to;
+          }
         }
 
         if (link.includeVars) {

--- a/public/app/features/panellinks/linkSrv.js
+++ b/public/app/features/panellinks/linkSrv.js
@@ -15,12 +15,14 @@ function (angular, _, kbn) {
         var params = {};
 
         if (link.keepTime) {
-          if(link.kibanaFormat) {
-            params['_g'] = timeSrv.timeRangeForKibanaUrl();
-          } else {
-            var range = timeSrv.timeRangeForUrl();
-            params['from'] = range.from;
-            params['to'] = range.to;
+          switch (link.timeFormat) {
+            case "kibana":
+              params['_g'] = timeSrv.timeRangeForKibanaUrl();
+              break;
+            default:
+              var range = timeSrv.timeRangeForUrl();
+              params['from'] = range.from;
+              params['to'] = range.to;
           }
         }
 
@@ -98,12 +100,14 @@ function (angular, _, kbn) {
         var params = {};
 
         if (link.keepTime) {
-          if(link.kibanaFormat) {
-            params['_g'] = timeSrv.timeRangeForKibanaUrl();
-          } else {
-            var range = timeSrv.timeRangeForUrl();
-            params['from'] = range.from;
-            params['to'] = range.to;
+          switch (link.timeFormat) {
+            case "kibana":
+              params['_g'] = timeSrv.timeRangeForKibanaUrl();
+              break;
+            default:
+              var range = timeSrv.timeRangeForUrl();
+              params['from'] = range.from;
+              params['to'] = range.to;
           }
         }
 

--- a/public/app/features/panellinks/linkSrv.js
+++ b/public/app/features/panellinks/linkSrv.js
@@ -100,6 +100,7 @@ function (angular, _, kbn) {
         var params = {};
 
         if (link.keepTime) {
+          link.timeFormat = link.type === 'dashboard' ? null : link.timeFormat;
           switch (link.timeFormat) {
             case "kibana":
               params['_g'] = timeSrv.timeRangeForKibanaUrl();

--- a/public/app/features/panellinks/module.html
+++ b/public/app/features/panellinks/module.html
@@ -34,6 +34,7 @@
 			</div>
 
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include time range" checked="link.keepTime"></gf-form-switch>
+			<gf-form-switch ng-show="link.keepTime" class="gf-form" label-class="width-10" label="In Kibana format" checked="link.kibanaFormat"></gf-form-switch>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include variables" checked="link.includeVars"></gf-form-switch>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Open in new tab " checked="link.targetBlank"></gf-form-switch>
 		</div>

--- a/public/app/features/panellinks/module.html
+++ b/public/app/features/panellinks/module.html
@@ -34,7 +34,12 @@
 			</div>
 
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include time range" checked="link.keepTime"></gf-form-switch>
-			<gf-form-switch ng-show="link.keepTime" class="gf-form" label-class="width-10" label="In Kibana format" checked="link.kibanaFormat"></gf-form-switch>
+      <div class="gf-form" ng-show="link.keepTime">
+        <span class="gf-form-label width-10">Time format</span>
+        <div class="gf-form-select-wrapper gf-form--grow width-10">
+          <select class="gf-form-input" ng-model="link.timeFormat" ng-options="format for format in ['grafana','kibana']" ng-change="updated()"></select>
+        </div>
+      </div>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include variables" checked="link.includeVars"></gf-form-switch>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Open in new tab " checked="link.targetBlank"></gf-form-switch>
 		</div>

--- a/public/app/features/panellinks/module.html
+++ b/public/app/features/panellinks/module.html
@@ -34,10 +34,10 @@
 			</div>
 
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include time range" checked="link.keepTime"></gf-form-switch>
-      <div class="gf-form" ng-show="link.keepTime">
+      <div class="gf-form" ng-show="link.keepTime && link.type == 'absolute'">
         <span class="gf-form-label width-10">Time format</span>
         <div class="gf-form-select-wrapper gf-form--grow width-10">
-          <select class="gf-form-input" ng-model="link.timeFormat" ng-options="format for format in ['grafana','kibana']" ng-change="updated()"></select>
+          <select class="gf-form-input" ng-model="link.timeFormat" ng-options="format for format in ['grafana','kibana']" ></select>
         </div>
       </div>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include variables" checked="link.includeVars"></gf-form-switch>

--- a/public/app/features/panellinks/module.js
+++ b/public/app/features/panellinks/module.js
@@ -26,6 +26,7 @@ function (angular, _) {
       $scope.addLink = function() {
         $scope.panel.links.push({
           type: 'dashboard',
+          timeFormat: 'grafana'
         });
       };
 


### PR DESCRIPTION
Hello.

Since Grafana is one of the leading monitoring solutions, we decided to make a sort of integration with Kibana, the most popular open source UI for logs.

We decided to synchronize time formats of Kibana and Grafana for urls. 
By clicking checkbox "Include time range" we can then click checkbox "in Kibana format"  and the time format for url will be changed.
Depending on selected time format (relative e.g. "Last 5 minutes" or absolute e.g. from "Jan 18, 2017 11:11:11 to Jan 19, 2017 11:11:11") istead of `from=now-6h&to=now` we will have `g=(time:(from:now-5m,mode:quick,to:now))` (or `g=(time:(from:'2016-12-18T11:11:11.111Z',mode:absolute,to:'2017-01-19T15:11:11.111Z'))`).

We understand that this is a bit specific case, but we hope that it will be suitable for people who enjoy use (and integrate with each other) open source solutions.

Thanks.
