### PR TITLE
Explore: Filter logs by log level

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -3,25 +3,26 @@ import { TimeSeries } from 'app/core/core';
 import colors from 'app/core/utils/colors';
 
 export enum LogLevel {
-  crit = 'crit',
-  warn = 'warn',
+  crit = 'critical',
+  critical = 'critical',
+  warn = 'warning',
+  warning = 'warning',
   err = 'error',
   error = 'error',
   info = 'info',
   debug = 'debug',
   trace = 'trace',
-  none = 'none',
+  unkown = 'unkown',
 }
 
 export const LogLevelColor = {
-  [LogLevel.crit]: colors[7],
-  [LogLevel.warn]: colors[1],
-  [LogLevel.err]: colors[4],
+  [LogLevel.critical]: colors[7],
+  [LogLevel.warning]: colors[1],
   [LogLevel.error]: colors[4],
   [LogLevel.info]: colors[0],
-  [LogLevel.debug]: colors[3],
-  [LogLevel.trace]: colors[3],
-  [LogLevel.none]: '#eee',
+  [LogLevel.debug]: colors[5],
+  [LogLevel.trace]: colors[2],
+  [LogLevel.unkown]: '#ddd',
 };
 
 export interface LogSearchMatch {
@@ -116,6 +117,24 @@ export function dedupLogRows(logs: LogsModel, strategy: LogsDedupStrategy): Logs
   return {
     ...logs,
     rows: dedupedRows,
+  };
+}
+
+export function filterLogLevels(logs: LogsModel, hiddenLogLevels: Set<LogLevel>): LogsModel {
+  if (hiddenLogLevels.size === 0) {
+    return logs;
+  }
+
+  const filteredRows = logs.rows.reduce((result: LogRow[], row: LogRow, index, list) => {
+    if (!hiddenLogLevels.has(row.logLevel)) {
+      result.push(row);
+    }
+    return result;
+  }, []);
+
+  return {
+    ...logs,
+    rows: filteredRows,
   };
 }
 

--- a/public/app/plugins/datasource/logging/result_transformer.test.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.test.ts
@@ -15,7 +15,13 @@ describe('getLoglevel()', () => {
   });
 
   it('returns no log level on when level is part of a word', () => {
-    expect(getLogLevel('this is a warning')).toBe(LogLevel.unkown);
+    expect(getLogLevel('this is information')).toBe(LogLevel.unkown);
+  });
+
+  it('returns same log level for long and short version', () => {
+    expect(getLogLevel('[Warn]')).toBe(LogLevel.warning);
+    expect(getLogLevel('[Warning]')).toBe(LogLevel.warning);
+    expect(getLogLevel('[Warn]')).toBe('warning');
   });
 
   it('returns log level on line contains a log level', () => {
@@ -102,7 +108,7 @@ describe('mergeStreamsToLogs()', () => {
         entry: 'WARN boooo',
         labels: '{foo="bar"}',
         key: 'EK1970-01-01T00:00:00Z{foo="bar"}',
-        logLevel: 'warn',
+        logLevel: 'warning',
         uniqueLabels: '',
       },
     ]);
@@ -141,7 +147,7 @@ describe('mergeStreamsToLogs()', () => {
       {
         entry: 'WARN boooo',
         labels: '{foo="bar", baz="1"}',
-        logLevel: 'warn',
+        logLevel: 'warning',
         uniqueLabels: '{baz="1"}',
       },
       {

--- a/public/app/plugins/datasource/logging/result_transformer.test.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.test.ts
@@ -11,11 +11,11 @@ import {
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
-    expect(getLogLevel('')).toBe(LogLevel.none);
+    expect(getLogLevel('')).toBe(LogLevel.unkown);
   });
 
   it('returns no log level on when level is part of a word', () => {
-    expect(getLogLevel('this is a warning')).toBe(LogLevel.none);
+    expect(getLogLevel('this is a warning')).toBe(LogLevel.unkown);
   });
 
   it('returns log level on line contains a log level', () => {

--- a/public/app/plugins/datasource/logging/result_transformer.ts
+++ b/public/app/plugins/datasource/logging/result_transformer.ts
@@ -14,13 +14,13 @@ import { DEFAULT_LIMIT } from './datasource';
 
 /**
  * Returns the log level of a log line.
- * Parse the line for level words. If no level is found, it returns `LogLevel.none`.
+ * Parse the line for level words. If no level is found, it returns `LogLevel.unknown`.
  *
  * Example: `getLogLevel('WARN 1999-12-31 this is great') // LogLevel.warn`
  */
 export function getLogLevel(line: string): LogLevel {
   if (!line) {
-    return LogLevel.none;
+    return LogLevel.unkown;
   }
   let level: LogLevel;
   Object.keys(LogLevel).forEach(key => {
@@ -32,7 +32,7 @@ export function getLogLevel(line: string): LogLevel {
     }
   });
   if (!level) {
-    level = LogLevel.none;
+    level = LogLevel.unkown;
   }
   return level;
 }

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -305,6 +305,7 @@
       opacity: 0.8;
     }
 
+    .logs-row-level-critical,
     .logs-row-level-crit {
       background-color: #705da0;
     }
@@ -314,6 +315,7 @@
       background-color: #e24d42;
     }
 
+    .logs-row-level-warning,
     .logs-row-level-warn {
       background-color: #eab839;
     }
@@ -322,9 +324,12 @@
       background-color: #7eb26d;
     }
 
-    .logs-row-level-trace,
     .logs-row-level-debug {
       background-color: #1f78c1;
+    }
+
+    .logs-row-level-trace {
+      background-color: #6ed0e0;
     }
 
     .logs-row-level__duplicates {


### PR DESCRIPTION
- add `onToggleSeries` to Explore Graph props
- toggling a Logging Graph series from the legend propagates its hidden series to Logs
- Logs translates hidden series alias to LogLevels
- Logs filters out hidden log levels
- also fix issue with duplicate dots rendering
- renamed loglevel `none` to `unknown`
