### PR TITLE
Avoid redirecting internal rendering requests

### DIFF
--- a/pkg/components/renderer/renderer.go
+++ b/pkg/components/renderer/renderer.go
@@ -72,7 +72,9 @@ func RenderToPng(params *RenderOpts) (string, error) {
 		localDomain = setting.HttpAddr
 	}
 
-	url := fmt.Sprintf("%s://%s:%s/%s", setting.Protocol, localDomain, setting.HttpPort, params.Path)
+	// &render=1 signals to the legacy redirect layer to
+	// avoid redirect these requests.
+	url := fmt.Sprintf("%s://%s:%s/%s&render=1", setting.Protocol, localDomain, setting.HttpPort, params.Path)
 
 	binPath, _ := filepath.Abs(filepath.Join(setting.PhantomDir, executable))
 	scriptPath, _ := filepath.Abs(filepath.Join(setting.PhantomDir, "render.js"))

--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
 )
 
@@ -36,9 +37,14 @@ func RedirectFromLegacyDashboardUrl() macaron.Handler {
 func RedirectFromLegacyDashboardSoloUrl() macaron.Handler {
 	return func(c *m.ReqContext) {
 		slug := c.Params("slug")
+		renderRequest := c.QueryBool("render")
 
 		if slug != "" {
 			if url, err := getDashboardUrlBySlug(c.OrgId, slug); err == nil {
+				if renderRequest && strings.Contains(url, setting.AppSubUrl) {
+					url = strings.Replace(url, setting.AppSubUrl, "", 1)
+				}
+
 				url = strings.Replace(url, "/d/", "/d-solo/", 1)
 				url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
 				c.Redirect(url, 301)


### PR DESCRIPTION
The middleware layer we introduced for redirecting from the old url format to the new url format caused some problems with the internal rendering requests by phantomjs, if grafana was configured to use sub path's. This PR fixes that and introduces a query parameter used by phantomjs to skip the redirect middleware. 

closes #11180

