### PR TITLE
[v4.5.x] fix XSS vulnerabilities in dashboard links

### DIFF
--- a/public/app/features/dashlinks/module.js
+++ b/public/app/features/dashlinks/module.js
@@ -39,7 +39,7 @@ function (angular, _) {
     };
   });
 
-  module.directive('dashLink', function($compile, linkSrv) {
+  module.directive('dashLink', function($compile, $sanitize, linkSrv) {
     return {
       restrict: 'E',
       link: function(scope, elem) {
@@ -68,10 +68,21 @@ function (angular, _) {
           var linkInfo = linkSrv.getAnchorInfo(link);
           span.text(linkInfo.title);
           anchor.attr("href", linkInfo.href);
+          sanitizeAnchor();
+
+          // tooltip
+          elem.find('a').tooltip({
+            title: $sanitize(scope.link.tooltip),
+            html: true,
+            container: 'body',
+          });
         }
 
-        // tooltip
-        elem.find('a').tooltip({ title: scope.link.tooltip, html: true, container: 'body' });
+        function sanitizeAnchor() {
+          var anchorSanitized = $sanitize(anchor.parent().html());
+          anchor.parent().html(anchorSanitized);
+        }
+
         icon.attr('class', 'fa fa-fw ' + scope.link.icon);
         anchor.attr('target', scope.link.target);
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -257,6 +257,7 @@ export class PanelCtrl {
     }
 
     var linkSrv = this.$injector.get('linkSrv');
+    var sanitize = this.$injector.get('$sanitize');
     var templateSrv = this.$injector.get('templateSrv');
     var interpolatedMarkdown = templateSrv.replace(markdown, this.panel.scopedVars);
     var html = '<div class="markdown-html">';
@@ -272,7 +273,8 @@ export class PanelCtrl {
       html += '</ul>';
     }
 
-    return html + '</div>';
+    html += '</div>';
+    return sanitize(html);
   }
 
   openInspector() {

--- a/public/test/specs/helpers.js
+++ b/public/test/specs/helpers.js
@@ -10,6 +10,7 @@ define([
 
     this.datasource = {};
     this.$element = {};
+    this.$sanitize = {};
     this.annotationsSrv = {};
     this.timeSrv = new TimeSrvStub();
     this.templateSrv = new TemplateSrvStub();
@@ -31,6 +32,7 @@ define([
         $provide.value('timeSrv', self.timeSrv);
         $provide.value('templateSrv', self.templateSrv);
         $provide.value('$element', self.$element);
+        $provide.value('$sanitize', self.$sanitize);
         _.each(mocks, function(value, key) {
           $provide.value(key, value);
         });


### PR DESCRIPTION
Dropped the whitespace changes for public/test/specs/helpers.js while
manually applying the change.

Backport of https://github.com/grafana/grafana/pull/11813
(cherry picked from commit 00454b32f5db19f9dee4fa05b5cff5e24941548d)