### PR TITLE
fix custom variable quoting in sql* query interpolations

### DIFF
--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -16,7 +16,7 @@ export class MssqlDatasource {
   interpolateVariable(value, variable) {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
-        return "'" + value + "'";
+        return "'" + value.replace(/'/g, `''`) + "'";
       } else {
         return value;
       }
@@ -31,7 +31,7 @@ export class MssqlDatasource {
         return value;
       }
 
-      return "'" + val + "'";
+      return "'" + val.replace(/'/g, `''`) + "'";
     });
     return quotedValues.join(',');
   }

--- a/public/app/plugins/datasource/mssql/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/mssql/specs/datasource.jest.ts
@@ -218,6 +218,13 @@ describe('MSSQLDatasource', function() {
       });
     });
 
+    describe('and variable contains single quote', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable("a'bc", ctx.variable)).toEqual("'a''bc'");
+      });
+    });
+
     describe('and variable allows all and value is a string', () => {
       it('should return a quoted value', () => {
         ctx.variable.includeAll = true;

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -16,7 +16,7 @@ export class MysqlDatasource {
   interpolateVariable(value, variable) {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
-        return "'" + value + "'";
+        return "'" + value.replace(/'/g, `''`) + "'";
       } else {
         return value;
       }
@@ -31,7 +31,7 @@ export class MysqlDatasource {
         return value;
       }
 
-      return "'" + val + "'";
+      return "'" + val.replace(/'/g, `''`) + "'";
     });
     return quotedValues.join(',');
   }

--- a/public/app/plugins/datasource/mysql/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.jest.ts
@@ -214,6 +214,13 @@ describe('MySQLDatasource', function() {
       });
     });
 
+    describe('and variable contains single quote', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable("a'bc", ctx.variable)).toEqual("'a''bc'");
+      });
+    });
+
     describe('and variable allows all and value is a string', () => {
       it('should return a quoted value', () => {
         ctx.variable.includeAll = true;

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -16,7 +16,7 @@ export class PostgresDatasource {
   interpolateVariable(value, variable) {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
-        return "'" + value + "'";
+        return "'" + value.replace(/'/g, `''`) + "'";
       } else {
         return value;
       }
@@ -27,7 +27,7 @@ export class PostgresDatasource {
     }
 
     var quotedValues = _.map(value, function(val) {
-      return "'" + val + "'";
+      return "'" + val.replace(/'/g, `''`) + "'";
     });
     return quotedValues.join(',');
   }

--- a/public/app/plugins/datasource/postgres/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.jest.ts
@@ -215,6 +215,13 @@ describe('PostgreSQLDatasource', function() {
       });
     });
 
+    describe('and variable contains single quote', () => {
+      it('should return a quoted value', () => {
+        ctx.variable.multi = true;
+        expect(ctx.ds.interpolateVariable("a'bc", ctx.variable)).toEqual("'a''bc'");
+      });
+    });
+
     describe('and variable allows all and is a string', () => {
       it('should return a quoted value', () => {
         ctx.variable.includeAll = true;


### PR DESCRIPTION
Attempt to fix 
https://github.com/grafana/grafana/issues/12785

Standart Sql way to escape `'` is to double the quotation mark `''`
here is my quick take on the thing.

