### PR TITLE
Explore: Dont set datasource in state if navigated away

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -94,6 +94,10 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
    * Not kept in component state to prevent edit-render roundtrips.
    */
   queryExpressions: string[];
+  /**
+   * Local ID cache to compare requested vs selected datasource
+   */
+  requestedDatasourceId: string;
 
   constructor(props) {
     super(props);
@@ -167,11 +171,19 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const datasourceId = datasource.meta.id;
     let datasourceError = null;
 
+    // Keep ID to track selection
+    this.requestedDatasourceId = datasourceId;
+
     try {
       const testResult = await datasource.testDatasource();
       datasourceError = testResult.status === 'success' ? null : testResult.message;
     } catch (error) {
       datasourceError = (error && error.statusText) || 'Network error';
+    }
+
+    if (datasourceId !== this.requestedDatasourceId) {
+      // User already changed datasource again, discard results
+      return;
     }
 
     const historyKey = `grafana.explore.history.${datasourceId}`;


### PR DESCRIPTION
Datasource selection triggers a connection test, on success
the DS is set in the Explore state. If the test takes long and user
selects a different DS, and just after that the first test succeeds,
then the first DS overwrites the state.

* when test returns check if datasource is still the requested one
