### PR TITLE
fix(render) use document.readyState to judge render state of phantomjs

### DIFF
--- a/vendor/phantomjs/render.js
+++ b/vendor/phantomjs/render.js
@@ -30,11 +30,8 @@
     height: params.height || '400'
   };
 
-  var tries = 0;
-
   page.open(params.url, function (status) {
     // console.log('Loading a web page: ' + params.url + ' status: ' + status);
-
     page.onError = function(msg, trace) {
       var msgStack = ['ERROR: ' + msg];
       if (trace && trace.length) {
@@ -59,7 +56,7 @@
         return rootScope.panelsRendered >= panels;
       });
 
-      if (panelsRendered || tries === 1000) {
+      if (panelsRendered && "complete" === document.readyState) {
         var bb = page.evaluate(function () {
           return document.getElementsByClassName("main-view")[0].getBoundingClientRect();
         });
@@ -75,7 +72,6 @@
         phantom.exit();
       }
       else {
-        tries++;
         setTimeout(checkIsReady, 10);
       }
     }


### PR DESCRIPTION
This PR might fix https://github.com/grafana/grafana/issues/7381.
Currently, it depends on blindly render-finished judge using tries count and timeout. I change the logic to use document.readyState instead.
