### PR TITLE
Add api_url value to Azure OAuth2 documentation

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -606,7 +606,7 @@ allowed_organizations =
     scopes = openid email name
     auth_url = https://login.microsoftonline.com/<directory id>/oauth2/authorize
     token_url = https://login.microsoftonline.com/<directory id>/oauth2/token
-    api_url =
+    api_url = https://login.microsoftonline.com/<directory id>/openid/userinfo
     team_ids =
     allowed_organizations =
     ```


### PR DESCRIPTION
The field api_url is required but not documented

