### PR TITLE
Updates mailer to include `from_name` value

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -296,6 +296,7 @@ cert_file =
 key_file =
 skip_verify = false
 from_address = admin@grafana.localhost
+from_name = Grafana Admin
 
 [emails]
 welcome_email_on_sign_up = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -282,6 +282,7 @@
 ;key_file =
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
+;from_name = Grafana Admin
 
 [emails]
 ;welcome_email_on_sign_up = false

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -158,6 +158,7 @@ with Grafana admin permission.
         "cert_file":"",
         "enabled":"false",
         "from_address":"admin@grafana.localhost",
+        "from_name":"Grafana Admin",
         "host":"localhost:25",
         "key_file":"",
         "password":"************",
@@ -292,4 +293,4 @@ Change password for specific user
     HTTP/1.1 200
     Content-Type: application/json
 
-    {state: "new state", message: "alerts pause/un paused", "alertsAffected": 100}    
+    {state: "new state", message: "alerts pause/un paused", "alertsAffected": 100}

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -542,6 +542,9 @@ Verify SSL for smtp server? defaults to `false`
 ### from_address
 Address used when sending out emails, defaults to `admin@grafana.localhost`
 
+### from_name
+Name to be used when sending out emails, defaults to `Grafana Admin`
+
 ## [log]
 
 ### mode

--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -150,7 +150,7 @@ func buildEmailMessage(cmd *m.SendEmailCommand) (*Message, error) {
 
 	return &Message{
 		To:           cmd.To,
-		From:         setting.Smtp.FromAddress,
+		From:         fmt.Sprintf("%s <%s>", setting.Smtp.FromName, setting.Smtp.FromAddress),
 		Subject:      subject,
 		Body:         buffer.String(),
 		EmbededFiles: cmd.EmbededFiles,

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -48,7 +48,7 @@ func Init() error {
 	}
 
 	if !util.IsEmail(setting.Smtp.FromAddress) {
-		return errors.New("Invalid email address for smpt from_address config")
+		return errors.New("Invalid email address for SMTP from_address config")
 	}
 
 	if setting.EmailCodeValidMinutes == 0 {

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -48,7 +48,7 @@ func Init() error {
 	}
 
 	if !util.IsEmail(setting.Smtp.FromAddress) {
-		return errors.New("Invalid email address for smpt from_adress config")
+		return errors.New("Invalid email address for smpt from_address config")
 	}
 
 	if setting.EmailCodeValidMinutes == 0 {

--- a/pkg/services/notifications/notifications_test.go
+++ b/pkg/services/notifications/notifications_test.go
@@ -23,6 +23,7 @@ func TestNotifications(t *testing.T) {
 		setting.Smtp.Enabled = true
 		setting.Smtp.TemplatesPattern = "emails/*.html"
 		setting.Smtp.FromAddress = "from@address.com"
+		setting.Smtp.FromName = "Grafana Admin"
 
 		err := Init()
 		So(err, ShouldBeNil)

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -18,6 +18,7 @@ func TestEmailIntegrationTest(t *testing.T) {
 		setting.Smtp.Enabled = true
 		setting.Smtp.TemplatesPattern = "emails/*.html"
 		setting.Smtp.FromAddress = "from@address.com"
+		setting.Smtp.FromName = "Grafana Admin"
 		setting.BuildVersion = "4.0.0"
 
 		err := Init()

--- a/pkg/setting/setting_smtp.go
+++ b/pkg/setting/setting_smtp.go
@@ -8,6 +8,7 @@ type SmtpSettings struct {
 	CertFile    string
 	KeyFile     string
 	FromAddress string
+	FromName    string
 	SkipVerify  bool
 
 	SendWelcomeEmailOnSignUp bool
@@ -23,6 +24,7 @@ func readSmtpSettings() {
 	Smtp.CertFile = sec.Key("cert_file").String()
 	Smtp.KeyFile = sec.Key("key_file").String()
 	Smtp.FromAddress = sec.Key("from_address").String()
+	Smtp.FromName = sec.Key("from_name").String()
 	Smtp.SkipVerify = sec.Key("skip_verify").MustBool(false)
 
 	emails := Cfg.Section("emails")


### PR DESCRIPTION
This updates the mailers to use a configurable `from_name` value which
allows a friendly name (such as "Grafana Admin") to be shown to the
recipients instead of just an email address.

Fixes #2131