### PR TITLE
Can't remove default avg column in table #4515

### DIFF
--- a/public/app/plugins/panel/table/editor.ts
+++ b/public/app/plugins/panel/table/editor.ts
@@ -53,6 +53,10 @@ export class TablePanelEditorCtrl {
 
   transformChanged() {
     this.panel.columns = [];
+    if (this.panel.transform === 'timeseries_aggregations') {
+      this.panel.columns.push({text: 'Avg', value: 'avg'});
+    }
+
     this.render();
   }
 

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -89,10 +89,6 @@ transformers['timeseries_aggregations'] = {
     var i, y;
     model.columns.push({text: 'Metric'});
 
-    if (panel.columns.length === 0) {
-      panel.columns.push({text: 'Avg', value: 'avg'});
-    }
-
     for (i = 0; i < panel.columns.length; i++) {
       model.columns.push({text: panel.columns[i].text});
     }


### PR DESCRIPTION
Avg column was being added at every rendering, if the table was empty.
Now the column will be added once as an initialization when selecting a
'timeseries_aggregations' transform.

https://github.com/grafana/grafana/issues/4515
