### PR TITLE
allow SSL/TLS renegotiation for datasources

### DIFF
--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -17,7 +17,10 @@ import (
 )
 
 var pluginProxyTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	TLSClientConfig: &tls.Config{
+		InsecureSkipVerify: true,
+		Renegotiation: tls.RenegotiateFreelyAsClient,
+	},
 	Proxy:           http.ProxyFromEnvironment,
 	Dial: (&net.Dialer{
 		Timeout:   30 * time.Second,

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -48,6 +48,7 @@ func (ds *DataSource) GetHttpTransport() (*http.Transport, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
+			Renegotiation: tls.RenegotiateFreelyAsClient,
 		},
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{


### PR DESCRIPTION
Allows server-specified SSL/TLS renegotiation.  This is useful in the case of an HTTP server allowing multiple forms of authentication, one of which being client certificates.  In this case, the client certificate may not be required and a renegotiation is triggered in order to attempt client cert auth.

Addresses #9250 