### PR TITLE
Add comma delimiter option to export data modal and file export

### DIFF
--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -4,21 +4,23 @@ import {saveAs} from 'file-saver';
 
 const DEFAULT_DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 
-export function exportSeriesListToCsv(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
-    var text = (excel ? 'sep=;\n' : '') + 'Series;Time;Value\n';
+export function exportSeriesListToCsv(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false, commaDelimited = false) {
+    var delimiter = selectDelimiter(commaDelimited);
+    var text = (excel ? 'sep=' + delimiter + '\n' : '') + 'Series' + delimiter + 'Time' + delimiter + 'Value\n';
     _.each(seriesList, function(series) {
         _.each(series.datapoints, function(dp) {
-            text += series.alias + ';' + moment(dp[1]).format(dateTimeFormat) + ';' + dp[0] + '\n';
+            text += series.alias + delimiter + moment(dp[1]).format(dateTimeFormat) + delimiter + dp[0] + '\n';
         });
     });
     saveSaveBlob(text, 'grafana_data_export.csv');
 }
 
-export function exportSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
-    var text = (excel ? 'sep=;\n' : '') + 'Time;';
+export function exportSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false, commaDelimited = false) {
+    var delimiter = selectDelimiter(commaDelimited);
+    var text = (excel ? 'sep=' + delimiter + '\n' : '') + 'Time' + delimiter;
     // add header
     _.each(seriesList, function(series) {
-        text += series.alias + ';';
+        text += series.alias + delimiter;
     });
     text = text.substring(0,text.length-1);
     text += '\n';
@@ -39,9 +41,9 @@ export function exportSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAUL
 
     // make text
     for (var i = 0; i < dataArr[0].length; i++) {
-        text += dataArr[0][i] + ';';
+        text += dataArr[0][i] + delimiter;
         for (var j = 1; j < dataArr.length; j++) {
-            text += dataArr[j][i] + ';';
+            text += dataArr[j][i] + delimiter;
         }
         text = text.substring(0,text.length-1);
         text += '\n';
@@ -49,17 +51,19 @@ export function exportSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAUL
     saveSaveBlob(text, 'grafana_data_export.csv');
 }
 
-export function exportTableDataToCsv(table, excel = false) {
-  var text = excel ? 'sep=;\n' : '';
+export function exportTableDataToCsv(table, excel = false, commaDelimited = false) {
+  var delimiter = selectDelimiter(commaDelimited);
+  var text = excel ? 'sep=' + delimiter +'\n' : '';
+
     // add header
     _.each(table.columns, function(column) {
-        text += (column.title || column.text) + ';';
+        text += (column.title || column.text) + delimiter;
     });
     text += '\n';
     // process data
     _.each(table.rows, function(row) {
         _.each(row, function(value) {
-            text += value + ';';
+            text += value + delimiter;
         });
         text += '\n';
     });
@@ -69,4 +73,8 @@ export function exportTableDataToCsv(table, excel = false) {
 export function saveSaveBlob(payload, fname) {
     var blob = new Blob([payload], { type: "text/csv;charset=utf-8" });
     saveAs(blob, fname);
+}
+
+export function selectDelimiter(commaDelimited) {
+  return commaDelimited ? ',' : ';';
 }

--- a/public/app/features/dashboard/export_data/export_data_modal.html
+++ b/public/app/features/dashboard/export_data/export_data_modal.html
@@ -26,6 +26,11 @@
         label="Excel CSV Dialect" label-class="width-10" switch-class="max-width-6"
         checked="ctrl.excel">
       </gf-form-switch>
+      <gf-form-switch class="gf-form"
+        label="Comma Delimited" label-class="width-10" switch-class="max-width-6"
+        checked="ctrl.commaDelimited">
+      </gf-form-switch>
+
     </div>
 
     <div class="gf-form-button-row text-center">

--- a/public/app/features/dashboard/export_data/export_data_modal.ts
+++ b/public/app/features/dashboard/export_data/export_data_modal.ts
@@ -8,15 +8,16 @@ export class ExportDataModalCtrl {
   asRows: Boolean = true;
   dateTimeFormat = 'YYYY-MM-DDTHH:mm:ssZ';
   excel: false;
+  commaDelimited: false;
 
   export() {
     if (this.panel === 'table') {
-      fileExport.exportTableDataToCsv(this.data, this.excel);
+      fileExport.exportTableDataToCsv(this.data, this.excel, this.commaDelimited);
     } else {
       if (this.asRows) {
-        fileExport.exportSeriesListToCsv(this.data, this.dateTimeFormat, this.excel);
+        fileExport.exportSeriesListToCsv(this.data, this.dateTimeFormat, this.excel, this.commaDelimited);
       } else {
-        fileExport.exportSeriesListToCsvColumns(this.data, this.dateTimeFormat, this.excel);
+        fileExport.exportSeriesListToCsvColumns(this.data, this.dateTimeFormat, this.excel, this.commaDelimited);
       }
     }
 


### PR DESCRIPTION
Fixing issue #9748 by adding option to delimit CSV export with comma instead of default semicolon.