### PR TITLE
case-insensitive LDAP group comparison

### DIFF
--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -53,6 +53,20 @@ func TestLdapAuther(t *testing.T) {
 			So(result, ShouldEqual, user1)
 		})
 
+		ldapAutherScenario("Given group match with different case", func(sc *scenarioContext) {
+			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
+				LdapGroups: []*LdapGroupToOrgRole{
+					{GroupDN: "cn=users", OrgRole: "Admin"},
+				},
+			})
+
+			sc.userQueryReturns(user1)
+
+			result, err := ldapAuther.GetGrafanaUserFor(&LdapUserInfo{MemberOf: []string{"CN=users"}})
+			So(err, ShouldBeNil)
+			So(result, ShouldEqual, user1)
+		})
+
 		ldapAutherScenario("Given no existing grafana user", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
 				LdapGroups: []*LdapGroupToOrgRole{

--- a/pkg/login/ldap_user.go
+++ b/pkg/login/ldap_user.go
@@ -1,5 +1,9 @@
 package login
 
+import (
+	"strings"
+)
+
 type LdapUserInfo struct {
 	DN        string
 	FirstName string
@@ -15,7 +19,7 @@ func (u *LdapUserInfo) isMemberOf(group string) bool {
 	}
 
 	for _, member := range u.MemberOf {
-		if member == group {
+		if strings.EqualFold(member, group) {
 			return true
 		}
 	}


### PR DESCRIPTION
According to RFC2251 4.1.5, LDAP strings are case-insensitive. Disregard case when comparing group mappings.

