### PR TITLE
Provisioning. Handle missing directory more graceful

### DIFF
--- a/pkg/services/provisioning/dashboards/config_reader.go
+++ b/pkg/services/provisioning/dashboards/config_reader.go
@@ -5,20 +5,25 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/log"
 	yaml "gopkg.in/yaml.v2"
 )
 
 type configReader struct {
 	path string
+	log  log.Logger
 }
 
 func (cr *configReader) readConfig() ([]*DashboardsAsConfig, error) {
+	var dashboards []*DashboardsAsConfig
+
 	files, err := ioutil.ReadDir(cr.path)
+
 	if err != nil {
-		return nil, err
+		cr.log.Error("cant read dashboard provisioning files from directory", "path", cr.path)
+		return dashboards, nil
 	}
 
-	var dashboards []*DashboardsAsConfig
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
 			continue
@@ -30,13 +35,13 @@ func (cr *configReader) readConfig() ([]*DashboardsAsConfig, error) {
 			return nil, err
 		}
 
-		var datasource []*DashboardsAsConfig
-		err = yaml.Unmarshal(yamlFile, &datasource)
+		var dashCfg []*DashboardsAsConfig
+		err = yaml.Unmarshal(yamlFile, &dashCfg)
 		if err != nil {
 			return nil, err
 		}
 
-		dashboards = append(dashboards, datasource...)
+		dashboards = append(dashboards, dashCfg...)
 	}
 
 	for i := range dashboards {

--- a/pkg/services/provisioning/dashboards/config_reader_test.go
+++ b/pkg/services/provisioning/dashboards/config_reader_test.go
@@ -17,8 +17,8 @@ func TestDashboardsAsConfig(t *testing.T) {
 
 		Convey("Can read config file", func() {
 
-			cfgProvifer := configReader{path: simpleDashboardConfig, log: log.New("test-logger")}
-			cfg, err := cfgProvifer.readConfig()
+			cfgProvider := configReader{path: simpleDashboardConfig, log: log.New("test-logger")}
+			cfg, err := cfgProvider.readConfig()
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)
 			}
@@ -50,8 +50,8 @@ func TestDashboardsAsConfig(t *testing.T) {
 
 		Convey("Should skip invalid path", func() {
 
-			cfgProvifer := configReader{path: "/invalid-directory", log: log.New("test-logger")}
-			cfg, err := cfgProvifer.readConfig()
+			cfgProvider := configReader{path: "/invalid-directory", log: log.New("test-logger")}
+			cfg, err := cfgProvider.readConfig()
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)
 			}
@@ -61,8 +61,8 @@ func TestDashboardsAsConfig(t *testing.T) {
 
 		Convey("Should skip broken config files", func() {
 
-			cfgProvifer := configReader{path: brokenConfigs, log: log.New("test-logger")}
-			cfg, err := cfgProvifer.readConfig()
+			cfgProvider := configReader{path: brokenConfigs, log: log.New("test-logger")}
+			cfg, err := cfgProvider.readConfig()
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)
 			}

--- a/pkg/services/provisioning/dashboards/config_reader_test.go
+++ b/pkg/services/provisioning/dashboards/config_reader_test.go
@@ -3,6 +3,7 @@ package dashboards
 import (
 	"testing"
 
+	"github.com/grafana/grafana/pkg/log"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -16,7 +17,7 @@ func TestDashboardsAsConfig(t *testing.T) {
 
 		Convey("Can read config file", func() {
 
-			cfgProvifer := configReader{path: simpleDashboardConfig}
+			cfgProvifer := configReader{path: simpleDashboardConfig, log: log.New("test-logger")}
 			cfg, err := cfgProvifer.readConfig()
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)
@@ -47,16 +48,26 @@ func TestDashboardsAsConfig(t *testing.T) {
 			So(ds2.Options["path"], ShouldEqual, "/var/lib/grafana/dashboards")
 		})
 
-		Convey("Should skip broken config files", func() {
+		Convey("Should skip invalid path", func() {
 
-			cfgProvifer := configReader{path: brokenConfigs}
+			cfgProvifer := configReader{path: "/invalid-directory", log: log.New("test-logger")}
 			cfg, err := cfgProvifer.readConfig()
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)
 			}
 
 			So(len(cfg), ShouldEqual, 0)
+		})
 
+		Convey("Should skip broken config files", func() {
+
+			cfgProvifer := configReader{path: brokenConfigs, log: log.New("test-logger")}
+			cfg, err := cfgProvifer.readConfig()
+			if err != nil {
+				t.Fatalf("readConfig return an error %v", err)
+			}
+
+			So(len(cfg), ShouldEqual, 0)
 		})
 	})
 }

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -14,9 +14,10 @@ type DashboardProvisioner struct {
 }
 
 func Provision(ctx context.Context, configDirectory string) (*DashboardProvisioner, error) {
+	log := log.New("provisioning.dashboard")
 	d := &DashboardProvisioner{
-		cfgReader: &configReader{path: configDirectory},
-		log:       log.New("provisioning.dashboard"),
+		cfgReader: &configReader{path: configDirectory, log: log},
+		log:       log,
 		ctx:       ctx,
 	}
 

--- a/pkg/services/provisioning/datasources/datasources_test.go
+++ b/pkg/services/provisioning/datasources/datasources_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	logger                          log.Logger = log.New("fake.logger")
+	logger                          log.Logger = log.New("fake.log")
 	oneDatasourcesConfig            string     = ""
 	twoDatasourcesConfig            string     = "./test-configs/two-datasources"
 	twoDatasourcesConfigPurgeOthers string     = "./test-configs/insert-two-delete-two"
@@ -115,12 +115,23 @@ func TestDatasourceAsConfig(t *testing.T) {
 		})
 
 		Convey("broken yaml should return error", func() {
-			_, err := configReader{}.readConfig(brokenYaml)
+			reader := &configReader{}
+			_, err := reader.readConfig(brokenYaml)
 			So(err, ShouldNotBeNil)
 		})
 
+		Convey("skip invalid directory", func() {
+			cfgProvifer := &configReader{log: log.New("test logger")}
+			cfg, err := cfgProvifer.readConfig("./invalid-directory")
+			if err != nil {
+				t.Fatalf("readConfig return an error %v", err)
+			}
+
+			So(len(cfg), ShouldEqual, 0)
+		})
+
 		Convey("can read all properties", func() {
-			cfgProvifer := configReader{}
+			cfgProvifer := &configReader{log: log.New("test logger")}
 			cfg, err := cfgProvifer.readConfig(allProperties)
 			if err != nil {
 				t.Fatalf("readConfig return an error %v", err)


### PR DESCRIPTION
This pr will stop Grafana from halting when the provisioning directory is missing. Halting on missing configuration is usually a good idea but we had a few reports about people just upgrading binaries instead of using packages. Which means they won't run the package scripts for creating folders for provisioning config files.