### PR TITLE
nicer collapsed row behaviour

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardRow.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardRow.tsx
@@ -30,7 +30,8 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     this.update = this.update.bind(this);
   }
 
-  toggle() {
+  toggle(e) {
+    e.stopPropagation();
     this.dashboard.toggleRow(this.props.panel);
 
     this.setState(prevState => {
@@ -38,12 +39,14 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     });
   }
 
-  update() {
+  update(e) {
+    e.stopPropagation();
     this.dashboard.processRepeats();
     this.forceUpdate();
   }
 
-  openSettings() {
+  openSettings(e) {
+    e.stopPropagation();
     appEvents.emit('show-modal', {
       templateHtml: `<row-options row="model.row" on-updated="model.onUpdated()" dismiss="dismiss()"></row-options>`,
       modalClass: 'modal--narrow',
@@ -84,15 +87,15 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
       'fa-chevron-right': this.state.collapsed,
     });
 
-    let title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
+    const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
     const hiddenPanels = this.props.panel.panels ? this.props.panel.panels.length : 0;
 
     return (
-      <div className={classes}>
+      <div className={classes} onClick={this.state.collapsed ? this.toggle : null}>
         <a className="dashboard-row__title pointer" onClick={this.toggle}>
           <i className={chevronClass} />
           {title}
-          <span className="dashboard-row__panel_count">({hiddenPanels} hidden panels)</span>
+          <span className="dashboard-row__panel_count">({hiddenPanels} panels)</span>
         </a>
         {this.dashboard.meta.canEdit === true && (
           <div className="dashboard-row__actions">

--- a/public/app/features/dashboard/dashgrid/DashboardRow.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardRow.tsx
@@ -30,8 +30,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     this.update = this.update.bind(this);
   }
 
-  toggle(e) {
-    e.stopPropagation();
+  toggle() {
     this.dashboard.toggleRow(this.props.panel);
 
     this.setState(prevState => {
@@ -39,14 +38,12 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     });
   }
 
-  update(e) {
-    e.stopPropagation();
+  update() {
     this.dashboard.processRepeats();
     this.forceUpdate();
   }
 
-  openSettings(e) {
-    e.stopPropagation();
+  openSettings() {
     appEvents.emit('show-modal', {
       templateHtml: `<row-options row="model.row" on-updated="model.onUpdated()" dismiss="dismiss()"></row-options>`,
       modalClass: 'modal--narrow',
@@ -90,8 +87,21 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
     const hiddenPanels = this.props.panel.panels ? this.props.panel.panels.length : 0;
 
+    const sss = {
+      border: '1px solid red',
+      display: 'flex',
+      flexDirection: 'row',
+      flex: 2,
+      cursor: 'pointer',
+      marginRight: '12px',
+    };
+
+    // {this.state.collapsed === '4true' && (
+    //   <div style={sss} onClick={this.toggle}>&nbsp;</div>
+    // )}
+
     return (
-      <div className={classes} onClick={this.state.collapsed ? this.toggle : null}>
+      <div className={classes}>
         <a className="dashboard-row__title pointer" onClick={this.toggle}>
           <i className={chevronClass} />
           {title}

--- a/public/app/features/dashboard/dashgrid/DashboardRow.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardRow.tsx
@@ -87,19 +87,6 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
     const hiddenPanels = this.props.panel.panels ? this.props.panel.panels.length : 0;
 
-    const sss = {
-      border: '1px solid red',
-      display: 'flex',
-      flexDirection: 'row',
-      flex: 2,
-      cursor: 'pointer',
-      marginRight: '12px',
-    };
-
-    // {this.state.collapsed === '4true' && (
-    //   <div style={sss} onClick={this.toggle}>&nbsp;</div>
-    // )}
-
     return (
       <div className={classes}>
         <a className="dashboard-row__title pointer" onClick={this.toggle}>
@@ -115,6 +102,11 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
             <a className="pointer" onClick={this.delete}>
               <i className="fa fa-trash" />
             </a>
+          </div>
+        )}
+        {this.state.collapsed === true && (
+          <div className="dashboard-row__toggle-target" onClick={this.toggle}>
+            &nbsp;
           </div>
         )}
         <div className="dashboard-row__drag grid-drag-handle" />

--- a/public/app/features/dashboard/dashgrid/DashboardRow.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardRow.tsx
@@ -85,14 +85,17 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     });
 
     const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
-    const hiddenPanels = this.props.panel.panels ? this.props.panel.panels.length : 0;
+    const count = this.props.panel.panels ? this.props.panel.panels.length : 0;
+    const panels = count === 1 ? 'panel' : 'panels';
 
     return (
       <div className={classes}>
         <a className="dashboard-row__title pointer" onClick={this.toggle}>
           <i className={chevronClass} />
           {title}
-          <span className="dashboard-row__panel_count">({hiddenPanels} panels)</span>
+          <span className="dashboard-row__panel_count">
+            ({count} {panels})
+          </span>
         </a>
         {this.dashboard.meta.canEdit === true && (
           <div className="dashboard-row__actions">

--- a/public/sass/components/_row.scss
+++ b/public/sass/components/_row.scss
@@ -6,15 +6,19 @@
 
   &--collapsed {
     background: $panel-bg;
+    cursor: pointer;
 
     .dashboard-row__panel_count {
       display: inline-block;
     }
 
-    .dashboard-row__drag,
-    .dashboard-row__actions {
+    .dashboard-row__drag {
       visibility: visible;
       opacity: 1;
+    }
+
+    .dashboard-row__actions {
+      visibility: hidden;
     }
   }
 
@@ -69,7 +73,7 @@
   cursor: move;
   width: 1rem;
   height: 100%;
-  background: url("../img/grab_dark.svg") no-repeat 50% 50%;
+  background: url('../img/grab_dark.svg') no-repeat 50% 50%;
   background-size: 8px;
   visibility: hidden;
   position: absolute;

--- a/public/sass/components/_row.scss
+++ b/public/sass/components/_row.scss
@@ -19,6 +19,12 @@
     .dashboard-row__actions {
       visibility: hidden;
     }
+
+    .dashboard-row__toggle-target {
+      flex: 1;
+      cursor: pointer;
+      margin-right: 15px;
+    }
   }
 
   &:hover {
@@ -46,7 +52,6 @@
   color: $text-muted;
   visibility: hidden;
   opacity: 0;
-  flex-grow: 1;
   transition: 200ms opacity ease-in 200ms;
 
   a {

--- a/public/sass/components/_row.scss
+++ b/public/sass/components/_row.scss
@@ -6,7 +6,6 @@
 
   &--collapsed {
     background: $panel-bg;
-    cursor: pointer;
 
     .dashboard-row__panel_count {
       display: inline-block;


### PR DESCRIPTION
resolves #12163

Before:
![before](https://user-images.githubusercontent.com/705951/41059687-88644106-69cd-11e8-84ea-42b5040a3c43.png)

After:
![image](https://user-images.githubusercontent.com/705951/41062136-203935de-69d5-11e8-96ce-3673cd20621f.png)

This patch
 * makes the actions only show up on hover
 * removes 'hidden' from the text
 * uses singular 'panel' when there is only one panel
 * allows clicking anywhere on the bar to toggle -- not just the title


