### PR TITLE
Alert Teams - Adding Action to view the graph by its public URL.

### DIFF
--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -96,14 +96,26 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 					},
 				},
 				"text": message,
-				"potentialAction": []map[string]interface{}{
-					{
-						"@context": "http://schema.org",
-						"@type":    "ViewAction",
-						"name":     "View Rule",
-						"target": []string{
-							ruleUrl,
-						},
+			},
+		},
+		"potentialAction": []map[string]interface{}{
+			{
+				"@context": "http://schema.org",
+				"@type":    "OpenUri",
+				"name":     "View Rule",
+				"targets": []map[string]interface{}{
+					{ 
+						"os": "default", "uri": ruleUrl,
+					},
+				},
+			},
+			{
+				"@context": "http://schema.org",
+				"@type":    "OpenUri",
+				"name":     "View Graph",
+				"targets": []map[string]interface{}{
+					{ 
+						"os": "default", "uri": evalContext.ImagePublicUrl,
 					},
 				},
 			},

--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -104,7 +104,7 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 				"@type":    "OpenUri",
 				"name":     "View Rule",
 				"targets": []map[string]interface{}{
-					{ 
+					{
 						"os": "default", "uri": ruleUrl,
 					},
 				},
@@ -114,7 +114,7 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 				"@type":    "OpenUri",
 				"name":     "View Graph",
 				"targets": []map[string]interface{}{
-					{ 
+					{
 						"os": "default", "uri": evalContext.ImagePublicUrl,
 					},
 				},


### PR DESCRIPTION
Fixes #13121

- Original:
![original](https://user-images.githubusercontent.com/4368491/45030401-0be90f80-b022-11e8-9da1-520b94c44a70.PNG)

- Added View Graph:
![attach_action](https://user-images.githubusercontent.com/4368491/45033963-8b7bdc00-b02c-11e8-8b28-1b75e69c9992.PNG)