### PR TITLE
remove unused variables detected by varcheck

### DIFF
--- a/pkg/cmd/grafana-cli/commands/remove_command.go
+++ b/pkg/cmd/grafana-cli/commands/remove_command.go
@@ -3,12 +3,11 @@ package commands
 import (
 	"errors"
 	"fmt"
-	m "github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
-	services "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"strings"
+
+	services "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 )
 
-var getPluginss func(path string) []m.InstalledPlugin = services.GetLocalPlugins
 var removePlugin func(pluginPath, id string) error = services.RemoveInstalledPlugin
 
 func removeCommand(c CommandLine) error {

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -33,7 +33,6 @@ import (
 var version = "5.0.0"
 var commit = "NA"
 var buildstamp string
-var build_date string
 
 var configFile = flag.String("config", "", "path to config file")
 var homePath = flag.String("homepath", "", "path to grafana install/home path, defaults to working directory")

--- a/pkg/components/dashdiffs/compare.go
+++ b/pkg/components/dashdiffs/compare.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/models"
 	diff "github.com/yudai/gojsondiff"
 	deltaFormatter "github.com/yudai/gojsondiff/formatter"
@@ -15,11 +14,8 @@ import (
 var (
 	// ErrUnsupportedDiffType occurs when an invalid diff type is used.
 	ErrUnsupportedDiffType = errors.New("dashdiff: unsupported diff type")
-
 	// ErrNilDiff occurs when two compared interfaces are identical.
 	ErrNilDiff = errors.New("dashdiff: diff is nil")
-
-	diffLogger = log.New("dashdiffs")
 )
 
 type DiffType int

--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -101,7 +101,3 @@ func sendWebRequestSync(ctx context.Context, webhook *Webhook) error {
 	webhookLog.Debug("Webhook failed", "statuscode", resp.Status, "body", string(body))
 	return fmt.Errorf("Webhook response status %v", resp.Status)
 }
-
-var addToWebhookQueue = func(msg *Webhook) {
-	webhookQueue <- msg
-}

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	logger                          log.Logger = log.New("fake.log")
-	oneDatasourcesConfig            string     = ""
 	twoDatasourcesConfig            string     = "./test-configs/two-datasources"
 	twoDatasourcesConfigPurgeOthers string     = "./test-configs/insert-two-delete-two"
 	doubleDatasourcesConfig         string     = "./test-configs/double-default"

--- a/pkg/services/sqlstore/migrations/migrations_test.go
+++ b/pkg/services/sqlstore/migrations/migrations_test.go
@@ -8,10 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 
 	. "github.com/smartystreets/goconvey/convey"
-	//"github.com/grafana/grafana/pkg/log"
 )
-
-var indexTypes = []string{"Unknown", "INDEX", "UNIQUE INDEX"}
 
 func TestMigrations(t *testing.T) {
 	testDBs := []sqlutil.TestDB{


### PR DESCRIPTION
Hi,

related to #10381, I fixed all [varcheck](github.com/opennota/check/cmd/varcheck) issues.

See,

```
$ gometalinter --vendor --disable-all --enable=varcheck ./...
pkg/cmd/grafana-cli/commands/remove_command.go:11:5:warning: unused variable or constant getPluginss (varcheck)
pkg/cmd/grafana-server/main.go:36:5:warning: unused variable or constant build_date (varcheck)
pkg/components/dashdiffs/compare.go:22:2:warning: unused variable or constant diffLogger (varcheck)
pkg/services/notifications/webhook.go:105:5:warning: unused variable or constant addToWebhookQueue (varcheck)
pkg/services/provisioning/datasources/config_reader_test.go:15:2:warning: unused variable or constant oneDatasourcesConfig (varcheck)
pkg/services/sqlstore/migrations/migrations_test.go:14:5:warning: unused variable or constant indexTypes (varcheck)
```