### PR TITLE
Always make sure dashboard exist in dashboard acl http api

### DIFF
--- a/pkg/api/dashboard_acl.go
+++ b/pkg/api/dashboard_acl.go
@@ -13,6 +13,11 @@ import (
 func GetDashboardAclList(c *middleware.Context) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
+	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")
+	if rsp != nil {
+		return rsp
+	}
+
 	guardian := guardian.NewDashboardGuardian(dashId, c.OrgId, c.SignedInUser)
 
 	if canAdmin, err := guardian.CanAdmin(); err != nil || !canAdmin {
@@ -35,6 +40,11 @@ func GetDashboardAclList(c *middleware.Context) Response {
 
 func UpdateDashboardAcl(c *middleware.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
 	dashId := c.ParamsInt64(":dashboardId")
+
+	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")
+	if rsp != nil {
+		return rsp
+	}
 
 	guardian := guardian.NewDashboardGuardian(dashId, c.OrgId, c.SignedInUser)
 	if canAdmin, err := guardian.CanAdmin(); err != nil || !canAdmin {
@@ -78,6 +88,11 @@ func UpdateDashboardAcl(c *middleware.Context, apiCmd dtos.UpdateDashboardAclCom
 func DeleteDashboardAcl(c *middleware.Context) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 	aclId := c.ParamsInt64(":aclId")
+
+	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")
+	if rsp != nil {
+		return rsp
+	}
 
 	guardian := guardian.NewDashboardGuardian(dashId, c.OrgId, c.SignedInUser)
 	if canAdmin, err := guardian.CanAdmin(); err != nil || !canAdmin {


### PR DESCRIPTION
Fixes #10842 

There still be some work left to do regarding add/remove user/team permission for dashboard when your admin in multiple organizations and user/team don't exist or user/team exists in other organization than for the dashboard your currently operating on.

Please see comments in issue 