### PR TITLE
Default sort order for GetDashboardTags

### DIFF
--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -294,7 +294,8 @@ func GetDashboardTags(query *m.GetDashboardTagsQuery) error {
 					FROM dashboard
 					INNER JOIN dashboard_tag on dashboard_tag.dashboard_id = dashboard.id
 					WHERE dashboard.org_id=?
-					GROUP BY term`
+					GROUP BY term
+					ORDER BY term`
 
 	query.Result = make([]*m.DashboardTagCloudItem, 0)
 	sess := x.Sql(sql, query.OrgId)


### PR DESCRIPTION
We had upgraded from 4.6.3 to 5.0.4 and when viewing the listing of searchable tags on the manage dashboards view the tags are not listed in alphabetical order. This fixes the problem.

![screen shot 2018-04-20 at 12 20 08 pm](https://user-images.githubusercontent.com/1041598/39062337-3775216e-4495-11e8-895f-4d66ff7423bd.png)
