### PR TITLE
Remove trusted HTML content in text panel

### DIFF
--- a/public/app/plugins/panel/text/module.ts
+++ b/public/app/plugins/panel/text/module.ts
@@ -71,10 +71,10 @@ export class TextPanelCtrl extends PanelCtrl {
 
   updateContent(html) {
     try {
-      this.content = this.$sce.trustAsHtml(this.templateSrv.replace(html, this.panel.scopedVars));
+      this.content = this.templateSrv.replace(html, this.panel.scopedVars);
     } catch (e) {
       console.log('Text panel error: ', e);
-      this.content = this.$sce.trustAsHtml(html);
+      this.content = html;
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/4117

If you put `<script>alert(1)</script>` in the text panel with a HTML rendering it works, and it shouldn't.