### PR TITLE
Take value instead of timestamp in select-query for template variable (influxdb)

### DIFF
--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -12,6 +12,7 @@ export default class ResponseParser {
     }
 
     var influxdb11format = query.toLowerCase().indexOf('show tag values') >= 0;
+    var influxdbSelect = query.toLowerCase().indexOf('select') >= 0;
 
     var res = {};
     _.each(influxResults.series, serie => {
@@ -19,6 +20,8 @@ export default class ResponseParser {
         if (_.isArray(value)) {
           if (influxdb11format) {
             addUnique(res, value[1] || value[0]);
+          } else if (influxdbSelect) {
+            addUnique(res, value[1]);
           } else {
             addUnique(res, value[0]);
           }


### PR DESCRIPTION
To get the value of a field instead of its timestamp in query for template variable with InfluxDB, I added a variable and if-clause to check if the query starts with select and take the right value then. This works for one field. 
Related to #5013
