### PR TITLE
Remove os.Kill as it cannot be trapped

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -100,7 +100,7 @@ func listenToSystemSignals(server *GrafanaServerImpl) {
 	sighupChan := make(chan os.Signal, 1)
 
 	signal.Notify(sighupChan, syscall.SIGHUP)
-	signal.Notify(signalChan, os.Interrupt, os.Kill, syscall.SIGTERM)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
 	for {
 		select {


### PR DESCRIPTION
Hi @torkelo @bergquist,

related to #10381, I fixed this *megacheck* issue.

See,
```sh
$ gometalinter --vendor --deadline 10m --disable-all --enable=megacheck ./...
pkg/cmd/grafana-server/main.go:103:42:warning: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016) (megacheck)
```

This should be **well tested** in all supported architectures, and that is why I submitted this separately.
[os.Kill](https://golang.org/pkg/os/#Process.Kill) is like `kill -9` which kills a process immediately. `syscall.SIGTERM` is equivalent to kill which allows the process time to cleanup.
