### PR TITLE
Use datasource cache for backend tsdb/query endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -320,7 +320,7 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Get("/search/", Search)
 
 		// metrics
-		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), Wrap(QueryMetrics))
+		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), Wrap(hs.QueryMetrics))
 		apiRoute.Get("/tsdb/testdata/scenarios", Wrap(GetTestDataScenarios))
 		apiRoute.Get("/tsdb/testdata/gensql", reqGrafanaAdmin, Wrap(GenerateSQLTestData))
 		apiRoute.Get("/tsdb/testdata/random-walk", Wrap(GetTestDataRandomWalk))

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -13,19 +13,20 @@ import (
 
 const HeaderNameNoBackendCache = "X-Grafana-NoCache"
 
-func (hs *HTTPServer) getDatasourceByID(id int64, orgID int64, nocache bool) (*m.DataSource, error) {
+func (hs *HTTPServer) getDatasourceByID(id int64, c *m.ReqContext) (*m.DataSource, error) {
+	nocache := c.Req.Header.Get(HeaderNameNoBackendCache) == "true"
 	cacheKey := fmt.Sprintf("ds-%d", id)
 
 	if !nocache {
 		if cached, found := hs.cache.Get(cacheKey); found {
 			ds := cached.(*m.DataSource)
-			if ds.OrgId == orgID {
+			if ds.OrgId == c.OrgId {
 				return ds, nil
 			}
 		}
 	}
 
-	query := m.GetDataSourceByIdQuery{Id: id, OrgId: orgID}
+	query := m.GetDataSourceByIdQuery{Id: id, OrgId: c.OrgId}
 	if err := bus.Dispatch(&query); err != nil {
 		return nil, err
 	}
@@ -37,10 +38,7 @@ func (hs *HTTPServer) getDatasourceByID(id int64, orgID int64, nocache bool) (*m
 func (hs *HTTPServer) ProxyDataSourceRequest(c *m.ReqContext) {
 	c.TimeRequest(metrics.M_DataSource_ProxyReq_Timer)
 
-	nocache := c.Req.Header.Get(HeaderNameNoBackendCache) == "true"
-
-	ds, err := hs.getDatasourceByID(c.ParamsInt64(":id"), c.OrgId, nocache)
-
+	ds, err := hs.getDatasourceByID(c.ParamsInt64(":id"), c)
 	if err != nil {
 		c.JsonApiErr(500, "Unable to load datasource meta data", err)
 		return

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -13,7 +13,7 @@ import (
 
 const HeaderNameNoBackendCache = "X-Grafana-NoCache"
 
-func (hs *HTTPServer) getDatasourceByID(id int64, c *m.ReqContext) (*m.DataSource, error) {
+func (hs *HTTPServer) getDatasourceFromCache(id int64, c *m.ReqContext) (*m.DataSource, error) {
 	nocache := c.Req.Header.Get(HeaderNameNoBackendCache) == "true"
 	cacheKey := fmt.Sprintf("ds-%d", id)
 
@@ -38,7 +38,7 @@ func (hs *HTTPServer) getDatasourceByID(id int64, c *m.ReqContext) (*m.DataSourc
 func (hs *HTTPServer) ProxyDataSourceRequest(c *m.ReqContext) {
 	c.TimeRequest(metrics.M_DataSource_ProxyReq_Timer)
 
-	ds, err := hs.getDatasourceByID(c.ParamsInt64(":id"), c)
+	ds, err := hs.getDatasourceFromCache(c.ParamsInt64(":id"), c)
 	if err != nil {
 		c.JsonApiErr(500, "Unable to load datasource meta data", err)
 		return

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -13,21 +13,21 @@ import (
 )
 
 // POST /api/tsdb/query
-func QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) Response {
+func (hs *HTTPServer) QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) Response {
 	timeRange := tsdb.NewTimeRange(reqDto.From, reqDto.To)
 
 	if len(reqDto.Queries) == 0 {
 		return Error(400, "No queries found in query", nil)
 	}
 
-	dsID, err := reqDto.Queries[0].Get("datasourceId").Int64()
+	datasourceId, err := reqDto.Queries[0].Get("datasourceId").Int64()
 	if err != nil {
 		return Error(400, "Query missing datasourceId", nil)
 	}
 
-	dsQuery := m.GetDataSourceByIdQuery{Id: dsID, OrgId: c.OrgId}
-	if err := bus.Dispatch(&dsQuery); err != nil {
-		return Error(500, "failed to fetch data source", err)
+	ds, err := hs.getDatasourceByID(datasourceId, c)
+	if err != nil {
+		return Error(500, "Unable to load datasource meta data", err)
 	}
 
 	request := &tsdb.TsdbQuery{TimeRange: timeRange}
@@ -38,11 +38,11 @@ func QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) Response {
 			MaxDataPoints: query.Get("maxDataPoints").MustInt64(100),
 			IntervalMs:    query.Get("intervalMs").MustInt64(1000),
 			Model:         query,
-			DataSource:    dsQuery.Result,
+			DataSource:    ds,
 		})
 	}
 
-	resp, err := tsdb.HandleRequest(context.Background(), dsQuery.Result, request)
+	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request)
 	if err != nil {
 		return Error(500, "Metric request error", err)
 	}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -25,7 +25,7 @@ func (hs *HTTPServer) QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) R
 		return Error(400, "Query missing datasourceId", nil)
 	}
 
-	ds, err := hs.getDatasourceByID(datasourceId, c)
+	ds, err := hs.getDatasourceFromCache(datasourceId, c)
 	if err != nil {
 		return Error(500, "Unable to load datasource meta data", err)
 	}


### PR DESCRIPTION
 fixes #13257

Discovered that the ds proxy cache is not being used by the backend tsdb/query endpoint.

Did some very minor refactor to make the function that uses the case easier to reuse. 