### PR TITLE
fix time handling when the JSON representation of that time is a string instead of an integer

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -166,7 +166,7 @@ export class ElasticDatasource {
 
         var event = {
           annotation: annotation,
-          time: moment.utc(time).valueOf(),
+          time: moment.utc(parseInt(time, 10)).valueOf(),
           text: getFieldFromSource(source, textField),
           tags: getFieldFromSource(source, tagsField),
         };


### PR DESCRIPTION
This is a fix for #4456, when the time field is returned from elasticsearch as a string instead of an integer, we need to parseInt it before passing it to moment.