### PR TITLE
enable google analytics anonymizeIP setting

### DIFF
--- a/public/app/core/services/analytics.ts
+++ b/public/app/core/services/analytics.ts
@@ -19,6 +19,7 @@ export class Analytics {
       });
     ga.l = +new Date();
     ga('create', (<any>config).googleAnalyticsId, 'auto');
+    ga('set', 'anonymizeIp', true);
     return ga;
   }
 


### PR DESCRIPTION
Partially fixes #11739

This PR updates the google analytics code to use the anonymizeIP setting to avoid collecting the end user's IP address, this is important for GDPR compliance.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp

It also switches from `$.getScript` to `$.ajax` for loading `analytics.js` so that we can avoid having jquery automatically append a timestamp query parameter which prevents the browser from caching it.