### PR TITLE
Set current org when adding/removing user to org

### DIFF
--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -150,7 +150,7 @@ func TestAccountDataAccess(t *testing.T) {
 				})
 
 				Convey("Can set using org", func() {
-					cmd := m.SetUsingOrgCommand{UserId: ac2.Id, OrgId: ac1.Id}
+					cmd := m.SetUsingOrgCommand{UserId: ac2.Id, OrgId: ac1.OrgId}
 					err := SetUsingOrg(&cmd)
 					So(err, ShouldBeNil)
 
@@ -159,12 +159,24 @@ func TestAccountDataAccess(t *testing.T) {
 						err := GetSignedInUser(&query)
 
 						So(err, ShouldBeNil)
-						So(query.Result.OrgId, ShouldEqual, ac1.Id)
+						So(query.Result.OrgId, ShouldEqual, ac1.OrgId)
 						So(query.Result.Email, ShouldEqual, "ac2@test.com")
 						So(query.Result.Name, ShouldEqual, "ac2 name")
 						So(query.Result.Login, ShouldEqual, "ac2")
 						So(query.Result.OrgName, ShouldEqual, "ac1@test.com")
 						So(query.Result.OrgRole, ShouldEqual, "Viewer")
+					})
+
+					Convey("Should set last org as current when removing user from current", func() {
+						remCmd := m.RemoveOrgUserCommand{OrgId: ac1.OrgId, UserId: ac2.Id}
+						err := RemoveOrgUser(&remCmd)
+						So(err, ShouldBeNil)
+
+						query := m.GetSignedInUserQuery{UserId: ac2.Id}
+						err = GetSignedInUser(&query)
+
+						So(err, ShouldBeNil)
+						So(query.Result.OrgId, ShouldEqual, ac2.OrgId)
 					})
 				})
 

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -290,14 +290,18 @@ func SetUsingOrg(cmd *m.SetUsingOrgCommand) error {
 	}
 
 	return inTransaction(func(sess *DBSession) error {
-		user := m.User{
-			Id:    cmd.UserId,
-			OrgId: cmd.OrgId,
-		}
-
-		_, err := sess.Id(cmd.UserId).Update(&user)
-		return err
+		return setUsingOrgInTransaction(sess, cmd.UserId, cmd.OrgId)
 	})
+}
+
+func setUsingOrgInTransaction(sess *DBSession, userID int64, orgID int64) error {
+	user := m.User{
+		Id:    userID,
+		OrgId: orgID,
+	}
+
+	_, err := sess.Id(userID).Update(&user)
+	return err
 }
 
 func GetUserProfile(query *m.GetUserProfileQuery) error {

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -96,33 +96,33 @@ func TestUserDataAccess(t *testing.T) {
 			})
 
 			Convey("when a user is an org member and has been assigned permissions", func() {
-				err = AddOrgUser(&m.AddOrgUserCommand{LoginOrEmail: users[0].Login, Role: m.ROLE_VIEWER, OrgId: users[0].OrgId})
+				err = AddOrgUser(&m.AddOrgUserCommand{LoginOrEmail: users[1].Login, Role: m.ROLE_VIEWER, OrgId: users[0].OrgId, UserId: users[1].Id})
 				So(err, ShouldBeNil)
 
-				testHelperUpdateDashboardAcl(1, m.DashboardAcl{DashboardId: 1, OrgId: users[0].OrgId, UserId: users[0].Id, Permission: m.PERMISSION_EDIT})
+				testHelperUpdateDashboardAcl(1, m.DashboardAcl{DashboardId: 1, OrgId: users[0].OrgId, UserId: users[1].Id, Permission: m.PERMISSION_EDIT})
 				So(err, ShouldBeNil)
 
-				err = SavePreferences(&m.SavePreferencesCommand{UserId: users[0].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, Theme: "dark"})
+				err = SavePreferences(&m.SavePreferencesCommand{UserId: users[1].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, Theme: "dark"})
 				So(err, ShouldBeNil)
 
 				Convey("when the user is deleted", func() {
-					err = DeleteUser(&m.DeleteUserCommand{UserId: users[0].Id})
+					err = DeleteUser(&m.DeleteUserCommand{UserId: users[1].Id})
 					So(err, ShouldBeNil)
 
 					Convey("Should delete connected org users and permissions", func() {
-						query := &m.GetOrgUsersQuery{OrgId: 1}
+						query := &m.GetOrgUsersQuery{OrgId: users[0].OrgId}
 						err = GetOrgUsersForTest(query)
 						So(err, ShouldBeNil)
 
 						So(len(query.Result), ShouldEqual, 1)
 
-						permQuery := &m.GetDashboardAclInfoListQuery{DashboardId: 1, OrgId: 1}
+						permQuery := &m.GetDashboardAclInfoListQuery{DashboardId: 1, OrgId: users[0].OrgId}
 						err = GetDashboardAclInfoList(permQuery)
 						So(err, ShouldBeNil)
 
 						So(len(permQuery.Result), ShouldEqual, 0)
 
-						prefsQuery := &m.GetPreferencesQuery{OrgId: users[0].OrgId, UserId: users[0].Id}
+						prefsQuery := &m.GetPreferencesQuery{OrgId: users[0].OrgId, UserId: users[1].Id}
 						err = GetPreferences(prefsQuery)
 						So(err, ShouldBeNil)
 

--- a/public/app/features/admin/admin_edit_user_ctrl.ts
+++ b/public/app/features/admin/admin_edit_user_ctrl.ts
@@ -75,6 +75,7 @@ export class AdminEditUserCtrl {
 
     $scope.removeOrgUser = function(orgUser) {
       backendSrv.delete('/api/orgs/' + orgUser.orgId + '/users/' + $scope.user_id).then(function() {
+        $scope.getUser($scope.user_id);
         $scope.getUserOrgs($scope.user_id);
       });
     };
@@ -108,6 +109,7 @@ export class AdminEditUserCtrl {
       $scope.newOrg.loginOrEmail = $scope.user.login;
 
       backendSrv.post('/api/orgs/' + orgInfo.id + '/users/', $scope.newOrg).then(function() {
+        $scope.getUser($scope.user_id);
         $scope.getUserOrgs($scope.user_id);
       });
     };


### PR DESCRIPTION
Fixes #11076

To not get into a situation where a user has a current organization assign which he is
not a member of we try to always make sure that a user has a valid current organization
assigned.