### PR TITLE
Adds example timeline in docs for alerting for

### DIFF
--- a/docs/sources/alerting/rules.md
+++ b/docs/sources/alerting/rules.md
@@ -56,10 +56,8 @@ If an alert rule has a configured `For` and the query violates the configured th
 
 Typically, it's always a good idea to use this setting since its often worse to get false positive than wait a few minutes before the alert notification triggers. Looking at the `Alert list` or `Alert list panels` you will be able to see alert in pending state. 
 
-Example timeline of an alert.
-{{< imgbox max-width="80%" img="/img/docs/v54/alerting-for-dark-theme.png" caption="Alerting For" >}}
-
-In the previous image you can see how an alert rule transition over time. 
+Below you can see an example timeline of an alert using the `For` setting. At ~16:04 the alert state changes to `Pending` and after 4minutes it changes to `Alerting` which is when alert notifications are sent. Once the series falls back to normal the alert rule goes back to `OK`.
+{{< imgbox img="/img/docs/v54/alerting-for-dark-theme.png" caption="Alerting For" >}}
 
 {{< imgbox max-width="40%" img="/img/docs/v4/alerting_conditions.png" caption="Alerting Conditions" >}}
 

--- a/docs/sources/alerting/rules.md
+++ b/docs/sources/alerting/rules.md
@@ -54,7 +54,7 @@ Here you can specify the name of the alert rule and how often the scheduler shou
 
 If an alert rule has a configured `For` and the query violates the configured threshold it will first go from `OK` to `Pending`. Going from `OK` to `Pending` Grafana will not send any notifications. Once the alert rule has been firing for more than `For` duration, it will change to `Alerting` and send alert notifications. 
 
-Typically, it's always a good idea to use this setting since its often worse to get false positive than wait a few minutes before the alert notification triggers. Looking at the `Alert list` or `Alert list panels` you will be able to see alert in pending state. 
+Typically, it's always a good idea to use this setting since it's often worse to get false positive than wait a few minutes before the alert notification triggers. Looking at the `Alert list` or `Alert list panels` you will be able to see alerts in pending state. 
 
 Below you can see an example timeline of an alert using the `For` setting. At ~16:04 the alert state changes to `Pending` and after 4minutes it changes to `Alerting` which is when alert notifications are sent. Once the series falls back to normal the alert rule goes back to `OK`.
 {{< imgbox img="/img/docs/v54/alerting-for-dark-theme.png" caption="Alerting For" >}}

--- a/docs/sources/alerting/rules.md
+++ b/docs/sources/alerting/rules.md
@@ -56,7 +56,7 @@ If an alert rule has a configured `For` and the query violates the configured th
 
 Typically, it's always a good idea to use this setting since it's often worse to get false positive than wait a few minutes before the alert notification triggers. Looking at the `Alert list` or `Alert list panels` you will be able to see alerts in pending state. 
 
-Below you can see an example timeline of an alert using the `For` setting. At ~16:04 the alert state changes to `Pending` and after 4minutes it changes to `Alerting` which is when alert notifications are sent. Once the series falls back to normal the alert rule goes back to `OK`.
+Below you can see an example timeline of an alert using the `For` setting. At ~16:04 the alert state changes to `Pending` and after 4 minutes it changes to `Alerting` which is when alert notifications are sent. Once the series falls back to normal the alert rule goes back to `OK`.
 {{< imgbox img="/img/docs/v54/alerting-for-dark-theme.png" caption="Alerting For" >}}
 
 {{< imgbox max-width="40%" img="/img/docs/v4/alerting_conditions.png" caption="Alerting Conditions" >}}

--- a/docs/sources/alerting/rules.md
+++ b/docs/sources/alerting/rules.md
@@ -54,7 +54,12 @@ Here you can specify the name of the alert rule and how often the scheduler shou
 
 If an alert rule has a configured `For` and the query violates the configured threshold it will first go from `OK` to `Pending`. Going from `OK` to `Pending` Grafana will not send any notifications. Once the alert rule has been firing for more than `For` duration, it will change to `Alerting` and send alert notifications. 
 
-Typically, it's always a good idea to use this setting since its often worse to get false positive than wait a few minutes before the alert notification triggers.
+Typically, it's always a good idea to use this setting since its often worse to get false positive than wait a few minutes before the alert notification triggers. Looking at the `Alert list` or `Alert list panels` you will be able to see alert in pending state. 
+
+Example timeline of an alert.
+{{< imgbox max-width="80%" img="/img/docs/v54/alerting-for-dark-theme.png" caption="Alerting For" >}}
+
+In the previous image you can see how an alert rule transition over time. 
 
 {{< imgbox max-width="40%" img="/img/docs/v4/alerting_conditions.png" caption="Alerting Conditions" >}}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/618863/48834588-79cde900-ed7e-11e8-9ad9-ff8b97986db6.png)


depends on https://github.com/grafana/grafana.org/pull/80