### PR TITLE
Fix cannot receive dingding alert when alert message is empty

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -57,6 +57,9 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 	message := evalContext.Rule.Message
 	picUrl := evalContext.ImagePublicUrl
 	title := evalContext.GetNotificationTitle()
+	if message == "" {
+		message = title
+	}
 
 	bodyJSON, err := simplejson.NewJson([]byte(`{
 		"msgtype": "link",


### PR DESCRIPTION
fix #13723 
When the "text" in request json send to Dingding is empty, Dingding will return an error
`{'errmsg': 'message param title or text is null ', 'errcode': 300001}`
