### PR TITLE
Optimized number of lines fetching in log file initialisation

### DIFF
--- a/pkg/log/file_test.go
+++ b/pkg/log/file_test.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func (w *FileLogWriter) WriteLine(line string) error {
+	n, err := w.mw.Write([]byte(line))
+	if err != nil {
+		return err
+	}
+	w.docheck(n)
+	return nil
+}
+
+func TestLogFile(t *testing.T) {
+
+	Convey("When logging to file", t, func() {
+		fileLogWrite := NewFileWriter()
+		So(fileLogWrite, ShouldNotBeNil)
+
+		fileLogWrite.Filename = "grafana_test.log"
+		err := fileLogWrite.Init()
+		So(err, ShouldBeNil)
+
+		Convey("Log file is empty", func() {
+			So(fileLogWrite.maxlines_curlines, ShouldEqual, 0)
+		})
+
+		Convey("Logging should add lines", func() {
+			err := fileLogWrite.WriteLine("test1\n")
+			err = fileLogWrite.WriteLine("test2\n")
+			err = fileLogWrite.WriteLine("test3\n")
+			So(err, ShouldBeNil)
+			So(fileLogWrite.maxlines_curlines, ShouldEqual, 3)
+		})
+
+		err = os.Remove(fileLogWrite.Filename)
+		So(err, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
I've optimized the way of counting the number of lines in the existing log file.
thanks stack overflow 😆  : https://stackoverflow.com/questions/24562942/golang-how-do-i-determine-the-number-of-lines-in-a-file-efficiently#24563853

Related Issue : https://github.com/grafana/grafana/issues/9948