### PR TITLE
Explore: POC dedup logging rows

### DIFF
--- a/public/app/core/specs/logs_model.test.ts
+++ b/public/app/core/specs/logs_model.test.ts
@@ -1,0 +1,108 @@
+import { dedupLogRows, LogsDedupStrategy, LogsModel } from '../logs_model';
+
+describe('dedupLogRows()', () => {
+  test('should return rows as is when dedup is set to none', () => {
+    const logs = {
+      rows: [
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+      ],
+    };
+    expect(dedupLogRows(logs as LogsModel, LogsDedupStrategy.none).rows).toMatchObject(logs.rows);
+  });
+
+  test('should dedup on exact matches', () => {
+    const logs = {
+      rows: [
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+        {
+          entry: 'INFO test 2.44 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+      ],
+    };
+    expect(dedupLogRows(logs as LogsModel, LogsDedupStrategy.exact).rows).toEqual([
+      {
+        duplicates: 1,
+        entry: 'WARN test 1.23 on [xxx]',
+      },
+      {
+        duplicates: 0,
+        entry: 'INFO test 2.44 on [xxx]',
+      },
+      {
+        duplicates: 0,
+        entry: 'WARN test 1.23 on [xxx]',
+      },
+    ]);
+  });
+
+  test('should dedup on number matches', () => {
+    const logs = {
+      rows: [
+        {
+          entry: 'WARN test 1.2323423 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+        {
+          entry: 'INFO test 2.44 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+      ],
+    };
+    expect(dedupLogRows(logs as LogsModel, LogsDedupStrategy.numbers).rows).toEqual([
+      {
+        duplicates: 1,
+        entry: 'WARN test 1.2323423 on [xxx]',
+      },
+      {
+        duplicates: 0,
+        entry: 'INFO test 2.44 on [xxx]',
+      },
+      {
+        duplicates: 0,
+        entry: 'WARN test 1.23 on [xxx]',
+      },
+    ]);
+  });
+
+  test('should dedup on signature matches', () => {
+    const logs = {
+      rows: [
+        {
+          entry: 'WARN test 1.2323423 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+        {
+          entry: 'INFO test 2.44 on [xxx]',
+        },
+        {
+          entry: 'WARN test 1.23 on [xxx]',
+        },
+      ],
+    };
+    expect(dedupLogRows(logs as LogsModel, LogsDedupStrategy.signature).rows).toEqual([
+      {
+        duplicates: 3,
+        entry: 'WARN test 1.2323423 on [xxx]',
+      },
+    ]);
+  });
+});

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -300,8 +300,8 @@
 
     .logs-row-level {
       background-color: transparent;
-      margin: 6px 0;
-      border-radius: 2px;
+      margin: 2px 0;
+      position: relative;
       opacity: 0.8;
     }
 
@@ -325,6 +325,25 @@
     .logs-row-level-trace,
     .logs-row-level-debug {
       background-color: #1f78c1;
+    }
+
+    .logs-row-level__duplicates {
+      position: absolute;
+      width: 9px;
+      height: 100%;
+      top: 0;
+      left: 5px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: flex-start;
+      align-content: flex-start;
+    }
+
+    .logs-row-level__duplicate {
+      width: 2px;
+      height: 3px;
+      background-color: #1f78c1;
+      margin: 0 1px 1px 0;
     }
   }
 }


### PR DESCRIPTION
- making dedup part of the logging viewer
- added dedup switches to logs view, will probably combine them to a dropdown
- strategy 'exact' matches rows exact strings (but strips ISO dates)
- strategy 'numbers' strips all numbers
- strategy 'signature' strips all letters and numbers to that only whitespace and punctuation remains
- added duplication indicator next to log level

