### PR TITLE
fix phantomjs render of graph panel when legend displayed as table to the right

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -137,6 +137,7 @@
 
     .graph-legend-table {
       display: table;
+      width: auto;
 
       .graph-legend-scroll {
         display: table;


### PR DESCRIPTION
Fixes #13616