### PR TITLE
Include triggering metrics to pagerduty alerts

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -74,6 +74,16 @@ func (this *PagerdutyNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if evalContext.Rule.State == m.AlertStateOK {
 		eventType = "resolve"
 	}
+	customData := make([]map[string]interface{}, 0)
+	fieldLimitCount := 4
+	for index, evt := range evalContext.EvalMatches {
+		customData = append(customData, map[string]interface{}{
+			evt.Metric: evt.Value,
+		})
+		if index > fieldLimitCount {
+			break
+		}
+	}
 
 	this.log.Info("Notifying Pagerduty", "event_type", eventType)
 
@@ -81,6 +91,7 @@ func (this *PagerdutyNotifier) Notify(evalContext *alerting.EvalContext) error {
 	bodyJSON.Set("service_key", this.Key)
 	bodyJSON.Set("description", evalContext.Rule.Name+" - "+evalContext.Rule.Message)
 	bodyJSON.Set("client", "Grafana")
+	bodyJSON.Set("details", customData)
 	bodyJSON.Set("event_type", eventType)
 	bodyJSON.Set("incident_key", "alertId-"+strconv.FormatInt(evalContext.Rule.Id, 10))
 


### PR DESCRIPTION
Assist the person receiving the alert in identifying the cause

Based on the slack notifier fields this will include up to 4 triggering
metrics in the custom details section in the pagerduty incident

Fixes #8479
