### PR TITLE
Add metrics/matches to Telegram notifications (proposed fix for #8110)

### DIFF
--- a/pkg/services/alerting/notifiers/telegram.go
+++ b/pkg/services/alerting/notifiers/telegram.go
@@ -106,7 +106,7 @@ func (this *TelegramNotifier) Notify(evalContext *alerting.EvalContext) error {
 		}
 	}
 	if metrics != "" {
-		message = message + fmt.Sprintf("\n<i>Metrics:</i>%s", metrics);
+		message = message + fmt.Sprintf("\n<i>Metrics:</i>%s", metrics)
 	}
 
 	bodyJSON.Set("text", message)

--- a/pkg/services/alerting/notifiers/telegram.go
+++ b/pkg/services/alerting/notifiers/telegram.go
@@ -87,7 +87,7 @@ func (this *TelegramNotifier) Notify(evalContext *alerting.EvalContext) error {
 	bodyJSON.Set("chat_id", this.ChatID)
 	bodyJSON.Set("parse_mode", "html")
 
-	message := fmt.Sprintf("%s\nState: %s\nMessage: %s\n", evalContext.GetNotificationTitle(), evalContext.Rule.Name, evalContext.Rule.Message)
+	message := fmt.Sprintf("<b>%s</b>\nState: %s\nMessage: %s\n", evalContext.GetNotificationTitle(), evalContext.Rule.Name, evalContext.Rule.Message)
 
 	ruleUrl, err := evalContext.GetRuleUrl()
 	if err == nil {
@@ -96,6 +96,19 @@ func (this *TelegramNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if evalContext.ImagePublicUrl != "" {
 		message = message + fmt.Sprintf("Image: %s\n", evalContext.ImagePublicUrl)
 	}
+
+	metrics := ""
+	fieldLimitCount := 4
+	for index, evt := range evalContext.EvalMatches {
+		metrics += fmt.Sprintf("\n%s: %s", evt.Metric, evt.Value)
+		if index > fieldLimitCount {
+			break
+		}
+	}
+	if metrics != "" {
+		message = message + fmt.Sprintf("\n<i>Metrics:</i>%s", metrics);
+	}
+
 	bodyJSON.Set("text", message)
 
 	url := fmt.Sprintf(telegeramApiUrl, this.BotToken, "sendMessage")


### PR DESCRIPTION
Adding metrics/matches to be send in Telegram notifications. Used the Slack notification as an example for the implementation. Also added some basic HTML to the notification to simply have a better overview when having multiple alerts firing. This should fix #8110 

Preview:
![image](https://cloud.githubusercontent.com/assets/4669888/25169317/2aff3a06-2519-11e7-8aa8-e9aa1041f442.png)
