### PR TITLE
Rename fielddata_fields to docvalue_fields

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -119,7 +119,7 @@ function (queryDef) {
     }
 
     query.script_fields = {},
-    query.fielddata_fields = [this.timeField];
+    query.docvalue_fields = [this.timeField];
     return query;
   };
 


### PR DESCRIPTION
The parameter fielddata_fields is deprecated and removed in elasticsearch 5.0 https://github.com/elastic/elasticsearch/issues/19027
