### PR TITLE
Explore: make query field suggestions more robust

### DIFF
--- a/public/app/features/explore/Typeahead.tsx
+++ b/public/app/features/explore/Typeahead.tsx
@@ -42,7 +42,7 @@ class TypeaheadItem extends React.PureComponent<TypeaheadItemProps> {
   render() {
     const { isSelected, item, prefix } = this.props;
     const className = isSelected ? 'typeahead-item typeahead-item__selected' : 'typeahead-item';
-    const { label } = item;
+    const label = item.label || '';
     return (
       <li ref={this.getRef} className={className} onClick={this.onClick}>
         <Highlighter textToHighlight={label} searchWords={[prefix]} highlightClassName="typeahead-match" />

--- a/public/app/plugins/datasource/logging/language_provider.ts
+++ b/public/app/plugins/datasource/logging/language_provider.ts
@@ -97,9 +97,10 @@ export default class LoggingLanguageProvider extends LanguageProvider {
 
     if (history && history.length > 0) {
       const historyItems = _.chain(history)
-        .uniqBy('query.expr')
-        .take(HISTORY_ITEM_COUNT)
         .map(h => h.query.expr)
+        .filter()
+        .uniq()
+        .take(HISTORY_ITEM_COUNT)
         .map(wrapLabel)
         .map(item => addHistoryMetadata(item, history))
         .value();

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -125,9 +125,10 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
     if (history && history.length > 0) {
       const historyItems = _.chain(history)
-        .uniqBy('query.expr')
-        .take(HISTORY_ITEM_COUNT)
         .map(h => h.query.expr)
+        .filter()
+        .uniq()
+        .take(HISTORY_ITEM_COUNT)
         .map(wrapLabel)
         .map(item => addHistoryMetadata(item, history))
         .value();


### PR DESCRIPTION
After the DataQuery rewrite some history items of the query field can be in a funky state. This PR makes sure that whatever gets passed as suggestions does not trip up the highlighter

- drop invalid history items
- make highlighter more robust by defaulting to empty string on text to highlight
