### PR TITLE
Mixed datasource min interval

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -93,6 +93,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     // load datasource service
     this.setTimeQueryStart();
     this.datasourceSrv.get(this.panel.datasource)
+    .then(datasource => this.datasource = datasource)
     .then(this.updateTimeRange.bind(this))
     .then(this.issueQueries.bind(this))
     .then(this.handleQueryResult.bind(this))
@@ -121,7 +122,6 @@ class MetricsPanelCtrl extends PanelCtrl {
     });
   }
 
-
   setTimeQueryStart() {
     this.timing.queryStart = new Date().getTime();
   }
@@ -130,8 +130,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     this.timing.queryEnd = new Date().getTime();
   }
 
-  updateTimeRange(datasource?) {
-    this.datasource = datasource || this.datasource;
+  updateTimeRange() {
     this.range = this.timeSrv.timeRange();
 
     this.applyPanelTimeOverrides();
@@ -143,8 +142,6 @@ class MetricsPanelCtrl extends PanelCtrl {
     }
 
     this.calculateInterval();
-
-    return this.datasource;
   }
 
   calculateInterval() {
@@ -204,9 +201,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     }
   }
 
-  issueQueries(datasource) {
-    this.datasource = datasource;
-
+  issueQueries() {
     if (!this.panel.targets || this.panel.targets.length === 0) {
       return this.$q.when([]);
     }
@@ -232,7 +227,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       cacheTimeout: this.panel.cacheTimeout
     };
 
-    return datasource.query(metricsQuery);
+    return this.datasource.query(metricsQuery);
   }
 
   handleQueryResult(result) {

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -95,6 +95,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     this.datasourceSrv.get(this.panel.datasource)
     .then(datasource => this.datasource = datasource)
     .then(this.updateTimeRange.bind(this))
+    .then(this.calculateInterval.bind(this))
     .then(this.issueQueries.bind(this))
     .then(this.handleQueryResult.bind(this))
     .catch(err => {
@@ -140,23 +141,33 @@ class MetricsPanelCtrl extends PanelCtrl {
     } else {
       this.resolution = Math.ceil($(window).width() * (this.panel.span / 12));
     }
-
-    this.calculateInterval();
   }
 
   calculateInterval() {
-    var intervalOverride = this.panel.interval;
+    var intervalOverride;
 
-    // if no panel interval check datasource
-    if (intervalOverride) {
-      intervalOverride = this.templateSrv.replace(intervalOverride, this.panel.scopedVars);
+    if (this.panel.interval) {
+      intervalOverride = this.$q.resolve(this.templateSrv.replace(this.panel.interval, this.panel.scopedVars));
     } else if (this.datasource && this.datasource.interval) {
-      intervalOverride = this.datasource.interval;
+      intervalOverride = this.$q.resolve(this.datasource.interval);
+    } else if (this.datasource && this.datasource.meta.mixed) {
+      var promises = _(this.panel.targets)
+      .map(target => target.datasource)
+      .uniq()
+      .map(datasource => this.datasourceSrv.get(datasource));
+      intervalOverride = this.$q.all(promises).then(datasources => {
+        var minInterval = _(datasources)
+        .filter('interval')
+        .maxBy(ds => kbn.interval_to_ms(ds.interval));
+        return minInterval ? minInterval.interval : undefined;
+      });
     }
 
-    var res = kbn.calculateInterval(this.range, this.resolution, intervalOverride);
-    this.interval = res.interval;
-    this.intervalMs = res.intervalMs;
+    return intervalOverride.then(override => {
+      var res = kbn.calculateInterval(this.range, this.resolution, override);
+      this.interval = res.interval;
+      this.intervalMs = res.intervalMs;
+    });
   }
 
   applyPanelTimeOverrides() {

--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -5,5 +5,9 @@
 
   "builtIn": true,
   "mixed": true,
-  "metrics": true
+  "metrics": true,
+
+  "queryOptions": {
+    "minInterval": true
+  }
 }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -147,13 +147,13 @@ class GraphCtrl extends MetricsPanelCtrl {
     actions.push({text: 'Toggle legend', click: 'ctrl.toggleLegend()'});
   }
 
-  issueQueries(datasource) {
+  issueQueries() {
     this.annotationsPromise = this.annotationsSrv.getAnnotations({
       dashboard: this.dashboard,
       panel: this.panel,
       range: this.range,
     });
-    return super.issueQueries(datasource);
+    return super.issueQueries();
   }
 
   zoomOut(evt) {

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -76,7 +76,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
     actions.push({text: 'Export CSV', click: 'ctrl.exportCsv()'});
   }
 
-  issueQueries(datasource) {
+  issueQueries() {
     this.pageIndex = 0;
 
     if (this.panel.transform === 'annotations') {
@@ -87,7 +87,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       });
     }
 
-    return super.issueQueries(datasource);
+    return super.issueQueries();
   }
 
   onDataError(err) {


### PR DESCRIPTION
This makes min interval settings useable with mixed datasource.
The mixed datasource does not know the datasources it will query and the min interval is enforced in MetricsPanelCtrl anyway, so I made it a special case in calculateInterval.
Because datasourceSrv returns a promise and I need the datasource settings from it, I made calculateInterval always return promises and put it explicitly in the chain in onMetricsPanelRefresh.
I found this issue #9240 mentioning this.

I can't get the query options menu in the edit metrics tab to show though. I added
```json
  "queryOptions": {
    "minInterval": true
  }
```
to plugin.json but the queryOptions attribute is missing in the debugger and the menu does not show.