### PR TITLE
Sorting datasources with case insensitive order

### DIFF
--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/models"
 	macaron "gopkg.in/macaron.v1"
 
 	"github.com/go-macaron/session"
@@ -26,9 +26,9 @@ func TestDataSourcesProxy(t *testing.T) {
 		loggedInUserScenario("When calling GET on", "/api/datasources/", func(sc *scenarioContext) {
 
 			// Stubs the database query
-			bus.AddHandler("test", func(query *m.GetDataSourcesQuery) error {
+			bus.AddHandler("test", func(query *models.GetDataSourcesQuery) error {
 				So(query.OrgId, ShouldEqual, TestOrgID)
-				query.Result = []*m.DataSource{
+				query.Result = []*models.DataSource{
 					{Name: "mmm"},
 					{Name: "ZZZ"},
 					{Name: "BBB"},
@@ -75,7 +75,7 @@ func loggedInUserScenario(desc string, url string, fn scenarioFunc) {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
-			sc.context.OrgRole = m.ROLE_EDITOR
+			sc.context.OrgRole = models.ROLE_EDITOR
 			if sc.handlerFunc != nil {
 				sc.handlerFunc(sc.context)
 			}
@@ -100,23 +100,12 @@ type scenarioContext struct {
 	m              *macaron.Macaron
 	context        *middleware.Context
 	resp           *httptest.ResponseRecorder
-	apiKey         string
-	authHeader     string
 	handlerFunc    handlerFunc
 	defaultHandler macaron.Handler
-
-	req *http.Request
+	req            *http.Request
 }
 
 func (sc *scenarioContext) exec() {
-	if sc.apiKey != "" {
-		sc.req.Header.Add("Authorization", "Bearer "+sc.apiKey)
-	}
-
-	if sc.authHeader != "" {
-		sc.req.Header.Add("Authorization", sc.authHeader)
-	}
-
 	sc.m.ServeHTTP(sc.resp, sc.req)
 }
 

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -91,7 +91,7 @@ func (slice DataSourceList) Len() int {
 }
 
 func (slice DataSourceList) Less(i, j int) bool {
-	return slice[i].Name < slice[j].Name
+	return strings.ToLower(slice[i].Name) < strings.ToLower(slice[j].Name)
 }
 
 func (slice DataSourceList) Swap(i, j int) {

--- a/public/app/core/services/datasource_srv.js
+++ b/public/app/core/services/datasource_srv.js
@@ -97,10 +97,19 @@ function (angular, _, coreModule, config) {
       }
 
       metricSources.sort(function(a, b) {
-        if (a.meta.builtIn || a.name > b.name) {
+        if (a.meta.builtIn) {
           return 1;
         }
-        if (a.name < b.name) {
+
+        if (b.meta.builtIn) {
+          return -1;
+        }
+
+        if (a.name.toLowerCase() > b.name.toLowerCase()) {
+          return 1;
+        }
+
+        if (a.name.toLowerCase() < b.name.toLowerCase()) {
           return -1;
         }
         return 0;

--- a/public/test/specs/datasource_srv_specs.js
+++ b/public/test/specs/datasource_srv_specs.js
@@ -1,0 +1,58 @@
+define([
+  'app/core/config',
+  'app/core/services/datasource_srv'
+], function(config) {
+  'use strict';
+
+  describe('datasource_srv', function() {
+    var _datasourceSrv;
+    var metricSources;
+    var templateSrv = {};
+
+    beforeEach(module('grafana.core'));
+    beforeEach(module(function($provide) {
+      $provide.value('templateSrv', templateSrv);
+    }));
+    beforeEach(module('grafana.services'));
+    beforeEach(inject(function(datasourceSrv) {
+      _datasourceSrv = datasourceSrv;
+    }));
+
+    describe('when loading metric sources', function() {
+      var unsortedDatasources = {
+        'mmm': {
+          type: 'test-db',
+          meta: { metrics: {m: 1} }
+        },
+        '--Mixed--': {
+          type: 'test-db',
+          meta: {builtIn: true, metrics: {m: 1} }
+        },
+        'ZZZ': {
+          type: 'test-db',
+          meta: {metrics: {m: 1} }
+        },
+        'aaa': {
+          type: 'test-db',
+          meta: { metrics: {m: 1} }
+        },
+        'BBB': {
+          type: 'test-db',
+          meta: { metrics: {m: 1} }
+        },
+      };
+      beforeEach(function() {
+        config.datasources = unsortedDatasources;
+        metricSources = _datasourceSrv.getMetricSources({skipVariables: true});
+      });
+
+      it('should return a list of sources sorted case insensitively with builtin sources last', function() {
+        expect(metricSources[0].name).to.be('aaa');
+        expect(metricSources[1].name).to.be('BBB');
+        expect(metricSources[2].name).to.be('mmm');
+        expect(metricSources[3].name).to.be('ZZZ');
+        expect(metricSources[4].name).to.be('--Mixed--');
+      });
+    });
+  });
+});


### PR DESCRIPTION
The first commit makes a change to the api so that the list of data sources is sorted in case insensitive order:

![image](https://cloud.githubusercontent.com/assets/434655/22729162/cbeee7dc-ede1-11e6-93ff-9743d8c3ba11.png)

The second commit is a change to datasource_srv.js that sorts the list of metric sources that is used in dropdown for Panel Data Source on the Metrics tab so that it is case insensitive and so that the builtin data sources are last in the list.

Before:
![image](https://cloud.githubusercontent.com/assets/434655/22728611/369f1122-eddf-11e6-82aa-4db88ff86d65.png)

After:
![image](https://cloud.githubusercontent.com/assets/434655/22728575/fa488c9e-edde-11e6-87fd-d713caf29eb3.png)

