### PR TITLE
Sort unsorted

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -78,6 +78,7 @@ export default class TimeSeries {
   scaledDecimals: number;
   hasMsResolution: boolean;
   isOutsideRange: boolean;
+  index: number;
 
   lines: any;
   dashes: any;
@@ -104,6 +105,7 @@ export default class TimeSeries {
     this.legend = true;
     this.unit = opts.unit;
     this.hasMsResolution = this.isMsResolutionNeeded();
+    this.index = opts.index !== undefined ? opts.index : 0;
   }
 
   applySeriesOverrides(overrides) {

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -78,7 +78,6 @@ export default class TimeSeries {
   scaledDecimals: number;
   hasMsResolution: boolean;
   isOutsideRange: boolean;
-  index: number;
 
   lines: any;
   dashes: any;
@@ -105,7 +104,6 @@ export default class TimeSeries {
     this.legend = true;
     this.unit = opts.unit;
     this.hasMsResolution = this.isMsResolutionNeeded();
-    this.index = opts.index !== undefined ? opts.index : 0;
   }
 
   applySeriesOverrides(overrides) {

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -108,7 +108,6 @@ export class DataProcessor {
       alias: alias,
       color: color,
       unit: seriesData.unit,
-      index: index,
     });
 
     if (datapoints && datapoints.length > 0) {

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -108,6 +108,7 @@ export class DataProcessor {
       alias: alias,
       color: color,
       unit: seriesData.unit,
+      index: index,
     });
 
     if (datapoints && datapoints.length > 0) {

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -68,6 +68,9 @@ function ($, core) {
       var last_value = 0; //needed for stacked values
 
       var minDistance, minTime;
+      seriesList.sort(function(a, b) {
+        return a.index - b.index;
+      });
 
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -68,6 +68,9 @@ function ($, core) {
       var last_value = 0; //needed for stacked values
 
       var minDistance, minTime;
+      seriesList.sort(function(a, b) {
+        return a.index - b.index;
+      })
 
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];

--- a/public/app/plugins/panel/graph/graph_tooltip.js
+++ b/public/app/plugins/panel/graph/graph_tooltip.js
@@ -68,9 +68,6 @@ function ($, core) {
       var last_value = 0; //needed for stacked values
 
       var minDistance, minTime;
-      seriesList.sort(function(a, b) {
-        return a.index - b.index;
-      })
 
       for (i = 0; i < seriesList.length; i++) {
         series = seriesList[i];

--- a/public/app/plugins/panel/graph/legend.ts
+++ b/public/app/plugins/panel/graph/legend.ts
@@ -156,10 +156,6 @@ module.directive('graphLegend', function(popoverSrv, $timeout) {
           if (panel.legend.sortDesc) {
             seriesList = seriesList.reverse();
           }
-        } else {
-          seriesList = _.sortBy(seriesList, function(series) {
-            return series.index;
-          })
         }
 
         // render first time for getting proper legend height

--- a/public/app/plugins/panel/graph/legend.ts
+++ b/public/app/plugins/panel/graph/legend.ts
@@ -156,6 +156,10 @@ module.directive('graphLegend', function(popoverSrv, $timeout) {
           if (panel.legend.sortDesc) {
             seriesList = seriesList.reverse();
           }
+        } else {
+          seriesList = _.sortBy(seriesList, function(series) {
+            return series.index;
+          })
         }
 
         // render first time for getting proper legend height

--- a/public/app/plugins/panel/graph/legend.ts
+++ b/public/app/plugins/panel/graph/legend.ts
@@ -156,6 +156,10 @@ module.directive('graphLegend', function(popoverSrv, $timeout) {
           if (panel.legend.sortDesc) {
             seriesList = seriesList.reverse();
           }
+        } else {
+          seriesList = _.sortBy(seriesList, function(series) {
+            return series.index;
+          });
         }
 
         // render first time for getting proper legend height


### PR DESCRIPTION
First, if you do not specify a sort. Second, if the metrics are more than ten. Then the legend elements will be mixed by the next pressing on any of them. The same happens with the tooltip elements.
![unsorted](https://user-images.githubusercontent.com/936530/35040326-7f4eb518-fba2-11e7-9155-ed8def29d951.jpg)
I suggest to sort elements of legend and tooltip in order of metrics, when the sorting is not explicitly specified.