### PR TITLE
Fix setting test

### DIFF
--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -130,7 +130,7 @@ func TestLoadingSettings(t *testing.T) {
 				cfg := NewCfg()
 				cfg.Load(&CommandLineArgs{
 					HomePath: "../../",
-					Config:   filepath.Join(HomePath, "tests/config-files/override_windows.ini"),
+					Config:   filepath.Join(HomePath, "pkg/setting/testdata/override_windows.ini"),
 					Args:     []string{`cfg:paths.data=c:\tmp\data`},
 				})
 


### PR DESCRIPTION
One path was missed in [PR 13301](https://github.com/grafana/grafana/pull/13301) which makes the test fail on windows.