### PR TITLE
Generate dashboard from url (example)

### DIFF
--- a/public/dashboards/scripted_from_url.js
+++ b/public/dashboards/scripted_from_url.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var _;
+
+var dashboard = JSON.parse(decodeURIComponent(ARGS.dashboard));
+if (!dashboard.version || !dashboard.schemaVersion || !dashboard.rows || dashboard.rows.length === 0) {
+    console.log('Please set version/schemaVersion/rows');
+    return {};
+}
+
+var isValidDashboard = _.every(dashboard.rows, function (r) {
+    return r.panels.length === 0 ||
+        _.every(r.panels, function (p) {
+            return p.type !== '' &&
+                p.datasource != '' &&
+                p.span &&
+                p.targets.length != 0;
+        });
+});
+if (!isValidDashboard) {
+    console.log('Please provide valid dashboard');
+    return {};
+}
+
+return dashboard;


### PR DESCRIPTION
Provide example script for https://github.com/grafana/grafana/issues/5594 .
Success to create dashboard by providing following converted json'

```
%7B%22rows%22:[%7B%22panels%22:[%7B%22type%22:%22graph%22,%22datasource%22:%22Prometheus%22,%22span%22:12,%22lines%22:true,%22targets%22:[%7B%22expr%22:%22node_cpu%22,%22format%22:%22time_series%22%7D]%7D]%7D],%22schemaVersion%22:14,%22version%22:1%7D
```
Converting command line.
`cat dashboard.json | jq -c . | ruby -r uri -ne 'puts URI.escape $_.chomp'`

Original JSON.
```
{
  "rows": [
    {
      "panels": [
        {
          "type": "graph",
          "datasource": "Prometheus",
          "span": 12,
          "lines": true,
          "targets": [
            {
              "expr": "node_cpu",
              "format": "time_series"
            }
          ]
        }
      ]
    }
  ],
  "schemaVersion": 14,
  "version": 1
}
```