### PR TITLE
Alerting: Fix OK state doesn't show up in Microsoft Teams

### DIFF
--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -83,7 +83,7 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if evalContext.Rule.State != m.AlertStateOK { //dont add message when going back to alert state ok.
 		message += " " + evalContext.Rule.Message
 	} else {
-		message += " "  // summary must not be empty
+		message += " " // summary must not be empty
 	}
 
 	body := map[string]interface{}{

--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -82,6 +82,8 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 	message := this.Mention
 	if evalContext.Rule.State != m.AlertStateOK { //dont add message when going back to alert state ok.
 		message += " " + evalContext.Rule.Message
+	} else {
+		message += " "  // summary must not be empty
 	}
 
 	body := map[string]interface{}{


### PR DESCRIPTION
Microsoft Teams didn't receive OK state notifications because of the following API error:
```
`400 Bad Request` response:
Summary or Text is required
```
This PR makes sure that there is at least a space character in the summary field.