### PR TITLE
Add more stats to graph legend

### DIFF
--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -7,7 +7,7 @@ function (angular, _, $) {
   'use strict';
 
   // Supported stats and the order they are displayed in
-  const stats = ['min','max','avg','first','current','diff','range','total'];
+  var stats = ['min','max','avg','first','current','diff','range','total'];
 
   var module = angular.module('grafana.directives');
 

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -129,14 +129,15 @@ function (angular, _, $) {
 
           $container.toggleClass('graph-legend-table', panel.legend.alignAsTable === true);
 
+          var j=0;
           var tableHeaderElem;
           if (panel.legend.alignAsTable) {
             var header = '<tr style="text-transform: capitalize;">';
             header += '<th colspan="2" style="text-align:left"></th>';
             if (panel.legend.values) {
-              _.forEach(stats, function(s) {
-                header += getTableHeaderHtml(s);
-              });
+              for(j=0; j<stats.length; j++) {
+                header += getTableHeaderHtml(stats[j]);
+              }
             }
             header += '</tr>';
             tableHeaderElem = $(header);
@@ -173,12 +174,13 @@ function (angular, _, $) {
             html += '<a class="graph-legend-alias pointer" title="' + series.aliasEscaped + '">' + series.aliasEscaped + '</a>';
 
             if (panel.legend.values) {
-              _.forEach(stats, function(stat) {
+              for(j=0; j<stats.length; j++) {
+                var stat = stats[j];
                 if(panel.legend[stat]) {
                   var val = series.formatValue(series.stats[stat]);
                   html += '<div class="graph-legend-value '+stat+'">' + val + '</div>';
                 }
-              });
+              }
             }
 
             html += '</div>';

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -6,6 +6,9 @@ define([
 function (angular, _, $) {
   'use strict';
 
+  // Supported stats and the order they are displayed in
+  const stats = ['min','max','avg','first','current','diff','range','total'];
+
   var module = angular.module('grafana.directives');
 
   module.directive('graphLegend', function(popoverSrv, $timeout) {
@@ -131,11 +134,9 @@ function (angular, _, $) {
             var header = '<tr>';
             header += '<th colspan="2" style="text-align:left"></th>';
             if (panel.legend.values) {
-              header += getTableHeaderHtml('min');
-              header += getTableHeaderHtml('max');
-              header += getTableHeaderHtml('avg');
-              header += getTableHeaderHtml('current');
-              header += getTableHeaderHtml('total');
+              _.forEach(stats, function(s) {
+                header += getTableHeaderHtml(s);
+              });
             }
             header += '</tr>';
             tableHeaderElem = $(header);
@@ -172,17 +173,12 @@ function (angular, _, $) {
             html += '<a class="graph-legend-alias pointer" title="' + series.aliasEscaped + '">' + series.aliasEscaped + '</a>';
 
             if (panel.legend.values) {
-              var avg = series.formatValue(series.stats.avg);
-              var current = series.formatValue(series.stats.current);
-              var min = series.formatValue(series.stats.min);
-              var max = series.formatValue(series.stats.max);
-              var total = series.formatValue(series.stats.total);
-
-              if (panel.legend.min) { html += '<div class="graph-legend-value min">' + min + '</div>'; }
-              if (panel.legend.max) { html += '<div class="graph-legend-value max">' + max + '</div>'; }
-              if (panel.legend.avg) { html += '<div class="graph-legend-value avg">' + avg + '</div>'; }
-              if (panel.legend.current) { html += '<div class="graph-legend-value current">' + current + '</div>'; }
-              if (panel.legend.total) { html += '<div class="graph-legend-value total">' + total + '</div>'; }
+              _.forEach(stats, function( stat ) {
+                if(panel.legend[stat]) {
+                  var val = series.formatValue(series.stats[stat]);
+                  html += '<div class="graph-legend-value '+stat+'">' + val + '</div>';
+                }
+              });
             }
 
             html += '</div>';

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -173,7 +173,7 @@ function (angular, _, $) {
             html += '<a class="graph-legend-alias pointer" title="' + series.aliasEscaped + '">' + series.aliasEscaped + '</a>';
 
             if (panel.legend.values) {
-              _.forEach(stats, function( stat ) {
+              _.forEach(stats, function(stat) {
                 if(panel.legend[stat]) {
                   var val = series.formatValue(series.stats[stat]);
                   html += '<div class="graph-legend-value '+stat+'">' + val + '</div>';

--- a/public/app/plugins/panel/graph/legend.js
+++ b/public/app/plugins/panel/graph/legend.js
@@ -131,7 +131,7 @@ function (angular, _, $) {
 
           var tableHeaderElem;
           if (panel.legend.alignAsTable) {
-            var header = '<tr>';
+            var header = '<tr style="text-transform: capitalize;">';
             header += '<th colspan="2" style="text-align:left"></th>';
             if (panel.legend.values) {
               _.forEach(stats, function(s) {

--- a/public/app/plugins/panel/graph/tab_legend.html
+++ b/public/app/plugins/panel/graph/tab_legend.html
@@ -34,7 +34,7 @@
 			</gf-form-switch>
 
 			<gf-form-switch class="gf-form"
-				label="Avg" label-class="width-6"
+				label="Avg" label-class="width-6" switch-class="width-5"
 				checked="ctrl.panel.legend.avg" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
@@ -53,7 +53,7 @@
 			</gf-form-switch>
 
 			<gf-form-switch class="gf-form"
-				label="Total" label-class="width-6"
+				label="Total" label-class="width-6" switch-class="width-5"
 				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 		</div>
@@ -76,7 +76,7 @@
 			</div>
 		</div>
 	</div>
-X
+
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Hide series</h5>
 		<gf-form-switch class="gf-form"

--- a/public/app/plugins/panel/graph/tab_legend.html
+++ b/public/app/plugins/panel/graph/tab_legend.html
@@ -28,16 +28,27 @@
 				checked="ctrl.panel.legend.min" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
-			<gf-form-switch class="gf-form max-width-12"
-				label="Max" label-class="width-6" switch-class="max-width-5"
-				checked="ctrl.panel.legend.max" on-change="ctrl.legendValuesOptionChanged()">
+			<gf-form-switch class="gf-form"
+				label="Total" label-class="width-4"
+				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
+
+			<gf-form-switch class="gf-form"
+				label="First" label-class="width-6"
+				checked="ctrl.panel.legend.first" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+
 		</div>
 
 		<div class="gf-form-inline">
-			<gf-form-switch class="gf-form"
-				label="Avg" label-class="width-4"
-				checked="ctrl.panel.legend.avg" on-change="ctrl.legendValuesOptionChanged()">
+			<gf-form-switch class="gf-form max-width-12"
+				label="Max" label-class="width-4" switch-class="max-width-5"
+				checked="ctrl.panel.legend.max" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+
+			<gf-form-switch class="gf-form max-width-12"
+				label="Diff" label-class="width-4" switch-class="max-width-5"
+				checked="ctrl.panel.legend.diff" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
 			<gf-form-switch class="gf-form max-width-12"
@@ -48,8 +59,13 @@
 
 		<div class="gf-form-inline">
 			<gf-form-switch class="gf-form"
-				label="Total" label-class="width-4"
-				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
+				label="Avg" label-class="width-4"
+				checked="ctrl.panel.legend.avg" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+
+			<gf-form-switch class="gf-form"
+				label="Range" label-class="width-4"
+				checked="ctrl.panel.legend.range" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
 			<div class="gf-form">

--- a/public/app/plugins/panel/graph/tab_legend.html
+++ b/public/app/plugins/panel/graph/tab_legend.html
@@ -29,42 +29,44 @@
 			</gf-form-switch>
 
 			<gf-form-switch class="gf-form"
-				label="Total" label-class="width-4"
-				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
-			</gf-form-switch>
-
-			<gf-form-switch class="gf-form"
-				label="First" label-class="width-6"
-				checked="ctrl.panel.legend.first" on-change="ctrl.legendValuesOptionChanged()">
-			</gf-form-switch>
-
-		</div>
-
-		<div class="gf-form-inline">
-			<gf-form-switch class="gf-form max-width-12"
-				label="Max" label-class="width-4" switch-class="max-width-5"
+				label="Max" label-class="width-5"
 				checked="ctrl.panel.legend.max" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
-			<gf-form-switch class="gf-form max-width-12"
-				label="Diff" label-class="width-4" switch-class="max-width-5"
-				checked="ctrl.panel.legend.diff" on-change="ctrl.legendValuesOptionChanged()">
+			<gf-form-switch class="gf-form"
+				label="Avg" label-class="width-6"
+				checked="ctrl.panel.legend.avg" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
-			<gf-form-switch class="gf-form max-width-12"
-				label="Current" label-class="width-6" switch-class="max-width-5"
+		</div>
+
+		<div class="gf-form-inline">
+
+			<gf-form-switch class="gf-form"
+				label="First" label-class="width-4"
+				checked="ctrl.panel.legend.first" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+
+			<gf-form-switch class="gf-form"
+				label="Current" label-class="width-5"
 				checked="ctrl.panel.legend.current" on-change="ctrl.legendValuesOptionChanged()">
+			</gf-form-switch>
+
+			<gf-form-switch class="gf-form"
+				label="Total" label-class="width-6"
+				checked="ctrl.panel.legend.total" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 		</div>
 
 		<div class="gf-form-inline">
+
 			<gf-form-switch class="gf-form"
-				label="Avg" label-class="width-4"
-				checked="ctrl.panel.legend.avg" on-change="ctrl.legendValuesOptionChanged()">
+				label="Diff" label-class="width-4"
+				checked="ctrl.panel.legend.diff" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
 			<gf-form-switch class="gf-form"
-				label="Range" label-class="width-4"
+				label="Range" label-class="width-5"
 				checked="ctrl.panel.legend.range" on-change="ctrl.legendValuesOptionChanged()">
 			</gf-form-switch>
 
@@ -74,7 +76,7 @@
 			</div>
 		</div>
 	</div>
-
+X
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Hide series</h5>
 		<gf-form-switch class="gf-form"

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -62,6 +62,15 @@
   &.avg::before {
     content: "Avg: "
   }
+  &.first::before {
+    content: "First: "
+  }
+  &.diff::before {
+    content: "Diff: "
+  }
+  &.range::before {
+    content: "Range: "
+  }
 }
 
 .graph-legend-icon .fa {


### PR DESCRIPTION
This patch exposes the stats: `first` `diff`, and `range`

![image](https://user-images.githubusercontent.com/705951/32961614-878330b4-cbc9-11e7-8c5e-5c89dd634766.png)


This also capitalises the field names in the table to be consistent with the non-table display.