### PR TITLE
legend: fixes Firefox/baron scroll bug

### DIFF
--- a/public/app/plugins/panel/graph/legend.ts
+++ b/public/app/plugins/panel/graph/legend.ts
@@ -287,6 +287,10 @@ module.directive('graphLegend', function(popoverSrv, $timeout) {
           destroyScrollbar();
           legendScrollbar = baron(scrollbarParams);
         }
+
+        // #11830 - compensates for Firefox scrollbar calculation error in the baron framework
+        scroller[0].style.marginRight = '-' + (scroller[0].offsetWidth - scroller[0].clientWidth) + 'px';
+
         legendScrollbar.scroll();
       }
 


### PR DESCRIPTION
Compensates for Firefox scrollbar calculation error in the baron framework. Offsetwidth and clientwidth are used to find the width of the scrollbar. In the legend these differ by 9px and cause the scroll div to grow by 9px for every refresh. This fix compensates with a negative margin-right in that case.

Fixes #11830