### PR TITLE
file_export.ts: #5325 missed exportTableDataToCsv when adding sep

### DIFF
--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -50,7 +50,7 @@ export function exportSeriesListToCsvColumns(seriesList) {
 };
 
 export function exportTableDataToCsv(table) {
-    var text = '';
+    var text = 'sep=;\n';
     // add header
     _.each(table.columns, function(column) {
         text += column.text + ';';


### PR DESCRIPTION
PR #5325 added the Excel sep=; line to the other two export functions, but didn't add it to exportTableDataToCsv, and this commit adds it.