### PR TITLE
Fix opentsdb json scientific notation

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -120,8 +120,8 @@ func (e *OpenTsdbExecutor) parseResponse(query OpenTsdbQuery, res *http.Response
 
 	var data []OpenTsdbResponse
 	dec := json.NewDecoder(bytes.NewBuffer(body))
-    dec.UseNumber()
-    err = dec.Decode(&data)
+	dec.UseNumber()
+	err = dec.Decode(&data)
 	if err != nil {
 		plog.Info("Failed to unmarshal opentsdb response", "error", err, "status", res.Status, "body", string(body))
 		return nil, err

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -119,7 +119,9 @@ func (e *OpenTsdbExecutor) parseResponse(query OpenTsdbQuery, res *http.Response
 	}
 
 	var data []OpenTsdbResponse
-	err = json.Unmarshal(body, &data)
+	dec := json.NewDecoder(bytes.NewBuffer(body))
+    dec.UseNumber()
+    err = dec.Decode(&data)
 	if err != nil {
 		plog.Info("Failed to unmarshal opentsdb response", "error", err, "status", res.Status, "body", string(body))
 		return nil, err


### PR DESCRIPTION

#13048 

same as https://github.com/grafana/grafana/blob/1165d098b0d0ae705955f9d2ea104beea98ca6eb/pkg/components/simplejson/simplejson_go11.go
```
// Implements the json.Unmarshaler interface.
func (j *Json) UnmarshalJSON(p []byte) error {
	dec := json.NewDecoder(bytes.NewBuffer(p))
	dec.UseNumber()
	return dec.Decode(&j.data)
}
```