### PR TITLE
Add delta window function to postgres query builder

### DIFF
--- a/public/app/plugins/datasource/postgres/postgres_query.ts
+++ b/public/app/plugins/datasource/postgres/postgres_query.ts
@@ -184,6 +184,11 @@ export default class PostgresQuery {
       switch (windows.type) {
         case 'window':
           switch (windows.params[0]) {
+            case 'delta':
+              curr = query;
+              prev = 'lag(' + curr + ') OVER (' + over + ')';
+              query = curr + ' - ' + prev;
+              break;
             case 'increase':
               curr = query;
               prev = 'lag(' + curr + ') OVER (' + over + ')';

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -158,6 +158,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
       text: 'Window Functions',
       value: 'window',
       submenu: [
+        { text: 'Delta', value: 'delta' },
         { text: 'Increase', value: 'increase' },
         { text: 'Rate', value: 'rate' },
         { text: 'Sum', value: 'sum' },

--- a/public/app/plugins/datasource/postgres/sql_part.ts
+++ b/public/app/plugins/datasource/postgres/sql_part.ts
@@ -107,7 +107,7 @@ register({
     {
       name: 'function',
       type: 'string',
-      options: ['increase', 'rate', 'sum'],
+      options: ['delta', 'increase', 'rate', 'sum'],
     },
   ],
   defaultParams: ['increase'],


### PR DESCRIPTION
Unlike the increase function delta doesn't check for resets
and can go negative. This is similar to the prometheus delta
function.

Fixes #13925