### PR TITLE
Support full height screenshots using phantomjs render script

### DIFF
--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -69,13 +69,6 @@
             height: bb.height
           };
 
-          page.clipRect = {
-            top:    bb.top,
-            left:   bb.left,
-            width:  bb.width,
-            height: bb.height
-          };
-
           page.render(params.png);
           phantom.exit();
         } else {

--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -50,7 +50,7 @@
 
       function checkIsReady() {
         var panelsRendered = page.evaluate(function() {
-          var panelCount = document.querySelectorAll('.panel').length;
+          var panelCount = document.querySelectorAll('plugin-component').length;
           return window.panelsRendered >= panelCount;
         });
 

--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -56,7 +56,11 @@
 
         if (panelsRendered || totalWaitMs > timeoutMs) {
           var bb = page.evaluate(function () {
-            return document.getElementsByClassName("dashboard-container")[0].getBoundingClientRect();
+            var container = document.getElementsByClassName("dashboard-container")
+            if (container.length == 0) {
+               container = document.getElementsByClassName("panel-container")
+            }
+            return container[0].getBoundingClientRect();
           });
           
           // reset viewport to render full page

--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -56,8 +56,14 @@
 
         if (panelsRendered || totalWaitMs > timeoutMs) {
           var bb = page.evaluate(function () {
-            return document.getElementsByClassName("main-view")[0].getBoundingClientRect();
+            return document.getElementsByClassName("dashboard-container")[0].getBoundingClientRect();
           });
+          
+          // reset viewport to render full page
+          page.viewportSize = {
+            width: bb.width,
+            height: bb.height
+          };
 
           page.clipRect = {
             top:    bb.top,


### PR DESCRIPTION
Previously, in grafana3 I used to set the `width` param in renderer to set up the resolution and  `height` value didn't matter as phantomjs computes the actual height of the document.

On grafana5, Phantomjs `render.js` renderer is tricked by `main-view` div 100% dynamic height.
 
Per phantomjs the viewport height should be ignored and overwritten with the actual height of the document. This happens when absolute height can be computed but in grafana5 the body height is set to 100% which makes phantomjs render only the set viewport rectangle:
![image](https://user-images.githubusercontent.com/728853/45867095-46c1a600-bd8b-11e8-96ff-28afeb6308b4.png)


Setting manually the `height=` param in `render` will increase the height of the screenshot but this is not what we want.

This patch workarounds this by:
1. relying on  `dashboard-container` (full dashboard screenshot) or `panel-container` (single panel screenshot) sizes as they have absolute values phantomjs can measure 
2. Resetting the viewport once the document is loaded to set it to the actual size of the container

![image](https://user-images.githubusercontent.com/728853/45867261-b768c280-bd8b-11e8-8fe7-05c23c6862d5.png)


