### PR TITLE
added id tag to Panels for html bookmarking on longer Dashboards

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -177,7 +177,7 @@ export class DashboardGrid extends React.Component<DashboardGridProps, any> {
     for (let panel of this.dashboard.panels) {
       const panelClasses = classNames({ panel: true, 'panel--fullscreen': panel.fullscreen });
       panelElements.push(
-        <div key={panel.id.toString()} className={panelClasses}>
+        <div key={panel.id.toString()} className={panelClasses} id={`panel-${panel.id.toString()}`}>
           <DashboardPanel panel={panel} getPanelContainer={this.props.getPanelContainer} />
         </div>
       );

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -177,6 +177,7 @@ export class DashboardGrid extends React.Component<DashboardGridProps, any> {
     for (let panel of this.dashboard.panels) {
       const panelClasses = classNames({ panel: true, 'panel--fullscreen': panel.fullscreen });
       panelElements.push(
+        /** panel-id is set for html bookmarks */
         <div key={panel.id.toString()} className={panelClasses} id={`panel-${panel.id.toString()}`}>
           <DashboardPanel panel={panel} getPanelContainer={this.props.getPanelContainer} />
         </div>


### PR DESCRIPTION
added an html id tag to the paneldiv, so one can use it to bookmark certain panel (and rows) on a (long) dashboard