### PR TITLE
Prometheus: Fix actual step computation logic for longer time ranges

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -128,7 +128,7 @@ export function PrometheusDatasource(instanceSettings, $q, backendSrv, templateS
     // Prometheus drop query if range/step > 11000
     // calibrate step if it is too big
     if (step !== 0 && range / step > 11000) {
-      return Math.ceil(range / 11000);
+      step = Math.ceil(range / 11000);
     }
     return Math.max(step, autoStep);
   };


### PR DESCRIPTION
PR #8073 introduced the concept of a minimum step (i.e. resolution) for Prometheus queries, e.g. at most 1 data point per 30 seconds because Prometheus only collects data once a minute.

There was however a bug introduced with that change, whereby the resulting interval was always `range / 11000` if the time range was long enough, annoyingly enough resulting in requesting 11k datapoints from Prometheus for very long ranges.