### PR TITLE
fix colorpicker colors order (width issue)

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -193,7 +193,7 @@
 }
 
 .graph-legend-popover {
-  width: 200px;
+  width: 210px;
   label {
     display: inline-block;
   }


### PR DESCRIPTION
This PR fixes wrong color order in color picker caused by too low container width.

![screenshot from 2017-12-12 11-00-22](https://user-images.githubusercontent.com/4932851/33894067-16a015fc-df6e-11e7-80ed-1aaaab1db92e.png)

![screenshot from 2017-12-12 18-55-48](https://user-images.githubusercontent.com/4932851/33894065-1657048e-df6e-11e7-8d06-7b0809b6bb10.png)

