### PR TITLE
Remove duplicate labels in the datasource query

### DIFF
--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -77,6 +77,7 @@ function addLabelToSelector(selector: string, labelKey: string, labelValue: stri
 
   // Sort labels by key and put them together
   return _.chain(parsedLabels)
+    .uniqWith(_.isEqual)
     .compact()
     .sortBy('key')
     .map(({ key, operator, value }) => `${key}${operator}${value}`)

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -40,4 +40,19 @@ describe('addLabelToQuery()', () => {
       'foo{bar="baz",x="yy"} * metric{a="bb",bar="baz",y="zz"} * metric2{bar="baz"}'
     );
   });
+
+  it('should not add duplicate labels to aquery', () => {
+    expect(addLabelToQuery(addLabelToQuery('foo{x="yy"}', 'bar', 'baz', '!='), 'bar', 'baz', '!=')).toBe(
+      'foo{bar!="baz",x="yy"}'
+    );
+    expect(addLabelToQuery(addLabelToQuery('rate(metric[1m])', 'foo', 'bar'), 'foo', 'bar')).toBe(
+      'rate(metric{foo="bar"}[1m])'
+    );
+    expect(addLabelToQuery(addLabelToQuery('foo{list="a,b,c"}', 'bar', 'baz'), 'bar', 'baz')).toBe(
+      'foo{bar="baz",list="a,b,c"}'
+    );
+    expect(addLabelToQuery(addLabelToQuery('avg(foo) + sum(xx_yy)', 'bar', 'baz'), 'bar', 'baz')).toBe(
+      'avg(foo{bar="baz"}) + sum(xx_yy{bar="baz"})'
+    );
+  });
 });


### PR DESCRIPTION
Summary of changes:

- Remove duplicate labels from datasource query
- Add unit tests

#13487 
