### PR TITLE
Add max span option for panel repeater

### DIFF
--- a/public/app/features/dashboard/dynamic_dashboard_srv.ts
+++ b/public/app/features/dashboard/dynamic_dashboard_srv.ts
@@ -182,7 +182,7 @@ export class DynamicDashboardSrv {
 
     _.each(selected, (option, index) => {
       var copy = this.getPanelClone(panel, row, index);
-      copy.span = Math.max(12 / selected.length, panel.minSpan || 4);
+      copy.span = Math.max(Math.min(12 / selected.length, panel.maxSpan || 12), panel.minSpan || 4);
       copy.scopedVars = copy.scopedVars || {};
       copy.scopedVars[variable.name] = option;
     });

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -213,7 +213,7 @@ export class PanelCtrl {
   compareRepeatSpans(changedSpan) {
     this.panel.maxSpan = (changedSpan === 'min' && this.panel.minSpan && this.panel.maxSpan) ?
       Math.min(Math.max(this.panel.minSpan, this.panel.maxSpan), 12) : this.panel.maxSpan;
-    this.panel.minSpan = (changedSpan ==='max' && this.panel.minSpan && this.panel.maxSpan) ?
+    this.panel.minSpan = (changedSpan === 'max' && this.panel.minSpan && this.panel.maxSpan) ?
       Math.max(Math.min(this.panel.minSpan, this.panel.maxSpan), 1) : this.panel.minSpan;
   }
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -210,6 +210,13 @@ export class PanelCtrl {
     });
   }
 
+  compareRepeatSpans(changedSpan) {
+    this.panel.maxSpan = (changedSpan === 'min' && this.panel.minSpan && this.panel.maxSpan) ?
+      Math.min(Math.max(this.panel.minSpan, this.panel.maxSpan), 12) : this.panel.maxSpan;
+    this.panel.minSpan = (changedSpan ==='max' && this.panel.minSpan && this.panel.maxSpan) ?
+      Math.max(Math.min(this.panel.minSpan, this.panel.maxSpan), 1) : this.panel.minSpan;
+  }
+
   removePanel() {
     this.row.removePanel(this.panel);
   }

--- a/public/app/partials/panelgeneral.html
+++ b/public/app/partials/panelgeneral.html
@@ -32,7 +32,13 @@
 		</div>
 		<div class="gf-form">
 			<span class="gf-form-label width-8">Min span</span>
-			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12]">
+			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12]" ng-change="ctrl.compareRepeatSpans('min')">
+				<option value=""></option>
+			</select>
+		</div>
+		<div class="gf-form">
+			<span class="gf-form-label width-8">Max span</span>
+			<select class="gf-form-input" ng-model="ctrl.panel.maxSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12]" ng-change="ctrl.compareRepeatSpans('max')">
 				<option value=""></option>
 			</select>
 		</div>


### PR DESCRIPTION
The gauge graph from the Singlestat plugin sometimes fails to render when combined with auto-repeating panels, as described in #7773.

Being able to enforce a max span width for the auto-created panels helps alleviate this, and could possibly be handy for better control of the dashboards in general.

The option was based on the already existing "min span" option, and a small sanity check was added to avoid any discrepancy between the two values:
 
![Quick demonstration](https://cloud.githubusercontent.com/assets/1952603/23718979/d40da76e-0439-11e7-92aa-f62c51bd5c05.gif)