### PR TITLE
fix: Folder picker fix for initial folder when you cannot save in Root (General)

### DIFF
--- a/public/app/features/dashboard/folder_picker/folder_picker.ts
+++ b/public/app/features/dashboard/folder_picker/folder_picker.ts
@@ -104,10 +104,7 @@ export class FolderPickerCtrl {
       appEvents.emit('alert-success', ['Folder Created', 'OK']);
 
       this.closeCreateFolder();
-      this.folder = {
-        text: result.title,
-        value: result.id,
-      };
+      this.folder = { text: result.title, value: result.id };
       this.onFolderChange(this.folder);
     });
   }
@@ -149,17 +146,14 @@ export class FolderPickerCtrl {
           folder = result.length > 0 ? result[0] : resetFolder;
         }
       }
-      this.folder = folder;
-      this.onFolderLoad();
-    });
-  }
 
-  private onFolderLoad() {
-    if (this.onLoad) {
-      this.onLoad({
-        $folder: { id: this.folder.value, title: this.folder.text },
-      });
-    }
+      this.folder = folder;
+
+      // if this is not the same as our initial value notify parent
+      if (this.folder.id !== this.initialFolderId) {
+        this.onChange({ $folder: { id: this.folder.value, title: this.folder.text } });
+      }
+    });
   }
 }
 
@@ -176,7 +170,6 @@ export function folderPicker() {
       labelClass: '@',
       rootName: '@',
       onChange: '&',
-      onLoad: '&',
       onCreateFolder: '&',
       enterFolderCreation: '&',
       exitFolderCreation: '&',


### PR DESCRIPTION
Fixes #12543

The folder picker did not notify the parent component that the initial value was not allowed and that it had changed it. There was an onLoad callback but could not find any usage of this callback. 

