### PR TITLE
(prometheus) prevent error to use $__interval_ms in query

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -222,7 +222,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     // and add built in variables interval and interval_ms
     var scopedVars = Object.assign({}, this.panel.scopedVars, {
       __interval: { text: this.interval, value: this.interval },
-      __interval_ms: { text: this.intervalMs, value: this.intervalMs },
+      __interval_ms: { text: String(this.intervalMs), value: String(this.intervalMs) },
     });
 
     var metricsQuery = {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -103,10 +103,6 @@ export class PrometheusDatasource {
   interpolateQueryExpr(value, variable, defaultFormatFn) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
-      if (typeof value === 'number') {
-        // $__interval_ms type is number, convert to string here
-        value = value.toString();
-      }
       return prometheusRegularEscape(value);
     }
 
@@ -200,7 +196,7 @@ export class PrometheusDatasource {
       interval = adjustedInterval;
       scopedVars = Object.assign({}, options.scopedVars, {
         __interval: { text: interval + 's', value: interval + 's' },
-        __interval_ms: { text: interval * 1000, value: interval * 1000 },
+        __interval_ms: { text: String(interval * 1000), value: String(interval * 1000) },
       });
     }
     query.step = interval;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -103,6 +103,10 @@ export class PrometheusDatasource {
   interpolateQueryExpr(value, variable, defaultFormatFn) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
+      if (typeof value === 'number') {
+        // $__interval_ms type is number, convert to string here
+        value = value.toString();
+      }
       return prometheusRegularEscape(value);
     }
 

--- a/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
@@ -201,10 +201,4 @@ describe('PrometheusDatasource', () => {
       expect(prometheusSpecialRegexEscape('+looking$glass?')).toEqual('\\\\+looking\\\\$glass\\\\?');
     });
   });
-
-  describe('interpolateQueryExpr', function() {
-    it('should return string if number passed', function() {
-      expect(ctx.ds.interpolateQueryExpr(100, {})).toEqual('100');
-    });
-  });
 });

--- a/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
@@ -201,4 +201,10 @@ describe('PrometheusDatasource', () => {
       expect(prometheusSpecialRegexEscape('+looking$glass?')).toEqual('\\\\+looking\\\\$glass\\\\?');
     });
   });
+
+  describe('interpolateQueryExpr', function() {
+    it('should return string if number passed', function() {
+      expect(ctx.ds.interpolateQueryExpr(100, {})).toEqual('100');
+    });
+  });
 });

--- a/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource_specs.ts
@@ -452,7 +452,7 @@ describe('PrometheusDatasource', function() {
         interval: '10s',
         scopedVars: {
           __interval: { text: '10s', value: '10s' },
-          __interval_ms: { text: 10 * 1000, value: 10 * 1000 },
+          __interval_ms: { text: String(10 * 1000), value: String(10 * 1000) },
         },
       };
       var urlExpected =
@@ -463,8 +463,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('10s');
       expect(query.scopedVars.__interval.value).to.be('10s');
-      expect(query.scopedVars.__interval_ms.text).to.be(10 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(10 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(10 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(10 * 1000));
     });
     it('should be min interval when it is greater than auto interval', function() {
       var query = {
@@ -479,7 +479,7 @@ describe('PrometheusDatasource', function() {
         interval: '5s',
         scopedVars: {
           __interval: { text: '5s', value: '5s' },
-          __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
+          __interval_ms: { text: String(5 * 1000), value: String(5 * 1000) },
         },
       };
       var urlExpected =
@@ -490,8 +490,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('5s');
       expect(query.scopedVars.__interval.value).to.be('5s');
-      expect(query.scopedVars.__interval_ms.text).to.be(5 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(5 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(5 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(5 * 1000));
     });
     it('should account for intervalFactor', function() {
       var query = {
@@ -507,7 +507,7 @@ describe('PrometheusDatasource', function() {
         interval: '10s',
         scopedVars: {
           __interval: { text: '10s', value: '10s' },
-          __interval_ms: { text: 10 * 1000, value: 10 * 1000 },
+          __interval_ms: { text: String(10 * 1000), value: String(10 * 1000) },
         },
       };
       var urlExpected =
@@ -518,8 +518,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('10s');
       expect(query.scopedVars.__interval.value).to.be('10s');
-      expect(query.scopedVars.__interval_ms.text).to.be(10 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(10 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(10 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(10 * 1000));
     });
     it('should be interval * intervalFactor when greater than min interval', function() {
       var query = {
@@ -535,7 +535,7 @@ describe('PrometheusDatasource', function() {
         interval: '5s',
         scopedVars: {
           __interval: { text: '5s', value: '5s' },
-          __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
+          __interval_ms: { text: String(5 * 1000), value: String(5 * 1000) },
         },
       };
       var urlExpected =
@@ -546,8 +546,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('5s');
       expect(query.scopedVars.__interval.value).to.be('5s');
-      expect(query.scopedVars.__interval_ms.text).to.be(5 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(5 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(5 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(5 * 1000));
     });
     it('should be min interval when greater than interval * intervalFactor', function() {
       var query = {
@@ -563,7 +563,7 @@ describe('PrometheusDatasource', function() {
         interval: '5s',
         scopedVars: {
           __interval: { text: '5s', value: '5s' },
-          __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
+          __interval_ms: { text: String(5 * 1000), value: String(5 * 1000) },
         },
       };
       var urlExpected =
@@ -574,8 +574,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('5s');
       expect(query.scopedVars.__interval.value).to.be('5s');
-      expect(query.scopedVars.__interval_ms.text).to.be(5 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(5 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(5 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(5 * 1000));
     });
     it('should be determined by the 11000 data points limit, accounting for intervalFactor', function() {
       var query = {
@@ -590,7 +590,7 @@ describe('PrometheusDatasource', function() {
         interval: '5s',
         scopedVars: {
           __interval: { text: '5s', value: '5s' },
-          __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
+          __interval_ms: { text: String(5 * 1000), value: String(5 * 1000) },
         },
       };
       var end = 7 * 24 * 60 * 60;
@@ -609,8 +609,8 @@ describe('PrometheusDatasource', function() {
 
       expect(query.scopedVars.__interval.text).to.be('5s');
       expect(query.scopedVars.__interval.value).to.be('5s');
-      expect(query.scopedVars.__interval_ms.text).to.be(5 * 1000);
-      expect(query.scopedVars.__interval_ms.value).to.be(5 * 1000);
+      expect(query.scopedVars.__interval_ms.text).to.be(String(5 * 1000));
+      expect(query.scopedVars.__interval_ms.value).to.be(String(5 * 1000));
     });
   });
 });


### PR DESCRIPTION
`$__interval_ms` type is integer. It cause error.