### PR TITLE
Combine multiple table formatted queries/series in table panel

### DIFF
--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -148,7 +148,16 @@ transformers['table'] = {
     }
 
     model.columns = data[0].columns;
-    model.rows = data[0].rows;
+    for (var i = 0; i < data.length; i++) {
+      var series = data[i];
+      if (series.columns.length !== data[0].columns.length) {
+        model.rows = data[0].rows;
+        break;
+      }
+      for (var y = 0; y < series.rows.length; y++) {
+        model.rows.push(series.rows[y]);
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Fix/new feature for #9170 (but not #9134)

Defaults to old behavior (only the first series) if the number of columns is not the same for all series in the table.