### PR TITLE
(prometheus) get label name/value from series API 

### DIFF
--- a/public/app/plugins/datasource/prometheus/completer.ts
+++ b/public/app/plugins/datasource/prometheus/completer.ts
@@ -264,7 +264,7 @@ export class PromCompleter {
     return Promise.resolve([]);
   }
 
-  getLabelNameAndValueForExpression(expr, type) {
+  getLabelNameAndValueForExpression(expr: string, type: string): Promise<any> {
     if (this.labelQueryCache[expr]) {
       return Promise.resolve(this.labelQueryCache[expr]);
     }
@@ -276,8 +276,8 @@ export class PromCompleter {
       }
       query = '{__name__' + op + '"' + expr + '"}';
     }
-    let range = this.datasource.getTimeRange();
-    let url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + range.from + '&end=' + range.to;
+    const { start, end } = this.datasource.getTimeRange();
+    const url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + start + '&end=' + end;
     return this.datasource.metadataRequest(url).then(response => {
       this.labelQueryCache[expr] = response.data.data;
       return response.data.data;

--- a/public/app/plugins/datasource/prometheus/completer.ts
+++ b/public/app/plugins/datasource/prometheus/completer.ts
@@ -113,7 +113,7 @@ export class PromCompleter {
         _.uniq(
           _.flatten(
             result.map(r => {
-              return Object.keys(r.metric);
+              return Object.keys(r);
             })
           )
         ),
@@ -151,7 +151,7 @@ export class PromCompleter {
       var labelValues = this.transformToCompletions(
         _.uniq(
           result.map(r => {
-            return r.metric[labelName];
+            return r[labelName];
           })
         ),
         'label value'
@@ -191,7 +191,7 @@ export class PromCompleter {
             _.uniq(
               _.flatten(
                 result.map(r => {
-                  return Object.keys(r.metric);
+                  return Object.keys(r);
                 })
               )
             ),
@@ -233,7 +233,7 @@ export class PromCompleter {
               _.uniq(
                 _.flatten(
                   result.map(r => {
-                    return Object.keys(r.metric);
+                    return Object.keys(r);
                   })
                 )
               ),
@@ -249,7 +249,7 @@ export class PromCompleter {
               _.uniq(
                 _.flatten(
                   result.map(r => {
-                    return Object.keys(r.metric);
+                    return Object.keys(r);
                   })
                 )
               ),
@@ -276,9 +276,11 @@ export class PromCompleter {
       }
       query = '{__name__' + op + '"' + expr + '"}';
     }
-    return this.datasource.performInstantQuery({ expr: query }, new Date().getTime() / 1000).then(response => {
-      this.labelQueryCache[expr] = response.data.data.result;
-      return response.data.data.result;
+    let range = this.datasource.getTimeRange();
+    let url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + range.from + '&end=' + range.to;
+    return this.datasource.metadataRequest(url).then(response => {
+      this.labelQueryCache[expr] = response.data.data;
+      return response.data.data;
     });
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -629,11 +629,11 @@ export class PrometheusDatasource {
     return Math.ceil(date.valueOf() / 1000);
   }
 
-  getTimeRange() {
+  getTimeRange(): { start: number; end: number } {
     let range = this.timeSrv.timeRange();
     return {
-      from: this.getPrometheusTime(range.from, false),
-      to: this.getPrometheusTime(range.to, true)
+      start: this.getPrometheusTime(range.from, false),
+      end: this.getPrometheusTime(range.to, true),
     };
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -629,6 +629,14 @@ export class PrometheusDatasource {
     return Math.ceil(date.valueOf() / 1000);
   }
 
+  getTimeRange() {
+    let range = this.timeSrv.timeRange();
+    return {
+      from: this.getPrometheusTime(range.from, false),
+      to: this.getPrometheusTime(range.to, true)
+    };
+  }
+
   getOriginalMetricName(labelData) {
     return this.resultTransformer.getOriginalMetricName(labelData);
   }

--- a/public/app/plugins/datasource/prometheus/specs/completer.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/completer.test.ts
@@ -4,7 +4,7 @@ import { BackendSrv } from 'app/core/services/backend_srv';
 jest.mock('../datasource');
 jest.mock('app/core/services/backend_srv');
 
-describe('Prometheus editor completer', function () {
+describe('Prometheus editor completer', function() {
   function getSessionStub(data) {
     return {
       getTokenAt: jest.fn(() => data.currentToken),
@@ -19,8 +19,11 @@ describe('Prometheus editor completer', function () {
   const datasourceStub = new PrometheusDatasource({}, {}, backendSrv, {}, {});
 
   datasourceStub.metadataRequest = jest.fn(() =>
-    Promise.resolve({ data: { data: [{ metric: { job: 'node', instance: 'localhost:9100', }, },], }, }));
-  datasourceStub.getTimeRange = jest.fn(() => { return { from: 1514732400, to: 1514818800 }; });
+    Promise.resolve({ data: { data: [{ metric: { job: 'node', instance: 'localhost:9100' } }] } })
+  );
+  datasourceStub.getTimeRange = jest.fn(() => {
+    return { start: 1514732400, end: 1514818800 };
+  });
   datasourceStub.performSuggestQuery = jest.fn(() => Promise.resolve(['node_cpu']));
 
   const templateSrv = {

--- a/public/app/plugins/datasource/prometheus/specs/completer.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/completer.test.ts
@@ -4,7 +4,7 @@ import { BackendSrv } from 'app/core/services/backend_srv';
 jest.mock('../datasource');
 jest.mock('app/core/services/backend_srv');
 
-describe('Prometheus editor completer', function() {
+describe('Prometheus editor completer', function () {
   function getSessionStub(data) {
     return {
       getTokenAt: jest.fn(() => data.currentToken),
@@ -18,22 +18,9 @@ describe('Prometheus editor completer', function() {
   const backendSrv = <BackendSrv>{};
   const datasourceStub = new PrometheusDatasource({}, {}, backendSrv, {}, {});
 
-  datasourceStub.performInstantQuery = jest.fn(() =>
-    Promise.resolve({
-      data: {
-        data: {
-          result: [
-            {
-              metric: {
-                job: 'node',
-                instance: 'localhost:9100',
-              },
-            },
-          ],
-        },
-      },
-    })
-  );
+  datasourceStub.metadataRequest = jest.fn(() =>
+    Promise.resolve({ data: { data: [{ metric: { job: 'node', instance: 'localhost:9100', }, },], }, }));
+  datasourceStub.getTimeRange = jest.fn(() => { return { from: 1514732400, to: 1514818800 }; });
   datasourceStub.performSuggestQuery = jest.fn(() => Promise.resolve(['node_cpu']));
 
   const templateSrv = {


### PR DESCRIPTION
instant query doesn't return all label name/value of dashboard time range.
So, change to use series API.

https://prometheus.io/docs/prometheus/latest/querying/api/#finding-series-by-label-matchers