### PR TITLE
Added icon for iOS web app

### DIFF
--- a/public/views/index.template.html
+++ b/public/views/index.template.html
@@ -15,7 +15,8 @@
 
   <link rel="icon" type="image/png" href="public/img/fav32.png">
   <link rel="mask-icon" href="public/img/grafana_mask_icon.svg" color="#F05A28">
-
+  <link rel="apple-touch-icon" href="public/img/fav32.png">
+  
 </head>
 
 <body ng-cloak class="theme-[[ .Theme ]]">


### PR DESCRIPTION
If you using Safari on a iOS device and save the page to home screen you will get the Grafana-icon as icon.