### PR TITLE
Remove confusing <> from variable intro

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -25,7 +25,7 @@ the value, using the dropdown at the top of the dashboard, your panel's metric q
 
 Panel titles and metric queries can refer to variables using two different syntaxes:
 
-- `$<varname>`  Example: apps.frontend.$server.requests.count
+- `$varname`  Example: apps.frontend.$server.requests.count
 - `[[varname]]` Example: apps.frontend.[[server]].requests.count
 
 Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of word. Use


### PR DESCRIPTION
The existing intro makes it look like you should use `$<varname>` to refer to a variable. That of course is incorrect, and you should use `$varname`. In my experience using the <> marker around variable names should only be used when there isn't something else explicit to set it off. In this case we have `$`. Below, you can see the <> are also not used, because we have the `[[]]` to set it off. The inconsistency is confusing.
