### PR TITLE
Interpolate $__interval in backend for alerting with sql datasources

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -138,7 +138,7 @@ func (c *baseClientImpl) encodeBatchRequests(requests []*multiRequest) ([]byte, 
 		}
 
 		body := string(reqBody)
-		body = strings.Replace(body, "$__interval_ms", strconv.FormatInt(r.interval.Value.Nanoseconds()/int64(time.Millisecond), 10), -1)
+		body = strings.Replace(body, "$__interval_ms", strconv.FormatInt(r.interval.Milliseconds(), 10), -1)
 		body = strings.Replace(body, "$__interval", r.interval.Text, -1)
 
 		payload.WriteString(body + "\n")

--- a/pkg/tsdb/influxdb/query.go
+++ b/pkg/tsdb/influxdb/query.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"regexp"
 
@@ -34,7 +33,7 @@ func (query *Query) Build(queryContext *tsdb.TsdbQuery) (string, error) {
 
 	res = strings.Replace(res, "$timeFilter", query.renderTimeFilter(queryContext), -1)
 	res = strings.Replace(res, "$interval", interval.Text, -1)
-	res = strings.Replace(res, "$__interval_ms", strconv.FormatInt(interval.Value.Nanoseconds()/int64(time.Millisecond), 10), -1)
+	res = strings.Replace(res, "$__interval_ms", strconv.FormatInt(interval.Milliseconds(), 10), -1)
 	res = strings.Replace(res, "$__interval", interval.Text, -1)
 	return res, nil
 }

--- a/pkg/tsdb/interval.go
+++ b/pkg/tsdb/interval.go
@@ -49,6 +49,10 @@ func NewIntervalCalculator(opt *IntervalOptions) *intervalCalculator {
 	return calc
 }
 
