### PR TITLE
Explore: Apply tab completion suggestion on Enter

### DIFF
--- a/public/app/containers/Explore/QueryField.tsx
+++ b/public/app/containers/Explore/QueryField.tsx
@@ -331,7 +331,7 @@ class QueryField extends React.Component<TypeaheadFieldProps, TypeaheadFieldStat
         }
         break;
       }
-
+      case 'Enter':
       case 'Tab': {
         if (this.menuEl) {
           // Dont blur input


### PR DESCRIPTION
By popular demand:

- if the suggestions menu is open, apply the selected item on Enter
- if not open, run the queries

Fixes #12869 