### PR TITLE
Adding a user in a specified organisation uses the admin API

### DIFF
--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -380,6 +380,8 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
   "role":"Viewer"
 }
 ```
+Note: The api will only work when you pass the admin name and password
+to the request http url, like http://admin:admin@localhost:3000/api/orgs/1/users
 
 **Example Response**:
 


### PR DESCRIPTION
There might be other occurances in the same file that need changing.

Also, would it be a good idea to change the `Authorization: Bearer ...` header to `Authorization: Basic ...` as how it's used in the `User` API docs?