### PR TITLE
Updated grafana_stats.json

### DIFF
--- a/public/app/plugins/datasource/prometheus/dashboards/grafana_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/grafana_stats.json
@@ -753,7 +753,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "expr": "increase(grafana_alerting_result_total[1m])",
+                "expr": "increase(grafana_alerting_active_alerts[1m])",
                 "format": "time_series",
                 "intervalFactor": 3,
                 "legendFormat": "{{state}}",
@@ -764,7 +764,7 @@
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Grafana alert results",
+            "title": "Grafana active alerts",
             "tooltip": {
               "shared": true,
               "sort": 0,


### PR DESCRIPTION
The grafana_stats.json used the following prometheus query: 

"increase(grafana_alerting_result_total[1m])" 

But a metric called "grafana_alerting_result_total" is currently not there anymore. So i changed the query to:

"increase(grafana_alerting_active_alerts[1m])" 

and updated the title as well (Before: "Grafana alert results", Now: "Grafana active alerts").
