### PR TITLE
#7312 Improve imguploader with custom endpoint

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -431,6 +431,10 @@ provider =
 bucket_url =
 access_key =
 secret_key =
+region =
+endpoint =
+disable_ssl =
+public_url =
 
 [external_image_storage.webdav]
 url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -387,6 +387,10 @@
 ;bucket_url =
 ;access_key =
 ;secret_key =
+;region =
+;endpoint =
+;disable_ssl =
+;public_url =
 
 [external_image_storage.webdav]
 ;url =

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -605,6 +605,18 @@ access key. ex AAAAAAAAAAAAAAAAAAAA
 ### secret_key
 secret key. ex AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
+### region
+custom region (default 'us-east-1')
+
+### endpoint
+endpoint location ex http://s3.your.internal.cluster
+
+### disable_ssl
+set to true to disable SSL for endpoint. (default false)
+
+### public_url
+public url for screenshots ex https://grafana.your.domain.com (default https://endpoint/bucket)
+
 ## [external_image_storage.webdav]
 
 ### url

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/grafana/grafana/pkg/setting"
+	"strings"
 )
 
 type ImageUploader interface {
@@ -27,25 +28,47 @@ func NewImageUploader() (ImageUploader, error) {
 			return nil, err
 		}
 
-		bucket := s3sec.Key("bucket_url").MustString("")
+		bucketUrl := s3sec.Key("bucket_url").MustString("")
 		accessKey := s3sec.Key("access_key").MustString("")
 		secretKey := s3sec.Key("secret_key").MustString("")
+		region := s3sec.Key("region").MustString("us-east-1")
+		disableSsl := s3sec.Key("disable_ssl").MustBool(false)
 
-		region := ""
-		rBucket := regexp.MustCompile(`https?:\/\/(.*)\.s3(-([^.]+))?\.amazonaws\.com\/?`)
-		matches := rBucket.FindStringSubmatch(bucket)
-		if len(matches) == 0 {
-			return nil, fmt.Errorf("Could not find bucket setting for image.uploader.s3")
-		} else {
-			bucket = matches[1]
-			if matches[3] != "" {
-				region = matches[3]
+		bucket := ""
+		endpoint := "https://s3.amazonaws.com"
+		if strings.Contains(bucketUrl, "amazonaws.com") {
+			rBucket := regexp.MustCompile(`https?:\/\/(.*)\.s3(-([^.]+))?\.amazonaws\.com\/?`)
+			matches := rBucket.FindStringSubmatch(bucketUrl)
+			if len(matches) == 0 {
+				return nil, fmt.Errorf("Could not find bucket setting for image.uploader.s3")
 			} else {
-				region = "us-east-1"
+				bucket = matches[1]
+				if matches[3] != "" {
+					region = matches[3]
+				}
 			}
-		}
+		} else {
+			rBucket := regexp.MustCompile(`^(https?://)([\w.]+\.[a-z]{2,}\.?)(/[\w.]*)*/?$`)
+			matches := rBucket.FindStringSubmatch(bucketUrl)
+			if len(matches) == 0 {
+				return nil, fmt.Errorf("Could not find bucket setting for image.uploader.s3")
+			}
+			protocol := matches[1]
+			domain := matches[2]
+			slug := matches[3]
+			if slug == "" {
+				domainParts := strings.Split(domain, ".")
+				bucket = domainParts[0]
+				domain = strings.Replace(domain, bucket+".", "", -1)
+			} else {
+				bucket = strings.Replace(slug, "/", "", -1)
+			}
+			endpoint = protocol + domain
 
-		return NewS3Uploader(region, bucket, "public-read", accessKey, secretKey), nil
+		}
+		publicUrl := s3sec.Key("public_url").MustString(endpoint + "/" + bucket)
+
+		return NewS3Uploader(region, endpoint, publicUrl, bucket, "public-read", accessKey, secretKey, disableSsl), nil
 	case "webdav":
 		webdavSec, err := setting.Cfg.GetSection("external_image_storage.webdav")
 		if err != nil {

--- a/pkg/components/imguploader/imguploader_test.go
+++ b/pkg/components/imguploader/imguploader_test.go
@@ -11,28 +11,113 @@ import (
 func TestImageUploaderFactory(t *testing.T) {
 	Convey("Can create image uploader for ", t, func() {
 		Convey("S3ImageUploader", func() {
-			var err error
-			setting.NewConfigContext(&setting.CommandLineArgs{
-				HomePath: "../../../",
+			Convey("with amazonawsbucket_url", func() {
+				var err error
+				setting.NewConfigContext(&setting.CommandLineArgs{
+					HomePath: "../../../",
+				})
+
+				setting.ImageUploadProvider = "s3"
+
+				s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
+				s3sec.NewKey("bucket_url", "https://foo.bar.baz.s3-us-east-2.amazonaws.com")
+				s3sec.NewKey("access_key", "access_key")
+				s3sec.NewKey("secret_key", "secret_key")
+
+				uploader, err := NewImageUploader()
+
+				So(err, ShouldBeNil)
+				original, ok := uploader.(*S3Uploader)
+
+				So(ok, ShouldBeTrue)
+				So(original.region, ShouldEqual, "us-east-2")
+				So(original.bucket, ShouldEqual, "foo.bar.baz")
+				So(original.accessKey, ShouldEqual, "access_key")
+				So(original.secretKey, ShouldEqual, "secret_key")
 			})
 
-			setting.ImageUploadProvider = "s3"
+			Convey("with custom s3 provider", func() {
+				var err error
+				setting.NewConfigContext(&setting.CommandLineArgs{
+					HomePath: "../../../",
+				})
 
-			s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
-			s3sec.NewKey("bucket_url", "https://foo.bar.baz.s3-us-east-2.amazonaws.com")
-			s3sec.NewKey("access_key", "access_key")
-			s3sec.NewKey("secret_key", "secret_key")
+				setting.ImageUploadProvider = "s3"
 
-			uploader, err := NewImageUploader()
+				s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
+				s3sec.NewKey("bucket_url", "https://bucket1234.hb.cldmail.ru")
+				s3sec.NewKey("access_key", "access_key")
+				s3sec.NewKey("secret_key", "secret_key")
+				s3sec.NewKey("region", "ru-msk")
 
-			So(err, ShouldBeNil)
-			original, ok := uploader.(*S3Uploader)
+				uploader, err := NewImageUploader()
 
-			So(ok, ShouldBeTrue)
-			So(original.region, ShouldEqual, "us-east-2")
-			So(original.bucket, ShouldEqual, "foo.bar.baz")
-			So(original.accessKey, ShouldEqual, "access_key")
-			So(original.secretKey, ShouldEqual, "secret_key")
+				So(err, ShouldBeNil)
+				original, ok := uploader.(*S3Uploader)
+
+				So(ok, ShouldBeTrue)
+				So(original.region, ShouldEqual, "ru-msk")
+				So(original.bucket, ShouldEqual, "bucket1234")
+				So(original.accessKey, ShouldEqual, "access_key")
+				So(original.secretKey, ShouldEqual, "secret_key")
+			})
+
+			Convey("with bucket in path", func() {
+				var err error
+				setting.NewConfigContext(&setting.CommandLineArgs{
+					HomePath: "../../../",
+				})
+
+				setting.ImageUploadProvider = "s3"
+
+				s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
+				s3sec.NewKey("bucket_url", "https://hb.cldmail.ru/bucket1234")
+				s3sec.NewKey("access_key", "access_key")
+				s3sec.NewKey("secret_key", "secret_key")
+				s3sec.NewKey("region", "ru-msk")
+
+				uploader, err := NewImageUploader()
+
+				So(err, ShouldBeNil)
+				original, ok := uploader.(*S3Uploader)
+
+				So(ok, ShouldBeTrue)
+				So(original.region, ShouldEqual, "ru-msk")
+				So(original.bucket, ShouldEqual, "bucket1234")
+				So(original.accessKey, ShouldEqual, "access_key")
+				So(original.secretKey, ShouldEqual, "secret_key")
+			})
+
+			Convey("with ceph configs", func() {
+				var err error
+				setting.NewConfigContext(&setting.CommandLineArgs{
+					HomePath: "../../../",
+				})
+
+				setting.ImageUploadProvider = "s3"
+
+				s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
+				s3sec.NewKey("bucket_url", "https://grafana.s3.ceph.cluster")
+				s3sec.NewKey("access_key", "access_key")
+				s3sec.NewKey("secret_key", "secret_key")
+				s3sec.NewKey("endpoint", "s3.ceph.cluster")
+				s3sec.NewKey("public_url", "https://grafana.my.domain.com")
+				s3sec.NewKey("disable_ssl", "true")
+
+				uploader, err := NewImageUploader()
+
+				So(err, ShouldBeNil)
+				original, ok := uploader.(*S3Uploader)
+
+				So(ok, ShouldBeTrue)
+				So(original.region, ShouldEqual, "us-east-1")
+				So(original.bucket, ShouldEqual, "grafana")
+				So(original.accessKey, ShouldEqual, "access_key")
+				So(original.secretKey, ShouldEqual, "secret_key")
+				So(original.endpoint, ShouldEqual, "https://s3.ceph.cluster")
+				So(original.publicUrl, ShouldEqual, "https://grafana.my.domain.com")
+				So(original.disableSsl, ShouldEqual, true)
+			})
 		})
 
 		Convey("Webdav uploader", func() {

--- a/pkg/components/imguploader/s3uploader.go
+++ b/pkg/components/imguploader/s3uploader.go
@@ -15,22 +15,28 @@ import (
 )
 
 type S3Uploader struct {
-	region    string
-	bucket    string
-	acl       string
-	secretKey string
-	accessKey string
-	log       log.Logger
+	region     string
+	endpoint   string
+	publicUrl  string
+	disableSsl bool
+	bucket     string
+	acl        string
+	secretKey  string
+	accessKey  string
+	log        log.Logger
 }
 
-func NewS3Uploader(region, bucket, acl, accessKey, secretKey string) *S3Uploader {
+func NewS3Uploader(region, endpoint, publicUrl, bucket, acl, accessKey, secretKey string, disableSsl bool) *S3Uploader {
 	return &S3Uploader{
-		region:    region,
-		bucket:    bucket,
-		acl:       acl,
-		accessKey: accessKey,
-		secretKey: secretKey,
-		log:       log.New("s3uploader"),
+		region:     region,
+		endpoint:   endpoint,
+		publicUrl:  publicUrl,
+		disableSsl: disableSsl,
+		bucket:     bucket,
+		acl:        acl,
+		accessKey:  accessKey,
+		secretKey:  secretKey,
+		log:        log.New("s3uploader"),
 	}
 }
 
@@ -47,11 +53,13 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 		})
 	cfg := &aws.Config{
 		Region:      aws.String(u.region),
+		Endpoint:    aws.String(u.endpoint),
+		DisableSSL:  aws.Bool(u.disableSsl),
 		Credentials: creds,
 	}
 
 	key := util.GetRandomString(20) + ".png"
-	log.Debug("Uploading image to s3", "bucket = ", u.bucket, ", key = ", key)
+	log.Debug("Uploading image to s3", "endpoint = ", u.endpoint, "bucket = ", u.bucket, ", key = ", key)
 
 	file, err := os.Open(imageDiskPath)
 	if err != nil {
@@ -71,5 +79,5 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 		return "", err
 	}
 
-	return "https://" + u.bucket + ".s3.amazonaws.com/" + key, nil
+	return u.publicUrl + "/" + key, nil
 }


### PR DESCRIPTION
I use not amazonaws S3 server, but it support aws sdk requests for S3 protocol.
So i improve `NewImageUploader` for S3 to work with endpoint url, with which aws-sdk could work.
There is PR #7341 but it add another config entity for ceph witch i think is redundant, so i add good features from it`s PR here.
I don't have any ceph or amazonaws s3 services, so i could test it only on my service, but i add as much test as i could =)