### PR TITLE
remove X-Forwarded-* headers added by nginx when proxying data source & plugin requests

### DIFF
--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -63,11 +64,23 @@ func NewReverseProxy(ds *m.DataSource, proxyPath string, targetUrl *url.URL) *ht
 		req.Header.Del("Cookie")
 		req.Header.Del("Set-Cookie")
 
-		// clear X-Forwarded headers
-		req.Header.Del("X-Forwarded-For")
+		// clear X-Forwarded Host/Port/Proto headers
 		req.Header.Del("X-Forwarded-Host")
 		req.Header.Del("X-Forwarded-Port")
 		req.Header.Del("X-Forwarded-Proto")
+
+		// set X-Forwarded-For header
+		if req.RemoteAddr != "" {
+			remoteAddr, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				remoteAddr = req.RemoteAddr
+			}
+			if req.Header.Get("X-Forwarded-For") != "" {
+				req.Header.Set("X-Forwarded-For", req.Header.Get("X-Forwarded-For")+", "+remoteAddr)
+			} else {
+				req.Header.Set("X-Forwarded-For", remoteAddr)
+			}
+		}
 
 		// reqBytes, _ := httputil.DumpRequestOut(req, true);
 		// log.Trace("Proxying datasource request: %s", string(reqBytes))

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -62,6 +62,15 @@ func NewReverseProxy(ds *m.DataSource, proxyPath string, targetUrl *url.URL) *ht
 		// clear cookie headers
 		req.Header.Del("Cookie")
 		req.Header.Del("Set-Cookie")
+
+		// clear X-Forwarded headers
+		req.Header.Del("X-Forwarded-For")
+		req.Header.Del("X-Forwarded-Host")
+		req.Header.Del("X-Forwarded-Port")
+		req.Header.Del("X-Forwarded-Proto")
+
+		// reqBytes, _ := httputil.DumpRequestOut(req, true);
+		// log.Trace("Proxying datasource request: %s", string(reqBytes))
 	}
 
 	return &httputil.ReverseProxy{Director: director, FlushInterval: time.Millisecond * 200}

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -71,13 +72,25 @@ func NewApiPluginProxy(ctx *middleware.Context, proxyPath string, route *plugins
 		req.Header.Del("Cookie")
 		req.Header.Del("Set-Cookie")
 
-		// clear X-Forwarded headers
-		req.Header.Del("X-Forwarded-For")
+		// clear X-Forwarded Host/Port/Proto headers
 		req.Header.Del("X-Forwarded-Host")
 		req.Header.Del("X-Forwarded-Port")
 		req.Header.Del("X-Forwarded-Proto")
 
-		//Create a HTTP header with the context in it.
+		// set X-Forwarded-For header
+		if req.RemoteAddr != "" {
+			remoteAddr, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				remoteAddr = req.RemoteAddr
+			}
+			if req.Header.Get("X-Forwarded-For") != "" {
+				req.Header.Set("X-Forwarded-For", req.Header.Get("X-Forwarded-For")+", "+remoteAddr)
+			} else {
+				req.Header.Set("X-Forwarded-For", remoteAddr)
+			}
+		}
+
+		// Create a HTTP header with the context in it.
 		ctxJson, err := json.Marshal(ctx.SignedInUser)
 		if err != nil {
 			ctx.JsonApiErr(500, "failed to marshal context to json.", err)

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -71,6 +71,12 @@ func NewApiPluginProxy(ctx *middleware.Context, proxyPath string, route *plugins
 		req.Header.Del("Cookie")
 		req.Header.Del("Set-Cookie")
 
+		// clear X-Forwarded headers
+		req.Header.Del("X-Forwarded-For")
+		req.Header.Del("X-Forwarded-Host")
+		req.Header.Del("X-Forwarded-Port")
+		req.Header.Del("X-Forwarded-Proto")
+
 		//Create a HTTP header with the context in it.
 		ctxJson, err := json.Marshal(ctx.SignedInUser)
 		if err != nil {
@@ -93,6 +99,8 @@ func NewApiPluginProxy(ctx *middleware.Context, proxyPath string, route *plugins
 			}
 		}
 
+		// reqBytes, _ := httputil.DumpRequestOut(req, true);
+		// log.Trace("Proxying plugin request: %s", string(reqBytes))
 	}
 
 	return &httputil.ReverseProxy{Director: director}


### PR DESCRIPTION
When running Grafana behind an nginx proxy it will add 4 `X-Forwarded-*` headers to each request, which can cause problems when they are passed on to upstream data sources or plugin routes.  This patch removes these headers from requests passing through the data source and plugin proxies.