### PR TITLE
Fix http logging `time_ms` unit is wrong

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -49,9 +49,9 @@ func Logger() macaron.Handler {
 		if ctx, ok := c.Data["ctx"]; ok {
 			ctxTyped := ctx.(*Context)
 			if status == 500 {
-				ctxTyped.Logger.Error("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", timeTakenMs, "size", rw.Size())
+				ctxTyped.Logger.Error("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", int64(timeTakenMs), "size", rw.Size())
 			} else {
-				ctxTyped.Logger.Info("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", timeTakenMs, "size", rw.Size())
+				ctxTyped.Logger.Info("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", int64(timeTakenMs), "size", rw.Size())
 			}
 		}
 	}


### PR DESCRIPTION
In fact, the unit of `time_ms` int http logging is not "ms", this patch fix it.

Before this patch the logging looks like:
```
t=2017-05-11T13:03:09+0800 lvl=info msg="Request Completed" logger=context userId=12 orgId=1 uname=chenjr method=POST path=/render status=200 remote_addr=30.30.32.2 time_ms=1.676µs size=577
```

after looks like:
```
t=2017-05-11T13:03:09+0800 lvl=info msg="Request Completed" logger=context userId=12 orgId=1 uname=chenjr method=POST path=/render status=200 remote_addr=30.30.32.2 time_ms=1676 size=577
```