### PR TITLE
extend singlestat panel to display and throb threshold values

### DIFF
--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -66,6 +66,12 @@
         <input type="text" class="gf-form-input" ng-model="ctrl.panel.thresholds" ng-blur="ctrl.render()" placeholder="50,80"></input>
       </div>
     </div>
+
+    <div class="gf-form-inline">
+      <gf-form-switch class="gf-form" label-class="width-8" label="Show Limits" checked="ctrl.panel.showLimits" on-change="ctrl.render()"></gf-form-switch>
+      <gf-form-switch class="gf-form" label-class="width-4panel.flashLimits && " label="Flash" checked="ctrl.panel.flashLimits" on-change="ctrl.render()"></gf-form-switch>
+    </div>
+
     <div class="gf-form">
       <label class="gf-form-label width-8">Colors</label>
       <span class="gf-form-label">

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -56,6 +56,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     thresholds: '',
     colorBackground: false,
     colorValue: false,
+    showLimits: false,
+    flashLimits: false,
     colors: ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
     sparkline: {
       show: false,
@@ -389,14 +391,51 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     function getBigValueHtml() {
       var body = '<div class="singlestat-panel-value-container">';
 
+      if (panel.showLimits) { body = getLimitsHtml() + body; }
+
       if (panel.prefix) { body += getSpan('singlestat-panel-prefix', panel.prefixFontSize, panel.prefix); }
 
       var value = applyColoringThresholds(data.value, data.valueFormatted);
-      body += getSpan('singlestat-panel-value', panel.valueFontSize, value);
+
+      var spvclass = 'singlestat-panel-value';
+          if (panel.flashLimits && (data.value < data.thresholds[0] || (data.thresholds.length > 1 && data.value > data.thresholds[1]))) {
+            spvclass += ' singlestat-flash';
+          }
+
+      body += getSpan(spvclass, panel.valueFontSize, value);
 
       if (panel.postfix) { body += getSpan('singlestat-panel-postfix', panel.postfixFontSize, panel.postfix); }
 
       body += '</div>';
+
+      return body;
+    }
+
+    function getLimitsHtml() {
+      var body = '';
+
+      if (data.thresholds) {
+        body += '<div class="singlestat-panel-limits-container">';
+        body += '<span class="singlestat-panel-low-limit-container';
+        if (panel.flashLimits && data.value < data.thresholds[0]) {
+          body += ' singlestat-flash';
+        }
+        body += '">';
+        body += '<span style="color:' + data.colorMap[0] + '">'+ data.thresholds[0] + '</span>';
+        body += '</span>';
+
+        if (data.thresholds.length > 1) {
+          body += '<span class="singlestat-panel-high-limit-container';
+          if (panel.flashLimits && data.value > data.thresholds[1]) {
+            body += ' singlestat-flash';
+          }
+          body += '">';
+          body += '<span style="color:' + data.colorMap[2] + '">'+ data.thresholds[1] + '</span>';
+          body += '</span>';
+        }
+
+        body += '</div>';
+      }
 
       return body;
     }

--- a/public/sass/components/_panel_singlestat.scss
+++ b/public/sass/components/_panel_singlestat.scss
@@ -14,6 +14,30 @@
   font-weight: bold;
 }
 
+.singlestat-panel-limits-container {
+  width: 100%;
+  position: absolute;
+  font-size: 2em;
+}
+
+.singlestat-panel-low-limit-container {
+  float: left;
+}
+
+.singlestat-panel-high-limit-container {
+  float: right;
+}
+
+.singlestat-flash {
+  animation: singlestat-flash 1s infinite;
+}
+
+@keyframes singlestat-flash {
+    0% { font-weight: bold; }
+    50% { font-weight: normal; }
+    100% { font-weight: bold; }
+}
+
 .singlestat-panel-prefix {
   padding-right: 20px;
 }


### PR DESCRIPTION
** Handy extension for singlestat panel that I'd like to propose for inclusion in the base release.

Following a client request, I've added two option flags - showLimits and flashLimits that, when set, display up to 2 colored threshold values above the value (1st top left, 2nd top right).  This is appropriate when monitoring a control value (voltage, temperature, whatever) that should be constrained within upper and lower limits.
When the flashLimits flag is set, the value and corresponding limit values 'throb' using CSS3 animation to further alert an operator of an alarm condition.

Only three files needed to be modified to make this change:

- editor.html
- module.ts
- _panel_singlestat.scss

This was sufficient to support my client's request, though I can think of a number of additional enhancements that really aught to be added:

1. The limits currently only display simple numeric values.  No unit type postfix (such as %), no support for text value mapping and no decimal place formatting.
2. The first threshold, if present, is reserved for a lower limit.  The second, if present is reserved for the upper limit.  There is no support for an upper limit without a lower limit.  A more general solution dealing with this would be considerably more complicated and probably should include expanding support for more than three color conditions too.
3. These changes have ignored the gauge-mode display - this mode seems to have a number of problems already so I ignored it.

![image](https://user-images.githubusercontent.com/3724718/27113300-e2b4ef38-5070-11e7-8824-57f914b9a40a.png)

![image](https://user-images.githubusercontent.com/3724718/27113348-1485b178-5071-11e7-9a2e-9b45d85489d8.png)






  