### PR TITLE
Enable datasources to be able to round off to a UTC day properly

### DIFF
--- a/public/app/core/utils/datemath.ts
+++ b/public/app/core/utils/datemath.ts
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 var units = ['y', 'M', 'w', 'd', 'h', 'm', 's'];
 
-export function parse(text, roundUp?) {
+export function parse(text, roundUp?, timezone?) {
   if (!text) { return undefined; }
   if (moment.isMoment(text)) { return text; }
   if (_.isDate(text)) { return moment(text); }
@@ -16,7 +16,11 @@ export function parse(text, roundUp?) {
   var parseString;
 
   if (text.substring(0, 3) === 'now') {
-    time = moment();
+    if (timezone === 'utc') {
+      time = moment.utc();
+    } else {
+      time = moment();
+    }
     mathString = text.substring('now'.length);
   } else {
     index = text.indexOf('||');

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -199,10 +199,11 @@ class TimeSrv {
       from: moment.isMoment(this.time.from) ? moment(this.time.from) : this.time.from,
       to: moment.isMoment(this.time.to) ? moment(this.time.to) : this.time.to,
     };
+    var timezone = this.dashboard && this.dashboard.getTimezone ? this.dashboard.getTimezone() : 'local';
 
     return {
-      from: dateMath.parse(raw.from, false),
-      to: dateMath.parse(raw.to, true),
+      from: dateMath.parse(raw.from, false, timezone),
+      to: dateMath.parse(raw.to, true, timezone),
       raw: raw
     };
   }

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -221,7 +221,10 @@ class MetricsPanelCtrl extends PanelCtrl {
       "__interval_ms":  {text: this.intervalMs, value: this.intervalMs},
     });
 
+    var timezone = this.dashboard.getTimezone ? this.dashboard.getTimezone() : 'local';
+
     var metricsQuery = {
+      timezone: timezone,
       panelId: this.panel.id,
       range: this.range,
       rangeRaw: this.range.raw,

--- a/public/test/core/utils/datemath_specs.ts
+++ b/public/test/core/utils/datemath_specs.ts
@@ -46,6 +46,14 @@ describe("DateMath", () => {
     expect(startOfDay).to.be(expected.getTime());
   });
 
+  it("now/d on a utc dashboard should be start of the current day in UTC time", () => {
+    var today = new Date();
+    var expected = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0));
+
+    var startOfDay = dateMath.parse('now/d', false, 'utc').valueOf();
+    expect(startOfDay).to.be(expected.getTime());
+  });
+
   describe('subtraction', () => {
     var now;
     var anchored;


### PR DESCRIPTION
This enables the various datasources to fix https://github.com/grafana/grafana/issues/7823 by passing in the dashboard timezone setting. I haven't touched any of the built in datasources because I don't have any way to test any of them (we only use a custom datasource.)