### PR TITLE
Added docs around session table requirement

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -697,9 +697,12 @@ session provider you have configured.
 
 - **file:** session file path, e.g. `data/sessions`
 - **mysql:** go-sql-driver/mysql dsn config string, e.g. `user:password@tcp(127.0.0.1:3306)/database_name`
-- **postgres:** ex:  `user=a password=b host=localhost port=5432 dbname=c sslmode=verify-full`
+- **postgres:** ex:  `user=a password=b host=localhost port=5432 dbname=database_name sslmode=verify-full`
 - **memcache:** ex:  `127.0.0.1:11211`
 - **redis:** ex: `addr=127.0.0.1:6379,pool_size=100,prefix=grafana`. For unix socket, use for example: `network=unix,addr=/var/run/redis/redis.sock,pool_size=100,db=grafana`
+
+For `postgress` and `mysql` providers the connected database must contain a suitable `session` table.
+The main DB referenced in the [database] section contains one, so it's easiest to reuse that.
 
 Postgres valid `sslmode` are `disable`, `require`, `verify-ca`, and `verify-full` (default).
 


### PR DESCRIPTION
I got the below error while trying to set up sessions in a new install with different postgres DBs for config and sessions; I think the docs could be improved to help others avoid future confusion.

```
lvl=eror msg="Failed to start session" logger=context error="pq: relation \"session\" does not exist"
```