### PR TITLE
Fix bug of panel repeat, add 13-24 for min width

### DIFF
--- a/public/app/partials/panelgeneral.html
+++ b/public/app/partials/panelgeneral.html
@@ -20,7 +20,7 @@
 		</div>
 		<div class="gf-form" ng-show="ctrl.panel.repeat">
 			<span class="gf-form-label width-9">Min width</span>
-			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12]">
+			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]">
 				<option value=""></option>
 			</select>
 		</div>


### PR DESCRIPTION
I guess the "min width" for panel repeat is incompatible between 4.x and 5.x.

https://github.com/grafana/grafana/blob/v5.0.0-beta1/public/app/features/dashboard/dashboard_model.ts#L398
GRID_COLUMN_COUNT = 24、so we need to add 13-24?

@torkelo 