### PR TITLE
Flowdock notification channel

### DIFF
--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -53,7 +53,6 @@ type FlowdockNotifier struct {
 
 func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {
 	this.log.Info("Executing Flowdock notification", "ruleId", evalContext.Rule.Id, "notification", this.Name)
-	this.log.Info("This took", "Ms", evalContext.GetDurationMs())
 	body := this.getBody(evalContext)
 	body["flow_token"] = this.FlowToken
 

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -13,7 +13,12 @@ func init() {
 		Factory:     NewFlowdockNotifier,
 		OptionsTemplate: `
       <h3 class="page-heading">Flowdock settings</h3>
-      <div class="gf-form">
+      <div class="gf-form max-width-30">
+        <span class="gf-form-label width-6">Flow token</span>
+        <input type="text" required class="gf-form-input max-width-30" ng-model="ctrl.model.settings.flowToken" placeholder="Flowdock flow token"></input>
+        <info-popover mode="right-absolute">
+            Instruction's for getting flow token can be found <a target="_blank" href="https://www.flowdock.com/api/integration-getting-started#/getting-started">here</a>
+        </info-popover>
       </div>
     `,
 	})

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -20,6 +20,11 @@ func init() {
 }
 
 func NewFlowdockNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	flowToken := model.Settings.Get("flowToken").MustString()
+	if flowToken == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find flowToken in settings"}
+	}
+
 	return &FlowdockNotifier{
 		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
 	}, nil

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -25,7 +25,7 @@ func init() {
         <span class="gf-form-label width-6">Flow token</span>
         <input type="text" required class="gf-form-input max-width-30" ng-model="ctrl.model.settings.flowToken" placeholder="Flowdock flow token"></input>
         <info-popover mode="right-absolute">
-            Instruction's for getting flow token can be found <a target="_blank" href="https://www.flowdock.com/api/integration-getting-started#/getting-started">here</a>
+            Instructions for getting the flow token can be found <a target="_blank" href="https://www.flowdock.com/api/integration-getting-started#/getting-started">here</a>
         </info-popover>
       </div>
     `,

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -1,0 +1,34 @@
+package notifiers
+
+import (
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "flowdock",
+		Name:        "Flowdock",
+		Description: "Sends notifications to Flowdock",
+		Factory:     NewFlowdockNotifier,
+		OptionsTemplate: `
+      <h3 class="page-heading">Flowdock settings</h3>
+      <div class="gf-form">
+      </div>
+    `,
+	})
+}
+
+func NewFlowdockNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	return &FlowdockNotifier{
+		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
+	}, nil
+}
+
+type FlowdockNotifier struct {
+	NotifierBase
+}
+
+func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {
+	return nil
+}

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -2,6 +2,7 @@ package notifiers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -66,10 +67,11 @@ func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 func (this *FlowdockNotifier) getBody(evalContext *alerting.EvalContext) map[string]interface{} {
 	return map[string]interface{}{
-		"event":  "activity",
-		"thread": this.getThread(evalContext),
-		"author": this.getAuthor(evalContext),
-		"title":  evalContext.GetNotificationTitle(),
+		"event":              "activity",
+		"thread":             this.getThread(evalContext),
+		"author":             this.getAuthor(evalContext),
+		"title":              evalContext.GetNotificationTitle(),
+		"external_thread_id": this.combineStartTimeAndRuleId(evalContext),
 	}
 }
 
@@ -126,4 +128,11 @@ func (this *FlowdockNotifier) getAuthor(evalContext *alerting.EvalContext) map[s
 		"name":   "Grafana",
 		"avatar": "https://grafana.com/assets/img/fav32.png",
 	}
+}
+
+func (this *FlowdockNotifier) combineStartTimeAndRuleId(evalContext *alerting.EvalContext) string {
+	startTime := evalContext.StartTime.Unix()
+	ruleId := evalContext.Rule.Id
+
+	return fmt.Sprintf("%d", (ruleId + startTime))
 }

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -74,10 +74,14 @@ func (this *FlowdockNotifier) getBody(evalContext *alerting.EvalContext) map[str
 }
 
 func (this *FlowdockNotifier) getThread(evalContext *alerting.EvalContext) map[string]interface{} {
+	ruleUrl, _ := evalContext.GetRuleUrl()
+
 	return map[string]interface{}{
-		"title":  evalContext.GetNotificationTitle(),
-		"status": this.getStatus(evalContext),
-		"fields": this.getFields(evalContext),
+		"title":        evalContext.GetNotificationTitle(),
+		"status":       this.getStatus(evalContext),
+		"fields":       this.getFields(evalContext),
+		"external_url": ruleUrl,
+		"body":         `<img src="` + evalContext.ImagePublicUrl + `">`,
 	}
 }
 

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -27,11 +27,13 @@ func NewFlowdockNotifier(model *models.AlertNotification) (alerting.Notifier, er
 
 	return &FlowdockNotifier{
 		NotifierBase: NewNotifierBase(model.Id, model.IsDefault, model.Name, model.Type, model.Settings),
+		FlowToken:    flowToken,
 	}, nil
 }
 
 type FlowdockNotifier struct {
 	NotifierBase
+	FlowToken string
 }
 
 func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -69,6 +69,7 @@ func (this *FlowdockNotifier) getBody(evalContext *alerting.EvalContext) map[str
 		"event":  "activity",
 		"status": this.getStatus(evalContext),
 		"fields": this.getFields(evalContext),
+		"author": this.getAuthor(evalContext),
 	}
 
 	return body
@@ -108,4 +109,11 @@ func (this *FlowdockNotifier) getFields(evalContext *alerting.EvalContext) []map
 		})
 	}
 	return fields
+}
+
+func (this *FlowdockNotifier) getAuthor(evalContext *alerting.EvalContext) map[string]string {
+	return map[string]string{
+		"name":   "Grafana",
+		"avatar": "https://grafana.com/assets/img/fav32.png",
+	}
 }

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -65,14 +65,20 @@ func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {
 }
 
 func (this *FlowdockNotifier) getBody(evalContext *alerting.EvalContext) map[string]interface{} {
-	body := map[string]interface{}{
+	return map[string]interface{}{
 		"event":  "activity",
+		"thread": this.getThread(evalContext),
+		"author": this.getAuthor(evalContext),
+		"title":  evalContext.GetNotificationTitle(),
+	}
+}
+
+func (this *FlowdockNotifier) getThread(evalContext *alerting.EvalContext) map[string]interface{} {
+	return map[string]interface{}{
+		"title":  evalContext.GetNotificationTitle(),
 		"status": this.getStatus(evalContext),
 		"fields": this.getFields(evalContext),
-		"author": this.getAuthor(evalContext),
 	}
-
-	return body
 }
 
 func (this *FlowdockNotifier) getStatus(evalContext *alerting.EvalContext) map[string]string {

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -52,14 +52,7 @@ type FlowdockNotifier struct {
 
 func (this *FlowdockNotifier) Notify(evalContext *alerting.EvalContext) error {
 	this.log.Info("Executing Flowdock notification", "ruleId", evalContext.Rule.Id, "notification", this.Name)
-
-	out, err := json.Marshal(evalContext)
-	if err != nil {
-		panic(err)
-	}
-
-	this.log.Info("Debug", string(out))
-
+	this.log.Info("This took", "Ms", evalContext.GetDurationMs())
 	body := this.getBody(evalContext)
 	body["flow_token"] = this.FlowToken
 

--- a/pkg/services/alerting/notifiers/flowdock.go
+++ b/pkg/services/alerting/notifiers/flowdock.go
@@ -3,6 +3,7 @@ package notifiers
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
@@ -142,8 +143,12 @@ func (this *FlowdockNotifier) getAuthor(evalContext *alerting.EvalContext) map[s
 }
 
 func (this *FlowdockNotifier) combineStartTimeAndRuleId(evalContext *alerting.EvalContext) string {
-	startTime := evalContext.StartTime.Unix()
+	startTime := evalContext.StartTime
+	beginningOfDay := time.Date(
+		startTime.Year(), startTime.Month(), startTime.Day(),
+		0, 0, 0, 0, startTime.Location())
+
 	ruleId := evalContext.Rule.Id
 
-	return fmt.Sprintf("%d", (ruleId + startTime))
+	return fmt.Sprintf("%d", (ruleId + beginningOfDay.Unix()))
 }

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -1,0 +1,15 @@
+package notifiers
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFlowdockNotifier(t *testing.T) {
+	Convey("Flowdock notifier tests", t, func() {
+		Convey("Parsing alert notification from settings", func() {
+			So(true, ShouldEqual, true)
+		})
+	})
+}

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -25,8 +25,9 @@ func BuildTestEvalContext() *alerting.EvalContext {
 	evalMatches := make([]*alerting.EvalMatch, 0)
 	evalMatches = append(evalMatches, evalMatch)
 
+	startTime, _ := time.Parse(time.RFC3339, "2018-05-06T18:30:00Z")
 	return &alerting.EvalContext{
-		StartTime:      time.Now(),
+		StartTime:      startTime,
 		Rule:           rule,
 		PrevAlertState: rule.State,
 		EvalMatches:    evalMatches,
@@ -186,6 +187,18 @@ func TestFlowdockNotifier(t *testing.T) {
 
 				correctBody := `<img src="https://example.com/image.png">`
 				So(threadMap["body"], ShouldEqual, correctBody)
+			})
+
+			Convey("calculate external thread id from rule and start time", func() {
+				json := `
+			{ "flowToken": "abcd1234" }
+				`
+				not, _ := BuildFlowdockNotifier(json)
+				flowdockNotifier := not.(*FlowdockNotifier)
+
+				testEvalContext := BuildTestEvalContext()
+				body := flowdockNotifier.getBody(testEvalContext)
+				So(body["external_thread_id"], ShouldEqual, "1525631400")
 			})
 		})
 	})

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -24,6 +24,25 @@ func TestFlowdockNotifier(t *testing.T) {
 				_, err := NewFlowdockNotifier(model)
 				So(err, ShouldNotBeNil)
 			})
+
+			Convey("settings with flowToken should return notifier", func() {
+				json := `
+			{ "flowToken": "abcd1234" }
+				`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &m.AlertNotification{
+					Name:     "flowdock_testing",
+					Type:     "flowdock",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewFlowdockNotifier(model)
+				flowdockNotifier := not.(*FlowdockNotifier)
+
+				So(err, ShouldBeNil)
+				So(flowdockNotifier.FlowToken, ShouldEqual, "abcd1234")
+			})
 		})
 	})
 }

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -189,7 +189,7 @@ func TestFlowdockNotifier(t *testing.T) {
 				So(threadMap["body"], ShouldEqual, correctBody)
 			})
 
-			Convey("calculate external thread id from rule and start time", func() {
+			Convey("calculate external thread id from rule and date", func() {
 				json := `
 			{ "flowToken": "abcd1234" }
 				`
@@ -198,7 +198,7 @@ func TestFlowdockNotifier(t *testing.T) {
 
 				testEvalContext := BuildTestEvalContext()
 				body := flowdockNotifier.getBody(testEvalContext)
-				So(body["external_thread_id"], ShouldEqual, "1525631400")
+				So(body["external_thread_id"], ShouldEqual, "1525564800")
 			})
 		})
 	})

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -30,6 +30,8 @@ func BuildTestEvalContext() *alerting.EvalContext {
 		Rule:           rule,
 		PrevAlertState: rule.State,
 		EvalMatches:    evalMatches,
+
+		ImagePublicUrl: "https://example.com/image.png",
 	}
 }
 
@@ -172,6 +174,18 @@ func TestFlowdockNotifier(t *testing.T) {
 			})
 
 			Convey("build thread", func() {
+				json := `
+			{ "flowToken": "abcd1234" }
+				`
+				not, _ := BuildFlowdockNotifier(json)
+				flowdockNotifier := not.(*FlowdockNotifier)
+
+				testEvalContext := BuildTestEvalContext()
+				thread := flowdockNotifier.getBody(testEvalContext)["thread"]
+				threadMap := thread.(map[string]interface{})
+
+				correctBody := `<img src="https://example.com/image.png">`
+				So(threadMap["body"], ShouldEqual, correctBody)
 			})
 		})
 	})

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -134,6 +134,21 @@ func TestFlowdockNotifier(t *testing.T) {
 				So(fieldsList[1]["label"], ShouldEqual, "Another metric")
 				So(fieldsList[1]["value"], ShouldEqual, "5.123")
 			})
+
+			Convey("Use Grafana as an author", func() {
+				json := `
+			{ "flowToken": "abcd1234" }
+				`
+				not, _ := BuildFlowdockNotifier(json)
+				flowdockNotifier := not.(*FlowdockNotifier)
+
+				testEvalContext := BuildTestEvalContext()
+				author := flowdockNotifier.getBody(testEvalContext)["author"]
+				authorMap := author.(map[string]string)
+
+				So(authorMap["name"], ShouldEqual, "Grafana")
+				So(authorMap["avatar"], ShouldEqual, "https://grafana.com/assets/img/fav32.png")
+			})
 		})
 	})
 }

--- a/pkg/services/alerting/notifiers/flowdock_test.go
+++ b/pkg/services/alerting/notifiers/flowdock_test.go
@@ -3,13 +3,27 @@ package notifiers
 import (
 	"testing"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	m "github.com/grafana/grafana/pkg/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestFlowdockNotifier(t *testing.T) {
 	Convey("Flowdock notifier tests", t, func() {
 		Convey("Parsing alert notification from settings", func() {
-			So(true, ShouldEqual, true)
+			Convey("empty settings should return error", func() {
+				json := `{ }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &m.AlertNotification{
+					Name:     "flowdock_testing",
+					Type:     "flowdock",
+					Settings: settingsJSON,
+				}
+
+				_, err := NewFlowdockNotifier(model)
+				So(err, ShouldNotBeNil)
+			})
 		})
 	})
 }


### PR DESCRIPTION
**Overview**
This PR adds functionality to `POST` alert notifications to Flowdock via [REST API](https://www.flowdock.com/api)

![image](https://user-images.githubusercontent.com/1257076/40009646-520620ea-57ab-11e8-8f07-632ab6a700e9.png)

The alert events from the same rule are grouped to the same thread if the event happened during the same day:
![image](https://user-images.githubusercontent.com/1257076/40009799-aee9bdda-57ab-11e8-9c3e-55241a795bfd.png)

Feature request https://github.com/grafana/grafana/issues/11932