### PR TITLE
Variable replacement syntax selection

### DIFF
--- a/public/app/features/templating/specs/template_srv.jest.ts
+++ b/public/app/features/templating/specs/template_srv.jest.ts
@@ -31,8 +31,36 @@ describe('templateSrv', function() {
       expect(target).toBe('this.mupp.filters');
     });
 
+    it('should replace ${test} with scoped value', function() {
+      var target = _templateSrv.replace('this.${test}.filters', {
+        test: { value: 'mupp', text: 'asd' },
+      });
+      expect(target).toBe('this.mupp.filters');
+    });
+
+    it('should replace ${test:glob} with scoped value', function() {
+      var target = _templateSrv.replace('this.${test:glob}.filters', {
+        test: { value: 'mupp', text: 'asd' },
+      });
+      expect(target).toBe('this.mupp.filters');
+    });
+
     it('should replace $test with scoped text', function() {
       var target = _templateSrv.replaceWithText('this.$test.filters', {
+        test: { value: 'mupp', text: 'asd' },
+      });
+      expect(target).toBe('this.asd.filters');
+    });
+
+    it('should replace ${test} with scoped text', function() {
+      var target = _templateSrv.replaceWithText('this.${test}.filters', {
+        test: { value: 'mupp', text: 'asd' },
+      });
+      expect(target).toBe('this.asd.filters');
+    });
+
+    it('should replace ${test:glob} with scoped text', function() {
+      var target = _templateSrv.replaceWithText('this.${test:glob}.filters', {
         test: { value: 'mupp', text: 'asd' },
       });
       expect(target).toBe('this.asd.filters');
@@ -79,8 +107,19 @@ describe('templateSrv', function() {
       ]);
     });
 
+
     it('should replace $test with globbed value', function() {
       var target = _templateSrv.replace('this.$test.filters', {}, 'glob');
+      expect(target).toBe('this.{value1,value2}.filters');
+    });
+
+    it('should replace ${test} with globbed value', function() {
+      var target = _templateSrv.replace('this.${test}.filters', {}, 'glob');
+      expect(target).toBe('this.{value1,value2}.filters');
+    });
+
+    it('should replace ${test:glob} with globbed value', function() {
+      var target = _templateSrv.replace('this.${test:glob}.filters', {});
       expect(target).toBe('this.{value1,value2}.filters');
     });
 
@@ -89,8 +128,13 @@ describe('templateSrv', function() {
       expect(target).toBe('this=value1|value2');
     });
 
-    it('should replace $test with piped value', function() {
-      var target = _templateSrv.replace('this=$test', {}, 'pipe');
+    it('should replace ${test} with piped value', function() {
+      var target = _templateSrv.replace('this=${test}', {}, 'pipe');
+      expect(target).toBe('this=value1|value2');
+    });
+
+    it('should replace ${test:pipe} with piped value', function() {
+      var target = _templateSrv.replace('this=${test:pipe}', {});
       expect(target).toBe('this=value1|value2');
     });
   });
@@ -109,6 +153,16 @@ describe('templateSrv', function() {
 
     it('should replace $test with formatted all value', function() {
       var target = _templateSrv.replace('this.$test.filters', {}, 'glob');
+      expect(target).toBe('this.{value1,value2}.filters');
+    });
+
+    it('should replace ${test} with formatted all value', function() {
+      var target = _templateSrv.replace('this.${test}.filters', {}, 'glob');
+      expect(target).toBe('this.{value1,value2}.filters');
+    });
+
+    it('should replace ${test:glob} with formatted all value', function() {
+      var target = _templateSrv.replace('this.${test:glob}.filters', {});
       expect(target).toBe('this.{value1,value2}.filters');
     });
   });
@@ -131,6 +185,16 @@ describe('templateSrv', function() {
       expect(target).toBe('this.*.filters');
     });
 
