### PR TITLE
Fix json_data field name in provisioning doc

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -124,7 +124,7 @@ datasources:
   # <bool> mark as default datasource. Max one per org
   isDefault:
   # <map> fields that will be converted to json and stored in json_data
-  jsonData:
+  json_data:
      graphiteVersion: "1.1"
      tlsAuth: true
      tlsAuthWithCACert: true


### PR DESCRIPTION
Fixes the example `datasource.yaml` in the provisioning documentation. The `json_data` field was incorrectly spelt `jsonData`.
