### PR TITLE
bug: metric-segment not able work without mouse

### DIFF
--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -127,7 +127,7 @@ function (_, $, coreModule) {
           return items ? this.process(items) : items;
         };
 
-        $button.keydown(function(evt) {
+        $button.keyup(function(evt) {
           // trigger typeahead on down arrow or enter key
           if (evt.keyCode === 40 || evt.keyCode === 13) {
             $button.click();


### PR DESCRIPTION
Change event subscribe from keydown to keyup, to able fill multiple
key-value pairs very fast.

Fixes #8284 