### PR TITLE
Fix adding annotation with tags on mysql

### DIFF
--- a/pkg/services/sqlstore/annotation.go
+++ b/pkg/services/sqlstore/annotation.go
@@ -43,7 +43,7 @@ func (r *SqlAnnotationRepo) ensureTagsExist(sess *DBSession, tags []*models.Tag)
 		var existingTag models.Tag
 
 		// check if it exists
-		if exists, err := sess.Table("tag").Where("key=? AND value=?", tag.Key, tag.Value).Get(&existingTag); err != nil {
+		if exists, err := sess.Table("tag").Where("`key`=? AND `value`=?", tag.Key, tag.Value).Get(&existingTag); err != nil {
 			return nil, err
 		} else if exists {
 			tag.Id = existingTag.Id


### PR DESCRIPTION
It's not possible to add annotation to grafana on mysql backend.
After trying to add annotatation in grafana logs you can find:
```
"Failed to save annotation" logger=context error="Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key=? AND value=? LIMIT 1' at line 1"
```

It's caused by using MySQL [reserved word](https://dev.mysql.com/doc/refman/5.7/en/keywords.html) `key` as column name without quoting.