### PR TITLE
Add alwaysDisplayed option to datasource plugins

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -102,18 +102,14 @@ func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, erro
 		datasources[ds.Name] = dsMap
 	}
 
-	// add grafana backend data source
-	grafanaDatasourceMeta, _ := plugins.DataSources["grafana"]
-	datasources["-- Grafana --"] = map[string]interface{}{
-		"type": "grafana",
-		"name": "-- Grafana --",
-		"meta": grafanaDatasourceMeta,
-	}
-
-	// add mixed backend data source
-	datasources["-- Mixed --"] = map[string]interface{}{
-		"type": "mixed",
-		"meta": plugins.DataSources["mixed"],
+	for _, ds := range plugins.DataSources {
+		if ds.AlwaysDisplay {
+			datasources[ds.Name] = map[string]interface{}{
+				"type": ds.Type,
+				"name": ds.Name,
+				"meta": plugins.DataSources[ds.Id],
+			}
+		}
 	}
 
 	if defaultDatasource == "" {

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -4,12 +4,13 @@ import "encoding/json"
 
 type DataSourcePlugin struct {
 	FrontendPluginBase
-	Annotations bool   `json:"annotations"`
-	Metrics     bool   `json:"metrics"`
-	Alerting    bool   `json:"alerting"`
-	BuiltIn     bool   `json:"builtIn"`
-	Mixed       bool   `json:"mixed"`
-	App         string `json:"app"`
+	Annotations   bool   `json:"annotations"`
+	Metrics       bool   `json:"metrics"`
+	Alerting      bool   `json:"alerting"`
+	BuiltIn       bool   `json:"builtIn"`
+	Mixed         bool   `json:"mixed"`
+	AlwaysDisplay bool   `json:"alwaysDisplay"`
+	App           string `json:"app"`
 }
 
 func (p *DataSourcePlugin) Load(decoder *json.Decoder, pluginDir string) error {

--- a/public/app/plugins/datasource/grafana/plugin.json
+++ b/public/app/plugins/datasource/grafana/plugin.json
@@ -1,9 +1,10 @@
 {
   "type": "datasource",
-  "name": "Grafana",
+  "name": "-- Grafana --",
   "id": "grafana",
 
   "builtIn": true,
   "annotations": true,
+  "alwaysDisplay": true,
   "metrics": true
 }

--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -1,9 +1,10 @@
 {
   "type": "datasource",
-  "name": "Mixed datasource",
+  "name": "-- Mixed --",
   "id": "mixed",
 
   "builtIn": true,
   "mixed": true,
+  "alwaysDisplay": true,
   "metrics": true
 }


### PR DESCRIPTION
This will allow it to show up as an option to select when adding queries to a panel without actually adding it as a datasource.

We have been trying to come up with a pure plugin way of adding a datasource that automatically aggregates all of our other datasources, and it doesn't seem quite possible to do cleanly at the moment. Once I add it as a real datasource, it starts to act differently with proxies than the 'builtin' magic datasources do. This simply allows external developers to also make magic datasource plugins. Hopefully this isn't considered a feature, since it shouldn't change any real existing behavior and should be hidden enough as we'd really like to avoid managing a fork of Grafana if possible.