### PR TITLE
[metrics]enabled = false should disable the /metrics endpoint.

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -233,6 +233,10 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 }
 
 func (hs *HTTPServer) metricsEndpoint(ctx *macaron.Context) {
+	if !hs.Cfg.MetricsEndpointEnabled {
+		return
+	}
+
 	if ctx.Req.Method != "GET" || ctx.Req.URL.Path != "/metrics" {
 		return
 	}

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -28,7 +28,6 @@ func init() {
 type InternalMetricsService struct {
 	Cfg *setting.Cfg `inject:""`
 
-	enabled         bool
 	intervalSeconds int64
 	graphiteCfg     *graphitebridge.Config
 }

--- a/pkg/metrics/settings.go
+++ b/pkg/metrics/settings.go
@@ -16,12 +16,7 @@ func (im *InternalMetricsService) readSettings() error {
 		return fmt.Errorf("Unable to find metrics config section %v", err)
 	}
 
-	im.enabled = section.Key("enabled").MustBool(false)
 	im.intervalSeconds = section.Key("interval_seconds").MustInt64(10)
-
-	if !im.enabled {
-		return nil
-	}
 
 	if err := im.parseGraphiteSettings(); err != nil {
 		return fmt.Errorf("Unable to parse metrics graphite section, %v", err)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -203,6 +203,8 @@ type Cfg struct {
 	DisableBruteForceLoginProtection bool
 
 	TempDataLifetime time.Duration
+
+	MetricsEndpointEnabled bool
 }
 
 type CommandLineArgs struct {
@@ -659,6 +661,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.ImagesDir = filepath.Join(DataPath, "png")
 	cfg.PhantomDir = filepath.Join(HomePath, "tools/phantomjs")
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
+	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)
 
 	analytics := iniFile.Section("analytics")
 	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)


### PR DESCRIPTION
We should still send metrics to graphite as long as [metrics.graphite] address is set. 

closes #10638

ping @DanCech 