### PR TITLE
Added scientific notation as a unit for #7763

### DIFF
--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -394,6 +394,10 @@ function($, _) {
     return "0x" + hexString;
   };
 
+  kbn.valueFormats.sci = function(value, decimals) {
+    return value.toExponential(decimals);
+  };
+
   // Currencies
   kbn.valueFormats.currencyUSD = kbn.formatBuilders.currency('$');
   kbn.valueFormats.currencyGBP = kbn.formatBuilders.currency('£');
@@ -703,15 +707,16 @@ function($, _) {
       {
         text: 'none',
         submenu: [
-          {text: 'none' ,             value: 'none'       },
-          {text: 'short',             value: 'short'      },
-          {text: 'percent (0-100)',   value: 'percent'    },
-          {text: 'percent (0.0-1.0)', value: 'percentunit'},
-          {text: 'Humidity (%H)',     value: 'humidity'   },
-          {text: 'ppm',               value: 'ppm'        },
-          {text: 'decibel',           value: 'dB'         },
-          {text: 'hexadecimal (0x)',  value: 'hex0x'      },
-          {text: 'hexadecimal',       value: 'hex'        },
+          {text: 'none' ,               value: 'none'       },
+          {text: 'short',               value: 'short'      },
+          {text: 'percent (0-100)',     value: 'percent'    },
+          {text: 'percent (0.0-1.0)',   value: 'percentunit'},
+          {text: 'Humidity (%H)',       value: 'humidity'   },
+          {text: 'ppm',                 value: 'ppm'        },
+          {text: 'decibel',             value: 'dB'         },
+          {text: 'hexadecimal (0x)',    value: 'hex0x'      },
+          {text: 'hexadecimal',         value: 'hex'        },
+          {text: 'scientific notation', value: 'sci'        },
         ]
       },
       {


### PR DESCRIPTION
Added a new value format for scientific notation/exponential as per  #7763 

<img width="698" alt="screen shot 2017-03-09 at 00 20 45" src="https://cloud.githubusercontent.com/assets/679355/23730230/4d65535e-045e-11e7-902d-e4467d3083bf.png">

Looks pretty much like the mockup @nagimov made.

I haven't implemented a "threshold" at which to apply this as it would require extra input fields which seemed nasty, however I can see why you may want that when `1` become `1e+0`
