### PR TITLE
fix selecting datasource using enter key

### DIFF
--- a/public/app/core/components/form_dropdown/form_dropdown.ts
+++ b/public/app/core/components/form_dropdown/form_dropdown.ts
@@ -88,7 +88,7 @@ export class FormDropdownCtrl {
       if (evt.keyCode === 13) {
         setTimeout(() => {
           this.inputElement.blur();
-        }, 100);
+        }, 300);
       }
     });
 


### PR DESCRIPTION
Fixes #13932

Don't know why gf-form-dropdown works in query editors/metric segment using enter key but not in datasource selector. Adding some extra timeout after enter key been pressed before blurring the input field seems to have resolved the problem in the datasource selector and it seems to still work in metric segment. Verified in Chrome and Firefox.