### PR TITLE
openshift authorization capabilities.

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -21,6 +21,7 @@ export class PrometheusDatasource {
   basicAuth: any;
   withCredentials: any;
   metricsNameCache: any;
+  token: any;
 
   /** @ngInject */
   constructor(instanceSettings,
@@ -36,6 +37,7 @@ export class PrometheusDatasource {
     this.directUrl = instanceSettings.directUrl;
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = instanceSettings.withCredentials;
+    this.token = instanceSettings.jsonData.token;
   }
 
   _request(method, url, requestId?) {
@@ -52,6 +54,12 @@ export class PrometheusDatasource {
     if (this.basicAuth) {
       options.headers = {
         "Authorization": this.basicAuth
+      };
+    }
+
+    if (this.token) {
+      options.headers = {
+        "Authorization": 'Bearer ' + this.token
       };
     }
 

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -1,3 +1,14 @@
 <datasource-http-settings current="ctrl.current" suggest-url="http://localhost:9090">
 </datasource-http-settings>
 
+<h3 class="page-heading">Prometheus settings</h3>
+
+<div class="gf-form-group">
+  <div class="gf-form-inline">
+    <div class="gf-form max-width-30">
+      <span class="gf-form-label width-7">Token</span>
+      <input type="password" class="gf-form-input" ng-model="ctrl.current.jsonData.token">
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
this patch let prometheus datasource plugin to use token string for authorization.
it extend the prometheus DS fields to have token input, and use it to initialise prometheus DS for openshift.

motivation:
openshift and kubernetes uses prometheus, openshift specifically uses oauth token for authorization and we want to be able to login with grafana.
currently prometheus plugin has no token capabilities, so it's no possible to login.
using OAuth token to authorised with openshift,  will resolve that issue.