### PR TITLE
DashboardID negative can bypass the right management in Annotation

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -272,9 +272,9 @@ func canSaveByDashboardID(c *m.ReqContext, dashboardID int64) (bool, error) {
 		return false, nil
 	}
 
-	if dashboardID > 0 {
-		guardian := guardian.New(dashboardID, c.OrgId, c.SignedInUser)
-		if canEdit, err := guardian.CanEdit(); err != nil || !canEdit {
+	if dashboardID != 0 {
+		guard := guardian.New(dashboardID, c.OrgId, c.SignedInUser)
+		if canEdit, err := guard.CanEdit(); err != nil || !canEdit {
 			return false, err
 		}
 	}


### PR DESCRIPTION
hello,

I think I find in the code a light security breaking. If the DashboardID is negative when we want to create an annotation, it will by pass the security checking and trying to insert the annotation in the database.

I also change the name of the variable in order to avoid a name collision with the same package name