### PR TITLE
REVERTED: Conditionally select a field to return in ResponseParser for InfluxDB

### DIFF
--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -38,7 +38,7 @@ export default class ResponseParser {
     });
 
     return _.map(res, value => {
-      return { text: value };
+      return { text: value.toString() };
     });
   }
 }

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -11,14 +11,23 @@ export default class ResponseParser {
       return [];
     }
 
-    var influxdb11format = query.toLowerCase().indexOf('show tag values') >= 0;
-
     var res = {};
     _.each(influxResults.series, serie => {
       _.each(serie.values, value => {
         if (_.isArray(value)) {
-          if (influxdb11format) {
-            addUnique(res, value[1] || value[0]);
+          // In general, there are 2 possible shapes for the returned value.
+          // The first one is a two-element array,
+          // where the first element is somewhat a metadata value:
+          // the tag name for SHOW TAG VALUES queries,
+          // the time field for SELECT queries, etc.
+          // The second shape is an one-element array,
+          // that is containing an immediate value.
+          // For example, SHOW FIELD KEYS queries return such shape.
+          // Note, pre-0.11 versions return
+          // the second shape for SHOW TAG VALUES queries
+          // (while the newer versions—first).
+          if (value[1] !== undefined) {
+            addUnique(res, value[1]);
           } else {
             addUnique(res, value[0]);
           }

--- a/public/app/plugins/datasource/influxdb/specs/response_parser.jest.ts
+++ b/public/app/plugins/datasource/influxdb/specs/response_parser.jest.ts
@@ -85,6 +85,32 @@ describe('influxdb response parser', () => {
     });
   });
 
+  describe('SELECT response', () => {
+    var query = 'SELECT "usage_iowait" FROM "cpu" LIMIT 10';
+    var response = {
+      results: [
+        {
+          series: [
+            {
+              name: 'cpu',
+              columns: ['time', 'usage_iowait'],
+              values: [[1488465190006040638, 0.0], [1488465190006040638, 15.0], [1488465190006040638, 20.2]],
+            },
+          ],
+        },
+      ],
+    };
+
+    var result = parser.parse(query, response);
+
+    it('should return second column', () => {
+      expect(_.size(result)).toBe(3);
+      expect(result[0].text).toBe(0.0);
+      expect(result[1].text).toBe(15.0);
+      expect(result[2].text).toBe(20.2);
+    });
+  });
+
   describe('SHOW FIELD response', () => {
     var query = 'SHOW FIELD KEYS FROM "cpu"';
     describe('response from 0.10.0', () => {

--- a/public/app/plugins/datasource/influxdb/specs/response_parser.jest.ts
+++ b/public/app/plugins/datasource/influxdb/specs/response_parser.jest.ts
@@ -105,9 +105,9 @@ describe('influxdb response parser', () => {
 
     it('should return second column', () => {
       expect(_.size(result)).toBe(3);
-      expect(result[0].text).toBe(0.0);
-      expect(result[1].text).toBe(15.0);
-      expect(result[2].text).toBe(20.2);
+      expect(result[0].text).toBe('0');
+      expect(result[1].text).toBe('15');
+      expect(result[2].text).toBe('20.2');
     });
   });
 


### PR DESCRIPTION
This is a possible fix for #7646 (the field selection could be added later if necessary).
I'm not sure why `value[0]` was ever used before, but for SELECT queries InfluxDB always returns "time" first.
Also it is not possible to request just time—non-time field is required.

If, for some reason, returning time is needed I think we could do the following change:
```javascript
var isReturningTime = query.toLowerCase().indexOf('time as') >= 0;
var position = if (isReturningTime) { 0 } else { 1 };
addUnique(res, value[position]);		
```
What are your thought on it?

_CC @melinlab_