### PR TITLE
Add milliseconds format in table panel's config

### DIFF
--- a/public/app/plugins/panel/table/column_options.ts
+++ b/public/app/plugins/panel/table/column_options.ts
@@ -40,6 +40,7 @@ export class ColumnOptionsCtrl {
     this.fontSizes = ['80%', '90%', '100%', '110%', '120%', '130%', '150%', '160%', '180%', '200%', '220%', '250%'];
     this.dateFormats = [
       {text: 'YYYY-MM-DD HH:mm:ss', value: 'YYYY-MM-DD HH:mm:ss'},
+      {text: 'YYYY-MM-DD HH:mm:ss.SSS', value: 'YYYY-MM-DD HH:mm:ss.SSS'},
       {text: 'MM/DD/YY h:mm:ss a', value: 'MM/DD/YY h:mm:ss a'},
       {text: 'MMMM D, YYYY LT',  value: 'MMMM D, YYYY LT'},
     ];


### PR DESCRIPTION
This changes introduce milliseconds format option in table panel
config GUI. Current grafana support milliseconds in time and
actually used at graph panel, however current table does not
provide the way to show milliseconds. This fix is to add format
in table panel to show milliseconds in table as well as graph.