### PR TITLE
Theme parameter is not working while refer theme set to 'light'

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -91,6 +91,9 @@ func setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, error) {
 	if themeURLParam == "light" {
 		data.User.LightTheme = true
 		data.Theme = "light"
+	} else if themeURLParam == "dark" {
+		data.User.LightTheme = false
+		data.Theme = "dark"
 	}
 
 	if hasEditPermissionInFoldersQuery.Result {


### PR DESCRIPTION
While prefer theme set to 'dark',theme will change as theme parameter change.But if prefer theme set to 'light',no matter which value is passed to theme parameter,dashboard always show in light theme.


What Grafana version are you using?
Grafana v5.2.3
What datasource are you using?
InfluxDB
What OS are you running grafana on?
Centos7.3
What did you do?
Set prefer UI Theme to 'light' in Preferences,access grafana dashboard by URL of 
"http://grafana_server/d/lIX4oHTik/testdashboard?orgId=1&theme=dark".
What was the expected result?
I expected to get a dashboard in the dark theme
What happened instead?
I got a dashboard in the light theme.