### PR TITLE
add query timeout option for Prometheus

### DIFF
--- a/public/app/features/plugins/partials/ds_http_settings.html
+++ b/public/app/features/plugins/partials/ds_http_settings.html
@@ -156,4 +156,13 @@
       </info-popover>
     </div>
   </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-10">Query timeout</span>
+      <input type="text" class="gf-form-input width-9" ng-model="current.jsonData.queryTimeout" spellcheck='false' placeholder="60s"></input>
+      <info-popover mode="right-absolute">
+        Set the Query timeout.
+      </info-popover>
+    </div>
+  </div>
 </div>

--- a/public/app/features/plugins/partials/ds_http_settings.html
+++ b/public/app/features/plugins/partials/ds_http_settings.html
@@ -156,13 +156,4 @@
       </info-popover>
     </div>
   </div>
-  <div class="gf-form-inline">
-    <div class="gf-form">
-      <span class="gf-form-label width-10">Query timeout</span>
-      <input type="text" class="gf-form-input width-9" ng-model="current.jsonData.queryTimeout" spellcheck='false' placeholder="60s"></input>
-      <info-popover mode="right-absolute">
-        Set the Query timeout.
-      </info-popover>
-    </div>
-  </div>
 </div>

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -27,6 +27,7 @@ export class PrometheusDatasource {
   withCredentials: any;
   metricsNameCache: any;
   interval: string;
+  queryTimeout: string;
   httpMethod: string;
   resultTransformer: ResultTransformer;
 
@@ -42,6 +43,7 @@ export class PrometheusDatasource {
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = instanceSettings.withCredentials;
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
+    this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
     this.resultTransformer = new ResultTransformer(templateSrv);
   }
@@ -231,6 +233,9 @@ export class PrometheusDatasource {
       end: end,
       step: query.step,
     };
+    if (this.queryTimeout) {
+      data['timeout'] = this.queryTimeout;
+    }
     return this._request(url, data, { requestId: query.requestId });
   }
 
@@ -240,6 +245,9 @@ export class PrometheusDatasource {
       query: query.expr,
       time: time,
     };
+    if (this.queryTimeout) {
+      data['timeout'] = this.queryTimeout;
+    }
     return this._request(url, data, { requestId: query.requestId });
   }
 

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -2,15 +2,25 @@
 </datasource-http-settings>
 
 <div class="gf-form-group">
-	<div class="gf-form-inline">
-		<div class="gf-form">
-			<span class="gf-form-label width-8">Scrape interval</span>
-			<input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="15s"></input>
-			<info-popover mode="right-absolute">
-                Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for
-                the Prometheus step query parameter.
-			</info-popover>
-		</div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-8">Scrape interval</span>
+      <input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="15s"></input>
+      <info-popover mode="right-absolute">
+        Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for the
+        Prometheus step query parameter.
+      </info-popover>
+    </div>
+  </div>
+
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-8">Query timeout</span>
+      <input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.queryTimeout" spellcheck='false' placeholder="60s"></input>
+      <info-popover mode="right-absolute">
+        Set the Prometheus query timeout.
+      </info-popover>
+    </div>
   </div>
 
   <div class="gf-form">

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -2,25 +2,15 @@
 </datasource-http-settings>
 
 <div class="gf-form-group">
-  <div class="gf-form-inline">
-    <div class="gf-form">
-      <span class="gf-form-label width-8">Scrape interval</span>
-      <input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="15s"></input>
-      <info-popover mode="right-absolute">
-        Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for the
-        Prometheus step query parameter.
-      </info-popover>
-    </div>
-  </div>
-
-  <div class="gf-form-inline">
-    <div class="gf-form">
-      <span class="gf-form-label width-8">Query timeout</span>
-      <input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.queryTimeout" spellcheck='false' placeholder="60s"></input>
-      <info-popover mode="right-absolute">
-        Set the Prometheus query timeout.
-      </info-popover>
-    </div>
+	<div class="gf-form-inline">
+		<div class="gf-form">
+			<span class="gf-form-label width-8">Scrape interval</span>
+			<input type="text" class="gf-form-input width-8" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="15s"></input>
+			<info-popover mode="right-absolute">
+                Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for
+                the Prometheus step query parameter.
+			</info-popover>
+		</div>
   </div>
 
   <div class="gf-form">


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/3168.

`query` and `query_range` has `timeout` option, I use it.
https://prometheus.io/docs/prometheus/latest/querying/api/