### PR TITLE
Explore: expand recording rules for queries

### DIFF
--- a/public/app/containers/Explore/Explore.tsx
+++ b/public/app/containers/Explore/Explore.tsx
@@ -169,6 +169,10 @@ export class Explore extends React.Component<any, IExploreState> {
     const historyKey = `grafana.explore.history.${datasourceId}`;
     const history = store.getObject(historyKey, []);
 
+    if (datasource.init) {
+      datasource.init();
+    }
+
     this.setState(
       {
         datasource,

--- a/public/app/containers/Explore/PromQueryField.jest.tsx
+++ b/public/app/containers/Explore/PromQueryField.jest.tsx
@@ -3,7 +3,7 @@ import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Plain from 'slate-plain-serializer';
 
-import PromQueryField from './PromQueryField';
+import PromQueryField, { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -175,5 +175,45 @@ describe('PromQueryField typeahead handling', () => {
       expect(result.context).toBe('context-aggregation');
       expect(result.suggestions).toEqual([{ items: [{ label: 'bar' }], label: 'Labels' }]);
     });
+  });
+});
+
+describe('groupMetricsByPrefix()', () => {
+  it('returns an empty group for no metrics', () => {
+    expect(groupMetricsByPrefix([])).toEqual([]);
+  });
+
+  it('returns options grouped by prefix', () => {
+    expect(groupMetricsByPrefix(['foo_metric'])).toMatchObject([
+      {
+        value: 'foo',
+        children: [
+          {
+            value: 'foo_metric',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns options without prefix as toplevel option', () => {
+    expect(groupMetricsByPrefix(['metric'])).toMatchObject([
+      {
+        value: 'metric',
+      },
+    ]);
+  });
+
+  it('returns recording rules grouped separately', () => {
+    expect(groupMetricsByPrefix([':foo_metric:'])).toMatchObject([
+      {
+        value: RECORDING_RULES_GROUP,
+        children: [
+          {
+            value: ':foo_metric:',
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.jest.ts
@@ -4,6 +4,7 @@ import q from 'q';
 import {
   alignRange,
   determineQueryHints,
+  extractRuleMappingFromGroups,
   PrometheusDatasource,
   prometheusSpecialRegexEscape,
   prometheusRegularEscape,
@@ -226,6 +227,36 @@ describe('PrometheusDatasource', () => {
           },
         },
       });
+    });
+  });
+
+  describe('extractRuleMappingFromGroups()', () => {
+    it('returns empty mapping for no rule groups', () => {
+      expect(extractRuleMappingFromGroups([])).toEqual({});
+    });
+
+    it('returns a mapping for recording rules only', () => {
+      const groups = [
+        {
+          rules: [
+            {
+              name: 'HighRequestLatency',
+              query: 'job:request_latency_seconds:mean5m{job="myjob"} > 0.5',
+              type: 'alerting',
+            },
+            {
+              name: 'job:http_inprogress_requests:sum',
+              query: 'sum(http_inprogress_requests) by (job)',
+              type: 'recording',
+            },
+          ],
+          file: '/rules.yaml',
+          interval: 60,
+          name: 'example',
+        },
+      ];
+      const mapping = extractRuleMappingFromGroups(groups);
+      expect(mapping).toEqual({ 'job:http_inprogress_requests:sum': 'sum(http_inprogress_requests) by (job)' });
     });
   });
 

--- a/public/vendor/css/rc-cascader.scss
+++ b/public/vendor/css/rc-cascader.scss
@@ -16,7 +16,7 @@
 }
 .rc-cascader-menus.slide-up-enter,
 .rc-cascader-menus.slide-up-appear {
-  animation-duration: .3s;
+  animation-duration: 0.3s;
   animation-fill-mode: both;
   transform-origin: 0 0;
   opacity: 0;
@@ -24,7 +24,7 @@
   animation-play-state: paused;
 }
 .rc-cascader-menus.slide-up-leave {
-  animation-duration: .3s;
+  animation-duration: 0.3s;
   animation-fill-mode: both;
   transform-origin: 0 0;
   opacity: 1;
@@ -66,7 +66,7 @@
 .rc-cascader-menu-item {
   height: 32px;
   line-height: 32px;
-  padding: 0 16px;
+  padding: 0 2.5em 0 16px;
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
- load recording rules from prometheus
- map rule name to rule query
- query hint to detect recording rules in query
- click on hint fix expands rule name to query

To test this, connect to a recently built prometheus that includes prometheus/prometheus#4318, then add a config with a recording rule:

Create rule file `rules.yaml`:

```yaml
groups:
    - name: example
      rules:
          - record: :go_gc_duration_seconds:ratio
            expr: go_gc_duration_seconds + go_gc_duration_seconds 
          - record: job:go_gc_duration_seconds:sum
            expr: sum(go_gc_duration_seconds) by (job)
```

Add rule file section to prometheus config:
```yaml
rule_files:
  - "/path/to/rules.yml"
```
 
Then select a Recording rule from the metrics selector, and click Expand on the hint.