### PR TITLE
Propagate errors from SQL row reading

### DIFF
--- a/vendor/github.com/go-xorm/xorm/session_get.go
+++ b/vendor/github.com/go-xorm/xorm/session_get.go
@@ -76,6 +76,9 @@ func (session *Session) nocacheGet(beanKind reflect.Kind, table *core.Table, bea
 	defer rows.Close()
 
 	if !rows.Next() {
+		if rows.Err() != nil {
+			return false, rows.Err()
+		}
 		return false, nil
 	}
 


### PR DESCRIPTION
Very small fix to error reporting, but a lot of issues could be clarified by this since it disambiguates between cursor errors and empty result sets. I discovered the underlying issue to #10727 using this, but I suspect a significant amount of the HTTP 401 issues (#11831 is a recent one, many more can be found) are actually caused by locking issues which this PR exposes properly. It doesn't attempt to actually fix the issue (turns out that's pretty hard, see https://github.com/grafana/grafana/issues/10727#issuecomment-409372160 and below).