### PR TITLE
scroll: fix scrolling on mobile Chrome

### DIFF
--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -44,9 +44,8 @@ div.flot-text {
   padding: $panel-padding;
   height: calc(100% - 27px);
   position: relative;
-  overflow: hidden;
   // Fixes scrolling on mobile devices
-  overflow-y: scroll;
+  overflow: auto;
 }
 
 .panel-title-container {

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -45,6 +45,8 @@ div.flot-text {
   height: calc(100% - 27px);
   position: relative;
   overflow: hidden;
+  // Fixes scrolling on mobile devices
+  overflow-y: scroll;
 }
 
 .panel-title-container {


### PR DESCRIPTION
This seems fixes #11710, but I can't replicate on my mobile chrome (Android, Chrome ver 66). I replicated in mobile view in desktop Chrome and this fixes a wrong behaviour there. So any help with testing on the real device with issue appreciated.