### PR TITLE
Enabled HTTP/2 protocol - fix #9530

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -143,25 +143,16 @@ func (hs *HTTPServer) listenAndServeTLS(certfile, keyfile string) error {
 
 	tlsCfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
+		PreferServerCipherSuites: false, // we support only safe ciphers, so client may decide preferred cipher
 		CipherSuites: []uint16{
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,  // the best cipher for mobile devices without HW AES support - Snapdragon 800-
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // must be enabled for http/2 support
 		},
+		NextProtos: []string{"h2", "http/1.1"},
 	}
 
 	hs.httpSrv.TLSConfig = tlsCfg
-	hs.httpSrv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 
 	return hs.httpSrv.ListenAndServeTLS(setting.CertFile, setting.KeyFile)
 }


### PR DESCRIPTION
WIP - feature request: https://github.com/grafana/grafana/issues/9530

Question for discussion:
1.) Do we want to support HTTP/2 protocol?
It will be available only for TLS connections. It may save a few ms for all users. In theory, it may improve performance for dashboards with many panels. Final implementation will require a change of default TLS configuration - some bad ciphers are blocked for HTTP/2 protocol.

Chrome test with 100 graph panels with random data doesn't show any significant improvement:
HTTP/2:
![image](https://user-images.githubusercontent.com/1182932/44903789-640fd100-ad05-11e8-8df7-f3afa1d9a05e.png)

HTTP/1.1:
![image](https://user-images.githubusercontent.com/1182932/44903928-b650f200-ad05-11e8-81cc-5651141553d9.png)

