### PR TITLE
JSON header support for Auth Proxy

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -293,6 +293,8 @@ log_queries =
 ;header_property = username
 ;auto_sign_up = true
 ;ldap_sync_ttl = 60
+;json_header = false
+;json_property = preferred_username
 ;whitelist = 192.168.1.1, 192.168.2.1
 
 #################################### Basic Auth ##########################

--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -29,6 +29,10 @@ header_property = username
 auto_sign_up = true
 # If combined with Grafana LDAP integration define sync interval
 ldap_sync_ttl = 60
+# If HTTP Header is a JSON string, set this to true. Defaults to 'false'.
+json_header = true
+# Needed when using json_header, specify the JSON key that will contain the user as a value.
+json_property = preferred_username
 # Limit where auth proxy requests come from by configuring a list of IP addresses.
 # This can be used to prevent users spoofing the X-WEBAUTH-USER header.
 whitelist =

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -13,15 +13,12 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"gopkg.in/ini.v1"
-
-	"github.com/go-macaron/session"
-
 	"time"
 
+	"github.com/go-macaron/session"
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/util"
+	"gopkg.in/ini.v1"
 )
 
 type Scheme string
@@ -119,13 +116,15 @@ var (
 	AnonymousOrgRole string
 
 	// Auth proxy settings
-	AuthProxyEnabled        bool
-	AuthProxyHeaderName     string
-	AuthProxyHeaderProperty string
-	AuthProxyAutoSignUp     bool
-	AuthProxyLdapSyncTtl    int
-	AuthProxyWhitelist      string
-	AuthProxyHeaders        map[string]string
+	AuthProxyEnabled            bool
+	AuthProxyHeaderName         string
+	AuthProxyHeaderProperty     string
+	AuthProxyAutoSignUp         bool
+	AuthProxyLdapSyncTtl        int
+	AuthProxyWhitelist          string
+	AuthProxyHeaders            map[string]string
+	AuthProxyJsonHeader         bool
+	AuthProxyJsonHeaderProperty string
 
 	// Basic Auth
 	BasicAuthEnabled bool
@@ -639,6 +638,8 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AuthProxyAutoSignUp = authProxy.Key("auto_sign_up").MustBool(true)
 	AuthProxyLdapSyncTtl = authProxy.Key("ldap_sync_ttl").MustInt()
 	AuthProxyWhitelist = authProxy.Key("whitelist").String()
+	AuthProxyJsonHeader = authProxy.Key("json_header").MustBool(false)
+	AuthProxyJsonHeaderProperty = authProxy.Key("json_property").String()
 
 	AuthProxyHeaders = make(map[string]string)
 	for _, propertyAndHeader := range util.SplitString(authProxy.Key("headers").String()) {


### PR DESCRIPTION
Many API gateway components ([this](https://github.com/nokia/kong-oidc), for example) add logged in user as a JSON string in a header instead of a separate header containing only the username. This addition allows the Auth Proxy to fetch username (or email) from the specified JSON key in a header. Documentation for this is also added. 

There doesn't exist an issue for this (AFAIK), but I can create one if needed.