### PR TITLE
Correct Provisioning documentation link

### DIFF
--- a/docs/sources/guides/whats-new-in-v5-1.md
+++ b/docs/sources/guides/whats-new-in-v5-1.md
@@ -115,7 +115,7 @@ Grafana v5.1 brings an improved workflow for provisioned dashboards:
 
 
 Available options in the dialog will let you `Copy JSON to Clipboard` and/or `Save JSON to file` which can help you synchronize your dashboard changes back to the provisioning source.
-More information in the [Provisioning documentation](/features/datasources/prometheus/).
+More information in the [Provisioning documentation](/administration/provisioning/).
 
 <div class="clearfix"></div>
 


### PR DESCRIPTION
It was pointing to Prometheus documentation instead.