### PR TITLE
Use configured database as session fallback if session config not provided

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -88,9 +88,11 @@ func main() {
 	server.Start()
 }
 
-func initSql() {
+func initSql() (string) {
 	sqlstore.NewEngine()
 	sqlstore.EnsureAdminUser()
+
+	return sqlstore.ConnString()
 }
 
 func listenToSystemSignals(server models.GrafanaServer) {

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -54,7 +54,7 @@ func (g *GrafanaServerImpl) Start() {
 	g.initLogging()
 	g.writePIDFile()
 
-	initSql()
+	setting.ReadSessionConfig(initSql())
 	metrics.Init(setting.Cfg)
 	search.Init()
 	login.Init()


### PR DESCRIPTION
Just took a stab at this.

Allows the user to re-use their postgres/mysql database config as the session store where the session provider config is blank:

```ini
[database]
type = mysql
host = 127.0.0.1:3306

[session]
provider = mysql
# provider_config will be set to the conn string as specified in [database]
```

Currently, if users wish to use their already-configured database for sessions, they have to duplicate the config from the `[database]` section to the `[session]` section (in a different format, no less).