### PR TITLE
graph: fix for the stack & legend sort sync

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -375,20 +375,8 @@ function graphDirective($rootScope, timeSrv, popoverSrv, contextSrv) {
         var sortOrder = panel.legend.sortDesc;
         var haveSortBy = sortBy !== null || sortBy !== undefined;
         var haveSortOrder = sortOrder !== null || sortOrder !== undefined;
-
-        if (panel.stack && haveSortBy && haveSortOrder) {
-          var desc = desc = panel.legend.sortDesc === true ? -1 : 1;
-          series.sort((x, y) => {
-            if (x.stats[sortBy] > y.stats[sortBy]) {
-              return 1 * desc;
-            }
-            if (x.stats[sortBy] < y.stats[sortBy]) {
-              return -1 * desc;
-            }
-
-            return 0;
-          });
-        }
+        var shouldSortBy = panel.stack && haveSortBy && haveSortOrder;
+        var sortDesc = panel.legend.sortDesc === true ? -1 : 1;
 
         series.sort((x, y) => {
           if (x.zindex > y.zindex) {
@@ -397,6 +385,15 @@ function graphDirective($rootScope, timeSrv, popoverSrv, contextSrv) {
 
           if (x.zindex < y.zindex) {
             return -1;
+          }
+
+          if (shouldSortBy) {
+            if (x.stats[sortBy] > y.stats[sortBy]) {
+              return 1 * sortDesc;
+            }
+            if (x.stats[sortBy] < y.stats[sortBy]) {
+              return -1 * sortDesc;
+            }
           }
 
           return 0;


### PR DESCRIPTION
fixes #9789 (one part of that issue at least)

zindex sorting that happened in after the legend sort order was applied and messed with the order even though the sort function returned zero for all entries. Solution was to combine the sort function to one sort function


