### PR TITLE
(prometheus) cache metric suggest query result

### DIFF
--- a/public/app/plugins/datasource/prometheus/completer.ts
+++ b/public/app/plugins/datasource/prometheus/completer.ts
@@ -23,7 +23,7 @@ export class PromCompleter {
     var query = prefix;
     var line = editor.session.getLine(pos.row);
 
-    return this.datasource.performSuggestQuery(query).then(metricNames => {
+    return this.datasource.performSuggestQuery(query, true).then(metricNames => {
       callback(null, metricNames.map(name => {
         let value = name;
         if (prefix === '(') {

--- a/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/metric_find_query_specs.ts
@@ -107,4 +107,25 @@ describe('PrometheusMetricFindQuery', function() {
       expect(results[0].text).to.be('metric{job="testjob"} 3846 1443454528000');
     });
   });
+
+  describe('When performing performSuggestQuery', function() {
+    var results;
+    var response;
+    it('cache response', function() {
+      response = {
+        status: "success",
+        data: ["value1", "value2", "value3"]
+      };
+      ctx.$httpBackend.expect('GET', 'proxied/api/v1/label/__name__/values').respond(response);
+      ctx.ds.performSuggestQuery('value', true).then(function(data) { results = data; });
+      ctx.$httpBackend.flush();
+      ctx.$rootScope.$apply();
+      expect(results.length).to.be(3);
+      ctx.ds.performSuggestQuery('value', true).then(function (data) {
+        // get from cache, no need to flush
+        results = data;
+        expect(results.length).to.be(3);
+      });
+    });
+  });
 });


### PR DESCRIPTION
When I am editing query, performSuggestQuery() is called many times.
I'm not sure how the query cost is big, but it might be better to cache the result.
By caching the result, editor responsibility might be improved.