### PR TITLE
remove lucene escaping-wip

### DIFF
--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -210,26 +210,6 @@ describe('templateSrv', () => {
     });
   });
 
-  describe('lucene format', () => {
-    it('should properly escape $test with lucene escape sequences', () => {
-      initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
-      const target = _templateSrv.replace('this:$test', {}, 'lucene');
-      expect(target).toBe('this:value\\/4');
-    });
-
-    it('should properly escape ${test} with lucene escape sequences', () => {
-      initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
-      const target = _templateSrv.replace('this:${test}', {}, 'lucene');
-      expect(target).toBe('this:value\\/4');
-    });
-
-    it('should properly escape ${test:lucene} with lucene escape sequences', () => {
-      initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'value/4' } }]);
-      const target = _templateSrv.replace('this:${test:lucene}', {});
-      expect(target).toBe('this:value\\/4');
-    });
-  });
-
   describe('format variable to string values', () => {
     it('single value should return value', () => {
       const result = _templateSrv.formatValue('test');

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -2,7 +2,9 @@ import kbn from 'app/core/utils/kbn';
 import _ from 'lodash';
 
 function luceneEscape(value) {
-  return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');
+  // this seems unnessary and breaks functionality of being able to use this in a template variable
+  // return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');
+  return value;
 }
 
 export class TemplateSrv {


### PR DESCRIPTION
#13721 
Simple fix to issue.  May be missing a dependency, but my tests couldn't find it.  Opens Elasticsearch Data-source up for Lucene queries on the Dashboard level (thanks to new Textbox variable).