### PR TITLE
alerting: Limits telegram captions to 200 chars.

### DIFF
--- a/pkg/services/alerting/notifiers/telegram_test.go
+++ b/pkg/services/alerting/notifiers/telegram_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -50,6 +51,71 @@ func TestTelegramNotifier(t *testing.T) {
 				So(telegramNotifier.ChatID, ShouldEqual, "-1234567890")
 			})
 
+			Convey("generateCaption should generate a message with all pertinent details", func() {
+				evalContext := alerting.NewEvalContext(nil, &alerting.Rule{
+					Name:    "This is an alarm",
+					Message: "Some kind of message.",
+					State:   m.AlertStateOK,
+				})
+
+				caption := generateImageCaption(evalContext, "http://grafa.url/abcdef", "")
+				So(len(caption), ShouldBeLessThanOrEqualTo, 200)
+				So(caption, ShouldContainSubstring, "Some kind of message.")
+				So(caption, ShouldContainSubstring, "[OK] This is an alarm")
+				So(caption, ShouldContainSubstring, "http://grafa.url/abcdef")
+			})
+
+			Convey("When generating a message", func() {
+
+				Convey("URL should be skipped if it's too long", func() {
+					evalContext := alerting.NewEvalContext(nil, &alerting.Rule{
+						Name:    "This is an alarm",
+						Message: "Some kind of message.",
+						State:   m.AlertStateOK,
+					})
+
+					caption := generateImageCaption(evalContext,
+						"http://grafa.url/abcdefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"foo bar")
+					So(len(caption), ShouldBeLessThanOrEqualTo, 200)
+					So(caption, ShouldContainSubstring, "Some kind of message.")
+					So(caption, ShouldContainSubstring, "[OK] This is an alarm")
+					So(caption, ShouldContainSubstring, "foo bar")
+					So(caption, ShouldNotContainSubstring, "http")
+				})
+
+				Convey("Message should be trimmed if it's too long", func() {
+					evalContext := alerting.NewEvalContext(nil, &alerting.Rule{
+						Name:    "This is an alarm",
+						Message: "Some kind of message that is too long for appending to our pretty little message, this line is actually exactly 197 chars long and I will get there in the end I promise I will. Yes siree that's it.",
+						State:   m.AlertStateOK,
+					})
+
+					caption := generateImageCaption(evalContext,
+						"http://grafa.url/foo",
+						"")
+					So(len(caption), ShouldBeLessThanOrEqualTo, 200)
+					So(caption, ShouldContainSubstring, "[OK] This is an alarm")
+					So(caption, ShouldNotContainSubstring, "http")
+					So(caption, ShouldContainSubstring, "Some kind of message that is too long for appending to our pretty little message, this line is actually exactly 197 chars long and I will get there in the end I promise ")
+				})
+
+				Convey("Metrics should be skipped if they dont fit", func() {
+					evalContext := alerting.NewEvalContext(nil, &alerting.Rule{
+						Name:    "This is an alarm",
+						Message: "Some kind of message that is too long for appending to our pretty little message, this line is actually exactly 197 chars long and I will get there in the end I ",
+						State:   m.AlertStateOK,
+					})
+
+					caption := generateImageCaption(evalContext,
+						"http://grafa.url/foo",
+						"foo bar long song")
+					So(len(caption), ShouldBeLessThanOrEqualTo, 200)
+					So(caption, ShouldContainSubstring, "[OK] This is an alarm")
+					So(caption, ShouldNotContainSubstring, "http")
+					So(caption, ShouldNotContainSubstring, "foo bar")
+				})
+			})
 		})
 	})
 }


### PR DESCRIPTION
First pass at fixing Telegram inline image notifications which will currently fail if the caption is longer than 200 chars. Would like to add an option to send extra information as a second message in the future but I don't think it's important enough that we should do it in 5.0.1.