### PR TITLE
[Bug] elasticsearch group by "filters *" response parsing not working

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response_specs.ts
@@ -508,6 +508,37 @@ describe('ElasticResponse', function() {
     });
   });
 
+  describe('Wilcard filter no group by time', function() {
+    beforeEach(function() {
+      targets = [{
+        refId: 'A',
+        metrics: [{type: 'cardinality', id: '1'}],
+        bucketAggs: [{id: '2', type: 'filters', query: '*', settings: {filters: [{query: '*'}]}}],
+      }];
+
+      response =  {
+        responses: [{
+          aggregations: {
+            "2": {
+              buckets: {
+                "*": {
+                  "1": { value: 314},
+                  doc_count: 1000,
+                }
+              }
+            }
+          }
+        }]
+      };
+
+      result = new ElasticResponse(targets, response).getTimeSeries();
+    });
+
+    it('should return table', function() {
+      expect(result.data.length).to.be(1);
+    });
+  });
+
   describe('Raw documents query', function() {
     beforeEach(function() {
       targets = [{ refId: 'A', metrics: [{type: 'raw_document', id: '1'}], bucketAggs: [] }];


### PR DESCRIPTION
This is a bug report but with an unit test -> PR

- What Grafana version are you using?
latest master
- What datasource are you using?
elasticsearch 5.0
- What OS are you running grafana on?
ubuntu 16.04
- What did you do?
try to create a "Singlestat" with a unique count metric in it
- What was the expected result?
it works ;)
- What happened instead?
"N/A" when using group by "filters *"

- If related to metric query / data viz:
```
{"search_type":"query_then_fetch","ignore_unavailable":true,"index":["access-logs-2017.02.28","access-logs-2017.03.01"]}
{"size":0,"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"1488311156711","lte":"1488340453687","format":"epoch_millis"}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"aggs":{"2":{"filters":{"filters":{"*":{"query_string":{"query":"*","analyze_wildcard":true}}}},"aggs":{"1":{"cardinality":{"field":"clientip"}}}}}}
```

```
{"responses":[{"took":6,"timed_out":false,"_shards":{"total":12,"successful":12,"failed":0},"hits":{"total":4461762,"max_score":0.0,"hits":[]},"aggregations":{"2":{"buckets":{"*":{"doc_count":4461762,"1":{"value":6480}}}}},"status":200}]}
```

request / response seems ok to me, only the response parsing is not working for me
