### PR TITLE
Added time_zone parameter to ES range and date_histogram queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -31,10 +31,10 @@ export class ElasticDatasource {
     this.indexPattern = new IndexPattern(instanceSettings.index, instanceSettings.jsonData.interval);
     this.interval = instanceSettings.jsonData.timeInterval;
     this.maxConcurrentShardRequests = instanceSettings.jsonData.maxConcurrentShardRequests;
-    if (timeSrv.dashboard && timeSrv.dashboard.timezone === 'browser') {
-      this.timeZone = moment().format('Z');
-    } else {
+    if (timeSrv.dashboard && timeSrv.dashboard.timezone === 'utc') {
       this.timeZone = 'UTC';
+    } else {
+      this.timeZone = moment().format('Z');
     }
     this.queryBuilder = new ElasticQueryBuilder({
       timeField: this.timeField,

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -15,6 +15,7 @@ export class ElasticDatasource {
   esVersion: number;
   interval: string;
   maxConcurrentShardRequests: number;
+  timeZone: string;
   queryBuilder: ElasticQueryBuilder;
   indexPattern: IndexPattern;
 
@@ -30,6 +31,11 @@ export class ElasticDatasource {
     this.indexPattern = new IndexPattern(instanceSettings.index, instanceSettings.jsonData.interval);
     this.interval = instanceSettings.jsonData.timeInterval;
     this.maxConcurrentShardRequests = instanceSettings.jsonData.maxConcurrentShardRequests;
+    if (timeSrv.dashboard && timeSrv.dashboard.timezone === 'browser') {
+      this.timeZone = moment().format('Z');
+    } else {
+      this.timeZone = 'UTC';
+    }
     this.queryBuilder = new ElasticQueryBuilder({
       timeField: this.timeField,
       esVersion: this.esVersion,
@@ -270,8 +276,9 @@ export class ElasticDatasource {
       return this.$q.when([]);
     }
 
-    payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
-    payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());
+    payload = payload.replace(/\$timeFrom/g, moment(options.range.from.valueOf()).format('YYYY-MM-DDTHH:mm:ss.SSS'));
+    payload = payload.replace(/\$timeTo/g, moment(options.range.to.valueOf()).format('YYYY-MM-DDTHH:mm:ss.SSS'));
+    payload = payload.replace(/\$timeZone/g, this.timeZone);
     payload = this.templateSrv.replace(payload, options.scopedVars);
 
     return this.post('_msearch', payload).then(function(res) {
@@ -364,8 +371,9 @@ export class ElasticDatasource {
     var header = this.getQueryHeader(searchType, range.from, range.to);
     var esQuery = angular.toJson(this.queryBuilder.getTermsQuery(queryDef));
 
-    esQuery = esQuery.replace(/\$timeFrom/g, range.from.valueOf());
-    esQuery = esQuery.replace(/\$timeTo/g, range.to.valueOf());
+    esQuery = esQuery.replace(/\$timeFrom/g, moment(range.from.valueOf()).format('YYYY-MM-DDTHH:mm:ss.SSS'));
+    esQuery = esQuery.replace(/\$timeTo/g, moment(range.to.valueOf()).format('YYYY-MM-DDTHH:mm:ss.SSS'));
+    esQuery = esQuery.replace(/\$timeZone/g, this.timeZone);
     esQuery = header + '\n' + esQuery + '\n';
 
     return this.post('_msearch?search_type=' + searchType, esQuery).then(function(res) {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -14,7 +14,8 @@ export class ElasticQueryBuilder {
     filter[this.timeField] = {
       gte: '$timeFrom',
       lte: '$timeTo',
-      format: 'epoch_millis',
+      time_zone: '$timeZone',
+      format: "yyyy-MM-dd'T'HH:mm:ss.SSS",
     };
 
     return filter;
@@ -66,7 +67,8 @@ export class ElasticQueryBuilder {
     esAgg.field = this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
-    esAgg.format = 'epoch_millis';
+    esAgg.format = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    esAgg.time_zone = '$timeZone';
 
     if (esAgg.interval === 'auto') {
       esAgg.interval = '$__interval';

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -132,6 +132,7 @@ export function DashboardViewStateStub() {
 export function TimeSrvStub() {
   this.init = sinon.spy();
   this.time = {from: 'now-1h', to: 'now'};
+  this.dashboard = { timezone: 'utc'};
   this.timeRange = function(parse) {
     if (parse === false) {
       return this.time;


### PR DESCRIPTION
I've added a `time_zone` parameter to elasticsearch `range` and `date_histogram` queries.

Because you can't add `time_zone` parameter on range queries when the date format is epoch_millis : elastic/elasticsearch#22621
I have to format `timeFrom` and `timeTo` to a `yyyy-MM-dd'T'HH:mm:ss.SSS` format without the time_zone `Z` formater. Then add the `time_zone` parameter in the `range` and `date_histogram` queries according to the users dashboard settings.

Related issues : https://github.com/grafana/grafana/issues/6222
Related PR : https://github.com/grafana/grafana/pull/8395