### PR TITLE
Sort Prometheus range suggestions by length

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -9,8 +9,8 @@ import {
   TypeaheadOutput,
 } from 'app/types/explore';
 
-import { parseSelector, processLabels, RATE_RANGES } from './language_utils';
-import PromqlSyntax, { FUNCTIONS } from './promql';
+import { parseSelector, processLabels } from './language_utils';
+import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
 const DEFAULT_KEYS = ['job', 'instance'];
 const EMPTY_SELECTOR = '{}';
@@ -171,7 +171,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
       suggestions: [
         {
           label: 'Range vector',
-          items: [...RATE_RANGES].map(wrapLabel),
+          items: [...RATE_RANGES],
         },
       ],
     };

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -1,8 +1,19 @@
 /* tslint:disable max-line-length */
 
+import { CompletionItem } from 'app/types/explore';
+
+export const RATE_RANGES: CompletionItem[] = [
+  { label: '1m', sortText: '00:01:00' },
+  { label: '5m', sortText: '00:05:00' },
+  { label: '10m', sortText: '00:10:00' },
+  { label: '30m', sortText: '00:30:00' },
+  { label: '1h', sortText: '01:00:00' },
+  { label: '1d', sortText: '24:00:00' },
+];
+
 export const OPERATORS = ['by', 'group_left', 'group_right', 'ignoring', 'on', 'offset', 'without'];
 
-const AGGREGATION_OPERATORS = [
+const AGGREGATION_OPERATORS: CompletionItem[] = [
   {
     label: 'sum',
     insertText: 'sum',

--- a/public/app/plugins/datasource/prometheus/specs/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/language_provider.test.ts
@@ -76,9 +76,16 @@ describe('Language completion provider', () => {
       });
       expect(result.context).toBe('context-range');
       expect(result.refresher).toBeUndefined();
-      expect(result.suggestions).toEqual([
+      expect(result.suggestions).toMatchObject([
         {
-          items: [{ label: '1m' }, { label: '5m' }, { label: '10m' }, { label: '30m' }, { label: '1h' }],
+          items: [
+            { label: '1m' },
+            { label: '5m' },
+            { label: '10m' },
+            { label: '30m' },
+            { label: '1h' },
+            { label: '1d' },
+          ],
           label: 'Range vector',
         },
       ]);


### PR DESCRIPTION
- add sortText property to range completion items

Fixes #14157