### PR TITLE
New alias for influx group by several tags

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -65,8 +65,8 @@ function (_, TableModel) {
 
       if(group==="t") {
         var r='';
-        for(var k in series.tags) { 
-          if (series.tags.hasOwnProperty(k)) { 
+        for(var k in series.tags) {
+          if (series.tags.hasOwnProperty(k)) {
             r+=k+': '+series.tags[k]+', ';
           }
         }

--- a/public/app/plugins/datasource/influxdb/influx_series.js
+++ b/public/app/plugins/datasource/influxdb/influx_series.js
@@ -63,6 +63,15 @@ function (_, TableModel) {
       var group = g1 || g2;
       var segIndex = parseInt(group, 10);
 
+      if(group==="t") {
+        var r='';
+        for(var k in series.tags) { 
+          if (series.tags.hasOwnProperty(k)) { 
+            r+=k+': '+series.tags[k]+', ';
+          }
+        }
+        return r.slice(0,-2);
+      }
       if (group === 'm' || group === 'measurement') { return series.name; }
       if (group === 'col') { return series.columns[index]; }
       if (!isNaN(segIndex)) { return segments[segIndex]; }


### PR DESCRIPTION
Add alias ($t) in case of grouping by several tag in influxDB to have more readable label. 
The result is : 
tag1:v1, tag2:v3, tag3:v4 
![image](https://user-images.githubusercontent.com/29224815/27188683-3f005406-51ef-11e7-87c3-3203d9ecd8f7.png)

instead of : 
agg.sum {tag1:v1, tag2:v3, tag3:v4 }
![image](https://user-images.githubusercontent.com/29224815/27188669-3451ad02-51ef-11e7-9b11-c6b5f5ee017b.png)
