### PR TITLE
Support panel repeat for data source template variable (with bug fix)

### DIFF
--- a/public/app/core/directives/plugin_component.ts
+++ b/public/app/core/directives/plugin_component.ts
@@ -102,7 +102,7 @@ function pluginDirectiveLoader($compile, datasourceSrv, $rootScope, $q, $http, $
       // QueryCtrl
       case "query-ctrl": {
         let datasource = scope.target.datasource || scope.ctrl.panel.datasource;
-        return datasourceSrv.get(datasource, scope.ctrl.panel.scopedVars || {}).then(ds => {
+        return datasourceSrv.get(datasource, scope.ctrl.panel.scopedVars).then(ds => {
           scope.datasource = ds;
 
           return System.import(ds.meta.module).then(dsModule => {
@@ -118,7 +118,7 @@ function pluginDirectiveLoader($compile, datasourceSrv, $rootScope, $q, $http, $
       }
       // QueryOptionsCtrl
       case "query-options-ctrl": {
-        return datasourceSrv.get(scope.ctrl.panel.datasource, scope.ctrl.panel.scopedVars || {}).then(ds => {
+        return datasourceSrv.get(scope.ctrl.panel.datasource, scope.ctrl.panel.scopedVars).then(ds => {
           return System.import(ds.meta.module).then((dsModule): any => {
             if (!dsModule.QueryOptionsCtrl) {
               return {notFound: true};

--- a/public/app/core/directives/plugin_component.ts
+++ b/public/app/core/directives/plugin_component.ts
@@ -102,7 +102,7 @@ function pluginDirectiveLoader($compile, datasourceSrv, $rootScope, $q, $http, $
       // QueryCtrl
       case "query-ctrl": {
         let datasource = scope.target.datasource || scope.ctrl.panel.datasource;
-        return datasourceSrv.get(datasource).then(ds => {
+        return datasourceSrv.get(datasource, scope.ctrl.panel.scopedVars || {}).then(ds => {
           scope.datasource = ds;
 
           return System.import(ds.meta.module).then(dsModule => {
@@ -118,7 +118,7 @@ function pluginDirectiveLoader($compile, datasourceSrv, $rootScope, $q, $http, $
       }
       // QueryOptionsCtrl
       case "query-options-ctrl": {
-        return datasourceSrv.get(scope.ctrl.panel.datasource).then(ds => {
+        return datasourceSrv.get(scope.ctrl.panel.datasource, scope.ctrl.panel.scopedVars || {}).then(ds => {
           return System.import(ds.meta.module).then((dsModule): any => {
             if (!dsModule.QueryOptionsCtrl) {
               return {notFound: true};

--- a/public/app/core/services/datasource_srv.js
+++ b/public/app/core/services/datasource_srv.js
@@ -14,12 +14,12 @@ function (angular, _, coreModule, config) {
       this.datasources = {};
     };
 
-    this.get = function(name) {
+    this.get = function(name, scopedDsVars) {
       if (!name) {
         return this.get(config.defaultDatasource);
       }
 
-      name = templateSrv.replace(name);
+      name = templateSrv.replace(name, scopedDsVars || {});
 
       if (name === 'default') {
         return this.get(config.defaultDatasource);

--- a/public/app/features/alerting/alert_tab_ctrl.ts
+++ b/public/app/features/alerting/alert_tab_ctrl.ts
@@ -248,7 +248,7 @@ export class AlertTabCtrl {
       }
 
       var datasourceName = foundTarget.datasource || this.panel.datasource;
-      this.datasourceSrv.get(datasourceName, this.panel.scopedVars || {}).then(ds => {
+      this.datasourceSrv.get(datasourceName, this.panel.scopedVars).then(ds => {
         if (!ds.meta.alerting) {
           this.error = 'The datasource does not support alerting queries';
         } else if (ds.targetContainsTemplate(foundTarget)) {

--- a/public/app/features/alerting/alert_tab_ctrl.ts
+++ b/public/app/features/alerting/alert_tab_ctrl.ts
@@ -248,7 +248,7 @@ export class AlertTabCtrl {
       }
 
       var datasourceName = foundTarget.datasource || this.panel.datasource;
-      this.datasourceSrv.get(datasourceName).then(ds => {
+      this.datasourceSrv.get(datasourceName, this.panel.scopedVars || {}).then(ds => {
         if (!ds.meta.alerting) {
           this.error = 'The datasource does not support alerting queries';
         } else if (ds.targetContainsTemplate(foundTarget)) {

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -93,7 +93,7 @@ class MetricsPanelCtrl extends PanelCtrl {
 
     // load datasource service
     this.setTimeQueryStart();
-    this.datasourceSrv.get(this.panel.datasource)
+    this.datasourceSrv.get(this.panel.datasource, this.panel.scopedVars)
     .then(this.updateTimeRange.bind(this))
     .then(this.issueQueries.bind(this))
     .then(this.handleQueryResult.bind(this))

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -11,6 +11,7 @@ export class DatasourceVariable implements Variable {
   options: any;
   current: any;
   multi: boolean;
+  includeAll: boolean;
   refresh: any;
 
  defaults = {
@@ -23,6 +24,7 @@ export class DatasourceVariable implements Variable {
     options: [],
     query: '',
     multi: false,
+    includeAll: false,
     refresh: 1,
   };
 
@@ -73,7 +75,14 @@ export class DatasourceVariable implements Variable {
     }
 
     this.options = options;
+    if (this.includeAll) {
+      this.addAllOption();
+    }
     return this.variableSrv.validateVariableSelectionState(this);
+  }
+
+  addAllOption() {
+    this.options.unshift({text: 'All', value: "$__all"});
   }
 
   dependsOn(variable) {
@@ -88,6 +97,9 @@ export class DatasourceVariable implements Variable {
   }
 
   getValueForUrl() {
+    if (this.current.text === 'All') {
+      return 'All';
+    }
     return this.current.value;
   }
 }

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -10,6 +10,7 @@ export class DatasourceVariable implements Variable {
   query: string;
   options: any;
   current: any;
+  multi: boolean;
   refresh: any;
 
  defaults = {
@@ -21,6 +22,7 @@ export class DatasourceVariable implements Variable {
     regex: '',
     options: [],
     query: '',
+    multi: false,
     refresh: 1,
   };
 
@@ -93,5 +95,6 @@ export class DatasourceVariable implements Variable {
 variableTypes['datasource'] = {
   name: 'Datasource',
   ctor: DatasourceVariable,
+  supportsMulti: true,
   description: 'Enabled you to dynamically switch the datasource for multiple panels',
 };

--- a/public/app/plugins/datasource/mixed/datasource.ts
+++ b/public/app/plugins/datasource/mixed/datasource.ts
@@ -17,7 +17,7 @@ class MixedDatasource {
         return this.$q([]);
       }
 
-      return this.datasourceSrv.get(dsName).then(function(ds) {
+      return this.datasourceSrv.get(dsName, options.scopedVars).then(function(ds) {
         var opt = angular.copy(options);
         opt.targets = targets;
         return ds.query(opt);


### PR DESCRIPTION
Fix https://github.com/grafana/grafana/issues/7030 .
Original PR is https://github.com/grafana/grafana/pull/7711 .

> And the data source selection in metrics tab where you pick the data source variable did not work after you repeat based on the variable. What I mean is after you repeat, the data source selection dropdown does not specify your variable anymore.

https://github.com/grafana/grafana/pull/8026#issuecomment-291418356

About this problem, I think this line cause the issue.
https://github.com/grafana/grafana/pull/8026/files#diff-cbd7cff86cf796b3ef747a6c1c365a99R58

When I first saw the error message in DevTools, I think the change is required.
But I notice that error message is caused by another bug.
https://github.com/grafana/grafana/issues/8186

So I can ignore the error message, change the code little.

> I consistently got strange issues with repeated panels that did not go away.

I'm trying to replicate the issue now.