### PR TITLE
Add image url to telegram alert notifier

### DIFF
--- a/pkg/services/alerting/notifiers/telegram.go
+++ b/pkg/services/alerting/notifiers/telegram.go
@@ -93,6 +93,9 @@ func (this *TelegramNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if err == nil {
 		message = message + fmt.Sprintf("URL: %s\n", ruleUrl)
 	}
+	if evalContext.ImagePublicUrl != "" {
+		message = message + fmt.Sprintf("Image: %s\n", evalContext.ImagePublicUrl)
+	}
 	bodyJSON.Set("text", message)
 
 	url := fmt.Sprintf(telegeramApiUrl, this.BotToken, "sendMessage")


### PR DESCRIPTION
If public image url of alert is exist add it to the telegram message
Improvement for #7098