### PR TITLE
#10724 Fix finding the x bucket

### DIFF
--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -157,11 +157,11 @@ export class HeatmapTooltip {
       return x-bucket.x <= data.xBucketSize && x-bucket.x >0;
     });
     let xBucketIndex;
-    if(!xBucket)
+    if (!xBucket) {
       xBucketIndex = getValueBucketBound(x, data.xBucketSize, 1);
-    else
+    } else {
       xBucketIndex = xBucket.x;
-
+    }
     return xBucketIndex;
   }
 

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -153,7 +153,15 @@ export class HeatmapTooltip {
 
   getXBucketIndex(offsetX, data) {
     let x = this.scope.xScale.invert(offsetX - this.scope.yAxisWidth).valueOf();
-    let xBucketIndex = getValueBucketBound(x, data.xBucketSize, 1);
+    let xBucket = _.find(data.buckets, (bucket, bucketIndex) => {
+      return x-bucket.x <= data.xBucketSize && x-bucket.x >0;
+    });
+    let xBucketIndex;
+    if(!xBucket)
+      xBucketIndex = getValueBucketBound(x, data.xBucketSize, 1);
+    else
+      xBucketIndex = xBucket.x;
+
     return xBucketIndex;
   }
 


### PR DESCRIPTION
This correctly finds the x bucket. There is an outstanding issue that a y bucket is not found on log scales if your buckets don't line up perfectly with the log scale
@alexanderzobnin  I'm not a ui guy so there may be better ways to handle this. I also don't know anything about js unit tests, but I've got test data that can make it fail if someone wants to build a unit test around it.