### PR TITLE
change http method for removing helpflags

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -129,7 +129,7 @@ func (hs *HTTPServer) registerRoutes() {
 			userRoute.Get("/quotas", Wrap(GetUserQuotas))
 			userRoute.Put("/helpflags/:id", Wrap(SetHelpFlag))
 			// For dev purpose
-			userRoute.Get("/helpflags/clear", Wrap(ClearHelpFlags))
+			userRoute.Delete("/helpflags/clear", Wrap(ClearHelpFlags))
 
 			userRoute.Get("/preferences", Wrap(GetUserPreferences))
 			userRoute.Put("/preferences", bind(dtos.UpdatePrefsCmd{}), Wrap(UpdateUserPreferences))


### PR DESCRIPTION
Hello,

I think that maybe the HTTP Delete method will be better than GET when we want to set the help flags at 0 :) 