### PR TITLE
Component name of plugin page contains 'undefined'

### DIFF
--- a/public/app/core/directives/plugin_component.ts
+++ b/public/app/core/directives/plugin_component.ts
@@ -181,7 +181,7 @@ function pluginDirectiveLoader($compile, datasourceSrv, $rootScope, $q, $http, $
         return System.import(appModel.module).then(function(appModule) {
           return {
             baseUrl: appModel.baseUrl,
-            name: 'app-page-' + appModel.appId + '-' + scope.ctrl.page.slug,
+            name: 'app-page-' + appModel.id + '-' + scope.ctrl.page.slug,
             bindings: {appModel: "="},
             attrs: {"app-model": "ctrl.appModel"},
             Component: appModule[scope.ctrl.page.component],


### PR DESCRIPTION
When building plugin page the component name for this page was build from the following strings:
String 'app-page' + unset property appId on the model + plugin page name

Some past refactoring probably missed that the plugin app string is stored in property id, not appId.