### PR TITLE
Simplify copy of panels between clipboards

### DIFF
--- a/public/app/features/dashboard/all.ts
+++ b/public/app/features/dashboard/all.ts
@@ -27,6 +27,7 @@ import './acl/acl';
 import './folder_picker/folder_picker';
 import './move_to_folder_modal/move_to_folder';
 import './settings/settings';
+import './panel_clipboard_srv';
 
 import coreModule from 'app/core/core_module';
 import { DashboardListCtrl } from './dashboard_list_ctrl';

--- a/public/app/features/dashboard/dashboard_ctrl.ts
+++ b/public/app/features/dashboard/dashboard_ctrl.ts
@@ -22,7 +22,8 @@ export class DashboardCtrl implements PanelContainer {
     private unsavedChangesSrv,
     private dashboardViewStateSrv,
     public playlistSrv,
-    private panelLoader
+    private panelLoader,
+    private panelClipboardSrv
   ) {
     // temp hack due to way dashboards are loaded
     // can't use controllerAs on route yet
@@ -120,6 +121,10 @@ export class DashboardCtrl implements PanelContainer {
 
   getPanelLoader() {
     return this.panelLoader;
+  }
+
+  getClipboardPanel() {
+    return this.panelClipboardSrv.getPanel();
   }
 
   timezoneChanged() {

--- a/public/app/features/dashboard/dashgrid/PanelContainer.ts
+++ b/public/app/features/dashboard/dashgrid/PanelContainer.ts
@@ -4,4 +4,5 @@ import { PanelLoader } from './PanelLoader';
 export interface PanelContainer {
   getPanelLoader(): PanelLoader;
   getDashboard(): DashboardModel;
+  getClipboardPanel(): any;
 }

--- a/public/app/features/dashboard/panel_clipboard_srv.ts
+++ b/public/app/features/dashboard/panel_clipboard_srv.ts
@@ -1,0 +1,21 @@
+import coreModule from 'app/core/core_module';
+import { appEvents } from 'app/core/core';
+
+class PanelClipboardSrv {
+  key = 'GrafanaDashboardClipboardPanel';
+
+  /** @ngInject **/
+  constructor(private $window) {
+    appEvents.on('copy-dashboard-panel', this.copyDashboardPanel.bind(this));
+  }
+
+  getPanel() {
+    return this.$window[this.key];
+  }
+
+  private copyDashboardPanel(payload) {
+    this.$window[this.key] = payload;
+  }
+}
+
+coreModule.service('panelClipboardSrv', PanelClipboardSrv);

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -195,6 +195,14 @@ export class PanelCtrl {
       text: 'Panel JSON',
       click: 'ctrl.editPanelJson(); dismiss();',
     });
+
+    menu.push({
+      text: 'Copy to Clipboard',
+      click: 'ctrl.copyPanelToClipboard()',
+      role: 'Editor',
+      directives: ['clipboard-button="ctrl.getPanelJson()"'],
+    });
+
     this.events.emit('init-panel-actions', menu);
     return menu;
   }
@@ -263,11 +271,23 @@ export class PanelCtrl {
     let editScope = this.$scope.$root.$new();
     editScope.object = this.panel.getSaveModel();
     editScope.updateHandler = this.replacePanel.bind(this);
+    editScope.enableCopy = true;
 
     this.publishAppEvent('show-modal', {
       src: 'public/app/partials/edit_json.html',
       scope: editScope,
     });
+  }
+
+  copyPanelToClipboard() {
+    appEvents.emit('copy-dashboard-panel', {
+      dashboard: this.dashboard.title,
+      panel: this.panel.getSaveModel(),
+    });
+  }
+
+  getPanelJson() {
+    return JSON.stringify(this.panel.getSaveModel(), null, 2);
   }
 
   replacePanel(newPanel, oldPanel) {

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -271,7 +271,6 @@ export class PanelCtrl {
     let editScope = this.$scope.$root.$new();
     editScope.object = this.panel.getSaveModel();
     editScope.updateHandler = this.replacePanel.bind(this);
-    editScope.enableCopy = true;
 
     this.publishAppEvent('show-modal', {
       src: 'public/app/partials/edit_json.html',

--- a/public/app/features/panel/panel_header.ts
+++ b/public/app/features/panel/panel_header.ts
@@ -51,6 +51,12 @@ function renderMenuItem(item, ctrl) {
     html += ` href="${item.href}"`;
   }
 
+  if (item.directives) {
+    for (let directive of item.directives) {
+      html += ` ${directive}`;
+    }
+  }
+
   html += `><i class="${item.icon}"></i>`;
   html += `<span class="dropdown-item-text">${item.text}</span>`;
 

--- a/public/sass/base/font-awesome/_larger.scss
+++ b/public/sass/base/font-awesome/_larger.scss
@@ -8,7 +8,7 @@
   vertical-align: -15%;
 }
 .#{$fa-css-prefix}-2x {
-  font-size: 2em;
+  font-size: 2em !important;
 }
 .#{$fa-css-prefix}-3x {
   font-size: 3em;

--- a/public/sass/components/_panel_add_panel.scss
+++ b/public/sass/components/_panel_add_panel.scss
@@ -65,3 +65,7 @@
 .add-panel__item-img {
   height: calc(100% - 15px);
 }
+
+.add-panel__item-icon {
+  padding: 2px;
+}


### PR DESCRIPTION
Work in progress for #10248 and #1004

Adds a new menu item *Copy to Clipboard* to panels, see screenshot below. 

![image](https://user-images.githubusercontent.com/1668778/34266863-04c3e7be-e67b-11e7-8b02-a6f2f1aae4de.png)

Clicking on that will first copy the panel JSON to the clipboard (making it available for pasting wherever), second the panel JSON object will temporarily be stored in the browsers window object. 

The temporarily stored panel object are available in Add Panel as *Paste copied panel* from any dashboard for as long you don't refresh the browser, see screenshot below.

![image](https://user-images.githubusercontent.com/1668778/34266877-11774a32-e67b-11e7-8df1-e8121ff252a8.png)

Some feedback would be appreciated:
* Sufficient to store temporarily in browsers window object or should we store it in local storage?
* Do we need another icon and/or copy for the *Paste copied panel* in Add Panel?
