### PR TITLE
Adds built in functions $__interval_s, $__interval_m, and $__interval_h

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -165,9 +165,9 @@ In the InfluxDB data source, the legacy variable `$interval` is the same variabl
 
 The InfluxDB and Elasticsearch data sources have `Group by time interval` fields that are used to hard code the interval or to set the minimum limit for the `$__interval` variable (by using the `>` syntax -> `>10m`).
 
-### The $__interval_ms Variable
+### The $__interval_ms, $__interval_s, $__interval_m, and $__interval_h Variable
 
-This variable is the `$__interval` variable in milliseconds (and not a time interval formatted string). For example, if the `$__interval` is `20m` then the `$__interval_ms` is `1200000`.
+This variable is the `$__interval` variable in milliseconds, seconds, minutes, or hours (and not a time interval formatted string). For example, if the `$__interval` is `20m` then the `$__interval_ms` is `1200000`.
 
 ### The $timeFilter or $__timeFilter Variable
 

--- a/public/app/core/utils/kbn.js
+++ b/public/app/core/utils/kbn.js
@@ -164,6 +164,9 @@ function($, _, moment) {
   kbn.calculateInterval = function(range, resolution, lowLimitInterval) {
     var lowLimitMs = 1; // 1 millisecond default low limit
     var intervalMs;
+    var intervalS;
+    var intervalM;
+    var intervalH;
 
     if (lowLimitInterval) {
       if (lowLimitInterval[0] === '>') {
@@ -176,9 +179,15 @@ function($, _, moment) {
     if (lowLimitMs > intervalMs) {
       intervalMs = lowLimitMs;
     }
+    intervalS = intervalMs / 1000;
+    intervalM = intervalS / 60;
+    intervalH = intervalM / 60;
 
     return {
       intervalMs: intervalMs,
+      intervalS: intervalS,
+      intervalM: intervalM,
+      intervalH: intervalH,
       interval: kbn.secondsToHms(intervalMs / 1000),
     };
   };

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -25,6 +25,9 @@ class MetricsPanelCtrl extends PanelCtrl {
   range: any;
   interval: any;
   intervalMs: any;
+  intervalS: any;
+  intervalM: any;
+  intervalH: any;
   resolution: any;
   timeInfo: any;
   skipDataOnInit: boolean;
@@ -161,6 +164,9 @@ class MetricsPanelCtrl extends PanelCtrl {
     var res = kbn.calculateInterval(this.range, this.resolution, intervalOverride);
     this.interval = res.interval;
     this.intervalMs = res.intervalMs;
+    this.intervalS = res.intervalS;
+    this.intervalM = res.intervalM;
+    this.intervalH = res.intervalH;
   }
 
   applyPanelTimeOverrides() {
@@ -217,6 +223,9 @@ class MetricsPanelCtrl extends PanelCtrl {
     var scopedVars = Object.assign({}, this.panel.scopedVars, {
       "__interval":     {text: this.interval,   value: this.interval},
       "__interval_ms":  {text: this.intervalMs, value: this.intervalMs},
+      "__interval_s":  {text: this.intervalS, value: this.intervalS},
+      "__interval_m":  {text: this.intervalM, value: this.intervalM},
+      "__interval_h":  {text: this.intervalH, value: this.intervalH},
     });
 
     var metricsQuery = {
@@ -225,6 +234,9 @@ class MetricsPanelCtrl extends PanelCtrl {
       rangeRaw: this.range.raw,
       interval: this.interval,
       intervalMs: this.intervalMs,
+      intervalS: this.intervalS,
+      intervalM: this.intervalM,
+      intervalH: this.intervalH,
       targets: this.panel.targets,
       format: this.panel.renderer === 'png' ? 'png' : 'json',
       maxDataPoints: this.resolution,

--- a/public/app/features/panel/partials/metrics_tab.html
+++ b/public/app/features/panel/partials/metrics_tab.html
@@ -41,7 +41,7 @@
 				<info-popover mode="right-absolute">
 					A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 					for example <code>1m</code> if your data is written every minute. Access auto interval via variable <code>$__interval</code> for time range
-					string and <code>$__interval_ms</code> for numeric variable that can be used in math expressions.
+					string and <code>$__interval_ms</code>, <code>$__interval_s</code>, <code>$__interval_m</code>, <code>$__interval_h</code> for numeric variable that can be used in math expressions.
 				</info-popover>
 			</div>
 			<div class="gf-form gf-form--flex-end" ng-if="ctrl.queryOptions.cacheTimeout">


### PR DESCRIPTION
This adds build in functions `$__interval_s`, `$__interval_m`, and `$__interval_h` similar to `$__interval_ms`.

These are convenient when doing calculations or scaling of a metric depending on the interval.

Example - to get _Requests per Seconds_ regardless of time range:
```
SELECT sum(m1_rate) / $__interval_s FROM resources WHERE $timeFilter GROUP BY time($interval)
```