### PR TITLE
org-switcher: should redirect to home page

### DIFF
--- a/public/app/core/components/org_switcher.ts
+++ b/public/app/core/components/org_switcher.ts
@@ -1,5 +1,6 @@
 import coreModule from 'app/core/core_module';
 import { contextSrv } from 'app/core/services/context_srv';
+import config from 'app/core/config';
 
 const template = `
 <div class="modal-body">
@@ -60,16 +61,11 @@ export class OrgSwitchCtrl {
 
   setUsingOrg(org) {
     return this.backendSrv.post('/api/user/using/' + org.orgId).then(() => {
-      const re = /orgId=\d+/gi;
-      this.setWindowLocationHref(this.getWindowLocationHref().replace(re, 'orgId=' + org.orgId));
+      this.setWindowLocation(config.appSubUrl + (config.appSubUrl.endsWith('/') ? '' : '/') + '?orgId=' + org.orgId);
     });
   }
 
-  getWindowLocationHref() {
-    return window.location.href;
-  }
-
-  setWindowLocationHref(href: string) {
+  setWindowLocation(href: string) {
     window.location.href = href;
   }
 }

--- a/public/app/core/specs/org_switcher.jest.ts
+++ b/public/app/core/specs/org_switcher.jest.ts
@@ -7,6 +7,12 @@ jest.mock('app/core/services/context_srv', () => ({
   },
 }));
 
+jest.mock('app/core/config', () => {
+  return {
+    appSubUrl: '/subUrl',
+  };
+});
+
 describe('OrgSwitcher', () => {
   describe('when switching org', () => {
     let expectedHref;
@@ -25,8 +31,7 @@ describe('OrgSwitcher', () => {
 
       const orgSwitcherCtrl = new OrgSwitchCtrl(backendSrvStub);
 
-      orgSwitcherCtrl.getWindowLocationHref = () => 'http://localhost:3000?orgId=1&from=now-3h&to=now';
-      orgSwitcherCtrl.setWindowLocationHref = href => (expectedHref = href);
+      orgSwitcherCtrl.setWindowLocation = href => (expectedHref = href);
 
       return orgSwitcherCtrl.setUsingOrg({ orgId: 2 });
     });
@@ -35,8 +40,8 @@ describe('OrgSwitcher', () => {
       expect(expectedUsingUrl).toBe('/api/user/using/2');
     });
 
-    it('should switch orgId in url', () => {
-      expect(expectedHref).toBe('http://localhost:3000?orgId=2&from=now-3h&to=now');
+    it('should switch orgId in url and redirect to home page', () => {
+      expect(expectedHref).toBe('/subUrl/?orgId=2');
     });
   });
 });


### PR DESCRIPTION
Fixes #10776

Use appSubUrl from the config so that it handles subpaths when switching org.
