### PR TITLE
Allow to hide invisible series in tooltip

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -59,6 +59,20 @@ function ($, core) {
       $tooltip.html(innerHtml).place_tt(pos.pageX + 20, pos.pageY);
     };
 
+    this.isSeriesInvisible = function(series) {
+      // returns true if series is not displayed in any way and it's legend
+      // is not shown
+      var seriesDisplayed = [
+        series.points,
+        series.dashes,
+        series.lines,
+        series.bars,
+        series.pie,
+        series.gauges,
+      ].some(function(v) { return v && v.show === true; });
+      return !(series.legend || seriesDisplayed);
+    };
+
     this.getMultiSeriesPlotHoverInfo = function(seriesList, pos) {
       var value, i, series, hoverIndex, hoverDistance, pointTime, yaxis;
       // 3 sub-arrays, 1st for hidden series, 2nd for left yaxis, 3rd for right yaxis.
@@ -72,12 +86,16 @@ function ($, core) {
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];
 
+        // if series is not visible, don't show it in tooltip
+        if (panel.tooltip.hide_invisible_series && this.isSeriesInvisible(series)) {
+          continue;
+        }
+
         if (!series.data.length || (panel.legend.hideEmpty && series.allIsNull)) {
           // Init value so that it does not brake series sorting
           results[0].push({ hidden: true, value: 0 });
           continue;
         }
-
         if (!series.data.length || (panel.legend.hideZero && series.allIsZero)) {
           // Init value so that it does not brake series sorting
           results[0].push({ hidden: true, value: 0 });

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -98,6 +98,7 @@ class GraphCtrl extends MetricsPanelCtrl {
       value_type: 'individual',
       shared: true,
       sort: 0,
+      hide_invisible_series: false,
     },
     // time overrides
     timeFrom: null,

--- a/public/app/plugins/panel/graph/specs/tooltip_specs.ts
+++ b/public/app/plugins/panel/graph/specs/tooltip_specs.ts
@@ -193,3 +193,36 @@ describeSharedTooltip("steppedLine false, stack true, individual true", function
     expect(ctx.results[1].value).to.be(2);
   });
 });
+
+describeSharedTooltip("series with hidden lines are displayed when hide_invisible_series is set to false", function(ctx) {
+  ctx.setup(function() {
+    ctx.data = [
+      {data: [[10, 15], [12, 20]], lines: {show: false}},
+      {data: [[10, 2], [12, 3]], lines: {show: true}}
+    ];
+    ctx.ctrl.panel.show = true;
+    ctx.ctrl.panel.tooltip.hide_invisible_series = false;
+    ctx.pos = { x: 11 };
+  });
+
+  it('should show 2 series', function() {
+    expect(ctx.results.length).to.be(2);
+  });
+});
+
+describeSharedTooltip("series with hidden lines are not displayed when hide_invisible_series is set to true", function(ctx) {
+  ctx.setup(function() {
+    ctx.data = [
+      {data: [[10, 15], [12, 20]], lines: {show: false}},
+      {data: [[10, 2], [12, 3]], lines: {show: true}}
+    ];
+    ctx.ctrl.panel.show = true;
+    ctx.ctrl.panel.tooltip.hide_invisible_series = true;
+    ctx.pos = { x: 11 };
+  });
+
+  it('should show 2 series', function() {
+    expect(ctx.results.length).to.be(1);
+    expect(ctx.results[0].value).to.be(2);
+  });
+});

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -50,23 +50,25 @@
 		<div class="section gf-form-group">
 			<h5 class="section-heading">Hover tooltip</h5>
 			<div class="gf-form">
-				<label class="gf-form-label width-9">Mode</label>
+				<label class="gf-form-label width-10">Mode</label>
 				<div class="gf-form-select-wrapper max-width-8">
 					<select class="gf-form-input" ng-model="ctrl.panel.tooltip.shared" ng-options="f.value as f.text for f in [{text: 'All series', value: true}, {text: 'Single', value: false}]" ng-change="ctrl.render()"></select>
 				</div>
 			</div>
 			<div class="gf-form">
-				<label class="gf-form-label width-9">Sort order</label>
+				<label class="gf-form-label width-10">Sort order</label>
 				<div class="gf-form-select-wrapper max-width-8">
 					<select class="gf-form-input" ng-model="ctrl.panel.tooltip.sort" ng-options="f.value as f.text for f in [{text: 'None', value: 0}, {text: 'Increasing', value: 1}, {text: 'Decreasing', value: 2}]" ng-change="ctrl.render()"></select>
 				</div>
 			</div>
 			<div class="gf-form" ng-show="ctrl.panel.stack">
-				<label class="gf-form-label width-9">Stacked value</label>
+				<label class="gf-form-label width-10">Stacked value</label>
 				<div class="gf-form-select-wrapper max-width-8">
 					<select class="gf-form-input" ng-model="ctrl.panel.tooltip.value_type" ng-options="f for f in ['cumulative','individual']" ng-change="ctrl.render()"></select>
 				</div>
 			</div>
+			<gf-form-switch class="gf-form" label="Hide invisible series" label-class="width-10" checked="ctrl.panel.tooltip.hide_invisible_series" on-change="ctrl.render()">
+			</gf-form-switch>
 		</div>
 
 		<div class="section gf-form-group">

--- a/public/dashboards/default.json
+++ b/public/dashboards/default.json
@@ -108,7 +108,8 @@
           "steppedLine": false,
           "tooltip": {
             "value_type": "cumulative",
-            "query_as_alias": true
+            "query_as_alias": true,
+            "hide_invisible_series": false
           },
           "targets": [
             {


### PR DESCRIPTION
This PR brings ability to hide invisible series in tooltip. Invisible series is
one without lines, bars, points and legend.

Example:
![graphite_tooltip_hide3](https://user-images.githubusercontent.com/107437/31819811-ab660614-b59e-11e7-8d82-180df3a61e67.gif)

(Look at CPU series)