### PR TITLE
fixed issue switching back from mixed data source

### DIFF
--- a/public/app/features/panel/metrics_tab.ts
+++ b/public/app/features/panel/metrics_tab.ts
@@ -76,7 +76,6 @@ export class MetricsTabCtrl {
       return;
     }
 
-    this.datasourceInstance = option.datasource;
     this.setDatasource(option.datasource);
     this.updateDatasourceOptions();
   }
@@ -96,6 +95,7 @@ export class MetricsTabCtrl {
       });
     }
 
+    this.datasourceInstance = datasource;
     this.panel.datasource = datasource.value;
     this.panel.refresh();
   }


### PR DESCRIPTION
React panels refactoring moved the setDatasource function from metrics panel controller, this moved caused the logic that cleanup after changing back from mixed data source to not work properly. 

