### PR TITLE
Enable grid CSS transforms

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -30,7 +30,7 @@ function GridWrapper({size, layout, onLayoutChange, children, onResize, onResize
       isResizable={true}
       measureBeforeMount={false}
       containerPadding={[0, 0]}
-      useCSSTransforms={false}
+      useCSSTransforms={true}
       margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}
       cols={GRID_COLUMN_COUNT}
       rowHeight={GRID_CELL_HEIGHT}

--- a/public/app/features/panel/panel_header.ts
+++ b/public/app/features/panel/panel_header.ts
@@ -1,5 +1,6 @@
 ///<reference path="../../headers/common.d.ts" />
 
+import $ from 'jquery';
 import {coreModule} from 'app/core/core';
 
 var template = `
@@ -106,10 +107,35 @@ function panelHeader($compile) {
         }
       });
 
+      elem.find('.panel-menu-toggle').click((evt) => {
+        console.log(evt);
+        togglePanelState();
+      });
+
       function togglePanelMenu(e) {
         if (!isDragged) {
           e.stopPropagation();
+          togglePanelState();
           elem.find('[data-toggle=dropdown]').dropdown('toggle');
+        }
+      }
+
+      /**
+       * Hack for adding special class 'dropdown-menu-open' to the panel.
+       * This class sets z-index for panel and prevents menu overlapping.
+       */
+      function togglePanelState() {
+        const menuOpenClass = 'dropdown-menu-open';
+        const panelGridClass = '.react-grid-item.panel';
+
+        let panelElem = elem.find('[data-toggle=dropdown]').parentsUntil('.panel').parent();
+        let menuElem = elem.find('[data-toggle=dropdown]').parent();
+        panelElem = panelElem && panelElem.length ? panelElem[0] : undefined;
+        if (panelElem) {
+          panelElem = $(panelElem);
+          $(panelGridClass).removeClass(menuOpenClass);
+          let state = !menuElem.hasClass('open');
+          panelElem.toggleClass(menuOpenClass, state);
         }
       }
 

--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -47,3 +47,10 @@
   }
 }
 
+// Hack for preventing panel menu overlapping.
+.react-grid-item.resizing.panel,
+.react-grid-item.panel.dropdown-menu-open,
+.react-grid-item.react-draggable-dragging.panel {
+  z-index: $zindex-dropdown;
+}
+


### PR DESCRIPTION
This PR enables grid CSS transforms and fixes issue with panel menu overlapping.
The reason why does it happen is styles in `react-grid-layout`. Each panel has class `.react-grid-item`. When grid layout has `useCSSTransforms` flag set and you click on the panel header it adds `react-draggable-dragging` class to the panel.
```css
.react-grid-item.react-draggable-dragging {
  transition: none;
  z-index: 3;
  will-change: transform;
}
```
This creates new _stacking contexts_ for the whole panel. So now z-index of panel menu works only inside this panel and menu may be overlapped by other panels (actually, it is overlapped only by the panels which follow it in the DOM).
In this PR I add CSS class with proper z-index to the panel which has menu open.