### PR TITLE
D3 split into modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,12 @@
     "tether": "^1.4.0",
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "^1.4.1",
-    "d3": "^4.11.0",
-    "d3-scale-chromatic": "^1.1.1"
+    "d3-array": "^1.2.1",
+    "d3-axis": "^1.0.8",
+    "d3-color": "^1.0.3",
+    "d3-scale": "^1.0.6",
+    "d3-selection": "^1.1.0",
+    "d3-scale-chromatic": "^1.1.1",
+    "d3-time-format": "^2.1.0"
   }
 }

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -15,7 +15,13 @@ import * as flatten from 'app/core/utils/flatten';
 import * as ticks from 'app/core/utils/ticks';
 import {impressions} from 'app/features/dashboard/impression_store';
 import builtInPlugins from './built_in_plugins';
-import * as d3 from 'd3';
+import * as d3Array from 'd3-array';
+import * as d3Axis from 'd3-axis';
+import * as d3Color from 'd3-color';
+import * as d3Scale from 'd3-scale';
+import * as d3Selection from 'd3-selection';
+import * as d3ScaleChromatic from 'd3-scale-chromatic';
+import * as d3TimeFormat from 'd3-time-format';
 
 // rxjs
 import {Observable} from 'rxjs/Observable';
@@ -66,7 +72,13 @@ exposeToPlugin('jquery', jquery);
 exposeToPlugin('angular', angular);
 exposeToPlugin('rxjs/Subject', Subject);
 exposeToPlugin('rxjs/Observable', Observable);
