### PR TITLE
Fix typo in docs/sources/reference/scripting.md

### DIFF
--- a/docs/sources/reference/scripting.md
+++ b/docs/sources/reference/scripting.md
@@ -12,7 +12,7 @@ weight = 9
 
 If you have lots of metric names that change (new servers etc) in a defined pattern it is irritating to constantly have to create new dashboards.
 
-With scripted dashboards you can dynamically create your dashboards using javascript. In the folder grafana install folder
+With scripted dashboards you can dynamically create your dashboards using javascript. In the grafana install folder
 under `public/dashboards/` there is a file named `scripted.js`. This file contains an example of a scripted dashboard. You can access it by using the url:
 `http://grafana_url/dashboard/script/scripted.js?rows=3&name=myName`
 


### PR DESCRIPTION
Change:

> In the folder grafana install folder under `public/dashboards/` there is a file named `scripted.js`.

…to:

> In the grafana install folder under `public/dashboards/` there is a file named `scripted.js`.