### PR TITLE
Phantom render.js is incorrectly retrieving number of active panels

### DIFF
--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -57,7 +57,7 @@
 
           var rootScope = body.injector().get('$rootScope');
           if (!rootScope) {return false;}
-          var panels = angular.element('div.panel:visible').length;
+          var panels = angular.element('plugin-component').length;
           return rootScope.panelsRendered >= panels;
         });
 


### PR DESCRIPTION
Fixes #11099
The change is required as the div.panel class is applied not only on panels but also of rows for example, leading to overcounting the actual data panels.
The consequence is that the check below (currentlyRenderedPanels >= panels) never evaluates to true.