### PR TITLE
templating: check for default data source

### DIFF
--- a/public/app/core/services/datasource_srv.js
+++ b/public/app/core/services/datasource_srv.js
@@ -21,6 +21,10 @@ function (angular, _, coreModule, config) {
 
       name = templateSrv.replace(name);
 
+      if (name === 'default') {
+        return this.get(config.defaultDatasource);
+      }
+
       if (this.datasources[name]) {
         return $q.when(this.datasources[name]);
       }


### PR DESCRIPTION
For data source template variables, check if the selected value is default and if so load the default data source.

Fixes #7586