### PR TITLE
Redirect of legacy dashboard url's should include querystring parameters

### DIFF
--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -24,6 +25,7 @@ func RedirectFromLegacyDashboardUrl() macaron.Handler {
 
 		if slug != "" {
 			if url, err := getDashboardUrlBySlug(c.OrgId, slug); err == nil {
+				url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
 				c.Redirect(url, 301)
 				return
 			}
@@ -38,6 +40,7 @@ func RedirectFromLegacyDashboardSoloUrl() macaron.Handler {
 		if slug != "" {
 			if url, err := getDashboardUrlBySlug(c.OrgId, slug); err == nil {
 				url = strings.Replace(url, "/d/", "/d-solo/", 1)
+				url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
 				c.Redirect(url, 301)
 				return
 			}

--- a/pkg/middleware/dashboard_redirect_test.go
+++ b/pkg/middleware/dashboard_redirect_test.go
@@ -30,19 +30,20 @@ func TestMiddlewareDashboardRedirect(t *testing.T) {
 		middlewareScenario("GET dashboard by legacy url", func(sc *scenarioContext) {
 			sc.m.Get("/dashboard/db/:slug", redirectFromLegacyDashboardUrl, sc.defaultHandler)
 
-			sc.fakeReqWithParams("GET", "/dashboard/db/dash", map[string]string{}).exec()
+			sc.fakeReqWithParams("GET", "/dashboard/db/dash?orgId=1&panelId=2", map[string]string{}).exec()
 
 			Convey("Should redirect to new dashboard url with a 301 Moved Permanently", func() {
 				So(sc.resp.Code, ShouldEqual, 301)
 				redirectUrl, _ := sc.resp.Result().Location()
 				So(redirectUrl.Path, ShouldEqual, m.GetDashboardUrl(fakeDash.Uid, fakeDash.Slug))
+				So(len(redirectUrl.Query()), ShouldEqual, 2)
 			})
 		})
 
 		middlewareScenario("GET dashboard solo by legacy url", func(sc *scenarioContext) {
 			sc.m.Get("/dashboard-solo/db/:slug", redirectFromLegacyDashboardSoloUrl, sc.defaultHandler)
 
-			sc.fakeReqWithParams("GET", "/dashboard-solo/db/dash", map[string]string{}).exec()
+			sc.fakeReqWithParams("GET", "/dashboard-solo/db/dash?orgId=1&panelId=2", map[string]string{}).exec()
 
 			Convey("Should redirect to new dashboard url with a 301 Moved Permanently", func() {
 				So(sc.resp.Code, ShouldEqual, 301)
@@ -50,6 +51,7 @@ func TestMiddlewareDashboardRedirect(t *testing.T) {
 				expectedUrl := m.GetDashboardUrl(fakeDash.Uid, fakeDash.Slug)
 				expectedUrl = strings.Replace(expectedUrl, "/d/", "/d-solo/", 1)
 				So(redirectUrl.Path, ShouldEqual, expectedUrl)
+				So(len(redirectUrl.Query()), ShouldEqual, 2)
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #10752