### PR TITLE
Use the secure flag when setting cookies anytime the protocol is https

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -45,7 +45,7 @@ func LoginView(c *middleware.Context) {
 	}
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
+		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
 		c.Redirect(redirectTo)
 		return
 	}
@@ -64,8 +64,8 @@ func tryLoginUsingRememberCookie(c *middleware.Context) bool {
 	defer func() {
 		if !isSucceed {
 			log.Trace("auto-login cookie cleared: %s", uname)
-			c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
-			c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
+			c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
+			c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
 			return
 		}
 	}()
@@ -124,7 +124,7 @@ func LoginPost(c *middleware.Context, cmd dtos.LoginCommand) Response {
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		result["redirectUrl"] = redirectTo
-		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
+		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
 	}
 
 	metrics.M_Api_Login_Post.Inc(1)
@@ -139,16 +139,16 @@ func loginUserWithUser(user *m.User, c *middleware.Context) {
 
 	days := 86400 * setting.LogInRememberDays
 	if days > 0 {
-		c.SetCookie(setting.CookieUserName, user.Login, days, setting.AppSubUrl+"/")
-		c.SetSuperSecureCookie(user.Rands+user.Password, setting.CookieRememberName, user.Login, days, setting.AppSubUrl+"/")
+		c.SetCookie(setting.CookieUserName, user.Login, days, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
+		c.SetSuperSecureCookie(user.Rands+user.Password, setting.CookieRememberName, user.Login, days, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&r.Req))
 	}
 
 	c.Session.Set(middleware.SESS_KEY_USERID, user.Id)
 }
 
 func Logout(c *middleware.Context) {
-	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
-	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
+	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
+	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/", nil, m.UseSecurecookie(&c.Req))
 	c.Session.Destory(c)
 	c.Redirect(setting.AppSubUrl + "/login")
 }

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -189,7 +189,7 @@ func OAuthLogin(ctx *middleware.Context) {
 	metrics.M_Api_Login_OAuth.Inc(1)
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		ctx.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
+		ctx.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&ctx.Req))
 		ctx.Redirect(redirectTo)
 		return
 	}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -42,7 +42,7 @@ func accessForbidden(c *Context) {
 		return
 	}
 
-	c.SetCookie("redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, setting.AppSubUrl+"/")
+	c.SetCookie("redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 
@@ -52,7 +52,7 @@ func notAuthorized(c *Context) {
 		return
 	}
 
-	c.SetCookie("redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, setting.AppSubUrl+"/")
+	c.SetCookie("redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, setting.AppSubUrl+"/", nil, m.UseSecureCookie(&c.Req))
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 

--- a/pkg/models/server.go
+++ b/pkg/models/server.go
@@ -1,6 +1,46 @@
 package models
 
+import (
+	"net/http"
+	"strings"
+)
+
 type GrafanaServer interface {
 	Start()
 	Shutdown(code int, reason string)
+}
+
+//GetRequestProto returns the protocol used by this connection
+//or by an upstream reverse proxy
+func GetRequestProto(r *http.Request) string {
+	if p := r.Header.Get(); p == "https" {
+	} else if p := r.Header.Get("X-FORWARDED-PROTO"); p == "https" {
+		return p
+	} else if p := r.Header.Get("X-FORWARDED-PROTOCOL"); p == "https" {
+		return p
+	} else if p := r.Header.Get("X-FORWARDED-SSL"); p == "on" {
+		return "https"
+	} else if p := r.Header.Get("X-FORWARDED-SCHEME"); p == "https" {
+		return p
+	} else if p := getForwardedProto(h); p == "https" {
+		return p
+	}
+
+	return r.URL.Scheme
+}
+
+func getForwardedProto(r *http.Request) string {
+	hVal := strings.Split(r.Header.Get("Forwarded"), ";")
+	for _, h := range hVal {
+		if strings.HasPrefix(h, "proto=") {
+			p := strings.Split(h, "=")
+			return p[len(p)-1]
+		}
+	}
+	return ""
+}
+
+//UseSecureCookie returns true if the upstream connection uses https
+func UseSecureCookie(r *http.Request) bool {
+	return GetRequestProto(r) == "https"
 }


### PR DESCRIPTION
Not setting the Secure flag on cookie generation can lead to the cookie being stolen over insecure connections at a future time.  This can lead to login session information being stolen and used by a malicious actor.
