### PR TITLE
Fix sortByName and percentileOfSeries in gfunc.js

### DIFF
--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -139,8 +139,8 @@ function (_, $) {
   addFuncDef({
     name: 'percentileOfSeries',
     category: categories.Combine,
-    params: [{ name: "n", type: "int" }, { name: "interpolate", type: "select", options: ["true", "false"] }],
-    defaultParams: [95, "false"]
+    params: [{ name: 'n', type: 'int' }, { name: 'interpolate', type: 'boolean', options: ['true', 'false'] }],
+    defaultParams: [95, 'false']
   });
 
   addFuncDef({
@@ -261,8 +261,8 @@ function (_, $) {
   addFuncDef({
     name: 'sortByName',
     category: categories.Special,
-    params: [{ name: "natural", type: "select", options: ["true", "false"], optional: true }],
-    defaultParams: ["false"]
+    params: [{ name: 'natural', type: 'boolean', options: ['true', 'false'], optional: true }],
+    defaultParams: ['false']
   });
 
   addFuncDef({


### PR DESCRIPTION
Fixing type of parameters from "select" to "boolean" for working with carbonapi (like it was done in summarize function) + some commas prettify.
