### PR TITLE
provisioning: changed update interval default 3 to 10 seconds

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -200,7 +200,7 @@ providers:
   folder: ''
   type: file
   disableDeletion: false
-  updateIntervalSeconds: 3 #how often Grafana will scan for changed dashboards
+  updateIntervalSeconds: 10 #how often Grafana will scan for changed dashboards
   options:
     path: /var/lib/grafana/dashboards
 ```

--- a/pkg/services/provisioning/dashboards/config_reader.go
+++ b/pkg/services/provisioning/dashboards/config_reader.go
@@ -83,7 +83,7 @@ func (cr *configReader) readConfig() ([]*DashboardsAsConfig, error) {
 		}
 
 		if dashboards[i].UpdateIntervalSeconds == 0 {
-			dashboards[i].UpdateIntervalSeconds = 3
+			dashboards[i].UpdateIntervalSeconds = 10
 		}
 	}
 

--- a/pkg/services/provisioning/dashboards/config_reader_test.go
+++ b/pkg/services/provisioning/dashboards/config_reader_test.go
@@ -70,7 +70,7 @@ func validateDashboardAsConfig(t *testing.T, cfg []*DashboardsAsConfig) {
 	So(len(ds.Options), ShouldEqual, 1)
 	So(ds.Options["path"], ShouldEqual, "/var/lib/grafana/dashboards")
 	So(ds.DisableDeletion, ShouldBeTrue)
-	So(ds.UpdateIntervalSeconds, ShouldEqual, 10)
+	So(ds.UpdateIntervalSeconds, ShouldEqual, 15)
 
 	ds2 := cfg[1]
 	So(ds2.Name, ShouldEqual, "default")
@@ -81,5 +81,5 @@ func validateDashboardAsConfig(t *testing.T, cfg []*DashboardsAsConfig) {
 	So(len(ds2.Options), ShouldEqual, 1)
 	So(ds2.Options["path"], ShouldEqual, "/var/lib/grafana/dashboards")
 	So(ds2.DisableDeletion, ShouldBeFalse)
-	So(ds2.UpdateIntervalSeconds, ShouldEqual, 3)
+	So(ds2.UpdateIntervalSeconds, ShouldEqual, 10)
 }

--- a/pkg/services/provisioning/dashboards/testdata/test-configs/dashboards-from-disk/dev-dashboards.yaml
+++ b/pkg/services/provisioning/dashboards/testdata/test-configs/dashboards-from-disk/dev-dashboards.yaml
@@ -6,7 +6,7 @@ providers:
   folder: 'developers'
   editable: true
   disableDeletion: true
-  updateIntervalSeconds: 10
+  updateIntervalSeconds: 15
   type: file
   options:
     path: /var/lib/grafana/dashboards

--- a/pkg/services/provisioning/dashboards/testdata/test-configs/version-0/version-0.yaml
+++ b/pkg/services/provisioning/dashboards/testdata/test-configs/version-0/version-0.yaml
@@ -3,7 +3,7 @@
   folder: 'developers'
   editable: true
   disableDeletion: true
-  updateIntervalSeconds: 10
+  updateIntervalSeconds: 15
   type: file
   options:
     path: /var/lib/grafana/dashboards


### PR DESCRIPTION
Think this was a bit too low a value for a default esp when you have a couple of mapped folders each generating syncs every 3 seconds. 

