### PR TITLE
enhance error message if phantomjs executable is not found

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -3,7 +3,9 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	m "github.com/grafana/grafana/pkg/models"
@@ -52,6 +54,15 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 
 	if err != nil && err == rendering.ErrTimeout {
 		c.Handle(500, err.Error(), err)
+		return
+	}
+
+	if err != nil && err == rendering.ErrPhantomJSNotInstalled {
+		if strings.HasPrefix(runtime.GOARCH, "arm") {
+			c.Handle(500, "Rendering failed - PhantomJS isn't included in arm build per default", err)
+		} else {
+			c.Handle(500, "Rendering failed - PhantomJS isn't installed correctly", err)
+		}
 		return
 	}
 

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -10,6 +10,7 @@ import (
 
 var ErrTimeout = errors.New("Timeout error. You can set timeout in seconds with &timeout url parameter")
 var ErrNoRenderer = errors.New("No renderer plugin found nor is an external render server configured")
+var ErrPhantomJSNotInstalled = errors.New("PhantomJS executable not found")
 
 type Opts struct {
 	Width    int

--- a/pkg/services/rendering/phantomjs.go
+++ b/pkg/services/rendering/phantomjs.go
@@ -24,6 +24,11 @@ func (rs *RenderingService) renderViaPhantomJS(ctx context.Context, opts Opts) (
 
 	url := rs.getURL(opts.Path)
 	binPath, _ := filepath.Abs(filepath.Join(rs.Cfg.PhantomDir, executable))
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		rs.log.Error("executable not found", "executable", binPath)
+		return nil, ErrPhantomJSNotInstalled
+	}
+
 	scriptPath, _ := filepath.Abs(filepath.Join(rs.Cfg.PhantomDir, "render.js"))
 	pngPath := rs.getFilePathForNewImage()
 


### PR DESCRIPTION
Fixes #11868 

if arm build, explain that phantomjs is not included by default in arm builds. If not explain that phantom js isn't installed correctly.

This was the best I could come up with using the existing error page. Please note that the error details section not are displayed if the environment setting of a build = production.

**If arm architecture:**
![image](https://user-images.githubusercontent.com/1668778/41101993-02e5cfa6-6a66-11e8-8e9f-1dbc15a85068.png)

log:
```
INFO[06-07|15:07:39] Rendering                                logger=rendering path="d-solo/RFCYwTSmz/testdata-graph-panel-last-1h?orgId=1&panelId=4&from=1528372675566&to=1528376275566&width
=1000&height=500&tz=Europe%2FStockholm"                                                                                                                                                       
EROR[06-07|15:07:39] executable not found                     logger=rendering executable=/home/marcus/go/src/github.com/grafana/grafana/tools/phantomjs/phantomjs                            
EROR[06-07|15:07:39] Rendering failed - PhantomJS isn't included in arm builds per default logger=context userId=1 orgId=1 uname=admin error="PhantomJS not installed/setup correctly"        
EROR[06-07|15:07:39] Request Completed                        logger=context userId=1 orgId=1 uname=admin method=GET path=/render/d-solo/RFCYwTSmz/testdata-graph-panel-last-1h status=500 remote_addr=[::1] time_ms=4 size=1937 referer=  
```

**If not arm architecture:**
![image](https://user-images.githubusercontent.com/1668778/41101994-0674f2fa-6a66-11e8-8532-21721badd69c.png)

log:
```
INFO[06-07|15:10:08] Rendering                                logger=rendering path="d-solo/RFCYwTSmz/testdata-graph-panel-last-1h?orgId=1&panelId=4&from=1528372675566&to=1528376275566&width
=1000&height=500&tz=Europe%2FStockholm"                                                                                                                                                       
EROR[06-07|15:10:08] executable not found                     logger=rendering executable=/home/marcus/go/src/github.com/grafana/grafana/tools/phantomjs/phantomjs                            
EROR[06-07|15:10:08] Rendering failed - PhantomJS isn't installed correctly logger=context userId=1 orgId=1 uname=admin error="PhantomJS executable not found"                                
EROR[06-07|15:10:08] Request Completed                        logger=context userId=1 orgId=1 uname=admin method=GET path=/render/d-solo/RFCYwTSmz/testdata-graph-panel-last-1h status=500 remote_addr=[::1] time_ms=3 size=1913 referer=                                  
```