### PR TITLE
explore: fixes #11953

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -312,7 +312,7 @@ class MetricsPanelCtrl extends PanelCtrl {
 
   getAdditionalMenuItems() {
     const items = [];
-    if (this.datasource.supportsExplore) {
+    if (this.datasource && this.datasource.supportsExplore) {
       items.push({
         text: 'Explore',
         click: 'ctrl.explore();',

--- a/public/app/features/panel/specs/metrics_panel_ctrl.jest.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.jest.ts
@@ -1,0 +1,65 @@
+jest.mock('app/core/core', () => ({}));
+
+import { MetricsPanelCtrl } from '../metrics_panel_ctrl';
+import q from 'q';
+import { PanelModel } from 'app/features/dashboard/panel_model';
+
+describe('MetricsPanelCtrl', () => {
+  let ctrl;
+
+  beforeEach(() => {
+    ctrl = setupController();
+  });
+
+  describe('when getting additional menu items', () => {
+    let additionalItems;
+
+    describe('and has no datasource set', () => {
+      beforeEach(() => {
+        additionalItems = ctrl.getAdditionalMenuItems();
+      });
+
+      it('should not return any items', () => {
+        expect(additionalItems.length).toBe(0);
+      });
+    });
+
+    describe('and has datasource set that supports explore', () => {
+      beforeEach(() => {
+        ctrl.datasource = { supportsExplore: true };
+        additionalItems = ctrl.getAdditionalMenuItems();
+      });
+
+      it('should not return any items', () => {
+        expect(additionalItems.length).toBe(1);
+      });
+    });
+  });
+});
+
+function setupController() {
+  const injectorStub = {
+    get: type => {
+      switch (type) {
+        case '$q': {
+          return q;
+        }
+        default: {
+          return jest.fn();
+        }
+      }
+    },
+  };
+
+  const scope = {
+    panel: { events: [] },
+    appEvent: jest.fn(),
+    onAppEvent: jest.fn(),
+    $on: jest.fn(),
+    colors: [],
+  };
+
+  MetricsPanelCtrl.prototype.panel = new PanelModel({ type: 'test' });
+
+  return new MetricsPanelCtrl(scope, injectorStub);
+}


### PR DESCRIPTION
Fixes #11953

Adds some defensive programming for panels where the datasource property is not set.

Noticed the metrics_panel_ctrl has no tests so added a jest test class. Ran into some issues with angular - what do you think of the prototype approach @marefr ? It is probably possible to get it working with angular mocks if I put some more time into it.
