### PR TITLE
Initial graphite tags support

### DIFF
--- a/public/app/plugins/datasource/graphite/config_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/config_ctrl.ts
@@ -16,6 +16,7 @@ export class GraphiteConfigCtrl {
   graphiteVersions = [
     {name: '0.9.x', value: '0.9'},
     {name: '1.0.x', value: '1.0'},
+    {name: '1.1.x', value: '1.1'},
   ];
 }
 

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -822,6 +822,18 @@ function (_, $) {
     version: '1.0'
   });
 
+  addFuncDef({
+    name: 'seriesByTag',
+    category: categories.Special,
+    params: [
+      { name: "tagExpression", type: "string" },
+      { name: "tagExpression", type: "string", optional: true },
+      { name: "tagExpression", type: "string", optional: true },
+      { name: "tagExpression", type: "string", optional: true },
+    ],
+    version: '1.0'
+  });
+
   _.each(categories, function(funcList, catName) {
     categories[catName] = _.sortBy(funcList, 'name');
   });

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -831,7 +831,7 @@ function (_, $) {
       { name: "tagExpression", type: "string", optional: true },
       { name: "tagExpression", type: "string", optional: true },
     ],
-    version: '1.0'
+    version: '1.1'
   });
 
   addFuncDef({
@@ -849,7 +849,7 @@ function (_, $) {
       { name: "tag", type: "string", optional: true },
     ],
     defaultParams: ["sum", "tag"],
-    version: '1.0'
+    version: '1.1'
   });
 
   addFuncDef({
@@ -862,7 +862,7 @@ function (_, $) {
       { name: "tag", type: "string", optional: true },
     ],
     defaultParams: ["tag"],
-    version: '1.0'
+    version: '1.1'
   });
 
   _.each(categories, function(funcList, catName) {

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -834,6 +834,24 @@ function (_, $) {
     version: '1.0'
   });
 
+  addFuncDef({
+    name: "groupByTags",
+    category: categories.Special,
+    params: [
+      {
+        name: "function",
+        type: "string",
+        options: ['sum', 'avg', 'maxSeries']
+      },
+      { name: "tag", type: "string" },
+      { name: "tag", type: "string", optional: true },
+      { name: "tag", type: "string", optional: true },
+      { name: "tag", type: "string", optional: true },
+    ],
+    defaultParams: ["sum", "tag"],
+    version: '1.0'
+  });
+
   _.each(categories, function(funcList, catName) {
     categories[catName] = _.sortBy(funcList, 'name');
   });

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -852,6 +852,19 @@ function (_, $) {
     version: '1.0'
   });
 
+  addFuncDef({
+    name: "aliasByTags",
+    category: categories.Special,
+    params: [
+      { name: "tag", type: "string" },
+      { name: "tag", type: "string", optional: true },
+      { name: "tag", type: "string", optional: true },
+      { name: "tag", type: "string", optional: true },
+    ],
+    defaultParams: ["tag"],
+    version: '1.0'
+  });
+
   _.each(categories, function(funcList, catName) {
     categories[catName] = _.sortBy(funcList, 'name');
   });

--- a/public/app/plugins/datasource/graphite/gfunc.js
+++ b/public/app/plugins/datasource/graphite/gfunc.js
@@ -916,7 +916,7 @@ function (_, $) {
     // if string contains ',' and next param is optional, split and update both
     if (this._hasMultipleParamsInString(strValue, index)) {
       _.each(strValue.split(','), function(partVal, idx) {
-        this.updateParam(partVal.trim(), idx);
+        this.updateParam(partVal.trim(), index + idx);
       }.bind(this));
       return;
     }

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -96,7 +96,8 @@ export class GraphiteQueryCtrl extends QueryCtrl {
         if ((index-1) >= func.def.params.length) {
           throw { message: 'invalid number of parameters to method ' + func.def.name };
         }
-        this.addFunctionParameter(func, astNode.value, index, true);
+        var shiftBack = this.isShiftParamsBack(func);
+        this.addFunctionParameter(func, astNode.value, index, shiftBack);
       break;
       case 'metric':
         if (this.segments.length > 0) {
@@ -111,6 +112,10 @@ export class GraphiteQueryCtrl extends QueryCtrl {
         return this.uiSegmentSrv.newSegment(segment);
       });
     }
+  }
+
+  isShiftParamsBack(func) {
+    return func.def.name !== 'seriesByTag';
   }
 
   getSegmentPathUpTo(index) {


### PR DESCRIPTION
This PR adds initial Graphite tags support (issue #9230) by using new functions:
- seriesByTag()
- groupByTags()
- aliasByTags()

Also, this fixes graphite function editor issue #9238 