### PR TITLE
(cloudwatch) add period alias

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -287,6 +287,7 @@ func formatAlias(query *CloudWatchQuery, stat string, dimensions map[string]stri
 	data["namespace"] = query.Namespace
 	data["metric"] = query.MetricName
 	data["stat"] = stat
+	data["period"] = strconv.Itoa(query.Period)
 	for k, v := range dimensions {
 		data[k] = v
 	}

--- a/public/app/plugins/datasource/cloudwatch/partials/query.parameter.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/query.parameter.html
@@ -49,6 +49,7 @@
 				<li>{{stat}}</li>
 				<li>{{namespace}}</li>
 				<li>{{region}}</li>
+				<li>{{period}}</li>
 				<li>{{YOUR_DIMENSION_NAME}}</li>
 			</ul>
 		</info-popover>


### PR DESCRIPTION
Especially `Sum` dimensions, sometimes I want to know query period.
Not like `Average` dimensions, `Sum` value becomes much big value by changing long query time range.
It is important information.
I want to know, the value is `Sum` of `300 seconds` or `1 hour` or `1 day`...