### PR TITLE
prometheus: prevent angular from evaluating {{hostname}} in legend format tooltip

### DIFF
--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -14,7 +14,7 @@
         data-min-length=0 data-items=1000 ng-model-onblur ng-change="ctrl.refreshMetricData()">
       </input>
       <info-popover mode="right-absolute">
-        Controls the name of the time series, using name or pattern. For example {{hostname}} will be replaced with label value for
+        Controls the name of the time series, using name or pattern. For example <span ng-non-bindable>{{hostname}}</span> will be replaced with label value for
         the label hostname.
       </info-popover>
     </div>


### PR DESCRIPTION
The tooltip for the legend format is evaluated by angular and so the example of how to use hostname as placeholder is replaced by an empty string. This change prevents angular from evaluating {{hostname}} in the legend format tooltip

Fixes #11516 