### PR TITLE
Update dashboard links on time range or variable value change

### DIFF
--- a/public/app/features/dashlinks/module.ts
+++ b/public/app/features/dashlinks/module.ts
@@ -169,6 +169,8 @@ export class DashLinksContainerCtrl {
 
     updateDashLinks();
     $rootScope.onAppEvent('dash-links-updated', updateDashLinks, $scope);
+    $rootScope.onAppEvent('time-range-changed', updateDashLinks, $scope);
+    $rootScope.onAppEvent('template-variable-value-updated', updateDashLinks, $scope);
   }
 }
 


### PR DESCRIPTION
Update dashboard links when the time range or a variable value has been changed.
This fixes #12660.