### PR TITLE
fix hipchat color code used for "no data" notifications

### DIFF
--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -125,7 +125,7 @@ func (this *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 	case models.AlertStateOK:
 		color = "green"
 	case models.AlertStateNoData:
-		color = "grey"
+		color = "gray"
 	case models.AlertStateAlerting:
 		color = "red"
 	}


### PR DESCRIPTION
Fixes #13283 