### PR TITLE
use pluginName consistently when upgrading plugins

### DIFF
--- a/pkg/cmd/grafana-cli/commands/upgrade_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command.go
@@ -16,7 +16,7 @@ func upgradeCommand(c CommandLine) error {
 		return err
 	}
 
-	v, err2 := s.GetPlugin(localPlugin.Id, c.RepoDirectory())
+	v, err2 := s.GetPlugin(pluginName, c.RepoDirectory())
 
 	if err2 != nil {
 		return err2
@@ -24,9 +24,9 @@ func upgradeCommand(c CommandLine) error {
 
 	if ShouldUpgrade(localPlugin.Info.Version, v) {
 		s.RemoveInstalledPlugin(pluginsDir, pluginName)
-		return InstallPlugin(localPlugin.Id, "", c)
+		return InstallPlugin(pluginName, "", c)
 	}
 
-	logger.Infof("%s %s is up to date \n", color.GreenString("✔"), localPlugin.Id)
+	logger.Infof("%s %s is up to date \n", color.GreenString("✔"), pluginName)
 	return nil
 }

--- a/pkg/cmd/grafana-cli/services/services.go
+++ b/pkg/cmd/grafana-cli/services/services.go
@@ -63,7 +63,7 @@ func ListAllPlugins(repoUrl string) (m.PluginRepo, error) {
 	var data m.PluginRepo
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		logger.Info("Failed to unmarshal graphite response error:", err)
+		logger.Info("Failed to unmarshal plugin repo response error:", err)
 		return m.PluginRepo{}, err
 	}
 
@@ -140,7 +140,7 @@ func GetPlugin(pluginId, repoUrl string) (m.Plugin, error) {
 	var data m.Plugin
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		logger.Info("Failed to unmarshal graphite response error:", err)
+		logger.Info("Failed to unmarshal plugin repo response error:", err)
 		return m.Plugin{}, err
 	}
 


### PR DESCRIPTION
This PR fixes #13268 by using `pluginName` consistently during plugin upgrades.

It also fixes a couple of copy+paste errors in the grafana-cli error messages.
