### PR TITLE
Update google analytics code to submit full URL not just path

### DIFF
--- a/public/app/core/services/analytics.ts
+++ b/public/app/core/services/analytics.ts
@@ -26,7 +26,7 @@ export class Analytics {
 
   init() {
     this.$rootScope.$on('$viewContentLoaded', () => {
-      const track = { page: this.$location.url() };
+      const track = { location: this.$location.url() };
       const ga = (window as any).ga || this.gaInit();
       ga('set', track);
       ga('send', 'pageview');


### PR DESCRIPTION
- Issue related to this pull request: https://github.com/grafana/grafana/issues/14091
- Essentially, makes a tiny change that means Grafana will record full URL to Google Analytics not just the URL path.

