### PR TITLE
Add ImagePublicUrl thumbnail for hipchat message

### DIFF
--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -131,6 +131,12 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"icon": map[string]interface{}{
 			"url": "https://grafana.com/assets/img/fav32.png",
 		},
+    "thumbnail": map[string]interface{}{
+			"url": evalContext.ImagePublicUrl,
+			"url@2x": evalContext.ImagePublicUrl,
+			"width": 1193,
+			"height": 564,
+		},
 		"date": evalContext.EndTime.Unix(),
 	}
 


### PR DESCRIPTION
Usage:
1) Create upload server (HTTP PUT for save image in folder and return 201 code, HTTP GET for getting image)
2)  Edit configuration file default.ini like this
[external_image_storage]
provider = webdav
[external_image_storage.webdav]
url = ImagePublicUrl like (http://server.ip/folder)

