### PR TITLE
Implement advanced permission control over orgs/teams for LDAP

### DIFF
--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -165,9 +165,10 @@ will be set to `Admin`
 
 ### Team Membership
 If no `team_id` is specified in TOML configuration file, team management feature will be
-completely be disabled. If any `group_mappings` entry is configured  with `team_id`,
-automatic team management will take place.
+completely disabled. If any `group_mappings` entry is configured  with `team_id`,
+automatic team management will take place, but, **only for that particular organisation**. 
 
-That means, any manual team assignments will be reset each time user logs in.
+So, any manual team assignments for LDAP-enabled accounts within organisation with enabled 
+automatic team membership feature, changes will be reset each time user logs in.
 If you change the LDAP groups of user, the change will take effect the next time
 the user logs in.

--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -81,6 +81,14 @@ group_dn = "cn=users,dc=grafana,dc=org"
 org_role = "Editor"
 
 [[servers.group_mappings]]
+group_dn = "cn=team-1,cn=teams,dc=grafana,dc=org"
+# Please check notes related to Team Membership feature below
+team_id = 1
+# Optional mappings
+# org_id = 1
+# org_role = "Viewer"
+
+[[servers.group_mappings]]
 # If you want to match all (or no ldap groups) then you can use wildcard
 group_dn = "*"
 org_role = "Viewer"
@@ -122,18 +130,44 @@ group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
 Also change set `member_of = "cn"` in the `[servers.attributes]` section.
 
 
-## LDAP to Grafana Org Role Sync
+## LDAP to Grafana Org Role and Team Membership Sync
 
 ### Mappings
-In `[[servers.group_mappings]]` you can map an LDAP group to a Grafana organization
-and role.  These will be synced every time the user logs in, with LDAP being
-the authoritative source.  So, if you change a user's role in the Grafana Org.
+In `[[servers.group_mappings]]` you can map an LDAP groups to a Grafana organization,
+role and team. These will be synced every time the user logs in, with LDAP being
+the authoritative source. So, if you change a user's role in the Grafana Org.
 Users page, this change will be reset the next time the user logs in. If you
 change the LDAP groups of a user, the change will take effect the next
 time the user logs in.
 
 ### Priority
-The first group mapping that an LDAP user is matched to will be used for the sync. If you have LDAP users that fit multiple mappings, the topmost mapping in the TOML config will be used.
+If you have LDAP users that fit multiple mappings, the less restrictive role mapping in the
+TOML config will be used.
+
+Example:
+```
+[[servers.group_mappings]]
+group_dn = "cn=org-editor"
+org_role = "Editor"
+
+[[servers.group_mappings]]
+group_dn = "cn=org-admin"
+org_role = "Admin"
+
+[[servers.group_mappings]]
+group_dn = "*"
+org_role = "Viewer"
+```
+
+So, if user belongs to `cn=org-editor` and `cn=org-admin` groups, `org_role`
+will be set to `Admin`
 
 
+### Team Membership
+If no `team_id` is specified in TOML configuration file, team management feature will be
+completely be disabled. If any `group_mappings` entry is configured  with `team_id`,
+automatic team management will take place.
 
