### PR TITLE
Adding option to disable sticky headers on table panels

### DIFF
--- a/public/app/plugins/panel/table/editor.html
+++ b/public/app/plugins/panel/table/editor.html
@@ -42,6 +42,7 @@
                                              ng-model-onblur>
     </div>
     <gf-form-switch class="gf-form" label-class="width-8" switch-class="max-width-7" label="Scroll" checked="editor.panel.scroll" on-change="editor.render()"></gf-form-switch>
+    <gf-form-switch class="gf-form" label-class="width-8" switch-class="max-width-7" label="Sticky header" checked="editor.panel.stickyHeader" on-change="editor.render()"></gf-form-switch>
     <div class="gf-form max-width-17">
       <label class="gf-form-label width-8">Font size</label>
       <div class="gf-form-select-wrapper width-7">

--- a/public/app/plugins/panel/table/module.html
+++ b/public/app/plugins/panel/table/module.html
@@ -1,12 +1,12 @@
 
 <div class="table-panel-container">
-	<div class="table-panel-header-bg" ng-show="ctrl.table.rows.length"></div>
+  <div class="table-panel-header-bg" ng-show="ctrl.table.rows.length" ng-if="ctrl.panel.stickyHeader"></div>
 	<div class="table-panel-scroll" ng-show="ctrl.table.rows.length">
 		<table class="table-panel-table">
-			<thead>
+			<thead class="table-panel-header">
 				<tr>
 					<th ng-repeat="col in ctrl.table.columns" ng-hide="col.hidden">
-						<div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)" ng-style="ctrl.table.stickyHeaderStyle">
+						<div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)">
 							{{col.title}}
 							<span class="table-panel-table-header-controls" ng-if="col.sort">
 								<i class="fa fa-caret-down" ng-show="col.desc"></i>

--- a/public/app/plugins/panel/table/module.html
+++ b/public/app/plugins/panel/table/module.html
@@ -6,7 +6,7 @@
 			<thead>
 				<tr>
 					<th ng-repeat="col in ctrl.table.columns" ng-hide="col.hidden">
-						<div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)">
+						<div class="table-panel-table-header-inner pointer" ng-click="ctrl.toggleColumnSort(col, $index)" ng-style="ctrl.table.stickyHeaderStyle">
 							{{col.title}}
 							<span class="table-panel-table-header-controls" ng-if="col.sort">
 								<i class="fa fa-caret-down" ng-show="col.desc"></i>

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -222,6 +222,9 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       var panelElem = elem.parents('.panel');
       var rootElem = elem.find('.table-panel-scroll');
       var tbodyElem = elem.find('tbody');
+      var containerElem = elem.find('table-panel-container');
+      var headerElem = elem.find('.table-panel-header');
+      var titleElem = elem.find('.table-panel-table-header-inner');
       var footerElem = elem.find('.table-panel-footer');
 
       elem.css({ 'font-size': panel.fontSize });
@@ -232,7 +235,19 @@ class TablePanelCtrl extends MetricsPanelCtrl {
 
       rootElem.css({ 'max-height': panel.scroll ? getTableHeight() : '' });
 
-      ctrl.table.stickyHeaderStyle = { position: panel.stickyHeader ? 'absolute' : 'relative' };
+      if (panel.stickyHeader) {
+        containerElem.removeClass('table-panel-container-rel').addClass('table-panel-container-abs');
+
+        headerElem.removeClass('table-panel-header-rel');
+
+        titleElem.css({ position: 'absolute' });
+      } else {
+        containerElem.removeClass('table-panel-container-abs').addClass('table-panel-container-rel');
+
+        headerElem.addClass('table-panel-header-rel');
+
+        titleElem.css({ position: 'relative' });
+      }
     }
 
     // hook up link tooltips

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -39,6 +39,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
     ],
     columns: [],
     scroll: true,
+    stickyHeader: true,
     fontSize: '100%',
     sort: { col: 0, desc: true },
   };
@@ -230,6 +231,8 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       appendPaginationControls(footerElem);
 
       rootElem.css({ 'max-height': panel.scroll ? getTableHeight() : '' });
+
+      ctrl.table.stickyHeaderStyle = { position: panel.stickyHeader ? 'absolute' : 'relative' };
     }
 
     // hook up link tooltips

--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -11,8 +11,13 @@
   overflow: auto;
 }
 
-.table-panel-container {
+.table-panel-container-abs {
   padding-top: 2.2em;
+  position: relative;
+}
+
+.table-panel-container-rel {
+  padding-top: 0em;
   position: relative;
 }
 
@@ -119,6 +124,12 @@
   top: 0;
   right: 0;
   left: 0;
+}
+
+.table-panel-header-rel {
+  background: $list-item-bg;
+  border-top: 2px solid $body-bg;
+  border-bottom: 2px solid $body-bg;
 }
 
 .table-panel-table-header-inner {


### PR DESCRIPTION
This change introduces the 'Sticky header' option to the table panel
plugin. This option toggles the position attribute on the table header
elements' div between absolute and relative. This change is backwards
compatible with the existing table panel plugin and defaults to the
pre-existing behavior.

The effect of this change allows the user to specify if the table's
header should stay in a fixed location as the user scrolls, or scroll
away with the adjacent rows.

This also resolves a display issue encountered when a table contains a
large number of columns. When a large number of columns exist, the
absolute positioning of the table header cells force the header cells'
content to be rendered over each other. Toggling to to relative
positioning allows the header cells' content to render as normally
expected.
