### PR TITLE
Stackdriver filter wildcards

### DIFF
--- a/docs/sources/features/datasources/stackdriver.md
+++ b/docs/sources/features/datasources/stackdriver.md
@@ -74,7 +74,11 @@ Click on the links above and click the `Enable` button:
 
 Choose a metric from the `Metric` dropdown.
 
+### Filter
+
 To add a filter, click the plus icon and choose a field to filter by and enter a filter value e.g. `instance_name = grafana-1`
+
+It is also possible to add wildcards to the filter value field. E.g `us-*` to capture all values that starts with "us-", `*central-a` to capture all that ends with "central-a". `*-central-*` captures values that has the substring of -central-. 
 
 ### Aggregation
 
@@ -105,20 +109,20 @@ The Alias By field allows you to control the format of the legend keys. The defa
 
 #### Metric Type Patterns
 
-Alias Pattern | Description | Example Result
------------------ | ---------------------------- | -------------
-`{{metric.type}}` | returns the full Metric Type | `compute.googleapis.com/instance/cpu/utilization`
-`{{metric.name}}` | returns the metric name part | `instance/cpu/utilization`
-`{{metric.service}}` | returns the service part | `compute`
+| Alias Pattern        | Description                  | Example Result                                    |
+| -------------------- | ---------------------------- | ------------------------------------------------- |
+| `{{metric.type}}`    | returns the full Metric Type | `compute.googleapis.com/instance/cpu/utilization` |
+| `{{metric.name}}`    | returns the metric name part | `instance/cpu/utilization`                        |
+| `{{metric.service}}` | returns the service part     | `compute`                                         |
 
 #### Label Patterns
 
 In the Group By dropdown, you can see a list of metric and resource labels for a metric. These can be included in the legend key using alias patterns.
 
-Alias Pattern Format | Description | Alias Pattern Example | Example Result
----------------------- | ---------------------------------- | ---------------------------- | -------------
-`{{metric.label.xxx}}` | returns the metric label value | `{{metric.label.instance_name}}` | `grafana-1-prod`
-`{{resource.label.xxx}}` | returns the resource label value | `{{resource.label.zone}}` | `us-east1-b`
+| Alias Pattern Format     | Description                      | Alias Pattern Example            | Example Result   |
+| ------------------------ | -------------------------------- | -------------------------------- | ---------------- |
+| `{{metric.label.xxx}}`   | returns the metric label value   | `{{metric.label.instance_name}}` | `grafana-1-prod` |
+| `{{resource.label.xxx}}` | returns the resource label value | `{{resource.label.zone}}`        | `us-east1-b`     |
 
 Example Alias By: `{{metric.type}} - {{metric.labels.instance_name}}`
 

--- a/docs/sources/features/datasources/stackdriver.md
+++ b/docs/sources/features/datasources/stackdriver.md
@@ -76,9 +76,15 @@ Choose a metric from the `Metric` dropdown.
 
 ### Filter
 
-To add a filter, click the plus icon and choose a field to filter by and enter a filter value e.g. `instance_name = grafana-1`
+To add a filter, click the plus icon and choose a field to filter by and enter a filter value e.g. `instance_name = grafana-1`. You can remove the filter by clicking on the filter name and select `--remove filter--`.
 
