### PR TITLE
docker: new block for elasticsearch6

### DIFF
--- a/docker/blocks/elastic6/docker-compose.yaml
+++ b/docker/blocks/elastic6/docker-compose.yaml
@@ -1,0 +1,15 @@
+# You need to run 'sysctl -w vm.max_map_count=262144' on the host machine
+
+  elasticsearch6:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4
+    command: elasticsearch
+    ports:
+      - "11200:9200"
+      - "11300:9300"
+
+  fake-elastic6-data:
+    image: grafana/fake-data-gen
+    network_mode: bridge
+    environment:
+      FD_DATASOURCE: elasticsearch6
+      FD_PORT: 11200

--- a/docker/blocks/elastic6/elasticsearch.yml
+++ b/docker/blocks/elastic6/elasticsearch.yml
@@ -1,0 +1,2 @@
+script.inline: on
+script.indexed: on


### PR DESCRIPTION
The [FakeData repo is already updated](https://github.com/grafana/fake-data-gen/commit/dad697846f0cc567b9829fdd1e6aa2d52e6ecdc5) and a new version pushed to dockerhub.


