### PR TITLE
(prometheus) allow ":" character for metric name

### DIFF
--- a/public/app/plugins/datasource/prometheus/completer.ts
+++ b/public/app/plugins/datasource/prometheus/completer.ts
@@ -8,7 +8,7 @@ export class PromCompleter {
   labelNameCache: any;
   labelValueCache: any;
 
-  identifierRegexps = [/[\[\]a-zA-Z_0-9=]/];
+  identifierRegexps = [/[\[\]a-zA-Z0-9_:=]/];
 
   constructor(private datasource: PrometheusDatasource) {
     this.labelQueryCache = {};

--- a/public/app/plugins/datasource/prometheus/mode-prometheus.js
+++ b/public/app/plugins/datasource/prometheus/mode-prometheus.js
@@ -43,7 +43,7 @@ var PrometheusHighlightRules = function() {
       regex : "\\d+[smhdwy]"
     }, {
       token : keywordMapper,
-      regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
+      regex : "[a-zA-Z_:][a-zA-Z0-9_:]*"
     }, {
       token : "keyword.operator",
       regex : "\\+|\\-|\\*|\\/|%|\\^|=|==|!=|<=|>=|<|>|=\\~|!\\~"


### PR DESCRIPTION
https://prometheus.io/docs/concepts/data_model/
Prometheus metric name pattern is `[a-zA-Z_:][a-zA-Z0-9_:]*`
Should allow like `instance_path:requests:rate5m`.

(I remove "$" from pattern, identifiers doesn't contain the character.)

Please check @alexanderzobnin @torkelo