### PR TITLE
webdav: allow specification of a different 'geturl' than upload url

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -442,3 +442,4 @@ secret_key =
 url =
 username =
 password =
+public_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -397,5 +397,6 @@
 
 [external_image_storage.webdav]
 ;url =
+;public_url =
 ;username =
 ;password =

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -635,6 +635,9 @@ Secret key. e.g. AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 ### url
 Url to where Grafana will send PUT request with images
 
+### public_url
+Url to send to users in notifications, directly appended with the resulting uploaded file name
+
 ### username
 basic auth username
 

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -47,10 +47,11 @@ func NewImageUploader() (ImageUploader, error) {
 			return nil, fmt.Errorf("Could not find url key for image.uploader.webdav")
 		}
 
+		public_url := webdavSec.Key("public_url").String()
 		username := webdavSec.Key("username").String()
 		password := webdavSec.Key("password").String()
 
-		return NewWebdavImageUploader(url, username, password)
+		return NewWebdavImageUploader(url, username, password, public_url)
 	}
 
 	return NopImageUploader{}, nil

--- a/pkg/components/imguploader/webdavuploader.go
+++ b/pkg/components/imguploader/webdavuploader.go
@@ -14,9 +14,10 @@ import (
 )
 
 type WebdavUploader struct {
-	url      string
-	username string
-	password string
+	url        string
+	username   string
+	password   string
+	public_url string
 }
 
 var netTransport = &http.Transport{
@@ -33,7 +34,8 @@ var netClient = &http.Client{
 
 func (u *WebdavUploader) Upload(pa string) (string, error) {
 	url, _ := url.Parse(u.url)
-	url.Path = path.Join(url.Path, util.GetRandomString(20)+".png")
+	filename := util.GetRandomString(20) + ".png"
+	url.Path = path.Join(url.Path, filename)
 
 	imgData, err := ioutil.ReadFile(pa)
 	req, err := http.NewRequest("PUT", url.String(), bytes.NewReader(imgData))
@@ -53,13 +55,18 @@ func (u *WebdavUploader) Upload(pa string) (string, error) {
 		return "", fmt.Errorf("Failed to upload image. Returned statuscode %v body %s", res.StatusCode, body)
 	}
 
-	return url.String(), nil
+	if u.public_url != "" {
+		return (u.public_url + filename), nil
+	} else {
+		return url.String(), nil
+	}
 }
 
-func NewWebdavImageUploader(url, username, passwrod string) (*WebdavUploader, error) {
+func NewWebdavImageUploader(url, username, password, public_url string) (*WebdavUploader, error) {
 	return &WebdavUploader{
-		url:      url,
-		username: username,
-		password: passwrod,
+		url:        url,
+		username:   username,
+		password:   password,
+		public_url: public_url,
 	}, nil
 }

--- a/pkg/components/imguploader/webdavuploader_test.go
+++ b/pkg/components/imguploader/webdavuploader_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestUploadToWebdav(t *testing.T) {
-	webdavUploader, _ := NewWebdavImageUploader("http://localhost:9998/dav/", "username", "password")
+	webdavUploader, _ := NewWebdavImageUploader("http://localhost:9998/dav/", "username", "password", "")
 
 	SkipConvey("[Integration test] for external_image_store.webdav", t, func() {
 		path, err := webdavUploader.Upload("../../../public/img/logo_transparent_400x.png")


### PR DESCRIPTION
Tentative fix for #7914 

Previously the WebDAV Image Uploader would use the provided URL both for upload, and external reference. Unfortunately, this just doesn't work for some systems such as Owncloud, where the WebDAV path is relative to the user: it would require to be logged in as the same user than Grafana to view the image.

This PR adds an additional "geturl" parameter that allows to specify a different base URL than the upload URL. It has no effect when the geturl parameter is not defined.

Example Owncloud 9.1 config (actual URL may vary depending on version) : 
 * Create an user and folder for Grafana in Owncloud
 * Enable public link sharing on the folder and note its ID in URL
 * Point Grafana WebDAV URL at owncloud/remote.php/webdav/FolderName, and configure user/pass accoridngly
 * Point Grafana WebDAV GetURL at owncloud/index.php/apps/files_sharing/ajax/publicpreview.php?x=9999&y=9999&scalingup=0&a=true&t=[FOLDERID]&file=

This is the first time I remotely touch a go program, so even though it's a simple modification, please review it carefully !