### PR TITLE
Elasticsearch: Accept annotation time field to be strings

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -164,6 +164,11 @@ export class ElasticDatasource {
           }
         }
 
+        var timeAsNumber = _.toNumber(time);
+        if (!_.isNaN(timeAsNumber)) {
+            time = timeAsNumber;
+        }
+
         var event = {
           annotation: annotation,
           time: moment.utc(time).valueOf(),


### PR DESCRIPTION
Elasticsearch allows timestamps to be both strings or integers.
However, momentjs only accepts timestamps as integer.

Fixes #4456

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>
