### PR TITLE
move quota to dedicated service

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -14,10 +14,10 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -202,7 +202,7 @@ func PostDashboard(c *m.ReqContext, cmd m.SaveDashboardCommand) Response {
 	dash := cmd.GetDashboardModel()
 
 	if dash.Id == 0 && dash.Uid == "" {
-		limitReached, err := middleware.QuotaReached(c, "dashboard")
+		limitReached, err := quota.QuotaReached(c, "dashboard")
 		if err != nil {
 			return ApiError(500, "failed to get quota", err)
 		}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -17,8 +17,8 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/middleware"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
@@ -168,7 +168,7 @@ func OAuthLogin(ctx *m.ReqContext) {
 			redirectWithError(ctx, ErrSignUpNotAllowed)
 			return
 		}
-		limitReached, err := middleware.QuotaReached(ctx, "user")
+		limitReached, err := quota.QuotaReached(ctx, "user")
 		if err != nil {
 			ctx.Handle(500, "Failed to get user quota", err)
 			return

--- a/pkg/middleware/quota.go
+++ b/pkg/middleware/quota.go
@@ -3,16 +3,15 @@ package middleware
 import (
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/bus"
-	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/session"
-	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
+
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/quota"
 )
 
 func Quota(target string) macaron.Handler {
 	return func(c *m.ReqContext) {
-		limitReached, err := QuotaReached(c, target)
+		limitReached, err := quota.QuotaReached(c, target)
 		if err != nil {
 			c.JsonApiErr(500, "failed to get quota", err)
 			return
@@ -22,83 +21,4 @@ func Quota(target string) macaron.Handler {
 			return
 		}
 	}
-}
-
-func QuotaReached(c *m.ReqContext, target string) (bool, error) {
-	if !setting.Quota.Enabled {
-		return false, nil
-	}
-
-	// get the list of scopes that this target is valid for. Org, User, Global
-	scopes, err := m.GetQuotaScopes(target)
-	if err != nil {
-		return false, err
-	}
-
-	for _, scope := range scopes {
-		c.Logger.Debug("Checking quota", "target", target, "scope", scope)
-
-		switch scope.Name {
-		case "global":
-			if scope.DefaultLimit < 0 {
-				continue
-			}
-			if scope.DefaultLimit == 0 {
-				return true, nil
-			}
-			if target == "session" {
-				usedSessions := session.GetSessionCount()
-				if int64(usedSessions) > scope.DefaultLimit {
-					c.Logger.Debug("Sessions limit reached", "active", usedSessions, "limit", scope.DefaultLimit)
-					return true, nil
-				}
-				continue
-			}
-			query := m.GetGlobalQuotaByTargetQuery{Target: scope.Target}
-			if err := bus.Dispatch(&query); err != nil {
-				return true, err
-			}
-			if query.Result.Used >= scope.DefaultLimit {
-				return true, nil
-			}
-		case "org":
-			if !c.IsSignedIn {
-				continue
-			}
-			query := m.GetOrgQuotaByTargetQuery{OrgId: c.OrgId, Target: scope.Target, Default: scope.DefaultLimit}
-			if err := bus.Dispatch(&query); err != nil {
-				return true, err
-			}
-			if query.Result.Limit < 0 {
-				continue
-			}
-			if query.Result.Limit == 0 {
-				return true, nil
-			}
-
-			if query.Result.Used >= query.Result.Limit {
-				return true, nil
-			}
-		case "user":
-			if !c.IsSignedIn || c.UserId == 0 {
-				continue
-			}
-			query := m.GetUserQuotaByTargetQuery{UserId: c.UserId, Target: scope.Target, Default: scope.DefaultLimit}
-			if err := bus.Dispatch(&query); err != nil {
-				return true, err
-			}
-			if query.Result.Limit < 0 {
-				continue
-			}
-			if query.Result.Limit == 0 {
-				return true, nil
-			}
-
-			if query.Result.Used >= query.Result.Limit {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
 }

--- a/pkg/services/quota/quota.go
+++ b/pkg/services/quota/quota.go
@@ -1,0 +1,87 @@
+package quota
+
+import (
+	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/session"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func QuotaReached(c *m.ReqContext, target string) (bool, error) {
+	if !setting.Quota.Enabled {
+		return false, nil
+	}
+
+	// get the list of scopes that this target is valid for. Org, User, Global
+	scopes, err := m.GetQuotaScopes(target)
+	if err != nil {
+		return false, err
+	}
+
+	for _, scope := range scopes {
+		c.Logger.Debug("Checking quota", "target", target, "scope", scope)
+
+		switch scope.Name {
+		case "global":
+			if scope.DefaultLimit < 0 {
+				continue
+			}
+			if scope.DefaultLimit == 0 {
+				return true, nil
+			}
+			if target == "session" {
+				usedSessions := session.GetSessionCount()
+				if int64(usedSessions) > scope.DefaultLimit {
+					c.Logger.Debug("Sessions limit reached", "active", usedSessions, "limit", scope.DefaultLimit)
+					return true, nil
+				}
+				continue
+			}
+			query := m.GetGlobalQuotaByTargetQuery{Target: scope.Target}
+			if err := bus.Dispatch(&query); err != nil {
+				return true, err
+			}
+			if query.Result.Used >= scope.DefaultLimit {
+				return true, nil
+			}
+		case "org":
+			if !c.IsSignedIn {
+				continue
+			}
+			query := m.GetOrgQuotaByTargetQuery{OrgId: c.OrgId, Target: scope.Target, Default: scope.DefaultLimit}
+			if err := bus.Dispatch(&query); err != nil {
+				return true, err
+			}
+			if query.Result.Limit < 0 {
+				continue
+			}
+			if query.Result.Limit == 0 {
+				return true, nil
+			}
+
+			if query.Result.Used >= query.Result.Limit {
+				return true, nil
+			}
+		case "user":
+			if !c.IsSignedIn || c.UserId == 0 {
+				continue
+			}
+			query := m.GetUserQuotaByTargetQuery{UserId: c.UserId, Target: scope.Target, Default: scope.DefaultLimit}
+			if err := bus.Dispatch(&query); err != nil {
+				return true, err
+			}
+			if query.Result.Limit < 0 {
+				continue
+			}
+			if query.Result.Limit == 0 {
+				return true, nil
+			}
+
+			if query.Result.Used >= query.Result.Limit {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This PR moved the quota code out of the `middleware` package and into a dedicated service.  This makes it available for use in parts of the system that are dependencies of the `middleware` package.