### PR TITLE
Kafka alerting

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -115,6 +115,17 @@ In DingTalk PC Client:
 
 Dingtalk supports the following "message type": `text`, `link` and `markdown`. Only the `text` message type is supported.
 
+### Kafka
+
+Notifications can be sent to a Kafka topic from Grafana using [Kafka REST Proxy](https://docs.confluent.io/1.0/kafka-rest/docs/index.html).
+There are couple of configurations options which need to be set in Grafana UI under Kafka Settings:
+
+1. Kafka REST Proxy endpoint.
+
+2. Kafka Topic.
+
+Once these two properties are set, you can send the alerts to Kafka for further processing or throttling them.
+
 ### Other Supported Notification Channels
 
 Grafana also supports the following Notification Channels:

--- a/pkg/services/alerting/notifiers/kafka.go
+++ b/pkg/services/alerting/notifiers/kafka.go
@@ -1,0 +1,120 @@
+package notifiers
+
+import (
+	"strconv"
+
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "kafka",
+		Name:        "Kafka REST Proxy",
+		Description: "Sends notifications to Kafka Rest Proxy",
+		Factory:     NewKafkaNotifier,
+		OptionsTemplate: `
+      <h3 class="page-heading">Kafka settings</h3>
+      <div class="gf-form">
+        <span class="gf-form-label width-14">Kafka REST Proxy</span>
+        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.kafkaRestProxy" placeholder="http://localhost:8082"></input>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-14">Topic</span>
+        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.kafkaTopic" placeholder="topic1"></input>
+      </div>
+    `,
+	})
+}
+
+func NewKafkaNotifier(model *m.AlertNotification) (alerting.Notifier, error) {
+	endpoint := model.Settings.Get("kafkaRestProxy").MustString()
+	if endpoint == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find kafka rest proxy endpoint property in settings"}
+	}
+	topic := model.Settings.Get("kafkaTopic").MustString()
+        if topic == "" {
+                return nil, alerting.ValidationError{Reason: "Could not find kafka topic property in settings"}
+        }
+
+	return &KafkaNotifier{
+		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
+		Endpoint:     endpoint,
+		Topic:        topic,
+		log:          log.New("alerting.notifier.kafka"),
+	}, nil
+}
+
+type KafkaNotifier struct {
+	NotifierBase
+	Endpoint    string
+	Topic       string
+	log         log.Logger
+}
+
+func (this *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
+
+	state := evalContext.Rule.State
+
+	customData := "Triggered metrics:\n\n"
+	for _, evt := range evalContext.EvalMatches {
+		customData = customData + fmt.Sprintf("%s: %v\n", evt.Metric, evt.Value)
+	}
+
+	this.log.Info("Notifying Kafka", "alert_state", state)
+
+	recordJSON := simplejson.New()
+	records := make([]interface{}, 1)
+
+	bodyJSON := simplejson.New()
+	bodyJSON.Set("description", evalContext.Rule.Name+" - "+evalContext.Rule.Message)
+	bodyJSON.Set("client", "Grafana")
+	bodyJSON.Set("details", customData)
+	bodyJSON.Set("incident_key", "alertId-"+strconv.FormatInt(evalContext.Rule.Id, 10))
+
+	ruleUrl, err := evalContext.GetRuleUrl()
+	if err != nil {
+		this.log.Error("Failed get rule link", "error", err)
+		return err
+	}
+	bodyJSON.Set("client_url", ruleUrl)
+
+	if evalContext.ImagePublicUrl != "" {
+		contexts := make([]interface{}, 1)
+		imageJSON := simplejson.New()
+		imageJSON.Set("type", "image")
+		imageJSON.Set("src", evalContext.ImagePublicUrl)
+		contexts[0] = imageJSON
+		bodyJSON.Set("contexts", contexts)
+	}
+
+	valueJSON := simplejson.New()
+	valueJSON.Set("value", bodyJSON)
+	records[0] = valueJSON
+	recordJSON.Set("records", records)
+	body, _ := recordJSON.MarshalJSON()
+
+	topicUrl := this.Endpoint+"/topics/"+this.Topic
+
+	cmd := &m.SendWebhookSync{
+		Url:        topicUrl,
+		Body:       string(body),
+		HttpMethod: "POST",
+		HttpHeader: map[string]string{
+                        "Content-Type":  "application/vnd.kafka.json.v2+json",
+                        "Accept": "application/vnd.kafka.v2+json",
+                },
+	}
+
+	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
+		this.log.Error("Failed to send notification to Kafka", "error", err, "body", string(body))
+		return err
+	}
+
+	return nil
+}

