### PR TITLE
ace: fix braces highlight in prometheus

### DIFF
--- a/public/app/core/components/code_editor/mode-prometheus.js
+++ b/public/app/core/components/code_editor/mode-prometheus.js
@@ -68,17 +68,17 @@ var PrometheusHighlightRules = function() {
       token : "label.name",
       regex : '[a-zA-Z_][a-zA-Z0-9_]*'
     }, {
-      token : "label.matching_operator",
+      token : "keyword.operator",
       regex : '=|!=|=~|!~'
     }, {
-      token : "label.value",
+      token : "text",
       regex : '"[^"]*"|\'[^\']*\''
     }, {
-      token : "label.matching_delimiter",
+      token : "punctuation.operator",
       regex : ",",
       push  : 'start-label-matcher'
     }, {
-      token : "label.matching_end",
+      token : "paren.rparen",
       regex : "}",
       next  : "start"
     } ]


### PR DESCRIPTION
This PR fixes highlighting issues introduced with #9167
This caused because ace themes use token name for adding CSS classes to keywords. So it's better to use existing names instead of creating new. For new names you should add classes to theme file for proper highlighting.