### PR TITLE
Adding ability to use a cell's content for link generation

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -129,6 +129,20 @@
           </span>
         </info-popover>
       </div>
+      <div class="gf-form">
+        <label class="gf-form-label width-9">Parameterize by</label>
+        <input type="text" placeholder="Name or regex" class="gf-form-input width-29" ng-model="style.parameterizePattern" bs-tooltip="'Specify regex using /my.*regex/ syntax'"
+          ng-model-onblur ng-blur="editor.render()" data-placement="right">
+        <info-popover mode="right-absolute">
+          <p>Specify an regular expression</p>
+          <span>
+            Use a regular expression to parameterize a cell's content:
+            <br>
+            <em>$__pattern_n</em> refers to Nth sub-string after splitting the cell's content. Sub-string indexes are started from 0. For instance,
+            <em>$__pattern_1</em> refers to second sub-string of a cell's content.
+          </span>
+        </info-popover>
+      </div>
       <gf-form-switch class="gf-form" label-class="width-9" label="Open in new tab" checked="style.linkTargetBlank"></gf-form-switch>
     </div>
 

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -180,6 +180,14 @@ export class TableRenderer {
       var scopedVars = this.renderRowVariables(rowIndex);
       scopedVars['__cell'] = { value: value };
 
+      let regex = column.style.parameterizePattern
+        ? kbn.stringToJsRegex(String(column.style.parameterizePattern))
+        : / /;
+      let splitVals = value.split(regex);
+      for (let i = 0; i < splitVals.length; i++) {
+        scopedVars[`__pattern_${i}`] = { value: splitVals[i] };
+      }
+
       var cellLink = this.templateSrv.replace(column.style.linkUrl, scopedVars);
       var cellLinkTooltip = this.templateSrv.replace(column.style.linkTooltip, scopedVars);
       var cellTarget = column.style.linkTargetBlank ? '_blank' : '';


### PR DESCRIPTION
This change adds an input box to the Link section of the Column Styles
tab in the table panel plugin. This 'Parameterize by' input box takes
a regular expression that will be used to split a cell's content. Once
the cell's content has been split the sub-strings will be available
for URL generation using the `$__pattern_n` variables starting from
0. The default behavior splits the cell's content by spaces.

fixes #11066 

