### PR TITLE
Fix freezing browser when loading plugin

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -56,7 +56,7 @@ System.config({
     css: 'vendor/plugin-css/css.js',
   },
   meta: {
-    '*': {
+    '/*': {
       esModule: true,
       authorization: true,
       loader: 'plugin-loader',


### PR DESCRIPTION
- broken since 4d2dd2209, #12573 
- `*` was previously working as a path matcher, but freezes browser when
  used with new cache-busting plugin loader
- changed matcher to be `/*`
