### PR TITLE
fix: handling of http errors without any data

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -179,7 +179,7 @@ export class BackendSrv {
       }
 
       // for Prometheus
-      if (!err.data.message && _.isString(err.data.error)) {
+      if (err.data && !err.data.message && _.isString(err.data.error)) {
         err.data.message = err.data.error;
       }
 

--- a/public/test/specs/backend_srv-specs.js
+++ b/public/test/specs/backend_srv-specs.js
@@ -1,0 +1,33 @@
+define([
+  'app/core/config',
+  'app/core/services/backend_srv'
+], function() {
+  'use strict';
+
+  describe('backend_srv', function() {
+    var _backendSrv;
+    var _http;
+    var _httpBackend;
+
+    beforeEach(module('grafana.core'));
+    beforeEach(module('grafana.services'));
+    beforeEach(inject(function ($httpBackend, $http, backendSrv) {
+      _httpBackend = $httpBackend;
+      _http = $http;
+      _backendSrv = backendSrv;
+    }));
+
+    describe('when handling errors', function() {
+      it('should return the http status code', function(done) {
+        _httpBackend.whenGET('gateway-error').respond(502);
+        _backendSrv.datasourceRequest({
+          url: 'gateway-error'
+        }).catch(function(err) {
+          expect(err.status).to.be(502);
+          done();
+        });
+        _httpBackend.flush();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This fixes https://github.com/grafana/grafana/issues/8776 and adds a unit test for the problem.