### PR TITLE
Split webpack dev config into dev and hot

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "scripts": {
     "dev": "webpack --progress --colors --config scripts/webpack/webpack.dev.js",
-    "start": "webpack-dev-server --progress --colors --config scripts/webpack/webpack.dev.js",
+    "start": "webpack-dev-server --progress --colors --config scripts/webpack/webpack.hot.js",
     "watch": "webpack --progress --colors --watch --config scripts/webpack/webpack.dev.js",
     "build": "grunt build",
     "test": "grunt test",


### PR DESCRIPTION
Motivation:

* too many conditionals for config, better to be explicit
* different priorities: faster build for hot mode
* working SCSS sources for styles in hot mode

The biggest differences:

* removed linter from TS loader in hot (should be editor or precommit
 or responsibility)
* simplified styles loading, no need for extractTextPlugin
* hot needs more extensions to resolve
* removed commons chunking for hot
* removed devServer from dev

Reduced HMR time from 8s to 4s on my machine.
