### PR TITLE
gave scroll-canvas-dashboard 100% height in kiosk-mode

### DIFF
--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -3,6 +3,9 @@
   .navbar {
     display: none;
   }
+  .scroll-canvas--dashboard {
+    height: 100%;
+  }
 }
 
 .playlist-active,


### PR DESCRIPTION
 fixes #11010

<img width="1440" alt="skarmavbild 2018-02-26 kl 10 42 29" src="https://user-images.githubusercontent.com/23470681/36663417-cc66c88c-1ae1-11e8-904b-e2145a2c70eb.png">
