### PR TITLE
Alerting: DingDing notification channel now includes alert values

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -10,19 +10,21 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 )
 
-func init() {
-	alerting.RegisterNotifier(&alerting.NotifierPlugin{
-		Type:        "dingding",
-		Name:        "DingDing",
-		Description: "Sends HTTP POST request to DingDing",
-		Factory:     NewDingDingNotifier,
-		OptionsTemplate: `
+const DingdingOptionsTemplate = `
       <h3 class="page-heading">DingDing settings</h3>
       <div class="gf-form">
         <span class="gf-form-label width-10">Url</span>
         <input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.url" placeholder="https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx"></input>
       </div>
-    `,
+`
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:            "dingding",
+		Name:            "DingDing",
+		Description:     "Sends HTTP POST request to DingDing",
+		Factory:         NewDingDingNotifier,
+		OptionsTemplate: DingdingOptionsTemplate,
 	})
 
 }
@@ -67,7 +69,7 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 		message += fmt.Sprintf("\\n%2d. %s value %s", i+1, match.Metric, match.Value)
 	}
 
-	bodyJSON, err := simplejson.NewJson([]byte(`{
+	bodyStr := `{
 		"msgtype": "link",
 		"link": {
 			"text": "` + message + `",
@@ -75,7 +77,8 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 			"picUrl": "` + picUrl + `",
 			"messageUrl": "` + messageUrl + `"
 		}
-	}`))
+	}`
+	bodyJSON, err := simplejson.NewJson([]byte(bodyStr))
 
 	if err != nil {
 		this.log.Error("Failed to create Json data", "error", err, "dingding", this.Name)

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -101,6 +101,11 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	var bodyStr string
 	if this.MsgType == "actionCard" {
+		// Embed the pic into the markdown directly because actionCard doesn't have a picUrl field
+		if picUrl != "" {
+			message = "![](" + picUrl + ")\\n\\n" + message
+		}
+
 		bodyStr = `{
 			"msgtype": "actionCard",
 			"actionCard": {

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -75,7 +75,7 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	for i, match := range evalContext.EvalMatches {
-		message += fmt.Sprintf("\\n%2d. %s value %s", i+1, match.Metric, match.Value)
+		message += fmt.Sprintf("\\n%2d. %s: %s", i+1, match.Metric, match.Value)
 	}
 
 	var bodyStr string

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -1,6 +1,8 @@
 package notifiers
 
 import (
+	"fmt"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/log"
@@ -59,6 +61,10 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 	title := evalContext.GetNotificationTitle()
 	if message == "" {
 		message = title
+	}
+
+	for i, match := range evalContext.EvalMatches {
+		message += fmt.Sprintf("\\n%2d. %s value %s", i+1, match.Metric, match.Value)
 	}
 
 	bodyJSON, err := simplejson.NewJson([]byte(`{

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -2,6 +2,7 @@ package notifiers
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -15,11 +16,16 @@ const DingdingOptionsTemplate = `
       <h3 class="page-heading">DingDing settings</h3>
       <div class="gf-form">
         <span class="gf-form-label width-10">Url</span>
-        <input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.url" placeholder="https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx"></input>
+        <input type="text" required class="gf-form-input max-width-70" ng-model="ctrl.model.settings.url" placeholder="https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx"></input>
       </div>
       <div class="gf-form">
         <span class="gf-form-label width-10">MessageType</span>
         <select class="gf-form-input max-width-14" ng-model="ctrl.model.settings.msgType" ng-options="s for s in ['link','actionCard']" ng-init="ctrl.model.settings.msgType=ctrl.model.settings.msgType || '` + DefaultDingdingMsgType + `'"></select>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-10">OpenInBrowser</span>
+        <gf-form-switch class="gf-form" checked="ctrl.model.settings.openInBrowser"></gf-form-switch>
+        <info-popover mode="right-normal">Open the message url in browser instead of inside of Dingding</info-popover>
       </div>
 `
 
@@ -41,20 +47,23 @@ func NewDingDingNotifier(model *m.AlertNotification) (alerting.Notifier, error) 
 	}
 
 	msgType := model.Settings.Get("msgType").MustString(DefaultDingdingMsgType)
+	openInBrowser := model.Settings.Get("openInBrowser").MustBool(true)
 
 	return &DingDingNotifier{
-		NotifierBase: NewNotifierBase(model),
-		MsgType:      msgType,
-		Url:          url,
-		log:          log.New("alerting.notifier.dingding"),
+		NotifierBase:  NewNotifierBase(model),
+		OpenInBrowser: openInBrowser,
+		MsgType:       msgType,
+		Url:           url,
+		log:           log.New("alerting.notifier.dingding"),
 	}, nil
 }
 
 type DingDingNotifier struct {
 	NotifierBase
-	MsgType string
-	Url     string
-	log     log.Logger
+	MsgType       string
+	OpenInBrowser bool //Set whether the message url will open outside of Dingding
+	Url           string
+	log           log.Logger
 }
 
 func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
@@ -65,6 +74,18 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 		this.log.Error("Failed to get messageUrl", "error", err, "dingding", this.Name)
 		messageUrl = ""
 	}
+
+	if this.OpenInBrowser {
+		q := url.Values{
+			"pc_slide": {"false"},
+			"url":      {messageUrl},
+		}
+
+		// Use special link to auto open the message url outside of Dingding
+		// Refer: https://open-doc.dingtalk.com/docs/doc.htm?treeId=385&articleId=104972&docType=1#s9
+		messageUrl = "dingtalk://dingtalkclient/page/link?" + q.Encode()
+	}
+
 	this.log.Info("messageUrl:" + messageUrl)
 
 	message := evalContext.Rule.Message

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -3,6 +3,7 @@ package notifiers
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -99,8 +100,8 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 		bodyStr = `{
 			"msgtype": "actionCard",
 			"actionCard": {
-				"text": "` + message + `",
-				"title": "` + title + `",
+				"text": "` + strings.Replace(message, `"`, "'", -1) + `",
+				"title": "` + strings.Replace(title, `"`, "'", -1) + `",
 				"singleTitle": "More",
 				"singleURL": "` + messageUrl + `"
 			}

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -22,11 +22,6 @@ const DingdingOptionsTemplate = `
         <span class="gf-form-label width-10">MessageType</span>
         <select class="gf-form-input max-width-14" ng-model="ctrl.model.settings.msgType" ng-options="s for s in ['link','actionCard']" ng-init="ctrl.model.settings.msgType=ctrl.model.settings.msgType || '` + DefaultDingdingMsgType + `'"></select>
       </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">OpenInBrowser</span>
-        <gf-form-switch class="gf-form" checked="ctrl.model.settings.openInBrowser"></gf-form-switch>
-        <info-popover mode="right-normal">Open the message url in browser instead of inside of Dingding</info-popover>
-      </div>
 `
 
 func init() {
@@ -47,23 +42,20 @@ func NewDingDingNotifier(model *m.AlertNotification) (alerting.Notifier, error) 
 	}
 
 	msgType := model.Settings.Get("msgType").MustString(DefaultDingdingMsgType)
-	openInBrowser := model.Settings.Get("openInBrowser").MustBool(true)
 
 	return &DingDingNotifier{
-		NotifierBase:  NewNotifierBase(model),
-		OpenInBrowser: openInBrowser,
-		MsgType:       msgType,
-		Url:           url,
-		log:           log.New("alerting.notifier.dingding"),
+		NotifierBase: NewNotifierBase(model),
+		MsgType:      msgType,
+		Url:          url,
+		log:          log.New("alerting.notifier.dingding"),
 	}, nil
 }
 
 type DingDingNotifier struct {
 	NotifierBase
-	MsgType       string
-	OpenInBrowser bool //Set whether the message url will open outside of Dingding
-	Url           string
-	log           log.Logger
+	MsgType string
+	Url     string
+	log     log.Logger
 }
 
 func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
@@ -75,16 +67,14 @@ func (this *DingDingNotifier) Notify(evalContext *alerting.EvalContext) error {
 		messageUrl = ""
 	}
 
-	if this.OpenInBrowser {
-		q := url.Values{
-			"pc_slide": {"false"},
-			"url":      {messageUrl},
-		}
-
-		// Use special link to auto open the message url outside of Dingding
-		// Refer: https://open-doc.dingtalk.com/docs/doc.htm?treeId=385&articleId=104972&docType=1#s9
-		messageUrl = "dingtalk://dingtalkclient/page/link?" + q.Encode()
+	q := url.Values{
+		"pc_slide": {"false"},
+		"url":      {messageUrl},
 	}
+
+	// Use special link to auto open the message url outside of Dingding
+	// Refer: https://open-doc.dingtalk.com/docs/doc.htm?treeId=385&articleId=104972&docType=1#s9
+	messageUrl = "dingtalk://dingtalkclient/page/link?" + q.Encode()
 
 	this.log.Info("messageUrl:" + messageUrl)
 


### PR DESCRIPTION
Add the match value('s) into Dingding's notification message.

First I just add the values into message. But it not work better. Because we always has many match values. The original code use only *link* msgtype, which will truncate the mass text.

So I add the msgtype scheleton support, with a new msgtype *actionCard*, which will never truncate anything.

```release-note
Dingding alert message now includes values and an option for a new actionCard type. 
```