### PR TITLE
table: addition of grouping to rows and columns transformation

### DIFF
--- a/docs/sources/features/panels/table_panel.md
+++ b/docs/sources/features/panels/table_panel.md
@@ -49,6 +49,12 @@ In the most simple mode you can turn time series to rows. This means you get a `
 
 This transform allows you to take multiple time series and group them by time. Which will result in the primary column being `Time` and a column for each time series.
 
+### Grouping to matrix
+
+![](/img/docs/v2/table_grouping_to_matrix.png)
+
+This table transformation will represent the groupings as a matrix. The first grouping will be set to the columns and the second grouping to the rows.
+
 ### Time series aggregations
 
 ![](/img/docs/v2/table_ts_to_aggregations2.png)

--- a/public/app/plugins/panel/table/specs/transformers_specs.ts
+++ b/public/app/plugins/panel/table/specs/transformers_specs.ts
@@ -71,6 +71,65 @@ describe('when transforming time series table', () => {
       });
     });
 
+    describe('grouping_to_matrix', () => {
+      var panel = {
+        transform: 'grouping_to_matrix'
+      };
+
+      var timeSeries = [
+        {
+          target: 'measure {x: a, y: i}',
+          datapoints: [[1, 7]]
+        },
+        {
+          target: 'measure {x: a, y: j}',
+          datapoints: [[2, 7]]
+        },
+        {
+          target: 'measure {x: a, y: k}',
+          datapoints: [[3, 7]]
+        },
+        {
+          target: 'measure {x: b, y: i}',
+          datapoints: [[4, 7]]
+        },
+        {
+          target: 'measure {x: b, y: k}',
+          datapoints: [[5, 7]]
+        }
+      ];
+
+      beforeEach(() => {
+        table = transformDataToTable(timeSeries, panel);
+      });
+
+      it ('should return 2 columns', () => {
+        expect(table.columns.length).to.be(3);
+        expect(table.columns[0].text).to.be('');
+        expect(table.columns[1].text).to.be('a');
+        expect(table.columns[2].text).to.be('b');
+      });
+
+      it ('should return 3 rows', () => {
+        expect(table.rows.length).to.be(3);
+        expect(table.rows[0][0]).to.be("i");
+        expect(table.rows[0][1]).to.be(1);
+        expect(table.rows[0][2]).to.be(4);
+
+        expect(table.rows[1][0]).to.be("j");
+        expect(table.rows[1][1]).to.be(2);
+
+        expect(table.rows[2][0]).to.be("k");
+        expect(table.rows[2][1]).to.be(3);
+        expect(table.rows[2][2]).to.be(5);
+
+      });
+
+      it ('should be undefined when no value that grouping', () => {
+        expect(table.rows[1][2]).to.be(undefined);
+      });
+    });
+
     describe('timeseries_aggregations', () => {
       var panel = {
         transform: 'timeseries_aggregations',

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -73,6 +73,60 @@ transformers['timeseries_to_columns'] = {
   }
 };
 
+transformers['grouping_to_matrix'] = {
+  description: 'Grouping to matrix',
+  getColumns: function() {
+    return [];
+  },
+  transform: function(data, panel, model) {
+    // Getting the columns
+    const points = new Map<string, Map<string, any>>();
+
+    const columns = new Set<string>();
+    const rows = new Set<string>();
+
+    for (let series of data) {
+      const columnsString = series.target.slice(
+        series.target.indexOf('{') + 1, -1);
+      const columnsArray = columnsString.split(', ');
+      const column = columnsArray[0].split(': ')[1];
+      const row = columnsArray[1].split(': ')[1];
+      columns.add(column);
+      rows.add(row);
+
+      if (!points.has(column)) {
+        points.set(column, new Map<string, any>());
+      }
+
+      // We take only the first measure reported (datapoints[0]) and
+      // we don't care about the timestamp of that measure (datapoints[0][0])
+      points.get(column).set(row, series.datapoints[0][0]);
+    }
+
+    // Removing the empty or 0-only rows and columns
+    /*const filteredRows = Array.from(rows.values()).filter(
+      r => points.has(r) && Array.from(points.get(r).values()).reduce(
+        (p, c) => p || c !== 0, false));
+
+    const filteredColumns = Array.from(columns.values()).filter(
+      c => Array.from(points.values()).reduce(
+        (p, r) => p || (r.has(c) && r.get(c) !== 0), false));*/
+
+    const filteredRows = Array.from(rows.values()).sort((a, b) => a.localeCompare(b));
+    const filteredColumns = Array.from(columns.values()).sort((a, b) => a.localeCompare(b));
+
+    // Addition of columns and rows to the model.
+    model.columns.push({text: ''});
+    filteredColumns.forEach(c => model.columns.push({text: c}));
+
+    filteredRows.forEach(r =>
+      model.rows.push([r].concat(filteredColumns.map(
+        c => points.has(c) && points.get(c).has(r) ?
+          points.get(c).get(r) : undefined)))
+    );
+  }
+};
+
 transformers['timeseries_aggregations'] = {
   description: 'Time series aggregations',
   getColumns: function() {


### PR DESCRIPTION
* Adds a new transformation that sets the first grouping as column and
  the second grouping as rows. (refers #7169)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>
