### PR TITLE
Oath2 logout

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -152,12 +152,11 @@ func loginUserWithUser(user *m.User, c *middleware.Context) {
 func Logout(c *middleware.Context) {
 	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
 	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
-	logoutUrl := c.GetCookie(oAuthLogoutCookie)
-	c.SetCookie(oAuthLogoutCookie, "", -1, setting.AppSubUrl+"/")
+	logoutUrl := c.Session.Get(oAuthLogoutUrl)
 	c.Session.Destory(c)
 
-	if logoutUrl != "" {
-		c.Redirect(logoutUrl)
+	if logoutUrl != nil {
+		c.Redirect(logoutUrl.(string))
 	} else {
 		c.Redirect(setting.AppSubUrl + "/login")
 	}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -156,7 +156,7 @@ func Logout(c *middleware.Context) {
 	c.SetCookie(oAuthLogoutCookie, "", -1, setting.AppSubUrl+"/")
 	c.Session.Destory(c)
 
-	if (logoutUrl != "") {
+	if logoutUrl != "" {
 		c.Redirect(logoutUrl)
 	} else {
 		c.Redirect(setting.AppSubUrl + "/login")

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -152,8 +152,10 @@ func loginUserWithUser(user *m.User, c *middleware.Context) {
 func Logout(c *middleware.Context) {
 	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
 	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
-	logoutUrl := OAuthLogout(c)
+	logoutUrl := c.GetCookie(oAuthLogoutCookie)
+	c.SetCookie(oAuthLogoutCookie, "", -1, setting.AppSubUrl+"/")
 	c.Session.Destory(c)
+
 	if (logoutUrl != "") {
 		c.Redirect(logoutUrl)
 	} else {

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -152,6 +152,11 @@ func loginUserWithUser(user *m.User, c *middleware.Context) {
 func Logout(c *middleware.Context) {
 	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
 	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
+	logoutUrl := OAuthLogout(c)
 	c.Session.Destory(c)
-	c.Redirect(setting.AppSubUrl + "/login")
+	if (logoutUrl != "") {
+		c.Redirect(logoutUrl)
+	} else {
+		c.Redirect(setting.AppSubUrl + "/login")
+	}
 }

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -21,7 +21,6 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
-	"sync"
 )
 
 var (

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -198,13 +198,11 @@ func OAuthLogin(ctx *middleware.Context) {
 	// login
 	loginUserWithUser(userQuery.Result, ctx)
 
-
-	if (setting.OAuthService.OAuthInfos[name].LogoutUrl != "") {
+	if setting.OAuthService.OAuthInfos[name].LogoutUrl != "" {
 		ctx.SetCookie(oAuthLogoutCookie, fmt.Sprintf("%s?client_id=%s&logout_uri=%s", setting.OAuthService.OAuthInfos[name].LogoutUrl,
-		setting.OAuthService.OAuthInfos[name].ClientId,
-		url.PathEscape(setting.AppUrl + "login")))
+			setting.OAuthService.OAuthInfos[name].ClientId,
+			url.PathEscape(setting.AppUrl+"login")))
 	}
-
 
 	metrics.M_Api_Login_OAuth.Inc()
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -33,7 +33,7 @@ var (
 )
 
 const (
-	oAuthLogoutCookie = "GrafanaOauthLogout"
+	oAuthLogoutUrl = "GrafanaOauthLogout"
 )
 
 func GenStateString() string {
@@ -198,7 +198,7 @@ func OAuthLogin(ctx *middleware.Context) {
 	loginUserWithUser(userQuery.Result, ctx)
 
 	if setting.OAuthService.OAuthInfos[name].LogoutUrl != "" {
-		ctx.SetCookie(oAuthLogoutCookie, fmt.Sprintf("%s?client_id=%s&logout_uri=%s", setting.OAuthService.OAuthInfos[name].LogoutUrl,
+		ctx.Session.Set(oAuthLogoutUrl, fmt.Sprintf("%s?client_id=%s&logout_uri=%s", setting.OAuthService.OAuthInfos[name].LogoutUrl,
 			setting.OAuthService.OAuthInfos[name].ClientId,
 			url.PathEscape(setting.AppUrl+"login")))
 	}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -33,6 +33,10 @@ var (
 	oauthLogger              = log.New("oauth.login")
 )
 
+const (
+	oAuthLogoutCookie = "GrafanaOauthLogout"
+)
+
 func GenStateString() string {
 	rnd := make([]byte, 32)
 	rand.Read(rnd)
@@ -195,9 +199,12 @@ func OAuthLogin(ctx *middleware.Context) {
 	loginUserWithUser(userQuery.Result, ctx)
 
 
-	logoutMap.Store(userQuery.Result.Id, fmt.Sprintf("%s?client_id=%s&logout_uri=%s", setting.OAuthService.OAuthInfos[name].LogoutUrl,
+	if (setting.OAuthService.OAuthInfos[name].LogoutUrl != "") {
+		ctx.SetCookie(oAuthLogoutCookie, fmt.Sprintf("%s?client_id=%s&logout_uri=%s", setting.OAuthService.OAuthInfos[name].LogoutUrl,
 		setting.OAuthService.OAuthInfos[name].ClientId,
 		url.PathEscape(setting.AppUrl + "login")))
+	}
+
 
 	metrics.M_Api_Login_OAuth.Inc()
 
@@ -215,15 +222,4 @@ func redirectWithError(ctx *middleware.Context, err error, v ...interface{}) {
 	// TODO: we can use the flash storage here once it's implemented
 	ctx.Session.Set("loginError", err.Error())
 	ctx.Redirect(setting.AppSubUrl + "/login")
-}
-
-var logoutMap sync.Map
-
-func OAuthLogout(ctx *middleware.Context) string {
-	logout, ok := logoutMap.Load(ctx.UserId)
-	if ok {
-		logoutMap.Delete(ctx.UserId)
-		return logout.(string)
-	}
-	return ""
 }

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -14,6 +14,7 @@ type OAuthInfo struct {
 	TlsClientKey           string
 	TlsClientCa            string
 	TlsSkipVerify          bool
+	LogoutUrl              string
 }
 
 type OAuther struct {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -69,7 +69,6 @@ func NewOAuthService() {
 			TlsClientCa:    sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:  sec.Key("tls_skip_verify_insecure").MustBool(),
 			LogoutUrl:      sec.Key("logout_url").String(),
-
 		}
 
 		if !info.Enabled {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -17,6 +17,7 @@ type BasicUserInfo struct {
 	Login   string
 	Company string
 	Role    string
+	Logout  string
 }
 
 type SocialConnector interface {
@@ -67,6 +68,8 @@ func NewOAuthService() {
 			TlsClientKey:   sec.Key("tls_client_key").String(),
 			TlsClientCa:    sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:  sec.Key("tls_skip_verify_insecure").MustBool(),
+			LogoutUrl:      sec.Key("logout_url").String(),
+
 		}
 
 		if !info.Enabled {


### PR DESCRIPTION
Added support for OAuth2 logout.  New setting 'logout_url'  in config file to setup provider logout url. If it set browser will be redirected to this url to clean up oauth session cookies during Grafana logout process. After that it'll be redirected back to login.
