### PR TITLE
Multiline title support

### DIFF
--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -31,8 +31,11 @@ div.flot-text {
 .panel-container {
   background-color: $panel-bg;
   border: $panel-border;
-  position: relative;
   border-radius: 3px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
 
   &.panel-transparent {
     background-color: transparent;


### PR DESCRIPTION
Personally, I'd prefer to see the whole title as it is probably so long for a reason rather than replacing overflowed part with ellipsis.

Eg. imagine title `Data Center 1 – Switch 2 – Port 3` shortened to `Data Center 1 – Switch 2 – Po...` when showing repeated panels for all ports in Switch 2 in Data Center 1

**Current state:**

![image](https://user-images.githubusercontent.com/327717/40542835-15b038d6-6022-11e8-84fd-aa4b4596a7a8.png)

**New state:**

![image](https://user-images.githubusercontent.com/327717/40542846-21616c36-6022-11e8-83c9-67ded01bcb02.png)

Fixes #11905