### PR TITLE
WIP: Dashboard & Persistent urls - Second Step

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -245,6 +245,7 @@ func (hs *HttpServer) registerRoutes() {
 			dashboardRoute.Get("/uid/:uid", wrap(GetDashboard))
 
 			dashboardRoute.Get("/db/:slug", wrap(GetDashboard))
+			dashboardRoute.Get("/db/:slug/uid", wrap(GetDashboardUidBySlug))
 			dashboardRoute.Delete("/db/:slug", reqEditorRole, wrap(DeleteDashboard))
 
 			dashboardRoute.Post("/calculate-diff", bind(dtos.CalculateDiffOptions{}), wrap(CalculateDashboardDiff))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -242,6 +242,8 @@ func (hs *HttpServer) registerRoutes() {
 
 		// Dashboard
 		apiRoute.Group("/dashboards", func(dashboardRoute RouteRegister) {
+			dashboardRoute.Get("/uid/:uid", wrap(GetDashboard))
+
 			dashboardRoute.Get("/db/:slug", wrap(GetDashboard))
 			dashboardRoute.Delete("/db/:slug", reqEditorRole, wrap(DeleteDashboard))
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -113,6 +113,21 @@ func GetDashboard(c *middleware.Context) Response {
 	return Json(200, dto)
 }
 
+func GetDashboardUidBySlug(c *middleware.Context) Response {
+	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, "")
+	if rsp != nil {
+		return rsp
+	}
+
+	guardian := guardian.NewDashboardGuardian(dash.Id, c.OrgId, c.SignedInUser)
+	if canView, err := guardian.CanView(); err != nil || !canView {
+		fmt.Printf("%v", err)
+		return dashboardGuardianResponse(err)
+	}
+
+	return Json(200, util.DynMap{"uid": dash.Uid})
+}
+
 func getUserLogin(userId int64) string {
 	query := m.GetUserByIdQuery{Id: userId}
 	err := bus.Dispatch(&query)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -44,7 +44,7 @@ func dashboardGuardianResponse(err error) Response {
 }
 
 func GetDashboard(c *middleware.Context) Response {
-	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0)
+	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, c.Params(":uid"))
 	if rsp != nil {
 		return rsp
 	}
@@ -124,8 +124,15 @@ func getUserLogin(userId int64) string {
 	}
 }
 
-func getDashboardHelper(orgId int64, slug string, id int64) (*m.Dashboard, Response) {
-	query := m.GetDashboardQuery{Slug: slug, Id: id, OrgId: orgId}
+func getDashboardHelper(orgId int64, slug string, id int64, uid string) (*m.Dashboard, Response) {
+	var query m.GetDashboardQuery
+
+	if len(uid) > 0 {
+		query = m.GetDashboardQuery{Uid: uid, Id: id, OrgId: orgId}
+	} else {
+		query = m.GetDashboardQuery{Slug: slug, Id: id, OrgId: orgId}
+	}
+
 	if err := bus.Dispatch(&query); err != nil {
 		return nil, ApiError(404, "Dashboard not found", err)
 	}
@@ -133,7 +140,7 @@ func getDashboardHelper(orgId int64, slug string, id int64) (*m.Dashboard, Respo
 }
 
 func DeleteDashboard(c *middleware.Context) Response {
-	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0)
+	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, "")
 	if rsp != nil {
 		return rsp
 	}
@@ -393,7 +400,7 @@ func CalculateDashboardDiff(c *middleware.Context, apiOptions dtos.CalculateDiff
 
 // RestoreDashboardVersion restores a dashboard to the given version.
 func RestoreDashboardVersion(c *middleware.Context, apiCmd dtos.RestoreDashboardVersionCommand) Response {
-	dash, rsp := getDashboardHelper(c.OrgId, "", c.ParamsInt64(":dashboardId"))
+	dash, rsp := getDashboardHelper(c.OrgId, "", c.ParamsInt64(":dashboardId"), "")
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -101,6 +101,12 @@ func GetDashboard(c *middleware.Context) Response {
 		meta.FolderTitle = query.Result.Title
 	}
 
+	if dash.IsFolder {
+		meta.Url = m.GetFolderUrl(dash.Uid, dash.Slug)
+	} else {
+		meta.Url = m.GetDashboardUrl(dash.Uid, dash.Slug)
+	}
+
 	// make sure db version is in sync with json model version
 	dash.Data.Set("version", dash.Version)
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -47,6 +47,11 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			return nil
 		})
 
+		bus.AddHandler("test", func(query *m.GetDashboardUidBySlugQuery) error {
+			query.Result = fakeDash.Uid
+			return nil
+		})
+
 		viewerRole := m.ROLE_VIEWER
 		editorRole := m.ROLE_EDITOR
 
@@ -104,6 +109,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				})
 			})
 
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
+				})
+			})
+
 			loggedInUserScenarioWithRole("When calling DELETE on", "DELETE", "/api/dashboards/db/child-dash", "/api/dashboards/db/:slug", role, func(sc *scenarioContext) {
 				CallDeleteDashboard(sc)
 				So(sc.resp.Code, ShouldEqual, 403)
@@ -157,6 +170,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 					So(dash.Meta.CanEdit, ShouldBeTrue)
 					So(dash.Meta.CanSave, ShouldBeTrue)
 					So(dash.Meta.CanAdmin, ShouldBeFalse)
+				})
+			})
+
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
 				})
 			})
 
