### PR TITLE
Internal metrics: starts counters at zero

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -61,6 +61,23 @@ var (
 	M_Grafana_Version        *prometheus.GaugeVec
 )
 
+func newCounterVecStartingAtZero(opts prometheus.CounterOpts, labels []string, labelValues ...string) *prometheus.CounterVec {
+	counter := prometheus.NewCounterVec(opts, labels)
+
+	for _, label := range labelValues {
+		counter.WithLabelValues(label).Add(0)
+	}
+
+	return counter
+}
+
+func newCounterStartingAtZero(opts prometheus.CounterOpts, labelValues ...string) prometheus.Counter {
+	counter := prometheus.NewCounter(opts)
+	counter.Add(0)
+
+	return counter
+}
+
 func init() {
 	M_Instance_Start = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "instance_start_total",
@@ -68,32 +85,27 @@ func init() {
 		Namespace: exporterName,
 	})
 
-	M_Page_Status = prometheus.NewCounterVec(
+	httpStatusCodes := []string{"200", "404", "500", "unknown"}
+	M_Page_Status = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "page_response_status_total",
 			Help:      "page http response status",
 			Namespace: exporterName,
-		},
-		[]string{"code"},
-	)
+		}, []string{"code"}, httpStatusCodes...)
 
-	M_Api_Status = prometheus.NewCounterVec(
+	M_Api_Status = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "api_response_status_total",
 			Help:      "api http response status",
 			Namespace: exporterName,
-		},
-		[]string{"code"},
-	)
+		}, []string{"code"}, httpStatusCodes...)
 
-	M_Proxy_Status = prometheus.NewCounterVec(
+	M_Proxy_Status = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "proxy_response_status_total",
 			Help:      "proxy http response status",
 			Namespace: exporterName,
-		},
-		[]string{"code"},
-	)
+		}, []string{"code"}, httpStatusCodes...)
 
 	M_Http_Request_Total = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -111,19 +123,19 @@ func init() {
 		[]string{"handler", "statuscode", "method"},
 	)
 
-	M_Api_User_SignUpStarted = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_User_SignUpStarted = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_started_total",
 		Help:      "amount of users who started the signup flow",
 		Namespace: exporterName,
 	})
 
-	M_Api_User_SignUpCompleted = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_User_SignUpCompleted = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_completed_total",
 		Help:      "amount of users who completed the signup flow",
 		Namespace: exporterName,
 	})
 
-	M_Api_User_SignUpInvite = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_User_SignUpInvite = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_invite_total",
 		Help:      "amount of users who have been invited",
 		Namespace: exporterName,
@@ -147,49 +159,49 @@ func init() {
 		Namespace: exporterName,
 	})
 
-	M_Api_Admin_User_Create = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Admin_User_Create = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_admin_user_created_total",
 		Help:      "api admin user created counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Login_Post = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Login_Post = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_login_post_total",
 		Help:      "api login post counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Login_OAuth = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Login_OAuth = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_login_oauth_total",
 		Help:      "api login oauth counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Org_Create = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Org_Create = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_org_create_total",
 		Help:      "api org created counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_Create = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Dashboard_Snapshot_Create = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_create_total",
 		Help:      "dashboard snapshots created",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_External = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Dashboard_Snapshot_External = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_external_total",
 		Help:      "external dashboard snapshots created",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_Get = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Dashboard_Snapshot_Get = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_get_total",
 		Help:      "loaded dashboards",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Insert = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Api_Dashboard_Insert = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_models_dashboard_insert_total",
 		Help:      "dashboards inserted ",
 		Namespace: exporterName,
@@ -207,25 +219,25 @@ func init() {
 		Namespace: exporterName,
 	}, []string{"type"})
 
-	M_Aws_CloudWatch_GetMetricStatistics = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Aws_CloudWatch_GetMetricStatistics = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_get_metric_statistics_total",
 		Help:      "counter for getting metric statistics from aws",
 		Namespace: exporterName,
 	})
 
-	M_Aws_CloudWatch_ListMetrics = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Aws_CloudWatch_ListMetrics = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_list_metrics_total",
 		Help:      "counter for getting list of metrics from aws",
 		Namespace: exporterName,
 	})
 
-	M_Aws_CloudWatch_GetMetricData = prometheus.NewCounter(prometheus.CounterOpts{
+	M_Aws_CloudWatch_GetMetricData = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_get_metric_data_total",
 		Help:      "counter for getting metric data time series from aws",
 		Namespace: exporterName,
 	})
 
-	M_DB_DataSource_QueryById = prometheus.NewCounter(prometheus.CounterOpts{
+	M_DB_DataSource_QueryById = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "db_datasource_query_by_id_total",
 		Help:      "counter for getting datasource by id",
 		Namespace: exporterName,


### PR DESCRIPTION
Without starting the counter as zero Grafana will not send any metrics to graphite using the Prometheus to graphite adapter.

This PR start all regular counters with zero and three counterVec's (`page_response_status_total`, `api_response_status_total` and `proxy_response_status_total` since they are limited to only 200,404, 500 and undefined labels) at zero. 

We don't start `http_request_total` at zero since that would create too many dimensions right now. We could limit the dimensions by grouping all 2** in 2xx, all 3** into 3xx, 4** into 4xx etc.

Depending on what time series we monitoring, I hope this should solve our problem with missing data. 


