### PR TITLE
10628 search media break

### DIFF
--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -273,7 +273,8 @@
 @include media-breakpoint-down(sm) {
   .search-dropdown__col_2 {
     flex-direction: column;
-    height: 100%;
+    height: 80%;
+    justify-content: flex-start;
   }
 
   .search-filter-box {

--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -248,6 +248,39 @@
   background: $panel-bg;
 }
 
+@include media-breakpoint-down(md) {
+  .search-dropdown {
+    flex-direction: column;
+  }
+
+  .search-dropdown__col_1 {
+    height: 100%;
+  }
+
+  .search-dropdown__col_2 {
+    max-width: 700px;
+    flex-direction: row;
+    margin: 0;
+    justify-content: space-between;
+    height: 260px;
+  }
+
+  .search-filter-box {
+    margin: 0;
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  .search-dropdown__col_2 {
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .search-filter-box {
+    margin-bottom: 1.5rem;
+  }
+}
+
 @include media-breakpoint-down(xs) {
   .search-container {
     left: 0;

--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -10,7 +10,7 @@
 }
 
 .search-container {
-  left: $side-menu-width;
+  left: 0;
   top: 0;
   right: 0;
   bottom: 0;
@@ -58,7 +58,7 @@
 
 .search-dropdown {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   height: calc(100% - #{$navbarHeight});
 }
 
@@ -74,7 +74,7 @@
   flex-grow: 1;
   height: 100%;
   padding-top: 16px;
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: flex-start;
 }
@@ -85,7 +85,6 @@
   padding: $spacer*1.5;
   min-width: 340px;
   margin-bottom: $spacer * 1.5;
-  margin-left: $spacer * 1.5;
 }
 
 .search-filter-box__header {
@@ -215,7 +214,8 @@
 }
 
 .search-item__tags {
-  padding: 10px;
+  display: none;
+  //padding: 10px;
 }
 
 .search-item__actions {
@@ -248,50 +248,45 @@
   background: $panel-bg;
 }
 
-@include media-breakpoint-down(md) {
-  .search-dropdown {
-    flex-direction: column;
+@include media-breakpoint-up(sm) {
+  .search-container {
+    left: $side-menu-width;
+  }
+
+  .search-dropdown__col_2 {
+    display: flex;
+    margin-bottom: 1rem;
+  }
+}
+
+@include media-breakpoint-up(md) {
+  .search-dropdown__col_2 {
+    flex-direction: row;
+    justify-content: space-between;
+    max-width: 700px;
+    height: 260px;
   }
 
   .search-dropdown__col_1 {
     height: 100%;
   }
 
-  .search-dropdown__col_2 {
-    max-width: 700px;
-    flex-direction: row;
-    margin: 0;
-    justify-content: space-between;
-    height: 260px;
-  }
-
   .search-filter-box {
     margin: 0;
   }
 }
 
-@include media-breakpoint-down(sm) {
+@include media-breakpoint-up(lg) {
+  .search-dropdown {
+    flex-direction: row;
+  }
+
   .search-dropdown__col_2 {
     flex-direction: column;
-    height: 80%;
-    justify-content: flex-start;
   }
 
   .search-filter-box {
-    margin-bottom: 1.5rem;
-  }
-}
-
-@include media-breakpoint-down(xs) {
-  .search-container {
-    left: 0;
-  }
-
-  .search-dropdown__col_2 {
-    display: none;
-  }
-
-  .search-item__tags {
-    display: none;
+    margin-left: $spacer * 1.5;
+    margin-bottom: $spacer * 1.5;
   }
 }


### PR DESCRIPTION

search_dropdown is now flex-direction column.
for md .search-dropdown__col_2 is in row with fixed height. scroll is done on .search-dropdown__col_1 only
md on laptop:
<img width="570" alt="skarmavbild 2018-01-26 kl 14 43 20" src="https://user-images.githubusercontent.com/23470681/35442671-5c0c254c-02a8-11e8-97e8-25348621dad6.png">
md on ipad:
<img width="570" alt="skarmavbild 2018-01-26 kl 14 43 20" src="https://user-images.githubusercontent.com/23470681/35442727-88a6f208-02a8-11e8-89e7-f3401c313312.png">

sm on laptop:
<img width="735" alt="skarmavbild 2018-01-26 kl 14 56 54" src="https://user-images.githubusercontent.com/23470681/35442946-7abc718a-02a9-11e8-8f51-b76e96fd32ef.png">



