### PR TITLE
Panel focus in react

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -117,6 +117,14 @@ export class DashboardPanel extends PureComponent<Props, State> {
     this.cleanUpAngularPanel();
   }
 
+  onMouseEnter = () => {
+    this.props.dashboard.setPanelFocus(this.props.panel.id);
+  };
+
+  onMouseLeave = () => {
+    this.props.dashboard.setPanelFocus(0);
+  };
+
   renderReactPanel() {
     const { dashboard, panel } = this.props;
     const { plugin } = this.state;
@@ -127,7 +135,7 @@ export class DashboardPanel extends PureComponent<Props, State> {
     // I want to try to keep markup (parents) for panel the same in edit mode to avoide unmount / new mount of panel
     return (
       <div className={containerClass}>
-        <div className={panelWrapperClass}>
+        <div className={panelWrapperClass} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
           <PanelChrome component={plugin.exports.Panel} panel={panel} dashboard={dashboard} />
         </div>
         {panel.isEditing && (
@@ -156,6 +164,13 @@ export class DashboardPanel extends PureComponent<Props, State> {
     }
 
     // legacy angular rendering
-    return <div ref={element => (this.element = element)} className="panel-height-helper" />;
+    return (
+      <div
+        ref={element => (this.element = element)}
+        className="panel-height-helper"
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      />
+    );
   }
 }

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -80,16 +80,6 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
       let lastAlertState;
       let hasAlertRule;
 
-      function mouseEnter() {
-        panelContainer.toggleClass('panel-hover-highlight', true);
-        ctrl.dashboard.setPanelFocus(ctrl.panel.id);
-      }
-
-      function mouseLeave() {
-        panelContainer.toggleClass('panel-hover-highlight', false);
-        ctrl.dashboard.setPanelFocus(0);
-      }
-
       function resizeScrollableContent() {
         if (panelScrollbar) {
           panelScrollbar.update();
@@ -211,9 +201,6 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
         infoDrop.close();
         scope.$apply(ctrl.openInspector.bind(ctrl));
       });
-
-      elem.on('mouseenter', mouseEnter);
-      elem.on('mouseleave', mouseLeave);
 
       scope.$on('$destroy', () => {
         elem.off();


### PR DESCRIPTION
* Fixes so that shortcuts e & v to edit / view panels now work for both react & angular panels 