### PR TITLE
Default value for uploading images in alert notifiers

### DIFF
--- a/pkg/services/alerting/notifiers/base.go
+++ b/pkg/services/alerting/notifiers/base.go
@@ -15,7 +15,11 @@ type NotifierBase struct {
 }
 
 func NewNotifierBase(id int64, isDefault bool, name, notifierType string, model *simplejson.Json) NotifierBase {
-	uploadImage := model.Get("uploadImage").MustBool(false)
+	uploadImage := true
+	value, exist := model.CheckGet("uploadImage")
+	if exist {
+		uploadImage = value.MustBool()
+	}
 
 	return NotifierBase{
 		Id:          id,

--- a/pkg/services/alerting/notifiers/base_test.go
+++ b/pkg/services/alerting/notifiers/base_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	. "github.com/smartystreets/goconvey/convey"
@@ -11,6 +12,29 @@ import (
 
 func TestBaseNotifier(t *testing.T) {
 	Convey("Base notifier tests", t, func() {
+		Convey("default constructor for notifiers", func() {
+			bJson := simplejson.New()
+
+			Convey("can parse false value", func() {
+				bJson.Set("uploadImage", false)
+
+				base := NewNotifierBase(1, false, "name", "email", bJson)
+				So(base.UploadImage, ShouldBeFalse)
+			})
+
+			Convey("can parse true value", func() {
+				bJson.Set("uploadImage", true)
+
+				base := NewNotifierBase(1, false, "name", "email", bJson)
+				So(base.UploadImage, ShouldBeTrue)
+			})
+
+			Convey("default value should be true for backwards compatibility", func() {
+				base := NewNotifierBase(1, false, "name", "email", bJson)
+				So(base.UploadImage, ShouldBeTrue)
+			})
+		})
+
 		Convey("should notify", func() {
 			Convey("pending -> ok", func() {
 				context := alerting.NewEvalContext(context.TODO(), &alerting.Rule{

--- a/public/app/features/alerting/notification_edit_ctrl.ts
+++ b/public/app/features/alerting/notification_edit_ctrl.ts
@@ -43,6 +43,7 @@ export class AlertNotificationEditCtrl {
         return this.backendSrv.get(`/api/alert-notifications/${this.$routeParams.id}`).then(result => {
           this.navModel.breadcrumbs.push({ text: result.name });
           this.navModel.node = { text: result.name };
+          result.settings = _.defaults(result.settings, this.defaults.settings);
           return result;
         });
       })
@@ -89,7 +90,7 @@ export class AlertNotificationEditCtrl {
   }
 
   typeChanged() {
-    this.model.settings = {};
+    this.model.settings = _.defaults({}, this.defaults.settings);
     this.notifierTemplateId = this.getNotifierTemplateId(this.model.type);
   }
 


### PR DESCRIPTION
when we made image upload optional we didn't
show the default value properly in the UI. Which
caused confusing. This commit applies the default
values to existing notifiers in the edit pages
and reverts back to using uploadimage=true as the
default value.

