### PR TITLE
[Bug #9139] Cancel the initial timer when changing the auto-refresh interval

### DIFF
--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -116,16 +116,14 @@ class TimeSrv {
 
   setAutoRefresh(interval) {
     this.dashboard.refresh = interval;
+    this.cancelNextRefresh();
     if (interval) {
       var intervalMs = kbn.interval_to_ms(interval);
 
-      this.$timeout(() => {
+      this.refreshTimer = this.timer.register(this.$timeout(() => {
         this.startNextRefreshTimer(intervalMs);
         this.refreshDashboard();
-      }, intervalMs);
-
-    } else {
-      this.cancelNextRefresh();
+      }, intervalMs));
     }
 
     // update url


### PR DESCRIPTION
This fixes #9139. 

Previously, the initial timer was not registered anywhere and would always trigger, even when the auto-refresh interval was subsequently changed.
