### PR TITLE
Alerting: Add external tags in alert definition

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -128,22 +128,22 @@ Once these two properties are set, you can send the alerts to Kafka for further 
 
 ### All supported notifier
 
-Name | Type |Support images
+Name | Type |Support images |Support external tags
 -----|------------ | ------
-Slack | `slack` | yes
-Pagerduty | `pagerduty` | yes
-Email | `email` | yes
-Webhook | `webhook` | link
-Kafka | `kafka` | no
-Hipchat | `hipchat` | yes
-VictorOps | `victorops` | yes
-Sensu | `sensu` | yes
-OpsGenie | `opsgenie` | yes
-Threema | `threema` | yes
-Pushover | `pushover` | no
-Telegram | `telegram` | no
-Line | `line` | no
-Prometheus Alertmanager | `prometheus-alertmanager` | no
+Slack | `slack` | yes | no
+Pagerduty | `pagerduty` | yes | no
+Email | `email` | yes | no
+Webhook | `webhook` | link | no
+Kafka | `kafka` | no | no
+Hipchat | `hipchat` | yes | no
+VictorOps | `victorops` | yes | no
+Sensu | `sensu` | yes | no
+OpsGenie | `opsgenie` | yes | no
+Threema | `threema` | yes | no
+Pushover | `pushover` | no | no
+Telegram | `telegram` | no | no
+Line | `line` | no | no
+Prometheus Alertmanager | `prometheus-alertmanager` | no | yes
 
 
 
@@ -157,6 +157,15 @@ Be aware that some notifiers requires public access to the image to be able to i
 Currently only the Email Channels attaches images if no external image store is specified. To include images in alert notifications for other channels then you need to set up an external image store.
 
 This is an optional requirement. You can get Slack and email notifications without setting this up.
+
+
+# Use external tags in notifications {#external-tags}
+
+Grafana can include a list of tags (key/value) in the notification.
+It's called external tags to contrast with tags parsed from timeseries.
+It currently supports only the Prometheus Alertmanager notifier.
+
+This is an optional feature. You can get notifications without using external tags.
 
 # Configure the link back to Grafana from alert notifications
 

--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -64,7 +64,8 @@ func (this *AlertmanagerNotifier) Notify(evalContext *alerting.EvalContext) erro
 			alertJSON.SetPath([]string{"annotations", "description"}, evalContext.Rule.Message)
 		}
 
-		tags := make(map[string]string)
+		tags := map[string]string{"alertname": evalContext.Rule.Name}
+		// Add tags from EvalMatch.
 		if len(match.Tags) == 0 {
 			tags["metric"] = match.Metric
 		} else {
@@ -72,7 +73,10 @@ func (this *AlertmanagerNotifier) Notify(evalContext *alerting.EvalContext) erro
 				tags[k] = v
 			}
 		}
-		tags["alertname"] = evalContext.Rule.Name
+		// Add tags from ExternalTags in alert rule.
+		for k, v := range evalContext.Rule.ExternalTags {
+			tags[k] = v
+		}
 		alertJSON.Set("labels", tags)
 
 		alerts = append(alerts, alertJSON)

