### PR TITLE
[3743] Adds support for user search based on login or email

### DIFF
--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -71,17 +71,19 @@ parent = "http_api"
 
 ## Get single user by Username(login) or Email
 
-    `GET /api/users/loginoremail/:loginOrEmail`
+    `GET /api/users/lookup`
 
-    **Example Request using the email option**:
+    **Parameter:** `loginOrEmail`
 
-        GET /api/loginoremail/user@mygraf.com HTTP/1.1
+    **Example Request using the email as option**:
+
+        GET /api/users/lookup?loginOrEmail=user@mygraf.com HTTP/1.1
         Accept: application/json
         Content-Type: application/json
         Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
-    **Example Request using the username option**:
-        GET /api/loginoremail/admin HTTP/1.1
+    **Example Request using the username as option**:
+        GET /api/users/lookup?loginOrEmail=admin HTTP/1.1
         Accept: application/json
         Content-Type: application/json
         Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk

--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -69,6 +69,38 @@ parent = "http_api"
       "isGrafanaAdmin": true
     }
 
+## Get single user by Username(login) or Email
+
+    `GET /api/users/loginoremail/:loginOrEmail`
+
+    **Example Request using the email option**:
+
+        GET /api/loginoremail/user@mygraf.com HTTP/1.1
+        Accept: application/json
+        Content-Type: application/json
+        Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+
+    **Example Request using the username option**:
+        GET /api/loginoremail/admin HTTP/1.1
+        Accept: application/json
+        Content-Type: application/json
+        Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+
+    **Example Response**:
+
+        HTTP/1.1 200
+        Content-Type: application/json
+
+        {
+          "email": "user@mygraf.com"
+          "name": "admin",
+          "login": "admin",
+          "theme": "light",
+          "orgId": 1,
+          "isGrafanaAdmin": true
+        }
+
+
 ## User Update
 
 `PUT /api/users/:id`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,7 +126,8 @@ func Register(r *macaron.Macaron) {
 			r.Get("/", wrap(SearchUsers))
 			r.Get("/:id", wrap(GetUserById))
 			r.Get("/:id/orgs", wrap(GetUserOrgList))
-			r.Get("/loginoremail/:loginOrEmail", wrap(GetUserByLoginOrEmail))
+			// query parameters /users/lookup?loginOrEmail=admin@example.com
+			r.Get("/lookup", wrap(GetUserByLoginOrEmail))
 			r.Put("/:id", bind(m.UpdateUserCommand{}), wrap(UpdateUser))
 			r.Post("/:id/using/:orgId", wrap(UpdateUserActiveOrg))
 		}, reqGrafanaAdmin)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,6 +126,7 @@ func Register(r *macaron.Macaron) {
 			r.Get("/", wrap(SearchUsers))
 			r.Get("/:id", wrap(GetUserById))
 			r.Get("/:id/orgs", wrap(GetUserOrgList))
+			r.Get("/loginoremail/:loginOrEmail", wrap(GetUserByLoginOrEmail))
 			r.Put("/:id", bind(m.UpdateUserCommand{}), wrap(UpdateUser))
 			r.Post("/:id/using/:orgId", wrap(UpdateUserActiveOrg))
 		}, reqGrafanaAdmin)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -31,9 +31,9 @@ func getUserUserProfile(userId int64) Response {
 	return Json(200, query.Result)
 }
 
