### PR TITLE
fix: hide modals when pressing Esc, fixes #8988

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -214,12 +214,8 @@ export class KeybindingSrv {
       if (popups.length > 0) {
         return;
       }
-      // close modals
-      var modalData = $(".modal").data();
-      if (modalData && modalData.$scope && modalData.$scope.dismiss) {
-        modalData.$scope.dismiss();
-      }
 
+      scope.appEvent('hide-modal');
       scope.appEvent('hide-dash-editor');
       scope.appEvent('panel-change-view', {fullscreen: false, edit: false});
     });


### PR DESCRIPTION
This fixes the issue reported in https://github.com/grafana/grafana/issues/8988

We now send a `hide-modal` event, handled by `UtilSrv` to close the modal, rather than trying to close it directly in the `KeybindingSrv`.
