### PR TITLE
Append field name to metric name for Elasticsearch table

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.js
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.js
@@ -126,13 +126,13 @@ function (_, queryDef) {
               stats.std_deviation_bounds_lower = stats.std_deviation_bounds.lower;
 
               metricName = this._getMetricName(statName);
-              doc[metricName] = stats[statName];
+              doc[metricName+' '+metric.field] = stats[statName];
             }
             break;
           }
           default:  {
             metricName = this._getMetricName(metric.type);
-            doc[metricName] =bucket[metric.id].value;
+            doc[metricName+' '+metric.field] =bucket[metric.id].value;
             break;
           }
         }

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response_specs.ts
@@ -467,7 +467,7 @@ describe('ElasticResponse', function() {
     beforeEach(function() {
       targets = [{
         refId: 'A',
-        metrics: [{type: 'avg', id: '1'}, {type: 'count' }],
+        metrics: [{type: 'avg', id: '1', field: 'foo'}, {type: 'count' }],
         bucketAggs: [{id: '2', type: 'terms', field: 'host'}],
       }];
 
@@ -500,11 +500,11 @@ describe('ElasticResponse', function() {
       expect(result.data[0].type).to.be('docs');
       expect(result.data[0].datapoints.length).to.be(2);
       expect(result.data[0].datapoints[0].host).to.be("server-1");
-      expect(result.data[0].datapoints[0].Average).to.be(1000);
+      expect(result.data[0].datapoints[0]["Average foo"]).to.be(1000);
       expect(result.data[0].datapoints[0].Count).to.be(369);
 
       expect(result.data[0].datapoints[1].host).to.be("server-2");
-      expect(result.data[0].datapoints[1].Average).to.be(2000);
+      expect(result.data[0].datapoints[1]["Average foo"]).to.be(2000);
     });
   });
 


### PR DESCRIPTION
This partly fix #4709

This is a first attemp, I gladly accept advice on what to do / where to fix this
For now this is a breaking change

For exemple column is now named "Average response_time" instead of just "Average"