### PR TITLE
Drill down link per legend

### DIFF
--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -314,6 +314,10 @@ export class PanelCtrl {
     return "";
   }
 
+  getLinkHint() {
+    return {};
+  }
+
   getInfoContent(options) {
     var markdown = this.panel.description;
 
@@ -334,7 +338,11 @@ export class PanelCtrl {
     if (this.panel.links && this.panel.links.length > 0) {
       html += "<ul>";
       for (let link of this.panel.links) {
-        var info = linkSrv.getPanelLinkAnchorInfo(link, this.panel.scopedVars);
+        var info = linkSrv.getPanelLinkAnchorInfo(
+          link,
+          this.panel.scopedVars,
+          this.getLinkHint()
+        );
         html +=
           '<li><a class="panel-menu-link" href="' +
           info.href +

--- a/public/app/features/panellinks/link_srv.ts
+++ b/public/app/features/panellinks/link_srv.ts
@@ -75,7 +75,7 @@ export class LinkSrv {
     return info;
   }
 
-  getPanelLinkAnchorInfo(link, scopedVars) {
+  getPanelLinkAnchorInfo(link, scopedVars, activeSeriesTags) {
     var info: any = {};
     if (link.type === "absolute") {
       info.target = link.targetBlank ? "_blank" : "_self";
@@ -101,6 +101,16 @@ export class LinkSrv {
 
     if (link.includeVars) {
       this.templateSrv.fillVariableValuesForUrl(params, scopedVars);
+    }
+
+    if (link.tagMappings) {
+      _.each(link.tagMappings.split(','), function (map) {
+        var kv = map.split('=');
+        var values = _.map(activeSeriesTags, kv[1]);
+        if (values) {
+          params['var-' + kv[0]] = values;
+        }
+      });
     }
 
     info.href = this.addParamsToUrl(info.href, params);

--- a/public/app/features/panellinks/module.html
+++ b/public/app/features/panellinks/module.html
@@ -32,6 +32,10 @@
 				<span class="gf-form-label width-10">Url params</span>
 				<input type="text" ng-model="link.params" class="gf-form-input width-10">
 			</div>
+			<div class="gf-form">
+				<span class="gf-form-label width-10">Tag Mappings</span>
+				<input type="text" ng-model="link.tagMappings" class="gf-form-input width-10">
+			</div>
 
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include time range" checked="link.keepTime"></gf-form-switch>
 			<gf-form-switch class="gf-form" label-class="width-10" label="Include variables" checked="link.includeVars"></gf-form-switch>

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -371,7 +371,7 @@ export class PrometheusDatasource {
       dps.push([null, t]);
     }
 
-    return { target: metricLabel, datapoints: dps };
+    return { target: metricLabel, tags: md.metric, datapoints: dps };
   }
 
   transformMetricDataToTable(md, resultCount: number, resultIndex: number) {

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -336,6 +336,15 @@ class GraphCtrl extends MetricsPanelCtrl {
       modalClass: "modal--narrow"
     });
   }
+
+  getLinkHint() {
+    var self = this;
+    return this.dataList.filter((data) => {
+      return !_.includes(self.hiddenSeries, data.target);
+    }).map((data) => {
+      return data.tags || {};
+    });
+  }
 }
 
 export { GraphCtrl, GraphCtrl as PanelCtrl };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/1232
I implement the idea described in https://github.com/grafana/grafana/issues/1232#issuecomment-285478826 .

Add new input field in drill down link setting.
It defines the mapping from time series meta data to Grafana template variables.
<img width="827" alt="drill_down" src="https://cloud.githubusercontent.com/assets/224552/24154535/c4f3279e-0e94-11e7-9627-19fcaf71c29a.png">
