### PR TITLE
stackdriver: adds missing nginject attribute

### DIFF
--- a/public/app/plugins/datasource/stackdriver/query_aggregation_ctrl.ts
+++ b/public/app/plugins/datasource/stackdriver/query_aggregation_ctrl.ts
@@ -24,6 +24,7 @@ export class StackdriverAggregationCtrl {
   alignOptions: any[];
   target: any;
 
+  /** @ngInject */
   constructor(private $scope) {
     this.$scope.ctrl = this;
     this.target = $scope.target;

--- a/public/app/plugins/datasource/stackdriver/query_filter_ctrl.ts
+++ b/public/app/plugins/datasource/stackdriver/query_filter_ctrl.ts
@@ -4,6 +4,7 @@ import { FilterSegments, DefaultRemoveFilterValue } from './filter_segments';
 import appEvents from 'app/core/app_events';
 
 export class StackdriverFilter {
+  /** @ngInject */
   constructor() {
     return {
       templateUrl: 'public/app/plugins/datasource/stackdriver/partials/query.filter.html',


### PR DESCRIPTION
Missing nginject attribute breaks the query editor.
