### PR TITLE
use SHOW RETENTION POLICIES to test influxdb connection

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -190,10 +190,13 @@ export default class InfluxDatasource {
   }
 
   testDatasource() {
-    return this.metricFindQuery('SHOW DATABASES').then(res => {
-      let found = _.find(res, {text: this.database});
-      if (!found) {
-        return { status: "error", message: "Could not find the specified database name." };
+    var queryBuilder = new InfluxQueryBuilder({measurement: '', tags: []}, this.database);
+    var query = queryBuilder.buildExploreQuery('RETENTION POLICIES');
+
+    return this._seriesQuery(query).then(res => {
+      let error = _.get(res, 'results[0].error');
+      if (error) {
+        return { status: "error", message: error };
       }
       return { status: "success", message: "Data source is working" };
     }).catch(err => {


### PR DESCRIPTION
Currently Grafana uses the `SHOW DATABASES` command to test InfluxDB data sources, but that fails for non-admin users (and the error message isn't helpful).

This PR changes that to instead use `SHOW RETENTION POLICIES on "<db>"`, which only requires READ access to the target DB.  It also exposes any error response from InfluxDB to the user, making it easier to debug connection issues.