### PR TITLE
Make file_reader follow symlinks

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -145,6 +145,17 @@ func createWalkFn(fr *fileReader, folderId int64) filepath.WalkFunc {
 			return nil
 		}
 
+		checkFilepath, err := filepath.EvalSymlinks(path)
+
+		if path != checkFilepath {
+			path = checkFilepath
+			fi, err := os.Lstat(checkFilepath)
+			if err != nil {
+				return err
+			}
+			fileInfo = fi
+		}
+
 		cachedDashboard, exist := fr.cache.getCache(path)
 		if exist && cachedDashboard.UpdatedAt == fileInfo.ModTime() {
 			return nil


### PR DESCRIPTION
When a dashboard is configured from a file and that file is a symlink the dashboard will never be updated with changes to the original file as the modtime of the symlinked file will not change. 

This PR adds a check to find out if the file is a symlinked file and follow the symlink if it is. 
