### PR TITLE
fix: url update loop fix

### DIFF
--- a/public/app/core/specs/url.test.ts
+++ b/public/app/core/specs/url.test.ts
@@ -1,0 +1,16 @@
+import { toUrlParams } from '../utils/url';
+
+describe('toUrlParams', () => {
+  it('should encode object properties as url parameters', () => {
+    const url = toUrlParams({
+      server: 'backend-01',
+      hasSpace: 'has space',
+      many: ['1', '2', '3'],
+      true: true,
+      number: 20,
+      isNull: null,
+      isUndefined: undefined,
+    });
+    expect(url).toBe('server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=');
+  });
+});

--- a/public/app/core/utils/url.ts
+++ b/public/app/core/utils/url.ts
@@ -50,7 +50,5 @@ export function toUrlParams(a) {
     return s;
   };
 
-  return buildParams('', a)
-    .join('&')
-    .replace(/%20/g, '+');
+  return buildParams('', a).join('&');
 }


### PR DESCRIPTION
fixes #13241 

The way urls was encoded in stores (mobx/redux) was different from angulars encoding when it came to space. Not sure why toUrlParams replaced + with %20 , removed this replace to align it with angular url encoding (and with encodeURIComponent) 