### PR TITLE
sass/base: import from current dir in _fonts.scss

### DIFF
--- a/public/sass/base/_fonts.scss
+++ b/public/sass/base/_fonts.scss
@@ -1,5 +1,5 @@
-@import "base/font_awesome";
-@import "base/grafana_icons";
+@import "font_awesome";
+@import "grafana_icons";
 
 /* cyrillic-ext */
 @font-face {


### PR DESCRIPTION
The import statement relative to base seems to confuse sass if there is
a colon (:) in the path name.

Fixes: #10866

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
