### PR TITLE
add keyboard shotcuts for collapse/expand rows

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -187,6 +187,20 @@ export class KeybindingSrv {
       }
     });
 
+    // collapse all rows
+    this.bind('r C', () => {
+      _.each(dashboard.rows, function(row) {
+        row.collapse = true;
+      });
+    });
+
+    // expand all rows
+    this.bind('r E', () => {
+      _.each(dashboard.rows, function(row) {
+        row.collapse = false;
+      });
+    });
+
     this.bind('d r', () => {
       scope.broadcastRefresh();
     });


### PR DESCRIPTION
Fixes, https://github.com/grafana/grafana/issues/552

I add keyboard shortcuts. Please see following comment.
https://github.com/grafana/grafana/pull/7536#issuecomment-279347385