### PR TITLE
Update building_from_source.md

### DIFF
--- a/docs/sources/project/building_from_source.md
+++ b/docs/sources/project/building_from_source.md
@@ -23,6 +23,8 @@ export GOPATH=`pwd`
 go get github.com/grafana/grafana
 ```
 
+You may see an error such as: `package github.com/grafana/grafana: no buildable Go source files`. This is just a warning, and you can proceed with the directions.
+
 ## Building the backend
 ```
 cd $GOPATH/src/github.com/grafana/grafana


### PR DESCRIPTION
Add a note about the `go get` warning that the user sees when following the setup instructions.
