### PR TITLE
grafana-10039: fix query time range ends in the past

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 type GraphiteExecutor struct {
@@ -158,7 +158,7 @@ func formatTimeRange(input string) string {
 	if input == "now" {
 		return input
 	}
-	return strings.Replace(strings.Replace(input, "m", "min", -1), "M", "mon", -1)
+	return strings.Replace(strings.Replace(strings.Replace(input, "now", "", -1), "m", "min", -1), "M", "mon", -1)
 }
 
 func fixIntervalFormat(target string) string {

--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -18,14 +18,14 @@ func TestGraphiteFunctions(t *testing.T) {
 		Convey("formatting time range for now-1m", func() {
 
 			timeRange := formatTimeRange("now-1m")
-			So(timeRange, ShouldEqual, "now-1min")
+			So(timeRange, ShouldEqual, "-1min")
 
 		})
 
 		Convey("formatting time range for now-1M", func() {
 
 			timeRange := formatTimeRange("now-1M")
-			So(timeRange, ShouldEqual, "now-1mon")
+			So(timeRange, ShouldEqual, "-1mon")
 
 		})
 


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/10039

Fix `query` time range end (relative time) in the integration with graphite: 
use `-Xmin` instead of `now-Xmin`. 

See http://graphite.readthedocs.io/en/latest/render_api.html#from-until