### PR TITLE
Add API GET /api/users/:id/teams for GrafanaAdmin

### DIFF
--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -226,6 +226,40 @@ Content-Type: application/json
 ]
 ```
 
+## Get Teams for user
+
+`GET /api/users/:id/teams`
+
+**Example Request**:
+
+```http
+GET /api/users/1/teams HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+Requires basic authentication and that the authenticated user is a Grafana Admin.
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+[
+  {
+    "id":1,
+    "orgId":1,
+    "name":"team1",
+    "email":"",
+    "avatarUrl":"/avatar/3fcfe295eae3bcb67a49349377428a66",
+    "memberCount":1
+  }
+]
+```
+
+
 ## User
 
 ## Actual User

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -140,6 +140,7 @@ func (hs *HTTPServer) registerRoutes() {
 			usersRoute.Get("/", Wrap(SearchUsers))
 			usersRoute.Get("/search", Wrap(SearchUsersWithPaging))
 			usersRoute.Get("/:id", Wrap(GetUserByID))
+			usersRoute.Get("/:id/teams", Wrap(GetUserTeams))
 			usersRoute.Get("/:id/orgs", Wrap(GetUserOrgList))
 			// query parameters /users/lookup?loginOrEmail=admin@example.com
 			usersRoute.Get("/lookup", Wrap(GetUserByLoginOrEmail))

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -113,7 +113,16 @@ func GetSignedInUserOrgList(c *m.ReqContext) Response {
 
 // GET /api/user/teams
 func GetSignedInUserTeamList(c *m.ReqContext) Response {
-	query := m.GetTeamsByUserQuery{OrgId: c.OrgId, UserId: c.UserId}
+	return getUserTeamList(c.OrgId, c.UserId)
+}
+
+// GET /api/users/:id/teams
+func GetUserTeams(c *m.ReqContext) Response {
+	return getUserTeamList(c.OrgId, c.ParamsInt64("id"))
+}
+
+func getUserTeamList(userID int64, orgID int64) Response {
+	query := m.GetTeamsByUserQuery{OrgId: orgID, UserId: userID}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return Error(500, "Failed to get user teams", err)
@@ -122,11 +131,10 @@ func GetSignedInUserTeamList(c *m.ReqContext) Response {
 	for _, team := range query.Result {
 		team.AvatarUrl = dtos.GetGravatarUrlWithDefault(team.Email, team.Name)
 	}
-
 	return JSON(200, query.Result)
 }
 
-// GET /api/user/:id/orgs
+// GET /api/users/:id/orgs
 func GetUserOrgList(c *m.ReqContext) Response {
 	return getUserOrgList(c.ParamsInt64(":id"))
 }

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -118,7 +118,7 @@ func GetSignedInUserTeamList(c *m.ReqContext) Response {
 
 // GET /api/users/:id/teams
 func GetUserTeams(c *m.ReqContext) Response {
-	return getUserTeamList(c.OrgId, c.ParamsInt64("id"))
+	return getUserTeamList(c.OrgId, c.ParamsInt64(":id"))
 }
 
 func getUserTeamList(userID int64, orgID int64) Response {


### PR DESCRIPTION
* Add an API `GET /api/users/:id/teams` to list teams for a given userID. This API is implemented similar to `GET /api/users/:id/orgs`.
* Also, fixed the comment for `GET /api/users/:id/orgs`
