### PR TITLE
Modify Grafana Pagerduty notifier to use Pagerduty API V2

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -111,6 +111,8 @@ func (this *PagerdutyNotifier) Notify(evalContext *alerting.EvalContext) error {
 	links := make([]interface{}, 1)
 	linkJSON := simplejson.New()
 	linkJSON.Set("href", ruleUrl)
+	bodyJSON.Set("client_url", ruleUrl)
+	bodyJSON.Set("client", "Grafana")
 	links[0] = linkJSON
 	bodyJSON.Set("links", links)
 

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -2,8 +2,8 @@ package notifiers
 
 import (
 	"os"
-	"time"
 	"strconv"
+	"time"
 
 	"fmt"
 


### PR DESCRIPTION
This PR is in response to issue #10531. This is not time sensitive as I previously thought because the endpoint that Grafana currently hits is under the `Events API` designation as opposed to the `REST API`. See [here](https://v2.developer.pagerduty.com/v2/docs/api-v2-frequently-asked-questions) for more information about end-of-life details for the two APIs.

These changes add support for V2 of the Events API. This endpoint is currently up and accessible and these code changes will allow users to notify using that API version endpoint instead of V1.