### PR TITLE
get s3 url via aws-sdk-go, fix #9189

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -458,7 +458,8 @@ url = https://grafana.com
 provider =
 
 [external_image_storage.s3]
-bucket_url =
+bucket =
+region =
 access_key =
 secret_key =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -403,7 +403,8 @@
 ;provider =
 
 [external_image_storage.s3]
-;bucket_url =
+;bucket =
+;region =
 ;access_key =
 ;secret_key =
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -648,12 +648,16 @@ These options control how images should be made public so they can be shared on 
 You can choose between (s3, webdav). If left empty Grafana will ignore the upload action.
 
 ## [external_image_storage.s3]
+### bucket
+Bucket name for S3. e.g. grafana.snapshot
+### region
+Region name for S3. e.g. 'us-east-1', 'cn-north-1', etc
 
 ### bucket_url
+(for backward compatibility, only works when no bucket or region are configured)
 Bucket URL for S3. AWS region can be specified within URL or defaults to 'us-east-1', e.g.
 - http://grafana.s3.amazonaws.com/
 - https://grafana.s3-ap-southeast-2.amazonaws.com/
-- https://grafana.s3-cn-north-1.amazonaws.com.cn
 
 ### access_key
 Access key. e.g. AAAAAAAAAAAAAAAAAAAA

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -27,15 +27,21 @@ func NewImageUploader() (ImageUploader, error) {
 			return nil, err
 		}
 
+		bucket := s3sec.Key("bucket").MustString("")
+		region := s3sec.Key("region").MustString("")
 		bucketUrl := s3sec.Key("bucket_url").MustString("")
 		accessKey := s3sec.Key("access_key").MustString("")
 		secretKey := s3sec.Key("secret_key").MustString("")
-		info, err := getRegionAndBucketFromUrl(bucketUrl)
-		if err != nil {
-			return nil, err
+		if bucket == "" || region == "" {
+			info, err := getRegionAndBucketFromUrl(bucketUrl)
+			if err != nil {
+				return nil, err
+			}
+			bucket = info.bucket
+			region = info.region
 		}
 
-		return NewS3Uploader(info.region, info.bucket, "public-read", accessKey, secretKey), nil
+		return NewS3Uploader(region, bucket, "public-read", accessKey, secretKey), nil
 	case "webdav":
 		webdavSec, err := setting.Cfg.GetSection("external_image_storage.webdav")
 		if err != nil {

--- a/pkg/components/imguploader/s3uploader.go
+++ b/pkg/components/imguploader/s3uploader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/grafana/grafana/pkg/log"
@@ -53,8 +54,10 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 		Credentials: creds,
 	}
 
+	s3_endpoint, _ := endpoints.DefaultResolver().EndpointFor("s3", u.region)
 	key := util.GetRandomString(20) + ".png"
-	log.Debug("Uploading image to s3", "bucket = ", u.bucket, ", key = ", key)
+	image_url := s3_endpoint.URL + "/" + u.bucket + "/" + key
+	log.Debug("Uploading image to s3", "url = ", image_url)
 
 	file, err := os.Open(imageDiskPath)
 	if err != nil {
@@ -77,10 +80,5 @@ func (u *S3Uploader) Upload(imageDiskPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	if u.region == "us-east-1" {
-		return "https://" + u.bucket + ".s3.amazonaws.com/" + key, nil
-	} else {
-		return "https://" + u.bucket + ".s3-" + u.region + ".amazonaws.com/" + key, nil
-	}
+	return image_url, nil
 }


### PR DESCRIPTION
ref #9189 

Debug log with uploading to s3 `ap-northeast-1`:

```go
DBUG[09-13|03:27:02] Image rendered                           logger=png-renderer path=/usr/share/grafana/data/png/4epc3CbtT0MCKVeatDjw.png
DBUG[09-13|03:27:02] Uploading image to s3%!(EXTRA string=url = , string=https://s3-ap-northeast-1.amazonaws.com/grafana.codo/J4W7M82V7wnsUJ4HobD4.png) 
INFO[09-13|03:27:03] uploaded                                 logger=alerting.notifier url=https://s3-ap-northeast-1.amazonaws.com/grafana.codo/J4W7M82V7wnsUJ4HobD4.png
INFO[09-13|03:27:03] Sending notification                     logger=alerting.notifier type=slack id=1 isDefault=false
```

Looks good for slack
<img width="691" alt="screen shot 2017-09-13 at 15 36 58" src="https://user-images.githubusercontent.com/3284451/30365168-7a3f095e-9899-11e7-8c9b-4d8fba86ef41.png">
