### PR TITLE
Alerting status api endpoint

### DIFF
--- a/docs/sources/http_api/alerting.md
+++ b/docs/sources/http_api/alerting.md
@@ -80,6 +80,8 @@ Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 ```
 
+**Example Response**:
+
 ```http
 HTTP/1.1 200
 Content-Type: application/json

--- a/docs/sources/http_api/alerting.md
+++ b/docs/sources/http_api/alerting.md
@@ -80,8 +80,6 @@ Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 ```
 
-**Example Response**:
-
 ```http
 HTTP/1.1 200
 Content-Type: application/json
@@ -97,6 +95,26 @@ Content-Type: application/json
   "url": "http://grafana.com/dashboard/db/sensors"
 }
 ```
+
+## Get current status of one alert
+
+`GET /api/alerts/status/:id`
+
+**Example Request**:
+
+```http
+GET /api/alerts/status/1 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+**Example Response**:
+
+see `GET /api/alerts/:id`
+
+This endpoint is the same as `GET /api/alerts/:id` during the "ok" state. 
+In other states it reloads the current EvalData on each call, rather than pulling it from cached values in the database.
+Therefore, the server-specific data provided by this endpoint should be more current, but it is also a somewhat more resource-intensive call.
 
 ## Pause alert
 

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -146,7 +146,7 @@ func GetAlertStatus(c *m.ReqContext) Response {
 		if validationErr, ok := err.(alerting.ValidationError); ok {
 			return Error(422, validationErr.Error(), nil)
 		}
-		return Error(500, "Failed to test rule", err)
+		return Error(500, "Failed to get alert status", err)
 	}
 
 	evalContext := backendCmd.Result

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
 func ValidateOrgAlert(c *m.ReqContext) {
@@ -159,7 +159,7 @@ func GetAlertStatus(c *m.ReqContext) Response {
 
 		evalMatches = append(evalMatches, map[string]interface{}{
 			"Metric": evt.Metric,
-			"Tags":	  evt.Tags,
+			"Tags":   evt.Tags,
 			"Value":  evt.Value.FullString(),
 		})
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -329,6 +329,7 @@ func (hs *HTTPServer) registerRoutes() {
 			alertsRoute.Post("/test", bind(dtos.AlertTestCommand{}), wrap(AlertTest))
 			alertsRoute.Post("/:alertId/pause", reqEditorRole, bind(dtos.PauseAlertCommand{}), wrap(PauseAlert))
 			alertsRoute.Get("/:alertId", ValidateOrgAlert, wrap(GetAlert))
+			alertsRoute.Get("/status/:alertId", ValidateOrgAlert, wrap(GetAlertStatus))
 			alertsRoute.Get("/", wrap(GetAlerts))
 			alertsRoute.Get("/states-for-dashboard", wrap(GetAlertStatesForDashboard))
 		})

--- a/pkg/api/dtos/alerting.go
+++ b/pkg/api/dtos/alerting.go
@@ -52,15 +52,6 @@ type AlertTestResultLog struct {
 	Data    interface{} `json:"data"`
 }
 
-type AlertStatusResult struct {
-	Firing         bool             `json:"firing"`
-	State          m.AlertStateType `json:"state"`
-	ConditionEvals string           `json:"conditionEvals"`
-	TimeMs         string           `json:"timeMs"`
-	Error          string           `json:"error,omitempty"`
-	EvalMatches    []*EvalMatch     `json:"matches,omitempty"`
-}
-
 type EvalMatch struct {
 	Tags   map[string]string `json:"tags,omitempty"`
 	Metric string            `json:"metric"`

--- a/pkg/api/dtos/alerting.go
+++ b/pkg/api/dtos/alerting.go
@@ -52,6 +52,15 @@ type AlertTestResultLog struct {
 	Data    interface{} `json:"data"`
 }
 
+type AlertStatusResult struct {
+	Firing         bool             `json:"firing"`
+	State          m.AlertStateType `json:"state"`
+	ConditionEvals string           `json:"conditionEvals"`
+	TimeMs         string           `json:"timeMs"`
+	Error          string           `json:"error,omitempty"`
+	EvalMatches    []*EvalMatch     `json:"matches,omitempty"`
+}
+
 type EvalMatch struct {
 	Tags   map[string]string `json:"tags,omitempty"`
 	Metric string            `json:"metric"`

--- a/pkg/services/alerting/status_rule.go
+++ b/pkg/services/alerting/status_rule.go
@@ -2,7 +2,6 @@ package alerting
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
@@ -26,8 +25,7 @@ func handleAlertStatusCommand(cmd *AlertStatusCommand) error {
 	}
 
 	cmd.Result = updateState(rule)
-
-	return fmt.Errorf("could not find alert with panel id %d", cmd.Alert.PanelId)
+	return nil
 }
 
 func updateState(rule *Rule) *EvalContext {

--- a/pkg/services/alerting/status_rule.go
+++ b/pkg/services/alerting/status_rule.go
@@ -9,7 +9,7 @@ import (
 )
 
 type AlertStatusCommand struct {
-	Alert   *m.Alert
+	Alert  *m.Alert
 
 	Result *EvalContext
 }
@@ -34,7 +34,6 @@ func updateState(rule *Rule) *EvalContext {
 	handler := NewEvalHandler()
 
 	evalContext := NewEvalContext(context.Background(), rule)
-	evalContext.IsTestRun = true
 
 	handler.Eval(evalContext)
 	evalContext.Rule.State = evalContext.GetNewState()

--- a/pkg/services/alerting/status_rule.go
+++ b/pkg/services/alerting/status_rule.go
@@ -27,7 +27,7 @@ func handleAlertStatusCommand(cmd *AlertStatusCommand) error {
 
 	cmd.Result = updateState(rule)
 
-	return fmt.Errorf("Could not find alert with panel id %d", cmd.Alert.PanelId)
+	return fmt.Errorf("could not find alert with panel id %d", cmd.Alert.PanelId)
 }
 
 func updateState(rule *Rule) *EvalContext {

--- a/pkg/services/alerting/status_rule.go
+++ b/pkg/services/alerting/status_rule.go
@@ -1,0 +1,57 @@
+package alerting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+type AlertStatusCommand struct {
+	Dashboard *m.Dashboard
+	PanelId int64
+	OrgId 	int64
+
+	Result *EvalContext
+}
+
+func init() {
+	bus.AddHandler("alerting", handleAlertStatusCommand)
+}
+
+func handleAlertStatusCommand(cmd *AlertStatusCommand) error {
+
+	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId)
+
+	alerts, err := extractor.GetAlerts()
+	if err != nil {
+		return err
+	}
+
+	for _, alert := range alerts {
+		if alert.PanelId == cmd.PanelId {
+			rule, err := NewRuleFromDBAlert(alert)
+			if err != nil {
+				return err
+			}
+
+			cmd.Result = updateState(rule)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Could not find alert with panel id %d", cmd.PanelId)
+}
+
+func updateState(rule *Rule) *EvalContext {
+	handler := NewEvalHandler()
+
+	context := NewEvalContext(context.Background(), rule)
+	context.IsTestRun = true
+
+	handler.Eval(context)
+	context.Rule.State = context.GetNewState()
+
+	return context
+}

--- a/pkg/services/alerting/status_rule.go
+++ b/pkg/services/alerting/status_rule.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AlertStatusCommand struct {
-	Alert  *m.Alert
+	Alert *m.Alert
 
 	Result *EvalContext
 }


### PR DESCRIPTION
This is the kind of api endpoint functionality I had in mind when I raised [#11849](https://github.com/grafana/grafana/issues/11849) about evalData not being updated when an alert is in the "alerting" state.

I can see why the alerts api should not be changed so I created a new endpoint that updates the evalData when the alert is not in an "ok" state. `GET /api/alerts/status/:id`

We're finding this endpoint very useful for keeping track of the state of multiple servers who's metrics might have entered an "alerting" state after the state was initially triggered. Otherwise, it provides the same content and format as `GET /api/alerts/:id`

The documentation will make more sense once #11934 is merged.
