### PR TITLE
[Issue #4157] fix overflowing panel table headers

### DIFF
--- a/public/app/plugins/panel/table/module.html
+++ b/public/app/plugins/panel/table/module.html
@@ -1,9 +1,8 @@
 
 <div class="table-panel-container">
-	<div class="table-panel-header-bg" ng-show="ctrl.table.rows.length"></div>
 	<div class="table-panel-scroll" ng-show="ctrl.table.rows.length">
 		<table class="table-panel-table">
-			<thead>
+			<thead class="table-panel-header-bg" ng-show="ctrl.table.rows.length">
 				<tr>
 					<th ng-repeat="col in ctrl.table.columns" ng-hide="col.hidden">
 						<div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)">

--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -12,7 +12,7 @@
 }
 
 .table-panel-container {
-  padding-top: 2.2em;
+  border-top: 2px solid $body-bg;
   position: relative;
 }
 
@@ -77,10 +77,8 @@
 
 .table-panel-header-bg {
   background: $grafanaListAccent;
-  border-top: 2px solid $body-bg;
   border-bottom: 2px solid $body-bg;
   height: 2.0em;
-  position: absolute;
   top: 0;
   right: 0;
   left: 0;
@@ -90,7 +88,6 @@
   padding: 0.45em 0 0.45em 1.1em;
   text-align: left;
   color: $blue;
-  position: absolute;
   top: 0;
 }
 


### PR DESCRIPTION
Fixing [Issue #4157](https://github.com/grafana/grafana/issues/4157)
In consequence table's headers are not pinned and the text is folding but not overflowing.