### PR TITLE
Avoid calling os.Exit outside main.go

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
+	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/metrics"
 	"github.com/grafana/grafana/pkg/setting"
 
@@ -87,7 +88,11 @@ func main() {
 
 	err := server.Run()
 
-	server.Exit(err)
+	code := server.Exit(err)
+	trace.Stop()
+	log.Close()
+
+	os.Exit(code)
 }
 
 func listenToSystemSignals(server *GrafanaServerImpl) {

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -175,7 +175,7 @@ func (g *GrafanaServerImpl) Shutdown(reason string) {
 	g.childRoutines.Wait()
 }
 
-func (g *GrafanaServerImpl) Exit(reason error) {
+func (g *GrafanaServerImpl) Exit(reason error) int {
 	// default exit code is 1
 	code := 1
 
@@ -185,9 +185,7 @@ func (g *GrafanaServerImpl) Exit(reason error) {
 	}
 
 	g.log.Error("Server shutdown", "reason", reason)
-
-	log.Close()
-	os.Exit(code)
+	return code
 }
 
 func (g *GrafanaServerImpl) writePIDFile() {


### PR DESCRIPTION
This is an alternative fix to #12439

We merged #12439 and included it in 5.2.1 since it solved
the problem but I think this is a prefered solution. IMO main.go
should be responsible for start/exiting the server and should, at
some point be able to restart grafana server graceful. So calling
os.Exit within Grafana server will cause problems in the future.