### PR TITLE
Explore: Fix JS error when switching between 2 prometheus datasources

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -437,7 +437,7 @@ export class PrometheusDatasource {
   }
 
   getQueryHints(query: DataQuery, result: any[]) {
-    return getQueryHints(query.expr, result, this);
+    return getQueryHints(query.expr || '', result, this);
   }
 
   loadRules() {

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -96,7 +96,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: any): 
     }
   }
 
-  if (series.length >= SUM_HINT_THRESHOLD_COUNT) {
+  if (series && series.length >= SUM_HINT_THRESHOLD_COUNT) {
     const simpleMetric = query.trim().match(/^\w+$/);
     if (simpleMetric) {
       hints.push({


### PR DESCRIPTION
- since the DataQuery rewrite, Explore starts by submitting its queries (Explore cant know if the queries are emtpty)
- The datasource intercepts an empty query and returns an empty list of time series, and also no table for the table query.
- The query hinter then received no series to analyse and was not guarding against this.
- This PR adds this guard.

Fixes #14190 