### PR TITLE
Add `DbClusterIdentifier` to CloudWatch dimensions

### DIFF
--- a/pkg/api/cloudwatch/metrics.go
+++ b/pkg/api/cloudwatch/metrics.go
@@ -126,7 +126,7 @@ func init() {
 		"AWS/NATGateway":       {"NatGatewayId"},
 		"AWS/OpsWorks":         {"StackId", "LayerId", "InstanceId"},
 		"AWS/Redshift":         {"NodeID", "ClusterIdentifier"},
-		"AWS/RDS":              {"DBInstanceIdentifier", "DBClusterIdentifier", "DatabaseClass", "EngineName", "Role"},
+		"AWS/RDS":              {"DBInstanceIdentifier", "DBClusterIdentifier", "DbClusterIdentifier", "DatabaseClass", "EngineName", "Role"},
 		"AWS/Route53":          {"HealthCheckId", "Region"},
 		"AWS/S3":               {"BucketName", "StorageType", "FilterId"},
 		"AWS/SES":              {},


### PR DESCRIPTION
Unfortunately CloudWatch dimensions are case-sensitive and it uses both `DBClusterIdentifier` and `DbClusterIdentifier` (notice the lower case `b`) depending on the metric. All metrics which also have the `Role` dimension appear to use `DBClusterIdentifier`, whereas metric with the `EngineName` dimension use `DbClusterIdentifier`.

Given this, I think think the best option is to support both. I ended up wasting a lot of time figuring out why my metrics were not showing up. If I had seen two options I would have noticed the issue more quickly.