### PR TITLE
Handle query string in storage public_url (#9351)

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -857,7 +857,7 @@ Secret key. e.g. AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 Url to where Grafana will send PUT request with images
 
 ### public_url
-Optional parameter. Url to send to users in notifications, directly appended with the resulting uploaded file name.
+Optional parameter. Url to send to users in notifications. If the string contains the sequence ${file}, it will be replaced with the uploaded filename. Otherwise, the file name will be appended to the path part of the url, leaving any query string unchanged.
 
 ### username
 basic auth username

--- a/pkg/components/imguploader/webdavuploader_test.go
+++ b/pkg/components/imguploader/webdavuploader_test.go
@@ -2,6 +2,7 @@ package imguploader
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -24,5 +25,17 @@ func TestUploadToWebdav(t *testing.T) {
 
 		So(err, ShouldBeNil)
 		So(path, ShouldStartWith, "http://publicurl:8888/webdav/")
+	})
+}
+
+func TestPublicURL(t *testing.T) {
+	Convey("Given a public URL with parameters, and no template", t, func() {
+		webdavUploader, _ := NewWebdavImageUploader("http://localhost:8888/webdav/", "test", "test", "http://cloudycloud.me/s/DOIFDOMV/download?files=")
+		parsed, _ := url.Parse(webdavUploader.PublicURL("fileyfile.png"))
+		So(parsed.Path, ShouldEndWith, "fileyfile.png")
+	})
+	Convey("Given a public URL with parameters, and a template", t, func() {
+		webdavUploader, _ := NewWebdavImageUploader("http://localhost:8888/webdav/", "test", "test", "http://cloudycloud.me/s/DOIFDOMV/download?files=${file}")
+		So(webdavUploader.PublicURL("fileyfile.png"), ShouldEndWith, "fileyfile.png")
 	})
 }


### PR DESCRIPTION
This is useful for linking to images stored in e.g. ownCloud/Nextcloud, where the file name goes in the query string instead of the path. The previous behavior is preserved if the `public_url` parameter does not contain the placeholder sequence. Also updated the docs to make it clear that the query string is preserved by default. Fixes #9351.