### PR TITLE
Display prefix on repeated SingleStat panel with variable All option …

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -418,7 +418,11 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     }
 
     function getSpan(className, fontSize, value) {
-      value = templateSrv.replace(value, data.scopedVars);
+      if (panel.repeat && !data.scopedVars) {
+        value = panel.repeat;
+      } else {
+        value = templateSrv.replace(value, data.scopedVars);
+      }
       return '<span class="' + className + '" style="font-size:' + fontSize + '">' + value + '</span>';
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/grafana/grafana/issues/11441.
When a variable is set to repeat and the "All" option is selected while the value is null, it should just display the variable name instead. 