### PR TITLE
Set $rootScope in DatasourceSrv

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -7,7 +7,7 @@ export class DatasourceSrv {
   datasources: any;
 
   /** @ngInject */
-  constructor(private $q, private $injector, $rootScope, private templateSrv) {
+  constructor(private $q, private $injector, private $rootScope, private templateSrv) {
     this.init();
   }
 
@@ -61,7 +61,7 @@ export class DatasourceSrv {
         this.datasources[name] = instance;
         deferred.resolve(instance);
       })
-      .catch(function(err) {
+      .catch(err => {
         this.$rootScope.appEvent('alert-error', [dsConfig.name + ' plugin failed', err.toString()]);
       });
 


### PR DESCRIPTION
$rootScope in DatasourceSrv was never set so you would get this error
`Uncaught (in promise) TypeError: Cannot read property '$rootScope' of undefined at datasource_srv.ts:65`
instead of alert when you have any error while importing your datasource plugin.

Problem gets referenced in these comments by @jonyrock :
https://github.com/grafana/grafana/pull/10328#discussion_r196847849
https://github.com/grafana/grafana/pull/10328#discussion_r196848108