### PR TITLE
Support timeFilter in query templating for InfluxDB

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -187,6 +187,11 @@ export default class InfluxDatasource {
       return this.$q.when({ results: [] });
     }
 
+    if (options && options.range) {
+      var timeFilter = this.getTimeFilter({ rangeRaw: options.range });
+      query = query.replace('$timeFilter', timeFilter);
+    }
+
     return this._influxRequest('GET', '/query', { q: query, epoch: 'ms' }, options);
   }
 

--- a/public/app/plugins/datasource/influxdb/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.jest.ts
@@ -19,8 +19,8 @@ describe('InfluxDataSource', () => {
     let query = 'SELECT max(value) FROM measurement WHERE $timeFilter';
     let queryOptions: any = {
       range: {
-        from: '2018-01-01 00:00:00',
-        to: '2018-01-02 00:00:00',
+        from: '2018-01-01T00:00:00Z',
+        to: '2018-01-02T00:00:00Z',
       },
     };
     let requestQuery;
@@ -47,7 +47,7 @@ describe('InfluxDataSource', () => {
     });
 
     it('should replace $timefilter', () => {
-      expect(requestQuery).toMatch('time >= 1514761200000ms and time <= 1514847600000ms');
+      expect(requestQuery).toMatch('time >= 1514764800000ms and time <= 1514851200000ms');
     });
   });
 });

--- a/public/app/plugins/datasource/influxdb/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.jest.ts
@@ -1,0 +1,53 @@
+import InfluxDatasource from '../datasource';
+import $q from 'q';
+import { TemplateSrvStub } from 'test/specs/helpers';
+
+describe('InfluxDataSource', () => {
+  let ctx: any = {
+    backendSrv: {},
+    $q: $q,
+    templateSrv: new TemplateSrvStub(),
+    instanceSettings: { url: 'url', name: 'influxDb', jsonData: {} },
+  };
+
+  beforeEach(function() {
+    ctx.instanceSettings.url = '/api/datasources/proxy/1';
+    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+  });
+
+  describe('When issuing metricFindQuery', () => {
+    let query = 'SELECT max(value) FROM measurement WHERE $timeFilter';
+    let queryOptions: any = {
+      range: {
+        from: '2018-01-01 00:00:00',
+        to: '2018-01-02 00:00:00',
+      },
+    };
+    let requestQuery;
+
+    beforeEach(async () => {
+      ctx.backendSrv.datasourceRequest = function(req) {
+        requestQuery = req.params.q;
+        return ctx.$q.when({
+          results: [
+            {
+              series: [
+                {
+                  name: 'measurement',
+                  columns: ['max'],
+                  values: [[1]],
+                },
+              ],
+            },
+          ],
+        });
+      };
+
+      await ctx.ds.metricFindQuery(query, queryOptions).then(function(_) {});
+    });
+
+    it('should replace $timefilter', () => {
+      expect(requestQuery).toMatch('time >= 1514761200000ms and time <= 1514847600000ms');
+    });
+  });
+});


### PR DESCRIPTION
After support for queries in template variables was added to InfluxDB, it can be necessary to added dymanic time constraints. This can now be done changing the variable refresh to "On Time Range Changed" for InfluxDB