### PR TITLE
Fix switching from es raw document metric breaks query editor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -160,6 +160,12 @@ export class ElasticMetricAggCtrl {
       $scope.agg.settings = {};
       $scope.agg.meta = {};
       $scope.showOptions = false;
+
+      // reset back to metric/group by query
+      if ($scope.target.bucketAggs.length === 0 && $scope.agg.type !== 'raw_document') {
+        $scope.target.bucketAggs = [queryDef.defaultBucketAgg()];
+      }
+
       $scope.updatePipelineAggOptions();
       $scope.onChange();
     };

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -181,8 +181,8 @@ export class ElasticQueryBuilder {
 
   build(target, adhocFilters?, queryString?) {
     // make sure query has defaults;
-    target.metrics = target.metrics || [{ type: 'count', id: '1' }];
-    target.bucketAggs = target.bucketAggs || [{ type: 'date_histogram', id: '2', settings: { interval: 'auto' } }];
+    target.metrics = target.metrics || [queryDef.defaultMetricAgg()];
+    target.bucketAggs = target.bucketAggs || [queryDef.defaultBucketAgg()];
     target.timeField = this.timeField;
 
     let i, nestedAggs, metric;

--- a/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
@@ -17,6 +17,19 @@ export class ElasticQueryCtrl extends QueryCtrl {
     super($scope, $injector);
 
     this.esVersion = this.datasource.esVersion;
+
+    this.target = this.target || {};
+    this.target.metrics = this.target.metrics || [queryDef.defaultMetricAgg()];
+    this.target.bucketAggs = this.target.bucketAggs || [queryDef.defaultBucketAgg()];
+
+    if (this.target.bucketAggs.length === 0) {
+      const metric = this.target.metrics[0];
+      if (!metric || metric.type !== 'raw_document') {
+        this.target.bucketAggs = [queryDef.defaultBucketAgg()];
+      }
+      this.refresh();
+    }
+
     this.queryUpdated();
   }
 

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -228,3 +228,11 @@ export function describeOrderBy(orderBy, target) {
     return 'metric not found';
   }
 }
+
+export function defaultMetricAgg() {
+  return { type: 'count', id: '1' };
+}
+
+export function defaultBucketAgg() {
+  return { type: 'date_histogram', id: '2', settings: { interval: 'auto' } };
+}


### PR DESCRIPTION
Time to submit PR's for some branches I have lying around.

Fixes #6367

* Fixes switching from raw document metric to non raw document metric
* Fixes loading broken metric query (switched from raw document metric to non raw document metric and saving dashboard)