### PR TITLE
Configurable signout menu activation

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -205,6 +205,9 @@ default_theme = dark
 # Set to true to disable (hide) the login form, useful if you use OAuth
 disable_login_form = false
 
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy
+disable_signout_menu = false
+
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -192,6 +192,9 @@
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false
 
+# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+;disable_signout_menu = false
+
 #################################### Anonymous Auth ##########################
 [auth.anonymous]
 # enable anonymous access

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -267,6 +267,10 @@ options are `Admin` and `Editor` and `Read Only Editor`. e.g. :
 
 Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false.
 
+### disable_signout_menu
+
+Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false.
+
 <hr>
 
 ## [auth.anonymous]

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -133,16 +133,17 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 	}
 
 	jsonObj := map[string]interface{}{
-		"defaultDatasource": defaultDatasource,
-		"datasources":       datasources,
-		"panels":            panels,
-		"appSubUrl":         setting.AppSubUrl,
-		"allowOrgCreate":    (setting.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
-		"authProxyEnabled":  setting.AuthProxyEnabled,
-		"ldapEnabled":       setting.LdapEnabled,
-		"alertingEnabled":   setting.AlertingEnabled,
-		"googleAnalyticsId": setting.GoogleAnalyticsId,
-		"disableLoginForm":  setting.DisableLoginForm,
+		"defaultDatasource":  defaultDatasource,
+		"datasources":        datasources,
+		"panels":             panels,
+		"appSubUrl":          setting.AppSubUrl,
+		"allowOrgCreate":     (setting.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
+		"authProxyEnabled":   setting.AuthProxyEnabled,
+		"ldapEnabled":        setting.LdapEnabled,
+		"alertingEnabled":    setting.AlertingEnabled,
+		"googleAnalyticsId":  setting.GoogleAnalyticsId,
+		"disableLoginForm":   setting.DisableLoginForm,
+		"disableSignoutMenu": setting.DisableSignoutMenu,
 		"buildInfo": map[string]interface{}{
 			"version":       setting.BuildVersion,
 			"commit":        setting.BuildCommit,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -96,6 +96,7 @@ var (
 	LoginHint          string
 	DefaultTheme       string
 	DisableLoginForm   bool
+	DisableSignoutMenu bool
 
 	// Http auth
 	AdminUser     string
@@ -528,6 +529,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	// auth
 	auth := Cfg.Section("auth")
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
+	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 
 	// anonymous access
 	AnonymousEnabled = Cfg.Section("auth.anonymous").Key("enabled").MustBool(false)

--- a/public/app/core/components/sidemenu/sidemenu.ts
+++ b/public/app/core/components/sidemenu/sidemenu.ts
@@ -23,7 +23,7 @@ export class SideMenuCtrl {
     this.isSignedIn = contextSrv.isSignedIn;
     this.user = contextSrv.user;
     this.appSubUrl = config.appSubUrl;
-    this.showSignout = this.contextSrv.isSignedIn && !config['authProxyEnabled'];
+    this.showSignout = this.contextSrv.isSignedIn && !config['disableSignoutMenu'];
     this.maxShownOrgs = 10;
 
     this.mainLinks = config.bootData.mainNavLinks;


### PR DESCRIPTION
Since the grafana-4.2.0 release, the signout menu was disabled when auth.proxy was enabled.
In my company, we use both `auth.ldap` and `auth.proxy` methods, so I made the signout menu activation configurable.
I added a new parameter in the `auth` section of the grafana.ini :
```
# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults false.
disable_signout_menu = false
```
Related issue #4564

