### PR TITLE
RFC: Variable from Client-Side Javascript

### DIFF
--- a/public/app/features/templating/all.ts
+++ b/public/app/features/templating/all.ts
@@ -9,6 +9,7 @@ import { DatasourceVariable } from './datasource_variable';
 import { CustomVariable } from './custom_variable';
 import { ConstantVariable } from './constant_variable';
 import { AdhocVariable } from './adhoc_variable';
+import { ScriptVariable } from './script_variable';
 
 coreModule.factory('templateSrv', () => {
   return templateSrv;
@@ -22,4 +23,5 @@ export {
   CustomVariable,
   ConstantVariable,
   AdhocVariable,
+  ScriptVariable,
 };

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -242,6 +242,15 @@
 			</div>
 		</div>
 
+		<div ng-if="current.type === 'script'" class="gf-form-group">
+			<h5 class="section-heading">Script</h5>
+			<h6>function(options){</h6>
+			<div class="gf-form">
+				<textarea class="gf-form-input" ng-model='current.query' rows=10 ng-blur="runQuery()" placeholder="your code here" onkeydown="if(event.keyCode===9){var v=this.value,s=this.selectionStart,e=this.selectionEnd;this.value=v.substring(0, s)+'\t'+v.substring(e);this.selectionStart=this.selectionEnd=s+1;return false;}"></textarea>
+			</div>
+			<h6>}</h6>
+		</div>
+
 		<div class="section gf-form-group" ng-show="variableTypes[current.type].supportsMulti">
 			<h5 class="section-heading">Selection Options</h5>
 			<div class="section">
@@ -302,4 +311,3 @@
 
 	</form>
 </div>
-

--- a/public/app/features/templating/script_variable.ts
+++ b/public/app/features/templating/script_variable.ts
@@ -1,0 +1,100 @@
+import _ from 'lodash';
+import { Variable, assignModelProperties, variableTypes } from './variable';
+import * as dateMath from 'app/core/utils/datemath';
+
+export class ScriptVariable implements Variable {
+  query: string;
+  options: any[];
+  current: any;
+  skipUrlSync: boolean;
+  refresh: number;
+  name: string;
+
+  defaults = {
+    type: 'script',
+    name: '',
+    hide: 2,
+    label: '',
+    query: 'with (options) {\n\treturn from;\n}',
+    current: {},
+    options: [],
+    skipUrlSync: false,
+    refresh: 2,
+  };
+
+  /** @ngInject */
+  constructor(private model, private variableSrv) {
+    assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
+
+  setValue(option) {
+    this.variableSrv.setOptionAsCurrent(this, option);
+  }
+
+  updateOptions() {
+    const options = {};
+
+    options['from'] = dateMath.parse(this.variableSrv.dashboard.time.from).unix();
+    options['to'] = dateMath.parse(this.variableSrv.dashboard.time.to).unix();
+    options['now'] = dateMath.parse('now').unix();
+    options['parsedate'] = text => dateMath.parse(text).unix();
+
+    for (const variable of this.variableSrv.variables) {
+      if (variable !== this) {
+        options[variable.name] = variable.current.value;
+      }
+    }
+
+    const func = new Function('options', this.query);
+
+    let value: any;
+    let text: any;
+    const result = func(options);
+
+    if (result instanceof Array) {
+      if (result.length === 2) {
+        value = result[0];
+        text = result[1];
+      } else {
+        value = text = 'not enough items in array';
+      }
+    } else {
+      value = text = result || 'undefined';
+    }
+
+    if (!(value instanceof String)) {
+      value = String(value);
+    }
+    if (!(text instanceof String)) {
+      text = String(text);
+    }
+
+    this.options = [{ text: text, value: value }];
+
+    this.setValue(this.options[0]);
+    return Promise.resolve();
+  }
+
+  dependsOn(variable) {
+    return this.query.includes(variable.name) && variable.name !== this.name;
+  }
+
+  setValueFromUrl(urlValue) {
+    return this.variableSrv.setOptionFromUrl(this, urlValue);
+  }
+
+  getValueForUrl() {
+    return this.current.value;
+  }
+}
+
+variableTypes['script'] = {
+  name: 'Script Variable',
+  ctor: ScriptVariable,
+  description: 'calculate value from other variables',
+};


### PR DESCRIPTION
Hi everyone,

first of all, I don't expect this to get merged in it's current state. There are probably some security concerns and no unit tests. This is more of an RFC for my attempt to solve a (IMO) big shortcoming of Grafana:

For InfluxDB datasources, it is impossible to set the retention policy automatically, depending on the time range. Instead you'd have to select the retention policy by hand which is inconvenient to say the least.

The discussion on this issue is here: #4262

My suggestion is a new variable type that gets its value from a short JavaScript snippet that runs in the browser window. For example it is possible to create a variable `$rp` with the script:

```
with (options) {
if (from < parsedate('now-14d'))
return 'historic';
return 'recent';
}
```

and use $rp as retention policy in every panel.

This snippet gets called with

```
const func = new Function('options', this.query);
const result = func(options);
```

where options is an object that contains the dashboard time range, other variables and `parsedate`, which converts date strings to unix timestamps.
I think this would be a good solution as it has pretty much unlimited flexibility and can be used for much more besides my use case.

There are still some issues to be fixed:

* Security: I don't know much about JS and hacked this together in ~6h, so I can't really answer that. Generally I think it would be ok as only Editors can modify the function body.
* `dependsOn(variable)` only searches the function body for the variable name and could introduce dependency cycles.
* Using another variable (not `to` and `from`) yields `TypeError: Cannot read property 'inputEdges' of undefined`, still works as far as I can tell.
* there are probably some unused variables in `ScriptVariable` as I just copied the code from another type.

Also some things that I didn't implement:

* Update the value when a variable, which the scripted one depends on, changes.
* Add more variables to `options`.
* Possibly add a global option to disable this feature entirely, could default to off to keep the default install secure.
* Option to restrict editing these variables to Admins only (probably hard due to dashboard json model)
* (in the far future) adding a building block editor like for queries

I'm looking forward to your feedback.

Cheers
Martin

