### PR TITLE
add codespell to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2
 
 jobs:
+  codespell:
+    docker:
+      - image: circleci/python
+    steps:
+      - checkout
+      - run:
+          name: install codespell
+          command: 'sudo pip install codespell'
+      - run:
+          name: check documentation spelling errors
+          command: 'codespell -x docs/sources/project/building_from_source.md docs/'
+
   test-frontend:
     docker:
       - image: circleci/node:6.11.4
@@ -103,6 +115,10 @@ workflows:
   version: 2
   test-and-build:
     jobs:
+      - codespell:
+          filters:
+            tags:
+              only: /.*/
       - build:
           filters:
             tags:


### PR DESCRIPTION
Hi @daniellee,

As you mentioned in #11588, this PR adds [codespell](https://github.com/lucasdemarchi/codespell) to CircleCI, but checking only the `docs/` directory.

I had to exclude `docs/sources/project/building_from_source.md` instead of only the word `Unknwon` because the word-exclude option in `codespell` is not working well now. 