### PR TITLE
[postgres] add timescaledb option to postgres datasource

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -290,4 +290,5 @@ datasources:
       password: "Password!"
     jsonData:
       sslmode: "disable" # disable/require/verify-ca/verify-full
+      timescaledb: false
 ```

--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -31,7 +31,7 @@ Name | Description
 *User* | Database user's login/username
 *Password* | Database user's password
 *SSL Mode* | This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-*TimescaleDB* | With this option enabled Grafana will use TimescaleDB features, e.g. use ```time_bucket``` for grouping by time.
+*TimescaleDB* | With this option enabled Grafana will use TimescaleDB features, e.g. use ```time_bucket``` for grouping by time (only available in Grafana 5.3+).
 
 ### Database User Permissions (Important!)
 

--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -31,6 +31,7 @@ Name | Description
 *User* | Database user's login/username
 *Password* | Database user's password
 *SSL Mode* | This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+*TimescaleDB* | With this option enabled Grafana will use TimescaleDB features, e.g. use ```time_bucket``` for grouping by time.
 
 ### Database User Permissions (Important!)
 

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -131,7 +131,7 @@ func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string,
 			}
 		}
 
-		if m.query.DataSource.JsonData.Get("timescaledb").MustString("auto") == "enabled" {
+		if m.query.DataSource.JsonData.Get("timescaledb").MustBool() {
 			return fmt.Sprintf("time_bucket('%vs',%s) AS time", interval.Seconds(), args[0]), nil
 		} else {
 			return fmt.Sprintf("floor(extract(epoch from %s)/%v)*%v AS time", args[0], interval.Seconds(), interval.Seconds()), nil

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
@@ -21,10 +20,8 @@ type postgresMacroEngine struct {
 	timescaledb bool
 }
 
-func newPostgresMacroEngine(datasource *models.DataSource) tsdb.SqlMacroEngine {
-	engine := &postgresMacroEngine{}
-	engine.timescaledb = datasource.JsonData.Get("timescaledb").MustBool(false)
-	return engine
+func newPostgresMacroEngine(timescaledb bool) tsdb.SqlMacroEngine {
+	return &postgresMacroEngine{timescaledb: timescaledb}
 }
 
 func (m *postgresMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -132,9 +132,9 @@ func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string,
 		}
 
 		if m.query.DataSource.JsonData.Get("timescaledb").MustBool() {
-			return fmt.Sprintf("time_bucket('%vs',%s) AS time", interval.Seconds(), args[0]), nil
+			return fmt.Sprintf("time_bucket('%vs',%s)", interval.Seconds(), args[0]), nil
 		} else {
-			return fmt.Sprintf("floor(extract(epoch from %s)/%v)*%v AS time", args[0], interval.Seconds(), interval.Seconds()), nil
+			return fmt.Sprintf("floor(extract(epoch from %s)/%v)*%v", args[0], interval.Seconds(), interval.Seconds()), nil
 		}
 	case "__timeGroupAlias":
 		tg, err := m.evaluateMacro("__timeGroup", args)

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -6,19 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMacroEngine(t *testing.T) {
 	Convey("MacroEngine", t, func() {
-		datasource := &models.DataSource{JsonData: simplejson.New()}
-		engine := newPostgresMacroEngine(datasource)
-		datasourceTS := &models.DataSource{JsonData: simplejson.New()}
-		datasourceTS.JsonData.Set("timescaledb", true)
-		engineTS := newPostgresMacroEngine(datasourceTS)
+		engine := newPostgresMacroEngine(false)
+		engineTS := newPostgresMacroEngine(true)
 		query := &tsdb.Query{}
 
 		Convey("Given a time range between 2018-04-12 00:00 and 2018-04-12 00:05", func() {

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -92,7 +92,7 @@ func TestMacroEngine(t *testing.T) {
 				sql, err := engine.Interpolate(queryTS, timeRange, "GROUP BY $__timeGroup(time_column,'5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column) AS time")
+				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
 			})
 
 			Convey("interpolate __timeGroup function with spaces between args and TimescaleDB enabled", func() {
@@ -100,7 +100,7 @@ func TestMacroEngine(t *testing.T) {
 				sql, err := engine.Interpolate(queryTS, timeRange, "GROUP BY $__timeGroup(time_column , '5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column) AS time")
+				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
 			})
 
 			Convey("interpolate __timeTo function", func() {

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -17,7 +17,7 @@ func TestMacroEngine(t *testing.T) {
 		engine := newPostgresMacroEngine()
 		query := &tsdb.Query{DataSource: &models.DataSource{JsonData: simplejson.New()}}
 		queryTS := &tsdb.Query{DataSource: &models.DataSource{JsonData: simplejson.New()}}
-		queryTS.DataSource.JsonData.Set("timescaledb", "enabled")
+		queryTS.DataSource.JsonData.Set("timescaledb", true)
 
 		Convey("Given a time range between 2018-04-12 00:00 and 2018-04-12 00:05", func() {
 			from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -14,10 +14,12 @@ import (
 
 func TestMacroEngine(t *testing.T) {
 	Convey("MacroEngine", t, func() {
-		engine := newPostgresMacroEngine()
-		query := &tsdb.Query{DataSource: &models.DataSource{JsonData: simplejson.New()}}
-		queryTS := &tsdb.Query{DataSource: &models.DataSource{JsonData: simplejson.New()}}
-		queryTS.DataSource.JsonData.Set("timescaledb", true)
+		datasource := &models.DataSource{JsonData: simplejson.New()}
+		engine := newPostgresMacroEngine(datasource)
+		datasourceTS := &models.DataSource{JsonData: simplejson.New()}
+		datasourceTS.JsonData.Set("timescaledb", true)
+		engineTS := newPostgresMacroEngine(datasourceTS)
+		query := &tsdb.Query{}
 
 		Convey("Given a time range between 2018-04-12 00:00 and 2018-04-12 00:05", func() {
 			from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
@@ -89,7 +91,7 @@ func TestMacroEngine(t *testing.T) {
 
 			Convey("interpolate __timeGroup function with TimescaleDB enabled", func() {
 
-				sql, err := engine.Interpolate(queryTS, timeRange, "GROUP BY $__timeGroup(time_column,'5m')")
+				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column,'5m')")
 				So(err, ShouldBeNil)
 
 				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
@@ -97,7 +99,7 @@ func TestMacroEngine(t *testing.T) {
 
 			Convey("interpolate __timeGroup function with spaces between args and TimescaleDB enabled", func() {
 
-				sql, err := engine.Interpolate(queryTS, timeRange, "GROUP BY $__timeGroup(time_column , '5m')")
+				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '5m')")
 				So(err, ShouldBeNil)
 
 				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestMacroEngine(t *testing.T) {
 	Convey("MacroEngine", t, func() {
-		engine := newPostgresMacroEngine(false)
-		engineTS := newPostgresMacroEngine(true)
+		timescaledbEnabled := false
+		engine := newPostgresMacroEngine(timescaledbEnabled)
+		timescaledbEnabled = true
+		engineTS := newPostgresMacroEngine(timescaledbEnabled)
 		query := &tsdb.Query{}
 
 		Convey("Given a time range between 2018-04-12 00:00 and 2018-04-12 00:05", func() {

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -32,7 +32,9 @@ func newPostgresQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndp
 		log: logger,
 	}
 
-	return tsdb.NewSqlQueryEndpoint(&config, &rowTransformer, newPostgresMacroEngine(datasource), logger)
+	timescaledb := datasource.JsonData.Get("timescaledb").MustBool(false)
+
+	return tsdb.NewSqlQueryEndpoint(&config, &rowTransformer, newPostgresMacroEngine(timescaledb), logger)
 }
 
 func generateConnectionString(datasource *models.DataSource) string {

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -32,7 +32,7 @@ func newPostgresQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndp
 		log: logger,
 	}
 
-	return tsdb.NewSqlQueryEndpoint(&config, &rowTransformer, newPostgresMacroEngine(), logger)
+	return tsdb.NewSqlQueryEndpoint(&config, &rowTransformer, newPostgresMacroEngine(datasource), logger)
 }
 
 func generateConnectionString(datasource *models.DataSource) string {

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -311,6 +311,7 @@ func TestPostgres(t *testing.T) {
 			query := &tsdb.TsdbQuery{
 				Queries: []*tsdb.Query{
 					{
+						DataSource: &models.DataSource{JsonData: simplejson.New()},
 						Model: simplejson.NewFromAny(map[string]interface{}{
 							"rawSql": "SELECT $__timeGroup(time, '5m', previous), avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 							"format": "time_series",

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -102,7 +102,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT * FROM postgres_types",
 								"format": "table",
@@ -183,7 +182,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m') AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -228,7 +226,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m', NULL) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -283,7 +280,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m', 1.5) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -311,7 +307,6 @@ func TestPostgres(t *testing.T) {
 			query := &tsdb.TsdbQuery{
 				Queries: []*tsdb.Query{
 					{
-						DataSource: &models.DataSource{JsonData: simplejson.New()},
 						Model: simplejson.NewFromAny(map[string]interface{}{
 							"rawSql": "SELECT $__timeGroup(time, '5m', previous), avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 							"format": "time_series",
@@ -406,7 +401,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt64" as time, "timeInt64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -429,7 +423,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt64Nullable" as time, "timeInt64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -452,7 +445,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat64" as time, "timeFloat64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -475,7 +467,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat64Nullable" as time, "timeFloat64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -520,7 +511,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt32Nullable" as time, "timeInt32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -543,7 +533,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat32" as time, "timeFloat32" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -566,7 +555,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat32Nullable" as time, "timeFloat32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -589,7 +577,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT $__timeEpoch(time), measurement || ' - value one' as metric, "valueOne" FROM metric_values ORDER BY 1`,
 								"format": "time_series",
