### PR TITLE
Series color picker fix

### DIFF
--- a/public/app/core/components/colorpicker/ColorPickerPopover.tsx
+++ b/public/app/core/components/colorpicker/ColorPickerPopover.tsx
@@ -88,7 +88,7 @@ export class ColorPickerPopover extends React.Component<IProps, any> {
     );
     const spectrumTab = (
       <div id="spectrum">
-        <GfSpectrumPicker color={this.props.color} onColorSelect={this.spectrumColorSelected.bind(this)} options={{}} />
+        <GfSpectrumPicker color={this.state.color} onColorSelect={this.spectrumColorSelected.bind(this)} options={{}} />
       </div>
     );
     const currentTab = this.state.tab === 'palette' ? paletteTab : spectrumTab;

--- a/public/app/core/components/colorpicker/SeriesColorPicker.tsx
+++ b/public/app/core/components/colorpicker/SeriesColorPicker.tsx
@@ -44,7 +44,7 @@ export class SeriesColorPicker extends React.Component<IProps, any> {
     return (
       <div className="graph-legend-popover">
         {this.props.series && this.renderAxisSelection()}
-        <ColorPickerPopover color="#7EB26D" onColorSelect={this.onColorChange} />
+        <ColorPickerPopover color={this.props.series.color} onColorSelect={this.onColorChange} />
       </div>
     );
   }


### PR DESCRIPTION
This fixes colorpicker bug introduced by refactor - when you change color via spectrum picker it doesn't update its own state. Also, colorpicker always opened with the same color `#7EB26D` instead of current series color.