### PR TITLE
allow heatmap parsing of scaled datapoints

### DIFF
--- a/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
@@ -207,15 +207,20 @@ function pushToXBuckets(buckets, point, bucketNum, seriesName) {
 }
 
 function pushToYBuckets(buckets, bucketNum, value, point, bounds) {
+  var count = 1;
+  // Use the 3rd argument as scale/count
+  if (point.length > 2) {
+    count = parseInt(point[2]);
+  }
   if (buckets[bucketNum]) {
     buckets[bucketNum].values.push(value);
-    buckets[bucketNum].count += 1;
+    buckets[bucketNum].count += count;
   } else {
     buckets[bucketNum] = {
       y: bucketNum,
       bounds: bounds,
       values: [value],
-      count: 1,
+      count: count,
     };
   }
 }


### PR DESCRIPTION
This PR allows a more natural consumption of histogram data from plugins.  By making the 3rd element of a datapoint be the scaling factor or count, we can consume data in a format that does not require creating redundant datapoints.

For example, if a datastore is able to produce histograms natively, they can be used directly by grafana while still having the benefit of the (re)bucketing logic.