-It is also possible to add wildcards to the filter value field. E.g `us-*` to capture all values that starts with "us-", `*central-a` to capture all that ends with "central-a". `*-central-*` captures values that has the substring of -central-. 
+#### Simple wildcards
+
+When the operator is set to `=` or `!=` it is possible to add wildcards to the filter value field. E.g `us-*` will capture all values that starts with "us-" and `*central-a` will capture all values that ends with "central-a". `*-central-*` captures all values that has the substring of -central-. Simple wildcards are less expensive than regular expressions. 
+
+#### Regular expressions
+
+When the operator is set to `=~` or `!=~` it is possible to add regular expressions to the filter value field. E.g `us-central[1-3]-[af]` would match all values that starts with "us-central", is followed by a number in the range of 1 to 3, a dash and then either an "a" or an "f". Leading and trailing slashes are not needed when creating regular expressions.
 
 ### Aggregation
 

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -179,7 +179,7 @@ func interpolateFilterWildcards(value string) string {
 	} else if matches == 1 && strings.HasSuffix(value, "*") {
 		value = reverse(strings.Replace(reverse(value), "*", "", 1))
 		value = fmt.Sprintf(`starts_with("%s")`, value)
-	} else if matches == 1 {
+	} else if matches != 0 {
 		re := regexp.MustCompile(`[-\/^$+?.()|[\]{}]`)
 		value = string(re.ReplaceAllFunc([]byte(value), func(in []byte) []byte {
 			return []byte(strings.Replace(string(in), string(in), `\\`+string(in), 1))

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -170,8 +170,11 @@ func reverse(s string) string {
 }
 
 func interpolateFilterWildcards(value string) string {
-	if strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
-		value = strings.Replace(value, "*", "", 1)
+	re := regexp.MustCompile("[*]")
+	matches := re.FindAllStringIndex(value, -1)
+	logger.Info("len", "len", len(matches))
+	if len(matches) == 2 && strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
+		value = strings.Replace(value, "*", "", -1)
 		value = fmt.Sprintf(`has_substring("%s")`, value)
 	} else if strings.HasPrefix(value, "*") {
 		value = strings.Replace(value, "*", "", 1)

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -169,23 +169,6 @@ func reverse(s string) string {
 	return string(chars)
 }
 
-func escapeDoubleBackslash(target string) string {
-	var re = regexp.MustCompile(`\\`)
-	return re.ReplaceAllString(target, `\\\\`)
-	// return strings.Replace(target, `\`, "", -1)
-}
-
-func escapeIllegalCharacters(target string) string {
-	var re = regexp.MustCompile(`[-\/^$+?.()|[\]{}]`)
-	return string(re.ReplaceAllFunc([]byte(target), func(in []byte) []byte {
-		return []byte(strings.Replace(string(in), string(in), `\\`+string(in), 1))
-	}))
-}
-
-func replaceSingleAsterixCharacters(target string) string {
-	return strings.Replace(target, "*", ".*", -1)
-}
-
 func interpolateFilterWildcards(value string) string {
 	if strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
 		value = strings.Replace(value, "*", "", 1)
@@ -197,8 +180,11 @@ func interpolateFilterWildcards(value string) string {
 		value = reverse(strings.Replace(reverse(value), "*", "", 1))
 		value = fmt.Sprintf(`starts_with("%s")`, value)
 	} else if strings.Contains(value, "*") {
-		value = escapeIllegalCharacters(value)
-		value = replaceSingleAsterixCharacters(value)
+		re := regexp.MustCompile(`[-\/^$+?.()|[\]{}]`)
+		value = string(re.ReplaceAllFunc([]byte(value), func(in []byte) []byte {
+			return []byte(strings.Replace(string(in), string(in), `\\`+string(in), 1))
+		}))
+		value = strings.Replace(value, "*", ".*", -1)
 		value = strings.Replace(value, `"`, `\\"`, -1)
 		value = fmt.Sprintf(`monitoring.regex.full_match("^%s$")`, value)
 	}

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
-
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/grafana/grafana/pkg/api/pluginproxy"
@@ -172,7 +170,6 @@ func reverse(s string) string {
 func interpolateFilterWildcards(value string) string {
 	re := regexp.MustCompile("[*]")
 	matches := len(re.FindAllStringIndex(value, -1))
-	logger.Info("len", "len", matches)
 	if matches == 2 && strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
 		value = strings.Replace(value, "*", "", -1)
 		value = fmt.Sprintf(`has_substring("%s")`, value)
@@ -191,8 +188,6 @@ func interpolateFilterWildcards(value string) string {
 		value = strings.Replace(value, `"`, `\\"`, -1)
 		value = fmt.Sprintf(`monitoring.regex.full_match("^%s$")`, value)
 	}
-
-	logger.Info("filter", "filter", value)
 
 	return value
 }
@@ -273,7 +268,6 @@ func (e *StackdriverExecutor) executeQuery(ctx context.Context, query *Stackdriv
 	}
 
 	req.URL.RawQuery = query.Params.Encode()
-	logger.Info("req.URL.RawQuery", "req.URL.RawQuery", req.URL.RawQuery)
 	queryResult.Meta.Set("rawQuery", req.URL.RawQuery)
 	alignmentPeriod, ok := req.URL.Query()["aggregation.alignmentPeriod"]
 

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -199,7 +199,11 @@ func buildFilterString(metricType string, filterParts []interface{}) string {
 		if part == "AND" {
 			filterString += " "
 		} else if mod == 2 {
-			if strings.Contains(part.(string), "*") {
+			operator := filterParts[i-1]
+			if operator == "=~" || operator == "!=~" {
+				filterString = reverse(strings.Replace(reverse(filterString), "~", "", 1))
+				filterString += fmt.Sprintf(`monitoring.regex.full_match("%s")`, part)
+			} else if strings.Contains(part.(string), "*") {
 				filterString += interpolateFilterWildcards(part.(string))
 			} else {
 				filterString += fmt.Sprintf(`"%s"`, part)

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -171,18 +171,18 @@ func reverse(s string) string {
 
 func interpolateFilterWildcards(value string) string {
 	re := regexp.MustCompile("[*]")
-	matches := re.FindAllStringIndex(value, -1)
-	logger.Info("len", "len", len(matches))
-	if len(matches) == 2 && strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
+	matches := len(re.FindAllStringIndex(value, -1))
+	logger.Info("len", "len", matches)
+	if matches == 2 && strings.HasSuffix(value, "*") && strings.HasPrefix(value, "*") {
 		value = strings.Replace(value, "*", "", -1)
 		value = fmt.Sprintf(`has_substring("%s")`, value)
-	} else if strings.HasPrefix(value, "*") {
+	} else if matches == 1 && strings.HasPrefix(value, "*") {
 		value = strings.Replace(value, "*", "", 1)
 		value = fmt.Sprintf(`ends_with("%s")`, value)
-	} else if strings.HasSuffix(value, "*") {
+	} else if matches == 1 && strings.HasSuffix(value, "*") {
 		value = reverse(strings.Replace(reverse(value), "*", "", 1))
 		value = fmt.Sprintf(`starts_with("%s")`, value)
-	} else if strings.Contains(value, "*") {
+	} else if matches == 1 {
 		re := regexp.MustCompile(`[-\/^$+?.()|[\]{}]`)
 		value = string(re.ReplaceAllFunc([]byte(value), func(in []byte) []byte {
 			return []byte(strings.Replace(string(in), string(in), `\\`+string(in), 1))

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -405,6 +405,19 @@ func TestStackdriver(t *testing.T) {
 			})
 		})
 
+		Convey("when building filter string", func() {
+			Convey("and there are wildcards in a filter value", func() {
+				filterParts := []interface{}{"zone", "=", "*-central1*"}
+				value := buildFilterString("somemetrictype", filterParts)
+				So(value, ShouldEqual, `metric.type="somemetrictype" zone=has_substring("-central1")`)
+			})
+
+			Convey("and there are no wildcards in any filter value", func() {
+				filterParts := []interface{}{"zone", "=", "us-central1-a"}
+				value := buildFilterString("somemetrictype", filterParts)
+				So(value, ShouldEqual, `metric.type="somemetrictype" zone="us-central1-a"`)
+			})
+		})
 	})
 }
 

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -342,6 +342,19 @@ func TestStackdriver(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("when interpolating filter wildcards", func() {
+			Convey("and wildcard is used in the beginning and the end of the word", func() {
+				Convey("and theres no wildcard in the middle of the word", func() {
+					value := interpolateFilterWildcards("*-central1*")
+					So(value, ShouldEqual, `has_substring("-central1")`)
+				})
+				Convey("and there is a wildcard in the middle of the word", func() {
+					value := interpolateFilterWildcards("*-cent*ral1*")
+					So(value, ShouldNotStartWith, `has_substring`)
+				})
+			})
+		})
 	})
 }
 

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -354,6 +354,50 @@ func TestStackdriver(t *testing.T) {
 					So(value, ShouldNotStartWith, `has_substring`)
 				})
 			})
+
+			Convey("and wildcard is used in the beginning of the word", func() {
+				Convey("and there is not a wildcard elsewhere in the word", func() {
+					value := interpolateFilterWildcards("*-central1")
+					So(value, ShouldEqual, `ends_with("-central1")`)
+				})
+				Convey("and there is a wildcard elsewhere in the word", func() {
+					value := interpolateFilterWildcards("*-cent*al1")
+					So(value, ShouldNotStartWith, `ends_with`)
+				})
+			})
+
+			Convey("and wildcard is used at the end of the word", func() {
+				Convey("and there is not a wildcard elsewhere in the word", func() {
+					value := interpolateFilterWildcards("us-central*")
+					So(value, ShouldEqual, `starts_with("us-central")`)
+				})
+				Convey("and there is a wildcard elsewhere in the word", func() {
+					value := interpolateFilterWildcards("*us-central*")
+					So(value, ShouldNotStartWith, `starts_with`)
+				})
+			})
+
+			Convey("and wildcard is used in the middle of the word", func() {
+				Convey("and there is only one wildcard", func() {
+					value := interpolateFilterWildcards("us-ce*tral1-b")
+					So(value, ShouldEqual, `monitoring.regex.full_match("^us\\-ce.*tral1\\-b$")`)
+				})
+
+				Convey("and there is more than one wildcard", func() {
+					value := interpolateFilterWildcards("us-ce*tra*1-b")
+					So(value, ShouldEqual, `monitoring.regex.full_match("^us\\-ce.*tra.*1\\-b$")`)
+				})
+			})
+
+			Convey("and wildcard is used in the middle of the word and in the beginning of the word", func() {
+				value := interpolateFilterWildcards("*s-ce*tral1-b")
+				So(value, ShouldEqual, `monitoring.regex.full_match("^.*s\\-ce.*tral1\\-b$")`)
+			})
+
+			Convey("and wildcard is used in the middle of the word and in the ending of the word", func() {
+				value := interpolateFilterWildcards("us-ce*tral1-*")
+				So(value, ShouldEqual, `monitoring.regex.full_match("^us\\-ce.*tral1\\-.*$")`)
+			})
 		})
 	})
 }

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -398,7 +398,13 @@ func TestStackdriver(t *testing.T) {
 				value := interpolateFilterWildcards("us-ce*tral1-*")
 				So(value, ShouldEqual, `monitoring.regex.full_match("^us\\-ce.*tral1\\-.*$")`)
 			})
