### PR TITLE
Prevent exception if this.datapoints[i][1] is undefined

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -220,7 +220,7 @@ export default class TimeSeries {
 
   isMsResolutionNeeded() {
     for (var i = 0; i < this.datapoints.length; i++) {
-      if (this.datapoints[i][1] !== null) {
+      if (this.datapoints[i][1]) {
         var timestamp = this.datapoints[i][1].toString();
         if (timestamp.length === 13 && (timestamp % 1000) !== 0) {
           return true;


### PR DESCRIPTION
found while trying to use Singlestat with elasticsearch datasource
metric count group by terms (no date histogram)
(this is still not working)

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>