### PR TITLE
Add autofocus tag for username field on login.html

### DIFF
--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -20,7 +20,7 @@
       <form name="loginForm" class="login-form gf-form-group" ng-hide="disableLoginForm">
 				<div class="gf-form" ng-if="loginMode">
 					<span class="gf-form-label width-7">User</span>
-					<input type="text" name="username" class="gf-form-input max-width-14" required ng-model='formModel.user' placeholder={{loginHint}}>
+					<input type="text" name="username" class="gf-form-input max-width-14" required ng-model='formModel.user' placeholder={{loginHint}} autofocus>
 				</div>
 				<div class="gf-form" ng-if="loginMode">
 					<span class="gf-form-label width-7">Password</span>


### PR DESCRIPTION
This is a ninja edit to ensure the login page autofocus on the username field on load.

While testing with Docker and completely clearing the entire data directory, I see the login page quite frequently. It'd be nice to be able to type in the user/pass without having to use my mouse or multiple tab presses.

Thanks for the great work! :)