### PR TITLE
embedded panel: hide side menu during init

### DIFF
--- a/public/app/features/panel/solo_panel_ctrl.ts
+++ b/public/app/features/panel/solo_panel_ctrl.ts
@@ -9,7 +9,7 @@ export class SoloPanelCtrl {
 
     $scope.init = function() {
       contextSrv.sidemenu = false;
-      appEvents.emit('toggle-sidemenu');
+      appEvents.emit('toggle-sidemenu-hidden');
 
       var params = $location.search();
       panelId = parseInt(params.panelId);


### PR DESCRIPTION
This PR fixes #10787 by emitting `toggle-sidemenu-hidden` event during dashboard init.