### PR TITLE
Add ability to toggle visibility of graph series in explore section

### DIFF
--- a/public/app/features/explore/Legend.tsx
+++ b/public/app/features/explore/Legend.tsx
@@ -1,23 +1,65 @@
-import React, { PureComponent } from 'react';
+import React, { MouseEvent, PureComponent } from 'react';
+import classNames from 'classnames';
+import { TimeSeries } from 'app/core/core';
 
-const LegendItem = ({ series }) => (
-  <div className="graph-legend-series">
-    <div className="graph-legend-icon">
-      <i className="fa fa-minus pointer" style={{ color: series.color }} />
-    </div>
-    <a className="graph-legend-alias pointer" title={series.alias}>
-      {series.alias}
-    </a>
-  </div>
-);
+interface LegendProps {
+  data: TimeSeries[];
+  hiddenSeries: Set<string>;
+  onToggleSeries?: (series: TimeSeries, exclusive: boolean) => void;
+}
 
-export default class Legend extends PureComponent<any, any> {
+interface LegendItemProps {
+  hidden: boolean;
+  onClickLabel?: (series: TimeSeries, event: MouseEvent) => void;
+  series: TimeSeries;
+}
+
+class LegendItem extends PureComponent<LegendItemProps> {
+  onClickLabel = e => this.props.onClickLabel(this.props.series, e);
+
   render() {
-    const { className = '', data } = this.props;
+    const { hidden, series } = this.props;
+    const seriesClasses = classNames({
+      'graph-legend-series-hidden': hidden,
+    });
+    return (
+      <div className={`graph-legend-series ${seriesClasses}`}>
+        <div className="graph-legend-icon">
+          <i className="fa fa-minus pointer" style={{ color: series.color }} />
+        </div>
+        <a className="graph-legend-alias pointer" title={series.alias} onClick={this.onClickLabel}>
+          {series.alias}
+        </a>
+      </div>
+    );
+  }
+}
+
+export default class Legend extends PureComponent<LegendProps> {
+  static defaultProps = {
+    onToggleSeries: () => {},
+  };
+
+  onClickLabel = (series: TimeSeries, event: MouseEvent) => {
+    const { onToggleSeries } = this.props;
+    const exclusive = event.ctrlKey || event.metaKey || event.shiftKey;
+    onToggleSeries(series, !exclusive);
+  };
+
+  render() {
+    const { data, hiddenSeries } = this.props;
     const items = data || [];
     return (
-      <div className={`${className} graph-legend ps`}>
-        {items.map(series => <LegendItem key={series.id} series={series} />)}
+      <div className="graph-legend ps">
+        {items.map((series, i) => (
+          <LegendItem
+            hidden={hiddenSeries.has(series.alias)}
+            // Workaround to resolve conflicts since series visibility tracks the alias property
+            key={`${series.id}-${i}`}
+            onClickLabel={this.onClickLabel}
+            series={series}
+          />
+        ))}
       </div>
     );
   }

--- a/public/app/features/explore/__snapshots__/Graph.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/Graph.test.tsx.snap
@@ -453,6 +453,8 @@ exports[`Render should render component 1`] = `
         },
       ]
     }
+    hiddenSeries={Set {}}
+    onToggleSeries={[Function]}
   />
 </Fragment>
 `;
@@ -947,6 +949,8 @@ exports[`Render should render component with disclaimer 1`] = `
         },
       ]
     }
+    hiddenSeries={Set {}}
+    onToggleSeries={[Function]}
   />
 </Fragment>
 `;
@@ -964,6 +968,8 @@ exports[`Render should show query return no time series 1`] = `
   />
   <Legend
     data={Array []}
+    hiddenSeries={Set {}}
+    onToggleSeries={[Function]}
   />
 </Fragment>
 `;

--- a/public/app/features/explore/utils/set.test.ts
+++ b/public/app/features/explore/utils/set.test.ts
@@ -1,0 +1,52 @@
+import { equal, intersect } from './set';
+
+describe('equal', () => {
+  it('returns false for two sets of differing sizes', () => {
+    const s1 = new Set([1, 2, 3]);
+    const s2 = new Set([4, 5, 6, 7]);
+    expect(equal(s1, s2)).toBe(false);
+  });
+  it('returns false for two sets where one is a subset of the other', () => {
+    const s1 = new Set([1, 2, 3]);
+    const s2 = new Set([1, 2, 3, 4]);
+    expect(equal(s1, s2)).toBe(false);
+  });
+  it('returns false for two sets with uncommon elements', () => {
+    const s1 = new Set([1, 2, 3, 4]);
+    const s2 = new Set([1, 2, 5, 6]);
+    expect(equal(s1, s2)).toBe(false);
+  });
+  it('returns false for two deeply equivalent sets', () => {
+    const s1 = new Set([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+    const s2 = new Set([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+    expect(equal(s1, s2)).toBe(false);
+  });
+  it('returns true for two sets with the same elements', () => {
+    const s1 = new Set([1, 2, 3, 4]);
+    const s2 = new Set([4, 3, 2, 1]);
+    expect(equal(s1, s2)).toBe(true);
+  });
+});
+
+describe('intersect', () => {
+  it('returns an empty set for two sets without any common elements', () => {
+    const s1 = new Set([1, 2, 3, 4]);
+    const s2 = new Set([5, 6, 7, 8]);
+    expect(intersect(s1, s2)).toEqual(new Set());
+  });
+  it('returns an empty set for two deeply equivalent sets', () => {
+    const s1 = new Set([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+    const s2 = new Set([{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }]);
+    expect(intersect(s1, s2)).toEqual(new Set());
+  });
+  it('returns a set containing common elements between two sets of the same size', () => {
+    const s1 = new Set([1, 2, 3, 4]);
+    const s2 = new Set([5, 2, 7, 4]);
+    expect(intersect(s1, s2)).toEqual(new Set([2, 4]));
+  });
+  it('returns a set containing common elements between two sets of differing sizes', () => {
+    const s1 = new Set([1, 2, 3, 4]);
+    const s2 = new Set([5, 4, 3, 2, 1]);
+    expect(intersect(s1, s2)).toEqual(new Set([1, 2, 3, 4]));
+  });
+});

--- a/public/app/features/explore/utils/set.ts
+++ b/public/app/features/explore/utils/set.ts
@@ -1,0 +1,34 @@
+/**
+ * Performs a shallow comparison of two sets with the same item type.
+ */
+export function equal<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+  const it = a.values();
+  while (true) {
+    const { value, done } = it.next();
+    if (b.has(value)) {
+      return false;
+    }
+    if (done) {
+      return true;
+    }
+  }
+}
+
+/**
+ * Returns the first set with items in the second set through shallow comparison.
+ */
+export function intersect<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const it = b.values();
+  while (true) {
+    const { value, done } = it.next();
+    if (!a.has(value)) {
+      a.delete(value);
+    }
+    if (done) {
+      return a;
+    }
+  }
+}

--- a/public/app/features/explore/utils/set.ts
+++ b/public/app/features/explore/utils/set.ts
@@ -8,27 +8,28 @@ export function equal<T>(a: Set<T>, b: Set<T>): boolean {
   const it = a.values();
   while (true) {
     const { value, done } = it.next();
-    if (b.has(value)) {
-      return false;
-    }
     if (done) {
       return true;
+    }
+    if (!b.has(value)) {
+      return false;
     }
   }
 }
 
 /**
- * Returns the first set with items in the second set through shallow comparison.
+ * Returns a new set with items in both sets using shallow comparison.
  */
 export function intersect<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const result = new Set<T>();
   const it = b.values();
   while (true) {
     const { value, done } = it.next();
-    if (!a.has(value)) {
-      a.delete(value);
-    }
     if (done) {
-      return a;
+      return result;
+    }
+    if (a.has(value)) {
+      result.add(value);
     }
   }
 }


### PR DESCRIPTION
Hello,

This pull request attempts to address #13522.

The implemented UX for toggling series mirrors the behaviour seen for the dashboard graph plugin:

* Single clicking a series label isolates visibility to that series
* Single clicking an isolated series label restores visibility of all series
* Single clicking a series label with a modifier key held (i.e. <kbd>ctrl</kbd>, <kbd>shift</kbd>, <kbd>meta</kbd>) inverts the visibility inclusion

Also noticed some incomplete (?) groundwork being laid for user options, presumably to support user preferences such as timezone setting. Hopefully these changes don't get in the way too much.

CC: @davkal