+    it('should replace ${test} with formatted all value', function() {
+      var target = _templateSrv.replace('this.${test}.filters', {}, 'glob');
+      expect(target).toBe('this.*.filters');
+    });
+
+    it('should replace ${test:glob} with formatted all value', function() {
+      var target = _templateSrv.replace('this.${test:glob}.filters', {});
+      expect(target).toBe('this.*.filters');
+    });
+
     it('should not escape custom all value', function() {
       var target = _templateSrv.replace('this.$test', {}, 'regex');
       expect(target).toBe('this.*');
@@ -141,6 +205,18 @@ describe('templateSrv', function() {
     it('should properly escape $test with lucene escape sequences', function() {
       initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
       var target = _templateSrv.replace('this:$test', {}, 'lucene');
+      expect(target).toBe('this:value\\/4');
+    });
+
+    it('should properly escape ${test} with lucene escape sequences', function() {
+      initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
+      var target = _templateSrv.replace('this:${test}', {}, 'lucene');
+      expect(target).toBe('this:value\\/4');
+    });
+
+    it('should properly escape ${test:lucene} with lucene escape sequences', function() {
+      initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
+      var target = _templateSrv.replace('this:${test:lucene}', {});
       expect(target).toBe('this:value\\/4');
     });
   });

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -8,6 +8,12 @@ function luceneEscape(value) {
 export class TemplateSrv {
   variables: any[];
 
+  /*
+   * This regex matches 3 types of variable reference with an optional format specifier
+   * \$(\w+)                          $var1
+   * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
+   * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
+   */
   private regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?::(\w+))?}/g;
   private index = {};
   private grafanaVariables = {};
@@ -143,8 +149,8 @@ export class TemplateSrv {
 
     str = _.escape(str);
     this.regex.lastIndex = 0;
-    return str.replace(this.regex, (match, g1, g2, g3, g4) => {
-      if (this.index[g1 || g2 || g4] || this.builtIns[g1 || g2 || g4]) {
+    return str.replace(this.regex, (match, var1, var2, fmt2, var3) => {
+      if (this.index[var1 || var2 || var3] || this.builtIns[var1 || var2 || var3]) {
         return '<span class="template-variable">' + match + '</span>';
       }
       return match;
@@ -170,11 +176,11 @@ export class TemplateSrv {
     var variable, systemValue, value;
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, g1, g2, g3, g4, g5) => {
-      variable = this.index[g1 || g2 || g4];
-      format = g3 || g5 || format;
+    return target.replace(this.regex, (match, var1, var2, fmt2, var3, fmt3) => {
+      variable = this.index[var1 || var2 || var3];
+      format = fmt2 || fmt3 || format;
       if (scopedVars) {
-        value = scopedVars[g1 || g2 || g4];
+        value = scopedVars[var1 || var2 || var3];
         if (value) {
           return this.formatValue(value.value, format, variable);
         }
@@ -215,15 +221,15 @@ export class TemplateSrv {
     var variable;
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, g1, g2, g3, g4) => {
+    return target.replace(this.regex, (match, var1, var2, fmt2, var3) => {
       if (scopedVars) {
-        var option = scopedVars[g1 || g2 || g4];
+        var option = scopedVars[var1 || var2 || var3];
         if (option) {
           return option.text;
         }
       }
 
-      variable = this.index[g1 || g2 || g4];
+      variable = this.index[var1 || var2 || var3];
       if (!variable) {
         return match;
       }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -8,7 +8,7 @@ function luceneEscape(value) {
 export class TemplateSrv {
   variables: any[];
 
-  private regex = /\$(\w+)|\[\[([\s\S]+?)\]\]|\${(\w+):?(\w+)?}/g;
+  private regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?::(\w+))?}/g;
   private index = {};
   private grafanaVariables = {};
   private builtIns = {};
@@ -143,8 +143,8 @@ export class TemplateSrv {
 
     str = _.escape(str);
     this.regex.lastIndex = 0;
-    return str.replace(this.regex, (match, g1, g2, g3) => {
-      if (this.index[g1 || g2 || g3] || this.builtIns[g1 || g2 || g3]) {
+    return str.replace(this.regex, (match, g1, g2, g3, g4) => {
+      if (this.index[g1 || g2 || g4] || this.builtIns[g1 || g2 || g4]) {
         return '<span class="template-variable">' + match + '</span>';
       }
       return match;
@@ -170,11 +170,11 @@ export class TemplateSrv {
     var variable, systemValue, value;
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, g1, g2, g3, g4) => {
-      variable = this.index[g1 || g2 || g3];
-      format = g4 || format;
+    return target.replace(this.regex, (match, g1, g2, g3, g4, g5) => {
+      variable = this.index[g1 || g2 || g4];
+      format = g3 || g5 || format;
       if (scopedVars) {
-        value = scopedVars[g1 || g2 || g3];
+        value = scopedVars[g1 || g2 || g4];
         if (value) {
           return this.formatValue(value.value, format, variable);
         }
@@ -215,15 +215,15 @@ export class TemplateSrv {
     var variable;
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, g1, g2, g3) => {
+    return target.replace(this.regex, (match, g1, g2, g3, g4) => {
       if (scopedVars) {
-        var option = scopedVars[g1 || g2 || g3];
+        var option = scopedVars[g1 || g2 || g4];
         if (option) {
           return option.text;
         }
       }
 
-      variable = this.index[g1 || g2 || g3];
+      variable = this.index[g1 || g2 || g4];
       if (!variable) {
         return match;
       }

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -348,6 +348,10 @@ export class GraphiteQueryCtrl extends QueryCtrl {
     let tagKey = tag.key;
     return this.datasource.getTagValuesAutoComplete(tagExpressions, tagKey, valuePrefix).then(values => {
       let altValues = _.map(values, 'text');
+      // Add template variables as additional values
+      _.eachRight(this.templateSrv.variables, variable => {
+        altValues.push('${' + variable.name + ':regex}');
+      });
       return mapToDropdownOptions(altValues);
     });
   }


### PR DESCRIPTION
This PR implements #9911, adding support for 2 new variable replacement syntax options `${variable:format}` and `[[variable:format]]`, where `format` is one of the formats supported by TemplateSrv.

It also updates the Graphite data source to offer variables in tag value dropdowns, using the "regex" syntax, and modifies the "regex" syntax to return `value` rather than `(value)` for a single selection.