### PR TITLE
Disable sign out for AuthProxyEnabled

### DIFF
--- a/public/app/core/components/sidemenu/sidemenu.ts
+++ b/public/app/core/components/sidemenu/sidemenu.ts
@@ -50,7 +50,7 @@ export class SideMenuCtrl {
      {text: 'Profile', url: this.getUrl('/profile')},
    ];
 
-   if (this.isSignedIn) {
+   if (this.showSignout) {
      this.orgMenu.push({text: "Sign out", url: this.getUrl("/logout"), target: "_self"});
    }
 


### PR DESCRIPTION
Sign out was disabled for AuthProxyEnabled in #3122.  This is to catch the one other instance of a sign out link in the side menu.