-// GET /api/users/loginoremail/:loginOrEmail
+// GET /api/users/lookup
 func GetUserByLoginOrEmail(c *middleware.Context) Response {
-	query := m.GetUserByLoginQuery{LoginOrEmail: c.QueryEscape("loginOrEmail")}
+	query := m.GetUserByLoginQuery{LoginOrEmail: c.Query("loginOrEmail")}
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrUserNotFound {
 			return ApiError(404, m.ErrUserNotFound.Error(), nil)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -33,7 +33,7 @@ func getUserUserProfile(userId int64) Response {
 
 // GET /api/users/loginoremail/:loginOrEmail
 func GetUserByLoginOrEmail(c *middleware.Context) Response {
-	query := m.GetUserByLoginQuery{LoginOrEmail: c.Params(":loginOrEmail")}
+	query := m.GetUserByLoginQuery{LoginOrEmail: c.QueryEscape("loginOrEmail")}
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrUserNotFound {
 			return ApiError(404, m.ErrUserNotFound.Error(), nil)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -13,7 +13,7 @@ func GetSignedInUser(c *middleware.Context) Response {
 	return getUserUserProfile(c.UserId)
 }
 
-// GET /api/user/:id
+// GET /api/users/:id
 func GetUserById(c *middleware.Context) Response {
 	return getUserUserProfile(c.ParamsInt64(":id"))
 }
@@ -22,10 +22,34 @@ func getUserUserProfile(userId int64) Response {
 	query := m.GetUserProfileQuery{UserId: userId}
 
 	if err := bus.Dispatch(&query); err != nil {
+		if err == m.ErrUserNotFound {
+			return ApiError(404, m.ErrUserNotFound.Error(), nil)
+		}
 		return ApiError(500, "Failed to get user", err)
 	}
 
 	return Json(200, query.Result)
+}
+
+// GET /api/users/loginoremail/:loginOrEmail
+func GetUserByLoginOrEmail(c *middleware.Context) Response {
+	query := m.GetUserByLoginQuery{LoginOrEmail: c.Params(":loginOrEmail")}
+	if err := bus.Dispatch(&query); err != nil {
+		if err == m.ErrUserNotFound {
+			return ApiError(404, m.ErrUserNotFound.Error(), nil)
+		}
+		return ApiError(500, "Failed to get user", err)
+	}
+	user := query.Result
+	result := m.UserProfileDTO{
+		Name:           user.Name,
+		Email:          user.Email,
+		Login:          user.Login,
+		Theme:          user.Theme,
+		IsGrafanaAdmin: user.IsAdmin,
+		OrgId:          user.OrgId,
+	}
+	return Json(200, &result)
 }
 
 // POST /api/user
@@ -60,7 +84,7 @@ func UpdateUserActiveOrg(c *middleware.Context) Response {
 	cmd := m.SetUsingOrgCommand{UserId: userId, OrgId: orgId}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return ApiError(500, "Failed change active organization", err)
+		return ApiError(500, "Failed to change active organization", err)
 	}
 
 	return ApiSuccess("Active organization changed")
@@ -70,12 +94,12 @@ func handleUpdateUser(cmd m.UpdateUserCommand) Response {
 	if len(cmd.Login) == 0 {
 		cmd.Login = cmd.Email
 		if len(cmd.Login) == 0 {
-			return ApiError(400, "Validation error, need specify either username or email", nil)
+			return ApiError(400, "Validation error, need to specify either username or email", nil)
 		}
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return ApiError(500, "failed to update user", err)
+		return ApiError(500, "Failed to update user", err)
 	}
 
 	return ApiSuccess("User updated")
@@ -95,7 +119,7 @@ func getUserOrgList(userId int64) Response {
 	query := m.GetUserOrgListQuery{UserId: userId}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return ApiError(500, "Faile to get user organziations", err)
+		return ApiError(500, "Failed to get user organizations", err)
 	}
 
 	return Json(200, query.Result)
@@ -130,7 +154,7 @@ func UserSetUsingOrg(c *middleware.Context) Response {
 	cmd := m.SetUsingOrgCommand{UserId: c.UserId, OrgId: orgId}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return ApiError(500, "Failed change active organization", err)
+		return ApiError(500, "Failed to change active organization", err)
 	}
 
 	return ApiSuccess("Active organization changed")


### PR DESCRIPTION
- Adds support for #3743 . I have used the already implemented `GetUserByLogin` in `sqlstore/user.go` to achieve this. The returned data is modelled upon the `UserProfileDTO` in order to keep consistency with the `GetUserById` call.
- Adds documentation for the new call.
- Adds correct http response header in `GetUserById` in case of the user is not found.
- Minor typo fixes.