### PR TITLE
Corrected a PostgreSQL SELECT statement.

### DIFF
--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -104,7 +104,7 @@ func (db *Postgres) SqlType(c *Column) string {
 
 func (db *Postgres) TableCheckSql(tableName string) (string, []interface{}) {
 	args := []interface{}{"grafana", tableName}
-	sql := "SELECT `TABLE_NAME` from `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=? and `TABLE_NAME`=?"
+	sql := "SELECT table_name FROM information_schema.tables WHERE table_schema=? and table_name=?"
 	return sql, args
 }
 


### PR DESCRIPTION
At least in my Postgresql 9.6.5, the old syntax of capitalized queries doesn't work (Linux).
The ` notations didn't work either, so removed those. I know those are used in MySQL - but rarely in PostgreSQL if at all? I'm no DBA specialist guru, but I've in my 10 years of using Postgres never used them.

* Issue #9459
* UTF-8 as encoding in PostgreSQL
* Tested in PostgreSQL 9.6.5