### PR TITLE
docs: default paths in the docker container.

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -20,7 +20,7 @@ $ docker run -d -p 3000:3000 grafana/grafana
 
 ## Configuration
 
-All options defined in conf/grafana.ini can be overridden using environment
+All options defined in `conf/grafana.ini` can be overridden using environment
 variables by using the syntax `GF_<SectionName>_<KeyName>`.
 For example:
 
@@ -39,6 +39,19 @@ The back-end web server has a number of configuration options. Go to the
 those options.
 
 > For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect you need to restart Grafana by restarting the Docker container.
+
+### Default Paths
+
+The following settings are hard-coded when launching the Grafana Docker container and can only be overridden using environment variables, not in `conf/grafana.ini`.
+
+Setting               | Default value
+----------------------|---------------------------
+GF_PATHS_CONFIG       | /etc/grafana/grafana.ini
+GF_PATHS_DATA         | /var/lib/grafana
+GF_PATHS_HOME         | /usr/share/grafana
+GF_PATHS_LOGS         | /var/log/grafana
+GF_PATHS_PLUGINS      | /var/lib/grafana/plugins
+GF_PATHS_PROVISIONING | /etc/grafana/provisioning
 
 ## Running a Specific Version of Grafana
 


### PR DESCRIPTION
A user mentioned that they had problems overriding the data path in `/etc/grafana/grafana.ini`. The reason for this is that we hard-code this path in the run-script of the docker container. Docs are updated to reflect this.