### PR TITLE
Fix typo in template help tab

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -74,7 +74,7 @@
 			<div class="grafana-info-box col-lg-8">
 				<h5>What does templating do?</h5>
 				<p>Templating allows for more interactive and dynamic dashboards. Instead of hard-coding things like server, application
-				and sensor name in you metric queries you can use variables in their place. Variables are shown as dropdown select boxes at the top of
+				and sensor name in your metric queries you can use variables in their place. Variables are shown as dropdown select boxes at the top of
 				the dashboard. These dropdowns make it easy to change the data being displayed in your dashboard.
 				<br>
 				<br>


### PR DESCRIPTION
There was a typo in the template help tab that needed fixing.
