### PR TITLE
Correct help message of api_dataproxy_request_all_milliseconds

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -225,7 +225,7 @@ func init() {
 
 	M_DataSource_ProxyReq_Timer = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "api_dataproxy_request_all_milliseconds",
-		Help:      "summary for dashboard search duration",
+		Help:      "summary for dataproxy request duration",
 		Namespace: exporterName,
 	})
 


### PR DESCRIPTION
The HELP message of metric **api_dataproxy_request_all_milliseconds** was wrong, it was documenting **api_dashboard_search_milliseconds** instead.