### PR TITLE
fix names of foreign arch packages

### DIFF
--- a/build.go
+++ b/build.go
@@ -144,7 +144,7 @@ func packageGrafana() {
 	grunt(postProcessArgs...)
 	pkgArch = previousPkgArch
 
-	if goos == "linux" && goarch == "amd64"{
+	if goos == "linux" {
 		createLinuxPackages()
 	}
 }
@@ -229,6 +229,10 @@ type linuxPackageOptions struct {
 }
 
 func createDebPackages() {
+	previousPkgArch := pkgArch
+	if pkgArch == "armv7" {
+		pkgArch = "armhf"
+    }
 	createPackage(linuxPackageOptions{
 		packageType:            "deb",
 		homeDir:                "/usr/share/grafana",
@@ -246,9 +250,15 @@ func createDebPackages() {
 
 		depends: []string{"adduser", "libfontconfig"},
 	})
+	pkgArch = previousPkgArch
 }
 
 func createRpmPackages() {
+	previousPkgArch := pkgArch
+	switch {
+		case pkgArch == "armv7" : pkgArch = "armhfp"
+		case pkgArch == "arm64" : pkgArch = "aarch64"
+	}
 	createPackage(linuxPackageOptions{
 		packageType:            "rpm",
 		homeDir:                "/usr/share/grafana",
@@ -266,6 +276,7 @@ func createRpmPackages() {
 
 		depends: []string{"/sbin/service", "fontconfig", "freetype", "urw-fonts"},
 	})
+	pkgArch = previousPkgArch
 }
 
 func createLinuxPackages() {


### PR DESCRIPTION
This PR is related to #11920 and #12045 and aims to better package support on linux non amd64 arch

On debian:
- armv7 is armhf
- arm64 is arm64

On rpm:
- armv7 is armhfp
- arm64 is aarch64

It also removes phantomjs amd64 binary from armv7/arm64 packages (tarball, rpm and deb)
