### PR TITLE
Add kibana like readable label to elasticsearch query builder

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -96,6 +96,8 @@
 			<div class="gf-form">
 				<label class="gf-form-label width-10">Query {{$index + 1}}</label>
 				<input type="text" class="gf-form-input max-width-12" ng-model="filter.query" spellcheck='false' placeholder="Lucene query" ng-blur="onChangeInternal()">
+				<label class="gf-form-label width-10">Label {{$index + 1}}</label>
+				<input type="text" class="gf-form-input max-width-12" ng-model="filter.label" spellcheck='false' placeholder="Readable Label" ng-blur="onChangeInternal()">
 			</div>
 			<div class="gf-form">
 				<label class="gf-form-label" ng-if="$first">

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -96,8 +96,9 @@ function (queryDef) {
     var filterObj = {};
     for (var i = 0; i < aggDef.settings.filters.length; i++) {
       var query = aggDef.settings.filters[i].query;
-
-      filterObj[query] = {
+      var label = aggDef.settings.filters[i].label;
+      label = label==='' || label === undefined?query:label;
+      filterObj[label] = {
         query_string: {
           query: query,
           analyze_wildcard: true


### PR DESCRIPTION
In kibana we can add a label to a filter 

![image](https://cloud.githubusercontent.com/assets/6689676/26232619/10a75656-3c8a-11e7-8198-d454b7cf6a21.png)

I can not find the same thing in grafana,so I made one.

![image](https://cloud.githubusercontent.com/assets/6689676/26232711/bcd57b4c-3c8a-11e7-822c-1620a5b0ead0.png)

