### PR TITLE
Makefile: dependency-driven target to build node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ all: deps build
 deps-go:
 	go run build.go setup
 
-deps-js:
-	yarn install --pure-lockfile --no-progress
+deps-js: node_modules
 
 deps: deps-js
 
@@ -43,3 +42,10 @@ test: test-go test-js
 
 run:
 	./bin/grafana-server
+
+clean:
+	rm -rf node_modules
+	rm -rf public/build
+
+node_modules: package.json yarn.lock
+	yarn install --pure-lockfile --no-progress


### PR DESCRIPTION
- added `node_modules` as new target
- dependency on `package.json` and `yarn.lock` allows for quick `make
  node_modules` after a branch change, which noops when the deps have
 not changed:

```
make node_modules 
make: `node_modules' is up to date.
```

- also added `clean` target
