### PR TITLE
[7312] Add ceph support as external image store

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -422,8 +422,17 @@ url = https://grafana.net
 
 #################################### External Image Storage ##############
 [external_image_storage]
-# You can choose between (s3, webdav)
+# You can choose between (ceph, s3, webdav)
 provider =
+
+[external_image_storage.ceph]
+bucket =
+access_key =
+secret_key =
+region =
+endpoint =
+disable_ssl =
+public_url =
 
 [external_image_storage.s3]
 bucket_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -381,8 +381,17 @@
 #################################### External image storage ##########################
 [external_image_storage]
 # Used for uploading images to public servers so they can be included in slack/email messages.
-# you can choose between (s3, webdav)
+# you can choose between (ceph, s3, webdav)
 ;provider =
+
+[external_image_storage.ceph]
+;bucket =
+;access_key =
+;secret_key =
+;region =
+;endpoint =
+;disable_ssl =
+;public_url =
 
 [external_image_storage.s3]
 ;bucket_url =

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -592,7 +592,30 @@ Time to live for snapshots.
 These options control how images should be made public so they can be shared on services like slack.
 
 ### provider
-You can choose between (s3, webdav). If left empty Grafana will ignore the upload action.
+You can choose between (ceph, s3, webdav). If left empty Grafana will ignore the upload action.
+
+## [external_image_storage.ceph]
+
+### bucket
+bucket name ex grafana
+
+### access_key
+access key. ex AAAAAAAAAAAAAAAAAAAA
+
+### secret_key
+secret key. ex AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+### region
+custom region (default 'us-east-1')
+
+### endpoint
+endpoint location ex http://s3.your.internal.ceph.cluster
+
+### disable_ssl
+set to true to disable SSL for endpoint. (default false)
+
+### public_url
+public url for screenshots ex https://grafana.your.domain.com (default https://bucket.endpoint)
 
 ## [external_image_storage.s3]
 

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -21,6 +21,28 @@ func (NopImageUploader) Upload(path string) (string, error) {
 func NewImageUploader() (ImageUploader, error) {
 
 	switch setting.ImageUploadProvider {
+	case "ceph":
+		cephsec, err := setting.Cfg.GetSection("external_image_storage.ceph")
+		if err != nil {
+			return nil, err
+		}
+
+		bucket := cephsec.Key("bucket").MustString("")
+		if bucket == "" {
+			return nil, fmt.Errorf("Could not find ceph bucket configuration")
+		}
+		accessKey := cephsec.Key("access_key").MustString("")
+		secretKey := cephsec.Key("secret_key").MustString("")
+
+		region := cephsec.Key("region").MustString("us-east-1")
+		endpoint := cephsec.Key("endpoint").MustString("")
+		if endpoint == "" {
+			return nil, fmt.Errorf("Could not find ceph endpoint configuration")
+		}
+		disableSsl := cephsec.Key("disable_ssl").MustBool(false)
+		publicUrl := cephsec.Key("public_url").MustString("https://" + bucket + "." + endpoint)
+
+		return NewS3Uploader(region, endpoint, publicUrl, bucket, "public-read", accessKey, secretKey, disableSsl), nil
 	case "s3":
 		s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
 		if err != nil {
@@ -45,7 +67,11 @@ func NewImageUploader() (ImageUploader, error) {
 			}
 		}
 
-		return NewS3Uploader(region, bucket, "public-read", accessKey, secretKey), nil
+		endpoint := ""
+		disableSsl := false
+		publicUrl := "https://" + bucket + ".s3.amazonaws.com"
+
+		return NewS3Uploader(region, endpoint, publicUrl, bucket, "public-read", accessKey, secretKey, disableSsl), nil
 	case "webdav":
 		webdavSec, err := setting.Cfg.GetSection("external_image_storage.webdav")
 		if err != nil {

--- a/pkg/components/imguploader/imguploader_test.go
+++ b/pkg/components/imguploader/imguploader_test.go
@@ -10,6 +10,37 @@ import (
 
 func TestImageUploaderFactory(t *testing.T) {
 	Convey("Can create image uploader for ", t, func() {
+		Convey("CephImageUploader", func() {
+			var err error
+			setting.NewConfigContext(&setting.CommandLineArgs{
+				HomePath: "../../../",
+			})
+
+			setting.ImageUploadProvider = "ceph"
+
+			cephsec, err := setting.Cfg.GetSection("external_image_storage.ceph")
+			cephsec.NewKey("bucket", "grafana")
+			cephsec.NewKey("access_key", "access_key")
+			cephsec.NewKey("secret_key", "secret_key")
+			cephsec.NewKey("endpoint", "s3.ceph.cluster")
+			cephsec.NewKey("public_url", "https://grafana.my.domain.com")
+			cephsec.NewKey("disable_ssl", "true")
+
+			uploader, err := NewImageUploader()
+
+			So(err, ShouldBeNil)
+			original, ok := uploader.(*S3Uploader)
+
+			So(ok, ShouldBeTrue)
+			So(original.region, ShouldEqual, "us-east-1")
+			So(original.bucket, ShouldEqual, "grafana")
+			So(original.accessKey, ShouldEqual, "access_key")
+			So(original.secretKey, ShouldEqual, "secret_key")
+			So(original.endpoint, ShouldEqual, "s3.ceph.cluster")
+			So(original.publicUrl, ShouldEqual, "https://grafana.my.domain.com")
+			So(original.disableSsl, ShouldEqual, true)
+		})
+
 		Convey("S3ImageUploader", func() {
 			var err error
 			setting.NewConfigContext(&setting.CommandLineArgs{

--- a/pkg/components/imguploader/s3uploader.go
+++ b/pkg/components/imguploader/s3uploader.go
@@ -15,22 +15,28 @@ import (
 )
 
 type S3Uploader struct {
-	region    string
-	bucket    string
-	acl       string
-	secretKey string
-	accessKey string
-	log       log.Logger
+	region     string
+	endpoint   string
+	publicUrl  string
+	disableSsl bool
+	bucket     string
+	acl        string
+	secretKey  string
+	accessKey  string
+	log        log.Logger
 }
 
-func NewS3Uploader(region, bucket, acl, accessKey, secretKey string) *S3Uploader {
+func NewS3Uploader(region, endpoint, publicUrl, bucket, acl, accessKey, secretKey string, disableSsl bool) *S3Uploader {
 	return &S3Uploader{
-		region:    region,
-		bucket:    bucket,
-		acl:       acl,
-		accessKey: accessKey,
-		secretKey: secretKey,
-		log:       log.New("s3uploader"),
+		region:     region,
+		endpoint:   endpoint,
+		publicUrl:  publicUrl,
+		disableSsl: disableSsl,
+		bucket:     bucket,
+		acl:        acl,
+		accessKey:  accessKey,
+		secretKey:  secretKey,
+		log:        log.New("s3uploader"),
 	}
 }
 
@@ -47,6 +53,8 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 		})
 	cfg := &aws.Config{
 		Region:      aws.String(u.region),
+		Endpoint:    aws.String(u.endpoint),
+		DisableSSL:  aws.Bool(u.disableSsl),
 		Credentials: creds,
 	}
 
@@ -71,5 +79,5 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 		return "", err
 	}
 
-	return "https://" + u.bucket + ".s3.amazonaws.com/" + key, nil
+	return u.publicUrl + "/" + key, nil
 }


### PR DESCRIPTION
Ceph since stable release Jewel supports AWS Signature Version 4, so it was possible to reuse existing S3 implementation and override some default settings (dedicated for AWS S3). To make it more clear I created a separate ImageUploadProvider - `ceph` and reuse existing s3uploader.

* Feature request: https://github.com/grafana/grafana/issues/7312