### PR TITLE
sql tsdb: fix value columns conversion to float when using timeseries query

### DIFF
--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -256,16 +256,10 @@ func (e MssqlQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *core.
 				continue
 			}
 
-			switch columnValue := values[i].(type) {
-			case int64:
-				value = null.FloatFrom(float64(columnValue))
-			case float64:
-				value = null.FloatFrom(columnValue)
-			case nil:
-				value.Valid = false
-			default:
-				return fmt.Errorf("Value column must have numeric datatype, column: %s type: %T value: %v", col, columnValue, columnValue)
+			if value, err = tsdb.ConvertSqlValueColumnToFloat(col, values[i]); err != nil {
+				return err
 			}
+
 			if metricIndex == -1 {
 				metric = col
 			}

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -374,12 +374,12 @@ func TestMSSQL(t *testing.T) {
 			_, err = sess.InsertMulti(series)
 			So(err, ShouldBeNil)
 
-			Convey("When doing a metric query using epoch (int64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64) as time column and value column (int64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeInt64 as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeInt64 as time, timeInt64 FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -396,12 +396,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64 nullable) as time column and value column (int64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeInt64Nullable as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeInt64Nullable as time, timeInt64Nullable FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -418,12 +418,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64) as time column and value column (float64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeFloat64 as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeFloat64 as time, timeFloat64 FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -440,12 +440,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64 nullable) as time column and value column (float64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeFloat64Nullable as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeFloat64Nullable as time, timeFloat64Nullable FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -462,12 +462,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32) as time column and value column (int32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeInt32 as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeInt32 as time, timeInt32 FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -484,12 +484,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32 nullable) as time column and value column (int32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeInt32Nullable as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeInt32Nullable as time, timeInt32Nullable FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -506,12 +506,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float32) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32) as time column and value column (float32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeFloat32 as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeFloat32 as time, timeFloat32 FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -528,12 +528,12 @@ func TestMSSQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(float64(float32(tInitial.Unix())))*1e3)
 			})
 
-			Convey("When doing a metric query using epoch (float32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32 nullable) as time column and value column (float32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT TOP 1 timeFloat32Nullable as time, valueOne FROM metric_values ORDER BY time`,
+								"rawSql": `SELECT TOP 1 timeFloat32Nullable as time, timeFloat32Nullable FROM metric_values ORDER BY time`,
 								"format": "time_series",
 							}),
 							RefId: "A",

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -265,16 +265,10 @@ func (e MysqlQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *core.
 				continue
 			}
 
-			switch columnValue := values[i].(type) {
-			case int64:
-				value = null.FloatFrom(float64(columnValue))
-			case float64:
-				value = null.FloatFrom(columnValue)
-			case nil:
-				value.Valid = false
-			default:
-				return fmt.Errorf("Value column must have numeric datatype, column: %s type: %T value: %v", col, columnValue, columnValue)
+			if value, err = tsdb.ConvertSqlValueColumnToFloat(col, values[i]); err != nil {
+				return err
 			}
+
 			if metricIndex == -1 {
 				metric = col
 			}

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -420,12 +420,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64) as time column and value column (int64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeInt64 as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeInt64 as time, timeInt64 FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -442,12 +442,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64 nullable) as time column and value column (int64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeInt64Nullable as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeInt64Nullable as time, timeInt64Nullable FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -464,12 +464,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64) as time column and value column (float64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeFloat64 as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeFloat64 as time, timeFloat64 FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -486,12 +486,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64 nullable) as time column and value column (float64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeFloat64Nullable as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeFloat64Nullable as time, timeFloat64Nullable FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -508,12 +508,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32) as time column should return metric with time in milliseconds", func() {
+			FocusConvey("When doing a metric query using epoch (int32) as time column and value column (int32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeInt32 as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeInt32 as time, timeInt32 FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -530,12 +530,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32 nullable) as time column and value column (int32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeInt32Nullable as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeInt32Nullable as time, timeInt32Nullable FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -552,12 +552,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float32) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32) as time column and value column (float32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeFloat32 as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeFloat32 as time, timeFloat32 FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -574,12 +574,12 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(float64(float32(tInitial.Unix())))*1e3)
 			})
 
-			Convey("When doing a metric query using epoch (float32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32 nullable) as time column and value column (float32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT timeFloat32Nullable as time, valueOne FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT timeFloat32Nullable as time, timeFloat32Nullable FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -245,16 +245,10 @@ func (e PostgresQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *co
 				continue
 			}
 
