### PR TITLE
Add more information for generic oauth2

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -410,7 +410,7 @@ browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
     allowed_domains = mycompany.com mycompany.org
     allow_sign_up = true
 
-Set api_url to the resource that returns basic user info.
+Set api_url to the resource that returns [OpenID UserInfo](https://connect2id.com/products/server/docs/api/userinfo) compatible information.
 
 <hr>
 


### PR DESCRIPTION
Add reference to OpenID's userinfo_endpoint (as in #6351), as this is nowhere mentioned.
