### PR TITLE
scroll: fix for double scrollbar issue

### DIFF
--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -44,8 +44,16 @@ div.flot-text {
   padding: $panel-padding;
   height: calc(100% - 27px);
   position: relative;
+
   // Fixes scrolling on mobile devices
   overflow: auto;
+}
+
+// For larger screens, set back to hidden to avoid double scroll bars
+@include media-breakpoint-up(md) {
+  .panel-content {
+    overflow: hidden;
+  }
 }
 
 .panel-title-container {


### PR DESCRIPTION
If #11939 is not merged in the patch release, then this is a temporary fix for 5.1.3. It sets overflow to hidden for larger screens and keeps the overflow set to auto for mobiles and tablets.

Fixes #11937