### PR TITLE
initial support for using regex with tags

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -273,6 +273,12 @@
 				<span class="gf-form-label width-10">Tags query</span>
 				<input type="text" class="gf-form-input" ng-model='current.tagsQuery' placeholder="metric name or tags query" ng-model-onblur></input>
 			</div>
+			<div class="gf-form">
+				<span class="gf-form-label width-7">
+					Tag Regex
+				</span>
+				<input type="text" class="gf-form-input" ng-model='current.tagRegex' placeholder="/.*-(.*)-.*/" ng-model-onblur ng-change="runQuery()"></input>
+			</div>
 			<div class="gf-form" ng-if="current.useTags">
 				<li class="gf-form-label width-10">Tag values query</li>
 				<input type="text" class="gf-form-input" ng-model='current.tagValuesQuery' placeholder="apps.$tag.*" ng-model-onblur></input>


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/2591

add support for using a regex with tags in templating.

example use case is using graphite with metrics like

prod.web01
prod.web02
prod.web03
prod.mysql01
prod.mysql02

where you wish to use tags of web|mysql to select relevant nodes