### PR TITLE
[WIP] Graph time format browser-localized with user preference override

### DIFF
--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -35,6 +35,7 @@ type CurrentUser struct {
 	IsGrafanaAdmin             bool         `json:"isGrafanaAdmin"`
 	GravatarUrl                string       `json:"gravatarUrl"`
 	Timezone                   string       `json:"timezone"`
+	MonthDayFormat             string       `json:"monthDayFormat"`
 	Locale                     string       `json:"locale"`
 	HelpFlags1                 m.HelpFlags1 `json:"helpFlags1"`
 	HasEditPermissionInFolders bool         `json:"hasEditPermissionInFolders"`

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -3,11 +3,13 @@ package dtos
 type Prefs struct {
 	Theme           string `json:"theme"`
 	HomeDashboardID int64  `json:"homeDashboardId"`
+	MonthDayFormat  string `json:"monthDayFormat"`
 	Timezone        string `json:"timezone"`
 }
 
 type UpdatePrefsCmd struct {
 	Theme           string `json:"theme"`
 	HomeDashboardID int64  `json:"homeDashboardId"`
+	MonthDayFormat  string `json:"monthDayFormat"`
 	Timezone        string `json:"timezone"`
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -68,6 +68,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 			IsGrafanaAdmin:             c.IsGrafanaAdmin,
 			LightTheme:                 prefs.Theme == lightName,
 			Timezone:                   prefs.Timezone,
+			MonthDayFormat:             prefs.MonthDayFormat,
 			Locale:                     locale,
 			HelpFlags1:                 c.HelpFlags1,
 			HasEditPermissionInFolders: hasEditPermissionInFoldersQuery.Result,

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -35,6 +35,7 @@ func getPreferencesFor(orgID int64, userID int64) Response {
 		Theme:           prefsQuery.Result.Theme,
 		HomeDashboardID: prefsQuery.Result.HomeDashboardId,
 		Timezone:        prefsQuery.Result.Timezone,
+		MonthDayFormat:  prefsQuery.Result.MonthDayFormat,
 	}
 
 	return JSON(200, &dto)
@@ -52,6 +53,7 @@ func updatePreferencesFor(orgID int64, userID int64, dtoCmd *dtos.UpdatePrefsCmd
 		Theme:           dtoCmd.Theme,
 		Timezone:        dtoCmd.Timezone,
 		HomeDashboardId: dtoCmd.HomeDashboardID,
+		MonthDayFormat:  dtoCmd.MonthDayFormat,
 	}
 
 	if err := bus.Dispatch(&saveCmd); err != nil {

--- a/pkg/models/preferences.go
+++ b/pkg/models/preferences.go
@@ -16,6 +16,7 @@ type Preferences struct {
 	UserId          int64
 	Version         int
 	HomeDashboardId int64
+	MonthDayFormat  string
 	Timezone        string
 	Theme           string
 	Created         time.Time
@@ -48,6 +49,7 @@ type SavePreferencesCommand struct {
 	OrgId  int64
 
 	HomeDashboardId int64  `json:"homeDashboardId"`
+	MonthDayFormat  string `json:"monthDayFormat"`
 	Timezone        string `json:"timezone"`
 	Theme           string `json:"theme"`
 }

--- a/pkg/services/sqlstore/migrations/preferences_mig.go
+++ b/pkg/services/sqlstore/migrations/preferences_mig.go
@@ -36,7 +36,7 @@ func addPreferencesMigrations(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Update preferences table add column", NewAddColumnMigration(preferencesV2, &Column{
-		Name: "month_day_format", Type: DB_NVarchar, Length: 50, Default: "",
+		Name: "month_day_format", Type: DB_NVarchar, Length: 50, Nullable: true,
 	}))
 
 }

--- a/pkg/services/sqlstore/migrations/preferences_mig.go
+++ b/pkg/services/sqlstore/migrations/preferences_mig.go
@@ -34,4 +34,9 @@ func addPreferencesMigrations(mg *Migrator) {
 		{Name: "timezone", Type: DB_NVarchar, Length: 50, Nullable: false},
 		{Name: "theme", Type: DB_NVarchar, Length: 20, Nullable: false},
 	}))
