### PR TITLE
[elasticsearch] Do not set a placeholder to index name, if it's already specified

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
@@ -28,9 +28,14 @@ export class ElasticConfigCtrl {
   ];
 
   indexPatternTypeChanged() {
-    const def = _.find(this.indexPatternTypes, {
-      value: this.current.jsonData.interval,
-    });
-    this.current.database = def.example || 'es-index-name';
+    if (!this.current.database ||
+        this.current.database.length == 0 ||
+        this.current.database.startsWith('[logstash-]')) {
+            
+        const def = _.find(this.indexPatternTypes, {
+          value: this.current.jsonData.interval,
+        });
+        this.current.database = def.example || 'es-index-name';
+    }
   }
 }


### PR DESCRIPTION
Fixes #14072

I'd propose to set `this.current.database` to a sample value only in case it's empty or it's already been set to some sample.

So any other value is considered as meaningful and doesn't get overridden.