### PR TITLE
add new dashboard shortcut

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -193,6 +193,10 @@ export class KeybindingSrv {
       }
     });
 
+    this.bind('d n', e => {
+      this.$location.url("/dashboard/new");
+    });
+
     this.bind('d r', () => {
       scope.broadcastRefresh();
     });


### PR DESCRIPTION
The `mod+n` is conflict to Chrome `New Window` shortcut.
`ctrl+n` is not consistent, because we use `mod+s` for saving dashboard.

Change is needed, this is just proposal.