### PR TITLE
docs: update installation instructions

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -15,10 +15,9 @@ weight = 1
 
 Description | Download
 ------------ | -------------
-Stable for Debian-based Linux | [grafana_5.1.4_amd64.deb](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.4_amd64.deb)
-<!--
-Beta for Debian-based Linux | [grafana_5.1.0-beta1_amd64.deb](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.0-beta1_amd64.deb)
--->
+Stable for Debian-based Linux | [x86-64](https://grafana.com/grafana/download?platform=linux)
+Stable for Debian-based Linux | [ARM64](https://grafana.com/grafana/download?platform=arm)
+Stable for Debian-based Linux | [ARMv7](https://grafana.com/grafana/download?platform=arm)
 
 Read [Upgrading Grafana]({{< relref "installation/upgrading.md" >}}) for tips and guidance on updating an existing
 installation.
@@ -27,17 +26,18 @@ installation.
 
 
 ```bash
-wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.4_amd64.deb
+wget <debian package url>
 sudo apt-get install -y adduser libfontconfig
 sudo dpkg -i grafana_5.1.4_amd64.deb
 ```
 
-<!-- ## Install Latest Beta
+Example:
+
 ```bash
-wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.0-beta1_amd64.deb
+wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.1.4_amd64.deb
 sudo apt-get install -y adduser libfontconfig
-sudo dpkg -i grafana_5.1.0-beta1_amd64.deb
-``` -->
+sudo dpkg -i grafana_5.1.4_amd64.deb
+```
 
 ## APT Repository
 

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -11,6 +11,8 @@ weight = 4
 
 # Installing on Mac
 
+## Install using homebrew
+
 Installation can be done using [homebrew](http://brew.sh/)
 
 Install latest stable:
@@ -74,4 +76,19 @@ If you want to manually install a plugin place it here: `/usr/local/var/lib/graf
 ### Database
 
 The default sqlite database is located at `/usr/local/var/lib/grafana`
+
+## Installing from binary tar file
+
+Download [the latest `.tar.gz` file](https://grafana.com/get) and
+extract it.  This will extract into a folder named after the version you
+downloaded. This folder contains all files required to run Grafana.  There are
+no init scripts or install scripts in this package.
+
+To configure Grafana add a configuration file named `custom.ini` to the
+`conf` folder and override any of the settings defined in
+`conf/defaults.ini`.
+
+Start Grafana by executing `./bin/grafana-server web`. The `grafana-server`
+binary needs the working directory to be the root install directory (where the
+binary and the `public` folder is located).
 

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -15,42 +15,49 @@ weight = 2
 
 Description | Download
 ------------ | -------------
-Stable for CentOS / Fedora / OpenSuse / Redhat Linux | [5.1.4 (x86-64 rpm)](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm)
-<!--
-Latest Beta for CentOS / Fedora / OpenSuse / Redhat Linux | [5.1.0-beta1 (x86-64 rpm)](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.0-beta1.x86_64.rpm)
--->
+Stable for CentOS / Fedora / OpenSuse / Redhat Linux | [x86-64](https://grafana.com/grafana/download?platform=linux)
+Stable for CentOS / Fedora / OpenSuse / Redhat Linux | [ARM64](https://grafana.com/grafana/download?platform=arm)
+Stable for CentOS / Fedora / OpenSuse / Redhat Linux | [ARMv7](https://grafana.com/grafana/download?platform=arm)
 
-Read [Upgrading Grafana]({{< relref "installation/upgrading.md" >}}) for tips and guidance on updating an existing
-installation.
+Read [Upgrading Grafana]({{< relref "installation/upgrading.md" >}}) for tips and guidance on updating an existing installation.
 
 ## Install Stable
 
 You can install Grafana using Yum directly.
 
 ```bash
+$ sudo yum install <rpm package url>
+```
+
+Example:
+
+```bash
 $ sudo yum install https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm
 ```
 
-<!-- ## Install Beta
+Or install manually using `rpm`. First execute
 
 ```bash
-$ sudo yum install https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.0-beta1.x86_64.rpm
-``` -->
+$ wget <rpm package url>
+```
 
-Or install manually using `rpm`.
-
-#### On CentOS / Fedora / Redhat:
+Example:
 
 ```bash
 $ wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4-1.x86_64.rpm
-$ sudo yum install initscripts fontconfig
-$ sudo rpm -Uvh grafana-5.1.4-1.x86_64.rpm
 ```
 
-#### On OpenSuse:
+### On CentOS / Fedora / Redhat:
 
 ```bash
-$ sudo rpm -i --nodeps grafana-5.1.4-1.x86_64.rpm
+$ sudo yum install initscripts fontconfig
+$ sudo rpm -Uvh <local rpm package>
+```
+
+### On OpenSuse:
+
+```bash
+$ sudo rpm -i --nodeps <local rpm package>
 ```
 
 ## Install via YUM Repository

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -12,11 +12,7 @@ weight = 3
 
 Description | Download
 ------------ | -------------
-Latest stable package for Windows | [grafana-5.1.4.windows-x64.zip](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.4.windows-x64.zip)
-
-<!--
-Latest beta package for Windows | [grafana.5.1.0-beta1.windows-x64.zip](https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.0.0-beta5.windows-x64.zip)
--->
+Latest stable package for Windows | [x64](https://grafana.com/grafana/download?platform=windows)
 
 Read [Upgrading Grafana]({{< relref "installation/upgrading.md" >}}) for tips and guidance on updating an existing
 installation.


### PR DESCRIPTION
Fixes #12140

* Decided to remove the hard coded links to latest stable debian, rpm and windows packages and instead linking to the download page with correct querystring parameter to filter by architecture (platform).
* Also adds links for ARM64 and ARMv7