### PR TITLE
chore: add comment to clarify that org_id usage

### DIFF
--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -73,7 +73,7 @@ email =  "email"
 [[servers.group_mappings]]
 group_dn = "cn=admins,dc=grafana,dc=org"
 org_role = "Admin"
-# The Grafana organization database id, optional, if left out the default org (id 1) will be used
+# The Grafana organization database id, optional, if left out the default org (id 1) will be used.  Setting this allows for multiple group_dn's to be assigned to the same org_role provided the org_id differs
 # org_id = 1
 
 [[servers.group_mappings]]


### PR DESCRIPTION
As described here: https://community.grafana.com/t/many-to-many-group-dn-org-role-mapping-in-ldap-config/729/2 org_id can be used to allow multiple group_dn's to map to the same org_role provided the org_id differs.