### PR TITLE
Frontend query changes corresponding #8336

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.js
+++ b/public/app/plugins/datasource/opentsdb/datasource.js
@@ -28,8 +28,8 @@ function (angular, _, dateMath) {
 
       _.each(options.targets, function(target) {
         if (!target.metric) { return; }
-        qs.push(convertTargetToQuery(target, options));
-      });
+        qs.push(convertTargetToQuery(target, options, this.tsdbVersion));
+      }.bind(this));
 
       var queries = _.compact(qs);
 
@@ -366,7 +366,7 @@ function (angular, _, dateMath) {
       return label;
     }
 
-    function convertTargetToQuery(target, options) {
+    function convertTargetToQuery(target, options, tsdbVersion) {
       if (!target.metric || target.hide) {
         return null;
       }
@@ -392,6 +392,11 @@ function (angular, _, dateMath) {
 
         if (target.counterResetValue && target.counterResetValue.length) {
           query.rateOptions.resetValue = parseInt(target.counterResetValue);
+        }
+
+        if(tsdbVersion >= 2) {
+          query.rateOptions.dropResets = !query.rateOptions.counterMax &&
+                (!query.rateOptions.ResetValue || query.rateOptions.ResetValue === 0);
         }
       }
 


### PR DESCRIPTION
#8336 only did API/Server fixes, this adds same query functionality at frontend

Graph before
![2017-05-29-215125_1690x559_scrot](https://cloud.githubusercontent.com/assets/629631/26556869/d010f622-44ba-11e7-9b76-23ec4a617626.png)

Graph After
![2017-05-29-220936_1696x552_scrot](https://cloud.githubusercontent.com/assets/629631/26556970/8ed13ca2-44bb-11e7-8b53-4359e73212c3.png)

Sorry about the scattered PRs, assumed the API/Server backend was firing queries.