### PR TITLE
snapshot: fix legend rendering bug

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -78,8 +78,11 @@ class MetricsPanelCtrl extends PanelCtrl {
         data = data.data;
       }
 
-      this.events.emit('data-snapshot-load', data);
-      return;
+      // Defer panel rendering till the next digest cycle.
+      // For some reason snapshot panels don't init at this time, so this helps to avoid rendering issues.
+      return this.$timeout(() => {
+        this.events.emit('data-snapshot-load', data);
+      });
     }
 
     // // ignore if we have data stream


### PR DESCRIPTION
This PR closes #11318
I didn't find the root cause, it would be very helpful in order to avoid this kind of issues further. So any help appreciated.

Update:
I think it may happen because loading panel not in snapshot mode causes some async operations like datasource loading and data fetching. So panel will be initialized successfully. But there’re no any async operations in the snapshot mode, so it causes this bug.