### PR TITLE
Add baron scrollbar to a node managed by gafana

### DIFF
--- a/docs/sources/plugins/developing/panels.md
+++ b/docs/sources/plugins/developing/panels.md
@@ -25,8 +25,6 @@ export class MyPanelCtrl extends PanelCtrl {
   ...
 ```
 
-In this case, make sure the template has a single `<div>...</div>` root.  The plugin loader will modifiy that element adding a scrollbar.
-
 
 
 ### Examples

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -21,7 +21,9 @@ var panelTemplate = `
     </div>
 
     <div class="panel-content">
-      <ng-transclude class="panel-height-helper"></ng-transclude>
+      <div class="panel-height-helper">
+        <div><ng-transclude ></ng-transclude></div>
+      </div>
     </div>
   </div>
 
@@ -113,7 +115,7 @@ module.directive('grafanaPanel', function($rootScope, $document, $timeout) {
           `;
 
           let scrollRoot = panelContent;
-          let scroller = panelContent.find(':first').find(':first');
+          let scroller = panelContent.find(':first');
 
           scrollRoot.addClass(scrollRootClass);
           $(scrollBarHTML).appendTo(scrollRoot);


### PR DESCRIPTION
*not* the plugin.

Solves #11820

This adds an extra layer of <div> so that grafana can manage the scrollbar directly rather than manipulate the plugin DOM without knowing how it is/was developed.

