### PR TITLE
Retain decimal precision when exporting CSV

### DIFF
--- a/public/app/core/specs/file_export.test.ts
+++ b/public/app/core/specs/file_export.test.ts
@@ -73,6 +73,7 @@ describe('file_export', () => {
         ],
         rows: [
           [123, 'some_string', 1.234, true],
+          [1000, 'some_string', 1.234567891, true],
           [0o765, 'some string with " in the middle', 1e-2, false],
           [0o765, 'some string with "" in the middle', 1e-2, false],
           [0o765, 'some string with """ in the middle', 1e-2, false],
@@ -89,6 +90,7 @@ describe('file_export', () => {
       const expectedText =
         '"integer_value";"string_value";"float_value";"boolean_value"\r\n' +
         '123;"some_string";1.234;true\r\n' +
+        '1000;"some_string";1.234567891;true\r\n' +
         '501;"some string with "" in the middle";0.01;false\r\n' +
         '501;"some string with """" in the middle";0.01;false\r\n' +
         '501;"some string with """""" in the middle";0.01;false\r\n' +

--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -41,10 +41,8 @@ function formatSpecialHeader(useExcelHeader) {
 function formatRow(row, addEndRowDelimiter = true) {
   let text = '';
   for (let i = 0; i < row.length; i += 1) {
-    if (isBoolean(row[i]) || isNullOrUndefined(row[i])) {
+    if (isBoolean(row[i]) || isNumber(row[i]) || isNullOrUndefined(row[i])) {
       text += row[i];
-    } else if (isNumber(row[i])) {
-      text += row[i].toLocaleString();
     } else {
       text += `${QUOTE}${csvEscaped(htmlUnescaped(htmlDecoded(row[i])))}${QUOTE}`;
     }


### PR DESCRIPTION
Using `Number.prototype.toLocaleString()` has the unexpected behavior of truncating anything
exceeding 3 decimal digits on floats.

Additionally, it introduces potential inconsistencies (comma vs period separators) which could make processing the output CSV harder than it should be.  The proposed solution here is to simply let numbers be cast automatically via string concatenation.

Alternatively, as proposed [here](https://github.com/grafana/grafana/issues/13929#issuecomment-439584353), a less aggressive solution would be to could continue using `toLocaleString()` and relying on the `minimumSignificantDigits` property.

Fixes #13929.