### PR TITLE
Make table panel display JSON string properly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "angular-sanitize": "1.6.1",
     "angular-native-dragdrop": "1.2.2",
     "angular-bindonce": "0.3.3",
-    "clipboard": "^1.5.16"
+    "clipboard": "^1.5.16",
+    "json-formatter-js": "^2.2.0"
   }
 }

--- a/public/app/headers/common.d.ts
+++ b/public/app/headers/common.d.ts
@@ -72,3 +72,8 @@ declare module 'd3' {
   var d3: any;
   export default d3;
 }
+
+declare module 'json-formatter-js' {
+  var JSONFormatter: any;
+  export default JSONFormatter;
+}

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -4,6 +4,11 @@ import _ from 'lodash';
 import moment from 'moment';
 import kbn from 'app/core/utils/kbn';
 
+interface EscapeJSON {
+  success: boolean;
+  result: string;
+}
+
 export class TableRenderer {
   formaters: any[];
   colorState: any;
@@ -136,7 +141,30 @@ export class TableRenderer {
       this.table.columns[columnIndex].hidden = false;
     }
 
-    return '<td' + style + '>' + value + widthHack + '</td>';
+    function isJSON(value: string): EscapeJSON {
+      try {
+        return {
+          success: true,
+          result: JSON.parse(_.unescape(value))
+        };
+      } catch (e) {
+        return {
+          success: false,
+          result: value
+        };
+      }
+    }
+
+    function formatJSON(value: string): string {
+      const jsonString = isJSON(value);
+      // To prevent a number from being stringified
+      if (jsonString.success && isNaN(Number.parseFloat(jsonString.result))) {
+        return '<pre>' + JSON.stringify(jsonString.result, null, 2) + '</pre>';
+      } else {
+        return jsonString.result;
+      }
+    }
+    return '<td' + style + '><div>' + formatJSON(value) + widthHack + '</div></td>';
   }
 
   render(page) {

--- a/public/app/plugins/panel/table/specs/renderer_specs.ts
+++ b/public/app/plugins/panel/table/specs/renderer_specs.ts
@@ -65,72 +65,89 @@ describe('when rendering table', () => {
 
     it('time column should be formated', () => {
       var html = renderer.renderCell(0, 1388556366666);
-      expect(html).to.be('<td>2014-01-01T06:06:06Z</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('2014-01-01T06:06:06Z');
     });
 
     it('undefined time column should be rendered as -', () => {
       var html = renderer.renderCell(0, undefined);
-      expect(html).to.be('<td>-</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('-');
     });
 
     it('null time column should be rendered as -', () => {
       var html = renderer.renderCell(0, null);
-      expect(html).to.be('<td>-</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('-');
     });
 
     it('number column with unit specified should ignore style unit', () => {
       var html = renderer.renderCell(5, 1230);
-      expect(html).to.be('<td>1.23 kbps</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('1.23 kbps');
     });
 
     it('number column should be formated', () => {
       var html = renderer.renderCell(1, 1230);
-      expect(html).to.be('<td>1.230 s</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('1.230 s');
     });
 
     it('number style should ignore string values', () => {
       var html = renderer.renderCell(1, 'asd');
-      expect(html).to.be('<td>asd</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('asd');
     });
 
     it('colored cell should have style', () => {
       var html = renderer.renderCell(2, 40);
-      expect(html).to.be('<td style="color:green">40.0</td>');
+      expect(html.is("td"));
+      expect(html.css('color')).to.be('green');
+      expect(html.html()).to.be('40.0');
     });
 
     it('colored cell should have style', () => {
       var html = renderer.renderCell(2, 55);
-      expect(html).to.be('<td style="color:orange">55.0</td>');
+      expect(html.is("td"));
+      expect(html.css('color')).to.be('orange');
+      expect(html.html()).to.be('55.0');
     });
 
     it('colored cell should have style', () => {
       var html = renderer.renderCell(2, 85);
-      expect(html).to.be('<td style="color:red">85.0</td>');
+      expect(html.is("td"));
+      expect(html.css('color')).to.be('red');
+      expect(html.html()).to.be('85.0');
     });
 
-    it('unformated undefined should be rendered as string', () => {
+    it('unformatted undefined should be rendered as string', () => {
       var html = renderer.renderCell(3, 'value');
-      expect(html).to.be('<td>value</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('value');
     });
 
     it('string style with escape html should return escaped html', () => {
       var html = renderer.renderCell(4, "&breaking <br /> the <br /> row");
-      expect(html).to.be('<td>&amp;breaking &lt;br /&gt; the &lt;br /&gt; row</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('&amp;breaking &lt;br /&gt; the &lt;br /&gt; row');
     });
 
-    it('undefined formater should return escaped html', () => {
+    it('undefined formatter should return escaped html', () => {
       var html = renderer.renderCell(3, "&breaking <br /> the <br /> row");
-      expect(html).to.be('<td>&amp;breaking &lt;br /&gt; the &lt;br /&gt; row</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('&amp;breaking &lt;br /&gt; the &lt;br /&gt; row');
     });
 
     it('undefined value should render as -', () => {
       var html = renderer.renderCell(3, undefined);
-      expect(html).to.be('<td></td>');
+      expect(html.is("td"));
+      expect(html.text()).to.be('');
     });
 
     it('sanitized value should render as', () => {
       var html = renderer.renderCell(6, 'text <a href="http://google.com">link</a>');
-      expect(html).to.be('<td>sanitized</td>');
+      expect(html.is("td"));
+      expect(html.html()).to.be('sanitized');
     });
   });
 });

--- a/public/app/system.conf.js
+++ b/public/app/system.conf.js
@@ -32,7 +32,8 @@ System.config({
     "jquery.flot.fillbelow": "vendor/flot/jquery.flot.fillbelow",
     "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge",
     "d3": "vendor/d3/d3.js",
-    "jquery.flot.dashes": "vendor/flot/jquery.flot.dashes"
+    "jquery.flot.dashes": "vendor/flot/jquery.flot.dashes",
+    "json-formatter-js": "vendor/json-formatter-js/dist/json-formatter"
   },
 
   packages: {

--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -1,4 +1,6 @@
 .table-panel-wrapper {
+  // Make text on a table panel selectable
+  user-select: text;
   .panel-content {
     padding: 0;
   }

--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -67,6 +67,7 @@
     padding: 0.45em 0 0.45em 1.1em;
     border-bottom: 2px solid $body-bg;
     border-right: 2px solid $body-bg;
+    vertical-align: top;
 
     &:first-child {
       padding-left: 15px;

--- a/public/test/test-main.js
+++ b/public/test/test-main.js
@@ -40,7 +40,8 @@
       "jquery.flot.fillbelow": "vendor/flot/jquery.flot.fillbelow",
       "jquery.flot.gauge": "vendor/flot/jquery.flot.gauge",
       "d3": "vendor/d3/d3.js",
-      "jquery.flot.dashes": "vendor/flot/jquery.flot.dashes"
+      "jquery.flot.dashes": "vendor/flot/jquery.flot.dashes",
+      "json-formatter-js": "vendor/json-formatter-js/dist/json-formatter"
     },
 
     packages: {


### PR DESCRIPTION
Refer to following feature request #8327 and #2083

- Now text on table panel should be selectable #2083 
It was solved by adding `user-select: text;` to **.table-panel-wrapper** as suggested by @valhallasw 

- Cell value that is a JSON string will be displayed as a collapsible JSON tree.
JSON string will be displayed as a JSON tree, which can be switched to JSON formatted text with a single click of a button. This change doesn't affect any text that isn't a JSON string.
The tree is implemented with [json-formatter-js](https://github.com/mohsen1/json-formatter-js).

BTW, there are typos in function names and variables containing the word "formater". Should they be corrected to "formatter"?
Take **TableRenderer**'s **formaters** as an example.