### PR TITLE
proxyds: delete cookies except those listed in keepCookies

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -152,8 +152,7 @@ func TestDSRouteRule(t *testing.T) {
 		Convey("When proxying a data source with no keepCookies specified", func() {
 			plugin := &plugins.DataSourcePlugin{}
 
-			json := simplejson.New()
-			json.Set("keepCookies", []string{})
+			json, _ := simplejson.NewJson([]byte(`{"keepCookies": []}`))
 
 			ds := &m.DataSource{
 				Type:     m.DS_GRAPHITE,
@@ -179,8 +178,7 @@ func TestDSRouteRule(t *testing.T) {
 		Convey("When proxying a data source with keep cookies specified", func() {
 			plugin := &plugins.DataSourcePlugin{}
 
-			json := simplejson.New()
-			json.Set("keepCookies", []string{"JSESSION_ID"})
+			json, _ := simplejson.NewJson([]byte(`{"keepCookies": ["JSESSION_ID"]}`))
 
 			ds := &m.DataSource{
 				Type:     m.DS_GRAPHITE,
@@ -199,7 +197,7 @@ func TestDSRouteRule(t *testing.T) {
 			proxy.getDirector()(&req)
 
 			Convey("Should keep named cookies", func() {
-				So(req.Header.Get("Cookie"), ShouldEqual, "JSESSION=test")
+				So(req.Header.Get("Cookie"), ShouldEqual, "JSESSION_ID=test")
 			})
 		})
 


### PR DESCRIPTION
Backend part of https://github.com/grafana/grafana/issues/5457, implemented during Go Stockholm meetup hack night in mob programming fashion.

Some things to note:

- Removed deletion of `Set-Cookie` header as that header is only valid in HTTP responses (https://tools.ietf.org/html/rfc6265#section-4.1).
- We got simplejson errors (from `StringArray()`) and failing tests when the `keepCookies` JSON fixture data was created from a Go string slice so replaced it with a JSON string.
