### PR TITLE
fix scripted dashboard loader, #10350

### DIFF
--- a/public/app/features/dashboard/dashboard_loader_srv.ts
+++ b/public/app/features/dashboard/dashboard_loader_srv.ts
@@ -20,7 +20,7 @@ export class DashboardLoaderSrv {
     private $rootScope
   ) {}
 
-  _dashboardLoadFailed(title, snapshot) {
+  _dashboardLoadFailed(title, snapshot?) {
     snapshot = snapshot || false;
     return {
       meta: {
@@ -74,9 +74,9 @@ export class DashboardLoaderSrv {
     var url = 'public/dashboards/' + file.replace(/\.(?!js)/, '/') + '?' + new Date().getTime();
 
     return this.$http({ url: url, method: 'GET' })
-      .then(this._executeScript)
+      .then(this._executeScript.bind(this))
       .then(
-        function(result) {
+        result => {
           return {
             meta: {
               fromScript: true,
@@ -87,7 +87,7 @@ export class DashboardLoaderSrv {
             dashboard: result.data,
           };
         },
-        function(err) {
+        err => {
           console.log('Script dashboard error ' + err);
           this.$rootScope.appEvent('alert-error', [
             'Script Error',


### PR DESCRIPTION
This fix #10350, bug also described partially in #10337
This caused by missing `this` bindings. Also replaced `function()` by arrow function due the same issue - `this` isn't passed into anonymous function.