### PR TITLE
Add an idiomatic plugin path for FreeBSD

### DIFF
--- a/pkg/cmd/grafana-cli/utils/grafana_path.go
+++ b/pkg/cmd/grafana-cli/utils/grafana_path.go
@@ -40,6 +40,8 @@ func returnOsDefault(currentOs string) string {
 		return "../data/plugins"
 	case "darwin":
 		return "/usr/local/var/lib/grafana/plugins"
+	case "freebsd":
+		return "/var/db/grafana/plugins"
 	default: //"linux"
 		return "/var/lib/grafana/plugins"
 	}


### PR DESCRIPTION
@swills has made a FreeBSD ports build for Grafana 4.1.1.  This is the only issue I have found in testing for him.