### PR TITLE
fix: remove $$hashKey from dashboard json export

### DIFF
--- a/public/app/features/annotations/partials/editor.html
+++ b/public/app/features/annotations/partials/editor.html
@@ -21,7 +21,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr ng-repeat="annotation in ctrl.annotations">
+				<tr ng-repeat="annotation in ctrl.annotations track by annotation.name">
 					<td style="width:90%" ng-hide="annotation.builtIn" class="pointer" ng-click="ctrl.edit(annotation)">
 						<i class="fa fa-comment" style="color:{{annotation.iconColor}}"></i> &nbsp;
 						{{annotation.name}}


### PR DESCRIPTION
Hi,

here is a quick fix for #11551 
As @bergquist  suggested, we should only using angular instead of JSON to stringify the json.