### PR TITLE
improve security of Prometheus datasource

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/cloudwatch"
@@ -106,6 +107,13 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 	}
 
 	proxyPath := c.Params("*")
+
+	if ds.Type == m.DS_PROMETHEUS {
+		if !(c.Req.Request.Method == "GET" && strings.Index(proxyPath, "api/") == 0) {
+			c.JsonApiErr(403, "GET is only allowed on proxied Prometheus datasource", nil)
+			return
+		}
+	}
 
 	if ds.Type == m.DS_ES {
 		if c.Req.Request.Method == "DELETE" {


### PR DESCRIPTION
I think it is better to Grafana proxy should block destructive request.
To acheive that, we should allow `GET` request and path should be `/api/.*`.
https://prometheus.io/docs/querying/api/