### PR TITLE
Explicitly refer to Github 'OAuth' applications

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -308,15 +308,15 @@ options are `Editor` and `Admin`.
 
 ## [auth.github]
 
-You need to create a GitHub application (you find this under the GitHub
-profile page). When you create the application you will need to specify
+You need to create a GitHub OAuth application (you find this under the GitHub
+settings page). When you create the application you will need to specify
 a callback URL. Specify this as callback:
 
     http://<my_grafana_server_name_or_ip>:<grafana_server_port>/login/github
 
 This callback URL must match the full HTTP address that you use in your
 browser to access Grafana, but with the prefix path of `/login/github`.
-When the GitHub application is created you will get a Client ID and a
+When the GitHub OAuth application is created you will get a Client ID and a
 Client Secret. Specify these in the Grafana configuration file. For
 example:
 


### PR DESCRIPTION
A 'Github Application' is now something else, and will not work with Grafana.
