### PR TITLE
bra should use the proper build script

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,6 @@
 [run]
 init_cmds = [
-  ["go", "build", "-o", "./bin/grafana-server", "./pkg/cmd/grafana-server"],
+  ["go", "run", "build.go", "build"],
 	["./bin/grafana-server", "cfg:app_mode=development"]
 ]
 watch_all = true
@@ -12,6 +12,6 @@ watch_dirs = [
 watch_exts = [".go", ".ini", ".toml"]
 build_delay = 1500
 cmds = [
-  ["go", "build", "-o", "./bin/grafana-server", "./pkg/cmd/grafana-server"],
+  ["go", "run", "build.go", "build"],
 	["./bin/grafana-server", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
* `bra run` is used during development, but it was not using build.go
which sets a couple of globals, e.g., the commit (currently set to "NA")
* This will help in reporting the commit that someone is basing their
screenshot on during development.

If there is a reason to keep using `go build`, feel free to close this PR.
