### PR TITLE
fix: close for 'Unsaved Changes' modal, #9284

### DIFF
--- a/public/app/features/dashboard/unsaved_changes_modal.ts
+++ b/public/app/features/dashboard/unsaved_changes_modal.ts
@@ -10,7 +10,7 @@ const  template = `
       <span class="p-l-1">Unsaved changes</span>
     </h2>
 
-    <a class="modal-header-close" ng-click="dismiss();">
+    <a class="modal-header-close" ng-click="ctrl.dismiss();">
       <i class="fa fa-remove"></i>
     </a>
   </div>


### PR DESCRIPTION
Missing reference to the controller instance.
Fix for issue #9284 
