### PR TITLE
Dashboard: View JSON improvements 

### DIFF
--- a/public/app/core/controllers/json_editor_ctrl.ts
+++ b/public/app/core/controllers/json_editor_ctrl.ts
@@ -6,11 +6,14 @@ export class JsonEditorCtrl {
   constructor($scope) {
     $scope.json = angular.toJson($scope.object, true);
     $scope.canUpdate = $scope.updateHandler !== void 0 && $scope.contextSrv.isEditor;
+    $scope.canCopy = $scope.enableCopy;
 
     $scope.update = function() {
       var newObject = angular.fromJson($scope.json);
       $scope.updateHandler(newObject, $scope.object);
     };
+
+    $scope.getContentForClipboard = () => $scope.json;
   }
 }
 

--- a/public/app/core/directives/misc.ts
+++ b/public/app/core/directives/misc.ts
@@ -2,6 +2,7 @@ import angular from 'angular';
 import Clipboard from 'clipboard';
 import coreModule from '../core_module';
 import kbn from 'app/core/utils/kbn';
+import { appEvents } from 'app/core/core';
 
 /** @ngInject */
 function tip($compile) {
@@ -30,6 +31,10 @@ function clipboardButton() {
         text: function() {
           return scope.getText();
         },
+      });
+
+      scope.clipboard.on('success', () => {
+        appEvents.emit('alert-success', ['Content copied to clipboard']);
       });
 
       scope.$on('$destroy', function() {

--- a/public/app/features/dashboard/export/export_modal.ts
+++ b/public/app/features/dashboard/export/export_modal.ts
@@ -31,6 +31,7 @@ export class DashExportCtrl {
     var clone = this.dash;
     let editScope = this.$rootScope.$new();
     editScope.object = clone;
+    editScope.enableCopy = true;
 
     this.$rootScope.appEvent('show-modal', {
       src: 'public/app/partials/edit_json.html',

--- a/public/app/features/dashboard/settings/settings.html
+++ b/public/app/features/dashboard/settings/settings.html
@@ -89,7 +89,7 @@
 	<h3 class="dashboard-settings__header">View JSON</h3>
 
 	<div class="gf-form">
-		<textarea class="gf-form-input" ng-model="ctrl.json" rows="30" spellcheck="false"></textarea>
+		<code-editor content="ctrl.json" data-mode="json" data-max-lines=30 ></code-editor>
 	</div>
 </div>
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -263,6 +263,7 @@ export class PanelCtrl {
     let editScope = this.$scope.$root.$new();
     editScope.object = this.panel.getSaveModel();
     editScope.updateHandler = this.replacePanel.bind(this);
+    editScope.enableCopy = true;
 
     this.publishAppEvent('show-modal', {
       src: 'public/app/partials/edit_json.html',

--- a/public/app/partials/edit_json.html
+++ b/public/app/partials/edit_json.html
@@ -16,6 +16,9 @@
 
 		<div class="gf-form-button-row">
 			<button type="button" class="btn btn-success" ng-show="canUpdate" ng-click="update(); dismiss();">Update</button>
+			<button class="btn btn-secondary" ng-if="canCopy" clipboard-button="getContentForClipboard()">
+				<i class="fa fa-clipboard"></i>&nbsp;Copy to Clipboard
+			</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Related to work done in #10323 

Decided to not include this in related pull request in case we don't want this.

Summary:
* Clipboard button directive will now show success alert *Content copied to clipboard* on successful copy of content. In my opinion great to get some feedback that something happened
* Show *Copy to Clipboard* button in *Panel JSON* dialog
* Show *Copy to Clipboard* button in Dashboard -> Share dashboard -> Export -> View JSON dialog
* Use code editor component for View JSON in dashboard settings