### PR TITLE
Allowing "Unique Count"s of any data type

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -162,6 +162,9 @@ function (angular, _, queryDef) {
     };
 
     $scope.getFieldsInternal = function() {
+      if ($scope.agg.type === 'cardinality') {
+        return $scope.getFields();
+      }
       return $scope.getFields({$fieldType: 'number'});
     };
 


### PR DESCRIPTION
Resolves: #3536

This PR removes the filter of only showing `number`s when doing metric aggregates *if* the aggregate type is `cardinality`, aka "Unique Count" (with ElasicSearch backend).  This already functionally works if the user has manually entered the field, now it'll just allow them to select from the dropdown.

#### gif in action

![2017-03-01 at 10 39 pm](https://cloud.githubusercontent.com/assets/39943/23494454/3371efcc-fed0-11e6-930f-fd88727a7757.gif)

(Using ElasticSearch as data source being fed data via [metricbeat](https://www.elastic.co/downloads/beats/metricbeat))