### PR TITLE
added support for listening on unix socket #4030

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -25,7 +25,7 @@ plugins = data/plugins
 
 #################################### Server ##############################
 [server]
-# Protocol (http or https)
+# Protocol (http, https, socket)
 protocol = http
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -56,6 +56,9 @@ enable_gzip = false
 # https certs & key file
 cert_file =
 cert_key =
+
+# Unix socket path
+socket = /tmp/grafana.sock
 
 #################################### Database ############################
 [database]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -26,7 +26,7 @@
 #
 #################################### Server ####################################
 [server]
-# Protocol (http or https)
+# Protocol (http, https, socket)
 ;protocol = http
 
 # The ip address to bind to, empty will bind to all interfaces
@@ -58,6 +58,9 @@
 # https certs & key file
 ;cert_file =
 ;cert_key =
+
+# Unix socket path
+;socket =
 
 #################################### Database ####################################
 [database]

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -27,6 +27,7 @@ type Scheme string
 const (
 	HTTP              Scheme = "http"
 	HTTPS             Scheme = "https"
+	SOCKET            Scheme = "socket"
 	DEFAULT_HTTP_ADDR string = "0.0.0.0"
 )
 
@@ -65,6 +66,7 @@ var (
 	HttpAddr, HttpPort string
 	SshPort            int
 	CertFile, KeyFile  string
+	SocketPath         string
 	RouterLogging      bool
 	DataProxyLogging   bool
 	StaticRootPath     string
@@ -472,6 +474,10 @@ func NewConfigContext(args *CommandLineArgs) error {
 		Protocol = HTTPS
 		CertFile = server.Key("cert_file").String()
 		KeyFile = server.Key("cert_key").String()
+	}
+	if server.Key("protocol").MustString("http") == "socket" {
+		Protocol = SOCKET
+		SocketPath = server.Key("socket").String()
 	}
 
 	Domain = server.Key("domain").MustString("localhost")


### PR DESCRIPTION
Added support for listening on unix socket #4030

You can test it with nginx, if you add following to nginx.conf

`
	location / {
            proxy_pass http://unix:/tmp/grafana.sock:/;
        }
`