### PR TITLE
Internationalise keybindings

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -74,7 +74,7 @@ export class KeybindingSrv {
       evt.stopPropagation();
       evt.returnValue = false;
       return this.$rootScope.$apply(fn.bind(this));
-    });
+    }, 'keydown');
   }
 
   showDashEditView(view) {


### PR DESCRIPTION
You can not use keybindings while in non-latin keyboard layout. Tested this on [demo site](http://play.grafana.org).

Grafana uses [Mousetrap](https://craig.is/killing/mice) for keybindings. We need to listen to `keydown` event in order to bind to keyboard key press, not character input.