### PR TITLE
foldername in dashboard header

### DIFF
--- a/public/app/features/dashboard/dashnav/dashnav.html
+++ b/public/app/features/dashboard/dashnav/dashnav.html
@@ -3,7 +3,7 @@
 	<div>
 		<a class="navbar-page-btn" ng-click="ctrl.showSearch()">
 			<i class="gicon gicon-dashboard"></i>
-			{{ctrl.dashboard.title}}
+			<span ng-if="ctrl.dashboard.meta.folderTitle !== 'General'" class="navbar-page-btn--folder">{{ctrl.dashboard.meta.folderTitle}} / </span>{{ctrl.dashboard.title}}
 			<i class="fa fa-caret-down"></i>
 		</a>
 	</div>

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -85,6 +85,10 @@
     // icon hidden on smaller screens
     display: none;
   }
+
+  &--folder {
+    color: $text-color-weak;
+  }
 }
 
 .navbar-buttons {


### PR DESCRIPTION
added span with folder name and a class for foldername in dashboard title

fixes #10895

<img width="955" alt="skarmavbild 2018-06-05 kl 10 37 35" src="https://user-images.githubusercontent.com/23470681/40964921-9f624834-68ac-11e8-80ee-92b1f4012260.png">



