### PR TITLE
use X-Grafana-Org-Id header to ensure backend uses correct org

### DIFF
--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func initContextWithAuthProxy(ctx *Context) bool {
+func initContextWithAuthProxy(ctx *Context, orgId int64) bool {
 	if !setting.AuthProxyEnabled {
 		return false
 	}
@@ -30,6 +30,7 @@ func initContextWithAuthProxy(ctx *Context) bool {
 	}
 
 	query := getSignedInUserQueryForProxyAuth(proxyHeaderValue)
+	query.OrgId = orgId
 	if err := bus.Dispatch(query); err != nil {
 		if err != m.ErrUserNotFound {
 			ctx.Handle(500, "Failed to find user specified in auth proxy header", err)
@@ -46,7 +47,7 @@ func initContextWithAuthProxy(ctx *Context) bool {
 				ctx.Handle(500, "Failed to create user specified in auth proxy header", err)
 				return true
 			}
-			query = &m.GetSignedInUserQuery{UserId: cmd.Result.Id}
+			query = &m.GetSignedInUserQuery{UserId: cmd.Result.Id, OrgId: orgId}
 			if err := bus.Dispatch(query); err != nil {
 				ctx.Handle(500, "Failed find user after creation", err)
 				return true

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -117,6 +117,7 @@ type GetSignedInUserQuery struct {
 	UserId int64
 	Login  string
 	Email  string
+	OrgId  int64
 	Result *SignedInUser
 }
 

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -9,8 +9,8 @@ export class BackendSrv {
   inFlightRequests = {};
   HTTP_REQUEST_CANCELLED = -1;
 
-    /** @ngInject */
-  constructor(private $http, private alertSrv, private $rootScope, private $q, private $timeout) {
+  /** @ngInject */
+  constructor(private $http, private alertSrv, private $rootScope, private $q, private $timeout, private contextSrv) {
   }
 
   get(url, params?) {
@@ -65,6 +65,11 @@ export class BackendSrv {
     options.retry = options.retry || 0;
     var requestIsLocal = options.url.indexOf('/') === 0;
     var firstAttempt = options.retry === 0;
+
+    if (!options.url.match('https?://') && this.contextSrv && this.contextSrv.user && this.contextSrv.user.orgId) {
+      options.headers = options.headers || {};
+      options.headers['X-Grafana-Org-Id'] = this.contextSrv.user.orgId;
+    }
 
     if (requestIsLocal && !options.hasSubUrl) {
       options.url = config.appSubUrl + options.url;
@@ -127,6 +132,11 @@ export class BackendSrv {
 
     var requestIsLocal = options.url.indexOf('/') === 0;
     var firstAttempt = options.retry === 0;
+
+    if (!options.url.match('https?://') && this.contextSrv && this.contextSrv.user && this.contextSrv.user.orgId) {
+      options.headers = options.headers || {};
+      options.headers['X-Grafana-Org-Id'] = this.contextSrv.user.orgId;
+    }
 
     if (requestIsLocal && !options.hasSubUrl && options.retry === 0) {
       options.url = config.appSubUrl + options.url;


### PR DESCRIPTION
This patch adds support for passing an X-Grafana-Org-Id header to override the org for a particular request, and updated the frontend to send that header with every request.

This allows the use of multiple tabs with different active orgs, and ensures that requests are always handled using the correct org.
