### PR TITLE
Add new build info metrics that contains more info

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -80,7 +80,7 @@ func main() {
 	setting.BuildBranch = buildBranch
 	setting.IsEnterprise = extensions.IsEnterprise
 
-	metrics.M_Grafana_Version.WithLabelValues(version).Set(1)
+	metrics.SetBuildInformation(version, commit, buildBranch)
 
 	server := NewGrafanaServer()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,9 +59,13 @@ var (
 	M_StatTotal_Orgs         prometheus.Gauge
 	M_StatTotal_Playlists    prometheus.Gauge
 
-	// Metrics about this binary
-	M_Grafana_Version       *prometheus.GaugeVec
-	M_Grafana_Build_Version *prometheus.GaugeVec
+	// M_Grafana_Version is a gauge that contains build info about this binary
+	//
+	// Deprecated: use M_Grafana_Build_Version instead.
+	M_Grafana_Version *prometheus.GaugeVec
+
+	// grafanaBuildVersion is a gauge that contains build info about this binary
+	grafanaBuildVersion *prometheus.GaugeVec
 )
 
 func newCounterVecStartingAtZero(opts prometheus.CounterOpts, labels []string, labelValues ...string) *prometheus.CounterVec {
@@ -296,11 +300,11 @@ func init() {
 
 	M_Grafana_Version = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "info",
-Help:      "Information about the Grafana. This metric is deprecated. please use `grafana_build_info`
+		Help:      "Information about the Grafana. This metric is deprecated. please use `grafana_build_info`",
 		Namespace: exporterName,
 	}, []string{"version"})
 
-	M_Grafana_Build_Version = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	grafanaBuildVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built.",
 		Namespace: exporterName,
@@ -314,7 +318,7 @@ func SetBuildInformation(version, revision, branch string) {
 	// The reason we added a new one is that its common practice in the prometheus community
 	// to name this metric `*_build_info` so its easy to do aggregation on all programs.
 	M_Grafana_Version.WithLabelValues(version).Set(1)
-	M_Grafana_Build_Version.WithLabelValues(version, revision, branch, runtime.Version()).Set(1)
+	grafanaBuildVersion.WithLabelValues(version, revision, branch, runtime.Version()).Set(1)
 }
 
 func initMetricVars() {
@@ -354,7 +358,7 @@ func initMetricVars() {
 		M_StatTotal_Orgs,
 		M_StatTotal_Playlists,
 		M_Grafana_Version,
-		M_Grafana_Build_Version)
+		grafanaBuildVersion)
 
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -296,7 +296,7 @@ func init() {
 
 	M_Grafana_Version = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "info",
-		Help:      "Information about the Grafana. This metrics is deprecated. please use `grafana_build_info`",
+Help:      "Information about the Grafana. This metric is deprecated. please use `grafana_build_info`
 		Namespace: exporterName,
 	}, []string{"version"})
 


### PR DESCRIPTION
The goal was to add more information about Grafana. But rather than just
adding those to the current metrics I created a new metric since its a
common pattern in the prometheus community to expose that info in a metric
named `*_build_info`.

We keep the old metric to avoid introducing any breaking changes but we
should be able to remove it the next breaking change