### PR TITLE
Explore: collapsible result panels

### DIFF
--- a/public/app/features/explore/Graph.tsx
+++ b/public/app/features/explore/Graph.tsx
@@ -77,7 +77,6 @@ interface GraphProps {
   data: any[];
   height?: string; // e.g., '200px'
   id?: string;
-  loading?: boolean;
   range: RawTimeRange;
   split?: boolean;
   size?: { width: number; height: number };
@@ -188,12 +187,11 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
   }
 
   render() {
-    const { height = '100px', id = 'graph', loading = false } = this.props;
+    const { height = '100px', id = 'graph' } = this.props;
     const data = this.getGraphData();
 
     return (
-      <div className="panel-container">
-        {loading && <div className="explore-panel__loader" />}
+      <>
         {this.props.data &&
           this.props.data.length > MAX_NUMBER_OF_TIME_SERIES &&
           !this.state.showAllTimeSeries && (
@@ -207,7 +205,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
           )}
         <div id={id} className="explore-graph" style={{ height }} />
         <Legend data={data} />
-      </div>
+      </>
     );
   }
 }

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -97,7 +97,7 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
           />
         </div>
 
-        <div className="panel-container logs-options">
+        <div className="logs-options">
           <div className="logs-controls">
             <Switch label="Timestamp" checked={showUtc} onChange={this.onChangeUtc} small />
             <Switch label="Local time" checked={showLocalTime} onChange={this.onChangeLocalTime} small />
@@ -116,33 +116,30 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
           </div>
         </div>
 
-        <div className="panel-container">
-          {loading && <div className="explore-panel__loader" />}
-          <div className="logs-entries" style={logEntriesStyle}>
-            {hasData &&
-              data.rows.map(row => (
-                <Fragment key={row.key}>
-                  <div className={row.logLevel ? `logs-row-level logs-row-level-${row.logLevel}` : ''} />
-                  {showUtc && <div title={`Local: ${row.timeLocal} (${row.timeFromNow})`}>{row.timestamp}</div>}
-                  {showLocalTime && <div title={`${row.timestamp} (${row.timeFromNow})`}>{row.timeLocal}</div>}
-                  {showLabels && (
-                    <div className="max-width" title={row.labels}>
-                      {row.labels}
-                    </div>
-                  )}
-                  <div>
-                    <Highlighter
-                      textToHighlight={row.entry}
-                      searchWords={row.searchWords}
-                      findChunks={findHighlightChunksInText}
-                      highlightClassName="logs-row-match-highlight"
-                    />
+        <div className="logs-entries" style={logEntriesStyle}>
+          {hasData &&
+            data.rows.map(row => (
+              <Fragment key={row.key}>
+                <div className={row.logLevel ? `logs-row-level logs-row-level-${row.logLevel}` : ''} />
+                {showUtc && <div title={`Local: ${row.timeLocal} (${row.timeFromNow})`}>{row.timestamp}</div>}
+                {showLocalTime && <div title={`${row.timestamp} (${row.timeFromNow})`}>{row.timeLocal}</div>}
+                {showLabels && (
+                  <div className="max-width" title={row.labels}>
+                    {row.labels}
                   </div>
-                </Fragment>
-              ))}
-          </div>
-          {!loading && !hasData && 'No data was returned.'}
+                )}
+                <div>
+                  <Highlighter
+                    textToHighlight={row.entry}
+                    searchWords={row.searchWords}
+                    findChunks={findHighlightChunksInText}
+                    highlightClassName="logs-row-match-highlight"
+                  />
+                </div>
+              </Fragment>
+            ))}
         </div>
+        {!loading && !hasData && 'No data was returned.'}
       </div>
     );
   }

