### PR TITLE
Added underline to links in table

### DIFF
--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -86,6 +86,8 @@
         padding: 0.45em 0 0.45em 1.1em;
         height: 100%;
         display: inline-block;
+        text-decoration: underline;
+        text-underline-position: under;
       }
     }
 


### PR DESCRIPTION
Adding underline to the links is the clearest way show that they are links since we can't use color. 

<img width="672" alt="skarmavbild 2018-09-14 kl 08 35 23" src="https://user-images.githubusercontent.com/23470681/45533804-2d53b380-b7f9-11e8-99a3-95909961b03b.png">

Fixes #12946