### PR TITLE
[GCS] Support for gcs path

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -495,3 +495,4 @@ public_url =
 [external_image_storage.gcs]
 key_file =
 bucket =
+path =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -438,3 +438,4 @@ log_queries =
 [external_image_storage.gcs]
 ;key_file =
 ;bucket =
+;path =

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -778,6 +778,9 @@ Service Account should have "Storage Object Writer" role.
 ### bucket name
 Bucket Name on Google Cloud Storage.
 
+### path
+Optional extra path inside bucket
+
 ## [alerting]
 
 ### enabled

--- a/pkg/components/imguploader/gcsuploader.go
+++ b/pkg/components/imguploader/gcsuploader.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/util"
@@ -20,19 +21,22 @@ const (
 type GCSUploader struct {
 	keyFile string
 	bucket  string
+	path    string
 	log     log.Logger
 }
 
-func NewGCSUploader(keyFile, bucket string) *GCSUploader {
+func NewGCSUploader(keyFile, bucket, path string) *GCSUploader {
 	return &GCSUploader{
 		keyFile: keyFile,
 		bucket:  bucket,
+		path:    path,
 		log:     log.New("gcsuploader"),
 	}
 }
 
 func (u *GCSUploader) Upload(ctx context.Context, imageDiskPath string) (string, error) {
-	key := util.GetRandomString(20) + ".png"
+	fileName := util.GetRandomString(20) + ".png"
+	key := path.Join(u.path, fileName)
 
 	u.log.Debug("Opening key file ", u.keyFile)
 	data, err := ioutil.ReadFile(u.keyFile)

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -73,8 +73,9 @@ func NewImageUploader() (ImageUploader, error) {
 
 		keyFile := gcssec.Key("key_file").MustString("")
 		bucketName := gcssec.Key("bucket").MustString("")
+		path := gcssec.Key("path").MustString("")
 
-		return NewGCSUploader(keyFile, bucketName), nil
+		return NewGCSUploader(keyFile, bucketName, path), nil
 	}
 
 	return NopImageUploader{}, nil


### PR DESCRIPTION
Extra path inside google storage bucket.

I use a single gcs bucket for multiple purposes, instead of creating a new gcs bucket and dedicate it for Grafana external images, we can use a single bucket and benefit from paths.