### PR TITLE
When Messasge field is set for an alert, map it to the output field i…

### DIFF
--- a/pkg/services/alerting/notifiers/sensu.go
+++ b/pkg/services/alerting/notifiers/sensu.go
@@ -112,7 +112,7 @@ func (this *SensuNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	if evalContext.Rule.Message != "" {
-		bodyJSON.Set("message", evalContext.Rule.Message)
+		bodyJSON.Set("output", evalContext.Rule.Message)
 	}
 
 	body, _ := bodyJSON.MarshalJSON()


### PR DESCRIPTION
…n a Sensu check result. If Message is empty, send "Grafana Metric Condition Met"

PR for issue #9551 

 Changes the behavior as follows, only for Notifications sent to Sensu:

- If the Message field in Graph -> Alerts -> Notifications != '', then map the contents of the Message field to the "output" field when shipping the check result to Sensu.

Previous behavior statically hardcoded the output field to "Grafana Metric Condition Met". Again, if Message is left empty, the prior behavior remains unchanged.

Here is the behavior prior to the change:
![screen shot 2017-10-17 at 10 12 33 am](https://user-images.githubusercontent.com/5324295/31675383-16a8881a-b32a-11e7-8093-d61402c6426c.png)

... and here is how it looks after (only triggered the thread-usage alert in this example):
![screen shot 2017-10-17 at 11 01 24 am](https://user-images.githubusercontent.com/5324295/31675539-986efdb6-b32a-11e7-973d-5e71733c6119.png)

Making this change allows us to pass useful info on to the recipient of the alert vs having a static bit of text that simply tells them the alert was triggered (which they already know, as they got paged :) ). 





