### PR TITLE
dsproxy: interpolate route url

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -320,9 +320,15 @@ func (proxy *DataSourceProxy) applyRoute(req *http.Request) {
 		SecureJsonData: proxy.ds.SecureJsonData.Decrypt(),
 	}
 
-	routeURL, err := url.Parse(proxy.route.Url)
+	interpolatedURL, err := interpolateString(proxy.route.Url, data)
 	if err != nil {
-		logger.Error("Error parsing plugin route url")
+		logger.Error("Error interpolating proxy url", "error", err)
+		return
+	}
+
+	routeURL, err := url.Parse(interpolatedURL)
+	if err != nil {
+		logger.Error("Error parsing plugin route url", "error", err)
 		return
 	}
 


### PR DESCRIPTION
Allows for dynamic urls for plugin routes. There are a few plugins where the route url should be configurable and this change allows using jsonData fields in the url field for a route in the plugin.json file for a plugin.

After this change the url field would be interpolated and would allow a datasource to have a configurable url and to be able to use Grafana's token auth feature:

```json
"routes": [
    {
      "path": "kustodb",
      "method": "POST",
      "url": "{{.JsonData.clusterUrl}}",
      "tokenAuth": {
        "url": "https://login.microsoftonline.com/{{.JsonData.tenantId}}/oauth2/token",
        "params": {
          "grant_type":  "client_credentials",
          "client_id": "{{.JsonData.clientId}}",
          "client_secret": "{{.SecureJsonData.clientSecret}}",
          "resource": "https://kusto.kusto.windows.net"
        }
        }
    }
  ],
```
