### PR TITLE
Fix gauge display accuracy for "percent (0.0-1.0)"

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -544,7 +544,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       elem.append(plotCanvas);
 
       const plotSeries = {
-        data: [[0, data.valueRounded]],
+        data: [[0, data.value]],
       };
 
       $.plot(plotCanvas, [plotSeries], options);


### PR DESCRIPTION
The "Decimals" value was incorrectly applied to the metric value used to calculate the gauge display in addition to the text value (so a "Decimals" value of "1" turns "45.1%" into "50%" in the gauge display even though the label still correctly says "45.1%").

Before:

![gauge-before](https://user-images.githubusercontent.com/161631/45520027-5ed26d80-b76c-11e8-93d3-978a70c44376.png)

After:

![gauge-after](https://user-images.githubusercontent.com/161631/45520032-62fe8b00-b76c-11e8-816e-44688cf8727f.png)

If you're interested in testing, here's the very simple dashboard I created these screenshots with: https://gist.github.com/tianon/7f69213f7d16c794a0bbab679a6d72a4