### PR TITLE
Change prometheus semantics from step to min step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Minor Enchancements
 
 * **Prometheus**: Make Prometheus query field a textarea [#7663](https://github.com/grafana/grafana/issues/7663), thx [@hagen1778](https://github.com/hagen1778)
+* **Prometheus**: Step parameter changed semantics to min step to reduce the load on Prometheus and rendering in browser [#8073](https://github.com/grafana/grafana/pull/8073), thx [@bobrik](https://github.com/bobrik)
 * **Templating**: Should not be possible to create self-referencing (recursive) template variable definitions [#7614](https://github.com/grafana/grafana/issues/7614) thx [@thuck](https://github.com/thuck)
 * **Cloudwatch**: Correctly obtain IAM roles within ECS container tasks [#7892](https://github.com/grafana/grafana/issues/7892) thx [@gomlgs](https://github.com/gomlgs)
 * **Units**: New number format: Scientific notation [#7781](https://github.com/grafana/grafana/issues/7781) thx [@cadnce](https://github.com/cadnce)

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -14,7 +14,7 @@
 			</input>
 		</div>
 		<div class="gf-form">
-			<label class="gf-form-label width-5">Step</label>
+			<label class="gf-form-label">Min step</label>
 			<input type="text" class="gf-form-input max-width-5" ng-model="ctrl.target.interval"
 					   data-placement="right"
 			       spellcheck='false'


### PR DESCRIPTION
Previously `Step` parameter would set a hard value for any zoom level.

Now it's renamed to `Min step` and sets the minimal value of `step` parameter
to Prometheus query. User would usually want to set it to the scraping interval
of the target metric to avoid having shap cliffs on graphs and extra load
on Prometheus. Actual `step` value is calculated as the minimum of automatically
selected step (based on zoom level) and user provided minimal step. If user
did not provide the step, then automatic value is used as is.

Example bahavior for `60s` scrape intervals:

* `5s` automatic interval, no user specified min step:
  * Before: `step=5`
  * After: `step=5`
* `5s` automatic interval, `1m` user specified min step:
  * Before: `step=5`
  * After: `step=60`
* `5m` automatic interval, `1m` user specified min step:
  * Before: `step=60` (not really visible, too dense)
  * After: `step=300` (automatic value is picked)

See:

* https://github.com/grafana/grafana/issues/8065
* https://github.com/prometheus/prometheus/issues/2564

* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**
