### PR TITLE
Stale permissions

### DIFF
--- a/pkg/api/dashboard_acl.go
+++ b/pkg/api/dashboard_acl.go
@@ -24,6 +24,12 @@ func GetDashboardAclList(c *middleware.Context) Response {
 		return ApiError(500, "Failed to get dashboard acl", err)
 	}
 
+	for _, perm := range acl {
+		if perm.Slug != "" {
+			perm.Url = m.GetDashboardFolderUrl(perm.IsFolder, perm.Uid, perm.Slug)
+		}
+	}
+
 	return Json(200, acl)
 }
 

--- a/pkg/models/dashboard_acl.go
+++ b/pkg/models/dashboard_acl.go
@@ -59,6 +59,11 @@ type DashboardAclInfoDTO struct {
 	Role           *RoleType      `json:"role,omitempty"`
 	Permission     PermissionType `json:"permission"`
 	PermissionName string         `json:"permissionName"`
+	Uid            string         `json:"uid"`
+	Title          string         `json:"title"`
+	Slug           string         `json:"slug"`
+	IsFolder       bool           `json:"isFolder"`
+	Url            string         `json:"url"`
 }
 
 //

--- a/public/app/containers/ManageDashboards/FolderPermissions.tsx
+++ b/public/app/containers/ManageDashboards/FolderPermissions.tsx
@@ -63,7 +63,7 @@ export class FolderPermissions extends Component<IContainerProps, any> {
             </button>
           </div>
           <SlideDown in={permissions.isAddPermissionsVisible}>
-            <AddPermissions permissions={permissions} backendSrv={backendSrv} dashboardId={dashboardId} />
+            <AddPermissions permissions={permissions} backendSrv={backendSrv} />
           </SlideDown>
           <Permissions permissions={permissions} isFolder={true} dashboardId={dashboardId} backendSrv={backendSrv} />
         </div>

--- a/public/app/core/components/Permissions/AddPermissions.jest.tsx
+++ b/public/app/core/components/Permissions/AddPermissions.jest.tsx
@@ -26,7 +26,7 @@ describe('AddPermissions', () => {
       }
     );
 
-    wrapper = shallow(<AddPermissions permissions={store.permissions} backendSrv={backendSrv} dashboardId={1} />);
+    wrapper = shallow(<AddPermissions permissions={store.permissions} backendSrv={backendSrv} />);
     instance = wrapper.instance();
     return store.permissions.load(1, true, false);
   });

