### PR TITLE
Allow use of DN in group_search_filter_user_attribute and member_of

### DIFF
--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -408,6 +408,10 @@ func (a *ldapAuther) searchForUser(username string) (*LdapUserInfo, error) {
 			if a.server.GroupSearchFilterUserAttribute == "" {
 				filter_replace = getLdapAttr(a.server.Attr.Username, searchResult)
 			}
+			if a.server.GroupSearchFilterUserAttribute == "dn" {
+				filter_replace = searchResult.Entries[0].DN
+			}
+
 			filter := strings.Replace(a.server.GroupSearchFilter, "%s", ldap.EscapeFilter(filter_replace), -1)
 
 			a.log.Info("Searching for user's groups", "filter", filter)
@@ -430,7 +434,11 @@ func (a *ldapAuther) searchForUser(username string) (*LdapUserInfo, error) {
 
 			if len(groupSearchResult.Entries) > 0 {
 				for i := range groupSearchResult.Entries {
-					memberOf = append(memberOf, getLdapAttrN(a.server.Attr.MemberOf, groupSearchResult, i))
+					if a.server.Attr.MemberOf == "dn" {
+						memberOf = append(memberOf, groupSearchResult.Entries[i].DN)
+					} else {
+						memberOf = append(memberOf, getLdapAttrN(a.server.Attr.MemberOf, groupSearchResult, i))
+					}
 				}
 				break
 			}


### PR DESCRIPTION
In our LDAP setup we use openLDAP with group schema where we use groupOfUniqueNames which contains multiple uniqueMember attributes that contain full DN of the member.

Because current code does not allow the use of DN in these fields as it only matches against attributes and go-ldap does not treat dn as an attribute. So we were unable to map users to their groups.

This will fill the fields with DN if they contain string "dn".

Seems to me it could resolve #3132