### PR TITLE
Support large github organisations

### DIFF
--- a/pkg/social/generic_oauth.go
+++ b/pkg/social/generic_oauth.go
@@ -83,20 +83,20 @@ func (s *GenericOAuth) FetchPrivateEmail(client *http.Client) (string, error) {
 		IsConfirmed bool   `json:"is_confirmed"`
 	}
 
-	body, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/emails"))
+	response, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/emails"))
 	if err != nil {
 		return "", fmt.Errorf("Error getting email address: %s", err)
 	}
 
 	var records []Record
 
-	err = json.Unmarshal(body, &records)
+	err = json.Unmarshal(response.Body, &records)
 	if err != nil {
 		var data struct {
 			Values []Record `json:"values"`
 		}
 
-		err = json.Unmarshal(body, &data)
+		err = json.Unmarshal(response.Body, &data)
 		if err != nil {
 			return "", fmt.Errorf("Error getting email address: %s", err)
 		}
@@ -120,14 +120,14 @@ func (s *GenericOAuth) FetchTeamMemberships(client *http.Client) ([]int, error) 
 		Id int `json:"id"`
 	}
 
-	body, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/teams"))
+	response, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/teams"))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting team memberships: %s", err)
 	}
 
 	var records []Record
 
-	err = json.Unmarshal(body, &records)
+	err = json.Unmarshal(response.Body, &records)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting team memberships: %s", err)
 	}
@@ -145,14 +145,14 @@ func (s *GenericOAuth) FetchOrganizations(client *http.Client) ([]string, error)
 		Login string `json:"login"`
 	}
 
-	body, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/orgs"))
+	response, err := HttpGet(client, fmt.Sprintf(s.apiUrl+"/orgs"))
 	if err != nil {
 		return nil, fmt.Errorf("Error getting organizations: %s", err)
 	}
 
 	var records []Record
 
-	err = json.Unmarshal(body, &records)
+	err = json.Unmarshal(response.Body, &records)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting organizations: %s", err)
 	}
@@ -175,12 +175,12 @@ func (s *GenericOAuth) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 		Attributes  map[string][]string `json:"attributes"`
 	}
 
-	body, err := HttpGet(client, s.apiUrl)
+	response, err := HttpGet(client, s.apiUrl)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}
 
-	err = json.Unmarshal(body, &data)
+	err = json.Unmarshal(response.Body, &data)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -36,12 +36,12 @@ func (s *SocialGoogle) UserInfo(client *http.Client) (*BasicUserInfo, error) {
 		Email string `json:"email"`
 	}
 
-	body, err := HttpGet(client, s.apiUrl)
+	response, err := HttpGet(client, s.apiUrl)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}
 
-	err = json.Unmarshal(body, &data)
+	err = json.Unmarshal(response.Body, &data)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}

--- a/pkg/social/grafana_com_oauth.go
+++ b/pkg/social/grafana_com_oauth.go
@@ -58,12 +58,12 @@ func (s *SocialGrafanaCom) UserInfo(client *http.Client) (*BasicUserInfo, error)
 		Orgs  []OrgRecord `json:"orgs"`
 	}
 
-	body, err := HttpGet(client, s.url+"/api/oauth2/user")
+	response, err := HttpGet(client, s.url+"/api/oauth2/user")
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}
 
-	err = json.Unmarshal(body, &data)
+	err = json.Unmarshal(response.Body, &data)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting user info: %s", err)
 	}


### PR DESCRIPTION
The current github integration only retrieves the first page of results when looking up user's team membership. For most organisations this isn't a problem. When you have a large organisation with over 100 teams not all the teams are retrieved. This patch solves this problem by doing the following things:

* Modify HttpGet() return to include the response headers
* Look up _all_ the teams the user is a member of