--- a/public/app/features/explore/Panel.tsx
+++ b/public/app/features/explore/Panel.tsx
@@ -1,0 +1,34 @@
+import React, { PureComponent } from 'react';
+
+interface Props {
+  isOpen: boolean;
+  label: string;
+  loading?: boolean;
+  onToggle: (isOpen: boolean) => void;
+}
+
+export default class Panel extends PureComponent<Props> {
+  onClickToggle = () => this.props.onToggle(!this.props.isOpen);
+
+  render() {
+    const { isOpen, loading } = this.props;
+    const iconClass = isOpen ? 'fa fa-caret-up' : 'fa fa-caret-down';
+    const loaderClass = loading ? 'explore-panel__loader explore-panel__loader--active' : 'explore-panel__loader';
+    return (
+      <div className="explore-panel panel-container">
+        <div className="explore-panel__header" onClick={this.onClickToggle}>
+          <div className="explore-panel__header-buttons">
+            <span className={iconClass} />
+          </div>
+          <div className="explore-panel__header-label">{this.props.label}</div>
+        </div>
+        {isOpen && (
+          <div className="explore-panel__body">
+            <div className={loaderClass} />
+            {this.props.children}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/public/app/features/explore/__snapshots__/Graph.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/Graph.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render should render component 1`] = `
-<div
-  className="panel-container"
->
+<Fragment>
   <div
     className="explore-graph"
     id="graph"
@@ -456,13 +454,11 @@ exports[`Render should render component 1`] = `
       ]
     }
   />
-</div>
+</Fragment>
 `;
 
 exports[`Render should render component with disclaimer 1`] = `
-<div
-  className="panel-container"
->
+<Fragment>
   <div
     className="time-series-disclaimer"
   >
@@ -952,13 +948,11 @@ exports[`Render should render component with disclaimer 1`] = `
       ]
     }
   />
-</div>
+</Fragment>
 `;
 
 exports[`Render should show query return no time series 1`] = `
-<div
-  className="panel-container"
->
+<Fragment>
   <div
     className="explore-graph"
     id="graph"
@@ -971,5 +965,5 @@ exports[`Render should show query return no time series 1`] = `
   <Legend
     data={Array []}
   />
-</div>
+</Fragment>
 `;

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -173,6 +173,7 @@ export interface ExploreState {
   range: RawTimeRange;
   showingGraph: boolean;
   showingLogs: boolean;
+  showingStartPage?: boolean;
   showingTable: boolean;
   supportsGraph: boolean | null;
   supportsLogs: boolean | null;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -18,10 +18,39 @@
     margin-left: 15px;
   }
 
-  // Graph panel needs a bit extra padding at top
-  .panel-container {
+  .explore-panel {
+    margin-top: $panel-margin;
+  }
+
+  .explore-panel__body {
     padding: $panel-padding;
-    padding-top: 10px;
+  }
+
+  .explore-panel__header {
+    padding: $panel-padding;
+    padding-top: 5px;
+    padding-bottom: 0;
+    display: flex;
+    cursor: pointer;
+    margin-bottom: 5px;
+    transition: all 0.1s linear;
+  }
+
+  .explore-panel__header:hover {
+    transform: translateY(-1px);
+  }
+
+  .explore-panel__header-label {
+    font-weight: 500;
+    margin-right: $panel-margin;
+    font-size: $font-size-h6;
+    box-shadow: $text-shadow-faint;
+  }
+
+  .explore-panel__header-buttons {
+    margin-right: $panel-margin;
+    font-size: $font-size-lg;
+    line-height: $font-size-h6;
   }
 
   // Make sure wrap buttons around on small screens
@@ -91,11 +120,16 @@
     height: 2px;
     position: relative;
     overflow: hidden;
-    background: $text-color-faint;
+    background: none;
     margin: $panel-margin / 2;
+    transition: background-color 1s ease;
   }
 
-  .explore-panel__loader:after {
+  .explore-panel__loader--active {
+    background: $text-color-faint;
+  }
+
+  .explore-panel__loader--active:after {
     content: ' ';
     display: block;
     width: 25%;
@@ -221,15 +255,16 @@
 
     .logs-controls {
       display: flex;
+      background-color: $page-bg;
+      padding: $panel-padding;
+      padding-top: 10px;
+      border-radius: $border-radius;
+      margin: 2*$panel-margin 0;
+      border: $panel-border;
 
       > * {
         margin-right: 1em;
       }
-    }
-
-    .logs-options,
-    .logs-graph {
-      margin-bottom: $panel-margin;
     }
 
     .logs-meta {


### PR DESCRIPTION
- replace the Graph/Table buttons with toggle control in a wrapper panel
- moved toggle control to left to be close to the label
- removed panel styles from Logs and Graph viewer
- moved loader animation to panel

Fixes #13738