+
+			Convey("and no wildcard is used", func() {
+				value := interpolateFilterWildcards("us-central1-a}")
+				So(value, ShouldEqual, `us-central1-a}`)
+			})
 		})
+
 	})
 }
 

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -406,16 +406,31 @@ func TestStackdriver(t *testing.T) {
 		})
 
 		Convey("when building filter string", func() {
-			Convey("and there are wildcards in a filter value", func() {
-				filterParts := []interface{}{"zone", "=", "*-central1*"}
-				value := buildFilterString("somemetrictype", filterParts)
-				So(value, ShouldEqual, `metric.type="somemetrictype" zone=has_substring("-central1")`)
+			Convey("and theres no regex operator", func() {
+				Convey("and there are wildcards in a filter value", func() {
+					filterParts := []interface{}{"zone", "=", "*-central1*"}
+					value := buildFilterString("somemetrictype", filterParts)
+					So(value, ShouldEqual, `metric.type="somemetrictype" zone=has_substring("-central1")`)
+				})
+
+				Convey("and there are no wildcards in any filter value", func() {
+					filterParts := []interface{}{"zone", "!=", "us-central1-a"}
+					value := buildFilterString("somemetrictype", filterParts)
+					So(value, ShouldEqual, `metric.type="somemetrictype" zone!="us-central1-a"`)
+				})
 			})
 
-			Convey("and there are no wildcards in any filter value", func() {
-				filterParts := []interface{}{"zone", "=", "us-central1-a"}
+			Convey("and there is a regex operator", func() {
+				filterParts := []interface{}{"zone", "=~", "us-central1-a~"}
 				value := buildFilterString("somemetrictype", filterParts)
-				So(value, ShouldEqual, `metric.type="somemetrictype" zone="us-central1-a"`)
+				Convey("it should remove the ~ character from the operator that belongs to the value", func() {
+					So(value, ShouldNotContainSubstring, `=~`)
+					So(value, ShouldContainSubstring, `zone=`)
+				})
+
+				Convey("it should insert monitoring.regex.full_match before filter value", func() {
+					So(value, ShouldContainSubstring, `zone=monitoring.regex.full_match("us-central1-a~")`)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #13495

In Google Stackdriver Metrics Explorer UI it is possible for a user to not only select from the available filter values in the dropdown, but also to manually input a filter value. This gives the user much more flexibility, not having to add multiple filters for different values but to use wildcards instead.  E.g when the filter value dropdown contains three values: us-central-1, us-central-2, and us-east-1. Instead of selecting alternative one and two, a user could type us-central-*. 

The stackdriver UI also supports filter value wildcards anywhere in the input value --> 
us-central-* --> starts with us-central-
*-central-1 --> ends with -central-1
*-central-* --> has a substring of -central-
us-c*tral-* --> starts with us-c, has a substring of tral-
and so on...

This feature is not yet supported in the Grafana Stackdriver datasource, but it should be.