### PR TITLE
Support Azure MySQL

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -114,7 +114,7 @@ func getEngine() (*xorm.Engine, error) {
 			protocol = "unix"
 		}
 
-		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?charset=utf8mb4",
+		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?charset=utf8mb4&allowNativePasswords=true",
 			DbCfg.User, DbCfg.Pwd, protocol, DbCfg.Host, DbCfg.Name)
 
 		if DbCfg.SslMode == "true" || DbCfg.SslMode == "skip-verify" {


### PR DESCRIPTION
Azure's MySQL implementation appears to always respond with an Authentication Method Switch Request Packet requesting `mysql_native_password` auth even though the client's initial Handshake Response already included the native password credentials.

Most MySQL client libraries support this but Golang's go-sql-driver/mysql requires the `allowNativePasswords` DSN parameter set to enable it. Without this parameter, Grafana fails to authenticate to the database with the error message "this user requires mysql native password authentication."

References:

* https://web.archive.org/web/20160814002743/http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest
* https://web.archive.org/web/20160814002743/http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
* https://github.com/go-sql-driver/mysql#user-content-allownativepasswords
