### PR TITLE
mysql: pass timerange for template variable queries

### DIFF
--- a/docs/sources/features/datasources/mysql.md
+++ b/docs/sources/features/datasources/mysql.md
@@ -127,6 +127,12 @@ A query can returns multiple columns and Grafana will automatically create a lis
 SELECT my_host.hostname, my_other_host.hostname2 FROM my_host JOIN my_other_host ON my_host.city = my_other_host.city
 ```
 
+To use time range dependent macros like `$__timeFilter(column)` in your query the refresh mode of the template variable needs to be set to *On Time Range Change*.
+
+```sql
+SELECT event_name FROM event_log WHERE $__timeFilter(time_column)
+```
+
 Another option is a query that can create a key/value variable. The query should return two columns that are named `__text` and `__value`. The `__text` column value should be unique (if it is not unique then the first value is used). The options in the dropdown will have a text and value that allows you to have a friendly name as text and an id as the value. An example query with `hostname` as the text and `id` as the value:
 
 ```sql

--- a/docs/sources/features/datasources/mysql.md
+++ b/docs/sources/features/datasources/mysql.md
@@ -146,6 +146,12 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM my_host  WHERE region IN($region)
 ```
 
+To use time range dependent macros like `$__timeFilter(column)` in your query, the refresh mode of the template variable needs to be set to *On Time Range Change*.
+
+```sql
+SELECT event_name FROM event_log WHERE $__timeFilter(time_column)
+```
+
 ### Using Variables in Queries
 
 From Grafana 4.3.0 to 4.6.0, template variables are always quoted automatically so if it is a string value do not wrap them in quotes in where clauses.

--- a/docs/sources/features/datasources/mysql.md
+++ b/docs/sources/features/datasources/mysql.md
@@ -146,12 +146,6 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM my_host  WHERE region IN($region)
 ```
 
-To use time range dependent macros like `$__timeFilter(column)` in your query, the refresh mode of the template variable needs to be set to *On Time Range Change*.
-
-```sql
-SELECT event_name FROM event_log WHERE $__timeFilter(time_column)
-```
-
 ### Using Variables in Queries
 
 From Grafana 4.3.0 to 4.6.0, template variables are always quoted automatically so if it is a string value do not wrap them in quotes in where clauses.

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -103,12 +103,21 @@ export class MysqlDatasource {
       format: 'table',
     };
 
+    var data = {
+        queries: [interpolatedQuery],
+    };
+
+    if (optionalOptions && optionalOptions.range && optionalOptions.range.from) {
+      data['from'] = optionalOptions.range.from.valueOf().toString();
+    }
+    if (optionalOptions && optionalOptions.range && optionalOptions.range.to) {
+      data['to'] = optionalOptions.range.to.valueOf().toString();
+    }
+
     return this.backendSrv.datasourceRequest({
       url: '/api/tsdb/query',
       method: 'POST',
-      data: {
-        queries: [interpolatedQuery],
-      }
+      data: data
     })
     .then(data => this.responseParser.parseMetricFindQueryResult(refId, data));
   }


### PR DESCRIPTION
atm the frontend does not pass the timerange on template variable queries in mysql. this patch changes the behaviour to include the timerange when the refresh mode for the variable is set to ```on time range change```
This fixes #10066 for mysql datasource