+
+	mg.AddMigration("Update preferences table add column", NewAddColumnMigration(preferencesV2, &Column{
+		Name: "month_day_format", Type: DB_NVarchar, Length: 50, Default: "",
+	}))
+
 }

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -30,6 +30,7 @@ func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error 
 	res := &m.Preferences{
 		Theme:           setting.DefaultTheme,
 		Timezone:        "browser",
+		MonthDayFormat:  "browser",
 		HomeDashboardId: 0,
 	}
 
@@ -42,6 +43,9 @@ func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error 
 		}
 		if p.HomeDashboardId != 0 {
 			res.HomeDashboardId = p.HomeDashboardId
+		}
+		if p.MonthDayFormat != "" {
+			res.MonthDayFormat = p.MonthDayFormat
 		}
 	}
 
@@ -81,6 +85,7 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 				UserId:          cmd.UserId,
 				OrgId:           cmd.OrgId,
 				HomeDashboardId: cmd.HomeDashboardId,
+				MonthDayFormat:  cmd.MonthDayFormat,
 				Timezone:        cmd.Timezone,
 				Theme:           cmd.Theme,
 				Created:         time.Now(),
@@ -90,6 +95,7 @@ func SavePreferences(cmd *m.SavePreferencesCommand) error {
 			return err
 		}
 		prefs.HomeDashboardId = cmd.HomeDashboardId
