### PR TITLE
Fixing wrong /public path, relative to the webpack.dev script

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -65,7 +65,7 @@ module.exports = merge(common, {
   },
 
   plugins: [
-    new CleanWebpackPlugin('../public/build', { allowExternal: true }),
+    new CleanWebpackPlugin('../../public/build', { allowExternal: true }),
     extractSass,
     new HtmlWebpackPlugin({
       filename: path.resolve(__dirname, '../../public/views/index.html'),


### PR DESCRIPTION
Fixing wrong /public path, relative to the webpack.dev script, that would avoid webpack from cleaning previous builds.