@@ -241,6 +262,11 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			return nil
 		})
 
+		bus.AddHandler("test", func(query *m.GetDashboardUidBySlugQuery) error {
+			query.Result = fakeDash.Uid
+			return nil
+		})
+
 		bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
 			query.Result = []*m.Team{}
 			return nil
@@ -278,6 +304,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				Convey("Should lookup dashboard by uid", func() {
 					So(getDashboardQueries[0].Uid, ShouldEqual, "abcdefghi")
 				})
+
+				Convey("Should be denied access", func() {
+					So(sc.resp.Code, ShouldEqual, 403)
+				})
+			})
+
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				CallGetDashboardUidBySlug(sc)
 
 				Convey("Should be denied access", func() {
 					So(sc.resp.Code, ShouldEqual, 403)
@@ -332,6 +366,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				Convey("Should lookup dashboard by uid", func() {
 					So(getDashboardQueries[0].Uid, ShouldEqual, "abcdefghi")
 				})
+
+				Convey("Should be denied access", func() {
+					So(sc.resp.Code, ShouldEqual, 403)
+				})
+			})
+
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				CallGetDashboardUidBySlug(sc)
 
 				Convey("Should be denied access", func() {
 					So(sc.resp.Code, ShouldEqual, 403)
@@ -400,6 +442,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 					So(dash.Meta.CanEdit, ShouldBeTrue)
 					So(dash.Meta.CanSave, ShouldBeTrue)
 					So(dash.Meta.CanAdmin, ShouldBeFalse)
+				})
+			})
+
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
 				})
 			})
 
@@ -474,6 +524,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				})
 			})
 
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
+				})
+			})
+
 			loggedInUserScenarioWithRole("When calling DELETE on", "DELETE", "/api/dashboards/db/child-dash", "/api/dashboards/db/:slug", role, func(sc *scenarioContext) {
 				CallDeleteDashboard(sc)
 				So(sc.resp.Code, ShouldEqual, 403)
@@ -521,6 +579,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 					So(dash.Meta.CanEdit, ShouldBeTrue)
 					So(dash.Meta.CanSave, ShouldBeTrue)
 					So(dash.Meta.CanAdmin, ShouldBeTrue)
+				})
+			})
+
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
 				})
 			})
 
@@ -592,6 +658,14 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				})
 			})
 
