### PR TITLE
Explore: Fix label suggestions for recording rules

### DIFF
--- a/public/app/containers/Explore/utils/prometheus.test.ts
+++ b/public/app/containers/Explore/utils/prometheus.test.ts
@@ -57,5 +57,8 @@ describe('parseSelector()', () => {
 
     parsed = parseSelector('baz{foo="bar"}', 12);
     expect(parsed.selector).toBe('{__name__="baz",foo="bar"}');
+
+    parsed = parseSelector('bar:metric:1m{}', 14);
+    expect(parsed.selector).toBe('{__name__="bar:metric:1m"}');
   });
 });

--- a/public/app/containers/Explore/utils/prometheus.ts
+++ b/public/app/containers/Explore/utils/prometheus.ts
@@ -32,7 +32,7 @@ const labelRegexp = /\b\w+="[^"\n]*?"/g;
 export function parseSelector(query: string, cursorOffset = 1): { labelKeys: any[]; selector: string } {
   if (!query.match(selectorRegexp)) {
     // Special matcher for metrics
-    if (query.match(/^\w+$/)) {
+    if (query.match(/^[A-Za-z:][\w:]*$/)) {
       return {
         selector: `{__name__="${query}"}`,
         labelKeys: ['__name__'],
@@ -76,7 +76,7 @@ export function parseSelector(query: string, cursorOffset = 1): { labelKeys: any
 
   // Add metric if there is one before the selector
   const metricPrefix = query.slice(0, prefixOpen);
-  const metricMatch = metricPrefix.match(/\w+$/);
+  const metricMatch = metricPrefix.match(/[A-Za-z:][\w:]*$/);
   if (metricMatch) {
     labels['__name__'] = `"${metricMatch[0]}"`;
   }


### PR DESCRIPTION
- parsing of recording rules failed for label suggestor
- added ':' to parsing routine

Fixes #13336 