### PR TITLE
JS tooling: run TS grunt tasks only when files changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-cssmin": "~1.0.2",
     "grunt-exec": "^1.0.1",
+    "grunt-newer": "^1.3.0",
     "grunt-notify": "^0.4.5",
     "grunt-postcss": "^0.8.0",
     "grunt-sass": "^2.0.0",

--- a/scripts/grunt/default_task.js
+++ b/scripts/grunt/default_task.js
@@ -17,8 +17,8 @@ module.exports = function (grunt) {
 
   grunt.registerTask('precommit', [
     'sasslint',
-    'exec:tslint',
-    'exec:tsc',
+    'newer:exec:tslint',
+    'newer:exec:tsc',
     'no-only-tests'
   ]);
 

--- a/scripts/grunt/options/exec.js
+++ b/scripts/grunt/options/exec.js
@@ -2,8 +2,14 @@ module.exports = function (config, grunt) {
   'use strict';
 
   return {
-    tslint: 'node ./node_modules/tslint/lib/tslintCli.js -c tslint.json --project ./tsconfig.json',
-    tsc: 'yarn tsc --noEmit',
+    tslint: {
+      command: 'node ./node_modules/tslint/lib/tslintCli.js -c tslint.json --project ./tsconfig.json',
+      src: ['public/app/**/*.ts*'],
+    },
+    tsc: {
+      command: 'yarn tsc --noEmit',
+      src: ['public/app/**/*.ts*'],
+    },
     jest: 'node ./node_modules/jest-cli/bin/jest.js --maxWorkers 2',
     webpack: 'node ./node_modules/webpack/bin/webpack.js --config scripts/webpack/webpack.prod.js',
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,6 +5971,14 @@ grunt-legacy-util@~1.0.0:
     underscore.string "~3.2.3"
     which "~1.2.1"
 
+grunt-newer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/grunt-newer/-/grunt-newer-1.3.0.tgz#83ccb7a1dda7cbd8ab23b059024ebe614ad2f342"
+  integrity sha1-g8y3od2ny9irI7BZAk6+YUrS80I=
+  dependencies:
+    async "^1.5.2"
+    rimraf "^2.5.2"
+
 grunt-notify@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/grunt-notify/-/grunt-notify-0.4.5.tgz#05293990616110db6bc0ad15e6c0592ffe18ac31"


### PR DESCRIPTION
- using grunt-newer to prefix precommit tasks
- only got it to work for tslint and tsc

Not applied to:

- sasslint does not take the file arguments in a way that grunt-newer
  recognizes
- no-only-tests throws an error when used with `newer`, but it's
  sub-second runtime
