### PR TITLE
Show grafana admins

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -242,8 +242,9 @@ func searchUser(c *middleware.Context) (*m.SearchUsersQuery, error) {
 	}
 
 	searchQuery := c.Query("query")
+	isAdmin := c.Query("isadmin")
 
-	query := &m.SearchUsersQuery{Query: searchQuery, Page: page, Limit: perPage}
+	query := &m.SearchUsersQuery{Query: searchQuery, Page: page, Limit: perPage, IsAdmin: isAdmin}
 	if err := bus.Dispatch(query); err != nil {
 		return nil, err
 	}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -128,10 +128,11 @@ type GetUserProfileQuery struct {
 }
 
 type SearchUsersQuery struct {
-	OrgId int64
-	Query string
-	Page  int
-	Limit int
+	OrgId   int64
+	Query   string
+	Page    int
+	Limit   int
+	IsAdmin string
 
 	Result SearchUserQueryResult
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -405,6 +405,14 @@ func SearchUsers(query *m.SearchUsersQuery) error {
 		whereParams = append(whereParams, queryWithWildcards, queryWithWildcards, queryWithWildcards)
 	}
 
+	if isadmin_int, err := strconv.Atoi(query.IsAdmin); err == nil {
+		if query.IsAdmin != "" && isadmin_int < 2 {
+			whereConditions = append(whereConditions, "is_admin = ?")
+			isadmin, _ := strconv.ParseBool(query.IsAdmin)
+			whereParams = append(whereParams, isadmin)
+		}
+	}
+
 	if len(whereConditions) > 0 {
 		sess.Where(strings.Join(whereConditions, " AND "), whereParams...)
 	}

--- a/public/app/features/dashboard/dashboard_ctrl.ts
+++ b/public/app/features/dashboard/dashboard_ctrl.ts
@@ -43,6 +43,10 @@ export class DashboardCtrl implements PanelContainer {
     }
   }
 
+  getAdminUsers() {
+    return this.dashboardSrv.adminEmails;
+  }
+
   setupDashboardInternal(data) {
     const dashboard = this.dashboardSrv.create(data.dashboard, data.meta);
     this.dashboardSrv.setCurrent(dashboard);

--- a/public/app/features/dashboard/dashboard_srv.ts
+++ b/public/app/features/dashboard/dashboard_srv.ts
@@ -1,11 +1,27 @@
 import coreModule from 'app/core/core_module';
 import { DashboardModel } from './dashboard_model';
+import _ from 'lodash';
 
 export class DashboardSrv {
   dash: any;
+  adminEmails: any;
 
   /** @ngInject */
-  constructor(private backendSrv, private $rootScope, private $location) {}
+  constructor(private backendSrv, private $rootScope, private $location) {
+    this.getAdminUsers();
+  }
+
+  getAdminUsers() {
+    this.backendSrv
+      .get(`/api/users/search?isadmin=1`)
+      .then(result => {
+        var emails = [];
+        _.forEach(result.users, function(user) {
+            emails.push(user["email"]);
+        });
+        this.adminEmails = emails.join(",");
+      });
+  }
 
   create(dashboard, meta) {
     return new DashboardModel(dashboard, meta);

--- a/public/app/partials/dashboard.html
+++ b/public/app/partials/dashboard.html
@@ -13,6 +13,7 @@
 
 			<dashboard-grid get-panel-container="ctrl.getPanelContainer">
 			</dashboard-grid>
+            <div class="text-center" ng-bind="'Administrator contacts: ' + ctrl.getAdminUsers()"></div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Shows the contact info for admins at the bottom of dashboards. I'm sure my javascript code could be neater. Also, I'm wondering what would happen if an installation had a large number of admins. Would be a pretty large footer.

I also did not use the "footer" css class because I noticed it is hidden on dashboard views. For me I wish the footer, with the current version etc., was always shown.

Resolves https://github.com/grafana/grafana/issues/4649