@@ -638,7 +625,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT $__timeEpoch(time), "valueOne", "valueTwo" FROM metric_values ORDER BY 1`,
 								"format": "time_series",
@@ -696,7 +682,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "time_sec" as time, description as text, tags FROM event WHERE $__unixEpochFilter(time_sec) AND tags='deploy' ORDER BY 1 ASC`,
 								"format": "table",
@@ -720,7 +705,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "time_sec" as time, description as text, tags FROM event WHERE $__unixEpochFilter(time_sec) AND tags='ticket' ORDER BY 1 ASC`,
 								"format": "table",
@@ -747,7 +731,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									CAST('%s' AS TIMESTAMP) as time,
@@ -778,7 +761,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 %d as time,
@@ -809,7 +791,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 cast(%d as bigint) as time,
@@ -840,7 +821,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 %d as time,
@@ -869,7 +849,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT
 									 cast(null as bigint) as time,
@@ -898,7 +877,6 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
-							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT
 									 cast(null as timestamp) as time,

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -27,7 +27,7 @@ import (
 // use to verify that the generated data are vizualized as expected, see
 // devenv/README.md for setup instructions.
 func TestPostgres(t *testing.T) {
-	// change to true to run the MySQL tests
+	// change to true to run the PostgreSQL tests
 	runPostgresTests := false
 	// runPostgresTests := true
 
@@ -102,6 +102,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT * FROM postgres_types",
 								"format": "table",
@@ -182,6 +183,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m') AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -226,6 +228,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m', NULL) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -280,6 +283,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, '5m', 1.5) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -401,6 +405,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt64" as time, "timeInt64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -423,6 +428,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt64Nullable" as time, "timeInt64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -445,6 +451,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat64" as time, "timeFloat64" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -467,6 +474,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat64Nullable" as time, "timeFloat64Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -511,6 +519,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeInt32Nullable" as time, "timeInt32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -533,6 +542,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat32" as time, "timeFloat32" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -555,6 +565,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "timeFloat32Nullable" as time, "timeFloat32Nullable" FROM metric_values ORDER BY time LIMIT 1`,
 								"format": "time_series",
