### PR TITLE
Fix resize bug for #10130

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -26,6 +26,14 @@ class GridWrapper extends React.Component<GridWrapperProps, any> {
 
   constructor(props) {
     super(props);
+  }
+
+  componentDidMount() {
+    // Disable animation on initial rendering and enable it when component has been mounted.
+    this.animated = true;
+  }
+
+  render() {
     if (this.props.size.width === 0) {
       console.log('size is zero!');
     }
@@ -35,14 +43,7 @@ class GridWrapper extends React.Component<GridWrapperProps, any> {
       this.props.onWidthChange();
       lastGridWidth = width;
     }
-  }
 
-  componentDidMount() {
-    // Disable animation on initial rendering and enable it when component has been mounted.
-    this.animated = true;
-  }
-
-  render() {
     return (
       <ReactGridLayout
         width={lastGridWidth}


### PR DESCRIPTION
This PR fixes issue with `sizeMe` not working after imlementing #10130 by moving size calculation to `render()` function.