### PR TITLE
Make timeout for snapshot creation configurable

### DIFF
--- a/public/app/features/dashboard/partials/shareModal.html
+++ b/public/app/features/dashboard/partials/shareModal.html
@@ -148,6 +148,19 @@
 					</div>
 				</div>
 
+				<div ng-if="step === 1">
+					<p class="share-modal-info-text">
+						You may need to configure the timeout value if it takes a long time to collect your dashboard's metrics.
+					</p>
+				</div>
+
+				<div class="gf-form-group share-modal-options">
+					<div class="gf-form" ng-if="step === 1">
+						<span class="gf-form-label width-12">Timeout (seconds)</span>
+						<input type="number" ng-model="snapshot.timeoutSeconds" class="gf-form-input max-width-15" >
+					</div>
+				</div>
+
 				<div ng-if="step === 1" class="gf-form-button-row">
 					<button class="btn gf-form-btn width-10 btn-success" ng-click="createSnapshot()" ng-disabled="loading">
 						<i class="fa fa-save"></i>

--- a/public/app/features/dashboard/shareSnapshotCtrl.js
+++ b/public/app/features/dashboard/shareSnapshotCtrl.js
@@ -12,6 +12,7 @@ function (angular, _) {
     $scope.snapshot = {
       name: $scope.dashboard.title,
       expires: 0,
+      timeoutSeconds: 4,
     };
 
     $scope.step = 1;
@@ -55,7 +56,7 @@ function (angular, _) {
 
       $timeout(function() {
         $scope.saveSnapshot(external);
-      }, 4000);
+      }, $scope.snapshot.timeoutSeconds * 1000);
     };
 
     $scope.saveSnapshot = function(external) {


### PR DESCRIPTION
#2537
Hi, I want to make the timeout for snapshot creation configurable. Some of my dashboards take so long a time to collect metrics that I can't successfully create snapshots.