### PR TITLE
Small fix for the "glow" when focus the field for LIMIT and SLIMIT

### DIFF
--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -83,12 +83,12 @@
 
 			<div class="gf-form max-width-14">
 				<label class="gf-form-label query-keyword width-5">LIMIT</label>
-				<input type="text" class="gf-form-input" ng-model="ctrl.target.limit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
+				<input type="text" class="gf-form-input width-9" ng-model="ctrl.target.limit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
 			</div>
 
 			<div class="gf-form max-width-14">
 				<label class="gf-form-label query-keyword width-5">SLIMIT</label>
-				<input type="text" class="gf-form-input" ng-model="ctrl.target.slimit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
+				<input type="text" class="gf-form-input width-9" ng-model="ctrl.target.slimit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
 			</div>
 			<div class="gf-form gf-form--grow">
 				<div class="gf-form-label gf-form-label--grow"></div>


### PR DESCRIPTION
When selecting the fields for LIMIT and SLIMIT the "glow" do not match the field, and in fact goes beyond the box.