### PR TITLE
Refactoring PluginManager to be a self registering service

### DIFF
--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -25,8 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/metrics"
-	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 
@@ -34,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/tracing"
 
 	_ "github.com/grafana/grafana/pkg/extensions"
+	_ "github.com/grafana/grafana/pkg/plugins"
 	_ "github.com/grafana/grafana/pkg/services/alerting"
 	_ "github.com/grafana/grafana/pkg/services/cleanup"
 	_ "github.com/grafana/grafana/pkg/services/search"
@@ -72,12 +71,6 @@ func (g *GrafanaServerImpl) Start() error {
 	metrics.Init(setting.Cfg)
 	login.Init()
 	social.NewOAuthService()
-
-	pluginManager, err := plugins.NewPluginManager(g.context)
-	if err != nil {
-		return fmt.Errorf("Failed to start plugins. error: %v", err)
-	}
-	g.childRoutines.Go(func() error { return pluginManager.Run(g.context) })
 
 	if err := provisioning.Init(g.context, setting.HomePath, setting.Cfg); err != nil {
 		return fmt.Errorf("Failed to provision Grafana from config. error: %v", err)

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/provisioning"
 
 	"golang.org/x/sync/errgroup"

--- a/pkg/plugins/dashboard_importer_test.go
+++ b/pkg/plugins/dashboard_importer_test.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"context"
 	"io/ioutil"
 	"testing"
 
@@ -91,10 +90,11 @@ func pluginScenario(desc string, t *testing.T, fn func()) {
 		setting.Cfg = ini.Empty()
 		sec, _ := setting.Cfg.NewSection("plugin.test-app")
 		sec.NewKey("path", "../../tests/test-app")
-		err := initPlugins(context.Background())
+
+		pm := &PluginManager{}
+		err := pm.Init()
 
 		So(err, ShouldBeNil)
-
 		Convey(desc, fn)
 	})
 }

--- a/pkg/plugins/dashboards_test.go
+++ b/pkg/plugins/dashboards_test.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -18,7 +17,9 @@ func TestPluginDashboards(t *testing.T) {
 		setting.Cfg = ini.Empty()
 		sec, _ := setting.Cfg.NewSection("plugin.test-app")
 		sec.NewKey("path", "../../tests/test-app")
-		err := initPlugins(context.Background())
+
+		pm := &PluginManager{}
+		err := pm.Init()
 
 		So(err, ShouldBeNil)
 

--- a/pkg/plugins/dashboards_updater.go
+++ b/pkg/plugins/dashboards_updater.go
@@ -1,8 +1,6 @@
 package plugins
 
 import (
-	"time"
-
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -11,10 +9,8 @@ func init() {
 	bus.AddEventListener(handlePluginStateChanged)
 }
 
-func updateAppDashboards() {
-	time.Sleep(time.Second * 5)
-
-	plog.Debug("Looking for App Dashboard Updates")
+func (pm *PluginManager) updateAppDashboards() {
+	pm.log.Debug("Looking for App Dashboard Updates")
 
 	query := m.GetPluginSettingsQuery{OrgId: 0}
 

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -76,7 +76,7 @@ func composeBinaryName(executable, os, arch string) string {
 	return fmt.Sprintf("%s_%s_%s%s", executable, os, strings.ToLower(arch), extension)
 }
 
-func (p *DataSourcePlugin) initBackendPlugin(ctx context.Context, log log.Logger) error {
+func (p *DataSourcePlugin) startBackendPlugin(ctx context.Context, log log.Logger) error {
 	p.log = log.New("plugin-id", p.Id)
 
 	err := p.spawnSubProcess()

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,7 +1,6 @@
 package plugins
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -15,7 +14,9 @@ func TestPluginScans(t *testing.T) {
 	Convey("When scanning for plugins", t, func() {
 		setting.StaticRootPath, _ = filepath.Abs("../../public/")
 		setting.Cfg = ini.Empty()
-		err := initPlugins(context.Background())
+
+		pm := &PluginManager{}
+		err := pm.Init()
 
 		So(err, ShouldBeNil)
 		So(len(DataSources), ShouldBeGreaterThan, 1)
@@ -30,7 +31,9 @@ func TestPluginScans(t *testing.T) {
 		setting.Cfg = ini.Empty()
 		sec, _ := setting.Cfg.NewSection("plugin.nginx-app")
 		sec.NewKey("path", "../../tests/test-app")
-		err := initPlugins(context.Background())
+
+		pm := &PluginManager{}
+		err := pm.Init()
 
 		So(err, ShouldBeNil)
 		So(len(Apps), ShouldBeGreaterThan, 0)

--- a/pkg/plugins/update_checker.go
+++ b/pkg/plugins/update_checker.go
@@ -26,23 +26,6 @@ type GithubLatest struct {
 	Testing string `json:"testing"`
 }
 
-func StartPluginUpdateChecker() {
-	if !setting.CheckForUpdates {
-		return
-	}
-
-	// do one check directly
-	go checkForUpdates()
-
-	ticker := time.NewTicker(time.Minute * 10)
-	for {
-		select {
-		case <-ticker.C:
-			checkForUpdates()
-		}
-	}
-}
-
 func getAllExternalPluginSlugs() string {
 	var result []string
 	for _, plug := range Plugins {
@@ -56,8 +39,12 @@ func getAllExternalPluginSlugs() string {
 	return strings.Join(result, ",")
 }
 
-func checkForUpdates() {
-	log.Trace("Checking for updates")
+func (pm *PluginManager) checkForUpdates() {
+	if !setting.CheckForUpdates {
+		return
+	}
+
+	pm.log.Debug("Checking for updates")
 
 	pluginSlugs := getAllExternalPluginSlugs()
 	resp, err := httpClient.Get("https://grafana.com/api/plugins/versioncheck?slugIn=" + pluginSlugs + "&grafanaVersion=" + setting.BuildVersion)


### PR DESCRIPTION
Partial refactoring of plugin manager to use new service interfaces.

1) Fixed some go routines so they are now in the Run part and are properly aborted when server shuts down

2) moved starting backend plugins to Run 

Not tested with a backend plugin yet