### PR TITLE
fix for wrong locale and text issues #8840

### DIFF
--- a/public/app/plugins/panel/alertlist/module.ts
+++ b/public/app/plugins/panel/alertlist/module.ts
@@ -125,7 +125,7 @@ class AlertListPanel extends PanelCtrl {
       .then(res => {
         this.currentAlerts = this.sortResult(_.map(res, al => {
           al.stateModel = alertDef.getStateDisplayModel(al.state);
-          al.newStateDateAgo = moment(al.newStateDate).fromNow().replace(" ago", "");
+          al.newStateDateAgo = moment(al.newStateDate).locale('en').fromNow(true);
           return al;
         }));
       });


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/8840
by setting a default locale. Also uses fromNow(true) to work around the replace.

