### PR TITLE
Add 'double quotes' variable formatting options.

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -219,9 +219,9 @@ ORDER BY atimestamp ASC
 
 #### Disabling Quoting for Multi-value Variables
 
-Grafana automatically creates a quoted, comma-separated string for multi-value variables. For example: if `server01` and `server02` are selected then it will be formatted as: `'server01', 'server02'`. Do disable quoting, use the csv formatting option for variables:
+Grafana automatically creates a quoted, comma-separated string for multi-value variables. For example: if `server01` and `server02` are selected then it will be formatted as: `'server01', 'server02'`. Postgres uses `"` to specify column names, `'` is used for strings. Use `dblq` format to select multiple Postgres columns.
 
-`${servers:csv}`
+`${servers:dblq}`
 
 Read more about variable formatting options in the [Variables]({{< relref "reference/templating.md#advanced-formatting-options" >}}) documentation.
 

--- a/docs/sources/guides/whats-new-in-v5-1.md
+++ b/docs/sources/guides/whats-new-in-v5-1.md
@@ -103,6 +103,7 @@ Filter Option | Example | Raw | Interpolated | Description
 `regex` | ${servers:regex} | `'test.', 'test2'` |  `(test\\.|test2)` | Formats multi-value variable into a regex string
 `pipe` | ${servers:pipe} | `'test.', 'test2'` |  `test.|test2` | Formats multi-value variable into a pipe-separated string
 `csv`| ${servers:csv} |  `'test1', 'test2'` | `test1,test2` | Formats multi-value variable as a comma-separated string
+`dblq`| ${servers:dblq} |  `'test1', 'test2'` | `"test1","test2"` | Formats multi-value variable as a comma-separated double-quoted string
 
 ## Improved workflow for provisioned dashboards
 

--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -52,6 +52,7 @@ Filter Option | Example | Raw | Interpolated | Description
 `csv`| ${servers:csv} |  `'test1', 'test2'` | `test1,test2` | Formats multi-value variable as a comma-separated string
 `distributed`| ${servers:distributed} | `'test1', 'test2'` | `test1,servers=test2` | Formats multi-value variable in custom format for OpenTSDB.
 `lucene`| ${servers:lucene} | `'test', 'test2'` | `("test" OR "test2")` | Formats multi-value variable as a lucene expression.
+`dblq`| ${servers:dblq} | `'test', 'test2'` | `"test","test2"` | Formats multi-value variable as a comma-separated double-quoted string expression.
 
 Test the formatting options on the [Grafana Play site](http://play.grafana.org/d/cJtIfcWiz/template-variable-formatting-options?orgId=1).
 

--- a/public/app/features/templating/specs/template_srv.jest.ts
+++ b/public/app/features/templating/specs/template_srv.jest.ts
@@ -275,6 +275,11 @@ describe('templateSrv', function() {
       expect(result).toBe('test,test2');
     });
 
+    it('multi value and dblq format should render double-quotted string', function() {
+      var result = _templateSrv.formatValue(['test', 'test2'], 'dblq');
+      expect(result).toBe('"test","test2"');
+    });
+
     it('slash should be properly escaped in regex format', function() {
       var result = _templateSrv.formatValue('Gi3/14', 'regex');
       expect(result).toBe('Gi3\\/14');

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -80,6 +80,16 @@ export class TemplateSrv {
     return '(' + quotedValues.join(' OR ') + ')';
   }
 
+  dblqFormat(value) {
+    if (typeof value === 'string') {
+      return value;
+    }
+    var quotedValues = _.map(value, function(val) {
+      return '"' + val + '"';
+    });
+    return quotedValues.join(',');
+  }
+
   formatValue(value, format, variable) {
     // for some scopedVars there is no variable
     variable = variable || {};
@@ -102,6 +112,9 @@ export class TemplateSrv {
       }
       case 'lucene': {
         return this.luceneFormat(value);
+      }
+      case 'dblq': {
+        return this.dblqFormat(value);
       }
       case 'pipe': {
         if (typeof value === 'string') {


### PR DESCRIPTION
When I was trying to use Postgres data source with multi-valued variables none of the [existing](http://docs.grafana.org/reference/templating/#advanced-formatting-options) variable formatting options worked.

By default we have `'`quoted `,` separated columns - this is just a list of `strings` for Postgres.

`${var:csv}` is "almost" good, it removes `'` (so I can add `"` quotes to my values) but unfortunately, it returns value in `{` and `}` and Postgres cannot use this.

This PR adds another formatting option `:dblq` that just returns `,` separated `"` quoted list of values:

Grafana's default `'col1','col2'` becomes `"col1","col2"` that is usable by postgres.
BTW: why `:csv` options returns data with `{}` `{col1,col2}` while the docs say `col1,col2`?
