### PR TITLE
Adding recursive evaluation of variables

### DIFF
--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -1,7 +1,7 @@
 ///<reference path="../../headers/common.d.ts" />
 
 import _ from 'lodash';
-import {Variable, assignModelProperties, variableTypes} from './variable';
+import {Variable, containsVariable, assignModelProperties, variableTypes} from './variable';
 import {VariableSrv} from './variable_srv';
 
 export class ConstantVariable implements Variable {
@@ -40,7 +40,7 @@ export class ConstantVariable implements Variable {
   }
 
   dependsOn(variable) {
-    return false;
+    return containsVariable(this.options[0], variable.name);
   }
 
   setValueFromUrl(urlValue) {


### PR DESCRIPTION
Some of the functionality is requested and described here:
https://github.com/grafana/grafana/issues/6987

With these changes the following example is possible:
![image](https://cloud.githubusercontent.com/assets/2803187/22690234/efe8add4-ed88-11e6-989c-b0098c55ab37.png)

Basically, variables can reference other variables internally. They will attempt to keep re-evaluating their contents until a final variable value is arrived at. This is currently limited to a max of 10 iterations of the variable evaluation (if there are cycles in the logic then it could go on forever)

I would like to add tests for this behaviour, though I haven't been able to find a sensible place to put them yet.. Perhaps someone knows a good place to put them and could suggest it?

The current changes could be polished up a little and common code collected into a single function - but I'm interested to get feedback before doing that.


