### PR TITLE
Add __timeFromRFC3339 and __timeToRFC3339 Postgres macros

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -47,7 +47,9 @@ Macro example | Description
 *$__timeSec(dateColumn)* | Will be replaced by an expression to rename the column to `time` and converting the value to unix timestamp. For example, *extract(epoch from dateColumn) as time*
 *$__timeFilter(dateColumn)* | Will be replaced by a time range filter using the specified column name. For example, *dateColumn > to_timestamp(1494410783) AND dateColumn < to_timestamp(1494497183)*
 *$__timeFrom()* | Will be replaced by the start of the currently active time selection. For example, *to_timestamp(1494410783)*
+*$__timeFromRFC3339()* | Will be replaced by the start of the currently active time selection, in RFC3339 format. For example, *2017-05-10T10:06:23Z*.
 *$__timeTo()* | Will be replaced by the end of the currently active time selection. For example, *to_timestamp(1494497183)*
+*$__timeToRFC3339()* | Will be replaced by the end of the currently active time selection, in RFC3339 format. For example, *2017-05-10T10:06:23Z*.
 *$__timeGroup(dateColumn,'5m')* | Will be replaced by an expression usable in GROUP BY clause. For example, *(extract(epoch from "dateColumn")/extract(epoch from '5m'::interval))::int*
 *$__unixEpochFilter(dateColumn)* | Will be replaced by a time range filter using the specified column name with times represented as unix timestamp. For example, *dateColumn > 1494410783 AND dateColumn < 1494497183*
 *$__unixEpochFrom()* | Will be replaced by the start of the currently active time selection as unix timestamp. For example, *1494410783*

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -77,8 +77,12 @@ func (m *PostgresMacroEngine) evaluateMacro(name string, args []string) (string,
 		return fmt.Sprintf("%s >= to_timestamp(%d) AND %s <= to_timestamp(%d)", args[0], uint64(m.TimeRange.GetFromAsMsEpoch()/1000), args[0], uint64(m.TimeRange.GetToAsMsEpoch()/1000)), nil
 	case "__timeFrom":
 		return fmt.Sprintf("to_timestamp(%d)", uint64(m.TimeRange.GetFromAsMsEpoch()/1000)), nil
+	case "__timeFromRFC3339":
+		return m.TimeRange.GetFromAsRFC3339(), nil
 	case "__timeTo":
 		return fmt.Sprintf("to_timestamp(%d)", uint64(m.TimeRange.GetToAsMsEpoch()/1000)), nil
+	case "__timeToRFC3339":
+		return m.TimeRange.GetToAsRFC3339(), nil
 	case "__timeGroup":
 		if len(args) < 2 {
 			return "", fmt.Errorf("macro %v needs time column and interval", name)

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -33,6 +33,13 @@ func TestMacroEngine(t *testing.T) {
 			So(sql, ShouldEqual, "WHERE time_column >= to_timestamp(18446744066914186738) AND time_column <= to_timestamp(18446744066914187038)")
 		})
 
+		Convey("interpolate __timeFromRFC3339 function", func() {
+			sql, err := engine.Interpolate(timeRange, "select '$__timeFromRFC3339()'")
+			So(err, ShouldBeNil)
+
+			So(sql, ShouldEqual, "select '0000-12-31T23:55:00Z'")
+		})
+
 		Convey("interpolate __timeFrom function", func() {
 			sql, err := engine.Interpolate(timeRange, "select $__timeFrom(time_column)")
 			So(err, ShouldBeNil)
@@ -53,6 +60,13 @@ func TestMacroEngine(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			So(sql, ShouldEqual, "select to_timestamp(18446744066914187038)")
+		})
+
+		Convey("interpolate __timeToRFC3339 function", func() {
+			sql, err := engine.Interpolate(timeRange, "select '$__timeToRFC3339()'")
+			So(err, ShouldBeNil)
+
+			So(sql, ShouldEqual, "select '0001-01-01T00:00:00Z'")
 		})
 
 		Convey("interpolate __unixEpochFilter function", func() {

--- a/pkg/tsdb/time_range.go
+++ b/pkg/tsdb/time_range.go
@@ -21,6 +21,14 @@ type TimeRange struct {
 	Now  time.Time
 }
 
+func (tr *TimeRange) GetFromAsRFC3339() string {
+	return tr.MustGetFrom().Format(time.RFC3339)
+}
+
+func (tr *TimeRange) GetToAsRFC3339() string {
+	return tr.MustGetTo().Format(time.RFC3339)
+}
+
 func (tr *TimeRange) GetFromAsMsEpoch() int64 {
 	return tr.MustGetFrom().UnixNano() / int64(time.Millisecond)
 }


### PR DESCRIPTION
AWS Redshift does not support the `to_timestamp(int)` function. This commit adds support for a macro that outputs the RFC3339 (ISO8601) formatted from/to timestamps.

This means on Redshift you can do the following:

```sql
SELECT "time", count
    FROM table
    WHERE "time" BETWEEN '$__timeFromRFC3339()' AND '$__timeToRFC3339()'
```