### PR TITLE
Fix anonymous usage stats for authentication types

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -350,7 +350,7 @@ func getEdition() string {
 	}
 }
 
-func sendUsageStats() {
+func sendUsageStats(oauthProviders map[string]bool) {
 	if !setting.ReportingEnabled {
 		return
 	}
@@ -448,6 +448,24 @@ func sendUsageStats() {
 
 	for _, stats := range anStats.Result {
 		metrics["stats.alert_notifiers."+stats.Type+".count"] = stats.Count
+	}
+
+	authTypes := map[string]bool{}
+	authTypes["anonymous"] = setting.AnonymousEnabled
+	authTypes["basic_auth"] = setting.BasicAuthEnabled
+	authTypes["ldap"] = setting.LdapEnabled
+	authTypes["auth_proxy"] = setting.AuthProxyEnabled
+
+	for provider, enabled := range oauthProviders {
+		authTypes["oauth_"+provider] = enabled
+	}
+
+	for authType, enabled := range authTypes {
+		enabledValue := 0
+		if enabled {
+			enabledValue = 1
+		}
+		metrics["stats.auth_enabled."+authType+".count"] = enabledValue
 	}
 
 	out, _ := json.MarshalIndent(report, "", " ")

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -31,6 +31,7 @@ type InternalMetricsService struct {
 	enabled         bool
 	intervalSeconds int64
 	graphiteCfg     *graphitebridge.Config
+	oauthProviders  map[string]bool
 }
 
 func (im *InternalMetricsService) Init() error {
@@ -61,7 +62,7 @@ func (im *InternalMetricsService) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-onceEveryDayTick.C:
-			sendUsageStats()
+			sendUsageStats(im.oauthProviders)
 		case <-everyMinuteTicker.C:
 			updateTotalStats()
 		case <-ctx.Done():

--- a/pkg/metrics/settings.go
+++ b/pkg/metrics/settings.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana/pkg/social"
+
 	"github.com/grafana/grafana/pkg/metrics/graphitebridge"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,6 +28,8 @@ func (im *InternalMetricsService) readSettings() error {
 	if err := im.parseGraphiteSettings(); err != nil {
 		return fmt.Errorf("Unable to parse metrics graphite section, %v", err)
 	}
+
+	im.oauthProviders = social.GetOAuthProviders(im.Cfg)
 
 	return nil
 }

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -49,13 +49,12 @@ func (e *Error) Error() string {
 var (
 	SocialBaseUrl = "/login/"
 	SocialMap     = make(map[string]SocialConnector)
+	allOauthes    = []string{"github", "gitlab", "google", "generic_oauth", "grafananet", "grafana_com"}
 )
 
 func NewOAuthService() {
 	setting.OAuthService = &setting.OAuther{}
 	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
-
-	allOauthes := []string{"github", "gitlab", "google", "generic_oauth", "grafananet", "grafana_com"}
 
 	for _, name := range allOauthes {
 		sec := setting.Raw.Section("auth." + name)
@@ -183,4 +182,27 @@ func NewOAuthService() {
 			}
 		}
 	}
+}
+
+// GetOAuthProviders returns available oauth providers and if they're enabled or not
+var GetOAuthProviders = func(cfg *setting.Cfg) map[string]bool {
+	result := map[string]bool{}
+
+	if cfg == nil || cfg.Raw == nil {
+		return result
+	}
+
+	for _, name := range allOauthes {
+		if name == "grafananet" {
+			name = "grafana_com"
+		}
+
+		sec := cfg.Raw.Section("auth." + name)
+		if sec == nil {
+			continue
+		}
+		result[name] = sec.Key("enabled").MustBool()
+	}
+
+	return result
 }


### PR DESCRIPTION
Fixes #13240 

Unsure how to send these metrics. My suggestion is to send them as boolean properties. 

For counting auth usage you'll filter in Elasticsearch on certain auth type and do a document count. No idea if we need to do anything specific to with ES index mapping? What happens with Graphite stats?

Feedback appreciated