### PR TITLE
Remove user form org in single org setup improvement 

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -103,8 +103,8 @@ func updateOrgUserHelper(cmd m.UpdateOrgUserCommand) Response {
 // DELETE /api/org/users/:userId
 func RemoveOrgUserForCurrentOrg(c *m.ReqContext) Response {
 	return removeOrgUserHelper(&m.RemoveOrgUserCommand{
-		UserId: c.ParamsInt64(":userId"),
-		OrgId:  c.OrgId,
+		UserId:                   c.ParamsInt64(":userId"),
+		OrgId:                    c.OrgId,
 		ShouldDeleteOrphanedUser: true,
 	})
 }

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -102,21 +102,23 @@ func updateOrgUserHelper(cmd m.UpdateOrgUserCommand) Response {
 
 // DELETE /api/org/users/:userId
 func RemoveOrgUserForCurrentOrg(c *m.ReqContext) Response {
-	userID := c.ParamsInt64(":userId")
-	return removeOrgUserHelper(c.OrgId, userID)
+	return removeOrgUserHelper(&m.RemoveOrgUserCommand{
+		UserId:                   c.ParamsInt64(":userId"),
+		OrgId:                    c.OrgId,
+		ShouldDeleteOrphanedUser: true,
+	})
 }
 
 // DELETE /api/orgs/:orgId/users/:userId
 func RemoveOrgUser(c *m.ReqContext) Response {
-	userID := c.ParamsInt64(":userId")
-	orgID := c.ParamsInt64(":orgId")
-	return removeOrgUserHelper(orgID, userID)
+	return removeOrgUserHelper(&m.RemoveOrgUserCommand{
+		UserId: c.ParamsInt64(":userId"),
+		OrgId:  c.ParamsInt64(":orgId"),
+	})
 }
 
-func removeOrgUserHelper(orgID int64, userID int64) Response {
-	cmd := m.RemoveOrgUserCommand{OrgId: orgID, UserId: userID}
-
-	if err := bus.Dispatch(&cmd); err != nil {
+func removeOrgUserHelper(cmd *m.RemoveOrgUserCommand) Response {
+	if err := bus.Dispatch(cmd); err != nil {
 		if err == m.ErrLastOrgAdmin {
 			return Error(400, "Cannot remove last organization admin", nil)
 		}

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -103,8 +103,8 @@ func updateOrgUserHelper(cmd m.UpdateOrgUserCommand) Response {
 // DELETE /api/org/users/:userId
 func RemoveOrgUserForCurrentOrg(c *m.ReqContext) Response {
 	return removeOrgUserHelper(&m.RemoveOrgUserCommand{
-		UserId:                   c.ParamsInt64(":userId"),
-		OrgId:                    c.OrgId,
+		UserId: c.ParamsInt64(":userId"),
+		OrgId:  c.OrgId,
 		ShouldDeleteOrphanedUser: true,
 	})
 }
@@ -125,7 +125,7 @@ func removeOrgUserHelper(cmd *m.RemoveOrgUserCommand) Response {
 		return Error(500, "Failed to remove user from organization", err)
 	}
 
-	if cmd.UserWasRemoved {
+	if cmd.UserWasDeleted {
 		return Success("User deleted")
 	}
 

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -125,5 +125,9 @@ func removeOrgUserHelper(cmd *m.RemoveOrgUserCommand) Response {
 		return Error(500, "Failed to remove user from organization", err)
 	}
 
+	if cmd.UserWasRemoved {
+		return Success("User deleted")
+	}
+
 	return Success("User removed from organization")
 }

--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -72,8 +72,9 @@ type OrgUser struct {
 // COMMANDS
 
 type RemoveOrgUserCommand struct {
-	UserId int64
-	OrgId  int64
+	UserId                   int64
+	OrgId                    int64
+	ShouldDeleteOrphanedUser bool
 }
 
 type AddOrgUserCommand struct {

--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -75,6 +75,7 @@ type RemoveOrgUserCommand struct {
 	UserId                   int64
 	OrgId                    int64
 	ShouldDeleteOrphanedUser bool
+	UserWasRemoved           bool
 }
 
 type AddOrgUserCommand struct {

--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -75,7 +75,7 @@ type RemoveOrgUserCommand struct {
 	UserId                   int64
 	OrgId                    int64
 	ShouldDeleteOrphanedUser bool
-	UserWasRemoved           bool
+	UserWasDeleted           bool
 }
 
 type AddOrgUserCommand struct {

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -191,6 +191,7 @@ func TestAccountDataAccess(t *testing.T) {
 					remCmd := m.RemoveOrgUserCommand{OrgId: ac1.OrgId, UserId: ac2.Id, ShouldDeleteOrphanedUser: true}
 					err = RemoveOrgUser(&remCmd)
 					So(err, ShouldBeNil)
+					So(remCmd.UserWasDeleted, ShouldBeTrue)
 
 					err = GetSignedInUser(&m.GetSignedInUserQuery{UserId: ac2.Id})
 					So(err, ShouldEqual, m.ErrUserNotFound)

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -182,6 +182,20 @@ func TestAccountDataAccess(t *testing.T) {
 					})
 				})
 
+				Convey("Removing user from org should delete user completely if in no other org", func() {
+					// make sure ac2 has no org
+					err := DeleteOrg(&m.DeleteOrgCommand{Id: ac2.OrgId})
+					So(err, ShouldBeNil)
+
+					// remove frome ac2 from ac1 org
+					remCmd := m.RemoveOrgUserCommand{OrgId: ac1.OrgId, UserId: ac2.Id, ShouldDeleteOrphanedUser: true}
+					err = RemoveOrgUser(&remCmd)
+					So(err, ShouldBeNil)
+
+					err = GetSignedInUser(&m.GetSignedInUserQuery{UserId: ac2.Id})
+					So(err, ShouldEqual, m.ErrUserNotFound)
+				})
+
 				Convey("Cannot delete last admin org user", func() {
 					cmd := m.RemoveOrgUserCommand{OrgId: ac1.OrgId, UserId: ac1.Id}
 					err := RemoveOrgUser(&cmd)

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -194,6 +194,8 @@ func RemoveOrgUser(cmd *m.RemoveOrgUserCommand) error {
 			if err := deleteUserInTransaction(sess, &m.DeleteUserCommand{UserId: user.Id}); err != nil {
 				return err
 			}
+
+			cmd.UserWasRemoved = true
 		}
 
 		return nil

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -195,7 +195,7 @@ func RemoveOrgUser(cmd *m.RemoveOrgUserCommand) error {
 				return err
 			}
 
-			cmd.UserWasRemoved = true
+			cmd.UserWasDeleted = true
 		}
 
 		return nil

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -157,6 +157,12 @@ func RemoveOrgUser(cmd *m.RemoveOrgUserCommand) error {
 			}
 		}
 
+		// validate that after delete there is at least one user with admin role in org
+		if err := validateOneAdminLeftInOrg(cmd.OrgId, sess); err != nil {
+			return err
+		}
+
+		// check user other orgs and update user current org
 		var userOrgs []*m.UserOrgDTO
 		sess.Table("org_user")
 		sess.Join("INNER", "org", "org_user.org_id=org.id")
@@ -168,22 +174,29 @@ func RemoveOrgUser(cmd *m.RemoveOrgUserCommand) error {
 			return err
 		}
 
-		hasCurrentOrgSet := false
-		for _, userOrg := range userOrgs {
-			if user.OrgId == userOrg.OrgId {
-				hasCurrentOrgSet = true
-				break
+		if len(userOrgs) > 0 {
+			hasCurrentOrgSet := false
+			for _, userOrg := range userOrgs {
+				if user.OrgId == userOrg.OrgId {
+					hasCurrentOrgSet = true
+					break
+				}
 			}
-		}
 
-		if !hasCurrentOrgSet && len(userOrgs) > 0 {
-			err = setUsingOrgInTransaction(sess, user.Id, userOrgs[0].OrgId)
-			if err != nil {
+			if !hasCurrentOrgSet {
+				err = setUsingOrgInTransaction(sess, user.Id, userOrgs[0].OrgId)
+				if err != nil {
+					return err
+				}
+			}
+		} else if cmd.ShouldDeleteOrphanedUser {
+			// no other orgs, delete the full user
+			if err := deleteUserInTransaction(sess, &m.DeleteUserCommand{UserId: user.Id}); err != nil {
 				return err
 			}
 		}
 
-		return validateOneAdminLeftInOrg(cmd.OrgId, sess)
+		return nil
 	})
 }
 

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -445,25 +445,29 @@ func SearchUsers(query *m.SearchUsersQuery) error {
 
 func DeleteUser(cmd *m.DeleteUserCommand) error {
 	return inTransaction(func(sess *DBSession) error {
-		deletes := []string{
-			"DELETE FROM star WHERE user_id = ?",
-			"DELETE FROM " + dialect.Quote("user") + " WHERE id = ?",
-			"DELETE FROM org_user WHERE user_id = ?",
-			"DELETE FROM dashboard_acl WHERE user_id = ?",
-			"DELETE FROM preferences WHERE user_id = ?",
-			"DELETE FROM team_member WHERE user_id = ?",
-			"DELETE FROM user_auth WHERE user_id = ?",
-		}
-
-		for _, sql := range deletes {
-			_, err := sess.Exec(sql, cmd.UserId)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
+		return deleteUserInTransaction(sess, cmd)
 	})
+}
+
+func deleteUserInTransaction(sess *DBSession, cmd *m.DeleteUserCommand) error {
+	deletes := []string{
+		"DELETE FROM star WHERE user_id = ?",
+		"DELETE FROM " + dialect.Quote("user") + " WHERE id = ?",
+		"DELETE FROM org_user WHERE user_id = ?",
+		"DELETE FROM dashboard_acl WHERE user_id = ?",
+		"DELETE FROM preferences WHERE user_id = ?",
+		"DELETE FROM team_member WHERE user_id = ?",
+		"DELETE FROM user_auth WHERE user_id = ?",
+	}
+
+	for _, sql := range deletes {
+		_, err := sess.Exec(sql, cmd.UserId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func UpdateUserPermissions(cmd *m.UpdateUserPermissionsCommand) error {


### PR DESCRIPTION
Problem: When removing users from the Org > Users page it does not actually remove the user from the system but will in many cases leave a user without any org membership (Orphaned). 

* This PR changes things. In the RemoveOrgUserCommand we now check if the user has any orgs left after org membership removal. If no other part of no other orgs the full user is removed. 
* This command is also used from the user admin pages, where just removing an org should not remove the user (maybe you were just about to remove and org and add another, where leaving a user orphaned temporarily would be fine). So have an option ShouldRemoveOrphanedUser on the command set by differently by the org level api and the admin level api. 
* Also had to change the success message text to no say "Removed user from organization". The command now returns a flag to inform API what actually was done so the UI message can be more correct. 
