### PR TITLE
Add basic authentication support to metrics endpoint

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -490,6 +490,10 @@ enabled = false
 enabled           = true
 interval_seconds  = 10
 
+#If both are set, basic auth will be required for the metrics endpoint.
+basic_auth_username =
+basic_auth_password =
+
 # Send internal Grafana metrics to graphite
 [metrics.graphite]
 # Enable by setting the address setting (ex localhost:2003)

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -454,6 +454,15 @@ Ex `filters = sqlstore:debug`
 ### enabled
 Enable metrics reporting. defaults true. Available via HTTP API `/metrics`.
 
+### basic_auth_enabled
+Enables basic authentication on the metrics endpoint. Defaults to false.
+
+### basic_auth_username
+Username to use for basic authentication on the metrics endpoint.
+
+### basic_auth_password
+Password to use for basic authentication on the metrics endpoint.
+
 ### interval_seconds
 
 Flush/Write interval when sending metrics to external TSDB. Defaults to 10s.

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -454,14 +454,11 @@ Ex `filters = sqlstore:debug`
 ### enabled
 Enable metrics reporting. defaults true. Available via HTTP API `/metrics`.
 
-### basic_auth_enabled
-Enables basic authentication on the metrics endpoint. Defaults to false.
-
 ### basic_auth_username
-Username to use for basic authentication on the metrics endpoint.
+If set configures the username to use for basic authentication on the metrics endpoint.
 
 ### basic_auth_password
-Password to use for basic authentication on the metrics endpoint.
+If set configures the password to use for basic authentication on the metrics endpoint.
 
 ### interval_seconds
 

--- a/pkg/api/basic_auth.go
+++ b/pkg/api/basic_auth.go
@@ -1,11 +1,11 @@
-package util
+package api
 
 import (
 	"crypto/subtle"
 	macaron "gopkg.in/macaron.v1"
 )
 
-// BasicAuthenticated parses the provided HTTP request for basic authentication credentials
+// BasicAuthenticatedRequest parses the provided HTTP request for basic authentication credentials
 // and returns true if the provided credentials match the expected username and password.
 // Returns false if the request is unauthenticated.
 // Uses constant-time comparison in order to mitigate timing attacks.

--- a/pkg/api/basic_auth_test.go
+++ b/pkg/api/basic_auth_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/macaron.v1"
+)
+
+func TestBasicAuthenticatedRequest(t *testing.T) {
+	expectedUser := "prometheus"
+	expectedPass := "password"
+
+	Convey("Given a valid set of basic auth credentials", t, func() {
+		httpReq, err := http.NewRequest("GET", "http://localhost:3000/metrics", nil)
+		So(err, ShouldBeNil)
+		req := macaron.Request{
+			Request: httpReq,
+		}
+		encodedCreds := encodeBasicAuthCredentials(expectedUser, expectedPass)
+		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
+		authenticated := BasicAuthenticatedRequest(req, expectedUser, expectedPass)
+		So(authenticated, ShouldBeTrue)
+	})
+
+	Convey("Given an invalid set of basic auth credentials", t, func() {
+		httpReq, err := http.NewRequest("GET", "http://localhost:3000/metrics", nil)
+		So(err, ShouldBeNil)
+		req := macaron.Request{
+			Request: httpReq,
+		}
+		encodedCreds := encodeBasicAuthCredentials("invaliduser", "invalidpass")
+		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
+		authenticated := BasicAuthenticatedRequest(req, expectedUser, expectedPass)
+		So(authenticated, ShouldBeFalse)
+	})
+}
+
+func encodeBasicAuthCredentials(user, pass string) string {
+	creds := fmt.Sprintf("%s:%s", user, pass)
+	return base64.StdEncoding.EncodeToString([]byte(creds))
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 func init() {
@@ -246,9 +245,7 @@ func (hs *HTTPServer) metricsEndpoint(ctx *macaron.Context) {
 		return
 	}
 
-	if hs.Cfg.MetricsEndpointBasicAuthUsername != "" &&
-		hs.Cfg.MetricsEndpointBasicAuthPassword != "" &&
-		!util.BasicAuthenticatedRequest(ctx.Req, hs.Cfg.MetricsEndpointBasicAuthUsername, hs.Cfg.MetricsEndpointBasicAuthPassword) {
+	if hs.metricsEndpointBasicAuthEnabled() && !BasicAuthenticatedRequest(ctx.Req, hs.Cfg.MetricsEndpointBasicAuthUsername, hs.Cfg.MetricsEndpointBasicAuthPassword) {
 		ctx.Resp.WriteHeader(http.StatusUnauthorized)
 		return
 	}
@@ -306,4 +303,8 @@ func (hs *HTTPServer) mapStatic(m *macaron.Macaron, rootDir string, dir string, 
 			AddHeaders:  headers,
 		},
 	))
+}
+
+func (hs *HTTPServer) metricsEndpointBasicAuthEnabled() bool {
+	return hs.Cfg.MetricsEndpointBasicAuthUsername != "" && hs.Cfg.MetricsEndpointBasicAuthPassword != ""
 }

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func init() {
@@ -243,6 +244,13 @@ func (hs *HTTPServer) metricsEndpoint(ctx *macaron.Context) {
 
 	if ctx.Req.Method != "GET" || ctx.Req.URL.Path != "/metrics" {
 		return
+	}
+
+	if hs.Cfg.MetricsEndpointBasicAuthEnabled {
+		if !util.BasicAuthenticatedRequest(ctx.Req, hs.Cfg.MetricsEndpointBasicAuthUsername, hs.Cfg.MetricsEndpointBasicAuthPassword) {
+			ctx.Resp.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 	}
 
 	promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}).

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -246,11 +246,11 @@ func (hs *HTTPServer) metricsEndpoint(ctx *macaron.Context) {
 		return
 	}
 
-	if hs.Cfg.MetricsEndpointBasicAuthEnabled {
-		if !util.BasicAuthenticatedRequest(ctx.Req, hs.Cfg.MetricsEndpointBasicAuthUsername, hs.Cfg.MetricsEndpointBasicAuthPassword) {
-			ctx.Resp.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+	if hs.Cfg.MetricsEndpointBasicAuthUsername != "" &&
+		hs.Cfg.MetricsEndpointBasicAuthPassword != "" &&
+		!util.BasicAuthenticatedRequest(ctx.Req, hs.Cfg.MetricsEndpointBasicAuthUsername, hs.Cfg.MetricsEndpointBasicAuthPassword) {
+		ctx.Resp.WriteHeader(http.StatusUnauthorized)
+		return
 	}
 
 	promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}).

--- a/pkg/api/http_server_test.go
+++ b/pkg/api/http_server_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/setting"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestHTTPServer(t *testing.T) {
+	Convey("Given a HTTPServer", t, func() {
+		ts := &HTTPServer{
+			Cfg: setting.NewCfg(),
+		}
+
+		Convey("Given that basic auth on the metrics endpoint is enabled", func() {
+			ts.Cfg.MetricsEndpointBasicAuthUsername = "foo"
+			ts.Cfg.MetricsEndpointBasicAuthPassword = "bar"
+
+			So(ts.metricsEndpointBasicAuthEnabled(), ShouldBeTrue)
+		})
+
+		Convey("Given that basic auth on the metrics endpoint is disabled", func() {
+			ts.Cfg.MetricsEndpointBasicAuthUsername = ""
+			ts.Cfg.MetricsEndpointBasicAuthPassword = ""
+
+			So(ts.metricsEndpointBasicAuthEnabled(), ShouldBeFalse)
+		})
+	})
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -215,6 +215,9 @@ type Cfg struct {
 	DisableBruteForceLoginProtection bool
 	TempDataLifetime                 time.Duration
 	MetricsEndpointEnabled           bool
+	MetricsEndpointBasicAuthEnabled  bool
+	MetricsEndpointBasicAuthUsername string
+	MetricsEndpointBasicAuthPassword string
 	EnableAlphaPanels                bool
 	EnterpriseLicensePath            string
 }
@@ -676,6 +679,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.PhantomDir = filepath.Join(HomePath, "tools/phantomjs")
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
 	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)
