### PR TITLE
[Back button] Make back to dashboard but visible

### DIFF
--- a/public/app/features/dashboard/dashnav/dashnav.html
+++ b/public/app/features/dashboard/dashnav/dashnav.html
@@ -1,5 +1,11 @@
 <div class="navbar">
 
+	<div class="navbar-buttons navbar-buttons--close">
+		<button class="btn navbar-button navbar-button--primary" ng-click="ctrl.close()" bs-tooltip="'Back to dashboard'" data-placement="bottom">
+			<i class="fa fa-reply"></i>
+		</button>
+	</div>
+  
 	<div>
 		<a class="navbar-page-btn" ng-click="ctrl.showSearch()">
 			<i class="gicon gicon-dashboard"></i>
@@ -50,11 +56,6 @@
 
 	<gf-time-picker class="gf-timepicker-nav" dashboard="ctrl.dashboard" ng-if="!ctrl.dashboard.timepicker.hidden"></gf-time-picker>
 
-	<div class="navbar-buttons navbar-buttons--close">
-		<button class="btn navbar-button navbar-button--primary" ng-click="ctrl.close()" bs-tooltip="'Back to dashboard'" data-placement="bottom">
-			<i class="fa fa-reply"></i>
-		</button>
-	</div>
 
 </div>
 


### PR DESCRIPTION
The Back to dashboard button is not intuitive since most of the back buttons in other applications(chrome, spotify.. ) are on the top left

Links to issue https://github.com/grafana/grafana/issues/13371

![updated screenshot](https://user-images.githubusercontent.com/9117091/45840276-524d9800-bccb-11e8-92f1-aff99cf762b2.png)



