### PR TITLE
pass api token via query params

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -33,7 +33,14 @@ func getApiKey(c *Context) string {
 		return key
 	}
 
-	return ""
+	api_key := c.Query("api_key")
+	if api_key != "" {
+		return api_key
+	}
+
+	api_key_persist := c.GetCookie("grafana_persist_api_key")
+
+	return api_key_persist
 }
 
 func accessForbidden(c *Context) {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -128,6 +128,9 @@ func initContextWithApiKey(ctx *Context) bool {
 			return true
 		}
 
+		// store key into cookie
+		ctx.SetCookie("grafana_persist_api_key", keyString, 20000, setting.AppSubUrl + "/")
+
 		ctx.IsSignedIn = true
 		ctx.SignedInUser = &m.SignedInUser{}
 		ctx.OrgRole = apikey.Role


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/7005
Hi, guys. I've made proof of concept for issue linked above.
Main ideas:
- Use api tokens for this: pass api_token as query parameter.
- Api tokens now stateles - we should pass it in each request. We cannot do this because JS will render page internals
- Store token in coockie if authentication was successfull and reuse it at next requests.
Additional:
- Make token storage optional and disable it by default
- Store token in coockie on  additional query parameter
- Store token in coockie on  additional query parameter header (to consistency with header-based API)
