### PR TITLE
adds unique index for org_id+folder_id+title on dashboards

### DIFF
--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -167,4 +167,8 @@ func addDashboardMigration(mg *Migrator) {
 	mg.AddMigration("Remove unique index org_id_slug", NewDropIndexMigration(dashboardV2, &Index{
 		Cols: []string{"org_id", "slug"}, Type: UniqueIndex,
 	}))
+
+	mg.AddMigration("Add unique index for dashboard_org_id_title_folder_id", NewAddIndexMigration(dashboardV2, &Index{
+		Cols: []string{"org_id", "folder_id", "title"}, Type: UniqueIndex,
+	}))
 }


### PR DESCRIPTION
This might fail if you already have a duplicate dashboard in the same folder. So make sure to check your db first. 