### PR TITLE
Fixing bug in url query reader and added test cases

### DIFF
--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -10,7 +10,7 @@ type UrlQueryReader struct {
 }
 
 func NewUrlQueryReader(urlInfo *url.URL) (*UrlQueryReader, error) {
-	u, err := url.ParseQuery(urlInfo.String())
+	u, err := url.ParseQuery(urlInfo.RawQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/url_test.go
+++ b/pkg/util/url_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"net/url"
 )
 
 func TestUrl(t *testing.T) {
@@ -42,5 +43,31 @@ func TestUrl(t *testing.T) {
 		result := JoinUrlFragments("http://localhost:8080", "api/")
 
 		So(result, ShouldEqual, "http://localhost:8080/api/")
+	})
+
+	Convey("When joining two urls where lefthand side has a trailing slash and righthand side has preceding slash", t, func() {
+		result := JoinUrlFragments("http://localhost:8080/", "/api/")
+
+		So(result, ShouldEqual, "http://localhost:8080/api/")
+	})
+}
+
+func TestNewUrlQueryReader(t *testing.T) {
+	u, _ := url.Parse("http://www.abc.com/foo?bar=baz&bar2=baz2")
+	uqr, _ := NewUrlQueryReader(u)
+
+	Convey("when trying to retrieve the first query value", t, func() {
+		result := uqr.Get("bar", "foodef")
+		So(result, ShouldEqual, "baz")
+	})
+
+	Convey("when trying to retrieve the second query value", t, func() {
+		result := uqr.Get("bar2", "foodef")
+		So(result, ShouldEqual, "baz2")
+	})
+
+	Convey("when trying to retrieve from a non-existent key, the default value is returned", t, func() {
+		result := uqr.Get("bar3", "foodef")
+		So(result, ShouldEqual, "foodef")
 	})
 }

--- a/pkg/util/validation_test.go
+++ b/pkg/util/validation_test.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestIsEmail(t *testing.T) {
+
+	Convey("When validating a string that is a valid email", t, func() {
+		result := IsEmail("abc@def.com")
+
+		So(result, ShouldEqual, true)
+	})
+
+	Convey("When validating a string that is not a valid email", t, func() {
+		result := IsEmail("abcdef.com")
+
+		So(result, ShouldEqual, false)
+	})
+}


### PR DESCRIPTION
Fixing a bug where url query strings are parsed incorrectly.

url.ParseQuery expects a query string to be passed rather than the entire URL. In the current code, one would never be able to retrieve the actual value of the first query key of the URL. This PR will fix that.

Also added a few test cases