### PR TITLE
Added google oauth account id

### DIFF
--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -48,6 +48,7 @@ func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	}
 
 	return &BasicUserInfo{
+		Id:    fmt.Sprintf("%d", data.Id),
 		Name:  data.Name,
 		Email: data.Email,
 		Login: data.Email,

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -32,6 +32,7 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 
 func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
+		Id    int    `json:"id"`
 		Name  string `json:"name"`
 		Email string `json:"email"`
 	}

--- a/pkg/social/google_oauth.go
+++ b/pkg/social/google_oauth.go
@@ -32,7 +32,7 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 
 func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
-		Id    int    `json:"id"`
+		Id    string `json:"id"`
 		Name  string `json:"name"`
 		Email string `json:"email"`
 	}
@@ -48,7 +48,7 @@ func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	}
 
 	return &BasicUserInfo{
-		Id:    fmt.Sprintf("%d", data.Id),
+		Id:    data.Id,
 		Name:  data.Name,
 		Email: data.Email,
 		Login: data.Email,


### PR DESCRIPTION
Fixes #13924
Google's OAuth API should return the account id according to the [api explorer](https://developers.google.com/apis-explorer/#p/oauth2/v1/oauth2.userinfo.get?_h=1&).