### PR TITLE
annotations: add endpoint for writing graphite-like events

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -292,6 +292,7 @@ func (hs *HttpServer) registerRoutes() {
 			annotationsRoute.Delete("/:annotationId", wrap(DeleteAnnotationById))
 			annotationsRoute.Put("/:annotationId", bind(dtos.UpdateAnnotationsCmd{}), wrap(UpdateAnnotation))
 			annotationsRoute.Delete("/region/:regionId", wrap(DeleteAnnotationRegion))
+			annotationsRoute.Post("/graphite", bind(dtos.PostGraphiteAnnotationsCmd{}), wrap(PostGraphiteAnnotation))
 		}, reqEditorRole)
 
 		// error test

--- a/pkg/api/dtos/annotations.go
+++ b/pkg/api/dtos/annotations.go
@@ -29,3 +29,10 @@ type DeleteAnnotationsCmd struct {
 	AnnotationId int64 `json:"annotationId"`
 	RegionId     int64 `json:"regionId"`
 }
+
+type PostGraphiteAnnotationsCmd struct {
+	When int64    `json:"when"`
+	What string   `json:"what"`
+	Data string   `json:"data"`
+	Tags []string `json:"tags"`
+}

--- a/pkg/api/dtos/annotations.go
+++ b/pkg/api/dtos/annotations.go
@@ -31,8 +31,8 @@ type DeleteAnnotationsCmd struct {
 }
 
 type PostGraphiteAnnotationsCmd struct {
-	When int64    `json:"when"`
-	What string   `json:"what"`
-	Data string   `json:"data"`
-	Tags []string `json:"tags"`
+	When int64       `json:"when"`
+	What string      `json:"what"`
+	Data string      `json:"data"`
+	Tags interface{} `json:"tags"`
 }

--- a/public/app/features/annotations/annotation_tooltip.ts
+++ b/public/app/features/annotations/annotation_tooltip.ts
@@ -66,7 +66,7 @@ export function annotationTooltipDirective($sanitize, dashboardSrv, contextSrv, 
       tooltip += '<div class="graph-annotation__body">';
 
       if (text) {
-        tooltip += '<div>' + sanitizeString(text).replace(/\n/g, '<br>') + '</div>';
+        tooltip += '<div>' + sanitizeString(text.replace(/\n/g, '<br>')) + '</div>';
       }
 
       var tags = event.tags;


### PR DESCRIPTION
This PR closes #9479 and adds endpoint (`api/annotations/graphite`) for pushing events in Graphite format like
```
{
  "what": "Event - deploy", 
  "tags": ["deploy"], 
  "when": 1467844481, 
  "data": "deploy of master branch" 
}
```