### PR TITLE
Fix doc error for DingDIng alert

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -140,7 +140,7 @@ In DingTalk PC Client:
 
 6. There will be a Webhook URL in the panel, looks like this: https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx. Copy this URL to the grafana Dingtalk setting page and then click "finish".
 
-Dingtalk supports the following "message type": `text`, `link` and `markdown`. Only the `text` message type is supported.
+Dingtalk supports the following "message type": `text`, `link` and `markdown`. Only the `link` message type is supported.
 
 ### Kafka
 


### PR DESCRIPTION
Based on the code, only link is supported.
https://github.com/grafana/grafana/blob/5a70327dcf9380cd99e955578c890282e6c2be4b/pkg/services/alerting/notifiers/dingding.go#L64-L72