### PR TITLE
Explore: switching to logging should keep prometheus labels in case o…

### DIFF
--- a/public/app/plugins/datasource/logging/language_provider.test.ts
+++ b/public/app/plugins/datasource/logging/language_provider.test.ts
@@ -95,5 +95,14 @@ describe('Query imports', () => {
       const result = await instance.importPrometheusQuery('metric{foo="bar",baz="42"}');
       expect(result).toEqual('{foo="bar"}');
     });
+
+    it('returns selector query from selector query with all labels if logging label list is empty', async () => {
+      const datasourceWithLabels = {
+        metadataRequest: url => (url === '/api/prom/label' ? { data: { data: [] } } : { data: { data: [] } }),
+      };
+      const instance = new LanguageProvider(datasourceWithLabels);
+      const result = await instance.importPrometheusQuery('metric{foo="bar",baz="42"}');
+      expect(result).toEqual('{baz="42",foo="bar"}');
+    });
   });
 });

--- a/public/app/plugins/datasource/logging/language_provider.ts
+++ b/public/app/plugins/datasource/logging/language_provider.ts
@@ -194,17 +194,24 @@ export default class LoggingLanguageProvider extends LanguageProvider {
 
       // Keep only labels that exist on origin and target datasource
       await this.start(); // fetches all existing label keys
-      const commonLabels = {};
-      for (const key in labels) {
-        const existingKeys = this.labelKeys[EMPTY_SELECTOR];
-        if (existingKeys && existingKeys.indexOf(key) > -1) {
-          // Should we check for label value equality here?
-          commonLabels[key] = labels[key];
+      const existingKeys = this.labelKeys[EMPTY_SELECTOR];
+      let labelsToKeep = {};
+      if (existingKeys && existingKeys.length > 0) {
+        // Check for common labels
+        for (const key in labels) {
+          if (existingKeys && existingKeys.indexOf(key) > -1) {
+            // Should we check for label value equality here?
+            labelsToKeep[key] = labels[key];
+          }
         }
+      } else {
+        // Keep all labels by default
+        labelsToKeep = labels;
       }
-      const labelKeys = Object.keys(commonLabels).sort();
+
+      const labelKeys = Object.keys(labelsToKeep).sort();
       const cleanSelector = labelKeys
-        .map(key => `${key}${commonLabels[key].operator}${commonLabels[key].value}`)
+        .map(key => `${key}${labelsToKeep[key].operator}${labelsToKeep[key].value}`)
         .join(',');
 
       return ['{', cleanSelector, '}'].join('');


### PR DESCRIPTION
Currently Logging's query importer drops all labels that are not common to both datasources.

- keep labels if label lookup of logging datasource came back empty
- easier to remove labels than having to add them in the first place

Fixes #14158 (showing errors will be done separately)