### PR TITLE
Removed reference to plugin_api.md (SDK Readme) 

### DIFF
--- a/docs/sources/plugins/developing/development.md
+++ b/docs/sources/plugins/developing/development.md
@@ -60,7 +60,6 @@ and [apps]({{< relref "apps.md" >}}) plugins in the documentation.
 The Grafana SDK is quite small so far and can be found here:
 
 - [SDK file in Grafana](https://github.com/grafana/grafana/blob/master/public/app/plugins/sdk.ts)
-- [SDK Readme](https://github.com/grafana/grafana/blob/master/public/app/plugins/plugin_api.md)
 
 The SDK contains three different plugin classes: PanelCtrl, MetricsPanelCtrl and QueryCtrl. For plugins of the panel type, the module.js file should export one of these. There are some extra classes for [data sources]({{< relref "datasources.md" >}}).
 


### PR DESCRIPTION
On the development page, I removed a reference to a readme that no longer exists. This addresses an [open issue](https://github.com/grafana/grafana.org/issues/68) on the grafana.org repo.
