### PR TITLE
Restrict Explore UI to Editor and Admin roles

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -77,6 +77,9 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboards/", reqSignedIn, Index)
 	r.Get("/dashboards/*", reqSignedIn, Index)
 
+	r.Get("/explore/", reqEditorRole, Index)
+	r.Get("/explore/*", reqEditorRole, Index)
+
 	r.Get("/playlists/", reqSignedIn, Index)
 	r.Get("/playlists/*", reqSignedIn, Index)
 	r.Get("/alerting/", reqSignedIn, Index)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -128,7 +128,7 @@ func setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, error) {
 		Children: dashboardChildNavs,
 	})
 
-	if setting.ExploreEnabled {
+	if setting.ExploreEnabled && (c.OrgRole == m.ROLE_ADMIN || c.OrgRole == m.ROLE_EDITOR) {
 		data.NavTree = append(data.NavTree, &dtos.NavLink{
 			Text:     "Explore",
 			Id:       "explore",

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -14,7 +14,7 @@ export class KeybindingSrv {
   timepickerOpen = false;
 
   /** @ngInject */
-  constructor(private $rootScope, private $location, private datasourceSrv, private timeSrv) {
+  constructor(private $rootScope, private $location, private datasourceSrv, private timeSrv, private contextSrv) {
     // clear out all shortcuts on route change
     $rootScope.$on('$routeChangeSuccess', () => {
       Mousetrap.reset();
@@ -177,21 +177,24 @@ export class KeybindingSrv {
       }
     });
 
-    this.bind('x', async () => {
-      if (dashboard.meta.focusPanelId) {
-        const panel = dashboard.getPanelById(dashboard.meta.focusPanelId);
-        const datasource = await this.datasourceSrv.get(panel.datasource);
-        if (datasource && datasource.supportsExplore) {
-          const range = this.timeSrv.timeRangeForUrl();
-          const state = {
-            ...datasource.getExploreState(panel),
-            range,
-          };
-          const exploreState = encodePathComponent(JSON.stringify(state));
-          this.$location.url(`/explore/${exploreState}`);
+    // jump to explore if permissions allow
+    if (this.contextSrv.isEditor) {
+      this.bind('x', async () => {
+        if (dashboard.meta.focusPanelId) {
+          const panel = dashboard.getPanelById(dashboard.meta.focusPanelId);
+          const datasource = await this.datasourceSrv.get(panel.datasource);
+          if (datasource && datasource.supportsExplore) {
+            const range = this.timeSrv.timeRangeForUrl();
+            const state = {
+              ...datasource.getExploreState(panel),
+              range,
+            };
+            const exploreState = encodePathComponent(JSON.stringify(state));
+            this.$location.url(`/explore/${exploreState}`);
+          }
         }
-      }
-    });
+      });
+    }
 
     // delete panel
     this.bind('p r', () => {

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -1,9 +1,9 @@
-import config from 'app/core/config';
 import $ from 'jquery';
 import _ from 'lodash';
+
+import config from 'app/core/config';
 import kbn from 'app/core/utils/kbn';
 import { PanelCtrl } from 'app/features/panel/panel_ctrl';
-
 import * as rangeUtil from 'app/core/utils/rangeutil';
 import * as dateMath from 'app/core/utils/datemath';
 import { encodePathComponent } from 'app/core/utils/location_util';

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -16,6 +16,7 @@ class MetricsPanelCtrl extends PanelCtrl {
   datasourceName: any;
   $q: any;
   $timeout: any;
+  contextSrv: any;
   datasourceSrv: any;
   timeSrv: any;
   templateSrv: any;
@@ -37,6 +38,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     // make metrics tab the default
     this.editorTabIndex = 1;
     this.$q = $injector.get('$q');
+    this.contextSrv = $injector.get('contextSrv');
     this.datasourceSrv = $injector.get('datasourceSrv');
     this.timeSrv = $injector.get('timeSrv');
     this.templateSrv = $injector.get('templateSrv');
@@ -312,7 +314,7 @@ class MetricsPanelCtrl extends PanelCtrl {
 
   getAdditionalMenuItems() {
     const items = [];
-    if (this.datasource && this.datasource.supportsExplore) {
+    if (this.contextSrv.isEditor && this.datasource && this.datasource.supportsExplore) {
       items.push({
         text: 'Explore',
         click: 'ctrl.explore();',

--- a/public/app/features/panel/specs/metrics_panel_ctrl.jest.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.jest.ts
@@ -24,8 +24,9 @@ describe('MetricsPanelCtrl', () => {
       });
     });
 
-    describe('and has datasource set that supports explore', () => {
+    describe('and has datasource set that supports explore and user has powers', () => {
       beforeEach(() => {
+        ctrl.contextSrv = { isEditor: true };
         ctrl.datasource = { supportsExplore: true };
         additionalItems = ctrl.getAdditionalMenuItems();
       });

--- a/public/app/routes/routes.ts
+++ b/public/app/routes/routes.ts
@@ -113,6 +113,7 @@ export function setupAngularRoutes($routeProvider, $locationProvider) {
     .when('/explore/:initial?', {
       template: '<react-container />',
       resolve: {
+        roles: () => ['Editor', 'Admin'],
         component: () => import(/* webpackChunkName: "explore" */ 'app/containers/Explore/Wrapper'),
       },
     })

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -11,6 +11,7 @@ export function ControllerTestContext() {
   this.$element = {};
   this.$sanitize = {};
   this.annotationsSrv = {};
+  this.contextSrv = {};
   this.timeSrv = new TimeSrvStub();
   this.templateSrv = new TemplateSrvStub();
   this.datasourceSrv = {
@@ -27,6 +28,7 @@ export function ControllerTestContext() {
 
   this.providePhase = function(mocks) {
     return angularMocks.module(function($provide) {
+      $provide.value('contextSrv', self.contextSrv);
       $provide.value('datasourceSrv', self.datasourceSrv);
       $provide.value('annotationsSrv', self.annotationsSrv);
       $provide.value('timeSrv', self.timeSrv);


### PR DESCRIPTION
Access is restricted via not showing in the following places:

* hide from sidemenu
* hide from panel header menu
* disable keybinding `x`

Also adds a `roles` property to reactContainer routes that will be
checked if `roles` is set, and on failure redirects to `/`.

Fixes #12001 