### PR TITLE
Support search/filter in new Add Panel 

### DIFF
--- a/public/app/features/dashboard/dashgrid/AddPanelPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/AddPanelPanel.tsx
@@ -56,6 +56,16 @@ export class AddPanelPanel extends React.Component<AddPanelPanelProps, AddPanelP
     return _.sortBy(panels, 'sort');
   }
 
+  getFilteredPlugins() {
+    if (this.state.filter.length > 0) {
+      const check = this.state.filter.toLowerCase();
+      return this.state.panelPlugins.filter(p => {
+        return p.name.toLowerCase().indexOf(check) >= 0;
+      });
+    }
+    return this.state.panelPlugins;
+  }
+
   onAddPanel = panelPluginInfo => {
     const panelContainer = this.props.getPanelContainer();
     const dashboard = panelContainer.getDashboard();
@@ -85,6 +95,10 @@ export class AddPanelPanel extends React.Component<AddPanelPanelProps, AddPanelP
     dashboard.removePanel(this.props.panel);
   };
 
+  onFilterChange = event => {
+    this.setState({ filter: event.target.value });
+  };
+
   handleCloseAddPanel(evt) {
     evt.preventDefault();
     const panelContainer = this.props.getPanelContainer();
@@ -93,7 +107,6 @@ export class AddPanelPanel extends React.Component<AddPanelPanelProps, AddPanelP
   }
 
   renderPanelItem(panel, index) {
-    console.log('render panel', index);
     return (
       <div key={index} className="add-panel__item" onClick={() => this.onAddPanel(panel)} title={panel.name}>
         <img className="add-panel__item-img" src={panel.info.logos.small} />
@@ -109,12 +122,18 @@ export class AddPanelPanel extends React.Component<AddPanelPanelProps, AddPanelP
           <div className="add-panel__header">
             <i className="gicon gicon-add-panel" />
             <span className="add-panel__title">New Panel</span>
-            <span className="add-panel__sub-title">Select a visualization</span>
+            <input
+              type="text"
+              autoFocus
+              className="add-panel__sub-title"
+              onChange={this.onFilterChange.bind(this)}
+              placeholder="Select a visualization"
+            />
             <button className="add-panel__close" onClick={this.handleCloseAddPanel}>
               <i className="fa fa-close" />
             </button>
           </div>
-          <ScrollBar className="add-panel__items">{this.state.panelPlugins.map(this.renderPanelItem)}</ScrollBar>
+          <ScrollBar className="add-panel__items">{this.getFilteredPlugins().map(this.renderPanelItem)}</ScrollBar>
         </div>
       </div>
     );

--- a/public/sass/components/_panel_add_panel.scss
+++ b/public/sass/components/_panel_add_panel.scss
@@ -30,6 +30,7 @@
   font-style: italic;
   color: $text-muted;
   position: relative;
+  background-color: transparent;
   top: 1px;
 }
 


### PR DESCRIPTION
In 4.x the Add Panel UI started with a 'panel search filter' -- this is super useful when you have a bunch of plugins installed!

This is a simple patch that turns the new 'Select a Visualization' text into an input field an uses it for the filter.

![image](https://user-images.githubusercontent.com/705951/35723575-12b3a732-07fb-11e8-9775-5d94aaf2d472.png)

![image](https://user-images.githubusercontent.com/705951/35723599-27bc0ee4-07fb-11e8-91f4-4254d6cde7fb.png)

I made the input background transparent so it looks the same as before -- but not great UX to have secret functions :)  Any style suggestions would be great.  The other option is a big search box above all the panels.



