### PR TITLE
Bugfix: Always verify TLS unless explicitly told otherwise

### DIFF
--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -13,24 +13,27 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-var pluginProxyTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{
-		InsecureSkipVerify: true,
-		Renegotiation:      tls.RenegotiateFreelyAsClient,
-	},
-	Proxy: http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		DualStack: true,
-	}).Dial,
-	TLSHandshakeTimeout: 10 * time.Second,
-}
+var pluginProxyTransport *http.Transport
 
 func InitAppPluginRoutes(r *macaron.Macaron) {
+	pluginProxyTransport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: setting.PluginAppsSkipVerifyTLS,
+			Renegotiation:      tls.RenegotiateFreelyAsClient,
+		},
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+
 	for _, plugin := range plugins.Apps {
 		for _, route := range plugin.Routes {
 			url := util.JoinUrlFragments("/api/plugin-proxy/"+plugin.Id, route.Path)

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -14,8 +13,7 @@ import (
 )
 
 var grafanaComProxyTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
-	Proxy:           http.ProxyFromEnvironment,
+	Proxy: http.ProxyFromEnvironment,
 	Dial: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -83,7 +83,7 @@ func OAuthLogin(ctx *middleware.Context) {
 			InsecureSkipVerify: setting.OAuthService.OAuthInfos[name].TlsSkipVerify,
 		},
 	}
-	sslcli := &http.Client{
+	oauthClient := &http.Client{
 		Transport: tr,
 	}
 
@@ -107,7 +107,7 @@ func OAuthLogin(ctx *middleware.Context) {
 		tr.TLSClientConfig.RootCAs = caCertPool
 	}
 
-	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, sslcli)
+	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, oauthClient)
 
 	// get token from provider
 	token, err := connect.Exchange(oauthCtx, code)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -97,7 +97,7 @@ func OAuthLogin(ctx *middleware.Context) {
 
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: setting.OAuthService.OAuthInfos[name].TlsSkipVerify,
 				Certificates:       []tls.Certificate{cert},
 				RootCAs:            caCertPool,
 			},

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -81,7 +81,7 @@ func OAuthLogin(ctx *middleware.Context) {
 
 	// initialize oauth2 context
 	oauthCtx := oauth2.NoContext
-	if setting.OAuthService.OAuthInfos[name].TlsClientCert != "" {
+	if setting.OAuthService.OAuthInfos[name].TlsClientCert != "" || setting.OAuthService.OAuthInfos[name].TlsClientKey != "" {
 		cert, err := tls.LoadX509KeyPair(setting.OAuthService.OAuthInfos[name].TlsClientCert, setting.OAuthService.OAuthInfos[name].TlsClientKey)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -78,16 +78,25 @@ func OAuthLogin(ctx *middleware.Context) {
 	}
 
 	// handle call back
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: setting.OAuthService.OAuthInfos[name].TlsSkipVerify,
+		},
+	}
+	sslcli := &http.Client{
+		Transport: tr,
+	}
 
-	// initialize oauth2 context
-	oauthCtx := oauth2.NoContext
 	if setting.OAuthService.OAuthInfos[name].TlsClientCert != "" || setting.OAuthService.OAuthInfos[name].TlsClientKey != "" {
 		cert, err := tls.LoadX509KeyPair(setting.OAuthService.OAuthInfos[name].TlsClientCert, setting.OAuthService.OAuthInfos[name].TlsClientKey)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		// Load CA cert
+		tr.TLSClientConfig.Certificates = append(tr.TLSClientConfig.Certificates, cert)
+	}
+
+	if setting.OAuthService.OAuthInfos[name].TlsClientCa != "" {
 		caCert, err := ioutil.ReadFile(setting.OAuthService.OAuthInfos[name].TlsClientCa)
 		if err != nil {
 			log.Fatal(err)
@@ -95,18 +104,10 @@ func OAuthLogin(ctx *middleware.Context) {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: setting.OAuthService.OAuthInfos[name].TlsSkipVerify,
-				Certificates:       []tls.Certificate{cert},
-				RootCAs:            caCertPool,
-			},
-		}
-		sslcli := &http.Client{Transport: tr}
-
-		oauthCtx = context.Background()
-		oauthCtx = context.WithValue(oauthCtx, oauth2.HTTPClient, sslcli)
+		tr.TLSClientConfig.RootCAs = caCertPool
 	}
+
+	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, sslcli)
 
 	// get token from provider
 	token, err := connect.Exchange(oauthCtx, code)

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -17,8 +17,6 @@ var version = "master"
 func main() {
 	setupLogging()
 
-	services.Init(version)
-
 	app := cli.NewApp()
 	app.Name = "Grafana cli"
 	app.Usage = ""
@@ -45,11 +43,19 @@ func main() {
 			EnvVar: "GF_PLUGIN_URL",
 		},
 		cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "Skip TLS verification (insecure)",
+		},
+		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "enable debug logging",
 		},
 	}
 
