### PR TITLE
Fix issues with metric reporting

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -54,6 +54,7 @@ var (
 	M_Alerting_Active_Alerts prometheus.Gauge
 	M_StatTotal_Dashboards   prometheus.Gauge
 	M_StatTotal_Users        prometheus.Gauge
+	M_StatActive_Users       prometheus.Gauge
 	M_StatTotal_Orgs         prometheus.Gauge
 	M_StatTotal_Playlists    prometheus.Gauge
 	M_Grafana_Version        *prometheus.GaugeVec
@@ -253,6 +254,12 @@ func init() {
 		Namespace: exporterName,
 	})
 
+	M_StatActive_Users = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_active_users",
+		Help:      "number of active users",
+		Namespace: exporterName,
+	})
+
 	M_StatTotal_Orgs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_total_orgs",
 		Help:      "total amount of orgs",
@@ -305,6 +312,7 @@ func initMetricVars(settings *MetricSettings) {
 		M_Alerting_Active_Alerts,
 		M_StatTotal_Dashboards,
 		M_StatTotal_Users,
+		M_StatActive_Users,
 		M_StatTotal_Orgs,
 		M_StatTotal_Playlists,
 		M_Grafana_Version)
@@ -341,6 +349,7 @@ func updateTotalStats() {
 
 		M_StatTotal_Dashboards.Set(float64(statsQuery.Result.Dashboards))
 		M_StatTotal_Users.Set(float64(statsQuery.Result.Users))
+		M_StatActive_Users.Set(float64(statsQuery.Result.ActiveUsers))
 		M_StatTotal_Playlists.Set(float64(statsQuery.Result.Playlists))
 		M_StatTotal_Orgs.Set(float64(statsQuery.Result.Orgs))
 	}

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -68,6 +68,9 @@ func GetSystemStats(query *m.GetSystemStatsQuery) error {
 	}
 
 	query.Result = &stats
+
+	bus.Publish(&stats)
+
 	return err
 }
 

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -69,8 +69,6 @@ func GetSystemStats(query *m.GetSystemStatsQuery) error {
 
 	query.Result = &stats
 
-	bus.Publish(&stats)
-
 	return err
 }
 


### PR DESCRIPTION
This PR fixes 2 issues with the current metric reporting framework:

The first commit adds the missing "active users" stat to the data reported to graphite.  This is straightforward and just adds the missing stat.

The second commit fixes an issue that causes the first set of stats reported to graphite after startup to have the system stats all set to 0.  This was a little more involved, since the stats are gathered at startup by `sqlstore.EnsureAdminUser()` but weren't finding their way into the prometheus stats.  Now whenever `GetSystemStats` runs it publishes the stats to the bus and the metrics module registers a listener so it can update the prometheus stats.