### PR TITLE
docs: Remove obsolete Ansible rule

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -66,7 +66,6 @@ Tool | Project
 -----|------------
 Puppet | [https://forge.puppet.com/puppet/grafana](https://forge.puppet.com/puppet/grafana)
 Ansible | [https://github.com/cloudalchemy/ansible-grafana](https://github.com/cloudalchemy/ansible-grafana)
-Ansible | [https://github.com/picotrading/ansible-grafana](https://github.com/picotrading/ansible-grafana)
 Chef | [https://github.com/JonathanTron/chef-grafana](https://github.com/JonathanTron/chef-grafana)
 Saltstack | [https://github.com/salt-formulas/salt-formula-grafana](https://github.com/salt-formulas/salt-formula-grafana)
 


### PR DESCRIPTION
According to the author, the Ansible role is obsolete:
https://github.com/picotrading/ansible-grafana/issues/8#issuecomment-342210822
As the proposed alternative (https://github.com/jtyr/ansible-grafana/) hasn't been updated in the last two years either, I'm suggesting it should be removed altogether in favor of the role maintained by cloudalchemy.