@@ -577,6 +588,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT $__timeEpoch(time), measurement || ' - value one' as metric, "valueOne" FROM metric_values ORDER BY 1`,
 								"format": "time_series",
@@ -625,6 +637,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT $__timeEpoch(time), "valueOne", "valueTwo" FROM metric_values ORDER BY 1`,
 								"format": "time_series",
@@ -682,6 +695,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "time_sec" as time, description as text, tags FROM event WHERE $__unixEpochFilter(time_sec) AND tags='deploy' ORDER BY 1 ASC`,
 								"format": "table",
@@ -705,6 +719,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT "time_sec" as time, description as text, tags FROM event WHERE $__unixEpochFilter(time_sec) AND tags='ticket' ORDER BY 1 ASC`,
 								"format": "table",
@@ -731,6 +746,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									CAST('%s' AS TIMESTAMP) as time,
@@ -761,6 +777,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 %d as time,
@@ -791,6 +808,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 cast(%d as bigint) as time,
@@ -821,6 +839,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": fmt.Sprintf(`SELECT
 									 %d as time,
@@ -849,6 +868,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT
 									 cast(null as bigint) as time,
@@ -877,6 +897,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{JsonData: simplejson.New()},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": `SELECT
 									 cast(null as timestamp) as time,

--- a/public/app/features/plugins/ds_edit_ctrl.ts
+++ b/public/app/features/plugins/ds_edit_ctrl.ts
@@ -132,7 +132,7 @@ export class DataSourceEditCtrl {
       this.backendSrv
         .withNoBackendCache(() => {
           return datasource
-            .testDatasource()
+            .testDatasource(this)
             .then(result => {
               this.testing.message = result.message;
               this.testing.status = result.status;

--- a/public/app/features/plugins/ds_edit_ctrl.ts
+++ b/public/app/features/plugins/ds_edit_ctrl.ts
@@ -132,7 +132,7 @@ export class DataSourceEditCtrl {
       this.backendSrv
         .withNoBackendCache(() => {
           return datasource
-            .testDatasource(this)
+            .testDatasource()
             .then(result => {
               this.testing.message = result.message;
               this.testing.status = result.status;

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -123,27 +123,9 @@ export class PostgresDatasource {
       .then(data => this.responseParser.parseMetricFindQueryResult(refId, data));
   }
 
-  testDatasource(control) {
+  testDatasource() {
     return this.metricFindQuery('SELECT 1', {})
       .then(res => {
-        if (control.current.jsonData.timescaledb === 'auto') {
-          return this.metricFindQuery("SELECT 1 FROM pg_extension WHERE extname='timescaledb'", {})
-            .then(res => {
-              if (res.length === 1) {
-                control.current.jsonData.timescaledb = 'enabled';
-                return this.backendSrv.put('/api/datasources/' + this.id, control.current).then(settings => {
-                  control.current = settings.datasource;
-                  control.updateFrontendSettings();
-                  return { status: 'success', message: 'Database Connection OK, TimescaleDB found' };
-                });
-              }
-              throw new Error('timescaledb not found');
-            })
-            .catch(err => {
-              // query errored out or empty so timescaledb is not available
-              return { status: 'success', message: 'Database Connection OK' };
-            });
-        }
         return { status: 'success', message: 'Database Connection OK' };
       })
       .catch(err => {

--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -42,7 +42,7 @@
 
 <div class="gf-form-group">
 	<div class="gf-form">
-		<gf-form-switch class="gf-form" label="TimescaleDB" tooltip="Use TimescaleDB features in Grafana" label-class="width-9" checked="ctrl.current.jsonData.timescaledb" switch-class="max-width-6"></gf-form-switch>
+		<gf-form-switch class="gf-form" label="TimescaleDB" tooltip="Use TimescaleDB features (e.g., time_bucket) in Grafana" label-class="width-9" checked="ctrl.current.jsonData.timescaledb" switch-class="max-width-6"></gf-form-switch>
 	</div>
 </div>
 

--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -42,13 +42,7 @@
 
 <div class="gf-form-group">
 	<div class="gf-form">
-		<label class="gf-form-label width-7">TimescaleDB</label>
-		<div class="gf-form-select-wrapper max-width-8 gf-form-select-wrapper--has-help-icon">
-			<select class="gf-form-input" ng-model="ctrl.current.jsonData.timescaledb" ng-options="mode for mode in ['auto', 'enabled', 'disabled']" ng-init="ctrl.current.jsonData.timescaledb=ctrl.current.jsonData.timescaledb || 'auto'"></select>
-			<info-popover mode="right-absolute">
-				This option determines whether TimescaleDB features will be used.
-			</info-popover>
-		</div>
+		<gf-form-switch class="gf-form" label="TimescaleDB" tooltip="Use TimescaleDB features in Grafana" label-class="width-9" checked="ctrl.current.jsonData.timescaledb" switch-class="max-width-6"></gf-form-switch>
 	</div>
 </div>
 

--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -38,6 +38,20 @@
 	</div>
 </div>
 
+<h3 class="page-heading">PostgreSQL details</h3>
+
+<div class="gf-form-group">
+	<div class="gf-form">
+		<label class="gf-form-label width-7">TimescaleDB</label>
+		<div class="gf-form-select-wrapper max-width-8 gf-form-select-wrapper--has-help-icon">
+			<select class="gf-form-input" ng-model="ctrl.current.jsonData.timescaledb" ng-options="mode for mode in ['auto', 'enabled', 'disabled']" ng-init="ctrl.current.jsonData.timescaledb=ctrl.current.jsonData.timescaledb || 'auto'"></select>
+			<info-popover mode="right-absolute">
+				This option determines whether TimescaleDB features will be used.
+			</info-popover>
+		</div>
+	</div>
+</div>
+
 <div class="gf-form-group">
 	<div class="grafana-info-box">
 		<h5>User Permission</h5>


### PR DESCRIPTION
This adds a checkbox to the postgres datasource config for
timescaledb support. 

When this option is enabled the $__timeGroup macro will
use the time_bucket function from timescaledb to group
times by an interval.