### PR TITLE
Change ruleUrl to link to 'view' instead of 'edit'

### DIFF
--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -113,7 +113,7 @@ func (c *EvalContext) GetRuleUrl() (string, error) {
 	if slug, err := c.GetDashboardSlug(); err != nil {
 		return "", err
 	} else {
-		ruleUrl := fmt.Sprintf("%sdashboard/db/%s?fullscreen&edit&tab=alert&panelId=%d&orgId=%d", setting.AppUrl, slug, c.Rule.PanelId, c.Rule.OrgId)
+		ruleUrl := fmt.Sprintf("%sdashboard/db/%s?fullscreen&tab=alert&panelId=%d&orgId=%d", setting.AppUrl, slug, c.Rule.PanelId, c.Rule.OrgId)
 		return ruleUrl, nil
 	}
 }


### PR DESCRIPTION
The ruleUrl that gets sent out in notifications currently points to the alerting graph in edit-mode,
I think view-mode is probably more suitable.
(Also: I don't really know my way around go but was told that opening a PR would make your life easier. If this PR does not make any sense just throw it out)