### PR TITLE
Fix #8998 by not overriding GOMAXPROCS

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -43,7 +43,6 @@ var pidFile = flag.String("pidfile", "", "path to pid file")
 var exitChan = make(chan int)
 
 func init() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 }
 
 func main() {


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/8998

Since Go 1.5 `GOMAXPROCS` is initialized with the number of cores available.
This change should not change anything if `GOMAXPROCS` is not explicitly set, but empowers the user to set a custom value.