### PR TITLE
Stackdriver: Add project selection

### DIFF
--- a/pkg/tsdb/stackdriver/types.go
+++ b/pkg/tsdb/stackdriver/types.go
@@ -12,6 +12,7 @@ type StackdriverQuery struct {
 	RefID    string
 	GroupBys []string
 	AliasBy  string
+	Project  string
 }
 
 type StackdriverBucketOptions struct {

--- a/public/app/plugins/datasource/stackdriver/partials/config.html
+++ b/public/app/plugins/datasource/stackdriver/partials/config.html
@@ -73,7 +73,7 @@
   <h6>Uploaded Key Details</h6>
 
   <div class="gf-form">
-    <span class="gf-form-label width-10">Project</span>
+    <span class="gf-form-label width-10">Default Project</span>
     <input class="gf-form-input width-40" disabled type="text" ng-model="ctrl.current.jsonData.defaultProject" />
   </div>
   <div class="gf-form">

--- a/public/app/plugins/datasource/stackdriver/partials/query.editor.html
+++ b/public/app/plugins/datasource/stackdriver/partials/query.editor.html
@@ -14,7 +14,7 @@
   </div>
   <div class="gf-form-inline">
     <div class="gf-form">
-      <span class="gf-form-label width-9">Project</span>
+      <span class="gf-form-label width-9">Default Project</span>
       <input class="gf-form-input" disabled type="text" ng-model='ctrl.target.defaultProject' css-class="min-width-12" />
     </div>
     <div class="gf-form">


### PR DESCRIPTION
This PR adds ability to pass `project` variable to Stackdriver search filter and retrieve metrics for another project (presuming service account permissions are in place).

This has been discussed here: #13757 
