### PR TITLE
teampicker: increase limit from 10 to 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "company": "Grafana Labs"
   },
   "name": "grafana",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"

--- a/public/app/core/components/Picker/TeamPicker.tsx
+++ b/public/app/core/components/Picker/TeamPicker.tsx
@@ -39,7 +39,7 @@ class TeamPicker extends Component<IProps, any> {
     const { toggleLoading, backendSrv } = this.props;
 
     toggleLoading(true);
-    return backendSrv.get(`/api/teams/search?perpage=10&page=1&query=${query}`).then(result => {
+    return backendSrv.get(`/api/teams/search?perpage=100&page=1&query=${query}`).then(result => {
       const teams = result.teams.map(team => {
         return {
           id: team.id,


### PR DESCRIPTION
Increase team picker limit from 10 to 100 to workaround strange TeamPicker bug where you cannot pick teams that do not appear in the initial list