### PR TITLE
pkg/social/github: Allow changing of userinfo data

### DIFF
--- a/pkg/social/github_oauth.go
+++ b/pkg/social/github_oauth.go
@@ -213,6 +213,7 @@ func (s *SocialGithub) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	userInfo := &BasicUserInfo{
 		Name:  data.Login,
 		Login: data.Login,
+		Id:    fmt.Sprintf("%d", data.Id),
 		Email: data.Email,
 	}
 


### PR DESCRIPTION
Experienced a problem where a user whose email changed was no longer
able to login. By using the ID as a primary identifier, we can avoid
conflicts of this variety within the github OAuth provider.

Closes https://github.com/grafana/grafana/issues/11818

Verified locally that this does cover the edge case I hit, thanks @DanCech for the point in the right direction!