### PR TITLE
Fix CSS to hide grid controls in fullscreen/low-activity views

### DIFF
--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -18,6 +18,20 @@
     height: 100% !important;
     transform: translate(0px, 0px) !important;
   }
+
+  // Disable grid interaction indicators in fullscreen panels
+
+  .panel-header:hover {
+    background-color: inherit;
+  }
+
+  .panel-title-container {
+    cursor: pointer;
+  }
+
+  .react-resizable-handle {
+    display: none;
+  }
 }
 
 @include media-breakpoint-down(sm) {

--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -10,7 +10,8 @@
 
 .playlist-active,
 .user-activity-low {
-  .react-resizable-handle .add-row-panel-hint,
+  .react-resizable-handle,
+  .add-row-panel-hint,
   .dash-row-menu-container,
   .navbar-button--refresh,
   .navbar-buttons--zoom,


### PR DESCRIPTION
* there was a comma missing to hide the handles, fixed now
* added new styles to hide header interaction in full screen panels

Fixes #11771 