### PR TITLE
When Messasge field is set for an alert, map it to the output field i…

### DIFF
--- a/pkg/services/alerting/notifiers/sensu.go
+++ b/pkg/services/alerting/notifiers/sensu.go
@@ -112,7 +112,7 @@ func (this *SensuNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	if evalContext.Rule.Message != "" {
-		bodyJSON.Set("message", evalContext.Rule.Message)
+		bodyJSON.Set("output", evalContext.Rule.Message)
 	}
 
 	body, _ := bodyJSON.MarshalJSON()


### PR DESCRIPTION
…n a Sensu check result. If Message is empty, send "Grafana Metric Condition Met"

PR for issue #9551 

