### PR TITLE
removed incorrect HTTP response data

### DIFF
--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -269,9 +269,3 @@ Status Codes:
         "isStarred":false
       }
     ]
-
-        "email":"admin@mygraf.com",
-        "login":"admin",
-        "role":"Admin"
-      }
-    ]


### PR DESCRIPTION
the example response body contained incorrect out-of-place data, presumably from a copy-paste operation