### PR TITLE
minor change: more accurate variable name

### DIFF
--- a/pkg/tsdb/time_range_test.go
+++ b/pkg/tsdb/time_range_test.go
@@ -52,8 +52,8 @@ func TestTimeRange(t *testing.T) {
 			})
 
 			Convey("now-10m ", func() {
-				fiveMinAgo, _ := time.ParseDuration("-10m")
-				expected := now.Add(fiveMinAgo)
+				tenMinAgo, _ := time.ParseDuration("-10m")
+				expected := now.Add(tenMinAgo)
 				res, err := tr.ParseTo()
 				So(err, ShouldBeNil)
 				So(res.Unix(), ShouldEqual, expected.Unix())


### PR DESCRIPTION
This is a minor fix I noticed while looking at the tests, just a variable named differently because or presumably copy-paste from previous block. :) 
