### PR TITLE
Full metric description

### DIFF
--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -167,7 +167,7 @@ function (angular, _, $) {
             html += '<i class="fa fa-minus pointer" style="color:' + series.color + '"></i>';
             html += '</div>';
 
-            html += '<a class="graph-legend-alias pointer">' + _.escape(series.label) + '</a>';
+            html += '<a class="graph-legend-alias pointer" title="' + _.escape(series.label) + '">' + _.escape(series.label) + '</a>';
 
             if (panel.legend.values) {
               var avg = series.formatValue(series.stats.avg);

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -133,6 +133,9 @@
     padding-left: 7px;
     text-align: left;
     width: 95%;
+    max-width: 650px;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   .graph-legend-series:nth-child(odd) {

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -133,9 +133,6 @@
     padding-left: 7px;
     text-align: left;
     width: 95%;
-    max-width: 650px;
-    text-overflow: ellipsis;
-    overflow: hidden;
   }
 
   .graph-legend-series:nth-child(odd) {


### PR DESCRIPTION
Hi, this patch implements change for plugins.panel.graph, add full metric description for tag a.graph-legend-alias title.
See screenshot:
![2017-02-08 13-55-59](https://cloud.githubusercontent.com/assets/15912852/22734366/d9f0ad16-ee0e-11e6-8466-cd4e786d6415.png)