### PR TITLE
Revert "Update google analytics code to submit full URL not just path"

### DIFF
--- a/public/app/core/services/analytics.ts
+++ b/public/app/core/services/analytics.ts
@@ -26,7 +26,7 @@ export class Analytics {
 
   init() {
     this.$rootScope.$on('$viewContentLoaded', () => {
-      const track = { location: this.$location.url() };
+      const track = { page: this.$location.url() };
       const ga = (window as any).ga || this.gaInit();
       ga('set', track);
       ga('send', 'pageview');


### PR DESCRIPTION
Reverts grafana/grafana#14092

Apologies. The original pull request (grafana/grafana#14092) actually does not do what it says it does. It doesn't make any difference to Google Analytics recording the whole URL. So rather than have some pointless change, could we revert this so that the code returns to how it is here: 

https://github.com/grafana/grafana/blob/v5.3.4/public/app/core/services/analytics.ts#L29

You can do what I was looking for in Google Analytics without making any change to the Grafana source. See: https://support.google.com/analytics/answer/1012243?hl=en 





