### PR TITLE
Fix dashboard menu overlapping

### DIFF
--- a/public/sass/_variables.scss
+++ b/public/sass/_variables.scss
@@ -202,6 +202,7 @@ $zindex-navbar-fixed:      1030;
 $zindex-modal-backdrop:    1040;
 $zindex-modal:             1050;
 $zindex-typeahead:         1060;
+$zindex-sidemenu : $zindex-navbar-fixed + 5;
 
 
 

--- a/public/sass/_variables.scss
+++ b/public/sass/_variables.scss
@@ -201,6 +201,9 @@ $zindex-tooltip:           1020;
 $zindex-navbar-fixed:      1030;
 $zindex-modal-backdrop:    1040;
 $zindex-modal:             1050;
+$zindex-typeahead:         1060;
+
+
 
 // Buttons
 //

--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -300,7 +300,7 @@
 // Typeahead
 // ---------
 .typeahead {
-  z-index: 1051;
+  z-index: $zindex-typeahead;
   margin-top: 2px; // give it some space to breathe
 }
 

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -5,7 +5,7 @@
   position: relative;
   padding-left: $side-menu-width;
   box-shadow: $navbarShadow;
-  z-index: 1;
+  z-index: 2;
   background: $navbarBackground;
 }
 

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -5,7 +5,7 @@
   position: relative;
   padding-left: $side-menu-width;
   box-shadow: $navbarShadow;
-  z-index: 2;
+  z-index: $zindex-navbar-fixed;
   background: $navbarBackground;
 }
 

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -19,7 +19,7 @@
     height: auto;
     box-shadow: $side-menu-shadow;
     position: relative;
-    z-index: 2;
+    z-index: 3;
   }
   .sidemenu__top,
   .sidemenu__bottom {
@@ -56,7 +56,7 @@
       // again by the mouse getting outside the hover space
       left: $side-menu-width - 2px;
       @include animation('dropdown-anim 150ms ease-in-out 100ms forwards');
-      z-index: 1;
+      z-index: 2;
     }
   }
 }

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -5,8 +5,7 @@
   flex-direction: column;
   width: $side-menu-width;
   background: $navbarBackground;
-  z-index: 10;
-
+  z-index: $zindex-sidemenu;
   a:focus {
     text-decoration: none;
   }
@@ -19,7 +18,7 @@
     height: auto;
     box-shadow: $side-menu-shadow;
     position: relative;
-    z-index: 3;
+    z-index: $zindex-sidemenu;
   }
   .sidemenu__top,
   .sidemenu__bottom {
@@ -56,7 +55,7 @@
       // again by the mouse getting outside the hover space
       left: $side-menu-width - 2px;
       @include animation('dropdown-anim 150ms ease-in-out 100ms forwards');
-      z-index: 2;
+      z-index: $zindex-sidemenu;
     }
   }
 }

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -19,6 +19,7 @@ div.flot-text {
   &--solo {
     .panel-container {
       border: none;
+      z-index: $zindex-sidemenu + 1
     }
   }
 }

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -144,14 +144,14 @@ div.flot-text {
   width: 27px;
   height: 27px;
   top: 0;
-  z-index: 10;
+  z-index: 1;
 
   .fa {
     position: relative;
     top: -4px;
     left: -6px;
     font-size: 75%;
-    z-index: 1000;
+    z-index: 1;
   }
 
   &--info {


### PR DESCRIPTION
This PR fixed #10030 by changing `z-index` of `.navbar` class. Not sure why, but `.dropdown-menu` z-index not works and menu inherit z-index from `.navbar`.
Also, this fixes issue with side menu (grafana icon) when panel in solo mode (when you share panel grafana icon is visible and overlaps graph).