### PR TITLE
Explore: add support for multiple queries

### DIFF
--- a/public/app/containers/Explore/QueryRows.tsx
+++ b/public/app/containers/Explore/QueryRows.tsx
@@ -1,0 +1,69 @@
+import React, { PureComponent } from 'react';
+
+import QueryField from './QueryField';
+
+class QueryRow extends PureComponent<any, any> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      query: '',
+    };
+  }
+
+  handleChangeQuery = value => {
+    const { index, onChangeQuery } = this.props;
+    this.setState({ query: value });
+    if (onChangeQuery) {
+      onChangeQuery(value, index);
+    }
+  };
+
+  handleClickAddButton = () => {
+    const { index, onAddQueryRow } = this.props;
+    if (onAddQueryRow) {
+      onAddQueryRow(index);
+    }
+  };
+
+  handleClickRemoveButton = () => {
+    const { index, onRemoveQueryRow } = this.props;
+    if (onRemoveQueryRow) {
+      onRemoveQueryRow(index);
+    }
+  };
+
+  handlePressEnter = () => {
+    const { onExecuteQuery } = this.props;
+    if (onExecuteQuery) {
+      onExecuteQuery();
+    }
+  };
+
+  render() {
+    const { request } = this.props;
+    return (
+      <div className="query-row">
+        <div className="query-row-tools">
+          <button className="btn btn-small btn-inverse" onClick={this.handleClickAddButton}>
+            <i className="fa fa-plus" />
+          </button>
+          <button className="btn btn-small btn-inverse" onClick={this.handleClickRemoveButton}>
+            <i className="fa fa-minus" />
+          </button>
+        </div>
+        <div className="query-field-wrapper">
+          <QueryField onPressEnter={this.handlePressEnter} onQueryChange={this.handleChangeQuery} request={request} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default class QueryRows extends PureComponent<any, any> {
+  render() {
+    const { className = '', queries, ...handlers } = this.props;
+    return (
+      <div className={className}>{queries.map((q, index) => <QueryRow key={q.key} index={index} {...handlers} />)}</div>
+    );
+  }
+}

--- a/public/app/containers/Explore/utils/query.ts
+++ b/public/app/containers/Explore/utils/query.ts
@@ -1,0 +1,31 @@
+export function buildQueryOptions({ format, interval, instant, now, queries }) {
+  const to = now;
+  const from = to - 1000 * 60 * 60 * 3;
+  return {
+    interval,
+    range: {
+      from,
+      to,
+    },
+    targets: queries.map(expr => ({
+      expr,
+      format,
+      instant,
+    })),
+  };
+}
+
+export function generateQueryKey(index = 0) {
+  return `Q-${Date.now()}-${Math.random()}-${index}`;
+}
+
+export function ensureQueries(queries?) {
+  if (queries && typeof queries === 'object' && queries.length > 0 && typeof queries[0] === 'string') {
+    return queries.map((query, i) => ({ key: generateQueryKey(i), query }));
+  }
+  return [{ key: generateQueryKey(), query: '' }];
+}
+
+export function hasQuery(queries) {
+  return queries.some(q => q.query);
+}

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -4,6 +4,23 @@
   }
 }
 
+.query-row {
+  position: relative;
+
+  & + & {
+    margin-top: 0.5rem;
+  }
+}
+
+.query-row-tools {
+  position: absolute;
+  left: -4rem;
+  top: 0.33rem;
+  > * {
+    margin-right: 0.25rem;
+  }
+}
+
 .query-field {
   font-size: 14px;
   font-family: Consolas, Menlo, Courier, monospace;
@@ -14,14 +31,14 @@
   position: relative;
   display: inline-block;
   padding: 6px 7px 4px;
-  width: calc(100% - 6rem);
+  width: 100%;
   cursor: text;
   line-height: 1.5;
   color: rgba(0, 0, 0, 0.65);
   background-color: #fff;
   background-image: none;
   border: 1px solid lightgray;
-  border-radius: 4px;
+  border-radius: 3px;
   transition: all 0.3s;
 }
 


### PR DESCRIPTION
* adds +/- buttons to query rows in the Explore section
* on Run Query all query expressions are submitted
* `generateQueryKey` and `ensureQueries` are helpers to ensure each
 query field has a unique key for react.
