### PR TITLE
postgres: dont loose subsecond precision when dealing with timestamp or timestamptz

### DIFF
--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -186,7 +186,7 @@ func (e PostgresQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *co
 		case float64:
 			timestamp = columnValue * 1000
 		case time.Time:
-			timestamp = float64(columnValue.Unix() * 1000)
+			timestamp = float64(columnValue.UnixNano() / 1e6)
 		default:
 			return fmt.Errorf("Invalid type for column time, must be of type timestamp or unix timestamp")
 		}


### PR DESCRIPTION
Fixes #9844 