### PR TITLE
(cloudwatch) fix cloudwatch query error over 24h

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.js
+++ b/public/app/plugins/datasource/cloudwatch/datasource.js
@@ -41,7 +41,7 @@ function (angular, _, moment, dateMath, kbn, templatingVariable) {
         item.namespace = templateSrv.replace(item.namespace, options.scopedVars);
         item.metricName = templateSrv.replace(item.metricName, options.scopedVars);
         item.dimensions = self.convertDimensionFormat(item.dimensions, options.scopeVars);
-        item.period = self.getPeriod(item, options);
+        item.period = String(self.getPeriod(item, options)); // use string format for period in graph query, and alerting
 
         return _.extend({
           refId: item.refId,

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource_specs.ts
@@ -37,7 +37,7 @@ describe('CloudWatchDatasource', function() {
             InstanceId: 'i-12345678'
           },
           statistics: ['Average'],
-          period: 300
+          period: '300'
         }
       ]
     };
@@ -109,7 +109,7 @@ describe('CloudWatchDatasource', function() {
 
       ctx.ds.query(query).then(function() {
         var params = requestParams.queries[0];
-        expect(params.period).to.be(600);
+        expect(params.period).to.be('600');
         done();
       });
       ctx.$rootScope.$apply();


### PR DESCRIPTION
Fix https://github.com/grafana/grafana/issues/9523.

Sorry for bug.
The backend code expect string type `period` parameter.
https://github.com/grafana/grafana/blob/v4.6.0-beta1/pkg/tsdb/cloudwatch/cloudwatch.go#L247