### PR TITLE
Add support for template variables in Y-MAX/MIN settings

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -20,7 +20,7 @@ import { EventManager } from 'app/features/annotations/all';
 import { convertValuesToHistogram, getSeriesValues } from './histogram';
 
 /** @ngInject **/
-function graphDirective(timeSrv, popoverSrv, contextSrv) {
+function graphDirective(timeSrv, popoverSrv, contextSrv, templateSrv) {
   return {
     restrict: 'A',
     template: '',
@@ -520,7 +520,7 @@ function graphDirective(timeSrv, popoverSrv, contextSrv) {
           return null;
         }
 
-        return _.toNumber(value);
+        return _.toNumber(templateSrv.replace(value, ctrl.panel.scopedVars));
       }
 
       function applyLogScale(axis, data) {

--- a/public/app/plugins/panel/graph/specs/graph_specs.ts
+++ b/public/app/plugins/panel/graph/specs/graph_specs.ts
@@ -20,7 +20,8 @@ describe('grafanaGraph', function() {
       ctx.setup = setupFunc => {
         beforeEach(
           angularMocks.module($provide => {
-            $provide.value('timeSrv', new helpers.TimeSrvStub());
+            $provide.value("timeSrv", new helpers.TimeSrvStub());
+            $provide.value("templateSrv", new helpers.TemplateSrvStub());
           })
         );
 


### PR DESCRIPTION
This PR allows you to use template variables for the Y axis setting of the graph panel.
Related issues: #3935