### PR TITLE
Don't import JSON dashboards from hidden directories.

### DIFF
--- a/pkg/services/search/json_index.go
+++ b/pkg/services/search/json_index.go
@@ -90,6 +90,9 @@ func (index *JsonDashIndex) updateIndex() error {
 			return err
 		}
 		if f.IsDir() {
+			if strings.HasPrefix(f.Name(), ".") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 


### PR DESCRIPTION
I store my JSON dashboards in a Kubernetes config map, which ends up in the container as a hidden directory (per version of the config map) and a set of symlinks to the latest version.  This ends up with my dashboards being repeated in the dashboard selector.

With this change, this doesn't happen any more.
