### PR TITLE
Add scale toggle to Singlestat panel

### DIFF
--- a/docs/sources/features/panels/singlestat.md
+++ b/docs/sources/features/panels/singlestat.md
@@ -57,8 +57,9 @@ Sparklines are a great way of seeing the historical data related to the summary 
 
 1. **Show**: The show checkbox will toggle whether the spark line is shown in the Panel. When unselected, only the Singlestat value will appear.
 2. **Full Height**: Check if you want the sparklines to take up the full panel height, or uncheck if they should be below the main Singlestat value.
-3. **Line Color**: This color selection applies to the color of the sparkline itself.
-4. **Fill Color**: This color selection applies to the area below the sparkline.
+3. **Zero Scale**: Check if you want the sparklines to be scaled relative to zero, or uncheck if they should be scaled automatically.
+4. **Line Color**: This color selection applies to the color of the sparkline itself.
+5. **Fill Color**: This color selection applies to the area below the sparkline.
 
 <div class="clearfix"></div>
 

--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -88,6 +88,7 @@
     <gf-form-switch class="gf-form" label-class="width-9" label="Show" checked="ctrl.panel.sparkline.show" on-change="ctrl.render()"></gf-form-switch>
     <div ng-if="ctrl.panel.sparkline.show">
       <gf-form-switch class="gf-form" label-class="width-9" label="Full height" checked="ctrl.panel.sparkline.full" on-change="ctrl.render()"></gf-form-switch>
+      <gf-form-switch class="gf-form" label-class="width-9" label="Zero Scale" checked="ctrl.panel.sparkline.zeroScale" on-change="ctrl.render()"></gf-form-switch>
       <div class="gf-form">
         <label class="gf-form-label width-9">Line Color</label>
         <span class="gf-form-label">

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -63,6 +63,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     sparkline: {
       show: false,
       full: false,
+      zeroScale: true,
       lineColor: 'rgb(31, 120, 193)',
       fillColor: 'rgba(31, 118, 189, 0.18)',
     },
@@ -575,7 +576,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
           lines: {
             show: true,
             fill: 1,
-            zero: false,
+            zero: panel.sparkline.zeroScale,
             lineWidth: 1,
             fillColor: panel.sparkline.fillColor,
           },


### PR DESCRIPTION
This PR is an attempt to address the issue reported in https://github.com/grafana/grafana/issues/13800.

I'm not totally sold on the "Zero Scale" nomenclature. I considered "Auto Scale" as well but wasn't too sure. Open to feedback on the naming and also a what sensible default should be — I went with the behavior prior to https://github.com/grafana/grafana/pull/12010 but can definitely update.

Just a note that if approved, we'll need a new PR in [grafana.org](https://github.com/grafana/grafana.org) to add a new revision of the [singlestat-spark-options](singlestat-spark-options) screenshot.