### PR TITLE
Explore: fix metric selector for additional rows

### DIFF
--- a/public/app/plugins/datasource/logging/components/LoggingQueryField.tsx
+++ b/public/app/plugins/datasource/logging/components/LoggingQueryField.tsx
@@ -95,9 +95,9 @@ class LoggingQueryField extends React.PureComponent<LoggingQueryFieldProps, Logg
       this.languageProvider
         .start()
         .then(remaining => {
-          remaining.map(task => task.then(this.onReceiveMetrics).catch(() => {}));
+          remaining.map(task => task.then(this.onUpdateLanguage).catch(() => {}));
         })
-        .then(() => this.onReceiveMetrics());
+        .then(() => this.onUpdateLanguage());
     }
   }
 
@@ -119,7 +119,7 @@ class LoggingQueryField extends React.PureComponent<LoggingQueryFieldProps, Logg
 
     this.languageProvider
       .fetchLabelValues(targetOption.value)
-      .then(this.onReceiveMetrics)
+      .then(this.onUpdateLanguage)
       .catch(() => {});
   };
 
@@ -147,7 +147,7 @@ class LoggingQueryField extends React.PureComponent<LoggingQueryFieldProps, Logg
     }
   };
 
-  onReceiveMetrics = () => {
+  onUpdateLanguage = () => {
     Prism.languages[PRISM_SYNTAX] = this.languageProvider.getSyntax();
     const { logLabelOptions } = this.languageProvider;
     this.setState({

--- a/public/app/plugins/datasource/logging/language_provider.ts
+++ b/public/app/plugins/datasource/logging/language_provider.ts
@@ -47,7 +47,6 @@ export default class LoggingLanguageProvider extends LanguageProvider {
     this.datasource = datasource;
     this.labelKeys = {};
     this.labelValues = {};
-    this.started = false;
 
     Object.assign(this, initialValues);
   }
@@ -63,11 +62,10 @@ export default class LoggingLanguageProvider extends LanguageProvider {
   };
 
   start = () => {
-    if (!this.started) {
-      this.started = true;
-      return this.fetchLogLabels();
+    if (!this.startTask) {
+      this.startTask = this.fetchLogLabels();
     }
-    return Promise.resolve([]);
+    return this.startTask;
   };
 
   // Keep this DOM-free for testing

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -134,9 +134,9 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
       this.languageProvider
         .start()
         .then(remaining => {
-          remaining.map(task => task.then(this.onReceiveMetrics).catch(() => {}));
+          remaining.map(task => task.then(this.onUpdateLanguage).catch(() => {}));
         })
-        .then(() => this.onReceiveMetrics());
+        .then(() => this.onUpdateLanguage());
     }
   }
 
@@ -176,7 +176,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     }
   };
 
-  onReceiveMetrics = () => {
+  onUpdateLanguage = () => {
     const { histogramMetrics, metrics } = this.languageProvider;
     if (!metrics) {
       return;

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -46,7 +46,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   labelKeys?: { [index: string]: string[] }; // metric -> [labelKey,...]
   labelValues?: { [index: string]: { [index: string]: string[] } }; // metric -> labelKey -> [labelValue,...]
   metrics?: string[];
-  started: boolean;
+  startTask: Promise<any>;
 
   constructor(datasource: any, initialValues?: any) {
     super();
@@ -56,7 +56,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     this.labelKeys = {};
     this.labelValues = {};
     this.metrics = [];
-    this.started = false;
 
     Object.assign(this, initialValues);
   }
@@ -72,11 +71,10 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   };
 
   start = () => {
-    if (!this.started) {
-      this.started = true;
-      return this.fetchMetricNames().then(() => [this.fetchHistogramMetrics()]);
+    if (!this.startTask) {
+      this.startTask = this.fetchMetricNames().then(() => [this.fetchHistogramMetrics()]);
     }
-    return Promise.resolve([]);
+    return this.startTask;
   };
 
   // Keep this DOM-free for testing

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -86,10 +86,11 @@ export abstract class LanguageProvider {
   datasource: any;
   request: (url) => Promise<any>;
   /**
-   * Returns a promise that resolves with a task list when main syntax is loaded.
+   * Returns startTask that resolves with a task list when main syntax is loaded.
    * Task list consists of secondary promises that load more detailed language features.
    */
   start: () => Promise<any[]>;
+  startTask?: Promise<any[]>;
 }
 
 export interface TypeaheadInput {


### PR DESCRIPTION
- race condition in language provider leads to only one query row getting
  selector options
- fixed by always returning the task promise when getting initial data
