### PR TITLE
Templating : return __empty__ value when all value return nothing 

### DIFF
--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -70,6 +70,9 @@ export class TemplateSrv {
     if (typeof value === 'string') {
       return luceneEscape(value);
     }
+    if (value instanceof Array && value.length === 0) {
+        return '__empty__';
+    }
     var quotedValues = _.map(value, function(val) {
       return '\"' + luceneEscape(val) + '\"';
     });


### PR DESCRIPTION
When a templated query return an empty array, return a custom `__empty__` value to prevent elasticsearch syntaxe error

Here is a related issue : https://github.com/grafana/grafana/issues/8179