-			switch columnValue := values[i].(type) {
-			case int64:
-				value = null.FloatFrom(float64(columnValue))
-			case float64:
-				value = null.FloatFrom(columnValue)
-			case nil:
-				value.Valid = false
-			default:
-				return fmt.Errorf("Value column must have numeric datatype, column: %s type: %T value: %v", col, columnValue, columnValue)
+			if value, err = tsdb.ConvertSqlValueColumnToFloat(col, values[i]); err != nil {
+				return err
 			}
+
 			if metricIndex == -1 {
 				metric = col
 			}

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -353,12 +353,12 @@ func TestPostgres(t *testing.T) {
 			_, err = sess.InsertMulti(series)
 			So(err, ShouldBeNil)
 
-			Convey("When doing a metric query using epoch (int64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64) as time column and value column (int64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeInt64" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeInt64" as time, "timeInt64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -375,12 +375,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int64 nullable) as time column and value column (int64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeInt64Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeInt64Nullable" as time, "timeInt64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -397,12 +397,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64) as time column and value column (float64) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeFloat64" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeFloat64" as time, "timeFloat64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -419,12 +419,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float64 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float64 nullable) as time column and value column (float64 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeFloat64Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeFloat64Nullable" as time, "timeFloat64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -441,12 +441,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32) as time column and value column (int32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeInt32" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeInt32" as time, "timeInt32" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -463,12 +463,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (int32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32 nullable) as time column and value column (int32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeInt32Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeInt32Nullable" as time, "timeInt32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -485,12 +485,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			Convey("When doing a metric query using epoch (float32) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32) as time column and value column (float32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeFloat32" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeFloat32" as time, "timeFloat32" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",
@@ -507,12 +507,12 @@ func TestPostgres(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(float64(float32(tInitial.Unix())))*1e3)
 			})
 
