### PR TITLE
Show min interval query option for mixed datasource

### DIFF
--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -5,5 +5,9 @@
 
   "builtIn": true,
   "mixed": true,
-  "metrics": true
+  "metrics": true,
+
+  "queryOptions": {
+    "minInterval": true
+  }
 }


### PR DESCRIPTION
Show min interval option in the edit metrics tab when using mixed datasource.
This is all that is needed.