### PR TITLE
support mysql2 connection string

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -341,7 +341,7 @@ func InitTestDB(t *testing.T) *SqlStore {
 	sec.NewKey("type", dbType)
 
 	switch dbType {
-	case "mysql":
+	case "mysql", "mysql2":
 		sec.NewKey("connection_string", sqlutil.TestDB_Mysql.ConnStr)
 	case "postgres":
 		sec.NewKey("connection_string", sqlutil.TestDB_Postgres.ConnStr)


### PR DESCRIPTION
So you can use [`DATABASE_URL` var from Cloud Foundry](https://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#DATABASE-URL)