### PR TITLE
Fix for #9500, thresholds for date

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -94,6 +94,35 @@
       </div>
     </div>
 
+    <div class="section gf-form-group"  ng-if="style.type === 'date'">
+      <h5 class="section-heading">Thresholds</h5>
+      <div class="gf-form">
+        <label class="gf-form-label width-8">Thresholds<tip>Comma separated values</tip></label>
+        <input type="text" class="gf-form-input width-10" ng-model="style.thresholds" placeholder="50,80" ng-blur="editor.render()" array-join>
+      </div>
+      <div class="gf-form">
+        <label class="gf-form-label width-8">Color Mode</label>
+        <div class="gf-form-select-wrapper width-10">
+          <select class="gf-form-input" ng-model="style.colorMode" ng-options="c.value as c.text for c in editor.colorModes" ng-change="editor.render()"></select>
+        </div>
+      </div>
+      <div class="gf-form">
+        <label class="gf-form-label width-8">Colors</label>
+        <span class="gf-form-label">
+          <color-picker color="style.colors[0]" onChange="editor.onColorChange($index, 0)"></color-picker>
+        </span>
+        <span class="gf-form-label">
+          <color-picker color="style.colors[1]" onChange="editor.onColorChange($index, 1)"></color-picker>
+        </span>
+        <span class="gf-form-label">
+          <color-picker color="style.colors[2]" onChange="editor.onColorChange($index, 2)"></color-picker>
+        </span>
+        <div class="gf-form-label">
+          <a class="pointer" ng-click="editor.invertColorOrder($index)">Invert</a>
+        </div>
+      </div>
+    </div>
+
     <div class="section gf-form-group" ng-if="style.link">
       <h5 class="section-heading">Link</h5>
       <div class="gf-form">

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -25,6 +25,9 @@ class TablePanelCtrl extends MetricsPanelCtrl {
         pattern: 'Time',
         alias: 'Time',
         dateFormat: 'YYYY-MM-DD HH:mm:ss',
+        colors: ['rgba(245, 54, 54, 0.9)', 'rgba(237, 129, 40, 0.89)', 'rgba(50, 172, 45, 0.97)'],
+        colorMode: null,
+        thresholds: [],
       },
       {
         unit: 'short',

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment';
 import kbn from 'app/core/utils/kbn';
+import * as dateMath from 'app/core/utils/datemath';
 
 export class TableRenderer {
   formatters: any[];
@@ -56,6 +57,19 @@ export class TableRenderer {
     return _.first(style.colors);
   }
 
+  getColorForDate(value, style) {
+    if (!style.thresholds) {
+      return null;
+    }
+    for (var i = 0; i < style.thresholds.length; i++) {
+      let threshold_moment = dateMath.parse(`now-${style.thresholds[i]}`).unix() * 1000;
+      if (value >= threshold_moment) {
+        return style.colors[i];
+      }
+    }
+    return _.last(style.colors);
+  }
+
   defaultCellFormatter(v, style) {
     if (v === null || v === void 0 || v === undefined) {
       return '';
@@ -96,6 +110,11 @@ export class TableRenderer {
         if (this.isUtc) {
           date = date.utc();
         }
+
+        if (column.style.colorMode) {
+          this.colorState[column.style.colorMode] = this.getColorForDate(v, column.style);
+        }
+
         return date.format(column.style.dateFormat);
       };
     }


### PR DESCRIPTION
This PR adds new functionality in Column styles section for TablePanel, and closes issue https://github.com/grafana/grafana/issues/9500

It allows to define thresholds for Date types. For example:
![0a55331d29](https://user-images.githubusercontent.com/1565642/35282351-52a30154-0066-11e8-9d62-459b84c68707.jpg)

Here I defined thresholds for Time column with such rules:

* All rows with time < now() - 2m will be green
* All rows between now()-2m and now()-4m will be yellow
* Other rows are red


