### PR TITLE
Add template variables to the annotations tags

### DIFF
--- a/public/app/features/templating/specs/template_srv.jest.ts
+++ b/public/app/features/templating/specs/template_srv.jest.ts
@@ -278,15 +278,17 @@ describe('templateSrv', function() {
 
   });
 
-  describe('variants', function() {
+  describe('getVariants', function() {
     it('should return empty array if no target', function() {
       initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+
       var target = _templateSrv.getVariants(undefined, {});
       expect(target).toEqual([]);
     });
 
     it('should return array with the same value if no template vars found', function() {
       initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+
       var target = _templateSrv.getVariants('this.is.filters', {});
       expect(target).toEqual(['this.is.filters']);
     });

--- a/public/app/features/templating/specs/template_srv.jest.ts
+++ b/public/app/features/templating/specs/template_srv.jest.ts
@@ -277,4 +277,62 @@ describe('templateSrv', function() {
     });
 
   });
+
+  describe('variants', function() {
+    it('should return empty array if no target', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+      var target = _templateSrv.getVariants(undefined, {});
+      expect(target).toEqual([]);
+    });
+
+    it('should return array with the same value if no template vars found', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+      var target = _templateSrv.getVariants('this.is.filters', {});
+      expect(target).toEqual(['this.is.filters']);
+    });
+
+    it('should return array with the same value if template var does not exists', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+
+      var target = _templateSrv.getVariants('this.$check.filters', {});
+      expect(target).toEqual(['this.$check.filters']);
+    });
+
+    it('should return $test with singular scoped value', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val0'}}]);
+
+      var target = _templateSrv.getVariants('this.$test.filters', {'test': {value: 'val1'}});
+      expect(target).toEqual(['this.val1.filters']);
+    });
+
+    it('should return $test with multi scoped value', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val0'}}]);
+
+      var target = _templateSrv.getVariants('this.$test.filters', {'test': {value: ['val1', 'val2']}});
+      expect(target).toEqual(['this.val1.filters', 'this.val2.filters']);
+    });
+
+    it('should return $test with singular value', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: 'val1'}}]);
+
+      var target = _templateSrv.getVariants('this.$test.filters', {});
+      expect(target).toEqual(['this.val1.filters']);
+    });
+
+    it('should return $test with multi value', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: ['val1', 'val2']}}]);
+
+      var target = _templateSrv.getVariants('this.$test.filters', {});
+      expect(target).toEqual(['this.val1.filters', 'this.val2.filters']);
+    });
+
+    it('should return $test with system value', function() {
+      initTemplateSrv([{type: 'query', name: 'test', current: {value: '$__system_value'}}]);
+      _templateSrv.setGrafanaVariable('$__system_value', 'val1');
+      _templateSrv.updateTemplateData();
+
+      var target = _templateSrv.getVariants('this.$test.filters', {});
+      expect(target).toEqual(['this.val1.filters']);
+    });
+  });
 });

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -198,6 +198,54 @@ export class TemplateSrv {
     });
   }
 
+  getVariants(target, scopedVars?) {
+    if (!target) { return []; }
+
+    var buildVariants, matches, variable, value, systemValue;
+    this.regex.lastIndex = 0;
+
+    buildVariants = (values) => {
+      if (!_.isArray(values)) {
+        return [target.replace(this.regex, values)];
+      }
+
+      return _.map(values, (val) => {
+        return target.replace(this.regex, val);
+      });
+    };
+
+    matches = this.regex.exec(target);
+    if (!matches) { return [target]; }
+
+    variable = this.index[matches[1] || matches[2]];
+
+    if (scopedVars) {
+      value = scopedVars[matches[1] || matches[2]];
+
+      if (value) {
+        return buildVariants(value.value);
+      }
+    }
+
+    if (!variable) { return [target]; }
+
+    systemValue = this.grafanaVariables[variable.current.value];
+    if (systemValue) {
+      return buildVariants(systemValue);
+    }
+
+    value = variable.current.value;
+    if (this.isAllValue(value)) {
+      value = this.getAllValue(variable);
+
+      if (variable.allValue) {
+        return buildVariants(value);
+      }
+    }
+
+    return buildVariants(value);
+  }
+
   isAllValue(value) {
     return value === '$__all' || Array.isArray(value) && value[0] === '$__all';
   }

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 class GrafanaDatasource {
 
   /** @ngInject */
-  constructor(private backendSrv, private $q) {}
+  constructor(private backendSrv, private $q, private templateSrv) {}
 
   query(options) {
     return this.backendSrv
@@ -35,7 +35,6 @@ class GrafanaDatasource {
     return this.$q.when({data: []});
   }
 
-
   annotationQuery(options) {
     const params: any = {
       from: options.range.from.valueOf(),
@@ -59,6 +58,10 @@ class GrafanaDatasource {
         return this.$q.when([]);
       }
     }
+
+    params.tags = _.flatMap(options.annotation.tags, (tag) => {
+      return this.templateSrv.getVariants(tag, {});
+    });
 
     return this.backendSrv.get('/api/annotations', params);
   }


### PR DESCRIPTION
Resolves https://github.com/grafana/grafana/issues/9735

Hola grafana comunity 👋 
I want to add my tiny contribusion to the great project.

Template variables are nice way to squize repeative dashboards to one. I've found that it's impossible to use `$var` in annotations when you try to filter them by tags.

### Motivation

As far we have 2 template variable which make annotation of deployments completely unusable for us. It's `environment` and something like `project`. With environment it's quite easy, just <5 possible values, but projects already count more than 10 ...

First of all we have tried to put `$project` right inside the tag value and as you know – it's not working. In the linked issue @PaulKuiper suggest to have some filter to filter out annotations, but I think we should follow less surprising approach and as soon as you expect that template variables are working in graphs, you will expect them working in tags also.

### UI

![general view](https://user-images.githubusercontent.com/920053/32723835-7f4763dc-c8a1-11e7-80bb-6824ad7ab68b.png)

### Implementation

Solution is quite simple – single value template variables is replaced with one `tag` option, multi – with multiple `tag`

![requests](https://user-images.githubusercontent.com/920053/32724482-0f457a44-c8a4-11e7-8fcc-b945f5309af5.png)