### PR TITLE
decrease length of auth_id column in user_auth table

### DIFF
--- a/pkg/services/sqlstore/migrations/user_auth_mig.go
+++ b/pkg/services/sqlstore/migrations/user_auth_mig.go
@@ -22,8 +22,8 @@ func addUserAuthMigrations(mg *Migrator) {
 	// add indices
 	addTableIndicesMigrations(mg, "v1", userAuthV1)
 
-	mg.AddMigration("alter user_auth.auth_id to length 255", new(RawSqlMigration).
+	mg.AddMigration("alter user_auth.auth_id to length 190", new(RawSqlMigration).
 		Sqlite("SELECT 0 WHERE 0;").
-		Postgres("ALTER TABLE user_auth ALTER COLUMN auth_id TYPE VARCHAR(255);").
-		Mysql("ALTER TABLE user_auth MODIFY auth_id VARCHAR(255);"))
+		Postgres("ALTER TABLE user_auth ALTER COLUMN auth_id TYPE VARCHAR(190);").
+		Mysql("ALTER TABLE user_auth MODIFY auth_id VARCHAR(190);"))
 }


### PR DESCRIPTION
Fixes #11862

certain mysql versions don't support having indices with a greater varchar length
than 190.

Unsure if it's okay/good idea to rename a migration? In this case the changes should be both backward and forward compatible as long as someone haven't stored a value with a length greater than 190.