### PR TITLE
make template variables wrap to the new rows

### DIFF
--- a/public/sass/components/_query_editor.scss
+++ b/public/sass/components/_query_editor.scss
@@ -17,7 +17,7 @@
 .gf-form-query {
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-content: flex-start;
   align-items: flex-start;
 


### PR DESCRIPTION
When there is a too much template variables, some of the selection fields is being overlapped by the next variable name, making it impossible to select some values.