### PR TITLE
Added basic support for alerts with crateDB Datasource plugin

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/alerting/conditions"
 	_ "github.com/grafana/grafana/pkg/services/alerting/notifiers"
 	_ "github.com/grafana/grafana/pkg/tsdb/cloudwatch"
+	_ "github.com/grafana/grafana/pkg/tsdb/crate"
 	_ "github.com/grafana/grafana/pkg/tsdb/elasticsearch"
 	_ "github.com/grafana/grafana/pkg/tsdb/graphite"
 	_ "github.com/grafana/grafana/pkg/tsdb/influxdb"

--- a/pkg/tsdb/crate/crate.go
+++ b/pkg/tsdb/crate/crate.go
@@ -1,0 +1,122 @@
+package crate
+
+import (
+	"context"
+	"database/sql"
+	_ "encoding/json"
+	"fmt"
+	_ "io/ioutil"
+	_ "net/http"
+	"net/url"
+	_ "net/url"
+	_ "path"
+	"strconv"
+	_ "strings"
+
+	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/models"
+	_ "github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tsdb"
+	_ "github.com/herenow/go-crate"
+	_ "golang.org/x/net/context/ctxhttp"
+)
+
+type CrateExecutor struct {
+}
+
+func NewCrateExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+	return &CrateExecutor{}, nil
+}
+
+var (
+	plog log.Logger
+)
+
+func init() {
+	plog = log.New("tsdb.crate")
+	tsdb.RegisterTsdbQueryEndpoint("crate-datasource", NewCrateExecutor)
+}
+func (e *CrateExecutor) Query(ctx context.Context, dsInfo *models.DataSource, queryContext *tsdb.TsdbQuery) (*tsdb.Response, error) {
+	dsJson, err := dsInfo.JsonData.Map()
+	if err != nil {
+		plog.Info("Failed to create datasource info", err)
+	}
+	timeColumn := dsJson["timeColumn"].(string)
+	schema := dsJson["schema"].(string)
+	table := dsJson["table"].(string)
+	dsUrl := dsInfo.Url
+	if len(dsInfo.BasicAuthUser) > 0 && len(dsInfo.BasicAuthPassword) > 0 {
+		u, err := url.Parse(dsInfo.Url)
+		if err != nil {
+			plog.Info("Failed to parse datasource URL", err)
+		}
+		dsUrl = u.Scheme + "://" + dsInfo.BasicAuthUser + ":" + dsInfo.BasicAuthPassword + "@" + u.Host
+	}
+	result := &tsdb.Response{}
+	start := queryContext.TimeRange.GetFromAsMsEpoch()
+	startTime := strconv.FormatInt(start, 10)
+	end := queryContext.TimeRange.GetToAsMsEpoch()
+	endTime := strconv.FormatInt(end, 10)
+	db, err := sql.Open("crate", dsUrl)
+	if err != nil {
+		plog.Info("Failed to open connection to datasource", err)
+	}
+	queryResults := make(map[string]*tsdb.QueryResult)
+	for _, query := range queryContext.Queries {
+		q, err := query.Model.Map()
+		if err != nil {
+			plog.Info("Failed to create query model map", err)
+		}
+		m, err := query.Model.Get("metricAggs").Array()
+		if err != nil {
+			plog.Info("Failed to create query model metric aggregate array", err)
+		}
+		metricColumn := m[0].(map[string]interface{})["column"].(string)
+		refID := q["refId"].(string)
+		queryString := fmt.Sprintf("SELECT %s,%s FROM %s.%s WHERE %s>%s AND %s<%s;", timeColumn, metricColumn, schema, table, timeColumn, startTime, timeColumn, endTime)
+		rows, err := db.Query(queryString)
+		if err != nil {
+			plog.Info("Query to datasource failed", err)
+		}
+		defer rows.Close()
+		queryRes := tsdb.NewQueryResult()
+		series := tsdb.TimeSeries{
+			Name: metricColumn,
+		}
+		for rows.Next() {
+			var timeValue string
+			var metricValue string
+			if err := rows.Scan(&timeValue, &metricValue); err != nil {
+				plog.Info("Failed to scan rows for time and metric values", err)
+			}
+			point, err := parseDbValues(timeValue, metricValue)
+			if err != nil {
+				plog.Info("Failed to create time series point", err)
+			}
+			series.Points = append(series.Points, *point)
+		}
+		if err := rows.Err(); err != nil {
+			plog.Info("Failed to parse row in datasource query response", err)
+		}
+		queryRes.Series = append(queryRes.Series, &series)
+		queryResults[refID] = queryRes
+	}
+	result.Results = queryResults
+	return result, nil
+}
+
+func parseDbValues(timeValue string, metricValue string) (*tsdb.TimePoint, error) {
+	floatTimeValue, err := strconv.ParseFloat(timeValue, 64)
+	if err != nil {
+		plog.Info("Failed to parse time value as float", err)
+		return nil, err
+	}
+	floatMetricValue, err := strconv.ParseFloat(metricValue, 64)
+	if err != nil {
+		plog.Info("Failed to parse metric value as float", err)
+		return nil, err
+	}
+	point := tsdb.NewTimePoint(null.FloatFrom(floatMetricValue), floatTimeValue)
+	return &point, nil
+}