--- a/pkg/services/alerting/notifiers/kafka.go
+++ b/pkg/services/alerting/notifiers/kafka.go
@@ -38,9 +38,9 @@ func NewKafkaNotifier(model *m.AlertNotification) (alerting.Notifier, error) {
 		return nil, alerting.ValidationError{Reason: "Could not find kafka rest proxy endpoint property in settings"}
 	}
 	topic := model.Settings.Get("kafkaTopic").MustString()
-        if topic == "" {
-                return nil, alerting.ValidationError{Reason: "Could not find kafka topic property in settings"}
-        }
+	if topic == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find kafka topic property in settings"}
+	}
 
 	return &KafkaNotifier{
 		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
@@ -52,9 +52,9 @@ func NewKafkaNotifier(model *m.AlertNotification) (alerting.Notifier, error) {
 
 type KafkaNotifier struct {
 	NotifierBase
-	Endpoint    string
-	Topic       string
-	log         log.Logger
+	Endpoint string
+	Topic    string
+	log      log.Logger
 }
 
 func (this *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
@@ -99,16 +99,16 @@ func (this *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
 	recordJSON.Set("records", records)
 	body, _ := recordJSON.MarshalJSON()
 
-	topicUrl := this.Endpoint+"/topics/"+this.Topic
+	topicUrl := this.Endpoint + "/topics/" + this.Topic
 
 	cmd := &m.SendWebhookSync{
 		Url:        topicUrl,
 		Body:       string(body),
 		HttpMethod: "POST",
 		HttpHeader: map[string]string{
-                        "Content-Type":  "application/vnd.kafka.json.v2+json",
-                        "Accept": "application/vnd.kafka.v2+json",
-                },
+			"Content-Type": "application/vnd.kafka.json.v2+json",
+			"Accept":       "application/vnd.kafka.v2+json",
+		},
 	}
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {

--- a/pkg/services/alerting/notifiers/kafka_test.go
+++ b/pkg/services/alerting/notifiers/kafka_test.go
@@ -29,7 +29,7 @@ func TestKafkaNotifier(t *testing.T) {
 			Convey("settings should send an event to kafka", func() {
 				json := `
 				{
-					"kafkaEndpoint": "http://localhost:8082",
+					"kafkaRestProxy": "http://localhost:8082",
 					"kafkaTopic": "topic1"
 				}`
 

--- a/pkg/services/alerting/notifiers/kafka_test.go
+++ b/pkg/services/alerting/notifiers/kafka_test.go
@@ -1,0 +1,55 @@
+package notifiers
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	m "github.com/grafana/grafana/pkg/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestKafkaNotifier(t *testing.T) {
+	Convey("Kafka notifier tests", t, func() {
+
+		Convey("Parsing alert notification from settings", func() {
+			Convey("empty settings should return error", func() {
+				json := `{ }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &m.AlertNotification{
+					Name:     "kafka_testing",
+					Type:     "kafka",
+					Settings: settingsJSON,
+				}
+
+				_, err := NewKafkaNotifier(model)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("settings should send an event to kafka", func() {
+				json := `
+				{
+					"kafkaEndpoint": "http://localhost:8082",
+					"kafkaTopic": "topic1"
+				}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &m.AlertNotification{
+					Name:     "kafka_testing",
+					Type:     "kafka",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewKafkaNotifier(model)
+				kafkaNotifier := not.(*KafkaNotifier)
+
+				So(err, ShouldBeNil)
+				So(kafkaNotifier.Name, ShouldEqual, "kafka_testing")
+				So(kafkaNotifier.Type, ShouldEqual, "kafka")
+				So(kafkaNotifier.Endpoint, ShouldEqual, "http://localhost:8082")
+				So(kafkaNotifier.Topic, ShouldEqual, "topic1")
+			})
+
+		})
+	})
+}

--- a/public/app/features/alerting/alert_tab_ctrl.ts
+++ b/public/app/features/alerting/alert_tab_ctrl.ts
@@ -94,6 +94,7 @@ export class AlertTabCtrl {
       case "opsgenie": return "fa fa-bell";
       case "hipchat": return "fa fa-mail-forward";
       case "pushover": return "fa fa-mobile";
+      case "kafka": return "fa fa-random";
     }
     return 'fa fa-bell';
   }


### PR DESCRIPTION
Resolves #7104

This PR enables Grafana to send alerts to a Kafka Topic. There are multiple use-cases for this need such as:
1. Post processing/Filtering/Throttling of alerts.
2. Correlating alerts with one another from the Kafka stream.
3. If selected as default for alerting, Kafka can receive all alerts from the Grafana installation.

Happy to contribute more to Grafana after a long-long time. :)