### PR TITLE
Use Passive eventListener for 'wheel'

### DIFF
--- a/public/app/core/components/grafana_app.ts
+++ b/public/app/core/components/grafana_app.ts
@@ -179,7 +179,6 @@ export function grafanaAppDirective(playlistSrv, contextSrv, $timeout, $rootScop
 
       function userActivityDetected() {
         lastActivity = new Date().getTime();
-        console.log('active', lastActivity);
         if (!activeUser) {
           activeUser = true;
           body.removeClass('user-activity-low');

--- a/public/app/core/components/grafana_app.ts
+++ b/public/app/core/components/grafana_app.ts
@@ -179,6 +179,7 @@ export function grafanaAppDirective(playlistSrv, contextSrv, $timeout, $rootScop
 
       function userActivityDetected() {
         lastActivity = new Date().getTime();
+        console.log('active', lastActivity);
         if (!activeUser) {
           activeUser = true;
           body.removeClass('user-activity-low');
@@ -199,7 +200,7 @@ export function grafanaAppDirective(playlistSrv, contextSrv, $timeout, $rootScop
       body.mousemove(userActivityDetected);
       body.keydown(userActivityDetected);
       // set useCapture = true to catch event here
-      document.addEventListener('wheel', userActivityDetected, true);
+      document.addEventListener('wheel', userActivityDetected, { capture: true, passive: true });
       // treat tab change as activity
       document.addEventListener('visibilitychange', userActivityDetected);
 


### PR DESCRIPTION
In chrome on windows (not OSX?) everytime grafana loads, it has this warning:
![image](https://user-images.githubusercontent.com/705951/40713036-5f48e7c8-63ff-11e8-8ea6-820e035d9a15.png)

If the event is marked as passive, that goes away.  I don't think its a big deal... but worth considering.  

https://caniuse.com/#feat=passive-event-listener
