### PR TITLE
Support deleting empty playlist

### DIFF
--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -33,7 +33,7 @@ func ValidateOrgPlaylist(c *m.ReqContext) {
 		return
 	}
 
-	if len(items) == 0 {
+	if len(items) == 0 && c.Context.Req.Method != "DELETE" {
 		c.JsonApiErr(404, "Playlist is empty", itemsErr)
 		return
 	}


### PR DESCRIPTION
The reason empty playlists cannot be deleted is that the playlist is validate before deletion, and it cannot be validated because there are no items in the playlist

fixes #11133 