### PR TITLE
Fix: Log close (ie flush) was done too early, before final shutdown log

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/metrics"
 	"github.com/grafana/grafana/pkg/setting"
 
@@ -87,9 +86,6 @@ func main() {
 	go listenToSystemSignals(server)
 
 	err := server.Run()
-
-	trace.Stop()
-	log.Close()
 
 	server.Exit(err)
 }

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -185,6 +185,8 @@ func (g *GrafanaServerImpl) Exit(reason error) {
 	}
 
 	g.log.Error("Server shutdown", "reason", reason)
+
+	log.Close()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
fixes #12438