### PR TITLE
Minio s3 image bucket support

### DIFF
--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -20,8 +20,21 @@ func (NopImageUploader) Upload(ctx context.Context, path string) (string, error)
 }
 
 func NewImageUploader() (ImageUploader, error) {
-
 	switch setting.ImageUploadProvider {
+	case "minio":
+    	minio, err := setting.Cfg.GetSection("external_image_storage.minio")
+    	if err != nil {
+    		return nil, err
+    	}
+
+        endpoint := minio.Key("endpoint").MustString("")
+    	bucketName := minio.Key("bucketName").MustString("")
+    	accessKeyID := minio.Key("accessKeyID").MustString("")
+    	secretAccessKey := minio.Key("secretAccessKey").MustString("")
+    	expiry := minio.Key("expiry").MustInt(86400)
+    	useSSL := minio.Key("useSSL").MustBool(true)
+
+        return NewMinioUploader(endpoint, bucketName, accessKeyID, secretAccessKey, expiry, useSSL), nil
 	case "s3":
 		s3sec, err := setting.Cfg.GetSection("external_image_storage.s3")
 		if err != nil {

--- a/pkg/components/imguploader/imguploader_test.go
+++ b/pkg/components/imguploader/imguploader_test.go
@@ -10,6 +10,35 @@ import (
 
 func TestImageUploaderFactory(t *testing.T) {
 	Convey("Can create image uploader for ", t, func() {
+		Convey("MINIO uploader", func() {
+            setting.NewConfigContext(&setting.CommandLineArgs{
+            	HomePath: "../../../",
+            })
+
+            setting.ImageUploadProvider = "minio"
+
+            minioSec, err := setting.Cfg.GetSection("external_image_storage.minio")
+            minioSec.NewKey("endpoint", "localhost:9000")
+            minioSec.NewKey("bucketName", "alerts")
+            minioSec.NewKey("accessKeyID", "admin")
+            minioSec.NewKey("secretAccessKey", "password")
+            minioSec.NewKey("expiry", "86400")
+            minioSec.NewKey("useSSL", "false")
+
+            uploader, err := NewImageUploader()
+
+            So(err, ShouldBeNil)
+            original, ok := uploader.(*MinioUploader)
+
+            So(ok, ShouldBeTrue)
+            So(original.endpoint, ShouldEqual, "localhost:9000")
+            So(original.bucketName, ShouldEqual, "alerts")
+            So(original.accessKeyID, ShouldEqual, "admin")
+            So(original.secretAccessKey, ShouldEqual, "password")
+            So(original.expiry, ShouldEqual, "86400")
+            So(original.useSSL, ShouldEqual, "false")
+        })
+
 		Convey("S3ImageUploader config", func() {
 			setting.NewConfigContext(&setting.CommandLineArgs{
 				HomePath: "../../../",

--- a/pkg/components/imguploader/miniouploader.go
+++ b/pkg/components/imguploader/miniouploader.go
@@ -1,0 +1,71 @@
+package imguploader
+
+import (
+	"context"
+    "net/url"
+    "time"
+    "log"
+
+	"github.com/minio/minio-go"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type MinioUploader struct {
+	endpoint        string
+	bucketName      string
+	accessKeyID     string
+	secretAccessKey string
+	expiry          int
+	useSSL          bool
+	log             log.Logger
+}
+
+func NewMinioUploader(endpoint string, bucketName string, accessKeyID string, secretAccessKey string, expiry int, useSSL bool) *MinioUploader {
+	return &MinioUploader{
+		endpoint:        endpoint,
+		bucketName:      bucketName,
+		accessKeyID:     accessKeyID,
+		secretAccessKey: secretAccessKey,
+		expiry:          expiry,
+		useSSL:          useSSL,
+	}
+}
+
+func (u *MinioUploader) Upload(ctx context.Context, imageDiskPath string) (string, error) {
+
+    // Initialize minio client object.
+    minioClient, err := minio.New(u.endpoint, u.accessKeyID, u.secretAccessKey, u.useSSL)
+
+    if err != nil {
+       return "", err
+    }
+
+    //create random name for image
+    objectName := util.GetRandomString(20) + ".png"
+    contentType := "image/png"
+
+    // Upload the image file with FPutObject
+    n, err := minioClient.FPutObject(u.bucketName, objectName, imageDiskPath, minio.PutObjectOptions{ContentType:contentType})
+    log.Printf("Successfully uploaded %s of size %d\n", objectName, n)
+
+    if err != nil {
+      return "", err
+    }
+
+    // Set request parameters for content-disposition.
+    reqParams := make(url.Values)
+    reqParams.Set("response-content-disposition", "attachment; filename=\"objectName\"")
+
+    //convert int to time Duration type for PresignedGetObject below
+    expirySeconds := time.Duration(u.expiry) * time.Second
+
+    // Generates a presigned url which expires per the expiry config setting
+    presignedURL, err := minioClient.PresignedGetObject(u.bucketName, objectName, expirySeconds, reqParams)
+    if err != nil {
+        return "", err
+    }
+
+    return presignedURL.String(), nil
+}
+
+

--- a/pkg/components/imguploader/miniouploader_test.go
+++ b/pkg/components/imguploader/miniouploader_test.go
@@ -1,0 +1,24 @@
+package imguploader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/setting"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUploadToMINIO(t *testing.T) {
+	SkipConvey("[Integration test] for external_image_store.minio", t, func() {
+		setting.NewConfigContext(&setting.CommandLineArgs{
+			HomePath: "../../../",
+		})
+
+		minioUploader, _ := NewImageUploader()
+
+		path, err := minioUploader.Upload(context.Background(), "../../../public/img/logo_transparent_400x.png")
+
+		So(err, ShouldBeNil)
+		So(path, ShouldNotEqual, "")
+	})
+}


### PR DESCRIPTION
[Feature Request] Allow to use S3 compatible services #8157

This PR will allow using Minio as an image store for notifications. 

Here is my setup I used to develop/test Grafana with Minio and Mattermost:

Mattermost:
docker run --name mattermost-preview -d --publish 8065:8065 mattermost/mattermost-preview

Activate Enable Incoming Webhooks (http://localhost:8065/admin_console/integrations/custom) then create an Incoming Webhook for use by Grafana (http://localhost:8065/test/integrations/incoming_webhooks)


Minio:

```
http://localhost:9000/minio/alerts/
docker run -p 9000:9000 --name minio  -e "MINIO_ACCESS_KEY=admin"   -e "MINIO_SECRET_KEY=password"   -v /mnt/data:/data   -v /mnt/config:/root/.minio   minio/minio server /data
```

Login to minio and create a bucket (via the red "+" button).


Grafana:
We use the Grafana CSV TestData to create a dashboard with a graph with an alert.
And created a new slack notification channel with Include Image checked.

Add the following to the custom.ini:

```
app_mode = development

[external_image_storage]
# You can choose between (s3, minio, webdav, gcs)
provider = minio

[external_image_storage.minio]
endpoint = localhost:9000
bucketName = alerts
accessKeyID = admin
secretAccessKey = password
expiry = 604800 # 1 week, 1 day is default
useSSL = false
```




Let me know if you need more infos on setting this up.