### PR TITLE
feature: add row background color option; hide row for selected user roles

### DIFF
--- a/public/app/features/dashboard/row/options.html
+++ b/public/app/features/dashboard/row/options.html
@@ -30,5 +30,31 @@
 				<dash-repeat-option model="ctrl.row"></dash-repeat-option>
 			</div>
 		</div>
+		<div class="section">
+			<div class="gf-form">
+				<span class="gf-form-label">Background (light theme)</span>
+				<span class="gf-form-label">
+					<spectrum-picker ng-model="ctrl.row.bgLightTheme" options='{"showInput": true}'></spectrum-picker>
+				</span>
+				<button class="btn btn-primary btn-mini" ng-click="ctrl.row.bgLightTheme=''" ng-show="ctrl.row.bgLightTheme" bs-tooltip="'Remove background color'">
+					<i class="fa fa-trash"></i>
+				</button>
+			</div>
+			<div class="gf-form">
+				<span class="gf-form-label">Background (dark theme)</span>
+				<span class="gf-form-label">
+					<spectrum-picker ng-model="ctrl.row.bgDarkTheme" options='{"showInput": true}'></spectrum-picker>
+				</span>
+				<button class="btn btn-primary btn-mini" ng-click="ctrl.row.bgDarkTheme=''" ng-show="ctrl.row.bgDarkTheme" bs-tooltip="'Remove background color'">
+					<i class="fa fa-trash"></i>
+				</button>
+			</div>
+		</div>
+		<div class="section">
+			<div class="gf-form">
+				<span class="gf-form-label">Hide row for</span>
+				<select multiple="multiple" ng-model="ctrl.row.rolesHidden" class="gf-form-input" ng-options="f for f in ['Viewer', 'Editor', 'Read Only Editor']"></select>
+			</div>
+		</div>
 	</div>
 </div>

--- a/public/app/features/dashboard/row/row.html
+++ b/public/app/features/dashboard/row/row.html
@@ -1,73 +1,74 @@
-<div class="dash-row-header" ng-if="ctrl.row.showTitle || ctrl.row.collapse">
-	<a class="dash-row-header-title" ng-click="ctrl.toggleCollapse()">
-		<span class="dash-row-collapse-toggle pointer">
-			<i class="fa fa-chevron-down" ng-show="!ctrl.row.collapse"></i>
-			<i class="fa fa-chevron-right" ng-show="ctrl.row.collapse"></i>
-		</span>
-		<span ng-class="ctrl.row.titleSize">{{ctrl.row.title | interpolateTemplateVars:this}}</span>
-	</a>
-</div>
-
-<div ng-if="ctrl.dropView === 1">
-	<dash-row-add-panel row-ctrl="ctrl"></dash-row-add-panel>
-</div>
-
-<div ng-if="ctrl.dropView === 2">
-	<dash-row-options row-ctrl="ctrl"></dash-row-options>
-</div>
-
-<div class="panels-wrapper" ng-if="!ctrl.row.collapse">
-  <div class="dash-row-menu-container" data-click-hide ng-hide="ctrl.dashboard.meta.fullscreen">
-    <ul class="dash-row-menu" role="menu">
-      <li>
-        <a ng-click="ctrl.toggleCollapse()">
-          <i class="fa fa-minus"></i> Collapse
-        </a>
-      </li>
-      <li ng-show="ctrl.dashboard.meta.canEdit">
-        <a ng-click="ctrl.onMenuAddPanel()">
-          <i class="fa fa-plus"></i> Add Panel
-        </a>
-      </li>
-      <li ng-show="ctrl.dashboard.meta.canEdit">
-        <a ng-click="ctrl.onMenuRowOptions()">
-          <i class="fa fa-cog"></i> Row Options
-        </a>
-      </li>
-      <li ng-show="ctrl.dashboard.meta.canEdit">
-        <a ng-click="ctrl.moveRow(-1)">
-          <i class="fa fa-arrow-up"></i> Move Up
-        </a>
-      </li>
-      <li ng-show="ctrl.dashboard.meta.canEdit">
-        <a ng-click="ctrl.moveRow(1)">
-          <i class="fa fa-arrow-down"></i> Move Down
-        </a>
-      </li>
-      <li ng-show="ctrl.dashboard.meta.canEdit">
-        <a ng-click="ctrl.onMenuDeleteRow()">
-          <i class="fa fa-trash"></i> Remove
-        </a>
-      </li>
-    </ul>
-    <div class="dash-row-menu-grip">
-      <i class="fa fa-ellipsis-v"></i>
-    </div>
+<div ng-if="!ctrl.row.hidden">
+  <div class="dash-row-header" ng-if="ctrl.row.showTitle || ctrl.row.collapse">
+    <a class="dash-row-header-title" ng-click="ctrl.toggleCollapse()">
+      <span class="dash-row-collapse-toggle pointer">
+        <i class="fa fa-chevron-down" ng-show="!ctrl.row.collapse"></i>
+        <i class="fa fa-chevron-right" ng-show="ctrl.row.collapse"></i>
+      </span>
+      <span ng-class="ctrl.row.titleSize">{{ctrl.row.title | interpolateTemplateVars:this}}</span>
+    </a>
   </div>
 
