### PR TITLE
Fix table header not moving with horizontal scroll

### DIFF
--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -222,6 +222,13 @@ class TablePanelCtrl extends MetricsPanelCtrl {
       footerElem.append(paginationList);
     }
 
+    function onTableScroll(e) {
+      // move table headers together with horizontal scroll
+      const rootElement = $(e.currentTarget);
+      const headerElements = rootElement.find('.table-panel-table-header-inner');
+      headerElements.css('margin-left', -rootElement.scrollLeft());
+    }
+
     function renderPanel() {
       const panelElem = elem.parents('.panel-content');
       const rootElem = elem.find('.table-panel-scroll');
@@ -230,6 +237,7 @@ class TablePanelCtrl extends MetricsPanelCtrl {
 
       elem.css({ 'font-size': panel.fontSize });
       panelElem.addClass('table-panel-content');
+      rootElem.scroll(onTableScroll);
 
       appendTableRows(tbodyElem);
       appendPaginationControls(footerElem);


### PR DESCRIPTION
The table headers from Table plugin don't move together with the data columns below when there is a horizontal scrollbar. This change in the CSS fixes the issue.

In the following screenshot you can see an example of the fixed header.

![screenshot_2018-08-30_14-50-58](https://user-images.githubusercontent.com/8865522/44852783-6a9a3c00-ac64-11e8-840e-9c4e1f7f42c7.png)

After applying the fix, it looks like this:
![screenshot_2018-08-30_15-07-16](https://user-images.githubusercontent.com/8865522/44853514-75ee6700-ac66-11e8-8868-3fde8312a876.png)
