### PR TITLE
Remove deprecated dataproxy logging setting

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -49,9 +49,6 @@
 # Log web requests
 ;router_logging = false
 
-# This enables query request audit logging, output at warn level, default is false
-;data_proxy_logging = false
-
 # the path relative working path
 ;static_root_path = public
 


### PR DESCRIPTION
This line should have been removed in 06440ef57b3a7d868de93dae694ec542218db092, but was probably forgotten.

Solves #7395.
