### PR TITLE
Explore: Scan for older logs

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import Highlighter from 'react-highlight-words';
 
+import * as rangeUtil from 'app/core/utils/rangeutil';
 import { RawTimeRange } from 'app/types/series';
 import { LogsDedupStrategy, LogsModel, dedupLogRows, filterLogLevels, LogLevel } from 'app/core/logs_model';
 import { findHighlightChunksInText } from 'app/core/utils/text';
@@ -29,8 +30,10 @@ interface LogsProps {
   position: string;
   range?: RawTimeRange;
   scanning?: boolean;
+  scanRange?: RawTimeRange;
   onChangeTime?: (range: RawTimeRange) => void;
-  onStartScanOlder?: () => void;
+  onStartScanning?: () => void;
+  onStopScanning?: () => void;
 }
 
 interface LogsState {
@@ -85,13 +88,18 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
     this.setState({ hiddenLogLevels });
   };
 
-  onClickScanOlder = (event: React.SyntheticEvent) => {
+  onClickScan = (event: React.SyntheticEvent) => {
     event.preventDefault();
-    this.props.onStartScanOlder();
+    this.props.onStartScanning();
+  };
+
+  onClickStopScan = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    this.props.onStopScanning();
   };
 
   render() {
-    const { className = '', data, loading = false, position, range, scanning } = this.props;
+    const { className = '', data, loading = false, position, range, scanning, scanRange } = this.props;
     const { dedup, hiddenLogLevels, showLabels, showLocalTime, showUtc } = this.state;
     const hasData = data && data.rows && data.rows.length > 0;
     const filteredData = filterLogLevels(data, hiddenLogLevels);
@@ -118,6 +126,7 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
     const logEntriesStyle = {
       gridTemplateColumns: cssColumnSizes.join(' '),
     };
+    const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
 
     return (
       <div className={`${className} logs`}>
@@ -208,18 +217,24 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
             ))}
         </div>
         {!loading &&
-          !hasData && (
-            <div>
+          !hasData &&
+          !scanning && (
+            <div className="logs-nodata">
               No logs found.
-              {scanning ? (
-                'Scanning...'
-              ) : (
-                <a className="link" onClick={this.onClickScanOlder}>
-                  Scan for older logs
-                </a>
-              )}
+              <a className="link" onClick={this.onClickScan}>
+                Scan for older logs
+              </a>
             </div>
           )}
+
+        {scanning && (
+          <div className="logs-nodata">
+            <span>{scanText}</span>
+            <a className="link" onClick={this.onClickStopScan}>
+              Stop scan
+            </a>
+          </div>
+        )}
       </div>
     );
   }

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -28,7 +28,9 @@ interface LogsProps {
   loading: boolean;
   position: string;
   range?: RawTimeRange;
+  scanning?: boolean;
   onChangeTime?: (range: RawTimeRange) => void;
+  onStartScanOlder?: () => void;
 }
 
 interface LogsState {
@@ -83,8 +85,13 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
     this.setState({ hiddenLogLevels });
   };
 
+  onClickScanOlder = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    this.props.onStartScanOlder();
+  };
+
   render() {
-    const { className = '', data, loading = false, position, range } = this.props;
+    const { className = '', data, loading = false, position, range, scanning } = this.props;
     const { dedup, hiddenLogLevels, showLabels, showLocalTime, showUtc } = this.state;
     const hasData = data && data.rows && data.rows.length > 0;
     const filteredData = filterLogLevels(data, hiddenLogLevels);
@@ -200,7 +207,19 @@ export default class Logs extends PureComponent<LogsProps, LogsState> {
               </Fragment>
             ))}
         </div>
-        {!loading && !hasData && 'No data was returned.'}
+        {!loading &&
+          !hasData && (
+            <div>
+              No logs found.
+              {scanning ? (
+                'Scanning...'
+              ) : (
+                <a className="link" onClick={this.onClickScanOlder}>
+                  Scan for older logs
+                </a>
+              )}
+            </div>
+          )}
       </div>
     );
   }

--- a/public/app/features/explore/TimePicker.tsx
+++ b/public/app/features/explore/TimePicker.tsx
@@ -92,7 +92,7 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     };
   }
 
-  move(direction: number, scanning?: boolean) {
+  move(direction: number, scanning?: boolean): RawTimeRange {
     const { onChangeTime } = this.props;
     const { fromRaw, toRaw } = this.state;
     const from = dateMath.parse(fromRaw, false);
@@ -131,6 +131,8 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
         onChangeTime(nextRange, scanning);
       }
     );
+
+    return nextRange;
   }
 
   handleChangeFrom = e => {

--- a/public/app/features/explore/TimePicker.tsx
+++ b/public/app/features/explore/TimePicker.tsx
@@ -35,7 +35,7 @@ interface TimePickerProps {
   isOpen?: boolean;
   isUtc?: boolean;
   range?: RawTimeRange;
-  onChangeTime?: (Range) => void;
+  onChangeTime?: (range: RawTimeRange, scanning?: boolean) => void;
 }
 
 interface TimePickerState {
@@ -92,12 +92,13 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     };
   }
 
-  move(direction: number) {
+  move(direction: number, scanning?: boolean) {
     const { onChangeTime } = this.props;
     const { fromRaw, toRaw } = this.state;
     const from = dateMath.parse(fromRaw, false);
     const to = dateMath.parse(toRaw, true);
-    const timespan = (to.valueOf() - from.valueOf()) / 2;
+    const step = scanning ? 1 : 2;
+    const timespan = (to.valueOf() - from.valueOf()) / step;
 
     let nextTo, nextFrom;
     if (direction === -1) {
@@ -127,7 +128,7 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
         toRaw: nextRange.to.format(DATE_FORMAT),
       },
       () => {
-        onChangeTime(nextRange);
+        onChangeTime(nextRange, scanning);
       }
     );
   }

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -164,6 +164,7 @@ export interface ExploreState {
   queryTransactions: QueryTransaction[];
   range: RawTimeRange;
   scanning?: boolean;
+  scanRange?: RawTimeRange;
   showingGraph: boolean;
   showingLogs: boolean;
   showingStartPage?: boolean;

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -140,6 +140,7 @@ export interface QueryTransaction {
   result?: any; // Table model / Timeseries[] / Logs
   resultType: ResultType;
   rowIndex: number;
+  scanning?: boolean;
 }
 
 export interface TextMatch {
@@ -162,6 +163,7 @@ export interface ExploreState {
   initialQueries: DataQuery[];
   queryTransactions: QueryTransaction[];
   range: RawTimeRange;
+  scanning?: boolean;
   showingGraph: boolean;
   showingLogs: boolean;
   showingStartPage?: boolean;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -267,6 +267,12 @@
       }
     }
 
+    .logs-nodata {
+      > * {
+        margin-left: 0.5em;
+      }
+    }
+
     .logs-meta {
       flex: 1;
       color: $text-color-weak;


### PR DESCRIPTION
Sometimes log streams dont return any lines for the given range. Would be great to automate the search until some logs are found.

- Allow Explore to drive TimePicker via ref
- Show `Scan` link in Logs when there is no data
- Click on `Scan` sets Explore into scanning state
- While scanning, tell Timepicker to shift left
- TimePicker change triggers new queries with shifted time range
- TimePicker `move()` now returns next range
- Remember if query transaction was started via scan
- keep scanning until something was found
- Manual use of timepicker cancels scanning
- "Stop Scan" button in Logs