### PR TITLE
Remove duplicate bus.AddHandler()

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -28,7 +28,6 @@ func init() {
 	bus.AddHandler("sql", SearchUsers)
 	bus.AddHandler("sql", GetUserOrgList)
 	bus.AddHandler("sql", DeleteUser)
-	bus.AddHandler("sql", SetUsingOrg)
 	bus.AddHandler("sql", UpdateUserPermissions)
 	bus.AddHandler("sql", SetUserHelpFlag)
 }


### PR DESCRIPTION
`bus.AddHandler("sql", SetUsingOrg)` is already called on line 24.

Very minor change.