### PR TITLE
Add support to render values of multiple queries in the same table

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -118,7 +118,7 @@ export class PrometheusDatasource {
         }
 
         if (activeTargets[index].format === "table") {
-          result.push(self.transformMetricDataToTable(response.data.data.result));
+          result.push(self.transformMetricDataToTable(response.data.data.result, responseList.length, index));
         } else {
           for (let metricData of response.data.data.result) {
             if (response.data.data.resultType === 'matrix') {
@@ -301,7 +301,7 @@ export class PrometheusDatasource {
     return { target: metricLabel, datapoints: dps };
   }
 
-  transformMetricDataToTable(md) {
+  transformMetricDataToTable(md, resultCount: number, resultIndex: number) {
     var table = new TableModel();
     var i, j;
     var metricLabels = {};
@@ -326,7 +326,8 @@ export class PrometheusDatasource {
       metricLabels[label] = labelIndex + 1;
       table.columns.push({text: label});
     });
-    table.columns.push({text: 'Value'});
+    let valueText = resultCount > 1 ? `Value #${String.fromCharCode(65 + resultIndex)}` : 'Value';
+    table.columns.push({text: valueText});
 
     // Populate rows, set value to empty string when label not present.
     _.each(md, function(series) {

--- a/public/app/plugins/panel/table/specs/transformers.jest.ts
+++ b/public/app/plugins/panel/table/specs/transformers.jest.ts
@@ -1,6 +1,6 @@
 import {transformers, transformDataToTable} from '../transformers';
 
-describe('when transforming time series table', () => {
+describe('when transforming time series table.', () => {
   var table;
 
   describe('given 2 time series', () => {
@@ -94,7 +94,60 @@ describe('when transforming time series table', () => {
         expect(table.columns[2].text).toBe('Min');
       });
     });
+  });
 
+  describe('table data sets', () => {
+    describe('Table', () => {
+      var panel = {
+        transform: 'table',
+      };
+      var time = new Date().getTime();
+      var rawData = [
+        {
+          type: 'table',
+          columns: [
+            { text: 'Time' },
+            { text: 'Label Key 1' },
+            { text: 'Value' },
+          ],
+          rows: [
+            [time, 'Label Value 1', 42],
+          ],
+        }
+      ];
+
+      describe('getColumns', function() {
+        it('should return data columns', function() {
+          var columns = transformers['table'].getColumns(rawData);
+          expect(columns[0].text).toBe('Time');
+          expect(columns[1].text).toBe('Label Key 1');
+          expect(columns[2].text).toBe('Value');
+        });
+      });
+
+      describe('transform', function() {
+        beforeEach(() => {
+          table = transformDataToTable(rawData, panel);
+        });
+
+        it ('should return 3 columns', () => {
+          expect(table.columns.length).toBe(3);
+          expect(table.columns[0].text).toBe('Time');
+          expect(table.columns[1].text).toBe('Label Key 1');
+          expect(table.columns[2].text).toBe('Value');
+        });
+
+        it ('should return 1 row', () => {
+          expect(table.rows.length).toBe(1);
+          expect(table.rows[0][0]).toBe(time);
+          expect(table.rows[0][1]).toBe('Label Value 1');
+          expect(table.rows[0][2]).toBe(42);
+        });
+      });
+    });
+  });
+
+  describe('doc data sets', () => {
     describe('JSON Data', () => {
       var panel = {
         transform: 'json',
@@ -148,7 +201,9 @@ describe('when transforming time series table', () => {
         });
       });
     });
+  });
 
+  describe('annotation data', () => {
     describe('Annnotations', () => {
       var panel = {transform: 'annotations'};
       var rawData = {

--- a/public/app/plugins/panel/table/specs/transformers.jest.ts
+++ b/public/app/plugins/panel/table/specs/transformers.jest.ts
@@ -156,6 +156,18 @@ describe('when transforming time series table', () => {
           rows: [
             [time, 'Label Value 1', 'Label Value 2', 13],
           ],
+        },
+        {
+          type: 'table',
+          columns: [
+            { text: 'Time' },
+            { text: 'Label Key 1' },
+            { text: 'Label Key 2' },
+            { text: 'Value' },
+          ],
+          rows: [
+            [time, 'Label Value 1', 'Label Value 2', 4],
+          ],
         }
       ];
 
@@ -226,12 +238,13 @@ describe('when transforming time series table', () => {
 
         it ('should return the union of columns for multiple queries', () => {
           table = transformDataToTable(multipleQueriesDataSameLabels, panel);
-          expect(table.columns.length).toBe(5);
+          expect(table.columns.length).toBe(6);
           expect(table.columns[0].text).toBe('Time');
           expect(table.columns[1].text).toBe('Label Key 1');
           expect(table.columns[2].text).toBe('Label Key 2');
           expect(table.columns[3].text).toBe('Value #A');
           expect(table.columns[4].text).toBe('Value #B');
+          expect(table.columns[5].text).toBe('Value #C');
         });
 
         it ('should return 1 row for a single query', () => {
@@ -250,6 +263,7 @@ describe('when transforming time series table', () => {
           expect(table.rows[0][2]).toBe('Label Value 2');
           expect(table.rows[0][3]).toBe(42);
           expect(table.rows[0][4]).toBe(13);
+          expect(table.rows[0][5]).toBe(4);
         });
 
         it ('should return 2 rows for a mulitple queries with different label values', () => {

--- a/public/app/plugins/panel/table/specs/transformers.jest.ts
+++ b/public/app/plugins/panel/table/specs/transformers.jest.ts
@@ -139,7 +139,7 @@ describe('when transforming time series table', () => {
             { text: 'Time' },
             { text: 'Label Key 1' },
             { text: 'Label Key 2' },
-            { text: 'Value' },
+            { text: 'Value #A' },
           ],
           rows: [
             [time, 'Label Value 1', 'Label Value 2', 42],
@@ -151,7 +151,7 @@ describe('when transforming time series table', () => {
             { text: 'Time' },
             { text: 'Label Key 1' },
             { text: 'Label Key 2' },
-            { text: 'Value' },
+            { text: 'Value #B' },
           ],
           rows: [
             [time, 'Label Value 1', 'Label Value 2', 13],
@@ -163,10 +163,22 @@ describe('when transforming time series table', () => {
             { text: 'Time' },
             { text: 'Label Key 1' },
             { text: 'Label Key 2' },
-            { text: 'Value' },
+            { text: 'Value #C' },
           ],
           rows: [
             [time, 'Label Value 1', 'Label Value 2', 4],
+          ],
+        },
+        {
+          type: 'table',
+          columns: [
+            { text: 'Time' },
+            { text: 'Label Key 1' },
+            { text: 'Label Key 2' },
+            { text: 'Value #C' },
+          ],
+          rows: [
+            [time, 'Label Value 1', 'Label Value 2', 7],
           ],
         }
       ];
@@ -177,7 +189,7 @@ describe('when transforming time series table', () => {
           columns: [
             { text: 'Time' },
             { text: 'Label Key 1' },
-            { text: 'Value' },
+            { text: 'Value #A' },
           ],
           rows: [
             [time, 'Label Value 1', 42],
@@ -188,10 +200,21 @@ describe('when transforming time series table', () => {
           columns: [
             { text: 'Time' },
             { text: 'Label Key 2' },
-            { text: 'Value' },
+            { text: 'Value #B' },
           ],
           rows: [
             [time, 'Label Value 2', 13],
+          ],
+        },
+        {
+          type: 'table',
+          columns: [
+            { text: 'Time' },
+            { text: 'Label Key 1' },
+            { text: 'Value #C' },
+          ],
+          rows: [
+            [time, 'Label Value 3', 7],
           ],
         }
       ];
@@ -217,9 +240,10 @@ describe('when transforming time series table', () => {
           var columns = transformers[transform].getColumns(multipleQueriesDataDifferentLabels);
           expect(columns[0].text).toBe('Time');
           expect(columns[1].text).toBe('Label Key 1');
-          expect(columns[2].text).toBe('Label Key 2');
-          expect(columns[3].text).toBe('Value #A');
+          expect(columns[2].text).toBe('Value #A');
+          expect(columns[3].text).toBe('Label Key 2');
           expect(columns[4].text).toBe('Value #B');
+          expect(columns[5].text).toBe('Value #C');
         });
       });
 
@@ -255,32 +279,41 @@ describe('when transforming time series table', () => {
           expect(table.rows[0][2]).toBe(42);
         });
 
-        it ('should return 1 row for a mulitple queries with same label values', () => {
+        it ('should return 2 rows for a mulitple queries with same label values plus one extra row', () => {
           table = transformDataToTable(multipleQueriesDataSameLabels, panel);
-          expect(table.rows.length).toBe(1);
+          expect(table.rows.length).toBe(2);
           expect(table.rows[0][0]).toBe(time);
           expect(table.rows[0][1]).toBe('Label Value 1');
           expect(table.rows[0][2]).toBe('Label Value 2');
           expect(table.rows[0][3]).toBe(42);
           expect(table.rows[0][4]).toBe(13);
           expect(table.rows[0][5]).toBe(4);
+          expect(table.rows[1][0]).toBe(time);
+          expect(table.rows[1][1]).toBe('Label Value 1');
+          expect(table.rows[1][2]).toBe('Label Value 2');
+          expect(table.rows[1][3]).toBeUndefined();
+          expect(table.rows[1][4]).toBeUndefined();
+          expect(table.rows[1][5]).toBe(7);
         });
 
-        it ('should return 2 rows for a mulitple queries with different label values', () => {
+        it ('should return 2 rows for mulitple queries with different label values', () => {
           table = transformDataToTable(multipleQueriesDataDifferentLabels, panel);
           expect(table.rows.length).toBe(2);
+          expect(table.columns.length).toBe(6);
 
           expect(table.rows[0][0]).toBe(time);
           expect(table.rows[0][1]).toBe('Label Value 1');
-          expect(table.rows[0][2]).toBeUndefined();
-          expect(table.rows[0][3]).toBe(42);
-          expect(table.rows[0][4]).toBeUndefined();
+          expect(table.rows[0][2]).toBe(42);
+          expect(table.rows[0][3]).toBe('Label Value 2');
+          expect(table.rows[0][4]).toBe(13);
+          expect(table.rows[0][5]).toBeUndefined();
 
           expect(table.rows[1][0]).toBe(time);
-          expect(table.rows[1][1]).toBeUndefined();
-          expect(table.rows[1][2]).toBe('Label Value 2');
+          expect(table.rows[1][1]).toBe('Label Value 3');
+          expect(table.rows[1][2]).toBeUndefined();
           expect(table.rows[1][3]).toBeUndefined();
-          expect(table.rows[1][4]).toBe(13);
+          expect(table.rows[1][4]).toBeUndefined();
+          expect(table.rows[1][5]).toBe(7);
         });
       });
     });

--- a/public/app/plugins/panel/table/specs/transformers.jest.ts
+++ b/public/app/plugins/panel/table/specs/transformers.jest.ts
@@ -1,6 +1,6 @@
 import {transformers, transformDataToTable} from '../transformers';
 
-describe('when transforming time series table.', () => {
+describe('when transforming time series table', () => {
   var table;
 
   describe('given 2 time series', () => {
@@ -189,7 +189,7 @@ describe('when transforming time series table.', () => {
           var columns = transformers[transform].getColumns(singleQueryData);
           expect(columns[0].text).toBe('Time');
           expect(columns[1].text).toBe('Label Key 1');
-          expect(columns[2].text).toBe('Value #A');
+          expect(columns[2].text).toBe('Value');
         });
 
         it('should return the union of data columns given a multiple queries', function() {
@@ -221,7 +221,7 @@ describe('when transforming time series table.', () => {
           expect(table.columns.length).toBe(3);
           expect(table.columns[0].text).toBe('Time');
           expect(table.columns[1].text).toBe('Label Key 1');
-          expect(table.columns[2].text).toBe('Value #A');
+          expect(table.columns[2].text).toBe('Value');
         });
 
         it ('should return the union of columns for multiple queries', () => {

--- a/public/app/plugins/panel/table/specs/transformers.jest.ts
+++ b/public/app/plugins/panel/table/specs/transformers.jest.ts
@@ -98,13 +98,15 @@ describe('when transforming time series table.', () => {
 
   describe('table data sets', () => {
     describe('Table', () => {
+      const transform = 'table';
       var panel = {
-        transform: 'table',
+        transform,
       };
       var time = new Date().getTime();
-      var rawData = [
+
+      var nonTableData = [
         {
-          type: 'table',
+          type: 'foo',
           columns: [
             { text: 'Time' },
             { text: 'Label Key 1' },
@@ -116,42 +118,6 @@ describe('when transforming time series table.', () => {
         }
       ];
 
-      describe('getColumns', function() {
-        it('should return data columns', function() {
-          var columns = transformers['table'].getColumns(rawData);
-          expect(columns[0].text).toBe('Time');
-          expect(columns[1].text).toBe('Label Key 1');
-          expect(columns[2].text).toBe('Value');
-        });
-      });
-
-      describe('transform', function() {
-        beforeEach(() => {
-          table = transformDataToTable(rawData, panel);
-        });
-
-        it ('should return 3 columns', () => {
-          expect(table.columns.length).toBe(3);
-          expect(table.columns[0].text).toBe('Time');
-          expect(table.columns[1].text).toBe('Label Key 1');
-          expect(table.columns[2].text).toBe('Value');
-        });
-
-        it ('should return 1 row', () => {
-          expect(table.rows.length).toBe(1);
-          expect(table.rows[0][0]).toBe(time);
-          expect(table.rows[0][1]).toBe('Label Value 1');
-          expect(table.rows[0][2]).toBe(42);
-        });
-      });
-    });
-
-    describe('Multi-Query Table', () => {
-      const transform = 'multiquery_table';
-      var panel = {
-        transform,
-      };
-      var time = new Date().getTime();
       var singleQueryData = [
         {
           type: 'table',
@@ -223,7 +189,7 @@ describe('when transforming time series table.', () => {
           var columns = transformers[transform].getColumns(singleQueryData);
           expect(columns[0].text).toBe('Time');
           expect(columns[1].text).toBe('Label Key 1');
-          expect(columns[2].text).toBe('Value A');
+          expect(columns[2].text).toBe('Value #A');
         });
 
         it('should return the union of data columns given a multiple queries', function() {
@@ -231,8 +197,8 @@ describe('when transforming time series table.', () => {
           expect(columns[0].text).toBe('Time');
           expect(columns[1].text).toBe('Label Key 1');
           expect(columns[2].text).toBe('Label Key 2');
-          expect(columns[3].text).toBe('Value A');
-          expect(columns[4].text).toBe('Value B');
+          expect(columns[3].text).toBe('Value #A');
+          expect(columns[4].text).toBe('Value #B');
         });
 
         it('should return the union of data columns given a multiple queries with different labels', function() {
@@ -240,18 +206,22 @@ describe('when transforming time series table.', () => {
           expect(columns[0].text).toBe('Time');
           expect(columns[1].text).toBe('Label Key 1');
           expect(columns[2].text).toBe('Label Key 2');
-          expect(columns[3].text).toBe('Value A');
-          expect(columns[4].text).toBe('Value B');
+          expect(columns[3].text).toBe('Value #A');
+          expect(columns[4].text).toBe('Value #B');
         });
       });
 
       describe('transform', function() {
+        it ('should throw an error with non-table data', () => {
+          expect(() => transformDataToTable(nonTableData, panel)).toThrow();
+        });
+
         it ('should return 3 columns for single queries', () => {
           table = transformDataToTable(singleQueryData, panel);
           expect(table.columns.length).toBe(3);
           expect(table.columns[0].text).toBe('Time');
           expect(table.columns[1].text).toBe('Label Key 1');
-          expect(table.columns[2].text).toBe('Value A');
+          expect(table.columns[2].text).toBe('Value #A');
         });
 
         it ('should return the union of columns for multiple queries', () => {
@@ -260,8 +230,8 @@ describe('when transforming time series table.', () => {
           expect(table.columns[0].text).toBe('Time');
           expect(table.columns[1].text).toBe('Label Key 1');
           expect(table.columns[2].text).toBe('Label Key 2');
-          expect(table.columns[3].text).toBe('Value A');
-          expect(table.columns[4].text).toBe('Value B');
+          expect(table.columns[3].text).toBe('Value #A');
+          expect(table.columns[4].text).toBe('Value #B');
         });
 
         it ('should return 1 row for a single query', () => {

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -235,26 +235,33 @@ transformers['table'] = {
     const mergedRows = {};
     rows = rows.reduce((acc, row, i) => {
       if (!mergedRows[i]) {
-        const match = _.findIndex(rows, (other, j) => {
-          let same = true;
-          for (let index = 0; index < nonValueColumnCount; index++) {
-            if (row[index] !== other[index]) {
-              same = false;
-              break;
+        let offset = i + 1;
+        while (offset < rows.length) {
+          const match = _.findIndex(rows, (other, j) => {
+            let same = true;
+            for (let index = 0; index < nonValueColumnCount; index++) {
+              if (row[index] !== other[index]) {
+                same = false;
+                break;
+              }
             }
-          }
-          return same;
-        }, i + 1);
-        if (match > -1) {
-          const matchedRow = rows[match];
-          // Merge values into current row
-          for (let index = nonValueColumnCount; index < columns.length; index++) {
-            if (row[index] === undefined && matchedRow[index] !== undefined) {
-              row[index] = matchedRow[index];
-              break;
+            return same;
+          }, offset);
+          if (match > -1) {
+            const matchedRow = rows[match];
+            // Merge values into current row
+            for (let index = nonValueColumnCount; index < columns.length; index++) {
+              if (row[index] === undefined && matchedRow[index] !== undefined) {
+                row[index] = matchedRow[index];
+                break;
+              }
             }
+            mergedRows[match] = matchedRow;
+            // Keep looking for more rows to merge
+            offset = match + 1;
+          } else {
+            break;
           }
-          mergedRows[match] = matchedRow;
         }
         acc.push(row);
       }

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -135,24 +135,7 @@ transformers['table'] = {
     if (!data || data.length === 0) {
       return [];
     }
-    return data[0].columns;
-  },
-  transform: function(data, panel, model) {
-    if (!data || data.length === 0) {
-      return;
-    }
 
-    if (data[0].type !== 'table') {
-      throw {message: 'Query result is not in table format, try using another transform.'};
-    }
-    model.columns = data[0].columns;
-    model.rows = data[0].rows;
-  }
-};
-
-transformers['multiquery_table'] = {
-  description: 'Multi-Query Table',
-  getColumns: function(data) {
     // Track column indexes: name -> index
     const columnNames = {};
 
@@ -173,7 +156,7 @@ transformers['multiquery_table'] = {
     // Append one value column per data set
     data.forEach((_, i) => {
       // Value (A), Value (B),...
-      const text = `Value ${String.fromCharCode(65 + i)}`;
+      const text = `Value #${String.fromCharCode(65 + i)}`;
       columnNames[text] = columns.length;
       columns.push({ text });
     });
@@ -185,8 +168,9 @@ transformers['multiquery_table'] = {
       return;
     }
 
-    if (data[0].type !== 'table') {
-      throw {message: 'Query result is not in table format, try using another transform.'};
+    const noTableIndex = _.findIndex(data, d => d.type !== 'table');
+    if (noTableIndex > -1) {
+      throw {message: `Result of query #${String.fromCharCode(65 + noTableIndex)} is not in table format, try using another transform.`};
     }
 
     // Track column indexes: name -> index
@@ -213,8 +197,8 @@ transformers['multiquery_table'] = {
 
     // Append one value column per data set
     data.forEach((_, i) => {
-      // Value (A), Value (B),...
-      const text = `Value ${String.fromCharCode(65 + i)}`;
+      // Value #A, Value #B,...
+      const text = `Value #${String.fromCharCode(65 + i)}`;
       columnNames[text] = columns.length;
       columns.push({ text });
       columnIndexes[i].push(columnNames[text]);

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -136,6 +136,11 @@ transformers['table'] = {
       return [];
     }
 
+    // Single query returns data columns as is
+    if (data.length === 1) {
+      return [...data[0].columns];
+    }
+
     // Track column indexes: name -> index
     const columnNames = {};
 
@@ -155,7 +160,7 @@ transformers['table'] = {
 
     // Append one value column per data set
     data.forEach((_, i) => {
-      // Value (A), Value (B),...
+      // Value #A, Value #B,...
       const text = `Value #${String.fromCharCode(65 + i)}`;
       columnNames[text] = columns.length;
       columns.push({ text });
@@ -171,6 +176,13 @@ transformers['table'] = {
     const noTableIndex = _.findIndex(data, d => d.type !== 'table');
     if (noTableIndex > -1) {
       throw {message: `Result of query #${String.fromCharCode(65 + noTableIndex)} is not in table format, try using another transform.`};
+    }
+
+    // Single query returns data columns and rows as is
+    if (data.length === 1) {
+      model.columns = [...data[0].columns];
+      model.rows = [...data[0].rows];
+      return;
     }
 
     // Track column indexes: name -> index


### PR DESCRIPTION
The current `table` transform renders only the first query.
This PR adds a new transform to render all query results in a JOIN-ish
semantic.

* new table transform: Multi-Query table
* columns is the union of all non-value fields
* one value column per query is added
* rows that share all the same label values are merged into one

How this PR relates to existing issues and PRs:

* Fixes #9170 
* Extends the solution of #9340 by returning the union of all columns and adding merging.

Screenshots:

2 queries render 2 value columns if the other fields match:
![screen shot 2017-12-01 at 14 39 47](https://user-images.githubusercontent.com/859729/33485128-886d138c-d6a5-11e7-981e-c613227982ec.png)

2 queries when fields dont match:
![screen shot 2017-12-01 at 14 43 14](https://user-images.githubusercontent.com/859729/33485266-063327b6-d6a6-11e7-90ed-a0d723f0b710.png)

Relabeling of value fields:
![screen shot 2017-12-01 at 14 45 13](https://user-images.githubusercontent.com/859729/33485322-479d0e42-d6a6-11e7-93c7-42446595d7bf.png)
