### PR TITLE
Allow commas on template variable #7681

### DIFF
--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -59,8 +59,9 @@ export class IntervalVariable implements Variable {
   }
 
   updateOptions() {
-   // extract options in comma separated string
-    this.options = _.map(this.query.split(/[,]+/), function(text) {
+    // extract options between quotes and/or comma
+    this.options = _.map(this.query.match(/(["'])(.*?)\1|\w+/g), function(text) {
+      text = text.replace(/["']+/g, '');
       return {text: text.trim(), value: text.trim()};
     });
 


### PR DESCRIPTION
This improvement allows to wrap an "expression" when using single or
double quotes. So now you can have time interval with offset for
influxdb.
