### PR TITLE
graphite: fix nested alerting queries

### DIFF
--- a/public/app/plugins/datasource/graphite/specs/graphite_query.jest.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.jest.ts
@@ -1,0 +1,47 @@
+import gfunc from '../gfunc';
+import GraphiteQuery from '../graphite_query';
+
+describe('Graphite query model', () => {
+  let ctx: any = {
+    datasource: {
+      getFuncDef: gfunc.getFuncDef,
+      getFuncDefs: jest.fn().mockReturnValue(Promise.resolve(gfunc.getFuncDefs('1.0'))),
+      waitForFuncDefsLoaded: jest.fn().mockReturnValue(Promise.resolve(null)),
+      createFuncInstance: gfunc.createFuncInstance,
+    },
+    templateSrv: {},
+    targets: [],
+  };
+
+  beforeEach(() => {
+    ctx.target = { refId: 'A', target: 'scaleToSeconds(#A, 60)' };
+    ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+  });
+
+  describe('when updating targets with nested queries', () => {
+    beforeEach(() => {
+      ctx.target = { refId: 'D', target: 'asPercent(#A, #C)' };
+      ctx.targets = [
+        { refId: 'A', target: 'first.query.count' },
+        { refId: 'B', target: 'second.query.count' },
+        { refId: 'C', target: 'diffSeries(#A, #B)' },
+        { refId: 'D', target: 'asPercent(#A, #C)' },
+      ];
+      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+    });
+
+    it('targetFull should include nested queries', () => {
+      ctx.queryModel.updateRenderedTarget(ctx.target, ctx.targets);
+      const targetFullExpected = 'asPercent(first.query.count, diffSeries(first.query.count, second.query.count))';
+      expect(ctx.queryModel.target.targetFull).toBe(targetFullExpected);
+    });
+
+    it('should not hang on circular references', () => {
+      ctx.target.target = 'asPercent(#A, #B)';
+      ctx.targets = [{ refId: 'A', target: 'asPercent(#B, #C)' }, { refId: 'B', target: 'asPercent(#A, #C)' }];
+      ctx.queryModel.updateRenderedTarget(ctx.target, ctx.targets);
+      // Just ensure updateRenderedTarget() is completed and doesn't hang
+      expect(ctx.queryModel.target.targetFull).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
This PR closes #9917
Changed way to detect circular references from dummy single level to more complicated based on ref count. Added tests for deeply nested queries and query with circular references.