### PR TITLE
vendor path shouldn't be excluded from containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,8 +11,6 @@ dump.rdb
 node_modules
 /local
 /tmp
-/vendor
 *.yml
 *.md
-/vendor
 /tmp


### PR DESCRIPTION
Excluding the vendor directory causes all sorts of `cannot find package` errors; these vendors should be preserved into the container.