### PR TITLE
Add only display date option to table panel column

### DIFF
--- a/public/app/plugins/panel/table/column_options.ts
+++ b/public/app/plugins/panel/table/column_options.ts
@@ -41,6 +41,7 @@ export class ColumnOptionsCtrl {
       { text: 'YYYY-MM-DD HH:mm:ss.SSS', value: 'YYYY-MM-DD HH:mm:ss.SSS' },
       { text: 'MM/DD/YY h:mm:ss a', value: 'MM/DD/YY h:mm:ss a' },
       { text: 'MMMM D, YYYY LT', value: 'MMMM D, YYYY LT' },
+      { text: 'YYYY-MM-DD', value: 'YYYY-MM-DD' },
     ];
     this.mappingTypes = [{ text: 'Value to text', value: 1 }, { text: 'Range to text', value: 2 }];
 


### PR DESCRIPTION
I got some data stored in mysql with type "DATE", and I want to display them in table pannel.
The table panel only supports these datetime formats.
https://github.com/grafana/grafana/blob/baea76c4ea4c5a9a013cae79c0ec294157509454/public/app/plugins/panel/table/column_options.ts#L40-L43

Therefore I added an extra option for only displaying date without time in table panel as shown in this screenshot.
<img width="985" alt="wx20181031-185327 2x" src="https://user-images.githubusercontent.com/3638888/47783860-c9506480-dd3e-11e8-9346-d79c77e4050b.png">