### PR TITLE
Add default message for Pushover notifications

### DIFF
--- a/pkg/services/alerting/notifiers/pushover.go
+++ b/pkg/services/alerting/notifiers/pushover.go
@@ -129,6 +129,7 @@ func (this *PushoverNotifier) Notify(evalContext *alerting.EvalContext) error {
 		this.log.Error("Failed get rule link", "error", err)
 		return err
 	}
+
 	message := evalContext.Rule.Message
 	for idx, evt := range evalContext.EvalMatches {
 		message += fmt.Sprintf("\n<b>%s</b>: %v", evt.Metric, evt.Value)
@@ -141,6 +142,9 @@ func (this *PushoverNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 	if evalContext.ImagePublicUrl != "" {
 		message += fmt.Sprintf("\n<a href=\"%s\">Show graph image</a>", evalContext.ImagePublicUrl)
+	}
+	if message == "" {
+		message = "Nothing to see here! (Set a notification message to replace this text.)"
 	}
 
 	q := url.Values{}


### PR DESCRIPTION
If the message field is left empty for Pushover notifications, the API will return an error. This adds a default message if the message would otherwise be empty.

This fixes #8006.