### PR TITLE
Fix typeahead to avoid generating new backend request on each keypress.

### DIFF
--- a/public/app/core/components/query_part/query_part_editor.ts
+++ b/public/app/core/components/query_part/query_part_editor.ts
@@ -123,18 +123,11 @@ export function queryPartEditorDirective($compile, templateSrv) {
         });
 
         var typeahead = $input.data('typeahead');
-        typeahead.lookup = function() {
-          if ($scope.lookupTimeout) {
-            clearTimeout($scope.lookupTimeout);
-          }
-          $scope.lookupTimeout = setTimeout($scope.doLookup.bind(this), 500);
-        };
-
-        $scope.doLookup = function() {
+        typeahead.lookup = _.debounce(function() {
           this.query = this.$element.val() || '';
           var items = this.source(this.query, $.proxy(this.process, this));
           return items ? this.process(items) : items;
-        };
+        }, 500);
       }
 
       $scope.showActionsMenu = function() {

--- a/public/app/core/components/query_part/query_part_editor.ts
+++ b/public/app/core/components/query_part/query_part_editor.ts
@@ -124,6 +124,13 @@ export function queryPartEditorDirective($compile, templateSrv) {
 
         var typeahead = $input.data('typeahead');
         typeahead.lookup = function() {
+          if ($scope.lookupTimeout) {
+            clearTimeout($scope.lookupTimeout);
+          }
+          $scope.lookupTimeout = setTimeout($scope.doLookup.bind(this), 500);
+        };
+
+        $scope.doLookup = function() {
           this.query = this.$element.val() || '';
           var items = this.source(this.query, $.proxy(this.process, this));
           return items ? this.process(items) : items;

--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -130,6 +130,13 @@ function (_, $, coreModule) {
 
         var typeahead = $input.data('typeahead');
         typeahead.lookup = function () {
+          if ($scope.lookupTimeout) {
+            clearTimeout($scope.lookupTimeout);
+          }
+          $scope.lookupTimeout = setTimeout($scope.doLookup.bind(this) , 500);
+        };
+
+        $scope.doLookup = function() {
           this.query = this.$element.val() || '';
           var items = this.source(this.query, $.proxy(this.process, this));
           return items ? this.process(items) : items;

--- a/public/app/core/directives/metric_segment.js
+++ b/public/app/core/directives/metric_segment.js
@@ -129,18 +129,11 @@ function (_, $, coreModule) {
         $input.typeahead({ source: $scope.source, minLength: 0, items: 10000, updater: $scope.updater, matcher: $scope.matcher });
 
         var typeahead = $input.data('typeahead');
-        typeahead.lookup = function () {
-          if ($scope.lookupTimeout) {
-            clearTimeout($scope.lookupTimeout);
-          }
-          $scope.lookupTimeout = setTimeout($scope.doLookup.bind(this) , 500);
-        };
-
-        $scope.doLookup = function() {
+        typeahead.lookup = _.debounce(function() {
           this.query = this.$element.val() || '';
           var items = this.source(this.query, $.proxy(this.process, this));
           return items ? this.process(items) : items;
-        };
+        }, 500);
 
         $button.keydown(function(evt) {
           // trigger typeahead on down arrow or enter key


### PR DESCRIPTION
In the query editor window when you start typing in the field, tag value, tag key, or measurement fields it sends an individual request to the influx backend for each and every key that you press.

If you have a large tag set on the backend Influx instance, these queries are very expensive and can cause the influx backend to tip over at times.

This change implements a half second wait when typing before sending the request to a backend.
