### PR TITLE
support passing api token in Basic auth password

### DIFF
--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -44,6 +44,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 The `Authorization` header value should be `Bearer <your api key>`.
 
+The API Token can also be passed as a Basic authorization password with the special username `api_key`:
+
+curl example:
+```bash
+?curl http://api_key:eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk@localhost:3000/api/org
+{"id":1,"name":"Main Org."}
+```
+
 # Auth HTTP resources / actions
 
 ## Api Keys

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/session"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 type AuthOptions struct {
@@ -32,6 +33,11 @@ func getApiKey(c *m.ReqContext) string {
 	if len(parts) == 2 && parts[0] == "Bearer" {
 		key := parts[1]
 		return key
+	}
+
+	username, password, err := util.DecodeBasicAuthHeader(header)
+	if err == nil && username == "api_key" {
+		return password
 	}
 
 	return ""


### PR DESCRIPTION
This PR adds support for passing an API token via Basic auth rather than via a Bearer token, to support external systems that don't allow specifying additional HTTP headers.  To use it, pass the token as the password with the special username `api_key`.