### PR TITLE
rm panel.type  constrain from threshold_mapper.ts

### DIFF
--- a/public/app/features/alerting/threshold_mapper.ts
+++ b/public/app/features/alerting/threshold_mapper.ts
@@ -1,9 +1,5 @@
 export class ThresholdMapper {
   static alertToGraphThresholds(panel) {
-    if (panel.type !== 'graph') {
-      return false;
-    }
-
     for (var i = 0; i < panel.alert.conditions.length; i++) {
       let condition = panel.alert.conditions[i];
       if (condition.type !== 'query') {


### PR DESCRIPTION
It is not possible to work with forks of default graph panel. I know that 
This else doesn't make code better in any sense, but makes it impossible to make better versions of graph panel: it limits alerts usage in forks. 

My motivation is to make graph panel hackable by making forks from this
https://github.com/CorpGlory/grafana-graph-panel 

Thx @corpglory team and @rozetko in particular for finding this. And thanks Grafana team for great software. :v:  
