### PR TITLE
Add support for internal image store

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -473,8 +473,8 @@ sampler_param = 1
 
 #################################### External Image Storage ##############
 [external_image_storage]
-# You can choose between (s3, webdav, gcs, azure_blob)
-provider =
+# You can choose between (s3, webdav, gcs, azure_blob, local)
+provider = local
 
 [external_image_storage.s3]
 bucket_url =
@@ -499,3 +499,6 @@ path =
 account_name =
 account_key =
 container_name =
+
+[external_image_storage.local]
+# does not require any configuration

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -149,8 +149,10 @@ Prometheus Alertmanager | `prometheus-alertmanager` | no
 
 # Enable images in notifications {#external-image-store}
 
-Grafana can render the panel associated with the alert rule and include that in the notification. Most Notification Channels require that this image be publicly accessible (Slack and PagerDuty for example). In order to include images in alert notifications, Grafana can upload the image to an image store. It currently supports
-Amazon S3, Webdav, and Azure Blob Storage for this. So to set that up you need to configure the [external image uploader](/installation/configuration/#external-image-storage) in your grafana-server ini config file.
+Grafana can render the panel associated with the alert rule and include that in the notification. Most Notification Channels require that this image be publicly accessable (Slack and PagerDuty for example). In order to include images in alert notifications, Grafana can upload the image to an image store. It currently supports
+Amazon S3, Webdav, Google Cloud Storage and Azure Blob Storage. So to set that up you need to configure the [external image uploader](/installation/configuration/#external-image-storage) in your grafana-server ini config file.
+
+By default the local image store is used which allows Grafana to serve the images by itself.
 
 Currently only the Email Channels attaches images if no external image store is specified. To include images in alert notifications for other channels then you need to set up an external image store.
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -162,6 +162,10 @@ func (hs *HttpServer) newMacaron() *macaron.Macaron {
 	hs.mapStatic(m, setting.StaticRootPath, "", "public")
 	hs.mapStatic(m, setting.StaticRootPath, "robots.txt", "robots.txt")
 
+	if setting.ImageUploadProvider == "local" {
+		hs.mapStatic(m, setting.ImagesDir, "", "/public/img/attachments")
+	}
+
 	m.Use(macaron.Renderer(macaron.RenderOptions{
 		Directory:  path.Join(setting.StaticRootPath, "views"),
 		IndentJSON: macaron.Env != macaron.PROD,

--- a/pkg/components/imguploader/imguploader.go
+++ b/pkg/components/imguploader/imguploader.go
@@ -88,6 +88,8 @@ func NewImageUploader() (ImageUploader, error) {
 		container_name := azureBlobSec.Key("container_name").MustString("")
 
 		return NewAzureBlobUploader(account_name, account_key, container_name), nil
+	case "local":
+		return NewLocalImageUploader()
 	}
 
 	if setting.ImageUploadProvider != "" {

--- a/pkg/components/imguploader/imguploader_test.go
+++ b/pkg/components/imguploader/imguploader_test.go
@@ -143,5 +143,23 @@ func TestImageUploaderFactory(t *testing.T) {
 				So(original.container_name, ShouldEqual, "container_name")
 			})
 		})
+
+		Convey("Local uploader", func() {
+			var err error
+
+			setting.NewConfigContext(&setting.CommandLineArgs{
+				HomePath: "../../../",
+			})
+
+			setting.ImageUploadProvider = "local"
+
+			uploader, err := NewImageUploader()
+
+			So(err, ShouldBeNil)
+			original, ok := uploader.(*LocalUploader)
+
+			So(ok, ShouldBeTrue)
+			So(original, ShouldNotBeNil)
+		})
 	})
 }

--- a/pkg/components/imguploader/localuploader.go
+++ b/pkg/components/imguploader/localuploader.go
@@ -1,0 +1,22 @@
+package imguploader
+
+import (
+	"context"
+	"path"
+	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type LocalUploader struct {
+}
+
+func (u *LocalUploader) Upload(ctx context.Context, imageOnDiskPath string) (string, error) {
+	filename := filepath.Base(imageOnDiskPath)
+	image_url := setting.ToAbsUrl(path.Join("public/img/attachments", filename))
+	return image_url, nil
+}
+
+func NewLocalImageUploader() (*LocalUploader, error) {
+	return &LocalUploader{}, nil
+}

--- a/pkg/components/imguploader/localuploader_test.go
+++ b/pkg/components/imguploader/localuploader_test.go
@@ -1,0 +1,18 @@
+package imguploader
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUploadToLocal(t *testing.T) {
+	Convey("[Integration test] for external_image_store.local", t, func() {
+		localUploader, _ := NewLocalImageUploader()
+		path, err := localUploader.Upload(context.Background(), "../../../public/img/logo_transparent_400x.png")
+
+		So(err, ShouldBeNil)
+		So(path, ShouldContainSubstring, "/public/img/attachments")
+	})
+}


### PR DESCRIPTION
This PR implements a basic local image uploader to allow Grafana to act as an image store for images used in notifiers as discussed in #6922.

It was already used successfully in production for a while.

If merged, I'd also recommend to refactor/rename the "imgupoader" component into "imagestore" as I think it is a suitable name for arbitrary features around storing/handling generated images.