+That means, any manual team assignments will be reset each time user logs in.
+If you change the LDAP groups of user, the change will take effect the next time
+the user logs in.

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -159,6 +159,7 @@ func OAuthLogin(ctx *m.ReqContext) {
 		Login:      userInfo.Login,
 		Email:      userInfo.Email,
 		OrgRoles:   map[int64]m.RoleType{},
+		OrgTeams:   map[int64][]int64{},
 	}
 
 	if userInfo.Role != "" {

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -153,13 +153,14 @@ func OAuthLogin(ctx *m.ReqContext) {
 	}
 
 	extUser := &m.ExternalUserInfo{
-		AuthModule: "oauth_" + name,
-		AuthId:     userInfo.Id,
-		Name:       userInfo.Name,
-		Login:      userInfo.Login,
-		Email:      userInfo.Email,
-		OrgRoles:   map[int64]m.RoleType{},
-		OrgTeams:   map[int64][]int64{},
+		AuthModule:  "oauth_" + name,
+		AuthId:      userInfo.Id,
+		Name:        userInfo.Name,
+		Login:       userInfo.Login,
+		Email:       userInfo.Email,
+		OrgRoles:    map[int64]m.RoleType{},
+		OrgTeams:    map[int64][]int64{},
+		HandleTeams: map[int64]bool{},
 	}
 
 	if userInfo.Role != "" {

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -84,8 +84,8 @@ func syncCheckUser(s *userSyncState) userSyncStateFn {
 func syncSignupUser(s *userSyncState) userSyncStateFn {
 	if !s.cmd.SignupAllowed {
 		s.log.Warn(
-			"Not allowing %s login, user not found in internal user database and allow signup = false",
-			s.cmd.ExternalUser.AuthModule)
+			"Not allowing login, user not found in internal user database and allow signup = false",
+			"auth_module", s.cmd.ExternalUser.AuthModule)
 
 		s.err = ErrInvalidCredentials
 		return nil

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -7,178 +7,415 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 )
 
+type (
+	// user sync fsm state
+	userSyncState struct {
+		cmd *m.UpsertUserCommand
+
+		orgsQuery   *m.GetUserOrgListQuery
+		deletedOrgs map[int64]bool // orgs user has left access to
+		updatedOrgs map[int64]bool // orgs user has access
+
+		user  *m.User
+		teams map[int64]map[int64]bool // {orgId: { teamId: bool, teamId: bool, ... }, ...}
+
+		err error // fsm error
+		log log.Logger
+	}
+
+	// user sync fsm func
+	userSyncStateFn func(s *userSyncState) userSyncStateFn
+)
+
 func init() {
 	bus.AddHandler("auth", UpsertUser)
 }
 
 func UpsertUser(cmd *m.UpsertUserCommand) error {
-	extUser := cmd.ExternalUser
-
-	userQuery := &m.GetUserByAuthInfoQuery{
-		AuthModule: extUser.AuthModule,
-		AuthId:     extUser.AuthId,
-		UserId:     extUser.UserId,
-		Email:      extUser.Email,
-		Login:      extUser.Login,
+	s := &userSyncState{
+		cmd: cmd,
+		log: log.New("upsert"),
 	}
+
+	for next := syncUserStart; next != nil; {
+		next = next(s)
+	}
+
+	cmd.Result = s.user
+	return s.err
+}
+
+// fsm: initialize state fields
+func syncUserStart(s *userSyncState) userSyncStateFn {
+	s.updatedOrgs = map[int64]bool{}
+	s.deletedOrgs = map[int64]bool{}
+	s.teams = map[int64]map[int64]bool{}
+
+	return syncCheckUser
+}
+
+// fsm: try to find user in database, in case user exists just go with update phase,
+// otherwise go straight to signup phase.
+func syncCheckUser(s *userSyncState) userSyncStateFn {
+	userQuery := &m.GetUserByAuthInfoQuery{
+		AuthModule: s.cmd.ExternalUser.AuthModule,
+		AuthId:     s.cmd.ExternalUser.AuthId,
+		UserId:     s.cmd.ExternalUser.UserId,
+		Email:      s.cmd.ExternalUser.Email,
+		Login:      s.cmd.ExternalUser.Login,
+	}
+
 	err := bus.Dispatch(userQuery)
 	if err != m.ErrUserNotFound && err != nil {
-		return err
+		s.err = err
+		return nil
 	}
 
 	if err != nil {
-		if !cmd.SignupAllowed {
-			log.Warn("Not allowing %s login, user not found in internal user database and allow signup = false", extUser.AuthModule)
-			return ErrInvalidCredentials
-		}
-
-		limitReached, err := quota.QuotaReached(cmd.ReqContext, "user")
-		if err != nil {
-			log.Warn("Error getting user quota", "err", err)
-			return ErrGettingUserQuota
-		}
-		if limitReached {
-			return ErrUsersQuotaReached
-		}
-
-		cmd.Result, err = createUser(extUser)
-		if err != nil {
-			return err
-		}
-
-		if extUser.AuthModule != "" && extUser.AuthId != "" {
-			cmd2 := &m.SetAuthInfoCommand{
-				UserId:     cmd.Result.Id,
-				AuthModule: extUser.AuthModule,
-				AuthId:     extUser.AuthId,
-			}
-			if err := bus.Dispatch(cmd2); err != nil {
-				return err
-			}
-		}
-
-	} else {
-		cmd.Result = userQuery.Result
-
-		err = updateUser(cmd.Result, extUser)
-		if err != nil {
-			return err
-		}
+		return syncSignupUser
 	}
 
-	return syncOrgRoles(cmd.Result, extUser)
+	s.user = userQuery.Result
+	return syncUpdateUser
 }
 
-func createUser(extUser *m.ExternalUserInfo) (*m.User, error) {
-	cmd := &m.CreateUserCommand{
-		Login:        extUser.Login,
-		Email:        extUser.Email,
-		Name:         extUser.Name,
-		SkipOrgSetup: len(extUser.OrgRoles) > 0,
-	}
-	if err := bus.Dispatch(cmd); err != nil {
-		return nil, err
+// fsm: user has not been found in database,
+// check allowance of signup and quotas and proceed with user creation.
+func syncSignupUser(s *userSyncState) userSyncStateFn {
+	if !s.cmd.SignupAllowed {
+		s.log.Warn(
+			"Not allowing %s login, user not found in internal user database and allow signup = false",
+			s.cmd.ExternalUser.AuthModule)
+
+		s.err = ErrInvalidCredentials
+		return nil
 	}
 
-	return &cmd.Result, nil
+	limitReached, err := quota.QuotaReached(s.cmd.ReqContext, "user")
+	if err != nil {
+		s.log.Warn("Error getting user quota", "err", err)
+		s.err = ErrGettingUserQuota
+		return nil
+	}
+	if limitReached {
+		s.err = ErrUsersQuotaReached
+		return nil
+	}
+
+	return syncCreateUser
 }
 
-func updateUser(user *m.User, extUser *m.ExternalUserInfo) error {
-	// sync user info
-	updateCmd := &m.UpdateUserCommand{
-		UserId: user.Id,
+// fsm: signup is allowed, quota limit is not hit, so, create user
+// and proceed with orgs/teams membership.
+func syncCreateUser(s *userSyncState) userSyncStateFn {
+	createCmd := &m.CreateUserCommand{
+		Login:        s.cmd.ExternalUser.Login,
+		Email:        s.cmd.ExternalUser.Email,
+		Name:         s.cmd.ExternalUser.Name,
+		SkipOrgSetup: len(s.cmd.ExternalUser.OrgRoles) > 0,
 	}
 
+	if err := bus.Dispatch(createCmd); err != nil {
+		s.err = err
+		return nil
+	}
+
+	s.user = &createCmd.Result
+	if s.cmd.ExternalUser.AuthModule != "" && s.cmd.ExternalUser.AuthId != "" {
+		authInfoCmd := &m.SetAuthInfoCommand{
+			UserId:     s.user.Id,
+			AuthModule: s.cmd.ExternalUser.AuthModule,
+			AuthId:     s.cmd.ExternalUser.AuthId,
+		}
+
+		if err := bus.Dispatch(authInfoCmd); err != nil {
+			s.err = err
+			return nil
+		}
+	}
+
+	return syncUserMembershipStart
+}
+
+// fsm: user has been found in database, update user base details if needed
+// and proceed with orgs/teams membership.
+func syncUpdateUser(s *userSyncState) userSyncStateFn {
 	needsUpdate := false
-	if extUser.Login != "" && extUser.Login != user.Login {
-		updateCmd.Login = extUser.Login
-		user.Login = extUser.Login
+	updateCmd := &m.UpdateUserCommand{UserId: s.user.Id}
+
+	if s.cmd.ExternalUser.Login != "" && s.cmd.ExternalUser.Login != s.user.Login {
 		needsUpdate = true
+		updateCmd.Login = s.cmd.ExternalUser.Login
+		s.user.Login = s.cmd.ExternalUser.Login
 	}
 
-	if extUser.Email != "" && extUser.Email != user.Email {
-		updateCmd.Email = extUser.Email
-		user.Email = extUser.Email
+	if s.cmd.ExternalUser.Email != "" && s.cmd.ExternalUser.Email != s.user.Email {
 		needsUpdate = true
+		updateCmd.Email = s.cmd.ExternalUser.Email
+		s.user.Email = s.cmd.ExternalUser.Email
 	}
 
-	if extUser.Name != "" && extUser.Name != user.Name {
-		updateCmd.Name = extUser.Name
-		user.Name = extUser.Name
+	if s.cmd.ExternalUser.Name != "" && s.cmd.ExternalUser.Name != s.user.Name {
 		needsUpdate = true
+		updateCmd.Name = s.cmd.ExternalUser.Name
+		s.user.Name = s.cmd.ExternalUser.Name
 	}
 
-	if !needsUpdate {
-		return nil
-	}
-
-	log.Debug("Syncing user info", "id", user.Id, "update", updateCmd)
-	return bus.Dispatch(updateCmd)
-}
-
-func syncOrgRoles(user *m.User, extUser *m.ExternalUserInfo) error {
-	// don't sync org roles if none are specified
-	if len(extUser.OrgRoles) == 0 {
-		return nil
-	}
-
-	orgsQuery := &m.GetUserOrgListQuery{UserId: user.Id}
-	if err := bus.Dispatch(orgsQuery); err != nil {
-		return err
-	}
-
-	handledOrgIds := map[int64]bool{}
-	deleteOrgIds := []int64{}
-
-	// update existing org roles
-	for _, org := range orgsQuery.Result {
-		handledOrgIds[org.OrgId] = true
-
-		if extUser.OrgRoles[org.OrgId] == "" {
-			deleteOrgIds = append(deleteOrgIds, org.OrgId)
-		} else if extUser.OrgRoles[org.OrgId] != org.Role {
-			// update role
-			cmd := &m.UpdateOrgUserCommand{OrgId: org.OrgId, UserId: user.Id, Role: extUser.OrgRoles[org.OrgId]}
-			if err := bus.Dispatch(cmd); err != nil {
-				return err
-			}
+	if needsUpdate {
+		s.log.Debug("Syncing user info", "user", s.user, "cmd", updateCmd)
+		err := bus.Dispatch(updateCmd)
+		if err != nil {
+			s.err = err
+			return nil
 		}
 	}
 
-	// add any new org roles
-	for orgId, orgRole := range extUser.OrgRoles {
-		if _, exists := handledOrgIds[orgId]; exists {
+	return syncUserMembershipStart
+}
+
+// fsm: in order to correctly handle orgs/teams membership, permissions sync is divided
+// into 4 phases:
+//  - grant/update org membership ->
+//  - grant team membership across all orgs user belongs to ->
+//  - revoke team membership across all orgs user belongs to ->
+//  - revoke org membership user left access to.
+//
+// before performing orgs/teams membership, make sure external
+// user contains configuration for orgs, otherwise, sync is not needed.
+func syncUserMembershipStart(s *userSyncState) userSyncStateFn {
+	if len(s.cmd.ExternalUser.OrgRoles) == 0 {
+		return nil
+	}
+
+	s.orgsQuery = &m.GetUserOrgListQuery{UserId: s.user.Id}
+	if err := bus.Dispatch(s.orgsQuery); err != nil {
+		s.err = err
+		return nil
+	}
+
+	return syncUserOrgJoin
+}
+
+// fsm: join orgs, while joining orgs, keep track of orgs user left access to
+// and proceed with team membership.
+func syncUserOrgJoin(s *userSyncState) userSyncStateFn {
+	for _, org := range s.orgsQuery.Result {
+		orgRole, exists := s.cmd.ExternalUser.OrgRoles[org.OrgId]
+
+		switch exists {
+		case true:
+			// track seen orgs user currently have in database
+			s.updatedOrgs[org.OrgId] = true
+
+			// if new role differ from current one
+			if orgRole != org.Role {
+				cmd := &m.UpdateOrgUserCommand{
+					OrgId:  org.OrgId,
+					UserId: s.user.Id,
+					Role:   orgRole,
+				}
+				if err := bus.Dispatch(cmd); err != nil {
+					s.err = err
+					return nil
+				}
+			}
+		default:
+			// track orgs removed in ldap
+			s.deletedOrgs[org.OrgId] = true
+		}
+	}
+
+	// for orgs we have in ldap, grant every org access user don't have access to
+	for orgId, orgRole := range s.cmd.ExternalUser.OrgRoles {
+		// is org known to be already updated?
+		if _, exists := s.updatedOrgs[orgId]; exists {
+			continue
+		}
+		// is org known to be scheduled for deletion?
+		if _, exists := s.deletedOrgs[orgId]; exists {
 			continue
 		}
 
-		// add role
-		cmd := &m.AddOrgUserCommand{UserId: user.Id, Role: orgRole, OrgId: orgId}
+		// add user org role
+		s.log.Debug("Adding user to org", "user", s.user, "orgId", orgId, "role", orgRole)
+		s.updatedOrgs[orgId] = true
+		cmd := &m.AddOrgUserCommand{
+			UserId: s.user.Id,
+			Role:   orgRole,
+			OrgId:  orgId,
+		}
 		err := bus.Dispatch(cmd)
 		if err != nil && err != m.ErrOrgNotFound {
-			return err
+			s.err = err
+			return nil
 		}
 	}
 
-	// delete any removed org roles
-	for _, orgId := range deleteOrgIds {
-		cmd := &m.RemoveOrgUserCommand{OrgId: orgId, UserId: user.Id}
-		if err := bus.Dispatch(cmd); err != nil {
-			return err
+	return syncUserTeamsStart
+}
+
+// fsm: at this point, user still have access to all orgs, even to orgs user lost access to,
+// so, loading up information about team membership and proceed with team join phase.
+func syncUserTeamsStart(s *userSyncState) userSyncStateFn {
+	for orgId := range s.updatedOrgs {
+		teamQuery := &m.GetTeamsByUserQuery{OrgId: orgId, UserId: s.user.Id}
+
+		err := bus.Dispatch(teamQuery)
+		if err != nil && err != m.ErrOrgNotFound {
+			s.err = err
+			return nil
+		}
+
+		s.teams[orgId] = teamQueryToMap(teamQuery)
+	}
+
+	for orgId := range s.deletedOrgs {
+		teamQuery := &m.GetTeamsByUserQuery{OrgId: orgId, UserId: s.user.Id}
+
+		err := bus.Dispatch(teamQuery)
+		if err != nil && err != m.ErrOrgNotFound {
+			s.err = err
+			return nil
+		}
+		s.teams[orgId] = teamQueryToMap(teamQuery)
+	}
+
+	return syncUserTeamJoin
+}
+
+// fsm: join all teams within orgs user have access to.
+func syncUserTeamJoin(s *userSyncState) userSyncStateFn {
+	for orgId := range s.updatedOrgs {
+		teamIdList, exists := s.cmd.ExternalUser.OrgTeams[orgId]
+		if !exists {
+			continue
+		}
+
+		// here, we adding teams are not registered in updated/deleted orgs
+		for _, teamId := range teamIdList {
+			if _, exists := s.teams[orgId][teamId]; exists {
+				continue
+			}
+
+			s.log.Debug("Adding user to team", "user", s.user, "orgId", orgId, "teamId", teamId, "role")
+
+			cmd := &m.AddTeamMemberCommand{UserId: s.user.Id, OrgId: orgId, TeamId: teamId}
+			err := bus.Dispatch(cmd)
+			if err != nil && err != m.ErrTeamNotFound && err != m.ErrTeamMemberAlreadyAdded {
+				s.err = err
+				return nil
+			}
 		}
 	}
 
-	// update user's default org if needed
-	if _, ok := extUser.OrgRoles[user.OrgId]; !ok {
-		for orgId := range extUser.OrgRoles {
-			user.OrgId = orgId
+	return syncUserTeamLeave
+}
+
+// fsm: revoke team membership for two cases:
+// - user doesn't belongs to org anymore
+// - user doesn't have access to team by configuration
+func syncUserTeamLeave(s *userSyncState) userSyncStateFn {
+	revokeTeams := map[int64][]int64{}
+
+	// revoke team membership by leaving orgs
+	for orgId := range s.deletedOrgs {
+		teamIdMap, exists := s.teams[orgId]
+		if !exists {
+			continue
+		}
+
+		for teamId := range teamIdMap {
+			revokeTeams[orgId] = append(revokeTeams[orgId], teamId)
+		}
+	}
+
+	// revoke team membership by configuration
+	for orgId, teamIdMap := range s.teams {
+		teamIdList, exists := s.cmd.ExternalUser.OrgTeams[orgId]
+		if !exists {
+			// user doesn't belong to org,
+			// revoke membership of all teams within org
+			for teamId := range teamIdMap {
+				revokeTeams[orgId] = append(revokeTeams[orgId], teamId)
+			}
+			continue
+		}
+
+		// check that every team membership is still valid
+		for teamId := range teamIdMap {
+			seen := false
+			for _, existTeamId := range teamIdList {
+				if existTeamId == teamId {
+					seen = true
+					break
+				}
+			}
+
+			if !seen {
+				revokeTeams[orgId] = append(revokeTeams[orgId], teamId)
+			}
+		}
+	}
+
+	// perform revoke
+	for orgId, teamIdList := range revokeTeams {
+		for _, teamId := range teamIdList {
+			s.log.Debug("Removing user from team", "user", s.user, "orgId", orgId, "teamId", teamId, "role")
+
+			cmd := &m.RemoveTeamMemberCommand{UserId: s.user.Id, OrgId: orgId, TeamId: teamId}
+			err := bus.Dispatch(cmd)
+			if err != nil && err != m.ErrTeamNotFound && err != m.ErrTeamMemberNotFound {
+				s.err = err
+				return nil
+			}
+		}
+	}
+
+	return syncUserOrgLeave
+}
+
+// fsm: all team membership for each deleted org has been revoked,
+// so just revoke access to orgs.
+func syncUserOrgLeave(s *userSyncState) userSyncStateFn {
+	for orgId := range s.deletedOrgs {
+		s.log.Debug("Removing user from org", "user", s.user, "orgId", orgId)
+
+		cmd := &m.RemoveOrgUserCommand{OrgId: orgId, UserId: s.user.Id}
+		err := bus.Dispatch(cmd)
+		if err != nil && err != m.ErrOrgNotFound {
+			s.err = err
+			return nil
+		}
+	}
+
+	return syncUserOrgUpdateDefault
+}
+
+// fsm: if user left access to default org, update default org
+// with first configured one
+// (actually is quite random here, since iteration over map is not stable)
+func syncUserOrgUpdateDefault(s *userSyncState) userSyncStateFn {
+	if _, ok := s.cmd.ExternalUser.OrgRoles[s.user.OrgId]; !ok {
+		for orgId := range s.cmd.ExternalUser.OrgRoles {
+			s.user.OrgId = orgId
 			break
 		}
 
-		return bus.Dispatch(&m.SetUsingOrgCommand{
-			UserId: user.Id,
-			OrgId:  user.OrgId,
-		})
+		s.log.Debug("Updating user default org", "user", s.user)
+		cmd := &m.SetUsingOrgCommand{UserId: s.user.Id, OrgId: s.user.OrgId}
+		if err := bus.Dispatch(cmd); err != nil {
+			s.err = err
+			return nil
+		}
 	}
 
 	return nil
+}
+
+func teamQueryToMap(q *m.GetTeamsByUserQuery) map[int64]bool {
+	r := map[int64]bool{}
+	for _, team := range q.Result {
+		r[team.Id] = true
+	}
+	return r
 }

--- a/pkg/login/ext_user.go
+++ b/pkg/login/ext_user.go
@@ -256,7 +256,12 @@ func syncUserOrgJoin(s *userSyncState) userSyncStateFn {
 
 // fsm: at this point, user still have access to all orgs, even to orgs user lost access to,
 // so, loading up information about team membership and proceed with team join phase.
+// if no teams configured in group mappings, skip whole join/leave phase.
 func syncUserTeamsStart(s *userSyncState) userSyncStateFn {
+	if !s.cmd.ExternalUser.HandleTeams {
+		return syncUserOrgLeave
+	}
+
 	for orgId := range s.updatedOrgs {
 		teamQuery := &m.GetTeamsByUserQuery{OrgId: orgId, UserId: s.user.Id}
 
@@ -329,7 +334,6 @@ func syncUserTeamLeave(s *userSyncState) userSyncStateFn {
 		}
 	}
 
-	// revoke team membership by configuration
 	for orgId, teamIdMap := range s.teams {
 		teamIdList, exists := s.cmd.ExternalUser.OrgTeams[orgId]
 		if !exists {

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -169,6 +169,13 @@ func (a *ldapAuther) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *LdapUserInfo
 
 	seenTeam := map[int64]bool{}
 	for _, group := range a.server.LdapGroupMappings {
+		// if configuration includes teams, automatically
+		// enable join/leave mechanism.
+		// in this case manual team assignments will
+		// not be possible for LDAP enabled accounts.
+		if group.TeamId > 0 {
+			extUser.HandleTeams = true
+		}
 
 		if ldapUser.isMemberOf(group.GroupDN) {
 			orgRole := extUser.OrgRoles[group.OrgId]

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -164,23 +164,41 @@ func (a *ldapAuther) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *LdapUserInfo
 		Login:      ldapUser.Username,
 		Email:      ldapUser.Email,
 		OrgRoles:   map[int64]m.RoleType{},
+		OrgTeams:   map[int64][]int64{},
 	}
 
-	for _, group := range a.server.LdapGroups {
-		// only use the first match for each org
-		if extUser.OrgRoles[group.OrgId] != "" {
-			continue
-		}
+	seenTeam := map[int64]bool{}
+	for _, group := range a.server.LdapGroupMappings {
 
 		if ldapUser.isMemberOf(group.GroupDN) {
-			extUser.OrgRoles[group.OrgId] = group.OrgRole
+			orgRole := extUser.OrgRoles[group.OrgId]
+
+			// if user belongs to multiple groups,
+			// find most powerful role granted to user
+			if group.OrgRole.Includes(orgRole) {
+				a.log.Debug("Ldap Auth: user belongs to org role",
+					"org", group.OrgId,
+					"role", group.OrgRole)
+				extUser.OrgRoles[group.OrgId] = group.OrgRole
+			}
+
+			// if teamId is defined, register team membership as well
+			// also, skip duplicate team ids
+			if group.TeamId > 0 && !seenTeam[group.TeamId] {
+				seenTeam[group.TeamId] = true
+
+				extUser.OrgTeams[group.OrgId] = append(
+					extUser.OrgTeams[group.OrgId],
+					group.TeamId,
+				)
+			}
 		}
 	}
 
 	// validate that the user has access
 	// if there are no ldap group mappings access is true
 	// otherwise a single group must match
-	if len(a.server.LdapGroups) > 0 && len(extUser.OrgRoles) < 1 {
+	if len(a.server.LdapGroupMappings) > 0 && len(extUser.OrgRoles) < 1 {
 		a.log.Info(
 			"Ldap Auth: user does not belong in any of the specified ldap groups",
 			"username", ldapUser.Username,

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -158,23 +158,24 @@ func (a *ldapAuther) SyncUser(query *m.LoginUserQuery) error {
 
 func (a *ldapAuther) GetGrafanaUserFor(ctx *m.ReqContext, ldapUser *LdapUserInfo) (*m.User, error) {
 	extUser := &m.ExternalUserInfo{
-		AuthModule: "ldap",
-		AuthId:     ldapUser.DN,
-		Name:       fmt.Sprintf("%s %s", ldapUser.FirstName, ldapUser.LastName),
-		Login:      ldapUser.Username,
-		Email:      ldapUser.Email,
-		OrgRoles:   map[int64]m.RoleType{},
-		OrgTeams:   map[int64][]int64{},
+		AuthModule:  "ldap",
+		AuthId:      ldapUser.DN,
+		Name:        fmt.Sprintf("%s %s", ldapUser.FirstName, ldapUser.LastName),
+		Login:       ldapUser.Username,
+		Email:       ldapUser.Email,
+		OrgRoles:    map[int64]m.RoleType{},
+		OrgTeams:    map[int64][]int64{},
+		HandleTeams: map[int64]bool{},
 	}
 
 	seenTeam := map[int64]bool{}
 	for _, group := range a.server.LdapGroupMappings {
 		// if configuration includes teams, automatically
-		// enable join/leave mechanism.
+		// enable join/leave mechanism per organisation basis.
 		// in this case manual team assignments will
 		// not be possible for LDAP enabled accounts.
 		if group.TeamId > 0 {
-			extUser.HandleTeams = true
+			extUser.HandleTeams[group.OrgId] = true
 		}
 
 		if ldapUser.isMemberOf(group.GroupDN) {

--- a/pkg/login/ldap_settings.go
+++ b/pkg/login/ldap_settings.go
@@ -1,7 +1,6 @@
 package login
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -32,7 +31,7 @@ type LdapServerConf struct {
 	GroupSearchFilterUserAttribute string   `toml:"group_search_filter_user_attribute"`
 	GroupSearchBaseDNs             []string `toml:"group_search_base_dns"`
 
-	LdapGroups []*LdapGroupToOrgRole `toml:"group_mappings"`
+	LdapGroupMappings []*LdapGroupToOrgRole `toml:"group_mappings"`
 }
 
 type LdapAttributeMap struct {
@@ -47,10 +46,11 @@ type LdapGroupToOrgRole struct {
 	GroupDN string     `toml:"group_dn"`
 	OrgId   int64      `toml:"org_id"`
 	OrgRole m.RoleType `toml:"org_role"`
+	TeamId  int64      `toml:"team_id"`
 }
 
 var LdapCfg LdapConfig
-var ldapLogger log.Logger = log.New("ldap")
+var ldapLogger = log.New("ldap")
 
 func loadLdapConfig() {
 	if !setting.LdapEnabled {
@@ -75,7 +75,7 @@ func loadLdapConfig() {
 		assertNotEmptyCfg(server.SearchFilter, "search_filter")
 		assertNotEmptyCfg(server.SearchBaseDNs, "search_base_dns")
 
-		for _, groupMap := range server.LdapGroups {
+		for _, groupMap := range server.LdapGroupMappings {
 			if groupMap.OrgId == 0 {
 				groupMap.OrgId = 1
 			}
@@ -96,6 +96,7 @@ func assertNotEmptyCfg(val interface{}, propName string) {
 			os.Exit(1)
 		}
 	default:
-		fmt.Println("unknown")
+		ldapLogger.Crit("LDAP config file has unknown type option", "option", propName)
+		os.Exit(1)
 	}
 }

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -16,7 +16,7 @@ func TestLdapAuther(t *testing.T) {
 
 		Convey("Given no ldap group map match", func() {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{{}},
+				LdapGroupMappings: []*LdapGroupToOrgRole{{}},
 			})
 			_, err := ldapAuther.GetGrafanaUserFor(nil, &LdapUserInfo{})
 
@@ -27,7 +27,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("Given wildcard group match", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "*", OrgRole: "Admin"},
 				},
 			})
@@ -41,7 +41,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("Given exact group match", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgRole: "Admin"},
 				},
 			})
@@ -55,7 +55,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("Given group match with different case", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgRole: "Admin"},
 				},
 			})
@@ -69,7 +69,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("Given no existing grafana user", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=admin", OrgRole: "Admin"},
 					{GroupDN: "cn=editor", OrgRole: "Editor"},
 					{GroupDN: "*", OrgRole: "Viewer"},
@@ -95,11 +95,11 @@ func TestLdapAuther(t *testing.T) {
 
 	})
 
-	Convey("When syncing ldap groups to grafana org roles", t, func() {
+	Convey("When syncing ldap groups to grafana org roles and teams", t, func() {
 
 		ldapAutherScenario("given no current user orgs", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgRole: "Admin"},
 				},
 			})
@@ -118,7 +118,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("given different current org role", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgId: 1, OrgRole: "Admin"},
 				},
 			})
@@ -138,7 +138,7 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("given current org role is removed in ldap", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgId: 2, OrgRole: "Admin"},
 				},
 			})
@@ -160,9 +160,9 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("given org role is updated in config", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
-					{GroupDN: "cn=admin", OrgId: 1, OrgRole: "Admin"},
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "cn=users", OrgId: 1, OrgRole: "Viewer"},
+					{GroupDN: "cn=admin", OrgId: 1, OrgRole: "Admin"},
 				},
 			})
 
@@ -179,11 +179,58 @@ func TestLdapAuther(t *testing.T) {
 			})
 		})
 
+		ldapAutherScenario("given no teams", func(sc *scenarioContext) {
+			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
+					{GroupDN: "cn=users", OrgRole: "Admin"},
+					{GroupDN: "cn=team1", TeamId: 1},
+				},
+			})
+
+			sc.userOrgsQueryReturns([]*m.UserOrgDTO{{OrgId: 1, Role: m.ROLE_ADMIN}})
+			sc.userTeamsQueryReturns(nil)
+			_, err := ldapAuther.GetGrafanaUserFor(nil, &LdapUserInfo{
+				MemberOf: []string{
+					"cn=users",
+					"cn=team1",
+				},
+			})
+
+			Convey("Should grant team membership to user", func() {
+				So(err, ShouldBeNil)
+				So(sc.addTeamUserCmd, ShouldNotBeNil)
+				So(sc.addTeamUserCmd.TeamId, ShouldEqual, 1)
+			})
+		})
+
+		ldapAutherScenario("given team is removed in ldap", func(sc *scenarioContext) {
+			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
+					{GroupDN: "cn=users", OrgRole: "Admin"},
+					{GroupDN: "cn=team1", TeamId: 1},
+				},
+			})
+
+			sc.userOrgsQueryReturns([]*m.UserOrgDTO{{OrgId: 1, Role: m.ROLE_ADMIN}})
+			sc.userTeamsQueryReturns([]*m.Team{{Id: 1}})
+			_, err := ldapAuther.GetGrafanaUserFor(nil, &LdapUserInfo{
+				MemberOf: []string{
+					"cn=users",
+				},
+			})
+
+			Convey("Should revoke team membership from user", func() {
+				So(err, ShouldBeNil)
+				So(sc.removeTeamUserCmd, ShouldNotBeNil)
+				So(sc.removeTeamUserCmd.TeamId, ShouldEqual, 1)
+			})
+		})
+
 		ldapAutherScenario("given multiple matching ldap groups", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
-					{GroupDN: "cn=admins", OrgId: 1, OrgRole: "Admin"},
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "*", OrgId: 1, OrgRole: "Viewer"},
+					{GroupDN: "cn=admins", OrgId: 1, OrgRole: "Admin"},
 				},
 			})
 
@@ -192,7 +239,7 @@ func TestLdapAuther(t *testing.T) {
 				MemberOf: []string{"cn=admins"},
 			})
 
-			Convey("Should take first match, and ignore subsequent matches", func() {
+			Convey("Should take most powerful role", func() {
 				So(err, ShouldBeNil)
 				So(sc.updateOrgUserCmd, ShouldBeNil)
 				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
@@ -201,9 +248,9 @@ func TestLdapAuther(t *testing.T) {
 
 		ldapAutherScenario("given multiple matching ldap groups and no existing groups", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
-				LdapGroups: []*LdapGroupToOrgRole{
-					{GroupDN: "cn=admins", OrgId: 1, OrgRole: "Admin"},
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "*", OrgId: 1, OrgRole: "Viewer"},
+					{GroupDN: "cn=admins", OrgId: 1, OrgRole: "Admin"},
 				},
 			})
 
@@ -212,7 +259,7 @@ func TestLdapAuther(t *testing.T) {
 				MemberOf: []string{"cn=admins"},
 			})
 
-			Convey("Should take first match, and ignore subsequent matches", func() {
+			Convey("Should take most powerful role", func() {
 				So(err, ShouldBeNil)
 				So(sc.addOrgUserCmd.Role, ShouldEqual, m.ROLE_ADMIN)
 				So(sc.setUsingOrgCmd.OrgId, ShouldEqual, 1)
@@ -228,7 +275,7 @@ func TestLdapAuther(t *testing.T) {
 			&LdapServerConf{
 				Host:       "",
 				RootCACert: "",
-				LdapGroups: []*LdapGroupToOrgRole{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
 					{GroupDN: "*", OrgRole: "Admin"},
 				},
 				Attr: LdapAttributeMap{
@@ -333,6 +380,11 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 			return nil
 		})
 
+		bus.AddHandler("test", func(cmd *m.GetTeamsByUserQuery) error {
+			sc.getTeamsByUserQuery = cmd
+			return nil
+		})
+
 		bus.AddHandler("test", func(cmd *m.CreateUserCommand) error {
 			sc.createUserCmd = cmd
 			sc.createUserCmd.Result = m.User{Login: cmd.Login}
@@ -341,6 +393,16 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 
 		bus.AddHandler("test", func(cmd *m.AddOrgUserCommand) error {
 			sc.addOrgUserCmd = cmd
+			return nil
+		})
+
+		bus.AddHandler("test", func(cmd *m.AddTeamMemberCommand) error {
+			sc.addTeamUserCmd = cmd
+			return nil
+		})
+
+		bus.AddHandler("test", func(cmd *m.RemoveTeamMemberCommand) error {
+			sc.removeTeamUserCmd = cmd
 			return nil
 		})
 
@@ -371,9 +433,12 @@ func ldapAutherScenario(desc string, fn scenarioFunc) {
 type scenarioContext struct {
 	getUserByAuthInfoQuery *m.GetUserByAuthInfoQuery
 	getUserOrgListQuery    *m.GetUserOrgListQuery
+	getTeamsByUserQuery    *m.GetTeamsByUserQuery
 	createUserCmd          *m.CreateUserCommand
 	addOrgUserCmd          *m.AddOrgUserCommand
 	updateOrgUserCmd       *m.UpdateOrgUserCommand
+	addTeamUserCmd         *m.AddTeamMemberCommand
+	removeTeamUserCmd      *m.RemoveTeamMemberCommand
 	removeOrgUserCmd       *m.RemoveOrgUserCommand
 	updateUserCmd          *m.UpdateUserCommand
 	setUsingOrgCmd         *m.SetUsingOrgCommand
@@ -395,6 +460,13 @@ func (sc *scenarioContext) userQueryReturns(user *m.User) {
 func (sc *scenarioContext) userOrgsQueryReturns(orgs []*m.UserOrgDTO) {
 	bus.AddHandler("test", func(query *m.GetUserOrgListQuery) error {
 		query.Result = orgs
+		return nil
+	})
+}
+
+func (sc *scenarioContext) userTeamsQueryReturns(teams []*m.Team) {
+	bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+		query.Result = teams
 		return nil
 	})
 }

--- a/pkg/login/ldap_test.go
+++ b/pkg/login/ldap_test.go
@@ -226,6 +226,27 @@ func TestLdapAuther(t *testing.T) {
 			})
 		})
 
+		ldapAutherScenario("given no teams configured in ldap", func(sc *scenarioContext) {
+			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
+				LdapGroupMappings: []*LdapGroupToOrgRole{
+					{GroupDN: "cn=users", OrgRole: "Admin"},
+				},
+			})
+
+			sc.userOrgsQueryReturns([]*m.UserOrgDTO{{OrgId: 1, Role: m.ROLE_ADMIN}})
+			sc.userTeamsQueryReturns([]*m.Team{{Id: 1}})
+			_, err := ldapAuther.GetGrafanaUserFor(nil, &LdapUserInfo{
+				MemberOf: []string{
+					"cn=users",
+				},
+			})
+
+			Convey("Shouldn't revoke team membership from user", func() {
+				So(err, ShouldBeNil)
+				So(sc.removeTeamUserCmd, ShouldBeNil)
+			})
+		})
+
 		ldapAutherScenario("given multiple matching ldap groups", func(sc *scenarioContext) {
 			ldapAuther := NewLdapAuthenticator(&LdapServerConf{
 				LdapGroupMappings: []*LdapGroupToOrgRole{

--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -28,15 +28,16 @@ func (r RoleType) IsValid() bool {
 }
 
 func (r RoleType) Includes(other RoleType) bool {
-	if r == ROLE_ADMIN {
+	switch r {
+	case ROLE_ADMIN:
 		return true
-	}
-
-	if r == ROLE_EDITOR {
+	case ROLE_EDITOR:
 		return other != ROLE_ADMIN
+	case ROLE_VIEWER:
+		return other != ROLE_EDITOR && other != ROLE_ADMIN
+	default:
+		return false
 	}
-
-	return false
 }
 
 func (r *RoleType) UnmarshalJSON(data []byte) error {

--- a/pkg/models/org_user_test.go
+++ b/pkg/models/org_user_test.go
@@ -1,0 +1,41 @@
+package models
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestRoleType_Includes(t *testing.T) {
+	Convey("Checking role includes", t, func() {
+
+		Convey("Empty role doesn't include any other role, even empty one", func() {
+			emptyRole := RoleType("")
+
+			So(emptyRole.Includes(emptyRole), ShouldBeFalse)
+			So(emptyRole.Includes(ROLE_VIEWER), ShouldBeFalse)
+			So(emptyRole.Includes(ROLE_EDITOR), ShouldBeFalse)
+			So(emptyRole.Includes(ROLE_ADMIN), ShouldBeFalse)
+		})
+
+		Convey("Viewer role includes empty role", func() {
+			So(ROLE_VIEWER.Includes(""), ShouldBeTrue)
+			So(ROLE_VIEWER.Includes(ROLE_VIEWER), ShouldBeTrue)
+			So(ROLE_VIEWER.Includes(ROLE_EDITOR), ShouldBeFalse)
+			So(ROLE_VIEWER.Includes(ROLE_ADMIN), ShouldBeFalse)
+		})
+
+		Convey("Editor role includes empty role and viewer role", func() {
+			So(ROLE_EDITOR.Includes(""), ShouldBeTrue)
+			So(ROLE_EDITOR.Includes(ROLE_VIEWER), ShouldBeTrue)
+			So(ROLE_EDITOR.Includes(ROLE_EDITOR), ShouldBeTrue)
+			So(ROLE_EDITOR.Includes(ROLE_ADMIN), ShouldBeFalse)
+		})
+
+		Convey("Admin role includes every role", func() {
+			So(ROLE_ADMIN.Includes(""), ShouldBeTrue)
+			So(ROLE_ADMIN.Includes(ROLE_VIEWER), ShouldBeTrue)
+			So(ROLE_ADMIN.Includes(ROLE_EDITOR), ShouldBeTrue)
+			So(ROLE_ADMIN.Includes(ROLE_ADMIN), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -19,7 +19,8 @@ type ExternalUserInfo struct {
 	Email      string
 	Login      string
 	Name       string
-	OrgRoles   map[int64]RoleType
+	OrgRoles   map[int64]RoleType // { orgId: RoleType, .. }
+	OrgTeams   map[int64][]int64  // { orgId: [ teamId, teamId, ...], }
 }
 
 // ---------------------

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -21,7 +21,7 @@ type ExternalUserInfo struct {
 	Name        string
 	OrgRoles    map[int64]RoleType // { orgId: RoleType, .. }
 	OrgTeams    map[int64][]int64  // { orgId: [ teamId, teamId, ...], }
-	HandleTeams bool
+	HandleTeams map[int64]bool
 }
 
 // ---------------------

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -13,14 +13,15 @@ type UserAuth struct {
 }
 
 type ExternalUserInfo struct {
-	AuthModule string
-	AuthId     string
-	UserId     int64
-	Email      string
-	Login      string
-	Name       string
-	OrgRoles   map[int64]RoleType // { orgId: RoleType, .. }
-	OrgTeams   map[int64][]int64  // { orgId: [ teamId, teamId, ...], }
+	AuthModule  string
+	AuthId      string
+	UserId      int64
+	Email       string
+	Login       string
+	Name        string
+	OrgRoles    map[int64]RoleType // { orgId: RoleType, .. }
+	OrgTeams    map[int64][]int64  // { orgId: [ teamId, teamId, ...], }
+	HandleTeams bool
 }
 
 // ---------------------


### PR DESCRIPTION
References #11301 

Patch contains slightly refactored `UpsertUser` handler and introduces ability to control team membership via LDAP.

I tried to keep backward-compatibility with previous implementation. Only thing is differ: in case of multiple group match, less restrictive role will be used (previous behaviour was about to use role from first group match and discard the rest).

Also, there additional warning: once at least one `group_mappings` entry will be configured with `team_id`, automatic grant/revoke team membership will take place. That means, for LDAP based users any manual team assignments will not be possible (I'd added test-case to cover such case).

Here is the example of configuration:
```
#
# Rules
# =====
# LDAP: cn=org-admin,cn=org-editor -> Grafana: org_id=1, role: admin
# LDAP: cn=org-editor              -> Grafana: org_id=1, role: editor
# LDAP: cn=team-1                  -> Grafana: org_id=1, role: viewer, team=1
#

[[servers.group_mappings]]
group_dn = "cn=org-editor"
org_role = "Editor"

[[servers.group_mappings]]
group_dn = "cn=org-admin"
org_role = "Admin"

[[servers.group_mappings]]
group_dn = "cn=team-1"
team_id = 1
#org_id = 1 (optional)

[[servers.group_mappings]]
group_dn = "*"
org_role = "Viewer"
```


