### PR TITLE
[Feature] Allow text to value mappings in Table panel

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -69,7 +69,27 @@
       </div>
     </div>
 
-    <div class="section gf-form-group" ng-if="style.type === 'number'">
+    <div class="section gf-form-group" ng-if="style.type === 'string'">
+      <h5 class="section-heading">Text to value mapping</h5>
+      <div class="gf-form" ng-repeat="mapping in style.textMappings">
+        <input type="text" class="gf-form-input width-11" ng-model="mapping.text" placeholder="Text or regex" ng-blur="editor.render()" array-join>
+        <label class="gf-form-label width-3">=></label>
+        <input type="text" class="gf-form-input width-6" ng-model="mapping.value" placeholder="Value" ng-blur="editor.render()" array-join>
+        <label class="gf-form-label">
+          <a class="pointer" tabindex="1" ng-click="editor.removeTextMapping(style, $index)">
+            <i class="fa fa-trash"></i>
+          </a>
+        </label>
+      </div>
+
+      <div class="gf-form">
+        <label class="gf-form-label">
+          <a class="pointer" ng-click="editor.addTextMapping(style)"><i class="fa fa-plus"></i></a>
+        </label>
+      </div>
+    </div>
+
+    <div class="section gf-form-group"  ng-if="['number', 'string'].indexOf(style.type) !== -1">
       <h5 class="section-heading">Thresholds</h5>
       <div class="gf-form">
         <label class="gf-form-label width-8">Thresholds

--- a/public/app/plugins/panel/table/column_options.ts
+++ b/public/app/plugins/panel/table/column_options.ts
@@ -110,6 +110,19 @@ export class ColumnOptionsCtrl {
       this.render();
     };
   }
+
+  addTextMapping(style) {
+    if (!style.textMappings) {
+      style.textMappings = [];
+    }
+    style.textMappings.push({ text: '', value: null });
+    this.panelCtrl.render();
+  }
+
+  removeTextMapping(style, index) {
+    style.textMappings.splice(index, 1);
+    this.panelCtrl.render();
+  }
 }
 
 /** @ngInject */

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -48,12 +48,13 @@ export class TableRenderer {
       return null;
     }
 
+    value = Number(value);
     for (var i = style.thresholds.length; i > 0; i--) {
-      if (value >= style.thresholds[i - 1]) {
+      if (value >= Number(style.thresholds[i - 1])) {
         return style.colors[i];
       }
     }
-    return _.first(style.colors);
+    return style.colors[0];
   }
 
   defaultCellFormatter(v, style) {
@@ -97,6 +98,27 @@ export class TableRenderer {
           date = date.utc();
         }
         return date.format(column.style.dateFormat);
+      };
+    }
+
+    if (column.style.type === 'string') {
+      return v => {
+        if (v === undefined || v === null) {
+          return '-';
+        }
+
+        if (column.style.textMappings && column.style.colorMode) {
+          for (let i = 0; i < column.style.textMappings.length; i++) {
+            let mapping = column.style.textMappings[i];
+            var regex = kbn.stringToJsRegex(mapping.text);
+            if (v.match(regex)) {
+              this.colorState[column.style.colorMode] = this.getColorForValue(mapping.value, column.style);
+              break;
+            }
+          }
+        }
+
+        return this.defaultCellFormatter(v, column.style);
       };
     }
 

--- a/public/app/plugins/panel/table/specs/renderer.jest.ts
+++ b/public/app/plugins/panel/table/specs/renderer.jest.ts
@@ -15,7 +15,9 @@ describe('when rendering table', () => {
       { text: 'Sanitized' },
       { text: 'Link' },
       { text: 'Array' },
+      { text: 'Colored Text' },
     ];
+    table.rows = [[1388556366666, 1230, 40, undefined, '', '', 'my.host.com', 'host1', ['value1', 'value2'], 'ok']];
     table.rows = [[1388556366666, 1230, 40, undefined, '', '', 'my.host.com', 'host1', ['value1', 'value2']]];
 
     var panel = {
@@ -71,6 +73,27 @@ describe('when rendering table', () => {
           type: 'number',
           unit: 'ms',
           decimals: 3,
+        },
+        {
+          pattern: 'Colored Text',
+          type: 'string',
+          colorMode: 'value',
+          thresholds: [50, 80],
+          textMappings: [
+            {
+              text: 'ok',
+              value: 30,
+            },
+            {
+              text: 'warning',
+              value: 60,
+            },
+            {
+              text: 'error',
+              value: 100,
+            },
+          ],
+          colors: ['green', 'orange', 'red'],
         },
       ],
     };
@@ -191,6 +214,21 @@ describe('when rendering table', () => {
     it('Array column should not use number as formatter', () => {
       var html = renderer.renderCell(8, 0, ['value1', 'value2']);
       expect(html).toBe('<td>value1, value2</td>');
+    });
+
+    it('colored text cell should have style', () => {
+      var html = renderer.renderCell(9, 0, 'ok');
+      expect(html).toBe('<td style="color:green">ok</td>');
+    });
+
+    it('colored text cell should have style', () => {
+      var html = renderer.renderCell(9, 0, 'warning');
+      expect(html).toBe('<td style="color:orange">warning</td>');
+    });
+
+    it('colored text cell should have style', () => {
+      var html = renderer.renderCell(9, 0, 'error');
+      expect(html).toBe('<td style="color:red">error</td>');
     });
   });
 });


### PR DESCRIPTION
This PR adds the ability to coloring values/cells/rows in table panels using text and closes the issues #7631, #3601, #7428, #8693 and #6343.

Basically, this PR implements the concept presented in the issue #7631.  
I created a new section called "Text to value mapping", that maps string regexes to values.  
Once the texts have been mapped to values, the rest of the logic that exists today remains intact.

The video below illustrates this new feature:

![output](https://user-images.githubusercontent.com/2574399/31294192-5dcae1de-aab0-11e7-947b-5b8574704896.gif)

If you think this solution is good, I can replicate it in Singlestat Panels too 😊 