### PR TITLE
[WIP] oauth user linking

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -150,6 +150,16 @@ func OAuthLogin(ctx *middleware.Context) {
 	userQuery := m.GetUserByEmailQuery{Email: userInfo.Email}
 	err = bus.Dispatch(&userQuery)
 
+	// if user not found and we have a username, try to look up user
+	if err == m.ErrUserNotFound && userInfo.Login != "" {
+		loginQuery := m.GetUserByLoginQuery{LoginOrEmail: userInfo.Login}
+		err = bus.Dispatch(&loginQuery)
+
+		if err == nil {
+			userQuery.Result = loginQuery.Result
+		}
+	}
+
 	// create account if missing
 	if err == m.ErrUserNotFound {
 		if !connect.IsSignupAllowed() {


### PR DESCRIPTION
This patch tries to look oauth users up by username if there is no email match, so that a user changing their email address on grafana.com will still be able to log into Grafana via oauth.  Currently what happens is that the user isn't found via email match, but Grafana also will not create a new account for them due to the unique username requirement.  The only way for the user to regain access to their Grafana account is to change their grafana.com email back, or to have another user update the email address in their Grafana account to match their updated grafana.com account email.

This does not update the Grafana account to match the modified email, so if the user were to subsequently change their username then the link would be broken.  I'm thinking that a solution here might be a config setting per login provider for whether to sync the account info on login.

To be able to maintain the link even when the user updates both username and email, we could add a new `user_external_login` table with `user_id, login_provider, external_id` columns so that if an external provider returns an immutable user id we can use that to look up the associated Grafana account and maintain the local match regardless of whether the email and/or username match.