### PR TITLE
migrate panels in collapsed rows

### DIFF
--- a/public/app/features/dashboard/dashboard_migration.ts
+++ b/public/app/features/dashboard/dashboard_migration.ts
@@ -18,7 +18,7 @@ export class DashboardMigrator {
   }
 
   updateSchema(old) {
-    var i, j, k;
+    var i, j, k, n;
     var oldVersion = this.dashboard.schemaVersion;
     var panelUpgrades = [];
     this.dashboard.schemaVersion = 16;
@@ -372,6 +372,11 @@ export class DashboardMigrator {
     for (j = 0; j < this.dashboard.panels.length; j++) {
       for (k = 0; k < panelUpgrades.length; k++) {
         panelUpgrades[k].call(this, this.dashboard.panels[j]);
+        if (this.dashboard.panels[j].panels) {
+          for (n = 0; n < this.dashboard.panels[j].panels.length; n++) {
+            panelUpgrades[k].call(this, this.dashboard.panels[j].panels[n]);
+          }
+        }
       }
     }
   }

--- a/public/app/features/dashboard/specs/dashboard_migration.jest.ts
+++ b/public/app/features/dashboard/specs/dashboard_migration.jest.ts
@@ -371,6 +371,14 @@ describe('DashboardModel', function() {
       let dashboard = new DashboardModel(model);
       expect(dashboard.panels[0].minSpan).toBe(24);
     });
+
+    it('should assign id', function() {
+      model.rows = [createRow({ collapse: true, height: 8 }, [[6], [6]])];
+      model.rows[0].panels[0] = { };
+
+      let dashboard = new DashboardModel(model);
+      expect(dashboard.panels[0].id).toBe(1);
+    });
   });
 });
 


### PR DESCRIPTION
I notice that pretty old scripted dashboard cause error in Grafana 5.x.
When I open a collapsed row, dashboard cause this error.
![image](https://user-images.githubusercontent.com/224552/36321880-b18f7842-138e-11e8-82a5-19a78a763c58.png)

After debugging, I found that the panel doesn't have `id`, and cause an error in this line.
https://github.com/grafana/grafana/blob/v5.0.0-beta3/public/app/features/dashboard/dashgrid/DashboardGrid.tsx#L97

I guess the root cause is, migration code doesn't care about panels in collapsed rows.

@torkelo How do you think this fix.
