### PR TITLE
move Context and session out of middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ deps: deps-js
 build-go:
 	go run build.go build
 
+build-server:
+	go run build.go build-server
+
+build-cli:
+	go run build.go build-cli
+
 build-js:
-	npm run build
+	yarn run build
 
 build: build-go build-js
 
@@ -20,7 +26,7 @@ test-go:
 	go test -v ./pkg/...
 
 test-js:
-	npm test
+	yarn test
 
 test: test-go test-js
 

--- a/build.go
+++ b/build.go
@@ -83,6 +83,10 @@ func main() {
 			clean()
 			build("grafana-cli", "./pkg/cmd/grafana-cli", []string{})
 
+		case "build-server":
+			clean()
+			build("grafana-server", "./pkg/cmd/grafana-server", []string{})
+
 		case "build":
 			clean()
 			for _, binary := range binaries {

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -4,12 +4,11 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func AdminGetSettings(c *middleware.Context) {
+func AdminGetSettings(c *m.Context) {
 	settings := make(map[string]interface{})
 
 	for _, section := range setting.Cfg.Sections() {
@@ -30,7 +29,7 @@ func AdminGetSettings(c *middleware.Context) {
 	c.JSON(200, settings)
 }
 
-func AdminGetStats(c *middleware.Context) {
+func AdminGetStats(c *m.Context) {
 
 	statsQuery := m.GetAdminStatsQuery{}
 

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func AdminGetSettings(c *m.Context) {
+func AdminGetSettings(c *m.ReqContext) {
 	settings := make(map[string]interface{})
 
 	for _, section := range setting.Cfg.Sections() {
@@ -29,7 +29,7 @@ func AdminGetSettings(c *m.Context) {
 	c.JSON(200, settings)
 }
 
-func AdminGetStats(c *m.Context) {
+func AdminGetStats(c *m.ReqContext) {
 
 	statsQuery := m.GetAdminStatsQuery{}
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -4,12 +4,11 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func AdminCreateUser(c *middleware.Context, form dtos.AdminCreateUserForm) {
+func AdminCreateUser(c *m.Context, form dtos.AdminCreateUserForm) {
 	cmd := m.CreateUserCommand{
 		Login:    form.Login,
 		Email:    form.Email,
@@ -47,7 +46,7 @@ func AdminCreateUser(c *middleware.Context, form dtos.AdminCreateUserForm) {
 	c.JSON(200, result)
 }
 
-func AdminUpdateUserPassword(c *middleware.Context, form dtos.AdminUpdateUserPasswordForm) {
+func AdminUpdateUserPassword(c *m.Context, form dtos.AdminUpdateUserPasswordForm) {
 	userId := c.ParamsInt64(":id")
 
 	if len(form.Password) < 4 {
@@ -77,7 +76,7 @@ func AdminUpdateUserPassword(c *middleware.Context, form dtos.AdminUpdateUserPas
 	c.JsonOK("User password updated")
 }
 
-func AdminUpdateUserPermissions(c *middleware.Context, form dtos.AdminUpdateUserPermissionsForm) {
+func AdminUpdateUserPermissions(c *m.Context, form dtos.AdminUpdateUserPermissionsForm) {
 	userId := c.ParamsInt64(":id")
 
 	cmd := m.UpdateUserPermissionsCommand{
@@ -93,7 +92,7 @@ func AdminUpdateUserPermissions(c *middleware.Context, form dtos.AdminUpdateUser
 	c.JsonOK("User permissions updated")
 }
 
-func AdminDeleteUser(c *middleware.Context) {
+func AdminDeleteUser(c *m.Context) {
 	userId := c.ParamsInt64(":id")
 
 	cmd := m.DeleteUserCommand{UserId: userId}

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func AdminCreateUser(c *m.Context, form dtos.AdminCreateUserForm) {
+func AdminCreateUser(c *m.ReqContext, form dtos.AdminCreateUserForm) {
 	cmd := m.CreateUserCommand{
 		Login:    form.Login,
 		Email:    form.Email,
@@ -46,7 +46,7 @@ func AdminCreateUser(c *m.Context, form dtos.AdminCreateUserForm) {
 	c.JSON(200, result)
 }
 
-func AdminUpdateUserPassword(c *m.Context, form dtos.AdminUpdateUserPasswordForm) {
+func AdminUpdateUserPassword(c *m.ReqContext, form dtos.AdminUpdateUserPasswordForm) {
 	userId := c.ParamsInt64(":id")
 
 	if len(form.Password) < 4 {
@@ -76,7 +76,7 @@ func AdminUpdateUserPassword(c *m.Context, form dtos.AdminUpdateUserPasswordForm
 	c.JsonOK("User password updated")
 }
 
-func AdminUpdateUserPermissions(c *m.Context, form dtos.AdminUpdateUserPermissionsForm) {
+func AdminUpdateUserPermissions(c *m.ReqContext, form dtos.AdminUpdateUserPermissionsForm) {
 	userId := c.ParamsInt64(":id")
 
 	cmd := m.UpdateUserPermissionsCommand{
@@ -92,7 +92,7 @@ func AdminUpdateUserPermissions(c *m.Context, form dtos.AdminUpdateUserPermissio
 	c.JsonOK("User permissions updated")
 }
 
-func AdminDeleteUser(c *m.Context) {
+func AdminDeleteUser(c *m.ReqContext) {
 	userId := c.ParamsInt64(":id")
 
 	cmd := m.DeleteUserCommand{UserId: userId}

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/models"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func ValidateOrgAlert(c *middleware.Context) {
+func ValidateOrgAlert(c *m.Context) {
 	id := c.ParamsInt64(":alertId")
-	query := models.GetAlertByIdQuery{Id: id}
+	query := m.GetAlertByIdQuery{Id: id}
 
 	if err := bus.Dispatch(&query); err != nil {
 		c.JsonApiErr(404, "Alert not found", nil)
@@ -26,14 +25,14 @@ func ValidateOrgAlert(c *middleware.Context) {
 	}
 }
 
-func GetAlertStatesForDashboard(c *middleware.Context) Response {
+func GetAlertStatesForDashboard(c *m.Context) Response {
 	dashboardId := c.QueryInt64("dashboardId")
 
 	if dashboardId == 0 {
 		return ApiError(400, "Missing query parameter dashboardId", nil)
 	}
 
-	query := models.GetAlertStatesForDashboardQuery{
+	query := m.GetAlertStatesForDashboardQuery{
 		OrgId:       c.OrgId,
 		DashboardId: c.QueryInt64("dashboardId"),
 	}
@@ -46,8 +45,8 @@ func GetAlertStatesForDashboard(c *middleware.Context) Response {
 }
 
 // GET /api/alerts
-func GetAlerts(c *middleware.Context) Response {
-	query := models.GetAlertsQuery{
+func GetAlerts(c *m.Context) Response {
+	query := m.GetAlertsQuery{
 		OrgId:       c.OrgId,
 		DashboardId: c.QueryInt64("dashboardId"),
 		PanelId:     c.QueryInt64("panelId"),
@@ -65,14 +64,14 @@ func GetAlerts(c *middleware.Context) Response {
 	}
 
 	for _, alert := range query.Result {
-		alert.Url = models.GetDashboardUrl(alert.DashboardUid, alert.DashboardSlug)
+		alert.Url = m.GetDashboardUrl(alert.DashboardUid, alert.DashboardSlug)
 	}
 
 	return Json(200, query.Result)
 }
 
 // POST /api/alerts/test
-func AlertTest(c *middleware.Context, dto dtos.AlertTestCommand) Response {
+func AlertTest(c *m.Context, dto dtos.AlertTestCommand) Response {
 	if _, idErr := dto.Dashboard.Get("id").Int64(); idErr != nil {
 		return ApiError(400, "The dashboard needs to be saved at least once before you can test an alert rule", nil)
 	}
@@ -114,9 +113,9 @@ func AlertTest(c *middleware.Context, dto dtos.AlertTestCommand) Response {
 }
 
 // GET /api/alerts/:id
-func GetAlert(c *middleware.Context) Response {
+func GetAlert(c *m.Context) Response {
 	id := c.ParamsInt64(":alertId")
-	query := models.GetAlertByIdQuery{Id: id}
+	query := m.GetAlertByIdQuery{Id: id}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return ApiError(500, "List alerts failed", err)
@@ -125,12 +124,12 @@ func GetAlert(c *middleware.Context) Response {
 	return Json(200, &query.Result)
 }
 
-func GetAlertNotifiers(c *middleware.Context) Response {
+func GetAlertNotifiers(c *m.Context) Response {
 	return Json(200, alerting.GetNotifiers())
 }
 
-func GetAlertNotifications(c *middleware.Context) Response {
-	query := &models.GetAllAlertNotificationsQuery{OrgId: c.OrgId}
+func GetAlertNotifications(c *m.Context) Response {
+	query := &m.GetAllAlertNotificationsQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(query); err != nil {
 		return ApiError(500, "Failed to get alert notifications", err)
@@ -152,8 +151,8 @@ func GetAlertNotifications(c *middleware.Context) Response {
 	return Json(200, result)
 }
 
-func GetAlertNotificationById(c *middleware.Context) Response {
-	query := &models.GetAlertNotificationsQuery{
+func GetAlertNotificationById(c *m.Context) Response {
+	query := &m.GetAlertNotificationsQuery{
 		OrgId: c.OrgId,
 		Id:    c.ParamsInt64("notificationId"),
 	}
@@ -165,7 +164,7 @@ func GetAlertNotificationById(c *middleware.Context) Response {
 	return Json(200, query.Result)
 }
 
-func CreateAlertNotification(c *middleware.Context, cmd models.CreateAlertNotificationCommand) Response {
+func CreateAlertNotification(c *m.Context, cmd m.CreateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -175,7 +174,7 @@ func CreateAlertNotification(c *middleware.Context, cmd models.CreateAlertNotifi
 	return Json(200, cmd.Result)
 }
 
-func UpdateAlertNotification(c *middleware.Context, cmd models.UpdateAlertNotificationCommand) Response {
+func UpdateAlertNotification(c *m.Context, cmd m.UpdateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -185,8 +184,8 @@ func UpdateAlertNotification(c *middleware.Context, cmd models.UpdateAlertNotifi
 	return Json(200, cmd.Result)
 }
 
-func DeleteAlertNotification(c *middleware.Context) Response {
-	cmd := models.DeleteAlertNotificationCommand{
+func DeleteAlertNotification(c *m.Context) Response {
+	cmd := m.DeleteAlertNotificationCommand{
 		OrgId: c.OrgId,
 		Id:    c.ParamsInt64("notificationId"),
 	}
@@ -199,7 +198,7 @@ func DeleteAlertNotification(c *middleware.Context) Response {
 }
 
 //POST /api/alert-notifications/test
-func NotificationTest(c *middleware.Context, dto dtos.NotificationTestCommand) Response {
+func NotificationTest(c *m.Context, dto dtos.NotificationTestCommand) Response {
 	cmd := &alerting.NotificationTestCommand{
 		Name:     dto.Name,
 		Type:     dto.Type,
@@ -207,7 +206,7 @@ func NotificationTest(c *middleware.Context, dto dtos.NotificationTestCommand) R
 	}
 
 	if err := bus.Dispatch(cmd); err != nil {
-		if err == models.ErrSmtpNotEnabled {
+		if err == m.ErrSmtpNotEnabled {
 			return ApiError(412, err.Error(), err)
 		}
 		return ApiError(500, "Failed to send alert notifications", err)
@@ -217,10 +216,10 @@ func NotificationTest(c *middleware.Context, dto dtos.NotificationTestCommand) R
 }
 
 //POST /api/alerts/:alertId/pause
-func PauseAlert(c *middleware.Context, dto dtos.PauseAlertCommand) Response {
+func PauseAlert(c *m.Context, dto dtos.PauseAlertCommand) Response {
 	alertId := c.ParamsInt64("alertId")
 
-	query := models.GetAlertByIdQuery{Id: alertId}
+	query := m.GetAlertByIdQuery{Id: alertId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return ApiError(500, "Get Alert failed", err)
@@ -235,7 +234,7 @@ func PauseAlert(c *middleware.Context, dto dtos.PauseAlertCommand) Response {
 		return ApiError(403, "Access denied to this dashboard and alert", nil)
 	}
 
-	cmd := models.PauseAlertCommand{
+	cmd := m.PauseAlertCommand{
 		OrgId:    c.OrgId,
 		AlertIds: []int64{alertId},
 		Paused:   dto.Paused,
@@ -245,10 +244,10 @@ func PauseAlert(c *middleware.Context, dto dtos.PauseAlertCommand) Response {
 		return ApiError(500, "", err)
 	}
 
-	var response models.AlertStateType = models.AlertStatePending
+	var response m.AlertStateType = m.AlertStatePending
 	pausedState := "un-paused"
 	if cmd.Paused {
-		response = models.AlertStatePaused
+		response = m.AlertStatePaused
 		pausedState = "paused"
 	}
 
@@ -262,8 +261,8 @@ func PauseAlert(c *middleware.Context, dto dtos.PauseAlertCommand) Response {
 }
 
 //POST /api/admin/pause-all-alerts
-func PauseAllAlerts(c *middleware.Context, dto dtos.PauseAllAlertsCommand) Response {
-	updateCmd := models.PauseAllAlertCommand{
+func PauseAllAlerts(c *m.Context, dto dtos.PauseAllAlertsCommand) Response {
+	updateCmd := m.PauseAllAlertCommand{
 		Paused: dto.Paused,
 	}
 
@@ -271,10 +270,10 @@ func PauseAllAlerts(c *middleware.Context, dto dtos.PauseAllAlertsCommand) Respo
 		return ApiError(500, "Failed to pause alerts", err)
 	}
 
-	var response models.AlertStateType = models.AlertStatePending
+	var response m.AlertStateType = m.AlertStatePending
 	pausedState := "un paused"
 	if updateCmd.Paused {
-		response = models.AlertStatePaused
+		response = m.AlertStatePaused
 		pausedState = "paused"
 	}
 

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func ValidateOrgAlert(c *m.Context) {
+func ValidateOrgAlert(c *m.ReqContext) {
 	id := c.ParamsInt64(":alertId")
 	query := m.GetAlertByIdQuery{Id: id}
 
@@ -25,7 +25,7 @@ func ValidateOrgAlert(c *m.Context) {
 	}
 }
 
-func GetAlertStatesForDashboard(c *m.Context) Response {
+func GetAlertStatesForDashboard(c *m.ReqContext) Response {
 	dashboardId := c.QueryInt64("dashboardId")
 
 	if dashboardId == 0 {
@@ -45,7 +45,7 @@ func GetAlertStatesForDashboard(c *m.Context) Response {
 }
 
 // GET /api/alerts
-func GetAlerts(c *m.Context) Response {
+func GetAlerts(c *m.ReqContext) Response {
 	query := m.GetAlertsQuery{
 		OrgId:       c.OrgId,
 		DashboardId: c.QueryInt64("dashboardId"),
@@ -71,7 +71,7 @@ func GetAlerts(c *m.Context) Response {
 }
 
 // POST /api/alerts/test
-func AlertTest(c *m.Context, dto dtos.AlertTestCommand) Response {
+func AlertTest(c *m.ReqContext, dto dtos.AlertTestCommand) Response {
 	if _, idErr := dto.Dashboard.Get("id").Int64(); idErr != nil {
 		return ApiError(400, "The dashboard needs to be saved at least once before you can test an alert rule", nil)
 	}
@@ -113,7 +113,7 @@ func AlertTest(c *m.Context, dto dtos.AlertTestCommand) Response {
 }
 
 // GET /api/alerts/:id
-func GetAlert(c *m.Context) Response {
+func GetAlert(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":alertId")
 	query := m.GetAlertByIdQuery{Id: id}
 
@@ -124,11 +124,11 @@ func GetAlert(c *m.Context) Response {
 	return Json(200, &query.Result)
 }
 
-func GetAlertNotifiers(c *m.Context) Response {
+func GetAlertNotifiers(c *m.ReqContext) Response {
 	return Json(200, alerting.GetNotifiers())
 }
 
-func GetAlertNotifications(c *m.Context) Response {
+func GetAlertNotifications(c *m.ReqContext) Response {
 	query := &m.GetAllAlertNotificationsQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(query); err != nil {
@@ -151,7 +151,7 @@ func GetAlertNotifications(c *m.Context) Response {
 	return Json(200, result)
 }
 
-func GetAlertNotificationById(c *m.Context) Response {
+func GetAlertNotificationById(c *m.ReqContext) Response {
 	query := &m.GetAlertNotificationsQuery{
 		OrgId: c.OrgId,
 		Id:    c.ParamsInt64("notificationId"),
@@ -164,7 +164,7 @@ func GetAlertNotificationById(c *m.Context) Response {
 	return Json(200, query.Result)
 }
 
-func CreateAlertNotification(c *m.Context, cmd m.CreateAlertNotificationCommand) Response {
+func CreateAlertNotification(c *m.ReqContext, cmd m.CreateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -174,7 +174,7 @@ func CreateAlertNotification(c *m.Context, cmd m.CreateAlertNotificationCommand)
 	return Json(200, cmd.Result)
 }
 
-func UpdateAlertNotification(c *m.Context, cmd m.UpdateAlertNotificationCommand) Response {
+func UpdateAlertNotification(c *m.ReqContext, cmd m.UpdateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -184,7 +184,7 @@ func UpdateAlertNotification(c *m.Context, cmd m.UpdateAlertNotificationCommand)
 	return Json(200, cmd.Result)
 }
 
-func DeleteAlertNotification(c *m.Context) Response {
+func DeleteAlertNotification(c *m.ReqContext) Response {
 	cmd := m.DeleteAlertNotificationCommand{
 		OrgId: c.OrgId,
 		Id:    c.ParamsInt64("notificationId"),
@@ -198,7 +198,7 @@ func DeleteAlertNotification(c *m.Context) Response {
 }
 
 //POST /api/alert-notifications/test
-func NotificationTest(c *m.Context, dto dtos.NotificationTestCommand) Response {
+func NotificationTest(c *m.ReqContext, dto dtos.NotificationTestCommand) Response {
 	cmd := &alerting.NotificationTestCommand{
 		Name:     dto.Name,
 		Type:     dto.Type,
@@ -216,7 +216,7 @@ func NotificationTest(c *m.Context, dto dtos.NotificationTestCommand) Response {
 }
 
 //POST /api/alerts/:alertId/pause
-func PauseAlert(c *m.Context, dto dtos.PauseAlertCommand) Response {
+func PauseAlert(c *m.ReqContext, dto dtos.PauseAlertCommand) Response {
 	alertId := c.ParamsInt64("alertId")
 
 	query := m.GetAlertByIdQuery{Id: alertId}
@@ -261,7 +261,7 @@ func PauseAlert(c *m.Context, dto dtos.PauseAlertCommand) Response {
 }
 
 //POST /api/admin/pause-all-alerts
-func PauseAllAlerts(c *m.Context, dto dtos.PauseAllAlertsCommand) Response {
+func PauseAllAlerts(c *m.ReqContext, dto dtos.PauseAllAlertsCommand) Response {
 	updateCmd := m.PauseAllAlertCommand{
 		Paused: dto.Paused,
 	}

--- a/pkg/api/alerting_test.go
+++ b/pkg/api/alerting_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -81,7 +80,7 @@ func postAlertScenario(desc string, url string, routePattern string, role m.Role
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID

--- a/pkg/api/alerting_test.go
+++ b/pkg/api/alerting_test.go
@@ -80,7 +80,7 @@ func postAlertScenario(desc string, url string, routePattern string, role m.Role
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetAnnotations(c *middleware.Context) Response {
+func GetAnnotations(c *m.Context) Response {
 
 	query := &annotations.ItemQuery{
 		From:        c.QueryInt64("from") / 1000,
@@ -52,7 +51,7 @@ func (e *CreateAnnotationError) Error() string {
 	return e.message
 }
 
-func PostAnnotation(c *middleware.Context, cmd dtos.PostAnnotationsCmd) Response {
+func PostAnnotation(c *m.Context, cmd dtos.PostAnnotationsCmd) Response {
 	if canSave, err := canSaveByDashboardId(c, cmd.DashboardId); err != nil || !canSave {
 		return dashboardGuardianResponse(err)
 	}
@@ -125,7 +124,7 @@ func formatGraphiteAnnotation(what string, data string) string {
 	return text
 }
 
-func PostGraphiteAnnotation(c *middleware.Context, cmd dtos.PostGraphiteAnnotationsCmd) Response {
+func PostGraphiteAnnotation(c *m.Context, cmd dtos.PostGraphiteAnnotationsCmd) Response {
 	repo := annotations.GetRepository()
 
 	if cmd.What == "" {
@@ -179,7 +178,7 @@ func PostGraphiteAnnotation(c *middleware.Context, cmd dtos.PostGraphiteAnnotati
 	})
 }
 
-func UpdateAnnotation(c *middleware.Context, cmd dtos.UpdateAnnotationsCmd) Response {
+func UpdateAnnotation(c *m.Context, cmd dtos.UpdateAnnotationsCmd) Response {
 	annotationId := c.ParamsInt64(":annotationId")
 
 	repo := annotations.GetRepository()
@@ -218,7 +217,7 @@ func UpdateAnnotation(c *middleware.Context, cmd dtos.UpdateAnnotationsCmd) Resp
 	return ApiSuccess("Annotation updated")
 }
 
-func DeleteAnnotations(c *middleware.Context, cmd dtos.DeleteAnnotationsCmd) Response {
+func DeleteAnnotations(c *m.Context, cmd dtos.DeleteAnnotationsCmd) Response {
 	repo := annotations.GetRepository()
 
 	err := repo.Delete(&annotations.DeleteParams{
@@ -234,7 +233,7 @@ func DeleteAnnotations(c *middleware.Context, cmd dtos.DeleteAnnotationsCmd) Res
 	return ApiSuccess("Annotations deleted")
 }
 
-func DeleteAnnotationById(c *middleware.Context) Response {
+func DeleteAnnotationById(c *m.Context) Response {
 	repo := annotations.GetRepository()
 	annotationId := c.ParamsInt64(":annotationId")
 
@@ -253,7 +252,7 @@ func DeleteAnnotationById(c *middleware.Context) Response {
 	return ApiSuccess("Annotation deleted")
 }
 
-func DeleteAnnotationRegion(c *middleware.Context) Response {
+func DeleteAnnotationRegion(c *m.Context) Response {
 	repo := annotations.GetRepository()
 	regionId := c.ParamsInt64(":regionId")
 
@@ -272,7 +271,7 @@ func DeleteAnnotationRegion(c *middleware.Context) Response {
 	return ApiSuccess("Annotation region deleted")
 }
 
-func canSaveByDashboardId(c *middleware.Context, dashboardId int64) (bool, error) {
+func canSaveByDashboardId(c *m.Context, dashboardId int64) (bool, error) {
 	if dashboardId == 0 && !c.SignedInUser.HasRole(m.ROLE_EDITOR) {
 		return false, nil
 	}
@@ -287,7 +286,7 @@ func canSaveByDashboardId(c *middleware.Context, dashboardId int64) (bool, error
 	return true, nil
 }
 
-func canSave(c *middleware.Context, repo annotations.Repository, annotationId int64) Response {
+func canSave(c *m.Context, repo annotations.Repository, annotationId int64) Response {
 	items, err := repo.Find(&annotations.ItemQuery{AnnotationId: annotationId, OrgId: c.OrgId})
 
 	if err != nil || len(items) == 0 {
@@ -303,7 +302,7 @@ func canSave(c *middleware.Context, repo annotations.Repository, annotationId in
 	return nil
 }
 
-func canSaveByRegionId(c *middleware.Context, repo annotations.Repository, regionId int64) Response {
+func canSaveByRegionId(c *m.Context, repo annotations.Repository, regionId int64) Response {
 	items, err := repo.Find(&annotations.ItemQuery{RegionId: regionId, OrgId: c.OrgId})
 
 	if err != nil || len(items) == 0 {

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetAnnotations(c *m.Context) Response {
+func GetAnnotations(c *m.ReqContext) Response {
 
 	query := &annotations.ItemQuery{
 		From:        c.QueryInt64("from") / 1000,
@@ -51,7 +51,7 @@ func (e *CreateAnnotationError) Error() string {
 	return e.message
 }
 
-func PostAnnotation(c *m.Context, cmd dtos.PostAnnotationsCmd) Response {
+func PostAnnotation(c *m.ReqContext, cmd dtos.PostAnnotationsCmd) Response {
 	if canSave, err := canSaveByDashboardId(c, cmd.DashboardId); err != nil || !canSave {
 		return dashboardGuardianResponse(err)
 	}
@@ -124,7 +124,7 @@ func formatGraphiteAnnotation(what string, data string) string {
 	return text
 }
 
-func PostGraphiteAnnotation(c *m.Context, cmd dtos.PostGraphiteAnnotationsCmd) Response {
+func PostGraphiteAnnotation(c *m.ReqContext, cmd dtos.PostGraphiteAnnotationsCmd) Response {
 	repo := annotations.GetRepository()
 
 	if cmd.What == "" {
@@ -178,7 +178,7 @@ func PostGraphiteAnnotation(c *m.Context, cmd dtos.PostGraphiteAnnotationsCmd) R
 	})
 }
 
-func UpdateAnnotation(c *m.Context, cmd dtos.UpdateAnnotationsCmd) Response {
+func UpdateAnnotation(c *m.ReqContext, cmd dtos.UpdateAnnotationsCmd) Response {
 	annotationId := c.ParamsInt64(":annotationId")
 
 	repo := annotations.GetRepository()
@@ -217,7 +217,7 @@ func UpdateAnnotation(c *m.Context, cmd dtos.UpdateAnnotationsCmd) Response {
 	return ApiSuccess("Annotation updated")
 }
 
-func DeleteAnnotations(c *m.Context, cmd dtos.DeleteAnnotationsCmd) Response {
+func DeleteAnnotations(c *m.ReqContext, cmd dtos.DeleteAnnotationsCmd) Response {
 	repo := annotations.GetRepository()
 
 	err := repo.Delete(&annotations.DeleteParams{
@@ -233,7 +233,7 @@ func DeleteAnnotations(c *m.Context, cmd dtos.DeleteAnnotationsCmd) Response {
 	return ApiSuccess("Annotations deleted")
 }
 
-func DeleteAnnotationById(c *m.Context) Response {
+func DeleteAnnotationById(c *m.ReqContext) Response {
 	repo := annotations.GetRepository()
 	annotationId := c.ParamsInt64(":annotationId")
 
@@ -252,7 +252,7 @@ func DeleteAnnotationById(c *m.Context) Response {
 	return ApiSuccess("Annotation deleted")
 }
 
-func DeleteAnnotationRegion(c *m.Context) Response {
+func DeleteAnnotationRegion(c *m.ReqContext) Response {
 	repo := annotations.GetRepository()
 	regionId := c.ParamsInt64(":regionId")
 
@@ -271,7 +271,7 @@ func DeleteAnnotationRegion(c *m.Context) Response {
 	return ApiSuccess("Annotation region deleted")
 }
 
-func canSaveByDashboardId(c *m.Context, dashboardId int64) (bool, error) {
+func canSaveByDashboardId(c *m.ReqContext, dashboardId int64) (bool, error) {
 	if dashboardId == 0 && !c.SignedInUser.HasRole(m.ROLE_EDITOR) {
 		return false, nil
 	}
@@ -286,7 +286,7 @@ func canSaveByDashboardId(c *m.Context, dashboardId int64) (bool, error) {
 	return true, nil
 }
 
-func canSave(c *m.Context, repo annotations.Repository, annotationId int64) Response {
+func canSave(c *m.ReqContext, repo annotations.Repository, annotationId int64) Response {
 	items, err := repo.Find(&annotations.ItemQuery{AnnotationId: annotationId, OrgId: c.OrgId})
 
 	if err != nil || len(items) == 0 {
@@ -302,7 +302,7 @@ func canSave(c *m.Context, repo annotations.Repository, annotationId int64) Resp
 	return nil
 }
 
-func canSaveByRegionId(c *m.Context, repo annotations.Repository, regionId int64) Response {
+func canSaveByRegionId(c *m.ReqContext, repo annotations.Repository, regionId int64) Response {
 	items, err := repo.Find(&annotations.ItemQuery{RegionId: regionId, OrgId: c.OrgId})
 
 	if err != nil || len(items) == 0 {

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/annotations"
 
@@ -200,7 +199,7 @@ func postAnnotationScenario(desc string, url string, routePattern string, role m
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
@@ -223,7 +222,7 @@ func putAnnotationScenario(desc string, url string, routePattern string, role m.
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -199,7 +199,7 @@ func postAnnotationScenario(desc string, url string, routePattern string, role m
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
@@ -222,7 +222,7 @@ func putAnnotationScenario(desc string, url string, routePattern string, role m.
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -4,11 +4,10 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/apikeygen"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func GetApiKeys(c *middleware.Context) Response {
+func GetApiKeys(c *m.Context) Response {
 	query := m.GetApiKeysQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -27,7 +26,7 @@ func GetApiKeys(c *middleware.Context) Response {
 	return Json(200, result)
 }
 
-func DeleteApiKey(c *middleware.Context) Response {
+func DeleteApiKey(c *m.Context) Response {
 	id := c.ParamsInt64(":id")
 
 	cmd := &m.DeleteApiKeyCommand{Id: id, OrgId: c.OrgId}
@@ -40,7 +39,7 @@ func DeleteApiKey(c *middleware.Context) Response {
 	return ApiSuccess("API key deleted")
 }
 
-func AddApiKey(c *middleware.Context, cmd m.AddApiKeyCommand) Response {
+func AddApiKey(c *m.Context, cmd m.AddApiKeyCommand) Response {
 	if !cmd.Role.IsValid() {
 		return ApiError(400, "Invalid role specified", nil)
 	}

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -7,7 +7,7 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func GetApiKeys(c *m.Context) Response {
+func GetApiKeys(c *m.ReqContext) Response {
 	query := m.GetApiKeysQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -26,7 +26,7 @@ func GetApiKeys(c *m.Context) Response {
 	return Json(200, result)
 }
 
-func DeleteApiKey(c *m.Context) Response {
+func DeleteApiKey(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 
 	cmd := &m.DeleteApiKeyCommand{Id: id, OrgId: c.OrgId}
@@ -39,7 +39,7 @@ func DeleteApiKey(c *m.Context) Response {
 	return ApiSuccess("API key deleted")
 }
 
-func AddApiKey(c *m.Context, cmd m.AddApiKeyCommand) Response {
+func AddApiKey(c *m.ReqContext, cmd m.AddApiKeyCommand) Response {
 	if !cmd.Role.IsValid() {
 		return ApiError(400, "Invalid role specified", nil)
 	}

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -56,7 +56,7 @@ func InitAppPluginRoutes(r *macaron.Macaron) {
 }
 
 func AppPluginRoute(route *plugins.AppPluginRoute, appId string) macaron.Handler {
-	return func(c *middleware.Context) {
+	return func(c *m.Context) {
 		path := c.Params("*")
 
 		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appId)

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -56,7 +56,7 @@ func InitAppPluginRoutes(r *macaron.Macaron) {
 }
 
 func AppPluginRoute(route *plugins.AppPluginRoute, appId string) macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		path := c.Params("*")
 
 		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appId)

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/grafana/grafana/pkg/middleware"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
 )
@@ -19,7 +19,7 @@ var (
 )
 
 type Response interface {
-	WriteTo(ctx *middleware.Context)
+	WriteTo(ctx *m.Context)
 }
 
 type NormalResponse struct {
@@ -32,7 +32,7 @@ type NormalResponse struct {
 
 func wrap(action interface{}) macaron.Handler {
 
-	return func(c *middleware.Context) {
+	return func(c *m.Context) {
 		var res Response
 		val, err := c.Invoke(action)
 		if err == nil && val != nil && len(val) > 0 {
@@ -45,7 +45,7 @@ func wrap(action interface{}) macaron.Handler {
 	}
 }
 
-func (r *NormalResponse) WriteTo(ctx *middleware.Context) {
+func (r *NormalResponse) WriteTo(ctx *m.Context) {
 	if r.err != nil {
 		ctx.Logger.Error(r.errMessage, "error", r.err)
 	}

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -19,7 +19,7 @@ var (
 )
 
 type Response interface {
-	WriteTo(ctx *m.Context)
+	WriteTo(ctx *m.ReqContext)
 }
 
 type NormalResponse struct {
@@ -32,7 +32,7 @@ type NormalResponse struct {
 
 func wrap(action interface{}) macaron.Handler {
 
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		var res Response
 		val, err := c.Invoke(action)
 		if err == nil && val != nil && len(val) > 0 {
@@ -45,7 +45,7 @@ func wrap(action interface{}) macaron.Handler {
 	}
 }
 
-func (r *NormalResponse) WriteTo(ctx *m.Context) {
+func (r *NormalResponse) WriteTo(ctx *m.ReqContext) {
 	if r.err != nil {
 		ctx.Logger.Error(r.errMessage, "error", r.err)
 	}

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -8,22 +8,22 @@ import (
 	"github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/models"
-	macaron "gopkg.in/macaron.v1"
+	m "github.com/grafana/grafana/pkg/models"
+	"gopkg.in/macaron.v1"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func loggedInUserScenario(desc string, url string, fn scenarioFunc) {
-	loggedInUserScenarioWithRole(desc, "GET", url, url, models.ROLE_EDITOR, fn)
+	loggedInUserScenarioWithRole(desc, "GET", url, url, m.ROLE_EDITOR, fn)
 }
 
-func loggedInUserScenarioWithRole(desc string, method string, url string, routePattern string, role models.RoleType, fn scenarioFunc) {
+func loggedInUserScenarioWithRole(desc string, method string, url string, routePattern string, role m.RoleType, fn scenarioFunc) {
 	Convey(desc+" "+url, func() {
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
@@ -71,7 +71,7 @@ func (sc *scenarioContext) fakeReqWithParams(method, url string, queryParams map
 
 type scenarioContext struct {
 	m              *macaron.Macaron
-	context        *middleware.Context
+	context        *m.Context
 	resp           *httptest.ResponseRecorder
 	handlerFunc    handlerFunc
 	defaultHandler macaron.Handler
@@ -84,7 +84,7 @@ func (sc *scenarioContext) exec() {
 }
 
 type scenarioFunc func(c *scenarioContext)
-type handlerFunc func(c *middleware.Context) Response
+type handlerFunc func(c *m.Context) Response
 
 func setupScenarioContext(url string) *scenarioContext {
 	sc := &scenarioContext{

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -23,7 +23,7 @@ func loggedInUserScenarioWithRole(desc string, method string, url string, routeP
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
@@ -71,7 +71,7 @@ func (sc *scenarioContext) fakeReqWithParams(method, url string, queryParams map
 
 type scenarioContext struct {
 	m              *macaron.Macaron
-	context        *m.Context
+	context        *m.ReqContext
 	resp           *httptest.ResponseRecorder
 	handlerFunc    handlerFunc
 	defaultHandler macaron.Handler
@@ -84,7 +84,7 @@ func (sc *scenarioContext) exec() {
 }
 
 type scenarioFunc func(c *scenarioContext)
-type handlerFunc func(c *m.Context) Response
+type handlerFunc func(c *m.ReqContext) Response
 
 func setupScenarioContext(url string) *scenarioContext {
 	sc := &scenarioContext{

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -22,7 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func isDashboardStarredByUser(c *middleware.Context, dashId int64) (bool, error) {
+func isDashboardStarredByUser(c *m.Context, dashId int64) (bool, error) {
 	if !c.IsSignedIn {
 		return false, nil
 	}
@@ -43,7 +43,7 @@ func dashboardGuardianResponse(err error) Response {
 	return ApiError(403, "Access denied to this dashboard", nil)
 }
 
-func GetDashboard(c *middleware.Context) Response {
+func GetDashboard(c *m.Context) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, c.Params(":uid"))
 	if rsp != nil {
 		return rsp
@@ -141,7 +141,7 @@ func getDashboardHelper(orgId int64, slug string, id int64, uid string) (*m.Dash
 	return query.Result, nil
 }
 
-func DeleteDashboard(c *middleware.Context) Response {
+func DeleteDashboard(c *m.Context) Response {
 	query := m.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: c.Params(":slug")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -173,7 +173,7 @@ func DeleteDashboard(c *middleware.Context) Response {
 	})
 }
 
-func DeleteDashboardByUid(c *middleware.Context) Response {
+func DeleteDashboardByUid(c *m.Context) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, "", 0, c.Params(":uid"))
 	if rsp != nil {
 		return rsp
@@ -195,7 +195,7 @@ func DeleteDashboardByUid(c *middleware.Context) Response {
 	})
 }
 
-func PostDashboard(c *middleware.Context, cmd m.SaveDashboardCommand) Response {
+func PostDashboard(c *m.Context, cmd m.SaveDashboardCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.UserId = c.UserId
 
@@ -278,7 +278,7 @@ func PostDashboard(c *middleware.Context, cmd m.SaveDashboardCommand) Response {
 	})
 }
 
-func GetHomeDashboard(c *middleware.Context) Response {
+func GetHomeDashboard(c *m.Context) Response {
 	prefsQuery := m.GetPreferencesWithDefaultsQuery{OrgId: c.OrgId, UserId: c.UserId}
 	if err := bus.Dispatch(&prefsQuery); err != nil {
 		return ApiError(500, "Failed to get preferences", err)
@@ -338,7 +338,7 @@ func addGettingStartedPanelToHomeDashboard(dash *simplejson.Json) {
 }
 
 // GetDashboardVersions returns all dashboard versions as JSON
-func GetDashboardVersions(c *middleware.Context) Response {
+func GetDashboardVersions(c *m.Context) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	guardian := guardian.New(dashId, c.OrgId, c.SignedInUser)
@@ -377,7 +377,7 @@ func GetDashboardVersions(c *middleware.Context) Response {
 }
 
 // GetDashboardVersion returns the dashboard version with the given ID.
-func GetDashboardVersion(c *middleware.Context) Response {
+func GetDashboardVersion(c *m.Context) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	guardian := guardian.New(dashId, c.OrgId, c.SignedInUser)
@@ -409,7 +409,7 @@ func GetDashboardVersion(c *middleware.Context) Response {
 }
 
 // POST /api/dashboards/calculate-diff performs diffs on two dashboards
-func CalculateDashboardDiff(c *middleware.Context, apiOptions dtos.CalculateDiffOptions) Response {
+func CalculateDashboardDiff(c *m.Context, apiOptions dtos.CalculateDiffOptions) Response {
 
 	guardianBase := guardian.New(apiOptions.Base.DashboardId, c.OrgId, c.SignedInUser)
 	if canSave, err := guardianBase.CanSave(); err != nil || !canSave {
@@ -454,7 +454,7 @@ func CalculateDashboardDiff(c *middleware.Context, apiOptions dtos.CalculateDiff
 }
 
 // RestoreDashboardVersion restores a dashboard to the given version.
-func RestoreDashboardVersion(c *middleware.Context, apiCmd dtos.RestoreDashboardVersionCommand) Response {
+func RestoreDashboardVersion(c *m.Context, apiCmd dtos.RestoreDashboardVersionCommand) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, "", c.ParamsInt64(":dashboardId"), "")
 	if rsp != nil {
 		return rsp
@@ -484,7 +484,7 @@ func RestoreDashboardVersion(c *middleware.Context, apiCmd dtos.RestoreDashboard
 	return PostDashboard(c, saveCmd)
 }
 
-func GetDashboardTags(c *middleware.Context) {
+func GetDashboardTags(c *m.Context) {
 	query := m.GetDashboardTagsQuery{OrgId: c.OrgId}
 	err := bus.Dispatch(&query)
 	if err != nil {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -22,7 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func isDashboardStarredByUser(c *m.Context, dashId int64) (bool, error) {
+func isDashboardStarredByUser(c *m.ReqContext, dashId int64) (bool, error) {
 	if !c.IsSignedIn {
 		return false, nil
 	}
@@ -43,7 +43,7 @@ func dashboardGuardianResponse(err error) Response {
 	return ApiError(403, "Access denied to this dashboard", nil)
 }
 
-func GetDashboard(c *m.Context) Response {
+func GetDashboard(c *m.ReqContext) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, c.Params(":uid"))
 	if rsp != nil {
 		return rsp
@@ -141,7 +141,7 @@ func getDashboardHelper(orgId int64, slug string, id int64, uid string) (*m.Dash
 	return query.Result, nil
 }
 
-func DeleteDashboard(c *m.Context) Response {
+func DeleteDashboard(c *m.ReqContext) Response {
 	query := m.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: c.Params(":slug")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -173,7 +173,7 @@ func DeleteDashboard(c *m.Context) Response {
 	})
 }
 
-func DeleteDashboardByUid(c *m.Context) Response {
+func DeleteDashboardByUid(c *m.ReqContext) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, "", 0, c.Params(":uid"))
 	if rsp != nil {
 		return rsp
@@ -195,7 +195,7 @@ func DeleteDashboardByUid(c *m.Context) Response {
 	})
 }
 
-func PostDashboard(c *m.Context, cmd m.SaveDashboardCommand) Response {
+func PostDashboard(c *m.ReqContext, cmd m.SaveDashboardCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.UserId = c.UserId
 
@@ -278,7 +278,7 @@ func PostDashboard(c *m.Context, cmd m.SaveDashboardCommand) Response {
 	})
 }
 
-func GetHomeDashboard(c *m.Context) Response {
+func GetHomeDashboard(c *m.ReqContext) Response {
 	prefsQuery := m.GetPreferencesWithDefaultsQuery{OrgId: c.OrgId, UserId: c.UserId}
 	if err := bus.Dispatch(&prefsQuery); err != nil {
 		return ApiError(500, "Failed to get preferences", err)
@@ -338,7 +338,7 @@ func addGettingStartedPanelToHomeDashboard(dash *simplejson.Json) {
 }
 
 // GetDashboardVersions returns all dashboard versions as JSON
-func GetDashboardVersions(c *m.Context) Response {
+func GetDashboardVersions(c *m.ReqContext) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	guardian := guardian.New(dashId, c.OrgId, c.SignedInUser)
@@ -377,7 +377,7 @@ func GetDashboardVersions(c *m.Context) Response {
 }
 
 // GetDashboardVersion returns the dashboard version with the given ID.
-func GetDashboardVersion(c *m.Context) Response {
+func GetDashboardVersion(c *m.ReqContext) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	guardian := guardian.New(dashId, c.OrgId, c.SignedInUser)
@@ -409,7 +409,7 @@ func GetDashboardVersion(c *m.Context) Response {
 }
 
 // POST /api/dashboards/calculate-diff performs diffs on two dashboards
-func CalculateDashboardDiff(c *m.Context, apiOptions dtos.CalculateDiffOptions) Response {
+func CalculateDashboardDiff(c *m.ReqContext, apiOptions dtos.CalculateDiffOptions) Response {
 
 	guardianBase := guardian.New(apiOptions.Base.DashboardId, c.OrgId, c.SignedInUser)
 	if canSave, err := guardianBase.CanSave(); err != nil || !canSave {
@@ -454,7 +454,7 @@ func CalculateDashboardDiff(c *m.Context, apiOptions dtos.CalculateDiffOptions) 
 }
 
 // RestoreDashboardVersion restores a dashboard to the given version.
-func RestoreDashboardVersion(c *m.Context, apiCmd dtos.RestoreDashboardVersionCommand) Response {
+func RestoreDashboardVersion(c *m.ReqContext, apiCmd dtos.RestoreDashboardVersionCommand) Response {
 	dash, rsp := getDashboardHelper(c.OrgId, "", c.ParamsInt64(":dashboardId"), "")
 	if rsp != nil {
 		return rsp
@@ -484,7 +484,7 @@ func RestoreDashboardVersion(c *m.Context, apiCmd dtos.RestoreDashboardVersionCo
 	return PostDashboard(c, saveCmd)
 }
 
-func GetDashboardTags(c *m.Context) {
+func GetDashboardTags(c *m.ReqContext) {
 	query := m.GetDashboardTagsQuery{OrgId: c.OrgId}
 	err := bus.Dispatch(&query)
 	if err != nil {

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func GetDashboardPermissionList(c *middleware.Context) Response {
+func GetDashboardPermissionList(c *m.Context) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")
@@ -38,7 +37,7 @@ func GetDashboardPermissionList(c *middleware.Context) Response {
 	return Json(200, acl)
 }
 
-func UpdateDashboardPermissions(c *middleware.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
+func UpdateDashboardPermissions(c *m.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func GetDashboardPermissionList(c *m.Context) Response {
+func GetDashboardPermissionList(c *m.ReqContext) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")
@@ -37,7 +37,7 @@ func GetDashboardPermissionList(c *m.Context) Response {
 	return Json(200, acl)
 }
 
-func UpdateDashboardPermissions(c *m.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
+func UpdateDashboardPermissions(c *m.ReqContext, apiCmd dtos.UpdateDashboardAclCommand) Response {
 	dashId := c.ParamsInt64(":dashboardId")
 
 	_, rsp := getDashboardHelper(c.OrgId, "", dashId, "")

--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
 
@@ -195,7 +194,7 @@ func updateDashboardPermissionScenario(desc string, url string, routePattern str
 
 		sc := setupScenarioContext(url)
 
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.OrgId = TestOrgID
 			sc.context.UserId = TestUserID

--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -194,7 +194,7 @@ func updateDashboardPermissionScenario(desc string, url string, routePattern str
 
 		sc := setupScenarioContext(url)
 
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.OrgId = TestOrgID
 			sc.context.UserId = TestUserID

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -6,14 +6,13 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetSharingOptions(c *middleware.Context) {
+func GetSharingOptions(c *m.Context) {
 	c.JSON(200, util.DynMap{
 		"externalSnapshotURL":  setting.ExternalSnapshotUrl,
 		"externalSnapshotName": setting.ExternalSnapshotName,
@@ -21,7 +20,7 @@ func GetSharingOptions(c *middleware.Context) {
 	})
 }
 
-func CreateDashboardSnapshot(c *middleware.Context, cmd m.CreateDashboardSnapshotCommand) {
+func CreateDashboardSnapshot(c *m.Context, cmd m.CreateDashboardSnapshotCommand) {
 	if cmd.Name == "" {
 		cmd.Name = "Unnamed snapshot"
 	}
@@ -58,7 +57,7 @@ func CreateDashboardSnapshot(c *middleware.Context, cmd m.CreateDashboardSnapsho
 }
 
 // GET /api/snapshots/:key
-func GetDashboardSnapshot(c *middleware.Context) {
+func GetDashboardSnapshot(c *m.Context) {
 	key := c.Params(":key")
 	query := &m.GetDashboardSnapshotQuery{Key: key}
 
@@ -93,7 +92,7 @@ func GetDashboardSnapshot(c *middleware.Context) {
 }
 
 // GET /api/snapshots-delete/:key
-func DeleteDashboardSnapshot(c *middleware.Context) Response {
+func DeleteDashboardSnapshot(c *m.Context) Response {
 	key := c.Params(":key")
 
 	query := &m.GetDashboardSnapshotQuery{DeleteKey: key}
@@ -129,7 +128,7 @@ func DeleteDashboardSnapshot(c *middleware.Context) Response {
 }
 
 // GET /api/dashboard/snapshots
-func SearchDashboardSnapshots(c *middleware.Context) Response {
+func SearchDashboardSnapshots(c *m.Context) Response {
 	query := c.Query("query")
 	limit := c.QueryInt("limit")
 

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetSharingOptions(c *m.Context) {
+func GetSharingOptions(c *m.ReqContext) {
 	c.JSON(200, util.DynMap{
 		"externalSnapshotURL":  setting.ExternalSnapshotUrl,
 		"externalSnapshotName": setting.ExternalSnapshotName,
@@ -20,7 +20,7 @@ func GetSharingOptions(c *m.Context) {
 	})
 }
 
-func CreateDashboardSnapshot(c *m.Context, cmd m.CreateDashboardSnapshotCommand) {
+func CreateDashboardSnapshot(c *m.ReqContext, cmd m.CreateDashboardSnapshotCommand) {
 	if cmd.Name == "" {
 		cmd.Name = "Unnamed snapshot"
 	}
@@ -57,7 +57,7 @@ func CreateDashboardSnapshot(c *m.Context, cmd m.CreateDashboardSnapshotCommand)
 }
 
 // GET /api/snapshots/:key
-func GetDashboardSnapshot(c *m.Context) {
+func GetDashboardSnapshot(c *m.ReqContext) {
 	key := c.Params(":key")
 	query := &m.GetDashboardSnapshotQuery{Key: key}
 
@@ -92,7 +92,7 @@ func GetDashboardSnapshot(c *m.Context) {
 }
 
 // GET /api/snapshots-delete/:key
-func DeleteDashboardSnapshot(c *m.Context) Response {
+func DeleteDashboardSnapshot(c *m.ReqContext) Response {
 	key := c.Params(":key")
 
 	query := &m.GetDashboardSnapshotQuery{DeleteKey: key}
@@ -128,7 +128,7 @@ func DeleteDashboardSnapshot(c *m.Context) Response {
 }
 
 // GET /api/dashboard/snapshots
-func SearchDashboardSnapshots(c *m.Context) Response {
+func SearchDashboardSnapshots(c *m.ReqContext) Response {
 	query := c.Query("query")
 	limit := c.QueryInt("limit")
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/setting"
@@ -862,7 +861,7 @@ func postDashboardScenario(desc string, url string, routePattern string, mock *d
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: cmd.OrgId, UserId: cmd.UserId}
 
@@ -887,7 +886,7 @@ func postDiffScenario(desc string, url string, routePattern string, cmd dtos.Cal
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{
 				OrgId:  TestOrgID,

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -861,7 +861,7 @@ func postDashboardScenario(desc string, url string, routePattern string, mock *d
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: cmd.OrgId, UserId: cmd.UserId}
 
@@ -886,7 +886,7 @@ func postDiffScenario(desc string, url string, routePattern string, cmd dtos.Cal
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{
 				OrgId:  TestOrgID,

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/pluginproxy"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 )
@@ -35,7 +34,7 @@ func (hs *HttpServer) getDatasourceById(id int64, orgId int64, nocache bool) (*m
 	return query.Result, nil
 }
 
-func (hs *HttpServer) ProxyDataSourceRequest(c *middleware.Context) {
+func (hs *HttpServer) ProxyDataSourceRequest(c *m.Context) {
 	c.TimeRequest(metrics.M_DataSource_ProxyReq_Timer)
 
 	nocache := c.Req.Header.Get(HeaderNameNoBackendCache) == "true"

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -34,7 +34,7 @@ func (hs *HttpServer) getDatasourceById(id int64, orgId int64, nocache bool) (*m
 	return query.Result, nil
 }
 
-func (hs *HttpServer) ProxyDataSourceRequest(c *m.Context) {
+func (hs *HttpServer) ProxyDataSourceRequest(c *m.ReqContext) {
 	c.TimeRequest(metrics.M_DataSource_ProxyReq_Timer)
 
 	nocache := c.Req.Header.Get(HeaderNameNoBackendCache) == "true"

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetDataSources(c *middleware.Context) Response {
+func GetDataSources(c *m.Context) Response {
 	query := m.GetDataSourcesQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -50,7 +49,7 @@ func GetDataSources(c *middleware.Context) Response {
 	return Json(200, &result)
 }
 
-func GetDataSourceById(c *middleware.Context) Response {
+func GetDataSourceById(c *m.Context) Response {
 	query := m.GetDataSourceByIdQuery{
 		Id:    c.ParamsInt64(":id"),
 		OrgId: c.OrgId,
@@ -69,7 +68,7 @@ func GetDataSourceById(c *middleware.Context) Response {
 	return Json(200, &dtos)
 }
 
-func DeleteDataSourceById(c *middleware.Context) Response {
+func DeleteDataSourceById(c *m.Context) Response {
 	id := c.ParamsInt64(":id")
 
 	if id <= 0 {
@@ -95,7 +94,7 @@ func DeleteDataSourceById(c *middleware.Context) Response {
 	return ApiSuccess("Data source deleted")
 }
 
-func DeleteDataSourceByName(c *middleware.Context) Response {
+func DeleteDataSourceByName(c *m.Context) Response {
 	name := c.Params(":name")
 
 	if name == "" {
@@ -120,7 +119,7 @@ func DeleteDataSourceByName(c *middleware.Context) Response {
 	return ApiSuccess("Data source deleted")
 }
 
-func AddDataSource(c *middleware.Context, cmd m.AddDataSourceCommand) Response {
+func AddDataSource(c *m.Context, cmd m.AddDataSourceCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -140,7 +139,7 @@ func AddDataSource(c *middleware.Context, cmd m.AddDataSourceCommand) Response {
 	})
 }
 
-func UpdateDataSource(c *middleware.Context, cmd m.UpdateDataSourceCommand) Response {
+func UpdateDataSource(c *m.Context, cmd m.UpdateDataSourceCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.Id = c.ParamsInt64(":id")
 
@@ -205,7 +204,7 @@ func getRawDataSourceById(id int64, orgId int64) (*m.DataSource, error) {
 }
 
 // Get /api/datasources/name/:name
-func GetDataSourceByName(c *middleware.Context) Response {
+func GetDataSourceByName(c *m.Context) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -221,7 +220,7 @@ func GetDataSourceByName(c *middleware.Context) Response {
 }
 
 // Get /api/datasources/id/:name
-func GetDataSourceIdByName(c *middleware.Context) Response {
+func GetDataSourceIdByName(c *m.Context) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetDataSources(c *m.Context) Response {
+func GetDataSources(c *m.ReqContext) Response {
 	query := m.GetDataSourcesQuery{OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -49,7 +49,7 @@ func GetDataSources(c *m.Context) Response {
 	return Json(200, &result)
 }
 
-func GetDataSourceById(c *m.Context) Response {
+func GetDataSourceById(c *m.ReqContext) Response {
 	query := m.GetDataSourceByIdQuery{
 		Id:    c.ParamsInt64(":id"),
 		OrgId: c.OrgId,
@@ -68,7 +68,7 @@ func GetDataSourceById(c *m.Context) Response {
 	return Json(200, &dtos)
 }
 
-func DeleteDataSourceById(c *m.Context) Response {
+func DeleteDataSourceById(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 
 	if id <= 0 {
@@ -94,7 +94,7 @@ func DeleteDataSourceById(c *m.Context) Response {
 	return ApiSuccess("Data source deleted")
 }
 
-func DeleteDataSourceByName(c *m.Context) Response {
+func DeleteDataSourceByName(c *m.ReqContext) Response {
 	name := c.Params(":name")
 
 	if name == "" {
@@ -119,7 +119,7 @@ func DeleteDataSourceByName(c *m.Context) Response {
 	return ApiSuccess("Data source deleted")
 }
 
-func AddDataSource(c *m.Context, cmd m.AddDataSourceCommand) Response {
+func AddDataSource(c *m.ReqContext, cmd m.AddDataSourceCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -139,7 +139,7 @@ func AddDataSource(c *m.Context, cmd m.AddDataSourceCommand) Response {
 	})
 }
 
-func UpdateDataSource(c *m.Context, cmd m.UpdateDataSourceCommand) Response {
+func UpdateDataSource(c *m.ReqContext, cmd m.UpdateDataSourceCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.Id = c.ParamsInt64(":id")
 
@@ -204,7 +204,7 @@ func getRawDataSourceById(id int64, orgId int64) (*m.DataSource, error) {
 }
 
 // Get /api/datasources/name/:name
-func GetDataSourceByName(c *m.Context) Response {
+func GetDataSourceByName(c *m.ReqContext) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -220,7 +220,7 @@ func GetDataSourceByName(c *m.Context) Response {
 }
 
 // Get /api/datasources/id/:name
-func GetDataSourceIdByName(c *m.Context) Response {
+func GetDataSourceIdByName(c *m.ReqContext) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetFolders(c *middleware.Context) Response {
+func GetFolders(c *m.Context) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folders, err := s.GetFolders(c.QueryInt("limit"))
 
@@ -32,7 +31,7 @@ func GetFolders(c *middleware.Context) Response {
 	return Json(200, result)
 }
 
-func GetFolderByUid(c *middleware.Context) Response {
+func GetFolderByUid(c *m.Context) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 
@@ -44,7 +43,7 @@ func GetFolderByUid(c *middleware.Context) Response {
 	return Json(200, toFolderDto(g, folder))
 }
 
-func GetFolderById(c *middleware.Context) Response {
+func GetFolderById(c *m.Context) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderById(c.ParamsInt64(":id"))
 	if err != nil {
@@ -55,7 +54,7 @@ func GetFolderById(c *middleware.Context) Response {
 	return Json(200, toFolderDto(g, folder))
 }
 
-func CreateFolder(c *middleware.Context, cmd m.CreateFolderCommand) Response {
+func CreateFolder(c *m.Context, cmd m.CreateFolderCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	err := s.CreateFolder(&cmd)
 	if err != nil {
@@ -66,7 +65,7 @@ func CreateFolder(c *middleware.Context, cmd m.CreateFolderCommand) Response {
 	return Json(200, toFolderDto(g, cmd.Result))
 }
 
-func UpdateFolder(c *middleware.Context, cmd m.UpdateFolderCommand) Response {
+func UpdateFolder(c *m.Context, cmd m.UpdateFolderCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	err := s.UpdateFolder(c.Params(":uid"), &cmd)
 	if err != nil {
@@ -77,7 +76,7 @@ func UpdateFolder(c *middleware.Context, cmd m.UpdateFolderCommand) Response {
 	return Json(200, toFolderDto(g, cmd.Result))
 }
 
-func DeleteFolder(c *middleware.Context) Response {
+func DeleteFolder(c *m.Context) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	f, err := s.DeleteFolder(c.Params(":uid"))
 	if err != nil {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetFolders(c *m.Context) Response {
+func GetFolders(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folders, err := s.GetFolders(c.QueryInt("limit"))
 
@@ -31,7 +31,7 @@ func GetFolders(c *m.Context) Response {
 	return Json(200, result)
 }
 
-func GetFolderByUid(c *m.Context) Response {
+func GetFolderByUid(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 
@@ -43,7 +43,7 @@ func GetFolderByUid(c *m.Context) Response {
 	return Json(200, toFolderDto(g, folder))
 }
 
-func GetFolderById(c *m.Context) Response {
+func GetFolderById(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderById(c.ParamsInt64(":id"))
 	if err != nil {
@@ -54,7 +54,7 @@ func GetFolderById(c *m.Context) Response {
 	return Json(200, toFolderDto(g, folder))
 }
 
-func CreateFolder(c *m.Context, cmd m.CreateFolderCommand) Response {
+func CreateFolder(c *m.ReqContext, cmd m.CreateFolderCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	err := s.CreateFolder(&cmd)
 	if err != nil {
@@ -65,7 +65,7 @@ func CreateFolder(c *m.Context, cmd m.CreateFolderCommand) Response {
 	return Json(200, toFolderDto(g, cmd.Result))
 }
 
-func UpdateFolder(c *m.Context, cmd m.UpdateFolderCommand) Response {
+func UpdateFolder(c *m.ReqContext, cmd m.UpdateFolderCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	err := s.UpdateFolder(c.Params(":uid"), &cmd)
 	if err != nil {
@@ -76,7 +76,7 @@ func UpdateFolder(c *m.Context, cmd m.UpdateFolderCommand) Response {
 	return Json(200, toFolderDto(g, cmd.Result))
 }
 
-func DeleteFolder(c *m.Context) Response {
+func DeleteFolder(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	f, err := s.DeleteFolder(c.Params(":uid"))
 	if err != nil {

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func GetFolderPermissionList(c *middleware.Context) Response {
+func GetFolderPermissionList(c *m.Context) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 
@@ -42,7 +41,7 @@ func GetFolderPermissionList(c *middleware.Context) Response {
 	return Json(200, acl)
 }
 
-func UpdateFolderPermissions(c *middleware.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
+func UpdateFolderPermissions(c *m.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 )
 
-func GetFolderPermissionList(c *m.Context) Response {
+func GetFolderPermissionList(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 
@@ -41,7 +41,7 @@ func GetFolderPermissionList(c *m.Context) Response {
 	return Json(200, acl)
 }
 
-func UpdateFolderPermissions(c *m.Context, apiCmd dtos.UpdateDashboardAclCommand) Response {
+func UpdateFolderPermissions(c *m.ReqContext, apiCmd dtos.UpdateDashboardAclCommand) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
 	folder, err := s.GetFolderByUid(c.Params(":uid"))
 

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
@@ -227,7 +226,7 @@ func updateFolderPermissionScenario(desc string, url string, routePattern string
 
 		sc := setupScenarioContext(url)
 
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.OrgId = TestOrgID
 			sc.context.UserId = TestUserID

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -226,7 +226,7 @@ func updateFolderPermissionScenario(desc string, url string, routePattern string
 
 		sc := setupScenarioContext(url)
 
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.OrgId = TestOrgID
 			sc.context.UserId = TestUserID

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -7,11 +7,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -155,7 +152,7 @@ func createFolderScenario(desc string, url string, routePattern string, mock *fa
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: TestOrgID, UserId: TestUserID}
 
@@ -184,7 +181,7 @@ func updateFolderScenario(desc string, url string, routePattern string, mock *fa
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *middleware.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.Context) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: TestOrgID, UserId: TestUserID}
 
@@ -205,50 +202,50 @@ func updateFolderScenario(desc string, url string, routePattern string, mock *fa
 }
 
 type fakeFolderService struct {
-	GetFoldersResult     []*models.Folder
+	GetFoldersResult     []*m.Folder
 	GetFoldersError      error
-	GetFolderByUidResult *models.Folder
+	GetFolderByUidResult *m.Folder
 	GetFolderByUidError  error
-	GetFolderByIdResult  *models.Folder
+	GetFolderByIdResult  *m.Folder
 	GetFolderByIdError   error
-	CreateFolderResult   *models.Folder
+	CreateFolderResult   *m.Folder
 	CreateFolderError    error
-	UpdateFolderResult   *models.Folder
+	UpdateFolderResult   *m.Folder
 	UpdateFolderError    error
-	DeleteFolderResult   *models.Folder
+	DeleteFolderResult   *m.Folder
 	DeleteFolderError    error
 	DeletedFolderUids    []string
 }
 
-func (s *fakeFolderService) GetFolders(limit int) ([]*models.Folder, error) {
+func (s *fakeFolderService) GetFolders(limit int) ([]*m.Folder, error) {
 	return s.GetFoldersResult, s.GetFoldersError
 }
 
-func (s *fakeFolderService) GetFolderById(id int64) (*models.Folder, error) {
+func (s *fakeFolderService) GetFolderById(id int64) (*m.Folder, error) {
 	return s.GetFolderByIdResult, s.GetFolderByIdError
 }
 
-func (s *fakeFolderService) GetFolderByUid(uid string) (*models.Folder, error) {
+func (s *fakeFolderService) GetFolderByUid(uid string) (*m.Folder, error) {
 	return s.GetFolderByUidResult, s.GetFolderByUidError
 }
 
-func (s *fakeFolderService) CreateFolder(cmd *models.CreateFolderCommand) error {
+func (s *fakeFolderService) CreateFolder(cmd *m.CreateFolderCommand) error {
 	cmd.Result = s.CreateFolderResult
 	return s.CreateFolderError
 }
 
-func (s *fakeFolderService) UpdateFolder(existingUid string, cmd *models.UpdateFolderCommand) error {
+func (s *fakeFolderService) UpdateFolder(existingUid string, cmd *m.UpdateFolderCommand) error {
 	cmd.Result = s.UpdateFolderResult
 	return s.UpdateFolderError
 }
 
-func (s *fakeFolderService) DeleteFolder(uid string) (*models.Folder, error) {
+func (s *fakeFolderService) DeleteFolder(uid string) (*m.Folder, error) {
 	s.DeletedFolderUids = append(s.DeletedFolderUids, uid)
 	return s.DeleteFolderResult, s.DeleteFolderError
 }
 
 func mockFolderService(mock *fakeFolderService) {
-	dashboards.NewFolderService = func(orgId int64, user *models.SignedInUser) dashboards.FolderService {
+	dashboards.NewFolderService = func(orgId int64, user *m.SignedInUser) dashboards.FolderService {
 		return mock
 	}
 }

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -152,7 +152,7 @@ func createFolderScenario(desc string, url string, routePattern string, mock *fa
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: TestOrgID, UserId: TestUserID}
 
@@ -181,7 +181,7 @@ func updateFolderScenario(desc string, url string, routePattern string, mock *fa
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = wrap(func(c *m.Context) Response {
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
 			sc.context = c
 			sc.context.SignedInUser = &m.SignedInUser{OrgId: TestOrgID, UserId: TestUserID}
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func getFrontendSettingsMap(c *middleware.Context) (map[string]interface{}, error) {
+func getFrontendSettingsMap(c *m.Context) (map[string]interface{}, error) {
 	orgDataSources := make([]*m.DataSource, 0)
 
 	if c.OrgId != 0 {
@@ -180,7 +179,7 @@ func getPanelSort(id string) int {
 	return sort
 }
 
-func GetFrontendSettings(c *middleware.Context) {
+func GetFrontendSettings(c *m.Context) {
 	settings, err := getFrontendSettingsMap(c)
 	if err != nil {
 		c.JsonApiErr(400, "Failed to get frontend settings", err)

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func getFrontendSettingsMap(c *m.Context) (map[string]interface{}, error) {
+func getFrontendSettingsMap(c *m.ReqContext) (map[string]interface{}, error) {
 	orgDataSources := make([]*m.DataSource, 0)
 
 	if c.OrgId != 0 {
@@ -179,7 +179,7 @@ func getPanelSort(id string) int {
 	return sort
 }
 
-func GetFrontendSettings(c *m.Context) {
+func GetFrontendSettings(c *m.ReqContext) {
 	settings, err := getFrontendSettingsMap(c)
 	if err != nil {
 		c.JsonApiErr(400, "Failed to get frontend settings", err)

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/grafana/grafana/pkg/middleware"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -41,7 +41,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{Director: director}
 }
 
-func ProxyGnetRequest(c *middleware.Context) {
+func ProxyGnetRequest(c *m.Context) {
 	proxyPath := c.Params("*")
 	proxy := ReverseProxyGnetReq(proxyPath)
 	proxy.Transport = grafanaComProxyTransport

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -41,7 +41,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{Director: director}
 }
 
-func ProxyGnetRequest(c *m.Context) {
+func ProxyGnetRequest(c *m.ReqContext) {
 	proxyPath := c.Params("*")
 	proxy := ReverseProxyGnetReq(proxyPath)
 	proxy.Transport = grafanaComProxyTransport

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func setIndexViewData(c *middleware.Context) (*dtos.IndexViewData, error) {
+func setIndexViewData(c *m.Context) (*dtos.IndexViewData, error) {
 	settings, err := getFrontendSettingsMap(c)
 	if err != nil {
 		return nil, err
@@ -299,7 +298,7 @@ func setIndexViewData(c *middleware.Context) (*dtos.IndexViewData, error) {
 	return &data, nil
 }
 
-func Index(c *middleware.Context) {
+func Index(c *m.Context) {
 	if data, err := setIndexViewData(c); err != nil {
 		c.Handle(500, "Failed to get settings", err)
 		return
@@ -308,7 +307,7 @@ func Index(c *middleware.Context) {
 	}
 }
 
-func NotFoundHandler(c *middleware.Context) {
+func NotFoundHandler(c *m.Context) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(404, "Not found", nil)
 		return

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func setIndexViewData(c *m.Context) (*dtos.IndexViewData, error) {
+func setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, error) {
 	settings, err := getFrontendSettingsMap(c)
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func setIndexViewData(c *m.Context) (*dtos.IndexViewData, error) {
 	return &data, nil
 }
 
-func Index(c *m.Context) {
+func Index(c *m.ReqContext) {
 	if data, err := setIndexViewData(c); err != nil {
 		c.Handle(500, "Failed to get settings", err)
 		return
@@ -307,7 +307,7 @@ func Index(c *m.Context) {
 	}
 }
 
-func NotFoundHandler(c *m.Context) {
+func NotFoundHandler(c *m.ReqContext) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(404, "Not found", nil)
 		return

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -8,8 +8,8 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -17,7 +17,7 @@ const (
 	VIEW_INDEX = "index"
 )
 
-func LoginView(c *middleware.Context) {
+func LoginView(c *m.Context) {
 	viewData, err := setIndexViewData(c)
 	if err != nil {
 		c.Handle(500, "Failed to get settings", err)
@@ -53,7 +53,7 @@ func LoginView(c *middleware.Context) {
 	c.Redirect(setting.AppSubUrl + "/")
 }
 
-func tryLoginUsingRememberCookie(c *middleware.Context) bool {
+func tryLoginUsingRememberCookie(c *m.Context) bool {
 	// Check auto-login.
 	uname := c.GetCookie(setting.CookieUserName)
 	if len(uname) == 0 {
@@ -87,7 +87,7 @@ func tryLoginUsingRememberCookie(c *middleware.Context) bool {
 	return true
 }
 
-func LoginApiPing(c *middleware.Context) {
+func LoginApiPing(c *m.Context) {
 	if !tryLoginUsingRememberCookie(c) {
 		c.JsonApiErr(401, "Unauthorized", nil)
 		return
@@ -96,7 +96,7 @@ func LoginApiPing(c *middleware.Context) {
 	c.JsonOK("Logged in")
 }
 
-func LoginPost(c *middleware.Context, cmd dtos.LoginCommand) Response {
+func LoginPost(c *m.Context, cmd dtos.LoginCommand) Response {
 	if setting.DisableLoginForm {
 		return ApiError(401, "Login is disabled", nil)
 	}
@@ -133,7 +133,7 @@ func LoginPost(c *middleware.Context, cmd dtos.LoginCommand) Response {
 	return Json(200, result)
 }
 
-func loginUserWithUser(user *m.User, c *middleware.Context) {
+func loginUserWithUser(user *m.User, c *m.Context) {
 	if user == nil {
 		log.Error(3, "User login with nil user")
 	}
@@ -146,13 +146,13 @@ func loginUserWithUser(user *m.User, c *middleware.Context) {
 		c.SetSuperSecureCookie(user.Rands+user.Password, setting.CookieRememberName, user.Login, days, setting.AppSubUrl+"/")
 	}
 
-	c.Session.RegenerateId(c)
-	c.Session.Set(middleware.SESS_KEY_USERID, user.Id)
+	c.Session.RegenerateId(c.Context)
+	c.Session.Set(session.SESS_KEY_USERID, user.Id)
 }
 
-func Logout(c *middleware.Context) {
+func Logout(c *m.Context) {
 	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
 	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
-	c.Session.Destory(c)
+	c.Session.Destory(c.Context)
 	c.Redirect(setting.AppSubUrl + "/login")
 }

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -17,7 +17,7 @@ const (
 	VIEW_INDEX = "index"
 )
 
-func LoginView(c *m.Context) {
+func LoginView(c *m.ReqContext) {
 	viewData, err := setIndexViewData(c)
 	if err != nil {
 		c.Handle(500, "Failed to get settings", err)
@@ -53,7 +53,7 @@ func LoginView(c *m.Context) {
 	c.Redirect(setting.AppSubUrl + "/")
 }
 
-func tryLoginUsingRememberCookie(c *m.Context) bool {
+func tryLoginUsingRememberCookie(c *m.ReqContext) bool {
 	// Check auto-login.
 	uname := c.GetCookie(setting.CookieUserName)
 	if len(uname) == 0 {
@@ -87,7 +87,7 @@ func tryLoginUsingRememberCookie(c *m.Context) bool {
 	return true
 }
 
-func LoginApiPing(c *m.Context) {
+func LoginApiPing(c *m.ReqContext) {
 	if !tryLoginUsingRememberCookie(c) {
 		c.JsonApiErr(401, "Unauthorized", nil)
 		return
@@ -96,7 +96,7 @@ func LoginApiPing(c *m.Context) {
 	c.JsonOK("Logged in")
 }
 
-func LoginPost(c *m.Context, cmd dtos.LoginCommand) Response {
+func LoginPost(c *m.ReqContext, cmd dtos.LoginCommand) Response {
 	if setting.DisableLoginForm {
 		return ApiError(401, "Login is disabled", nil)
 	}
@@ -133,7 +133,7 @@ func LoginPost(c *m.Context, cmd dtos.LoginCommand) Response {
 	return Json(200, result)
 }
 
-func loginUserWithUser(user *m.User, c *m.Context) {
+func loginUserWithUser(user *m.User, c *m.ReqContext) {
 	if user == nil {
 		log.Error(3, "User login with nil user")
 	}
@@ -150,7 +150,7 @@ func loginUserWithUser(user *m.User, c *m.Context) {
 	c.Session.Set(session.SESS_KEY_USERID, user.Id)
 }
 
-func Logout(c *m.Context) {
+func Logout(c *m.ReqContext) {
 	c.SetCookie(setting.CookieUserName, "", -1, setting.AppSubUrl+"/")
 	c.SetCookie(setting.CookieRememberName, "", -1, setting.AppSubUrl+"/")
 	c.Session.Destory(c.Context)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/metrics"
 	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
 )
@@ -38,7 +39,7 @@ func GenStateString() string {
 	return base64.URLEncoding.EncodeToString(rnd)
 }
 
-func OAuthLogin(ctx *middleware.Context) {
+func OAuthLogin(ctx *m.Context) {
 	if setting.OAuthService == nil {
 		ctx.Handle(404, "OAuth not enabled", nil)
 		return
@@ -62,7 +63,7 @@ func OAuthLogin(ctx *middleware.Context) {
 	code := ctx.Query("code")
 	if code == "" {
 		state := GenStateString()
-		ctx.Session.Set(middleware.SESS_KEY_OAUTH_STATE, state)
+		ctx.Session.Set(session.SESS_KEY_OAUTH_STATE, state)
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
 			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
 		} else {
@@ -71,7 +72,7 @@ func OAuthLogin(ctx *middleware.Context) {
 		return
 	}
 
-	savedState, ok := ctx.Session.Get(middleware.SESS_KEY_OAUTH_STATE).(string)
+	savedState, ok := ctx.Session.Get(session.SESS_KEY_OAUTH_STATE).(string)
 	if !ok {
 		ctx.Handle(500, "login.OAuthLogin(missing saved state)", nil)
 		return
@@ -208,7 +209,7 @@ func OAuthLogin(ctx *middleware.Context) {
 	ctx.Redirect(setting.AppSubUrl + "/")
 }
 
-func redirectWithError(ctx *middleware.Context, err error, v ...interface{}) {
+func redirectWithError(ctx *m.Context, err error, v ...interface{}) {
 	ctx.Logger.Error(err.Error(), v...)
 	ctx.Session.Set("loginError", err.Error())
 	ctx.Redirect(setting.AppSubUrl + "/login")

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -39,7 +39,7 @@ func GenStateString() string {
 	return base64.URLEncoding.EncodeToString(rnd)
 }
 
-func OAuthLogin(ctx *m.Context) {
+func OAuthLogin(ctx *m.ReqContext) {
 	if setting.OAuthService == nil {
 		ctx.Handle(404, "OAuth not enabled", nil)
 		return
@@ -209,7 +209,7 @@ func OAuthLogin(ctx *m.Context) {
 	ctx.Redirect(setting.AppSubUrl + "/")
 }
 
-func redirectWithError(ctx *m.Context, err error, v ...interface{}) {
+func redirectWithError(ctx *m.ReqContext, err error, v ...interface{}) {
 	ctx.Logger.Error(err.Error(), v...)
 	ctx.Session.Set("loginError", err.Error())
 	ctx.Redirect(setting.AppSubUrl + "/login")

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -6,15 +6,14 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/models"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/tsdb/testdata"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // POST /api/tsdb/query
-func QueryMetrics(c *middleware.Context, reqDto dtos.MetricRequest) Response {
+func QueryMetrics(c *m.Context, reqDto dtos.MetricRequest) Response {
 	timeRange := tsdb.NewTimeRange(reqDto.From, reqDto.To)
 
 	if len(reqDto.Queries) == 0 {
@@ -26,7 +25,7 @@ func QueryMetrics(c *middleware.Context, reqDto dtos.MetricRequest) Response {
 		return ApiError(400, "Query missing datasourceId", nil)
 	}
 
-	dsQuery := models.GetDataSourceByIdQuery{Id: dsId, OrgId: c.OrgId}
+	dsQuery := m.GetDataSourceByIdQuery{Id: dsId, OrgId: c.OrgId}
 	if err := bus.Dispatch(&dsQuery); err != nil {
 		return ApiError(500, "failed to fetch data source", err)
 	}
@@ -61,7 +60,7 @@ func QueryMetrics(c *middleware.Context, reqDto dtos.MetricRequest) Response {
 }
 
 // GET /api/tsdb/testdata/scenarios
-func GetTestDataScenarios(c *middleware.Context) Response {
+func GetTestDataScenarios(c *m.Context) Response {
 	result := make([]interface{}, 0)
 
 	for _, scenario := range testdata.ScenarioRegistry {
@@ -77,14 +76,14 @@ func GetTestDataScenarios(c *middleware.Context) Response {
 }
 
 // Genereates a index out of range error
-func GenerateError(c *middleware.Context) Response {
+func GenerateError(c *m.Context) Response {
 	var array []string
 	return Json(200, array[20])
 }
 
 // GET /api/tsdb/testdata/gensql
-func GenerateSqlTestData(c *middleware.Context) Response {
-	if err := bus.Dispatch(&models.InsertSqlTestDataCommand{}); err != nil {
+func GenerateSqlTestData(c *m.Context) Response {
+	if err := bus.Dispatch(&m.InsertSqlTestDataCommand{}); err != nil {
 		return ApiError(500, "Failed to insert test data", err)
 	}
 
@@ -92,7 +91,7 @@ func GenerateSqlTestData(c *middleware.Context) Response {
 }
 
 // GET /api/tsdb/testdata/random-walk
-func GetTestDataRandomWalk(c *middleware.Context) Response {
+func GetTestDataRandomWalk(c *m.Context) Response {
 	from := c.Query("from")
 	to := c.Query("to")
 	intervalMs := c.QueryInt64("intervalMs")
@@ -100,7 +99,7 @@ func GetTestDataRandomWalk(c *middleware.Context) Response {
 	timeRange := tsdb.NewTimeRange(from, to)
 	request := &tsdb.TsdbQuery{TimeRange: timeRange}
 
-	dsInfo := &models.DataSource{Type: "grafana-testdata-datasource"}
+	dsInfo := &m.DataSource{Type: "grafana-testdata-datasource"}
 	request.Queries = append(request.Queries, &tsdb.Query{
 		RefId:      "A",
 		IntervalMs: intervalMs,

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -13,7 +13,7 @@ import (
 )
 
 // POST /api/tsdb/query
-func QueryMetrics(c *m.Context, reqDto dtos.MetricRequest) Response {
+func QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) Response {
 	timeRange := tsdb.NewTimeRange(reqDto.From, reqDto.To)
 
 	if len(reqDto.Queries) == 0 {
@@ -60,7 +60,7 @@ func QueryMetrics(c *m.Context, reqDto dtos.MetricRequest) Response {
 }
 
 // GET /api/tsdb/testdata/scenarios
-func GetTestDataScenarios(c *m.Context) Response {
+func GetTestDataScenarios(c *m.ReqContext) Response {
 	result := make([]interface{}, 0)
 
 	for _, scenario := range testdata.ScenarioRegistry {
@@ -76,13 +76,13 @@ func GetTestDataScenarios(c *m.Context) Response {
 }
 
 // Genereates a index out of range error
-func GenerateError(c *m.Context) Response {
+func GenerateError(c *m.ReqContext) Response {
 	var array []string
 	return Json(200, array[20])
 }
 
 // GET /api/tsdb/testdata/gensql
-func GenerateSqlTestData(c *m.Context) Response {
+func GenerateSqlTestData(c *m.ReqContext) Response {
 	if err := bus.Dispatch(&m.InsertSqlTestDataCommand{}); err != nil {
 		return ApiError(500, "Failed to insert test data", err)
 	}
@@ -91,7 +91,7 @@ func GenerateSqlTestData(c *m.Context) Response {
 }
 
 // GET /api/tsdb/testdata/random-walk
-func GetTestDataRandomWalk(c *m.Context) Response {
+func GetTestDataRandomWalk(c *m.ReqContext) Response {
 	from := c.Query("from")
 	to := c.Query("to")
 	intervalMs := c.QueryInt64("intervalMs")

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -4,24 +4,23 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // GET /api/org
-func GetOrgCurrent(c *middleware.Context) Response {
+func GetOrgCurrent(c *m.Context) Response {
 	return getOrgHelper(c.OrgId)
 }
 
 // GET /api/orgs/:orgId
-func GetOrgById(c *middleware.Context) Response {
+func GetOrgById(c *m.Context) Response {
 	return getOrgHelper(c.ParamsInt64(":orgId"))
 }
 
 // Get /api/orgs/name/:name
-func GetOrgByName(c *middleware.Context) Response {
+func GetOrgByName(c *m.Context) Response {
 	query := m.GetOrgByNameQuery{Name: c.Params(":name")}
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrOrgNotFound {
@@ -76,7 +75,7 @@ func getOrgHelper(orgId int64) Response {
 }
 
 // POST /api/orgs
-func CreateOrg(c *middleware.Context, cmd m.CreateOrgCommand) Response {
+func CreateOrg(c *m.Context, cmd m.CreateOrgCommand) Response {
 	if !c.IsSignedIn || (!setting.AllowUserOrgCreate && !c.IsGrafanaAdmin) {
 		return ApiError(403, "Access denied", nil)
 	}
@@ -98,12 +97,12 @@ func CreateOrg(c *middleware.Context, cmd m.CreateOrgCommand) Response {
 }
 
 // PUT /api/org
-func UpdateOrgCurrent(c *middleware.Context, form dtos.UpdateOrgForm) Response {
+func UpdateOrgCurrent(c *m.Context, form dtos.UpdateOrgForm) Response {
 	return updateOrgHelper(form, c.OrgId)
 }
 
 // PUT /api/orgs/:orgId
-func UpdateOrg(c *middleware.Context, form dtos.UpdateOrgForm) Response {
+func UpdateOrg(c *m.Context, form dtos.UpdateOrgForm) Response {
 	return updateOrgHelper(form, c.ParamsInt64(":orgId"))
 }
 
@@ -120,12 +119,12 @@ func updateOrgHelper(form dtos.UpdateOrgForm, orgId int64) Response {
 }
 
 // PUT /api/org/address
-func UpdateOrgAddressCurrent(c *middleware.Context, form dtos.UpdateOrgAddressForm) Response {
+func UpdateOrgAddressCurrent(c *m.Context, form dtos.UpdateOrgAddressForm) Response {
 	return updateOrgAddressHelper(form, c.OrgId)
 }
 
 // PUT /api/orgs/:orgId/address
-func UpdateOrgAddress(c *middleware.Context, form dtos.UpdateOrgAddressForm) Response {
+func UpdateOrgAddress(c *m.Context, form dtos.UpdateOrgAddressForm) Response {
 	return updateOrgAddressHelper(form, c.ParamsInt64(":orgId"))
 }
 
@@ -150,7 +149,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgId int64) Respons
 }
 
 // GET /api/orgs/:orgId
-func DeleteOrgById(c *middleware.Context) Response {
+func DeleteOrgById(c *m.Context) Response {
 	if err := bus.Dispatch(&m.DeleteOrgCommand{Id: c.ParamsInt64(":orgId")}); err != nil {
 		if err == m.ErrOrgNotFound {
 			return ApiError(404, "Failed to delete organization. ID not found", nil)
@@ -160,7 +159,7 @@ func DeleteOrgById(c *middleware.Context) Response {
 	return ApiSuccess("Organization deleted")
 }
 
-func SearchOrgs(c *middleware.Context) Response {
+func SearchOrgs(c *m.Context) Response {
 	query := m.SearchOrgsQuery{
 		Query: c.Query("query"),
 		Name:  c.Query("name"),

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -10,17 +10,17 @@ import (
 )
 
 // GET /api/org
-func GetOrgCurrent(c *m.Context) Response {
+func GetOrgCurrent(c *m.ReqContext) Response {
 	return getOrgHelper(c.OrgId)
 }
 
 // GET /api/orgs/:orgId
-func GetOrgById(c *m.Context) Response {
+func GetOrgById(c *m.ReqContext) Response {
 	return getOrgHelper(c.ParamsInt64(":orgId"))
 }
 
 // Get /api/orgs/name/:name
-func GetOrgByName(c *m.Context) Response {
+func GetOrgByName(c *m.ReqContext) Response {
 	query := m.GetOrgByNameQuery{Name: c.Params(":name")}
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrOrgNotFound {
@@ -75,7 +75,7 @@ func getOrgHelper(orgId int64) Response {
 }
 
 // POST /api/orgs
-func CreateOrg(c *m.Context, cmd m.CreateOrgCommand) Response {
+func CreateOrg(c *m.ReqContext, cmd m.CreateOrgCommand) Response {
 	if !c.IsSignedIn || (!setting.AllowUserOrgCreate && !c.IsGrafanaAdmin) {
 		return ApiError(403, "Access denied", nil)
 	}
@@ -97,12 +97,12 @@ func CreateOrg(c *m.Context, cmd m.CreateOrgCommand) Response {
 }
 
 // PUT /api/org
-func UpdateOrgCurrent(c *m.Context, form dtos.UpdateOrgForm) Response {
+func UpdateOrgCurrent(c *m.ReqContext, form dtos.UpdateOrgForm) Response {
 	return updateOrgHelper(form, c.OrgId)
 }
 
 // PUT /api/orgs/:orgId
-func UpdateOrg(c *m.Context, form dtos.UpdateOrgForm) Response {
+func UpdateOrg(c *m.ReqContext, form dtos.UpdateOrgForm) Response {
 	return updateOrgHelper(form, c.ParamsInt64(":orgId"))
 }
 
@@ -119,12 +119,12 @@ func updateOrgHelper(form dtos.UpdateOrgForm, orgId int64) Response {
 }
 
 // PUT /api/org/address
-func UpdateOrgAddressCurrent(c *m.Context, form dtos.UpdateOrgAddressForm) Response {
+func UpdateOrgAddressCurrent(c *m.ReqContext, form dtos.UpdateOrgAddressForm) Response {
 	return updateOrgAddressHelper(form, c.OrgId)
 }
 
 // PUT /api/orgs/:orgId/address
-func UpdateOrgAddress(c *m.Context, form dtos.UpdateOrgAddressForm) Response {
+func UpdateOrgAddress(c *m.ReqContext, form dtos.UpdateOrgAddressForm) Response {
 	return updateOrgAddressHelper(form, c.ParamsInt64(":orgId"))
 }
 
@@ -149,7 +149,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgId int64) Respons
 }
 
 // GET /api/orgs/:orgId
-func DeleteOrgById(c *m.Context) Response {
+func DeleteOrgById(c *m.ReqContext) Response {
 	if err := bus.Dispatch(&m.DeleteOrgCommand{Id: c.ParamsInt64(":orgId")}); err != nil {
 		if err == m.ErrOrgNotFound {
 			return ApiError(404, "Failed to delete organization. ID not found", nil)
@@ -159,7 +159,7 @@ func DeleteOrgById(c *m.Context) Response {
 	return ApiSuccess("Organization deleted")
 }
 
-func SearchOrgs(c *m.Context) Response {
+func SearchOrgs(c *m.ReqContext) Response {
 	query := m.SearchOrgsQuery{
 		Query: c.Query("query"),
 		Name:  c.Query("name"),

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -7,13 +7,12 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetPendingOrgInvites(c *middleware.Context) Response {
+func GetPendingOrgInvites(c *m.Context) Response {
 	query := m.GetTempUsersQuery{OrgId: c.OrgId, Status: m.TmpUserInvitePending}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -27,7 +26,7 @@ func GetPendingOrgInvites(c *middleware.Context) Response {
 	return Json(200, query.Result)
 }
 
-func AddOrgInvite(c *middleware.Context, inviteDto dtos.AddInviteForm) Response {
+func AddOrgInvite(c *m.Context, inviteDto dtos.AddInviteForm) Response {
 	if !inviteDto.Role.IsValid() {
 		return ApiError(400, "Invalid role specified", nil)
 	}
@@ -89,7 +88,7 @@ func AddOrgInvite(c *middleware.Context, inviteDto dtos.AddInviteForm) Response 
 	return ApiSuccess(fmt.Sprintf("Created invite for %s", inviteDto.LoginOrEmail))
 }
 
-func inviteExistingUserToOrg(c *middleware.Context, user *m.User, inviteDto *dtos.AddInviteForm) Response {
+func inviteExistingUserToOrg(c *m.Context, user *m.User, inviteDto *dtos.AddInviteForm) Response {
 	// user exists, add org role
 	createOrgUserCmd := m.AddOrgUserCommand{OrgId: c.OrgId, UserId: user.Id, Role: inviteDto.Role}
 	if err := bus.Dispatch(&createOrgUserCmd); err != nil {
@@ -119,7 +118,7 @@ func inviteExistingUserToOrg(c *middleware.Context, user *m.User, inviteDto *dto
 	}
 }
 
-func RevokeInvite(c *middleware.Context) Response {
+func RevokeInvite(c *m.Context) Response {
 	if ok, rsp := updateTempUserStatus(c.Params(":code"), m.TmpUserRevoked); !ok {
 		return rsp
 	}
@@ -127,7 +126,7 @@ func RevokeInvite(c *middleware.Context) Response {
 	return ApiSuccess("Invite revoked")
 }
 
-func GetInviteInfoByCode(c *middleware.Context) Response {
+func GetInviteInfoByCode(c *m.Context) Response {
 	query := m.GetTempUserByCodeQuery{Code: c.Params(":code")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -147,7 +146,7 @@ func GetInviteInfoByCode(c *middleware.Context) Response {
 	})
 }
 
-func CompleteInvite(c *middleware.Context, completeInvite dtos.CompleteInviteForm) Response {
+func CompleteInvite(c *m.Context, completeInvite dtos.CompleteInviteForm) Response {
 	query := m.GetTempUserByCodeQuery{Code: completeInvite.InviteCode}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func GetPendingOrgInvites(c *m.Context) Response {
+func GetPendingOrgInvites(c *m.ReqContext) Response {
 	query := m.GetTempUsersQuery{OrgId: c.OrgId, Status: m.TmpUserInvitePending}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -26,7 +26,7 @@ func GetPendingOrgInvites(c *m.Context) Response {
 	return Json(200, query.Result)
 }
 
-func AddOrgInvite(c *m.Context, inviteDto dtos.AddInviteForm) Response {
+func AddOrgInvite(c *m.ReqContext, inviteDto dtos.AddInviteForm) Response {
 	if !inviteDto.Role.IsValid() {
 		return ApiError(400, "Invalid role specified", nil)
 	}
@@ -88,7 +88,7 @@ func AddOrgInvite(c *m.Context, inviteDto dtos.AddInviteForm) Response {
 	return ApiSuccess(fmt.Sprintf("Created invite for %s", inviteDto.LoginOrEmail))
 }
 
-func inviteExistingUserToOrg(c *m.Context, user *m.User, inviteDto *dtos.AddInviteForm) Response {
+func inviteExistingUserToOrg(c *m.ReqContext, user *m.User, inviteDto *dtos.AddInviteForm) Response {
 	// user exists, add org role
 	createOrgUserCmd := m.AddOrgUserCommand{OrgId: c.OrgId, UserId: user.Id, Role: inviteDto.Role}
 	if err := bus.Dispatch(&createOrgUserCmd); err != nil {
@@ -118,7 +118,7 @@ func inviteExistingUserToOrg(c *m.Context, user *m.User, inviteDto *dtos.AddInvi
 	}
 }
 
-func RevokeInvite(c *m.Context) Response {
+func RevokeInvite(c *m.ReqContext) Response {
 	if ok, rsp := updateTempUserStatus(c.Params(":code"), m.TmpUserRevoked); !ok {
 		return rsp
 	}
@@ -126,7 +126,7 @@ func RevokeInvite(c *m.Context) Response {
 	return ApiSuccess("Invite revoked")
 }
 
-func GetInviteInfoByCode(c *m.Context) Response {
+func GetInviteInfoByCode(c *m.ReqContext) Response {
 	query := m.GetTempUserByCodeQuery{Code: c.Params(":code")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -146,7 +146,7 @@ func GetInviteInfoByCode(c *m.Context) Response {
 	})
 }
 
-func CompleteInvite(c *m.Context, completeInvite dtos.CompleteInviteForm) Response {
+func CompleteInvite(c *m.ReqContext, completeInvite dtos.CompleteInviteForm) Response {
 	query := m.GetTempUserByCodeQuery{Code: completeInvite.InviteCode}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -3,18 +3,17 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 // POST /api/org/users
-func AddOrgUserToCurrentOrg(c *middleware.Context, cmd m.AddOrgUserCommand) Response {
+func AddOrgUserToCurrentOrg(c *m.Context, cmd m.AddOrgUserCommand) Response {
 	cmd.OrgId = c.OrgId
 	return addOrgUserHelper(cmd)
 }
 
 // POST /api/orgs/:orgId/users
-func AddOrgUser(c *middleware.Context, cmd m.AddOrgUserCommand) Response {
+func AddOrgUser(c *m.Context, cmd m.AddOrgUserCommand) Response {
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	return addOrgUserHelper(cmd)
 }
@@ -45,12 +44,12 @@ func addOrgUserHelper(cmd m.AddOrgUserCommand) Response {
 }
 
 // GET /api/org/users
-func GetOrgUsersForCurrentOrg(c *middleware.Context) Response {
+func GetOrgUsersForCurrentOrg(c *m.Context) Response {
 	return getOrgUsersHelper(c.OrgId, c.Params("query"), c.ParamsInt("limit"))
 }
 
 // GET /api/orgs/:orgId/users
-func GetOrgUsers(c *middleware.Context) Response {
+func GetOrgUsers(c *m.Context) Response {
 	return getOrgUsersHelper(c.ParamsInt64(":orgId"), "", 0)
 }
 
@@ -73,14 +72,14 @@ func getOrgUsersHelper(orgId int64, query string, limit int) Response {
 }
 
 // PATCH /api/org/users/:userId
-func UpdateOrgUserForCurrentOrg(c *middleware.Context, cmd m.UpdateOrgUserCommand) Response {
+func UpdateOrgUserForCurrentOrg(c *m.Context, cmd m.UpdateOrgUserCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.UserId = c.ParamsInt64(":userId")
 	return updateOrgUserHelper(cmd)
 }
 
 // PATCH /api/orgs/:orgId/users/:userId
-func UpdateOrgUser(c *middleware.Context, cmd m.UpdateOrgUserCommand) Response {
+func UpdateOrgUser(c *m.Context, cmd m.UpdateOrgUserCommand) Response {
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	cmd.UserId = c.ParamsInt64(":userId")
 	return updateOrgUserHelper(cmd)
@@ -102,13 +101,13 @@ func updateOrgUserHelper(cmd m.UpdateOrgUserCommand) Response {
 }
 
 // DELETE /api/org/users/:userId
-func RemoveOrgUserForCurrentOrg(c *middleware.Context) Response {
+func RemoveOrgUserForCurrentOrg(c *m.Context) Response {
 	userId := c.ParamsInt64(":userId")
 	return removeOrgUserHelper(c.OrgId, userId)
 }
 
 // DELETE /api/orgs/:orgId/users/:userId
-func RemoveOrgUser(c *middleware.Context) Response {
+func RemoveOrgUser(c *m.Context) Response {
 	userId := c.ParamsInt64(":userId")
 	orgId := c.ParamsInt64(":orgId")
 	return removeOrgUserHelper(orgId, userId)

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -7,13 +7,13 @@ import (
 )
 
 // POST /api/org/users
-func AddOrgUserToCurrentOrg(c *m.Context, cmd m.AddOrgUserCommand) Response {
+func AddOrgUserToCurrentOrg(c *m.ReqContext, cmd m.AddOrgUserCommand) Response {
 	cmd.OrgId = c.OrgId
 	return addOrgUserHelper(cmd)
 }
 
 // POST /api/orgs/:orgId/users
-func AddOrgUser(c *m.Context, cmd m.AddOrgUserCommand) Response {
+func AddOrgUser(c *m.ReqContext, cmd m.AddOrgUserCommand) Response {
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	return addOrgUserHelper(cmd)
 }
@@ -44,12 +44,12 @@ func addOrgUserHelper(cmd m.AddOrgUserCommand) Response {
 }
 
 // GET /api/org/users
-func GetOrgUsersForCurrentOrg(c *m.Context) Response {
+func GetOrgUsersForCurrentOrg(c *m.ReqContext) Response {
 	return getOrgUsersHelper(c.OrgId, c.Params("query"), c.ParamsInt("limit"))
 }
 
 // GET /api/orgs/:orgId/users
-func GetOrgUsers(c *m.Context) Response {
+func GetOrgUsers(c *m.ReqContext) Response {
 	return getOrgUsersHelper(c.ParamsInt64(":orgId"), "", 0)
 }
 
@@ -72,14 +72,14 @@ func getOrgUsersHelper(orgId int64, query string, limit int) Response {
 }
 
 // PATCH /api/org/users/:userId
-func UpdateOrgUserForCurrentOrg(c *m.Context, cmd m.UpdateOrgUserCommand) Response {
+func UpdateOrgUserForCurrentOrg(c *m.ReqContext, cmd m.UpdateOrgUserCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.UserId = c.ParamsInt64(":userId")
 	return updateOrgUserHelper(cmd)
 }
 
 // PATCH /api/orgs/:orgId/users/:userId
-func UpdateOrgUser(c *m.Context, cmd m.UpdateOrgUserCommand) Response {
+func UpdateOrgUser(c *m.ReqContext, cmd m.UpdateOrgUserCommand) Response {
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	cmd.UserId = c.ParamsInt64(":userId")
 	return updateOrgUserHelper(cmd)
@@ -101,13 +101,13 @@ func updateOrgUserHelper(cmd m.UpdateOrgUserCommand) Response {
 }
 
 // DELETE /api/org/users/:userId
-func RemoveOrgUserForCurrentOrg(c *m.Context) Response {
+func RemoveOrgUserForCurrentOrg(c *m.ReqContext) Response {
 	userId := c.ParamsInt64(":userId")
 	return removeOrgUserHelper(c.OrgId, userId)
 }
 
 // DELETE /api/orgs/:orgId/users/:userId
-func RemoveOrgUser(c *m.Context) Response {
+func RemoveOrgUser(c *m.ReqContext) Response {
 	userId := c.ParamsInt64(":userId")
 	orgId := c.ParamsInt64(":orgId")
 	return removeOrgUserHelper(orgId, userId)

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -3,12 +3,11 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func SendResetPasswordEmail(c *middleware.Context, form dtos.SendResetPasswordEmailForm) Response {
+func SendResetPasswordEmail(c *m.Context, form dtos.SendResetPasswordEmailForm) Response {
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: form.UserOrEmail}
 
 	if err := bus.Dispatch(&userQuery); err != nil {
@@ -24,7 +23,7 @@ func SendResetPasswordEmail(c *middleware.Context, form dtos.SendResetPasswordEm
 	return ApiSuccess("Email sent")
 }
 
-func ResetPassword(c *middleware.Context, form dtos.ResetUserPasswordForm) Response {
+func ResetPassword(c *m.Context, form dtos.ResetUserPasswordForm) Response {
 	query := m.ValidateResetPasswordCodeQuery{Code: form.Code}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func SendResetPasswordEmail(c *m.Context, form dtos.SendResetPasswordEmailForm) Response {
+func SendResetPasswordEmail(c *m.ReqContext, form dtos.SendResetPasswordEmailForm) Response {
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: form.UserOrEmail}
 
 	if err := bus.Dispatch(&userQuery); err != nil {
@@ -23,7 +23,7 @@ func SendResetPasswordEmail(c *m.Context, form dtos.SendResetPasswordEmailForm) 
 	return ApiSuccess("Email sent")
 }
 
-func ResetPassword(c *m.Context, form dtos.ResetUserPasswordForm) Response {
+func ResetPassword(c *m.ReqContext, form dtos.ResetUserPasswordForm) Response {
 	query := m.ValidateResetPasswordCodeQuery{Code: form.Code}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -3,11 +3,10 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/bus"
 	_ "github.com/grafana/grafana/pkg/log"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func ValidateOrgPlaylist(c *middleware.Context) {
+func ValidateOrgPlaylist(c *m.Context) {
 	id := c.ParamsInt64(":id")
 	query := m.GetPlaylistByIdQuery{Id: id}
 	err := bus.Dispatch(&query)
@@ -40,7 +39,7 @@ func ValidateOrgPlaylist(c *middleware.Context) {
 	}
 }
 
-func SearchPlaylists(c *middleware.Context) Response {
+func SearchPlaylists(c *m.Context) Response {
 	query := c.Query("query")
 	limit := c.QueryInt("limit")
 
@@ -62,7 +61,7 @@ func SearchPlaylists(c *middleware.Context) Response {
 	return Json(200, searchQuery.Result)
 }
 
-func GetPlaylist(c *middleware.Context) Response {
+func GetPlaylist(c *m.Context) Response {
 	id := c.ParamsInt64(":id")
 	cmd := m.GetPlaylistByIdQuery{Id: id}
 
@@ -115,7 +114,7 @@ func LoadPlaylistItems(id int64) ([]m.PlaylistItem, error) {
 	return *itemQuery.Result, nil
 }
 
-func GetPlaylistItems(c *middleware.Context) Response {
+func GetPlaylistItems(c *m.Context) Response {
 	id := c.ParamsInt64(":id")
 
 	playlistDTOs, err := LoadPlaylistItemDTOs(id)
@@ -127,7 +126,7 @@ func GetPlaylistItems(c *middleware.Context) Response {
 	return Json(200, playlistDTOs)
 }
 
-func GetPlaylistDashboards(c *middleware.Context) Response {
+func GetPlaylistDashboards(c *m.Context) Response {
 	playlistId := c.ParamsInt64(":id")
 
 	playlists, err := LoadPlaylistDashboards(c.OrgId, c.SignedInUser, playlistId)
@@ -138,7 +137,7 @@ func GetPlaylistDashboards(c *middleware.Context) Response {
 	return Json(200, playlists)
 }
 
-func DeletePlaylist(c *middleware.Context) Response {
+func DeletePlaylist(c *m.Context) Response {
 	id := c.ParamsInt64(":id")
 
 	cmd := m.DeletePlaylistCommand{Id: id, OrgId: c.OrgId}
@@ -149,7 +148,7 @@ func DeletePlaylist(c *middleware.Context) Response {
 	return Json(200, "")
 }
 
-func CreatePlaylist(c *middleware.Context, cmd m.CreatePlaylistCommand) Response {
+func CreatePlaylist(c *m.Context, cmd m.CreatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -159,7 +158,7 @@ func CreatePlaylist(c *middleware.Context, cmd m.CreatePlaylistCommand) Response
 	return Json(200, cmd.Result)
 }
 
-func UpdatePlaylist(c *middleware.Context, cmd m.UpdatePlaylistCommand) Response {
+func UpdatePlaylist(c *m.Context, cmd m.UpdatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -6,7 +6,7 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func ValidateOrgPlaylist(c *m.Context) {
+func ValidateOrgPlaylist(c *m.ReqContext) {
 	id := c.ParamsInt64(":id")
 	query := m.GetPlaylistByIdQuery{Id: id}
 	err := bus.Dispatch(&query)
@@ -39,7 +39,7 @@ func ValidateOrgPlaylist(c *m.Context) {
 	}
 }
 
-func SearchPlaylists(c *m.Context) Response {
+func SearchPlaylists(c *m.ReqContext) Response {
 	query := c.Query("query")
 	limit := c.QueryInt("limit")
 
@@ -61,7 +61,7 @@ func SearchPlaylists(c *m.Context) Response {
 	return Json(200, searchQuery.Result)
 }
 
-func GetPlaylist(c *m.Context) Response {
+func GetPlaylist(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 	cmd := m.GetPlaylistByIdQuery{Id: id}
 
@@ -114,7 +114,7 @@ func LoadPlaylistItems(id int64) ([]m.PlaylistItem, error) {
 	return *itemQuery.Result, nil
 }
 
-func GetPlaylistItems(c *m.Context) Response {
+func GetPlaylistItems(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 
 	playlistDTOs, err := LoadPlaylistItemDTOs(id)
@@ -126,7 +126,7 @@ func GetPlaylistItems(c *m.Context) Response {
 	return Json(200, playlistDTOs)
 }
 
-func GetPlaylistDashboards(c *m.Context) Response {
+func GetPlaylistDashboards(c *m.ReqContext) Response {
 	playlistId := c.ParamsInt64(":id")
 
 	playlists, err := LoadPlaylistDashboards(c.OrgId, c.SignedInUser, playlistId)
@@ -137,7 +137,7 @@ func GetPlaylistDashboards(c *m.Context) Response {
 	return Json(200, playlists)
 }
 
-func DeletePlaylist(c *m.Context) Response {
+func DeletePlaylist(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 
 	cmd := m.DeletePlaylistCommand{Id: id, OrgId: c.OrgId}
@@ -148,7 +148,7 @@ func DeletePlaylist(c *m.Context) Response {
 	return Json(200, "")
 }
 
-func CreatePlaylist(c *m.Context, cmd m.CreatePlaylistCommand) Response {
+func CreatePlaylist(c *m.ReqContext, cmd m.CreatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -158,7 +158,7 @@ func CreatePlaylist(c *m.Context, cmd m.CreatePlaylistCommand) Response {
 	return Json(200, cmd.Result)
 }
 
-func UpdatePlaylist(c *m.Context, cmd m.UpdatePlaylistCommand) Response {
+func UpdatePlaylist(c *m.ReqContext, cmd m.UpdatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/grafana/pkg/log"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
@@ -42,14 +41,14 @@ type jwtToken struct {
 
 type DataSourceProxy struct {
 	ds        *m.DataSource
-	ctx       *middleware.Context
+	ctx       *m.Context
 	targetUrl *url.URL
 	proxyPath string
 	route     *plugins.AppPluginRoute
 	plugin    *plugins.DataSourcePlugin
 }
 
-func NewDataSourceProxy(ds *m.DataSource, plugin *plugins.DataSourcePlugin, ctx *middleware.Context, proxyPath string) *DataSourceProxy {
+func NewDataSourceProxy(ds *m.DataSource, plugin *plugins.DataSourcePlugin, ctx *m.Context, proxyPath string) *DataSourceProxy {
 	targetUrl, _ := url.Parse(ds.Url)
 
 	return &DataSourceProxy{
@@ -255,7 +254,7 @@ func (proxy *DataSourceProxy) logRequest() {
 		"body", body)
 }
 
-func checkWhiteList(c *middleware.Context, host string) bool {
+func checkWhiteList(c *m.Context, host string) bool {
 	if host != "" && len(setting.DataProxyWhiteList) > 0 {
 		if _, exists := setting.DataProxyWhiteList[host]; !exists {
 			c.JsonApiErr(403, "Data proxy hostname and ip are not included in whitelist", nil)

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -41,14 +41,14 @@ type jwtToken struct {
 
 type DataSourceProxy struct {
 	ds        *m.DataSource
-	ctx       *m.Context
+	ctx       *m.ReqContext
 	targetUrl *url.URL
 	proxyPath string
 	route     *plugins.AppPluginRoute
 	plugin    *plugins.DataSourcePlugin
 }
 
-func NewDataSourceProxy(ds *m.DataSource, plugin *plugins.DataSourcePlugin, ctx *m.Context, proxyPath string) *DataSourceProxy {
+func NewDataSourceProxy(ds *m.DataSource, plugin *plugins.DataSourcePlugin, ctx *m.ReqContext, proxyPath string) *DataSourceProxy {
 	targetUrl, _ := url.Parse(ds.Url)
 
 	return &DataSourceProxy{
@@ -254,7 +254,7 @@ func (proxy *DataSourceProxy) logRequest() {
 		"body", body)
 }
 
-func checkWhiteList(c *m.Context, host string) bool {
+func checkWhiteList(c *m.ReqContext, host string) bool {
 	if host != "" && len(setting.DataProxyWhiteList) > 0 {
 		if _, exists := setting.DataProxyWhiteList[host]; !exists {
 			c.JsonApiErr(403, "Data proxy hostname and ip are not included in whitelist", nil)

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -8,7 +8,6 @@ import (
 	macaron "gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
@@ -61,7 +60,7 @@ func TestDSRouteRule(t *testing.T) {
 			}
 
 			req, _ := http.NewRequest("GET", "http://localhost/asd", nil)
-			ctx := &middleware.Context{
+			ctx := &m.Context{
 				Context: &macaron.Context{
 					Req: macaron.Request{Request: req},
 				},
@@ -104,7 +103,7 @@ func TestDSRouteRule(t *testing.T) {
 		Convey("When proxying graphite", func() {
 			plugin := &plugins.DataSourcePlugin{}
 			ds := &m.DataSource{Url: "htttp://graphite:8080", Type: m.DS_GRAPHITE}
-			ctx := &middleware.Context{}
+			ctx := &m.Context{}
 
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "/render")
 
@@ -130,7 +129,7 @@ func TestDSRouteRule(t *testing.T) {
 				Password: "password",
 			}
 
-			ctx := &middleware.Context{}
+			ctx := &m.Context{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")
@@ -160,7 +159,7 @@ func TestDSRouteRule(t *testing.T) {
 				JsonData: json,
 			}
 
-			ctx := &middleware.Context{}
+			ctx := &m.Context{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")
@@ -186,7 +185,7 @@ func TestDSRouteRule(t *testing.T) {
 				JsonData: json,
 			}
 
-			ctx := &middleware.Context{}
+			ctx := &m.Context{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -60,7 +60,7 @@ func TestDSRouteRule(t *testing.T) {
 			}
 
 			req, _ := http.NewRequest("GET", "http://localhost/asd", nil)
-			ctx := &m.Context{
+			ctx := &m.ReqContext{
 				Context: &macaron.Context{
 					Req: macaron.Request{Request: req},
 				},
@@ -103,7 +103,7 @@ func TestDSRouteRule(t *testing.T) {
 		Convey("When proxying graphite", func() {
 			plugin := &plugins.DataSourcePlugin{}
 			ds := &m.DataSource{Url: "htttp://graphite:8080", Type: m.DS_GRAPHITE}
-			ctx := &m.Context{}
+			ctx := &m.ReqContext{}
 
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "/render")
 
@@ -129,7 +129,7 @@ func TestDSRouteRule(t *testing.T) {
 				Password: "password",
 			}
 
-			ctx := &m.Context{}
+			ctx := &m.ReqContext{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")
@@ -159,7 +159,7 @@ func TestDSRouteRule(t *testing.T) {
 				JsonData: json,
 			}
 
-			ctx := &m.Context{}
+			ctx := &m.ReqContext{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")
@@ -185,7 +185,7 @@ func TestDSRouteRule(t *testing.T) {
 				JsonData: json,
 			}
 
-			ctx := &m.Context{}
+			ctx := &m.ReqContext{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestUrl, _ := url.Parse("http://grafana.com/sub")

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/util"
@@ -38,7 +37,7 @@ func getHeaders(route *plugins.AppPluginRoute, orgId int64, appId string) (http.
 	return result, err
 }
 
-func NewApiPluginProxy(ctx *middleware.Context, proxyPath string, route *plugins.AppPluginRoute, appId string) *httputil.ReverseProxy {
+func NewApiPluginProxy(ctx *m.Context, proxyPath string, route *plugins.AppPluginRoute, appId string) *httputil.ReverseProxy {
 	targetUrl, _ := url.Parse(route.Url)
 
 	director := func(req *http.Request) {

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -37,7 +37,7 @@ func getHeaders(route *plugins.AppPluginRoute, orgId int64, appId string) (http.
 	return result, err
 }
 
-func NewApiPluginProxy(ctx *m.Context, proxyPath string, route *plugins.AppPluginRoute, appId string) *httputil.ReverseProxy {
+func NewApiPluginProxy(ctx *m.ReqContext, proxyPath string, route *plugins.AppPluginRoute, appId string) *httputil.ReverseProxy {
 	targetUrl, _ := url.Parse(route.Url)
 
 	director := func(req *http.Request) {

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func GetPluginList(c *middleware.Context) Response {
+func GetPluginList(c *m.Context) Response {
 	typeFilter := c.Query("type")
 	enabledFilter := c.Query("enabled")
 	embeddedFilter := c.Query("embedded")
@@ -79,7 +78,7 @@ func GetPluginList(c *middleware.Context) Response {
 	return Json(200, result)
 }
 
-func GetPluginSettingById(c *middleware.Context) Response {
+func GetPluginSettingById(c *m.Context) Response {
 	pluginId := c.Params(":pluginId")
 
 	if def, exists := plugins.Plugins[pluginId]; !exists {
@@ -116,7 +115,7 @@ func GetPluginSettingById(c *middleware.Context) Response {
 	}
 }
 
-func UpdatePluginSetting(c *middleware.Context, cmd m.UpdatePluginSettingCmd) Response {
+func UpdatePluginSetting(c *m.Context, cmd m.UpdatePluginSettingCmd) Response {
 	pluginId := c.Params(":pluginId")
 
 	cmd.OrgId = c.OrgId
@@ -133,7 +132,7 @@ func UpdatePluginSetting(c *middleware.Context, cmd m.UpdatePluginSettingCmd) Re
 	return ApiSuccess("Plugin settings updated")
 }
 
-func GetPluginDashboards(c *middleware.Context) Response {
+func GetPluginDashboards(c *m.Context) Response {
 	pluginId := c.Params(":pluginId")
 
 	if list, err := plugins.GetPluginDashboards(c.OrgId, pluginId); err != nil {
@@ -147,7 +146,7 @@ func GetPluginDashboards(c *middleware.Context) Response {
 	}
 }
 
-func GetPluginMarkdown(c *middleware.Context) Response {
+func GetPluginMarkdown(c *m.Context) Response {
 	pluginId := c.Params(":pluginId")
 	name := c.Params(":name")
 
@@ -164,7 +163,7 @@ func GetPluginMarkdown(c *middleware.Context) Response {
 	}
 }
 
-func ImportDashboard(c *middleware.Context, apiCmd dtos.ImportDashboardCommand) Response {
+func ImportDashboard(c *m.Context, apiCmd dtos.ImportDashboardCommand) Response {
 
 	cmd := plugins.ImportDashboardCommand{
 		OrgId:     c.OrgId,

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func GetPluginList(c *m.Context) Response {
+func GetPluginList(c *m.ReqContext) Response {
 	typeFilter := c.Query("type")
 	enabledFilter := c.Query("enabled")
 	embeddedFilter := c.Query("embedded")
@@ -78,7 +78,7 @@ func GetPluginList(c *m.Context) Response {
 	return Json(200, result)
 }
 
-func GetPluginSettingById(c *m.Context) Response {
+func GetPluginSettingById(c *m.ReqContext) Response {
 	pluginId := c.Params(":pluginId")
 
 	if def, exists := plugins.Plugins[pluginId]; !exists {
@@ -115,7 +115,7 @@ func GetPluginSettingById(c *m.Context) Response {
 	}
 }
 
-func UpdatePluginSetting(c *m.Context, cmd m.UpdatePluginSettingCmd) Response {
+func UpdatePluginSetting(c *m.ReqContext, cmd m.UpdatePluginSettingCmd) Response {
 	pluginId := c.Params(":pluginId")
 
 	cmd.OrgId = c.OrgId
@@ -132,7 +132,7 @@ func UpdatePluginSetting(c *m.Context, cmd m.UpdatePluginSettingCmd) Response {
 	return ApiSuccess("Plugin settings updated")
 }
 
-func GetPluginDashboards(c *m.Context) Response {
+func GetPluginDashboards(c *m.ReqContext) Response {
 	pluginId := c.Params(":pluginId")
 
 	if list, err := plugins.GetPluginDashboards(c.OrgId, pluginId); err != nil {
@@ -146,7 +146,7 @@ func GetPluginDashboards(c *m.Context) Response {
 	}
 }
 
-func GetPluginMarkdown(c *m.Context) Response {
+func GetPluginMarkdown(c *m.ReqContext) Response {
 	pluginId := c.Params(":pluginId")
 	name := c.Params(":name")
 
@@ -163,7 +163,7 @@ func GetPluginMarkdown(c *m.Context) Response {
 	}
 }
 
-func ImportDashboard(c *m.Context, apiCmd dtos.ImportDashboardCommand) Response {
+func ImportDashboard(c *m.ReqContext, apiCmd dtos.ImportDashboardCommand) Response {
 
 	cmd := plugins.ImportDashboardCommand{
 		OrgId:     c.OrgId,

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -3,12 +3,11 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 // POST /api/preferences/set-home-dash
-func SetHomeDashboard(c *middleware.Context, cmd m.SavePreferencesCommand) Response {
+func SetHomeDashboard(c *m.Context, cmd m.SavePreferencesCommand) Response {
 
 	cmd.UserId = c.UserId
 	cmd.OrgId = c.OrgId
@@ -21,7 +20,7 @@ func SetHomeDashboard(c *middleware.Context, cmd m.SavePreferencesCommand) Respo
 }
 
 // GET /api/user/preferences
-func GetUserPreferences(c *middleware.Context) Response {
+func GetUserPreferences(c *m.Context) Response {
 	return getPreferencesFor(c.OrgId, c.UserId)
 }
 
@@ -42,7 +41,7 @@ func getPreferencesFor(orgId int64, userId int64) Response {
 }
 
 // PUT /api/user/preferences
-func UpdateUserPreferences(c *middleware.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
+func UpdateUserPreferences(c *m.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
 	return updatePreferencesFor(c.OrgId, c.UserId, &dtoCmd)
 }
 
@@ -63,11 +62,11 @@ func updatePreferencesFor(orgId int64, userId int64, dtoCmd *dtos.UpdatePrefsCmd
 }
 
 // GET /api/org/preferences
-func GetOrgPreferences(c *middleware.Context) Response {
+func GetOrgPreferences(c *m.Context) Response {
 	return getPreferencesFor(c.OrgId, 0)
 }
 
 // PUT /api/org/preferences
-func UpdateOrgPreferences(c *middleware.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
+func UpdateOrgPreferences(c *m.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
 	return updatePreferencesFor(c.OrgId, 0, &dtoCmd)
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -7,7 +7,7 @@ import (
 )
 
 // POST /api/preferences/set-home-dash
-func SetHomeDashboard(c *m.Context, cmd m.SavePreferencesCommand) Response {
+func SetHomeDashboard(c *m.ReqContext, cmd m.SavePreferencesCommand) Response {
 
 	cmd.UserId = c.UserId
 	cmd.OrgId = c.OrgId
@@ -20,7 +20,7 @@ func SetHomeDashboard(c *m.Context, cmd m.SavePreferencesCommand) Response {
 }
 
 // GET /api/user/preferences
-func GetUserPreferences(c *m.Context) Response {
+func GetUserPreferences(c *m.ReqContext) Response {
 	return getPreferencesFor(c.OrgId, c.UserId)
 }
 
@@ -41,7 +41,7 @@ func getPreferencesFor(orgId int64, userId int64) Response {
 }
 
 // PUT /api/user/preferences
-func UpdateUserPreferences(c *m.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
+func UpdateUserPreferences(c *m.ReqContext, dtoCmd dtos.UpdatePrefsCmd) Response {
 	return updatePreferencesFor(c.OrgId, c.UserId, &dtoCmd)
 }
 
@@ -62,11 +62,11 @@ func updatePreferencesFor(orgId int64, userId int64, dtoCmd *dtos.UpdatePrefsCmd
 }
 
 // GET /api/org/preferences
-func GetOrgPreferences(c *m.Context) Response {
+func GetOrgPreferences(c *m.ReqContext) Response {
 	return getPreferencesFor(c.OrgId, 0)
 }
 
 // PUT /api/org/preferences
-func UpdateOrgPreferences(c *m.Context, dtoCmd dtos.UpdatePrefsCmd) Response {
+func UpdateOrgPreferences(c *m.ReqContext, dtoCmd dtos.UpdatePrefsCmd) Response {
 	return updatePreferencesFor(c.OrgId, 0, &dtoCmd)
 }

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -2,12 +2,11 @@ package api
 
 import (
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func GetOrgQuotas(c *middleware.Context) Response {
+func GetOrgQuotas(c *m.Context) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -20,7 +19,7 @@ func GetOrgQuotas(c *middleware.Context) Response {
 	return Json(200, query.Result)
 }
 
-func UpdateOrgQuota(c *middleware.Context, cmd m.UpdateOrgQuotaCmd) Response {
+func UpdateOrgQuota(c *m.Context, cmd m.UpdateOrgQuotaCmd) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -37,7 +36,7 @@ func UpdateOrgQuota(c *middleware.Context, cmd m.UpdateOrgQuotaCmd) Response {
 	return ApiSuccess("Organization quota updated")
 }
 
-func GetUserQuotas(c *middleware.Context) Response {
+func GetUserQuotas(c *m.Context) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -50,7 +49,7 @@ func GetUserQuotas(c *middleware.Context) Response {
 	return Json(200, query.Result)
 }
 
-func UpdateUserQuota(c *middleware.Context, cmd m.UpdateUserQuotaCmd) Response {
+func UpdateUserQuota(c *m.Context, cmd m.UpdateUserQuotaCmd) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func GetOrgQuotas(c *m.Context) Response {
+func GetOrgQuotas(c *m.ReqContext) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -19,7 +19,7 @@ func GetOrgQuotas(c *m.Context) Response {
 	return Json(200, query.Result)
 }
 
-func UpdateOrgQuota(c *m.Context, cmd m.UpdateOrgQuotaCmd) Response {
+func UpdateOrgQuota(c *m.ReqContext, cmd m.UpdateOrgQuotaCmd) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -36,7 +36,7 @@ func UpdateOrgQuota(c *m.Context, cmd m.UpdateOrgQuotaCmd) Response {
 	return ApiSuccess("Organization quota updated")
 }
 
-func GetUserQuotas(c *m.Context) Response {
+func GetUserQuotas(c *m.ReqContext) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}
@@ -49,7 +49,7 @@ func GetUserQuotas(c *m.Context) Response {
 	return Json(200, query.Result)
 }
 
-func UpdateUserQuota(c *m.Context, cmd m.UpdateUserQuotaCmd) Response {
+func UpdateUserQuota(c *m.ReqContext, cmd m.UpdateUserQuotaCmd) Response {
 	if !setting.Quota.Enabled {
 		return ApiError(404, "Quotas not enabled", nil)
 	}

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/components/renderer"
-	"github.com/grafana/grafana/pkg/middleware"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func RenderToPng(c *middleware.Context) {
+func RenderToPng(c *m.Context) {
 	queryReader, err := util.NewUrlQueryReader(c.Req.URL)
 	if err != nil {
 		c.Handle(400, "Render parameters error", err)

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func RenderToPng(c *m.Context) {
+func RenderToPng(c *m.ReqContext) {
 	queryReader, err := util.NewUrlQueryReader(c.Req.URL)
 	if err != nil {
 		c.Handle(400, "Render parameters error", err)

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -5,25 +5,24 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
-	"github.com/grafana/grafana/pkg/models"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/search"
 )
 
-func Search(c *middleware.Context) {
+func Search(c *m.Context) {
 	query := c.Query("query")
 	tags := c.QueryStrings("tag")
 	starred := c.Query("starred")
 	limit := c.QueryInt("limit")
 	dashboardType := c.Query("type")
-	permission := models.PERMISSION_VIEW
+	permission := m.PERMISSION_VIEW
 
 	if limit == 0 {
 		limit = 1000
 	}
 
 	if c.Query("permission") == "Edit" {
-		permission = models.PERMISSION_EDIT
+		permission = m.PERMISSION_EDIT
 	}
 
 	dbids := make([]int64, 0)

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/search"
 )
 
-func Search(c *m.Context) {
+func Search(c *m.ReqContext) {
 	query := c.Query("query")
 	tags := c.QueryStrings("tag")
 	starred := c.Query("starred")

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -5,14 +5,13 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // GET /api/user/signup/options
-func GetSignUpOptions(c *middleware.Context) Response {
+func GetSignUpOptions(c *m.Context) Response {
 	return Json(200, util.DynMap{
 		"verifyEmailEnabled": setting.VerifyEmailEnabled,
 		"autoAssignOrg":      setting.AutoAssignOrg,
@@ -20,7 +19,7 @@ func GetSignUpOptions(c *middleware.Context) Response {
 }
 
 // POST /api/user/signup
-func SignUp(c *middleware.Context, form dtos.SignUpForm) Response {
+func SignUp(c *m.Context, form dtos.SignUpForm) Response {
 	if !setting.AllowUserSignUp {
 		return ApiError(401, "User signup is disabled", nil)
 	}
@@ -52,7 +51,7 @@ func SignUp(c *middleware.Context, form dtos.SignUpForm) Response {
 	return Json(200, util.DynMap{"status": "SignUpCreated"})
 }
 
-func SignUpStep2(c *middleware.Context, form dtos.SignUpStep2Form) Response {
+func SignUpStep2(c *m.Context, form dtos.SignUpStep2Form) Response {
 	if !setting.AllowUserSignUp {
 		return ApiError(401, "User signup is disabled", nil)
 	}

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GET /api/user/signup/options
-func GetSignUpOptions(c *m.Context) Response {
+func GetSignUpOptions(c *m.ReqContext) Response {
 	return Json(200, util.DynMap{
 		"verifyEmailEnabled": setting.VerifyEmailEnabled,
 		"autoAssignOrg":      setting.AutoAssignOrg,
@@ -19,7 +19,7 @@ func GetSignUpOptions(c *m.Context) Response {
 }
 
 // POST /api/user/signup
-func SignUp(c *m.Context, form dtos.SignUpForm) Response {
+func SignUp(c *m.ReqContext, form dtos.SignUpForm) Response {
 	if !setting.AllowUserSignUp {
 		return ApiError(401, "User signup is disabled", nil)
 	}
@@ -51,7 +51,7 @@ func SignUp(c *m.Context, form dtos.SignUpForm) Response {
 	return Json(200, util.DynMap{"status": "SignUpCreated"})
 }
 
-func SignUpStep2(c *m.Context, form dtos.SignUpStep2Form) Response {
+func SignUpStep2(c *m.ReqContext, form dtos.SignUpStep2Form) Response {
 	if !setting.AllowUserSignUp {
 		return ApiError(401, "User signup is disabled", nil)
 	}

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -2,11 +2,10 @@ package api
 
 import (
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func StarDashboard(c *middleware.Context) Response {
+func StarDashboard(c *m.Context) Response {
 	if !c.IsSignedIn {
 		return ApiError(412, "You need to sign in to star dashboards", nil)
 	}
@@ -24,7 +23,7 @@ func StarDashboard(c *middleware.Context) Response {
 	return ApiSuccess("Dashboard starred!")
 }
 
-func UnstarDashboard(c *middleware.Context) Response {
+func UnstarDashboard(c *m.Context) Response {
 
 	cmd := m.UnstarDashboardCommand{UserId: c.UserId, DashboardId: c.ParamsInt64(":id")}
 

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -5,7 +5,7 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func StarDashboard(c *m.Context) Response {
+func StarDashboard(c *m.ReqContext) Response {
 	if !c.IsSignedIn {
 		return ApiError(412, "You need to sign in to star dashboards", nil)
 	}
@@ -23,7 +23,7 @@ func StarDashboard(c *m.Context) Response {
 	return ApiSuccess("Dashboard starred!")
 }
 
-func UnstarDashboard(c *m.Context) Response {
+func UnstarDashboard(c *m.ReqContext) Response {
 
 	cmd := m.UnstarDashboardCommand{UserId: c.UserId, DashboardId: c.ParamsInt64(":id")}
 

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -3,13 +3,12 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // POST /api/teams
-func CreateTeam(c *middleware.Context, cmd m.CreateTeamCommand) Response {
+func CreateTeam(c *m.Context, cmd m.CreateTeamCommand) Response {
 	cmd.OrgId = c.OrgId
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == m.ErrTeamNameTaken {
@@ -25,7 +24,7 @@ func CreateTeam(c *middleware.Context, cmd m.CreateTeamCommand) Response {
 }
 
 // PUT /api/teams/:teamId
-func UpdateTeam(c *middleware.Context, cmd m.UpdateTeamCommand) Response {
+func UpdateTeam(c *m.Context, cmd m.UpdateTeamCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.Id = c.ParamsInt64(":teamId")
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -39,7 +38,7 @@ func UpdateTeam(c *middleware.Context, cmd m.UpdateTeamCommand) Response {
 }
 
 // DELETE /api/teams/:teamId
-func DeleteTeamById(c *middleware.Context) Response {
+func DeleteTeamById(c *m.Context) Response {
 	if err := bus.Dispatch(&m.DeleteTeamCommand{OrgId: c.OrgId, Id: c.ParamsInt64(":teamId")}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return ApiError(404, "Failed to delete Team. ID not found", nil)
@@ -50,7 +49,7 @@ func DeleteTeamById(c *middleware.Context) Response {
 }
 
 // GET /api/teams/search
-func SearchTeams(c *middleware.Context) Response {
+func SearchTeams(c *m.Context) Response {
 	perPage := c.QueryInt("perpage")
 	if perPage <= 0 {
 		perPage = 1000
@@ -83,7 +82,7 @@ func SearchTeams(c *middleware.Context) Response {
 }
 
 // GET /api/teams/:teamId
-func GetTeamById(c *middleware.Context) Response {
+func GetTeamById(c *m.Context) Response {
 	query := m.GetTeamByIdQuery{OrgId: c.OrgId, Id: c.ParamsInt64(":teamId")}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -8,7 +8,7 @@ import (
 )
 
 // POST /api/teams
-func CreateTeam(c *m.Context, cmd m.CreateTeamCommand) Response {
+func CreateTeam(c *m.ReqContext, cmd m.CreateTeamCommand) Response {
 	cmd.OrgId = c.OrgId
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == m.ErrTeamNameTaken {
@@ -24,7 +24,7 @@ func CreateTeam(c *m.Context, cmd m.CreateTeamCommand) Response {
 }
 
 // PUT /api/teams/:teamId
-func UpdateTeam(c *m.Context, cmd m.UpdateTeamCommand) Response {
+func UpdateTeam(c *m.ReqContext, cmd m.UpdateTeamCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.Id = c.ParamsInt64(":teamId")
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -38,7 +38,7 @@ func UpdateTeam(c *m.Context, cmd m.UpdateTeamCommand) Response {
 }
 
 // DELETE /api/teams/:teamId
-func DeleteTeamById(c *m.Context) Response {
+func DeleteTeamById(c *m.ReqContext) Response {
 	if err := bus.Dispatch(&m.DeleteTeamCommand{OrgId: c.OrgId, Id: c.ParamsInt64(":teamId")}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return ApiError(404, "Failed to delete Team. ID not found", nil)
@@ -49,7 +49,7 @@ func DeleteTeamById(c *m.Context) Response {
 }
 
 // GET /api/teams/search
-func SearchTeams(c *m.Context) Response {
+func SearchTeams(c *m.ReqContext) Response {
 	perPage := c.QueryInt("perpage")
 	if perPage <= 0 {
 		perPage = 1000
@@ -82,7 +82,7 @@ func SearchTeams(c *m.Context) Response {
 }
 
 // GET /api/teams/:teamId
-func GetTeamById(c *m.Context) Response {
+func GetTeamById(c *m.ReqContext) Response {
 	query := m.GetTeamByIdQuery{OrgId: c.OrgId, Id: c.ParamsInt64(":teamId")}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -3,13 +3,12 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // GET /api/teams/:teamId/members
-func GetTeamMembers(c *middleware.Context) Response {
+func GetTeamMembers(c *m.Context) Response {
 	query := m.GetTeamMembersQuery{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -24,7 +23,7 @@ func GetTeamMembers(c *middleware.Context) Response {
 }
 
 // POST /api/teams/:teamId/members
-func AddTeamMember(c *middleware.Context, cmd m.AddTeamMemberCommand) Response {
+func AddTeamMember(c *m.Context, cmd m.AddTeamMemberCommand) Response {
 	cmd.TeamId = c.ParamsInt64(":teamId")
 	cmd.OrgId = c.OrgId
 
@@ -46,7 +45,7 @@ func AddTeamMember(c *middleware.Context, cmd m.AddTeamMemberCommand) Response {
 }
 
 // DELETE /api/teams/:teamId/members/:userId
-func RemoveTeamMember(c *middleware.Context) Response {
+func RemoveTeamMember(c *m.Context) Response {
 	if err := bus.Dispatch(&m.RemoveTeamMemberCommand{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId"), UserId: c.ParamsInt64(":userId")}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return ApiError(404, "Team not found", nil)

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GET /api/teams/:teamId/members
-func GetTeamMembers(c *m.Context) Response {
+func GetTeamMembers(c *m.ReqContext) Response {
 	query := m.GetTeamMembersQuery{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId")}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -23,7 +23,7 @@ func GetTeamMembers(c *m.Context) Response {
 }
 
 // POST /api/teams/:teamId/members
-func AddTeamMember(c *m.Context, cmd m.AddTeamMemberCommand) Response {
+func AddTeamMember(c *m.ReqContext, cmd m.AddTeamMemberCommand) Response {
 	cmd.TeamId = c.ParamsInt64(":teamId")
 	cmd.OrgId = c.OrgId
 
@@ -45,7 +45,7 @@ func AddTeamMember(c *m.Context, cmd m.AddTeamMemberCommand) Response {
 }
 
 // DELETE /api/teams/:teamId/members/:userId
-func RemoveTeamMember(c *m.Context) Response {
+func RemoveTeamMember(c *m.ReqContext) Response {
 	if err := bus.Dispatch(&m.RemoveTeamMemberCommand{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId"), UserId: c.ParamsInt64(":userId")}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return ApiError(404, "Team not found", nil)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -3,19 +3,18 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 // GET /api/user  (current authenticated user)
-func GetSignedInUser(c *middleware.Context) Response {
+func GetSignedInUser(c *m.Context) Response {
 	return getUserUserProfile(c.UserId)
 }
 
 // GET /api/users/:id
-func GetUserById(c *middleware.Context) Response {
+func GetUserById(c *m.Context) Response {
 	return getUserUserProfile(c.ParamsInt64(":id"))
 }
 
@@ -33,7 +32,7 @@ func getUserUserProfile(userId int64) Response {
 }
 
 // GET /api/users/lookup
-func GetUserByLoginOrEmail(c *middleware.Context) Response {
+func GetUserByLoginOrEmail(c *m.Context) Response {
 	query := m.GetUserByLoginQuery{LoginOrEmail: c.Query("loginOrEmail")}
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrUserNotFound {
@@ -55,7 +54,7 @@ func GetUserByLoginOrEmail(c *middleware.Context) Response {
 }
 
 // POST /api/user
-func UpdateSignedInUser(c *middleware.Context, cmd m.UpdateUserCommand) Response {
+func UpdateSignedInUser(c *m.Context, cmd m.UpdateUserCommand) Response {
 	if setting.AuthProxyEnabled {
 		if setting.AuthProxyHeaderProperty == "email" && cmd.Email != c.Email {
 			return ApiError(400, "Not allowed to change email when auth proxy is using email property", nil)
@@ -69,13 +68,13 @@ func UpdateSignedInUser(c *middleware.Context, cmd m.UpdateUserCommand) Response
 }
 
 // POST /api/users/:id
-func UpdateUser(c *middleware.Context, cmd m.UpdateUserCommand) Response {
+func UpdateUser(c *m.Context, cmd m.UpdateUserCommand) Response {
 	cmd.UserId = c.ParamsInt64(":id")
 	return handleUpdateUser(cmd)
 }
 
 //POST /api/users/:id/using/:orgId
-func UpdateUserActiveOrg(c *middleware.Context) Response {
+func UpdateUserActiveOrg(c *m.Context) Response {
 	userId := c.ParamsInt64(":id")
 	orgId := c.ParamsInt64(":orgId")
 
@@ -108,12 +107,12 @@ func handleUpdateUser(cmd m.UpdateUserCommand) Response {
 }
 
 // GET /api/user/orgs
-func GetSignedInUserOrgList(c *middleware.Context) Response {
+func GetSignedInUserOrgList(c *m.Context) Response {
 	return getUserOrgList(c.UserId)
 }
 
 // GET /api/user/:id/orgs
-func GetUserOrgList(c *middleware.Context) Response {
+func GetUserOrgList(c *m.Context) Response {
 	return getUserOrgList(c.ParamsInt64(":id"))
 }
 
@@ -146,7 +145,7 @@ func validateUsingOrg(userId int64, orgId int64) bool {
 }
 
 // POST /api/user/using/:id
-func UserSetUsingOrg(c *middleware.Context) Response {
+func UserSetUsingOrg(c *m.Context) Response {
 	orgId := c.ParamsInt64(":id")
 
 	if !validateUsingOrg(c.UserId, orgId) {
@@ -163,7 +162,7 @@ func UserSetUsingOrg(c *middleware.Context) Response {
 }
 
 // GET /profile/switch-org/:id
-func ChangeActiveOrgAndRedirectToHome(c *middleware.Context) {
+func ChangeActiveOrgAndRedirectToHome(c *m.Context) {
 	orgId := c.ParamsInt64(":id")
 
 	if !validateUsingOrg(c.UserId, orgId) {
@@ -179,7 +178,7 @@ func ChangeActiveOrgAndRedirectToHome(c *middleware.Context) {
 	c.Redirect(setting.AppSubUrl + "/")
 }
 
-func ChangeUserPassword(c *middleware.Context, cmd m.ChangeUserPasswordCommand) Response {
+func ChangeUserPassword(c *m.Context, cmd m.ChangeUserPasswordCommand) Response {
 	if setting.LdapEnabled || setting.AuthProxyEnabled {
 		return ApiError(400, "Not allowed to change password when LDAP or Auth Proxy is enabled", nil)
 	}
@@ -211,7 +210,7 @@ func ChangeUserPassword(c *middleware.Context, cmd m.ChangeUserPasswordCommand) 
 }
 
 // GET /api/users
-func SearchUsers(c *middleware.Context) Response {
+func SearchUsers(c *m.Context) Response {
 	query, err := searchUser(c)
 	if err != nil {
 		return ApiError(500, "Failed to fetch users", err)
@@ -221,7 +220,7 @@ func SearchUsers(c *middleware.Context) Response {
 }
 
 // GET /api/users/search
-func SearchUsersWithPaging(c *middleware.Context) Response {
+func SearchUsersWithPaging(c *m.Context) Response {
 	query, err := searchUser(c)
 	if err != nil {
 		return ApiError(500, "Failed to fetch users", err)
@@ -230,7 +229,7 @@ func SearchUsersWithPaging(c *middleware.Context) Response {
 	return Json(200, query.Result)
 }
 
-func searchUser(c *middleware.Context) (*m.SearchUsersQuery, error) {
+func searchUser(c *m.Context) (*m.SearchUsersQuery, error) {
 	perPage := c.QueryInt("perpage")
 	if perPage <= 0 {
 		perPage = 1000
@@ -258,7 +257,7 @@ func searchUser(c *middleware.Context) (*m.SearchUsersQuery, error) {
 	return query, nil
 }
 
-func SetHelpFlag(c *middleware.Context) Response {
+func SetHelpFlag(c *m.Context) Response {
 	flag := c.ParamsInt64(":id")
 
 	bitmask := &c.HelpFlags1
@@ -276,7 +275,7 @@ func SetHelpFlag(c *middleware.Context) Response {
 	return Json(200, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
 }
 
-func ClearHelpFlags(c *middleware.Context) Response {
+func ClearHelpFlags(c *m.Context) Response {
 	cmd := m.SetUserHelpFlagCommand{
 		UserId:     c.UserId,
 		HelpFlags1: m.HelpFlags1(0),

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -15,8 +16,8 @@ type AuthOptions struct {
 	ReqSignedIn     bool
 }
 
-func getRequestUserId(c *Context) int64 {
-	userId := c.Session.Get(SESS_KEY_USERID)
+func getRequestUserId(c *m.Context) int64 {
+	userId := c.Session.Get(session.SESS_KEY_USERID)
 
 	if userId != nil {
 		return userId.(int64)
@@ -25,7 +26,7 @@ func getRequestUserId(c *Context) int64 {
 	return 0
 }
 
-func getApiKey(c *Context) string {
+func getApiKey(c *m.Context) string {
 	header := c.Req.Header.Get("Authorization")
 	parts := strings.SplitN(header, " ", 2)
 	if len(parts) == 2 && parts[0] == "Bearer" {
@@ -36,7 +37,7 @@ func getApiKey(c *Context) string {
 	return ""
 }
 
-func accessForbidden(c *Context) {
+func accessForbidden(c *m.Context) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(403, "Permission denied", nil)
 		return
@@ -45,7 +46,7 @@ func accessForbidden(c *Context) {
 	c.Redirect(setting.AppSubUrl + "/")
 }
 
-func notAuthorized(c *Context) {
+func notAuthorized(c *m.Context) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(401, "Unauthorized", nil)
 		return
@@ -57,7 +58,7 @@ func notAuthorized(c *Context) {
 }
 
 func RoleAuth(roles ...m.RoleType) macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		ok := false
 		for _, role := range roles {
 			if role == c.OrgRole {
@@ -72,7 +73,7 @@ func RoleAuth(roles ...m.RoleType) macaron.Handler {
 }
 
 func Auth(options *AuthOptions) macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		if !c.IsSignedIn && options.ReqSignedIn && !c.AllowAnonymous {
 			notAuthorized(c)
 			return

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -16,7 +16,7 @@ type AuthOptions struct {
 	ReqSignedIn     bool
 }
 
-func getRequestUserId(c *m.Context) int64 {
+func getRequestUserId(c *m.ReqContext) int64 {
 	userId := c.Session.Get(session.SESS_KEY_USERID)
 
 	if userId != nil {
@@ -26,7 +26,7 @@ func getRequestUserId(c *m.Context) int64 {
 	return 0
 }
 
-func getApiKey(c *m.Context) string {
+func getApiKey(c *m.ReqContext) string {
 	header := c.Req.Header.Get("Authorization")
 	parts := strings.SplitN(header, " ", 2)
 	if len(parts) == 2 && parts[0] == "Bearer" {
@@ -37,7 +37,7 @@ func getApiKey(c *m.Context) string {
 	return ""
 }
 
-func accessForbidden(c *m.Context) {
+func accessForbidden(c *m.ReqContext) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(403, "Permission denied", nil)
 		return
@@ -46,7 +46,7 @@ func accessForbidden(c *m.Context) {
 	c.Redirect(setting.AppSubUrl + "/")
 }
 
-func notAuthorized(c *m.Context) {
+func notAuthorized(c *m.ReqContext) {
 	if c.IsApiRequest() {
 		c.JsonApiErr(401, "Unauthorized", nil)
 		return
@@ -58,7 +58,7 @@ func notAuthorized(c *m.Context) {
 }
 
 func RoleAuth(roles ...m.RoleType) macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		ok := false
 		for _, role := range roles {
 			if role == c.OrgRole {
@@ -73,7 +73,7 @@ func RoleAuth(roles ...m.RoleType) macaron.Handler {
 }
 
 func Auth(options *AuthOptions) macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		if !c.IsSignedIn && options.ReqSignedIn && !c.AllowAnonymous {
 			notAuthorized(c)
 			return

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -10,10 +10,11 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func initContextWithAuthProxy(ctx *Context, orgId int64) bool {
+func initContextWithAuthProxy(ctx *m.Context, orgId int64) bool {
 	if !setting.AuthProxyEnabled {
 		return false
 	}
@@ -58,7 +59,7 @@ func initContextWithAuthProxy(ctx *Context, orgId int64) bool {
 	}
 
 	// initialize session
-	if err := ctx.Session.Start(ctx); err != nil {
+	if err := ctx.Session.Start(ctx.Context); err != nil {
 		log.Error(3, "Failed to start session", err)
 		return false
 	}
@@ -66,12 +67,12 @@ func initContextWithAuthProxy(ctx *Context, orgId int64) bool {
 	// Make sure that we cannot share a session between different users!
 	if getRequestUserId(ctx) > 0 && getRequestUserId(ctx) != query.Result.UserId {
 		// remove session
-		if err := ctx.Session.Destory(ctx); err != nil {
+		if err := ctx.Session.Destory(ctx.Context); err != nil {
 			log.Error(3, "Failed to destroy session, err")
 		}
 
 		// initialize a new session
-		if err := ctx.Session.Start(ctx); err != nil {
+		if err := ctx.Session.Start(ctx.Context); err != nil {
 			log.Error(3, "Failed to start session", err)
 		}
 	}
@@ -89,17 +90,17 @@ func initContextWithAuthProxy(ctx *Context, orgId int64) bool {
 
 	ctx.SignedInUser = query.Result
 	ctx.IsSignedIn = true
-	ctx.Session.Set(SESS_KEY_USERID, ctx.UserId)
+	ctx.Session.Set(session.SESS_KEY_USERID, ctx.UserId)
 
 	return true
 }
 
-var syncGrafanaUserWithLdapUser = func(ctx *Context, query *m.GetSignedInUserQuery) error {
+var syncGrafanaUserWithLdapUser = func(ctx *m.Context, query *m.GetSignedInUserQuery) error {
 	if setting.LdapEnabled {
 		expireEpoch := time.Now().Add(time.Duration(-setting.AuthProxyLdapSyncTtl) * time.Minute).Unix()
 
 		var lastLdapSync int64
-		if lastLdapSyncInSession := ctx.Session.Get(SESS_KEY_LASTLDAPSYNC); lastLdapSyncInSession != nil {
+		if lastLdapSyncInSession := ctx.Session.Get(session.SESS_KEY_LASTLDAPSYNC); lastLdapSyncInSession != nil {
 			lastLdapSync = lastLdapSyncInSession.(int64)
 		}
 
@@ -113,14 +114,14 @@ var syncGrafanaUserWithLdapUser = func(ctx *Context, query *m.GetSignedInUserQue
 				}
 			}
 
-			ctx.Session.Set(SESS_KEY_LASTLDAPSYNC, time.Now().Unix())
+			ctx.Session.Set(session.SESS_KEY_LASTLDAPSYNC, time.Now().Unix())
 		}
 	}
 
 	return nil
 }
 
-func checkAuthenticationProxy(ctx *Context, proxyHeaderValue string) error {
+func checkAuthenticationProxy(ctx *m.Context, proxyHeaderValue string) error {
 	if len(strings.TrimSpace(setting.AuthProxyWhitelist)) > 0 {
 		proxies := strings.Split(setting.AuthProxyWhitelist, ",")
 		remoteAddrSplit := strings.Split(ctx.Req.RemoteAddr, ":")

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func initContextWithAuthProxy(ctx *m.Context, orgId int64) bool {
+func initContextWithAuthProxy(ctx *m.ReqContext, orgId int64) bool {
 	if !setting.AuthProxyEnabled {
 		return false
 	}
@@ -95,7 +95,7 @@ func initContextWithAuthProxy(ctx *m.Context, orgId int64) bool {
 	return true
 }
 
-var syncGrafanaUserWithLdapUser = func(ctx *m.Context, query *m.GetSignedInUserQuery) error {
+var syncGrafanaUserWithLdapUser = func(ctx *m.ReqContext, query *m.GetSignedInUserQuery) error {
 	if setting.LdapEnabled {
 		expireEpoch := time.Now().Add(time.Duration(-setting.AuthProxyLdapSyncTtl) * time.Minute).Unix()
 
@@ -121,7 +121,7 @@ var syncGrafanaUserWithLdapUser = func(ctx *m.Context, query *m.GetSignedInUserQ
 	return nil
 }
 
-func checkAuthenticationProxy(ctx *m.Context, proxyHeaderValue string) error {
+func checkAuthenticationProxy(ctx *m.ReqContext, proxyHeaderValue string) error {
 	if len(strings.TrimSpace(setting.AuthProxyWhitelist)) > 0 {
 		proxies := strings.Split(setting.AuthProxyWhitelist, ",")
 		remoteAddrSplit := strings.Split(ctx.Req.RemoteAddr, ":")

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/macaron.v1"
 )
 
 func TestAuthProxyWithLdapEnabled(t *testing.T) {
@@ -29,45 +31,45 @@ func TestAuthProxyWithLdapEnabled(t *testing.T) {
 
 		Convey("When session variable lastLdapSync not set, call syncSignedInUser and set lastLdapSync", func() {
 			// arrange
-			session := mockSession{}
-			ctx := Context{Session: &session}
-			So(session.Get(SESS_KEY_LASTLDAPSYNC), ShouldBeNil)
+			sess := mockSession{}
+			ctx := m.Context{Session: &sess}
+			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeNil)
 
 			// act
 			syncGrafanaUserWithLdapUser(&ctx, &query)
 
 			// assert
 			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeTrue)
-			So(session.Get(SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, 0)
+			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, 0)
 		})
 
 		Convey("When session variable not expired, don't sync and don't change session var", func() {
 			// arrange
-			session := mockSession{}
-			ctx := Context{Session: &session}
+			sess := mockSession{}
+			ctx := m.Context{Session: &sess}
 			now := time.Now().Unix()
-			session.Set(SESS_KEY_LASTLDAPSYNC, now)
+			sess.Set(session.SESS_KEY_LASTLDAPSYNC, now)
 
 			// act
 			syncGrafanaUserWithLdapUser(&ctx, &query)
 
 			// assert
-			So(session.Get(SESS_KEY_LASTLDAPSYNC), ShouldEqual, now)
+			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldEqual, now)
 			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeFalse)
 		})
 
 		Convey("When lastldapsync is expired, session variable should be updated", func() {
 			// arrange
-			session := mockSession{}
-			ctx := Context{Session: &session}
+			sess := mockSession{}
+			ctx := m.Context{Session: &sess}
 			expiredTime := time.Now().Add(time.Duration(-120) * time.Minute).Unix()
-			session.Set(SESS_KEY_LASTLDAPSYNC, expiredTime)
+			sess.Set(session.SESS_KEY_LASTLDAPSYNC, expiredTime)
 
 			// act
 			syncGrafanaUserWithLdapUser(&ctx, &query)
 
 			// assert
-			So(session.Get(SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, expiredTime)
+			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, expiredTime)
 			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeTrue)
 		})
 	})
@@ -77,7 +79,7 @@ type mockSession struct {
 	value interface{}
 }
 
-func (s *mockSession) Start(c *Context) error {
+func (s *mockSession) Start(c *macaron.Context) error {
 	return nil
 }
 
@@ -102,11 +104,11 @@ func (s *mockSession) Release() error {
 	return nil
 }
 
-func (s *mockSession) Destory(c *Context) error {
+func (s *mockSession) Destory(c *macaron.Context) error {
 	return nil
 }
 
-func (s *mockSession) RegenerateId(c *Context) error {
+func (s *mockSession) RegenerateId(c *macaron.Context) error {
 	return nil
 }
 

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -32,7 +32,7 @@ func TestAuthProxyWithLdapEnabled(t *testing.T) {
 		Convey("When session variable lastLdapSync not set, call syncSignedInUser and set lastLdapSync", func() {
 			// arrange
 			sess := mockSession{}
-			ctx := m.Context{Session: &sess}
+			ctx := m.ReqContext{Session: &sess}
 			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeNil)
 
 			// act
@@ -46,7 +46,7 @@ func TestAuthProxyWithLdapEnabled(t *testing.T) {
 		Convey("When session variable not expired, don't sync and don't change session var", func() {
 			// arrange
 			sess := mockSession{}
-			ctx := m.Context{Session: &sess}
+			ctx := m.ReqContext{Session: &sess}
 			now := time.Now().Unix()
 			sess.Set(session.SESS_KEY_LASTLDAPSYNC, now)
 
@@ -61,7 +61,7 @@ func TestAuthProxyWithLdapEnabled(t *testing.T) {
 		Convey("When lastldapsync is expired, session variable should be updated", func() {
 			// arrange
 			sess := mockSession{}
-			ctx := m.Context{Session: &sess}
+			ctx := m.ReqContext{Session: &sess}
 			expiredTime := time.Now().Add(time.Duration(-120) * time.Minute).Unix()
 			sess.Set(session.SESS_KEY_LASTLDAPSYNC, expiredTime)
 

--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -20,7 +20,7 @@ func getDashboardUrlBySlug(orgId int64, slug string) (string, error) {
 }
 
 func RedirectFromLegacyDashboardUrl() macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		slug := c.Params("slug")
 
 		if slug != "" {
@@ -34,7 +34,7 @@ func RedirectFromLegacyDashboardUrl() macaron.Handler {
 }
 
 func RedirectFromLegacyDashboardSoloUrl() macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		slug := c.Params("slug")
 
 		if slug != "" {

--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -20,7 +20,7 @@ func getDashboardUrlBySlug(orgId int64, slug string) (string, error) {
 }
 
 func RedirectFromLegacyDashboardUrl() macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		slug := c.Params("slug")
 
 		if slug != "" {
@@ -34,7 +34,7 @@ func RedirectFromLegacyDashboardUrl() macaron.Handler {
 }
 
 func RedirectFromLegacyDashboardSoloUrl() macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		slug := c.Params("slug")
 
 		if slug != "" {

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/macaron.v1"
@@ -47,7 +48,7 @@ func Logger() macaron.Handler {
 		}
 
 		if ctx, ok := c.Data["ctx"]; ok {
-			ctxTyped := ctx.(*Context)
+			ctxTyped := ctx.(*m.Context)
 			if status == 500 {
 				ctxTyped.Logger.Error("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", int64(timeTakenMs), "size", rw.Size(), "referer", req.Referer())
 			} else {

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -48,7 +48,7 @@ func Logger() macaron.Handler {
 		}
 
 		if ctx, ok := c.Data["ctx"]; ok {
-			ctxTyped := ctx.(*m.Context)
+			ctxTyped := ctx.(*m.ReqContext)
 			if status == 500 {
 				ctxTyped.Logger.Error("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status, "remote_addr", c.RemoteAddr(), "time_ms", int64(timeTakenMs), "size", rw.Size(), "referer", req.Referer())
 			} else {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"strconv"
-	"strings"
 
 	"gopkg.in/macaron.v1"
 
@@ -11,29 +10,17 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	l "github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
 )
-
-type Context struct {
-	*macaron.Context
-	*m.SignedInUser
-
-	Session SessionStore
-
-	IsSignedIn     bool
-	IsRenderCall   bool
-	AllowAnonymous bool
-	Logger         log.Logger
-}
 
 func GetContextHandler() macaron.Handler {
 	return func(c *macaron.Context) {
-		ctx := &Context{
+		ctx := &m.Context{
 			Context:        c,
 			SignedInUser:   &m.SignedInUser{},
-			Session:        GetSession(),
+			Session:        session.GetSession(),
 			IsSignedIn:     false,
 			AllowAnonymous: false,
 			Logger:         log.New("context"),
@@ -74,7 +61,7 @@ func GetContextHandler() macaron.Handler {
 	}
 }
 
-func initContextWithAnonymousUser(ctx *Context) bool {
+func initContextWithAnonymousUser(ctx *m.Context) bool {
 	if !setting.AnonymousEnabled {
 		return false
 	}
@@ -94,9 +81,9 @@ func initContextWithAnonymousUser(ctx *Context) bool {
 	return true
 }
 
-func initContextWithUserSessionCookie(ctx *Context, orgId int64) bool {
+func initContextWithUserSessionCookie(ctx *m.Context, orgId int64) bool {
 	// initialize session
-	if err := ctx.Session.Start(ctx); err != nil {
+	if err := ctx.Session.Start(ctx.Context); err != nil {
 		ctx.Logger.Error("Failed to start session", "error", err)
 		return false
 	}
@@ -117,7 +104,7 @@ func initContextWithUserSessionCookie(ctx *Context, orgId int64) bool {
 	return true
 }
 
-func initContextWithApiKey(ctx *Context) bool {
+func initContextWithApiKey(ctx *m.Context) bool {
 	var keyString string
 	if keyString = getApiKey(ctx); keyString == "" {
 		return false
@@ -153,7 +140,7 @@ func initContextWithApiKey(ctx *Context) bool {
 	return true
 }
 
-func initContextWithBasicAuth(ctx *Context, orgId int64) bool {
+func initContextWithBasicAuth(ctx *m.Context, orgId int64) bool {
 
 	if !setting.BasicAuthEnabled {
 		return false
@@ -195,70 +182,8 @@ func initContextWithBasicAuth(ctx *Context, orgId int64) bool {
 	return true
 }
 
-// Handle handles and logs error by given status.
-func (ctx *Context) Handle(status int, title string, err error) {
-	if err != nil {
-		ctx.Logger.Error(title, "error", err)
-		if setting.Env != setting.PROD {
-			ctx.Data["ErrorMsg"] = err
-		}
-	}
-
-	ctx.Data["Title"] = title
-	ctx.Data["AppSubUrl"] = setting.AppSubUrl
-	ctx.Data["Theme"] = "dark"
-
-	ctx.HTML(status, "error")
-}
-
-func (ctx *Context) JsonOK(message string) {
-	resp := make(map[string]interface{})
-	resp["message"] = message
-	ctx.JSON(200, resp)
-}
-
-func (ctx *Context) IsApiRequest() bool {
-	return strings.HasPrefix(ctx.Req.URL.Path, "/api")
-}
-
-func (ctx *Context) JsonApiErr(status int, message string, err error) {
-	resp := make(map[string]interface{})
-
-	if err != nil {
-		ctx.Logger.Error(message, "error", err)
-		if setting.Env != setting.PROD {
-			resp["error"] = err.Error()
-		}
-	}
-
-	switch status {
-	case 404:
-		resp["message"] = "Not Found"
-	case 500:
-		resp["message"] = "Internal Server Error"
-	}
-
-	if message != "" {
-		resp["message"] = message
-	}
-
-	ctx.JSON(status, resp)
-}
-
-func (ctx *Context) HasUserRole(role m.RoleType) bool {
-	return ctx.OrgRole.Includes(role)
-}
-
-func (ctx *Context) HasHelpFlag(flag m.HelpFlags1) bool {
-	return ctx.HelpFlags1.HasFlag(flag)
-}
-
-func (ctx *Context) TimeRequest(timer prometheus.Summary) {
-	ctx.Data["perfmon.timer"] = timer
-}
-
 func AddDefaultResponseHeaders() macaron.Handler {
-	return func(ctx *Context) {
+	return func(ctx *m.Context) {
 		if ctx.IsApiRequest() && ctx.Req.Method == "GET" {
 			ctx.Resp.Header().Add("Cache-Control", "no-cache")
 			ctx.Resp.Header().Add("Pragma", "no-cache")

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -17,7 +17,7 @@ import (
 
 func GetContextHandler() macaron.Handler {
 	return func(c *macaron.Context) {
-		ctx := &m.Context{
+		ctx := &m.ReqContext{
 			Context:        c,
 			SignedInUser:   &m.SignedInUser{},
 			Session:        session.GetSession(),
@@ -61,7 +61,7 @@ func GetContextHandler() macaron.Handler {
 	}
 }
 
-func initContextWithAnonymousUser(ctx *m.Context) bool {
+func initContextWithAnonymousUser(ctx *m.ReqContext) bool {
 	if !setting.AnonymousEnabled {
 		return false
 	}
@@ -81,7 +81,7 @@ func initContextWithAnonymousUser(ctx *m.Context) bool {
 	return true
 }
 
-func initContextWithUserSessionCookie(ctx *m.Context, orgId int64) bool {
+func initContextWithUserSessionCookie(ctx *m.ReqContext, orgId int64) bool {
 	// initialize session
 	if err := ctx.Session.Start(ctx.Context); err != nil {
 		ctx.Logger.Error("Failed to start session", "error", err)
@@ -104,7 +104,7 @@ func initContextWithUserSessionCookie(ctx *m.Context, orgId int64) bool {
 	return true
 }
 
-func initContextWithApiKey(ctx *m.Context) bool {
+func initContextWithApiKey(ctx *m.ReqContext) bool {
 	var keyString string
 	if keyString = getApiKey(ctx); keyString == "" {
 		return false
@@ -140,7 +140,7 @@ func initContextWithApiKey(ctx *m.Context) bool {
 	return true
 }
 
-func initContextWithBasicAuth(ctx *m.Context, orgId int64) bool {
+func initContextWithBasicAuth(ctx *m.ReqContext, orgId int64) bool {
 
 	if !setting.BasicAuthEnabled {
 		return false
@@ -183,7 +183,7 @@ func initContextWithBasicAuth(ctx *m.Context, orgId int64) bool {
 }
 
 func AddDefaultResponseHeaders() macaron.Handler {
-	return func(ctx *m.Context) {
+	return func(ctx *m.ReqContext) {
 		if ctx.IsApiRequest() && ctx.Req.Method == "GET" {
 			ctx.Resp.Header().Add("Cache-Control", "no-cache")
 			ctx.Resp.Header().Add("Pragma", "no-cache")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-macaron/session"
+	ms "github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
 	l "github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	. "github.com/smartystreets/goconvey/convey"
@@ -130,8 +131,8 @@ func TestMiddlewareContext(t *testing.T) {
 
 		middlewareScenario("UserId in session", func(sc *scenarioContext) {
 
-			sc.fakeReq("GET", "/").handler(func(c *Context) {
-				c.Session.Set(SESS_KEY_USERID, int64(12))
+			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
@@ -276,8 +277,8 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			// create session
-			sc.fakeReq("GET", "/").handler(func(c *Context) {
-				c.Session.Set(SESS_KEY_USERID, int64(33))
+			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+				c.Session.Set(session.SESS_KEY_USERID, int64(33))
 			}).exec()
 
 			oldSessionID := sc.context.Session.ID()
@@ -300,7 +301,7 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.LdapEnabled = true
 
 			called := false
-			syncGrafanaUserWithLdapUser = func(ctx *Context, query *m.GetSignedInUserQuery) error {
+			syncGrafanaUserWithLdapUser = func(ctx *m.Context, query *m.GetSignedInUserQuery) error {
 				called = true
 				return nil
 			}
@@ -336,12 +337,12 @@ func middlewareScenario(desc string, fn scenarioFunc) {
 
 		sc.m.Use(GetContextHandler())
 		// mock out gc goroutine
-		startSessionGC = func() {}
-		sc.m.Use(Sessioner(&session.Options{}))
+		session.StartSessionGC = func() {}
+		sc.m.Use(Sessioner(&ms.Options{}))
 		sc.m.Use(OrgRedirect())
 		sc.m.Use(AddDefaultResponseHeaders())
 
-		sc.defaultHandler = func(c *Context) {
+		sc.defaultHandler = func(c *m.Context) {
 			sc.context = c
 			if sc.handlerFunc != nil {
 				sc.handlerFunc(sc.context)
@@ -356,7 +357,7 @@ func middlewareScenario(desc string, fn scenarioFunc) {
 
 type scenarioContext struct {
 	m              *macaron.Macaron
-	context        *Context
+	context        *m.Context
 	resp           *httptest.ResponseRecorder
 	apiKey         string
 	authHeader     string
@@ -436,4 +437,4 @@ func (sc *scenarioContext) exec() {
 }
 
 type scenarioFunc func(c *scenarioContext)
-type handlerFunc func(c *Context)
+type handlerFunc func(c *m.Context)

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -131,7 +131,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 		middlewareScenario("UserId in session", func(sc *scenarioContext) {
 
-			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+			sc.fakeReq("GET", "/").handler(func(c *m.ReqContext) {
 				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
@@ -277,7 +277,7 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			// create session
-			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+			sc.fakeReq("GET", "/").handler(func(c *m.ReqContext) {
 				c.Session.Set(session.SESS_KEY_USERID, int64(33))
 			}).exec()
 
@@ -301,7 +301,7 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.LdapEnabled = true
 
 			called := false
-			syncGrafanaUserWithLdapUser = func(ctx *m.Context, query *m.GetSignedInUserQuery) error {
+			syncGrafanaUserWithLdapUser = func(ctx *m.ReqContext, query *m.GetSignedInUserQuery) error {
 				called = true
 				return nil
 			}
@@ -342,7 +342,7 @@ func middlewareScenario(desc string, fn scenarioFunc) {
 		sc.m.Use(OrgRedirect())
 		sc.m.Use(AddDefaultResponseHeaders())
 
-		sc.defaultHandler = func(c *m.Context) {
+		sc.defaultHandler = func(c *m.ReqContext) {
 			sc.context = c
 			if sc.handlerFunc != nil {
 				sc.handlerFunc(sc.context)
@@ -357,7 +357,7 @@ func middlewareScenario(desc string, fn scenarioFunc) {
 
 type scenarioContext struct {
 	m              *macaron.Macaron
-	context        *m.Context
+	context        *m.ReqContext
 	resp           *httptest.ResponseRecorder
 	apiKey         string
 	authHeader     string
@@ -437,4 +437,4 @@ func (sc *scenarioContext) exec() {
 }
 
 type scenarioFunc func(c *scenarioContext)
-type handlerFunc func(c *m.Context)
+type handlerFunc func(c *m.ReqContext)

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/models"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"gopkg.in/macaron.v1"
@@ -22,7 +22,7 @@ func OrgRedirect() macaron.Handler {
 			return
 		}
 
-		ctx, ok := c.Data["ctx"].(*Context)
+		ctx, ok := c.Data["ctx"].(*m.Context)
 		if !ok || !ctx.IsSignedIn {
 			return
 		}
@@ -31,7 +31,7 @@ func OrgRedirect() macaron.Handler {
 			return
 		}
 
-		cmd := models.SetUsingOrgCommand{UserId: ctx.UserId, OrgId: orgId}
+		cmd := m.SetUsingOrgCommand{UserId: ctx.UserId, OrgId: orgId}
 		if err := bus.Dispatch(&cmd); err != nil {
 			if ctx.IsApiRequest() {
 				ctx.JsonApiErr(404, "Not found", nil)

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -22,7 +22,7 @@ func OrgRedirect() macaron.Handler {
 			return
 		}
 
-		ctx, ok := c.Data["ctx"].(*m.Context)
+		ctx, ok := c.Data["ctx"].(*m.ReqContext)
 		if !ok || !ctx.IsSignedIn {
 			return
 		}

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/models"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -14,16 +15,16 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 	Convey("Can redirect to correct org", t, func() {
 		middlewareScenario("when setting a correct org for the user", func(sc *scenarioContext) {
-			sc.fakeReq("GET", "/").handler(func(c *Context) {
-				c.Session.Set(SESS_KEY_USERID, int64(12))
+			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
-			bus.AddHandler("test", func(query *models.SetUsingOrgCommand) error {
+			bus.AddHandler("test", func(query *m.SetUsingOrgCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetSignedInUserQuery) error {
-				query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
+			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+				query.Result = &m.SignedInUser{OrgId: 1, UserId: 12}
 				return nil
 			})
 
@@ -36,16 +37,16 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 		})
 
 		middlewareScenario("when setting an invalid org for user", func(sc *scenarioContext) {
-			sc.fakeReq("GET", "/").handler(func(c *Context) {
-				c.Session.Set(SESS_KEY_USERID, int64(12))
+			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
-			bus.AddHandler("test", func(query *models.SetUsingOrgCommand) error {
+			bus.AddHandler("test", func(query *m.SetUsingOrgCommand) error {
 				return fmt.Errorf("")
 			})
 
-			bus.AddHandler("test", func(query *models.GetSignedInUserQuery) error {
-				query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
+			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+				query.Result = &m.SignedInUser{OrgId: 1, UserId: 12}
 				return nil
 			})
 

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -15,7 +15,7 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 	Convey("Can redirect to correct org", t, func() {
 		middlewareScenario("when setting a correct org for the user", func(sc *scenarioContext) {
-			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+			sc.fakeReq("GET", "/").handler(func(c *m.ReqContext) {
 				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
@@ -37,7 +37,7 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 		})
 
 		middlewareScenario("when setting an invalid org for user", func(sc *scenarioContext) {
-			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+			sc.fakeReq("GET", "/").handler(func(c *m.ReqContext) {
 				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 

--- a/pkg/middleware/perf.go
+++ b/pkg/middleware/perf.go
@@ -4,9 +4,11 @@ import (
 	"net/http"
 
 	"gopkg.in/macaron.v1"
+
+	m "github.com/grafana/grafana/pkg/models"
 )
 
 func MeasureRequestTime() macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *Context) {
+	return func(res http.ResponseWriter, req *http.Request, c *m.Context) {
 	}
 }

--- a/pkg/middleware/perf.go
+++ b/pkg/middleware/perf.go
@@ -9,6 +9,6 @@ import (
 )
 
 func MeasureRequestTime() macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *m.Context) {
+	return func(res http.ResponseWriter, req *http.Request, c *m.ReqContext) {
 	}
 }

--- a/pkg/middleware/quota.go
+++ b/pkg/middleware/quota.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
 )
 
 func Quota(target string) macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		limitReached, err := QuotaReached(c, target)
 		if err != nil {
 			c.JsonApiErr(500, "failed to get quota", err)
@@ -23,7 +24,7 @@ func Quota(target string) macaron.Handler {
 	}
 }
 
-func QuotaReached(c *Context, target string) (bool, error) {
+func QuotaReached(c *m.Context, target string) (bool, error) {
 	if !setting.Quota.Enabled {
 		return false, nil
 	}
@@ -46,7 +47,7 @@ func QuotaReached(c *Context, target string) (bool, error) {
 				return true, nil
 			}
 			if target == "session" {
-				usedSessions := getSessionCount()
+				usedSessions := session.GetSessionCount()
 				if int64(usedSessions) > scope.DefaultLimit {
 					c.Logger.Debug("Sessions limit reached", "active", usedSessions, "limit", scope.DefaultLimit)
 					return true, nil

--- a/pkg/middleware/quota.go
+++ b/pkg/middleware/quota.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Quota(target string) macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		limitReached, err := QuotaReached(c, target)
 		if err != nil {
 			c.JsonApiErr(500, "failed to get quota", err)
@@ -24,7 +24,7 @@ func Quota(target string) macaron.Handler {
 	}
 }
 
-func QuotaReached(c *m.Context, target string) (bool, error) {
+func QuotaReached(c *m.ReqContext, target string) (bool, error) {
 	if !setting.Quota.Enabled {
 		return false, nil
 	}

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -12,7 +13,7 @@ import (
 func TestMiddlewareQuota(t *testing.T) {
 
 	Convey("Given the grafana quota middleware", t, func() {
-		getSessionCount = func() int {
+		session.GetSessionCount = func() int {
 			return 4
 		}
 
@@ -74,8 +75,8 @@ func TestMiddlewareQuota(t *testing.T) {
 
 		middlewareScenario("with user logged in", func(sc *scenarioContext) {
 			// log us in, so we have a user_id and org_id in the context
-			sc.fakeReq("GET", "/").handler(func(c *Context) {
-				c.Session.Set(SESS_KEY_USERID, int64(12))
+			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -75,7 +75,7 @@ func TestMiddlewareQuota(t *testing.T) {
 
 		middlewareScenario("with user logged in", func(sc *scenarioContext) {
 			// log us in, so we have a user_id and org_id in the context
-			sc.fakeReq("GET", "/").handler(func(c *m.Context) {
+			sc.fakeReq("GET", "/").handler(func(c *m.ReqContext) {
 				c.Session.Set(session.SESS_KEY_USERID, int64(12))
 			}).exec()
 

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -106,7 +107,7 @@ func Recovery() macaron.Handler {
 				panicLogger := log.Root
 				// try to get request logger
 				if ctx, ok := c.Data["ctx"]; ok {
-					ctxTyped := ctx.(*Context)
+					ctxTyped := ctx.(*m.Context)
 					panicLogger = ctxTyped.Logger
 				}
 
@@ -123,7 +124,7 @@ func Recovery() macaron.Handler {
 					c.Data["ErrorMsg"] = string(stack)
 				}
 
-				ctx, ok := c.Data["ctx"].(*Context)
+				ctx, ok := c.Data["ctx"].(*m.Context)
 
 				if ok && ctx.IsApiRequest() {
 					resp := make(map[string]interface{})

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -107,7 +107,7 @@ func Recovery() macaron.Handler {
 				panicLogger := log.Root
 				// try to get request logger
 				if ctx, ok := c.Data["ctx"]; ok {
-					ctxTyped := ctx.(*m.Context)
+					ctxTyped := ctx.(*m.ReqContext)
 					panicLogger = ctxTyped.Logger
 				}
 
@@ -124,7 +124,7 @@ func Recovery() macaron.Handler {
 					c.Data["ErrorMsg"] = string(stack)
 				}
 
-				ctx, ok := c.Data["ctx"].(*m.Context)
+				ctx, ok := c.Data["ctx"].(*m.ReqContext)
 
 				if ok && ctx.IsApiRequest() {
 					resp := make(map[string]interface{})

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -4,8 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-macaron/session"
+	ms "github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/macaron.v1"
 )
@@ -37,7 +39,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 	})
 }
 
-func PanicHandler(c *Context) {
+func PanicHandler(c *m.Context) {
 	panic("Handler has panicked")
 }
 
@@ -60,12 +62,12 @@ func recoveryScenario(desc string, url string, fn scenarioFunc) {
 
 		sc.m.Use(GetContextHandler())
 		// mock out gc goroutine
-		startSessionGC = func() {}
-		sc.m.Use(Sessioner(&session.Options{}))
+		session.StartSessionGC = func() {}
+		sc.m.Use(Sessioner(&ms.Options{}))
 		sc.m.Use(OrgRedirect())
 		sc.m.Use(AddDefaultResponseHeaders())
 
-		sc.defaultHandler = func(c *Context) {
+		sc.defaultHandler = func(c *m.Context) {
 			sc.context = c
 			if sc.handlerFunc != nil {
 				sc.handlerFunc(sc.context)

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -39,7 +39,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 	})
 }
 
-func PanicHandler(c *m.Context) {
+func PanicHandler(c *m.ReqContext) {
 	panic("Handler has panicked")
 }
 
@@ -67,7 +67,7 @@ func recoveryScenario(desc string, url string, fn scenarioFunc) {
 		sc.m.Use(OrgRedirect())
 		sc.m.Use(AddDefaultResponseHeaders())
 
-		sc.defaultHandler = func(c *m.Context) {
+		sc.defaultHandler = func(c *m.ReqContext) {
 			sc.context = c
 			if sc.handlerFunc != nil {
 				sc.handlerFunc(sc.context)

--- a/pkg/middleware/render_auth.go
+++ b/pkg/middleware/render_auth.go
@@ -10,7 +10,7 @@ import (
 var renderKeysLock sync.Mutex
 var renderKeys map[string]*m.SignedInUser = make(map[string]*m.SignedInUser)
 
-func initContextWithRenderAuth(ctx *Context) bool {
+func initContextWithRenderAuth(ctx *m.Context) bool {
 	key := ctx.GetCookie("renderKey")
 	if key == "" {
 		return false

--- a/pkg/middleware/render_auth.go
+++ b/pkg/middleware/render_auth.go
@@ -10,7 +10,7 @@ import (
 var renderKeysLock sync.Mutex
 var renderKeys map[string]*m.SignedInUser = make(map[string]*m.SignedInUser)
 
-func initContextWithRenderAuth(ctx *m.Context) bool {
+func initContextWithRenderAuth(ctx *m.ReqContext) bool {
 	key := ctx.GetCookie("renderKey")
 	if key == "" {
 		return false

--- a/pkg/middleware/session.go
+++ b/pkg/middleware/session.go
@@ -1,170 +1,21 @@
 package middleware
 
 import (
-	"math/rand"
-	"time"
-
-	"github.com/go-macaron/session"
-	_ "github.com/go-macaron/session/memcache"
-	_ "github.com/go-macaron/session/mysql"
-	_ "github.com/go-macaron/session/postgres"
-	_ "github.com/go-macaron/session/redis"
-	"github.com/grafana/grafana/pkg/log"
+	ms "github.com/go-macaron/session"
 	"gopkg.in/macaron.v1"
+
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
 )
 
-const (
-	SESS_KEY_USERID       = "uid"
-	SESS_KEY_OAUTH_STATE  = "state"
-	SESS_KEY_APIKEY       = "apikey_id" // used for render requests with api keys
-	SESS_KEY_LASTLDAPSYNC = "last_ldap_sync"
-)
+func Sessioner(options *ms.Options) macaron.Handler {
+	session.Init(options)
 
-var sessionManager *session.Manager
-var sessionOptions *session.Options
-var startSessionGC func()
-var getSessionCount func() int
-var sessionLogger = log.New("session")
-
-func init() {
-	startSessionGC = func() {
-		sessionManager.GC()
-		sessionLogger.Debug("Session GC")
-		time.AfterFunc(time.Duration(sessionOptions.Gclifetime)*time.Second, startSessionGC)
-	}
-	getSessionCount = func() int {
-		return sessionManager.Count()
-	}
-}
-
-func prepareOptions(opt *session.Options) *session.Options {
-	if len(opt.Provider) == 0 {
-		opt.Provider = "memory"
-	}
-	if len(opt.ProviderConfig) == 0 {
-		opt.ProviderConfig = "data/sessions"
-	}
-	if len(opt.CookieName) == 0 {
-		opt.CookieName = "grafana_sess"
-	}
-	if len(opt.CookiePath) == 0 {
-		opt.CookiePath = "/"
-	}
-	if opt.Gclifetime == 0 {
-		opt.Gclifetime = 3600
-	}
-	if opt.Maxlifetime == 0 {
-		opt.Maxlifetime = opt.Gclifetime
-	}
-	if opt.IDLength == 0 {
-		opt.IDLength = 16
-	}
-
-	return opt
-}
-
-func Sessioner(options *session.Options) macaron.Handler {
-	var err error
-	sessionOptions = prepareOptions(options)
-	sessionManager, err = session.NewManager(options.Provider, *options)
-	if err != nil {
-		panic(err)
-	}
-
-	// start GC threads after some random seconds
-	rndSeconds := 10 + rand.Int63n(180)
-	time.AfterFunc(time.Duration(rndSeconds)*time.Second, startSessionGC)
-
-	return func(ctx *Context) {
+	return func(ctx *m.Context) {
 		ctx.Next()
 
-		if err = ctx.Session.Release(); err != nil {
+		if err := ctx.Session.Release(); err != nil {
 			panic("session(release): " + err.Error())
 		}
 	}
-}
-
-func GetSession() SessionStore {
-	return &SessionWrapper{manager: sessionManager}
-}
-
-type SessionStore interface {
-	// Set sets value to given key in session.
-	Set(interface{}, interface{}) error
-	// Get gets value by given key in session.
-	Get(interface{}) interface{}
-	// Delete deletes a key from session.
-	Delete(interface{}) interface{}
-	// ID returns current session ID.
-	ID() string
-	// Release releases session resource and save data to provider.
-	Release() error
-	// Destory deletes a session.
-	Destory(*Context) error
-	// init
-	Start(*Context) error
-	// RegenerateId regenerates the session id
-	RegenerateId(*Context) error
-}
-
-type SessionWrapper struct {
-	session session.RawStore
-	manager *session.Manager
-}
-
-func (s *SessionWrapper) Start(c *Context) error {
-	var err error
-	s.session, err = s.manager.Start(c.Context)
-	return err
-}
-
-func (s *SessionWrapper) RegenerateId(c *Context) error {
-	var err error
-	s.session, err = s.manager.RegenerateId(c.Context)
-	return err
-}
-
-func (s *SessionWrapper) Set(k interface{}, v interface{}) error {
-	if s.session != nil {
-		return s.session.Set(k, v)
-	}
-	return nil
-}
-
-func (s *SessionWrapper) Get(k interface{}) interface{} {
-	if s.session != nil {
-		return s.session.Get(k)
-	}
-	return nil
-}
-
-func (s *SessionWrapper) Delete(k interface{}) interface{} {
-	if s.session != nil {
-		return s.session.Delete(k)
-	}
-	return nil
-}
-
-func (s *SessionWrapper) ID() string {
-	if s.session != nil {
-		return s.session.ID()
-	}
-	return ""
-}
-
-func (s *SessionWrapper) Release() error {
-	if s.session != nil {
-		return s.session.Release()
-	}
-	return nil
-}
-
-func (s *SessionWrapper) Destory(c *Context) error {
-	if s.session != nil {
-		if err := s.manager.Destory(c.Context); err != nil {
-			return err
-		}
-		s.session = nil
-	}
-	return nil
 }

--- a/pkg/middleware/session.go
+++ b/pkg/middleware/session.go
@@ -11,7 +11,7 @@ import (
 func Sessioner(options *ms.Options) macaron.Handler {
 	session.Init(options)
 
-	return func(ctx *m.Context) {
+	return func(ctx *m.ReqContext) {
 		ctx.Next()
 
 		if err := ctx.Session.Release(); err != nil {

--- a/pkg/middleware/validate_host.go
+++ b/pkg/middleware/validate_host.go
@@ -3,12 +3,13 @@ package middleware
 import (
 	"strings"
 
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
 )
 
 func ValidateHostHeader(domain string) macaron.Handler {
-	return func(c *Context) {
+	return func(c *m.Context) {
 		// ignore local render calls
 		if c.IsRenderCall {
 			return

--- a/pkg/middleware/validate_host.go
+++ b/pkg/middleware/validate_host.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ValidateHostHeader(domain string) macaron.Handler {
-	return func(c *m.Context) {
+	return func(c *m.ReqContext) {
 		// ignore local render calls
 		if c.IsRenderCall {
 			return

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -1,0 +1,86 @@
+package models
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/macaron.v1"
+
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/services/session"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type Context struct {
+	*macaron.Context
+	*SignedInUser
+
+	Session session.SessionStore
+
+	IsSignedIn     bool
+	IsRenderCall   bool
+	AllowAnonymous bool
+	Logger         log.Logger
+}
+
+// Handle handles and logs error by given status.
+func (ctx *Context) Handle(status int, title string, err error) {
+	if err != nil {
+		ctx.Logger.Error(title, "error", err)
+		if setting.Env != setting.PROD {
+			ctx.Data["ErrorMsg"] = err
+		}
+	}
+
+	ctx.Data["Title"] = title
+	ctx.Data["AppSubUrl"] = setting.AppSubUrl
+	ctx.Data["Theme"] = "dark"
+
+	ctx.HTML(status, "error")
+}
+
+func (ctx *Context) JsonOK(message string) {
+	resp := make(map[string]interface{})
+	resp["message"] = message
+	ctx.JSON(200, resp)
+}
+
+func (ctx *Context) IsApiRequest() bool {
+	return strings.HasPrefix(ctx.Req.URL.Path, "/api")
+}
+
+func (ctx *Context) JsonApiErr(status int, message string, err error) {
+	resp := make(map[string]interface{})
+
+	if err != nil {
+		ctx.Logger.Error(message, "error", err)
+		if setting.Env != setting.PROD {
+			resp["error"] = err.Error()
+		}
+	}
+
+	switch status {
+	case 404:
+		resp["message"] = "Not Found"
+	case 500:
+		resp["message"] = "Internal Server Error"
+	}
+
+	if message != "" {
+		resp["message"] = message
+	}
+
+	ctx.JSON(status, resp)
+}
+
+func (ctx *Context) HasUserRole(role RoleType) bool {
+	return ctx.OrgRole.Includes(role)
+}
+
+func (ctx *Context) HasHelpFlag(flag HelpFlags1) bool {
+	return ctx.HelpFlags1.HasFlag(flag)
+}
+
+func (ctx *Context) TimeRequest(timer prometheus.Summary) {
+	ctx.Data["perfmon.timer"] = timer
+}

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type Context struct {
+type ReqContext struct {
 	*macaron.Context
 	*SignedInUser
 
@@ -24,7 +24,7 @@ type Context struct {
 }
 
 // Handle handles and logs error by given status.
-func (ctx *Context) Handle(status int, title string, err error) {
+func (ctx *ReqContext) Handle(status int, title string, err error) {
 	if err != nil {
 		ctx.Logger.Error(title, "error", err)
 		if setting.Env != setting.PROD {
@@ -39,17 +39,17 @@ func (ctx *Context) Handle(status int, title string, err error) {
 	ctx.HTML(status, "error")
 }
 
-func (ctx *Context) JsonOK(message string) {
+func (ctx *ReqContext) JsonOK(message string) {
 	resp := make(map[string]interface{})
 	resp["message"] = message
 	ctx.JSON(200, resp)
 }
 
-func (ctx *Context) IsApiRequest() bool {
+func (ctx *ReqContext) IsApiRequest() bool {
 	return strings.HasPrefix(ctx.Req.URL.Path, "/api")
 }
 
-func (ctx *Context) JsonApiErr(status int, message string, err error) {
+func (ctx *ReqContext) JsonApiErr(status int, message string, err error) {
 	resp := make(map[string]interface{})
 
 	if err != nil {
@@ -73,14 +73,14 @@ func (ctx *Context) JsonApiErr(status int, message string, err error) {
 	ctx.JSON(status, resp)
 }
 
-func (ctx *Context) HasUserRole(role RoleType) bool {
+func (ctx *ReqContext) HasUserRole(role RoleType) bool {
 	return ctx.OrgRole.Includes(role)
 }
 
-func (ctx *Context) HasHelpFlag(flag HelpFlags1) bool {
+func (ctx *ReqContext) HasHelpFlag(flag HelpFlags1) bool {
 	return ctx.HelpFlags1.HasFlag(flag)
 }
 
-func (ctx *Context) TimeRequest(timer prometheus.Summary) {
+func (ctx *ReqContext) TimeRequest(timer prometheus.Summary) {
 	ctx.Data["perfmon.timer"] = timer
 }

--- a/pkg/services/session/session.go
+++ b/pkg/services/session/session.go
@@ -1,0 +1,162 @@
+package session
+
+import (
+	"math/rand"
+	"time"
+
+	ms "github.com/go-macaron/session"
+	_ "github.com/go-macaron/session/memcache"
+	_ "github.com/go-macaron/session/mysql"
+	_ "github.com/go-macaron/session/postgres"
+	_ "github.com/go-macaron/session/redis"
+	"github.com/grafana/grafana/pkg/log"
+	"gopkg.in/macaron.v1"
+)
+
+const (
+	SESS_KEY_USERID       = "uid"
+	SESS_KEY_OAUTH_STATE  = "state"
+	SESS_KEY_APIKEY       = "apikey_id" // used for render requests with api keys
+	SESS_KEY_LASTLDAPSYNC = "last_ldap_sync"
+)
+
+var sessionManager *ms.Manager
+var sessionOptions *ms.Options
+var StartSessionGC func()
+var GetSessionCount func() int
+var sessionLogger = log.New("session")
+
+func init() {
+	StartSessionGC = func() {
+		sessionManager.GC()
+		sessionLogger.Debug("Session GC")
+		time.AfterFunc(time.Duration(sessionOptions.Gclifetime)*time.Second, StartSessionGC)
+	}
+	GetSessionCount = func() int {
+		return sessionManager.Count()
+	}
+}
+
+func Init(options *ms.Options) {
+	var err error
+	sessionOptions = prepareOptions(options)
+	sessionManager, err = ms.NewManager(options.Provider, *options)
+	if err != nil {
+		panic(err)
+	}
+
+	// start GC threads after some random seconds
+	rndSeconds := 10 + rand.Int63n(180)
+	time.AfterFunc(time.Duration(rndSeconds)*time.Second, StartSessionGC)
+}
+
+func prepareOptions(opt *ms.Options) *ms.Options {
+	if len(opt.Provider) == 0 {
+		opt.Provider = "memory"
+	}
+	if len(opt.ProviderConfig) == 0 {
+		opt.ProviderConfig = "data/sessions"
+	}
+	if len(opt.CookieName) == 0 {
+		opt.CookieName = "grafana_sess"
+	}
+	if len(opt.CookiePath) == 0 {
+		opt.CookiePath = "/"
+	}
+	if opt.Gclifetime == 0 {
+		opt.Gclifetime = 3600
+	}
+	if opt.Maxlifetime == 0 {
+		opt.Maxlifetime = opt.Gclifetime
+	}
+	if opt.IDLength == 0 {
+		opt.IDLength = 16
+	}
+
+	return opt
+}
+
+func GetSession() SessionStore {
+	return &SessionWrapper{manager: sessionManager}
+}
+
+type SessionStore interface {
+	// Set sets value to given key in session.
+	Set(interface{}, interface{}) error
+	// Get gets value by given key in session.
+	Get(interface{}) interface{}
+	// Delete deletes a key from session.
+	Delete(interface{}) interface{}
+	// ID returns current session ID.
+	ID() string
+	// Release releases session resource and save data to provider.
+	Release() error
+	// Destory deletes a session.
+	Destory(*macaron.Context) error
+	// init
+	Start(*macaron.Context) error
+	// RegenerateId regenerates the session id
+	RegenerateId(*macaron.Context) error
+}
+
+type SessionWrapper struct {
+	session ms.RawStore
+	manager *ms.Manager
+}
+
+func (s *SessionWrapper) Start(c *macaron.Context) error {
+	var err error
+	s.session, err = s.manager.Start(c)
+	return err
+}
+
+func (s *SessionWrapper) RegenerateId(c *macaron.Context) error {
+	var err error
+	s.session, err = s.manager.RegenerateId(c)
+	return err
+}
+
+func (s *SessionWrapper) Set(k interface{}, v interface{}) error {
+	if s.session != nil {
+		return s.session.Set(k, v)
+	}
+	return nil
+}
+
+func (s *SessionWrapper) Get(k interface{}) interface{} {
+	if s.session != nil {
+		return s.session.Get(k)
+	}
+	return nil
+}
+
+func (s *SessionWrapper) Delete(k interface{}) interface{} {
+	if s.session != nil {
+		return s.session.Delete(k)
+	}
+	return nil
+}
+
+func (s *SessionWrapper) ID() string {
+	if s.session != nil {
+		return s.session.ID()
+	}
+	return ""
+}
+
+func (s *SessionWrapper) Release() error {
+	if s.session != nil {
+		return s.session.Release()
+	}
+	return nil
+}
+
+func (s *SessionWrapper) Destory(c *macaron.Context) error {
+	if s.session != nil {
+		if err := s.manager.Destory(c); err != nil {
+			return err
+		}
+		s.session = nil
+	}
+	return nil
+}


### PR DESCRIPTION
This PR moves the definition of the `Context` type out of the `middleware` package and into `models`, and moves the session store into a dedicated service.  The goal of this change is to remove the need for code throughout the system to depend on the `middleware` package, which causes issues with circular imports.

I'm not sure whether `models` is technically the "right" place for `Context`, but it seemed to make sense since it's already a dependency for almost everything in the system.  As I went through I also tried to standardize on aliasing the `models` import as `m`, to make things consistent across the system.

Following this PR there will be a follow-up to move quota handling into a dedicated service also, the session handling had to be included here to avoid a circular dependency between the `models` and `middleware` packages.

I did also roll in a couple of changes to Makefile and build.go that I found helpful while testing these changes, they can be broken out into a separate PR if required.