### PR TITLE
Fix ldap ca_cert example/docs for proper syntax

### DIFF
--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -11,7 +11,7 @@ use_ssl = false
 # set to true if you want to skip ssl cert validation
 ssl_skip_verify = false
 # set to the path to your root CA certificate or leave unset to use system defaults
-# root_ca_cert = /path/to/certificate.crt
+# root_ca_cert = "/path/to/certificate.crt"
 
 # Search user bind dn
 bind_dn = "cn=admin,dc=grafana,dc=org"

--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -30,7 +30,7 @@ use_ssl = false
 # set to true if you want to skip ssl cert validation
 ssl_skip_verify = false
 # set to the path to your root CA certificate or leave unset to use system defaults
-# root_ca_cert = /path/to/certificate.crt
+# root_ca_cert = "/path/to/certificate.crt"
 
 # Search user bind dn
 bind_dn = "cn=admin,dc=grafana,dc=org"


### PR DESCRIPTION
Omitting the quotes in the `root_ca_cert` options in ldap.toml produces an error: `msg="Failed to load ldap config file" logger=ldap error="Near line 14 (last key parsed 'servers.root_ca_cert'): Expected value but found '/' instead."`

This PR makes the documentation and sample config valid.