### PR TITLE
Fix CSS asset loading for yarn start (HMR)

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -12,6 +12,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, '../../public/build'),
     filename: '[name].[hash].js',
+    // Keep publicPath relative for host.com/grafana/ deployments
     publicPath: "public/build/",
   },
   resolve: {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -85,7 +85,7 @@ module.exports = merge(common, {
         ]
       },
       require('./sass.rule.js')({
-        sourceMap: true, minimize: false, preserveUrl: false
+        sourceMap: true, minimize: false, preserveUrl: HOT
       }, extractSass),
       {
         test: /\.(ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,


### PR DESCRIPTION
* enable url() processing in CSS to ensure assets load in HMR mode (broken since 249c1e8d3dbbca74e7a060fccc1952c7179d94b4)
* only needed when running `yarn start` which needs this for the hot
reloader

Related to #11811 