### PR TITLE
fix render http[get] params error

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -10,7 +10,11 @@ import (
 )
 
 func RenderToPng(c *middleware.Context) {
-	queryReader := util.NewUrlQueryReader(c.Req.URL)
+	queryReader, err := util.NewUrlQueryReader(c.Req.URL)
+	if err != nil {
+		c.Handle(400, "Rander parameters error", err)
+		return
+	}
 	queryParams := fmt.Sprintf("?%s", c.Req.URL.RawQuery)
 
 	renderOpts := &renderer.RenderOpts{

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -9,10 +9,15 @@ type UrlQueryReader struct {
 	values url.Values
 }
 
-func NewUrlQueryReader(url *url.URL) *UrlQueryReader {
-	return &UrlQueryReader{
-		values: url.Query(),
+func NewUrlQueryReader(urlInfo *url.URL) (*UrlQueryReader, error) {
+	u, err := url.ParseQuery(urlInfo.String())
+	if err != nil {
+		return nil, err
 	}
+
+	return &UrlQueryReader{
+		values: u,
+	}, nil
 }
 
 func (r *UrlQueryReader) Get(name string, def string) string {


### PR DESCRIPTION
render image URL can not be `url.Query()`

testURL:
 `http://admin:admin@192.168.2.188:3000/render/dashboard/db/test-cluster&from=1510535835702&to=1511075844572&width=1000&height=500&tz=UTC%2B02%3A00&timeout=5000`
such like param `timeout`.

grafana document:
http://docs.grafana.org/reference/sharing/#direct-link-rendered-image

