### PR TITLE
[Feature Request] [elasticsearch] Add option for result set size in raw_document

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -103,6 +103,8 @@ function (angular, _, queryDef) {
           break;
         }
         case 'raw_document': {
+          $scope.agg.settings.size = $scope.agg.settings.size || 500;
+          $scope.settingsLinkText = 'Size: ' + $scope.agg.settings.size ;
           $scope.target.metrics = [$scope.agg];
           $scope.target.bucketAggs = [];
           break;

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.js
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.js
@@ -67,7 +67,6 @@ function (angular, _, queryDef) {
       } else if (!$scope.agg.field) {
         $scope.agg.field = 'select field';
       }
-
       switch($scope.agg.type) {
         case 'cardinality': {
           var precision_threshold = $scope.agg.settings.precision_threshold || '';
@@ -105,12 +104,12 @@ function (angular, _, queryDef) {
         case 'raw_document': {
           $scope.agg.settings.size = $scope.agg.settings.size || 500;
           $scope.settingsLinkText = 'Size: ' + $scope.agg.settings.size ;
-          $scope.target.metrics = [$scope.agg];
+          $scope.target.metrics.splice(0,$scope.target.metrics.length, $scope.agg);
+
           $scope.target.bucketAggs = [];
           break;
         }
       }
-
       if ($scope.aggDef.supportsInlineScript) {
         // I know this stores the inline script twice
         // but having it like this simplifes the query_builder

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -74,7 +74,7 @@
   </div>
   <div class="gf-form offset-width-7" ng-if="agg.type === 'raw_document'">
     <label class="gf-form-label width-10">Size</label>
-    <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.size" ng-blur="onChange()"></input>
+    <input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.size" ng-blur="onChange()"></input>
   </div>
 
 

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -72,6 +72,11 @@
     <label class="gf-form-label width-10">Percentiles</label>
     <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.percents" array-join ng-blur="onChange()"></input>
   </div>
+  <div class="gf-form offset-width-7" ng-if="agg.type === 'raw_document'">
+    <label class="gf-form-label width-10">Size</label>
+    <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.size" ng-blur="onChange()"></input>
+  </div>
+
 
   <div class="gf-form offset-width-7" ng-if="agg.type === 'cardinality'">
     <label class="gf-form-label width-10">Precision threshold</label>

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -194,11 +194,12 @@ function (queryDef) {
     if (target.bucketAggs.length === 0) {
       metric = target.metrics[0];
       if (metric && metric.type !== 'raw_document') {
-        throw {message: 'Invalid query'};
-      }
-      var size = metric && metric.hasOwnProperty("settings") && metric.settings.hasOwnProperty("size")
+        target.bucketAggs = [{type: 'date_histogram', id: '2', settings: {interval: 'auto'}}];
+      } else {
+        var size = metric && metric.hasOwnProperty("settings") && metric.settings.hasOwnProperty("size")
                    && metric.settings["size"] !== null ? metric.settings["size"] : 500 ;
-      return this.documentQuery(query,size);
+        return this.documentQuery(query,size);
+      }
     }
 
     nestedAggs = query;

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -109,8 +109,8 @@ function (queryDef) {
     return filterObj;
   };
 
-  ElasticQueryBuilder.prototype.documentQuery = function(query) {
-    query.size = 500;
+  ElasticQueryBuilder.prototype.documentQuery = function(query, size) {
+    query.size = size === undefined ? 500 : parseInt(size , 10);
     query.sort = {};
     query.sort[this.timeField] = {order: 'desc', unmapped_type: 'boolean'};
 
@@ -196,7 +196,9 @@ function (queryDef) {
       if (metric && metric.type !== 'raw_document') {
         throw {message: 'Invalid query'};
       }
-      return this.documentQuery(query, target);
+      var size = metric && metric.hasOwnProperty("settings") && metric.settings.hasOwnProperty("size")
+                   && metric.settings["size"] !== null ? metric.settings["size"] : 500 ;
+      return this.documentQuery(query,size);
     }
 
     nestedAggs = query;

--- a/public/app/plugins/datasource/elasticsearch/query_builder.js
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.js
@@ -110,7 +110,7 @@ function (queryDef) {
   };
 
   ElasticQueryBuilder.prototype.documentQuery = function(query, size) {
-    query.size = size === undefined ? 500 : parseInt(size , 10);
+    query.size = size === undefined ? 500 : size;
     query.sort = {};
     query.sort[this.timeField] = {order: 'desc', unmapped_type: 'boolean'};
 

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
@@ -165,7 +165,7 @@ describe('ElasticQueryBuilder', function() {
   });
   it('with raw_document metric size set', function() {
     var query = builder.build({
-      metrics: [{type: 'raw_document', id: '1',settings: {size: '1337'}}],
+      metrics: [{type: 'raw_document', id: '1',settings: {size: 1337}}],
       timeField: '@timestamp',
       bucketAggs: [],
     });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder_specs.ts
@@ -156,12 +156,21 @@ describe('ElasticQueryBuilder', function() {
 
   it('with raw_document metric', function() {
     var query = builder.build({
-      metrics: [{type: 'raw_document', id: '1'}],
+      metrics: [{type: 'raw_document', id: '1',settings: {}}],
       timeField: '@timestamp',
       bucketAggs: [],
     });
 
     expect(query.size).to.be(500);
+  });
+  it('with raw_document metric size set', function() {
+    var query = builder.build({
+      metrics: [{type: 'raw_document', id: '1',settings: {size: '1337'}}],
+      timeField: '@timestamp',
+      bucketAggs: [],
+    });
+
+    expect(query.size).to.be(1337);
   });
 
   it('with moving average', function() {


### PR DESCRIPTION
Hello,

In elasticsearch data source we could get raw document to show them in table panel for example. The size of the query is "hard coded" to 500. I have been faced to many case where i want to increase the limit to fetch more element , or decrease it to get fewer element and faster the panel rendering on large objects. On aggregation  previous commits had added the size parameter to the aggregation, and this pull request do add the size parameter to raw document. 
I add it as option for the metric when "Raw document" is selected 
Also there are 2 fix for interface to make the switch of metric type to and from "raw document" work properly.
Please Tell me if you need the commit in different pull request.


Regards
Dhia
