### PR TITLE
Render DashboardRow drag handle only when edit mode is enabled

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardRow.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardRow.tsx
@@ -87,6 +87,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
     const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
     const count = this.props.panel.panels ? this.props.panel.panels.length : 0;
     const panels = count === 1 ? 'panel' : 'panels';
+    const editModeEnabled = this.dashboard.meta.canEdit === true;
 
     return (
       <div className={classes}>
@@ -97,7 +98,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
             ({count} {panels})
           </span>
         </a>
-        {this.dashboard.meta.canEdit === true && (
+        {editModeEnabled && (
           <div className="dashboard-row__actions">
             <a className="pointer" onClick={this.openSettings}>
               <i className="fa fa-cog" />
@@ -112,7 +113,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
             &nbsp;
           </div>
         )}
-        <div className="dashboard-row__drag grid-drag-handle" />
+        {editModeEnabled && <div className="dashboard-row__drag grid-drag-handle" />}
       </div>
     );
   }

--- a/public/app/features/dashboard/specs/DashboardRow.test.tsx
+++ b/public/app/features/dashboard/specs/DashboardRow.test.tsx
@@ -39,6 +39,12 @@ describe('DashboardRow', () => {
     expect(wrapper.find('.dashboard-row__actions .pointer')).toHaveLength(2);
   });
 
+  it('should not show row drag handle when cannot edit', () => {
+    dashboardMock.meta.canEdit = false;
+    wrapper = shallow(<DashboardRow panel={panel} getPanelContainer={getPanelContainer} />);
+    expect(wrapper.find('.dashboard-row__drag')).toHaveLength(0);
+  });
+
   it('should have zero actions when cannot edit', () => {
     dashboardMock.meta.canEdit = false;
     panel = new PanelModel({ collapsed: false });


### PR DESCRIPTION
Summary of Changes:
- Extracted dashboard 'canEdit' meta to an individual variable to reuse it
- Rendering dashboard row drag handle only when edit mode is enabled
- Adding unit tests to test this functionality

#13555 
