### PR TITLE
Fix small singlestat value display

### DIFF
--- a/public/sass/components/_panel_singlestat.scss
+++ b/public/sass/components/_panel_singlestat.scss
@@ -6,6 +6,7 @@
 }
 
 .singlestat-panel-value-container {
+  line-height: 1;
   display: table-cell;
   vertical-align: middle;
   text-align: center;


### PR DESCRIPTION
This fix improves the rendering of singlestats in small boxes in grafana
5. This allows the user to get boxes oh height=1 and still see the value
of the stat entirely.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

Closes #10326 