### PR TITLE
Updated cloudwatch plugin to allow specific tag selection

### DIFF
--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -84,8 +84,8 @@ Name | Description
 *metrics(namespace, [region])* | Returns a list of metrics in the namespace. (specify region for custom metrics)
 *dimension_keys(namespace)* | Returns a list of dimension keys in the namespace.
 *dimension_values(region, namespace, metric, dimension_key)* | Returns a list of dimension values matching the specified `region`, `namespace`, `metric` and `dimension_key`.
-*ebs_volume_ids(region, instance_id)* | Returns a list of volume id matching the specified `region`, `instance_id`.
-*ec2_instance_attribute(region, attribute_name, filters)* | Returns a list of attribute matching the specified `region`, `attribute_name`, `filters`.
+*ebs_volume_ids(region, instance_id)* | Returns a list of volume ids matching the specified `region`, `instance_id`.
+*ec2_instance_attribute(region, attribute_name, filters)* | Returns a list of attributes matching the specified `region`, `attribute_name`, `filters`.
 
 For details about the metrics CloudWatch provides, please refer to the [CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 
@@ -101,10 +101,13 @@ Query | Service
 *dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier)* | RDS
 *dimension_values(us-east-1,AWS/S3,BucketSizeBytes,BucketName)* | S3
 
-#### ec2_instance_attribute JSON filters
+## ec2_instance_attribute examples
 
-The `ec2_instance_attribute` query take `filters` in JSON format.
+### JSON filters
+
+The `ec2_instance_attribute` query takes `filters` in JSON format.
 You can specify [pre-defined filters of ec2:DescribeInstances](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html).
+Note that the actual filtering takes place on Amazon's servers, not in Grafana.
 
 Filters syntax:
 
@@ -115,6 +118,45 @@ Filters syntax:
 Example `ec2_instance_attribute()` query
 
     ec2_instance_attribute(us-east-1, InstanceId, { "tag:Environment": [ "production" ] })
+
+### Selecting Attributes
+
+Only 1 attribute per instance can be returned. Any flat attribute can be selected (i.e. if the attribute has a single value and isn't an object or array). Below is a list of available flat attributes:
+
+  * `AmiLaunchIndex`
+  * `Architecture`
+  * `ClientToken`
+  * `EbsOptimized`
+  * `EnaSupport`
+  * `Hypervisor`
+  * `IamInstanceProfile`
+  * `ImageId`
+  * `InstanceId`
+  * `InstanceLifecycle`
+  * `InstanceType`
+  * `KernelId`
+  * `KeyName`
+  * `LaunchTime`
+  * `Platform`
+  * `PrivateDnsName`
+  * `PrivateIpAddress`
+  * `PublicDnsName`
+  * `PublicIpAddress`
+  * `RamdiskId`
+  * `RootDeviceName`
+  * `RootDeviceType`
+  * `SourceDestCheck`
+  * `SpotInstanceRequestId`
+  * `SriovNetSupport`
+  * `SubnetId`
+  * `VirtualizationType`
+  * `VpcId`
+
+Tags can be selected by prepending the tag name with `Tags.`
+
+Example `ec2_instance_attribute()` query
+
+    ec2_instance_attribute(us-east-1, Tags.Name, { "tag:Team": [ "sysops" ] })
 
 ## Cost
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -260,7 +260,17 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
         return this.performEC2DescribeInstances(region, filters, null).then(function(result) {
           var attributes = _.chain(result.Reservations)
           .map(function(reservations) {
-            return _.map(reservations.Instances, targetAttributeName);
+            return _.map(reservations.Instances, function(instance) {
+              var tags = {};
+              _.each(instance.Tags, function(tag) {
+                tags[tag.Key] = tag.Value;
+              });
+              instance.Tags = tags;
+              return instance;
+            });
+          })
+          .map(function(instances) {
+            return _.map(instances, targetAttributeName);
           })
           .flatten().uniq().sortBy().value();
           return transformSuggestData(attributes);

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -318,4 +318,38 @@ describe('CloudWatchDatasource', function() {
       expect(scenario.request.data.action).to.be('ListMetrics');
     });
   });
+
+  describeMetricFindQuery('ec2_instance_attribute(us-east-1, Tags.Name, { "tag:team": [ "sysops" ] })', scenario => {
+    scenario.setup(() => {
+      scenario.requestResponse = {
+        Reservations: [
+          {
+            Instances: [
+              {
+                Tags: [
+                  { Key: 'InstanceId', Value: 'i-123456' },
+                  { Key: 'Name', Value: 'Sysops Dev Server' },
+                  { Key: 'env', Value: 'dev' },
+                  { Key: 'team', Value: 'sysops' }
+                ]
+              },
+              {
+                Tags: [
+                  { Key: 'InstanceId', Value: 'i-789012' },
+                  { Key: 'Name', Value: 'Sysops Staging Server' },
+                  { Key: 'env', Value: 'staging' },
+                  { Key: 'team', Value: 'sysops' }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+    });
+
+    it('should return the "Name" tag for each instance', function() {
+      expect(scenario.result[0].text).to.be('Sysops Dev Server');
+      expect(scenario.result[1].text).to.be('Sysops Staging Server');
+    });
+  });
 });


### PR DESCRIPTION
Tags come back from AWS as a key value pair inside an array
This array is now converted to an object
Tags can be selected when using the 'ec2_instance_attribute' query
Example: `ec2_instance_attribute(us-east-1, Tags.Name, { "tag:Grafana": [ "true" ] })`

Fixes #7294 