-			Convey("When doing a metric query using epoch (float32 nullable) as time column should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (float32 nullable) as time column and value column (float32 nullable) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
 							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": `SELECT "timeFloat32Nullable" as time, "valueOne" FROM metric_values ORDER BY time LIMIT 1`,
+								"rawSql": `SELECT "timeFloat32Nullable" as time, "timeFloat32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
 							}),
 							RefId: "A",

--- a/pkg/tsdb/sql_engine.go
+++ b/pkg/tsdb/sql_engine.go
@@ -2,8 +2,11 @@ package tsdb
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/grafana/grafana/pkg/components/null"
 
 	"github.com/go-xorm/core"
 	"github.com/go-xorm/xorm"
@@ -184,4 +187,110 @@ func ConvertSqlTimeColumnToEpochMs(values RowValues, timeIndex int) {
 			}
 		}
 	}
+}
+
+// ConvertSqlValueColumnToFloat converts timeseries value column to float.
+func ConvertSqlValueColumnToFloat(columnName string, columnValue interface{}) (null.Float, error) {
+	var value null.Float
+
+	switch typedValue := columnValue.(type) {
+	case int:
+		value = null.FloatFrom(float64(typedValue))
+	case *int:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case int64:
+		value = null.FloatFrom(float64(typedValue))
+	case *int64:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case int32:
+		value = null.FloatFrom(float64(typedValue))
+	case *int32:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case int16:
+		value = null.FloatFrom(float64(typedValue))
+	case *int16:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case int8:
+		value = null.FloatFrom(float64(typedValue))
+	case *int8:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case uint:
+		value = null.FloatFrom(float64(typedValue))
+	case *uint:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case uint64:
+		value = null.FloatFrom(float64(typedValue))
+	case *uint64:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case uint32:
+		value = null.FloatFrom(float64(typedValue))
+	case *uint32:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case uint16:
+		value = null.FloatFrom(float64(typedValue))
+	case *uint16:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case uint8:
+		value = null.FloatFrom(float64(typedValue))
+	case *uint8:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case float64:
+		value = null.FloatFrom(typedValue)
+	case *float64:
+		value = null.FloatFromPtr(typedValue)
+	case float32:
+		value = null.FloatFrom(float64(typedValue))
+	case *float32:
+		if typedValue == nil {
+			value.Valid = false
+		} else {
+			value = null.FloatFrom(float64(*typedValue))
+		}
+	case nil:
+		value.Valid = false
+	default:
+		return null.NewFloat(0, false), fmt.Errorf("Value column must have numeric datatype, column: %s type: %T value: %v", columnName, typedValue, typedValue)
+	}
+
+	return value, nil
 }

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -1,9 +1,10 @@
 package tsdb
 
 import (
-	"fmt"
 	"testing"
 	"time"
+
+	"github.com/grafana/grafana/pkg/components/null"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -156,8 +157,6 @@ func TestSqlEngine(t *testing.T) {
 				So(fixtures[1].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[2].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[3].(float64), ShouldEqual, tMilliseconds)
-				fmt.Println(fixtures[4].(float64))
-				fmt.Println(tMilliseconds)
 				So(fixtures[4].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[5].(float64), ShouldEqual, tMilliseconds)
 				So(fixtures[6], ShouldBeNil)
@@ -181,6 +180,102 @@ func TestSqlEngine(t *testing.T) {
 				So(fixtures[0].(float64), ShouldEqual, float32(dt.Unix()*1e3))
 				So(fixtures[1].(float64), ShouldEqual, float32(dt.Unix()*1e3))
 				So(fixtures[2], ShouldBeNil)
+			})
+		})
+
+		Convey("Given row with value columns", func() {
+			intValue := 1
+			int64Value := int64(1)
+			int32Value := int32(1)
+			int16Value := int16(1)
+			int8Value := int8(1)
+			float64Value := float64(1)
+			float32Value := float32(1)
+			uintValue := uint(1)
+			uint64Value := uint64(1)
+			uint32Value := uint32(1)
+			uint16Value := uint16(1)
+			uint8Value := uint8(1)
+
+			fixtures := make([]interface{}, 24)
+			fixtures[0] = intValue
+			fixtures[1] = &intValue
+			fixtures[2] = int64Value
+			fixtures[3] = &int64Value
+			fixtures[4] = int32Value
+			fixtures[5] = &int32Value
+			fixtures[6] = int16Value
+			fixtures[7] = &int16Value
+			fixtures[8] = int8Value
+			fixtures[9] = &int8Value
+			fixtures[10] = float64Value
+			fixtures[11] = &float64Value
+			fixtures[12] = float32Value
+			fixtures[13] = &float32Value
+			fixtures[14] = uintValue
+			fixtures[15] = &uintValue
+			fixtures[16] = uint64Value
+			fixtures[17] = &uint64Value
+			fixtures[18] = uint32Value
+			fixtures[19] = &uint32Value
+			fixtures[20] = uint16Value
+			fixtures[21] = &uint16Value
+			fixtures[22] = uint8Value
+			fixtures[23] = &uint8Value
+
+			var intNilPointer *int
+			var int64NilPointer *int64
+			var int32NilPointer *int32
+			var int16NilPointer *int16
+			var int8NilPointer *int8
+			var float64NilPointer *float64
+			var float32NilPointer *float32
+			var uintNilPointer *uint
+			var uint64NilPointer *uint64
+			var uint32NilPointer *uint32
+			var uint16NilPointer *uint16
+			var uint8NilPointer *uint8
+
+			nilPointerFixtures := make([]interface{}, 12)
+			nilPointerFixtures[0] = intNilPointer
+			nilPointerFixtures[1] = int64NilPointer
+			nilPointerFixtures[2] = int32NilPointer
+			nilPointerFixtures[3] = int16NilPointer
+			nilPointerFixtures[4] = int8NilPointer
+			nilPointerFixtures[5] = float64NilPointer
+			nilPointerFixtures[6] = float32NilPointer
+			nilPointerFixtures[7] = uintNilPointer
+			nilPointerFixtures[8] = uint64NilPointer
+			nilPointerFixtures[9] = uint32NilPointer
+			nilPointerFixtures[10] = uint16NilPointer
+			nilPointerFixtures[11] = uint8NilPointer
+
+			Convey("When converting values to float should return expected value", func() {
+				for _, f := range fixtures {
+					value, _ := ConvertSqlValueColumnToFloat("col", f)
+
+					if !value.Valid {
+						t.Fatalf("Failed to convert %T value, expected a valid float value", f)
+					}
+
+					if value.Float64 != null.FloatFrom(1).Float64 {
+						t.Fatalf("Failed to convert %T value, expected a float value of 1.000, but got %v", f, value)
+					}
+				}
+			})
+
+			Convey("When converting nil pointer values to float should return expected value", func() {
+				for _, f := range nilPointerFixtures {
+					value, err := ConvertSqlValueColumnToFloat("col", f)
+
+					if err != nil {
+						t.Fatalf("Failed to convert %T value, expected a non nil error, but got %v", f, err)
+					}
+
+					if value.Valid {
+						t.Fatalf("Failed to convert %T value, expected an invalid float value", f)
+					}
+				}
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #11703

Started to fix this for MySql, but realized that MSSQL had similar problems so decided to extract a common function for converting value columns that's now used by all three SQL datasources.