### PR TITLE
Fix cache busting for systemjs imports for plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -27,6 +27,13 @@ import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/combineAll';
 
+// add cache busting
+const bust = `?_cache=${Date.now()}`;
+function locate(load) {
+  return load.address + bust;
+}
+System.registry.set('plugin-loader', System.newModule({ locate: locate }));
+
 System.config({
   baseURL: 'public',
   defaultExtension: 'js',
@@ -40,22 +47,13 @@ System.config({
     css: 'vendor/plugin-css/css.js',
   },
   meta: {
-    '*': {
+    'plugin*': {
       esModule: true,
       authorization: true,
+      loader: 'plugin-loader',
     },
   },
 });
-
-// add cache busting
-var systemLocate = System.locate;
-System.cacheBust = '?bust=' + Date.now();
-System.locate = function(load) {
-  var System = this;
-  return Promise.resolve(systemLocate.call(this, load)).then(function(address) {
-    return address + System.cacheBust;
-  });
-};
 
 function exposeToPlugin(name: string, component: any) {
   System.registerDynamic(name, [], true, function(require, exports, module) {

--- a/public/vendor/plugin-css/css.js
+++ b/public/vendor/plugin-css/css.js
@@ -1,6 +1,7 @@
 "use strict";
 
 if (typeof window !== 'undefined') {
+  var bust = '?_cache=' + Date.now();
   var waitSeconds = 100;
 
   var head = document.getElementsByTagName('head')[0];
@@ -13,8 +14,8 @@ if (typeof window !== 'undefined') {
   }
 
   var isWebkit = !!window.navigator.userAgent.match(/AppleWebKit\/([^ ;]*)/);
-  var webkitLoadCheck = function(link, callback) {
-    setTimeout(function() {
+  var webkitLoadCheck = function (link, callback) {
+    setTimeout(function () {
       for (var i = 0; i < document.styleSheets.length; i++) {
         var sheet = document.styleSheets[i];
         if (sheet.href === link.href) {
@@ -25,17 +26,17 @@ if (typeof window !== 'undefined') {
     }, 10);
   };
 
-  var noop = function() {};
+  var noop = function () { };
 
-  var loadCSS = function(url) {
-    return new Promise(function(resolve, reject) {
-      var timeout = setTimeout(function() {
+  var loadCSS = function (url) {
+    return new Promise(function (resolve, reject) {
+      var timeout = setTimeout(function () {
         reject('Unable to load CSS');
       }, waitSeconds * 1000);
-      var _callback = function(error) {
+      var _callback = function (error) {
         clearTimeout(timeout);
         link.onload = link.onerror = noop;
-        setTimeout(function() {
+        setTimeout(function () {
           if (error) {
             reject(error);
           }
@@ -47,22 +48,22 @@ if (typeof window !== 'undefined') {
       var link = document.createElement('link');
       link.type = 'text/css';
       link.rel = 'stylesheet';
-      link.href = url;
+      link.href = url + bust;
       if (!isWebkit) {
-        link.onload = function() {
+        link.onload = function () {
           _callback();
         }
       } else {
         webkitLoadCheck(link, _callback);
       }
-      link.onerror = function(event) {
+      link.onerror = function (event) {
         _callback(event.error || new Error('Error loading CSS file.'));
       };
       head.appendChild(link);
     });
   };
 
-  exports.fetch = function(load) {
+  exports.fetch = function (load) {
     // dont reload styles loaded in the head
     for (var i = 0; i < linkHrefs.length; i++)
       if (load.address == linkHrefs[i])


### PR DESCRIPTION
* everything imported via systemjs in the path `plugin/` will get a
 timestamp appended for cache busting
* timestamp is set once on page load
* plugin css loader gets cache buster too

Fixes #11446 