### PR TITLE
fix root_url in docs & comments

### DIFF
--- a/docker/blocks/apache_proxy/docker-compose.yaml
+++ b/docker/blocks/apache_proxy/docker-compose.yaml
@@ -2,7 +2,7 @@
 # http://localhost:3000 (Grafana running locally)
 #
 # Please note that you'll need to change the root_url in the Grafana configuration:
-# root_url = %(protocol)s://%(domain)s/grafana/
+# root_url = %(protocol)s://%(domain)s:10081/grafana/
 
   apacheproxy:
     build: blocks/apache_proxy

--- a/docker/blocks/apache_proxy/docker-compose.yaml
+++ b/docker/blocks/apache_proxy/docker-compose.yaml
@@ -2,7 +2,7 @@
 # http://localhost:3000 (Grafana running locally)
 #
 # Please note that you'll need to change the root_url in the Grafana configuration:
-# root_url = %(protocol)s://%(domain)s:/grafana/
+# root_url = %(protocol)s://%(domain)s/grafana/
 
   apacheproxy:
     build: blocks/apache_proxy

--- a/docker/blocks/nginx_proxy/docker-compose.yaml
+++ b/docker/blocks/nginx_proxy/docker-compose.yaml
@@ -2,7 +2,7 @@
 # http://localhost:3000 (Grafana running locally)
 #
 # Please note that you'll need to change the root_url in the Grafana configuration:
-# root_url = %(protocol)s://%(domain)s:/grafana/
+# root_url = %(protocol)s://%(domain)s/grafana/
 
   nginxproxy:
     build: blocks/nginx_proxy

--- a/docker/blocks/nginx_proxy/docker-compose.yaml
+++ b/docker/blocks/nginx_proxy/docker-compose.yaml
@@ -2,7 +2,7 @@
 # http://localhost:3000 (Grafana running locally)
 #
 # Please note that you'll need to change the root_url in the Grafana configuration:
-# root_url = %(protocol)s://%(domain)s/grafana/
+# root_url = %(protocol)s://%(domain)s:10080/grafana/
 
   nginxproxy:
     build: blocks/nginx_proxy

--- a/docs/sources/installation/behind_proxy.md
+++ b/docs/sources/installation/behind_proxy.md
@@ -53,7 +53,7 @@ server {
 ```bash
 [server]
 domain = foo.bar
-root_url = %(protocol)s://%(domain)s:/grafana
+root_url = %(protocol)s://%(domain)s/grafana/
 ```
 
 #### Nginx configuration with sub path
@@ -98,7 +98,7 @@ Given:
     ```bash
     [server]
     domain = localhost:8080
-    root_url = %(protocol)s://%(domain)s:/grafana
+    root_url = %(protocol)s://%(domain)s/grafana/
     ```
 
 Create an Inbound Rule for the parent website (localhost:8080 in this example) in IIS Manager with the following settings:

--- a/docs/sources/tutorials/iis.md
+++ b/docs/sources/tutorials/iis.md
@@ -16,7 +16,7 @@ Example:
 - Parent site: http://localhost:8080
 - Grafana: http://localhost:3000
 
-Grafana as a subpath: http://localhost:8080/grafana 
+Grafana as a subpath: http://localhost:8080/grafana
 
 ## Setup
 
@@ -33,7 +33,7 @@ Given that the subpath should be `grafana` and the parent site is `localhost:808
  ```bash
 [server]
 domain = localhost:8080
-root_url = %(protocol)s://%(domain)s:/grafana
+root_url = %(protocol)s://%(domain)s/grafana/
 ```
 
 Restart the Grafana server after changing the config file.
@@ -74,11 +74,11 @@ When navigating to the grafana url (`http://localhost:8080/grafana` in the examp
 
 1. The `root_url` setting in the Grafana config file does not match the parent url with subpath. This could happen if the root_url is commented out by mistake (`;` is used for commenting out a line in .ini files):
 
-    `; root_url = %(protocol)s://%(domain)s:/grafana`
+    `; root_url = %(protocol)s://%(domain)s/grafana/`
 
 2. or if the subpath in the `root_url` setting does not match the subpath used in the pattern in the Inbound Rule in IIS:
 
-    `root_url = %(protocol)s://%(domain)s:/grafana`
+    `root_url = %(protocol)s://%(domain)s/grafana/`
 
     pattern in Inbound Rule: `wrongsubpath(/)?(.*)`
 


### PR DESCRIPTION
The documentation recommends setting `root_url` to `%(protocol)s://%(domain)s:/grafana/` which will result in a url with an extraneous colon like `https://my.grafana:/grafana`.  This PR removes the colon so that the url will be correct, it also makes the use of a trailing slash consistent.