### PR TITLE
dataproxy: adds dashboardid and panelid as tags

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -222,6 +222,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     var metricsQuery = {
       timezone: this.dashboard.getTimezone(),
       panelId: this.panel.id,
+      dashboardId: this.dashboard.id,
       range: this.range,
       rangeRaw: this.range.raw,
       interval: this.interval,

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -50,6 +50,8 @@ export function GraphiteDatasource(instanceSettings, $q, backendSrv, templateSrv
       data: params.join('&'),
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Dashboard-Id': options.dashboardId, // enables distributed tracing in ds_proxy
+        'X-Panel-Id': options.panelId, // enables distributed tracing in ds_proxy
       },
     };
 


### PR DESCRIPTION
ref #11315

Feels dirty that the datasource have to add the headers since it these dtrace tags will only be available for datasource we add support for. But that's the only solution I can think of at the moment that won't require refactoring metrics_panel -> datasource API.  


