### PR TITLE
npm run watch -> npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For this you need nodejs (v.6+).
 ```bash
 npm install -g yarn
 yarn install --pure-lockfile
-npm run watch
+npm run dev
 ```
 
 Run tests 


### PR DESCRIPTION
We are building from sources. I suppose that we just want to build instead of watching the sources. 
There should be even `npm run build` , but  I personally prefer `dev` 