### PR TITLE
Graphite target parsing and reference handling update

### DIFF
--- a/public/app/plugins/datasource/graphite/func_editor.js
+++ b/public/app/plugins/datasource/graphite/func_editor.js
@@ -208,7 +208,7 @@ function (angular, _, $) {
 
               if ($target.hasClass('fa-arrow-left')) {
                 $scope.$apply(function() {
-                  _.move(ctrl.functions, $scope.$index, $scope.$index - 1);
+                  _.move(ctrl.queryModel.functions, $scope.$index, $scope.$index - 1);
                   ctrl.targetChanged();
                 });
                 return;
@@ -216,7 +216,7 @@ function (angular, _, $) {
 
               if ($target.hasClass('fa-arrow-right')) {
                 $scope.$apply(function() {
-                  _.move(ctrl.functions, $scope.$index, $scope.$index + 1);
+                  _.move(ctrl.queryModel.functions, $scope.$index, $scope.$index + 1);
                   ctrl.targetChanged();
                 });
                 return;

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -152,7 +152,7 @@ export default class GraphiteQuery {
   updateModelTarget(targets) {
     // render query
     if (!this.target.textEditor) {
-      var metricPath = this.getSegmentPathUpTo(this.segments.length);
+      var metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.select metric$/, '');
       this.target.target = _.reduce(this.functions, wrapFunction, metricPath);
     }
 

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -219,10 +219,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
     this.updateModelTarget();
 
     if (this.queryModel.target !== oldTarget) {
-      var lastSegment = this.segments.length > 0 ? this.segments[this.segments.length - 1] : {};
-      if (lastSegment.value !== 'select metric') {
-        this.panelCtrl.refresh();
-      }
+      this.panelCtrl.refresh();
     }
   }
 

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -62,6 +62,10 @@ export class GraphiteQueryCtrl extends QueryCtrl {
   }
 
   checkOtherSegments(fromIndex) {
+    if (this.queryModel.segments.length === 1 && this.queryModel.segments[0].type === 'series-ref') {
+      return;
+    }
+
     if (fromIndex === 0) {
       this.addSelectMetricSegment();
       return;
@@ -108,8 +112,23 @@ export class GraphiteQueryCtrl extends QueryCtrl {
 
       if (altSegments.length === 0) { return altSegments; }
 
+      // add query references
+      if (index === 0) {
+        _.eachRight(this.panelCtrl.panel.targets, target => {
+          if (target.refId === this.queryModel.target.refId) {
+            return;
+          }
+
+          altSegments.unshift(this.uiSegmentSrv.newSegment({
+            type: 'series-ref',
+            value: '#' + target.refId,
+            expandable: false,
+          }));
+        });
+      }
+
       // add template variables
-      _.each(this.templateSrv.variables, variable => {
+      _.eachRight(this.templateSrv.variables, variable => {
         altSegments.unshift(this.uiSegmentSrv.newSegment({
           type: 'template',
           value: '$' + variable.name,

--- a/public/app/plugins/datasource/graphite/specs/query_ctrl_specs.ts
+++ b/public/app/plugins/datasource/graphite/specs/query_ctrl_specs.ts
@@ -170,7 +170,7 @@ describe('GraphiteQueryCtrl', function() {
 
   describe('when updating targets with nested query', function() {
     beforeEach(function() {
-      ctx.ctrl.target.target = 'scaleToSeconds(#A)';
+      ctx.ctrl.target.target = 'scaleToSeconds(#A, 60)';
       ctx.ctrl.datasource.metricFindQuery = sinon.stub().returns(ctx.$q.when([{expandable: false}]));
       ctx.ctrl.parseTarget();
 
@@ -183,11 +183,11 @@ describe('GraphiteQueryCtrl', function() {
     });
 
     it('target should remain the same', function() {
-      expect(ctx.ctrl.target.target).to.be('scaleToSeconds(#A)');
+      expect(ctx.ctrl.target.target).to.be('scaleToSeconds(#A, 60)');
     });
 
     it('targetFull should include nexted queries', function() {
-      expect(ctx.ctrl.target.targetFull).to.be('scaleToSeconds(nested.query.count)');
+      expect(ctx.ctrl.target.targetFull).to.be('scaleToSeconds(nested.query.count, 60)');
     });
   });
 

--- a/public/app/plugins/datasource/graphite/specs/query_ctrl_specs.ts
+++ b/public/app/plugins/datasource/graphite/specs/query_ctrl_specs.ts
@@ -95,11 +95,11 @@ describe('GraphiteQueryCtrl', function() {
     });
 
     it('should not add select metric segment', function() {
-      expect(ctx.ctrl.segments.length).to.be(0);
+      expect(ctx.ctrl.segments.length).to.be(1);
     });
 
-    it('should add both series refs as params', function() {
-      expect(ctx.ctrl.queryModel.functions[0].params.length).to.be(2);
+    it('should add second series ref as param', function() {
+      expect(ctx.ctrl.queryModel.functions[0].params.length).to.be(1);
     });
   });
 


### PR DESCRIPTION
This PR fixes the issue identified in #10139 and improves handling of queries that reference other queries.

When adding a new query, the initial "select metric" dropdown will now include `#A`-style references to any other defined queries that can be selected and used as a base.

Queries that pass series names as secondary parameters can also now be parsed and converted back into the UI editor.

When parsing a query like `group(#A, some.metric)` the Series selector will show `#A` and the Functions list will show `group(a.b.c.d)`.
