### PR TITLE
Readme: Fix path to source from go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the latest master builds [here](https://grafana.com/grafana/download)
 ### Building the backend
 ```bash
 go get github.com/grafana/grafana
-cd ~/go/src/github.com/grafana/grafana
+cd $GOPATH/src/github.com/grafana/grafana
 go run build.go setup
 go run build.go build
 ```


### PR DESCRIPTION
Minor tweak to readme to fix path to source after running go get
