### PR TITLE
dashboard: show save as button if user has edit permission

### DIFF
--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -22,21 +22,22 @@ type LoginCommand struct {
 }
 
 type CurrentUser struct {
-	IsSignedIn     bool         `json:"isSignedIn"`
-	Id             int64        `json:"id"`
-	Login          string       `json:"login"`
-	Email          string       `json:"email"`
-	Name           string       `json:"name"`
-	LightTheme     bool         `json:"lightTheme"`
-	OrgCount       int          `json:"orgCount"`
-	OrgId          int64        `json:"orgId"`
-	OrgName        string       `json:"orgName"`
-	OrgRole        m.RoleType   `json:"orgRole"`
-	IsGrafanaAdmin bool         `json:"isGrafanaAdmin"`
-	GravatarUrl    string       `json:"gravatarUrl"`
-	Timezone       string       `json:"timezone"`
-	Locale         string       `json:"locale"`
-	HelpFlags1     m.HelpFlags1 `json:"helpFlags1"`
+	IsSignedIn                 bool         `json:"isSignedIn"`
+	Id                         int64        `json:"id"`
+	Login                      string       `json:"login"`
+	Email                      string       `json:"email"`
+	Name                       string       `json:"name"`
+	LightTheme                 bool         `json:"lightTheme"`
+	OrgCount                   int          `json:"orgCount"`
+	OrgId                      int64        `json:"orgId"`
+	OrgName                    string       `json:"orgName"`
+	OrgRole                    m.RoleType   `json:"orgRole"`
+	IsGrafanaAdmin             bool         `json:"isGrafanaAdmin"`
+	GravatarUrl                string       `json:"gravatarUrl"`
+	Timezone                   string       `json:"timezone"`
+	Locale                     string       `json:"locale"`
+	HelpFlags1                 m.HelpFlags1 `json:"helpFlags1"`
+	HasEditPermissionInFolders bool         `json:"hasEditPermissionInFolders"`
 }
 
 type MetricRequest struct {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -42,23 +42,29 @@ func setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, error) {
 		settings["appSubUrl"] = ""
 	}
 
+	hasEditPermissionInFoldersQuery := m.HasEditPermissionInFoldersQuery{SignedInUser: c.SignedInUser}
+	if err := bus.Dispatch(&hasEditPermissionInFoldersQuery); err != nil {
+		return nil, err
+	}
+
 	var data = dtos.IndexViewData{
 		User: &dtos.CurrentUser{
-			Id:             c.UserId,
-			IsSignedIn:     c.IsSignedIn,
-			Login:          c.Login,
-			Email:          c.Email,
-			Name:           c.Name,
-			OrgCount:       c.OrgCount,
-			OrgId:          c.OrgId,
-			OrgName:        c.OrgName,
-			OrgRole:        c.OrgRole,
-			GravatarUrl:    dtos.GetGravatarUrl(c.Email),
-			IsGrafanaAdmin: c.IsGrafanaAdmin,
-			LightTheme:     prefs.Theme == "light",
-			Timezone:       prefs.Timezone,
-			Locale:         locale,
-			HelpFlags1:     c.HelpFlags1,
+			Id:                         c.UserId,
+			IsSignedIn:                 c.IsSignedIn,
+			Login:                      c.Login,
+			Email:                      c.Email,
+			Name:                       c.Name,
+			OrgCount:                   c.OrgCount,
+			OrgId:                      c.OrgId,
+			OrgName:                    c.OrgName,
+			OrgRole:                    c.OrgRole,
+			GravatarUrl:                dtos.GetGravatarUrl(c.Email),
+			IsGrafanaAdmin:             c.IsGrafanaAdmin,
+			LightTheme:                 prefs.Theme == "light",
+			Timezone:                   prefs.Timezone,
+			Locale:                     locale,
+			HelpFlags1:                 c.HelpFlags1,
+			HasEditPermissionInFolders: hasEditPermissionInFoldersQuery.Result,
 		},
 		Settings:                settings,
 		Theme:                   prefs.Theme,

--- a/pkg/models/folders.go
+++ b/pkg/models/folders.go
@@ -89,3 +89,12 @@ type UpdateFolderCommand struct {
 
 	Result *Folder
 }
+
+//
+// QUERIES
+//
+
+type HasEditPermissionInFoldersQuery struct {
+	SignedInUser *SignedInUser
+	Result       bool
+}

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -221,7 +221,6 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		})
 
 		Convey("Given two dashboard folders", func() {
-
 			folder1 := insertTestDashboard("1 test dash folder", 1, 0, true, "prod")
 			folder2 := insertTestDashboard("2 test dash folder", 1, 0, true, "prod")
 			insertTestDashboard("folder in another org", 2, 0, true, "prod")
@@ -263,6 +262,15 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					So(query.Result[0].Permission, ShouldEqual, m.PERMISSION_ADMIN)
 					So(query.Result[1].DashboardId, ShouldEqual, folder2.Id)
 					So(query.Result[1].Permission, ShouldEqual, m.PERMISSION_ADMIN)
+				})
+
+				Convey("should have edit permission in folders", func() {
+					query := &m.HasEditPermissionInFoldersQuery{
+						SignedInUser: &m.SignedInUser{UserId: adminUser.Id, OrgId: 1, OrgRole: m.ROLE_ADMIN},
+					}
+					err := HasEditPermissionInFolders(query)
+					So(err, ShouldBeNil)
+					So(query.Result, ShouldBeTrue)
 				})
 			})
 
