### PR TITLE
Elasticsearch - Term aggregation limit fix  (should fix #7112)

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -244,12 +244,7 @@ function (queryDef) {
     }
     var size = 500;
     if(queryDef.size){
-      if(this.esVersion >= 5 && queryDef.size !== 0) {
-        size = queryDef.size;
-      }
-      else if(this.esVersion < 5) {
-        size = queryDef.size;
-      }
+      size = queryDef.size;
     }
     query.aggs =  {
       "1": {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -29,7 +29,6 @@ function (queryDef) {
     }
 
     queryNode.terms.size = parseInt(aggDef.settings.size, 10) === 0 ? 500 : parseInt(aggDef.settings.size, 10);
-
     if (aggDef.settings.orderBy !== void 0) {
       queryNode.terms.order = {};
       queryNode.terms.order[aggDef.settings.orderBy] = aggDef.settings.order;
@@ -243,19 +242,26 @@ function (queryDef) {
         }
       });
     }
-
+    var size = 500;
+    if(queryDef.size){
+      if(this.esVersion >= 5 && queryDef.size !== 0) {
+        size = queryDef.size;
+      }
+      else if(this.esVersion < 5) {
+        size = queryDef.size;
+      }
+    }
     query.aggs =  {
       "1": {
         "terms": {
           "field": queryDef.field,
-          "size": 500,
+          "size": size,
           "order": {
             "_term": "asc"
           }
         },
       }
     };
-
     return query;
   };
 


### PR DESCRIPTION
Should fix #7112 
I added a possibility to have a templating query like so `{"find":"terms", "field":"someField", "size": 0}`. I kept the default 500 value in case the templating query doesn't have the size member.
I also check and skip the case size=0 on ES 5.x so it should work fine.