### PR TITLE
Add a time offset option to InfluxDB

### DIFF
--- a/public/app/plugins/datasource/influxdb/partials/query.editor.html
+++ b/public/app/plugins/datasource/influxdb/partials/query.editor.html
@@ -5,6 +5,10 @@
       <textarea rows="3" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" placeholder="InfuxDB Query" ng-model-onblur ng-change="ctrl.refresh()"></textarea>
     </div>
     <div class="gf-form-inline">
+      <div class="gf-form max-width-25">
+        <label class="gf-form-label query-keyword">TIME OFFSET</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.offset" spellcheck='false' placeholder="seconds" ng-blur="ctrl.refresh()">
+      </div>
       <div class="gf-form">
         <label class="gf-form-label query-keyword">FORMAT AS</label>
         <div class="gf-form-select-wrapper">
@@ -117,6 +121,16 @@
       <div class="gf-form gf-form--grow">
 				<div class="gf-form-label gf-form-label--grow"></div>
 			</div>
+    </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-7">TIME OFFSET</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.offset" spellcheck='false' placeholder="seconds" ng-blur="ctrl.refresh()">
+      </div>
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
     </div>
 
     <div class="gf-form-inline">


### PR DESCRIPTION
This allows data returned from InfluxDB to be shifted forward or backward in time by some number of seconds, enabling previously impossible visualisations such as week-over-week graphs.

The team at Thumbtack has been using this patch for a while in order to display WoW graphs:
![wow](https://user-images.githubusercontent.com/1375517/41132093-d1287b68-6a73-11e8-8f04-029e7e9997b5.png)

Partially related to #6401