### PR TITLE
dashfolders: relative links should work when root_path is specified

### DIFF
--- a/public/app/core/components/manage_dashboards/manage_dashboards.html
+++ b/public/app/core/components/manage_dashboards/manage_dashboards.html
@@ -9,7 +9,7 @@
       <i class="fa fa-plus"></i>
       Dashboard
     </a>
-    <a class="btn btn-success" href="/dashboards/folder/new" ng-if="!ctrl.folderId">
+    <a class="btn btn-success" href="dashboards/folder/new" ng-if="!ctrl.folderId">
       <i class="fa fa-plus"></i>
       Folder
     </a>
@@ -108,11 +108,11 @@
   <empty-list-cta model="{
     title: 'This folder doesn\'t have any dashboards yet',
     buttonIcon: 'gicon gicon-dashboard-new',
-    buttonLink: '/dashboard/new?folderId={{ctrl.folderId}}',
+    buttonLink: 'dashboard/new?folderId={{ctrl.folderId}}',
     buttonTitle: 'Create Dashboard',
     proTip: 'Add dashboards into your folder at ->',
-    proTipLink: '/dashboards',
+    proTipLink: 'dashboards',
     proTipLinkTitle: 'Manage dashboards',
-    proTipTarget: '_blank'
+    proTipTarget: ''
   }" />
 </div>

--- a/public/app/core/components/manage_dashboards/manage_dashboards.ts
+++ b/public/app/core/components/manage_dashboards/manage_dashboards.ts
@@ -276,7 +276,7 @@ export class ManageDashboardsCtrl {
   }
 
   createDashboardUrl() {
-    let url = '/dashboard/new';
+    let url = 'dashboard/new';
 
     if (this.folderId) {
       url += `?folderId=${this.folderId}`;

--- a/public/app/features/dashboard/create_folder_ctrl.ts
+++ b/public/app/features/dashboard/create_folder_ctrl.ts
@@ -20,7 +20,7 @@ export class CreateFolderCtrl {
     return this.backendSrv.createDashboardFolder(this.title).then(result => {
       appEvents.emit('alert-success', ['Folder Created', 'OK']);
 
-      var folderUrl = `/dashboards/folder/${result.dashboard.id}/${result.meta.slug}`;
+      var folderUrl = `dashboards/folder/${result.dashboard.id}/${result.meta.slug}`;
       this.$location.url(folderUrl);
     });
   }

--- a/public/app/features/dashboard/folder_page_loader.ts
+++ b/public/app/features/dashboard/folder_page_loader.ts
@@ -65,6 +65,6 @@ export class FolderPageLoader {
   }
 
   createFolderUrl(folderId: number, type: string, slug: string) {
-    return `/dashboards/folder/${folderId}/${slug}`;
+    return `dashboards/folder/${folderId}/${slug}`;
   }
 }

--- a/public/app/features/dashboard/folder_settings_ctrl.ts
+++ b/public/app/features/dashboard/folder_settings_ctrl.ts
@@ -67,7 +67,7 @@ export class FolderSettingsCtrl {
       onConfirm: () => {
         return this.backendSrv.deleteDashboard(this.meta.slug).then(() => {
           appEvents.emit('alert-success', ['Folder Deleted', `${this.dashboard.title} has been deleted`]);
-          this.$location.url('/dashboards');
+          this.$location.url('dashboards');
         });
       },
     });


### PR DESCRIPTION
Fixes #10336