-exposeToPlugin('d3', d3);
+exposeToPlugin('d3-array', d3Array);
+exposeToPlugin('d3-axis', d3Axis);
+exposeToPlugin('d3-color', d3Color);
+exposeToPlugin('d3-scale', d3Scale);
+exposeToPlugin('d3-selection', d3Selection);
+exposeToPlugin('d3-scale-chromatic', d3ScaleChromatic);
+exposeToPlugin('d3-time-format', d3TimeFormat);
 
 exposeToPlugin('app/features/dashboard/impression_store', {
   impressions: impressions,

--- a/public/app/plugins/panel/heatmap/color_legend.ts
+++ b/public/app/plugins/panel/heatmap/color_legend.ts
@@ -1,7 +1,10 @@
 import angular from 'angular';
 import _ from 'lodash';
 import $ from 'jquery';
-import * as d3 from 'd3';
+import * as d3Array from 'd3-array';
+import * as d3Axis from 'd3-axis';
+import * as d3Scale from 'd3-scale';
+import * as d3Selection from 'd3-selection';
 import {contextSrv} from 'app/core/core';
 import {tickStep} from 'app/core/utils/ticks';
 import {getColorScale, getOpacityScale} from './color_scale';
@@ -81,7 +84,7 @@ module.directive('heatmapLegend', function() {
 
 function drawColorLegend(elem, colorScheme, rangeFrom, rangeTo, maxValue, minValue) {
   let legendElem = $(elem).find('svg');
-  let legend = d3.select(legendElem.get(0));
+  let legend = d3Selection.select(legendElem.get(0));
   clearLegend(elem);
 
   let legendWidth = Math.floor(legendElem.outerWidth()) - 30;
@@ -92,7 +95,7 @@ function drawColorLegend(elem, colorScheme, rangeFrom, rangeTo, maxValue, minVal
     rangeStep = Math.floor((rangeTo - rangeFrom) / legendWidth);
   }
   let widthFactor = legendWidth / (rangeTo - rangeFrom);
-  let valuesRange = d3.range(rangeFrom, rangeTo, rangeStep);
+  let valuesRange = d3Array.range(rangeFrom, rangeTo, rangeStep);
 
   let colorScale = getColorScale(colorScheme, contextSrv.user.lightTheme, maxValue, minValue);
   legend.selectAll(".heatmap-color-legend-rect")
@@ -110,7 +113,7 @@ function drawColorLegend(elem, colorScheme, rangeFrom, rangeTo, maxValue, minVal
 
 function drawOpacityLegend(elem, options, rangeFrom, rangeTo, maxValue, minValue) {
   let legendElem = $(elem).find('svg');
-  let legend = d3.select(legendElem.get(0));
+  let legend = d3Selection.select(legendElem.get(0));
   clearLegend(elem);
 
   let legendWidth = Math.floor(legendElem.outerWidth()) - 30;
@@ -121,7 +124,7 @@ function drawOpacityLegend(elem, options, rangeFrom, rangeTo, maxValue, minValue
     rangeStep = Math.floor((rangeTo - rangeFrom) / legendWidth);
   }
   let widthFactor = legendWidth / (rangeTo - rangeFrom);
-  let valuesRange = d3.range(rangeFrom, rangeTo, rangeStep);
+  let valuesRange = d3Array.range(rangeFrom, rangeTo, rangeStep);
 
   let opacityScale = getOpacityScale(options, maxValue, minValue);
   legend.selectAll(".heatmap-opacity-legend-rect")
@@ -140,18 +143,18 @@ function drawOpacityLegend(elem, options, rangeFrom, rangeTo, maxValue, minValue
 
 function drawLegendValues(elem, colorScale, rangeFrom, rangeTo, maxValue, minValue, legendWidth) {
   let legendElem = $(elem).find('svg');
-  let legend = d3.select(legendElem.get(0));
+  let legend = d3Selection.select(legendElem.get(0));
 
   if (legendWidth <= 0 || legendElem.get(0).childNodes.length === 0) {
     return;
   }
 
-  let legendValueScale = d3.scaleLinear()
+  let legendValueScale = d3Scale.scaleLinear()
     .domain([0, rangeTo])
     .range([0, legendWidth]);
 
   let ticks = buildLegendTicks(0, rangeTo, maxValue, minValue);
-  let xAxis = d3.axisBottom(legendValueScale)
+  let xAxis = d3Axis.axisBottom(legendValueScale)
     .tickValues(ticks)
     .tickSize(2);
 
@@ -159,7 +162,7 @@ function drawLegendValues(elem, colorScale, rangeFrom, rangeTo, maxValue, minVal
   let posY = getSvgElemHeight(legendElem) + 2;
   let posX = getSvgElemX(colorRect);
 
-  d3.select(legendElem.get(0)).append("g")
+  d3Selection.select(legendElem.get(0)).append("g")
     .attr("class", "axis")
     .attr("transform", "translate(" + posX + "," + posY + ")")
     .call(xAxis);
@@ -177,9 +180,9 @@ function drawSimpleColorLegend(elem, colorScale) {
   if (legendWidth) {
     let valuesNumber = Math.floor(legendWidth / 2);
     let rangeStep  = Math.floor(legendWidth / valuesNumber);
-    let valuesRange = d3.range(0, legendWidth, rangeStep);
+    let valuesRange = d3Array.range(0, legendWidth, rangeStep);
 
-    let legend = d3.select(legendElem.get(0));
+    let legend = d3Selection.select(legendElem.get(0));
     var legendRects = legend.selectAll(".heatmap-color-legend-rect").data(valuesRange);
 
     legendRects.enter().append("rect")
@@ -196,24 +199,24 @@ function drawSimpleOpacityLegend(elem, options) {
   let legendElem = $(elem).find('svg');
   clearLegend(elem);
 
-  let legend = d3.select(legendElem.get(0));
+  let legend = d3Selection.select(legendElem.get(0));
   let legendWidth = Math.floor(legendElem.outerWidth());
   let legendHeight = legendElem.attr("height");
 
   if (legendWidth) {
     let legendOpacityScale;
     if (options.colorScale === 'linear') {
-      legendOpacityScale = d3.scaleLinear()
+      legendOpacityScale = d3Scale.scaleLinear()
       .domain([0, legendWidth])
       .range([0, 1]);
     } else if (options.colorScale === 'sqrt') {
-      legendOpacityScale = d3.scalePow().exponent(options.exponent)
+      legendOpacityScale = d3Scale.scalePow().exponent(options.exponent)
       .domain([0, legendWidth])
       .range([0, 1]);
     }
 
     let rangeStep = 10;
-    let valuesRange = d3.range(0, legendWidth, rangeStep);
+    let valuesRange = d3Array.range(0, legendWidth, rangeStep);
     var legendRects = legend.selectAll(".heatmap-opacity-legend-rect").data(valuesRange);
 
     legendRects.enter().append("rect")

--- a/public/app/plugins/panel/heatmap/color_scale.ts
+++ b/public/app/plugins/panel/heatmap/color_scale.ts
@@ -1,4 +1,4 @@
-import * as d3 from 'd3';
+import * as d3Scale from 'd3-scale';
 import * as d3ScaleChromatic from 'd3-scale-chromatic';
 
 export function getColorScale(colorScheme: any, lightTheme: boolean, maxValue: number, minValue = 0): (d: any) => any {
@@ -9,17 +9,17 @@ export function getColorScale(colorScheme: any, lightTheme: boolean, maxValue: n
   let start = colorScaleInverted ? maxValue : minValue;
   let end = colorScaleInverted ? minValue : maxValue;
 
-  return d3.scaleSequential(colorInterpolator).domain([start, end]);
+  return d3Scale.scaleSequential(colorInterpolator).domain([start, end]);
 }
 
 export function getOpacityScale(options, maxValue, minValue = 0) {
   let legendOpacityScale;
   if (options.colorScale === 'linear') {
-    legendOpacityScale = d3.scaleLinear()
+    legendOpacityScale = d3Scale.scaleLinear()
     .domain([minValue, maxValue])
     .range([0, 1]);
   } else if (options.colorScale === 'sqrt') {
-    legendOpacityScale = d3.scalePow().exponent(options.exponent)
+    legendOpacityScale = d3Scale.scalePow().exponent(options.exponent)
     .domain([minValue, maxValue])
     .range([0, 1]);
   }

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -1,6 +1,7 @@
-import * as d3 from 'd3';
 import $ from 'jquery';
 import _ from 'lodash';
+import * as d3Scale from 'd3-scale';
+import * as d3Selection from 'd3-selection';
 import kbn from 'app/core/utils/kbn';
 import {getValueBucketBound} from './heatmap_data_converter';
 
@@ -52,7 +53,7 @@ export class HeatmapTooltip {
   }
 
   add() {
-    this.tooltip = d3.select("body")
+    this.tooltip = d3Selection.select("body")
       .append("div")
       .attr("class", "heatmap-tooltip graph-tooltip grafana-tooltip");
   }
@@ -190,7 +191,7 @@ export class HeatmapTooltip {
 
     // Normalize histogram Y axis
     let histogramDomain = _.reduce(_.map(histogramData, d => d[1]), (sum, val) => sum + val, 0);
-    let histYScale = d3.scaleLinear()
+    let histYScale = d3Scale.scaleLinear()
       .domain([0, histogramDomain])
       .range([0, HISTOGRAM_HEIGHT]);
 

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -1,7 +1,11 @@
 import _ from 'lodash';
 import $ from 'jquery';
 import moment from 'moment';
-import * as d3 from 'd3';
+import * as d3Axis from 'd3-axis';
+import * as d3Color from 'd3-color';
+import * as d3Scale from 'd3-scale';
+import * as d3Selection from 'd3-selection';
+import * as d3TimeFormat from 'd3-time-format';
 import kbn from 'app/core/utils/kbn';
 import {appEvents, contextSrv} from 'app/core/core';
 import {tickStep, getScaledDecimals, getFlotTickSize} from 'app/core/utils/ticks';
@@ -92,7 +96,7 @@ export default function link(scope, elem, attrs, ctrl) {
   }
 
   function addXAxis() {
-    scope.xScale = xScale = d3.scaleTime()
+    scope.xScale = xScale = d3Scale.scaleTime()
       .domain([timeRange.from, timeRange.to])
       .range([0, chartWidth]);
 
@@ -101,12 +105,12 @@ export default function link(scope, elem, attrs, ctrl) {
     let timeFormat;
     let dashboardTimeZone = ctrl.dashboard.getTimezone();
     if (dashboardTimeZone === 'utc') {
-      timeFormat = d3.utcFormat(grafanaTimeFormatter);
+      timeFormat = d3TimeFormat.utcFormat(grafanaTimeFormatter);
     } else {
-      timeFormat = d3.timeFormat(grafanaTimeFormatter);
+      timeFormat = d3TimeFormat.timeFormat(grafanaTimeFormatter);
     }
 
-    let xAxis = d3.axisBottom(xScale)
+    let xAxis = d3Axis.axisBottom(xScale)
       .ticks(ticks)
       .tickFormat(timeFormat)
       .tickPadding(X_AXIS_TICK_PADDING)
@@ -158,11 +162,11 @@ export default function link(scope, elem, attrs, ctrl) {
       ticks: ticks
     };
 
-    scope.yScale = yScale = d3.scaleLinear()
+    scope.yScale = yScale = d3Scale.scaleLinear()
       .domain([y_min, y_max])
       .range([chartHeight, 0]);
 
-    let yAxis = d3.axisLeft(yScale)
+    let yAxis = d3Axis.axisLeft(yScale)
       .ticks(ticks)
       .tickFormat(tickValueFormatter(decimals, scaledDecimals))
       .tickSizeInner(0 - width)
@@ -217,7 +221,7 @@ export default function link(scope, elem, attrs, ctrl) {
       y_min = 1;
     }
 
-    scope.yScale = yScale = d3.scaleLog()
+    scope.yScale = yScale = d3Scale.scaleLog()
       .base(panel.yAxis.logBase)
       .domain([y_min, y_max])
       .range([chartHeight, 0]);
@@ -240,7 +244,7 @@ export default function link(scope, elem, attrs, ctrl) {
       ticks: tick_values.length
     };
 
-    let yAxis = d3.axisLeft(yScale)
+    let yAxis = d3Axis.axisLeft(yScale)
       .tickValues(tick_values)
       .tickFormat(tickValueFormatter(decimals, scaledDecimals))
       .tickSizeInner(0 - width)
@@ -365,7 +369,7 @@ export default function link(scope, elem, attrs, ctrl) {
       heatmap.remove();
     }
 
-    heatmap = d3.select(heatmap_elem)
+    heatmap = d3Selection.select(heatmap_elem)
       .append("svg")
       .attr("width", width)
       .attr("height", height);
@@ -419,10 +423,10 @@ export default function link(scope, elem, attrs, ctrl) {
   }
 
   function highlightCard(event) {
-    let color = d3.select(event.target).style("fill");
-    let highlightColor = d3.color(color).darker(2);
-    let strokeColor = d3.color(color).brighter(4);
-    let current_card = d3.select(event.target);
+    let color = d3Selection.select(event.target).style("fill");
+    let highlightColor = d3Color.color(color).darker(2);
+    let strokeColor = d3Color.color(color).brighter(4);
+    let current_card = d3Selection.select(event.target);
     tooltip.originalFillColor = color;
     current_card.style("fill", highlightColor.toString())
     .style("stroke", strokeColor.toString())
@@ -430,7 +434,7 @@ export default function link(scope, elem, attrs, ctrl) {
   }
 
   function resetCardHighLight(event) {
-    d3.select(event.target).style("fill", tooltip.originalFillColor)
+    d3Selection.select(event.target).style("fill", tooltip.originalFillColor)
     .style("stroke", tooltip.originalFillColor)
     .style("stroke-width", 0);
   }


### PR DESCRIPTION
This PR solves the second part of #9480 and imports only needed d3 modules. Not sure this is a better way for 3rd party plugins because it's may be tricky to use `d3` by this way.