### PR TITLE
Add MSSQL sqlstore

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -65,7 +65,7 @@ socket = /tmp/grafana.sock
 # You can configure the database connection by specifying type, host, name, user and password
 # as separate properties or as on string using the url property.
 
-# Either "mysql", "postgres" or "sqlite3", it's your choice
+# Either "mysql", "mssql", "postgres" or "sqlite3", it's your choice
 type = sqlite3
 host = 127.0.0.1:3306
 name = grafana
@@ -90,6 +90,7 @@ log_queries =
 
 # For "postgres", use either "disable", "require" or "verify-full"
 # For "mysql", use either "true", "false", or "skip-verify".
+# For "mssql", use either "true", "false", or "none"
 ssl_mode = disable
 
 ca_cert_path =

--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -18,8 +18,8 @@ func addDashboardAclMigrations(mg *Migrator) {
 		},
 		Indices: []*Index{
 			{Cols: []string{"dashboard_id"}},
-			{Cols: []string{"dashboard_id", "user_id"}, Type: UniqueIndex},
-			{Cols: []string{"dashboard_id", "team_id"}, Type: UniqueIndex},
+			{Cols: []string{"dashboard_id", "user_id"}, Type: UniqueIndex, NullableCols: []string{"user_id"}},
+			{Cols: []string{"dashboard_id", "team_id"}, Type: UniqueIndex, NullableCols: []string{"team_id"}},
 		},
 	}
 

--- a/pkg/services/sqlstore/migrations/user_auth_mig.go
+++ b/pkg/services/sqlstore/migrations/user_auth_mig.go
@@ -24,5 +24,10 @@ func addUserAuthMigrations(mg *Migrator) {
 
 	mg.AddMigration("alter user_auth.auth_id to length 190", NewRawSqlMigration("").
 		Postgres("ALTER TABLE user_auth ALTER COLUMN auth_id TYPE VARCHAR(190);").
-		Mysql("ALTER TABLE user_auth MODIFY auth_id VARCHAR(190);"))
+		Mysql("ALTER TABLE user_auth MODIFY auth_id VARCHAR(190);").
+		Mssql(`
+			DROP INDEX IDX_user_auth_auth_module_auth_id ON user_auth;
+			ALTER TABLE user_auth ALTER COLUMN auth_id VARCHAR(190) NOT NULL;
+			CREATE INDEX "IDX_user_auth_auth_module_auth_id" ON "user_auth" ("auth_module","auth_id");
+			`))
 }

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -55,6 +55,8 @@ func NewDialect(engine *xorm.Engine) Dialect {
 		return NewSqlite3Dialect(engine)
 	case POSTGRES:
 		return NewPostgresDialect(engine)
+	case MSSQL:
+		return NewMssqlDialect(engine)
 	}
 
 	panic("Unsupported database type: " + name)

--- a/pkg/services/sqlstore/migrator/mssql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mssql_dialect.go
@@ -183,3 +183,13 @@ func (db *Mssql) PostInsertId(table string, sess *xorm.Session) error {
 	_, err := sess.Exec(fmt.Sprintf("SET IDENTITY_INSERT %s OFF", db.Quote(table)))
 	return err
 }
+
+func (db *Mssql) Limit(limit int64) string {
+	return db.LimitOffset(limit, 0)
+}
+
+func (db *Mssql) LimitOffset(limit int64, offset int64) string {
+	// really rather hacky, but works in sql server 2012+.
+	// alternatively, a bunch of queries would need to be reworked to support TOP N
+	return fmt.Sprintf(" OFFSET %d ROWS FETCH NEXT %d ROWS ONLY", offset, limit)
+}

