### PR TITLE
always quote template variables for postgres when multi-value or include all is allowed

### DIFF
--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -15,9 +15,13 @@ export class PostgresDatasource {
     this.responseParser = new ResponseParser(this.$q);
   }
 
-  interpolateVariable(value) {
+  interpolateVariable(value, variable) {
     if (typeof value === 'string') {
-      return value;
+      if (variable.multi || variable.includeAll) {
+        return '\'' + value + '\'';
+      } else {
+        return value;
+      }
     }
 
     if (typeof value === 'number') {

--- a/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
@@ -2,6 +2,7 @@ import {describe, beforeEach, it, expect, angularMocks} from 'test/lib/common';
 import moment from 'moment';
 import helpers from 'test/specs/helpers';
 import {PostgresDatasource} from '../datasource';
+import {CustomVariable} from 'app/features/templating/custom_variable';
 
 describe('PostgreSQLDatasource', function() {
   var ctx = new helpers.ServiceTestContext();
@@ -195,22 +196,41 @@ describe('PostgreSQLDatasource', function() {
   });
 
   describe('When interpolating variables', () => {
+    beforeEach(function() {
+      ctx.variable = new CustomVariable({},{});
+    });
+
     describe('and value is a string', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable('abc')).to.eql('abc');
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('abc');
       });
     });
 
     describe('and value is a number', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable(1000)).to.eql(1000);
+        expect(ctx.ds.interpolateVariable(1000, ctx.variable)).to.eql(1000);
       });
     });
 
     describe('and value is an array of strings', () => {
       it('should return comma separated quoted values', () => {
-        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'])).to.eql('\'a\',\'b\',\'c\'');
+        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'], ctx.variable)).to.eql('\'a\',\'b\',\'c\'');
       });
     });
+
+    describe('and variable allows multi-value and is a string', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
+      });
+    });
+
+    describe('and variable allows all and is a string', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.includeAll = true;
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('\'abc\'');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
#9030

Currently its not possible to use a template variable with multi value allowed and only selecting a single item with postgres as datasource. This patch changes the behaviour to always quote variables when they are from a variable where multiple values or include all is allowed.

This is similar to #9712 but for postgres.