+			loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/dashboards/db/child-dash/uid", "/api/dashboards/db/:slug/uid", role, func(sc *scenarioContext) {
+				uid := GetDashboardUidBySlugShouldReturn200(sc)
+
+				Convey("Should return uid", func() {
+					So(uid, ShouldEqual, fakeDash.Uid)
+				})
+			})
+
 			loggedInUserScenarioWithRole("When calling DELETE on", "DELETE", "/api/dashboards/db/child-dash", "/api/dashboards/db/:slug", role, func(sc *scenarioContext) {
 				CallDeleteDashboard(sc)
 				So(sc.resp.Code, ShouldEqual, 403)
@@ -630,6 +704,20 @@ func GetDashboardShouldReturn200(sc *scenarioContext) dtos.DashboardFullWithMeta
 	So(err, ShouldBeNil)
 
 	return dash
+}
+
+func GetDashboardUidBySlugShouldReturn200(sc *scenarioContext) string {
+	CallGetDashboardUidBySlug(sc)
+
+	So(sc.resp.Code, ShouldEqual, 200)
+
+	result := sc.ToJson()
+	return result.Get("uid").MustString()
+}
+
+func CallGetDashboardUidBySlug(sc *scenarioContext) {
+	sc.handlerFunc = GetDashboardUidBySlug
+	sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
 }
 
 func CallGetDashboardVersion(sc *scenarioContext) {

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -16,6 +16,7 @@ type DashboardMeta struct {
 	CanAdmin    bool      `json:"canAdmin"`
 	CanStar     bool      `json:"canStar"`
 	Slug        string    `json:"slug"`
+	Url         string    `json:"url"`
 	Expires     time.Time `json:"expires"`
 	Created     time.Time `json:"created"`
 	Updated     time.Time `json:"updated"`

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -2,11 +2,13 @@ package models
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/gosimple/slug"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -154,6 +156,16 @@ func (dash *Dashboard) UpdateSlug() {
 
 func SlugifyTitle(title string) string {
 	return slug.Make(strings.ToLower(title))
+}
+
+// GetDashboardUrl return the html url for a dashboard
+func GetDashboardUrl(uid string, slug string) string {
+	return fmt.Sprintf("%s/d/%s/%s", setting.AppSubUrl, uid, slug)
+}
+
+// GetFolderUrl return the html url for a folder
+func GetFolderUrl(folderUid string, slug string) string {
+	return fmt.Sprintf("%s/f/%v/%s", setting.AppSubUrl, folderUid, slug)
 }
 
 //

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -219,3 +219,9 @@ type GetDashboardSlugByIdQuery struct {
 	Id     int64
 	Result string
 }
+
+type GetDashboardUidBySlugQuery struct {
+	OrgId  int64
+	Slug   string
+	Result string
+}

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -186,8 +186,9 @@ type DeleteDashboardCommand struct {
 //
 
 type GetDashboardQuery struct {
-	Slug  string // required if no Id is specified
+	Slug  string // required if no Id or Uid is specified
 	Id    int64  // optional if slug is set
+	Uid   string // optional if slug is set
 	OrgId int64
 
 	Result *Dashboard

--- a/pkg/services/search/models.go
+++ b/pkg/services/search/models.go
@@ -15,6 +15,7 @@ type Hit struct {
 	Id          int64    `json:"id"`
 	Title       string   `json:"title"`
 	Uri         string   `json:"uri"`
+	Url         string   `json:"url"`
 	Slug        string   `json:"slug"`
 	Type        HitType  `json:"type"`
 	Tags        []string `json:"tags"`

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -165,7 +165,7 @@ func setHasAcl(sess *DBSession, dash *m.Dashboard) error {
 }
 
 func GetDashboard(query *m.GetDashboardQuery) error {
-	dashboard := m.Dashboard{Slug: query.Slug, OrgId: query.OrgId, Id: query.Id}
+	dashboard := m.Dashboard{Slug: query.Slug, OrgId: query.OrgId, Id: query.Id, Uid: query.Uid}
 	has, err := x.Get(&dashboard)
 
 	if err != nil {

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -182,6 +182,7 @@ func GetDashboard(query *m.GetDashboardQuery) error {
 
 type DashboardSearchProjection struct {
 	Id          int64
+	Uid         string
 	Title       string
 	Slug        string
 	Term        string
@@ -257,10 +258,17 @@ func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []Dashboard
 	for _, item := range res {
 		hit, exists := hits[item.Id]
 		if !exists {
+			var url string
+			if item.IsFolder {
+				url = m.GetFolderUrl(item.Uid, item.Slug)
+			} else {
+				url = m.GetDashboardUrl(item.Uid, item.Slug)
+			}
 			hit = &search.Hit{
 				Id:          item.Id,
 				Title:       item.Title,
 				Uri:         "db/" + item.Slug,
+				Url:         url,
 				Slug:        item.Slug,
 				Type:        getHitType(item),
 				FolderId:    item.FolderId,
@@ -268,6 +276,7 @@ func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []Dashboard
 				FolderSlug:  item.FolderSlug,
 				Tags:        []string{},
 			}
+
 			query.Result = append(query.Result, hit)
 			hits[item.Id] = hit
 		}

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-xorm/xorm"
@@ -145,6 +146,7 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(len(query.Result), ShouldEqual, 1)
 				hit := query.Result[0]
 				So(hit.Type, ShouldEqual, search.DashHitFolder)
+				So(hit.Url, ShouldEqual, fmt.Sprintf("/f/%s/%s", savedFolder.Uid, savedFolder.Slug))
 			})
 
 			Convey("Should be able to search for a dashboard folder's children", func() {
@@ -160,6 +162,7 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(len(query.Result), ShouldEqual, 2)
 				hit := query.Result[0]
 				So(hit.Id, ShouldEqual, savedDash.Id)
+				So(hit.Url, ShouldEqual, fmt.Sprintf("/d/%s/%s", savedDash.Uid, savedDash.Slug))
 			})
 
 			Convey("Should be able to search for dashboard by dashboard ids", func() {

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -30,15 +30,33 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(savedDash.Id, ShouldNotEqual, 0)
 				So(savedDash.IsFolder, ShouldBeFalse)
 				So(savedDash.FolderId, ShouldBeGreaterThan, 0)
+				So(len(savedDash.Uid), ShouldBeGreaterThan, 0)
 
 				So(savedFolder.Title, ShouldEqual, "1 test dash folder")
 				So(savedFolder.Slug, ShouldEqual, "1-test-dash-folder")
 				So(savedFolder.Id, ShouldNotEqual, 0)
 				So(savedFolder.IsFolder, ShouldBeTrue)
 				So(savedFolder.FolderId, ShouldEqual, 0)
+				So(len(savedFolder.Uid), ShouldBeGreaterThan, 0)
 			})
 
-			Convey("Should be able to get dashboard", func() {
+			Convey("Should be able to get dashboard by id", func() {
+				query := m.GetDashboardQuery{
+					Id:    savedDash.Id,
+					OrgId: 1,
+				}
+
+				err := GetDashboard(&query)
+				So(err, ShouldBeNil)
+
+				So(query.Result.Title, ShouldEqual, "test dash 23")
+				So(query.Result.Slug, ShouldEqual, "test-dash-23")
+				So(query.Result.Id, ShouldEqual, savedDash.Id)
+				So(query.Result.Uid, ShouldEqual, savedDash.Uid)
+				So(query.Result.IsFolder, ShouldBeFalse)
+			})
+
+			Convey("Should be able to get dashboard by slug", func() {
 				query := m.GetDashboardQuery{
 					Slug:  "test-dash-23",
 					OrgId: 1,
@@ -49,6 +67,24 @@ func TestDashboardDataAccess(t *testing.T) {
 
 				So(query.Result.Title, ShouldEqual, "test dash 23")
 				So(query.Result.Slug, ShouldEqual, "test-dash-23")
+				So(query.Result.Id, ShouldEqual, savedDash.Id)
+				So(query.Result.Uid, ShouldEqual, savedDash.Uid)
+				So(query.Result.IsFolder, ShouldBeFalse)
+			})
+
+			Convey("Should be able to get dashboard by uid", func() {
+				query := m.GetDashboardQuery{
+					Uid:   savedDash.Uid,
+					OrgId: 1,
+				}
+
+				err := GetDashboard(&query)
+				So(err, ShouldBeNil)
+
+				So(query.Result.Title, ShouldEqual, "test dash 23")
+				So(query.Result.Slug, ShouldEqual, "test-dash-23")
+				So(query.Result.Id, ShouldEqual, savedDash.Id)
+				So(query.Result.Uid, ShouldEqual, savedDash.Uid)
 				So(query.Result.IsFolder, ShouldBeFalse)
 			})
 

--- a/pkg/services/sqlstore/search_builder.go
+++ b/pkg/services/sqlstore/search_builder.go
@@ -101,6 +101,7 @@ func (sb *SearchBuilder) buildSelect() {
 	sb.sql.WriteString(
 		`SELECT
 			dashboard.id,
+			dashboard.uid,
 			dashboard.title,
 			dashboard.slug,
 			dashboard_tag.term,


### PR DESCRIPTION
Work in progress tracking **Second Step** of #7883. This is a continuation of **First Step** PR #10666  

### Second step

- [x] Add support for retrieving a dashboard by unique identifier (HTTP API)

- [x] Add url to dashboard meta and search api responses

- [x] API/internal query for retrieving unique identifier by slug (fallback)