### PR TITLE
Keyboard shortcut to duplicate panel

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -178,6 +178,14 @@ export class KeybindingSrv {
       }
     });
 
+    // duplicate panel
+    this.bind('p d', () => {
+      if (dashboard.meta.focusPanelId && dashboard.meta.canEdit) {
+        let panelIndex = dashboard.getPanelInfoById(dashboard.meta.focusPanelId).index;
+        dashboard.duplicatePanel(dashboard.panels[panelIndex]);
+      }
+    });
+
     // share panel
     this.bind('p s', () => {
       if (dashboard.meta.focusPanelId) {


### PR DESCRIPTION
Works when panel menu is open.

Fixes #11102
