### PR TITLE
added persistent colors #221

### DIFF
--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -91,7 +91,7 @@ export class DataProcessor {
   }
 
   hashStr(str) {
-  //Implementation of Java's hashcode function	
+  //Implementation of Java's hashcode function
     var hash = 0, i, utfCode;
     if (str.length === 0) {
       return hash;
@@ -108,7 +108,7 @@ export class DataProcessor {
     var datapoints = seriesData.datapoints || [];
     var alias = seriesData.target;
 
-    var colorIndex = hashStr(alias) % colors.length;
+    var colorIndex = this.hashStr(alias) % colors.length;
     var color = this.panel.aliasColors[alias] || colors[colorIndex];
 
     var series = new TimeSeries({datapoints: datapoints, alias: alias, color: color, unit: seriesData.unit});

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -1,5 +1,5 @@
 ///<reference path="../../../headers/common.d.ts" />
-
+/* tslint:disable:no-bitwise */
 import kbn from 'app/core/utils/kbn';
 import _ from 'lodash';
 import moment from 'moment';
@@ -89,12 +89,25 @@ export class DataProcessor {
       }
     }
   }
+  hashStr(str) {
+  //Implementation of Java's hashcode function	
+    var hash = 0, i, utfCode;
+    if (str.length === 0) {
+      return hash;
+    }
+    for (i = 0; i < str.length; i++) {
+      utfCode = str.charCodeAt(i);
+      utfCode = ((hash << 5) - hash) + utfCode;
+      utfCode = utfCode & utfCode;
+    }
+    return hash;
+    }
 
   timeSeriesHandler(seriesData, index, options) {
     var datapoints = seriesData.datapoints || [];
     var alias = seriesData.target;
 
-    var colorIndex = index % colors.length;
+    var colorIndex = hashStr(alias) % colors.length;
     var color = this.panel.aliasColors[alias] || colors[colorIndex];
 
     var series = new TimeSeries({datapoints: datapoints, alias: alias, color: color, unit: seriesData.unit});

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -89,6 +89,7 @@ export class DataProcessor {
       }
     }
   }
+
   hashStr(str) {
   //Implementation of Java's hashcode function	
     var hash = 0, i, utfCode;


### PR DESCRIPTION
I've made the colors for graph data persistent using a hash function implementation of Java's hash function and keeping the colors consistent for aliases of the same name (fixes issue #221). This will be helpful when comparing metrics on multiple graphs. Using this hash function enables Grafana to choose distinct colors from the array of colors it stores in public/app/core/utils/colors.ts
