### PR TITLE
revert renaming of unit key ppm

### DIFF
--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -596,7 +596,7 @@ kbn.valueFormats.radr = kbn.formatBuilders.decimalSIPrefix('R');
 kbn.valueFormats.radsvh = kbn.formatBuilders.decimalSIPrefix('Sv/h');
 
 // Concentration
-kbn.valueFormats.conppm = kbn.formatBuilders.fixedUnit('ppm');
+kbn.valueFormats.ppm = kbn.formatBuilders.fixedUnit('ppm');
 kbn.valueFormats.conppb = kbn.formatBuilders.fixedUnit('ppb');
 kbn.valueFormats.conngm3 = kbn.formatBuilders.fixedUnit('ng/m3');
 kbn.valueFormats.conngNm3 = kbn.formatBuilders.fixedUnit('ng/Nm3');
@@ -1101,7 +1101,7 @@ kbn.getUnitFormats = function() {
     {
       text: 'concentration',
       submenu: [
-        { text: 'parts-per-million (ppm)', value: 'conppm' },
+        { text: 'parts-per-million (ppm)', value: 'ppm' },
         { text: 'parts-per-billion (ppb)', value: 'conppb' },
         { text: 'nanogram per cubic metre (ng/m3)', value: 'conngm3' },
         { text: 'nanogram per normal cubic metre (ng/Nm3)', value: 'conngNm3' },

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -634,6 +634,9 @@ function graphDirective(timeSrv, popoverSrv, contextSrv) {
 
       function configureAxisMode(axis, format) {
         axis.tickFormatter = function(val, axis) {
+          if (!kbn.valueFormats[format]) {
+            throw new Error(`Unit '${format}' is not supported`);
+          }
           return kbn.valueFormats[format](val, axis.tickDecimals, axis.scaledDecimals);
         };
       }


### PR DESCRIPTION
#11211 removed the unit key ppm in favor of conppm. A change which is not forward compatible.
This commit revert the unit key back to ppm.
Also adds some better error description if trying to use a unit which don't exists.

Fixes #11743 