### PR TITLE
(prometheus) fix reverted editor auto focus

### DIFF
--- a/public/app/core/components/code_editor/code_editor.ts
+++ b/public/app/core/components/code_editor/code_editor.ts
@@ -111,7 +111,14 @@ function link(scope, elem, attrs) {
   let textarea = elem.find("textarea");
   textarea.addClass('gf-form-input');
   if (attrs.giveFocus) {
-    textarea.attr('give-focus', attrs.giveFocus);
+    setTimeout(function () {
+      textarea.focus();
+      var domEl = textarea[0];
+      if (domEl.setSelectionRange) {
+        var pos = textarea.val().length * 2;
+        domEl.setSelectionRange(pos, pos);
+      }
+    }, 200);
   }
 
   // Event handlers

--- a/public/app/core/components/code_editor/code_editor.ts
+++ b/public/app/core/components/code_editor/code_editor.ts
@@ -110,7 +110,7 @@ function link(scope, elem, attrs) {
   elem.addClass("gf-code-editor");
   let textarea = elem.find("textarea");
   textarea.addClass('gf-form-input');
-  if (attrs.giveFocus) {
+  if (scope.focus) {
     setTimeout(function () {
       textarea.focus();
       var domEl = textarea[0];
@@ -209,6 +209,7 @@ export function codeEditorDirective() {
     template: editorTemplate,
     scope: {
       content: "=",
+      focus: "=",
       onChange: "&",
       getCompleter: "&"
     },

--- a/public/app/core/components/code_editor/code_editor.ts
+++ b/public/app/core/components/code_editor/code_editor.ts
@@ -110,6 +110,9 @@ function link(scope, elem, attrs) {
   elem.addClass("gf-code-editor");
   let textarea = elem.find("textarea");
   textarea.addClass('gf-form-input');
+  if (attrs.giveFocus) {
+    textarea.attr('give-focus', attrs.giveFocus);
+  }
 
   // Event handlers
   editorSession.on('change', (e) => {

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -2,7 +2,7 @@
 	<div class="gf-form-inline">
 		<div class="gf-form gf-form--grow">
 			<code-editor content="ctrl.target.expr" on-change="ctrl.refreshMetricData()"
-				get-completer="ctrl.getCompleter()" data-mode="prometheus">
+				get-completer="ctrl.getCompleter()" data-mode="prometheus" give-focus="ctrl.target.refId == 'A'">
 			</code-editor>
 		</div>
 	</div>

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -2,7 +2,7 @@
 	<div class="gf-form-inline">
 		<div class="gf-form gf-form--grow">
 			<code-editor content="ctrl.target.expr" on-change="ctrl.refreshMetricData()"
-				get-completer="ctrl.getCompleter()" data-mode="prometheus" give-focus="ctrl.target.refId == 'A'">
+				get-completer="ctrl.getCompleter()" data-mode="prometheus" focus="ctrl.target.refId == 'A'">
 			</code-editor>
 		</div>
 	</div>


### PR DESCRIPTION
This change is accidentally reverted when switching to ace editor.
https://github.com/grafana/grafana/pull/8879/files

I try to fix it, but due to my poor knowledge of AngularJS, I can't fix it without copying code from `giveFocus` directive.