### PR TITLE
If earlier dashboard refresh was supressed, force a new one on page becoming visible

### DIFF
--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -15,6 +15,7 @@ class TimeSrv {
   oldRefresh: boolean;
   dashboard: any;
   timeAtLoad: any;
+  private autoRefreshBlocked: boolean;
 
   /** @ngInject **/
   constructor(private $rootScope, private $timeout, private $location, private timer, private contextSrv) {
@@ -23,6 +24,14 @@ class TimeSrv {
 
     $rootScope.$on('zoom-out', this.zoomOut.bind(this));
     $rootScope.$on('$routeUpdate', this.routeUpdated.bind(this));
+
+    document.addEventListener('visibilitychange', () => {
+      if (this.autoRefreshBlocked && document.visibilityState === 'visible') {
+        this.autoRefreshBlocked = false;
+
+        this.refreshDashboard();
+      }
+    });
   }
 
   init(dashboard) {
@@ -137,6 +146,8 @@ class TimeSrv {
       this.startNextRefreshTimer(afterMs);
       if (this.contextSrv.isGrafanaVisible()) {
         this.refreshDashboard();
+      } else {
+        this.autoRefreshBlocked = true;
       }
     }, afterMs));
   }


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/7219#issuecomment-292866409

This should do it, right?

Use case is being able to switch between multiple tabs of dashboards, and have them be updated even if an earlier auto-update was suppressed by the tab being in the background