### PR TITLE
Reopen log files after receiving a SIGHUP signal

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -96,13 +96,17 @@ func main() {
 
 func listenToSystemSignals(server *GrafanaServerImpl) {
 	signalChan := make(chan os.Signal, 1)
-	ignoreChan := make(chan os.Signal, 1)
+	sighupChan := make(chan os.Signal, 1)
 
-	signal.Notify(ignoreChan, syscall.SIGHUP)
+	signal.Notify(sighupChan, syscall.SIGHUP)
 	signal.Notify(signalChan, os.Interrupt, os.Kill, syscall.SIGTERM)
 
-	select {
-	case sig := <-signalChan:
-		server.Shutdown(fmt.Sprintf("System signal: %s", sig))
+	for {
+		select {
+		case _ = <-sighupChan:
+			log.Reload()
+		case sig := <-signalChan:
+			server.Shutdown(fmt.Sprintf("System signal: %s", sig))
+		}
 	}
 }

--- a/pkg/log/file.go
+++ b/pkg/log/file.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -91,7 +89,6 @@ func (w *FileLogWriter) Init() error {
 	if len(w.Filename) == 0 {
 		return errors.New("config must have filename")
 	}
-	go w.listenToSystemSignals()
 	return w.StartLogger()
 }
 
@@ -240,29 +237,8 @@ func (w *FileLogWriter) Flush() {
 	w.mw.fd.Sync()
 }
 
-// listen to system signals
-func (w *FileLogWriter) listenToSystemSignals() {
-	sighupChan := make(chan os.Signal, 1)
-	terminationChan := make(chan os.Signal, 1)
-
-	signal.Notify(sighupChan, syscall.SIGHUP)
-	signal.Notify(terminationChan, os.Interrupt, os.Kill, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-sighupChan:
-			_, err := os.Lstat(w.Filename)
-			if err == nil { // file exists
-				w.doReload()
-			}
-		case <-terminationChan:
-			break
-		}
-	}
-}
-
-// doReload closes the file and open it again
-func (w *FileLogWriter) doReload() (err error) {
+// Reload file logger
+func (w *FileLogWriter) Reload() {
 	// block Logger's io.Writer
 	w.mw.Lock()
 	defer w.mw.Unlock()
@@ -272,11 +248,8 @@ func (w *FileLogWriter) doReload() (err error) {
 	fd.Close()
 
 	// Open again
-	err = w.StartLogger()
+	err := w.StartLogger()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Reload StartLogger: %s\n", err)
-		return err
 	}
-
-	return nil
 }

--- a/pkg/log/handlers.go
+++ b/pkg/log/handlers.go
@@ -3,3 +3,7 @@ package log
 type DisposableHandler interface {
 	Close()
 }
+
+type ReloadableHandler interface {
+	Reload()
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,10 +21,12 @@ import (
 
 var Root log15.Logger
 var loggersToClose []DisposableHandler
+var loggersToReload []ReloadableHandler
 var filters map[string]log15.Lvl
 
 func init() {
 	loggersToClose = make([]DisposableHandler, 0)
+	loggersToReload = make([]ReloadableHandler, 0)
 	Root = log15.Root()
 	Root.SetHandler(log15.DiscardHandler())
 }
@@ -113,6 +115,12 @@ func Close() {
 		logger.Close()
 	}
 	loggersToClose = make([]DisposableHandler, 0)
+}
+
+func Reload() {
+	for _, logger := range loggersToReload {
+		logger.Reload()
+	}
 }
 
 func GetLogLevelFor(name string) Lvl {
@@ -230,6 +238,7 @@ func ReadLoggingConfig(modes []string, logsPath string, cfg *ini.File) {
 			fileHandler.Init()
 
 			loggersToClose = append(loggersToClose, fileHandler)
+			loggersToReload = append(loggersToReload, fileHandler)
 			handler = fileHandler
 		case "syslog":
 			sysLogHandler := NewSyslog(sec, format)


### PR DESCRIPTION
Implements a system signals listener in log.FileLogWriter.

After receiving a SIGHUP signal from the system, the listener will close the current log file and then open it again.

The listener will finish after receiving a SIGINT, SIGKILL or SIGTERM signal.

Closes grafana/grafana#2497
