### PR TITLE
External auth refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 * **Permission list**: Improved ux [#10747](https://github.com/grafana/grafana/issues/10747)
 * **Dashboard**: Sizing and positioning of settings menu icons [#11572](https://github.com/grafana/grafana/pull/11572)
 * **Folders**: User with org viewer role should not be able to save/move dashboards in/to general folder [#11553](https://github.com/grafana/grafana/issues/11553)
+* **Tech**: Backend code simplification [#11613](https://github.com/grafana/grafana/pull/11613), thx [@knweiss](https://github.com/knweiss)
+* **Tech**: Add codespell to CI [#11602](https://github.com/grafana/grafana/pull/11602), thx [@mjtrangoni](https://github.com/mjtrangoni)
 
 ### Tech
 * Migrated JavaScript files to TypeScript

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -101,13 +101,14 @@ func LoginPost(c *m.ReqContext, cmd dtos.LoginCommand) Response {
 		return Error(401, "Login is disabled", nil)
 	}
 
-	authQuery := m.LoginUserQuery{
-		Username:  cmd.User,
-		Password:  cmd.Password,
-		IpAddress: c.Req.RemoteAddr,
+	authQuery := &m.LoginUserQuery{
+		ReqContext: c,
+		Username:   cmd.User,
+		Password:   cmd.Password,
+		IpAddress:  c.Req.RemoteAddr,
 	}
 
-	if err := login.AuthenticateUser(c, &authQuery); err != nil {
+	if err := bus.Dispatch(authQuery); err != nil {
 		if err == login.ErrInvalidCredentials || err == login.ErrTooManyLoginAttempts {
 			return Error(401, "Invalid username or password", err)
 		}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -101,13 +101,13 @@ func LoginPost(c *m.ReqContext, cmd dtos.LoginCommand) Response {
 		return Error(401, "Login is disabled", nil)
 	}
 
-	authQuery := login.LoginUserQuery{
+	authQuery := m.LoginUserQuery{
 		Username:  cmd.User,
 		Password:  cmd.Password,
 		IpAddress: c.Req.RemoteAddr,
 	}
 
-	if err := bus.Dispatch(&authQuery); err != nil {
+	if err := login.AuthenticateUser(c, &authQuery); err != nil {
 		if err == login.ErrInvalidCredentials || err == login.ErrTooManyLoginAttempts {
 			return Error(401, "Invalid username or password", err)
 		}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,24 +13,16 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/metrics"
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/social"
 )
 
-var (
-	ErrProviderDeniedRequest = errors.New("Login provider denied login request")
-	ErrEmailNotAllowed       = errors.New("Required email domain not fulfilled")
-	ErrSignUpNotAllowed      = errors.New("Signup is not allowed for this adapter")
-	ErrUsersQuotaReached     = errors.New("Users quota reached")
-	ErrNoEmail               = errors.New("Login provider didn't return an email address")
-	oauthLogger              = log.New("oauth")
-)
+var oauthLogger = log.New("oauth")
 
 func GenStateString() string {
 	rnd := make([]byte, 32)
@@ -56,7 +47,7 @@ func OAuthLogin(ctx *m.ReqContext) {
 	if errorParam != "" {
 		errorDesc := ctx.Query("error_description")
 		oauthLogger.Error("failed to login ", "error", errorParam, "errorDesc", errorDesc)
-		redirectWithError(ctx, ErrProviderDeniedRequest, "error", errorParam, "errorDesc", errorDesc)
+		redirectWithError(ctx, login.ErrProviderDeniedRequest, "error", errorParam, "errorDesc", errorDesc)
 		return
 	}
 
@@ -149,54 +140,42 @@ func OAuthLogin(ctx *m.ReqContext) {
 
 	// validate that we got at least an email address
 	if userInfo.Email == "" {
-		redirectWithError(ctx, ErrNoEmail)
+		redirectWithError(ctx, login.ErrNoEmail)
 		return
 	}
 
 	// validate that the email is allowed to login to grafana
 	if !connect.IsEmailAllowed(userInfo.Email) {
-		redirectWithError(ctx, ErrEmailNotAllowed)
+		redirectWithError(ctx, login.ErrEmailNotAllowed)
 		return
 	}
 
-	userQuery := m.GetUserByEmailQuery{Email: userInfo.Email}
-	err = bus.Dispatch(&userQuery)
+	extUser := m.ExternalUserInfo{
+		AuthModule: "oauth_" + name,
+		AuthId:     userInfo.Id,
+		Name:       userInfo.Name,
+		Login:      userInfo.Login,
+		Email:      userInfo.Email,
+		OrgRoles:   map[int64]m.RoleType{},
+	}
 
-	// create account if missing
-	if err == m.ErrUserNotFound {
-		if !connect.IsSignupAllowed() {
-			redirectWithError(ctx, ErrSignUpNotAllowed)
-			return
-		}
-		limitReached, err := quota.QuotaReached(ctx, "user")
-		if err != nil {
-			ctx.Handle(500, "Failed to get user quota", err)
-			return
-		}
-		if limitReached {
-			redirectWithError(ctx, ErrUsersQuotaReached)
-			return
-		}
-		cmd := m.CreateUserCommand{
-			Login:          userInfo.Login,
-			Email:          userInfo.Email,
-			Name:           userInfo.Name,
-			Company:        userInfo.Company,
-			DefaultOrgRole: userInfo.Role,
-		}
+	if userInfo.Role != "" {
+		extUser.OrgRoles[1] = m.RoleType(userInfo.Role)
+	}
 
-		if err = bus.Dispatch(&cmd); err != nil {
-			ctx.Handle(500, "Failed to create account", err)
-			return
-		}
-
-		userQuery.Result = &cmd.Result
-	} else if err != nil {
-		ctx.Handle(500, "Unexpected error", err)
+	// add/update user in grafana
+	userQuery := &m.UpsertUserCommand{
+		ExternalUser:  &extUser,
+		SignupAllowed: connect.IsSignupAllowed(),
+	}
+	err = login.UpsertUser(ctx, userQuery)
+	if err != nil {
+		redirectWithError(ctx, err)
+		return
 	}
 
 	// login
-	loginUserWithUser(userQuery.Result, ctx)
+	loginUserWithUser(userQuery.User, ctx)
 
 	metrics.M_Api_Login_OAuth.Inc()
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -164,18 +164,18 @@ func OAuthLogin(ctx *m.ReqContext) {
 	}
 
 	// add/update user in grafana
-	userQuery := &m.UpsertUserCommand{
+	cmd := &m.UpsertUserCommand{
 		ExternalUser:  &extUser,
 		SignupAllowed: connect.IsSignupAllowed(),
 	}
-	err = login.UpsertUser(ctx, userQuery)
+	err = login.UpsertUser(ctx, cmd)
 	if err != nil {
 		redirectWithError(ctx, err)
 		return
 	}
 
 	// login
-	loginUserWithUser(userQuery.User, ctx)
+	loginUserWithUser(cmd.Result, ctx)
 
 	metrics.M_Api_Login_OAuth.Inc()
 

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -8,23 +8,22 @@ import (
 )
 
 var (
-	ErrInvalidCredentials   = errors.New("Invalid Username or Password")
-	ErrTooManyLoginAttempts = errors.New("Too many consecutive incorrect login attempts for user. Login for user temporarily blocked")
+	ErrEmailNotAllowed       = errors.New("Required email domain not fulfilled")
+	ErrInvalidCredentials    = errors.New("Invalid Username or Password")
+	ErrNoEmail               = errors.New("Login provider didn't return an email address")
+	ErrProviderDeniedRequest = errors.New("Login provider denied login request")
+	ErrSignUpNotAllowed      = errors.New("Signup is not allowed for this adapter")
+	ErrTooManyLoginAttempts  = errors.New("Too many consecutive incorrect login attempts for user. Login for user temporarily blocked")
+	ErrUsersQuotaReached     = errors.New("Users quota reached")
+	ErrGettingUserQuota      = errors.New("Error getting user quota")
 )
-
-type LoginUserQuery struct {
-	Username  string
-	Password  string
-	User      *m.User
-	IpAddress string
-}
 
 func Init() {
 	bus.AddHandler("auth", AuthenticateUser)
 	loadLdapConfig()
 }
 
-func AuthenticateUser(query *LoginUserQuery) error {
+func AuthenticateUser(ctx *m.ReqContext, query *m.LoginUserQuery) error {
 	if err := validateLoginAttempts(query.Username); err != nil {
 		return err
 	}
@@ -34,7 +33,7 @@ func AuthenticateUser(query *LoginUserQuery) error {
 		return err
 	}
 
-	ldapEnabled, ldapErr := loginUsingLdap(query)
+	ldapEnabled, ldapErr := loginUsingLdap(ctx, query)
 	if ldapEnabled {
 		if ldapErr == nil || ldapErr != ErrInvalidCredentials {
 			return ldapErr

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -23,7 +23,7 @@ func Init() {
 	loadLdapConfig()
 }
 
-func AuthenticateUser(ctx *m.ReqContext, query *m.LoginUserQuery) error {
+func AuthenticateUser(query *m.LoginUserQuery) error {
 	if err := validateLoginAttempts(query.Username); err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func AuthenticateUser(ctx *m.ReqContext, query *m.LoginUserQuery) error {
 		return err
 	}
 
-	ldapEnabled, ldapErr := loginUsingLdap(ctx, query)
+	ldapEnabled, ldapErr := loginUsingLdap(query)
 	if ldapEnabled {
 		if ldapErr == nil || ldapErr != ErrInvalidCredentials {
 			return ldapErr

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -151,7 +151,7 @@ func TestAuthenticateUser(t *testing.T) {
 }
 
 type authScenarioContext struct {
-	loginUserQuery                   *LoginUserQuery
+	loginUserQuery                   *m.LoginUserQuery
 	grafanaLoginWasCalled            bool
 	ldapLoginWasCalled               bool
 	loginAttemptValidationWasCalled  bool
@@ -161,14 +161,14 @@ type authScenarioContext struct {
 type authScenarioFunc func(sc *authScenarioContext)
 
 func mockLoginUsingGrafanaDB(err error, sc *authScenarioContext) {
-	loginUsingGrafanaDB = func(query *LoginUserQuery) error {
+	loginUsingGrafanaDB = func(query *m.LoginUserQuery) error {
 		sc.grafanaLoginWasCalled = true
 		return err
 	}
 }
 
 func mockLoginUsingLdap(enabled bool, err error, sc *authScenarioContext) {
-	loginUsingLdap = func(query *LoginUserQuery) (bool, error) {
+	loginUsingLdap = func(query *m.LoginUserQuery) (bool, error) {
 		sc.ldapLoginWasCalled = true
 		return enabled, err
 	}
@@ -182,7 +182,7 @@ func mockLoginAttemptValidation(err error, sc *authScenarioContext) {
 }
 
 func mockSaveInvalidLoginAttempt(sc *authScenarioContext) {
-	saveInvalidLoginAttempt = func(query *LoginUserQuery) {
+	saveInvalidLoginAttempt = func(query *m.LoginUserQuery) {
 		sc.saveInvalidLoginAttemptWasCalled = true
 	}
 }
@@ -195,7 +195,7 @@ func authScenario(desc string, fn authScenarioFunc) {
 		origSaveInvalidLoginAttempt := saveInvalidLoginAttempt
 
 		sc := &authScenarioContext{
-			loginUserQuery: &LoginUserQuery{
+			loginUserQuery: &m.LoginUserQuery{
 				Username:  "user",
 				Password:  "pwd",
 				IpAddress: "192.168.1.1:56433",

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -16,7 +16,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrTooManyLoginAttempts)
@@ -33,7 +33,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, nil)
@@ -51,7 +51,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -68,7 +68,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(false, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -85,7 +85,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -102,7 +102,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldBeNil)
@@ -120,7 +120,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, customErr, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -137,7 +137,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(nil, sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -168,7 +168,7 @@ func mockLoginUsingGrafanaDB(err error, sc *authScenarioContext) {
 }
 
 func mockLoginUsingLdap(enabled bool, err error, sc *authScenarioContext) {
-	loginUsingLdap = func(query *m.LoginUserQuery) (bool, error) {
+	loginUsingLdap = func(c *m.ReqContext, query *m.LoginUserQuery) (bool, error) {
 		sc.ldapLoginWasCalled = true
 		return enabled, err
 	}

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -16,7 +16,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrTooManyLoginAttempts)
@@ -33,7 +33,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, nil)
@@ -51,7 +51,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -68,7 +68,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(false, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -85,7 +85,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -102,7 +102,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldBeNil)
@@ -120,7 +120,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, customErr, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -137,7 +137,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLdap(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(nil, sc.loginUserQuery)
+			err := AuthenticateUser(sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -168,7 +168,7 @@ func mockLoginUsingGrafanaDB(err error, sc *authScenarioContext) {
 }
 
 func mockLoginUsingLdap(enabled bool, err error, sc *authScenarioContext) {
-	loginUsingLdap = func(c *m.ReqContext, query *m.LoginUserQuery) (bool, error) {
+	loginUsingLdap = func(query *m.LoginUserQuery) (bool, error) {
 		sc.ldapLoginWasCalled = true
 		return enabled, err
 	}

--- a/pkg/login/brute_force_login_protection.go
+++ b/pkg/login/brute_force_login_protection.go
@@ -34,7 +34,7 @@ var validateLoginAttempts = func(username string) error {
 	return nil
 }
 
-var saveInvalidLoginAttempt = func(query *LoginUserQuery) {
+var saveInvalidLoginAttempt = func(query *m.LoginUserQuery) {
 	if setting.DisableBruteForceLoginProtection {
 		return
 	}

--- a/pkg/login/brute_force_login_protection_test.go
+++ b/pkg/login/brute_force_login_protection_test.go
@@ -50,7 +50,7 @@ func TestLoginAttemptsValidation(t *testing.T) {
 					return nil
 				})
 
-				saveInvalidLoginAttempt(&LoginUserQuery{
+				saveInvalidLoginAttempt(&m.LoginUserQuery{
 					Username:  "user",
 					Password:  "pwd",
 					IpAddress: "192.168.1.1:56433",
@@ -103,7 +103,7 @@ func TestLoginAttemptsValidation(t *testing.T) {
 					return nil
 				})
 
-				saveInvalidLoginAttempt(&LoginUserQuery{
+				saveInvalidLoginAttempt(&m.LoginUserQuery{
 					Username:  "user",
 					Password:  "pwd",
 					IpAddress: "192.168.1.1:56433",

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -1,0 +1,157 @@
+package login
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/log"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/quota"
+)
+
+func UpsertUser(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+	extUser := cmd.ExternalUser
+
+	userQuery := m.GetUserByAuthInfoQuery{
+		AuthModule: extUser.AuthModule,
+		AuthId:     extUser.AuthId,
+		UserId:     extUser.UserId,
+		Email:      extUser.Email,
+		Login:      extUser.Login,
+	}
+	err := bus.Dispatch(&userQuery)
+	if err != nil {
+		if err != m.ErrUserNotFound {
+			return err
+		}
+
+		if !cmd.SignupAllowed {
+			log.Warn(fmt.Sprintf("Not allowing %s login, user not found in internal user database and allow signup = false", extUser.AuthModule))
+			return ErrInvalidCredentials
+		}
+
+		limitReached, err := quota.QuotaReached(ctx, "user")
+		if err != nil {
+			log.Warn("Error getting user quota", "err", err)
+			return ErrGettingUserQuota
+		}
+		if limitReached {
+			return ErrUsersQuotaReached
+		}
+
+		cmd.User, err = createUser(extUser)
+		if err != nil {
+			return err
+		}
+	} else {
+		cmd.User = userQuery.User
+
+		// sync user info
+		err = updateUser(cmd.User, extUser)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = syncOrgRoles(cmd.User, extUser)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {
+	cmd := m.CreateUserCommand{
+		Login: extUser.Login,
+		Email: extUser.Email,
+		Name:  extUser.Name,
+	}
+	if err := bus.Dispatch(&cmd); err != nil {
+		return nil, err
+	}
+
+	cmd2 := m.SetAuthInfoCommand{
+		UserId:     cmd.Result.Id,
+		AuthModule: extUser.AuthModule,
+		AuthId:     extUser.AuthId,
+	}
+	if err := bus.Dispatch(&cmd2); err != nil {
+		return nil, err
+	}
+
+	return &cmd.Result, nil
+}
+
+func updateUser(user *m.User, extUser *m.ExternalUserInfo) error {
+	// sync user info
+	if user.Login != extUser.Login || user.Email != extUser.Email || user.Name != extUser.Name {
+		log.Debug("Syncing user info", "id", user.Id, "login", extUser.Login, "email", extUser.Email)
+		updateCmd := m.UpdateUserCommand{
+			UserId: user.Id,
+			Login:  extUser.Login,
+			Email:  extUser.Email,
+			Name:   extUser.Name,
+		}
+		err := bus.Dispatch(&updateCmd)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
+	if len(extUser.OrgRoles) == 0 {
+		// log.Warn("No group mappings defined")
+		return nil
+	}
+
+	orgsQuery := m.GetUserOrgListQuery{UserId: user.Id}
+	if err := bus.Dispatch(&orgsQuery); err != nil {
+		return err
+	}
+
+	handledOrgIds := map[int64]bool{}
+	deleteOrgIds := []int64{}
+
+	// update existing org roles
+	for _, org := range orgsQuery.Result {
+		handledOrgIds[org.OrgId] = true
+
+		if extUser.OrgRoles[org.OrgId] == "" {
+			deleteOrgIds = append(deleteOrgIds, org.OrgId)
+		} else if extUser.OrgRoles[org.OrgId] != org.Role {
+			// update role
+			cmd := m.UpdateOrgUserCommand{OrgId: org.OrgId, UserId: user.Id, Role: extUser.OrgRoles[org.OrgId]}
+			if err := bus.Dispatch(&cmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	// add any new org roles
+	for orgId, orgRole := range extUser.OrgRoles {
+		if _, exists := handledOrgIds[orgId]; exists {
+			continue
+		}
+
+		// add role
+		cmd := m.AddOrgUserCommand{UserId: user.Id, Role: orgRole, OrgId: orgId}
+		err := bus.Dispatch(&cmd)
+		if err != nil && err != m.ErrOrgNotFound {
+			return err
+		}
+	}
+
+	// delete any removed org roles
+	for _, orgId := range deleteOrgIds {
+		cmd := m.RemoveOrgUserCommand{OrgId: orgId, UserId: user.Id}
+		if err := bus.Dispatch(&cmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -39,15 +39,15 @@ var UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
 			return ErrUsersQuotaReached
 		}
 
-		cmd.User, err = createUser(extUser)
+		cmd.Result, err = createUser(extUser)
 		if err != nil {
 			return err
 		}
 	} else {
-		cmd.User = userQuery.User
+		cmd.Result = userQuery.User
 
 		// sync user info
-		err = updateUser(cmd.User, extUser)
+		err = updateUser(cmd.Result, extUser)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ var UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
 
 	if userQuery.UserAuth == nil && extUser.AuthModule != "" && extUser.AuthId != "" {
 		cmd2 := m.SetAuthInfoCommand{
-			UserId:     cmd.User.Id,
+			UserId:     cmd.Result.Id,
 			AuthModule: extUser.AuthModule,
 			AuthId:     extUser.AuthId,
 		}
@@ -64,7 +64,7 @@ var UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
 		}
 	}
 
-	err = syncOrgRoles(cmd.User, extUser)
+	err = syncOrgRoles(cmd.Result, extUser)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -9,7 +9,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 )
 
-var UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+func init() {
+	bus.AddHandler("auth", UpsertUser)
+}
+
+func UpsertUser(cmd *m.UpsertUserCommand) error {
 	extUser := cmd.ExternalUser
 
 	userQuery := m.GetUserByAuthInfoQuery{
@@ -30,7 +34,7 @@ var UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
 			return ErrInvalidCredentials
 		}
 
-		limitReached, err := quota.QuotaReached(ctx, "user")
+		limitReached, err := quota.QuotaReached(cmd.ReqContext, "user")
 		if err != nil {
 			log.Warn("Error getting user quota", "err", err)
 			return ErrGettingUserQuota

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -117,8 +117,8 @@ func updateUser(user *m.User, extUser *m.ExternalUserInfo) error {
 }
 
 func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
+	// don't sync org roles if none are specified
 	if len(extUser.OrgRoles) == 0 {
-		// log.Warn("No group mappings defined")
 		return nil
 	}
 

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -16,14 +16,14 @@ func init() {
 func UpsertUser(cmd *m.UpsertUserCommand) error {
 	extUser := cmd.ExternalUser
 
-	userQuery := m.GetUserByAuthInfoQuery{
+	userQuery := &m.GetUserByAuthInfoQuery{
 		AuthModule: extUser.AuthModule,
 		AuthId:     extUser.AuthId,
 		UserId:     extUser.UserId,
 		Email:      extUser.Email,
 		Login:      extUser.Login,
 	}
-	err := bus.Dispatch(&userQuery)
+	err := bus.Dispatch(userQuery)
 	if err != nil {
 		if err != m.ErrUserNotFound {
 			return err
@@ -47,23 +47,23 @@ func UpsertUser(cmd *m.UpsertUserCommand) error {
 		if err != nil {
 			return err
 		}
+
+		if extUser.AuthModule != "" && extUser.AuthId != "" {
+			cmd2 := &m.SetAuthInfoCommand{
+				UserId:     cmd.Result.Id,
+				AuthModule: extUser.AuthModule,
+				AuthId:     extUser.AuthId,
+			}
+			if err := bus.Dispatch(cmd2); err != nil {
+				return err
+			}
+		}
 	} else {
-		cmd.Result = userQuery.User
+		cmd.Result = userQuery.Result
 
 		// sync user info
 		err = updateUser(cmd.Result, extUser)
 		if err != nil {
-			return err
-		}
-	}
-
-	if userQuery.UserAuth == nil && extUser.AuthModule != "" && extUser.AuthId != "" {
-		cmd2 := m.SetAuthInfoCommand{
-			UserId:     cmd.Result.Id,
-			AuthModule: extUser.AuthModule,
-			AuthId:     extUser.AuthId,
-		}
-		if err := bus.Dispatch(&cmd2); err != nil {
 			return err
 		}
 	}
@@ -77,12 +77,12 @@ func UpsertUser(cmd *m.UpsertUserCommand) error {
 }
 
 func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {
-	cmd := m.CreateUserCommand{
+	cmd := &m.CreateUserCommand{
 		Login: extUser.Login,
 		Email: extUser.Email,
 		Name:  extUser.Name,
 	}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.Dispatch(cmd); err != nil {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {
 
 func updateUser(user *m.User, extUser *m.ExternalUserInfo) error {
 	// sync user info
-	updateCmd := m.UpdateUserCommand{
+	updateCmd := &m.UpdateUserCommand{
 		UserId: user.Id,
 	}
 	needsUpdate := false
@@ -111,7 +111,7 @@ func updateUser(user *m.User, extUser *m.ExternalUserInfo) error {
 
 	if needsUpdate {
 		log.Debug("Syncing user info", "id", user.Id, "update", updateCmd)
-		err := bus.Dispatch(&updateCmd)
+		err := bus.Dispatch(updateCmd)
 		if err != nil {
 			return err
 		}
@@ -126,8 +126,8 @@ func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
 		return nil
 	}
 
-	orgsQuery := m.GetUserOrgListQuery{UserId: user.Id}
-	if err := bus.Dispatch(&orgsQuery); err != nil {
+	orgsQuery := &m.GetUserOrgListQuery{UserId: user.Id}
+	if err := bus.Dispatch(orgsQuery); err != nil {
 		return err
 	}
 
@@ -142,8 +142,8 @@ func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
 			deleteOrgIds = append(deleteOrgIds, org.OrgId)
 		} else if extUser.OrgRoles[org.OrgId] != org.Role {
 			// update role
-			cmd := m.UpdateOrgUserCommand{OrgId: org.OrgId, UserId: user.Id, Role: extUser.OrgRoles[org.OrgId]}
-			if err := bus.Dispatch(&cmd); err != nil {
+			cmd := &m.UpdateOrgUserCommand{OrgId: org.OrgId, UserId: user.Id, Role: extUser.OrgRoles[org.OrgId]}
+			if err := bus.Dispatch(cmd); err != nil {
 				return err
 			}
 		}
@@ -156,8 +156,8 @@ func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
 		}
 
 		// add role
-		cmd := m.AddOrgUserCommand{UserId: user.Id, Role: orgRole, OrgId: orgId}
-		err := bus.Dispatch(&cmd)
+		cmd := &m.AddOrgUserCommand{UserId: user.Id, Role: orgRole, OrgId: orgId}
+		err := bus.Dispatch(cmd)
 		if err != nil && err != m.ErrOrgNotFound {
 			return err
 		}
@@ -165,8 +165,8 @@ func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
 
 	// delete any removed org roles
 	for _, orgId := range deleteOrgIds {
-		cmd := m.RemoveOrgUserCommand{OrgId: orgId, UserId: user.Id}
-		if err := bus.Dispatch(&cmd); err != nil {
+		cmd := &m.RemoveOrgUserCommand{OrgId: orgId, UserId: user.Id}
+		if err := bus.Dispatch(cmd); err != nil {
 			return err
 		}
 	}

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -68,12 +68,7 @@ func UpsertUser(cmd *m.UpsertUserCommand) error {
 		}
 	}
 
-	err = syncOrgRoles(cmd.Result, extUser)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return syncOrgRoles(cmd.Result, extUser)
 }
 
 func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -78,9 +78,10 @@ func UpsertUser(cmd *m.UpsertUserCommand) error {
 
 func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {
 	cmd := &m.CreateUserCommand{
-		Login: extUser.Login,
-		Email: extUser.Email,
-		Name:  extUser.Name,
+		Login:        extUser.Login,
+		Email:        extUser.Email,
+		Name:         extUser.Name,
+		SkipOrgSetup: len(extUser.OrgRoles) > 0,
 	}
 	if err := bus.Dispatch(cmd); err != nil {
 		return nil, err

--- a/pkg/login/grafana_login.go
+++ b/pkg/login/grafana_login.go
@@ -17,7 +17,7 @@ var validatePassword = func(providedPassword string, userPassword string, userSa
 	return nil
 }
 
-var loginUsingGrafanaDB = func(query *LoginUserQuery) error {
+var loginUsingGrafanaDB = func(query *m.LoginUserQuery) error {
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: query.Username}
 
 	if err := bus.Dispatch(&userQuery); err != nil {

--- a/pkg/login/grafana_login_test.go
+++ b/pkg/login/grafana_login_test.go
@@ -66,7 +66,7 @@ func TestGrafanaLogin(t *testing.T) {
 }
 
 type grafanaLoginScenarioContext struct {
-	loginUserQuery         *LoginUserQuery
+	loginUserQuery         *m.LoginUserQuery
 	validatePasswordCalled bool
 }
 
@@ -77,7 +77,7 @@ func grafanaLoginScenario(desc string, fn grafanaLoginScenarioFunc) {
 		origValidatePassword := validatePassword
 
 		sc := &grafanaLoginScenarioContext{
-			loginUserQuery: &LoginUserQuery{
+			loginUserQuery: &m.LoginUserQuery{
 				Username:  "user",
 				Password:  "pwd",
 				IpAddress: "192.168.1.1:56433",

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -199,7 +199,7 @@ func (a *ldapAuther) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *LdapUserInfo
 		return nil, err
 	}
 
-	return userQuery.User, nil
+	return userQuery.Result, nil
 }
 
 func (a *ldapAuther) serverBind() error {

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -1,17 +1,18 @@
 package login
 
 import (
+	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var loginUsingLdap = func(query *LoginUserQuery) (bool, error) {
+var loginUsingLdap = func(ctx *m.ReqContext, query *m.LoginUserQuery) (bool, error) {
 	if !setting.LdapEnabled {
 		return false, nil
 	}
 
 	for _, server := range LdapCfg.Servers {
 		author := NewLdapAuthenticator(server)
-		err := author.Login(query)
+		err := author.Login(ctx, query)
 		if err == nil || err != ErrInvalidCredentials {
 			return true, err
 		}

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -5,14 +5,14 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var loginUsingLdap = func(ctx *m.ReqContext, query *m.LoginUserQuery) (bool, error) {
+var loginUsingLdap = func(query *m.LoginUserQuery) (bool, error) {
 	if !setting.LdapEnabled {
 		return false, nil
 	}
 
 	for _, server := range LdapCfg.Servers {
 		author := NewLdapAuthenticator(server)
-		err := author.Login(ctx, query)
+		err := author.Login(query)
 		if err == nil || err != ErrInvalidCredentials {
 			return true, err
 		}

--- a/pkg/login/ldap_login_test.go
+++ b/pkg/login/ldap_login_test.go
@@ -79,7 +79,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(false)
-				enabled, err := loginUsingLdap(&LoginUserQuery{
+				enabled, err := loginUsingLdap(&m.LoginUserQuery{
 					Username: "user",
 					Password: "pwd",
 				})
@@ -117,7 +117,7 @@ type mockLdapAuther struct {
 	loginCalled bool
 }
 
-func (a *mockLdapAuther) Login(query *LoginUserQuery) error {
+func (a *mockLdapAuther) Login(query *m.LoginUserQuery) error {
 	a.loginCalled = true
 
 	if !a.validLogin {
@@ -140,7 +140,7 @@ func (a *mockLdapAuther) SyncOrgRoles(user *m.User, ldapUser *LdapUserInfo) erro
 }
 
 type ldapLoginScenarioContext struct {
-	loginUserQuery        *LoginUserQuery
+	loginUserQuery        *m.LoginUserQuery
 	ldapAuthenticatorMock *mockLdapAuther
 }
 
@@ -151,7 +151,7 @@ func ldapLoginScenario(desc string, fn ldapLoginScenarioFunc) {
 		origNewLdapAuthenticator := NewLdapAuthenticator
 
 		sc := &ldapLoginScenarioContext{
-			loginUserQuery: &LoginUserQuery{
+			loginUserQuery: &m.LoginUserQuery{
 				Username:  "user",
 				Password:  "pwd",
 				IpAddress: "192.168.1.1:56433",

--- a/pkg/login/ldap_login_test.go
+++ b/pkg/login/ldap_login_test.go
@@ -19,7 +19,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login with invalid credentials", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(false)
-				enabled, err := loginUsingLdap(sc.loginUserQuery)
+				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -36,7 +36,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login with valid credentials", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(true)
-				enabled, err := loginUsingLdap(sc.loginUserQuery)
+				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -58,7 +58,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(true)
-				enabled, err := loginUsingLdap(sc.loginUserQuery)
+				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -79,7 +79,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(false)
-				enabled, err := loginUsingLdap(&m.LoginUserQuery{
+				enabled, err := loginUsingLdap(nil, &m.LoginUserQuery{
 					Username: "user",
 					Password: "pwd",
 				})
@@ -117,7 +117,7 @@ type mockLdapAuther struct {
 	loginCalled bool
 }
 
-func (a *mockLdapAuther) Login(query *m.LoginUserQuery) error {
+func (a *mockLdapAuther) Login(ctx *m.ReqContext, query *m.LoginUserQuery) error {
 	a.loginCalled = true
 
 	if !a.validLogin {
@@ -127,16 +127,12 @@ func (a *mockLdapAuther) Login(query *m.LoginUserQuery) error {
 	return nil
 }
 
-func (a *mockLdapAuther) SyncSignedInUser(signedInUser *m.SignedInUser) error {
+func (a *mockLdapAuther) SyncSignedInUser(ctx *m.ReqContext, signedInUser *m.SignedInUser) error {
 	return nil
 }
 
-func (a *mockLdapAuther) GetGrafanaUserFor(ldapUser *LdapUserInfo) (*m.User, error) {
+func (a *mockLdapAuther) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *LdapUserInfo) (*m.User, error) {
 	return nil, nil
-}
-
-func (a *mockLdapAuther) SyncOrgRoles(user *m.User, ldapUser *LdapUserInfo) error {
-	return nil
 }
 
 type ldapLoginScenarioContext struct {

--- a/pkg/login/ldap_login_test.go
+++ b/pkg/login/ldap_login_test.go
@@ -19,7 +19,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login with invalid credentials", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(false)
-				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
+				enabled, err := loginUsingLdap(sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -36,7 +36,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login with valid credentials", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(true)
-				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
+				enabled, err := loginUsingLdap(sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -58,7 +58,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(true)
-				enabled, err := loginUsingLdap(nil, sc.loginUserQuery)
+				enabled, err := loginUsingLdap(sc.loginUserQuery)
 
 				Convey("it should return true", func() {
 					So(enabled, ShouldBeTrue)
@@ -79,7 +79,7 @@ func TestLdapLogin(t *testing.T) {
 
 			ldapLoginScenario("When login", func(sc *ldapLoginScenarioContext) {
 				sc.withLoginResult(false)
-				enabled, err := loginUsingLdap(nil, &m.LoginUserQuery{
+				enabled, err := loginUsingLdap(&m.LoginUserQuery{
 					Username: "user",
 					Password: "pwd",
 				})
@@ -117,7 +117,7 @@ type mockLdapAuther struct {
 	loginCalled bool
 }
 
-func (a *mockLdapAuther) Login(ctx *m.ReqContext, query *m.LoginUserQuery) error {
+func (a *mockLdapAuther) Login(query *m.LoginUserQuery) error {
 	a.loginCalled = true
 
 	if !a.validLogin {

--- a/pkg/login/ldap_login_test.go
+++ b/pkg/login/ldap_login_test.go
@@ -127,7 +127,7 @@ func (a *mockLdapAuther) Login(query *m.LoginUserQuery) error {
 	return nil
 }
 
-func (a *mockLdapAuther) SyncSignedInUser(ctx *m.ReqContext, signedInUser *m.SignedInUser) error {
+func (a *mockLdapAuther) SyncUser(query *m.LoginUserQuery) error {
 	return nil
 }
 

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -196,7 +196,7 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 
 		bus.AddHandler("test", func(cmd *m.GetUserByAuthInfoQuery) error {
 			sc.getUserByAuthInfoQuery = cmd
-			sc.getUserByAuthInfoQuery.User = &m.User{Login: cmd.Login}
+			sc.getUserByAuthInfoQuery.Result = &m.User{Login: cmd.Login}
 			return nil
 		})
 
@@ -250,7 +250,7 @@ func (sc *scenarioContext) userQueryReturns(user *m.User) {
 		if user == nil {
 			return m.ErrUserNotFound
 		} else {
-			query.User = user
+			query.Result = user
 			return nil
 		}
 	})

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -65,6 +65,7 @@ func TestLdapAuther(t *testing.T) {
 			sc.userQueryReturns(nil)
 
 			result, err := ldapAuther.GetGrafanaUserFor(nil, &LdapUserInfo{
+				DN:       "torkelo",
 				Username: "torkelo",
 				Email:    "my@email.com",
 				MemberOf: []string{"cn=editor"},

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -192,6 +192,8 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 
 		sc := &scenarioContext{}
 
+		bus.AddHandler("test", UpsertUser)
+
 		bus.AddHandler("test", func(cmd *m.GetUserByAuthInfoQuery) error {
 			sc.getUserByAuthInfoQuery = cmd
 			sc.getUserByAuthInfoQuery.User = &m.User{Login: cmd.Login}

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -125,7 +125,7 @@ func TestLdapAuther(t *testing.T) {
 		ldapAutherScenario("given current org role is removed in ldap", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
 				LdapGroups: []*LdapGroupToOrgRole{
-					{GroupDN: "cn=users", OrgId: 1, OrgRole: "Admin"},
+					{GroupDN: "cn=users", OrgId: 2, OrgRole: "Admin"},
 				},
 			})
 
@@ -140,7 +140,7 @@ func TestLdapAuther(t *testing.T) {
 			Convey("Should remove org role", func() {
 				So(err, ShouldBeNil)
 				So(sc.removeOrgUserCmd, ShouldNotBeNil)
-				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 2)
 			})
 		})
 

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -91,7 +91,7 @@ func TestLdapAuther(t *testing.T) {
 
 	})
 
-	Convey("When calling SyncSignedInUser", t, func() {
+	Convey("When calling SyncUser", t, func() {
 
 		mockLdapConnection := &mockLdapConn{}
 		ldapAuther := NewLdapAuthenticator(
@@ -131,11 +131,8 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("When ldapUser found call syncInfo and orgRoles", func(sc *scenarioContext) {
 			// arrange
-			signedInUser := &m.SignedInUser{
-				Email:  "roel@test.net",
-				UserId: 1,
-				Name:   "Roel Gerrits",
-				Login:  "roelgerrits",
+			query := &m.LoginUserQuery{
+				Username: "roelgerrits",
 			}
 
 			sc.userQueryReturns(&m.User{
@@ -147,7 +144,7 @@ func TestLdapAuther(t *testing.T) {
 			sc.userOrgsQueryReturns([]*m.UserOrgDTO{})
 
 			// act
-			syncErrResult := ldapAuther.SyncSignedInUser(nil, signedInUser)
+			syncErrResult := ldapAuther.SyncUser(query)
 
 			// assert
 			So(dialCalled, ShouldBeTrue)

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -118,6 +118,7 @@ func TestLdapAuther(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(sc.updateOrgUserCmd, ShouldNotBeNil)
 				So(sc.updateOrgUserCmd.Role, ShouldEqual, m.ROLE_ADMIN)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
 			})
 		})
 
@@ -139,6 +140,7 @@ func TestLdapAuther(t *testing.T) {
 			Convey("Should remove org role", func() {
 				So(err, ShouldBeNil)
 				So(sc.removeOrgUserCmd, ShouldNotBeNil)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
 			})
 		})
 
@@ -159,6 +161,7 @@ func TestLdapAuther(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(sc.removeOrgUserCmd, ShouldBeNil)
 				So(sc.updateOrgUserCmd, ShouldNotBeNil)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
 			})
 		})
 
@@ -178,6 +181,7 @@ func TestLdapAuther(t *testing.T) {
 			Convey("Should take first match, and ignore subsequent matches", func() {
 				So(err, ShouldBeNil)
 				So(sc.updateOrgUserCmd, ShouldBeNil)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
 			})
 		})
 
@@ -197,6 +201,7 @@ func TestLdapAuther(t *testing.T) {
 			Convey("Should take first match, and ignore subsequent matches", func() {
 				So(err, ShouldBeNil)
 				So(sc.addOrgUserCmd.Role, ShouldEqual, m.ROLE_ADMIN)
+				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
 			})
 		})
 
@@ -340,6 +345,11 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 			return nil
 		})
 
+		bus.AddHandler("test", func(cmd *m.SetUsingOrgCommand) error {
+			sc.setUsingOrgCmd = cmd
+			return nil
+		})
+
 		fn(sc)
 	})
 }
@@ -352,6 +362,7 @@ type scenarioContext struct {
 	updateOrgUserCmd       *m.UpdateOrgUserCommand
 	removeOrgUserCmd       *m.RemoveOrgUserCommand
 	updateUserCmd          *m.UpdateUserCommand
+	setUsingOrgCmd         *m.SetUsingOrgCommand
 }
 
 func (sc *scenarioContext) userQueryReturns(user *m.User) {

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -77,16 +77,6 @@ func TestLdapAuther(t *testing.T) {
 				So(result.Login, ShouldEqual, "torkelo")
 			})
 
-			/*
-				Convey("Should create new user", func() {
-					So(sc.getUserByAuthInfoQuery.Login, ShouldEqual, "torkelo")
-					So(sc.getUserByAuthInfoQuery.Email, ShouldEqual, "my@email.com")
-
-					So(sc.createUserCmd.Login, ShouldEqual, "torkelo")
-					So(sc.createUserCmd.Email, ShouldEqual, "my@email.com")
-				})
-			*/
-
 		})
 
 	})

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -50,7 +50,7 @@ func initContextWithAuthProxy(ctx *m.ReqContext, orgID int64) bool {
 			return true
 		}
 	} else {
-		extUser := m.ExternalUserInfo{
+		extUser := &m.ExternalUserInfo{
 			AuthModule: "authproxy",
 			AuthId:     proxyHeaderValue,
 		}
@@ -73,10 +73,11 @@ func initContextWithAuthProxy(ctx *m.ReqContext, orgID int64) bool {
 
 		// add/update user in grafana
 		cmd := &m.UpsertUserCommand{
-			ExternalUser:  &extUser,
+			ReqContext:    ctx,
+			ExternalUser:  extUser,
 			SignupAllowed: setting.AuthProxyAutoSignUp,
 		}
-		err := login.UpsertUser(ctx, cmd)
+		err := bus.Dispatch(cmd)
 		if err != nil {
 			ctx.Handle(500, "Failed to login as user specified in auth proxy header", err)
 			return true

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -71,17 +71,17 @@ func initContextWithAuthProxy(ctx *m.ReqContext, orgID int64) bool {
 		}
 
 		// add/update user in grafana
-		userQuery := &m.UpsertUserCommand{
+		cmd := &m.UpsertUserCommand{
 			ExternalUser:  &extUser,
 			SignupAllowed: setting.AuthProxyAutoSignUp,
 		}
-		err := login.UpsertUser(ctx, userQuery)
+		err := login.UpsertUser(ctx, cmd)
 		if err != nil {
 			ctx.Handle(500, "Failed to login as user specified in auth proxy header", err)
 			return true
 		}
 
-		query.UserId = userQuery.User.Id
+		query.UserId = cmd.Result.Id
 
 		if err := bus.Dispatch(query); err != nil {
 			ctx.Handle(500, "Failed to find user", err)

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -68,6 +68,7 @@ func initContextWithAuthProxy(ctx *m.ReqContext, orgID int64) bool {
 			extUser.Login = proxyHeaderValue
 		} else {
 			ctx.Handle(500, "Auth proxy header property invalid", nil)
+			return true
 		}
 
 		// add/update user in grafana

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -112,7 +112,7 @@ var syncGrafanaUserWithLdapUser = func(ctx *m.ReqContext, query *m.GetSignedInUs
 
 		for _, server := range ldapCfg.Servers {
 			author := login.NewLdapAuthenticator(server)
-			if err := author.SyncSignedInUser(query.Result); err != nil {
+			if err := author.SyncSignedInUser(ctx, query.Result); err != nil {
 				return err
 			}
 		}

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -65,6 +65,8 @@ func initContextWithAuthProxy(ctx *m.ReqContext, orgID int64) bool {
 		query.UserId = getRequestUserId(ctx)
 		// if we're using ldap, pass authproxy login name to ldap user sync
 	} else if setting.LdapEnabled {
+		ctx.Session.Delete(session.SESS_KEY_LASTLDAPSYNC)
+
 		syncQuery := &m.LoginUserQuery{
 			ReqContext: ctx,
 			Username:   proxyHeaderValue,

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -116,18 +116,15 @@ type mockLdapAuthenticator struct {
 	syncSignedInUserCalled bool
 }
 
-func (a *mockLdapAuthenticator) Login(query *m.LoginUserQuery) error {
+func (a *mockLdapAuthenticator) Login(ctx *m.ReqContext, query *m.LoginUserQuery) error {
 	return nil
 }
 
-func (a *mockLdapAuthenticator) SyncSignedInUser(signedInUser *m.SignedInUser) error {
+func (a *mockLdapAuthenticator) SyncSignedInUser(ctx *m.ReqContext, signedInUser *m.SignedInUser) error {
 	a.syncSignedInUserCalled = true
 	return nil
 }
 
-func (a *mockLdapAuthenticator) GetGrafanaUserFor(ldapUser *login.LdapUserInfo) (*m.User, error) {
+func (a *mockLdapAuthenticator) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *login.LdapUserInfo) (*m.User, error) {
 	return nil, nil
-}
-func (a *mockLdapAuthenticator) SyncOrgRoles(user *m.User, ldapUser *login.LdapUserInfo) error {
-	return nil
 }

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -116,7 +116,7 @@ type mockLdapAuthenticator struct {
 	syncSignedInUserCalled bool
 }
 
-func (a *mockLdapAuthenticator) Login(query *login.LoginUserQuery) error {
+func (a *mockLdapAuthenticator) Login(query *m.LoginUserQuery) error {
 	return nil
 }
 

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -116,7 +116,7 @@ type mockLdapAuthenticator struct {
 	syncSignedInUserCalled bool
 }
 
-func (a *mockLdapAuthenticator) Login(ctx *m.ReqContext, query *m.LoginUserQuery) error {
+func (a *mockLdapAuthenticator) Login(query *m.LoginUserQuery) error {
 	return nil
 }
 

--- a/pkg/middleware/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy_test.go
@@ -26,57 +26,71 @@ func TestAuthProxyWithLdapEnabled(t *testing.T) {
 			return &mockLdapAuther
 		}
 
-		signedInUser := m.SignedInUser{}
-		query := m.GetSignedInUserQuery{Result: &signedInUser}
-
-		Convey("When session variable lastLdapSync not set, call syncSignedInUser and set lastLdapSync", func() {
+		Convey("When user logs in, call SyncUser", func() {
 			// arrange
-			sess := mockSession{}
+			sess := newMockSession()
 			ctx := m.ReqContext{Session: &sess}
 			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeNil)
 
 			// act
-			syncGrafanaUserWithLdapUser(&ctx, &query)
+			syncGrafanaUserWithLdapUser(&m.LoginUserQuery{
+				ReqContext: &ctx,
+				Username:   "test",
+			})
 
 			// assert
-			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeTrue)
+			So(mockLdapAuther.syncUserCalled, ShouldBeTrue)
 			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, 0)
 		})
 
 		Convey("When session variable not expired, don't sync and don't change session var", func() {
 			// arrange
-			sess := mockSession{}
+			sess := newMockSession()
 			ctx := m.ReqContext{Session: &sess}
 			now := time.Now().Unix()
 			sess.Set(session.SESS_KEY_LASTLDAPSYNC, now)
+			sess.Set(AUTH_PROXY_SESSION_VAR, "test")
 
 			// act
-			syncGrafanaUserWithLdapUser(&ctx, &query)
+			syncGrafanaUserWithLdapUser(&m.LoginUserQuery{
+				ReqContext: &ctx,
+				Username:   "test",
+			})
 
 			// assert
 			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldEqual, now)
-			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeFalse)
+			So(mockLdapAuther.syncUserCalled, ShouldBeFalse)
 		})
 
 		Convey("When lastldapsync is expired, session variable should be updated", func() {
 			// arrange
-			sess := mockSession{}
+			sess := newMockSession()
 			ctx := m.ReqContext{Session: &sess}
 			expiredTime := time.Now().Add(time.Duration(-120) * time.Minute).Unix()
 			sess.Set(session.SESS_KEY_LASTLDAPSYNC, expiredTime)
+			sess.Set(AUTH_PROXY_SESSION_VAR, "test")
 
 			// act
-			syncGrafanaUserWithLdapUser(&ctx, &query)
+			syncGrafanaUserWithLdapUser(&m.LoginUserQuery{
+				ReqContext: &ctx,
+				Username:   "test",
+			})
 
 			// assert
 			So(sess.Get(session.SESS_KEY_LASTLDAPSYNC), ShouldBeGreaterThan, expiredTime)
-			So(mockLdapAuther.syncSignedInUserCalled, ShouldBeTrue)
+			So(mockLdapAuther.syncUserCalled, ShouldBeTrue)
 		})
 	})
 }
 
 type mockSession struct {
-	value interface{}
+	value map[interface{}]interface{}
+}
+
+func newMockSession() mockSession {
+	session := mockSession{}
+	session.value = make(map[interface{}]interface{})
+	return session
 }
 
 func (s *mockSession) Start(c *macaron.Context) error {
@@ -84,15 +98,16 @@ func (s *mockSession) Start(c *macaron.Context) error {
 }
 
 func (s *mockSession) Set(k interface{}, v interface{}) error {
-	s.value = v
+	s.value[k] = v
 	return nil
 }
 
 func (s *mockSession) Get(k interface{}) interface{} {
-	return s.value
+	return s.value[k]
 }
 
 func (s *mockSession) Delete(k interface{}) interface{} {
+	delete(s.value, k)
 	return nil
 }
 
@@ -113,15 +128,15 @@ func (s *mockSession) RegenerateId(c *macaron.Context) error {
 }
 
 type mockLdapAuthenticator struct {
-	syncSignedInUserCalled bool
+	syncUserCalled bool
 }
 
 func (a *mockLdapAuthenticator) Login(query *m.LoginUserQuery) error {
 	return nil
 }
 
-func (a *mockLdapAuthenticator) SyncSignedInUser(ctx *m.ReqContext, signedInUser *m.SignedInUser) error {
-	a.syncSignedInUserCalled = true
+func (a *mockLdapAuthenticator) SyncUser(query *m.LoginUserQuery) error {
+	a.syncUserCalled = true
 	return nil
 }
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/apikeygen"
 	"github.com/grafana/grafana/pkg/log"
-	l "github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
@@ -165,7 +164,7 @@ func initContextWithBasicAuth(ctx *m.ReqContext, orgId int64) bool {
 
 	user := loginQuery.Result
 
-	loginUserQuery := l.LoginUserQuery{Username: username, Password: password, User: user}
+	loginUserQuery := m.LoginUserQuery{Username: username, Password: password, User: user}
 	if err := bus.Dispatch(&loginUserQuery); err != nil {
 		ctx.JsonApiErr(401, "Invalid username or password", err)
 		return true

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -9,7 +9,6 @@ import (
 
 	ms "github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
-	l "github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
@@ -72,7 +71,7 @@ func TestMiddlewareContext(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("test", func(loginUserQuery *l.LoginUserQuery) error {
+			bus.AddHandler("test", func(loginUserQuery *m.LoginUserQuery) error {
 				return nil
 			})
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -9,7 +9,6 @@ import (
 
 	ms "github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
@@ -183,10 +182,10 @@ func TestMiddlewareContext(t *testing.T) {
 				return nil
 			})
 
-			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+			bus.AddHandler("test", func(cmd *m.UpsertUserCommand) error {
 				cmd.Result = &m.User{Id: 12}
 				return nil
-			}
+			})
 
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")
@@ -214,10 +213,10 @@ func TestMiddlewareContext(t *testing.T) {
 				}
 			})
 
-			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+			bus.AddHandler("test", func(cmd *m.UpsertUserCommand) error {
 				cmd.Result = &m.User{Id: 33}
 				return nil
-			}
+			})
 
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")
@@ -276,10 +275,10 @@ func TestMiddlewareContext(t *testing.T) {
 				return nil
 			})
 
-			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+			bus.AddHandler("test", func(cmd *m.UpsertUserCommand) error {
 				cmd.Result = &m.User{Id: 33}
 				return nil
-			}
+			})
 
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")
@@ -298,6 +297,11 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.AuthProxyHeaderName = "X-WEBAUTH-USER"
 			setting.AuthProxyHeaderProperty = "username"
 			setting.AuthProxyWhitelist = ""
+
+			bus.AddHandler("test", func(query *m.UpsertUserCommand) error {
+				query.Result = &m.User{Id: 32}
+				return nil
+			})
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 4, UserId: 32}
@@ -333,6 +337,11 @@ func TestMiddlewareContext(t *testing.T) {
 				called = true
 				return nil
 			}
+
+			bus.AddHandler("test", func(query *m.UpsertUserCommand) error {
+				query.Result = &m.User{Id: 32}
+				return nil
+			})
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 4, UserId: 32}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -184,7 +184,7 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
-				cmd.User = &m.User{Id: 12}
+				cmd.Result = &m.User{Id: 12}
 				return nil
 			}
 
@@ -215,7 +215,7 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
-				cmd.User = &m.User{Id: 33}
+				cmd.Result = &m.User{Id: 33}
 				return nil
 			}
 
@@ -277,7 +277,7 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
-				cmd.User = &m.User{Id: 33}
+				cmd.Result = &m.User{Id: 33}
 				return nil
 			}
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -9,6 +9,7 @@ import (
 
 	ms "github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/login"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
@@ -182,6 +183,11 @@ func TestMiddlewareContext(t *testing.T) {
 				return nil
 			})
 
+			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+				cmd.User = &m.User{Id: 12}
+				return nil
+			}
+
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")
 			sc.exec()
@@ -208,10 +214,10 @@ func TestMiddlewareContext(t *testing.T) {
 				}
 			})
 
-			bus.AddHandler("test", func(cmd *m.CreateUserCommand) error {
-				cmd.Result = m.User{Id: 33}
+			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+				cmd.User = &m.User{Id: 33}
 				return nil
-			})
+			}
 
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")
@@ -269,6 +275,11 @@ func TestMiddlewareContext(t *testing.T) {
 				query.Result = &m.SignedInUser{OrgId: 4, UserId: 33}
 				return nil
 			})
+
+			login.UpsertUser = func(ctx *m.ReqContext, cmd *m.UpsertUserCommand) error {
+				cmd.User = &m.User{Id: 33}
+				return nil
+			}
 
 			sc.fakeReq("GET", "/")
 			sc.req.Header.Add("X-WEBAUTH-USER", "torkelo")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -176,6 +176,7 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.AuthProxyEnabled = true
 			setting.AuthProxyHeaderName = "X-WEBAUTH-USER"
 			setting.AuthProxyHeaderProperty = "username"
+			setting.LdapEnabled = false
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 2, UserId: 12}
@@ -203,6 +204,7 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.AuthProxyHeaderName = "X-WEBAUTH-USER"
 			setting.AuthProxyHeaderProperty = "username"
 			setting.AuthProxyAutoSignUp = true
+			setting.LdapEnabled = false
 
 			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
 				if query.UserId > 0 {
@@ -333,8 +335,9 @@ func TestMiddlewareContext(t *testing.T) {
 			setting.LdapEnabled = true
 
 			called := false
-			syncGrafanaUserWithLdapUser = func(ctx *m.ReqContext, query *m.GetSignedInUserQuery) error {
+			syncGrafanaUserWithLdapUser = func(query *m.LoginUserQuery) error {
 				called = true
+				query.User = &m.User{Id: 32}
 				return nil
 			}
 

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -1,0 +1,66 @@
+package models
+
+type UserAuth struct {
+	Id         int64
+	UserId     int64
+	AuthModule string
+	AuthId     string
+}
+
+type ExternalUserInfo struct {
+	AuthModule string
+	AuthId     string
+	UserId     int64
+	Email      string
+	Login      string
+	Name       string
+	OrgRoles   map[int64]RoleType
+}
+
+// ---------------------
+// COMMANDS
+
+type UpsertUserCommand struct {
+	ExternalUser  *ExternalUserInfo
+	SignupAllowed bool
+
+	User *User
+}
+
+type SetAuthInfoCommand struct {
+	AuthModule string
+	AuthId     string
+	UserId     int64
+}
+
+type DeleteAuthInfoCommand struct {
+	UserAuth *UserAuth
+}
+
+// ----------------------
+// QUERIES
+
+type LoginUserQuery struct {
+	Username  string
+	Password  string
+	User      *User
+	IpAddress string
+}
+
+type GetUserByAuthInfoQuery struct {
+	AuthModule string
+	AuthId     string
+	UserId     int64
+	Email      string
+	Login      string
+
+	User     *User
+	UserAuth *UserAuth
+}
+
+type GetAuthInfoQuery struct {
+	AuthModule string
+	AuthId     string
+
+	UserAuth *UserAuth
+}

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -1,10 +1,15 @@
 package models
 
+import (
+	"time"
+)
+
 type UserAuth struct {
 	Id         int64
 	UserId     int64
 	AuthModule string
 	AuthId     string
+	Created    time.Time
 }
 
 type ExternalUserInfo struct {

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -69,5 +69,5 @@ type GetAuthInfoQuery struct {
 	AuthModule string
 	AuthId     string
 
-	UserAuth *UserAuth
+	Result *UserAuth
 }

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -29,7 +29,7 @@ type UpsertUserCommand struct {
 	ExternalUser  *ExternalUserInfo
 	SignupAllowed bool
 
-	User *User
+	Result *User
 }
 
 type SetAuthInfoCommand struct {

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -26,6 +26,7 @@ type ExternalUserInfo struct {
 // COMMANDS
 
 type UpsertUserCommand struct {
+	ReqContext    *ReqContext
 	ExternalUser  *ExternalUserInfo
 	SignupAllowed bool
 
@@ -46,10 +47,11 @@ type DeleteAuthInfoCommand struct {
 // QUERIES
 
 type LoginUserQuery struct {
-	Username  string
-	Password  string
-	User      *User
-	IpAddress string
+	ReqContext *ReqContext
+	Username   string
+	Password   string
+	User       *User
+	IpAddress  string
 }
 
 type GetUserByAuthInfoQuery struct {

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -61,8 +61,7 @@ type GetUserByAuthInfoQuery struct {
 	Email      string
 	Login      string
 
-	User     *User
-	UserAuth *UserAuth
+	Result *User
 }
 
 type GetAuthInfoQuery struct {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -30,6 +30,7 @@ func AddMigrations(mg *Migrator) {
 	addDashboardAclMigrations(mg)
 	addTagMigration(mg)
 	addLoginAttemptMigrations(mg)
+	addUserAuthMigrations(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/user_auth_mig.go
+++ b/pkg/services/sqlstore/migrations/user_auth_mig.go
@@ -1,0 +1,24 @@
+package migrations
+
+import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func addUserAuthMigrations(mg *Migrator) {
+	userAuthV1 := Table{
+		Name: "user_auth",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "user_id", Type: DB_BigInt, Nullable: false},
+			{Name: "auth_module", Type: DB_NVarchar, Length: 30, Nullable: false},
+			{Name: "auth_id", Type: DB_NVarchar, Length: 100, Nullable: false},
+			{Name: "created", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"auth_module", "auth_id"}},
+		},
+	}
+
+	// create table
+	mg.AddMigration("create user auth table", NewAddTableMigration(userAuthV1))
+	// add indices
+	addTableIndicesMigrations(mg, "v1", userAuthV1)
+}

--- a/pkg/services/sqlstore/migrations/user_auth_mig.go
+++ b/pkg/services/sqlstore/migrations/user_auth_mig.go
@@ -8,7 +8,7 @@ func addUserAuthMigrations(mg *Migrator) {
 		Columns: []*Column{
 			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "user_id", Type: DB_BigInt, Nullable: false},
-			{Name: "auth_module", Type: DB_NVarchar, Length: 30, Nullable: false},
+			{Name: "auth_module", Type: DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "auth_id", Type: DB_NVarchar, Length: 100, Nullable: false},
 			{Name: "created", Type: DB_DateTime, Nullable: false},
 		},

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -445,6 +445,7 @@ func DeleteUser(cmd *m.DeleteUserCommand) error {
 			"DELETE FROM dashboard_acl WHERE user_id = ?",
 			"DELETE FROM preferences WHERE user_id = ?",
 			"DELETE FROM team_member WHERE user_id = ?",
+			"DELETE FROM user_auth WHERE user_id = ?",
 		}
 
 		for _, sql := range deletes {

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -295,11 +295,12 @@ func SetUsingOrg(cmd *m.SetUsingOrgCommand) error {
 	}
 
 	return inTransaction(func(sess *DBSession) error {
-		user := m.User{}
-		sess.Id(cmd.UserId).Get(&user)
+		user := m.User{
+			Id:    cmd.UserId,
+			OrgId: cmd.OrgId,
+		}
 
-		user.OrgId = cmd.OrgId
-		_, err := sess.Id(user.Id).Update(&user)
+		_, err := sess.Id(cmd.UserId).Update(&user)
 		return err
 	})
 }

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -1,6 +1,8 @@
 package sqlstore
 
 import (
+	"time"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -107,6 +109,7 @@ func SetAuthInfo(cmd *m.SetAuthInfoCommand) error {
 			UserId:     cmd.UserId,
 			AuthModule: cmd.AuthModule,
 			AuthId:     cmd.AuthId,
+			Created:    time.Now(),
 		}
 
 		_, err := sess.Insert(&authUser)

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -1,0 +1,130 @@
+package sqlstore
+
+import (
+	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+func init() {
+	bus.AddHandler("sql", GetUserByAuthInfo)
+	bus.AddHandler("sql", GetAuthInfo)
+	bus.AddHandler("sql", SetAuthInfo)
+	bus.AddHandler("sql", DeleteAuthInfo)
+}
+
+func GetUserByAuthInfo(query *m.GetUserByAuthInfoQuery) error {
+	user := new(m.User)
+	has := false
+	var err error
+
+	// Try to find the user by auth module and id first
+	if query.AuthModule != "" && query.AuthId != "" {
+		authQuery := &m.GetAuthInfoQuery{
+			AuthModule: query.AuthModule,
+			AuthId:     query.AuthId,
+		}
+
+		err = GetAuthInfo(authQuery)
+		// if user id was specified and doesn't match the user_auth entry, remove it
+		if err == nil && query.UserId != 0 && query.UserId != authQuery.UserAuth.UserId {
+			DeleteAuthInfo(&m.DeleteAuthInfoCommand{
+				UserAuth: authQuery.UserAuth,
+			})
+		} else if err == nil {
+			has, err = x.Id(authQuery.UserAuth.UserId).Get(user)
+			if err != nil {
+				return err
+			}
+
+			if has {
+				query.UserAuth = authQuery.UserAuth
+			} else {
+				// if the user has been deleted then remove the entry
+				DeleteAuthInfo(&m.DeleteAuthInfoCommand{
+					UserAuth: authQuery.UserAuth,
+				})
+			}
+		} else if err != m.ErrUserNotFound {
+			return err
+		}
+	}
+
+	// If not found, try to find the user by id
+	if !has && query.UserId != 0 {
+		has, err = x.Id(query.UserId).Get(user)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If not found, try to find the user by email address
+	if !has && query.Email != "" {
+		user = &m.User{Email: query.Email}
+		has, err = x.Get(user)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If not found, try to find the user by login
+	if !has && query.Login != "" {
+		user = &m.User{Login: query.Login}
+		has, err = x.Get(user)
+		if err != nil {
+			return err
+		}
+	}
+
+	// No user found
+	if !has {
+		return m.ErrUserNotFound
+	}
+
+	query.User = user
+	return nil
+}
+
+func GetAuthInfo(query *m.GetAuthInfoQuery) error {
+	userAuth := &m.UserAuth{
+		AuthModule: query.AuthModule,
+		AuthId:     query.AuthId,
+	}
+	has, err := x.Get(userAuth)
+	if err != nil {
+		return err
+	}
+	if !has {
+		return m.ErrUserNotFound
+	}
+
+	query.UserAuth = userAuth
+	return nil
+}
+
+func SetAuthInfo(cmd *m.SetAuthInfoCommand) error {
+	return inTransaction(func(sess *DBSession) error {
+		authUser := m.UserAuth{
+			UserId:     cmd.UserId,
+			AuthModule: cmd.AuthModule,
+			AuthId:     cmd.AuthId,
+		}
+
+		_, err := sess.Insert(&authUser)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func DeleteAuthInfo(cmd *m.DeleteAuthInfoCommand) error {
+	return inTransaction(func(sess *DBSession) error {
+		_, err := sess.Delete(cmd.UserAuth)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func GetUserByAuthInfo(query *m.GetUserByAuthInfoQuery) error {
-	user := new(m.User)
+	user := &m.User{}
 	has := false
 	var err error
 

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -28,22 +28,22 @@ func GetUserByAuthInfo(query *m.GetUserByAuthInfoQuery) error {
 
 		err = GetAuthInfo(authQuery)
 		// if user id was specified and doesn't match the user_auth entry, remove it
-		if err == nil && query.UserId != 0 && query.UserId != authQuery.UserAuth.UserId {
+		if err == nil && query.UserId != 0 && query.UserId != authQuery.Result.UserId {
 			DeleteAuthInfo(&m.DeleteAuthInfoCommand{
-				UserAuth: authQuery.UserAuth,
+				UserAuth: authQuery.Result,
 			})
 		} else if err == nil {
-			has, err = x.Id(authQuery.UserAuth.UserId).Get(user)
+			has, err = x.Id(authQuery.Result.UserId).Get(user)
 			if err != nil {
 				return err
 			}
 
 			if has {
-				query.UserAuth = authQuery.UserAuth
+				query.UserAuth = authQuery.Result
 			} else {
 				// if the user has been deleted then remove the entry
 				DeleteAuthInfo(&m.DeleteAuthInfoCommand{
-					UserAuth: authQuery.UserAuth,
+					UserAuth: authQuery.Result,
 				})
 			}
 		} else if err != m.ErrUserNotFound {
@@ -99,7 +99,7 @@ func GetAuthInfo(query *m.GetAuthInfoQuery) error {
 		return m.ErrUserNotFound
 	}
 
-	query.UserAuth = userAuth
+	query.Result = userAuth
 	return nil
 }
 

--- a/pkg/services/sqlstore/user_auth_test.go
+++ b/pkg/services/sqlstore/user_auth_test.go
@@ -1,0 +1,131 @@
+package sqlstore
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+func TestUserAuth(t *testing.T) {
+	InitTestDB(t)
+
+	Convey("Given 5 users", t, func() {
+		var err error
+		var cmd *m.CreateUserCommand
+		users := []m.User{}
+		for i := 0; i < 5; i++ {
+			cmd = &m.CreateUserCommand{
+				Email: fmt.Sprint("user", i, "@test.com"),
+				Name:  fmt.Sprint("user", i),
+				Login: fmt.Sprint("loginuser", i),
+			}
+			err = CreateUser(cmd)
+			So(err, ShouldBeNil)
+			users = append(users, cmd.Result)
+		}
+
+		Reset(func() {
+			_, err := x.Exec("DELETE FROM org_user WHERE 1=1")
+			So(err, ShouldBeNil)
+			_, err = x.Exec("DELETE FROM org WHERE 1=1")
+			So(err, ShouldBeNil)
+			_, err = x.Exec("DELETE FROM user WHERE 1=1")
+			So(err, ShouldBeNil)
+			_, err = x.Exec("DELETE FROM user_auth WHERE 1=1")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Can find existing user", func() {
+			// By Login
+			login := "loginuser0"
+
+			query := &m.GetUserByAuthInfoQuery{Login: login}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Login, ShouldEqual, login)
+
+			// By ID
+			id := query.Result.Id
+
+			query = &m.GetUserByAuthInfoQuery{UserId: id}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Id, ShouldEqual, id)
+
+			// By Email
+			email := "user1@test.com"
+
+			query = &m.GetUserByAuthInfoQuery{Email: email}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Email, ShouldEqual, email)
+
+			// Don't find nonexistent user
+			email = "nonexistent@test.com"
+
+			query = &m.GetUserByAuthInfoQuery{Email: email}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldEqual, m.ErrUserNotFound)
+			So(query.Result, ShouldBeNil)
+		})
+
+		Convey("Can set & locate by AuthModule and AuthId", func() {
+			// get nonexistent user_auth entry
+			query := &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldEqual, m.ErrUserNotFound)
+			So(query.Result, ShouldBeNil)
+
+			// create user_auth entry
+			login := "loginuser0"
+
+			query.Login = login
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Login, ShouldEqual, login)
+
+			// get via user_auth
+			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Login, ShouldEqual, login)
+
+			// get with non-matching id
+			id := query.Result.Id
+
+			query.UserId = id + 1
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Login, ShouldEqual, "loginuser1")
+
+			// get via user_auth
+			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldBeNil)
+			So(query.Result.Login, ShouldEqual, "loginuser1")
+
+			// remove user
+			_, err = x.Exec("DELETE FROM user WHERE id=?", query.Result.Id)
+			So(err, ShouldBeNil)
+
+			// get via user_auth for deleted user
+			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
+			err = GetUserByAuthInfo(query)
+
+			So(err, ShouldEqual, m.ErrUserNotFound)
+			So(query.Result, ShouldBeNil)
+		})
+	})
+}

--- a/pkg/social/grafana_com_oauth.go
+++ b/pkg/social/grafana_com_oauth.go
@@ -51,6 +51,7 @@ func (s *SocialGrafanaCom) IsOrganizationMember(organizations []OrgRecord) bool 
 
 func (s *SocialGrafanaCom) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
+		Id    int         `json:"id"`
 		Name  string      `json:"name"`
 		Login string      `json:"username"`
 		Email string      `json:"email"`
@@ -69,6 +70,7 @@ func (s *SocialGrafanaCom) UserInfo(client *http.Client, token *oauth2.Token) (*
 	}
 
 	userInfo := &BasicUserInfo{
+		Id:    fmt.Sprintf("%d", data.Id),
 		Name:  data.Name,
 		Login: data.Login,
 		Email: data.Email,

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -14,6 +14,7 @@ import (
 )
 
 type BasicUserInfo struct {
+	Id      string
 	Name    string
 	Email   string
 	Login   string


### PR DESCRIPTION
This PR aims to bring the code used to synchronize Grafana user accounts with external authentication stores into a single workflow, implemented by the `login.UpsertUser` function.  This accepts a `models.ExternalUserInfo` struct and handles checking whether a local account exists, creating or updating it as necessary, managing org membership, and maintaining entries in the new `user_auth` table to link Grafana user accounts to external user accounts.

The tests are still quite lacking, and I'm not sure of the best way to implement those.  It may be easier to test if we implement `bus.DispatchReqCtx` and use that instead of calling `login.UpsertUser` directly, but I'm not sure.

There are a few behavior changes involved here, since users authenticating via oauth, auth-proxy and ldap now all go through the same account sync, but I have done my best to make sure that we won't break any existing logins.

The new user account linking code will work with ldap (based on DN), authproxy (based on the header value) and grafana.com auth (based on user id).  Other oauth/openid providers will need to be extended to return an Id element to take advantage of the `user_auth` table.

The other major change to the authproxy system is to avoid the overhead of looking the user up by username/email on every request, it now stores the proxy header value in the session and only does a lookup if the value changed.

All feedback appreciated!