### PR TITLE
Update class graph-legend-alias

### DIFF
--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -167,7 +167,7 @@ function (angular, _, $) {
             html += '<i class="fa fa-minus pointer" style="color:' + series.color + '"></i>';
             html += '</div>';
 
-            html += '<a class="graph-legend-alias pointer">' + _.escape(series.label) + '</a>';
+            html += '<a class="graph-legend-alias pointer" title="' + _.escape(series.label) + '">' + _.escape(series.label) + '</a>';
 
             if (panel.legend.values) {
               var avg = series.formatValue(series.stats.avg);

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -167,7 +167,7 @@ function (angular, _, $) {
             html += '<i class="fa fa-minus pointer" style="color:' + series.color + '"></i>';
             html += '</div>';
 
-            html += '<a class="graph-legend-alias pointer" title="' + _.escape(series.label) + '">' + _.escape(series.label) + '</a>';
+            html += '<a class="graph-legend-alias pointer">' + _.escape(series.label) + '</a>';
 
             if (panel.legend.values) {
               var avg = series.formatValue(series.stats.avg);

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -133,6 +133,9 @@
     padding-left: 7px;
     text-align: left;
     width: 95%;
+    max-width: 650px;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   .graph-legend-series:nth-child(odd) {

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -272,8 +272,6 @@
     overflow: hidden;
    }
 
-  }
-
   .graph-tooltip-value {
     display: table-cell;
     font-weight: bold;

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -267,6 +267,11 @@
   .graph-tooltip-series-name {
     display: table-cell;
     padding: 0.15rem;
+    max-width: 650px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+   }
+
   }
 
   .graph-tooltip-value {


### PR DESCRIPTION
add to class '.graph-legend-alias' and '.graph-tooltip-series-name' new param:
  max-width: 650px;
  text-overflow: ellipsis;
  overflow: hidden;
https://github.com/grafana/grafana/issues/2385