### PR TITLE
Only authenticate logins when password is set

### DIFF
--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -13,7 +13,7 @@ var (
 	ErrProviderDeniedRequest = errors.New("Login provider denied login request")
 	ErrSignUpNotAllowed      = errors.New("Signup is not allowed for this adapter")
 	ErrTooManyLoginAttempts  = errors.New("Too many consecutive incorrect login attempts for user. Login for user temporarily blocked")
-	ErrPasswordTooShort      = errors.New("Password too short.")
+	ErrPasswordEmpty         = errors.New("No password provided.")
 	ErrUsersQuotaReached     = errors.New("Users quota reached")
 	ErrGettingUserQuota      = errors.New("Error getting user quota")
 )
@@ -28,7 +28,7 @@ func AuthenticateUser(query *m.LoginUserQuery) error {
 		return err
 	}
 
-	if err := validatePasswordLength(query.Password); err != nil {
+	if err := validatePasswordSet(query.Password); err != nil {
 		return err
 	}
 
@@ -56,9 +56,9 @@ func AuthenticateUser(query *m.LoginUserQuery) error {
 
 	return err
 }
-func validatePasswordLength(password string) error {
-	if len(password) < 4 {
-		return ErrPasswordTooShort
+func validatePasswordSet(password string) error {
+	if len(password) == 0 {
+		return ErrPasswordEmpty
 	}
 
 	return nil

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -28,8 +28,8 @@ func AuthenticateUser(query *m.LoginUserQuery) error {
 		return err
 	}
 
-	if len(query.Password) < 4 {
-		return ErrPasswordTooShort
+	if err := validatePasswordLength(query.Password); err != nil {
+		return err
 	}
 
 	err := loginUsingGrafanaDB(query)
@@ -55,4 +55,11 @@ func AuthenticateUser(query *m.LoginUserQuery) error {
 	}
 
 	return err
+}
+func validatePasswordLength(password string) error {
+	if len(password) < 4 {
+		return ErrPasswordTooShort
+	}
+
+	return nil
 }

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -2,7 +2,6 @@ package login
 
 import (
 	"errors"
-
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -14,6 +13,7 @@ var (
 	ErrProviderDeniedRequest = errors.New("Login provider denied login request")
 	ErrSignUpNotAllowed      = errors.New("Signup is not allowed for this adapter")
 	ErrTooManyLoginAttempts  = errors.New("Too many consecutive incorrect login attempts for user. Login for user temporarily blocked")
+	ErrPasswordTooShort      = errors.New("Password too short.")
 	ErrUsersQuotaReached     = errors.New("Users quota reached")
 	ErrGettingUserQuota      = errors.New("Error getting user quota")
 )
@@ -26,6 +26,10 @@ func Init() {
 func AuthenticateUser(query *m.LoginUserQuery) error {
 	if err := validateLoginAttempts(query.Username); err != nil {
 		return err
+	}
+
+	if len(query.Password) < 4 {
+		return ErrPasswordTooShort
 	}
 
 	err := loginUsingGrafanaDB(query)

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAuthenticateUser(t *testing.T) {
 	Convey("Authenticate user", t, func() {
-		authScenario("When a user authenticates without a password", func(sc *authScenarioContext) {
+		authScenario("When a user authenticates without setting a password", func(sc *authScenarioContext) {
 			mockLoginAttemptValidation(nil, sc)
 			mockLoginUsingGrafanaDB(nil, sc)
 			mockLoginUsingLdap(false, nil, sc)
@@ -24,7 +24,7 @@ func TestAuthenticateUser(t *testing.T) {
 			Convey("login should fail", func() {
 				So(sc.grafanaLoginWasCalled, ShouldBeFalse)
 				So(sc.ldapLoginWasCalled, ShouldBeFalse)
-				So(err, ShouldEqual, ErrPasswordTooShort)
+				So(err, ShouldEqual, ErrPasswordEmpty)
 			})
 		})
 

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -215,7 +215,7 @@ func authScenario(desc string, fn authScenarioFunc) {
 		sc := &authScenarioContext{
 			loginUserQuery: &m.LoginUserQuery{
 				Username:  "user",
-				Password:  "password",
+				Password:  "pwd",
 				IpAddress: "192.168.1.1:56433",
 			},
 		}


### PR DESCRIPTION
Currently, it's possible to go through the login flow with an empty password. This is a bit strange as we require the password to be at least 4 characters long when a user is created. It also means we are vulnerable to the `go-ldap` vulnerability in #13010 that bypasses authentication if "unauthenticated bind" is enabled in the ldap server.

As I see it there are three potential fixes to the `go-ldap` problem:
- upgrade to a fixed `go-ldap` version (not yet possible, we'd have to use master)
- set a password length requirement (this pr sets it to 4, we could potentially make this configurable but do we want another config option?)
- require the password to be non-empty before we do auth (the safest option as this will still allow someone using a short password to login while simulaneously fixing the `go-ldap` problem)

Closes #13010 