### PR TITLE
pkg/tsdb: fix ineffassign isues

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -271,7 +271,7 @@ func parseQuery(model *simplejson.Json) (*CloudWatchQuery, error) {
 		}
 	}
 
-	period := 300
+	var period int
 	if regexp.MustCompile(`^\d+$`).Match([]byte(p)) {
 		period, err = strconv.Atoi(p)
 		if err != nil {

--- a/pkg/tsdb/influxdb/model_parser.go
+++ b/pkg/tsdb/influxdb/model_parser.go
@@ -40,6 +40,9 @@ func (qp *InfluxdbQueryParser) Parse(model *simplejson.Json, dsInfo *models.Data
 	}
 
 	parsedInterval, err := tsdb.GetIntervalFrom(dsInfo, model, time.Millisecond*1)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Query{
 		Measurement:  measurement,

--- a/pkg/tsdb/influxdb/query.go
+++ b/pkg/tsdb/influxdb/query.go
@@ -62,9 +62,8 @@ func (query *Query) renderTags() []string {
 			}
 		}
 
-		textValue := ""
-
 		// quote value unless regex or number
+		var textValue string
 		if tag.Operator == "=~" || tag.Operator == "!~" {
 			textValue = tag.Value
 		} else if tag.Operator == "<" || tag.Operator == ">" {
@@ -107,7 +106,7 @@ func (query *Query) renderSelectors(queryContext *tsdb.TsdbQuery) string {
 }
 
 func (query *Query) renderMeasurement() string {
-	policy := ""
+	var policy string
 	if query.Policy == "" || query.Policy == "default" {
 		policy = ""
 	} else {

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -83,6 +83,10 @@ func (e *OpenTsdbExecutor) createRequest(dsInfo *models.DataSource, data OpenTsd
 	u.Path = path.Join(u.Path, "api/query")
 
 	postData, err := json.Marshal(data)
+	if err != nil {
+		plog.Info("Failed marshalling data", "error", err)
+		return nil, fmt.Errorf("Failed to create request. error: %v", err)
+	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(string(postData)))
 	if err != nil {


### PR DESCRIPTION
Hi @bergquist,

Related to #10381, I fixed some [ineffassign](https://github.com/gordonklaus/ineffassign) in `pkgs/tsdb`. See,

```
pkg/tsdb/cloudwatch/cloudwatch.go:274:2:warning: ineffectual assignment to period (ineffassign)
pkg/tsdb/influxdb/model_parser.go:42:18:warning: ineffectual assignment to err (ineffassign)
pkg/tsdb/influxdb/query.go:65:3:warning: ineffectual assignment to textValue (ineffassign)
pkg/tsdb/influxdb/query.go:110:2:warning: ineffectual assignment to policy (ineffassign)
pkg/tsdb/opentsdb/opentsdb.go:85:12:warning: ineffectual assignment to err (ineffassign)
```