### PR TITLE
update email template default year and name

### DIFF
--- a/emails/templates/layouts/default.html
+++ b/emails/templates/layouts/default.html
@@ -143,7 +143,7 @@ td[class="stack-column-center"] {
 											<center>
 												<p style="text-align: center; font-size: 12px; color: #999999;">
 													Sent by <a href="[[.AppUrl]]">Grafana v[[.BuildVersion]]</a>
-													<br />&copy; 2016 Grafana and raintank
+													<br />&copy; 2018 Grafana Labs
 												</p>
 											</center>
 										</td>


### PR DESCRIPTION
from 2016 Grafana and raintank  > 2018 Grafana Labs
