### PR TITLE
Add version sort for variables

### DIFF
--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -192,12 +192,7 @@ export class QueryVariable implements Variable {
       options = _.sortBy(options, 'text');
     } else if (sortType === 2) {
       options = _.sortBy(options, opt => {
-        const matches = opt.text.match(/.*?(\d+).*/);
-        if (!matches || matches.length < 2) {
-          return -1;
-        } else {
-          return parseInt(matches[1], 10);
-        }
+        return opt.text.replace(/\d{1,15}/g, n => +n+Math.pow(10,15));
       });
     } else if (sortType === 3) {
       options = _.sortBy(options, opt => {


### PR DESCRIPTION
Adds support for "version" sorting for variables. It's not bulletproof and doesn't work with very long numbers, but it's simple, fast and works with all kind of separators. It should be enough for all common use cases – network interface names, IPv4-addresses encoded into hostnames, version numbers of course etc.

Implements the feature request #7307. 