### PR TITLE
dont quote variables for mysql and postgres datasource

### DIFF
--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -17,7 +17,7 @@ export class MysqlDatasource {
 
   interpolateVariable(value) {
     if (typeof value === 'string') {
-      return '\'' + value + '\'';
+      return value;
     }
 
     if (typeof value === 'number') {

--- a/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
@@ -196,8 +196,8 @@ describe('MySQLDatasource', function() {
 
   describe('When interpolating variables', () => {
     describe('and value is a string', () => {
-      it('should return a quoted value', () => {
-        expect(ctx.ds.interpolateVariable('abc')).to.eql('\'abc\'');
+      it('should return an unquoted value', () => {
+        expect(ctx.ds.interpolateVariable('abc')).to.eql('abc');
       });
     });
 

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -17,11 +17,11 @@ export class PostgresDatasource {
 
   interpolateVariable(value) {
     if (typeof value === 'string') {
-      return '\'' + value + '\'';
+      return value;
     }
 
     if (typeof value === 'number') {
-      return value.toString();
+      return value;
     }
 
     var quotedValues = _.map(value, function(val) {

--- a/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
@@ -193,4 +193,24 @@ describe('PostgreSQLDatasource', function() {
       expect(results[0].value).to.be('same');
     });
   });
+
+  describe('When interpolating variables', () => {
+    describe('and value is a string', () => {
+      it('should return an unquoted value', () => {
+        expect(ctx.ds.interpolateVariable('abc')).to.eql('abc');
+      });
+    });
+
+    describe('and value is a number', () => {
+      it('should return an unquoted value', () => {
+        expect(ctx.ds.interpolateVariable(1000)).to.eql(1000);
+      });
+    });
+
+    describe('and value is an array of strings', () => {
+      it('should return comma separated quoted values', () => {
+        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'])).to.eql('\'a\',\'b\',\'c\'');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Dont quote variables for mysql and postgres datasource unless they are array.
According to issue #9030 