### PR TITLE
cloudwatch: fix Templated queries ebs_volume_ids(region, instance_id) call

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -188,18 +188,6 @@ func (e *CloudWatchExecutor) executeMetricFindQuery(ctx context.Context, queryCo
 		data, err = e.handleGetEbsVolumeIds(ctx, parameters, queryContext)
 		break
 	case "ec2_instance_attribute":
-		region := parameters.Get("region").MustString()
-		dsInfo := e.getDsInfo(region)
-		cfg, err := e.getAwsConfig(dsInfo)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to call ec2:DescribeInstances, %v", err)
-		}
-		sess, err := session.NewSession(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to call ec2:DescribeInstances, %v", err)
-		}
-		e.ec2Svc = ec2.New(sess, cfg)
-
 		data, err = e.handleGetEc2InstanceAttribute(ctx, parameters, queryContext)
 		break
 	}
@@ -365,9 +353,30 @@ func (e *CloudWatchExecutor) handleGetDimensionValues(ctx context.Context, param
 	return result, nil
 }
 
+func (e *CloudWatchExecutor) ensureClientSession(region string) error {
+	if e.ec2Svc == nil {
+		dsInfo := e.getDsInfo(region)
+		cfg, err := e.getAwsConfig(dsInfo)
+		if err != nil {
+			return fmt.Errorf("Failed to call ec2:getAwsConfig, %v", err)
+		}
+		sess, err := session.NewSession(cfg)
+		if err != nil {
+			return fmt.Errorf("Failed to call ec2:NewSession, %v", err)
+		}
+		e.ec2Svc = ec2.New(sess, cfg)
+	}
+	return nil
+}
+
 func (e *CloudWatchExecutor) handleGetEbsVolumeIds(ctx context.Context, parameters *simplejson.Json, queryContext *tsdb.TsdbQuery) ([]suggestData, error) {
 	region := parameters.Get("region").MustString()
 	instanceId := parameters.Get("instanceId").MustString()
+
+	err := e.ensureClientSession(region)
+	if err != nil {
+		return nil, err
+	}
 
 	instanceIds := []*string{aws.String(instanceId)}
 	instances, err := e.ec2DescribeInstances(region, nil, instanceIds)
@@ -402,6 +411,11 @@ func (e *CloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 				Values: vvvvv,
 			})
 		}
+	}
+
+	err := e.ensureClientSession(region)
+	if err != nil {
+		return nil, err
 	}
 
 	instances, err := e.ec2DescribeInstances(region, filters, nil)


### PR DESCRIPTION
Templated queries  `ebs_volume_ids(region, instance_id)`  causes a runtime error.

Stacktrace 
``` 
runtime error: invalid memory address or nil pointer dereference" stack="/usr/local/go/src/runtime/panic.go:491 (0x431e62)
/usr/local/go/src/runtime/panic.go:63 (0x430d6d)
/usr/local/go/src/runtime/signal_unix.go:367 (0x44924b)
/go/src/github.com/grafana/grafana/pkg/tsdb/cloudwatch/metric_find_query.go:490 (0xd28174)
/go/src/github.com/grafana/grafana/pkg/tsdb/cloudwatch/metric_find_query.go:368 (0xd264b4)
/go/src/github.com/grafana/grafana/pkg/tsdb/cloudwatch/metric_find_query.go:183 (0xd22a57)
....
```

Reson: 
* the `ec2 client session` was not create before calling `ec2DescribeInstances`. 
