### PR TITLE
add moment-tz and expose to modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "mobx-react": "^4.3.5",
     "mobx-state-tree": "^1.3.1",
     "moment": "^2.18.1",
+    "moment-timezone": "^0.5.14",
     "mousetrap": "^1.6.0",
     "mousetrap-global-bind": "^1.1.0",
     "perfect-scrollbar": "^1.2.0",

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import * as sdk from 'app/plugins/sdk';
 import kbn from 'app/core/utils/kbn';
 import moment from 'moment';
+import * as momenttz from 'moment-timezone';
 import angular from 'angular';
 import jquery from 'jquery';
 import config from 'app/core/config';
@@ -65,6 +66,7 @@ function exposeToPlugin(name: string, component: any) {
 
 exposeToPlugin('lodash', _);
 exposeToPlugin('moment', moment);
+exposeToPlugin('moment-timezone', momenttz);
 exposeToPlugin('jquery', jquery);
 exposeToPlugin('angular', angular);
 exposeToPlugin('d3', d3);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6521,6 +6521,16 @@ mocha@^4.0.1:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
+moment-timezone@^0.5.14:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
+
 moment@^2.18.1:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"


### PR DESCRIPTION
Related to #7453
Replaces #11387

Revised changes to work with v5.x. Doing some initial testing with clock-panel, initial indications are that the change is small on the grafana side. From initial testing, the dependency mentioned in the above ticket was likely resolved upstream and is now no longer applicable.