### PR TITLE
graphite: use a query when testing data source

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -453,7 +453,13 @@ export function GraphiteDatasource(instanceSettings, $q, backendSrv, templateSrv
   };
 
   this.testDatasource = function() {
-    return this.metricFindQuery('*').then(function() {
+    let query = {
+      panelId: 3,
+      rangeRaw: { from: 'now-1h', to: 'now' },
+      targets: [{ target: 'constantLine(100)' }],
+      maxDataPoints: 300,
+    };
+    return this.query(query).then(function() {
       return { status: 'success', message: 'Data source is working' };
     });
   };


### PR DESCRIPTION
Using a query (POST /render) request instead of GET /metrics/find to better mimic an actual request for rendering a panel in a dashboard. The POST /render request will add at least one custom HTTP header which can be problematic when using direct access mode since it will trigger a CORS prerequest check. 

By doing this kind of query when testing the data source any possible CORS issues can be detected at this stage instead of later when trying to use the data source in a dashboard.

This also makes the testing behavior similar to both Prometheus and Influxdb. 

Seems like the `constantLine` is supported since at least Graphite 0.9.9 so should be compatible with all supported Graphite version in Grafana right?