### PR TITLE
Support requesting only active tags from influxdb in a time range

### DIFF
--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -89,7 +89,7 @@ export class QueryVariable implements Variable {
 
   updateTags(datasource) {
     if (this.useTags) {
-      return datasource.metricFindQuery({query: this.tagsQuery, rangeRaw: this.timeSrv.time}).then(results => {
+      return datasource.metricFindQuery({query: this.tagsQuery, rangeRaw: this.timeSrv.timeRange()}).then(results => {
         this.tags = [];
         for (var i = 0; i < results.length; i++) {
           this.tags.push(results[i].text);
@@ -106,7 +106,7 @@ export class QueryVariable implements Variable {
   getValuesForTag(tagKey) {
     return this.datasourceSrv.get(this.datasource).then(datasource => {
       var query = this.tagValuesQuery.replace('$tag', tagKey);
-      return datasource.metricFindQuery({query: query, rangeRaw: this.timeSrv.time}).then(function (results) {
+      return datasource.metricFindQuery({query: query, rangeRaw: this.timeSrv.timeRange()}).then(function (results) {
         return _.map(results, function(value) {
           return value.text;
         });
@@ -115,7 +115,7 @@ export class QueryVariable implements Variable {
   }
 
   updateOptionsFromMetricFindQuery(datasource) {
-    return datasource.metricFindQuery({query: this.query, rangeRaw: this.timeSrv.time}).then(results => {
+    return datasource.metricFindQuery({query: this.query, rangeRaw: this.timeSrv.timeRange()}).then(results => {
       this.options = this.metricNamesToVariableValues(results);
       if (this.includeAll) {
         this.addAllOption();

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -48,7 +48,7 @@ export class QueryVariable implements Variable {
   };
 
   /** @ngInject **/
-  constructor(private model, private datasourceSrv, private templateSrv, private variableSrv, private $q)  {
+  constructor(private model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv, private $q)  {
     // copy model properties to this instance
     assignModelProperties(this, model, this.defaults);
   }
@@ -89,7 +89,7 @@ export class QueryVariable implements Variable {
 
   updateTags(datasource) {
     if (this.useTags) {
-      return datasource.metricFindQuery(this.tagsQuery).then(results => {
+      return datasource.metricFindQuery({query: this.tagsQuery, rangeRaw: this.timeSrv.time}).then(results => {
         this.tags = [];
         for (var i = 0; i < results.length; i++) {
           this.tags.push(results[i].text);
@@ -106,7 +106,7 @@ export class QueryVariable implements Variable {
   getValuesForTag(tagKey) {
     return this.datasourceSrv.get(this.datasource).then(datasource => {
       var query = this.tagValuesQuery.replace('$tag', tagKey);
-      return datasource.metricFindQuery(query).then(function (results) {
+      return datasource.metricFindQuery({query: query, rangeRaw: this.timeSrv.time}).then(function (results) {
         return _.map(results, function(value) {
           return value.text;
         });
@@ -115,7 +115,7 @@ export class QueryVariable implements Variable {
   }
 
   updateOptionsFromMetricFindQuery(datasource) {
-    return datasource.metricFindQuery(this.query).then(results => {
+    return datasource.metricFindQuery({query: this.query, rangeRaw: this.timeSrv.time}).then(results => {
       this.options = this.metricNamesToVariableValues(results);
       if (this.includeAll) {
         this.addAllOption();

--- a/public/app/features/templating/specs/query_variable_specs.ts
+++ b/public/app/features/templating/specs/query_variable_specs.ts
@@ -7,7 +7,7 @@ describe('QueryVariable', () => {
   describe('when creating from model', () => {
 
     it('should set defaults', () => {
-      var variable = new QueryVariable({}, null, null, null, null);
+      var variable = new QueryVariable({}, null, null, null, null, null);
       expect(variable.datasource).to.be(null);
       expect(variable.refresh).to.be(0);
       expect(variable.sort).to.be(0);
@@ -19,7 +19,7 @@ describe('QueryVariable', () => {
     });
 
     it('get model should copy changes back to model', () => {
-      var variable = new QueryVariable({}, null, null, null, null);
+      var variable = new QueryVariable({}, null, null, null, null, null);
       variable.options = [{text: 'test'}];
       variable.datasource = 'google';
       variable.regex = 'asd';
@@ -34,7 +34,7 @@ describe('QueryVariable', () => {
     });
 
     it('if refresh != 0 then remove options in presisted mode', () => {
-      var variable = new QueryVariable({}, null, null, null, null);
+      var variable = new QueryVariable({}, null, null, null, null, null);
       variable.options = [{text: 'test'}];
       variable.refresh = 1;
 
@@ -44,7 +44,7 @@ describe('QueryVariable', () => {
   });
 
   describe('can convert and sort metric names',() => {
-    var variable = new QueryVariable({}, null, null, null, null);
+    var variable = new QueryVariable({}, null, null, null, null, null);
     variable.sort = 3; // Numerical (asc)
 
     describe('can sort a mixed array of metric variables', () => {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -157,7 +157,9 @@ export default class InfluxDatasource {
     return false;
   };
 
-  metricFindQuery(query) {
+  metricFindQuery(options) {
+    var timeFilter = this.getTimeFilter({rangeRaw: options.rangeRaw});
+    var query = options.query.replace('$timeFilter', timeFilter);
     var interpolated = this.templateSrv.replace(query, null, 'regex');
 
     return this._seriesQuery(interpolated)

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -13,27 +13,17 @@ export default class ResponseParser {
     }
 
     var influxdb11format = query.toLowerCase().indexOf('show tag values') >= 0;
-
-
-    var arbitraryColumn = 0;
-    if (query.indexOf(';;') >= 0) {
-      var part = query.substr(query.indexOf(';;'));
-      arbitraryColumn = part.split(';').length - 2;
-    }
+    var isSelectQuery = query.toLowerCase().trim().indexOf('select') === 0;
 
     var res = {};
     _.each(influxResults.series, serie => {
       _.each(serie.values, value => {
         if (_.isArray(value)) {
-          if (arbitraryColumn === 0) {
-            if (influxdb11format) {
+            if (influxdb11format || isSelectQuery) {
               addUnique(res, value[1] || value[0]);
             } else {
               addUnique(res, value[0]);
             }
-          } else {
-            addUnique(res, value[arbitraryColumn]);
-          }
         } else {
           addUnique(res, value);
         }

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -14,14 +14,25 @@ export default class ResponseParser {
 
     var influxdb11format = query.toLowerCase().indexOf('show tag values') >= 0;
 
+
+    var arbitraryColumn = 0;
+    if (query.indexOf(';;') >= 0) {
+      var part = query.substr(query.indexOf(';;'));
+      arbitraryColumn = part.split(';').length - 2;
+    }
+
     var res = {};
     _.each(influxResults.series, serie => {
       _.each(serie.values, value => {
         if (_.isArray(value)) {
-          if (influxdb11format) {
-            addUnique(res, value[1] || value[0]);
+          if (arbitraryColumn === 0) {
+            if (influxdb11format) {
+              addUnique(res, value[1] || value[0]);
+            } else {
+              addUnique(res, value[0]);
+            }
           } else {
-            addUnique(res, value[0]);
+            addUnique(res, value[arbitraryColumn]);
           }
         } else {
           addUnique(res, value);
@@ -30,7 +41,7 @@ export default class ResponseParser {
     });
 
     return _.map(res, value => {
-      return { text: value};
+      return { text: value };
     });
   }
 }

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -18,13 +18,13 @@ export default class ResponseParser {
     var res = {};
     _.each(influxResults.series, serie => {
       _.each(serie.values, value => {
-        if (_.isArray(value)) {
-            if (influxdb11format || isSelectQuery) {
-              addUnique(res, value[1] || value[0]);
-            } else {
-              addUnique(res, value[0]);
-            }
+      if (_.isArray(value)) {
+        if (influxdb11format || isSelectQuery) {
+          addUnique(res, value[1] || value[0]);
         } else {
+          addUnique(res, value[0]);
+        }
+      } else {
           addUnique(res, value);
         }
       });

--- a/public/app/plugins/datasource/influxdb/specs/response_parser_specs.ts
+++ b/public/app/plugins/datasource/influxdb/specs/response_parser_specs.ts
@@ -27,6 +27,43 @@ describe("influxdb response parser", () => {
     });
   });
 
+  describe("SELECT pod_name, LAST(value)", () => {
+    var query = 'SELECT pod_name, LAST(value) FROM uptime';
+    var response = {
+      "results": [
+        {
+          "statement_id": 0,
+          "series": [{
+            "name": "uptime",
+            "tags": {"pod_name": "default-http-backend-2138921206-ttr2c"},
+            "columns": ["time", "pod_name", "last"],
+            "values": [[1499708520000, "default-http-backend-2138921206-ttr2c", 192650245]]
+          }, {
+            "name": "uptime",
+            "tags": {"pod_name": "es-0"},
+            "columns": ["time", "pod_name", "last"],
+            "values": [[1499708520000, "es-0", 278733206]]
+          }, {
+            "name": "uptime",
+            "tags": {"pod_name": "es-1"},
+            "columns": ["time", "pod_name", "last"],
+            "values": [[1499708520000, "es-1", 279640344]]
+          }, {
+            "name": "uptime",
+            "tags": {"pod_name": "es-2"},
+            "columns": ["time", "pod_name", "last"],
+            "values": [[1499708520000, "es-2", 278435090]]
+          }]}]};
+    var result = this.parser.parse(query, response);
+    it("should get four responses", () => {
+        expect(_.size(result)).to.be(4);
+        expect(result[0].text).to.be("default-http-backend-2138921206-ttr2c");
+        expect(result[1].text).to.be("es-0");
+        expect(result[2].text).to.be("es-1");
+        expect(result[3].text).to.be("es-2");
+      });
+  });
+
   describe("SHOW TAG VALUES response", () => {
     var query = 'SHOW TAG VALUES FROM "cpu" WITH KEY = "hostname"';
 


### PR DESCRIPTION
Issues involved
#5327 #1322  #7918

It adds two things to templating. 

1. If the query starts with a `select`, then it takes the second column from the output (skips the time column)
2. $timeFilter is processed as in annotation queries.

Example usage:

In template query input something like this:
`SELECT pod_name,last(value) FROM uptime WHERE $timeFilter AND namespace_name = '$namespace' GROUP BY pod_name`

The output from this query is `time, pod_name` lines, and pod_name is being taken.
The query output will be limited to only active pod_names in the time range!

Works like a charm for me :D