### PR TITLE
alerting: increase default duration for queries

### DIFF
--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -166,7 +166,7 @@ export class AlertTabCtrl {
 
     alert.noDataState = alert.noDataState || config.alertingNoDataOrNullValues;
     alert.executionErrorState = alert.executionErrorState || config.alertingErrorOrTimeout;
-    alert.frequency = alert.frequency || '60s';
+    alert.frequency = alert.frequency || '1m';
     alert.handler = alert.handler || 1;
     alert.notifications = alert.notifications || [];
 
@@ -217,7 +217,7 @@ export class AlertTabCtrl {
   buildDefaultCondition() {
     return {
       type: 'query',
-      query: { params: ['A', '5m', 'now'] },
+      query: { params: ['A', '15m', 'now'] },
       reducer: { type: 'avg', params: [] },
       evaluator: { type: 'gt', params: [null] },
       operator: { type: 'and' },


### PR DESCRIPTION
we should promote using longer queries since this should
increase the quality of the alerts. only using a 5min range
means that we will only have 4 datapoints in data is written
every min which is not good enough for the generic alert rule