### PR TITLE
Explore: Don't suggest term items when text follows

### DIFF
--- a/public/app/plugins/datasource/prometheus/specs/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/language_provider.test.ts
@@ -7,18 +7,47 @@ describe('Language completion provider', () => {
     metadataRequest: () => ({ data: { data: [] } }),
   };
 
-  it('returns default suggestions on emtpty context', () => {
-    const instance = new LanguageProvider(datasource);
-    const result = instance.provideCompletionItems({ text: '', prefix: '', wrapperClasses: [] });
-    expect(result.context).toBeUndefined();
-    expect(result.refresher).toBeUndefined();
-    expect(result.suggestions.length).toEqual(2);
+  describe('empty query suggestions', () => {
+    it('returns default suggestions on emtpty context', () => {
+      const instance = new LanguageProvider(datasource);
+      const value = Plain.deserialize('');
+      const result = instance.provideCompletionItems({ text: '', prefix: '', value, wrapperClasses: [] });
+      expect(result.context).toBeUndefined();
+      expect(result.refresher).toBeUndefined();
+      expect(result.suggestions).toMatchObject([
+        {
+          label: 'Functions',
+        },
+      ]);
+    });
+
+    it('returns default suggestions with metrics on emtpty context when metrics were provided', () => {
+      const instance = new LanguageProvider(datasource, { metrics: ['foo', 'bar'] });
+      const value = Plain.deserialize('');
+      const result = instance.provideCompletionItems({ text: '', prefix: '', value, wrapperClasses: [] });
+      expect(result.context).toBeUndefined();
+      expect(result.refresher).toBeUndefined();
+      expect(result.suggestions).toMatchObject([
+        {
+          label: 'Functions',
+        },
+        {
+          label: 'Metrics',
+        },
+      ]);
+    });
   });
 
   describe('range suggestions', () => {
     it('returns range suggestions in range context', () => {
       const instance = new LanguageProvider(datasource);
-      const result = instance.provideCompletionItems({ text: '1', prefix: '1', wrapperClasses: ['context-range'] });
+      const value = Plain.deserialize('1');
+      const result = instance.provideCompletionItems({
+        text: '1',
+        prefix: '1',
+        value,
+        wrapperClasses: ['context-range'],
+      });
       expect(result.context).toBe('context-range');
       expect(result.refresher).toBeUndefined();
       expect(result.suggestions).toEqual([
@@ -31,20 +60,54 @@ describe('Language completion provider', () => {
   });
 
   describe('metric suggestions', () => {
-    it('returns metrics suggestions by default', () => {
+    it('returns metrics and function suggestions in an unknown context', () => {
       const instance = new LanguageProvider(datasource, { metrics: ['foo', 'bar'] });
-      const result = instance.provideCompletionItems({ text: 'a', prefix: 'a', wrapperClasses: [] });
+      const value = Plain.deserialize('a');
+      const result = instance.provideCompletionItems({ text: 'a', prefix: 'a', value, wrapperClasses: [] });
       expect(result.context).toBeUndefined();
       expect(result.refresher).toBeUndefined();
-      expect(result.suggestions.length).toEqual(2);
+      expect(result.suggestions).toMatchObject([
+        {
+          label: 'Functions',
+        },
+        {
+          label: 'Metrics',
+        },
+      ]);
     });
 
-    it('returns default suggestions after a binary operator', () => {
+    it('returns metrics and function  suggestions after a binary operator', () => {
       const instance = new LanguageProvider(datasource, { metrics: ['foo', 'bar'] });
-      const result = instance.provideCompletionItems({ text: '*', prefix: '', wrapperClasses: [] });
+      const value = Plain.deserialize('*');
+      const result = instance.provideCompletionItems({ text: '*', prefix: '', value, wrapperClasses: [] });
       expect(result.context).toBeUndefined();
       expect(result.refresher).toBeUndefined();
-      expect(result.suggestions.length).toEqual(2);
+      expect(result.suggestions).toMatchObject([
+        {
+          label: 'Functions',
+        },
+        {
+          label: 'Metrics',
+        },
+      ]);
+    });
+
+    it('returns no suggestions at the beginning of a non-empty function', () => {
+      const instance = new LanguageProvider(datasource, { metrics: ['foo', 'bar'] });
+      const value = Plain.deserialize('sum(up)');
+      const range = value.selection.merge({
+        anchorOffset: 4,
+      });
+      const valueWithSelection = value.change().select(range).value;
+      const result = instance.provideCompletionItems({
+        text: '',
+        prefix: '',
+        value: valueWithSelection,
+        wrapperClasses: [],
+      });
+      expect(result.context).toBeUndefined();
+      expect(result.refresher).toBeUndefined();
+      expect(result.suggestions.length).toEqual(0);
     });
   });
 


### PR DESCRIPTION
Prometheus tab completion gets in the way when constructing a query from the inside
out:

```
up| => |up => sum(|up)
```

* treat term context separately from empty context
* fix tests for empty context