### PR TITLE
Fix datasource sorting with template variables

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -142,10 +142,12 @@ export class DatasourceSrv {
       var ds = config.datasources[first];
 
       if (ds) {
+        const key = `$${variable.name}`;
         list.push({
-          name: '$' + variable.name,
-          value: '$' + variable.name,
+          name: key,
+          value: key,
           meta: ds.meta,
+          sort: key,
         });
       }
     }

--- a/public/app/features/plugins/specs/datasource_srv.jest.ts
+++ b/public/app/features/plugins/specs/datasource_srv.jest.ts
@@ -2,8 +2,21 @@ import config from 'app/core/config';
 import 'app/features/plugins/datasource_srv';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
+// Datasource variable $datasource with current value 'BBB'
+const templateSrv = {
+  variables: [
+    {
+      type: 'datasource',
+      name: 'datasource',
+      current: {
+        value: 'BBB',
+      },
+    },
+  ],
+};
+
 describe('datasource_srv', function() {
-  let _datasourceSrv = new DatasourceSrv({}, {}, {}, {});
+  let _datasourceSrv = new DatasourceSrv({}, {}, {}, templateSrv);
   let metricSources;
 
   describe('when loading metric sources', () => {
@@ -35,25 +48,27 @@ describe('datasource_srv', function() {
     };
     beforeEach(() => {
       config.datasources = unsortedDatasources;
-      metricSources = _datasourceSrv.getMetricSources({ skipVariables: true });
-    });
-
-    it('should return a list of sources sorted case insensitively with builtin sources last', () => {
-      expect(metricSources[0].name).toBe('aaa');
-      expect(metricSources[1].name).toBe('BBB');
-      expect(metricSources[2].name).toBe('mmm');
-      expect(metricSources[3].name).toBe('ZZZ');
-      expect(metricSources[4].name).toBe('--Grafana--');
-      expect(metricSources[5].name).toBe('--Mixed--');
-    });
-
-    beforeEach(() => {
+      metricSources = _datasourceSrv.getMetricSources({});
       config.defaultDatasource = 'BBB';
     });
 
+    it('should return a list of sources sorted case insensitively with builtin sources last', () => {
+      expect(metricSources[1].name).toBe('aaa');
+      expect(metricSources[2].name).toBe('BBB');
+      expect(metricSources[3].name).toBe('mmm');
+      expect(metricSources[4].name).toBe('ZZZ');
+      expect(metricSources[5].name).toBe('--Grafana--');
+      expect(metricSources[6].name).toBe('--Mixed--');
+    });
+
     it('should set default data source', () => {
-      expect(metricSources[2].name).toBe('default');
-      expect(metricSources[2].sort).toBe('BBB');
+      expect(metricSources[3].name).toBe('default');
+      expect(metricSources[3].sort).toBe('BBB');
+    });
+
+    it('should set default inject the variable datasources', () => {
+      expect(metricSources[0].name).toBe('$datasource');
+      expect(metricSources[0].sort).toBe('$datasource');
     });
   });
 });


### PR DESCRIPTION
- fixes sorting when template variables are present
- simplified existing test cases
- added test to cover variable usage in datasource service
