### PR TITLE
influxdb: Check before assuming first column to be 'time'

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -151,11 +151,17 @@ export default class InfluxSeries {
 
     _.each(this.series, (series, seriesIndex) => {
       if (seriesIndex === 0) {
-        table.columns.push({ text: 'Time', type: 'time' });
+        j = 0;
+        // Check that the first column is indeed 'time'
+        if (series.columns[0] === 'time') {
+          // Push this now before the tags and with the right type
+          table.columns.push({ text: 'Time', type: 'time' });
+          j++;
+        }
         _.each(_.keys(series.tags), function(key) {
           table.columns.push({ text: key });
         });
-        for (j = 1; j < series.columns.length; j++) {
+        for (; j < series.columns.length; j++) {
           table.columns.push({ text: series.columns[j] });
         }
       }

--- a/public/app/plugins/datasource/influxdb/specs/influx_series.jest.ts
+++ b/public/app/plugins/datasource/influxdb/specs/influx_series.jest.ts
@@ -195,7 +195,31 @@ describe('when generating timeseries from influxdb response', function() {
 
       expect(table.type).toBe('table');
       expect(table.columns.length).toBe(5);
+      expect(table.columns[0].text).toEqual('Time');
       expect(table.rows[0]).toEqual([1431946625000, 'Africa', 'server2', 23, 10]);
+    });
+  });
+
+  describe('given table response from SHOW CARDINALITY', function() {
+    var options = {
+      alias: '',
+      series: [
+        {
+          name: 'cpu',
+          columns: ['count'],
+          values: [[37]],
+        },
+      ],
+    };
+
+    it('should return table', function() {
+      var series = new InfluxSeries(options);
+      var table = series.getTable();
+
+      expect(table.type).toBe('table');
+      expect(table.columns.length).toBe(1);
+      expect(table.columns[0].text).toEqual('count');
+      expect(table.rows[0]).toEqual([37]);
     });
   });
 

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -159,8 +159,8 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   }
 
   setTableColumnToSensibleDefault(tableData) {
-    if (this.tableColumnOptions.length === 1) {
-      this.panel.tableColumn = this.tableColumnOptions[0];
+    if (tableData.columns.length === 1) {
+      this.panel.tableColumn = tableData.columns[0].text;
     } else {
       this.panel.tableColumn = _.find(tableData.columns, col => {
         return col.type !== 'time';


### PR DESCRIPTION
When running queries like `SHOW [...] CARDINALITY` introduced with InfluxDB 1.4 there is only a single column `count`. However, the data source always assumed `time` which threw an error because the code couldn't find a non-time column to display.

This change actually checks this assumption and thereby fixes displaying the result in a Singlestat in Table mode (closes #11476).