### PR TITLE
dev: Mac compatible prometheus block.

### DIFF
--- a/docker/blocks/prometheus_mac/Dockerfile
+++ b/docker/blocks/prometheus_mac/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus:v1.8.2
+ADD prometheus.yml /etc/prometheus/
+ADD alert.rules /etc/prometheus/

--- a/docker/blocks/prometheus_mac/alert.rules
+++ b/docker/blocks/prometheus_mac/alert.rules
@@ -1,0 +1,10 @@
+# Alert Rules
+
+ALERT AppCrash
+  IF process_open_fds > 0
+  FOR 15s
+  LABELS { severity="critical" }
+  ANNOTATIONS {
+   summary = "Number of open fds > 0",
+   description = "Just testing"
+  }

--- a/docker/blocks/prometheus_mac/docker-compose.yaml
+++ b/docker/blocks/prometheus_mac/docker-compose.yaml
@@ -1,0 +1,26 @@
+  prometheus:
+    build: blocks/prometheus
+    ports:
+      - "9090:9090"
+
+  node_exporter:
+    image: prom/node-exporter
+    ports:
+      - "9100:9100"
+
+  fake-prometheus-data:
+    image: grafana/fake-data-gen
+    ports:
+      - "9091:9091"
+    environment:
+      FD_DATASOURCE: prom
+
+  alertmanager:
+    image: quay.io/prometheus/alertmanager
+    ports:
+      - "9093:9093"
+
+  prometheus-random-data:
+    build: blocks/prometheus_random_data
+    ports:
+      - "8081:8080"

--- a/docker/blocks/prometheus_mac/docker-compose.yaml
+++ b/docker/blocks/prometheus_mac/docker-compose.yaml
@@ -1,5 +1,5 @@
   prometheus:
-    build: blocks/prometheus
+    build: blocks/prometheus_mac
     ports:
       - "9090:9090"
 

--- a/docker/blocks/prometheus_mac/prometheus.yml
+++ b/docker/blocks/prometheus_mac/prometheus.yml
@@ -1,0 +1,39 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.rules"
+  # - "first.rules"
+  # - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']


### PR DESCRIPTION
Accessing the local host is available in different ways on Linux and Mac (through docker). In linux you can simply use host networking but on the Mac that isn't possible. The ip of the local host is available through host.docker.internal instead which can be used to solve the same problem.