### PR TITLE
stackdriver metric name fix. Fixes #13562

### DIFF
--- a/public/app/plugins/datasource/stackdriver/datasource.ts
+++ b/public/app/plugins/datasource/stackdriver/datasource.ts
@@ -241,7 +241,17 @@ export default class StackdriverDatasource {
     try {
       const metricsApiPath = `v3/projects/${projectId}/metricDescriptors`;
       const { data } = await this.doRequest(`${this.baseUrl}${metricsApiPath}`);
-      return data.metricDescriptors;
+
+      const metrics = data.metricDescriptors.map(m => {
+        const [service] = m.type.split('/');
+        const [serviceShortName] = service.split('.');
+        m.service = service;
+        m.serviceShortName = serviceShortName;
+        m.displayName = m.displayName || m.type;
+        return m;
+      });
+
+      return metrics;
     } catch (error) {
       console.log(error);
     }

--- a/public/app/plugins/datasource/stackdriver/query_filter_ctrl.ts
+++ b/public/app/plugins/datasource/stackdriver/query_filter_ctrl.ts
@@ -96,11 +96,9 @@ export class StackdriverFilterCtrl {
   getServicesList() {
     const defaultValue = { value: this.$scope.defaultServiceValue, text: this.$scope.defaultServiceValue };
     const services = this.metricDescriptors.map(m => {
-      const [service] = m.type.split('/');
-      const [serviceShortName] = service.split('.');
       return {
-        value: service,
-        text: serviceShortName,
+        value: m.service,
+        text: m.serviceShortName,
       };
     });
 
@@ -113,12 +111,10 @@ export class StackdriverFilterCtrl {
 
   getMetricsList() {
     const metrics = this.metricDescriptors.map(m => {
-      const [service] = m.type.split('/');
-      const [serviceShortName] = service.split('.');
       return {
-        service,
+        service: m.service,
         value: m.type,
-        serviceShortName,
+        serviceShortName: m.serviceShortName,
         text: m.displayName,
         title: m.description,
       };

--- a/public/app/plugins/datasource/stackdriver/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/stackdriver/specs/datasource.test.ts
@@ -164,11 +164,11 @@ describe('StackdriverDataSource', () => {
               metricDescriptors: [
                 {
                   displayName: 'test metric name 1',
-                  type: 'test metric type 1',
+                  type: 'compute.googleapis.com/instance/cpu/test-metric-type-1',
+                  description: 'A description',
                 },
                 {
-                  displayName: 'test metric name 2',
-                  type: 'test metric type 2',
+                  type: 'logging.googleapis.com/user/logbased-metric-with-no-display-name',
                 },
               ],
             },
@@ -180,8 +180,13 @@ describe('StackdriverDataSource', () => {
     });
     it('should return successfully', () => {
       expect(result.length).toBe(2);
-      expect(result[0].type).toBe('test metric type 1');
+      expect(result[0].service).toBe('compute.googleapis.com');
+      expect(result[0].serviceShortName).toBe('compute');
+      expect(result[0].type).toBe('compute.googleapis.com/instance/cpu/test-metric-type-1');
       expect(result[0].displayName).toBe('test metric name 1');
+      expect(result[0].description).toBe('A description');
+      expect(result[1].type).toBe('logging.googleapis.com/user/logbased-metric-with-no-display-name');
+      expect(result[1].displayName).toBe('logging.googleapis.com/user/logbased-metric-with-no-display-name');
     });
   });
 


### PR DESCRIPTION
Sets metric name even when the metric does not have a displayName field. Closes #13562.
