### PR TITLE
Fixed multiple Base Auth prompt by checking if grafana_remember exist…

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -101,7 +101,8 @@ export class BackendSrv {
       },
       err => {
         // handle unauthorized
-        if (err.status === 401 && this.contextSrv.user.isSignedIn && firstAttempt) {
+        const isRemembered = document.cookie.indexOf('grafana_remember') !== -1;
+        if (err.status === 401 && this.contextSrv.user.isSignedIn && firstAttempt && isRemembered) {
           return this.loginPing().then(() => {
             options.retry = 1;
             return this.request(options);
@@ -181,7 +182,8 @@ export class BackendSrv {
         }
 
         // handle unauthorized for backend requests
-        if (requestIsLocal && firstAttempt && err.status === 401) {
+        const isRemembered = document.cookie.indexOf('grafana_remember') !== -1;
+        if (requestIsLocal && firstAttempt && err.status === 401 && isRemembered) {
           return this.loginPing().then(() => {
             options.retry = 1;
             if (canceler) {


### PR DESCRIPTION
…s in cookies.

[#12979](https://github.com/grafana/grafana/issues/12979) Multiple asks for users/password with Basic Auth when `loginPing() /api/login/ping` request goes in race.