### PR TITLE
docker: supports AWS STS credentials.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -31,12 +31,19 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     for profile in ${GF_AWS_PROFILES}; do
         access_key_varname="GF_AWS_${profile}_ACCESS_KEY_ID"
         secret_key_varname="GF_AWS_${profile}_SECRET_ACCESS_KEY"
+        session_token_varname="GF_AWS_${profile}_SESSION_TOKEN"
         region_varname="GF_AWS_${profile}_REGION"
 
         if [ ! -z "${!access_key_varname}" -a ! -z "${!secret_key_varname}" ]; then
             echo "[${profile}]" >> "$GF_PATHS_HOME/.aws/credentials"
             echo "aws_access_key_id = ${!access_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
             echo "aws_secret_access_key = ${!secret_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+
+            if [ ! -z "${!session_token_varname}" ]; then
+                echo "aws_session_token = ${!session_token_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+                echo "aws_security_token = ${!session_token_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+            fi
+
             if [ ! -z "${!region_varname}" ]; then
                 echo "region = ${!region_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
             fi


### PR DESCRIPTION
Support for (temporary) AWS STS credentials as environment variables when booting the docker container.

Originally by @a-panickar in https://github.com/grafana/grafana-docker. Thanks.