### PR TITLE
Added option to allow LDAP login when a user does not match a group f…

### DIFF
--- a/conf/ldap.toml
+++ b/conf/ldap.toml
@@ -60,6 +60,11 @@ search_base_dns = ["dc=grafana,dc=org"]
 ## An array of the base DNs to search through for groups. Typically uses ou=groups
 # group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
 
+## If you'd like to use LDAP group mappings, but not for all groups (e.g. Admins only)
+## then this option will allow LDAP users which don't find any valid group mappings
+## to be created with the default org group.
+#allow_no_group = true
+
 # Specify names of the ldap attributes your ldap uses
 [servers.attributes]
 name = "givenName"

--- a/pkg/login/ldap_settings.go
+++ b/pkg/login/ldap_settings.go
@@ -20,6 +20,7 @@ type LdapServerConf struct {
 	UseSSL        bool             `toml:"use_ssl"`
 	StartTLS      bool             `toml:"start_tls"`
 	SkipVerifySSL bool             `toml:"ssl_skip_verify"`
+	AllowNoGroup  bool             `toml:"allow_no_group"`
 	RootCACert    string           `toml:"root_ca_cert"`
 	BindDN        string           `toml:"bind_dn"`
 	BindPassword  string           `toml:"bind_password"`


### PR DESCRIPTION
We have a desired mode of usage with LDAP auth which involves setting a single group mapping ("Admins") synced from LDAP and then all other users get the default role for the org on login.

The idea behind this is so that we can set a group of global admin users on multiple grafana instances, organisation-wide, and they can promote "normal" users to editors/admins per grafana instance.

Since the code changes were minimal and I figured it could go some way to address some of the problems described in #6907, I thought it might be worth submitting a pull request.

First time contributor, please let me know what else you need from me!
