### PR TITLE
Fix query builder queries for interval start

### DIFF
--- a/public/app/plugins/datasource/postgres/postgres_query.ts
+++ b/public/app/plugins/datasource/postgres/postgres_query.ts
@@ -187,7 +187,8 @@ export default class PostgresQuery {
             case 'increase':
               curr = query;
               prev = 'lag(' + curr + ') OVER (' + over + ')';
-              query = '(CASE WHEN ' + curr + ' >= ' + prev + ' THEN ' + curr + ' - ' + prev + ' ELSE ' + curr + ' END)';
+              query = '(CASE WHEN ' + curr + ' >= ' + prev + ' THEN ' + curr + ' - ' + prev;
+              query += ' WHEN ' + prev + ' IS NULL THEN NULL ELSE ' + curr + ' END)';
               break;
             case 'rate':
               let timeColumn = this.target.timeColumn;
@@ -197,7 +198,8 @@ export default class PostgresQuery {
 
               curr = query;
               prev = 'lag(' + curr + ') OVER (' + over + ')';
-              query = '(CASE WHEN ' + curr + ' >= ' + prev + ' THEN ' + curr + ' - ' + prev + ' ELSE ' + curr + ' END)';
+              query = '(CASE WHEN ' + curr + ' >= ' + prev + ' THEN ' + curr + ' - ' + prev;
+              query += ' WHEN ' + prev + ' IS NULL THEN NULL ELSE ' + curr + ' END)';
               query += '/extract(epoch from ' + timeColumn + ' - lag(' + timeColumn + ') OVER (' + over + '))';
               break;
             default:
@@ -279,6 +281,9 @@ export default class PostgresQuery {
     query += this.buildGroupClause();
 
     query += '\nORDER BY 1';
+    if (this.hasMetricColumn()) {
+      query += ',2';
+    }
 
     return query;
   }

--- a/public/app/plugins/datasource/postgres/specs/postgres_query.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/postgres_query.test.ts
@@ -72,7 +72,9 @@ describe('PostgresQuery', () => {
       { type: 'window', params: ['increase'] },
     ];
     expect(query.buildValueColumn(column)).toBe(
-      '(CASE WHEN v >= lag(v) OVER (ORDER BY time) THEN v - lag(v) OVER (ORDER BY time) ELSE v END) AS "a"'
+      '(CASE WHEN v >= lag(v) OVER (ORDER BY time) ' +
+        'THEN v - lag(v) OVER (ORDER BY time) ' +
+        'WHEN lag(v) OVER (ORDER BY time) IS NULL THEN NULL ELSE v END) AS "a"'
     );
   });
 
@@ -96,7 +98,9 @@ describe('PostgresQuery', () => {
       { type: 'window', params: ['increase'] },
     ];
     expect(query.buildValueColumn(column)).toBe(
-      '(CASE WHEN v >= lag(v) OVER (PARTITION BY host ORDER BY time) THEN v - lag(v) OVER (PARTITION BY host ORDER BY time) ELSE v END) AS "a"'
+      '(CASE WHEN v >= lag(v) OVER (PARTITION BY host ORDER BY time) ' +
+        'THEN v - lag(v) OVER (PARTITION BY host ORDER BY time) ' +
+        'WHEN lag(v) OVER (PARTITION BY host ORDER BY time) IS NULL THEN NULL ELSE v END) AS "a"'
     );
     column = [
       { type: 'column', params: ['v'] },
@@ -106,7 +110,8 @@ describe('PostgresQuery', () => {
     ];
     expect(query.buildValueColumn(column)).toBe(
       '(CASE WHEN max(v) >= lag(max(v)) OVER (PARTITION BY host ORDER BY time) ' +
-        'THEN max(v) - lag(max(v)) OVER (PARTITION BY host ORDER BY time) ELSE max(v) END) AS "a"'
+        'THEN max(v) - lag(max(v)) OVER (PARTITION BY host ORDER BY time) ' +
+        'WHEN lag(max(v)) OVER (PARTITION BY host ORDER BY time) IS NULL THEN NULL ELSE max(v) END) AS "a"'
     );
   });
 
@@ -149,7 +154,7 @@ describe('PostgresQuery', () => {
     expect(query.buildQuery()).toBe(result);
 
     query.target.metricColumn = 'm';
-    result = 'SELECT\n  t AS "time",\n  m AS metric,\n  value\nFROM table\nORDER BY 1';
+    result = 'SELECT\n  t AS "time",\n  m AS metric,\n  value\nFROM table\nORDER BY 1,2';
     expect(query.buildQuery()).toBe(result);
   });
 });


### PR DESCRIPTION
This changes the rate and increase queries to not calculate
a value when there is no previous value. This also adds an
order by metric column to prevent inconsistent series ordering
in the legend.

Fixes #13198
Fixes #13199 