### PR TITLE
Add .css import loader

### DIFF
--- a/scripts/webpack/sass.rule.js
+++ b/scripts/webpack/sass.rule.js
@@ -4,34 +4,64 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 module.exports = function (options, extractSass) {
   return {
-    test: /\.scss$/,
-    use: (extractSass || ExtractTextPlugin).extract({
-      use: [
-        {
-          loader: 'css-loader',
+    css: {
+      test: /\.css$/,
+      use: (extractSass || ExtractTextPlugin).extract({
+        use: [
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 2,
+              url: options.preserveUrl,
+              sourceMap: options.sourceMap,
+              minimize: options.minimize,
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: options.sourceMap,
+              config: { path: __dirname + '/postcss.config.js' }
+            }
+          },
+        ],
+        fallback: [{
+          loader: 'style-loader',
           options: {
-            importLoaders: 2,
-            url: options.preserveUrl,
             sourceMap: options.sourceMap,
-            minimize: options.minimize,
           }
-        },
-        {
-          loader: 'postcss-loader',
+        }]
+      })
+    },
+    scss: {
+      test: /\.scss$/,
+      use: (extractSass || ExtractTextPlugin).extract({
+        use: [
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 2,
+              url: options.preserveUrl,
+              sourceMap: options.sourceMap,
+              minimize: options.minimize,
+            }
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: options.sourceMap,
+              config: { path: __dirname + '/postcss.config.js' }
+            }
+          },
+          { loader: 'sass-loader', options: { sourceMap: options.sourceMap } }
+        ],
+        fallback: [{
+          loader: 'style-loader',
           options: {
-            sourceMap: options.sourceMap,
-            config: { path: __dirname + '/postcss.config.js' }
+            sourceMap: true
           }
-        },
-        { loader: 'sass-loader', options: { sourceMap: options.sourceMap } }
-      ],
-      fallback: [{
-        loader: 'style-loader',
-        options: {
-          sourceMap: true
-        }
-      }]
-    })
+        }]
+      })
+    }
   };
 }
-

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -19,7 +19,7 @@ const extractSass = new ExtractTextPlugin({
 });
 
 const styleRules = require('./sass.rule.js')({
-  sourceMap: true, minimize: false, preserveUrl: true
+  sourceMap: HOT, minimize: false, preserveUrl: true
 }, extractSass);
 
 const entries = HOT ? {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -18,6 +18,10 @@ const extractSass = new ExtractTextPlugin({
   disable: HOT
 });
 
+const styleRules = require('./sass.rule.js')({
+  sourceMap: true, minimize: false, preserveUrl: true
+}, extractSass);
+
 const entries = HOT ? {
   app: [
     'webpack-dev-server/client?http://localhost:3333',
@@ -83,9 +87,8 @@ module.exports = merge(common, {
           }
         ]
       },
-      require('./sass.rule.js')({
-        sourceMap: true, minimize: false, preserveUrl: true
-      }, extractSass),
+      styleRules.css,
+      styleRules.scss,
       {
         test: /\.(ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
         loader: 'file-loader'

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -9,6 +9,10 @@ const ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
+const styleRules = require('./sass.rule.js')({
+  sourceMap: false, minimize: true, preserveUrl: false
+});
+
 module.exports = merge(common, {
   devtool: "source-map",
 
@@ -39,9 +43,8 @@ module.exports = merge(common, {
           { loader: "awesome-typescript-loader" }
         ]
       },
-      require('./sass.rule.js')({
-        sourceMap: false, minimize: true, preserveUrl: false
-      })
+      styleRules.css,
+      styleRules.scss,
     ]
   },
 


### PR DESCRIPTION
This PR allows for `import 'style.css'` which is needed when adding styles
from vendored components that bring their own styles as part of their npm packages,
 e.g., prism highlighting.
    
- adds `.css` as a rule to webpack to allow `import 'style.css'`
- kept the config explicit
- BONUS: disabled sass sourcemaps for `yarn watch` (follow-up from #11652)