### PR TITLE
fixing spelling of millesecond -> millisecond

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -102,7 +102,7 @@ func init() {
 
 	M_Http_Request_Summary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "http_request_duration_milleseconds",
+			Name: "http_request_duration_milliseconds",
 			Help: "http request summary",
 		},
 		[]string{"handler", "statuscode", "method"},
@@ -127,19 +127,19 @@ func init() {
 	})
 
 	M_Api_Dashboard_Save = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_save_milleseconds",
+		Name:      "api_dashboard_save_milliseconds",
 		Help:      "summary for dashboard save duration",
 		Namespace: exporterName,
 	})
 
 	M_Api_Dashboard_Get = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_get_milleseconds",
+		Name:      "api_dashboard_get_milliseconds",
 		Help:      "summary for dashboard get duration",
 		Namespace: exporterName,
 	})
 
 	M_Api_Dashboard_Search = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_search_milleseconds",
+		Name:      "api_dashboard_search_milliseconds",
 		Help:      "summary for dashboard search duration",
 		Namespace: exporterName,
 	})
@@ -223,7 +223,7 @@ func init() {
 	})
 
 	M_DataSource_ProxyReq_Timer = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dataproxy_request_all_milleseconds",
+		Name:      "api_dataproxy_request_all_milliseconds",
 		Help:      "summary for dashboard search duration",
 		Namespace: exporterName,
 	})


### PR DESCRIPTION
I noticed this today when exploring data via Prometheus.