### PR TITLE
Fix broken markdown links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ### Fixes
 
 - **MySQL** Fixed new migration issue with index length [#10931](https://github.com/grafana/grafana/issues/10931)
-- **Modal** Escape key no closes modals everywhere, fixes [#10887]https://github.com/grafana/grafana/issues/10887)
-- **Row repeats** Fix for repeating rows issue, fixes [#10932]https://github.com/grafana/grafana/issues/10932)
-- **Docs** Team api documented, fixes [#10832]https://github.com/grafana/grafana/issues/10832)
-- **Plugins** Plugin info page broken, fixes [#10943]https://github.com/grafana/grafana/issues/10943)
+- **Modal** Escape key no closes modals everywhere, fixes [#10887](https://github.com/grafana/grafana/issues/10887)
+- **Row repeats** Fix for repeating rows issue, fixes [#10932](https://github.com/grafana/grafana/issues/10932)
+- **Docs** Team api documented, fixes [#10832](https://github.com/grafana/grafana/issues/10832)
+- **Plugins** Plugin info page broken, fixes [#10943](https://github.com/grafana/grafana/issues/10943)
 
 # 5.0.0-beta2 (2018-02-15)
 


### PR DESCRIPTION
Updated CHANGELOG.md which had broken markdown links. Should be a Friday thing that this typo happened ;)