--- a/pkg/tsdb/crate/crate_test.go
+++ b/pkg/tsdb/crate/crate_test.go
@@ -1,0 +1,78 @@
+package crate
+
+import (
+	"database/sql"
+	_ "encoding/json"
+	_ "io/ioutil"
+	_ "net/http"
+	_ "net/url"
+	_ "path"
+	_ "strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	_ "github.com/grafana/grafana/pkg/setting"
+	_ "github.com/herenow/go-crate"
+	_ "golang.org/x/net/context/ctxhttp"
+)
+
+func TestCrate(t *testing.T) {
+	runCrateTests := false
+
+	if !(runCrateTests) {
+		t.Skip()
+	}
+
+	Convey("CrateDB", t, func() {
+		db, err := sql.Open("crate", "http://test:test@localhost:4200")
+		So(err, ShouldBeNil)
+
+		Convey("Given a table with different data types", func() {
+			queryString := `
+				DROP TABLE IF EXISTS "test_types";
+			`
+			_, err := db.Query(queryString)
+			So(err, ShouldBeNil)
+			queryString = `
+				CREATE TABLE test_types(
+					"0_integer" integer,
+					"1_long" long,
+					"2_float" float,
+					"3_double" double,
+					"4_timestamp" timestamp
+				);
+			`
+			_, err = db.Query(queryString)
+			So(err, ShouldBeNil)
+			queryString = `
+				INSERT INTO test_types VALUES(
+					1,2,1.1,1.2,1536154645000
+				);
+			`
+			_, err = db.Query(queryString)
+			So(err, ShouldBeNil)
+			queryString = `
+				INSERT INTO test_types VALUES
+					(1,2,1.1,1.2,1536154645000);
+			`
+			_, err = db.Query(queryString)
+			So(err, ShouldBeNil)
+			Convey("Converts types", func() {
+				queryString := `
+					SELECT "4_timestamp","0_integer" FROM doc.test_types WHERE "4_timestamp">1536154644000 AND "4_timestamp"<1536154649000;
+				`
+				rows, err := db.Query(queryString)
+				So(err, ShouldBeNil)
+				for rows.Next() {
+					var timeValue string
+					var metricValue string
+					err := rows.Scan(&timeValue, &metricValue)
+					So(err, ShouldBeNil)
+					_, err = parseDbValues(timeValue, metricValue)
+					So(err, ShouldBeNil)
+				}
+			})
+		})
+	})
+}

