### PR TITLE
Add silent option to backend requests

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -170,7 +170,9 @@ export class BackendSrv {
 
     return this.$http(options)
       .then(response => {
-        appEvents.emit('ds-request-response', response);
+        if (!options.silent) {
+          appEvents.emit('ds-request-response', response);
+        }
         return response;
       })
       .catch(err => {
@@ -201,8 +203,9 @@ export class BackendSrv {
         if (err.data && !err.data.message && _.isString(err.data.error)) {
           err.data.message = err.data.error;
         }
-
-        appEvents.emit('ds-request-error', err);
+        if (!options.silent) {
+          appEvents.emit('ds-request-error', err);
+        }
         throw err;
       })
       .finally(() => {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -81,6 +81,20 @@ export class PrometheusDatasource {
     return this.backendSrv.datasourceRequest(options);
   }
 
+  // Use this for tab completion features, wont publish response to other components
+  helperRequest(url) {
+    const options: any = {
+      url: this.url + url,
+      silent: true,
+    };
+
+    if (this.basicAuth || this.withCredentials) {
+      options.withCredentials = true;
+    }
+
+    return this.backendSrv.datasourceRequest(options);
+  }
+
   interpolateQueryExpr(value, variable, defaultFormatFn) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
@@ -229,7 +243,7 @@ export class PrometheusDatasource {
       );
     }
 
-    return this._request('GET', url).then(result => {
+    return this.helperRequest(url).then(result => {
       this.metricsNameCache = {
         data: result.data.data,
         expire: Date.now() + 60 * 1000,

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -84,7 +84,7 @@ export class PrometheusDatasource {
 
   // Use this for tab completion features, wont publish response to other components
   metadataRequest(url) {
-    return this._request(url, null, { silent: true });
+    return this._request(url, null, { method: 'GET', silent: true });
   }
 
   interpolateQueryExpr(value, variable, defaultFormatFn) {

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -46,7 +46,7 @@ export default class PrometheusMetricFindQuery {
       // return label values globally
       url = '/api/v1/label/' + label + '/values';
 
-      return this.datasource.helperRequest(url).then(function(result) {
+      return this.datasource.metadataRequest(url).then(function(result) {
         return _.map(result.data.data, function(value) {
           return { text: value };
         });
@@ -56,7 +56,7 @@ export default class PrometheusMetricFindQuery {
       var end = this.datasource.getPrometheusTime(this.range.to, true);
       url = '/api/v1/series?match[]=' + encodeURIComponent(metric) + '&start=' + start + '&end=' + end;
 
-      return this.datasource.helperRequest(url).then(function(result) {
+      return this.datasource.metadataRequest(url).then(function(result) {
         var _labels = _.map(result.data.data, function(metric) {
           return metric[label] || '';
         }).filter(function(label) {
@@ -76,7 +76,7 @@ export default class PrometheusMetricFindQuery {
   metricNameQuery(metricFilterPattern) {
     var url = '/api/v1/label/__name__/values';
 
-    return this.datasource.helperRequest(url).then(function(result) {
+    return this.datasource.metadataRequest(url).then(function(result) {
       return _.chain(result.data.data)
         .filter(function(metricName) {
           var r = new RegExp(metricFilterPattern);
@@ -120,7 +120,7 @@ export default class PrometheusMetricFindQuery {
     var url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + start + '&end=' + end;
 
     var self = this;
-    return this.datasource.helperRequest(url).then(function(result) {
+    return this.datasource.metadataRequest(url).then(function(result) {
       return _.map(result.data.data, function(metric) {
         return {
           text: self.datasource.getOriginalMetricName(metric),

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -46,7 +46,7 @@ export default class PrometheusMetricFindQuery {
       // return label values globally
       url = '/api/v1/label/' + label + '/values';
 
-      return this.datasource._request('GET', url).then(function(result) {
+      return this.datasource.helperRequest(url).then(function(result) {
         return _.map(result.data.data, function(value) {
           return { text: value };
         });
@@ -56,7 +56,7 @@ export default class PrometheusMetricFindQuery {
       var end = this.datasource.getPrometheusTime(this.range.to, true);
       url = '/api/v1/series?match[]=' + encodeURIComponent(metric) + '&start=' + start + '&end=' + end;
 
-      return this.datasource._request('GET', url).then(function(result) {
+      return this.datasource.helperRequest(url).then(function(result) {
         var _labels = _.map(result.data.data, function(metric) {
           return metric[label] || '';
         }).filter(function(label) {
@@ -76,7 +76,7 @@ export default class PrometheusMetricFindQuery {
   metricNameQuery(metricFilterPattern) {
     var url = '/api/v1/label/__name__/values';
 
-    return this.datasource._request('GET', url).then(function(result) {
+    return this.datasource.helperRequest(url).then(function(result) {
       return _.chain(result.data.data)
         .filter(function(metricName) {
           var r = new RegExp(metricFilterPattern);
@@ -120,7 +120,7 @@ export default class PrometheusMetricFindQuery {
     var url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + start + '&end=' + end;
 
     var self = this;
-    return this.datasource._request('GET', url).then(function(result) {
+    return this.datasource.helperRequest(url).then(function(result) {
       return _.map(result.data.data, function(metric) {
         return {
           text: self.datasource.getOriginalMetricName(metric),

--- a/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
@@ -14,6 +14,7 @@ describe('PrometheusDatasource', () => {
   };
 
   ctx.backendSrvMock = {};
+
   ctx.templateSrvMock = {
     replace: a => a,
   };
@@ -21,6 +22,25 @@ describe('PrometheusDatasource', () => {
 
   beforeEach(() => {
     ctx.ds = new PrometheusDatasource(instanceSettings, q, ctx.backendSrvMock, ctx.templateSrvMock, ctx.timeSrvMock);
+  });
+
+  describe('Datasource metadata requests', () => {
+    it('should perform a GET request with the default config', () => {
+      ctx.backendSrvMock.datasourceRequest = jest.fn();
+      ctx.ds.metadataRequest('/foo');
+      expect(ctx.backendSrvMock.datasourceRequest.mock.calls.length).toBe(1);
+      expect(ctx.backendSrvMock.datasourceRequest.mock.calls[0][0].method).toBe('GET');
+    });
+
+    it('should still perform a GET request with the DS HTTP method set to POST', () => {
+      ctx.backendSrvMock.datasourceRequest = jest.fn();
+      const postSettings = _.cloneDeep(instanceSettings);
+      postSettings.jsonData.httpMethod = 'POST';
+      const ds = new PrometheusDatasource(postSettings, q, ctx.backendSrvMock, ctx.templateSrvMock, ctx.timeSrvMock);
+      ds.metadataRequest('/foo');
+      expect(ctx.backendSrvMock.datasourceRequest.mock.calls.length).toBe(1);
+      expect(ctx.backendSrvMock.datasourceRequest.mock.calls[0][0].method).toBe('GET');
+    });
   });
 
   describe('When converting prometheus histogram to heatmap format', () => {


### PR DESCRIPTION
* When set to `true`, the `silent` option for backend_srv requests
 suppresses all event emitters that are triggered when the response is
received.
* Added `metadataRequest()` to the Prometheus datasource to support
 requests that are not triggered by the user, e.g., for tab completion.
`metadataRequest()` sets the `silent` option.
* Migrated all non-timeseries queries of the Prometheus datasource to
 use `metadataRequest()`.
* Combined positional args of `_request` into `options` dict.

Fixes #11673
