### PR TITLE
Use URLEncoding instead of StdEncoding to be sure state value will be…

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -35,7 +35,7 @@ var (
 func GenStateString() string {
 	rnd := make([]byte, 32)
 	rand.Read(rnd)
-	return base64.StdEncoding.EncodeToString(rnd)
+	return base64.URLEncoding.EncodeToString(rnd)
 }
 
 func OAuthLogin(ctx *middleware.Context) {


### PR DESCRIPTION
… corectly decoded
Fix for #9823.
For my understanding Grafana sends state parameter 'as is', auth server do not change received value as per [https://tools.ietf.org/html/rfc6749#section-4.1.2](rfc6749). But macaron.v1 performs decoding of received parameters which causes 'State mismatch' error in some cases. (When generated value contains '+' signs, which is different between StdEncoding and URLEncoding).
When URLEncoding is used instead of StdEncoding decoding received value inside macaron.v1 gives the same value.
