### PR TITLE
Corrects an issue where nightly rpms would be misstagged.

### DIFF
--- a/scripts/build/release_publisher/externalrelease.go
+++ b/scripts/build/release_publisher/externalrelease.go
@@ -17,14 +17,18 @@ type releaseFromExternalContent struct {
 func (re releaseFromExternalContent) prepareRelease(baseArchiveUrl, whatsNewUrl string, releaseNotesUrl string, nightly bool) (*release, error) {
 	version := re.rawVersion[1:]
 	isBeta := strings.Contains(version, "beta")
+	var rt ReleaseType
+	if isBeta {
+		rt = BETA
+	}
 
 	builds := []build{}
 	for _, ba := range re.artifactConfigurations {
-		sha256, err := re.getter.getContents(fmt.Sprintf("%s.sha256", ba.getUrl(baseArchiveUrl, version, isBeta)))
+		sha256, err := re.getter.getContents(fmt.Sprintf("%s.sha256", ba.getUrl(baseArchiveUrl, version, rt)))
 		if err != nil {
 			return nil, err
 		}
-		builds = append(builds, newBuild(baseArchiveUrl, ba, version, isBeta, sha256))
+		builds = append(builds, newBuild(baseArchiveUrl, ba, version, rt, sha256))
 	}
 
 	r := release{

--- a/scripts/build/release_publisher/externalrelease.go
+++ b/scripts/build/release_publisher/externalrelease.go
@@ -16,10 +16,14 @@ type releaseFromExternalContent struct {
 
 func (re releaseFromExternalContent) prepareRelease(baseArchiveUrl, whatsNewUrl string, releaseNotesUrl string, nightly bool) (*release, error) {
 	version := re.rawVersion[1:]
-	isBeta := strings.Contains(version, "beta")
+	beta := strings.Contains(version, "beta")
 	var rt ReleaseType
-	if isBeta {
+	if beta {
 		rt = BETA
+	} else if nightly {
+		rt = NIGHTLY
+	} else {
+		rt = STABLE
 	}
 
 	builds := []build{}
@@ -34,9 +38,9 @@ func (re releaseFromExternalContent) prepareRelease(baseArchiveUrl, whatsNewUrl 
 	r := release{
 		Version:         version,
 		ReleaseDate:     time.Now().UTC(),
-		Stable:          !isBeta && !nightly,
-		Beta:            isBeta,
-		Nightly:         nightly,
+		Stable:          rt.stable(),
+		Beta:            rt.beta(),
+		Nightly:         rt.nightly(),
 		WhatsNewUrl:     whatsNewUrl,
 		ReleaseNotesUrl: releaseNotesUrl,
 		Builds:          builds,

--- a/scripts/build/release_publisher/localrelease.go
+++ b/scripts/build/release_publisher/localrelease.go
@@ -18,6 +18,9 @@ type releaseLocalSources struct {
 }
 
 func (r releaseLocalSources) prepareRelease(baseArchiveUrl, whatsNewUrl string, releaseNotesUrl string, nightly bool) (*release, error) {
+	if !nightly {
+		return nil, errors.New("Local releases only supported for nightly builds.")
+	}
 	buildData := r.findBuilds(baseArchiveUrl)
 
 	rel := release{

--- a/scripts/build/release_publisher/localrelease.go
+++ b/scripts/build/release_publisher/localrelease.go
@@ -70,7 +70,7 @@ func createBuildWalker(path string, data *buildData, archiveTypes []buildArtifac
 				data.version = version
 				data.builds = append(data.builds, build{
 					Os:     archive.os,
-					Url:    archive.getUrl(baseArchiveUrl, version, false),
+					Url:    archive.getUrl(baseArchiveUrl, version, NIGHTLY),
 					Sha256: string(shaBytes),
 					Arch:   archive.arch,
 				})

--- a/scripts/build/release_publisher/publisher.go
+++ b/scripts/build/release_publisher/publisher.go
@@ -95,7 +95,7 @@ func (t buildArtifact) getUrl(baseArchiveUrl, version string, releaseType Releas
 		prefix = "_"
 	}
 
-	if releaseType == STABLE && t.os == "rhel" {
+	if releaseType.stable() && t.os == "rhel" {
 		rhelReleaseExtra = "-1"
 	}
 

--- a/scripts/build/release_publisher/publisher.go
+++ b/scripts/build/release_publisher/publisher.go
@@ -69,13 +69,25 @@ const (
 	NIGHTLY
 )
 
+func (rt ReleaseType) beta() bool {
+	return rt == BETA
+}
+
+func (rt ReleaseType) stable() bool {
+	return rt == STABLE
+}
+
+func (rt ReleaseType) nightly() bool {
+	return rt == NIGHTLY
+}
+
 type buildArtifact struct {
 	os         string
 	arch       string
 	urlPostfix string
 }
 
-func (t buildArtifact) getUrl(baseArchiveUrl, version string, rt ReleaseType) string {
+func (t buildArtifact) getUrl(baseArchiveUrl, version string, releaseType ReleaseType) string {
 	prefix := "-"
 	rhelReleaseExtra := ""
 
@@ -83,7 +95,7 @@ func (t buildArtifact) getUrl(baseArchiveUrl, version string, rt ReleaseType) st
 		prefix = "_"
 	}
 
-	if rt == BETA && t.os == "rhel" {
+	if releaseType == STABLE && t.os == "rhel" {
 		rhelReleaseExtra = "-1"
 	}
 

--- a/scripts/build/release_publisher/publisher.go
+++ b/scripts/build/release_publisher/publisher.go
@@ -61,13 +61,21 @@ func (p *publisher) postRelease(r *release) error {
 	return nil
 }
 
+type ReleaseType int
+
+const (
+	STABLE ReleaseType = iota + 1
+	BETA
+	NIGHTLY
+)
+
 type buildArtifact struct {
 	os         string
 	arch       string
 	urlPostfix string
 }
 
-func (t buildArtifact) getUrl(baseArchiveUrl, version string, isBeta bool) string {
+func (t buildArtifact) getUrl(baseArchiveUrl, version string, rt ReleaseType) string {
 	prefix := "-"
 	rhelReleaseExtra := ""
 
@@ -75,7 +83,7 @@ func (t buildArtifact) getUrl(baseArchiveUrl, version string, isBeta bool) strin
 		prefix = "_"
 	}
 
-	if !isBeta && t.os == "rhel" {
+	if rt == BETA && t.os == "rhel" {
 		rhelReleaseExtra = "-1"
 	}
 
@@ -141,10 +149,10 @@ var buildArtifactConfigurations = []buildArtifact{
 	},
 }
 
-func newBuild(baseArchiveUrl string, ba buildArtifact, version string, isBeta bool, sha256 string) build {
+func newBuild(baseArchiveUrl string, ba buildArtifact, version string, rt ReleaseType, sha256 string) build {
 	return build{
 		Os:     ba.os,
-		Url:    ba.getUrl(baseArchiveUrl, version, isBeta),
+		Url:    ba.getUrl(baseArchiveUrl, version, rt),
 		Sha256: sha256,
 		Arch:   ba.arch,
 	}

--- a/scripts/build/release_publisher/publisher_test.go
+++ b/scripts/build/release_publisher/publisher_test.go
@@ -63,8 +63,7 @@ func TestPreparingReleaseFromRemote(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		var builder releaseBuilder
-		builder = releaseFromExternalContent{
+		builder := releaseFromExternalContent{
 			getter:                 mockHttpGetter{},
 			rawVersion:             test.version,
 			artifactConfigurations: test.buildArtifacts,


### PR DESCRIPTION
Nightly builds would get -1 added to the version,
some thing only stable releases should have.