### PR TITLE
alerting: show alerts for user with Viewer role

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -79,7 +79,7 @@ func GetAlerts(c *m.ReqContext) Response {
 			DashboardIds: dashboardIDs,
 			Type:         string(search.DashHitDB),
 			FolderIds:    folderIDs,
-			Permission:   m.PERMISSION_EDIT,
+			Permission:   m.PERMISSION_VIEW,
 		}
 
 		err := bus.Dispatch(&searchQuery)

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -116,7 +116,7 @@ func HandleAlertsQuery(query *m.GetAlertsQuery) error {
 	}
 
 	if query.User.OrgRole != m.ROLE_ADMIN {
-		builder.writeDashboardPermissionFilter(query.User, m.PERMISSION_EDIT)
+		builder.writeDashboardPermissionFilter(query.User, m.PERMISSION_VIEW)
 	}
 
 	builder.Write(" ORDER BY name ASC")

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -2,7 +2,6 @@ package sqlstore
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -110,11 +109,12 @@ func TestAlertingDataAccess(t *testing.T) {
 		})
 
 		Convey("Viewer cannot read alerts", func() {
-			alertQuery := m.GetAlertsQuery{DashboardIDs: []int64{testDash.Id}, PanelId: 1, OrgId: 1, User: &m.SignedInUser{OrgRole: m.ROLE_VIEWER}}
+			viewerUser := &m.SignedInUser{OrgRole: m.ROLE_VIEWER, OrgId: 1}
+			alertQuery := m.GetAlertsQuery{DashboardIDs: []int64{testDash.Id}, PanelId: 1, OrgId: 1, User: viewerUser}
 			err2 := HandleAlertsQuery(&alertQuery)
 
 			So(err2, ShouldBeNil)
-			So(alertQuery.Result, ShouldHaveLength, 0)
+			So(alertQuery.Result, ShouldHaveLength, 1)
 		})
 
 		Convey("Alerts with same dashboard id and panel id should update", func() {


### PR DESCRIPTION
This PR fixes #11167. Also, a little fix for the test, it was wrong - without _OrgId_ specified for user _HandleAlertsQuery()_ always returns an emty set of alerts (even for Editor role), because dashboard's OrgId=1.