### PR TITLE
Encode row variables as URL components

### DIFF
--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -129,7 +129,7 @@ export class TableRenderer {
     let row = this.table.rows[rowIndex];
     for (let i = 0; i < row.length; i++) {
       cell_variable = `__cell_${i}`;
-      scopedVars[cell_variable] = { value: row[i] };
+      scopedVars[cell_variable] = { value: encodeURIComponent(row[i]) };
     }
     return scopedVars;
   }


### PR DESCRIPTION
I've discovered an issue with the clickable cell link functionality 
https://github.com/grafana/grafana/pull/8738

When the link to another dashboard was generated, using variables from other rows they were not URL encoded properly, rendering the links unusable (not encoded quote marks were direct cause of the problem). This PR fixes this issue.