### PR TITLE
New series override: tooltip

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -27,6 +27,7 @@ export default class TimeSeries {
   valueFormater: any;
   stats: any;
   legend: boolean;
+  tooltip: boolean;
   allIsNull: boolean;
   allIsZero: boolean;
   decimals: number;
@@ -56,6 +57,7 @@ export default class TimeSeries {
     this.valueFormater = kbn.valueFormats.none;
     this.stats = {};
     this.legend = true;
+    this.tooltip = true;
     this.unit = opts.unit;
     this.hasMsResolution = this.isMsResolutionNeeded();
   }
@@ -100,7 +102,7 @@ export default class TimeSeries {
       if (override.color !== void 0) { this.color = override.color; }
       if (override.transform !== void 0) { this.transform = override.transform; }
       if (override.legend !== void 0) { this.legend = override.legend; }
-
+      if (override.tooltip !== void 0) { this.tooltip = override.tooltip; }
       if (override.yaxis !== void 0) {
         this.yaxis = override.yaxis;
       }

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -72,13 +72,10 @@ function ($, core) {
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];
 
-        if (!series.data.length || (panel.legend.hideEmpty && series.allIsNull)) {
-          // Init value so that it does not brake series sorting
-          results[0].push({ hidden: true, value: 0 });
-          continue;
-        }
-
-        if (!series.data.length || (panel.legend.hideZero && series.allIsZero)) {
+        if (!series.tooltip
+            || !series.data.length
+            || (panel.legend.hideEmpty && series.allIsNull)
+            || (panel.legend.hideZero && series.allIsZero)) {
           // Init value so that it does not brake series sorting
           results[0].push({ hidden: true, value: 0 });
           continue;

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.js
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.js
@@ -111,6 +111,7 @@ define([
     $scope.addOverrideOption('Z-index', 'zindex', [-3,-2,-1,0,1,2,3]);
     $scope.addOverrideOption('Transform', 'transform', ['negative-Y']);
     $scope.addOverrideOption('Legend', 'legend', [true, false]);
+    $scope.addOverrideOption('Tooltip', 'tooltip', [true, false]);
     $scope.updateCurrentOverrides();
   });
 });

--- a/public/app/plugins/panel/graph/specs/tooltip_specs.ts
+++ b/public/app/plugins/panel/graph/specs/tooltip_specs.ts
@@ -42,7 +42,7 @@ function describeSharedTooltip(desc, fn) {
 
 describe("findHoverIndexFromData", function() {
   var tooltip = new GraphTooltip(elem, dashboard, scope);
-  var series = { data: [[100, 0], [101, 0], [102, 0], [103, 0], [104, 0], [105, 0], [106, 0], [107, 0]] };
+  var series = { data: [[100, 0], [101, 0], [102, 0], [103, 0], [104, 0], [105, 0], [106, 0], [107, 0]], tooltip: true };
 
   it("should return 0 if posX out of lower bounds", function() {
     var posX = 99;
@@ -68,8 +68,8 @@ describe("findHoverIndexFromData", function() {
 describeSharedTooltip("steppedLine false, stack false", function(ctx) {
   ctx.setup(function() {
     ctx.data = [
-      { data: [[10, 15], [12, 20]], lines: {} },
-      { data: [[10, 2], [12, 3]], lines: {} }
+      { data: [[10, 15], [12, 20]], lines: {}, tooltip: true },
+      { data: [[10, 2], [12, 3]], lines: {}, tooltip: true }
     ];
     ctx.pos = { x: 11 };
   });
@@ -92,10 +92,27 @@ describeSharedTooltip("steppedLine false, stack false", function(ctx) {
 describeSharedTooltip("one series is hidden", function(ctx) {
   ctx.setup(function() {
     ctx.data = [
-      { data: [[10, 15], [12, 20]], },
-      { data: [] }
+      { data: [[10, 15], [12, 20]], tooltip: true },
+      { data: [], tooltip: true }
     ];
     ctx.pos = { x: 11 };
+  });
+});
+
+describeSharedTooltip("one series is explicitly hidden", function(ctx) {
+  ctx.setup(function() {
+    ctx.data = [
+      { data: [[10, 15], [12, 20]], lines: {}, tooltip: true },
+      { data: [[10, 2], [12, 3]], tooltip: false }
+    ];
+    ctx.pos = { x: 11 };
+  });
+
+  it('should show one series on tooltip', function() {
+    expect(ctx.results.length).to.be(2);
+    expect(ctx.results[0].value).to.be(15);
+    expect(ctx.results[0].hidden).not.to.be(true);
+    expect(ctx.results[1].hidden).to.be(true);
   });
 });
 
@@ -110,6 +127,7 @@ describeSharedTooltip("steppedLine false, stack true, individual false", functio
           points: [[10,15], [12,20]],
         },
         stack: true,
+        tooltip: true,
       },
       {
         data: [[10, 2], [12, 3]],
@@ -118,7 +136,8 @@ describeSharedTooltip("steppedLine false, stack true, individual false", functio
           pointsize: 2,
           points: [[10, 2], [12, 3]],
         },
-        stack: true
+        stack: true,
+        tooltip: true,
       }
     ];
     ctx.ctrl.panel.stack = true;
@@ -140,7 +159,8 @@ describeSharedTooltip("steppedLine false, stack true, individual false, series s
           pointsize: 2,
           points: [[10, 15], [12, 20]],
         },
-        stack: true
+        stack: true,
+        tooltip: true,
       },
       {
         data: [[10, 2], [12, 3]],
@@ -149,7 +169,8 @@ describeSharedTooltip("steppedLine false, stack true, individual false, series s
           pointsize: 2,
           points: [[10, 2], [12, 3]],
         },
-        stack: false
+        stack: false,
+        tooltip: true,
       }
     ];
     ctx.ctrl.panel.stack = true;
@@ -172,7 +193,8 @@ describeSharedTooltip("steppedLine false, stack true, individual true", function
           pointsize: 2,
           points: [[10, 15], [12, 20]],
         },
-        stack: true
+        stack: true,
+        tooltip: true,
       },
       {
         data: [[10, 2], [12, 3]],
@@ -181,7 +203,8 @@ describeSharedTooltip("steppedLine false, stack true, individual true", function
           pointsize: 2,
           points: [[10, 2], [12, 3]],
         },
-        stack: false
+        stack: false,
+        tooltip: true,
       }
     ];
     ctx.ctrl.panel.stack = true;


### PR DESCRIPTION
Fix #3341

This PR introduces new series override: toolip. It allows to enable/disable (displaying in) tooltip for single series.
