### PR TITLE
WIP: Initial commit for web hook notifications for annotations.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -349,6 +349,17 @@ ehlo_identity =
 welcome_email_on_sign_up = false
 templates_pattern = emails/*.html
 
+#################################### Webhook #####################
+[webhook]
+enabled = false
+url = http://localhost:8080
+user =
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+password =
+cert_file =
+key_file =
+skip_verify = false
+
 #################################### Logging ##########################
 [log]
 # Either "console", "file", "syslog". Default is console and  file

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -319,6 +319,17 @@ log_queries =
 [emails]
 ;welcome_email_on_sign_up = false
 
+#################################### Webhook ##########################
+[webhook]
+;enabled = false
+;url = http://localhost:8080
+;user =
+# If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+;password =
+;cert_file =
+;key_file =
+;skip_verify = false
+
 #################################### Logging ##########################
 [log]
 # Either "console", "file", "syslog". Default is console and  file

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/events"
 )
 
 func GetAnnotations(c *m.ReqContext) Response {
@@ -103,6 +105,16 @@ func PostAnnotation(c *m.ReqContext, cmd dtos.PostAnnotationsCmd) Response {
 			"id":      startID,
 			"endId":   item.Id,
 		})
+	}
+
+	// notify via webhook if payload has 'notify' field
+	if item.Data != nil && item.Data.Get("notify").MustBool() {
+		b, err := item.Data.MarshalJSON()
+		if err == nil {
+			bus.Publish(&events.AnnotationCreated{
+				Body: string(b),
+			})
+		}
 	}
 
 	return JSON(200, util.DynMap{

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/events"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/events"
 )
 
 func GetAnnotations(c *m.ReqContext) Response {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -89,3 +89,13 @@ type UserUpdated struct {
 	Login     string    `json:"login"`
 	Email     string    `json:"email"`
 }
+
+type AnnotationCreated struct {
+	Timestamp time.Time `json:"timestamp"`
+	Body      string    `json:"body"`
+}
+
+type AnnotationUpdated struct {
+	Timestamp time.Time `json:"timestamp"`
+	Body      string    `json:"body"`
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -50,6 +50,9 @@ var (
 	M_DataSource_ProxyReq_Timer prometheus.Summary
 	M_Alerting_Execution_Time   prometheus.Summary
 
+	// Webhook
+	M_Webhook_Execution_Time *prometheus.SummaryVec
+
 	// StatTotals
 	M_Alerting_Active_Alerts prometheus.Gauge
 	M_StatTotal_Dashboards   prometheus.Gauge
@@ -236,6 +239,15 @@ func init() {
 		Namespace: exporterName,
 	})
 
+	M_Webhook_Execution_Time = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:      "webhook_execution_time_milliseconds",
+			Help:      "summary of webhook request duration",
+			Namespace: exporterName,
+		},
+		[]string{"type", "statuscode"},
+	)
+
 	M_Alerting_Active_Alerts = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "alerting_active_alerts",
 		Help:      "amount of active alerts",
@@ -295,6 +307,7 @@ func initMetricVars() {
 		M_Api_Dashboard_Search,
 		M_DataSource_ProxyReq_Timer,
 		M_Alerting_Execution_Time,
+		M_Webhook_Execution_Time,
 		M_Api_Admin_User_Create,
 		M_Api_Login_Post,
 		M_Api_Login_OAuth,
@@ -428,4 +441,25 @@ func sendUsageStats() {
 
 	client := http.Client{Timeout: 5 * time.Second}
 	go client.Post(usageStatsURL, "application/json", data)
+}
+
+func NewSummaryTimer(summaryVec *prometheus.SummaryVec, status *int, labels ...string) *prometheus.Timer {
+	return prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		if *status == 0 {
+			return
+		}
+		switch {
+		case *status >= 500:
+			labels = append(labels, "5xx")
+		case *status >= 400:
+			labels = append(labels, "4xx")
+		case *status >= 300:
+			labels = append(labels, "3xx")
+		case *status >= 200:
+			labels = append(labels, "2xx")
+		default:
+			labels = append(labels, "1xx")
+		}
+		summaryVec.WithLabelValues(labels...).Observe(v)
+	}))
 }

--- a/pkg/models/notifications.go
+++ b/pkg/models/notifications.go
@@ -26,6 +26,7 @@ type SendWebhookSync struct {
 	HttpMethod  string
 	HttpHeader  map[string]string
 	ContentType string
+	Type        string
 }
 
 type SendResetPasswordEmailCommand struct {

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -113,6 +113,7 @@ func (ns *NotificationService) sendWebhookSync(ctx context.Context, cmd *m.SendW
 		HttpMethod:  cmd.HttpMethod,
 		HttpHeader:  cmd.HttpHeader,
 		ContentType: cmd.ContentType,
+		Type:        cmd.Type,
 	})
 }
 
@@ -230,6 +231,7 @@ func (ns *NotificationService) annotationCreatedHandler(evt *events.AnnotationCr
 			User:     ns.Cfg.Webhook.User,
 			Password: ns.Cfg.Webhook.Password,
 			Body:     evt.Body,
+			Type:     "annotation",
 		}
 	}
 	return nil
@@ -242,6 +244,7 @@ func (ns *NotificationService) annotationUpdatedHandler(evt *events.AnnotationUp
 			User:     ns.Cfg.Webhook.User,
 			Password: ns.Cfg.Webhook.Password,
 			Body:     evt.Body,
+			Type:     "annotation",
 		}
 	}
 	return nil

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -191,6 +191,9 @@ type Cfg struct {
 	// SMTP email settings
 	Smtp SmtpSettings
 
+	// Webhook settings
+	Webhook WebhookSettings
+
 	// Rendering
 	ImagesDir                        string
 	PhantomDir                       string
@@ -662,6 +665,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 
 	cfg.readSessionConfig()
 	cfg.readSmtpSettings()
+	cfg.readWebhookSettings()
 	cfg.readQuotaSettings()
 
 	if VerifyEmailEnabled && !cfg.Smtp.Enabled {

--- a/pkg/setting/setting_webhook.go
+++ b/pkg/setting/setting_webhook.go
@@ -1,0 +1,22 @@
+package setting
+
+type WebhookSettings struct {
+	Enabled    bool
+	Url        string
+	User       string
+	Password   string
+	CertFile   string
+	KeyFile    string
+	SkipVerify bool
+}
+
+func (cfg *Cfg) readWebhookSettings() {
+	sec := cfg.Raw.Section("webhook")
+	cfg.Webhook.Enabled = sec.Key("enabled").MustBool(false)
+	cfg.Webhook.Url = sec.Key("url").String()
+	cfg.Webhook.User = sec.Key("user").String()
+	cfg.Webhook.Password = sec.Key("password").String()
+	cfg.Webhook.CertFile = sec.Key("cert_file").String()
+	cfg.Webhook.KeyFile = sec.Key("key_file").String()
+	cfg.Webhook.SkipVerify = sec.Key("skip_verify").MustBool(false)
+}


### PR DESCRIPTION
Hi,
I want to create a dashboard panel with action buttons. 
After searching for the feature is grafana. I found few posts and feature request for the same.
https://github.com/grafana/grafana/issues/7343

I posted this query in community.
https://community.grafana.com/t/panel-annotation-as-notification-webhook/7671

This pull request will fixes #7343 

**Approach**:
Allow webhook notifications to be sent when an annotation is posted/updated.
Annotation data should have a flag 'notify' and webhook settings should be enabled in grafana. settings. This webhook is different from alerting webhook.

Please review this and let me know if this is acceptable. I will continue writing tests for this.

Thanks,
Harsha
