### PR TITLE
templating: fix dependent variable updating

### DIFF
--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -43,7 +43,6 @@ export class VariableSrv {
       var previousOptions = variable.options.slice();
 
       return variable.updateOptions()
-      .then(this.variableUpdated.bind(this, variable))
       .then(() => {
         if (angular.toJson(previousOptions) !== angular.toJson(variable.options)) {
           this.$rootScope.$emit('template-variable-value-updated');


### PR DESCRIPTION
This PR fixes #9185 
Seems, it was caused by unnecessary `variableUpdated()` call. This function is called by `setOptionAsCurrent()` from `updateOptions()` call. So calling `variableUpdated()` after `updateOptions()` caused this behaviour.
