### PR TITLE
fix filter issue

### DIFF
--- a/public/app/features/org/org_users_ctrl.ts
+++ b/public/app/features/org/org_users_ctrl.ts
@@ -44,7 +44,7 @@ export class OrgUsersCtrl {
   }
 
   onQueryUpdated() {
-    let regex = new RegExp(this.searchQuery, 'ig');
+    let regex = new RegExp(this.searchQuery, 'i');
     this.users = _.filter(this.unfiltered, item => {
       return regex.test(item.email) || regex.test(item.login);
     });

--- a/public/app/features/plugins/ds_list_ctrl.ts
+++ b/public/app/features/plugins/ds_list_ctrl.ts
@@ -17,7 +17,7 @@ export class DataSourcesCtrl {
   }
 
   onQueryUpdated() {
-    let regex = new RegExp(this.searchQuery, 'ig');
+    let regex = new RegExp(this.searchQuery, 'i');
     this.datasources = _.filter(this.unfiltered, item => {
       return regex.test(item.name) || regex.test(item.type);
     });

--- a/public/app/features/plugins/plugin_list_ctrl.ts
+++ b/public/app/features/plugins/plugin_list_ctrl.ts
@@ -20,7 +20,7 @@ export class PluginListCtrl {
   }
 
   onQueryUpdated() {
-    let regex = new RegExp(this.searchQuery, 'ig');
+    let regex = new RegExp(this.searchQuery, 'i');
     this.plugins = _.filter(this.allPlugins, item => {
       return regex.test(item.name) || regex.test(item.type);
     });


### PR DESCRIPTION
there has been an issue in filtering for a long time.
The `g` modifier in RegExp causes the regex object to maintain state. It tracks the index after the last match.
```
const re = /hello/gi
re.test('hello') // output: true
re.test('hello') // output: false
```