### PR TITLE
Propagate specific git-sha into tarball and docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,18 +185,18 @@ jobs:
           name: deploy to s3
           command: |
             # Also
-            cp dist/grafana-latest.linux-x64.tar.gz dist/grafana-master-${CIRCLE_SHA1:7}.linux-x64.tar.gz
+            cp dist/grafana-latest.linux-x64.tar.gz dist/grafana-master-$(echo "${CIRCLE_SHA1}" | cut -b1-7).linux-x64.tar.gz
             aws s3 sync ./dist s3://$BUCKET_NAME/master
       - run:
           name: Trigger Windows build
           command: './scripts/trigger_windows_build.sh ${APPVEYOR_TOKEN} ${CIRCLE_SHA1} master'
       - run:
           name: Trigger Docker build
-          command: './scripts/trigger_docker_build.sh ${TRIGGER_GRAFANA_PACKER_CIRCLECI_TOKEN} master-${CIRCLE_SHA1:7}'
+          command: './scripts/trigger_docker_build.sh ${TRIGGER_GRAFANA_PACKER_CIRCLECI_TOKEN} master-$(echo "${CIRCLE_SHA1}" | cut -b1-7)'
       - run:
           name: Publish to Grafana.com
           command: |
-            rm dist/grafana-master-${CIRCLE_SHA1:7}.linux-x64.tar.gz
+            rm dist/grafana-master-$(echo "${CIRCLE_SHA1}" | cut -b1-7).linux-x64.tar.gz
             ./scripts/publish -apiKey ${GRAFANA_COM_API_KEY}
 
   deploy-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,16 +183,21 @@ jobs:
           command: 'sudo pip install awscli'
       - run:
           name: deploy to s3
-          command: 'aws s3 sync ./dist s3://$BUCKET_NAME/master'
+          command: |
+            # Also
+            cp dist/grafana-latest.linux-x64.tar.gz dist/grafana-master-${CIRCLE_SHA1:7}.linux-x64.tar.gz
+            aws s3 sync ./dist s3://$BUCKET_NAME/master
       - run:
           name: Trigger Windows build
           command: './scripts/trigger_windows_build.sh ${APPVEYOR_TOKEN} ${CIRCLE_SHA1} master'
       - run:
           name: Trigger Docker build
-          command: './scripts/trigger_docker_build.sh ${TRIGGER_GRAFANA_PACKER_CIRCLECI_TOKEN}'
+          command: './scripts/trigger_docker_build.sh ${TRIGGER_GRAFANA_PACKER_CIRCLECI_TOKEN} master-${CIRCLE_SHA1:7}'
       - run:
           name: Publish to Grafana.com
-          command: './scripts/publish -apiKey ${GRAFANA_COM_API_KEY}'
+          command: |
+            rm dist/grafana-master-${CIRCLE_SHA1:7}.linux-x64.tar.gz
+            ./scripts/publish -apiKey ${GRAFANA_COM_API_KEY}
 
   deploy-release:
     docker:
@@ -240,9 +245,9 @@ workflows:
             - gometalinter
             - mysql-integration-test
             - postgres-integration-test
-          filters:
-            branches:
-              only: master
+          #filters:
+          #  branches:
+          #    only: master
   release:
     jobs:
       - build-all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,9 +245,9 @@ workflows:
             - gometalinter
             - mysql-integration-test
             - postgres-integration-test
-          #filters:
-          #  branches:
-          #    only: master
+          filters:
+           branches:
+             only: master
   release:
     jobs:
       - build-all:

--- a/scripts/trigger_docker_build.sh
+++ b/scripts/trigger_docker_build.sh
@@ -3,7 +3,7 @@
 _circle_token=$1
 _grafana_version=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/grafana/grafana-docker/tree/master?circle-token=${_circle_token}
+trigger_build_url=https://circleci.com/api/v1/project/grafana/grafana-docker/tree/deploy?circle-token=${_circle_token}
 
 post_data=$(cat <<EOF
 {

--- a/scripts/trigger_docker_build.sh
+++ b/scripts/trigger_docker_build.sh
@@ -3,7 +3,7 @@
 _circle_token=$1
 _grafana_version=$2
 
-trigger_build_url=https://circleci.com/api/v1/project/grafana/grafana-docker/tree/deploy?circle-token=${_circle_token}
+trigger_build_url=https://circleci.com/api/v1/project/grafana/grafana-docker/tree/master?circle-token=${_circle_token}
 
 post_data=$(cat <<EOF
 {


### PR DESCRIPTION
See https://github.com/grafana/grafana-docker/pull/169

We need a specific git sha so we can:
- guarantee we download the right tarball in grafana-docker
- tag the docker image with the right git sha
- trigger a deployment in out k8s clusters.