### PR TITLE
Tooltip explains how regex work in series override

### DIFF
--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -90,6 +90,9 @@
 			<div class="gf-form-inline" ng-repeat="override in ctrl.panel.seriesOverrides" ng-controller="SeriesOverridesCtrl">
 				<div class="gf-form">
 					<label class="gf-form-label">alias or regex</label>
+          <md-tooltip>
+            You need to wrap the series override expression in / characters to let Grafana know you want regex matching.
+          </md-tooltip>
 				</div>
 				<div class="gf-form width-15">
 					<input type="text" ng-model="override.alias" bs-typeahead="getSeriesNames" ng-blur="ctrl.render()" data-min-length=0 data-items=100 class="gf-form-input width-15">


### PR DESCRIPTION
Regex didn't seem to work for me in series overrides of a graph.

So I found #1404 which told me how to use it. But it also mentioned a tooltip which I wasn't able to find.

I applied this patch to change my local installation. I'm guessing those files are cached somewhere, so it didn't make any difference.

I sadly don't have time to dig deeper, so I provide this patch UNTESTED!