### PR TITLE
Opportunities to unindent code (unindent)

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -99,10 +99,8 @@ func Error(status int, message string, err error) *NormalResponse {
 		data["message"] = message
 	}
 
-	if err != nil {
-		if setting.Env != setting.PROD {
-			data["error"] = err.Error()
-		}
+	if err != nil && setting.Env != setting.PROD {
+		data["error"] = err.Error()
 	}
 
 	resp := JSON(status, data)

--- a/pkg/components/dynmap/dynmap.go
+++ b/pkg/components/dynmap/dynmap.go
@@ -639,26 +639,24 @@ func (v *Value) Object() (*Object, error) {
 		valid = true
 	}
 
+	if !valid {
+		return nil, ErrNotObject
+	}
+	obj := new(Object)
+	obj.valid = valid
+
+	m := make(map[string]*Value)
+
 	if valid {
-		obj := new(Object)
-		obj.valid = valid
-
-		m := make(map[string]*Value)
-
-		if valid {
-			for key, element := range v.data.(map[string]interface{}) {
-				m[key] = &Value{element, true}
-
-			}
+		for key, element := range v.data.(map[string]interface{}) {
+			m[key] = &Value{element, true}
 		}
-
-		obj.data = v.data
-		obj.m = m
-
-		return obj, nil
 	}
 
-	return nil, ErrNotObject
+	obj.data = v.data
+	obj.m = m
+
+	return obj, nil
 }
 
 // Attempts to typecast the current value into an object arrau.
@@ -678,23 +676,19 @@ func (v *Value) ObjectArray() ([]*Object, error) {
 	// Unsure if this is a good way to use slices, it's probably not
 	var slice []*Object
 
-	if valid {
-
-		for _, element := range v.data.([]interface{}) {
-			childValue := Value{element, true}
-			childObject, err := childValue.Object()
-
-			if err != nil {
-				return nil, ErrNotObjectArray
-			}
-			slice = append(slice, childObject)
-		}
-
-		return slice, nil
+	if !valid {
+		return nil, ErrNotObjectArray
 	}
+	for _, element := range v.data.([]interface{}) {
+		childValue := Value{element, true}
+		childObject, err := childValue.Object()
 
-	return nil, ErrNotObjectArray
-
+		if err != nil {
+			return nil, ErrNotObjectArray
+		}
+		slice = append(slice, childObject)
+	}
+	return slice, nil
 }
 
 // Attempts to typecast the current value into a string.

--- a/pkg/components/simplejson/simplejson.go
+++ b/pkg/components/simplejson/simplejson.go
@@ -168,10 +168,8 @@ func (j *Json) GetPath(branch ...string) *Json {
 //    js.Get("top_level").Get("array").GetIndex(1).Get("key").Int()
 func (j *Json) GetIndex(index int) *Json {
 	a, err := j.Array()
-	if err == nil {
-		if len(a) > index {
-			return &Json{a[index]}
-		}
+	if err == nil && len(a) > index {
+		return &Json{a[index]}
 	}
 	return &Json{nil}
 }

--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -24,12 +24,12 @@ func RedirectFromLegacyDashboardURL() macaron.Handler {
 	return func(c *m.ReqContext) {
 		slug := c.Params("slug")
 
-		if slug != "" {
-			if url, err := getDashboardURLBySlug(c.OrgId, slug); err == nil {
-				url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
-				c.Redirect(url, 301)
-				return
-			}
+		if slug == "" {
+			return
+		}
+		if url, err := getDashboardURLBySlug(c.OrgId, slug); err == nil {
+			url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
+			c.Redirect(url, 301)
 		}
 	}
 }
@@ -39,17 +39,16 @@ func RedirectFromLegacyDashboardSoloURL() macaron.Handler {
 		slug := c.Params("slug")
 		renderRequest := c.QueryBool("render")
 
-		if slug != "" {
-			if url, err := getDashboardURLBySlug(c.OrgId, slug); err == nil {
-				if renderRequest && strings.Contains(url, setting.AppSubUrl) {
-					url = strings.Replace(url, setting.AppSubUrl, "", 1)
-				}
-
-				url = strings.Replace(url, "/d/", "/d-solo/", 1)
-				url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
-				c.Redirect(url, 301)
-				return
+		if slug == "" {
+			return
+		}
+		if url, err := getDashboardURLBySlug(c.OrgId, slug); err == nil {
+			if renderRequest && strings.Contains(url, setting.AppSubUrl) {
+				url = strings.Replace(url, setting.AppSubUrl, "", 1)
 			}
+			url = strings.Replace(url, "/d/", "/d-solo/", 1)
+			url = fmt.Sprintf("%s?%s", url, c.Req.URL.RawQuery)
+			c.Redirect(url, 301)
 		}
 	}
 }

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -298,18 +298,19 @@ func (e MssqlQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *core.
 		key := elem.Value.(string)
 		result.Series = append(result.Series, pointsBySeries[key])
 
-		if fillMissing {
-			series := pointsBySeries[key]
-			// fill in values from last fetched value till interval end
-			intervalStart := series.Points[len(series.Points)-1][1].Float64
-			intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
+		if !fillMissing {
+			break
+		}
+		series := pointsBySeries[key]
+		// fill in values from last fetched value till interval end
+		intervalStart := series.Points[len(series.Points)-1][1].Float64
+		intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
 
-			// align interval start
-			intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
-			for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
-				series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
-				rowCount++
-			}
+		// align interval start
+		intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
+		for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
+			series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
+			rowCount++
 		}
 	}
 

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -309,18 +309,19 @@ func (e MysqlQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *core.
 		key := elem.Value.(string)
 		result.Series = append(result.Series, pointsBySeries[key])
 
-		if fillMissing {
-			series := pointsBySeries[key]
-			// fill in values from last fetched value till interval end
-			intervalStart := series.Points[len(series.Points)-1][1].Float64
-			intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
+		if !fillMissing {
+			break
+		}
+		series := pointsBySeries[key]
+		// fill in values from last fetched value till interval end
+		intervalStart := series.Points[len(series.Points)-1][1].Float64
+		intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
 
-			// align interval start
-			intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
-			for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
-				series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
-				rowCount++
-			}
+		// align interval start
+		intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
+		for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
+			series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
+			rowCount++
 		}
 	}
 

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -289,18 +289,19 @@ func (e PostgresQueryEndpoint) transformToTimeSeries(query *tsdb.Query, rows *co
 		key := elem.Value.(string)
 		result.Series = append(result.Series, pointsBySeries[key])
 
-		if fillMissing {
-			series := pointsBySeries[key]
-			// fill in values from last fetched value till interval end
-			intervalStart := series.Points[len(series.Points)-1][1].Float64
-			intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
+		if !fillMissing {
+			break
+		}
+		series := pointsBySeries[key]
+		// fill in values from last fetched value till interval end
+		intervalStart := series.Points[len(series.Points)-1][1].Float64
+		intervalEnd := float64(tsdbQuery.TimeRange.MustGetTo().UnixNano() / 1e6)
 
-			// align interval start
-			intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
-			for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
-				series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
-				rowCount++
-			}
+		// align interval start
+		intervalStart = math.Floor(intervalStart/fillInterval) * fillInterval
+		for i := intervalStart + fillInterval; i < intervalEnd; i += fillInterval {
+			series.Points = append(series.Points, tsdb.TimePoint{fillValue, null.FloatFrom(i)})
+			rowCount++
 		}
 	}
 

--- a/pkg/tsdb/sql_engine.go
+++ b/pkg/tsdb/sql_engine.go
@@ -141,50 +141,51 @@ func (e *DefaultSqlEngine) Query(
 // ConvertSqlTimeColumnToEpochMs converts column named time to unix timestamp in milliseconds
 // to make native datetime types and epoch dates work in annotation and table queries.
 func ConvertSqlTimeColumnToEpochMs(values RowValues, timeIndex int) {
-	if timeIndex >= 0 {
-		switch value := values[timeIndex].(type) {
-		case time.Time:
-			values[timeIndex] = EpochPrecisionToMs(float64(value.UnixNano()))
-		case *time.Time:
-			if value != nil {
-				values[timeIndex] = EpochPrecisionToMs(float64((*value).UnixNano()))
-			}
-		case int64:
-			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
-		case *int64:
-			if value != nil {
-				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
-			}
-		case uint64:
-			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
-		case *uint64:
-			if value != nil {
-				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
-			}
-		case int32:
-			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
-		case *int32:
-			if value != nil {
-				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
-			}
-		case uint32:
-			values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
-		case *uint32:
-			if value != nil {
-				values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
-			}
-		case float64:
-			values[timeIndex] = EpochPrecisionToMs(value)
-		case *float64:
-			if value != nil {
-				values[timeIndex] = EpochPrecisionToMs(*value)
-			}
-		case float32:
-			values[timeIndex] = EpochPrecisionToMs(float64(value))
-		case *float32:
-			if value != nil {
-				values[timeIndex] = EpochPrecisionToMs(float64(*value))
-			}
+	if timeIndex < 0 {
+		return
+	}
+	switch value := values[timeIndex].(type) {
+	case time.Time:
+		values[timeIndex] = EpochPrecisionToMs(float64(value.UnixNano()))
+	case *time.Time:
+		if value != nil {
+			values[timeIndex] = EpochPrecisionToMs(float64((*value).UnixNano()))
+		}
+	case int64:
+		values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+	case *int64:
+		if value != nil {
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+		}
+	case uint64:
+		values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+	case *uint64:
+		if value != nil {
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+		}
+	case int32:
+		values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+	case *int32:
+		if value != nil {
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+		}
+	case uint32:
+		values[timeIndex] = int64(EpochPrecisionToMs(float64(value)))
+	case *uint32:
+		if value != nil {
+			values[timeIndex] = int64(EpochPrecisionToMs(float64(*value)))
+		}
+	case float64:
+		values[timeIndex] = EpochPrecisionToMs(value)
+	case *float64:
+		if value != nil {
+			values[timeIndex] = EpochPrecisionToMs(*value)
+		}
+	case float32:
+		values[timeIndex] = EpochPrecisionToMs(float64(value))
+	case *float32:
+		if value != nil {
+			values[timeIndex] = EpochPrecisionToMs(float64(*value))
 		}
 	}
 }


### PR DESCRIPTION
@bergquist Related to #10381 I gave [unindent](https://github.com/mvdan/unindent) a shot.

This commit fixes the following findings:
```
pkg/api/common.go:102:2: "if x { if y" should be "if x && y"
pkg/components/dynmap/dynmap.go:642:2: invert condition and early return
pkg/components/dynmap/dynmap.go:681:2: invert condition and early return
pkg/components/simplejson/simplejson.go:171:2: "if x { if y" should be "if x && y"
pkg/middleware/dashboard_redirect.go:42:3: invert condition and early return
pkg/tsdb/mssql/mssql.go:301:3: invert condition and early break
pkg/tsdb/mysql/mysql.go:312:3: invert condition and early break
pkg/tsdb/postgres/postgres.go:292:3: invert condition and early break
pkg/tsdb/sql_engine.go:144:2: invert condition and early return
```
