### PR TITLE
Include the vendor directory when copying source in to Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,8 +11,5 @@ dump.rdb
 node_modules
 /local
 /tmp
-/vendor
 *.yml
 *.md
-/vendor
-/tmp


### PR DESCRIPTION
This change updates the `.dockerignore` file to no longer contain the `vendor/`
directory. When a Go project provides a `vendor/` directory within the
repository, the best practice is to build that project using their vendored
dependencies. By putting it in the `.dockerignore` file we prevent consumers
from easily doing that.

The `vendor/` directory is used to include all of the dependencies needed to
build a project. This makes it so that we can reproducibly build the project, at
any given commit, because the dependencies will always be present. Also, using
the vendor directory avoids us needing to continually re-download all the
dependencies, and it protects us from build failures if GitHub is down or a
dependency gets removed or renamed.

In addition to the change above, this also removes an extra `/tmp` entry from
the `.dockerignore` file.

Fixes #12304

Signed-off-by: Tim Heckman <t@heckman.io>