### PR TITLE
Adjust UI depth of query statistics

### DIFF
--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -165,7 +165,7 @@
   position: absolute;
   top: 0;
   right: 90px;
-  z-index: 1024;
+  z-index: 1015;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Hello,

This pull request addresses #14004.

A `z-index` value of less than `1020` is needed because the time selection dropdown shares the latter value via inheritance (i.e. `$zindex-navbar-fixed`). I've arbitrarily picked `1015` because it is a notch down.

CC: @davkal