### PR TITLE
[Bugfix] Don't drop the value when it's equal to None

### DIFF
--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -28,7 +28,7 @@ export class TemplateSrv {
     const existsOrEmpty = value => value || value === '';
 
     this.index = this.variables.reduce((acc, currentValue) => {
-      if (currentValue.current && !currentValue.current.isNone && existsOrEmpty(currentValue.current.value)) {
+      if (currentValue.current && (currentValue.current.isNone || existsOrEmpty(currentValue.current.value))) {
         acc[currentValue.name] = currentValue;
       }
       return acc;


### PR DESCRIPTION
Hello,

There is a regression introduced in the PR : #13791. Indeed before the commit, the value `None` was kept and after the PR, it is dropped.

This PR is just to reintroduce the value None as a legit value when you use a variable in a Dashboard

Close #14009 