### PR TITLE
Use uid when linking to dashboards internally in a dashboard

### DIFF
--- a/public/app/features/dashlinks/module.ts
+++ b/public/app/features/dashlinks/module.ts
@@ -145,6 +145,7 @@ export class DashLinksContainerCtrl {
               memo.push({
                 title: dash.title,
                 url: dash.url,
+                target: link.target === '_self' ? '' : link.target,
                 icon: 'fa fa-th-large',
                 keepTime: link.keepTime,
                 includeVars: link.includeVars,

--- a/public/app/features/dashlinks/module.ts
+++ b/public/app/features/dashlinks/module.ts
@@ -144,8 +144,7 @@ export class DashLinksContainerCtrl {
             if (dash.id !== currentDashId) {
               memo.push({
                 title: dash.title,
-                url: 'dashboard/' + dash.uri,
-                target: link.target,
+                url: dash.url,
                 icon: 'fa fa-th-large',
                 keepTime: link.keepTime,
                 includeVars: link.includeVars,

--- a/public/app/features/panellinks/link_srv.ts
+++ b/public/app/features/panellinks/link_srv.ts
@@ -77,6 +77,10 @@ export class LinkSrv {
       info.target = link.targetBlank ? '_blank' : '_self';
       info.href = this.templateSrv.replace(link.url || '', scopedVars);
       info.title = this.templateSrv.replace(link.title || '', scopedVars);
+    } else if (link.url) {
+      info.href = link.url;
+      info.title = this.templateSrv.replace(link.title || '', scopedVars);
+      info.target = link.targetBlank ? '_blank' : '';
     } else if (link.dashUri) {
       info.href = 'dashboard/' + link.dashUri + '?';
       info.title = this.templateSrv.replace(link.title || '', scopedVars);

--- a/public/app/features/panellinks/module.ts
+++ b/public/app/features/panellinks/module.ts
@@ -39,7 +39,12 @@ export class PanelLinksEditorCtrl {
       backendSrv.search({ query: link.dashboard }).then(function(hits) {
         var dashboard = _.find(hits, { title: link.dashboard });
         if (dashboard) {
-          link.dashUri = dashboard.uri;
+          if (dashboard.url) {
+            link.url = dashboard.url;
+          } else {
+            // To support legacy url's
+            link.dashUri = dashboard.uri;
+          }
           link.title = dashboard.title;
         }
       });


### PR DESCRIPTION
Fixes #10705 

When creating panel links there are a new property called url saved in the dashboard model instead of uri (old legacy dashboard url) - is this a good approach? An alternative would be to store the uid instead. 

Guess storing uid would be easier when scripting dashboards, but unsure how big a problem it would be to include `/d/<uid>` instead.