### PR TITLE
Refresh variables before panels

### DIFF
--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -44,6 +44,7 @@ export class DashboardModel {
   iteration: number;
   meta: any;
   events: Emitter;
+  updateVariablesOnTimeRangeChange: boolean;
 
   static nonPersistedProperties: { [str: string]: boolean } = {
     events: true,
@@ -52,6 +53,7 @@ export class DashboardModel {
     templating: true, // needs special handling
     originalTime: true,
     originalTemplating: true,
+    updateVariablesOnTimeRangeChange: true, // variableSrv sets this
   };
 
   constructor(data, meta?) {

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -12,6 +12,7 @@ export class TimeSrv {
   dashboard: any;
   timeAtLoad: any;
   private autoRefreshBlocked: boolean;
+  loading: boolean;
 
   /** @ngInject */
   constructor(private $rootScope, private $timeout, private $location, private timer, private contextSrv) {
@@ -20,6 +21,7 @@ export class TimeSrv {
 
     $rootScope.$on('zoom-out', this.zoomOut.bind(this));
     $rootScope.$on('$routeUpdate', this.routeUpdated.bind(this));
+    $rootScope.$on('refresh', this.onRefresh.bind(this));
 
     document.addEventListener('visibilitychange', () => {
       if (this.autoRefreshBlocked && document.visibilityState === 'visible') {
@@ -141,8 +143,13 @@ export class TimeSrv {
     }
   }
 
+  onRefresh() {
+    this.loading = false;
+  }
+
   refreshDashboard() {
     if (this.dashboard.updateVariablesOnTimeRangeChange) {
+      this.loading = true;
       this.$rootScope.appEvent('time-range-changed');
     } else {
       this.$rootScope.$broadcast('refresh');

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -142,7 +142,11 @@ export class TimeSrv {
   }
 
   refreshDashboard() {
-    this.$rootScope.$broadcast('refresh');
+    if (this.dashboard.updateVariablesOnTimeRangeChange) {
+      this.$rootScope.appEvent('time-range-changed');
+    } else {
+      this.$rootScope.$broadcast('refresh');
+    }
   }
 
   private startNextRefreshTimer(afterMs) {
@@ -184,7 +188,6 @@ export class TimeSrv {
       this.$location.search(urlParams);
     }
 
-    this.$rootScope.appEvent('time-range-changed', this.time);
     this.$timeout(this.refreshDashboard.bind(this), 0);
   }
 

--- a/public/app/features/dashboard/time_srv.ts
+++ b/public/app/features/dashboard/time_srv.ts
@@ -115,7 +115,9 @@ export class TimeSrv {
   }
 
   private timeHasChangedSinceLoad() {
-    return this.timeAtLoad.from !== this.time.from || this.timeAtLoad.to !== this.time.to;
+    const from = moment.isMoment(this.time.from) ? !this.time.from.isSame(this.timeAtLoad.from) : this.time.from !== this.timeAtLoad.from;
+    const to = moment.isMoment(this.time.to) ? !this.time.to.isSame(this.timeAtLoad.to) : this.time.to !== this.timeAtLoad.to;
+    return from || to;
   }
 
   setAutoRefresh(interval) {

--- a/public/app/features/dashboard/timepicker/timepicker.html
+++ b/public/app/features/dashboard/timepicker/timepicker.html
@@ -19,7 +19,7 @@
 	</button>
 
   <button class="btn navbar-button navbar-button--refresh" ng-click="ctrl.timeSrv.refreshDashboard()">
-		<i class="fa fa-refresh"></i>
+    <i class="fa fa-refresh" ng-class="{'fa-spin': ctrl.timeSrv.loading}"></i>
 	</button>
 </div>
 

--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -32,6 +32,7 @@ export class TimePickerCtrl {
     $rootScope.onAppEvent('shift-time-forward', () => this.move(1), $scope);
     $rootScope.onAppEvent('shift-time-backward', () => this.move(-1), $scope);
     $rootScope.onAppEvent('refresh', this.onRefresh.bind(this), $scope);
+    $rootScope.onAppEvent('time-range-changed', this.onRefresh.bind(this), $scope);
     $rootScope.onAppEvent('closeTimepicker', this.openDropdown.bind(this), $scope);
 
     // init options

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -122,6 +122,7 @@ export class VariableEditorCtrl {
 
     $scope.update = () => {
       if ($scope.isValid()) {
+        variableSrv.updateVariable($scope.current);
         $scope.runQuery().then(() => {
           $scope.reset();
           $scope.mode = 'list';


### PR DESCRIPTION
I gave the dashboard model a new property `updateVariablesOnTimeRangeChange`.
timeSrv checks this property on refresh and then signals variableSrv to refresh the variables before variableSrv then signals a global refresh.
I made the refresh button's icon spin when variables are being refreshed since there was no other feedback.

One issue is that there is no feedback when opening the dashboard.

Related issue: #12497