--- a/vendor/github.com/herenow/go-crate/LICENSE
+++ b/vendor/github.com/herenow/go-crate/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/herenow/go-crate/README.md
+++ b/vendor/github.com/herenow/go-crate/README.md
@@ -1,0 +1,41 @@
+go-crate
+========
+
+[![CircleCI](https://circleci.com/gh/herenow/go-crate.svg?style=svg)](https://circleci.com/gh/herenow/go-crate)
+
+Golang Sql Driver for Crate Data Storage. (https://crate.io/)
+
+[http://godoc.org/github.com/herenow/go-crate](http://godoc.org/github.com/herenow/go-crate)
+
+[http://golang.org/pkg/database/sql/](http://golang.org/pkg/database/sql/)
+
+
+Install & Usage
+--------
+```
+go get github.com/herenow/go-crate
+```
+
+```golang
+import "database/sql"
+import _ "github.com/herenow/go-crate"
+
+db, err := sql.Open("crate", "http://localhost:4200/")
+```
+
+
+Not Supported SQL Functions
+------
+
+Some functions of the `database/sql` package may not be supported, due to a lack of support of Crate or this package.
+`Transactions` are not supported by crate.
+
+
+Notes
+-----
+* Feel free to send in contributions to this package.
+
+
+TODO
+-----
+* Possible type checking when receving data from crate, and convert it to documented Go types.

--- a/vendor/github.com/herenow/go-crate/blob/blob.go
+++ b/vendor/github.com/herenow/go-crate/blob/blob.go
@@ -1,0 +1,240 @@
+package blob
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	_ "github.com/herenow/go-crate"
+	"io"
+	"net/http"
+	"time"
+)
+
+type Driver struct {
+	url string
+	db  *sql.DB
+}
+
+type Table struct {
+	Name string
+	drv  *Driver
+	c    *http.Client
+}
+
+// DownloadError represents an error that occurs when downloading a blob.
+type DownloadError struct {
+	Status string
+	StatusCode int
+	Message string
+}
+
+// Error returns a string representation of the DownloadError.
+func (e DownloadError) Error() string {
+	return e.Message
+}
+
+// New creates a new connection with crate server
+func New(crate_url string) (*Driver, error) {
+	db, err := sql.Open("crate", crate_url)
+	if err != nil {
+		return nil, err
+	}
+	return &Driver{
+		url: crate_url,
+		db:  db,
+	}, nil
+}
+
+// NewTable create new blob table with name and extra int to specify
+// shards(the second argument) and
+// replicas(by the third int argument)
+func (d *Driver) NewTable(name string, shards ...int) (*Table, error) {
+	sql := fmt.Sprintf(
+		"create blob table %s",
+		name,
+	)
+	if len(shards) == 1 {
+		sql = fmt.Sprintf(
+			"create blob table %s clustered into %d shards",
+			name, shards[0],
+		)
+	}
+	if len(shards) >= 2 {
+		sql = fmt.Sprintf(
+			"create blob table %s clustered into %d shards with (number_of_replicas=%d)",
+			name, shards[0], shards[1],
+		)
+	}
+	_, err := d.db.Exec(sql)
+	if err != nil {
+		return nil, err
+	}
+	return &Table{
+		Name: name,
+		drv:  d,
+		c:    new(http.Client),
+	}, nil
+}
+
+// Get an existing table from the crate server
+// or error when this table does not exist
+func (d *Driver) GetTable(name string) (*Table, error) {
+	row := d.db.QueryRow(
+		"select table_name from information_schema.tables where table_name = ? and table_schema = 'blob'",
+		name,
+	)
+	if err := row.Scan(&name); err != nil {
+		return nil, err
+	}
+	return &Table{
+		Name: name,
+		drv:  d,
+		c:    new(http.Client),
+	}, nil
+}
+
+// Close the database connection
+func (d *Driver) Close() error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
+type Record struct {
+	Digest       string
+	LastModified time.Time
+}
+
+// Sha1Digest calculates the sha1 digest for the io.Reader
+func Sha1Digest(r io.Reader) string {
+	h := sha1.New()
+	io.Copy(h, r)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (t *Table) url(digest string) string {
+	return fmt.Sprintf("%s/_blobs/%s/%s", t.drv.url, t.Name, digest)
+}
+
+// Upload upload the blob(r) with sha1 hash(digest)
+func (t *Table) Upload(digest string, r io.Reader) (*Record, error) {
+	req, err := t.newRequest("PUT", digest, r)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 201 {
+		return nil, fmt.Errorf("Upload failed: %s", resp.Status)
+	}
+	return &Record{
+		Digest: digest,
+	}, nil
+}
+
+// UploadEx upload a io.ReadSeeker, and computes the sha1 hash automatically
+func (t *Table) UploadEx(r io.ReadSeeker) (*Record, error) {
+	digest := Sha1Digest(r)
+	_, err := r.Seek(0, 0)
+	if err != nil {
+		return nil, err
+	}
+	req, err := t.newRequest("PUT", digest, r)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 201 {
+		return nil, fmt.Errorf("Upload failed: %s", resp.Status)
+	}
+	return &Record{
+		Digest: digest,
+	}, nil
+}
+
+// List all blobs inside a blob table
+func (t *Table) List() (*sql.Rows, error) {
+	query := fmt.Sprintf("select digest, last_modified from blob.%s", t.Name)
+	rows, err := t.drv.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	return rows, err
+}
+
+// Is the blob specified by the digest exist in the table
+func (t *Table) Has(digest string) (bool, error) {
+	req, err := t.newRequest("HEAD", digest, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := t.c.Do(req)
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Download a blob in a blob table with the specific digest
+func (t *Table) Download(digest string) (io.ReadCloser, error) {
+	req, err := t.newRequest("GET", digest, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return resp.Body, &DownloadError{resp.Status, resp.StatusCode, "problem downloading blob"}
+	}
+	return resp.Body, nil
+}
+
+// Delete a blob in a blob table with the specific digest
+func (t *Table) Delete(digest string) error {
+	req, err := t.newRequest("DELETE", digest, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := t.c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return fmt.Errorf("%s", resp.Status)
+}
+
+// Drop the blob table
+func (t *Table) Drop() error {
+	sql := fmt.Sprintf("drop blob table \"%s\"", t.Name)
+	_, err := t.drv.db.Exec(sql)
+	return err
+}
+
+func (t *Table) newRequest(method, digest string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, t.url(digest), body)
+	if err != nil {
+		return nil ,err
+	}
+	// in some cases where trying to upload or download a blob resulted in non 2xx response,
+	// it seems Crate was not closing the connection (ticket to be opened soon against Crate)
+	// which resulted in strange behavior when requests were made after getting an error.
+	//
+	// For example, if downloading a blob result in a 404, attempting to download another
+	// blob would also result ina  404 even if that second blob absolutely was there.
+	req.Header.Set("Connection", "close")
+	return req, nil
+}

--- a/vendor/github.com/herenow/go-crate/crate.go
+++ b/vendor/github.com/herenow/go-crate/crate.go
@@ -1,0 +1,278 @@
+package crate
+
+import (
+	"bytes"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// Crate conn structure
+type CrateDriver struct {
+	Url        string // Crate http endpoint url
+	username   string
+	password   string
+	httpClient *http.Client
+}
+
+// Init a new "Connection" to a Crate Data Storage instance.
+// Note that the connection is not tested until the first query.
+func (c *CrateDriver) Open(crate_url string) (driver.Conn, error) {
+	u, err := url.Parse(crate_url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	sanUrl := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+
+	c.Url = sanUrl
+	c.httpClient = &http.Client{}
+
+	if u.User != nil {
+		username := u.User.Username()
+		password, _ := u.User.Password()
+
+		c.username = username
+		c.password = password
+	}
+
+	return c, nil
+}
+
+// JSON endpoint response struct
+// We expect error to be null or ommited
+type endpointResponse struct {
+	Error struct {
+		Message string
+		Code    int
+	} `json:"error"`
+	Cols        []string        `json:"cols"`
+	Duration    float64         `json:"duration"`
+	ColumnTypes []interface{}   `json:"col_types"`
+	Rowcount    int64           `json:"rowcount"`
+	Rows        [][]interface{} `json:"rows"`
+}
+
+// JSON endpoint request struct
+type endpointQuery struct {
+	Stmt string         `json:"stmt"`
+	Args []driver.Value `json:"args,omitempty"`
+}
+
+// Query the database using prepared statements.
+// Read: https://crate.io/docs/stable/sql/rest.html for more information about the returned response.
+// Example: crate.Query("SELECT * FROM sys.cluster LIMIT ?", 10)
+// "Parameter Substitution" is also supported, read, https://crate.io/docs/stable/sql/rest.html#parameter-substitution
+// This is the internal query function
+func (c *CrateDriver) query(stmt string, args []driver.Value) (*endpointResponse, error) {
+	endpoint := c.Url + "/_sql?types"
+
+	query := &endpointQuery{
+		Stmt: stmt,
+	}
+
+	if len(args) > 0 {
+		query.Args = args
+	}
+
+	buf, err := json.Marshal(query)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data := bytes.NewReader(buf)
+
+	req, err := http.NewRequest("POST", endpoint, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		// Parse response
+		res := &endpointResponse{}
+		d := json.NewDecoder(resp.Body)
+
+		// We need to set this, or long integers will be interpreted as floats
+		d.UseNumber()
+
+		err = d.Decode(res)
+
+		if err != nil {
+			return nil, err
+		}
+
+		// Check for db errors
+		if res.Error.Code != 0 {
+			err = &CrateErr{
+				Code:    res.Error.Code,
+				Message: res.Error.Message,
+			}
+			return nil, err
+		}
+
+		return res, nil
+	} else {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		msg := fmt.Sprintf("Invalid http status code %d, body: %s", resp.StatusCode, string(body))
+
+		return nil, errors.New(msg)
+	}
+}
+
+// Queries the database
+func (c *CrateDriver) Query(stmt string, args []driver.Value) (driver.Rows, error) {
+	res, err := c.query(stmt, args)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Rows reader
+	rows := &Rows{
+		columns:  res.Cols,
+		values:   res.Rows,
+		rowcount: res.Rowcount,
+	}
+
+	return rows, nil
+}
+
+// Exec queries on the dataabase
+func (c *CrateDriver) Exec(stmt string, args []driver.Value) (result driver.Result, err error) {
+	res, err := c.query(stmt, args)
+
+	if err != nil {
+		return nil, err
+	}
+
+	result = &Result{res.Rowcount}
+
+	return result, nil
+}
+
+// Result interface
+type Result struct {
+	affectedRows int64
+}
+
+// Last inserted id
+func (r *Result) LastInsertId() (int64, error) {
+	err := errors.New("LastInsertId() not supported.")
+	return 0, err
+}
+
+// # of affected rows on exec
+func (r *Result) RowsAffected() (int64, error) {
+	return r.affectedRows, nil
+}
+
+// Rows reader
+type Rows struct {
+	columns  []string
+	values   [][]interface{}
+	rowcount int64
+	pos      int64 // index position on the values array
+}
+
+// Row columns
+func (r *Rows) Columns() []string {
+	return r.columns
+}
+
+// Get the next row
+func (r *Rows) Next(dest []driver.Value) error {
+	if r.pos >= r.rowcount {
+		return io.EOF
+	}
+
+	for i := range dest {
+		dest[i] = r.values[r.pos][i]
+	}
+
+	r.pos++
+
+	return nil
+}
+
+// Close
+func (r *Rows) Close() error {
+	r.pos = r.rowcount // Set to end of list
+	return nil
+}
+
+// Yet not supported
+func (c *CrateDriver) Begin() (driver.Tx, error) {
+	err := errors.New("Transactions are not supported by this driver.")
+	return nil, err
+}
+
+// Nothing to close, crate is stateless
+func (c *CrateDriver) Close() error {
+	return nil
+}
+
+// Prepared stmt interface
+type CrateStmt struct {
+	stmt   string // Query stmt
+	driver *CrateDriver
+}
+
+// Driver method that initiates the prepared stmt interface
+func (c *CrateDriver) Prepare(query string) (driver.Stmt, error) {
+	stmt := &CrateStmt{
+		stmt:   query,
+		driver: c,
+	}
+
+	return stmt, nil
+}
+
+// Just pass it to the driver's' default Query() function
+func (s *CrateStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return s.driver.Query(s.stmt, args)
+}
+
+// Just pass it to the driver's default Exec() function
+func (s *CrateStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return s.driver.Exec(s.stmt, args)
+}
+
+// No need to implement close
+func (s *CrateStmt) Close() error {
+	return nil
+}
+
+// The NumInput method is not supported, return -1 so the database/sql packages knows.
+func (s *CrateStmt) NumInput() int {
+	return -1
+}
+
+// Register the driver
+func init() {
+	sql.Register("crate", &CrateDriver{})
+}

--- a/vendor/github.com/herenow/go-crate/errors.go
+++ b/vendor/github.com/herenow/go-crate/errors.go
@@ -1,0 +1,13 @@
+package crate
+
+// Specific Crate errors returned by the endpoint.
+// Use this to type check for database errors.
+type CrateErr struct {
+	Code    int
+	Message string
+}
+
+// Return error message, this is part of the error interface.
+func (e *CrateErr) Error() string {
+	return e.Message
+}

--- a/vendor/github.com/herenow/go-crate/types.go
+++ b/vendor/github.com/herenow/go-crate/types.go
@@ -1,0 +1,22 @@
+package crate
+
+// Crate column types id.
+// As listed in the documentation, see: https://crate.io/docs/stable/sql/rest.html#column-types
+const (
+	typeNull         = 0
+	typeNotSupported = 1
+	typeByte         = 2
+	typeBoolean      = 3
+	typeString       = 4
+	typeIp           = 5
+	typeDouble       = 6
+	typeFloat        = 7
+	typeShort        = 8
+	typeInteger      = 9
+	typeLong         = 10
+	typeTimestamp    = 11
+	typeObject       = 12
+	typeGeoPoint     = 13
+	typeArray        = 100
+	typeSet          = 101
+)


### PR DESCRIPTION
As mentioned in an issue a while back ( #9207 )

A basic implementation of an executor to enable Alerts with the [CrateDB Datasource Plugin](https://grafana.com/plugins/crate-datasource).

This is being worked on as part of an effort to deploy Grafana as part of [Orchestra Cities](https://www.orchestracities.com/): a Smart Cities Platform currently in development.