### PR TITLE
Fix typos in init.d comment

### DIFF
--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -91,7 +91,7 @@ case "$1" in
 	then
 	  sleep 1
 
-    # check if pid file has been written two
+    # check if pid file has been written to
 	  if ! [[ -s $PID_FILE ]]; then
 	    log_end_msg 1
 	    exit 1

--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -96,7 +96,7 @@ case "$1" in
     if [ $return -eq 0 ]
     then
       sleep 1
-      # check if pid file has been written two
+      # check if pid file has been written to
       if ! [[ -s $PID_FILE ]]; then
         echo "FAILED"
         exit 1


### PR DESCRIPTION
Fixes a minor typo in init.d scripts for rpm and deb builds.