### PR TITLE
Datasource Print the received error

### DIFF
--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -104,7 +104,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 	}
 
 	if err := bus.Dispatch(getDsInfo); err != nil {
-		return nil, fmt.Errorf("Could not find datasource")
+		return nil, fmt.Errorf("Could not find datasource %v", err)
 	}
 
 	req := c.getRequestForAlertRule(getDsInfo.Result, timeRange)


### PR DESCRIPTION
We had a problem with database of grafana, and received a lot of alerts of could not find datasource:
![image](https://user-images.githubusercontent.com/2526486/29358704-9ed5ca12-8284-11e7-912d-d41ea9f28714.png)

This should help to better understand what was happening.