### PR TITLE
allow alert notification to take custom ID via API

### DIFF
--- a/pkg/models/alert_notifications.go
+++ b/pkg/models/alert_notifications.go
@@ -18,6 +18,7 @@ type AlertNotification struct {
 }
 
 type CreateAlertNotificationCommand struct {
+	Id        int64            `json:"id"`
 	Name      string           `json:"name"  binding:"Required"`
 	Type      string           `json:"type"  binding:"Required"`
 	IsDefault bool             `json:"isDefault"`

--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -143,6 +143,7 @@ func CreateAlertNotificationCommand(cmd *m.CreateAlertNotificationCommand) error
 		}
 
 		alertNotification := &m.AlertNotification{
+			Id:        cmd.Id,
 			OrgId:     cmd.OrgId,
 			Name:      cmd.Name,
 			Type:      cmd.Type,


### PR DESCRIPTION
Allowing custom alert IDs makes it possible to programmatically create dashboards and corresponding alerts.