### PR TITLE
provisioning: uses unix epoch timestamps.

### DIFF
--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -229,7 +229,7 @@ type DashboardProvisioning struct {
 	DashboardId int64
 	Name        string
 	ExternalId  string
-	Updated     time.Time
+	Updated     int64
 }
 
 type SaveProvisionedDashboardCommand struct {

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -147,7 +147,7 @@ func (fr *fileReader) saveDashboard(path string, folderId int64, fileInfo os.Fil
 	}
 
 	provisionedData, alreadyProvisioned := provisionedDashboardRefs[path]
-	upToDate := alreadyProvisioned && provisionedData.Updated.Unix() == resolvedFileInfo.ModTime().Unix()
+	upToDate := alreadyProvisioned && provisionedData.Updated == resolvedFileInfo.ModTime().Unix()
 
 	dash, err := fr.readDashboardFromFile(path, resolvedFileInfo.ModTime(), folderId)
 	if err != nil {
@@ -173,7 +173,7 @@ func (fr *fileReader) saveDashboard(path string, folderId int64, fileInfo os.Fil
 	}
 
 	fr.log.Debug("saving new dashboard", "file", path)
-	dp := &models.DashboardProvisioning{ExternalId: path, Name: fr.Cfg.Name, Updated: resolvedFileInfo.ModTime()}
+	dp := &models.DashboardProvisioning{ExternalId: path, Name: fr.Cfg.Name, Updated: resolvedFileInfo.ModTime().Unix()}
 	_, err = fr.dashboardRepo.SaveProvisionedDashboard(dash, dp)
 	return provisioningMetadata, err
 }

--- a/pkg/services/sqlstore/dashboard_provisioning.go
+++ b/pkg/services/sqlstore/dashboard_provisioning.go
@@ -26,8 +26,8 @@ func SaveProvisionedDashboard(cmd *models.SaveProvisionedDashboardCommand) error
 		}
 
 		cmd.Result = cmd.DashboardCmd.Result
-		if cmd.DashboardProvisioning.Updated.IsZero() {
-			cmd.DashboardProvisioning.Updated = cmd.Result.Updated
+		if cmd.DashboardProvisioning.Updated == 0 {
+			cmd.DashboardProvisioning.Updated = cmd.Result.Updated.Unix()
 		}
 
 		return saveProvionedData(sess, cmd.DashboardProvisioning, cmd.Result)

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -31,7 +31,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 				DashboardProvisioning: &models.DashboardProvisioning{
 					Name:       "default",
 					ExternalId: "/var/grafana.json",
-					Updated:    now,
+					Updated:    now.Unix(),
 				},
 			}
 
@@ -48,7 +48,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 
 				So(len(query.Result), ShouldEqual, 1)
 				So(query.Result[0].DashboardId, ShouldEqual, dashId)
-				So(query.Result[0].Updated.Unix(), ShouldEqual, now.Unix())
+				So(query.Result[0].Updated, ShouldEqual, now.Unix())
 			})
 		})
 	})

--- a/pkg/services/sqlstore/migrations/common.go
+++ b/pkg/services/sqlstore/migrations/common.go
@@ -24,3 +24,15 @@ func addTableRenameMigration(mg *Migrator, oldName string, newName string, versi
 	migrationId := fmt.Sprintf("Rename table %s to %s - %s", oldName, newName, versionSuffix)
 	mg.AddMigration(migrationId, NewRenameTableMigration(oldName, newName))
 }
+
+func addTableReplaceMigrations(mg *Migrator, from Table, to Table, migrationVersion int64, tableDataMigration map[string]string) {
+	fromV := fmt.Sprintf("v%v", migrationVersion-1)
+	toV := fmt.Sprintf("v%v", migrationVersion)
+	tmpTableName := "dashboard_provisioning_" + fromV
+
+	addTableRenameMigration(mg, from.Name, tmpTableName, fromV)
+	mg.AddMigration(fmt.Sprintf("create %v %v", to.Name, toV), NewAddTableMigration(to))
+	addTableIndicesMigrations(mg, toV, to)
+	mg.AddMigration(fmt.Sprintf("copy %v %v to %v", to.Name, fromV, toV), NewCopyTableDataMigration(to.Name, tmpTableName, tableDataMigration))
+	mg.AddMigration(fmt.Sprintf("drop %v", tmpTableName), NewDropTableMigration(tmpTableName))
+}

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -1,6 +1,8 @@
 package migrations
 
-import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+import (
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
 
 func addDashboardMigration(mg *Migrator) {
 	var dashboardV1 = Table{
@@ -192,4 +194,26 @@ func addDashboardMigration(mg *Migrator) {
 	}
 
 	mg.AddMigration("create dashboard_provisioning", NewAddTableMigration(dashboardExtrasTable))
+
+	dashboardExtrasTableV2 := Table{
+		Name: "dashboard_provisioning",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "dashboard_id", Type: DB_BigInt, Nullable: true},
+			{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
+			{Name: "external_id", Type: DB_Text, Nullable: false},
+			{Name: "updated", Type: DB_Int, Default: "0", Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"dashboard_id"}},
+			{Cols: []string{"dashboard_id", "name"}, Type: IndexType},
+		},
+	}
+
+	addTableReplaceMigrations(mg, dashboardExtrasTable, dashboardExtrasTableV2, 2, map[string]string{
+		"id":           "id",
+		"dashboard_id": "dashboard_id",
+		"name":         "name",
+		"external_id":  "external_id",
+	})
 }


### PR DESCRIPTION
DateTime was used previously but as the timezone info is not
persisted in the database that might cause issues with
up-to-date checking. Unix epoch timestamps sidesteps this issue
as they are always in UTC.

Fixes #10904