### PR TITLE
Singlestat value: vertical alignment fix

### DIFF
--- a/public/sass/components/_panel_singlestat.scss
+++ b/public/sass/components/_panel_singlestat.scss
@@ -8,13 +8,11 @@
 .singlestat-panel-value-container {
   line-height: 1;
   display: table-cell;
-  vertical-align: middle;
-  text-align: center;
+  position: absolute;
   z-index: 1;
   font-size: 3em;
   font-weight: bold;
   margin: 0;
-  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/public/sass/components/_panel_singlestat.scss
+++ b/public/sass/components/_panel_singlestat.scss
@@ -10,10 +10,15 @@
   display: table-cell;
   vertical-align: middle;
   text-align: center;
-  position: relative;
   z-index: 1;
   font-size: 3em;
   font-weight: bold;
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding-bottom: 10px;
 }
 
 .singlestat-panel-prefix {


### PR DESCRIPTION
There is a problem with vertical alignment of Singlestat value - it's a bit lower then it has to be.
This hack fix it.

Before:
![before](https://user-images.githubusercontent.com/1700286/40282241-07b734b0-5c75-11e8-8dbb-209b1ea377d8.jpg)

After:
![after](https://user-images.githubusercontent.com/1700286/40282245-10ca389a-5c75-11e8-81a6-f0f2d74cff48.jpg)

