### PR TITLE
sql tsdb: fix precision and data type support for time columns

### DIFF
--- a/docker/blocks/mssql_tests/dashboard.json
+++ b/docker/blocks/mssql_tests/dashboard.json
@@ -100,7 +100,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1521715844826,
+  "iteration": 1523320861623,
   "links": [],
   "panels": [
     {
@@ -443,7 +443,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -522,7 +526,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -601,7 +609,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -680,7 +692,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -759,7 +775,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -838,7 +858,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -927,7 +951,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1026,7 +1054,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1115,7 +1147,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1196,7 +1232,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1285,7 +1325,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1366,7 +1410,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1455,7 +1503,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1536,7 +1588,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1619,7 +1675,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1702,7 +1762,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1792,7 +1856,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1875,7 +1943,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1965,7 +2037,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2048,7 +2124,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2138,7 +2218,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2221,7 +2305,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2311,7 +2399,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2394,7 +2486,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -2504,5 +2600,5 @@
   "timezone": "",
   "title": "Microsoft SQL Server Data Source Test",
   "uid": "GlAqcPgmz",
-  "version": 57
+  "version": 58
 }

--- a/docker/blocks/mysql/dashboard.json
+++ b/docker/blocks/mysql/dashboard.json
@@ -2,7 +2,7 @@
   "__inputs": [
     {
       "name": "DS_MYSQL",
-      "label": "Mysql",
+      "label": "MySQL",
       "description": "",
       "type": "datasource",
       "pluginId": "mysql",
@@ -20,19 +20,19 @@
       "type": "panel",
       "id": "graph",
       "name": "Graph",
-      "version": ""
+      "version": "5.0.0"
     },
     {
       "type": "datasource",
       "id": "mysql",
       "name": "MySQL",
-      "version": "1.0.0"
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "table",
       "name": "Table",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
   "annotations": {
@@ -53,7 +53,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1518602729468,
+  "iteration": 1523372133566,
   "links": [],
   "panels": [
     {
@@ -118,7 +118,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
-      "timeShift": "1h",
+      "timeShift": null,
       "title": "Average logins / $summarize",
       "tooltip": {
         "shared": true,
@@ -150,7 +150,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -204,7 +208,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
-      "timeShift": "1h",
+      "timeShift": null,
       "title": "Average payments started/ended / $summarize",
       "tooltip": {
         "shared": true,
@@ -236,7 +240,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -284,7 +292,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
-      "timeShift": "1h",
+      "timeShift": null,
       "title": "Max CPU / $summarize",
       "tooltip": {
         "shared": true,
@@ -316,7 +324,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "columns": [],
@@ -369,7 +381,7 @@
           "target": ""
         }
       ],
-      "timeShift": "1h",
+      "timeShift": null,
       "title": "Values",
       "transform": "table",
       "type": "table"
@@ -428,7 +440,6 @@
         "auto_count": 5,
         "auto_min": "10s",
         "current": {
-          "selected": true,
           "text": "1m",
           "value": "1m"
         },
@@ -545,5 +556,5 @@
   "timezone": "",
   "title": "Grafana Fake Data Gen - MySQL",
   "uid": "DGsCac3kz",
-  "version": 6
+  "version": 8
 }

--- a/docker/blocks/mysql/docker-compose.yaml
+++ b/docker/blocks/mysql/docker-compose.yaml
@@ -7,9 +7,6 @@
       MYSQL_PASSWORD: password
     ports:
       - "3306:3306"
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb_monitor_enable=all]
 
   fake-mysql-data:

--- a/docker/blocks/mysql_tests/Dockerfile
+++ b/docker/blocks/mysql_tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:latest
+ADD setup.sql /docker-entrypoint-initdb.d
+CMD ["mysqld"]

--- a/docker/blocks/mysql_tests/dashboard.json
+++ b/docker/blocks/mysql_tests/dashboard.json
@@ -7,14 +7,6 @@
       "type": "datasource",
       "pluginId": "mysql",
       "pluginName": "MySQL"
-    },
-    {
-      "name": "DS_MSSQL_TEST",
-      "label": "MSSQL Test",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "mssql",
-      "pluginName": "Microsoft SQL Server"
     }
   ],
   "__requires": [
@@ -29,12 +21,6 @@
       "id": "graph",
       "name": "Graph",
       "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "mssql",
-      "name": "Microsoft SQL Server",
-      "version": "1.0.0"
     },
     {
       "type": "datasource",
@@ -114,7 +100,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1521715720483,
+  "iteration": 1523320712115,
   "links": [],
   "panels": [
     {
@@ -349,7 +335,7 @@
         {
           "alias": "Time",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "time_sec",
+          "pattern": "time",
           "type": "date"
         },
         {
@@ -457,7 +443,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -536,7 +526,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -615,7 +609,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -694,7 +692,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -773,7 +775,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -852,7 +858,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -941,7 +951,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1034,7 +1048,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1123,7 +1141,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1204,7 +1226,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1293,7 +1319,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1374,7 +1404,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1463,7 +1497,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1544,7 +1582,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1634,14 +1676,18 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_MSSQL_TEST}",
+      "datasource": "${DS_MYSQL_TEST}",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -1717,7 +1763,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1807,7 +1857,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1890,7 +1944,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1980,7 +2038,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2063,7 +2125,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2153,7 +2219,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2236,7 +2306,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -2315,8 +2389,8 @@
     ]
   },
   "time": {
-    "from": "2018-03-15T11:30:00.000Z",
-    "to": "2018-03-15T12:55:01.000Z"
+    "from": "2018-03-15T12:30:00.000Z",
+    "to": "2018-03-15T13:55:01.000Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -2346,5 +2420,5 @@
   "timezone": "",
   "title": "MySQL Data Source Test",
   "uid": "Hmf8FDkmz",
-  "version": 9
+  "version": 12
 }

--- a/docker/blocks/mysql_tests/docker-compose.yaml
+++ b/docker/blocks/mysql_tests/docker-compose.yaml
@@ -1,5 +1,6 @@
   mysqltests:
-    image: mysql:latest
+    build:
+      context: blocks/mysql_tests
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: grafana_tests
@@ -7,7 +8,4 @@
       MYSQL_PASSWORD: password
     ports:
       - "3306:3306"
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     tmpfs: /var/lib/mysql:rw

--- a/docker/blocks/mysql_tests/setup.sql
+++ b/docker/blocks/mysql_tests/setup.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE grafana_ds_tests;
+GRANT ALL PRIVILEGES ON grafana_ds_tests.* TO 'grafana';

--- a/docker/blocks/postgres_tests/Dockerfile
+++ b/docker/blocks/postgres_tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:latest
+ADD setup.sql /docker-entrypoint-initdb.d
+CMD ["postgres"]

--- a/docker/blocks/postgres_tests/dashboard.json
+++ b/docker/blocks/postgres_tests/dashboard.json
@@ -100,7 +100,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1521725946837,
+  "iteration": 1523320929325,
   "links": [],
   "panels": [
     {
@@ -443,7 +443,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -522,7 +526,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -601,7 +609,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -680,7 +692,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -759,7 +775,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -838,7 +858,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -927,7 +951,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1008,7 +1036,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1097,7 +1129,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1178,7 +1214,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1267,7 +1307,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1348,7 +1392,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1437,7 +1485,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1518,7 +1570,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1608,7 +1664,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1691,7 +1751,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1781,7 +1845,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1864,7 +1932,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1954,7 +2026,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2037,7 +2113,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2127,7 +2207,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -2210,7 +2294,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,

--- a/docker/blocks/postgres_tests/docker-compose.yaml
+++ b/docker/blocks/postgres_tests/docker-compose.yaml
@@ -1,5 +1,6 @@
   postgrestest:
-    image: postgres:latest
+    build:
+      context: blocks/postgres_tests
     environment:
       POSTGRES_USER: grafanatest
       POSTGRES_PASSWORD: grafanatest

--- a/docker/blocks/postgres_tests/setup.sql
+++ b/docker/blocks/postgres_tests/setup.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE grafanadstest;
+REVOKE CONNECT ON DATABASE grafanadstest FROM PUBLIC;
+GRANT CONNECT ON DATABASE grafanadstest TO grafanatest;

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -258,7 +258,7 @@ func InitTestDB(t *testing.T) *xorm.Engine {
 	// x.ShowSQL()
 
 	if err != nil {
-		t.Fatalf("Failed to init in memory sqllite3 db %v", err)
+		t.Fatalf("Failed to init test database: %v", err)
 	}
 
 	sqlutil.CleanDB(x)
@@ -269,3 +269,12 @@ func InitTestDB(t *testing.T) *xorm.Engine {
 
 	return x
 }
+
+func IsTestDbMySql() bool {
+	if db, present := os.LookupEnv("GRAFANA_TEST_DB"); present {
+		return db == dbMySql
+	}
+
+	return false
+}
+

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -278,3 +278,10 @@ func IsTestDbMySql() bool {
 	return false
 }
 
+func IsTestDbPostgres() bool {
+	if db, present := os.LookupEnv("GRAFANA_TEST_DB"); present {
+		return db == dbPostgres
+	}
+
+	return false
+}

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -309,7 +309,7 @@ func TestMySQL(t *testing.T) {
 		Convey("Given a table with metrics having multiple values and measurements", func() {
 			type metric_values struct {
 				Time                time.Time  `xorm:"datetime 'time' not null"`
-				TimeNullable        *time.Time `xorm:"datetime 'timeNullable' null"`
+				TimeNullable        *time.Time `xorm:"datetime(6) 'timeNullable' null"`
 				TimeInt64           int64      `xorm:"bigint(20) 'timeInt64' not null"`
 				TimeInt64Nullable   *int64     `xorm:"bigint(20) 'timeInt64Nullable' null"`
 				TimeFloat64         float64    `xorm:"double 'timeFloat64' not null"`

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -156,8 +156,7 @@ func TestPostgres(t *testing.T) {
 				})
 			}
 
-			for _, s := range series {
-				_, err = sess.Insert(s)
+			_, err = sess.InsertMulti(series)
 				So(err, ShouldBeNil)
 			}
 
@@ -280,10 +279,18 @@ func TestPostgres(t *testing.T) {
 
 		Convey("Given a table with metrics having multiple values and measurements", func() {
 			type metric_values struct {
-				Time        time.Time
-				Measurement string
-				ValueOne    int64 `xorm:"integer 'valueOne'"`
-				ValueTwo    int64 `xorm:"integer 'valueTwo'"`
+				Time                time.Time
+				TimeInt64           int64    `xorm:"bigint 'timeInt64' not null"`
+				TimeInt64Nullable   *int64   `xorm:"bigint 'timeInt64Nullable' null"`
+				TimeFloat64         float64  `xorm:"double 'timeFloat64' not null"`
+				TimeFloat64Nullable *float64 `xorm:"double 'timeFloat64Nullable' null"`
+				TimeInt32           int32    `xorm:"int(11) 'timeInt32' not null"`
+				TimeInt32Nullable   *int32   `xorm:"int(11) 'timeInt32Nullable' null"`
+				TimeFloat32         float32  `xorm:"double 'timeFloat32' not null"`
+				TimeFloat32Nullable *float32 `xorm:"double 'timeFloat32Nullable' null"`
+				Measurement         string
+				ValueOne            int64 `xorm:"integer 'valueOne'"`
+				ValueTwo            int64 `xorm:"integer 'valueTwo'"`
 			}
 
 			if exist, err := sess.IsTableExist(metric_values{}); err != nil || exist {
@@ -298,26 +305,219 @@ func TestPostgres(t *testing.T) {
 				return rand.Int63n(max-min) + min
 			}
 
+			var tInitial time.Time
+
 			series := []*metric_values{}
-			for _, t := range genTimeRangeByInterval(fromStart.Add(-30*time.Minute), 90*time.Minute, 5*time.Minute) {
-				series = append(series, &metric_values{
-					Time:        t,
-					Measurement: "Metric A",
-					ValueOne:    rnd(0, 100),
-					ValueTwo:    rnd(0, 100),
-				})
-				series = append(series, &metric_values{
-					Time:        t,
-					Measurement: "Metric B",
-					ValueOne:    rnd(0, 100),
-					ValueTwo:    rnd(0, 100),
-				})
+			for i, t := range genTimeRangeByInterval(fromStart.Add(-30*time.Minute), 90*time.Minute, 5*time.Minute) {
+				if i == 0 {
+					tInitial = t
+				}
+				tSeconds := t.Unix()
+				tSecondsInt32 := int32(tSeconds)
+				tSecondsFloat32 := float32(tSeconds)
+				tMilliseconds := tSeconds * 1e3
+				tMillisecondsFloat := float64(tMilliseconds)
+				first := metric_values{
+					Time:                t,
+					TimeInt64:           tMilliseconds,
+					TimeInt64Nullable:   &(tMilliseconds),
+					TimeFloat64:         tMillisecondsFloat,
+					TimeFloat64Nullable: &tMillisecondsFloat,
+					TimeInt32:           tSecondsInt32,
+					TimeInt32Nullable:   &tSecondsInt32,
+					TimeFloat32:         tSecondsFloat32,
+					TimeFloat32Nullable: &tSecondsFloat32,
+					Measurement:         "Metric A",
+					ValueOne:            rnd(0, 100),
+					ValueTwo:            rnd(0, 100),
+				}
+				second := first
+				second.Measurement = "Metric B"
+				second.ValueOne = rnd(0, 100)
+				second.ValueTwo = rnd(0, 100)
+
+				series = append(series, &first)
+				series = append(series, &second)
 			}
 
-			for _, s := range series {
-				_, err := sess.Insert(s)
+			_, err = sess.InsertMulti(series)
+			So(err, ShouldBeNil)
+
+			Convey("When doing a metric query using epoch (int64) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeInt64" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
 				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+			})
+
+			Convey("When doing a metric query using epoch (int64 nullable) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeInt64Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+			})
+
+			Convey("When doing a metric query using epoch (float64) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeFloat64" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+			})
+
+			Convey("When doing a metric query using epoch (float64 nullable) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeFloat64Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+			})
+
+			Convey("When doing a metric query using epoch (int32) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeInt32" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+				})
+
+			Convey("When doing a metric query using epoch (int32 nullable) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeInt32Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
+				})
+
+			Convey("When doing a metric query using epoch (float32) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeFloat32" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
 			}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(float64(float32(tInitial.Unix())))*1e3)
+			})
+
+			Convey("When doing a metric query using epoch (float32 nullable) as time column should return metric with time in milliseconds", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": `SELECT "timeFloat32Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+			}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+
+				So(len(queryResult.Series), ShouldEqual, 1)
+				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(float64(float32(tInitial.Unix())))*1e3)
+			})
 
 			Convey("When doing a metric query grouping by time and select metric column should return correct series", func() {
 				query := &tsdb.TsdbQuery{
@@ -473,7 +673,7 @@ func TestPostgres(t *testing.T) {
 				columns := queryResult.Tables[0].Rows[0]
 
 				//Should be in milliseconds
-				So(columns[0].(float64), ShouldEqual, float64(dt.Unix()*1000))
+				So(columns[0].(float64), ShouldEqual, float64(dt.UnixNano()/1e6))
 			})
 
 			Convey("When doing an annotation query with a time column in epoch second format should return ms", func() {

--- a/pkg/tsdb/sql_engine.go
+++ b/pkg/tsdb/sql_engine.go
@@ -135,20 +135,38 @@ func (e *DefaultSqlEngine) Query(
 	return result, nil
 }
 
-// ConvertTimeColumnToEpochMs converts column named time to unix timestamp in milliseconds
+// ConvertSqlTimeColumnToEpochMs converts column named time to unix timestamp in milliseconds
 // to make native datetime types and epoch dates work in annotation and table queries.
 func ConvertSqlTimeColumnToEpochMs(values RowValues, timeIndex int) {
 	if timeIndex >= 0 {
 		switch value := values[timeIndex].(type) {
 		case time.Time:
-			values[timeIndex] = EpochPrecisionToMs(float64(value.Unix()))
+			values[timeIndex] = EpochPrecisionToMs(float64(value.UnixNano()))
 		case *time.Time:
 			if value != nil {
-				values[timeIndex] = EpochPrecisionToMs(float64((*value).Unix()))
+				values[timeIndex] = EpochPrecisionToMs(float64((*value).UnixNano()))
 			}
 		case int64:
 			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
 		case *int64:
+			if value != nil {
+				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+			}
+		case uint64:
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+		case *uint64:
+			if value != nil {
+				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+			}
+		case int32:
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+		case *int32:
+			if value != nil {
+				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+			}
+		case uint32:
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+		case *uint32:
 			if value != nil {
 				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
 			}
@@ -157,6 +175,12 @@ func ConvertSqlTimeColumnToEpochMs(values RowValues, timeIndex int) {
 		case *float64:
 			if value != nil {
 				values[timeIndex] = EpochPrecisionToMs(*value)
+			}
+		case float32:
+			values[timeIndex] = EpochPrecisionToMs(float64(value))
+		case *float32:
+			if value != nil {
+				values[timeIndex] = EpochPrecisionToMs(float64(*value))
 			}
 		}
 	}

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -9,37 +9,175 @@ import (
 
 func TestSqlEngine(t *testing.T) {
 	Convey("SqlEngine", t, func() {
-		Convey("Given row values with time columns when converting them", func() {
-			dt := time.Date(2018, 3, 14, 21, 20, 6, 527e6, time.UTC)
-			fixtures := make([]interface{}, 8)
-			fixtures[0] = dt
-			fixtures[1] = dt.Unix() * 1000
-			fixtures[2] = dt.Unix()
-			fixtures[3] = float64(dt.Unix() * 1000)
-			fixtures[4] = float64(dt.Unix())
+		dt := time.Date(2018, 3, 14, 21, 20, 6, 527e6, time.UTC)
 
-			var nilDt *time.Time
-			var nilInt64 *int64
-			var nilFloat64 *float64
-			fixtures[5] = nilDt
-			fixtures[6] = nilInt64
-			fixtures[7] = nilFloat64
+		Convey("Given row values with time.Time as time columns", func() {
+			var nilPointer *time.Time
+
+			fixtures := make([]interface{}, 3)
+			fixtures[0] = dt
+			fixtures[1] = &dt
+			fixtures[2] = nilPointer
 
 			for i := range fixtures {
 				ConvertSqlTimeColumnToEpochMs(fixtures, i)
 			}
 
-			Convey("Should convert sql time columns to epoch time in ms ", func() {
-				expected := float64(dt.Unix() * 1000)
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				expected := float64(dt.UnixNano() / 1e6)
 				So(fixtures[0].(float64), ShouldEqual, expected)
-				So(fixtures[1].(int64), ShouldEqual, expected)
-				So(fixtures[2].(int64), ShouldEqual, expected)
-				So(fixtures[3].(float64), ShouldEqual, expected)
-				So(fixtures[4].(float64), ShouldEqual, expected)
+				So(fixtures[1].(float64), ShouldEqual, expected)
+				So(fixtures[2], ShouldBeNil)
+			})
+		})
 
-				So(fixtures[5], ShouldBeNil)
+		Convey("Given row values with int64 as time columns", func() {
+			tSeconds := dt.Unix()
+			tMilliseconds := dt.UnixNano() / 1e6
+			tNanoSeconds := dt.UnixNano()
+			var nilPointer *int64
+
+			fixtures := make([]interface{}, 7)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = tMilliseconds
+			fixtures[3] = &tMilliseconds
+			fixtures[4] = tNanoSeconds
+			fixtures[5] = &tNanoSeconds
+			fixtures[6] = nilPointer
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(int64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[1].(int64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[2].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[3].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[4].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[5].(int64), ShouldEqual, tMilliseconds)
 				So(fixtures[6], ShouldBeNil)
-				So(fixtures[7], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row values with uin64 as time columns", func() {
+			tSeconds := uint64(dt.Unix())
+			tMilliseconds := uint64(dt.UnixNano() / 1e6)
+			tNanoSeconds := uint64(dt.UnixNano())
+			var nilPointer *uint64
+
+			fixtures := make([]interface{}, 7)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = tMilliseconds
+			fixtures[3] = &tMilliseconds
+			fixtures[4] = tNanoSeconds
+			fixtures[5] = &tNanoSeconds
+			fixtures[6] = nilPointer
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(int64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[1].(int64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[2].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[3].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[4].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[5].(int64), ShouldEqual, tMilliseconds)
+				So(fixtures[6], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row values with int32 as time columns", func() {
+			tSeconds := int32(dt.Unix())
+			var nilInt *int32
+
+			fixtures := make([]interface{}, 3)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = nilInt
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(int64), ShouldEqual, dt.Unix()*1e3)
+				So(fixtures[1].(int64), ShouldEqual, dt.Unix()*1e3)
+				So(fixtures[2], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row values with uint32 as time columns", func() {
+			tSeconds := uint32(dt.Unix())
+			var nilInt *uint32
+
+			fixtures := make([]interface{}, 3)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = nilInt
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(int64), ShouldEqual, dt.Unix()*1e3)
+				So(fixtures[1].(int64), ShouldEqual, dt.Unix()*1e3)
+				So(fixtures[2], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row values with float64 as time columns", func() {
+			tSeconds := float64(dt.Unix())
+			tMilliseconds := float64(dt.UnixNano() / 1e6)
+			tNanoSeconds := float64(dt.UnixNano())
+			var nilPointer *float64
+
+			fixtures := make([]interface{}, 7)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = tMilliseconds
+			fixtures[3] = &tMilliseconds
+			fixtures[4] = tNanoSeconds
+			fixtures[5] = &tNanoSeconds
+			fixtures[6] = nilPointer
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(float64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[1].(float64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[2].(float64), ShouldEqual, tMilliseconds)
+				So(fixtures[3].(float64), ShouldEqual, tMilliseconds)
+				So(fixtures[4].(float64), ShouldEqual, tMilliseconds)
+				So(fixtures[5].(float64), ShouldEqual, tMilliseconds)
+				So(fixtures[6], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row values with float32 as time columns", func() {
+			tSeconds := float32(dt.Unix())
+			var nilInt *float32
+
+			fixtures := make([]interface{}, 3)
+			fixtures[0] = tSeconds
+			fixtures[1] = &tSeconds
+			fixtures[2] = nilInt
+
+			for i := range fixtures {
+				ConvertSqlTimeColumnToEpochMs(fixtures, i)
+			}
+
+			Convey("When converting them should return epoch time with millisecond precision ", func() {
+				So(fixtures[0].(float64), ShouldEqual, float32(dt.Unix()*1e3))
+				So(fixtures[1].(float64), ShouldEqual, float32(dt.Unix()*1e3))
+				So(fixtures[2], ShouldBeNil)
 			})
 		})
 	})

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -1,6 +1,7 @@
 package tsdb
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 
 func TestSqlEngine(t *testing.T) {
 	Convey("SqlEngine", t, func() {
-		dt := time.Date(2018, 3, 14, 21, 20, 6, 527e6, time.UTC)
+		dt := time.Date(2018, 3, 14, 21, 20, 6, int(527345*time.Microsecond), time.UTC)
 
 		Convey("Given row values with time.Time as time columns", func() {
 			var nilPointer *time.Time
@@ -24,7 +25,7 @@ func TestSqlEngine(t *testing.T) {
 			}
 
 			Convey("When converting them should return epoch time with millisecond precision ", func() {
-				expected := float64(dt.UnixNano() / 1e6)
+				expected := float64(dt.UnixNano()) / float64(time.Millisecond)
 				So(fixtures[0].(float64), ShouldEqual, expected)
 				So(fixtures[1].(float64), ShouldEqual, expected)
 				So(fixtures[2], ShouldBeNil)
@@ -132,8 +133,8 @@ func TestSqlEngine(t *testing.T) {
 		})
 
 		Convey("Given row values with float64 as time columns", func() {
-			tSeconds := float64(dt.Unix())
-			tMilliseconds := float64(dt.UnixNano() / 1e6)
+			tSeconds := float64(dt.UnixNano()) / float64(time.Second)
+			tMilliseconds := float64(dt.UnixNano()) / float64(time.Millisecond)
 			tNanoSeconds := float64(dt.UnixNano())
 			var nilPointer *float64
 
@@ -151,10 +152,12 @@ func TestSqlEngine(t *testing.T) {
 			}
 
 			Convey("When converting them should return epoch time with millisecond precision ", func() {
-				So(fixtures[0].(float64), ShouldEqual, tSeconds*1e3)
-				So(fixtures[1].(float64), ShouldEqual, tSeconds*1e3)
+				So(fixtures[0].(float64), ShouldEqual, tMilliseconds)
+				So(fixtures[1].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[2].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[3].(float64), ShouldEqual, tMilliseconds)
+				fmt.Println(fixtures[4].(float64))
+				fmt.Println(tMilliseconds)
 				So(fixtures[4].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[5].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[6], ShouldBeNil)

--- a/pkg/tsdb/time_range.go
+++ b/pkg/tsdb/time_range.go
@@ -92,14 +92,14 @@ func (tr *TimeRange) ParseTo() (time.Time, error) {
 // EpochPrecisionToMs converts epoch precision to millisecond, if needed.
 // Only seconds to milliseconds supported right now
 func EpochPrecisionToMs(value float64) float64 {
-	if int64(value)/1e10 == 0 {
-		return float64(value * 1e3)
+	s := strconv.FormatFloat(value, 'e', -1, 64)
+	if strings.HasSuffix(s, "e+09") {
+		return value * float64(1e3)
 	}
 
-	s := strconv.FormatFloat(value, 'f', -1, 64)
-	if len(s) == 19 {
-		return float64(value / 1e6)
+	if strings.HasSuffix(s, "e+18") {
+		return value / float64(time.Millisecond)
 	}
 
-	return float64(value)
+	return value
 }

--- a/pkg/tsdb/time_range.go
+++ b/pkg/tsdb/time_range.go
@@ -96,5 +96,10 @@ func EpochPrecisionToMs(value float64) float64 {
 		return float64(value * 1e3)
 	}
 
+	s := strconv.FormatFloat(value, 'f', -1, 64)
+	if len(s) == 19 {
+		return float64(value / 1e6)
+	}
+
 	return float64(value)
 }


### PR DESCRIPTION
Fixes #11535
Fixes #10212
Fixes #9381
Fixes #8666

Basically adds support for more data types when converting sql time column to epoch (ms) using time series query. This is the same function used for converting sql time column when using table/annotation query.

Issues are targeting mysql, but the same changes apply to postgres and mssql as well.

Changed so that the mysql test docker container uses UTC instead of local timezone and updated tests accordingly.

By using two separate test databases when running mysql or postgres integration tests it's now possible to run both the integration tests for grafana config db and mysql/postgres data source using 

```bash
GRAFANA_TEST_DB=mysql go test ./pkg/... # all integration tests
GRAFANA_TEST_DB=mysql go test -v ./pkg/tsdb/mysql # only tsdb tests
GRAFANA_TEST_DB=postgres go test ./pkg/... # all integration tests
GRAFANA_TEST_DB=postgres go test -v ./pkg/tsdb/postgres # only tsdb tests
```