### PR TITLE
[doc] Fix extra alerting options in installation->configuration

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -875,6 +875,4 @@ Defaults to true. Set to false to disable alerting engine and hide Alerting from
 
 ### execute_alerts
 
-### execute_alerts = true
-
 Makes it possible to turn off alert rule execution.


### PR DESCRIPTION
Removing extra information in `alerting` section on `installation->configuration`documentation path.

This extra info does not match with standard of this document, that is something like:

```
[section]

`option`
Default value. Description of option.

```