### PR TITLE
[elasticsearch] Allow nested fields for annotation time field

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -166,7 +166,7 @@ export class ElasticDatasource {
 
       for (var i = 0; i < hits.length; i++) {
         var source = hits[i]._source;
-        var time = source[timeField];
+        var time = getFieldFromSource(source, timeField);
         if (typeof hits[i].fields !== 'undefined') {
           var fields = hits[i].fields;
           if (_.isString(fields[timeField]) || _.isNumber(fields[timeField])) {


### PR DESCRIPTION
Enables https://github.com/grafana/grafana/issues/10935

There doesn't appear to be an explicit reason the `"time"` field was excluded when the `"text"` and `"tags"` fields had nested source added for them (https://github.com/grafana/grafana/commit/10f9022d). So I've modified the value access to use the same helper to get the time value, after this my annotations can properly pull from the nested field.

I tried finding an example `"hits[i].fields"` response to see if these came back as nested objects or not, but am unable to find one as that field appears to have been deprecated in favor of source filtering back in Elasticsearch 1.x. If we have an example I'm happy to make appropriate modifications in that if block, but didn't want to make a modification I can't verify.

Cheers!