### PR TITLE
Concept: Added PSQL filter `field BETWEEN "Y-m-d h:m:s" AND "Y-m-d h:m:s"`

### DIFF
--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -77,6 +77,13 @@ func (m *PostgresMacroEngine) evaluateMacro(name string, args []string) (string,
 			return "", fmt.Errorf("missing time column argument for macro %v", name)
 		}
 		return fmt.Sprintf("extract(epoch from %s) BETWEEN %d AND %d", args[0], uint64(m.TimeRange.GetFromAsMsEpoch()/1000), uint64(m.TimeRange.GetToAsMsEpoch()/1000)), nil
+	case "__timeFilterDateTime":
+		if len(args) == 0 {
+			return "", fmt.Errorf("missing time column argument for macro %v", name)
+		}
+
+		format := "2006-01-02 15:04:05"
+		return fmt.Sprintf("%s BETWEEN '%s' AND '%s'", args[0], m.TimeRange.MustGetFrom().Format(format), m.TimeRange.MustGetTo().Format(format)), nil
 	case "__timeFrom":
 		return fmt.Sprintf("to_timestamp(%d)", uint64(m.TimeRange.GetFromAsMsEpoch()/1000)), nil
 	case "__timeTo":


### PR DESCRIPTION
Would you be interested in a feature creating a macro for PSQL and MySQL that filters data using raw datetime instead of functions like `extract(epoch from %s)`?

The reason for it is that I had to create function indexes just for grafana. 

So instead of `extract(epoch from field) BETWEEN 1512860400 AND 1513465199` generated by `__timeFilter`, my new `__timeFilterDateTime` generates `field BETWEEN '2017-12-10 00:00:00' AND  '2017-12-16 23:59:59'`

If this sounds ok, I can tune up this PR