### PR TITLE
elasticsearch: When fetching templating terms order by doc_count.

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -312,9 +312,6 @@ export class ElasticQueryBuilder {
         terms: {
           field: queryDef.field,
           size: size,
-          order: {
-            _term: 'asc',
-          },
         },
       },
     };


### PR DESCRIPTION
This fixes #7715. Fetching terms by term value is pretty useless since that can be handled in the frontend using alphabetical/numerical sort.
