### PR TITLE
lock caniuse-db version to resolve phantomjs rendering issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,5 +179,8 @@
     "tether": "^1.4.0",
     "tether-drop": "https://github.com/torkelo/drop/tarball/master",
     "tinycolor2": "^1.4.1"
+  },
+  "resolutions": {
+    "caniuse-db": "1.0.30000772"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,9 +1655,9 @@ caniuse-api@^1.5.2:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000830"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000830.tgz#6e45255b345649fd15ff59072da1e12bb3de2f13"
+caniuse-db@1.0.30000772, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
For some reason a newer version of this sub-dependency makes phantomjs
rendering unable to generate and save a png image, however without
any error message logged

Verified that this resolves phantomjs rendering in production build and in development mode (watch) when uncommenting the babel-loader section in webpack.dev.js.
