### PR TITLE
set annotation_id as primary key in annotation_tag table

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -71,7 +71,7 @@ func addAnnotationMig(mg *Migrator) {
 	annotationTagTable := Table{
 		Name: "annotation_tag",
 		Columns: []*Column{
-			{Name: "annotation_id", Type: DB_BigInt, Nullable: false},
+			{Name: "annotation_id", Type: DB_BigInt, Nullable: false, IsPrimaryKey: true},
 			{Name: "tag_id", Type: DB_BigInt, Nullable: false},
 		},
 		Indices: []*Index{


### PR DESCRIPTION
This corrects a failure to migrate/create the annotation_tag table on MariaDB with `innodb_force_primary_key=1` which is required for Galera clustering.

setting annotation_id as primary key in table to satisfy innodb_force_primary_key=1

Related to [#12971](https://github.com/grafana/grafana/issues/12971)