### PR TITLE
Light improve of massive delete annotation api

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -214,7 +214,8 @@ func DeleteAnnotations(c *m.ReqContext, cmd dtos.DeleteAnnotationsCmd) Response 
 	repo := annotations.GetRepository()
 
 	err := repo.Delete(&annotations.DeleteParams{
-		AlertId:     cmd.PanelId,
+		Id:          cmd.AnnotationId,
+		RegionId:    cmd.RegionId,
 		DashboardId: cmd.DashboardId,
 		PanelId:     cmd.PanelId,
 	})

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -37,7 +37,6 @@ func GetAnnotations(c *m.ReqContext) Response {
 		if item.Email != "" {
 			item.AvatarUrl = dtos.GetGravatarUrl(item.Email)
 		}
-		item.Time = item.Time
 	}
 
 	return JSON(200, items)

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -100,6 +100,11 @@ func TestAnnotationsApiEndpoint(t *testing.T) {
 			Id:       1,
 		}
 
+		deleteCmd := dtos.DeleteAnnotationsCmd{
+			DashboardId: 1,
+			PanelId:     1,
+		}
+
 		viewerRole := m.ROLE_VIEWER
 		editorRole := m.ROLE_EDITOR
 
@@ -171,6 +176,25 @@ func TestAnnotationsApiEndpoint(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("When user is an Admin", func() {
+			role := m.ROLE_ADMIN
+			Convey("Should be able to do anything", func() {
+				postAnnotationScenario("When calling POST on", "/api/annotations", "/api/annotations", role, cmd, func(sc *scenarioContext) {
+					sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+					So(sc.resp.Code, ShouldEqual, 200)
+				})
+
+				putAnnotationScenario("When calling PUT on", "/api/annotations/1", "/api/annotations/:annotationId", role, updateCmd, func(sc *scenarioContext) {
+					sc.fakeReqWithParams("PUT", sc.url, map[string]string{}).exec()
+					So(sc.resp.Code, ShouldEqual, 200)
+				})
+				deleteAnnotationsScenario("When calling POST on", "/api/annotations/mass-delete", "/api/annotations/mass-delete", role, deleteCmd, func(sc *scenarioContext) {
+					sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+					So(sc.resp.Code, ShouldEqual, 200)
+				})
+			})
+		})
 	})
 }
 
@@ -235,6 +259,29 @@ func putAnnotationScenario(desc string, url string, routePattern string, role m.
 		annotations.SetRepository(fakeAnnoRepo)
 
 		sc.m.Put(routePattern, sc.defaultHandler)
+
+		fn(sc)
+	})
+}
+
+func deleteAnnotationsScenario(desc string, url string, routePattern string, role m.RoleType, cmd dtos.DeleteAnnotationsCmd, fn scenarioFunc) {
+	Convey(desc+" "+url, func() {
+		defer bus.ClearBusHandlers()
+
+		sc := setupScenarioContext(url)
+		sc.defaultHandler = wrap(func(c *m.ReqContext) Response {
+			sc.context = c
+			sc.context.UserId = TestUserID
+			sc.context.OrgId = TestOrgID
+			sc.context.OrgRole = role
+
+			return DeleteAnnotations(c, cmd)
+		})
+
+		fakeAnnoRepo = &fakeAnnotationsRepo{}
+		annotations.SetRepository(fakeAnnoRepo)
+
+		sc.m.Post(routePattern, sc.defaultHandler)
 
 		fn(sc)
 	})


### PR DESCRIPTION
Hello, 

As the `Delete` method from `sqlstore` package doesn't take in count the attribute `AlertId` of `annotations.DeleteParams` struct, I simply removed it and added the `regionID` and the `annotationID`.

I also remove a self assignment that seems to just be a forget