### PR TITLE
Recommend a limit on database query for influxdb annotations

### DIFF
--- a/public/app/plugins/datasource/influxdb/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/annotations.editor.html
@@ -1,7 +1,7 @@
 
 <div class="gf-form-group">
 	<div class="gf-form">
-		<input type="text" class="gf-form-input" ng-model='ctrl.annotation.query' placeholder="select text from events where $timeFilter"></input>
+		<input type="text" class="gf-form-input" ng-model='ctrl.annotation.query' placeholder="select text from events where $timeFilter limit 1000"></input>
 	</div>
 </div>
 


### PR DESCRIPTION
Users not putting a limit on can end up causing bad performance. A recommended limit in the placehold is a quick little help.

There are many better solutions.