### PR TITLE
Add feet to the length menu

### DIFF
--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -891,6 +891,7 @@ kbn.getUnitFormats = function() {
       submenu: [
         { text: 'millimetre (mm)', value: 'lengthmm' },
         { text: 'meter (m)', value: 'lengthm' },
+        { text: 'feet (ft)', value: 'lengthft' },
         { text: 'kilometer (km)', value: 'lengthkm' },
         { text: 'mile (mi)', value: 'lengthmi' },
       ],


### PR DESCRIPTION
Somehow this is missing!  

`kbn.valueFormats.lengthft` already exits