### PR TITLE
Make size of repeated panels more adaptable

### DIFF
--- a/public/app/features/dashboard/dynamic_dashboard_srv.ts
+++ b/public/app/features/dashboard/dynamic_dashboard_srv.ts
@@ -187,7 +187,9 @@ export class DynamicDashboardSrv {
         return acc -= p.span;
       }
     };
-    var span = Math.max(_.reduce(row.panels, subSpan, 12) / selected.length, panel.minSpan || 4);
+    // min span to fit them all in one line
+    var minFit = _.reduce(row.panels, subSpan, 12) / selected.length;
+    var span = Math.max(panel.minSpan || 4, Math.min(panel.span, minFit));
     _.each(selected, (option, index) => {
       var copy = this.getPanelClone(panel, row, index);
       copy.span = span;

--- a/public/app/features/dashboard/dynamic_dashboard_srv.ts
+++ b/public/app/features/dashboard/dynamic_dashboard_srv.ts
@@ -180,9 +180,17 @@ export class DynamicDashboardSrv {
       selected = _.filter(variable.options, {selected: true});
     }
 
+    var subSpan = function(acc, p) {
+      if (p === panel || p.repeatPanelId === panel.id) {
+        return acc;
+      } else {
+        return acc -= p.span;
+      }
+    };
+    var span = Math.max(_.reduce(row.panels, subSpan, 12) / selected.length, panel.minSpan || 4);
     _.each(selected, (option, index) => {
       var copy = this.getPanelClone(panel, row, index);
-      copy.span = Math.max(12 / selected.length, panel.minSpan || 4);
+      copy.span = span;
       copy.scopedVars = copy.scopedVars || {};
       copy.scopedVars[variable.name] = option;
     });

--- a/public/app/features/dashboard/dynamic_dashboard_srv.ts
+++ b/public/app/features/dashboard/dynamic_dashboard_srv.ts
@@ -188,7 +188,7 @@ export class DynamicDashboardSrv {
       }
     };
     // min span to fit them all in one line
-    var minFit = _.reduce(row.panels, subSpan, 12) / selected.length;
+    var minFit = Math.floor(_.reduce(row.panels, subSpan, 12) / selected.length);
     var span = Math.max(panel.minSpan || 4, Math.min(panel.span, minFit));
     _.each(selected, (option, index) => {
       var copy = this.getPanelClone(panel, row, index);


### PR DESCRIPTION
This PR changes the span of repeated panels in two ways:
* They aren't made wider than they are.
* Consider other panels in the same row so the clones don't spill over onto a second line even though their min span would still allow them to fit.

Looks like this:
![repeat1](https://cloud.githubusercontent.com/assets/6831775/25339848/3aaf1be4-2904-11e7-95ff-8e8b5f0f7305.gif)
The leftmost panel is just a panel. The one with the time override has an initial span of 4 and gets repeated with a min span of 2.

This fixes #8118.

There is one issue though:
* Clone a panel that fills the row.
* Save the dashboard. When saving the dashboard the original span is overwritten.
* Reduce the number of clones. The panels no longer stretch to full width.