### PR TITLE
Margin when listing multiple gf-form 

### DIFF
--- a/public/sass/components/_gf-form.scss
+++ b/public/sass/components/_gf-form.scss
@@ -82,7 +82,7 @@ $input-border: 1px solid $input-border-color;
   align-content: flex-start;
 
   .gf-form + .gf-form {
-    margin-right: $gf-form-margin;
+    margin-left: $gf-form-margin;
   }
 }
 


### PR DESCRIPTION
when listing multiple gf-form elements this style is applied to all elements except the first. By having the
margin on the right side there will always be some margin between all gf-forms.

Found this in the template variable edit page. Not sure it applied to all gf-forms. 

before
![image](https://user-images.githubusercontent.com/618863/48895779-3343c180-ee46-11e8-8563-01b01b6debfc.png)

after
![image](https://user-images.githubusercontent.com/618863/48895786-376fdf00-ee46-11e8-8556-91613d046f48.png)
