### PR TITLE
feat: adding a option to disable quotes as values in query (Datasourc…

### DIFF
--- a/public/app/core/components/switch.ts
+++ b/public/app/core/components/switch.ts
@@ -9,7 +9,7 @@ var template = `
 </label>
 <div class="gf-form-switch {{ctrl.switchClass}}" ng-if="ctrl.show">
   <input id="check-{{ctrl.id}}" type="checkbox" ng-model="ctrl.checked" ng-change="ctrl.internalOnChange()">
-  <label for="check-{{ctrl.id}}" data-on="Yes" data-off="No"></label>
+  <label for="check-{{ctrl.id}}" class="{{ctrl.switchLabelClass}}" data-on="Yes" data-off="No"></label>
 </div>
 `;
 
@@ -45,6 +45,7 @@ export function switchDirective() {
       labelClass: '@',
       tooltip: '@',
       switchClass: '@',
+      switchLabelClass: '@',
       onChange: '&',
     },
     template: template,

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -6,6 +6,7 @@ export class CustomVariable implements Variable {
   options: any;
   includeAll: boolean;
   multi: boolean;
+  disableWrapWithQuotes: boolean;
   current: any;
 
   defaults = {
@@ -18,6 +19,7 @@ export class CustomVariable implements Variable {
     query: '',
     includeAll: false,
     multi: false,
+    disableWrapWithQuotes: false,
     allValue: null,
   };
 

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -258,6 +258,13 @@
 		 checked="current.includeAll"
 	 on-change="runQuery()">
 				</gf-form-switch>
+				<gf-form-switch class="gf-form"
+								label="Disable quotes wrapped in Values"
+								label-class="width-10"
+								switch-label-class="height-54"
+								checked="current.disableWrapWithQuotes"
+								on-change="runQuery()">
+				</gf-form-switch>
 			</div>
 			<div class="gf-form" ng-if="current.includeAll">
 				<span class="gf-form-label width-10">Custom all value</span>

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -17,6 +17,7 @@ export class QueryVariable implements Variable {
   hide: number;
   name: string;
   multi: boolean;
+  disableWrapWithQuotes: boolean;
   includeAll: boolean;
   useTags: boolean;
   tagsQuery: string;
@@ -35,6 +36,7 @@ export class QueryVariable implements Variable {
     name: '',
     multi: false,
     includeAll: false,
+    disableWrapWithQuotes: false,
     allValue: null,
     options: [],
     current: {},

--- a/public/app/features/templating/specs/query_variable.jest.ts
+++ b/public/app/features/templating/specs/query_variable.jest.ts
@@ -12,6 +12,7 @@ describe('QueryVariable', () => {
       expect(variable.options.length).toBe(0);
       expect(variable.multi).toBe(false);
       expect(variable.includeAll).toBe(false);
+      expect(variable.disableWrapWithQuotes).toBe(false);
     });
 
     it('get model should copy changes back to model', () => {

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -15,10 +15,10 @@ export class PostgresDatasource {
 
   interpolateVariable(value, variable) {
     if (typeof value === 'string') {
-      if (variable.multi || variable.includeAll) {
-        return "'" + value + "'";
-      } else {
+      if (variable.disableWrapWithQuotes) {
         return value;
+      } else {
+        return "'" + value + "'";
       }
     }
 
@@ -27,7 +27,11 @@ export class PostgresDatasource {
     }
 
     var quotedValues = _.map(value, function(val) {
-      return "'" + val + "'";
+      if (variable.disableWrapWithQuotes) {
+        return val;
+      } else {
+        return "'" + val + "'";
+      }
     });
     return quotedValues.join(',');
   }

--- a/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
@@ -208,7 +208,7 @@ describe('PostgreSQLDatasource', function() {
     });
 
     describe('and value is a string and wrap with quotes is enabled', () => {
-      it('should return an unquoted value', () => {
+      it('should return an quoted value', () => {
         ctx.variable.disableWrapWithQuotes = false;
         expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql("'abc'");
       });

--- a/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource_specs.ts
@@ -200,9 +200,17 @@ describe('PostgreSQLDatasource', function() {
       ctx.variable = new CustomVariable({}, {});
     });
 
-    describe('and value is a string', () => {
+    describe('and value is a string and wrap with quotes is disabled', () => {
       it('should return an unquoted value', () => {
+        ctx.variable.disableWrapWithQuotes = true;
         expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql('abc');
+      });
+    });
+
+    describe('and value is a string and wrap with quotes is enabled', () => {
+      it('should return an unquoted value', () => {
+        ctx.variable.disableWrapWithQuotes = false;
+        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).to.eql("'abc'");
       });
     });
 

--- a/public/sass/components/_switch.scss
+++ b/public/sass/components/_switch.scss
@@ -28,6 +28,9 @@
     border: 1px solid $input-border-color;
     border-left: none;
     border-radius: $input-border-radius;
+    &.height-54 {
+      height: 54px;
+    }
   }
 
   input + label::before,
@@ -64,8 +67,8 @@
   }
 
   input + label::before {
-    font-family: "FontAwesome";
-    content: "\f096"; // square-o
+    font-family: 'FontAwesome';
+    content: '\f096'; // square-o
     color: $text-color-weak;
     transition: transform 0.4s;
     backface-visibility: hidden;
@@ -73,11 +76,11 @@
   }
 
   input + label::after {
-    content: "\f046"; // check-square-o
+    content: '\f046'; // check-square-o
     color: $orange;
     text-shadow: $text-shadow-strong;
 
-    font-family: "FontAwesome";
+    font-family: 'FontAwesome';
     transition: transform 0.4s;
     transform: rotateY(180deg);
     backface-visibility: hidden;


### PR DESCRIPTION
This gives the possibility to disable quotes when needed for your template values (only applicable for PostgreSQL datasource for the time being)

Example : 
` select $columnName from myTable where column="value" `

`$columnName` gets wrapped with quotes " " i.e converted to string - this gives the possibility to use the original value as is. 

**Reason for having this feature :** 
- https://community.grafana.com/t/remove-single-quote-around-template-variable/4128
- https://github.com/grafana/grafana/issues/9030 

**Work Around being created:** 
- https://github.com/grafana/grafana/pull/9611 (this was reverted)

**Final Version after revert :**
- https://github.com/grafana/grafana/pull/9712
https://github.com/svenklemm/grafana/blob/master/public/app/plugins/datasource/postgres/datasource.ts#L16-L33 
(This gives the possibility to remove quotes only for single values)

## Pull request solution : 
![disable-quotes-wrapped](https://user-images.githubusercontent.com/31237114/36677483-8833a784-1b0e-11e8-83bb-6ca1b0527734.PNG)
- Adds the possibility to define when to disable quotes by adding a checkbox option - by default its disabled but if enabled it will remove the extra quotes being applied for both single and multi variable values - without breaking the current functionality. 

Please take my pull request with a pinch of salt if i have missed something as this is my first contribution to the community. 

CC: @daniellee  || @torkelo || @svenklemm 

Cheers,
V


