### PR TITLE
Cloudwatch dimension_values add dimension filter.

### DIFF
--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -87,7 +87,7 @@ Name | Description
 *namespaces()* | Returns a list of namespaces CloudWatch support.
 *metrics(namespace, [region])* | Returns a list of metrics in the namespace. (specify region or use "default" for custom metrics)
 *dimension_keys(namespace)* | Returns a list of dimension keys in the namespace.
-*dimension_values(region, namespace, metric, dimension_key)* | Returns a list of dimension values matching the specified `region`, `namespace`, `metric` and `dimension_key`.
+*dimension_values(region, namespace, metric, dimension_key, [filters])* | Returns a list of dimension values matching the specified `region`, `namespace`, `metric`, `dimension_key` or you can use dimension `filters` to get more specific result as well.
 *ebs_volume_ids(region, instance_id)* | Returns a list of volume ids matching the specified `region`, `instance_id`.
 *ec2_instance_attribute(region, attribute_name, filters)* | Returns a list of attributes matching the specified `region`, `attribute_name`, `filters`.
 
@@ -104,6 +104,7 @@ Query | Service
 *dimension_values(us-east-1,AWS/Redshift,CPUUtilization,ClusterIdentifier)* | RedShift
 *dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier)* | RDS
 *dimension_values(us-east-1,AWS/S3,BucketSizeBytes,BucketName)* | S3
+*dimension_values(us-east-1,CWAgent,disk_used_percent,device,{"InstanceId":"$instance_id"})* | CloudWatch Agent
 
 ## ec2_instance_attribute examples
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -212,6 +212,7 @@ export default class CloudWatchDatasource {
     var region;
     var namespace;
     var metricName;
+    var filterJson;
 
     var regionQuery = query.match(/^regions\(\)/);
     if (regionQuery) {
@@ -237,14 +238,20 @@ export default class CloudWatchDatasource {
       return this.getDimensionKeys(namespace, region);
     }
 
-    var dimensionValuesQuery = query.match(/^dimension_values\(([^,]+?),\s?([^,]+?),\s?([^,]+?),\s?([^,]+?)\)/);
+    var dimensionValuesQuery = query.match(
+      /^dimension_values\(([^,]+?),\s?([^,]+?),\s?([^,]+?),\s?([^,]+?)(,\s?(.+))?\)/
+    );
     if (dimensionValuesQuery) {
       region = dimensionValuesQuery[1];
       namespace = dimensionValuesQuery[2];
       metricName = dimensionValuesQuery[3];
       var dimensionKey = dimensionValuesQuery[4];
+      filterJson = {};
+      if (dimensionValuesQuery[6]) {
+        filterJson = JSON.parse(this.templateSrv.replace(dimensionValuesQuery[6]));
+      }
 
-      return this.getDimensionValues(region, namespace, metricName, dimensionKey, {});
+      return this.getDimensionValues(region, namespace, metricName, dimensionKey, filterJson);
     }
 
     var ebsVolumeIdsQuery = query.match(/^ebs_volume_ids\(([^,]+?),\s?([^,]+?)\)/);
@@ -258,7 +265,7 @@ export default class CloudWatchDatasource {
     if (ec2InstanceAttributeQuery) {
       region = ec2InstanceAttributeQuery[1];
       var targetAttributeName = ec2InstanceAttributeQuery[2];
-      var filterJson = JSON.parse(this.templateSrv.replace(ec2InstanceAttributeQuery[3]));
+      filterJson = JSON.parse(this.templateSrv.replace(ec2InstanceAttributeQuery[3]));
       return this.getEc2InstanceAttribute(region, targetAttributeName, filterJson);
     }
 


### PR DESCRIPTION
Issue #10029

Allow dimension_values query pass dimension filter.

e.g.
- dimension_values($region, $namespace, cpu_usage_system, cpu, {"InstanceId": "$instance_id"})
- dimension_values($region, $namespace, disk_used_percent, device, {"InstanceId": "$instance_id"})
- dimension_values($region, $namespace, disk_used_percent, path, {"InstanceId": "$instance_id", "device": "$device"})