+	cfg.MetricsEndpointBasicAuthEnabled = iniFile.Section("metrics").Key("basic_auth_enabled").MustBool(true)
+	cfg.MetricsEndpointBasicAuthUsername = iniFile.Section("metrics").Key("basic_auth_username").String()
+	cfg.MetricsEndpointBasicAuthPassword = iniFile.Section("metrics").Key("basic_auth_password").String()
 
 	analytics := iniFile.Section("analytics")
 	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -215,7 +215,6 @@ type Cfg struct {
 	DisableBruteForceLoginProtection bool
 	TempDataLifetime                 time.Duration
 	MetricsEndpointEnabled           bool
-	MetricsEndpointBasicAuthEnabled  bool
 	MetricsEndpointBasicAuthUsername string
 	MetricsEndpointBasicAuthPassword string
 	EnableAlphaPanels                bool
@@ -679,7 +678,6 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.PhantomDir = filepath.Join(HomePath, "tools/phantomjs")
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
 	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)
-	cfg.MetricsEndpointBasicAuthEnabled = iniFile.Section("metrics").Key("basic_auth_enabled").MustBool(true)
 	cfg.MetricsEndpointBasicAuthUsername = iniFile.Section("metrics").Key("basic_auth_username").String()
 	cfg.MetricsEndpointBasicAuthPassword = iniFile.Section("metrics").Key("basic_auth_password").String()
 

--- a/pkg/util/auth.go
+++ b/pkg/util/auth.go
@@ -11,7 +11,7 @@ import (
 // Uses constant-time comparison in order to mitigate timing attacks.
 func BasicAuthenticatedRequest(req macaron.Request, expectedUser, expectedPass string) bool {
 	user, pass, ok := req.BasicAuth()
-	if !ok ||  subtle.ConstantTimeCompare([]byte(user), []byte(expectedUser)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(expectedPass)) != 1 {
+	if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(expectedUser)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(expectedPass)) != 1 {
 		return false
 	}
 

--- a/pkg/util/auth.go
+++ b/pkg/util/auth.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"crypto/subtle"
+	macaron "gopkg.in/macaron.v1"
+)
+
+// BasicAuthenticated parses the provided HTTP request for basic authentication credentials
+// and returns true if the provided credentials match the expected username and password.
+// Returns false if the request is unauthenticated.
+// Uses constant-time comparison in order to mitigate timing attacks.
+func BasicAuthenticatedRequest(req macaron.Request, expectedUser, expectedPass string) bool {
+	user, pass, ok := req.BasicAuth()
+	if !ok ||  subtle.ConstantTimeCompare([]byte(user), []byte(expectedUser)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(expectedPass)) != 1 {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Closes #13577.

- Adds `metrics.basic_auth_username` and `metrics.basic_auth_password` configuration options that enable and configure basic authentication on the Grafana metrics endpoint.

