### PR TITLE
(cloudwatch) fix scoped var existence check

### DIFF
--- a/public/app/features/templating/templateSrv.js
+++ b/public/app/features/templating/templateSrv.js
@@ -130,6 +130,16 @@ function (angular, _, kbn) {
       return match[1] || match[2];
     };
 
+    this.getVariableNames = function(expression) {
+      this._regex.lastIndex = 0;
+      var match;
+      var names = [];
+      while (match = this._regex.exec(expression)) {
+        names.push(match[1] || match[2]);
+      }
+      return names;
+    };
+
     this.variableExists = function(expression) {
       var name = this.getVariableName(expression);
       return name && (self._index[name] !== void 0);

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -416,7 +416,18 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
       return _.chain(targets)
       .map(function(target) {
         var dimensionKey = _.findKey(target.dimensions, function(v) {
-          return templateSrv.variableExists(v) && !_.has(scopedVars, templateSrv.getVariableName(v));
+          if (!templateSrv.variableExists(v)) {
+            return false;
+          }
+
+          var variableName;
+          while (variableName = templateSrv.getVariableName(v)) {
+            if (_.has(scopedVars, variableName)) {
+              return false;
+            }
+            v = v.replace('$' + variableName, '').replace('[[' + variableName + ']]', '');
+          }
+          return true;
         });
 
         if (dimensionKey) {

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -420,13 +420,11 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
             return false;
           }
 
-          var variableName;
-          while (variableName = templateSrv.getVariableName(v)) {
+          templateSrv.getVariableNames(v).forEach(function(variableName) {
             if (_.has(scopedVars, variableName)) {
               return false;
             }
-            v = v.replace('$' + variableName, '').replace('[[' + variableName + ']]', '');
-          }
+          });
           return true;
         });
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -415,6 +415,7 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
       var self = this;
       return _.chain(targets)
       .map(function(target) {
+        // find dimension key which value includes template variable, but not includes scoped variable
         var dimensionKey = _.findKey(target.dimensions, function(v) {
           if (!templateSrv.variableExists(v)) {
             return false;

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -420,12 +420,9 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
             return false;
           }
 
-          templateSrv.getVariableNames(v).forEach(function(variableName) {
-            if (_.has(scopedVars, variableName)) {
-              return false;
-            }
+          return !templateSrv.getVariableNames(v).some(function(variableName) {
+            return _.has(scopedVars, variableName);
           });
-          return true;
         });
 
         if (dimensionKey) {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -129,10 +129,12 @@ describe('CloudWatchDatasource', function() {
     });
 
     it('should generate the correct targets by expanding template variables', function() {
+      var variableName = 'instance_id';
       var templateSrv = {
         variables: [
           {
             name: 'instance_id',
+            multi: true,
             options: [
               { text: 'i-23456789', value: 'i-23456789', selected: false },
               { text: 'i-34567890', value: 'i-34567890', selected: true }
@@ -146,7 +148,11 @@ describe('CloudWatchDatasource', function() {
             return '';
           }
         },
-        getVariableName: function (e) { return 'instance_id'; },
+        getVariableName: function (e) {
+          var result = variableName;
+          variableName = '';
+          return result;
+        },
         variableExists: function (e) { return true; },
         containsVariable: function (str, variableName) { return str.indexOf('$' + variableName) !== -1; }
       };

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -129,7 +129,6 @@ describe('CloudWatchDatasource', function() {
     });
 
     it('should generate the correct targets by expanding template variables', function() {
-      var variableName = 'instance_id';
       var templateSrv = {
         variables: [
           {
@@ -148,11 +147,8 @@ describe('CloudWatchDatasource', function() {
             return '';
           }
         },
-        getVariableName: function (e) {
-          var result = variableName;
-          variableName = '';
-          return result;
-        },
+        getVariableName: function (e) { return 'instance_id'; },
+        getVariableNames: function (e) { return [ 'instance_id' ]; },
         variableExists: function (e) { return true; },
         containsVariable: function (str, variableName) { return str.indexOf('$' + variableName) !== -1; }
       };


### PR DESCRIPTION
The `templateSrv.getVariableName` only return first match variable name.
It has problem for the existence check for "[[foo]]_[[bar]]".