### PR TITLE
middleware: recover and retry on session start

### DIFF
--- a/pkg/services/session/session.go
+++ b/pkg/services/session/session.go
@@ -105,6 +105,18 @@ type SessionWrapper struct {
 }
 
 func (s *SessionWrapper) Start(c *macaron.Context) error {
+	// See https://github.com/grafana/grafana/issues/11155 for details on why
+	// a recover and retry is needed
+	defer func() error {
+		if err := recover(); err != nil {
+			var retryErr error
+			s.session, retryErr = s.manager.Start(c)
+			return retryErr
+		}
+
+		return nil
+	}()
+
 	var err error
 	s.session, err = s.manager.Start(c)
 	return err


### PR DESCRIPTION
Partial fix for #11155 - the Macaron session middleware panics if mysql returns an error. This fix recovers from the panic and retries once.

- Does not fix the session GC function. The GC function [does not return the error](https://github.com/go-macaron/session/blob/master/mysql/mysql.go#L188-L190) meaning that we can't check the error and do a retry.
- Both the Macaron session middleware and the [Golang sql driver](https://github.com/go-sql-driver/mysql/blob/master/connection.go#L99) will log an error that will be visible in the Grafana logs. 

Closes #11155 

Will open a new issue for the two problems that are left to solve. 
