### PR TITLE
duplicate keys for auth.github for allow_sign_up

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -313,7 +313,6 @@ example:
     auth_url = https://github.com/login/oauth/authorize
     token_url = https://github.com/login/oauth/access_token
     api_url = https://api.github.com/user
-    allow_sign_up = false
     team_ids =
     allowed_organizations =
 


### PR DESCRIPTION
`allow_sign_up` was listed 2x in the github example