### PR TITLE
Add DeliveryStreamName dimension to AWS/Firehose Cloudwatch namespace

### DIFF
--- a/pkg/api/cloudwatch/metrics.go
+++ b/pkg/api/cloudwatch/metrics.go
@@ -111,7 +111,7 @@ func init() {
 		"AWS/ElasticMapReduce": {"ClusterId", "JobFlowId", "JobId"},
 		"AWS/ES":               {"ClientId", "DomainName"},
 		"AWS/Events":           {"RuleName"},
-		"AWS/Firehose":         {},
+		"AWS/Firehose":         {"DeliveryStreamName"},
 		"AWS/IoT":              {"Protocol"},
 		"AWS/Kinesis":          {"StreamName", "ShardID"},
 		"AWS/KinesisAnalytics": {"Flow", "Id", "Application"},


### PR DESCRIPTION
This dimension is not mentioned in the official documentation, but I can't graph without it.
http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/akf-metricscollected.html