### PR TITLE
Add an After= DB ordering relation to systemd .service

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -3,6 +3,7 @@ Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target
+After=postgresql.service mariadb.service mysql.service
 
 [Service]
 EnvironmentFile=/etc/default/grafana-server

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -3,6 +3,7 @@ Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target
+After=postgresql.service mariadb.service mysql.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/grafana-server


### PR DESCRIPTION
In systemd `After=` merely codes an ordering relation and does not start
other units.

Grafana needs to specify that it wants to start up _after_ either of the
supported DB services have started, _if they start_.

Enabling the database services, however, is out of scope for Grafana.

The list in this PR seems to cover all supported DB service names, including Percona Server.

Fixes #7113