### PR TITLE
Use hex.EncodeToString to encode to hex

### DIFF
--- a/pkg/util/encoding.go
+++ b/pkg/util/encoding.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"hash"
 	"strings"
 )
@@ -30,7 +29,7 @@ func GetRandomString(n int, alphabets ...byte) string {
 
 func EncodePassword(password string, salt string) string {
 	newPasswd := PBKDF2([]byte(password), []byte(salt), 10000, 50, sha256.New)
-	return fmt.Sprintf("%x", newPasswd)
+	return hex.EncodeToString(newPasswd)
 }
 
 // Encode string to md5 hex value.


### PR DESCRIPTION
Using the EncodeToString function from the encoding/hex package
is much faster than calling the fmt.Sprintf with %x

Benchmark results below with the following code

```go
func BenchmarkHexPrint(b *testing.B) {
  data := []byte("hellothere")
  for n := 0; n < b.N; n++ {
    // _ = fmt.Sprintf("%x", data)
    _ = hex.EncodeToString(data)
  }
}
```

```
name        old time/op    new time/op    delta
HexPrint-4     188ns ± 1%      99ns ± 1%  -47.40%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
HexPrint-4     64.0B ± 0%     64.0B ± 0%     ~     (all equal)

name        old allocs/op  new allocs/op  delta
HexPrint-4      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```