--- a/public/app/core/components/Permissions/AddPermissions.tsx
+++ b/public/app/core/components/Permissions/AddPermissions.tsx
@@ -9,7 +9,6 @@ import { permissionOptions } from 'app/stores/PermissionsStore/PermissionsStore'
 export interface IProps {
   permissions: any;
   backendSrv: any;
-  dashboardId: any;
 }
 @observer
 class AddPermissions extends Component<IProps, any> {
@@ -30,12 +29,6 @@ class AddPermissions extends Component<IProps, any> {
   typeChanged(evt) {
     const { value } = evt.target;
     const { permissions } = this.props;
-
-    // if (value === 'Viewer' || value === 'Editor') {
-    // //   permissions.addStoreItem({ permission: 1, role: value, dashboardId: dashboardId }, dashboardId);
-    // //   this.resetNewType();
-    //   return;
-    // }
 
     permissions.setNewType(value);
   }

--- a/public/app/core/components/Permissions/DashboardPermissions.tsx
+++ b/public/app/core/components/Permissions/DashboardPermissions.tsx
@@ -53,7 +53,7 @@ class DashboardPermissions extends Component<IProps, any> {
           </div>
         </div>
         <SlideDown in={this.permissions.isAddPermissionsVisible}>
-          <AddPermissions permissions={this.permissions} backendSrv={backendSrv} dashboardId={dashboardId} />
+          <AddPermissions permissions={this.permissions} backendSrv={backendSrv} />
         </SlideDown>
         <Permissions
           permissions={this.permissions}

--- a/public/app/features/dashboard/settings/settings.html
+++ b/public/app/features/dashboard/settings/settings.html
@@ -96,11 +96,14 @@
 </div>
 
 <div class="dashboard-settings__content" ng-if="ctrl.viewId === 'permissions'" >
-  <dashboard-permissions ng-if="ctrl.dashboard"
+  <dashboard-permissions ng-if="ctrl.dashboard && !ctrl.hasUnsavedFolderChange"
     dashboardId="ctrl.dashboard.id"
     backendSrv="ctrl.backendSrv"
     folder="ctrl.getFolder()"
   />
+  <div ng-if="ctrl.hasUnsavedFolderChange">
+    <h5>You have changed folder, please save to view permissions.</h5>
+  </div>
 </div>
 
 <div class="dashboard-settings__content" ng-if="ctrl.viewId === '404'">

--- a/public/app/features/dashboard/settings/settings.ts
+++ b/public/app/features/dashboard/settings/settings.ts
@@ -201,7 +201,6 @@ export class SettingsCtrl {
   onFolderChange(folder) {
     this.dashboard.meta.folderId = folder.id;
     this.dashboard.meta.folderTitle = folder.title;
-    this.dashboard.meta.folderSlug = folder.slug;
     this.hasUnsavedFolderChange = true;
   }
 

--- a/public/app/features/dashboard/settings/settings.ts
+++ b/public/app/features/dashboard/settings/settings.ts
@@ -14,6 +14,7 @@ export class SettingsCtrl {
   canSave: boolean;
   canDelete: boolean;
   sections: any[];
+  hasUnsavedFolderChange: boolean;
 
   /** @ngInject */
   constructor(private $scope, private $location, private $rootScope, private backendSrv, private dashboardSrv) {
@@ -38,6 +39,7 @@ export class SettingsCtrl {
 
     this.$rootScope.onAppEvent('$routeUpdate', this.onRouteUpdated.bind(this), $scope);
     this.$rootScope.appEvent('dash-scroll', { animate: false, pos: 0 });
+    this.$rootScope.onAppEvent('dashboard-saved', this.onPostSave.bind(this), $scope);
   }
 
   buildSectionList() {
@@ -135,6 +137,10 @@ export class SettingsCtrl {
     this.dashboardSrv.saveDashboard();
   }
 
+  onPostSave() {
+    this.hasUnsavedFolderChange = false;
+  }
+
   hideSettings() {
     var urlParams = this.$location.search();
     delete urlParams.editview;
@@ -196,6 +202,7 @@ export class SettingsCtrl {
     this.dashboard.meta.folderId = folder.id;
     this.dashboard.meta.folderTitle = folder.title;
     this.dashboard.meta.folderSlug = folder.slug;
+    this.hasUnsavedFolderChange = true;
   }
 
   getFolder() {

--- a/public/app/stores/FolderStore/FolderStore.ts
+++ b/public/app/stores/FolderStore/FolderStore.ts
@@ -2,6 +2,7 @@ import { types, getEnv, flow } from 'mobx-state-tree';
 
 export const Folder = types.model('Folder', {
   id: types.identifier(types.number),
+  uid: types.string,
   title: types.string,
   url: types.string,
   canSave: types.boolean,
@@ -18,6 +19,7 @@ export const FolderStore = types
       const res = yield backendSrv.getDashboardByUid(uid);
       self.folder = Folder.create({
         id: res.dashboard.id,
+        uid: uid,
         title: res.dashboard.title,
         url: res.meta.url,
         canSave: res.meta.canSave,

--- a/public/app/stores/FolderStore/FolderStore.ts
+++ b/public/app/stores/FolderStore/FolderStore.ts
@@ -2,7 +2,6 @@ import { types, getEnv, flow } from 'mobx-state-tree';
 
 export const Folder = types.model('Folder', {
   id: types.identifier(types.number),
-  uid: types.string,
   title: types.string,
   url: types.string,
   canSave: types.boolean,
@@ -19,7 +18,6 @@ export const FolderStore = types
       const res = yield backendSrv.getDashboardByUid(uid);
       self.folder = Folder.create({
         id: res.dashboard.id,
-        uid: uid,
         title: res.dashboard.title,
         url: res.meta.url,
         canSave: res.meta.canSave,


### PR DESCRIPTION
Handles the usecase where a user changes folder in dashboard settings and the permissions list shows permissions from the original folder. This PR hides the permission list in that case and shows a message saying to save the dashboard first.
