### PR TITLE
plugins: return table with empty rows array insteaf of nil

### DIFF
--- a/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper.go
+++ b/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper.go
@@ -125,6 +125,7 @@ func (tw *DatasourcePluginWrapper) mapTable(t *datasource.Table) (*tsdb.Table, e
 		})
 	}
 
+	table.Rows = make([]tsdb.RowValues, 0)
 	for _, r := range t.GetRows() {
 		row := tsdb.RowValues{}
 		for _, rv := range r.Values {


### PR DESCRIPTION
This PR fixes issue when table query returns an empty set and rows passed as `null` to frontend instead of an empty array.