+		prefs.MonthDayFormat = cmd.MonthDayFormat
 		prefs.Timezone = cmd.Timezone
 		prefs.Theme = cmd.Theme
 		prefs.Updated = time.Now()

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -125,7 +125,7 @@ func TestUserDataAccess(t *testing.T) {
 				testHelperUpdateDashboardAcl(1, m.DashboardAcl{DashboardId: 1, OrgId: users[0].OrgId, UserId: users[1].Id, Permission: m.PERMISSION_EDIT})
 				So(err, ShouldBeNil)
 
-				err = SavePreferences(&m.SavePreferencesCommand{UserId: users[1].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, Theme: "dark"})
+				err = SavePreferences(&m.SavePreferencesCommand{UserId: users[1].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, MonthDayFormat: "browser", Theme: "dark"})
 				So(err, ShouldBeNil)
 
 				Convey("when the user is deleted", func() {

--- a/public/app/core/components/sidemenu/BottomNavLinks.test.tsx
+++ b/public/app/core/components/sidemenu/BottomNavLinks.test.tsx
@@ -14,6 +14,7 @@ const setup = (propOverrides?: object) => {
       user: {
         isGrafanaAdmin: false,
         isSignedIn: false,
+        monthDayFormat: '',
         orgCount: 2,
         orgRole: '',
         orgId: 1,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -19,7 +19,6 @@ export class User {
   constructor() {
     if (config.bootData.user) {
       _.extend(this, config.bootData.user);
-      this.monthDayFormat = 'browser'; // '%d/%m'; // '%d.%m';
     }
   }
 }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -14,10 +14,12 @@ export class User {
   helpFlags1: number;
   lightTheme: boolean;
   hasEditPermissionInFolders: boolean;
+  monthDayFormat: string;
 
   constructor() {
     if (config.bootData.user) {
       _.extend(this, config.bootData.user);
+      this.monthDayFormat = 'browser'; // '%d/%m'; // '%d.%m';
     }
   }
 }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -16,10 +16,8 @@ export class User {
   hasEditPermissionInFolders: boolean;
   monthDayFormat: string;
 
-  constructor() {
-    if (config.bootData.user) {
-      _.extend(this, config.bootData.user);
-    }
+  constructor(user?: any, overrides?: any) {
+    _.extend(this, user, overrides);
   }
 }
 
@@ -41,7 +39,17 @@ export class ContextSrv {
       config.bootData = { user: {}, settings: {} };
     }
 
-    this.user = new User();
+    // User overrides from URL params
+    const userUrlParams = ['monthDayFormat'];
+    const userOverrides = userUrlParams.reduce((acc, param) => {
+      const match = new RegExp(`${param}=([^&]*)`).exec(location.search);
+      if (match) {
+        acc[param] = decodeURIComponent(match[1]);
+      }
+      return acc;
+    }, {});
+
+    this.user = new User(config.bootData.user, userOverrides);
     this.isSignedIn = this.user.isSignedIn;
     this.isGrafanaAdmin = this.user.isGrafanaAdmin;
     this.isEditor = this.hasRole('Editor') || this.hasRole('Admin');

--- a/public/app/features/dashboard/shareModalCtrl.ts
+++ b/public/app/features/dashboard/shareModalCtrl.ts
@@ -1,6 +1,9 @@
 import angular from 'angular';
-import config from 'app/core/config';
 import moment from 'moment';
+
+// Context provides access to user preferences for data formatting
+import { contextSrv } from 'app/core/services/context_srv';
+import config from 'app/core/config';
 
 /** @ngInject */
 export function ShareModalCtrl($scope, $rootScope, $location, $timeout, timeSrv, templateSrv, linkSrv) {
@@ -48,6 +51,12 @@ export function ShareModalCtrl($scope, $rootScope, $location, $timeout, timeSrv,
     params.from = range.from.valueOf();
     params.to = range.to.valueOf();
     params.orgId = config.bootData.user.orgId;
+
+    // Graph date formatting
+    const { monthDayFormat } = contextSrv.user;
+    if (monthDayFormat && monthDayFormat !== 'browser') {
+      params.monthDayFormat = monthDayFormat;
+    }
 
     if ($scope.options.includeTemplateVars) {
       templateSrv.fillVariableValuesForUrl(params);

--- a/public/app/features/explore/Graph.tsx
+++ b/public/app/features/explore/Graph.tsx
@@ -7,36 +7,11 @@ import 'vendor/flot/jquery.flot';
 import 'vendor/flot/jquery.flot.time';
 import * as dateMath from 'app/core/utils/datemath';
 import TimeSeries from 'app/core/time_series2';
+import { grafanaTimeFormat } from 'app/core/utils/ticks';
 
 import Legend from './Legend';
 
 const MAX_NUMBER_OF_TIME_SERIES = 20;
-
-// Copied from graph.ts
-function time_format(ticks, min, max) {
-  if (min && max && ticks) {
-    const range = max - min;
-    const secPerTick = range / ticks / 1000;
-    const oneDay = 86400000;
-    const oneYear = 31536000000;
-
-    if (secPerTick <= 45) {
-      return '%H:%M:%S';
-    }
-    if (secPerTick <= 7200 || range <= oneDay) {
-      return '%H:%M';
-    }
-    if (secPerTick <= 80000) {
-      return '%m/%d %H:%M';
-    }
-    if (secPerTick <= 2419200 || range <= oneYear) {
-      return '%m/%d';
-    }
-    return '%Y-%m';
-  }
-
-  return '%H:%M';
-}
 
 const FLOT_OPTIONS = {
   legend: {
@@ -151,7 +126,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
         max: max,
         label: 'Datetime',
         ticks: ticks,
-        timeformat: time_format(ticks, min, max),
+        timeformat: grafanaTimeFormat(ticks, min, max),
       },
     };
     const options = {
@@ -182,7 +157,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
               {`Showing only ${MAX_NUMBER_OF_TIME_SERIES} time series. `}
               <span className="show-all-time-series" onClick={this.onShowAllTimeSeries}>{`Show all ${
                 this.props.data.length
-              }`}</span>
+                }`}</span>
             </div>
           )}
         <div className="panel-container">

--- a/public/app/features/org/prefs_control.ts
+++ b/public/app/features/org/prefs_control.ts
@@ -10,8 +10,16 @@ export class PrefsControlCtrl {
   monthDayFormats: any = [
     { value: '', text: 'Default' },
     { value: 'browser', text: 'Local browser formatting' },
-    { value: 'mm/dd', text: 'mm/dd' },
-    { value: 'dd/mm', text: 'dd/mm' },
+    // US
+    { value: '%m/%d', text: 'mm/dd' },
+    // UK
+    { value: '%d/%m', text: 'dd/mm' },
+    // Europe
+    { value: '%m-%d', text: 'mm-dd' },
+    // Asia
+    { value: '%d-%m', text: 'dd-mm' },
+    // DE
+    { value: '%d.%m.', text: 'dd.mm.' },
   ];
   timezones: any = [
     { value: '', text: 'Default' },

--- a/public/app/features/org/prefs_control.ts
+++ b/public/app/features/org/prefs_control.ts
@@ -7,6 +7,12 @@ export class PrefsControlCtrl {
   prefsForm: any;
   mode: string;
 
+  monthDayFormats: any = [
+    { value: '', text: 'Default' },
+    { value: 'browser', text: 'Local browser formatting' },
+    { value: 'mm/dd', text: 'mm/dd' },
+    { value: 'dd/mm', text: 'dd/mm' },
+  ];
   timezones: any = [
     { value: '', text: 'Default' },
     { value: 'browser', text: 'Local browser time' },
@@ -32,6 +38,7 @@ export class PrefsControlCtrl {
     const cmd = {
       theme: this.prefs.theme,
       timezone: this.prefs.timezone,
+      monthDayFormat: this.prefs.monthDayFormat,
       homeDashboardId: this.prefs.homeDashboardId,
     };
 
@@ -67,6 +74,13 @@ const template = `
     <label class="gf-form-label width-11">Timezone</label>
     <div class="gf-form-select-wrapper max-width-20">
       <select class="gf-form-input" ng-model="ctrl.prefs.timezone" ng-options="f.value as f.text for f in ctrl.timezones"></select>
+    </div>
+  </div>
+
+  <div class="gf-form">
+    <label class="gf-form-label width-11">Month/Day Formatting in Graphs</label>
+    <div class="gf-form-select-wrapper max-width-20">
+      <select class="gf-form-input" ng-model="ctrl.prefs.monthDayFormat" ng-options="f.value as f.text for f in ctrl.monthDayFormats"></select>
     </div>
   </div>
 

--- a/public/app/features/org/prefs_control.ts
+++ b/public/app/features/org/prefs_control.ts
@@ -78,7 +78,13 @@ const template = `
   </div>
 
   <div class="gf-form">
-    <label class="gf-form-label width-11">Month/Day Formatting in Graphs</label>
+    <label class="gf-form-label width-11">
+      Graph Date Format
+      <info-popover mode="right-normal">
+        On long-range graphs the dates on the y-axis show only the month and day instead of the exact time.
+        The setting 'browser' is the default and it uses the browser's language to infer a display format.
+      </info-popover>
+    </label>
     <div class="gf-form-select-wrapper max-width-20">
       <select class="gf-form-input" ng-model="ctrl.prefs.monthDayFormat" ng-options="f.value as f.text for f in ctrl.monthDayFormats"></select>
     </div>

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -715,7 +715,7 @@ class GraphElement {
       return contextSrv.user.monthDayFormat;
     }
 
-    if (!this.toLocaleDateStringSupportsLocales()) {
+    if (!this.canUseLocaleDateStringLocales()) {
       return '%m/%d';
     }
 
@@ -726,7 +726,7 @@ class GraphElement {
       .replace('20', '%d');
   }
 
-  toLocaleDateStringSupportsLocales() {
+  canUseLocaleDateStringLocales() {
     try {
       new Date().toLocaleDateString('i');
     } catch (e) {


### PR DESCRIPTION
When viewing longer range graphs, the dates on the x-axis are formatted in the US style: mm/dd. This PR allows more flexibility:

- use browser language to determine formatting
- allow user to override format in user preferences

Fixes #1459