### PR TITLE
Fix User/Org default timezone bug

### DIFF
--- a/public/app/features/dashboard/model.ts
+++ b/public/app/features/dashboard/model.ts
@@ -247,9 +247,9 @@ export class DashboardModel {
   formatDate(date, format?) {
     date = moment.isMoment(date) ? date : moment(date);
     format = format || 'YYYY-MM-DD HH:mm:ss';
-    this.timezone = this.getTimezone();
+    let timezone = this.getTimezone();
 
-    return this.timezone === 'browser' ?
+    return timezone === 'browser' ?
       moment(date).format(format) :
       moment.utc(date).format(format);
   }

--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -56,6 +56,7 @@ export class TimePickerCtrl {
       if (moment.isMoment(timeRaw.to)) {
         timeRaw.to.local();
       }
+      this.isUtc = false;
     } else {
       this.isUtc = true;
     }


### PR DESCRIPTION
Fixes #8503 
This happens because `formatDate()` function overrides dashboard timezone by default value from user/org preferences if it set to default (default is empty string value). So we should keep dashboard timezone unchanged in this case.

Also, this fixes small UI bug: when you set dashboard timezone to UTC, the corresponding label will be shown. But if you'll change it back, nothing happens until dashboard reload.