### PR TITLE
Allow database query within influx datasource

### DIFF
--- a/public/app/plugins/datasource/influxdb/config_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/config_ctrl.ts
@@ -1,0 +1,53 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import angular from 'angular';
+import _ from 'lodash';
+
+export class InfluxConfigCtrl {
+  static templateUrl = 'partials/config.html';
+  current: any;
+  datasourceSrv: any;
+  dbSegment: any;
+
+
+  /** @ngInject **/
+  constructor($scope, $injector, private uiSegmentSrv) {
+    this.datasourceSrv = $injector.get('datasourceSrv');
+
+      console.log( "BEFORE", this );
+   // if (!_.isBoolean(this.current.jsonData.allowDBQuery)) {
+   //   this.current.jsonData.allowDBQuery = false;
+   // }
+
+    if (!_.isUndefined(this.current.url)) {
+      this.current.url = this.current.url.trim().replace(/\/$/,"");
+    }
+
+    if (_.isUndefined(this.current.database)) {
+      this.dbSegment = uiSegmentSrv.newSegment({value: '-- Enter Database --', fake: true});
+    } else {
+      this.dbSegment = uiSegmentSrv.newSegment({value: this.current.database});
+    }
+  }
+
+  getDBSegments() {
+    return this.datasourceSrv.get(this.current.name).then(ds => {
+      return ds.getDatabases( {} ).then( results => {
+        var segs = [];
+        for ( let i = 0; i < results.length; i++ ) {
+          segs.push( this.uiSegmentSrv.newSegment( results[i].text ) );
+        }
+        return segs;
+      });
+    }).catch( ex => {
+      console.log( "ERROR Getting", this, this.current.name );
+      return []; // empty list
+    });
+  }
+
+  dbChanged() {
+    this.current.database = this.dbSegment.value;
+
+      console.log( "CHANGE", this );
+  }
+}

--- a/public/app/plugins/datasource/influxdb/module.ts
+++ b/public/app/plugins/datasource/influxdb/module.ts
@@ -1,9 +1,6 @@
 import InfluxDatasource from './datasource';
 import {InfluxQueryCtrl} from './query_ctrl';
-
-class InfluxConfigCtrl {
-  static templateUrl = 'partials/config.html';
-}
+import {InfluxConfigCtrl} from './config_ctrl';
 
 class InfluxQueryOptionsCtrl {
   static templateUrl = 'partials/query.options.html';

--- a/public/app/plugins/datasource/influxdb/partials/config.html
+++ b/public/app/plugins/datasource/influxdb/partials/config.html
@@ -5,10 +5,15 @@
 
 <div class="gf-form-group">
 	<div class="gf-form-inline">
-		<div class="gf-form max-width-30">
+		<div class="gf-form">
 			<span class="gf-form-label width-7">Database</span>
-			<input type="text" class="gf-form-input" ng-model='ctrl.current.database' placeholder="" required></input>
+
+			<metric-segment segment="ctrl.dbSegment" get-options="ctrl.getDBSegments()" on-change="ctrl.dbChanged()"></metric-segment>
+
 		</div>
+		<gf-form-switch class="gf-form" label="Query" tooltip="Add the Database as a query option"
+				 checked="ctrl.current.jsonData.allowDBQuery" label-class="width-7" switch-class="max-width-6">
+		</gf-form-switch>
 	</div>
 
 	<div class="gf-form-inline">

--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -1,6 +1,9 @@
 <query-editor-row query-ctrl="ctrl" can-collapse="true" has-text-edit-mode="true">
 
 	<div class="gf-form" ng-if="ctrl.target.rawQuery">
+		<label ng-if="ctrl.datasource.allowDBQuery" class="gf-form-label query-keyword width-3">DB</label>
+		<metric-segment ng-if="ctrl.datasource.allowDBQuery" segment="ctrl.dbSegment" get-options="ctrl.getDBSegments()" on-change="ctrl.dbChanged()"></metric-segment>
+
 		<input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.refresh()"></input>
 	</div>
 
@@ -89,6 +92,10 @@
 			<div class="gf-form max-width-14">
 				<label class="gf-form-label query-keyword width-5">SLIMIT</label>
 				<input type="text" class="gf-form-input width-9" ng-model="ctrl.target.slimit" spellcheck='false' placeholder="No Limit" ng-blur="ctrl.refresh()">
+			</div>
+			<div ng-if="ctrl.datasource.allowDBQuery" class="gf-form">
+				<label class="gf-form-label query-keyword width-3">DB</label>
+				<metric-segment segment="ctrl.dbSegment" get-options="ctrl.getDBSegments()" on-change="ctrl.dbChanged()"></metric-segment>
 			</div>
 			<div class="gf-form gf-form--grow">
 				<div class="gf-form-label gf-form-label--grow"></div>

--- a/public/app/plugins/datasource/influxdb/query_builder.js
+++ b/public/app/plugins/datasource/influxdb/query_builder.js
@@ -64,6 +64,9 @@ function (_) {
     } else if (type === 'RETENTION POLICIES') {
       query = 'SHOW RETENTION POLICIES on "' + this.database + '"';
       return query;
+    } else if (type === 'DATABASES') {
+      query = 'SHOW DATABASES';
+      return query;
     }
 
     if (measurement) {

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -13,6 +13,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
   queryModel: InfluxQuery;
   queryBuilder: any;
   groupBySegment: any;
+  dbSegment: any;
   resultFormats: any[];
   orderByTime: any[];
   policySegment: any;
@@ -39,6 +40,12 @@ export class InfluxQueryCtrl extends QueryCtrl {
     ];
 
     this.policySegment = uiSegmentSrv.newSegment(this.target.policy);
+
+    if (this.target.db) {
+      this.dbSegment = uiSegmentSrv.newSegment(this.target.db);
+    } else {
+      this.dbSegment = uiSegmentSrv.newFake(this.datasource.database);
+    }
 
     if (!this.target.measurement) {
       this.measurementSegment = uiSegmentSrv.newSelectMeasurement();
@@ -185,6 +192,18 @@ export class InfluxQueryCtrl extends QueryCtrl {
   policyChanged() {
     this.target.policy = this.policySegment.value;
     this.panelCtrl.refresh();
+  }
+
+  getDBSegments() {
+    var query = this.queryBuilder.buildExploreQuery('DATABASES');
+    return this.datasource.metricFindQuery(query)
+    .then(this.transformToSegments(false))
+    .catch(this.handleQueryError.bind(this));
+  }
+
+  dbChanged() {
+    this.target.db = this.dbSegment.value;
+    console.log( "CHANGE", this );
   }
 
   toggleEditorMode() {


### PR DESCRIPTION
Currently each influxdb datasource is tied to a single database.  It would be great to (optionally) select the database as part of the query