### PR TITLE
fix panel solo mode

### DIFF
--- a/public/app/features/dashboard/panel_model.ts
+++ b/public/app/features/dashboard/panel_model.ts
@@ -29,6 +29,7 @@ export class PanelModel {
   minSpan?: number;
   collapsed?: boolean;
   panels?: any;
+  soloMode?: boolean;
 
   // non persisted
   fullscreen: boolean;

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -172,6 +172,10 @@ export class PanelCtrl {
       this.containerHeight = this.panel.gridPos.h * GRID_CELL_HEIGHT + ((this.panel.gridPos.h-1) * GRID_CELL_VMARGIN);
     }
 
+    if (this.panel.soloMode) {
+      this.containerHeight = $(window).height();
+    }
+
     this.height = this.containerHeight - (PANEL_BORDER + TITLE_HEIGHT);
   }
 

--- a/public/app/features/panel/solo_panel_ctrl.ts
+++ b/public/app/features/panel/solo_panel_ctrl.ts
@@ -1,14 +1,9 @@
-define([
-  'angular',
-  'jquery',
-],
-function (angular, $) {
-  "use strict";
+import angular from 'angular';
 
-  var module = angular.module('grafana.routes');
+export class SoloPanelCtrl{
 
-  module.controller('SoloPanelCtrl', function($scope, $routeParams, $location, dashboardLoaderSrv, contextSrv) {
-
+  /** @ngInject */
+  constructor($scope, $routeParams, $location, dashboardLoaderSrv, contextSrv) {
     var panelId;
 
     $scope.init = function() {
@@ -26,26 +21,25 @@ function (angular, $) {
     };
 
     $scope.initPanelScope = function() {
-      var panelInfo = $scope.dashboard.getPanelInfoById(panelId);
+      let panelInfo = $scope.dashboard.getPanelInfoById(panelId);
 
       // fake row ctrl scope
       $scope.ctrl = {
-        row: panelInfo.row,
         dashboard: $scope.dashboard,
       };
 
-      $scope.ctrl.row.height = $(window).height();
       $scope.panel = panelInfo.panel;
+      $scope.panel.soloMode = true;
       $scope.$index = 0;
 
       if (!$scope.panel) {
         $scope.appEvent('alert-error', ['Panel not found', '']);
         return;
       }
-
-      $scope.panel.span = 12;
     };
 
     $scope.init();
-  });
-});
+  }
+}
+
+angular.module('grafana.routes').controller('SoloPanelCtrl', SoloPanelCtrl);


### PR DESCRIPTION
This PR fixes #9998 - broken solo panel mode.
There's another issue: even if panel is fullscreen, sidemenu overlap it (due to `z-index=10` in css):

![screenshot from 2017-11-27 18 46 52](https://user-images.githubusercontent.com/4932851/33275246-678c7f90-d3a3-11e7-87ef-4514276c21e2.png)


