### PR TITLE
tweak column lengths for utf8mb4 support on older mysql

### DIFF
--- a/pkg/services/sqlstore/migrations/alert_mig.go
+++ b/pkg/services/sqlstore/migrations/alert_mig.go
@@ -16,7 +16,7 @@ func addAlertMigrations(mg *Migrator) {
 			{Name: "org_id", Type: DB_BigInt, Nullable: false},
 			{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
 			{Name: "message", Type: DB_Text, Nullable: false},
-			{Name: "state", Type: DB_NVarchar, Length: 255, Nullable: false},
+			{Name: "state", Type: DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "settings", Type: DB_Text, Nullable: false},
 			{Name: "frequency", Type: DB_BigInt, Nullable: false},
 			{Name: "handler", Type: DB_BigInt, Nullable: false},
@@ -70,7 +70,7 @@ func addAlertMigrations(mg *Migrator) {
 	mg.AddMigration("Update alert table charset", NewTableCharsetMigration("alert", []*Column{
 		{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
 		{Name: "message", Type: DB_Text, Nullable: false},
-		{Name: "state", Type: DB_NVarchar, Length: 255, Nullable: false},
+		{Name: "state", Type: DB_NVarchar, Length: 190, Nullable: false},
 		{Name: "settings", Type: DB_Text, Nullable: false},
 		{Name: "severity", Type: DB_Text, Nullable: false},
 		{Name: "execution_error", Type: DB_Text, Nullable: false},

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -56,7 +56,7 @@ func addDashboardMigration(mg *Migrator) {
 		Columns: []*Column{
 			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "version", Type: DB_Int, Nullable: false},
-			{Name: "slug", Type: DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "slug", Type: DB_NVarchar, Length: 189, Nullable: false},
 			{Name: "title", Type: DB_NVarchar, Length: 255, Nullable: false},
 			{Name: "data", Type: DB_Text, Nullable: false},
 			{Name: "org_id", Type: DB_BigInt, Nullable: false},
@@ -127,7 +127,7 @@ func addDashboardMigration(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Update dashboard table charset", NewTableCharsetMigration("dashboard", []*Column{
-		{Name: "slug", Type: DB_NVarchar, Length: 190, Nullable: false},
+		{Name: "slug", Type: DB_NVarchar, Length: 189, Nullable: false},
 		{Name: "title", Type: DB_NVarchar, Length: 255, Nullable: false},
 		{Name: "plugin_id", Type: DB_NVarchar, Nullable: true, Length: 255},
 		{Name: "data", Type: DB_MediumText, Nullable: false},

--- a/pkg/services/sqlstore/migrations/temp_user.go
+++ b/pkg/services/sqlstore/migrations/temp_user.go
@@ -9,10 +9,10 @@ func addTempUserMigrations(mg *Migrator) {
 			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "org_id", Type: DB_BigInt, Nullable: false},
 			{Name: "version", Type: DB_Int, Nullable: false},
-			{Name: "email", Type: DB_NVarchar, Length: 255},
+			{Name: "email", Type: DB_NVarchar, Length: 190},
 			{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: true},
 			{Name: "role", Type: DB_NVarchar, Length: 20, Nullable: true},
-			{Name: "code", Type: DB_NVarchar, Length: 255},
+			{Name: "code", Type: DB_NVarchar, Length: 190},
 			{Name: "status", Type: DB_Varchar, Length: 20},
 			{Name: "invited_by_user_id", Type: DB_BigInt, Nullable: true},
 			{Name: "email_sent", Type: DB_Bool},
@@ -37,10 +37,10 @@ func addTempUserMigrations(mg *Migrator) {
 	addTableIndicesMigrations(mg, "v1-7", tempUserV1)
 
 	mg.AddMigration("Update temp_user table charset", NewTableCharsetMigration("temp_user", []*Column{
-		{Name: "email", Type: DB_NVarchar, Length: 255},
+		{Name: "email", Type: DB_NVarchar, Length: 190},
 		{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: true},
 		{Name: "role", Type: DB_NVarchar, Length: 20, Nullable: true},
-		{Name: "code", Type: DB_NVarchar, Length: 255},
+		{Name: "code", Type: DB_NVarchar, Length: 190},
 		{Name: "status", Type: DB_Varchar, Length: 20},
 		{Name: "remote_addr", Type: DB_Varchar, Length: 255, Nullable: true},
 	}))


### PR DESCRIPTION
Fixes #8450 

dashboard.slug needs to be 189 because it's part of a compound index.