### PR TITLE
fix: The /logout route should always full page reload (#10277)

### DIFF
--- a/public/app/core/services/global_event_srv.ts
+++ b/public/app/core/services/global_event_srv.ts
@@ -6,10 +6,13 @@ import appEvents from 'app/core/app_events';
 // Good for communication react > angular and vice verse
 export class GlobalEventSrv {
   private appSubUrl;
+  private fullPageReloadRoutes;
+
 
   /** @ngInject */
-  constructor(private $location, private $timeout) {
+  constructor(private $location, private $timeout, private $window) {
     this.appSubUrl = config.appSubUrl;
+    this.fullPageReloadRoutes = ['/logout'];
   }
 
   // Angular's $location does not like <base href...> and absolute urls
@@ -26,9 +29,13 @@ export class GlobalEventSrv {
   init() {
     appEvents.on('location-change', payload => {
       const urlWithoutBase = this.stripBaseFromUrl(payload.href);
+      if (this.fullPageReloadRoutes.indexOf(urlWithoutBase) > -1) {
+        this.$window.location.href = payload.href;
+        return;
+      }
 
       this.$timeout(() => { // A hack to use timeout when we're changing things (in this case the url) from outside of Angular.
-          this.$location.url(urlWithoutBase);
+        this.$location.url(urlWithoutBase);
       });
     });
   }

--- a/public/app/core/specs/global_event_srv.jest.ts
+++ b/public/app/core/specs/global_event_srv.jest.ts
@@ -1,23 +1,23 @@
-﻿import { GlobalEventSrv } from 'app/core/services/global_event_srv';
-import { beforeEach } from 'test/lib/common';
+import { GlobalEventSrv } from "app/core/services/global_event_srv";
+import { beforeEach } from "test/lib/common";
 
-jest.mock('app/core/config', () => {
+jest.mock("app/core/config", () => {
   return {
-    appSubUrl: '/subUrl'
+    appSubUrl: "/subUrl"
   };
 });
 
-describe('GlobalEventSrv', () => {
+describe("GlobalEventSrv", () => {
   let searchSrv;
 
   beforeEach(() => {
-    searchSrv = new GlobalEventSrv(null, null);
+    searchSrv = new GlobalEventSrv(null, null, null);
   });
 
-  describe('With /subUrl as appSubUrl', () => {
-    it('/subUrl should be stripped', () => {
-        const urlWithoutMaster = searchSrv.stripBaseFromUrl('/subUrl/grafana/');
-        expect(urlWithoutMaster).toBe('/grafana/');
+  describe("With /subUrl as appSubUrl", () => {
+    it("/subUrl should be stripped", () => {
+      const urlWithoutMaster = searchSrv.stripBaseFromUrl("/subUrl/grafana/");
+      expect(urlWithoutMaster).toBe("/grafana/");
     });
   });
 });


### PR DESCRIPTION
Solved by having an array of urls that will always full page reload. 