@@ -310,6 +318,14 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					So(query.Result[0].Id, ShouldEqual, folder2.Id)
 				})
 
+				Convey("should have edit permission in folders", func() {
+					query := &m.HasEditPermissionInFoldersQuery{
+						SignedInUser: &m.SignedInUser{UserId: editorUser.Id, OrgId: 1, OrgRole: m.ROLE_EDITOR},
+					}
+					err := HasEditPermissionInFolders(query)
+					So(err, ShouldBeNil)
+					So(query.Result, ShouldBeTrue)
+				})
 			})
 
 			Convey("Viewer users", func() {
@@ -352,6 +368,41 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 
 					So(len(query.Result), ShouldEqual, 1)
 					So(query.Result[0].Id, ShouldEqual, folder1.Id)
+				})
+
+				Convey("should not have edit permission in folders", func() {
+					query := &m.HasEditPermissionInFoldersQuery{
+						SignedInUser: &m.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER},
+					}
+					err := HasEditPermissionInFolders(query)
+					So(err, ShouldBeNil)
+					So(query.Result, ShouldBeFalse)
+				})
+
+				Convey("and admin permission is given for user with org role viewer in one dashboard folder", func() {
+					testHelperUpdateDashboardAcl(folder1.Id, m.DashboardAcl{DashboardId: folder1.Id, OrgId: 1, UserId: viewerUser.Id, Permission: m.PERMISSION_ADMIN})
+
+					Convey("should have edit permission in folders", func() {
+						query := &m.HasEditPermissionInFoldersQuery{
+							SignedInUser: &m.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER},
+						}
+						err := HasEditPermissionInFolders(query)
+						So(err, ShouldBeNil)
+						So(query.Result, ShouldBeTrue)
+					})
+				})
+
+				Convey("and edit permission is given for user with org role viewer in one dashboard folder", func() {
+					testHelperUpdateDashboardAcl(folder1.Id, m.DashboardAcl{DashboardId: folder1.Id, OrgId: 1, UserId: viewerUser.Id, Permission: m.PERMISSION_EDIT})
+
+					Convey("should have edit permission in folders", func() {
+						query := &m.HasEditPermissionInFoldersQuery{
+							SignedInUser: &m.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER},
+						}
+						err := HasEditPermissionInFolders(query)
+						So(err, ShouldBeNil)
+						So(query.Result, ShouldBeTrue)
+					})
 				})
 			})
 		})

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -11,6 +11,7 @@ export class User {
   timezone: string;
   helpFlags1: number;
   lightTheme: boolean;
+  hasEditPermissionInFolders: boolean;
 
   constructor() {
     if (config.bootData.user) {
@@ -28,6 +29,7 @@ export class ContextSrv {
   isEditor: any;
   sidemenu: any;
   sidemenuSmallBreakpoint = false;
+  hasEditPermissionInFolders: boolean;
 
   constructor() {
     this.sidemenu = store.getBool('grafana.sidemenu', true);
@@ -44,6 +46,7 @@ export class ContextSrv {
     this.isSignedIn = this.user.isSignedIn;
     this.isGrafanaAdmin = this.user.isGrafanaAdmin;
     this.isEditor = this.hasRole('Editor') || this.hasRole('Admin');
+    this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
   }
 
   hasRole(role) {

--- a/public/app/features/dashboard/settings/settings.ts
+++ b/public/app/features/dashboard/settings/settings.ts
@@ -30,7 +30,7 @@ export class SettingsCtrl {
       });
     });
 
-    this.canSaveAs = contextSrv.isEditor;
+    this.canSaveAs = this.dashboard.meta.canEdit && contextSrv.hasEditPermissionInFolders;
     this.canSave = this.dashboard.meta.canSave;
     this.canDelete = this.dashboard.meta.canSave;
 


### PR DESCRIPTION
Fixes #11625

This will show the "Save As..." button on dashboard settings page if the user has edit permissions (org role admin/editor or *viewers_can_edit* enabled) and has at least edit permission in any folder. 

Old logic checked if the user had org role editor, but now it's relying on editor permission from backend which takes *viewers_can_edit* configuration into account. If *viewers_can_edit* enabled and user is viewer then dashboard settings is enabled and if the user has at least edit permissions in any folder then the "Save As..." button will be visible. 

The naming of the new property *HasEditPermissionInFolders* can definitely be discussed. Didn't come up with any better name as of writing. The idea is that this property can be used to solve additional open issues, for example to decide if the Create Dashboard link in side nav should be visible or not.