### PR TITLE
Prometheus does not need the escape of the period.

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -6,7 +6,7 @@ import PrometheusMetricFindQuery from './metric_find_query';
 import TableModel from 'app/core/table_model';
 
 function prometheusSpecialRegexEscape(value) {
-  return value.replace(/[\\^$*+?.()|[\]{}]/g, '\\\\$&');
+  return value.replace(/[\\^$*+?()|[\]{}]/g, '\\\\$&');
 }
 
 export class PrometheusDatasource {


### PR DESCRIPTION
This is a fix for https://github.com/grafana/grafana/issues/9977.
An unnecessary escape has occurred when using the template function.

