### PR TITLE
Move the loading flag to PanelCtrl

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -11,7 +11,6 @@ import {metricsTabDirective} from './metrics_tab';
 
 class MetricsPanelCtrl extends PanelCtrl {
   scope: any;
-  loading: boolean;
   datasource: any;
   datasourceName: any;
   $q: any;

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -31,6 +31,7 @@ export class PanelCtrl {
   containerHeight: any;
   events: Emitter;
   timing: any;
+  loading: boolean;
 
   constructor($scope, $injector) {
     this.$injector = $injector;


### PR DESCRIPTION
Setting the `loading` flag in a panel will make the spinner show up in the upper right.

Currently that is defined in MetricPanelCtrl, but is actually used in PanelCtrl.  See:

https://github.com/grafana/grafana/blob/master/public/app/features/panel/panel_directive.ts#L17

Any panel can set the loading flag.  

I noticed this while building a plugin with:
https://github.com/grafana/grafana-sdk-mocks/blob/master/app/features/panel/panel_ctrl.ts



