### PR TITLE
interpolate 'field' again in Elasticsearch terms queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -380,6 +380,9 @@ export class ElasticDatasource {
     }
 
     if (query.find === 'terms') {
+      if ('field' in query) {
+        query.field = this.templateSrv.replace(query.field, {}, 'lucene');
+      }
       query.query = this.templateSrv.replace(query.query || '*', {}, 'lucene');
       return this.getTerms(query);
     }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -380,9 +380,7 @@ export class ElasticDatasource {
     }
 
     if (query.find === 'terms') {
-      if ('field' in query) {
-        query.field = this.templateSrv.replace(query.field, {}, 'lucene');
-      }
+      query.field = this.templateSrv.replace(query.field, {}, 'lucene');
       query.query = this.templateSrv.replace(query.query || '*', {}, 'lucene');
       return this.getTerms(query);
     }


### PR DESCRIPTION
Fix for #8662 which was regressed in commit e4950c2dc1012cb1a36cca947666244417e56194 (the field 'field' was no longer interpolated)

This interpolates the field 'field' in terms queries allowing you for example to select the field you which to filter by in a drop down