### PR TITLE
docker: makes it possible to set a specific plugin url.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -67,7 +67,13 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   IFS=','
   for plugin in ${GF_INSTALL_PLUGINS}; do
     IFS=$OLDIFS
-    grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    if [[ $plugin =~ .*\;.* ]]; then
+        pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
+        pluginWithoutUrl=$(echo "$plugin" | cut -d';' -f 2)
+        grafana-cli --pluginUrl "${pluginUrl}" --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${pluginWithoutUrl}
+    else
+        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    fi
   done
 fi
 


### PR DESCRIPTION
Originally from the grafana/grafana-docker repo, authored
by @ClementGautier.

Makes it possible to use `-e GF_INSTALL_PLUGINS="http://mycompany.com/mysuperplugin.zip;mysuperplugin"` when starting the docker container to install a plugin not listed on the official plugin pages.


Original PR: https://github.com/grafana/grafana-docker/pull/157