### PR TITLE
fix move dashboard variables, #10347

### DIFF
--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -8,6 +8,7 @@ export class VariableEditorCtrl {
     $scope.variableTypes = variableTypes;
     $scope.ctrl = {};
     $scope.namePattern = /^(?!__).*$/;
+    $scope._ = _;
 
     $scope.refreshOptions = [
       { value: 0, text: 'Never' },


### PR DESCRIPTION
This was caused by missing `$scope._` property. This wasn't set explicitly in the previous version but was inherited from one of the parent scopes (seems, from `GrafanaCtrl`). Not sure what was changed in scope hierarchy in v5.0, so just assigned it explicitly in the constructor.