### PR TITLE
Add defaultProject to Stackdriver provisioning documentation

### DIFF
--- a/docs/sources/features/datasources/stackdriver.md
+++ b/docs/sources/features/datasources/stackdriver.md
@@ -206,6 +206,7 @@ datasources:
     jsonData:
       tokenUri: https://oauth2.googleapis.com/token
       clientEmail: stackdriver@myproject.iam.gserviceaccount.com
+      defaultProject: my-project-name
     secureJsonData:
       privateKey: |
         -----BEGIN PRIVATE KEY-----


### PR DESCRIPTION
defaultProject is needed when provisioning stackdriver datasource, hence it should be in the documentation. 

fixes #13533
