### PR TITLE
9903 fix templating

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -36,7 +36,7 @@ export default class CloudWatchDatasource {
       item.region = this.templateSrv.replace(this.getActualRegion(item.region), options.scopedVars);
       item.namespace = this.templateSrv.replace(item.namespace, options.scopedVars);
       item.metricName = this.templateSrv.replace(item.metricName, options.scopedVars);
-      item.dimensions = this.convertDimensionFormat(item.dimensions, options.scopeVars);
+      item.dimensions = this.convertDimensionFormat(item.dimensions, options.scopedVars);
       item.period = String(this.getPeriod(item, options)); // use string format for period in graph query, and alerting
 
       return _.extend(


### PR DESCRIPTION
This PR should fix the issue #9903:

Steps to verify that templating is working with cloudwatch:

* Add a aws-cloudwatch datasource to grafana
* Add a new dashboard 
* Add a variable to the new dashboard
  * Name: "instanceId"
  * Type: "Query"
  * Data source: select the aws-cloudwatch datasource
  * Query: "ec2_instance_attribute(<your-region>, InstanceId, {})"
  * Select:  "Multi-value" and "Include All option"
* Add Graf to Dashboard:
  * under General: 
    * Title: $instanceId
    * select Repeat-> "For each value of" -> instanceId (name of var)
  * under metic:
    * select same Datasource
    * add a query with region, 
      * Namespace=AWS/EC2,
      *  metric=CPUUtilization 
      * Dimensions: InstanceId=$instanceId
  * save and reload the dashboard
* go an select "All" for instanceId
* The result should be one CPUUtilization graph for each instance you have running in the aws.
