### PR TITLE
Add the possibility to process time extremities when using InfluxDB

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -263,10 +263,10 @@ export default class InfluxDatasource {
     var fromIsAbsolute = from[from.length-1] === 'ms';
 
     if (until === 'now()' && !fromIsAbsolute) {
-      return 'time > ' + from;
+      return 'time >= ' + from;
     }
 
-    return 'time > ' + from + ' and time < ' + until;
+    return 'time >= ' + from + ' and time <= ' + until;
   }
 
   getInfluxTime(date, roundUp) {
@@ -287,4 +287,3 @@ export default class InfluxDatasource {
     return date.valueOf() + 'ms';
   }
 }
-


### PR DESCRIPTION
Implement the functionality discussed in #8319 

This is a work in progress. I did what I could but I would loved to have some advice / reviews :)

I added a check box in the time parameter section of a dashboard to activate or deactivate this functionality.

For now this functionality is usable only when using InfluxDB, I would love to add it for others but I didn't saw the same problematic with them, maybe someone could help me on that.

If this is juste possible with InfluxDB, do you know how to make this checkbox appear only when the database used is InfluxDB ? Should I moved it inside the MetricPanel ?

And do you know what do I have to change to save the state of the checkbox when exporting the dashboard ?

![06_28_1710_02_58](https://user-images.githubusercontent.com/1645673/27626572-da6be812-5be8-11e7-8b33-e806a29cf79d.png)

