### PR TITLE
Remove preceding `/` from public JS path

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -12,7 +12,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, '../../public/build'),
     filename: '[name].[hash].js',
-    publicPath: "/public/build/",
+    publicPath: "public/build/",
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.es6', '.js', '.json'],


### PR DESCRIPTION
When running Grafana from eg. `/grafana` it didn't load JS resources as they have been loaded from `/public`. So the path was `domain.com/public/....jsresource` instead of `domain.com/grafana/public/....jsresource`