### PR TITLE
Expose react and slate to external plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -7,7 +7,6 @@ import angular from 'angular';
 import jquery from 'jquery';
 
 // Experimental module exports
-import papaparse from 'papaparse';
 import prismjs from 'prismjs';
 import slate from 'slate';
 import slateReact from 'slate-react';
@@ -86,7 +85,6 @@ exposeToPlugin('slate-react', slateReact);
 exposeToPlugin('slate-plain-serializer', slatePlain);
 exposeToPlugin('react', react);
 exposeToPlugin('react-dom', reactDom);
-exposeToPlugin('papaparse', papaparse);
 
 // backward compatible path
 exposeToPlugin('vendor/npm/rxjs/Rx', {

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -5,6 +5,16 @@ import kbn from 'app/core/utils/kbn';
 import moment from 'moment';
 import angular from 'angular';
 import jquery from 'jquery';
+
+// Experimental module exports
+import papaparse from 'papaparse';
+import prismjs from 'prismjs';
+import slate from 'slate';
+import slateReact from 'slate-react';
+import slatePlain from 'slate-plain-serializer';
+import react from 'react';
+import reactDom from 'react-dom';
+
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 import TableModel from 'app/core/table_model';
@@ -68,6 +78,15 @@ exposeToPlugin('angular', angular);
 exposeToPlugin('d3', d3);
 exposeToPlugin('rxjs/Subject', Subject);
 exposeToPlugin('rxjs/Observable', Observable);
+
+// Experimental modules
+exposeToPlugin('prismjs', prismjs);
+exposeToPlugin('slate', slate);
+exposeToPlugin('slate-react', slateReact);
+exposeToPlugin('slate-plain-serializer', slatePlain);
+exposeToPlugin('react', react);
+exposeToPlugin('react-dom', reactDom);
+exposeToPlugin('papaparse', papaparse);
 
 // backward compatible path
 exposeToPlugin('vendor/npm/rxjs/Rx', {


### PR DESCRIPTION
Experimental support for react in external plugins

- react
- slate (editor)
- papaparse (csv parsing)
- prismjs (syntax highlighting)

This is needed for new external datasource plugins like Flux

Supercedes #12223 
