### PR TITLE
fix gofmt tests output

### DIFF
--- a/scripts/circle-test-backend.sh
+++ b/scripts/circle-test-backend.sh
@@ -11,7 +11,7 @@ function exit_if_fail {
 }
 
 echo "running go fmt"
-exit_if_fail test -z "$(gofmt -s -l ./pkg | tee /dev/stderr)"
+exit_if_fail test -z \"'$(gofmt -s -l ./pkg | tee /dev/stderr)'\"
 
 echo "building backend with install to cache pkgs"
 exit_if_fail time go install ./pkg/cmd/grafana-server


### PR DESCRIPTION
fix #12563

This PR changes `scripts/circle-test-backend.sh` to print the whole command in "Execute ..." and "... returned 1" logs and fixes "binary operator expected" error, which happens when there are several style errors.

```
% ./scripts/circle-test-backend.sh
running go fmt
Executing 'test -z "$(gofmt -s -l ./pkg | tee /dev/stderr)"'
pkg/api/admin.go
pkg/api/api.go
'test -z "$(gofmt -s -l ./pkg | tee /dev/stderr)"' returned 1.
```
