### PR TITLE
Add example OR search_filter to docs

### DIFF
--- a/docs/sources/installation/ldap.md
+++ b/docs/sources/installation/ldap.md
@@ -48,6 +48,7 @@ bind_dn = "cn=admin,dc=grafana,dc=org"
 bind_password = 'grafana'
 
 # User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"
+# Allow login from email or username, example "(|(sAMAccountName=%s)(userPrincipalName=%s))"
 search_filter = "(cn=%s)"
 
 # An array of base dns to search through


### PR DESCRIPTION
It's not obvious that the search filter is what's used to log users in. I was able to map the user attributes with no problem but couldn't figure out why users couldn't login with their email address (as stated in the login field)
![image](https://user-images.githubusercontent.com/1497790/43850031-b3d36ec6-9aeb-11e8-9f6e-15d89e34541a.png)

Using the `OR` operator in the LDAP filter allowed my users to login with either email or username. 
My hope is that this change might help someone else.