### PR TITLE
Hip Chat notification doesn't include information on what is being alerted on

### DIFF
--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -84,11 +84,14 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		return err
 	}
 
-	message := evalContext.GetNotificationTitle() + " in state " + evalContext.GetStateModel().Text + "<br><a href=" + ruleUrl + ">Check Dasboard</a>"
-	fields := make([]map[string]interface{}, 0)
-	message += "<br>"
+  message := evalContext.GetNotificationTitle() + " in state " + evalContext.GetStateModel().Text
+  cardMessage := message + "\n"
+	message += "<br><a href=" + ruleUrl + ">Check Dasboard</a><br>"
+  fields := make([]map[string]interface{}, 0)
 	for index, evt := range evalContext.EvalMatches {
-		message += evt.Metric + " :: " + strconv.FormatFloat(evt.Value.Float64, 'f', -1, 64) + "<br>"
+    metricValue = evt.Metric + " :: " + strconv.FormatFloat(evt.Value.Float64, 'f', -1, 64)
+		message += metricValue + "<br>"
+    cardMessage += metricValue + "\n"
 		fields = append(fields, map[string]interface{}{
 			"title": evt.Metric,
 			"value": evt.Value,
@@ -109,6 +112,7 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if evalContext.Rule.State != models.AlertStateOK { //dont add message when going back to alert state ok.
 		message += " " + evalContext.Rule.Message
+    cardMessage += " " + evalContext.Rule.Message
 	}
 	//HipChat has a set list of colors
 	var color string
@@ -127,7 +131,7 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"url":         ruleUrl,
 		"id":          "1",
 		"title":       evalContext.GetNotificationTitle(),
-		"description": evalContext.GetNotificationTitle() + " in state " + evalContext.GetStateModel().Text,
+		"description": cardMessage,
 		"icon": map[string]interface{}{
 			"url": "https://grafana.com/assets/img/fav32.png",
 		},

--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -96,7 +96,7 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		return err
 	}
 
-	message := evalContext.GetNotificationTitle() + " in state " + evalContext.GetStateModel().Text + "<br><a href=" + ruleUrl + ">Check Dasboard</a>"
+	message := evalContext.GetNotificationTitle() + " in state " + evalContext.GetStateModel().Text + "<br><a href=" + ruleUrl + ">Check Dashboard</a>"
 	fields := make([]map[string]interface{}, 0)
 	message += "<br>"
 	for index, evt := range evalContext.EvalMatches {

--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -37,11 +37,11 @@ func init() {
           data-placement="right">
         </input>
       </div>
-			<div class="gf-form">
+			<div class="gf-form max-width-30">
         <gf-form-switch
-           class="gf-form"
+           class="gf-form max-width-30"
            label="Plain Text"
-           label-class="width-14"
+           label-class="width-8"
            checked="ctrl.model.settings.plainText"
            tooltip="Send Hip Chat messages as text instead of the default card (Allows for more detailed messages).">
         </gf-form-switch>
@@ -66,7 +66,7 @@ func NewHipChatNotifier(model *models.AlertNotification) (alerting.Notifier, err
 
 	apikey := model.Settings.Get("apikey").MustString()
 	roomId := model.Settings.Get("roomid").MustString()
-	plainText := model.Settings.Get("plainText").MustBool(true)
+	plainText := model.Settings.Get("plainText").MustBool(false)
 
 	return &HipChatNotifier{
 		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),


### PR DESCRIPTION
Raised here: https://github.com/grafana/grafana/issues/8426

Provided the option to send plain text messages to Hip Chat rather than just Cards.

Originally the issue was that Cards did not contain information about the series that was in alerting state, I then realised that a Cards description is truncated and could not contain the additional information that would be useful.

To resolve this issue I have added an option to the Alert setup to allow Hip Chat messages to be sent in plain text message format, rather than as cards.

I am still a little uncertain about the terminology, please let me know if you are unhappy with "Plain Text".

New option to turn off cards
![screen shot 2017-05-19 at 19 09 33](https://cloud.githubusercontent.com/assets/4939016/26260832/ba3fd4a4-3cc6-11e7-9b0b-3c73db4de33e.png)

Original Card Message (which only details alert name)
![screen shot 2017-05-19 at 19 10 17](https://cloud.githubusercontent.com/assets/4939016/26260866/e4e57d62-3cc6-11e7-9d15-1463aefffc46.png)

Plain Text (Non Card) Message (which has additional details about what is being alerted on)
![screen shot 2017-05-19 at 19 10 34](https://cloud.githubusercontent.com/assets/4939016/26260887/fda9c6be-3cc6-11e7-9f28-e7d50b176b73.png)

Truncated Card Message (This was my original attempt, but I backed it out because it was truncated)
![screen shot 2017-05-19 at 19 12 25](https://cloud.githubusercontent.com/assets/4939016/26260928/1eea90f6-3cc7-11e7-853c-98500265ab22.png)

I have signed the CLA.

Sam


