### PR TITLE
(prometheus) fix to show vector range popup

### DIFF
--- a/public/app/plugins/datasource/prometheus/completer.ts
+++ b/public/app/plugins/datasource/prometheus/completer.ts
@@ -8,7 +8,7 @@ export class PromCompleter {
   labelNameCache: any;
   labelValueCache: any;
 
-  identifierRegexps = [/[\[\]a-zA-Z0-9_:=]/];
+  identifierRegexps = [/\[/, /[a-zA-Z0-9_:]/];
 
   constructor(private datasource: PrometheusDatasource) {
     this.labelQueryCache = {};
@@ -73,7 +73,7 @@ export class PromCompleter {
         });
     }
 
-    if (prefix === '[') {
+    if (token.type === 'paren.lparen' && token.value === '[') {
       var vectors = [];
       for (let unit of ['s', 'm', 'h']) {
         for (let value of [1,5,10,30]) {


### PR DESCRIPTION
Fix https://github.com/grafana/grafana/issues/9521.

This line seems to be important.
https://github.com/ajaxorg/ace/blob/v1.2.9/lib/ace/ext/language_tools.js#L150

This PR doesn't fix all problem.
For like `up` metrics, it matches many candidate, we need to close popup by pressing Esc, and then input `[`.