+	app.Before = func(c *cli.Context) error {
+		services.Init(version, c.GlobalBool("insecure"))
+		return nil
+	}
 	app.Commands = commands.Commands
 	app.CommandNotFound = cmdNotFound
 

--- a/pkg/cmd/grafana-cli/services/services.go
+++ b/pkg/cmd/grafana-cli/services/services.go
@@ -22,7 +22,7 @@ var (
 	grafanaVersion string
 )
 
-func Init(version string) {
+func Init(version string, skipTLSVerify bool) {
 	grafanaVersion = version
 
 	tr := &http.Transport{
@@ -36,8 +36,9 @@ func Init(version string) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: skipTLSVerify,
+		},
 	}
 
 	HttpClient = http.Client{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -122,6 +122,9 @@ var (
 	// Basic Auth
 	BasicAuthEnabled bool
 
+	// Plugin settings
+	PluginAppsSkipVerifyTLS bool
+
 	// Session settings.
 	SessionOptions session.Options
 
@@ -559,6 +562,9 @@ func NewConfigContext(args *CommandLineArgs) error {
 	// basic auth
 	authBasic := Cfg.Section("auth.basic")
 	BasicAuthEnabled = authBasic.Key("enabled").MustBool(true)
+
+	// global plugin settings
+	PluginAppsSkipVerifyTLS = Cfg.Section("plugins").Key("app_tls_skip_verify_insecure").MustBool(false)
 
 	// PhantomJS rendering
 	ImagesDir = filepath.Join(DataPath, "png")

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -13,6 +13,7 @@ type OAuthInfo struct {
 	TlsClientCert          string
 	TlsClientKey           string
 	TlsClientCa            string
+	TlsSkipVerify          bool
 }
 
 type OAuther struct {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -66,6 +66,7 @@ func NewOAuthService() {
 			TlsClientCert:  sec.Key("tls_client_cert").String(),
 			TlsClientKey:   sec.Key("tls_client_key").String(),
 			TlsClientCa:    sec.Key("tls_client_ca").String(),
+			TlsSkipVerify:  sec.Key("tls_skip_verify_insecure").MustBool(),
 		}
 
 		if !info.Enabled {


### PR DESCRIPTION
TLS was not being verified in a number of places:

- connections to grafana.com

- connections to OAuth providers when TLS client authentication was
  enabled

- connections to self-hosted Grafana installations when using the CLI
  tool

TLS should always be verified unless the user explicitly enables an
option to skip verification.

Removes some instances where `InsecureSkipVerify` is explicitly set to
`false`, the default, to help avoid confusion and make it more difficult
to regress on this fix by accident.

Adds a `--insecure` flag to `grafana-cli` to skip TLS verification.

Adds a `tls_skip_verify_insecure` setting for OAuth.

Adds a `app_tls_skip_verify_insecure` setting under a new `[plugins]`
section.

I'm not super happy with the way the global setting is used by
`pkg/api/app_routes.go` but that seems to be the existing pattern used.
16c5d0e  

Fixes #9373, #9419 and is similar to #9377 (which fixes this for datasources).