### PR TITLE
codespell: exclude by words instead of files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,12 @@ jobs:
           name: install codespell
           command: 'sudo pip install codespell'
       - run:
+          # Important: all words have to be in lowercase, and separated by "\n".
+          name: exclude known exceptions
+          command: 'echo -e "unknwon" > words_to_ignore.txt'
+      - run:
           name: check documentation spelling errors
-          command: 'codespell -x docs/sources/project/building_from_source.md docs/'
+          command: 'codespell -I ./words_to_ignore.txt docs/'
 
   test-frontend:
     docker:


### PR DESCRIPTION
Hi @bergquist ,

This fix the small issue at #11602, where I could not exclude by words.

Is it ok for you to generate the exclude list at **CircleCI** on-the-fly, or should I create the exclude list file at some place? Where should I put this file?

Thanks! 