### PR TITLE
Make location for plugins consistent

### DIFF
--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -99,6 +99,6 @@ To manually install a Plugin via the Grafana.com API:
     }
     ```
 
-4. Download the plugin with `https://grafana.com/api/plugins/<plugin id from step 1>/versions/<current version>/download` (for example: https://grafana.com/api/plugins/jdbranham-diagram-panel/versions/1.4.0/download). Unzip the downloaded file into the Grafana Server's `data/plugins` directory.
+4. Download the plugin with `https://grafana.com/api/plugins/<plugin id from step 1>/versions/<current version>/download` (for example: https://grafana.com/api/plugins/jdbranham-diagram-panel/versions/1.4.0/download). Unzip the downloaded file into the Grafana Server's `plugins` directory.
 
 5. Restart the Grafana Server.


### PR DESCRIPTION
Please let me know if this changed in a more recent version of Grafana or if I'm just misreading the documentation, but when using 4.2.0 the manual install directions seemed off a little (there was no `data/plugins` directory, only a `plugins` directory, as in: `/var/lib/grafana/plugins`).

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>
