### PR TITLE
Make time series aggregations work with Prometheus again

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -204,7 +204,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     }
   }
 
-  issueQueries(datasource) {
+  issueQueries(datasource, query = {}) {
     this.datasource = datasource;
 
     if (!this.panel.targets || this.panel.targets.length === 0) {
@@ -218,7 +218,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       "__interval_ms":  {text: this.intervalMs, value: this.intervalMs},
     });
 
-    var metricsQuery = {
+    var metricsQuery = Object.assign(query, {
       timezone: this.dashboard.getTimezone(),
       panelId: this.panel.id,
       range: this.range,
@@ -229,7 +229,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       maxDataPoints: this.resolution,
       scopedVars: scopedVars,
       cacheTimeout: this.panel.cacheTimeout
-    };
+    });
 
     return datasource.query(metricsQuery);
   }

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -117,7 +117,7 @@ export class PrometheusDatasource {
           throw response.error;
         }
 
-        if (activeTargets[index].format === "table") {
+        if (options.transform === "table") {
           result.push(self.transformMetricDataToTable(response.data.data.result));
         } else {
           for (let metricData of response.data.data.result) {

--- a/public/app/plugins/panel/table/editor.ts
+++ b/public/app/plugins/panel/table/editor.ts
@@ -74,7 +74,7 @@ export class TablePanelEditorCtrl {
     }
 
     this.updateTransformHints();
-    this.render();
+    this.panelCtrl.refresh();
   }
 
   render() {

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -87,7 +87,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       });
     }
 
-    return super.issueQueries(datasource);
+    return super.issueQueries(datasource, { transform: this.panel.transform });
   }
 
   onDataError(err) {
@@ -107,7 +107,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
         if (this.dataRaw[0].type === 'docs') {
           this.panel.transform = 'json';
         } else {
-          if (this.panel.transform === 'table' || this.panel.transform === 'json') {
+          if (this.panel.transform === 'table') {
             this.panel.transform = 'timeseries_to_rows';
           }
         }


### PR DESCRIPTION
This resolves #8721

Prometheus datasource greedly performs `transformMetricDataToTable` on any
table type. This returns rows and columns for the table module to consume.
However other transforms does not expect the inputs to be in this format.
Rather they prefer the `transformMetricData`.

Added a query param to metrics_panel_ctrl so we pass it implementation
specific queries to the datasource. Uses this passed in transform value
to check if we need to do `transformMetricDataToTable`.

Make the table to refresh on table transform change instead of just rendering
to force the query result to be transformed.

Remove JSON from the automatic transform mode to no make JSON table
convert to timeseries_to_rows.
