### PR TITLE
Graphite 1.0 functions

### DIFF
--- a/public/app/plugins/datasource/graphite/add_graphite_func.js
+++ b/public/app/plugins/datasource/graphite/add_graphite_func.js
@@ -22,11 +22,10 @@ function (angular, _, $, gfunc) {
         link: function($scope, elem) {
           var ctrl = $scope.ctrl;
           var graphiteVersion = ctrl.datasource.graphiteVersion;
+          var categories = gfunc.getCategories(graphiteVersion);
+          var allFunctions = getAllFunctionNames(categories);
 
-          var categories = gfunc.getCategories();
-          var allFunctions = getAllFunctionNames(categories, graphiteVersion);
-
-          $scope.functionMenu = createFunctionDropDownMenu(categories, graphiteVersion);
+          $scope.functionMenu = createFunctionDropDownMenu(categories);
 
           var $input = $(inputTemplate);
           var $button = $(buttonTemplate);
@@ -85,23 +84,18 @@ function (angular, _, $, gfunc) {
       };
     });
 
-  function getAllFunctionNames(categories, graphiteVersion) {
+  function getAllFunctionNames(categories) {
     return _.reduce(categories, function(list, category) {
       _.each(category, function(func) {
-        if (isVersionRelatedFunction(func, graphiteVersion)) {
-          list.push(func.name);
-        }
+        list.push(func.name);
       });
       return list;
     }, []);
   }
 
-  function createFunctionDropDownMenu(categories, graphiteVersion) {
+  function createFunctionDropDownMenu(categories) {
     return _.map(categories, function(list, category) {
-      var versionRelatedList = _.filter(list, function(func) {
-        return isVersionRelatedFunction(func, graphiteVersion);
-      });
-      var submenu = _.map(versionRelatedList, function(value) {
+      var submenu = _.map(list, function(value) {
         return {
           text: value.name,
           click: "ctrl.addFunction('" + value.name + "')",
@@ -113,15 +107,5 @@ function (angular, _, $, gfunc) {
         submenu: submenu
       };
     });
-  }
-
-  function isVersionRelatedFunction(func, graphiteVersion) {
-    return isVersionGreaterOrEqual(graphiteVersion, func.version) || !func.version;
-  }
-
-  function isVersionGreaterOrEqual(a, b) {
-    var a_num = Number(a);
-    var b_num = Number(b);
-    return a_num >= b_num;
   }
 });

--- a/public/app/plugins/datasource/graphite/config_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/config_ctrl.ts
@@ -1,0 +1,20 @@
+///<reference path="../../../headers/common.d.ts" />
+
+import angular from 'angular';
+import _ from 'lodash';
+
+export class GraphiteConfigCtrl {
+  static templateUrl = 'public/app/plugins/datasource/graphite/partials/config.html';
+  current: any;
+
+  /** @ngInject */
+  constructor($scope) {
+    this.current.jsonData.graphiteVersion = this.current.jsonData.graphiteVersion || '0.9';
+  }
+
+  graphiteVersions = [
+    {name: '0.9.x', value: '0.9'},
+    {name: '1.0.x', value: '1.0'},
+  ];
+}
+

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -11,6 +11,7 @@ export function GraphiteDatasource(instanceSettings, $q, backendSrv, templateSrv
   this.basicAuth = instanceSettings.basicAuth;
   this.url = instanceSettings.url;
   this.name = instanceSettings.name;
+  this.graphiteVersion = instanceSettings.jsonData.graphiteVersion || '0.9';
   this.cacheTimeout = instanceSettings.cacheTimeout;
   this.withCredentials = instanceSettings.withCredentials;
   this.render_method = instanceSettings.render_method || 'POST';

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -116,27 +116,6 @@ function (_, $) {
   });
 
   addFuncDef({
-    name: 'mapSeries',
-    shortName: 'map',
-    params: [{ name: "node", type: 'int' }],
-    defaultParams: [3],
-    category: categories.Combine,
-  });
-
-  addFuncDef({
-    name: 'reduceSeries',
-    shortName: 'reduce',
-    params: [
-      { name: "function", type: 'string', options: ['asPercent', 'diffSeries', 'divideSeries'] },
-      { name: "reduceNode", type: 'int', options: [0,1,2,3,4,5,6,7,8,9,10,11,12,13] },
-      { name: "reduceMatchers", type: 'string' },
-      { name: "reduceMatchers", type: 'string' },
-    ],
-    defaultParams: ['asPercent', 2, 'used_bytes', 'total_bytes'],
-    category: categories.Combine,
-  });
-
-  addFuncDef({
     name: 'sumSeries',
     shortName: 'sum',
     category: categories.Combine,
@@ -150,11 +129,6 @@ function (_, $) {
     category: categories.Combine,
     params: optionalSeriesRefArgs,
     defaultParams: [''],
-  });
-
-  addFuncDef({
-    name: 'isNonNull',
-    category: categories.Combine,
   });
 
   addFuncDef({
@@ -263,23 +237,6 @@ function (_, $) {
   });
 
   addFuncDef({
-    name: "groupByNodes",
-    category: categories.Special,
-    params: [
-      {
-        name: "function",
-        type: "string",
-        options: ['sum', 'avg', 'maxSeries']
-      },
-      { name: "node", type: "int", options: [0,1,2,3,4,5,6,7,8,9,10,12] },
-      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
-      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
-      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
-    ],
-    defaultParams: ["sum", 3]
-  });
-
-  addFuncDef({
     name: 'aliasByNode',
     category: categories.Special,
     params: [
@@ -379,11 +336,6 @@ function (_, $) {
     category: categories.Transform,
     params: [{ name: "amount", type: "int", }],
     defaultParams: [10]
-  });
-
-  addFuncDef({
-    name: 'offsetToZero',
-    category: categories.Transform,
   });
 
   addFuncDef({
@@ -543,13 +495,6 @@ function (_, $) {
   });
 
   addFuncDef({
-    name: "grep",
-    category: categories.Filter,
-    params: [{ name: "grep", type: 'string' }],
-    defaultParams: ['grep']
-  });
-
-  addFuncDef({
     name: 'highestCurrent',
     category: categories.Filter,
     params: [{ name: "count", type: "int" }],
@@ -575,16 +520,6 @@ function (_, $) {
     category: categories.Filter,
     params: [{ name: "windowSize", type: "int_or_interval", options: ['5', '7', '10', '5min', '10min', '30min', '1hour'] }],
     defaultParams: [10]
-  });
-
-  addFuncDef({
-    name: 'weightedAverage',
-    category: categories.Filter,
-    params: [
-      { name: 'other', type: 'value_or_series', optional: true },
-      { name: "node", type: "int", options: [0,1,2,3,4,5,6,7,8,9,10,12] },
-    ],
-    defaultParams: ['#A', 4]
   });
 
   addFuncDef({
@@ -644,11 +579,6 @@ function (_, $) {
   });
 
   addFuncDef({
-    name: 'removeEmptySeries',
-    category: categories.Filter
-  });
-
-  addFuncDef({
     name: 'useSeriesAbove',
     category: categories.Filter,
     params: [
@@ -668,6 +598,227 @@ function (_, $) {
     category: categories.Combine,
     params: [{ name: "func", type: "select", options: ['sum', 'avg', 'min', 'max', 'last']}],
     defaultParams: ['avg'],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'averageOutsidePercentile',
+    category: categories.Filter,
+    params: [{ name: "n", type: "int", }],
+    defaultParams: [95],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'delay',
+    category: categories.Transform,
+    params: [{ name: 'steps', type: 'int', }],
+    defaultParams: [1],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'exponentialMovingAverage',
+    category: categories.Calculate,
+    params: [{ name: 'windowSize', type: 'int_or_interval', options: ['5', '7', '10', '5min', '10min', '30min', '1hour'] }],
+    defaultParams: [10],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'fallbackSeries',
+    category: categories.Special,
+    params: [{ name: 'fallback', type: 'string' }],
+    defaultParams: ['constantLine(0)'],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: "grep",
+    category: categories.Filter,
+    params: [{ name: "grep", type: 'string' }],
+    defaultParams: ['grep'],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: "groupByNodes",
+    category: categories.Special,
+    params: [
+      {
+        name: "function",
+        type: "string",
+        options: ['sum', 'avg', 'maxSeries']
+      },
+      { name: "node", type: "int", options: [0,1,2,3,4,5,6,7,8,9,10,12] },
+      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+      { name: "node", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+    ],
+    defaultParams: ["sum", 3],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'integralByInterval',
+    category: categories.Transform,
+    params: [{ name: "intervalUnit", type: "select", options: ['1h', '6h', '12h', '1d', '2d', '7d', '14d', '30d'] }],
+    defaultParams: ['1d'],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'interpolate',
+    category: categories.Transform,
+    params: [{ name: 'limit', type: 'int', optional: true}],
+    defaultParams: [],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'invert',
+    category: categories.Transform,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'isNonNull',
+    category: categories.Combine,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'linearRegression',
+    category: categories.Calculate,
+    params: [
+      { name: "startSourceAt", type: "select", options: ['-1h', '-6h', '-12h', '-1d', '-2d', '-7d', '-14d', '-30d'], optional: true },
+      { name: "endSourceAt", type: "select", options: ['-1h', '-6h', '-12h', '-1d', '-2d', '-7d', '-14d', '-30d'], optional: true }
+    ],
+    defaultParams: [],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'mapSeries',
+    shortName: 'map',
+    params: [{ name: "node", type: 'int' }],
+    defaultParams: [3],
+    category: categories.Combine,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'movingMin',
+    category: categories.Calculate,
+    params: [{ name: 'windowSize', type: 'int_or_interval', options: ['5', '7', '10', '5min', '10min', '30min', '1hour'] }],
+    defaultParams: [10],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'movingMax',
+    category: categories.Calculate,
+    params: [{ name: 'windowSize', type: 'int_or_interval', options: ['5', '7', '10', '5min', '10min', '30min', '1hour'] }],
+    defaultParams: [10],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'movingSum',
+    category: categories.Calculate,
+    params: [{ name: 'windowSize', type: 'int_or_interval', options: ['5', '7', '10', '5min', '10min', '30min', '1hour'] }],
+    defaultParams: [10],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: "multiplySeriesWithWildcards",
+    category: categories.Calculate,
+    params: [
+      { name: "position", type: "int", options: [0,1,2,3,4,5,6,7,8,9,10,12] },
+      { name: "position", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+      { name: "position", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+      { name: "position", type: "int", options: [0,-1,-2,-3,-4,-5,-6,-7], optional: true },
+    ],
+    defaultParams: [2],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'offsetToZero',
+    category: categories.Transform,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'pow',
+    category: categories.Transform,
+    params: [{ name: 'factor', type: 'int' }],
+    defaultParams: [10],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'powSeries',
+    category: categories.Transform,
+    params: optionalSeriesRefArgs,
+    defaultParams: [''],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'reduceSeries',
+    shortName: 'reduce',
+    params: [
+      { name: "function", type: 'string', options: ['asPercent', 'diffSeries', 'divideSeries'] },
+      { name: "reduceNode", type: 'int', options: [0,1,2,3,4,5,6,7,8,9,10,11,12,13] },
+      { name: "reduceMatchers", type: 'string' },
+      { name: "reduceMatchers", type: 'string' },
+    ],
+    defaultParams: ['asPercent', 2, 'used_bytes', 'total_bytes'],
+    category: categories.Combine,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'removeBetweenPercentile',
+    category: categories.Filter,
+    params: [{ name: "n", type: "int", }],
+    defaultParams: [95],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'removeEmptySeries',
+    category: categories.Filter,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'squareRoot',
+    category: categories.Transform,
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'timeSlice',
+    category: categories.Transform,
+    params: [
+      { name: "startSliceAt", type: "select", options: ['-1h', '-6h', '-12h', '-1d', '-2d', '-7d', '-14d', '-30d']},
+      { name: "endSliceAt", type: "select", options: ['-1h', '-6h', '-12h', '-1d', '-2d', '-7d', '-14d', '-30d'], optional: true }
+    ],
+    defaultParams: ['-1h'],
+    version: '1.0'
+  });
+
+  addFuncDef({
+    name: 'weightedAverage',
+    category: categories.Filter,
+    params: [
+      { name: 'other', type: 'value_or_series', optional: true },
+      { name: "node", type: "int", options: [0,1,2,3,4,5,6,7,8,9,10,12] },
+    ],
+    defaultParams: ['#A', 4],
     version: '1.0'
   });
 

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -659,6 +659,18 @@ function (_, $) {
     defaultParams: [0, 'search', 'replace']
   });
 
+  ////////////////////
+  // Graphite 1.0.x //
+  ////////////////////
+
+  addFuncDef({
+    name: 'aggregateLine',
+    category: categories.Combine,
+    params: [{ name: "func", type: "select", options: ['sum', 'avg', 'min', 'max', 'last']}],
+    defaultParams: ['avg'],
+    version: '1.0'
+  });
+
   _.each(categories, function(funcList, catName) {
     categories[catName] = _.sortBy(funcList, 'name');
   });

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -749,6 +749,16 @@ function (_, $) {
     this.text = text;
   };
 
+  function isVersionRelatedFunction(func, graphiteVersion) {
+    return isVersionGreaterOrEqual(graphiteVersion, func.version) || !func.version;
+  }
+
+  function isVersionGreaterOrEqual(a, b) {
+    var a_num = Number(a);
+    var b_num = Number(b);
+    return a_num >= b_num;
+  }
+
   return {
     createFuncInstance: function(funcDef, options) {
       if (_.isString(funcDef)) {
@@ -764,8 +774,18 @@ function (_, $) {
       return index[name];
     },
 
-    getCategories: function() {
-      return categories;
+    getCategories: function(graphiteVersion) {
+      var filteredCategories = {};
+      _.each(categories, function(functions, category) {
+        var filteredFuncs = _.filter(functions, function(func) {
+          return isVersionRelatedFunction(func, graphiteVersion);
+        });
+        if (filteredFuncs.length) {
+          filteredCategories[category] = filteredFuncs;
+        }
+      });
+
+      return filteredCategories;
     }
   };
 

--- a/public/app/plugins/datasource/graphite/module.ts
+++ b/public/app/plugins/datasource/graphite/module.ts
@@ -1,9 +1,6 @@
 import {GraphiteDatasource} from './datasource';
 import {GraphiteQueryCtrl} from './query_ctrl';
-
-class GraphiteConfigCtrl {
-  static templateUrl = 'partials/config.html';
-}
+import {GraphiteConfigCtrl} from './config_ctrl';
 
 class GraphiteQueryOptionsCtrl {
   static templateUrl = 'partials/query.options.html';

--- a/public/app/plugins/datasource/graphite/partials/config.html
+++ b/public/app/plugins/datasource/graphite/partials/config.html
@@ -3,3 +3,11 @@
 	suggest-url="http://localhost:8080">
 </datasource-http-settings>
 
+<h3 class="page-heading">Graphite details</h3>
+
+<div class="gf-form-group">
+	<div class="gf-form">
+		<span class="gf-form-label width-8">Version</span>
+		<select class="gf-form-input gf-size-auto" ng-model="ctrl.current.jsonData.graphiteVersion" ng-options="f.value as f.name for f in ctrl.graphiteVersions"></select>
+	</div>
+</div>

--- a/public/app/plugins/datasource/graphite/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/graphite/specs/datasource_specs.ts
@@ -5,7 +5,7 @@ import {GraphiteDatasource} from "../datasource";
 
 describe('graphiteDatasource', function() {
   var ctx = new helpers.ServiceTestContext();
-  var instanceSettings: any = {url: [''], name: 'graphiteProd'};
+  var instanceSettings: any = {url: [''], name: 'graphiteProd', jsonData: {}};
 
   beforeEach(angularMocks.module('grafana.core'));
   beforeEach(angularMocks.module('grafana.services'));


### PR DESCRIPTION
This PR adds new Graphite 1.0 functions (issue #8261) and new graphite data source option _graphite version_, which allows user to specify its' graphite version and filter functions related only to this particular version (issue #4622).

**Note**: some functions were existed, but caused an error when applying it to graphite 0.9.x. These functions were marked as `1.0`-specific.