--- a/pkg/services/sqlstore/migrator/mssql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mssql_dialect.go
@@ -1,0 +1,185 @@
+package migrator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-xorm/xorm"
+)
+
+type Mssql struct {
+	BaseDialect
+}
+
+func NewMssqlDialect(engine *xorm.Engine) *Mssql {
+	d := Mssql{}
+	d.BaseDialect.dialect = &d
+	d.BaseDialect.engine = engine
+	d.BaseDialect.driverName = MSSQL
+	return &d
+}
+
+func (db *Mssql) SqlType(c *Column) string {
+	var res string
+	switch c.Type {
+	case DB_Bool:
+		res = DB_Bit
+		if strings.EqualFold(c.Default, "true") {
+			c.Default = "1"
+		} else {
+			c.Default = "0"
+		}
+	case DB_Serial:
+		c.IsAutoIncrement = true
+		c.IsPrimaryKey = true
+		c.Nullable = false
+		res = DB_Int
+	case DB_BigSerial:
+		c.IsAutoIncrement = true
+		c.IsPrimaryKey = true
+		c.Nullable = false
+		res = DB_BigInt
+	case DB_Bytea, DB_Blob, DB_Binary, DB_TinyBlob, DB_MediumBlob, DB_LongBlob:
+		res = DB_VarBinary
+		if c.Length == 0 {
+			c.Length = 50
+		}
+	case DB_TimeStamp:
+		res = DB_DateTime
+	case DB_TimeStampz:
+		res = "DATETIMEOFFSET"
+		c.Length = 7
+	case DB_MediumInt, DB_Integer, DB_Int:
+		res = DB_Int
+		c.Length = 0
+	case DB_Text, DB_MediumText, DB_TinyText, DB_LongText:
+		res = DB_Varchar + "(MAX)"
+	case DB_Double:
+		res = DB_Real
+	case DB_Uuid:
+		res = DB_Varchar
+		c.Length = 40
+	case DB_TinyInt:
+		res = DB_TinyInt
+		c.Length = 0
+	default:
+		res = c.Type
+	}
+
+	if res == DB_Int {
+		return DB_Int
+	}
+
+	hasLen1 := (c.Length > 0)
+	hasLen2 := (c.Length2 > 0)
+
+	if hasLen2 {
+		res += "(" + strconv.Itoa(c.Length) + "," + strconv.Itoa(c.Length2) + ")"
+	} else if hasLen1 {
+		res += "(" + strconv.Itoa(c.Length) + ")"
+	}
+	return res
+}
+
+func (db *Mssql) Quote(name string) string {
+	return "\"" + name + "\""
+}
+
+func (db *Mssql) QuoteStr() string {
+	return "\""
+}
+
+func (db *Mssql) SupportEngine() bool {
+	return false
+}
+
+func (db *Mssql) AutoIncrStr() string {
+	return "IDENTITY"
+}
+
+func (db *Mssql) BooleanStr(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func (db *Mssql) TableCheckSql(tableName string) (string, []interface{}) {
+	args := []interface{}{}
+	sql := "select * from sysobjects where id = object_id(N'" + tableName + "') and OBJECTPROPERTY(id, N'IsUserTable') = 1"
+	return sql, args
+}
+
+func (db *Mssql) CreateTableSql(table *Table) string {
+	var sql string
+
+	sql = "IF NOT EXISTS (SELECT [name] FROM sys.tables WHERE [name] = '" + table.Name + "' ) CREATE TABLE "
+
+	sql += db.QuoteStr() + table.Name + db.QuoteStr() + " ("
+
+	pkList := table.PrimaryKeys
+
+	for _, col := range table.Columns {
+		if col.IsPrimaryKey && len(pkList) == 1 {
+			sql += col.String(db)
+		} else {
+			sql += col.StringNoPk(db)
+		}
+		sql = strings.TrimSpace(sql)
+		sql += ", "
+	}
+
+	if len(pkList) > 1 {
+		sql += "PRIMARY KEY ( "
+		sql += strings.Join(pkList, ",")
+		sql += " ), "
+	}
+
+	sql = sql[:len(sql)-2] + ")"
+	sql += ";"
+	return sql
+}
+
+func (db *Mssql) RenameTable(oldName string, newName string) string {
+	q := db.dialect.Quote
+	return fmt.Sprintf("exec sp_rename %s, %s", q(oldName), q(newName))
+}
+
+func (db *Mssql) CopyTableData(sourceTable string, targetTable string, sourceCols []string, targetCols []string) string {
+	sourceColsSql := db.QuoteColList(sourceCols)
+	targetColsSql := db.QuoteColList(targetCols)
+
+	quote := db.dialect.Quote
+	return fmt.Sprintf("SET IDENTITY_INSERT %s ON ; INSERT INTO %s (%s) SELECT %s FROM %s ; SET IDENTITY_INSERT %s OFF",
+		quote(targetTable), quote(targetTable), targetColsSql, sourceColsSql, quote(sourceTable), quote(targetTable))
+}
+
+func (db *Mssql) AddColumnSql(tableName string, col *Column) string {
+	return fmt.Sprintf("ALTER TABLE %s ADD %s", db.dialect.Quote(tableName), col.StringNoPk(db.dialect))
+}
+
+func (db *Mssql) CreateIndexSql(tableName string, index *Index) string {
+	idx := db.BaseDialect.CreateIndexSql(tableName, index)
+	// mssql includes nulls in the index checks. Others do not.
+	if len(index.NullableCols) == 0 {
+		return idx
+	}
+	idx = strings.TrimSuffix(idx, ";")
+	wheres := []string{}
+	for _, nc := range index.NullableCols {
+		wheres = append(wheres, fmt.Sprintf("%s IS NOT NULL", db.Quote(nc)))
+	}
+	idx += " WHERE " + strings.Join(wheres, " AND ") + ";"
+	return idx
+}
+
+func (db *Mssql) PreInsertId(table string, sess *xorm.Session) error {
+	_, err := sess.Exec(fmt.Sprintf("SET IDENTITY_INSERT %s ON", db.Quote(table)))
+	return err
+}
+
+func (db *Mssql) PostInsertId(table string, sess *xorm.Session) error {
+	_, err := sess.Exec(fmt.Sprintf("SET IDENTITY_INSERT %s OFF", db.Quote(table)))
+	return err
+}

--- a/pkg/services/sqlstore/migrator/types.go
+++ b/pkg/services/sqlstore/migrator/types.go
@@ -40,9 +40,10 @@ const (
 )
 
 type Index struct {
-	Name string
-	Type int
-	Cols []string
+	Name         string
+	Type         int
+	Cols         []string
+	NullableCols []string // columns that should not be included in unique index when null
 }
 
 func (index *Index) XName(tableName string) string {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -170,11 +170,16 @@ func (ss *SqlStore) buildConnectionString() (string, error) {
 		if len(fields) > 1 && len(strings.TrimSpace(fields[1])) > 0 {
 			port = fields[1]
 		}
-		// xorm only supports the 'semicolon seperated key=value pairs' style connection string currently
-		cnnstr = fmt.Sprintf(`log=8;user id=%s;password=%s;server=%s;port=%s;database=%s`,
-			ss.dbCfg.User, ss.dbCfg.Pwd, host, port,
-			ss.dbCfg.Name,
-		)
+		cnnstr = fmt.Sprintf(`server=%s;port=%s;database=%s`, host, port, ss.dbCfg.Name)
+		if ss.dbCfg.User != "" {
+			cnnstr += fmt.Sprintf(";user id=%s;password=%s", ss.dbCfg.User, ss.dbCfg.Pwd)
+		}
+		if ss.dbCfg.SslMode == "true" || ss.dbCfg.SslMode == "none" || ss.dbCfg.SslMode == "false" {
+			if ss.dbCfg.SslMode == "none" {
+				ss.dbCfg.SslMode = "disable" //disable is a bad default for mssql. Need to set to 'none' in order to use mssql driver's "disable" mode
+			}
+			cnnstr += ";encrypt=" + ss.dbCfg.SslMode
+		}
 		fmt.Println(cnnstr)
 	default:
 		return "", fmt.Errorf("Unknown database type: %s", ss.dbCfg.Type)

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -171,7 +171,7 @@ func (ss *SqlStore) buildConnectionString() (string, error) {
 			port = fields[1]
 		}
 		cnnstr = fmt.Sprintf(`server=%s;port=%s;database=%s`, host, port, ss.dbCfg.Name)
-		if ss.dbCfg.User != "" {
+		if ss.dbCfg.User != "" && ss.dbCfg.Pwd != "" {
 			cnnstr += fmt.Sprintf(";user id=%s;password=%s", ss.dbCfg.User, ss.dbCfg.Pwd)
 		}
 		if ss.dbCfg.SslMode == "true" || ss.dbCfg.SslMode == "none" || ss.dbCfg.SslMode == "false" {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 
+	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/go-sql-driver/mysql"
 	"github.com/go-xorm/xorm"
 	_ "github.com/lib/pq"
@@ -160,6 +161,12 @@ func (ss *SqlStore) buildConnectionString() (string, error) {
 		}
 		os.MkdirAll(path.Dir(ss.dbCfg.Path), os.ModePerm)
 		cnnstr = "file:" + ss.dbCfg.Path + "?cache=shared&mode=rwc"
+	case migrator.MSSQL:
+		cnnstr = fmt.Sprintf(`server=%s;password=%s;user id=%s;database=%s`,
+			ss.dbCfg.Host, ss.dbCfg.Pwd, ss.dbCfg.User,
+			ss.dbCfg.Name,
+		)
+		fmt.Println(cnnstr)
 	default:
 		return "", fmt.Errorf("Unknown database type: %s", ss.dbCfg.Type)
 	}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -162,8 +162,17 @@ func (ss *SqlStore) buildConnectionString() (string, error) {
 		os.MkdirAll(path.Dir(ss.dbCfg.Path), os.ModePerm)
 		cnnstr = "file:" + ss.dbCfg.Path + "?cache=shared&mode=rwc"
 	case migrator.MSSQL:
-		cnnstr = fmt.Sprintf(`server=%s;password=%s;user id=%s;database=%s`,
-			ss.dbCfg.Host, ss.dbCfg.Pwd, ss.dbCfg.User,
+		var host, port = "127.0.0.1", "1433"
+		fields := strings.Split(ss.dbCfg.Host, ":")
+		if len(fields) > 0 && len(strings.TrimSpace(fields[0])) > 0 {
+			host = fields[0]
+		}
+		if len(fields) > 1 && len(strings.TrimSpace(fields[1])) > 0 {
+			port = fields[1]
+		}
+		// xorm only supports the 'semicolon seperated key=value pairs' style connection string currently
+		cnnstr = fmt.Sprintf(`log=8;user id=%s;password=%s;server=%s;port=%s;database=%s`,
+			ss.dbCfg.User, ss.dbCfg.Pwd, host, port,
 			ss.dbCfg.Name,
 		)
 		fmt.Println(cnnstr)

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -59,7 +59,6 @@ func getOrgIdForNewUser(cmd *m.CreateUserCommand, sess *DBSession) (int64, error
 
 	org.Created = time.Now()
 	org.Updated = time.Now()
-	fmt.Println("IORGG???????", org.Id)
 	if org.Id != 0 {
 		if _, err := sess.InsertId(&org); err != nil {
 			return 0, err

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -59,7 +59,7 @@ func getOrgIdForNewUser(cmd *m.CreateUserCommand, sess *DBSession) (int64, error
 
 	org.Created = time.Now()
 	org.Updated = time.Now()
-
+	fmt.Println("IORGG???????", org.Id)
 	if org.Id != 0 {
 		if _, err := sess.InsertId(&org); err != nil {
 			return 0, err


### PR DESCRIPTION
Fixes #8674 

Adds mssql dialect to the migrator, and allows you to store dashboards and other grafana data in microsoft sql server.

Tested on Azure SQL, and on SQL server 2012R2. All migrations succeed, and what I've done in the ui so far has worked. Not sure how to test it more extensively.