### PR TITLE
Add query filter icons to filterable table fields in explore section

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -429,8 +429,13 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     );
   };
 
-  onClickTableCell = (columnKey: string, rowValue: string) => {
-    this.onModifyQueries({ type: 'ADD_FILTER', key: columnKey, value: rowValue });
+  onClickTableCell = (columnKey: string, rowValue: string, options: {}) => {
+    this.onModifyQueries({
+      key: columnKey,
+      options,
+      type: 'ADD_FILTER',
+      value: rowValue,
+    });
   };
 
   onModifyQueries = (action, index?: number) => {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -66,7 +66,11 @@ function addLabelToSelector(selector: string, labelKey: string, labelValue: stri
   if (selector) {
     let match = labelRegexp.exec(selector);
     while (match) {
-      parsedLabels.push({ key: match[1], operator: match[2], value: match[3] });
+      const key = match[1];
+      // Ignore existing label selector when the incoming one should replace it
+      if (key !== labelKey) {
+        parsedLabels.push({ key, operator: match[2], value: match[3] });
+      }
       match = labelRegexp.exec(selector);
     }
   }

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -459,7 +459,14 @@ export class PrometheusDatasource {
     let expression = query.expr || '';
     switch (action.type) {
       case 'ADD_FILTER': {
-        expression = addLabelToQuery(expression, action.key, action.value);
+        let operator: string;
+        const filter = action.options.filter;
+        if (filter === 'INCLUDE') {
+          operator = '=';
+        } else if (filter === 'EXCLUDE') {
+          operator = '!=';
+        }
+        expression = addLabelToQuery(expression, action.key, action.value, operator);
         break;
       }
       case 'ADD_HISTOGRAM_QUANTILE': {

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -54,5 +54,8 @@ describe('addLabelToQuery()', () => {
     expect(addLabelToQuery(addLabelToQuery('avg(foo) + sum(xx_yy)', 'bar', 'baz'), 'bar', 'baz')).toBe(
       'avg(foo{bar="baz"}) + sum(xx_yy{bar="baz"})'
     );
+    expect(addLabelToQuery(addLabelToQuery('metric', 'label', 'value', '!='), 'label', 'value', '=')).toBe(
+      'metric{label="value"}'
+    );
   });
 });

--- a/public/sass/components/_panel_table.scss
+++ b/public/sass/components/_panel_table.scss
@@ -94,11 +94,13 @@
     &.cell-highlighted:hover {
       background-color: $tight-form-func-bg;
     }
+  }
+}
 
-    &:hover {
-      .table-panel-filter-link {
-        visibility: visible;
-      }
+.table-panel-cell-filterable {
+  &:hover {
+    .table-panel-filter-link {
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
Hello,

This pull request attempts to address #13520.

Apart from introducing the query filter icons, the only other notable change was updating a function used to modify queries to apply filtering. If applying a filter concerning a label selector already present in a query, the incoming filter should replace the existing one (i.e. doesn't make sense to specify the same selector more than once, `{job="a", job="a"}`).