### PR TITLE
alerting: dedupe alert notifications when running multiple servers

### DIFF
--- a/pkg/models/alert.go
+++ b/pkg/models/alert.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	ErrCannotChangeStateOnPausedAlert error = fmt.Errorf("Cannot change state on pause alert")
+	ErrRequiresNewState               error = fmt.Errorf("update alert state requires a new state.")
 )
 
 func (s AlertStateType) IsValid() bool {

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -61,6 +61,12 @@ func (handler *DefaultResultHandler) Handle(evalContext *EvalContext) error {
 				handler.log.Error("Cannot change state on alert thats pause", "error", err)
 				return err
 			}
+
+			if err == m.ErrRequiresNewState {
+				handler.log.Info("Alert already updated")
+				return nil
+			}
+
 			handler.log.Error("Failed to save state", "error", err)
 		}
 

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -240,6 +240,10 @@ func SetAlertState(cmd *m.SetAlertStateCommand) error {
 			return m.ErrCannotChangeStateOnPausedAlert
 		}
 
+		if alert.State == cmd.State {
+			return m.ErrRequiresNewState
+		}
+
 		alert.State = cmd.State
 		alert.StateChanges += 1
 		alert.NewStateDate = time.Now()


### PR DESCRIPTION
de dupe alert notification when running multiple servers.

ref https://github.com/grafana/grafana/issues/6957

This PR does not close the issue for multi server support. We still need workload balancing. 