### PR TITLE
Explore: Logging graph overview and view options

### DIFF
--- a/public/app/core/components/Switch/Switch.tsx
+++ b/public/app/core/components/Switch/Switch.tsx
@@ -5,6 +5,7 @@ export interface Props {
   label: string;
   checked: boolean;
   labelClass?: string;
+  small?: boolean;
   switchClass?: string;
   onChange: (event) => any;
 }
@@ -24,10 +25,14 @@ export class Switch extends PureComponent<Props, State> {
   };
 
   render() {
-    const { labelClass, switchClass, label, checked } = this.props;
+    const { labelClass = '', switchClass = '', label, checked, small } = this.props;
     const labelId = `check-${this.state.id}`;
-    const labelClassName = `gf-form-label ${labelClass} pointer`;
-    const switchClassName = `gf-form-switch ${switchClass}`;
+    let labelClassName = `gf-form-label ${labelClass} pointer`;
+    let switchClassName = `gf-form-switch ${switchClass}`;
+    if (small) {
+      labelClassName += ' gf-form-label--small';
+      switchClassName += ' gf-form-switch--small';
+    }
 
     return (
       <div className="gf-form">

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { TimeSeries } from 'app/core/core';
+import colors from 'app/core/utils/colors';
 
 export enum LogLevel {
   crit = 'crit',
@@ -9,7 +10,19 @@ export enum LogLevel {
   info = 'info',
   debug = 'debug',
   trace = 'trace',
+  none = 'none',
 }
+
+export const LogLevelColor = {
+  [LogLevel.crit]: colors[7],
+  [LogLevel.warn]: colors[1],
+  [LogLevel.err]: colors[4],
+  [LogLevel.error]: colors[4],
+  [LogLevel.info]: colors[0],
+  [LogLevel.debug]: colors[3],
+  [LogLevel.trace]: colors[3],
+  [LogLevel.none]: '#eee',
+};
 
 export interface LogSearchMatch {
   start: number;
@@ -44,7 +57,7 @@ export interface LogsStream {
   labels: string;
   entries: LogsStreamEntry[];
   parsedLabels: { [key: string]: string };
-  graphSeries: TimeSeries;
+  intervalMs?: number;
 }
 
 export interface LogsStreamEntry {

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -31,15 +31,16 @@ export interface LogSearchMatch {
 }
 
 export interface LogRow {
-  key: string;
   entry: string;
+  key: string; // timestamp + labels
   labels: string;
   logLevel: LogLevel;
-  timestamp: string;
-  timeFromNow: string;
-  timeJs: number;
-  timeLocal: string;
   searchWords?: string[];
+  timestamp: string; // ISO with nanosec precision
+  timeFromNow: string;
+  timeEpochMs: number;
+  timeLocal: string;
+  uniqueLabels?: string;
 }
 
 export interface LogsMetaItem {
@@ -56,11 +57,46 @@ export interface LogsModel {
 export interface LogsStream {
   labels: string;
   entries: LogsStreamEntry[];
-  parsedLabels: { [key: string]: string };
-  intervalMs?: number;
+  search?: string;
+  parsedLabels?: LogsStreamLabels;
+  uniqueLabels?: string;
 }
 
 export interface LogsStreamEntry {
   line: string;
   timestamp: string;
+}
+
+export interface LogsStreamLabels {
+  [key: string]: string;
+}
+
+export function makeSeriesForLogs(rows: LogRow[], intervalMs: number): TimeSeries[] {
+  // Graph time series by log level
+  const seriesByLevel = {};
+  rows.forEach(row => {
+    if (!seriesByLevel[row.logLevel]) {
+      seriesByLevel[row.logLevel] = { lastTs: null, datapoints: [], alias: row.logLevel };
+    }
+    const levelSeries = seriesByLevel[row.logLevel];
+
+    // Bucket to nearest minute
+    const time = Math.round(row.timeEpochMs / intervalMs / 10) * intervalMs * 10;
+    // Entry for time
+    if (time === levelSeries.lastTs) {
+      levelSeries.datapoints[levelSeries.datapoints.length - 1][0]++;
+    } else {
+      levelSeries.datapoints.push([1, time]);
+      levelSeries.lastTs = time;
+    }
+  });
+
+  return Object.keys(seriesByLevel).reduce((acc, level) => {
+    if (seriesByLevel[level]) {
+      const gs = new TimeSeries(seriesByLevel[level]);
+      gs.setColor(LogLevelColor[level]);
+      acc.push(gs);
+    }
+    return acc;
+  }, []);
 }

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { TimeSeries } from 'app/core/core';
 
 export enum LogLevel {
   crit = 'crit',
@@ -19,25 +20,34 @@ export interface LogSearchMatch {
 export interface LogRow {
   key: string;
   entry: string;
+  labels: string;
   logLevel: LogLevel;
   timestamp: string;
   timeFromNow: string;
+  timeJs: number;
   timeLocal: string;
   searchWords?: string[];
 }
 
-export interface LogsModel {
-  rows: LogRow[];
+export interface LogsMetaItem {
+  label: string;
+  value: string;
 }
 
-export function mergeStreams(streams: LogsModel[], limit?: number): LogsModel {
-  const combinedEntries = streams.reduce((acc, stream) => {
-    return [...acc, ...stream.rows];
-  }, []);
-  const sortedEntries = _.chain(combinedEntries)
-    .sortBy('timestamp')
-    .reverse()
-    .slice(0, limit || combinedEntries.length)
-    .value();
-  return { rows: sortedEntries };
+export interface LogsModel {
+  meta?: LogsMetaItem[];
+  rows: LogRow[];
+  series?: TimeSeries[];
+}
+
+export interface LogsStream {
+  labels: string;
+  entries: LogsStreamEntry[];
+  parsedLabels: { [key: string]: string };
+  graphSeries: TimeSeries;
+}
+
+export interface LogsStreamEntry {
+  line: string;
+  timestamp: string;
 }

--- a/public/app/core/utils/colors.ts
+++ b/public/app/core/utils/colors.ts
@@ -10,16 +10,16 @@ export const NO_DATA_COLOR = 'rgba(150, 150, 150, 1)';
 export const REGION_FILL_ALPHA = 0.09;
 
 const colors = [
-  '#7EB26D',
-  '#EAB839',
-  '#6ED0E0',
-  '#EF843C',
-  '#E24D42',
-  '#1F78C1',
-  '#BA43A9',
-  '#705DA0',
-  '#508642',
-  '#CCA300',
+  '#7EB26D', // 0: pale green
+  '#EAB839', // 1: mustard
+  '#6ED0E0', // 2: light blue
+  '#EF843C', // 3: orange
+  '#E24D42', // 4: red
+  '#1F78C1', // 5: ocean
+  '#BA43A9', // 6: purple
+  '#705DA0', // 7: violet
+  '#508642', // 8: dark green
+  '#CCA300', // 9: dark sand
   '#447EBC',
   '#C15C17',
   '#890F02',

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -475,7 +475,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
       from: parseDate(range.from, false),
       to: parseDate(range.to, true),
     };
-    const { interval } = kbn.calculateInterval(absoluteRange, resolution, datasource.interval);
+    const { interval, intervalMs } = kbn.calculateInterval(absoluteRange, resolution, datasource.interval);
     const targets = [
       {
         ...targetOptions,
@@ -490,6 +490,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
 
     return {
       interval,
+      intervalMs,
       targets,
       range: queryRange,
     };

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -898,6 +898,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                           height={graphHeight}
                           loading={graphLoading}
                           id={`explore-graph-${position}`}
+                          onChangeTime={this.onChangeTime}
                           range={graphRange}
                           split={split}
                         />
@@ -908,7 +909,13 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                       </div>
                     ) : null}
                     {supportsLogs && showingLogs ? (
-                      <Logs data={logsResult} loading={logsLoading} position={position} range={range} />
+                      <Logs
+                        data={logsResult}
+                        loading={logsLoading}
+                        position={position}
+                        onChangeTime={this.onChangeTime}
+                        range={range}
+                      />
                     ) : null}
                   </>
                 )}

--- a/public/app/features/explore/Graph.tsx
+++ b/public/app/features/explore/Graph.tsx
@@ -5,6 +5,7 @@ import { withSize } from 'react-sizeme';
 
 import 'vendor/flot/jquery.flot';
 import 'vendor/flot/jquery.flot.time';
+import 'vendor/flot/jquery.flot.selection';
 
 import { RawTimeRange } from 'app/types/series';
 import * as dateMath from 'app/core/utils/datemath';
@@ -62,10 +63,10 @@ const FLOT_OPTIONS = {
     margin: { left: 0, right: 0 },
     labelMarginX: 0,
   },
-  // selection: {
-  //   mode: 'x',
-  //   color: '#666',
-  // },
+  selection: {
+    mode: 'x',
+    color: '#666',
+  },
   // crosshair: {
   //   mode: 'x',
   // },
@@ -80,6 +81,7 @@ interface GraphProps {
   split?: boolean;
   size?: { width: number; height: number };
   userOptions?: any;
+  onChangeTime?: (range: RawTimeRange) => void;
 }
 
 interface GraphState {
@@ -87,6 +89,8 @@ interface GraphState {
 }
 
 export class Graph extends PureComponent<GraphProps, GraphState> {
+  $el: any;
+
   state = {
     showAllTimeSeries: false,
   };
@@ -99,6 +103,8 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
 
   componentDidMount() {
     this.draw();
+    this.$el = $(`#${this.props.id}`);
+    this.$el.bind('plotselected', this.onPlotSelected);
   }
 
   componentDidUpdate(prevProps: GraphProps) {
@@ -112,6 +118,20 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
       this.draw();
     }
   }
+
+  componentWillUnmount() {
+    this.$el.unbind('plotselected', this.onPlotSelected);
+  }
+
+  onPlotSelected = (event, ranges) => {
+    if (this.props.onChangeTime) {
+      const range = {
+        from: moment(ranges.xaxis.from),
+        to: moment(ranges.xaxis.to),
+      };
+      this.props.onChangeTime(range);
+    }
+  };
 
   onShowAllTimeSeries = () => {
     this.setState(

--- a/public/app/features/explore/Graph.tsx
+++ b/public/app/features/explore/Graph.tsx
@@ -79,6 +79,7 @@ interface GraphProps {
   range: RawTimeRange;
   split?: boolean;
   size?: { width: number; height: number };
+  userOptions?: any;
 }
 
 interface GraphState {
@@ -122,7 +123,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
   };
 
   draw() {
-    const { range, size } = this.props;
+    const { range, size, userOptions = {} } = this.props;
     const data = this.getGraphData();
 
     const $el = $(`#${this.props.id}`);
@@ -153,12 +154,14 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
         max: max,
         label: 'Datetime',
         ticks: ticks,
+        timezone: 'browser',
         timeformat: time_format(ticks, min, max),
       },
     };
     const options = {
       ...FLOT_OPTIONS,
       ...dynamicOptions,
+      ...userOptions,
     };
     $.plot($el, series, options);
   }

--- a/public/app/features/explore/Graph.tsx
+++ b/public/app/features/explore/Graph.tsx
@@ -6,6 +6,7 @@ import { withSize } from 'react-sizeme';
 import 'vendor/flot/jquery.flot';
 import 'vendor/flot/jquery.flot.time';
 import 'vendor/flot/jquery.flot.selection';
+import 'vendor/flot/jquery.flot.stack';
 
 import { RawTimeRange } from 'app/types/series';
 import * as dateMath from 'app/core/utils/datemath';

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -1,29 +1,130 @@
 import React, { Fragment, PureComponent } from 'react';
 import Highlighter from 'react-highlight-words';
 
+import { RawTimeRange } from 'app/types/series';
 import { LogsModel } from 'app/core/logs_model';
 import { findHighlightChunksInText } from 'app/core/utils/text';
+import { Switch } from 'app/core/components/Switch/Switch';
+
+import Graph from './Graph';
+
+const graphOptions = {
+  series: {
+    bars: {
+      show: true,
+    },
+  },
+  yaxis: {
+    tickDecimals: 0,
+  },
+};
 
 interface LogsProps {
   className?: string;
   data: LogsModel;
   loading: boolean;
+  position: string;
+  range?: RawTimeRange;
 }
 
-export default class Logs extends PureComponent<LogsProps, {}> {
+interface LogsState {
+  showLabels: boolean;
+  showLocalTime: boolean;
+  showUtc: boolean;
+}
+
+export default class Logs extends PureComponent<LogsProps, LogsState> {
+  state = {
+    showLabels: true,
+    showLocalTime: true,
+    showUtc: false,
+  };
+
+  onChangeLabels = (event: React.SyntheticEvent) => {
+    const target = event.target as HTMLInputElement;
+    this.setState({
+      showLabels: target.checked,
+    });
+  };
+
+  onChangeLocalTime = (event: React.SyntheticEvent) => {
+    const target = event.target as HTMLInputElement;
+    this.setState({
+      showLocalTime: target.checked,
+    });
+  };
+
+  onChangeUtc = (event: React.SyntheticEvent) => {
+    const target = event.target as HTMLInputElement;
+    this.setState({
+      showUtc: target.checked,
+    });
+  };
+
   render() {
-    const { className = '', data, loading = false } = this.props;
+    const { className = '', data, loading = false, position, range } = this.props;
+    const { showLabels, showLocalTime, showUtc } = this.state;
     const hasData = data && data.rows && data.rows.length > 0;
+    const cssColumnSizes = ['4px'];
+    if (showUtc) {
+      cssColumnSizes.push('minmax(100px, max-content)');
+    }
+    if (showLocalTime) {
+      cssColumnSizes.push('minmax(100px, max-content)');
+    }
+    if (showLabels) {
+      cssColumnSizes.push('minmax(100px, 25%)');
+    }
+    cssColumnSizes.push('1fr');
+    const logEntriesStyle = {
+      gridTemplateColumns: cssColumnSizes.join(' '),
+    };
+
     return (
       <div className={`${className} logs`}>
+        <div className="logs-graph">
+          <Graph
+            data={data.series}
+            height="100px"
+            range={range}
+            id={`explore-logs-graph-${position}`}
+            userOptions={graphOptions}
+          />
+        </div>
+
+        <div className="panel-container logs-options">
+          <div className="logs-controls">
+            <Switch label="Timestamp" checked={showUtc} onChange={this.onChangeUtc} small />
+            <Switch label="Local time" checked={showLocalTime} onChange={this.onChangeLocalTime} small />
+            <Switch label="Labels" checked={showLabels} onChange={this.onChangeLabels} small />
+            {hasData &&
+              data.meta && (
+                <div className="logs-meta">
+                  {data.meta.map(item => (
+                    <div className="logs-meta-item" key={item.label}>
+                      <span className="logs-meta-item__label">{item.label}:</span>
+                      <span className="logs-meta-item__value">{item.value}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+          </div>
+        </div>
+
         <div className="panel-container">
           {loading && <div className="explore-panel__loader" />}
-          <div className="logs-entries">
+          <div className="logs-entries" style={logEntriesStyle}>
             {hasData &&
               data.rows.map(row => (
                 <Fragment key={row.key}>
                   <div className={row.logLevel ? `logs-row-level logs-row-level-${row.logLevel}` : ''} />
-                  <div title={`${row.timestamp} (${row.timeFromNow})`}>{row.timeLocal}</div>
+                  {showUtc && <div title={`Local: ${row.timeLocal} (${row.timeFromNow})`}>{row.timestamp}</div>}
+                  {showLocalTime && <div title={`${row.timestamp} (${row.timeFromNow})`}>{row.timeLocal}</div>}
+                  {showLabels && (
+                    <div className="max-width" title={row.labels}>
+                      {row.labels}
+                    </div>
+                  )}
                   <div>
                     <Highlighter
                       textToHighlight={row.entry}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -12,7 +12,10 @@ const graphOptions = {
   series: {
     bars: {
       show: true,
+      lineWidth: 5,
+      // barWidth: 10,
     },
+    // stack: true,
   },
   yaxis: {
     tickDecimals: 0,

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -25,6 +25,7 @@ interface LogsProps {
   loading: boolean;
   position: string;
   range?: RawTimeRange;
+  onChangeTime?: (range: RawTimeRange) => void;
 }
 
 interface LogsState {
@@ -88,6 +89,7 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
             height="100px"
             range={range}
             id={`explore-logs-graph-${position}`}
+            onChangeTime={this.props.onChangeTime}
             userOptions={graphOptions}
           />
         </div>

--- a/public/app/features/explore/TimePicker.tsx
+++ b/public/app/features/explore/TimePicker.tsx
@@ -43,7 +43,7 @@ interface TimePickerState {
   isUtc: boolean;
   rangeString: string;
   refreshInterval?: string;
-  initialRange: RawTimeRange;
+  initialRange?: RawTimeRange;
 
   // Input-controlled text, keep these in a shape that is human-editable
   fromRaw: string;
@@ -53,24 +53,27 @@ interface TimePickerState {
 export default class TimePicker extends PureComponent<TimePickerProps, TimePickerState> {
   dropdownEl: any;
 
-  state = {
-    isOpen: false,
-    isUtc: false,
-    rangeString: '',
-    initialRange: DEFAULT_RANGE,
-    fromRaw: '',
-    toRaw: '',
-    refreshInterval: '',
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: props.isOpen,
+      isUtc: props.isUtc,
+      rangeString: '',
+      fromRaw: '',
+      toRaw: '',
+      initialRange: DEFAULT_RANGE,
+      refreshInterval: '',
+    };
+  }
 
   static getDerivedStateFromProps(props, state) {
-    if (state.range && state.range === props.range) {
-      return null;
+    if (state.initialRange && state.initialRange === props.range) {
+      return state;
     }
 
     const from = props.range ? props.range.from : DEFAULT_RANGE.from;
     const to = props.range ? props.range.to : DEFAULT_RANGE.to;
-    const initialRange = props.range || DEFAULT_RANGE;
 
     // Ensure internal format
     const fromRaw = parseTime(from, props.isUtc);
@@ -81,10 +84,10 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     };
 
     return {
+      ...state,
       fromRaw,
       toRaw,
-      initialRange,
-      isUtc: props.isUtc,
+      initialRange: props.range,
       rangeString: rangeUtil.describeTimeRange(range),
     };
   }

--- a/public/app/features/explore/TimePicker.tsx
+++ b/public/app/features/explore/TimePicker.tsx
@@ -16,6 +16,9 @@ export const DEFAULT_RANGE = {
  * @param value Epoch or relative time
  */
 export function parseTime(value: string, isUtc = false): string {
+  if (moment.isMoment(value)) {
+    return value;
+  }
   if (value.indexOf('now') !== -1) {
     return value;
   }
@@ -39,7 +42,8 @@ interface TimePickerState {
   isOpen: boolean;
   isUtc: boolean;
   rangeString: string;
-  refreshInterval: string;
+  refreshInterval?: string;
+  initialRange: RawTimeRange;
 
   // Input-controlled text, keep these in a shape that is human-editable
   fromRaw: string;
@@ -49,11 +53,24 @@ interface TimePickerState {
 export default class TimePicker extends PureComponent<TimePickerProps, TimePickerState> {
   dropdownEl: any;
 
-  constructor(props) {
-    super(props);
+  state = {
+    isOpen: false,
+    isUtc: false,
+    rangeString: '',
+    initialRange: DEFAULT_RANGE,
+    fromRaw: '',
+    toRaw: '',
+    refreshInterval: '',
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.range && state.range === props.range) {
+      return null;
+    }
 
     const from = props.range ? props.range.from : DEFAULT_RANGE.from;
     const to = props.range ? props.range.to : DEFAULT_RANGE.to;
+    const initialRange = props.range || DEFAULT_RANGE;
 
     // Ensure internal format
     const fromRaw = parseTime(from, props.isUtc);
@@ -63,13 +80,12 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
       to: toRaw,
     };
 
-    this.state = {
+    return {
       fromRaw,
       toRaw,
-      isOpen: props.isOpen,
+      initialRange,
       isUtc: props.isUtc,
       rangeString: rangeUtil.describeTimeRange(range),
-      refreshInterval: '',
     };
   }
 

--- a/public/app/plugins/datasource/logging/datasource.ts
+++ b/public/app/plugins/datasource/logging/datasource.ts
@@ -3,9 +3,10 @@ import _ from 'lodash';
 import * as dateMath from 'app/core/utils/datemath';
 
 import LanguageProvider from './language_provider';
-import { processStreams } from './result_transformer';
+import { mergeStreams, processStream } from './result_transformer';
+import { LogsStream } from 'app/core/logs_model';
 
-const DEFAULT_LIMIT = 100;
+const DEFAULT_LIMIT = 1000;
 
 const DEFAULT_QUERY_PARAMS = {
   direction: 'BACKWARD',
@@ -67,6 +68,10 @@ export default class LoggingDatasource {
     return this.backendSrv.datasourceRequest(req);
   }
 
+  mergeStreams(streams: LogsStream[]) {
+    return mergeStreams(streams, DEFAULT_LIMIT);
+  }
+
   prepareQueryTarget(target, options) {
     const interpolated = this.templateSrv.replace(target.expr);
     const start = this.getTime(options.range.from, false);
@@ -100,8 +105,8 @@ export default class LoggingDatasource {
         });
         return [...acc, ...streams];
       }, []);
-      const model = processStreams(allStreams, DEFAULT_LIMIT);
-      return { data: model };
+      const processedStreams = allStreams.map(stream => processStream(stream, DEFAULT_LIMIT));
+      return { data: processedStreams };
     });
   }
 

--- a/public/app/plugins/datasource/logging/datasource.ts
+++ b/public/app/plugins/datasource/logging/datasource.ts
@@ -105,7 +105,7 @@ export default class LoggingDatasource {
         });
         return [...acc, ...streams];
       }, []);
-      const processedStreams = allStreams.map(stream => processStream(stream, DEFAULT_LIMIT));
+      const processedStreams = allStreams.map(stream => processStream(stream, DEFAULT_LIMIT, options.intervalMs));
       return { data: processedStreams };
     });
   }

--- a/public/app/plugins/datasource/logging/result_transformer.test.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.test.ts
@@ -4,11 +4,11 @@ import { findCommonLabels, findUncommonLabels, formatLabels, getLogLevel, parseL
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
-    expect(getLogLevel('')).toBe(undefined);
+    expect(getLogLevel('')).toBe(LogLevel.none);
   });
 
   it('returns no log level on when level is part of a word', () => {
-    expect(getLogLevel('this is a warning')).toBe(undefined);
+    expect(getLogLevel('this is a warning')).toBe(LogLevel.none);
   });
 
   it('returns log level on line contains a log level', () => {

--- a/public/app/plugins/datasource/logging/result_transformer.test.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.test.ts
@@ -1,6 +1,13 @@
-import { LogLevel } from 'app/core/logs_model';
+import { LogLevel, LogsStream } from 'app/core/logs_model';
 
-import { findCommonLabels, findUncommonLabels, formatLabels, getLogLevel, parseLabels } from './result_transformer';
+import {
+  findCommonLabels,
+  findUniqueLabels,
+  formatLabels,
+  getLogLevel,
+  mergeStreamsToLogs,
+  parseLabels,
+} from './result_transformer';
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
@@ -61,16 +68,88 @@ describe('findCommonLabels()', () => {
   });
 });
 
-describe('findUncommonLabels()', () => {
+describe('findUniqueLabels()', () => {
   it('returns no uncommon labels on empty sets', () => {
-    expect(findUncommonLabels({}, {})).toEqual({});
+    expect(findUniqueLabels({}, {})).toEqual({});
   });
 
   it('returns all labels given no common labels', () => {
-    expect(findUncommonLabels({ foo: '"bar"' }, {})).toEqual({ foo: '"bar"' });
+    expect(findUniqueLabels({ foo: '"bar"' }, {})).toEqual({ foo: '"bar"' });
   });
 
   it('returns all labels except the common labels', () => {
-    expect(findUncommonLabels({ foo: '"bar"', baz: '"42"' }, { foo: '"bar"' })).toEqual({ baz: '"42"' });
+    expect(findUniqueLabels({ foo: '"bar"', baz: '"42"' }, { foo: '"bar"' })).toEqual({ baz: '"42"' });
+  });
+});
+
+describe('mergeStreamsToLogs()', () => {
+  it('returns empty logs given no streams', () => {
+    expect(mergeStreamsToLogs([]).rows).toEqual([]);
+  });
+
+  it('returns processed logs from single stream', () => {
+    const stream1: LogsStream = {
+      labels: '{foo="bar"}',
+      entries: [
+        {
+          line: 'WARN boooo',
+          timestamp: '1970-01-01T00:00:00Z',
+        },
+      ],
+    };
+    expect(mergeStreamsToLogs([stream1]).rows).toMatchObject([
+      {
+        entry: 'WARN boooo',
+        labels: '{foo="bar"}',
+        key: 'EK1970-01-01T00:00:00Z{foo="bar"}',
+        logLevel: 'warn',
+        uniqueLabels: '',
+      },
+    ]);
+  });
+
+  it('returns merged logs from multiple streams sorted by time and with unique labels', () => {
+    const stream1: LogsStream = {
+      labels: '{foo="bar", baz="1"}',
+      entries: [
+        {
+          line: 'WARN boooo',
+          timestamp: '1970-01-01T00:00:01Z',
+        },
+      ],
+    };
+    const stream2: LogsStream = {
+      labels: '{foo="bar", baz="2"}',
+      entries: [
+        {
+          line: 'INFO 1',
+          timestamp: '1970-01-01T00:00:00Z',
+        },
+        {
+          line: 'INFO 2',
+          timestamp: '1970-01-01T00:00:02Z',
+        },
+      ],
+    };
+    expect(mergeStreamsToLogs([stream1, stream2]).rows).toMatchObject([
+      {
+        entry: 'INFO 2',
+        labels: '{foo="bar", baz="2"}',
+        logLevel: 'info',
+        uniqueLabels: '{baz="2"}',
+      },
+      {
+        entry: 'WARN boooo',
+        labels: '{foo="bar", baz="1"}',
+        logLevel: 'warn',
+        uniqueLabels: '{baz="1"}',
+      },
+      {
+        entry: 'INFO 1',
+        labels: '{foo="bar", baz="2"}',
+        logLevel: 'info',
+        uniqueLabels: '{baz="2"}',
+      },
+    ]);
   });
 });

--- a/public/app/plugins/datasource/logging/result_transformer.test.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.test.ts
@@ -1,6 +1,6 @@
 import { LogLevel } from 'app/core/logs_model';
 
-import { getLogLevel } from './result_transformer';
+import { findCommonLabels, findUncommonLabels, formatLabels, getLogLevel, parseLabels } from './result_transformer';
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
@@ -18,5 +18,59 @@ describe('getLoglevel()', () => {
 
   it('returns first log level found', () => {
     expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
+  });
+});
+
+describe('parseLabels()', () => {
+  it('returns no labels on emtpy labels string', () => {
+    expect(parseLabels('')).toEqual({});
+    expect(parseLabels('{}')).toEqual({});
+  });
+
+  it('returns labels on labels string', () => {
+    expect(parseLabels('{foo="bar", baz="42"}')).toEqual({ foo: '"bar"', baz: '"42"' });
+  });
+});
+
+describe('formatLabels()', () => {
+  it('returns no labels on emtpy label set', () => {
+    expect(formatLabels({})).toEqual('');
+    expect(formatLabels({}, 'foo')).toEqual('foo');
+  });
+
+  it('returns label string on label set', () => {
+    expect(formatLabels({ foo: '"bar"', baz: '"42"' })).toEqual('{baz="42", foo="bar"}');
+  });
+});
+
+describe('findCommonLabels()', () => {
+  it('returns no common labels on empty sets', () => {
+    expect(findCommonLabels([{}])).toEqual({});
+    expect(findCommonLabels([{}, {}])).toEqual({});
+  });
+
+  it('returns no common labels on differing sets', () => {
+    expect(findCommonLabels([{ foo: '"bar"' }, {}])).toEqual({});
+    expect(findCommonLabels([{}, { foo: '"bar"' }])).toEqual({});
+    expect(findCommonLabels([{ baz: '42' }, { foo: '"bar"' }])).toEqual({});
+    expect(findCommonLabels([{ foo: '42', baz: '"bar"' }, { foo: '"bar"' }])).toEqual({});
+  });
+
+  it('returns the single labels set as common labels', () => {
+    expect(findCommonLabels([{ foo: '"bar"' }])).toEqual({ foo: '"bar"' });
+  });
+});
+
+describe('findUncommonLabels()', () => {
+  it('returns no uncommon labels on empty sets', () => {
+    expect(findUncommonLabels({}, {})).toEqual({});
+  });
+
+  it('returns all labels given no common labels', () => {
+    expect(findUncommonLabels({ foo: '"bar"' }, {})).toEqual({ foo: '"bar"' });
+  });
+
+  it('returns all labels except the common labels', () => {
+    expect(findUncommonLabels({ foo: '"bar"', baz: '"42"' }, { foo: '"bar"' })).toEqual({ baz: '"42"' });
   });
 });

--- a/public/app/plugins/datasource/logging/result_transformer.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.ts
@@ -1,7 +1,9 @@
 import _ from 'lodash';
 import moment from 'moment';
 
-import { LogLevel, LogsModel, LogRow } from 'app/core/logs_model';
+import { LogLevel, LogsMetaItem, LogsModel, LogRow, LogsStream } from 'app/core/logs_model';
+import { TimeSeries } from 'app/core/core';
+import colors from 'app/core/utils/colors';
 
 export function getLogLevel(line: string): LogLevel {
   if (!line) {
@@ -19,11 +21,65 @@ export function getLogLevel(line: string): LogLevel {
   return level;
 }
 
+const labelRegexp = /\b(\w+)(!?=~?)("[^"\n]*?")/g;
+export function parseLabels(labels: string): { [key: string]: string } {
+  const labelsByKey = {};
+  labels.replace(labelRegexp, (_, key, operator, value) => {
+    labelsByKey[key] = value;
+    return '';
+  });
+  return labelsByKey;
+}
+
+export function findCommonLabels(labelsSets: any[]) {
+  return labelsSets.reduce((acc, labels) => {
+    if (!labels) {
+      throw new Error('Need parsed labels to find common labels.');
+    }
+    if (!acc) {
+      // Initial set
+      acc = { ...labels };
+    } else {
+      // Remove incoming labels that are missing or not matching in value
+      Object.keys(labels).forEach(key => {
+        if (acc[key] === undefined || acc[key] !== labels[key]) {
+          delete acc[key];
+        }
+      });
+      // Remove common labels that are missing from incoming label set
+      Object.keys(acc).forEach(key => {
+        if (labels[key] === undefined) {
+          delete acc[key];
+        }
+      });
+    }
+    return acc;
+  }, undefined);
+}
+
+export function findUncommonLabels(labels, commonLabels) {
+  const uncommonLabels = { ...labels };
+  Object.keys(commonLabels).forEach(key => {
+    delete uncommonLabels[key];
+  });
+  return uncommonLabels;
+}
+
+export function formatLabels(labels, defaultValue = '') {
+  if (!labels || Object.keys(labels).length === 0) {
+    return defaultValue;
+  }
+  const labelKeys = Object.keys(labels).sort();
+  const cleanSelector = labelKeys.map(key => `${key}=${labels[key]}`).join(', ');
+  return ['{', cleanSelector, '}'].join('');
+}
+
 export function processEntry(entry: { line: string; timestamp: string }, stream): LogRow {
   const { line, timestamp } = entry;
   const { labels } = stream;
   const key = `EK${timestamp}${labels}`;
   const time = moment(timestamp);
+  const timeJs = time.valueOf();
   const timeFromNow = time.fromNow();
   const timeLocal = time.format('YYYY-MM-DD HH:mm:ss');
   const logLevel = getLogLevel(line);
@@ -32,21 +88,89 @@ export function processEntry(entry: { line: string; timestamp: string }, stream)
     key,
     logLevel,
     timeFromNow,
+    timeJs,
     timeLocal,
     entry: line,
+    labels: formatLabels(labels),
     searchWords: [stream.search],
     timestamp: timestamp,
   };
 }
 
-export function processStreams(streams, limit?: number): LogsModel {
+export function mergeStreams(streams: LogsStream[], limit?: number): LogsModel {
+  // Find meta data
+  const commonLabels = findCommonLabels(streams.map(stream => stream.parsedLabels));
+  const meta: LogsMetaItem[] = [
+    {
+      label: 'Common labels',
+      value: formatLabels(commonLabels),
+    },
+  ];
+
+  // Flatten entries of streams
   const combinedEntries = streams.reduce((acc, stream) => {
-    return [...acc, ...stream.entries.map(entry => processEntry(entry, stream))];
+    // Overwrite labels to be only the non-common ones
+    const labels = formatLabels(findUncommonLabels(stream.parsedLabels, commonLabels));
+    return [
+      ...acc,
+      ...stream.entries.map(entry => ({
+        ...entry,
+        labels,
+      })),
+    ];
   }, []);
+
+  const commonLabelsAlias =
+    streams.length === 1 ? formatLabels(commonLabels) : `Stream with common labels ${formatLabels(commonLabels)}`;
+  const series = streams.map((stream, index) => {
+    const colorIndex = index % colors.length;
+    stream.graphSeries.setColor(colors[colorIndex]);
+    stream.graphSeries.alias = formatLabels(findUncommonLabels(stream.parsedLabels, commonLabels), commonLabelsAlias);
+    return stream.graphSeries;
+  });
+
   const sortedEntries = _.chain(combinedEntries)
     .sortBy('timestamp')
     .reverse()
     .slice(0, limit || combinedEntries.length)
     .value();
-  return { rows: sortedEntries };
+
+  meta.push({
+    label: 'Limit',
+    value: `${limit} (${sortedEntries.length} returned)`,
+  });
+
+  return { meta, series, rows: sortedEntries };
+}
+
+export function processStream(stream: LogsStream, limit?: number): LogsStream {
+  const sortedEntries: any[] = _.chain(stream.entries)
+    .map(entry => processEntry(entry, stream))
+    .sortBy('timestamp')
+    .reverse()
+    .slice(0, limit || stream.entries.length)
+    .value();
+
+  // Build graph data
+  let previousTime;
+  const datapoints = sortedEntries.reduce((acc, entry, index) => {
+    // Bucket to nearest minute
+    const time = Math.round(entry.timeJs / 1000 / 60) * 1000 * 60;
+    // Entry for time
+    if (time === previousTime) {
+      acc[acc.length - 1][0]++;
+    } else {
+      acc.push([1, time]);
+      previousTime = time;
+    }
+    return acc;
+  }, []);
+  const graphSeries = new TimeSeries({ datapoints, alias: stream.labels });
+
+  return {
+    ...stream,
+    graphSeries,
+    entries: sortedEntries,
+    parsedLabels: parseLabels(stream.labels),
+  };
 }

--- a/public/app/plugins/datasource/logging/result_transformer.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.ts
@@ -143,7 +143,7 @@ export function mergeStreams(streams: LogsStream[], limit?: number): LogsModel {
   return { meta, series, rows: sortedEntries };
 }
 
-export function processStream(stream: LogsStream, limit?: number): LogsStream {
+export function processStream(stream: LogsStream, limit?: number, intervalMs?: number): LogsStream {
   const sortedEntries: any[] = _.chain(stream.entries)
     .map(entry => processEntry(entry, stream))
     .sortBy('timestamp')
@@ -155,7 +155,7 @@ export function processStream(stream: LogsStream, limit?: number): LogsStream {
   let previousTime;
   const datapoints = sortedEntries.reduce((acc, entry, index) => {
     // Bucket to nearest minute
-    const time = Math.round(entry.timeJs / 1000 / 60) * 1000 * 60;
+    const time = Math.round(entry.timeJs / intervalMs / 10) * intervalMs * 10;
     // Entry for time
     if (time === previousTime) {
       acc[acc.length - 1][0]++;

--- a/public/sass/components/_gf-form.scss
+++ b/public/sass/components/_gf-form.scss
@@ -116,6 +116,11 @@ $input-border: 1px solid $input-border-color;
     color: $critical;
   }
 
+  &--small {
+    padding: ($input-padding-y / 2) ($input-padding-x / 2);
+    font-size: $font-size-xs;
+  }
+
   &:disabled {
     color: $text-color-weak;
   }

--- a/public/sass/components/_switch.scss
+++ b/public/sass/components/_switch.scss
@@ -41,7 +41,6 @@
     bottom: 0;
     right: 0;
     color: #fff;
-    font-size: $font-size-sm;
     text-align: center;
     font-size: 150%;
     display: flex;
@@ -89,6 +88,20 @@
 
   input:checked + label::after {
     transform: rotateY(0);
+  }
+
+  &--small {
+    max-width: 2rem;
+    min-width: 1.5rem;
+
+    input + label {
+      height: 25px;
+    }
+
+    input + label::before,
+    input + label::after {
+      font-size: $font-size-sm;
+    }
   }
 
   &--table-cell {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -214,7 +214,42 @@
       display: grid;
       grid-column-gap: 1rem;
       grid-row-gap: 0.1rem;
-      grid-template-columns: 4px minmax(100px, max-content) 1fr;
+      grid-template-columns: 4px minmax(100px, max-content) minmax(100px, 25%) 1fr;
+      font-family: $font-family-monospace;
+      font-size: 12px;
+    }
+
+    .logs-controls {
+      display: flex;
+
+      > * {
+        margin-right: 1em;
+      }
+    }
+
+    .logs-options,
+    .logs-graph {
+      margin-bottom: $panel-margin;
+    }
+
+    .logs-meta {
+      flex: 1;
+      color: $text-color-weak;
+      padding: 2px 0;
+    }
+
+    .logs-meta-item {
+      display: inline-block;
+      margin-right: 1em;
+    }
+
+    .logs-meta-item__label {
+      margin-right: 0.5em;
+      font-size: 0.9em;
+      font-weight: 500;
+    }
+
+    .logs-meta-item__value {
       font-family: $font-family-monospace;
     }
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -270,18 +270,26 @@
       opacity: 0.8;
     }
 
-    .logs-row-level-crit,
+    .logs-row-level-crit {
+      background-color: #705da0;
+    }
+
     .logs-row-level-error,
     .logs-row-level-err {
-      background-color: $red;
+      background-color: #e24d42;
     }
 
     .logs-row-level-warn {
-      background-color: $orange;
+      background-color: #eab839;
     }
 
     .logs-row-level-info {
-      background-color: $green;
+      background-color: #7eb26d;
+    }
+
+    .logs-row-level-trace,
+    .logs-row-level-debug {
+      background-color: #1f78c1;
     }
   }
 }


### PR DESCRIPTION
- Logging gets a graph for log distribution (currently per stream, but I
  think I'll change that to per log-level)
- added grid columns for timestamp and unique labels
- show common labels of streams
- View options to show/hide time columns, label columns
- created `--small` modifier for Switch CSS classes
- merging of streams is now a datasource responsibility
