### PR TITLE
[Bugfix] Colors being applied only after 2 updates on table panels (#9445)

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -69,7 +69,7 @@
       <h5 class="section-heading">Thresholds</h5>
       <div class="gf-form">
         <label class="gf-form-label width-8">Thresholds<tip>Comma separated values</tip></label>
-        <input type="text" class="gf-form-input width-10" ng-model="style.thresholds" placeholder="50,80" ng-blur="editor.render()" array-join ng-model-onblur>
+        <input type="text" class="gf-form-input width-10" ng-model="style.thresholds" placeholder="50,80" ng-blur="editor.render()" array-join>
       </div>
       <div class="gf-form">
         <label class="gf-form-label width-8">Color Mode</label>


### PR DESCRIPTION
Fixes issue #9445.

Apparently there's a bug (or at least a weird behavior) with `ng-model-onblur` directive.  
Just removing it from the threshold's `input` element fixed the issue.