### PR TITLE
ES: Add timezone option to date histogram, solves #6222

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.js
@@ -120,6 +120,10 @@ function (angular, _, queryDef) {
           $scope.agg.field = $scope.target.timeField;
           settingsLinkText = 'Interval: ' + settings.interval;
 
+          if (settings.time_zone) {
+            settingsLinkText += ', Time Zone: ' + settings.time_zone;
+          }
+
           if (settings.min_doc_count > 0) {
             settingsLinkText += ', Min Doc Count: ' + settings.min_doc_count;
           }

--- a/public/app/plugins/datasource/elasticsearch/datasource.js
+++ b/public/app/plugins/datasource/elasticsearch/datasource.js
@@ -224,8 +224,8 @@ function (angular, _, moment, kbn, ElasticQueryBuilder, IndexPattern, ElasticRes
         return $q.when([]);
       }
 
-      payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
-      payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());
+      payload = payload.replace(/"\$timeFrom"/g, options.range.from.valueOf());
+      payload = payload.replace(/"\$timeTo"/g, options.range.to.valueOf());
       payload = templateSrv.replace(payload, options.scopedVars);
 
       return this._post('_msearch', payload).then(function(res) {

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -36,6 +36,11 @@
 			<metric-segment-model property="agg.settings.interval" get-options="getIntervalOptions()" on-change="onChangeInternal()" css-class="width-12" custom="true"></metric-segment-model>
 		</div>
 
+                <div class="gf-form offset-width-7">
+                        <label class="gf-form-label width-10">Time Zone</label>
+                        <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.time_zone" ng-blur="onChangeInternal()">
+                </div>
+
 		<div class="gf-form offset-width-7">
 			<label class="gf-form-label width-10">Min Doc Count</label>
 			<input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.min_doc_count" ng-blur="onChangeInternal()">

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -72,6 +72,10 @@ function (queryDef) {
       esAgg.interval = "$__interval";
     }
 
+    if (settings.time_zone) {
+      esAgg.time_zone = settings.time_zone;
+    }
+
     if (settings.missing) {
       esAgg.missing = settings.missing;
     }


### PR DESCRIPTION
This PR adds a time zone option for the date histograms in elasticsearch.
I think it still needs to support an "auto" value, so it takes automatically whatever timezone you have defined for your dashboard.
It solves feature request #6222 