### PR TITLE
Elasticsearch max_concurrent_shard_requests parameter for es 5.6+

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
@@ -8,6 +8,7 @@ export class ElasticConfigCtrl {
   constructor($scope) {
     this.current.jsonData.timeField = this.current.jsonData.timeField || '@timestamp';
     this.current.jsonData.esVersion = this.current.jsonData.esVersion || 5;
+    this.current.jsonData.maxConcurrentShardRequests = this.current.jsonData.maxConcurrentShardRequests || 256;
   }
 
   indexPatternTypes = [
@@ -22,6 +23,7 @@ export class ElasticConfigCtrl {
   esVersions = [
     {name: '2.x', value: 2},
     {name: '5.x', value: 5},
+    {name: '5.6+', value: 56},
   ];
 
   indexPatternTypeChanged() {

--- a/public/app/plugins/datasource/elasticsearch/partials/config.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/config.html
@@ -25,6 +25,10 @@
 		<span class="gf-form-label width-9">Version</span>
 		<select class="gf-form-input gf-size-auto" ng-model="ctrl.current.jsonData.esVersion" ng-options="f.value as f.name for f in ctrl.esVersions"></select>
 	</div>
+    <div class="gf-form max-width-30" ng-if="ctrl.current.jsonData.esVersion>=56">
+        <span class="gf-form-label width-15">Max concurrent Shard Requests</span>
+        <input class="gf-form-input" type="text"  ng-model='ctrl.current.jsonData.maxConcurrentShardRequests' placeholder="" required></input>
+    </div>
 	<div class="gf-form-inline">
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Min interval</span>


### PR DESCRIPTION
This PR add the `max_concurrent_shard_requests` in elasticsearch datasource when elasticsearch version is > 5.6
This parameter should be used to protect a singe request from overloading a cluster.

Related Issue : https://github.com/grafana/grafana/issues/3925