### PR TITLE
fix(prometheus) when tag value duplicate, tags not working.

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.js
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.js
@@ -59,9 +59,13 @@ function (_) {
 
       return this.datasource._request('GET', url)
       .then(function(result) {
-        return _.map(result.data.data, function(metric) {
+        var _labels = _.map(result.data.data, function(metric) {
+          return metric[label];
+        });
+
+        return _.uniq(_labels).map(function(metric) {
           return {
-            text: metric[label],
+            text: metric,
             expandable: true
           };
         });


### PR DESCRIPTION
When I used label_values function in `Tags query`, Tags not working.
I think that if results of `Tags query` should be unique.

before
<img width="570" alt="3a4a7b66-799e-4f6a-b5a5-f44ad6dd3315" src="https://cloud.githubusercontent.com/assets/1210536/24710910/7ce97892-1a59-11e7-97df-2fb1c5b8e18f.png">

after
<img width="557" alt="f8c4b1e0-747d-453b-9d78-2993e6830c09" src="https://cloud.githubusercontent.com/assets/1210536/24710955/94dc6acc-1a59-11e7-9f29-a345cd7c520a.png">
