### PR TITLE
provisioning: dont ignore sample yaml files

### DIFF
--- a/conf/provisioning/dashboards/sample.yaml
+++ b/conf/provisioning/dashboards/sample.yaml
@@ -1,8 +1,5 @@
-# This file is only an example.
-# Grafana will never read sample.yaml files
-
 # # config file version
-# apiVersion: 1
+apiVersion: 1
 
 #providers:
 # - name: 'default'

--- a/conf/provisioning/datasources/sample.yaml
+++ b/conf/provisioning/datasources/sample.yaml
@@ -1,8 +1,5 @@
-# This file is only an example.
-# Grafana will never read sample.yaml files
-
 # # config file version
-# apiVersion: 1
+apiVersion: 1
 
 # # list of datasources that should be deleted from the database
 #deleteDatasources:

--- a/pkg/services/provisioning/dashboards/config_reader.go
+++ b/pkg/services/provisioning/dashboards/config_reader.go
@@ -63,7 +63,7 @@ func (cr *configReader) readConfig() ([]*DashboardsAsConfig, error) {
 	}
 
 	for _, file := range files {
-		if (!strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml")) || file.Name() == "sample.yaml" {
+		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
 			continue
 		}
 

--- a/pkg/services/provisioning/dashboards/test-configs/dashboards-from-disk/sample.yaml
+++ b/pkg/services/provisioning/dashboards/test-configs/dashboards-from-disk/sample.yaml
@@ -1,10 +1,10 @@
 apiVersion: 1
 
-providers:
-- name: 'gasdf'
-  orgId: 2
-  folder: 'developers'
-  editable: true
-  type: file
-  options:
-    path: /var/lib/grafana/dashboards
+#providers:
+#- name: 'gasdf'
+#  orgId: 2
+#  folder: 'developers'
+#  editable: true
+#  type: file
+#  options:
+#    path: /var/lib/grafana/dashboards

--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -24,7 +24,7 @@ func (cr *configReader) readConfig(path string) ([]*DatasourcesAsConfig, error) 
 	}
 
 	for _, file := range files {
-		if (strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml")) && file.Name() != "sample.yaml" {
+		if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
 			datasource, err := cr.parseDatasourceConfig(path, file)
 			if err != nil {
 				return nil, err

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -138,7 +138,7 @@ func TestDatasourceAsConfig(t *testing.T) {
 				t.Fatalf("readConfig return an error %v", err)
 			}
 
-			So(len(cfg), ShouldEqual, 2)
+			So(len(cfg), ShouldEqual, 3)
 
 			dsCfg := cfg[0]
 
@@ -146,6 +146,17 @@ func TestDatasourceAsConfig(t *testing.T) {
 
 			validateDatasource(dsCfg)
 			validateDeleteDatasources(dsCfg)
+
+			dsCount := 0
+			delDsCount := 0
+
+			for _, c := range cfg {
+				dsCount += len(c.Datasources)
+				delDsCount += len(c.DeleteDatasources)
+			}
+
+			So(dsCount, ShouldEqual, 2)
+			So(delDsCount, ShouldEqual, 1)
 		})
 
 		Convey("can read all properties from version 0", func() {

--- a/pkg/services/provisioning/datasources/test-configs/all-properties/sample.yaml
+++ b/pkg/services/provisioning/datasources/test-configs/all-properties/sample.yaml
@@ -3,30 +3,30 @@
 
 apiVersion: 1
 
-datasources:
-  - name: name
-    type: type
-    access: proxy
-    orgId: 2
-    url: url
-    password: password
-    user: user
-    database: database
-    basicAuth: true
-    basicAuthUser: basic_auth_user
-    basicAuthPassword: basic_auth_password
-    withCredentials: true
-    jsonData:
-      graphiteVersion: "1.1"
-      tlsAuth: true
-      tlsAuthWithCACert: true
-    secureJsonData:
-      tlsCACert: "MjNOcW9RdkbUDHZmpco2HCYzVq9dE+i6Yi+gmUJotq5CDA=="
-      tlsClientCert: "ckN0dGlyMXN503YNfjTcf9CV+GGQneN+xmAclQ=="
-      tlsClientKey: "ZkN4aG1aNkja/gKAB1wlnKFIsy2SRDq4slrM0A=="
-    editable: true
-    version: 10
-
-deleteDatasources:
-  - name: old-graphite3
-    orgId: 2
+#datasources:
+#  - name: name
+#    type: type
+#    access: proxy
+#    orgId: 2
+#    url: url
+#    password: password
+#    user: user
+#    database: database
+#    basicAuth: true
+#    basicAuthUser: basic_auth_user
+#    basicAuthPassword: basic_auth_password
+#    withCredentials: true
+#    jsonData:
+#      graphiteVersion: "1.1"
+#      tlsAuth: true
+#      tlsAuthWithCACert: true
+#    secureJsonData:
+#      tlsCACert: "MjNOcW9RdkbUDHZmpco2HCYzVq9dE+i6Yi+gmUJotq5CDA=="
+#      tlsClientCert: "ckN0dGlyMXN503YNfjTcf9CV+GGQneN+xmAclQ=="
+#      tlsClientKey: "ZkN4aG1aNkja/gKAB1wlnKFIsy2SRDq4slrM0A=="
+#    editable: true
+#    version: 10
+#
+#deleteDatasources:
+#  - name: old-graphite3
+#    orgId: 2


### PR DESCRIPTION
When I introduced versioning for provisioning configs I added logging saying the old Format is deprecated. To avoid causing warn logs to those who run the beta version I ignored sample.yaml files since they would be in the old format. Which might be nice to those who run the beta but in the long run its better to not ignore sample.yaml files. 

closes #10963

