### PR TITLE
Fully fill out nulls in cloudfront data source

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -386,8 +386,9 @@ function (angular, _, moment, dateMath, kbn, templatingVariable, CloudWatchAnnot
         })
         .each(function(dp) {
           var timestamp = new Date(dp.Timestamp).getTime();
-          if (lastTimestamp && (timestamp - lastTimestamp) > periodMs) {
+          while (lastTimestamp && (timestamp - lastTimestamp) > periodMs) {
             dps.push([null, lastTimestamp + periodMs]);
+            lastTimestamp = lastTimestamp + periodMs;
           }
           lastTimestamp = timestamp;
           if (!extended) {


### PR DESCRIPTION
Summary:
Previously, cloudwatch data sources would only fill in a single null value if
there was missing data. This results in behavior described in #9267. This
resolves that issue by filling the entire missing period with null values. The
null values can then be interpreted as normal by the graphing frontend.

Test Plan:
Used on a data source that had missing data for many consecutive periods.
Ensured that the graph remained at 0 across the entire window.
