### PR TITLE
Return correct path for OpenBSD in cli's returnOsDefault

### DIFF
--- a/pkg/cmd/grafana-cli/utils/grafana_path.go
+++ b/pkg/cmd/grafana-cli/utils/grafana_path.go
@@ -42,6 +42,8 @@ func returnOsDefault(currentOs string) string {
 		return "/usr/local/var/lib/grafana/plugins"
 	case "freebsd":
 		return "/var/db/grafana/plugins"
+	case "openbsd":
+		return "/var/grafana/plugins"
 	default: //"linux"
 		return "/var/lib/grafana/plugins"
 	}


### PR DESCRIPTION
This commit allows grafana-cli to recognize OpenBSD and use the correct plugin path for said platform.

This patch is also part of the [OpenBSD package for grafana](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/sysutils/grafana/).