### PR TITLE
alert: fixes broken link back to grafana

### DIFF
--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -209,14 +209,14 @@ func GetDashboardFolderUrl(isFolder bool, uid string, slug string) string {
 	return GetDashboardUrl(uid, slug)
 }
 
-// Return the html url for a dashboard
+// GetDashboardUrl return the html url for a dashboard
 func GetDashboardUrl(uid string, slug string) string {
 	return fmt.Sprintf("%s/d/%s/%s", setting.AppSubUrl, uid, slug)
 }
 
-// Return the full url for a dashboard
+// GetFullDashboardUrl return the full url for a dashboard
 func GetFullDashboardUrl(uid string, slug string) string {
-	return fmt.Sprintf("%s%s", setting.AppUrl, GetDashboardUrl(uid, slug))
+	return fmt.Sprintf("%sd/%s/%s", setting.AppUrl, uid, slug)
 }
 
 // GetFolderUrl return the html url for a folder

--- a/pkg/models/dashboards_test.go
+++ b/pkg/models/dashboards_test.go
@@ -4,10 +4,23 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestDashboardModel(t *testing.T) {
+
+	Convey("Generate full dashboard url", t, func() {
+		setting.AppUrl = "http://grafana.local/"
+		fullUrl := GetFullDashboardUrl("uid", "my-dashboard")
+		So(fullUrl, ShouldEqual, "http://grafana.local/d/uid/my-dashboard")
+	})
+
+	Convey("Generate relative dashboard url", t, func() {
+		setting.AppUrl = ""
+		fullUrl := GetDashboardUrl("uid", "my-dashboard")
+		So(fullUrl, ShouldEqual, "/d/uid/my-dashboard")
+	})
 
 	Convey("When generating slug", t, func() {
 		dashboard := NewDashboard("Grafana Play Home")


### PR DESCRIPTION
If Grafana was configured to use a subpath it
was included twice in the link from the
alert notification back to Grafana.

closes #11403

