### PR TITLE
Set User-Agent header in datasource proxied requests

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -203,6 +203,7 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 		req.Header.Del("X-Forwarded-Host")
 		req.Header.Del("X-Forwarded-Port")
 		req.Header.Del("X-Forwarded-Proto")
+		req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s Proxied-DS-Request %s", setting.BuildVersion, proxy.ds.Type))
 
 		// set X-Forwarded-For header
 		if req.RemoteAddr != "" {

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -203,7 +203,7 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 		req.Header.Del("X-Forwarded-Host")
 		req.Header.Del("X-Forwarded-Port")
 		req.Header.Del("X-Forwarded-Proto")
-		req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s Proxied-DS-Request %s", setting.BuildVersion, proxy.ds.Type))
+		req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
 
 		// set X-Forwarded-For header
 		if req.RemoteAddr != "" {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -219,7 +219,7 @@ func TestDSRouteRule(t *testing.T) {
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "/render")
 
 			requestURL, _ := url.Parse("http://grafana.com/sub")
-			req := http.Request{URL: requestURL}
+			req := http.Request{URL: requestURL, Header: http.Header{}}
 
 			proxy.getDirector()(&req)
 
@@ -244,7 +244,7 @@ func TestDSRouteRule(t *testing.T) {
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
 			requestURL, _ := url.Parse("http://grafana.com/sub")
-			req := http.Request{URL: requestURL}
+			req := http.Request{URL: requestURL, Header: http.Header{}}
 
 			proxy.getDirector()(&req)
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -212,20 +212,21 @@ func TestDSRouteRule(t *testing.T) {
 		})
 
 		Convey("When proxying graphite", func() {
+			setting.BuildVersion = "5.3.0"
 			plugin := &plugins.DataSourcePlugin{}
 			ds := &m.DataSource{Url: "htttp://graphite:8080", Type: m.DS_GRAPHITE}
 			ctx := &m.ReqContext{}
 
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "/render")
+			req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+			So(err, ShouldBeNil)
 
-			requestURL, _ := url.Parse("http://grafana.com/sub")
-			req := http.Request{URL: requestURL, Header: http.Header{}}
-
-			proxy.getDirector()(&req)
+			proxy.getDirector()(req)
 
 			Convey("Can translate request url and path", func() {
 				So(req.URL.Host, ShouldEqual, "graphite:8080")
 				So(req.URL.Path, ShouldEqual, "/render")
+				So(req.Header.Get("User-Agent"), ShouldEqual, "Grafana/5.3.0")
 			})
 		})
 
@@ -243,10 +244,10 @@ func TestDSRouteRule(t *testing.T) {
 			ctx := &m.ReqContext{}
 			proxy := NewDataSourceProxy(ds, plugin, ctx, "")
 
-			requestURL, _ := url.Parse("http://grafana.com/sub")
-			req := http.Request{URL: requestURL, Header: http.Header{}}
+			req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+			So(err, ShouldBeNil)
 
-			proxy.getDirector()(&req)
+			proxy.getDirector()(req)
 
 			Convey("Should add db to url", func() {
 				So(req.URL.Path, ShouldEqual, "/db/site/")


### PR DESCRIPTION
Will be set to: 
`Grafana/<Version>`

closes #12831