### PR TITLE
Document the HTTP Endpoint for Deleting an Organization

### DIFF
--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -331,6 +331,27 @@ Content-Type: application/json
 {"message":"Organization updated"}
 ```
 
+## Delete Organisation
+
+`DELETE /api/orgs/:orgId`
+
+**Example Request**:
+
+```http
+DELETE /api/orgs/1 HTTP/1.1
+Accept: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{"message":"Organization deleted"}
+```
+
 ## Get Users in Organisation
 
 `GET /api/orgs/:orgId/users`


### PR DESCRIPTION
The Grafana HTTP API exposes an endpoint for deleting organizations (see #4990), however the endpoint is not documented. This PR updates the documentation to clarify that the endpoint is available and provides a sample request/response.