### PR TITLE
Fixed position of tooltip with description at graph.

### DIFF
--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -160,6 +160,7 @@ module.directive('grafanaPanel', function($rootScope, $document) {
             classes: ctrl.error ? 'drop-error' : 'drop-help',
             openOn: 'hover',
             hoverOpenDelay: 100,
+            constrainToScrollParent: false,
           });
         }
       }


### PR DESCRIPTION
Fixed a position of a tooltip, with description, at graph. Issue #7708 

![fix-tooltip-position](https://cloud.githubusercontent.com/assets/2538638/24009441/acb0ca44-0a7d-11e7-9527-d68d75143aa4.gif)