### PR TITLE
Improve Elasticsearch-Annotation Docs

### DIFF
--- a/docs/sources/reference/annotations.md
+++ b/docs/sources/reference/annotations.md
@@ -36,7 +36,7 @@ You can leave the search query blank or specify a lucene query.
 If your elasticsearch document has a timestamp field other than `@timestamp` you will need to specify that. As well
 as the name for the fields that should be used for the annotation title, tags and text. Tags and text are optional.
 
-> **Note** The annotation timestamp field in elasticsearch need to be in UTC format.
+> **Note** The annotation timestamp field in elasticsearch needs to be in ISO 8601 format.
 
 ## InfluxDB Annotations
 ![](/img/docs/v2/annotations_influxdb.png)


### PR DESCRIPTION
The docs suggest a timestamp in "UTC format", however, that doesn't accurately describe what's required. `UTC` isn't a format, it just refers to a time zone. An epoch timestamp, for example, would be considered UTC. However, as far as I can tell epoch timestamps aren't accepted, rather, the accepted format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

