### PR TITLE
Adding Timeticks unit

### DIFF
--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -783,6 +783,10 @@ kbn.valueFormats.dtdurations = function(size, decimals) {
   return kbn.toDuration(size, decimals, 'second');
 };
 
+kbn.valueFormats.timeticks = function(size, decimals, scaledDecimals) {
+  return kbn.valueFormats.s(size / 100, decimals, scaledDecimals);
+};
+
 kbn.valueFormats.dateTimeAsIso = function(epoch) {
   var time = moment(epoch);
 
@@ -854,6 +858,7 @@ kbn.getUnitFormats = function() {
         { text: 'days (d)', value: 'd' },
         { text: 'duration (ms)', value: 'dtdurationms' },
         { text: 'duration (s)', value: 'dtdurations' },
+        { text: 'Timeticks (s/100)', value: 'timeticks' },
       ],
     },
     {


### PR DESCRIPTION
This PR is adding a new time unit called [Timeticks](https://www.webnms.com/snmp/help/snmpapi/snmpv3/using_mibs_in_applns/timeticks_datatype.html) which is defined like "hundredth of a second" and is common in the world of SNMP monitoring.