### PR TITLE
Makes the singlestat threshold to scale based on the Unit selected

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -409,6 +409,13 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       return result;
     }
 
+    function getThresholdValue(value){
+      var decimalInfo = ctrl.getDecimalsForValue(value);
+      var formatFunc = kbn.valueFormats[panel.format];
+
+      return formatFunc(value, decimalInfo.decimals, decimalInfo.scaledDecimals).replace(/\D/g,'');
+    }
+
     function addGauge() {
       var width = elem.width();
       var height = elem.height();
@@ -472,7 +479,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
               label: {
                 show: panel.gauge.thresholdLabels,
                 margin: 8,
-                font: { size: 18 }
+                font: { size: 18 },
+                formatter: function(value) { return getThresholdValue(value); },
               },
               show: panel.gauge.thresholdMarkers,
               width: thresholdMarkersWidth,

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -413,7 +413,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       var decimalInfo = ctrl.getDecimalsForValue(value);
       var formatFunc = kbn.valueFormats[panel.format];
 
-      return formatFunc(value, decimalInfo.decimals, decimalInfo.scaledDecimals).replace(/\D/g,'');
+      return formatFunc(value, decimalInfo.decimals, decimalInfo.scaledDecimals);
     }
 
     function addGauge() {


### PR DESCRIPTION
This should help with the request #8679
There is two possibilities; the first one implemented here do not include the Unit in front of the thresholds on the gauge:
![Imgur](http://i.imgur.com/Kwkksne.png)

The second one is basically the same thing, but with the Unit in front of the thresholds (small update necessary):
![Imgur](http://i.imgur.com/lrybZIN.png)

@torkelo which one would you prefer?