### PR TITLE
Added --pluginUrl option to grafana-cli for local network plugin inst…

### DIFF
--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -72,6 +72,11 @@ The Download URL from Grafana.com API is in this form:
 
 `https://grafana.com/api/plugins/<plugin id>/versions/<version number>/download`
 
+You can specify a local URL by using the `--pluginUrl` option.
+```
+grafana-cli --pluginUrl https://nexus.company.com/grafana/plugins/<plugin-id>-<plugin-version>.zip plugins install <plugin-id>
+```
+
 To manually install a Plugin via the Grafana.com API:
 
 1. Find the plugin you want to download, the plugin id can be found on the Installation Tab on the plugin's page on Grafana.com. In this example, the plugin id is `jdbranham-diagram-panel`:

--- a/pkg/cmd/grafana-cli/commands/command_line.go
+++ b/pkg/cmd/grafana-cli/commands/command_line.go
@@ -19,6 +19,7 @@ type CommandLine interface {
 
 	PluginDirectory() string
 	RepoDirectory() string
+	PluginURL() string
 }
 
 type contextCommandLine struct {
@@ -43,4 +44,8 @@ func (c *contextCommandLine) PluginDirectory() string {
 
 func (c *contextCommandLine) RepoDirectory() string {
 	return c.GlobalString("repo")
+}
+
+func (c *contextCommandLine) PluginURL() string {
+	return c.GlobalString("pluginUrl")
 }

--- a/pkg/cmd/grafana-cli/commands/commandstest/fake_commandLine.go
+++ b/pkg/cmd/grafana-cli/commands/commandstest/fake_commandLine.go
@@ -101,3 +101,7 @@ func (fcli *FakeCommandLine) RepoDirectory() string {
 func (fcli *FakeCommandLine) PluginDirectory() string {
 	return fcli.GlobalString("pluginsDir")
 }
+
+func (fcli *FakeCommandLine) PluginURL() string {
+	return fcli.GlobalString("pluginUrl")
+}

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -58,37 +58,39 @@ func installCommand(c CommandLine) error {
 }
 
 func InstallPlugin(pluginName, version string, c CommandLine) error {
-	plugin, err := s.GetPlugin(pluginName, c.RepoDirectory())
 	pluginFolder := c.PluginDirectory()
-	if err != nil {
-		return err
+	downloadURL := c.PluginURL()
+	if downloadURL == "" {
+		plugin, err := s.GetPlugin(pluginName, c.RepoDirectory())
+		if err != nil {
+			return err
+		}
+
+		v, err := SelectVersion(plugin, version)
+		if err != nil {
+			return err
+		}
+
+		if version == "" {
+			version = v.Version
+		}
+		downloadURL = fmt.Sprintf("%s/%s/versions/%s/download",
+			c.GlobalString("repo"),
+			pluginName,
+			version)
 	}
 
-	v, err := SelectVersion(plugin, version)
-	if err != nil {
-		return err
-	}
-
-	if version == "" {
-		version = v.Version
-	}
-
-	downloadURL := fmt.Sprintf("%s/%s/versions/%s/download",
-		c.GlobalString("repo"),
-		pluginName,
-		version)
-
-	logger.Infof("installing %v @ %v\n", plugin.Id, version)
+	logger.Infof("installing %v @ %v\n", pluginName, version)
 	logger.Infof("from url: %v\n", downloadURL)
 	logger.Infof("into: %v\n", pluginFolder)
 	logger.Info("\n")
 
-	err = downloadFile(plugin.Id, pluginFolder, downloadURL)
+	err := downloadFile(pluginName, pluginFolder, downloadURL)
 	if err != nil {
 		return err
 	}
 
-	logger.Infof("%s Installed %s successfully \n", color.GreenString("✔"), plugin.Id)
+	logger.Infof("%s Installed %s successfully \n", color.GreenString("✔"), pluginName)
 
 	res, _ := s.ReadPlugin(pluginFolder, pluginName)
 	for _, v := range res.Dependencies.Plugins {

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -38,6 +38,12 @@ func main() {
 			Value:  "https://grafana.com/api/plugins",
 			EnvVar: "GF_PLUGIN_REPO",
 		},
+		cli.StringFlag{
+			Name:   "pluginUrl",
+			Usage:  "Full url to the plugin zip file instead of downloading the plugin from grafana.com/api",
+			Value:  "",
+			EnvVar: "GF_PLUGIN_URL",
+		},
 		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "enable debug logging",


### PR DESCRIPTION
## Grafana-cli

New option `--pluginUrl` to allow local network plugin installation
Related Issue : #5873

example :
```
grafana-cli --pluginUrl <url-to-zip-file> plugins install <plugin-id>
```