### PR TITLE
Respect dashboard timezone setting when doing CSV export (issue #10497)

### DIFF
--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -6,23 +6,47 @@ const DEFAULT_DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 const POINT_TIME_INDEX = 1;
 const POINT_VALUE_INDEX = 0;
 
-export function convertSeriesListToCsv(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
+export function convertSeriesListToCsv(
+  seriesList,
+  dateTimeFormat = DEFAULT_DATETIME_FORMAT,
+  excel = false,
+  isUtc = false
+) {
   var text = (excel ? 'sep=;\n' : '') + 'Series;Time;Value\n';
   _.each(seriesList, function(series) {
     _.each(series.datapoints, function(dp) {
       text +=
-        series.alias + ';' + moment(dp[POINT_TIME_INDEX]).format(dateTimeFormat) + ';' + dp[POINT_VALUE_INDEX] + '\n';
+        series.alias +
+        ';' +
+        (isUtc
+          ? moment(dp[POINT_TIME_INDEX])
+              .utc()
+              .format(dateTimeFormat)
+          : moment(dp[POINT_TIME_INDEX]).format(dateTimeFormat)) +
+        ';' +
+        dp[POINT_VALUE_INDEX] +
+        '\n';
     });
   });
   return text;
 }
 
-export function exportSeriesListToCsv(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
-  var text = convertSeriesListToCsv(seriesList, dateTimeFormat, excel);
+export function exportSeriesListToCsv(
+  seriesList,
+  dateTimeFormat = DEFAULT_DATETIME_FORMAT,
+  excel = false,
+  isUtc = false
+) {
+  var text = convertSeriesListToCsv(seriesList, dateTimeFormat, excel, isUtc);
   saveSaveBlob(text, 'grafana_data_export.csv');
 }
 
-export function convertSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
+export function convertSeriesListToCsvColumns(
+  seriesList,
+  dateTimeFormat = DEFAULT_DATETIME_FORMAT,
+  excel = false,
+  isUtc = false
+) {
   let text = (excel ? 'sep=;\n' : '') + 'Time;';
   // add header
   _.each(seriesList, function(series) {
@@ -39,7 +63,11 @@ export function convertSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAU
     var cIndex = 0;
     dataArr.push([]);
     _.each(series.datapoints, function(dp) {
-      dataArr[0][cIndex] = moment(dp[POINT_TIME_INDEX]).format(dateTimeFormat);
+      dataArr[0][cIndex] = isUtc
+        ? moment(dp[POINT_TIME_INDEX])
+            .utc()
+            .format(dateTimeFormat)
+        : moment(dp[POINT_TIME_INDEX]).format(dateTimeFormat);
       dataArr[sIndex][cIndex] = dp[POINT_VALUE_INDEX];
       cIndex++;
     });
@@ -91,8 +119,13 @@ function mergeSeriesByTime(seriesList) {
   return seriesList;
 }
 
-export function exportSeriesListToCsvColumns(seriesList, dateTimeFormat = DEFAULT_DATETIME_FORMAT, excel = false) {
-  let text = convertSeriesListToCsvColumns(seriesList, dateTimeFormat, excel);
+export function exportSeriesListToCsvColumns(
+  seriesList,
+  dateTimeFormat = DEFAULT_DATETIME_FORMAT,
+  excel = false,
+  isUtc = false
+) {
+  let text = convertSeriesListToCsvColumns(seriesList, dateTimeFormat, excel, isUtc);
   saveSaveBlob(text, 'grafana_data_export.csv');
 }
 

--- a/public/app/features/dashboard/export_data/export_data_modal.ts
+++ b/public/app/features/dashboard/export_data/export_data_modal.ts
@@ -5,6 +5,7 @@ import appEvents from 'app/core/app_events';
 export class ExportDataModalCtrl {
   private data: any[];
   private panel: string;
+  private utc: boolean;
   asRows: Boolean = true;
   dateTimeFormat = 'YYYY-MM-DDTHH:mm:ssZ';
   excel: false;
@@ -14,9 +15,9 @@ export class ExportDataModalCtrl {
       fileExport.exportTableDataToCsv(this.data, this.excel);
     } else {
       if (this.asRows) {
-        fileExport.exportSeriesListToCsv(this.data, this.dateTimeFormat, this.excel);
+        fileExport.exportSeriesListToCsv(this.data, this.dateTimeFormat, this.excel, this.utc);
       } else {
-        fileExport.exportSeriesListToCsvColumns(this.data, this.dateTimeFormat, this.excel);
+        fileExport.exportSeriesListToCsvColumns(this.data, this.dateTimeFormat, this.excel, this.utc);
       }
     }
 
@@ -37,6 +38,7 @@ export function exportDataModal() {
     scope: {
       panel: '<',
       data: '<', // The difference to '=' is that the bound properties are not watched
+      utc: '<',
     },
     bindToController: true,
   };

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -319,8 +319,9 @@ class GraphCtrl extends MetricsPanelCtrl {
   exportCsv() {
     var scope = this.$scope.$new(true);
     scope.seriesList = this.seriesList;
+    scope.isUtc = this.dashboard.isTimezoneUtc();
     this.publishAppEvent('show-modal', {
-      templateHtml: '<export-data-modal data="seriesList"></export-data-modal>',
+      templateHtml: '<export-data-modal data="seriesList" utc="isUtc"></export-data-modal>',
       scope,
       modalClass: 'modal--narrow',
     });


### PR DESCRIPTION
This should fix https://github.com/grafana/grafana/issues/10497

This is my first PR for Grafana, so apologies if I haven't got something right. In that context, a couple of notes:
- I'm not quite sure why my edits to `file_export.ts` got "pretty-formatted" and split over multiple lines like that. Is it possible it was the pre-commit script? Should I try to revert to the original (single-line) formatting?
- I ended up naming the boolean flag `utc`, as the export-data modal seemed to take issue with the camel case in `isUtc`, and I figured that `isutc` in on balance more confusing than just`utc`.
- The existing tests were all based on CSV exports using unix timestamps only, so this change would not have made a difference. Therefore I haven't updated the tests - and I also haven't written new ones. I can add tests if that would be desirable. Though figured I'd get this out sooner rather than later and get feedback.