### PR TITLE
Add panel scrolling docs

### DIFF
--- a/docs/sources/plugins/developing/apps.md
+++ b/docs/sources/plugins/developing/apps.md
@@ -5,7 +5,7 @@ type = "docs"
 [menu.docs]
 name = "Developing App Plugins"
 parent = "developing"
-weight = 6
+weight = 4
 +++
 
 # Grafana Apps

--- a/docs/sources/plugins/developing/datasources.md
+++ b/docs/sources/plugins/developing/datasources.md
@@ -5,7 +5,7 @@ type = "docs"
 [menu.docs]
 name = "Developing Datasource Plugins"
 parent = "developing"
-weight = 6
+weight = 5
 +++
 
 # Datasources

--- a/docs/sources/plugins/developing/panels.md
+++ b/docs/sources/plugins/developing/panels.md
@@ -1,16 +1,11 @@
----
-page_title: Plugin panel
-page_description: Panel plugins for Grafana
-page_keywords: grafana, plugins, documentation
----
-
-
 +++
-title = "Installing Plugins"
+title = "Developing Panel Plugins"
+keywords = ["grafana", "plugins", "panel", "documentation"]
 type = "docs"
 [menu.docs]
+name = "Developing Panel Plugins"
 parent = "developing"
-weight = 1
+weight = 4
 +++
 
 
@@ -20,7 +15,21 @@ Panels are the main building blocks of dashboards.
 
 ## Panel development
 
-Examples
+
+### Scrolling
+The grafana dashboard framework controls the panel height.  To enable a scrollbar within the panel the PanelCtrl needs to set the scrollable static variable:
+
+```javascript
+export class MyPanelCtrl extends PanelCtrl {
+  static scrollable = true;
+  ...
+```
+
+In this case, make sure the template has a single `<div>...</div>` root.  The plugin loader will modifiy that element adding a scrollbar.
+
+
+
+### Examples
 
 - [clock-panel](https://github.com/grafana/clock-panel)
 - [singlestat-panel](https://github.com/grafana/grafana/blob/master/public/app/plugins/panel/singlestat/module.ts)

--- a/docs/sources/plugins/developing/plugin.json.md
+++ b/docs/sources/plugins/developing/plugin.json.md
@@ -5,7 +5,7 @@ type = "docs"
 [menu.docs]
 name = "plugin.json Schema"
 parent = "developing"
-weight = 6
+weight = 8
 +++
 
 # Plugin.json


### PR DESCRIPTION
This adds documentation about the scrolling gotchas for plugin developers.  See #11820

It looks like the current `panels.md` file is not included in the docs, and generates a bad file:
http://docs.grafana.org/plugins/developing/panels/

Does the continuous build system publish the docs anywhere?  

