### PR TITLE
introduce smtp config option for EHLO identity

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -318,6 +318,7 @@ key_file =
 skip_verify = false
 from_address = admin@grafana.localhost
 from_name = Grafana
+ehlo_identity =
 
 [emails]
 welcome_email_on_sign_up = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -295,6 +295,8 @@
 ;skip_verify = false
 ;from_address = admin@grafana.localhost
 ;from_name = Grafana
+# EHLO identity in SMTP dialog (defaults to instance_name)
+;ehlo_identity = dashboard.example.com
 
 [emails]
 ;welcome_email_on_sign_up = false

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -161,6 +161,7 @@ Only works with Basic Authentication (username and password). See [introduction]
         "enabled":"false",
         "from_address":"admin@grafana.localhost",
         "from_name":"Grafana",
+        "ehlo_identity":"dashboard.example.com",
         "host":"localhost:25",
         "key_file":"",
         "password":"************",

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -593,6 +593,9 @@ Address used when sending out emails, defaults to `admin@grafana.localhost`
 ### from_name
 Name to be used when sending out emails, defaults to `Grafana`
 
+### ehlo_identity
+Name to be used as client identity for EHLO in SMTP dialog, defaults to instance_name.
+
 ## [log]
 
 ### mode

--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -101,7 +101,11 @@ func createDialer() (*gomail.Dialer, error) {
 
 	d := gomail.NewDialer(host, iPort, setting.Smtp.User, setting.Smtp.Password)
 	d.TLSConfig = tlsconfig
-	d.LocalName = setting.InstanceName
+	if setting.Smtp.EhloIdentity != "" {
+		d.LocalName = setting.Smtp.EhloIdentity
+	} else {
+		d.LocalName = setting.InstanceName
+	}
 	return d, nil
 }
 

--- a/pkg/setting/setting_smtp.go
+++ b/pkg/setting/setting_smtp.go
@@ -1,15 +1,16 @@
 package setting
 
 type SmtpSettings struct {
-	Enabled     bool
-	Host        string
-	User        string
-	Password    string
-	CertFile    string
-	KeyFile     string
-	FromAddress string
-	FromName    string
-	SkipVerify  bool
+	Enabled      bool
+	Host         string
+	User         string
+	Password     string
+	CertFile     string
+	KeyFile      string
+	FromAddress  string
+	FromName     string
+	EhloIdentity string
+	SkipVerify   bool
 
 	SendWelcomeEmailOnSignUp bool
 	TemplatesPattern         string
@@ -25,6 +26,7 @@ func readSmtpSettings() {
 	Smtp.KeyFile = sec.Key("key_file").String()
 	Smtp.FromAddress = sec.Key("from_address").String()
 	Smtp.FromName = sec.Key("from_name").String()
+	Smtp.EhloIdentity = sec.Key("ehlo_identity").String()
 	Smtp.SkipVerify = sec.Key("skip_verify").MustBool(false)
 
 	emails := Cfg.Section("emails")


### PR DESCRIPTION
This PR introduces the configurability of the EHLO (HELO) identity used in the beginning of the SMTP dialog when sending out emails.

( implements #9319 )
