### PR TITLE
Add IsGrafanaAdmin=true for apiKey with admin role

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -140,7 +140,7 @@ func initContextWithApiKey(ctx *m.ReqContext) bool {
 	}
 
 	ctx.IsSignedIn = true
-	ctx.SignedInUser = &m.SignedInUser{}
+	ctx.SignedInUser = &m.SignedInUser{IsGrafanaAdmin: apikey.Role == m.ROLE_ADMIN}
 	ctx.OrgRole = apikey.Role
 	ctx.ApiKeyId = apikey.Id
 	ctx.OrgId = apikey.OrgId


### PR DESCRIPTION
For API key with admin role, it's reasonable to set IsGrafanaAdmin=true.

I add this line for I need to automate the initialization process of Grafana with terraform, so I need an API with GrafanaAdmin permission to create users.