### PR TITLE
Pass dropcounter rate option if no max counter and no reset value or reset value as 0 is specified

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -190,6 +190,10 @@ func (e *OpenTsdbExecutor) buildMetric(query *tsdb.Query) map[string]interface{}
 			rateOptions["resetValue"] = resetValue.MustFloat64()
 		}
 
+		if !counterMaxCheck && (!resetValueCheck || resetValue.MustFloat64() == 0) {
+			rateOptions["dropcounter"] = true
+		}
+
 		metric["rateOptions"] = rateOptions
 	}
 


### PR DESCRIPTION
Counter roll overs / resets result in large values while querying, this adds an option supported
since opentsdb 2.2.0-RC1 to simply drop those values

Reference

https://github.com/OpenTSDB/opentsdb/pull/465
https://github.com/OpenTSDB/opentsdb/issues/460
https://github.com/OpenTSDB/opentsdb/blob/951173b1d4e71dc0c5d260a89e66d81c2d4c0ca8/src/tsd/client/MetricForm.java#L410
https://github.com/OpenTSDB/opentsdb/commit/4be59101e3797842c5be89044f2a186ee13ed9e3