### PR TITLE
Fixes signing of packages.

### DIFF
--- a/scripts/build/rpmmacros
+++ b/scripts/build/rpmmacros
@@ -1,4 +1,4 @@
 %_signature gpg
-%_gpg_path /home/ubuntu/.gnupg
+%_gpg_path /root/.gnupg
 %_gpg_name Grafana
 %_gpgbin /usr/bin/gpg


### PR DESCRIPTION
Signing was failing to add our key as the builds
were expected to run as ubuntu but is currently
run as root.

Closes #11686
