### PR TITLE
Avoid ID validation before provisioning dashboards

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -121,6 +121,9 @@ func (fr *fileReader) walkFolder() error {
 			return nil
 		}
 
+		// id = 0 indicates ID validation should be avoided before writing to the db.
+		dash.Dashboard.Id = 0
+
 		cmd := &models.GetDashboardQuery{Slug: dash.Dashboard.Slug}
 		err = bus.Dispatch(cmd)
 


### PR DESCRIPTION
Attempting to provision grafana using a previously exported
JSON dashboard with the ID field already set, might result in an error.
In fact, Grafana might believe that a dashboard with that
given ID already exists in the database, throwing an error if it doesn't.
(see pkg/services/sqlstore/dashboard.go#L32)

The dashboard provisioner should set the dashboard id to zero in order to
avoid this behaviour inducing the dashboard to be written to the DB
without ID validation.

Issue #5269 and #9654
