### PR TITLE
Don't save dashboard on make editable, #10236

### DIFF
--- a/public/app/features/dashboard/dashboard_srv.ts
+++ b/public/app/features/dashboard/dashboard_srv.ts
@@ -80,6 +80,8 @@ export class DashboardSrv {
 
     this.$rootScope.appEvent('dashboard-saved', this.dash);
     this.$rootScope.appEvent('alert-success', ['Dashboard saved']);
+
+    return this.dash;
   }
 
   save(clone, options) {

--- a/public/app/features/dashboard/save_modal.ts
+++ b/public/app/features/dashboard/save_modal.ts
@@ -4,47 +4,47 @@ import coreModule from 'app/core/core_module';
 
 const template = `
 <div class="modal-body">
-	<div class="modal-header">
-		<h2 class="modal-header-title">
-			<i class="fa fa-save"></i>
-			<span class="p-l-1">Save changes</span>
-		</h2>
+  <div class="modal-header">
+    <h2 class="modal-header-title">
+      <i class="fa fa-save"></i>
+      <span class="p-l-1">Save changes</span>
+    </h2>
 
-		<a class="modal-header-close" ng-click="ctrl.dismiss();">
-			<i class="fa fa-remove"></i>
-		</a>
-	</div>
+    <a class="modal-header-close" ng-click="ctrl.dismiss();">
+      <i class="fa fa-remove"></i>
+    </a>
+  </div>
 
-	<form name="ctrl.saveForm" ng-submit="ctrl.save()" class="modal-content" novalidate>
-		<h6 class="text-center">Add a note to describe your changes</h6>
-		<div class="p-t-2">
-			<div class="gf-form">
-				<label class="gf-form-hint">
-					<input
-						type="text"
-						name="message"
-						class="gf-form-input"
-						placeholder="Updates to &hellip;"
-						give-focus="true"
-						ng-model="ctrl.message"
-						ng-model-options="{allowInvalid: true}"
-						ng-maxlength="this.max"
-						autocomplete="off" />
-					<small class="gf-form-hint-text muted" ng-cloak>
-						<span ng-class="{'text-error': ctrl.saveForm.message.$invalid && ctrl.saveForm.message.$dirty }">
-							{{ctrl.message.length || 0}}
-						</span>
-						/ {{ctrl.max}} characters
-					</small>
-				</label>
-			</div>
-		</div>
+  <form name="ctrl.saveForm" ng-submit="ctrl.save()" class="modal-content" novalidate>
+    <h6 class="text-center">Add a note to describe your changes</h6>
+    <div class="p-t-2">
+      <div class="gf-form">
+        <label class="gf-form-hint">
+          <input
+            type="text"
+            name="message"
+            class="gf-form-input"
+            placeholder="Updates to &hellip;"
+            give-focus="true"
+            ng-model="ctrl.message"
+            ng-model-options="{allowInvalid: true}"
+            ng-maxlength="this.max"
+            autocomplete="off" />
+          <small class="gf-form-hint-text muted" ng-cloak>
+            <span ng-class="{'text-error': ctrl.saveForm.message.$invalid && ctrl.saveForm.message.$dirty }">
+              {{ctrl.message.length || 0}}
+            </span>
+            / {{ctrl.max}} characters
+          </small>
+        </label>
+      </div>
+    </div>
 
-		<div class="gf-form-button-row text-center">
-			<button type="submit" class="btn btn-success" ng-disabled="ctrl.saveForm.$invalid">Save</button>
-			<button class="btn btn-inverse" ng-click="ctrl.dismiss();">Cancel</button>
-		</div>
-	</form>
+    <div class="gf-form-button-row text-center">
+      <button type="submit" class="btn btn-success" ng-disabled="ctrl.saveForm.$invalid">Save</button>
+      <button class="btn btn-inverse" ng-click="ctrl.dismiss();">Cancel</button>
+    </div>
+  </form>
 </div>
 `;
 

--- a/public/app/features/dashboard/settings/settings.ts
+++ b/public/app/features/dashboard/settings/settings.ts
@@ -128,9 +128,19 @@ export class SettingsCtrl {
 
   makeEditable() {
     this.dashboard.editable = true;
+    this.dashboard.meta.canMakeEditable = false;
+    this.dashboard.meta.canEdit = true;
+    this.dashboard.meta.canSave = true;
+    this.canDelete = true;
+    this.viewId = 'settings';
+    this.buildSectionList();
 
-    return this.dashboardSrv.saveDashboard({ makeEditable: true, overwrite: false }).then(() => {
-      // force refresh whole page
+    const currentSection = _.find(this.sections, { id: this.viewId });
+    this.$location.url(currentSection.url);
+    this.onRouteUpdated();
+
+    // Force dashboard reload after saving to update view
+    appEvents.on('dashboard-saved', () => {
       window.location.href = window.location.href;
     });
   }


### PR DESCRIPTION
This PR fixes #10236
now `makeEditable()` doesn't save dashboard, instead of that it just updates view and allows to edit dashboard settings and save it later.
Not sure if this is right completely, check it, maybe I should add something else.