### PR TITLE
Add param ShouldGenPassword for API "POST /api/admin/users"

### DIFF
--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -228,6 +228,22 @@ Content-Type: application/json
 }
 ```
 
+If you wish to create a user with no password just for thirdpart LDAP/SSO login, you can provide the shouldGenPassword parameter. Here is an example:
+```json
+
+POST /api/admin/users HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+
+{
+  "name":"User",
+  "email":"user@graf.com",
+  "login":"user",
+  "shouldGenPassword":true
+}
+```
+This request will create a user with a random generated password, and the user can only login through thirdpart LDAP/SSO.
+
 **Example Response**:
 
 ```json

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -24,7 +24,7 @@ func AdminCreateUser(c *m.ReqContext, form dtos.AdminCreateUserForm) {
 		}
 	}
 
-	if form.ThirdPartUser && cmd.Password == "" {
+	if form.ShouldGenPassword && cmd.Password == "" {
 		// Generate a random password so that nobody can login with password
 		cmd.Password = util.GetRandomString(10)
 	}

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -23,16 +23,15 @@ func AdminCreateUser(c *m.ReqContext, form dtos.AdminCreateUserForm) {
 			return
 		}
 	}
-	if !form.ThirdPartUser {
-		if len(cmd.Password) < 4 {
-			c.JsonApiErr(400, "Password is missing or too short", nil)
-			return
-		}
-	} else {
-		if cmd.Password == "" {
-			// Generate a random password so that nobody can login with password
-			cmd.Password = util.GetRandomString(10)
-		}
+
+	if form.ThirdPartUser && cmd.Password == "" {
+		// Generate a random password so that nobody can login with password
+		cmd.Password = util.GetRandomString(10)
+	}
+
+	if len(cmd.Password) < 4 {
+		c.JsonApiErr(400, "Password is missing or too short", nil)
+		return
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -23,10 +23,16 @@ func AdminCreateUser(c *m.ReqContext, form dtos.AdminCreateUserForm) {
 			return
 		}
 	}
-
-	if len(cmd.Password) < 4 {
-		c.JsonApiErr(400, "Password is missing or too short", nil)
-		return
+	if !form.ThirdPartUser {
+		if len(cmd.Password) < 4 {
+			c.JsonApiErr(400, "Password is missing or too short", nil)
+			return
+		}
+	} else {
+		if cmd.Password == "" {
+			// Generate a random password so that nobody can login with password
+			cmd.Password = util.GetRandomString(10)
+		}
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -14,10 +14,11 @@ type SignUpStep2Form struct {
 }
 
 type AdminCreateUserForm struct {
-	Email    string `json:"email"`
-	Login    string `json:"login"`
-	Name     string `json:"name"`
-	Password string `json:"password" binding:"Required"`
+	Email         string `json:"email"`
+	Login         string `json:"login"`
+	Name          string `json:"name"`
+	Password      string `json:"password"`
+	ThirdPartUser bool   `json:"is_thirdpart"`
 }
 
 type AdminUpdateUserForm struct {

--- a/pkg/api/dtos/user.go
+++ b/pkg/api/dtos/user.go
@@ -14,11 +14,11 @@ type SignUpStep2Form struct {
 }
 
 type AdminCreateUserForm struct {
-	Email         string `json:"email"`
-	Login         string `json:"login"`
-	Name          string `json:"name"`
-	Password      string `json:"password"`
-	ThirdPartUser bool   `json:"is_thirdpart"`
+	Email             string `json:"email"`
+	Login             string `json:"login"`
+	Name              string `json:"name"`
+	Password          string `json:"password"`
+	ShouldGenPassword bool   `json:"shouldGenPassword"`
 }
 
 type AdminUpdateUserForm struct {


### PR DESCRIPTION
Issue Link: #14093 

Add param `is_thirdpart ` in `POST /api/admin/users` to indicate this user comes from a thirdpart LDAP/SSO.
A third-party user can be created without providing a password because users can log in with their LDAP.