### PR TITLE
colorpicker: fix color string change #9769

### DIFF
--- a/public/app/core/components/colorpicker/ColorPickerPopover.tsx
+++ b/public/app/core/components/colorpicker/ColorPickerPopover.tsx
@@ -56,10 +56,11 @@ export class ColorPickerPopover extends React.Component<IProps, any> {
     let newColor = tinycolor(colorString);
     if (newColor.isValid()) {
       // Update only color state
+      let newColorString = newColor.toString();
       this.setState({
-        color: newColor.toString(),
+        color: newColorString,
       });
-      this.props.onColorSelect(newColor);
+      this.props.onColorSelect(newColorString);
     }
   }
 


### PR DESCRIPTION
This PR fixes #9769 -  Broken graphs after editing rgb colours for series `aliasColors`