--- a/pkg/services/alerting/rule.go
+++ b/pkg/services/alerting/rule.go
@@ -23,6 +23,7 @@ type Rule struct {
 	State               m.AlertStateType
 	Conditions          []Condition
 	Notifications       []int64
+	ExternalTags        map[string]string
 }
 
 type ValidationError struct {
@@ -108,6 +109,10 @@ func NewRuleFromDBAlert(ruleDef *m.Alert) (*Rule, error) {
 		} else {
 			model.Notifications = append(model.Notifications, id)
 		}
+	}
+	model.ExternalTags = map[string]string{}
+	for tagName, tagValue := range ruleDef.Settings.Get("externalTags").MustMap() {
+		model.ExternalTags[tagName] = tagValue.(string)
 	}
 
 	for index, condition := range ruleDef.Settings.Get("conditions").MustArray() {

--- a/public/app/features/alerting/alert_tab_ctrl.ts
+++ b/public/app/features/alerting/alert_tab_ctrl.ts
@@ -24,6 +24,7 @@ export class AlertTabCtrl {
   error: string;
   appSubUrl: string;
   alertHistory: any;
+  newExternalTag: any;
 
   /** @ngInject */
   constructor(
@@ -153,6 +154,18 @@ export class AlertTabCtrl {
     this.alertNotifications.splice(index, 1);
   }
 
+  addExternalTag() {
+    if (this.newExternalTag.name) {
+      this.alert.externalTags[this.newExternalTag.name] = this.newExternalTag.value;
+    }
+    this.newExternalTag.name = '';
+    this.newExternalTag.value = '';
+  }
+
+  removeExternalTag(tagName) {
+    delete this.alert.externalTags[tagName];
+  }
+
   initModel() {
     var alert = (this.alert = this.panel.alert);
     if (!alert) {
@@ -169,6 +182,7 @@ export class AlertTabCtrl {
     alert.frequency = alert.frequency || '60s';
     alert.handler = alert.handler || 1;
     alert.notifications = alert.notifications || [];
+    alert.externalTags = alert.externalTags || {};
 
     var defaultName = this.panel.title + ' alert';
     alert.name = alert.name || defaultName;

--- a/public/app/features/alerting/partials/alert_tab.html
+++ b/public/app/features/alerting/partials/alert_tab.html
@@ -115,20 +115,54 @@
 		</div>
 
 		<div class="gf-form-group" ng-if="ctrl.subTabIndex === 1">
-			<h5 class="section-heading">Notifications</h5>
-			<div class="gf-form-inline">
-				<div class="gf-form max-width-30">
-					<span class="gf-form-label width-8">Send to</span>
-					<span class="gf-form-label" ng-repeat="nc in ctrl.alertNotifications" ng-style="{'background-color': nc.bgColor }">
-						<i class="{{nc.iconClass}}"></i>&nbsp;{{nc.name}}&nbsp;
-						<i class="fa fa-remove pointer muted" ng-click="ctrl.removeNotification($index)" ng-if="nc.isDefault === false"></i>
-					</span>
-					<metric-segment segment="ctrl.addNotificationSegment" get-options="ctrl.getNotifications()" on-change="ctrl.notificationAdded()"></metric-segment>
+			<div class="gf-form-group">
+				<h5 class="section-heading">Notifications</h5>
+				<div class="gf-form-inline">
+					<div class="gf-form max-width-30">
+						<span class="gf-form-label width-8">Send to</span>
+						<span class="gf-form-label" ng-repeat="nc in ctrl.alertNotifications" ng-style="{'background-color': nc.bgColor }">
+							<i class="{{nc.iconClass}}"></i>&nbsp;{{nc.name}}&nbsp;
+							<i class="fa fa-remove pointer muted" ng-click="ctrl.removeNotification($index)" ng-if="nc.isDefault === false"></i>
+						</span>
+						<metric-segment segment="ctrl.addNotificationSegment" get-options="ctrl.getNotifications()" on-change="ctrl.notificationAdded()"></metric-segment>
+					</div>
+				</div>
+				<div class="gf-form gf-form--v-stretch">
+					<span class="gf-form-label width-8">Message</span>
+					<textarea class="gf-form-input" rows="10" ng-model="ctrl.alert.message"  placeholder="Notification message details..."></textarea>
 				</div>
 			</div>
-			<div class="gf-form gf-form--v-stretch">
-				<span class="gf-form-label width-8">Message</span>
-				<textarea class="gf-form-input" rows="10" ng-model="ctrl.alert.message"  placeholder="Notification message details..."></textarea>
+
+			<div class="gf-form-group">
+				<h5 class="section-heading">External tags</h5>
+				<div class="gf-form-group">
+					<div class="gf-form-inline" ng-repeat="(key, value) in ctrl.alert.externalTags">
+						<div class="gf-form-inline">
+							<input type="text" ng-model="key" class="gf-form-label width-15">
+							<input type="text" ng-model="ctrl.alert.externalTags[key]" class="gf-form-input width-15" placeholder="Tag value...">
+						</div>
+						<div class="gf-form">
+							<label class="gf-form-label">
+								<a class="pointer" tabindex="1" ng-click="ctrl.removeExternalTag(key)">
+									<i class="fa fa-trash"></i>
+								</a>
+							</label>
+						</div>
+					</div>
+				</div>
+				<div class="gf-form-inline">
+					<div class="gf-form">
+						<input type="text" ng-model="ctrl.newExternalTag.name" class="gf-form-input width-15" placeholder="Tag name...">
+						<input type="text" ng-model="ctrl.newExternalTag.value" class="gf-form-input width-15" placeholder="Tag value...">
+					</div>
+					<div class="gf-form">
+						<label class="gf-form-label">
+							<a class="pointer" tabindex="1" ng-click="ctrl.addExternalTag()">
+								<i class="fa fa-plus"></i>&nbsp;Add Tag
+							</a>
+						</label>
+					</div>
+				</div>
 			</div>
 		</div>
 


### PR DESCRIPTION
Will looks like:
![screenshot-2018-2-15 grafana - new dashboard copy](https://user-images.githubusercontent.com/13062201/36267771-00f093e6-1275-11e8-9c4d-7639316498d8.png)

Also provide usage example with prometheus alertmanager notifier.