### PR TITLE
Moved tooltip icon from input to label #12945

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -156,30 +156,35 @@
     <div class="section gf-form-group" ng-if="style.link">
       <h5 class="section-heading">Link</h5>
       <div class="gf-form">
-        <label class="gf-form-label width-9">Url</label>
+        <label class="gf-form-label width-9">
+          Url
+          <info-popover mode="right-normal">
+            <p>Specify an URL (relative or absolute)</p>
+            <span>
+              Use special variables to specify cell values:
+              <br>
+              <em>${__cell}</em> refers to current cell value
+              <br>
+              <em>${__cell_n}</em> refers to Nth column value in current row. Column indexes are started from 0. For instance,
+              <em>${__cell_1}</em> refers to second column's value.
+              <br>
+              <em>${__cell:raw}</em> syntax. By default values are URI encoded. If the value is a complete URL you can disable all encoding using
+            </span>
+          </info-popover>
+        </label>
         <input type="text" class="gf-form-input width-29" ng-model="style.linkUrl" ng-blur="editor.render()" ng-model-onblur data-placement="right">
-        <info-popover mode="right-absolute">
-          <p>Specify an URL (relative or absolute)</p>
-          <span>
-            Use special variables to specify cell values:
-            <br>
-            <em>${__cell}</em> refers to current cell value
-            <br>
-            <em>${__cell_n}</em> refers to Nth column value in current row. Column indexes are started from 0. For instance,
-            <em>${__cell_1}</em> refers to second column's value.
-          </span>
-        </info-popover>
       </div>
       <div class="gf-form">
-        <label class="gf-form-label width-9">Tooltip</label>
+        <label class="gf-form-label width-9">
+          Tooltip
+          <info-popover mode="right-normal">
+            <p>Specify text for link tooltip.</p>
+            <span>
+              This title appears when user hovers pointer over the cell with link. Use the same variables as for URL.
+            </span>
+          </info-popover></label>
         <input type="text" class="gf-form-input width-29" ng-model="style.linkTooltip" ng-blur="editor.render()" ng-model-onblur
           data-placement="right">
-        <info-popover mode="right-absolute">
-          <p>Specify text for link tooltip.</p>
-          <span>
-            This title appears when user hovers pointer over the cell with link. Use the same variables as for URL.
-          </span>
-        </info-popover>
       </div>
       <gf-form-switch class="gf-form" label-class="width-9" label="Open in new tab" checked="style.linkTargetBlank"></gf-form-switch>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,7 +850,7 @@ async@^1.4.0, async@^1.5.0, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.0, async@^2.1.4, async@^2.4.1, async@^2.6.0:
+async@^2.0.0, async@^2.1.4, async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:


### PR DESCRIPTION
## What
Moved the tooltip icon from the input field to the label. Fixes issue https://github.com/grafana/grafana/issues/12945

## Why
When creating a new table dashboard, there was an issue when entering an url for rendering a value as a link. See issue above for screenshot. 

