### PR TITLE
[render image]add encoding param

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -24,6 +24,7 @@ func RenderToPng(c *middleware.Context) {
 		OrgId:    c.OrgId,
 		Timeout:  queryReader.Get("timeout", "60"),
 		Timezone: queryReader.Get("tz", ""),
+		Encoding: queryReader.Get("encoding", ""),
 	}
 
 	pngPath, err := renderer.RenderToPng(renderOpts)

--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -27,6 +27,7 @@ type RenderOpts struct {
 	Timeout  string
 	OrgId    int64
 	Timezone string
+	Encoding string
 }
 
 var ErrTimeout = errors.New("Timeout error. You can set timeout in seconds with &timeout url parameter")
@@ -93,6 +94,10 @@ func RenderToPng(params *RenderOpts) (string, error) {
 		"domain=" + localDomain,
 		"timeout=" + strconv.Itoa(timeout),
 		"renderKey=" + renderKey,
+	}
+
+	if params.Encoding != "" {
+		cmdArgs = append([]string{fmt.Sprintf("--output-encoding=%s", params.Encoding)}, cmdArgs...)
 	}
 
 	cmd := exec.Command(binPath, cmdArgs...)


### PR DESCRIPTION
phantomjs render image
when grafana server `env` param `LANG` is not `en_US.UTF-8`;
render image's fonts will mojibake