### PR TITLE
Documentation fix: "~/go" to "$GOPATH"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the latest master builds [here](https://grafana.com/grafana/download)
 ### Building the backend
 ```bash
 go get github.com/grafana/grafana
-cd ~/go/src/github.com/grafana/grafana
+cd $GOPATH/src/github.com/grafana/grafana
 go run build.go setup
 go run build.go build
 ```


### PR DESCRIPTION
In "Install from source" section supposed that Grafana's sources installed to `~/go` , but it is not always true. 
In other hand, `go get ..` command would install project to `$GOPATH`

https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies

* Link the PR to an issue for new features
* Rebase your PR if it gets out of sync with master

**REMOVE THE TEXT ABOVE BEFORE CREATING THE PULL REQUEST**
