### PR TITLE
always quote template variables for mysql when multi-value is allowed

### DIFF
--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -17,7 +17,7 @@ export class MysqlDatasource {
 
   interpolateVariable(value, variable) {
     if (typeof value === 'string') {
-      if (variable.multi) {
+      if (variable.multi || variable.includeAll) {
         return '\'' + value + '\'';
       } else {
         return value;

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -15,9 +15,13 @@ export class MysqlDatasource {
     this.responseParser = new ResponseParser(this.$q);
   }
 
-  interpolateVariable(value) {
+  interpolateVariable(value, variable) {
     if (typeof value === 'string') {
-      return value;
+      if (variable.multi) {
+        return '\'' + value + '\'';
+      } else {
+        return value;
+      }
     }
 
     if (typeof value === 'number') {

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -2,6 +2,8 @@
 
 import _ from 'lodash';
 import ResponseParser from './response_parser';
+import { QueryVariable } from 'app/features/templating/query_variable';
+import { CustomVariable } from 'app/features/templating/custom_variable';
 
 export class MysqlDatasource {
   id: any;
@@ -15,7 +17,7 @@ export class MysqlDatasource {
     this.responseParser = new ResponseParser(this.$q);
   }
 
-  interpolateVariable(value, variable) {
+  interpolateVariable(value, variable: QueryVariable | CustomVariable) {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
         return '\'' + value + '\'';

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -2,8 +2,6 @@
 
 import _ from 'lodash';
 import ResponseParser from './response_parser';
-import { QueryVariable } from 'app/features/templating/query_variable';
-import { CustomVariable } from 'app/features/templating/custom_variable';
 
 export class MysqlDatasource {
   id: any;
@@ -17,7 +15,7 @@ export class MysqlDatasource {
     this.responseParser = new ResponseParser(this.$q);
   }
 
-  interpolateVariable(value, variable: QueryVariable | CustomVariable) {
+  interpolateVariable(value, variable) {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
         return '\'' + value + '\'';

--- a/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
@@ -218,16 +218,16 @@ describe('MySQLDatasource', function() {
       });
     });
 
-    describe(' and variable allows multi-value and value is a string', () => {
+    describe('and variable allows multi-value and value is a string', () => {
       it('should return a quoted value', () => {
         ctx.variable.multi = true;
         expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
       });
     });
 
-    describe(' and variable allows all and value is a string', () => {
+    describe('and variable allows all and value is a string', () => {
       it('should return a quoted value', () => {
-        ctx.variable.multi = true;
+        ctx.variable.includeAll = true;
         expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
       });
     });

--- a/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource_specs.ts
@@ -2,6 +2,7 @@ import {describe, beforeEach, it, expect, angularMocks} from 'test/lib/common';
 import moment from 'moment';
 import helpers from 'test/specs/helpers';
 import {MysqlDatasource} from '../datasource';
+import {CustomVariable} from 'app/features/templating/custom_variable';
 
 describe('MySQLDatasource', function() {
   var ctx = new helpers.ServiceTestContext();
@@ -195,22 +196,41 @@ describe('MySQLDatasource', function() {
   });
 
   describe('When interpolating variables', () => {
+    beforeEach(function() {
+      ctx.variable = new CustomVariable({},{});
+    });
+
     describe('and value is a string', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable('abc')).to.eql('abc');
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('abc');
       });
     });
 
     describe('and value is a number', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable(1000)).to.eql(1000);
+        expect(ctx.ds.interpolateVariable(1000, ctx.variable)).to.eql(1000);
       });
     });
 
     describe('and value is an array of strings', () => {
       it('should return comma separated quoted values', () => {
-        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'])).to.eql('\'a\',\'b\',\'c\'');
+        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'], ctx.variable)).to.eql('\'a\',\'b\',\'c\'');
       });
     });
+
+    describe(' and variable allows multi-value and value is a string', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
+      });
+    });
+
+    describe(' and variable allows all and value is a string', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
#9030 

Currently its not possible to use a template variable with multi value allowed and only selecting a single item with mysql as datasource. This patch changes the behaviour to always quote variables when they are from a variable where multiple values are allowed.
