### PR TITLE
metrics: disable gzip for /metrics endpoint

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -187,7 +189,9 @@ func (hs *HttpServer) metricsEndpoint(ctx *macaron.Context) {
 		return
 	}
 
-	promhttp.Handler().ServeHTTP(ctx.Resp, ctx.Req.Request)
+	promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		DisableCompression: true,
+	}).ServeHTTP(ctx.Resp, ctx.Req.Request)
 }
 
 func (hs *HttpServer) healthHandler(ctx *macaron.Context) {


### PR DESCRIPTION
Prometheus client lib support gzip by itself. we should leave it up to the client/promhttp to decide if gzip should be used rather then requiring users to configure it.

I dislike the fact that the `metricsEndpoint` middle ware have to be executed before gzip middle ware but cannot find a better solution right now. 

closes #9464
