### PR TITLE
Added suppressing of empty results to table plugin

### DIFF
--- a/public/app/plugins/panel/table/editor.html
+++ b/public/app/plugins/panel/table/editor.html
@@ -21,6 +21,10 @@
 				<metric-segment segment="editor.addColumnSegment" get-options="editor.getColumnOptions()" on-change="editor.addColumn()"></metric-segment>
 			</div>
 		</div>
+    <gf-form-switch class="gf-form" label-class="width-10"
+                    label="Filter null values"
+                    checked="editor.panel.filterNull"
+                    on-change="editor.render()"></gf-form-switch>
 	</div>
 
 	<div class="section gf-form-group">

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -42,6 +42,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
     scroll: true,
     fontSize: '100%',
     sort: {col: 0, desc: true},
+    filterNull: false,
   };
 
   /** @ngInject */

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import flatten from '../../../core/utils/flatten';
 import TimeSeries from '../../../core/time_series2';
 import TableModel from '../../../core/table_model';
+import angular from "angular";
 
 var transformers = {};
 
@@ -219,7 +220,8 @@ transformers['json'] = {
 };
 
 function transformDataToTable(data, panel) {
-  var model = new TableModel();
+  var model = new TableModel(),
+    copyData = angular.copy(data);
 
   if (!data || data.length === 0) {
     return model;
@@ -230,7 +232,13 @@ function transformDataToTable(data, panel) {
     throw {message: 'Transformer ' + panel.transformer + ' not found'};
   }
 
-  transformer.transform(data, panel, model);
+  if (panel.filterNull) {
+    for (var i = 0; i < copyData.length; i++) {
+      copyData[i].datapoints = copyData[i].datapoints.filter((dp) => dp[0] != null);
+    }
+  }
+
+  transformer.transform(copyData, panel, model);
   return model;
 }
 


### PR DESCRIPTION
Hi.

This PR adds a new checkbox to the table plugin to allow suppression of empty values.
Use case - to only show values above/below threshold.
(e.g. `removeBelowValue(collectd.server1.cpu.0.percent.wait, 10)`)

Without checkbox:
![_103](https://cloud.githubusercontent.com/assets/5230129/23069194/8f5fb212-f537-11e6-88dd-d282e2bf881e.png)

With checkbox:
![_102](https://cloud.githubusercontent.com/assets/5230129/23069202/97ce7168-f537-11e6-9db4-12c577338763.png)

Checkbox:
![_104](https://cloud.githubusercontent.com/assets/5230129/23069213/a12ea3a4-f537-11e6-97cd-e9b9e9ab383d.png)

