### PR TITLE
Prevent refresh on fixed time window

### DIFF
--- a/public/app/features/dashboard/specs/time_srv.test.ts
+++ b/public/app/features/dashboard/specs/time_srv.test.ts
@@ -29,6 +29,7 @@ describe('timeSrv', () => {
   beforeEach(() => {
     timeSrv = new TimeSrv(rootScope, jest.fn(), location, timer, { isGrafanaVisibile: jest.fn() });
     timeSrv.init(_dashboard);
+    _dashboard.refresh = false;
   });
 
   describe('timeRange', () => {
@@ -77,6 +78,23 @@ describe('timeSrv', () => {
       const time = timeSrv.timeRange();
       expect(time.from.valueOf()).toEqual(new Date('2014-04-10T05:20:10Z').getTime());
       expect(time.to.valueOf()).toEqual(new Date('2014-05-20T03:10:22Z').getTime());
+    });
+
+    it('should ignore refresh if time absolute', () => {
+      location = {
+        search: jest.fn(() => ({
+          from: '20140410T052010',
+          to: '20140520T031022',
+        })),
+      };
+
+      timeSrv = new TimeSrv(rootScope, jest.fn(), location, timer, { isGrafanaVisibile: jest.fn() });
+
+      // dashboard saved with refresh on
+      _dashboard.refresh = true;
+      timeSrv.init(_dashboard);
+
+      expect(timeSrv.refresh).toBe(false);
     });
 
     it('should handle formatted dates without time', () => {

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -85,6 +85,11 @@ export class TimeSrv {
     if (params.to) {
       this.time.to = this.parseUrlParam(params.to) || this.time.to;
     }
+    // if absolute ignore refresh option saved to dashboard
+    if (params.to && params.to.indexOf('now') === -1) {
+      this.refresh = false;
+    }
+    // but if refresh explicitly set then use that
     if (params.refresh) {
       this.refresh = params.refresh || this.refresh;
     }

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -88,6 +88,7 @@ export class TimeSrv {
     // if absolute ignore refresh option saved to dashboard
     if (params.to && params.to.indexOf('now') === -1) {
       this.refresh = false;
+      this.dashboard.refresh = false;
     }
     // but if refresh explicitly set then use that
     if (params.refresh) {


### PR DESCRIPTION
This is my attempt to fix https://github.com/grafana/grafana/issues/12030. I am new to the code base, any advice and comments are very appreciated.

During the `TimeSrv.init()` call, if `dashboard.refresh` is previously saved, it will trigger `this.setAutoRefresh(this.refresh);`. I added a `params.to` check to prevent that from happening.

I also tried to refactor the `setAutoRefresh()` method while working on this bug, there was some duplicate logic that I thought should be cleaned up.