### PR TITLE
Do not collapse if there is only 1-3 queries #7836

### DIFF
--- a/public/app/features/panel/query_editor_row.ts
+++ b/public/app/features/panel/query_editor_row.ts
@@ -29,6 +29,10 @@ export class QueryRowCtrl {
       delete this.target.isNew;
       this.toggleCollapse(false);
     }
+
+    if (this.panel.targets.length < 4) {
+      this.collapsed = false;
+    }
   }
 
   toggleHideQuery() {


### PR DESCRIPTION
Also has the side effect of new panels having not collapsed queries when
being created. #7836

