### PR TITLE
dont shadow format passed in as function parameter in replace function in templatesrv

### DIFF
--- a/public/app/features/templating/specs/template_srv.jest.ts
+++ b/public/app/features/templating/specs/template_srv.jest.ts
@@ -136,6 +136,11 @@ describe('templateSrv', function() {
       var target = _templateSrv.replace('this=${test:pipe}', {});
       expect(target).toBe('this=value1|value2');
     });
+
+    it('should replace ${test:pipe} with piped value and $test with globbed value', function() {
+      var target = _templateSrv.replace('${test:pipe},$test', {}, 'glob');
+      expect(target).toBe('value1|value2,{value1,value2}');
+    });
   });
 
   describe('variable with all option', function() {
@@ -163,6 +168,11 @@ describe('templateSrv', function() {
     it('should replace ${test:glob} with formatted all value', function() {
       var target = _templateSrv.replace('this.${test:glob}.filters', {});
       expect(target).toBe('this.{value1,value2}.filters');
+    });
+
+    it('should replace ${test:pipe} with piped value and $test with globbed value', function() {
+      var target = _templateSrv.replace('${test:pipe},$test', {}, 'glob');
+      expect(target).toBe('value1|value2,{value1,value2}');
     });
   });
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -179,16 +179,16 @@ export class TemplateSrv {
       return target;
     }
 
-    var variable, systemValue, value;
+    var variable, systemValue, value, fmt;
     this.regex.lastIndex = 0;
 
     return target.replace(this.regex, (match, var1, var2, fmt2, var3, fmt3) => {
       variable = this.index[var1 || var2 || var3];
-      format = fmt2 || fmt3 || format;
+      fmt = fmt2 || fmt3 || format;
       if (scopedVars) {
         value = scopedVars[var1 || var2 || var3];
         if (value) {
-          return this.formatValue(value.value, format, variable);
+          return this.formatValue(value.value, fmt, variable);
         }
       }
 
@@ -198,7 +198,7 @@ export class TemplateSrv {
 
       systemValue = this.grafanaVariables[variable.current.value];
       if (systemValue) {
-        return this.formatValue(systemValue, format, variable);
+        return this.formatValue(systemValue, fmt, variable);
       }
 
       value = variable.current.value;
@@ -210,7 +210,7 @@ export class TemplateSrv {
         }
       }
 
-      var res = this.formatValue(value, format, variable);
+      var res = this.formatValue(value, fmt, variable);
       return res;
     });
   }


### PR DESCRIPTION
If a variable specifies a specific format with the new ${foo:format} syntax all further variable interpolations in that call will use the same format unless they specify another format. The format Variable passed into the replace Function gets shadowed by the replacement run of the first variable.

Fixes #11800 