### PR TITLE
[Bug] Coloring Background on siglestat panel #7242

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -569,8 +569,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       var body = panel.gauge.show ? '' : getBigValueHtml();
 
-      if (panel.colorBackground && !isNaN(data.valueRounded)) {
-        var color = getColorForValue(data, data.valueRounded);
+      if (panel.colorBackground && !isNaN(data.value)) {
+        var color = getColorForValue(data, data.value);
         if (color) {
           $panelContainer.css('background-color', color);
           if (scope.fullscreen) {


### PR DESCRIPTION
This bug was not limited to percent. It could be reproduced with any other formatting. 
What happened is the background color comparison was done by comparing the rounded value (accounting the user defined decimals) against the thresholds. In this case, 0.89 rounded to 0 decimals equals 1, hence the color.
I checked the table functionality and noted that the table does not account for user defined decimals when color coding thresholds, and the value color option doesn't as well (in the singlestat panel). Therefore, the fix here was simply making the background use the pure value, instead of the rounded one.

https://github.com/grafana/grafana/issues/7242
