### PR TITLE
GitLab authentication backend

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -270,6 +270,18 @@ api_url = https://api.github.com/user
 team_ids =
 allowed_organizations =
 
+#################################### GitLab Auth #########################
+[auth.gitlab]
+enabled = false
+allow_sign_up = true
+client_id = some_id
+client_secret = some_secret
+scopes = api
+auth_url = https://gitlab.com/oauth/authorize
+token_url = https://gitlab.com/oauth/token
+api_url = https://gitlab.com/api/v4
+allowed_groups =
+
 #################################### Google Auth #########################
 [auth.google]
 enabled = false

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -84,7 +84,7 @@ command line in the init.d script or the systemd service file.
 
 ### temp_data_lifetime
 
-How long temporary images in `data` directory should be kept. Defaults to: `24h`. Supported modifiers: `h` (hours), 
+How long temporary images in `data` directory should be kept. Defaults to: `24h`. Supported modifiers: `h` (hours),
 `m` (minutes), for example: `168h`, `30m`, `10h30m`. Use `0` to never clean up temporary files.
 
 ### logs
@@ -431,6 +431,8 @@ allowed_organizations = github google
 <hr>
 
 ## [auth.gitlab]
+
+> Only available in Grafana v5.3+.
 
 You need to [create a GitLab OAuth
 application](https://docs.gitlab.com/ce/integration/oauth_provider.html).

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -430,6 +430,102 @@ allowed_organizations = github google
 
 <hr>
 
+## [auth.gitlab]
+
+You need to [create a GitLab OAuth
+application](https://docs.gitlab.com/ce/integration/oauth_provider.html).
+Choose a descriptive *Name*, and use the following *Redirect URI*:
+
+```
+https://grafana.example.com/login/gitlab
+```
+
+where `https://grafana.example.com` is the URL you use to connect to Grafana.
+Adjust it as needed if you don't use HTTPS or if you use a different port; for
+instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
+
+```
+http://203.0.113.31:3000/login/gitlab
+```
+
+Finally, select *api* as the *Scope* and submit the form. You'll get an
+*Application Id* and a *Secret* in return; we'll call them
+`GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this
+section.
+
+Add the following to your Grafana configuration file to enable GitLab
+authentication:
+
+```ini
+[auth.gitlab]
+enabled = false
+allow_sign_up = false
+client_id = GITLAB_APPLICATION_ID
+client_secret = GITLAB_SECRET
+scopes = api
+auth_url = https://gitlab.com/oauth/authorize
+token_url = https://gitlab.com/oauth/token
+api_url = https://gitlab.com/api/v4
+allowed_groups =
+```
+
+Restart the Grafana backend for your changes to take effect.
+
+If you use your own instance of GitLab instead of `gitlab.com`, adjust
+`auth_url`, `token_url` and `api_url` accordingly by replacing the `gitlab.com`
+hostname with your own.
+
+With `allow_sign_up` set to `false`, only existing users will be able to login
+using their GitLab account, but with `allow_sign_up` set to `true`, *any* user
+who can authenticate on GitLab will be able to login on your Grafana instance;
+if you use the public `gitlab.com`, it means anyone in the world would be able
+to login on your Grafana instance.
+
+You can can however limit access to only members of a given group or list of
+groups by setting the `allowed_groups` option.
+
+### allowed_groups
+
+To limit access to authenticated users that are members of one or more [GitLab
+groups](https://docs.gitlab.com/ce/user/group/index.html), set `allowed_groups`
+to a comma- or space-separated list of groups. For instance, if you want to
+only give access to members of the `example` group, set
+
+
+```ini
+allowed_groups = example
+```
+
+If you want to also give access to members of the subgroup `bar`, which is in
+the group `foo`, set
+
+```ini
+allowed_groups = example, foo/bar
+```
+
+Note that in GitLab, the group or subgroup name doesn't always match its
+display name, especially if the display name contains spaces or special
+characters. Make sure you always use the group or subgroup name as it appears
+in the URL of the group or subgroup.
+
+Here's a complete example with `alloed_sign_up` enabled, and access limited to
+the `example` and `foo/bar` groups:
+
+```ini
+[auth.gitlab]
+enabled = false
+allow_sign_up = true
+client_id = GITLAB_APPLICATION_ID
+client_secret = GITLAB_SECRET
+scopes = api
+auth_url = https://gitlab.com/oauth/authorize
+token_url = https://gitlab.com/oauth/token
+api_url = https://gitlab.com/api/v4
+allowed_groups = example, foo/bar
+```
+
+<hr>
+
 ## [auth.google]
 
 First, you need to create a Google OAuth Client:

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -448,8 +448,12 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select *api* as the *Scope* and submit the form. You'll get an
-*Application Id* and a *Secret* in return; we'll call them
+Finally, select *api* as the *Scope* and submit the form. Note that if you're
+not going to use GitLab groups for authorization (i.e. not setting
+`allowed_groups`, see below), you can select *read_user* instead of *api* as
+the *Scope*, thus giving a more restricted access to your GitLab API.
+
+You'll get an *Application Id* and a *Secret* in return; we'll call them
 `GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this
 section.
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -8,4 +8,5 @@ const (
 	TWITTER
 	GENERIC
 	GRAFANA_COM
+	GITLAB
 )

--- a/pkg/social/gitlab_oauth.go
+++ b/pkg/social/gitlab_oauth.go
@@ -1,0 +1,131 @@
+package social
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/grafana/grafana/pkg/models"
+
+	"golang.org/x/oauth2"
+)
+
+type SocialGitlab struct {
+	*SocialBase
+	allowedDomains []string
+	allowedGroups  []string
+	apiUrl         string
+	allowSignup    bool
+}
+
+var (
+	ErrMissingGroupMembership = &Error{"User not a member of one of the required groups"}
+)
+
+func (s *SocialGitlab) Type() int {
+	return int(models.GITLAB)
+}
+
+func (s *SocialGitlab) IsEmailAllowed(email string) bool {
+	return isEmailAllowed(email, s.allowedDomains)
+}
+
+func (s *SocialGitlab) IsSignupAllowed() bool {
+	return s.allowSignup
+}
+
+func (s *SocialGitlab) IsGroupMember(client *http.Client) bool {
+	if len(s.allowedGroups) == 0 {
+		return true
+	}
+
+	for groups, url := s.GetGroups(client, s.apiUrl+"/groups"); groups != nil; groups, url = s.GetGroups(client, url) {
+		for _, allowedGroup := range s.allowedGroups {
+			for _, group := range groups {
+				if group == allowedGroup {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func (s *SocialGitlab) GetGroups(client *http.Client, url string) ([]string, string) {
+	type Group struct {
+		FullPath string `json:"full_path"`
+	}
+
+	var (
+		groups []Group
+		next   string
+	)
+
+	if url == "" {
+		return nil, next
+	}
+
+	response, err := HttpGet(client, url)
+	if err != nil {
+		s.log.Error("Error getting groups from GitLab API", "err", err)
+		return nil, next
+	}
+
+	if err := json.Unmarshal(response.Body, &groups); err != nil {
+		s.log.Error("Error parsing JSON from GitLab API", "err", err)
+		return nil, next
+	}
+
+	fullPaths := make([]string, len(groups))
+	for i, group := range groups {
+		fullPaths[i] = group.FullPath
+	}
+
+	if link, ok := response.Headers["Link"]; ok {
+		pattern := regexp.MustCompile(`<([^>]+)>; rel="next"`)
+		if matches := pattern.FindStringSubmatch(link[0]); matches != nil {
+			next = matches[1]
+		}
+	}
+
+	return fullPaths, next
+}
+
+func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
+
+	var data struct {
+		Id       int
+		Username string
+		Email    string
+		Name     string
+		State    string
+	}
+
+	response, err := HttpGet(client, s.apiUrl+"/user")
+	if err != nil {
+		return nil, fmt.Errorf("Error getting user info: %s", err)
+	}
+
+	err = json.Unmarshal(response.Body, &data)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting user info: %s", err)
+	}
+
+	if data.State != "active" {
+		return nil, fmt.Errorf("User %s is inactive", data.Username)
+	}
+
+	userInfo := &BasicUserInfo{
+		Name:  data.Name,
+		Login: data.Username,
+		Email: data.Email,
+	}
+
+	if !s.IsGroupMember(client) {
+		return nil, ErrMissingGroupMembership
+	}
+
+	return userInfo, nil
+}

--- a/pkg/social/gitlab_oauth.go
+++ b/pkg/social/gitlab_oauth.go
@@ -118,6 +118,7 @@ func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	}
 
 	userInfo := &BasicUserInfo{
+		Id:    fmt.Sprintf("%d", data.Id),
 		Name:  data.Name,
 		Login: data.Username,
 		Email: data.Email,

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -55,7 +55,7 @@ func NewOAuthService() {
 	setting.OAuthService = &setting.OAuther{}
 	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
 
-	allOauthes := []string{"github", "google", "generic_oauth", "grafananet", "grafana_com"}
+	allOauthes := []string{"github", "gitlab", "google", "generic_oauth", "grafananet", "grafana_com"}
 
 	for _, name := range allOauthes {
 		sec := setting.Raw.Section("auth." + name)
@@ -112,6 +112,20 @@ func NewOAuthService() {
 				allowSignup:          info.AllowSignup,
 				teamIds:              sec.Key("team_ids").Ints(","),
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
+			}
+		}
+
+		// GitLab.
+		if name == "gitlab" {
+			SocialMap["gitlab"] = &SocialGitlab{
+				SocialBase: &SocialBase{
+					Config: &config,
+					log:    logger,
+				},
+				allowedDomains: info.AllowedDomains,
+				apiUrl:         info.ApiUrl,
+				allowSignup:    info.AllowSignup,
+				allowedGroups:  util.SplitString(sec.Key("allowed_groups").String()),
 			}
 		}
 

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -51,6 +51,10 @@
             <i class="btn-service-icon fa fa-github"></i>
             Sign in with GitHub
           </a>
+          <a class="btn btn-medium btn-service btn-service--gitlab login-btn" href="login/gitlab" target="_self" ng-if="oauth.gitlab">
+            <i class="btn-service-icon fa fa-gitlab"></i>
+            Sign in with GitLab
+          </a>
           <a class="btn btn-medium btn-inverse btn-service btn-service--grafanacom login-btn" href="login/grafana_com" target="_self"
             ng-if="oauth.grafana_com">
             <i class="btn-service-icon"></i>

--- a/public/sass/_variables.scss
+++ b/public/sass/_variables.scss
@@ -195,6 +195,7 @@ $tabs-padding: 10px 15px 9px;
 
 $external-services: (
     github: (bgColor: #464646, borderColor: #393939, icon: ''),
+    gitlab: (bgColor: #fc6d26, borderColor: #e24329, icon: ''),
     google: (bgColor: #e84d3c, borderColor: #b83e31, icon: ''),
     grafanacom: (bgColor: inherit, borderColor: #393939, icon: ''),
     oauth: (bgColor: inherit, borderColor: #393939, icon: '')


### PR DESCRIPTION
This feature was requested in #5623, but it was closed after `auth.generic_oauth` was introduced in #4718.

However, as @kri5 mentioned in #5623, `auth.generic_oauth` doesn't let admins filter access based on GitLab group membership, which limits its usefulness in the case of a public GitLab instance.

This PR introduces an `auth.gitlab` backend which is very similar to `auth.github` and introduces an `allowed_groups` option that takes a list of allowed groups.

Fixes #5623 