### PR TITLE
dashboard: fix import dashboard with alert rule(s)

### DIFF
--- a/pkg/plugins/dashboard_importer.go
+++ b/pkg/plugins/dashboard_importer.go
@@ -80,7 +80,7 @@ func ImportDashboard(cmd *ImportDashboardCommand) error {
 		User:      cmd.User,
 	}
 
-	savedDash, err := dashboards.NewService().SaveDashboard(dto)
+	savedDash, err := dashboards.NewService().ImportDashboard(dto)
 
 	if err != nil {
 		return err

--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -13,6 +13,7 @@ import (
 // DashboardService service for operating on dashboards
 type DashboardService interface {
 	SaveDashboard(dto *SaveDashboardDTO) (*models.Dashboard, error)
+	ImportDashboard(dto *SaveDashboardDTO) (*models.Dashboard, error)
 }
 
 // DashboardProvisioningService service for operating on provisioned dashboards
@@ -214,6 +215,20 @@ func (dr *dashboardServiceImpl) SaveDashboard(dto *SaveDashboardDTO) (*models.Da
 	return cmd.Result, nil
 }
 
+func (dr *dashboardServiceImpl) ImportDashboard(dto *SaveDashboardDTO) (*models.Dashboard, error) {
+	cmd, err := dr.buildSaveDashboardCommand(dto, false)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bus.Dispatch(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return cmd.Result, nil
+}
+
 type FakeDashboardService struct {
 	SaveDashboardResult *models.Dashboard
 	SaveDashboardError  error
@@ -228,6 +243,10 @@ func (s *FakeDashboardService) SaveDashboard(dto *SaveDashboardDTO) (*models.Das
 	}
 
 	return s.SaveDashboardResult, s.SaveDashboardError
+}
+
+func (s *FakeDashboardService) ImportDashboard(dto *SaveDashboardDTO) (*models.Dashboard, error) {
+	return s.SaveDashboard(dto)
 }
 
 func MockDashboardService(mock *FakeDashboardService) {


### PR DESCRIPTION
Importing a dashboard with alert rule(s) should be possible without receiving invalid
alert data error. This fix reverts the import logic to how it worked before Grafana v5.0,
that is import will allow dashboard with alert rule(s) but no alerts will be created.
After an import the user will need to update the dashboard for the alerts to be created.

Fixes #11227 
