### PR TITLE
Add support for offset in date histogram aggregation

### DIFF
--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -240,6 +240,7 @@ type DateHistogramAgg struct {
 	Missing        *string         `json:"missing,omitempty"`
 	ExtendedBounds *ExtendedBounds `json:"extended_bounds"`
 	Format         string          `json:"format"`
+	Offset         string          `json:"offset,omitempty"`
 }
 
 // FiltersAggregation represents a filters aggregation

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -134,9 +134,10 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 			a.Interval = "$__interval"
 		}
 
-		if bucketAgg.Settings.Get("offset").MustString("") != "" {
-			a.Offset = bucketAgg.Settings.Get("offset").MustString("")
+		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {
+			a.Offset = offset
 		}
+
 		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
 			a.Missing = &missing
 		}

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -134,6 +134,9 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 			a.Interval = "$__interval"
 		}
 
+		if bucketAgg.Settings.Get("offset").MustString("") != "" {
+			a.Offset = bucketAgg.Settings.Get("offset").MustString("")
+		}
 		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
 			a.Missing = &missing
 		}

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -74,8 +74,7 @@
 			<label class="gf-form-label width-10">
 				Offset
 				<info-popover mode="right-normal">
-					Change the start value of each bucket by the specified positive (+) or negative offset (-) duration, such as 1h for an hour, or 1d for a day, 
-					see https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units for further details
+					Change the start value of each bucket by the specified positive (+) or negative offset (-) duration, such as 1h for an hour, or 1d for a day
 				</info-popover>
 			</label>
 			<input class="gf-form-input max-width-12" type="text" ng-model="agg.settings.offset" ng-change="onChangeInternal()">

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -74,7 +74,8 @@
 			<label class="gf-form-label width-10">
 				Offset
 				<info-popover mode="right-normal">
-					Interval Offset
+					Change the start value of each bucket by the specified positive (+) or negative offset (-) duration, such as 1h for an hour, or 1d for a day, 
+					see https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units for further details
 				</info-popover>
 			</label>
 			<input class="gf-form-input max-width-12" type="text" ng-model="agg.settings.offset" ng-change="onChangeInternal()">

--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -70,6 +70,16 @@
 			</label>
 			<input class="gf-form-input max-width-12" type="number" ng-model="agg.settings.trimEdges" ng-change="onChangeInternal()">
 		</div>
+		<div class="gf-form offset-width-7">
+			<label class="gf-form-label width-10">
+				Offset
+				<info-popover mode="right-normal">
+					Interval Offset
+				</info-popover>
+			</label>
+			<input class="gf-form-input max-width-12" type="text" ng-model="agg.settings.offset" ng-change="onChangeInternal()">
+		</div>
+
 	</div>
 
 	<div ng-if="agg.type === 'histogram'">

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -71,6 +71,7 @@ export class ElasticQueryBuilder {
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';
+    esAgg.offset = settings.offset || '0';
 
     if (esAgg.interval === 'auto') {
       esAgg.interval = '$__interval';

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -71,7 +71,10 @@ export class ElasticQueryBuilder {
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';
-    esAgg.offset = settings.offset || '0';
+
+    if (settings.offset !== '') {
+      esAgg.offset = settings.offset;
+    }
 
     if (esAgg.interval === 'auto') {
       esAgg.interval = '$__interval';


### PR DESCRIPTION
This patch adds support for specifying an offset when using the date_histogram aggregate when using the elastisearch datasource

Fixes #12653