### PR TITLE
Homogenized `docker run` command

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -14,7 +14,7 @@ weight = 4
 
 Grafana is very easy to install and run using the offical docker container.
 
-    $ docker run -i -p 3000:3000 grafana/grafana
+    $ docker run -d -p 3000:3000 grafana/grafana
 
 All Grafana configuration settings can be defined using environment
 variables, this is especially useful when using the above container.


### PR DESCRIPTION
There are three locations where the `docker run` command is referenced:
- 2x http://docs.grafana.org/installation/docker/
- 1x https://grafana.com/grafana/download?platform=docker

The fix syncs the given `docker run` command arguments with the other two.

