### PR TITLE
Show min-width option only for horizontal repeat

### DIFF
--- a/public/app/partials/panelgeneral.html
+++ b/public/app/partials/panelgeneral.html
@@ -18,15 +18,15 @@
 			<span class="gf-form-label width-9">For each value of</span>
 			<dash-repeat-option panel="ctrl.panel"></dash-repeat-option>
 		</div>
-		<div class="gf-form" ng-show="ctrl.panel.repeat">
-			<span class="gf-form-label width-9">Min width</span>
-			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]">
-				<option value=""></option>
-			</select>
-		</div>
     <div class="gf-form" ng-show="ctrl.panel.repeat">
 			<span class="gf-form-label width-9">Direction</span>
 			<select class="gf-form-input" ng-model="ctrl.panel.repeatDirection" ng-options="f.value as f.text for f in [{value: 'v', text: 'Vertical'}, {value: 'h', text: 'Horizontal'}]">
+				<option value=""></option>
+			</select>
+		</div>
+		<div class="gf-form" ng-show="ctrl.panel.repeat && ctrl.panel.repeatDirection == 'h'">
+			<span class="gf-form-label width-9">Min width</span>
+			<select class="gf-form-input" ng-model="ctrl.panel.minSpan" ng-options="f for f in [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]">
 				<option value=""></option>
 			</select>
 		</div>


### PR DESCRIPTION
As far as I understand, the `min-width` option only has an influence for `horizontal` direction. With this PR, the corresponding field only appears when horizontal is chosen.

![capture du 2018-08-20 13-44-38](https://user-images.githubusercontent.com/319774/44338746-3e6e0680-a47f-11e8-88c2-695768494d26.png)
![capture du 2018-08-20 13-44-48](https://user-images.githubusercontent.com/319774/44338752-3f9f3380-a47f-11e8-8787-b485c91437ca.png)
