### PR TITLE
Make Table Transform changes update Format As to apporpiate value

### DIFF
--- a/public/app/plugins/panel/table/editor.ts
+++ b/public/app/plugins/panel/table/editor.ts
@@ -72,9 +72,13 @@ export class TablePanelEditorCtrl {
     if (this.panel.transform === 'timeseries_aggregations') {
       this.panel.columns.push({text: 'Avg', value: 'avg'});
     }
+    let targetFormat = this.panel.transform === 'table' ? 'table' : 'time_series';
+    _.each(this.panel.targets, function(target) {
+      target.format = targetFormat;
+    });
 
     this.updateTransformHints();
-    this.render();
+    this.panelCtrl.refresh();
   }
 
   render() {

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -107,7 +107,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
         if (this.dataRaw[0].type === 'docs') {
           this.panel.transform = 'json';
         } else {
-          if (this.panel.transform === 'table' || this.panel.transform === 'json') {
+          if (this.panel.transform === 'table') {
             this.panel.transform = 'timeseries_to_rows';
           }
         }


### PR DESCRIPTION
Resolves #9927

Only the table transformer in the table panel expect the data payload to
be in columns and rows format. Other tranformers expect time series
datapoints.

When toggling the table transform options, we update the target.format
to the correct value.

Remove json from the automatic transform mode check.