### PR TITLE
Fix heatmap decimals calculation for Y-axis and tooltip

### DIFF
--- a/public/app/core/utils/ticks.ts
+++ b/public/app/core/utils/ticks.ts
@@ -25,3 +25,7 @@ export function tickStep(start: number, stop: number, count: number): number {
 
   return stop < start ? -step1 : step1;
 }
+
+export function getScaledDecimals(decimals, tick_size) {
+  return decimals - Math.floor(Math.log(tick_size) / Math.LN10);
+}

--- a/public/app/core/utils/ticks.ts
+++ b/public/app/core/utils/ticks.ts
@@ -29,3 +29,39 @@ export function tickStep(start: number, stop: number, count: number): number {
 export function getScaledDecimals(decimals, tick_size) {
   return decimals - Math.floor(Math.log(tick_size) / Math.LN10);
 }
+
+/**
+ * Calculate tick size based on min and max values, number of ticks and precision.
+ * @param min           Axis minimum
+ * @param max           Axis maximum
+ * @param noTicks       Number of ticks
+ * @param tickDecimals  Tick decimal precision
+ */
+export function getFlotTickSize(min: number, max: number, noTicks: number, tickDecimals: number) {
+  var delta = (max - min) / noTicks,
+    dec = -Math.floor(Math.log(delta) / Math.LN10),
+    maxDec = tickDecimals;
+
+  var magn = Math.pow(10, -dec),
+    norm = delta / magn, // norm is between 1.0 and 10.0
+    size;
+
+  if (norm < 1.5) {
+    size = 1;
+  } else if (norm < 3) {
+    size = 2;
+    // special case for 2.5, requires an extra decimal
+    if (norm > 2.25 && (maxDec == null || dec + 1 <= maxDec)) {
+      size = 2.5;
+      ++dec;
+    }
+  } else if (norm < 7.5) {
+    size = 5;
+  } else {
+    size = 10;
+  }
+
+  size *= magn;
+
+  return size;
+}

--- a/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
@@ -95,6 +95,8 @@ export class HeatmapCtrl extends MetricsPanelCtrl {
   series: any;
   timeSrv: any;
   dataWarning: any;
+  decimals: number;
+  scaledDecimals: number;
 
   /** @ngInject */
   constructor($scope, $injector, private $rootScope, timeSrv) {

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -88,9 +88,17 @@ export class HeatmapTooltip {
     let tooltipTimeFormat = 'YYYY-MM-DD HH:mm:ss';
     let time = this.dashboard.formatDate(xData.x, tooltipTimeFormat);
 
-    let decimals = this.panel.tooltipDecimals || this.panelCtrl.decimals;
-    let scaledDecimals = this.panel.tooltipDecimals ? decimals - 2 : this.panelCtrl.scaledDecimals;
-    let valueFormatter = this.valueFormatter(decimals, scaledDecimals);
+    // Decimals override. Code from panel/graph/graph.ts
+    let valueFormatter;
+    if (_.isNumber(this.panel.tooltipDecimals)) {
+      valueFormatter = this.valueFormatter(this.panel.tooltipDecimals, null);
+    } else {
+      // auto decimals
+      // legend and tooltip gets one more decimal precision
+      // than graph legend ticks
+      let decimals = (this.panelCtrl.decimals || -1) + 1;
+      valueFormatter = this.valueFormatter(this.panel.tooltipDecimals, this.panelCtrl.scaledDecimals + 2);
+    }
 
     let tooltipHtml = `<div class="graph-tooltip-time">${time}</div>
       <div class="heatmap-histogram"></div>`;
@@ -227,9 +235,6 @@ export class HeatmapTooltip {
   valueFormatter(decimals, scaledDecimals = null) {
     let format = this.panel.yAxis.format;
     return function(value) {
-      if (_.isInteger(value)) {
-        decimals = 0;
-      }
       return kbn.valueFormats[format](value, decimals, scaledDecimals);
     };
   }

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -15,6 +15,7 @@ export class HeatmapTooltip {
   tooltip: any;
   scope: any;
   dashboard: any;
+  panelCtrl: any;
   panel: any;
   heatmapPanel: any;
   mouseOverBucket: boolean;
@@ -23,6 +24,7 @@ export class HeatmapTooltip {
   constructor(elem, scope) {
     this.scope = scope;
     this.dashboard = scope.ctrl.dashboard;
+    this.panelCtrl = scope.ctrl;
     this.panel = scope.ctrl.panel;
     this.heatmapPanel = elem;
     this.mouseOverBucket = false;
@@ -85,8 +87,10 @@ export class HeatmapTooltip {
 
     let tooltipTimeFormat = 'YYYY-MM-DD HH:mm:ss';
     let time = this.dashboard.formatDate(xData.x, tooltipTimeFormat);
-    let decimals = this.panel.tooltipDecimals || 5;
-    let valueFormatter = this.valueFormatter(decimals);
+
+    let decimals = this.panel.tooltipDecimals || this.panelCtrl.decimals;
+    let scaledDecimals = decimals - 2;
+    let valueFormatter = this.valueFormatter(decimals, scaledDecimals);
 
     let tooltipHtml = `<div class="graph-tooltip-time">${time}</div>
       <div class="heatmap-histogram"></div>`;
@@ -220,13 +224,13 @@ export class HeatmapTooltip {
       .style("top", top + "px");
   }
 
-  valueFormatter(decimals) {
+  valueFormatter(decimals, scaledDecimals = null) {
     let format = this.panel.yAxis.format;
     return function(value) {
       if (_.isInteger(value)) {
         decimals = 0;
       }
-      return kbn.valueFormats[format](value, decimals);
+      return kbn.valueFormats[format](value, decimals, scaledDecimals);
     };
   }
 }

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -89,7 +89,7 @@ export class HeatmapTooltip {
     let time = this.dashboard.formatDate(xData.x, tooltipTimeFormat);
 
     let decimals = this.panel.tooltipDecimals || this.panelCtrl.decimals;
-    let scaledDecimals = decimals - 2;
+    let scaledDecimals = this.panel.tooltipDecimals ? decimals - 2 : this.panelCtrl.scaledDecimals;
     let valueFormatter = this.valueFormatter(decimals, scaledDecimals);
 
     let tooltipHtml = `<div class="graph-tooltip-time">${time}</div>

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import moment from 'moment';
 import kbn from 'app/core/utils/kbn';
 import {appEvents, contextSrv} from 'app/core/core';
-import {tickStep} from 'app/core/utils/ticks';
+import {tickStep, getScaledDecimals} from 'app/core/utils/ticks';
 import d3 from 'd3';
 import {HeatmapTooltip} from './heatmap_tooltip';
 import {convertToCards, mergeZeroBuckets} from './heatmap_data_converter';
@@ -134,6 +134,8 @@ export default function link(scope, elem, attrs, ctrl) {
     let decimalsAuto = getPrecision(tick_interval);
     let decimals = panel.yAxis.decimals === null ? decimalsAuto : panel.yAxis.decimals;
     let scaledDecimals = getScaledDecimals(decimals, tick_interval);
+    ctrl.decimals = decimals;
+    ctrl.scaledDecimals = scaledDecimals;
 
     // Set default Y min and max if no data
     if (_.isEmpty(data.buckets)) {
@@ -218,7 +220,10 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let decimalsAuto = getPrecision(y_min);
     let decimals = panel.yAxis.decimals || decimalsAuto;
+    // TODO: calculate scaledDecimals for log scales using tick size (as in jquery.flot.js)
     let scaledDecimals = decimals - 2;
+    ctrl.decimals = decimals;
+    ctrl.scaledDecimals = scaledDecimals;
 
     data.yAxis = {
       min: y_min,
@@ -296,10 +301,6 @@ export default function link(scope, elem, attrs, ctrl) {
     }
 
     return tickValues;
-  }
-
-  function getScaledDecimals(decimals, tick_size) {
-    return decimals - Math.floor(Math.log(tick_size) / Math.LN10);
   }
 
   function tickValueFormatter(decimals, scaledDecimals = null) {

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import moment from 'moment';
 import kbn from 'app/core/utils/kbn';
 import {appEvents, contextSrv} from 'app/core/core';
-import {tickStep, getScaledDecimals} from 'app/core/utils/ticks';
+import {tickStep, getScaledDecimals, getFlotTickSize} from 'app/core/utils/ticks';
 import d3 from 'd3';
 import {HeatmapTooltip} from './heatmap_tooltip';
 import {convertToCards, mergeZeroBuckets} from './heatmap_data_converter';
@@ -133,7 +133,9 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let decimalsAuto = getPrecision(tick_interval);
     let decimals = panel.yAxis.decimals === null ? decimalsAuto : panel.yAxis.decimals;
-    let scaledDecimals = getScaledDecimals(decimals, tick_interval);
+    // Calculate scaledDecimals for log scales using tick size (as in jquery.flot.js)
+    let flot_tick_size = getFlotTickSize(y_min, y_max, ticks, decimalsAuto);
+    let scaledDecimals = getScaledDecimals(decimals, flot_tick_size);
     ctrl.decimals = decimals;
     ctrl.scaledDecimals = scaledDecimals;
 
@@ -220,8 +222,10 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let decimalsAuto = getPrecision(y_min);
     let decimals = panel.yAxis.decimals || decimalsAuto;
-    // TODO: calculate scaledDecimals for log scales using tick size (as in jquery.flot.js)
-    let scaledDecimals = decimals - 2;
+
+    // Calculate scaledDecimals for log scales using tick size (as in jquery.flot.js)
+    let flot_tick_size = getFlotTickSize(y_min, y_max, tick_values.length, decimalsAuto);
+    let scaledDecimals = getScaledDecimals(decimals, flot_tick_size);
     ctrl.decimals = decimals;
     ctrl.scaledDecimals = scaledDecimals;
 

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -132,7 +132,7 @@ export default function link(scope, elem, attrs, ctrl) {
     ticks = Math.ceil((y_max - y_min) / tick_interval);
 
     let decimalsAuto = getPrecision(tick_interval);
-    let decimals = panel.yAxis.decimals === null ? getPrecision(tick_interval) : panel.yAxis.decimals;
+    let decimals = panel.yAxis.decimals === null ? decimalsAuto : panel.yAxis.decimals;
     let scaledDecimals = getScaledDecimals(decimals, tick_interval);
 
     // Set default Y min and max if no data
@@ -215,7 +215,10 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let domain = yScale.domain();
     let tick_values = logScaleTickValues(domain, log_base);
-    let decimals = panel.yAxis.decimals;
+
+    let decimalsAuto = getPrecision(y_min);
+    let decimals = panel.yAxis.decimals || decimalsAuto;
+    let scaledDecimals = decimals - 2;
 
     data.yAxis = {
       min: y_min,
@@ -225,7 +228,7 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let yAxis = d3.axisLeft(yScale)
       .tickValues(tick_values)
-      .tickFormat(tickValueFormatter(decimals))
+      .tickFormat(tickValueFormatter(decimals, scaledDecimals))
       .tickSizeInner(0 - width)
       .tickSizeOuter(0)
       .tickPadding(Y_AXIS_TICK_PADDING);

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -131,7 +131,9 @@ export default function link(scope, elem, attrs, ctrl) {
     tick_interval = tickStep(y_min, y_max, ticks);
     ticks = Math.ceil((y_max - y_min) / tick_interval);
 
+    let decimalsAuto = getPrecision(tick_interval);
     let decimals = panel.yAxis.decimals === null ? getPrecision(tick_interval) : panel.yAxis.decimals;
+    let scaledDecimals = getScaledDecimals(decimals, tick_interval);
 
     // Set default Y min and max if no data
     if (_.isEmpty(data.buckets)) {
@@ -153,7 +155,7 @@ export default function link(scope, elem, attrs, ctrl) {
 
     let yAxis = d3.axisLeft(yScale)
       .ticks(ticks)
-      .tickFormat(tickValueFormatter(decimals))
+      .tickFormat(tickValueFormatter(decimals, scaledDecimals))
       .tickSizeInner(0 - width)
       .tickSizeOuter(0)
       .tickPadding(Y_AXIS_TICK_PADDING);
@@ -293,10 +295,14 @@ export default function link(scope, elem, attrs, ctrl) {
     return tickValues;
   }
 
-  function tickValueFormatter(decimals) {
+  function getScaledDecimals(decimals, tick_size) {
+    return decimals - Math.floor(Math.log(tick_size) / Math.LN10);
+  }
+
+  function tickValueFormatter(decimals, scaledDecimals = null) {
     let format = panel.yAxis.format;
     return function(value) {
-      return kbn.valueFormats[format](value, decimals);
+      return kbn.valueFormats[format](value, decimals, scaledDecimals);
     };
   }
 

--- a/public/app/plugins/panel/heatmap/specs/renderer_specs.ts
+++ b/public/app/plugins/panel/heatmap/specs/renderer_specs.ts
@@ -204,7 +204,7 @@ describe('grafanaHeatmap', function () {
 
     it('should draw correct Y axis', function () {
       var yTicks = getTicks(ctx.element, ".axis-y");
-      expect(yTicks).to.eql(['1', '32', '1 K']);
+      expect(yTicks).to.eql(['1', '32', '1.0 K']);
     });
   });
 
@@ -221,7 +221,7 @@ describe('grafanaHeatmap', function () {
 
     it('should draw correct Y axis', function () {
       var yTicks = getTicks(ctx.element, ".axis-y");
-      expect(yTicks).to.eql(['1', '1 K', '1 Mil']);
+      expect(yTicks).to.eql(['1', '1 K', '1.0 Mil']);
     });
   });
 
@@ -247,7 +247,7 @@ describe('grafanaHeatmap', function () {
 
     it('should draw correct Y axis', function () {
       var yTicks = getTicks(ctx.element, ".axis-y");
-      expect(yTicks).to.eql(['0 ns', '17 min', '33 min', '50 min', '1 hour']);
+      expect(yTicks).to.eql(['0 ns', '17 min', '33 min', '50 min', '1.11 hour']);
     });
   });
 


### PR DESCRIPTION
This PR fixes #8566.

Note for review. Actually, I should spend more time on log scales decimals calculation. Now fix contains a simple workaround for it (`scaledDecimals = decimals - 2`). Seems, it covers most of cases, but we should do that more accurately.