### PR TITLE
feat(alerting): Add emoji to Threema alert notifications

### DIFF
--- a/pkg/services/alerting/notifiers/threema.go
+++ b/pkg/services/alerting/notifiers/threema.go
@@ -126,9 +126,21 @@ func (notifier *ThreemaNotifier) Notify(evalContext *alerting.EvalContext) error
 	data.Set("to", notifier.RecipientID)
 	data.Set("secret", notifier.APISecret)
 
+	// Determine emoji
+	stateEmoji := ""
+	switch evalContext.Rule.State {
+	case m.AlertStateOK:
+		stateEmoji = "\u2705 " // White Heavy Check Mark
+	case m.AlertStateNoData:
+		stateEmoji = "\u2753 " // Black Question Mark Ornament
+	case m.AlertStateAlerting:
+		stateEmoji = "\u26A0 " // Warning sign
+	}
+
 	// Build message
-	message := fmt.Sprintf("%s\n\n*State:* %s\n*Message:* %s\n",
-		evalContext.GetNotificationTitle(), evalContext.Rule.Name, evalContext.Rule.Message)
+	message := fmt.Sprintf("%s%s\n\n*State:* %s\n*Message:* %s\n",
+		stateEmoji, evalContext.GetNotificationTitle(),
+		evalContext.Rule.Name, evalContext.Rule.Message)
 	ruleURL, err := evalContext.GetRuleUrl()
 	if err == nil {
 		message = message + fmt.Sprintf("*URL:* %s\n", ruleURL)


### PR DESCRIPTION
This simple change prepends emoji to Threema alert notifications to make it easier to discern various notification types (e.g. alert, no data, ok).

Before and after:

![image-14094](https://cloud.githubusercontent.com/assets/105168/23369007/32b09384-fd10-11e6-9749-76c2fb06c404.jpg)
