### PR TITLE
Fix for Graphite function parameter quoting 

### DIFF
--- a/public/app/plugins/datasource/graphite/gfunc.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.ts
@@ -978,7 +978,7 @@ export class FuncInstance {
           return value;
         }
         // param types that might be quoted
-        if (_.includes(['int_or_interval', 'node_or_tag', 'node'], paramType) && _.isFinite(+value)) {
+        if (_.includes(['int_or_interval', 'node_or_tag'], paramType) && _.isFinite(+value)) {
           return _.toString(+value);
         }
         return "'" + value + "'";

--- a/public/app/plugins/datasource/graphite/gfunc.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.ts
@@ -973,13 +973,12 @@ export class FuncInstance {
         } else if (_.get(_.last(this.def.params), 'multiple')) {
           paramType = _.get(_.last(this.def.params), 'type');
         }
-        if (paramType === 'value_or_series') {
+        // param types that should never be quoted
+        if (_.includes(['value_or_series', 'boolean', 'int', 'float', 'node'], paramType)) {
           return value;
         }
-        if (paramType === 'boolean' && _.includes(['true', 'false'], value)) {
-          return value;
-        }
-        if (_.includes(['int', 'float', 'int_or_interval', 'node_or_tag', 'node'], paramType) && _.isFinite(+value)) {
+        // param types that might be quoted
+        if (_.includes(['int_or_interval', 'node_or_tag', 'node'], paramType) && _.isFinite(+value)) {
           return _.toString(+value);
         }
         return "'" + value + "'";

--- a/public/app/plugins/datasource/graphite/specs/gfunc.jest.ts
+++ b/public/app/plugins/datasource/graphite/specs/gfunc.jest.ts
@@ -55,6 +55,24 @@ describe('when rendering func instance', function() {
     expect(func.render('hello')).toEqual("movingMedian(hello, '5min')");
   });
 
+  it('should never quote boolean paramater', function() {
+    var func = gfunc.createFuncInstance('sortByName');
+    func.params[0] = '$natural';
+    expect(func.render('hello')).toEqual('sortByName(hello, $natural)');
+  });
+
+  it('should never quote int paramater', function() {
+    var func = gfunc.createFuncInstance('maximumAbove');
+    func.params[0] = '$value';
+    expect(func.render('hello')).toEqual('maximumAbove(hello, $value)');
+  });
+
+  it('should never quote node paramater', function() {
+    var func = gfunc.createFuncInstance('aliasByNode');
+    func.params[0] = '$node';
+    expect(func.render('hello')).toEqual('aliasByNode(hello, $node)');
+  });
+
   it('should handle metric param and int param and string param', function() {
     var func = gfunc.createFuncInstance('groupByNode');
     func.params[0] = 5;


### PR DESCRIPTION
fixes #11927

Now Grafana will never quote boolean, node, int, float or node parameters