-  <div ng-repeat="panel in ctrl.row.panels track by panel.id" class="panel" ui-draggable="!ctrl.dashboard.meta.fullscreen" drag="panel.id" ui-on-drop="ctrl.onDrop($data, panel)" drag-handle-class="drag-handle" panel-width>
-    <plugin-component type="panel" class="panel-margin">
-    </plugin-component>
+  <div ng-if="ctrl.dropView === 1">
+    <dash-row-add-panel row-ctrl="ctrl"></dash-row-add-panel>
   </div>
 
-  <div panel-drop-zone class="panel panel-drop-zone" ui-on-drop="ctrl.onDrop($data)" data-drop="true">
-    <div class="panel-margin">
-      <div class="panel-container">
-        <div class="panel-drop-zone-text"></div>
+  <div ng-if="ctrl.dropView === 2">
+    <dash-row-options row-ctrl="ctrl"></dash-row-options>
+  </div>
+
+  <div class="panels-wrapper" ng-if="!ctrl.row.collapse">
+    <div class="dash-row-menu-container" data-click-hide ng-hide="ctrl.dashboard.meta.fullscreen" ng-if="ctrl.dashboard.meta.canEdit">
+      <ul class="dash-row-menu" role="menu">
+        <li>
+          <a ng-click="ctrl.toggleCollapse()">
+            <i class="fa fa-minus"></i> Collapse
+          </a>
+        </li>
+        <li ng-show="ctrl.dashboard.meta.canEdit">
+          <a ng-click="ctrl.onMenuAddPanel()">
+            <i class="fa fa-plus"></i> Add Panel
+          </a>
+        </li>
+        <li ng-show="ctrl.dashboard.meta.canEdit">
+          <a ng-click="ctrl.onMenuRowOptions()">
+            <i class="fa fa-cog"></i> Row Options
+          </a>
+        </li>
+        <li ng-show="ctrl.dashboard.meta.canEdit">
+          <a ng-click="ctrl.moveRow(-1)">
+            <i class="fa fa-arrow-up"></i> Move Up
+          </a>
+        </li>
+        <li ng-show="ctrl.dashboard.meta.canEdit">
+          <a ng-click="ctrl.moveRow(1)">
+            <i class="fa fa-arrow-down"></i> Move Down
+          </a>
+        </li>
+        <li ng-show="ctrl.dashboard.meta.canEdit">
+          <a ng-click="ctrl.onMenuDeleteRow()">
+            <i class="fa fa-trash"></i> Remove
+          </a>
+        </li>
+      </ul>
+      <div class="dash-row-menu-grip">
+        <i class="fa fa-ellipsis-v"></i>
       </div>
     </div>
+
+    <div ng-repeat="panel in ctrl.row.panels track by panel.id" class="panel" ui-draggable="!ctrl.dashboard.meta.fullscreen" drag="panel.id" ui-on-drop="ctrl.onDrop($data, panel)" drag-handle-class="drag-handle" panel-width>
+      <plugin-component type="panel" class="panel-margin">
+      </plugin-component>
+    </div>
+
+    <div panel-drop-zone class="panel panel-drop-zone" ui-on-drop="ctrl.onDrop($data)" data-drop="true">
+      <div class="panel-margin">
+        <div class="panel-container">
+          <div class="panel-drop-zone-text"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="clearfix"></div>
   </div>
-
-  <div class="clearfix"></div>
-</div>
-
+</div>

--- a/public/app/features/dashboard/row/row_model.ts
+++ b/public/app/features/dashboard/row/row_model.ts
@@ -12,6 +12,9 @@ export class DashboardRow {
   span: number;
   height: number;
   collapse: boolean;
+  bgLightTheme: string;
+  bgDarkTheme: string;
+  rolesHidden: any;
 
   defaults = {
     title: 'Dashboard Row',
@@ -24,6 +27,9 @@ export class DashboardRow {
     repeatRowId: null,
     repeatIteration: null,
     collapse: false,
+    bgLightTheme: '',
+    bgDarkTheme: '',
+    rolesHidden: []
   };
 
   constructor(private model) {

--- a/public/sass/components/_row.scss
+++ b/public/sass/components/_row.scss
@@ -12,6 +12,14 @@
       margin-bottom: $panel-margin*2;
     }
   }
+
+  &.dash-row--background {
+    margin-bottom: 0.8rem;
+    padding-top: 0.8rem;
+    &.dash-row--title {
+      padding-top: 0;
+    }
+  }
 }
 
 .dash-row-header {


### PR DESCRIPTION
Added two new options to rows:
- You can set the background color on a row basis. There is a background color option for each theme (light and dark).
- You can hide rows for specific user roles. Grafana admins and Org admins will always see all the rows.

![row-options](https://user-images.githubusercontent.com/1091537/27014781-5fadb9ee-4f08-11e7-9778-7cf5c0c94092.gif)