### PR TITLE
sidemenu fix for internet explorer 11, 

### DIFF
--- a/public/sass/base/_icons.scss
+++ b/public/sass/base/_icons.scss
@@ -1,8 +1,10 @@
 .gicon {
   line-height: 1;
   display: inline-block;
-  width: 1.1057142857em;
-  height: 1.1057142857em;
+  //width: 1.1057142857em;
+  //height: 1.1057142857em;
+  height: 22px;
+  width: 22px;
   text-align: center;
   background-repeat: no-repeat;
   background-position: center;

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -178,6 +178,7 @@ li.sidemenu-org-switcher {
   padding: 0.4rem 1rem 0.4rem 0.65rem;
   min-height: $navbarHeight;
   position: relative;
+  height: $navbarHeight - 1px;
 
   &:hover {
     background: $navbarButtonBackgroundHighlight;


### PR DESCRIPTION
changed icon width/height to pixels and added height to logo

<img width="510" alt="skarmavbild 2018-03-27 kl 10 37 56" src="https://user-images.githubusercontent.com/23470681/37956466-beccdd2a-31ab-11e8-92c5-1e3cef0680c9.png">

