### PR TITLE
Postgres: set default for sslmode to verify-full in postgres datasource editor

### DIFF
--- a/public/app/plugins/datasource/postgres/module.ts
+++ b/public/app/plugins/datasource/postgres/module.ts
@@ -8,7 +8,7 @@ class PostgresConfigCtrl {
 
   /** @ngInject **/
   constructor($scope) {
-    this.current.jsonData.sslmode = this.current.jsonData.sslmode || 'require';
+    this.current.jsonData.sslmode = this.current.jsonData.sslmode || 'verify-full';
   }
 }
 


### PR DESCRIPTION
This changes the default for sslmode to verify-full when creating a new postgres datasource. This should have already been implemented but the default in the frontend got overlooked, it was default in the backend though.

#9736
#9366
