### PR TITLE
Strip Cloudfront headers from plugin-proxy

### DIFF
--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -56,6 +56,13 @@ func NewApiPluginProxy(ctx *m.ReqContext, proxyPath string, route *plugins.AppPl
 		req.Header.Del("X-Forwarded-Host")
 		req.Header.Del("X-Forwarded-Port")
 		req.Header.Del("X-Forwarded-Proto")
+		
+		// clear Cloudfront specific headers
+		req.Header.Del("CF-Connecting-IP")
+		req.Header.Del("CF-IPCountry")
+		req.Header.Del("CF-RAY")
+		req.Header.Del("CF-Visitor")
+		req.Header.Del("True-Client-IP")
 
 		// set X-Forwarded-For header
 		if req.RemoteAddr != "" {


### PR DESCRIPTION
# Issue and solution
If the Grafana application is behind Cloudflare and tries to proxy requests to a host behind Cloudflare, the proxy fails because the response to the proxied request is a Cloudflare error:
> You've requested a page on a website (api.cloudflare.com) that is on the Cloudflare network. Unfortunately,it is resolving to an IP address that is creating a conflict within Cloudflare's system.

It is because when grafana receives the original requests, the request has the Cloudflare headers which are then proxied forward to the target host. As it is also behind Cloudflare, the original Cloudflare headers cause conflicts and an error is returned.

This was noted by several users at the official Cloudflare-Grafana app, used to import CF metrics:
https://github.com/cloudflare/cloudflare-grafana-app/issues/4
https://github.com/cloudflare/cloudflare-grafana-app/issues/6

The solution is to strip the Cloudflare specific headers, so they are not proxied forward to the target host which might be behind Cloudflare (like api.cloudflare.com).

## Testing
It is also possible to strip headers in the reverse proxy, which fixed the issue as is a possible workaround. I used this Nginx config to strip the Cloudflare headers before proxying any request to the Grafana docker container and the error was gone.
```
    location ~ / {
        proxy_set_header CF-Connecting-IP "";
        proxy_set_header CF-IPCountry "";
        proxy_set_header CF-RAY "";
        proxy_set_header CF-Visitor "";
        proxy_set_header True-Client-IP "";

        proxy_pass http://127.0.0.1:3000;
    }
```