### PR TITLE
fix: return id from api when creating new annotation, fixes #9798

### DIFF
--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -89,7 +89,7 @@ Content-Type: application/json
 
 ## Create Annotation
 
-Creates an annotation in the Grafana database. The `dashboardId` and `panelId` fields are optional. If they are not specified then a global annotation is created and can be queried in any dashboard that adds the Grafana annotations data source.
+Creates an annotation in the Grafana database. The `dashboardId` and `panelId` fields are optional. If they are not specified then a global annotation is created and can be queried in any dashboard that adds the Grafana annotations data source. When creating a region annotation the response will include both `id` and `endId`, if not only `id`.
 
 `POST /api/annotations`
 
@@ -117,7 +117,11 @@ Content-Type: application/json
 HTTP/1.1 200
 Content-Type: application/json
 
-{"message":"Annotation added"}
+{
+    "message":"Annotation added",
+    "id": 1,
+    "endId": 2
+}
 ```
 
 ## Create Annotation in Graphite format
@@ -148,7 +152,10 @@ Content-Type: application/json
 HTTP/1.1 200
 Content-Type: application/json
 
-{"message":"Graphite annotation added"}
+{
+    "message":"Graphite annotation added",
+    "id": 1
+}
 ```
 
 ## Update Annotation

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -288,11 +288,11 @@ func (hs *HttpServer) registerRoutes() {
 		apiRoute.Post("/annotations/mass-delete", reqOrgAdmin, bind(dtos.DeleteAnnotationsCmd{}), wrap(DeleteAnnotations))
 
 		apiRoute.Group("/annotations", func(annotationsRoute RouteRegister) {
-			annotationsRoute.Post("/", bind(dtos.PostAnnotationsCmd{}), wrap(PostAnnotation))
+			annotationsRoute.Post("/", bind(dtos.PostAnnotationsCmd{}), PostAnnotation)
 			annotationsRoute.Delete("/:annotationId", wrap(DeleteAnnotationById))
 			annotationsRoute.Put("/:annotationId", bind(dtos.UpdateAnnotationsCmd{}), wrap(UpdateAnnotation))
 			annotationsRoute.Delete("/region/:regionId", wrap(DeleteAnnotationRegion))
-			annotationsRoute.Post("/graphite", bind(dtos.PostGraphiteAnnotationsCmd{}), wrap(PostGraphiteAnnotation))
+			annotationsRoute.Post("/graphite", bind(dtos.PostGraphiteAnnotationsCmd{}), PostGraphiteAnnotation)
 		}, reqEditorRole)
 
 		// error test

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -288,11 +288,11 @@ func (hs *HttpServer) registerRoutes() {
 		apiRoute.Post("/annotations/mass-delete", reqOrgAdmin, bind(dtos.DeleteAnnotationsCmd{}), wrap(DeleteAnnotations))
 
 		apiRoute.Group("/annotations", func(annotationsRoute RouteRegister) {
-			annotationsRoute.Post("/", bind(dtos.PostAnnotationsCmd{}), PostAnnotation)
+			annotationsRoute.Post("/", bind(dtos.PostAnnotationsCmd{}), wrap(PostAnnotation))
 			annotationsRoute.Delete("/:annotationId", wrap(DeleteAnnotationById))
 			annotationsRoute.Put("/:annotationId", bind(dtos.UpdateAnnotationsCmd{}), wrap(UpdateAnnotation))
 			annotationsRoute.Delete("/region/:regionId", wrap(DeleteAnnotationRegion))
-			annotationsRoute.Post("/graphite", bind(dtos.PostGraphiteAnnotationsCmd{}), PostGraphiteAnnotation)
+			annotationsRoute.Post("/graphite", bind(dtos.PostGraphiteAnnotationsCmd{}), wrap(PostGraphiteAnnotation))
 		}, reqEditorRole)
 
 		// error test

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -199,10 +199,10 @@ func (hs *HttpServer) registerRoutes() {
 		// Data sources
 		apiRoute.Group("/datasources", func(datasourceRoute RouteRegister) {
 			datasourceRoute.Get("/", wrap(GetDataSources))
-			datasourceRoute.Post("/", quota("data_source"), bind(m.AddDataSourceCommand{}), AddDataSource)
+			datasourceRoute.Post("/", quota("data_source"), bind(m.AddDataSourceCommand{}), wrap(AddDataSource))
 			datasourceRoute.Put("/:id", bind(m.UpdateDataSourceCommand{}), wrap(UpdateDataSource))
-			datasourceRoute.Delete("/:id", DeleteDataSourceById)
-			datasourceRoute.Delete("/name/:name", DeleteDataSourceByName)
+			datasourceRoute.Delete("/:id", wrap(DeleteDataSourceById))
+			datasourceRoute.Delete("/name/:name", wrap(DeleteDataSourceByName))
 			datasourceRoute.Get("/:id", wrap(GetDataSourceById))
 			datasourceRoute.Get("/name/:name", wrap(GetDataSourceByName))
 		}, reqOrgAdmin)

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -37,16 +37,18 @@ func TestAnnotations(t *testing.T) {
 		repo := SqlAnnotationRepo{}
 
 		Convey("Can save annotation", func() {
-			err := repo.Save(&annotations.Item{
+			annotation := &annotations.Item{
 				OrgId:       1,
 				UserId:      1,
 				DashboardId: 1,
 				Text:        "hello",
 				Epoch:       10,
 				Tags:        []string{"outage", "error", "type:outage", "server:server-1"},
-			})
+			}
+			err := repo.Save(annotation)
 
 			So(err, ShouldBeNil)
+			So(annotation.Id, ShouldBeGreaterThan, 0)
 
 			Convey("Can query for annotation", func() {
 				items, err := repo.Find(&annotations.ItemQuery{


### PR DESCRIPTION
Return id from api when creating new annotation/graphite annotation

When creating a region annotation the response will include both
id (region start id) and endId (region end id), if not only id.

closes https://github.com/grafana/grafana/issues/9798