### PR TITLE
[Alerting] Use LINE notify api to upload image

### DIFF
--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"net/url"
 
+	"bytes"
+	"io"
+	"mime/multipart"
+	"os"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
@@ -70,23 +75,52 @@ func (this *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
 		return err
 	}
 
-	form := url.Values{}
-	body := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleUrl, evalContext.Rule.Message)
-	form.Add("message", body)
+	message := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleUrl, evalContext.Rule.Message)
+	var body string
+	headers := map[string]string{
+		"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
+		"Authorization": fmt.Sprintf("Bearer %s", this.Token),
+	}
 
+	form := url.Values{}
+	form.Add("message", message)
+	body = form.Encode()
+	// add image url if external image uploader is set
 	if evalContext.ImagePublicUrl != "" {
 		form.Add("imageThumbnail", evalContext.ImagePublicUrl)
 		form.Add("imageFullsize", evalContext.ImagePublicUrl)
+	} else {
+		// upload image to line server
+		file := evalContext.ImageOnDiskPath
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		fw, err := w.CreateFormFile("imageFile", file)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(fw, f)
+		if err != nil {
+			return err
+		}
+		err = w.WriteField("message", message)
+		if err != nil {
+			return err
+		}
+		w.Close()
+		headers["Content-Type"] = w.FormDataContentType()
+		body = b.String()
 	}
 
 	cmd := &m.SendWebhookSync{
 		Url:        lineNotifyUrl,
 		HttpMethod: "POST",
-		HttpHeader: map[string]string{
-			"Authorization": fmt.Sprintf("Bearer %s", this.Token),
-			"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
-		},
-		Body: form.Encode(),
+		HttpHeader: headers,
+		Body:       body,
 	}
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {


### PR DESCRIPTION
I didn't file an issue since this PR is very straightforward.

LINE Notify let user to uploaded image via [API](https://notify-bot.line.me/doc/en/)(see Notification session). 
This PR modifies the LINE notifier to utilize the feature.

<img width="677" alt="grafana-line-notify 2" src="https://user-images.githubusercontent.com/11385129/33873106-05062f54-df5d-11e7-909e-fd29fdc00873.png">

PTAL 
