### PR TITLE
Fix dropcounter option, is called dropResets

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -191,7 +191,7 @@ func (e *OpenTsdbExecutor) buildMetric(query *tsdb.Query) map[string]interface{}
 		}
 
 		if !counterMaxCheck && (!resetValueCheck || resetValue.MustFloat64() == 0) {
-			rateOptions["dropcounter"] = true
+			rateOptions["dropResets"] = true
 		}
 
 		metric["rateOptions"] = rateOptions


### PR DESCRIPTION
Fixes #8255 regression introduced in #7743 

Verification via a test in opentsdb code base, same query as in #8255

Failing one

```
$ git diff -U1
diff --git a/test/tsd/TestHttpJsonSerializer.java b/test/tsd/TestHttpJsonSerializer.java
index fc8acad..cf1ebf0 100644
--- a/test/tsd/TestHttpJsonSerializer.java
+++ b/test/tsd/TestHttpJsonSerializer.java
@@ -132,2 +132,14 @@ public final class TestHttpJsonSerializer {
   @Test
+  public void parseQueryRateOptionsV1() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "", 
+        "{\"queries\": [ { \"aggregator\": \"max\", \"downsample\": \"1m-avg\", \"metric\": \"proc.net.bytes\", \"rate\": true, \"rateOptions\": { \"counter\": false, \"dropcounter\": true } } ]}", "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    TSQuery tsq = serdes.parseQueryV1();
+    assertNotNull(tsq);
+  }
+  
+  @Test
   public void parseSuggestV1() throws Exception {
$ ./build.sh check test_SRC=test/tsd/TestHttpJsonSerializer.java
---cut--
Caused by: java.lang.IllegalArgumentException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "dropcounter" (class net.opentsdb.core.RateOptions), not marked as ignorable (5 known properties: "resetValue", "isCounter", "dropResets", "counterMax", "counter"])
 at [Source: {"queries": [ { "aggregator": "max", "downsample": "1m-avg", "metric": "proc.net.bytes", "rate": true, "rateOptions": { "counter": false, "dropcounter": true } } ]}; line: 1, column: 158] (through reference chain: net.opentsdb.core.TSQuery["queries"]->java.util.ArrayList[0]->net.opentsdb.core.TSSubQuery["rateOptions"]->net.opentsdb.core.RateOptions["dropcounter"])
	at net.opentsdb.utils.JSON.parseToObject(JSON.java:112)
	at net.opentsdb.tsd.HttpJsonSerializer.parseQueryV1(HttpJsonSerializer.java:230)
	... 38 more
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "dropcounter" (class net.opentsdb.core.RateOptions), not marked as ignorable (5 known properties: "resetValue", "isCounter", "dropResets", "counterMax", "counter"])
 at [Source: {"queries": [ { "aggregator": "max", "downsample": "1m-avg", "metric": "proc.net.bytes", "rate": true, "rateOptions": { "counter": false, "dropcounter": true } } ]}; line: 1, column: 158] (through reference chain: net.opentsdb.core.TSQuery["queries"]->java.util.ArrayList[0]->net.opentsdb.core.TSSubQuery["rateOptions"]->net.opentsdb.core.RateOptions["dropcounter"])
--cut--
```

Succeeding one

```
$ git diff -U1
diff --git a/test/tsd/TestHttpJsonSerializer.java b/test/tsd/TestHttpJsonSerializer.java
index fc8acad..e878833 100644
--- a/test/tsd/TestHttpJsonSerializer.java
+++ b/test/tsd/TestHttpJsonSerializer.java
@@ -132,2 +132,14 @@ public final class TestHttpJsonSerializer {
   @Test
+  public void parseQueryRateOptionsV1() throws Exception {
+    HttpQuery query = NettyMocks.postQuery(tsdb, "", 
+        "{\"queries\": [ { \"aggregator\": \"max\", \"downsample\": \"1m-avg\", \"metric\": \"proc.net.bytes\", \"rate\": true, \"rateOptions\": { \"counter\": false, \"dropResets\": true } } ]}", "");
+    HttpJsonSerializer serdes = new HttpJsonSerializer(query);
+    TSQuery tsq = serdes.parseQueryV1();
+    assertNotNull(tsq);
+  }
+  
+  @Test
   public void parseSuggestV1() throws Exception {
$ ./build.sh check test_SRC=test/tsd/TestHttpJsonSerializer.java
--cut--
OK (38 tests)

======================
  All 1 tests passed  
======================
make[2]: Leaving directory '/home/cpk/src/java/opentsdb/build'
make[1]: Leaving directory '/home/cpk/src/java/opentsdb/build'
```

