### PR TITLE
Add a total tooltip type

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -94,7 +94,11 @@ function ($, core) {
             value = series.data[hoverIndex][1];
           } else {
             last_value += series.data[hoverIndex][1];
-            value = last_value;
+            if (panel.tooltip.value_type === 'total') {
+              value = series.data[hoverIndex][1];
+            } else {
+              value = last_value;
+            }
           }
         } else {
           value = series.data[hoverIndex][1];
@@ -127,6 +131,17 @@ function ($, core) {
 
       // Contat the 3 sub-arrays
       results = results[0].concat(results[1],results[2]);
+      if (panel.tooltip.value_type === 'total') {
+        results.push({
+          hoverIndex: 0,
+          distance: 0,
+          value: last_value,
+          index: 0,
+          label: 'Total',
+          time: pointTime,
+          color: '#000000'
+        });
+      }
 
       // Time of the point closer to pointer
       results.time = minTime;

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -64,7 +64,7 @@
 			<div class="gf-form" ng-show="ctrl.panel.stack">
 				<label class="gf-form-label width-9">Stacked value</label>
 				<div class="gf-form-select-wrapper max-width-8">
-					<select class="gf-form-input" ng-model="ctrl.panel.tooltip.value_type" ng-options="f for f in ['cumulative','individual']" ng-change="ctrl.render()"></select>
+					<select class="gf-form-input" ng-model="ctrl.panel.tooltip.value_type" ng-options="f for f in ['cumulative','individual','total']" ng-change="ctrl.render()"></select>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This will add a 'total' value to the end of the tooltip that displays the aggregation of all the displayed values. We wanted to be able to see each of the individual values when hovering, but also get the summation.