### PR TITLE
fix CircleCI gometalinter test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,18 +20,19 @@ jobs:
   gometalinter:
     docker:
       - image: circleci/golang:1.10
+        environment:
+          # we need CGO because of go-sqlite3
+          CGO_ENABLED: 1
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout
+      - run: 'go get -u gopkg.in/alecthomas/gometalinter.v2'
+      - run: 'go get -u github.com/opennota/check/cmd/structcheck'
+      - run: 'go get -u github.com/mdempsky/unconvert'
+      - run: 'go get -u github.com/opennota/check/cmd/varcheck'
       - run:
-          name: install gometalinter tool
-          command: 'go get -u github.com/alecthomas/gometalinter'
-      - run:
-          name: install linters
-          command: 'gometalinter --install'
-      - run:
-          name: run some linters
-          command: 'gometalinter --vendor --deadline 6m --disable-all --enable=structcheck --enable=unconvert --enable=varcheck ./pkg/...'
+          name: run linters
+          command: 'gometalinter.v2 --enable-gc --vendor --deadline 10m --disable-all --enable=structcheck --enable=unconvert --enable=varcheck ./...'
 
   test-frontend:
     docker:
@@ -136,6 +137,10 @@ workflows:
   test-and-build:
     jobs:
       - codespell:
+          filters:
+            tags:
+              only: /.*/
+      - gometalinter:
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Hi @bergquist @daniellee ,

I found [gometalinter](https://github.com/alecthomas/gometalinter) was failing on `go-sqlite3` because it uses [CGO](https://golang.org/cmd/cgo/), and this is disabled by default. Enabling CGO with `CGO_ENABLED=1` fix the problem and is reproducible as well.
 