### PR TITLE
Kinesis Metric Capitalization

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -127,7 +127,7 @@ func init() {
 		"AWS/Events":           {"RuleName"},
 		"AWS/Firehose":         {"DeliveryStreamName"},
 		"AWS/IoT":              {"Protocol"},
-		"AWS/Kinesis":          {"StreamName", "ShardID"},
+		"AWS/Kinesis":          {"StreamName", "ShardId"},
 		"AWS/KinesisAnalytics": {"Flow", "Id", "Application"},
 		"AWS/Lambda":           {"FunctionName", "Resource", "Version", "Alias"},
 		"AWS/Logs":             {"LogGroupName", "DestinationType", "FilterName"},


### PR DESCRIPTION
Fixes the capitalization of the AWS/Kinesis ShardId metric, which was incorrectly specified as "ShardID" instead of "ShardId" as specified in the AWS documentation:

http://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html

This will resolve #10239