### PR TITLE
Fix coloring in singlestat if null value

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -589,8 +589,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
       var body = panel.gauge.show ? '' : getBigValueHtml();
 
-      if (panel.colorBackground && !isNaN(data.value)) {
-        var color = getColorForValue(data, data.value);
+      if (panel.colorBackground && !isNaN(Number(data.valueFormatted))) {
+        var color = getColorForValue(data, Number(data.valueFormatted));
         if (color) {
           $panelContainer.css('background-color', color);
           if (scope.fullscreen) {


### PR DESCRIPTION
This modification aim to allow users to set value via textMapping and
these values to be used in background coloring as it text coloring.

This pull request closes #8404, but doesn't agree with #9012.
The issue #9012 consider that no coloring output should be put when
there is no data. I partially agree with this as I explicitely setted a
value in the textMapping I obviously want to treat `N/A` as a number.

`data.valueFormatted` contain the stringified version of `data.value`

If `Number()` cannot convert a string into a number a `NaN` value is
returned. So the code is still valid if the inputted value in
`data.valueFormatted` is not a number.