+func (i *Interval) Milliseconds() int64 {
+	return i.Value.Nanoseconds() / 1e6
+}
+
 func (ic *intervalCalculator) Calculate(timerange *TimeRange, minInterval time.Duration) Interval {
 	to := timerange.MustGetTo().UnixNano()
 	from := timerange.MustGetFrom().UnixNano()

--- a/pkg/tsdb/interval.go
+++ b/pkg/tsdb/interval.go
@@ -50,7 +50,7 @@ func NewIntervalCalculator(opt *IntervalOptions) *intervalCalculator {
 }
 
 func (i *Interval) Milliseconds() int64 {
-	return i.Value.Nanoseconds() / 1e6
+	return i.Value.Nanoseconds() / int64(time.Millisecond)
 }
 
 func (ic *intervalCalculator) Calculate(timerange *TimeRange, minInterval time.Duration) Interval {

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -27,7 +27,7 @@ func (m *msSqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = replaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = tsdb.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")
@@ -45,23 +45,6 @@ func (m *msSqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	}
 
 	return sql, nil
-}
-
-func replaceAllStringSubmatchFunc(re *regexp.Regexp, str string, repl func([]string) string) string {
-	result := ""
-	lastIndex := 0
-
-	for _, v := range re.FindAllSubmatchIndex([]byte(str), -1) {
-		groups := []string{}
-		for i := 0; i < len(v); i += 2 {
-			groups = append(groups, str[v[i]:v[i+1]])
-		}
-
-		result += str[lastIndex:v[0]] + repl(groups)
-		lastIndex = v[1]
-	}
-
-	return result + str[lastIndex:]
 }
 
 func (m *msSqlMacroEngine) evaluateMacro(name string, args []string) (string, error) {

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -13,12 +13,13 @@ const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
 type msSqlMacroEngine struct {
+	*tsdb.SqlMacroEngineBase
 	timeRange *tsdb.TimeRange
 	query     *tsdb.Query
 }
 
 func newMssqlMacroEngine() tsdb.SqlMacroEngine {
-	return &msSqlMacroEngine{}
+	return &msSqlMacroEngine{SqlMacroEngineBase: tsdb.NewSqlMacroEngineBase()}
 }
 
 func (m *msSqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
@@ -27,7 +28,7 @@ func (m *msSqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = tsdb.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -295,6 +295,31 @@ func TestMSSQL(t *testing.T) {
 
 			})
 
+			Convey("When doing a metric query using timeGroup and $__interval", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+					TimeRange: &tsdb.TimeRange{
+						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+						To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT FLOOR(DATEDIFF(second, '1970-01-01', time)/1800)*1800 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+
+			})
+
 			Convey("When doing a metric query using timeGroup with float fill enabled", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -299,6 +299,7 @@ func TestMSSQL(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -316,7 +317,7 @@ func TestMSSQL(t *testing.T) {
 				So(err, ShouldBeNil)
 				queryResult := resp.Results["A"]
 				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT FLOOR(DATEDIFF(second, '1970-01-01', time)/1800)*1800 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT FLOOR(DATEDIFF(second, '1970-01-01', time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
 
 			})
 

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -35,6 +35,11 @@ func TestMSSQL(t *testing.T) {
 			return x, nil
 		}
 
+		origInterpolate := tsdb.Interpolate
+		tsdb.Interpolate = func(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
+			return sql, nil
+		}
+
 		endpoint, err := newMssqlQueryEndpoint(&models.DataSource{
 			JsonData:       simplejson.New(),
 			SecureJsonData: securejsondata.SecureJsonData{},
@@ -47,6 +52,7 @@ func TestMSSQL(t *testing.T) {
 		Reset(func() {
 			sess.Close()
 			tsdb.NewXormEngine = origXormEngine
+			tsdb.Interpolate = origInterpolate
 		})
 
 		Convey("Given a table with different native data types", func() {
@@ -296,29 +302,37 @@ func TestMSSQL(t *testing.T) {
 			})
 
 			Convey("When doing a metric query using timeGroup and $__interval", func() {
-				query := &tsdb.TsdbQuery{
-					Queries: []*tsdb.Query{
-						{
-							DataSource: &models.DataSource{},
-							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
-								"format": "time_series",
-							}),
-							RefId: "A",
+				mockInterpolate := tsdb.Interpolate
+				tsdb.Interpolate = origInterpolate
+
+				Reset(func() {
+					tsdb.Interpolate = mockInterpolate
+				})
+
+				Convey("Should replace $__interval", func() {
+					query := &tsdb.TsdbQuery{
+						Queries: []*tsdb.Query{
+							{
+								DataSource: &models.DataSource{},
+								Model: simplejson.NewFromAny(map[string]interface{}{
+									"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY $__timeGroup(time, $__interval) ORDER BY 1",
+									"format": "time_series",
+								}),
+								RefId: "A",
+							},
 						},
-					},
-					TimeRange: &tsdb.TimeRange{
-						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
-						To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
-					},
-				}
+						TimeRange: &tsdb.TimeRange{
+							From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+							To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
+						},
+					}
 
-				resp, err := endpoint.Query(nil, nil, query)
-				So(err, ShouldBeNil)
-				queryResult := resp.Results["A"]
-				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT FLOOR(DATEDIFF(second, '1970-01-01', time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
-
+					resp, err := endpoint.Query(nil, nil, query)
+					So(err, ShouldBeNil)
+					queryResult := resp.Results["A"]
+					So(queryResult.Error, ShouldBeNil)
+					So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT FLOOR(DATEDIFF(second, '1970-01-01', time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY FLOOR(DATEDIFF(second, '1970-01-01', time)/60)*60 ORDER BY 1")
+				})
 			})
 
 			Convey("When doing a metric query using timeGroup with float fill enabled", func() {

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -9,17 +9,17 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
-//const rsString = `(?:"([^"]*)")`;
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
 type mySqlMacroEngine struct {
+	*tsdb.SqlMacroEngineBase
 	timeRange *tsdb.TimeRange
 	query     *tsdb.Query
 }
 
 func newMysqlMacroEngine() tsdb.SqlMacroEngine {
-	return &mySqlMacroEngine{}
+	return &mySqlMacroEngine{SqlMacroEngineBase: tsdb.NewSqlMacroEngineBase()}
 }
 
 func (m *mySqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
@@ -28,7 +28,7 @@ func (m *mySqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = tsdb.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -28,7 +28,7 @@ func (m *mySqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = replaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = tsdb.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")
@@ -46,23 +46,6 @@ func (m *mySqlMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRa
 	}
 
 	return sql, nil
-}
-
-func replaceAllStringSubmatchFunc(re *regexp.Regexp, str string, repl func([]string) string) string {
-	result := ""
-	lastIndex := 0
-
-	for _, v := range re.FindAllSubmatchIndex([]byte(str), -1) {
-		groups := []string{}
-		for i := 0; i < len(v); i += 2 {
-			groups = append(groups, str[v[i]:v[i+1]])
-		}
-
-		result += str[lastIndex:v[0]] + repl(groups)
-		lastIndex = v[1]
-	}
-
-	return result + str[lastIndex:]
 }
 
 func (m *mySqlMacroEngine) evaluateMacro(name string, args []string) (string, error) {

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -299,6 +299,7 @@ func TestMySQL(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -316,7 +317,7 @@ func TestMySQL(t *testing.T) {
 				So(err, ShouldBeNil)
 				queryResult := resp.Results["A"]
 				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT UNIX_TIMESTAMP(time) DIV 1800 * 1800 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
 
 			})
 

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -42,6 +42,11 @@ func TestMySQL(t *testing.T) {
 			return x, nil
 		}
 
+		origInterpolate := tsdb.Interpolate
+		tsdb.Interpolate = func(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
+			return sql, nil
+		}
+
 		endpoint, err := newMysqlQueryEndpoint(&models.DataSource{
 			JsonData:       simplejson.New(),
 			SecureJsonData: securejsondata.SecureJsonData{},
@@ -54,6 +59,7 @@ func TestMySQL(t *testing.T) {
 		Reset(func() {
 			sess.Close()
 			tsdb.NewXormEngine = origXormEngine
+			tsdb.Interpolate = origInterpolate
 		})
 
 		Convey("Given a table with different native data types", func() {
@@ -296,29 +302,37 @@ func TestMySQL(t *testing.T) {
 			})
 
 			Convey("When doing a metric query using timeGroup and $__interval", func() {
-				query := &tsdb.TsdbQuery{
-					Queries: []*tsdb.Query{
-						{
-							DataSource: &models.DataSource{},
-							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
-								"format": "time_series",
-							}),
-							RefId: "A",
+				mockInterpolate := tsdb.Interpolate
+				tsdb.Interpolate = origInterpolate
+
+				Reset(func() {
+					tsdb.Interpolate = mockInterpolate
+				})
+
+				Convey("Should replace $__interval", func() {
+					query := &tsdb.TsdbQuery{
+						Queries: []*tsdb.Query{
+							{
+								DataSource: &models.DataSource{},
+								Model: simplejson.NewFromAny(map[string]interface{}{
+									"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
+									"format": "time_series",
+								}),
+								RefId: "A",
+							},
 						},
-					},
-					TimeRange: &tsdb.TimeRange{
-						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
-						To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
-					},
-				}
+						TimeRange: &tsdb.TimeRange{
+							From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+							To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
+						},
+					}
 
-				resp, err := endpoint.Query(nil, nil, query)
-				So(err, ShouldBeNil)
-				queryResult := resp.Results["A"]
-				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
-
+					resp, err := endpoint.Query(nil, nil, query)
+					So(err, ShouldBeNil)
+					queryResult := resp.Results["A"]
+					So(queryResult.Error, ShouldBeNil)
+					So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+				})
 			})
 
 			Convey("When doing a metric query using timeGroup with value fill enabled", func() {

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -295,6 +295,31 @@ func TestMySQL(t *testing.T) {
 
 			})
 
+			Convey("When doing a metric query using timeGroup and $__interval", func() {
+				query := &tsdb.TsdbQuery{
+					Queries: []*tsdb.Query{
+						{
+							Model: simplejson.NewFromAny(map[string]interface{}{
+								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
+								"format": "time_series",
+							}),
+							RefId: "A",
+						},
+					},
+					TimeRange: &tsdb.TimeRange{
+						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+						To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
+					},
+				}
+
+				resp, err := endpoint.Query(nil, nil, query)
+				So(err, ShouldBeNil)
+				queryResult := resp.Results["A"]
+				So(queryResult.Error, ShouldBeNil)
+				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT UNIX_TIMESTAMP(time) DIV 1800 * 1800 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+
+			})
+
 			Convey("When doing a metric query using timeGroup with value fill enabled", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -9,18 +9,21 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
-//const rsString = `(?:"([^"]*)")`;
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
 
 type postgresMacroEngine struct {
+	*tsdb.SqlMacroEngineBase
 	timeRange   *tsdb.TimeRange
 	query       *tsdb.Query
 	timescaledb bool
 }
 
 func newPostgresMacroEngine(timescaledb bool) tsdb.SqlMacroEngine {
-	return &postgresMacroEngine{timescaledb: timescaledb}
+	return &postgresMacroEngine{
+		SqlMacroEngineBase: tsdb.NewSqlMacroEngineBase(),
+		timescaledb:        timescaledb,
+	}
 }
 
 func (m *postgresMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
@@ -29,7 +32,7 @@ func (m *postgresMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.Tim
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
 
-	sql = replaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
+	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 
 		// detect if $__timeGroup is supposed to add AS time for pre 5.3 compatibility
 		// if there is a ',' directly after the macro call $__timeGroup is probably used
@@ -64,23 +67,6 @@ func (m *postgresMacroEngine) Interpolate(query *tsdb.Query, timeRange *tsdb.Tim
 	}
 
 	return sql, nil
-}
-
-func replaceAllStringSubmatchFunc(re *regexp.Regexp, str string, repl func([]string) string) string {
-	result := ""
-	lastIndex := 0
-
-	for _, v := range re.FindAllSubmatchIndex([]byte(str), -1) {
-		groups := []string{}
-		for i := 0; i < len(v); i += 2 {
-			groups = append(groups, str[v[i]:v[i+1]])
-		}
-
-		result += str[lastIndex:v[0]] + repl(groups)
-		lastIndex = v[1]
-	}
-
-	return result + str[lastIndex:]
 }
 
 func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string, error) {

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -226,6 +226,7 @@ func TestPostgres(t *testing.T) {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{
+							DataSource: &models.DataSource{},
 							Model: simplejson.NewFromAny(map[string]interface{}{
 								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
 								"format": "time_series",
@@ -243,7 +244,7 @@ func TestPostgres(t *testing.T) {
 				So(err, ShouldBeNil)
 				queryResult := resp.Results["A"]
 				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT floor(extract(epoch from time)/1800)*1800 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT floor(extract(epoch from time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
 
 			})
 

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -43,6 +43,11 @@ func TestPostgres(t *testing.T) {
 			return x, nil
 		}
 
+		origInterpolate := tsdb.Interpolate
+		tsdb.Interpolate = func(query *tsdb.Query, timeRange *tsdb.TimeRange, sql string) (string, error) {
+			return sql, nil
+		}
+
 		endpoint, err := newPostgresQueryEndpoint(&models.DataSource{
 			JsonData:       simplejson.New(),
 			SecureJsonData: securejsondata.SecureJsonData{},
@@ -55,6 +60,7 @@ func TestPostgres(t *testing.T) {
 		Reset(func() {
 			sess.Close()
 			tsdb.NewXormEngine = origXormEngine
+			tsdb.Interpolate = origInterpolate
 		})
 
 		Convey("Given a table with different native data types", func() {
@@ -223,29 +229,37 @@ func TestPostgres(t *testing.T) {
 			})
 
 			Convey("When doing a metric query using timeGroup and $__interval", func() {
-				query := &tsdb.TsdbQuery{
-					Queries: []*tsdb.Query{
-						{
-							DataSource: &models.DataSource{},
-							Model: simplejson.NewFromAny(map[string]interface{}{
-								"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
-								"format": "time_series",
-							}),
-							RefId: "A",
+				mockInterpolate := tsdb.Interpolate
+				tsdb.Interpolate = origInterpolate
+
+				Reset(func() {
+					tsdb.Interpolate = mockInterpolate
+				})
+
+				Convey("Should replace $__interval", func() {
+					query := &tsdb.TsdbQuery{
+						Queries: []*tsdb.Query{
+							{
+								DataSource: &models.DataSource{},
+								Model: simplejson.NewFromAny(map[string]interface{}{
+									"rawSql": "SELECT $__timeGroup(time, $__interval) AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1",
+									"format": "time_series",
+								}),
+								RefId: "A",
+							},
 						},
-					},
-					TimeRange: &tsdb.TimeRange{
-						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
-						To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
-					},
-				}
+						TimeRange: &tsdb.TimeRange{
+							From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+							To:   fmt.Sprintf("%v", fromStart.Add(30*time.Minute).Unix()*1000),
+						},
+					}
 
-				resp, err := endpoint.Query(nil, nil, query)
-				So(err, ShouldBeNil)
-				queryResult := resp.Results["A"]
-				So(queryResult.Error, ShouldBeNil)
-				So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT floor(extract(epoch from time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
-
+					resp, err := endpoint.Query(nil, nil, query)
+					So(err, ShouldBeNil)
+					queryResult := resp.Results["A"]
+					So(queryResult.Error, ShouldBeNil)
+					So(queryResult.Meta.Get("sql").MustString(), ShouldEqual, "SELECT floor(extract(epoch from time)/60)*60 AS time, avg(value) as value FROM metric GROUP BY 1 ORDER BY 1")
+				})
 			})
 
 			Convey("When doing a metric query using timeGroup with NULL fill enabled", func() {

--- a/pkg/tsdb/sql_engine.go
+++ b/pkg/tsdb/sql_engine.go
@@ -180,17 +180,21 @@ func Interpolate(query *Query, timeRange *TimeRange, sql string) (string, error)
 	sql = ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		switch groups[1] {
 		case "interval":
-			interval, err := GetIntervalFrom(query.DataSource, query.Model, time.Second*60)
+			minInterval, err := GetIntervalFrom(query.DataSource, query.Model, time.Second*60)
 			if err != nil {
 				return sql
 			}
-			return formatDuration(interval)
+			calculator := NewIntervalCalculator(nil)
+			interval := calculator.Calculate(timeRange, minInterval)
+			return interval.Text
 		case "interval_ms":
-			interval, err := GetIntervalFrom(query.DataSource, query.Model, time.Second*60)
+			minInterval, err := GetIntervalFrom(query.DataSource, query.Model, time.Second*60)
 			if err != nil {
 				return sql
 			}
-			return fmt.Sprintf("%.0f", interval.Seconds()*1000)
+			calculator := NewIntervalCalculator(nil)
+			interval := calculator.Calculate(timeRange, minInterval)
+			return fmt.Sprintf("%d", interval.Milliseconds())
 		default:
 			return groups[0]
 		}

--- a/pkg/tsdb/sql_engine.go
+++ b/pkg/tsdb/sql_engine.go
@@ -184,7 +184,7 @@ func Interpolate(query *Query, timeRange *TimeRange, sql string) (string, error)
 			if err != nil {
 				return sql
 			}
-			return fmt.Sprintf("%.0fs", interval.Seconds())
+			return formatDuration(interval)
 		case "interval_ms":
 			interval, err := GetIntervalFrom(query.DataSource, query.Model, time.Second*60)
 			if err != nil {

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -27,6 +27,13 @@ func TestSqlEngine(t *testing.T) {
 				So(sql, ShouldEqual, "select 300s ")
 			})
 
+			Convey("interpolate $__interval in $__timeGroup", func() {
+				sql, err := Interpolate(query, timeRange, "select $__timeGroupAlias(time,$__interval)")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, "select $__timeGroupAlias(time,300s)")
+			})
+
 			Convey("interpolate $__interval_ms", func() {
 				sql, err := Interpolate(query, timeRange, "select $__interval_ms ")
 				So(err, ShouldBeNil)

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -26,14 +26,14 @@ func TestSqlEngine(t *testing.T) {
 				sql, err := Interpolate(query, timeRange, "select $__interval ")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "select 60s ")
+				So(sql, ShouldEqual, "select 1m ")
 			})
 
 			Convey("interpolate $__interval in $__timeGroup", func() {
 				sql, err := Interpolate(query, timeRange, "select $__timeGroupAlias(time,$__interval)")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "select $__timeGroupAlias(time,60s)")
+				So(sql, ShouldEqual, "select $__timeGroupAlias(time,1m)")
 			})
 
 			Convey("interpolate $__interval_ms", func() {

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -18,27 +20,27 @@ func TestSqlEngine(t *testing.T) {
 			from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
 			to := from.Add(5 * time.Minute)
 			timeRange := NewFakeTimeRange("5m", "now", to)
-			query := &Query{}
+			query := &Query{DataSource: &models.DataSource{}, Model: simplejson.New()}
 
 			Convey("interpolate $__interval", func() {
 				sql, err := Interpolate(query, timeRange, "select $__interval ")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "select 300s ")
+				So(sql, ShouldEqual, "select 60s ")
 			})
 
 			Convey("interpolate $__interval in $__timeGroup", func() {
 				sql, err := Interpolate(query, timeRange, "select $__timeGroupAlias(time,$__interval)")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "select $__timeGroupAlias(time,300s)")
+				So(sql, ShouldEqual, "select $__timeGroupAlias(time,60s)")
 			})
 
 			Convey("interpolate $__interval_ms", func() {
 				sql, err := Interpolate(query, timeRange, "select $__interval_ms ")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "select 300000 ")
+				So(sql, ShouldEqual, "select 60000 ")
 			})
 
 		})

--- a/pkg/tsdb/sql_engine_test.go
+++ b/pkg/tsdb/sql_engine_test.go
@@ -14,6 +14,28 @@ func TestSqlEngine(t *testing.T) {
 		dt := time.Date(2018, 3, 14, 21, 20, 6, int(527345*time.Microsecond), time.UTC)
 		earlyDt := time.Date(1970, 3, 14, 21, 20, 6, int(527345*time.Microsecond), time.UTC)
 
+		Convey("Given a time range between 2018-04-12 00:00 and 2018-04-12 00:05", func() {
+			from := time.Date(2018, 4, 12, 18, 0, 0, 0, time.UTC)
+			to := from.Add(5 * time.Minute)
+			timeRange := NewFakeTimeRange("5m", "now", to)
+			query := &Query{}
+
+			Convey("interpolate $__interval", func() {
+				sql, err := Interpolate(query, timeRange, "select $__interval ")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, "select 300s ")
+			})
+
+			Convey("interpolate $__interval_ms", func() {
+				sql, err := Interpolate(query, timeRange, "select $__interval_ms ")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, "select 300000 ")
+			})
+
+		})
+
 		Convey("Given row values with time.Time as time columns", func() {
 			var nilPointer *time.Time
 


### PR DESCRIPTION
Refactor sql datasources to use shared string replace
function and add support for interpolating $__interval
and $__interval_ms in backend to allow using those variables
in alerting queries.

Fixes #11555 