### PR TITLE
POC: Adds basic support for global variables.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -276,6 +276,11 @@ func (hs *HTTPServer) registerRoutes() {
 			})
 		})
 
+		// Variables
+		apiRoute.Group("/variables", func(vr routing.RouteRegister) {
+			vr.Get("/", Wrap(GetGlobalVariables))
+		})
+
 		// Dashboard
 		apiRoute.Group("/dashboards", func(dashboardRoute routing.RouteRegister) {
 			dashboardRoute.Get("/uid/:uid", Wrap(GetDashboard))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -279,6 +279,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// Variables
 		apiRoute.Group("/variables", func(vr routing.RouteRegister) {
 			vr.Get("/", Wrap(GetGlobalVariables))
+			vr.Get("/find", Wrap(FindGlobalVariables))
 		})
 
 		// Dashboard

--- a/pkg/api/variables.go
+++ b/pkg/api/variables.go
@@ -1,0 +1,67 @@
+package api
+
+import "github.com/grafana/grafana/pkg/models"
+
+// GetGlobalVariables returns all available global template variables
+// GET /api/variables
+func GetGlobalVariables(c *models.ReqContext) Response {
+	return JSON(200, `{ 
+    "qwerty": {
+      "uid": "qwerty",
+      "allValue": null,
+      "current": {
+        "text": "fake-data-gen",
+        "value": "fake-data-gen"
+      },
+      "datasource": "gdev-prometheus",
+      "definition": "label_values(job)",
+      "hide": 0,
+      "includeAll": true,
+      "label": null,
+      "multi": true,
+      "name": "query",
+      "options": [
+        {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        {
+          "selected": true,
+          "text": "fake-data-gen",
+          "value": "fake-data-gen"
+        },
+        {
+          "selected": false,
+          "text": "grafana",
+          "value": "grafana"
+        },
+        {
+          "selected": false,
+          "text": "node_exporter",
+          "value": "node_exporter"
+        },
+        {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        {
+          "selected": false,
+          "text": "prometheus-random-data",
+          "value": "prometheus-random-data"
+        }
+      ],
+      "query": "label_values(job)",
+      "refresh": 0,
+      "regex": "",
+      "skipUrlSync": false,
+      "sort": 0,
+      "tagValuesQuery": "",
+      "tags": [],
+      "tagsQuery": "",
+      "type": "query",
+      "useTags": false
+    }
+  }`)
+}

--- a/pkg/api/variables.go
+++ b/pkg/api/variables.go
@@ -27,8 +27,8 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       "name": "GlobalQueryVar"
     },
     {
-      "uid": "g_query_var2",
-      "name": "GlobalQueryVar2"
+      "uid": "g_query_vartwo",
+      "name": "GlobalQueryVarTwo"
     }
   ]
   `)
@@ -239,54 +239,25 @@ func FindGlobalVariables(c *models.ReqContext) Response {
       "type": "query",
       "useTags": false
     },
-    "g_query_var2": {
-      "uid": "g_query_var2",
+    "g_query_vartwo": {
+      "uid": "g_query_vartwo",
       "allValue": null,
       "current": {
         "text": "fake-data-gen",
         "value": "fake-data-gen"
       },
       "datasource": "gdev-prometheus",
-      "definition": "label_values(job)",
+      "definition": "label_values(instance)",
       "hide": 0,
       "includeAll": true,
       "label": null,
       "multi": true,
-      "name": "GlobalQueryVar2",
+      "name": "GlobalQueryVarTwo",
       "options": [
-        {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        {
-          "selected": true,
-          "text": "fake-data-gen",
-          "value": "fake-data-gen"
-        },
-        {
-          "selected": false,
-          "text": "grafana",
-          "value": "grafana"
-        },
-        {
-          "selected": false,
-          "text": "node_exporter",
-          "value": "node_exporter"
-        },
-        {
-          "selected": false,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
-        {
-          "selected": false,
-          "text": "prometheus-random-data",
-          "value": "prometheus-random-data"
-        }
+        
       ],
-      "query": "label_values(job)",
-      "refresh": 0,
+      "query": "label_values(instance)",
+      "refresh": 2,
       "regex": "",
       "skipUrlSync": false,
       "sort": 0,

--- a/pkg/api/variables.go
+++ b/pkg/api/variables.go
@@ -6,8 +6,150 @@ import "github.com/grafana/grafana/pkg/models"
 // GET /api/variables
 func GetGlobalVariables(c *models.ReqContext) Response {
 	return JSON(200, `{ 
-    "qwerty": {
-      "uid": "qwerty",
+    "g_interval_var": {
+      "uid": "g_interval_var",
+      "auto": false,
+      "auto_count": 30,
+      "auto_min": "10s",
+      "current": {
+        "text": "1m",
+        "value": "1m"
+      },
+      "hide": 0,
+      "label": null,
+      "name": "global interval var",
+      "options": [
+        {
+          "selected": true,
+          "text": "1m",
+          "value": "1m"
+        },
+        {
+          "selected": false,
+          "text": "10m",
+          "value": "10m"
+        },
+        {
+          "selected": false,
+          "text": "30m",
+          "value": "30m"
+        },
+        {
+          "selected": false,
+          "text": "1h",
+          "value": "1h"
+        },
+        {
+          "selected": false,
+          "text": "6h",
+          "value": "6h"
+        },
+        {
+          "selected": false,
+          "text": "12h",
+          "value": "12h"
+        },
+        {
+          "selected": false,
+          "text": "1d",
+          "value": "1d"
+        },
+        {
+          "selected": false,
+          "text": "7d",
+          "value": "7d"
+        },
+        {
+          "selected": false,
+          "text": "14d",
+          "value": "14d"
+        },
+        {
+          "selected": false,
+          "text": "30d",
+          "value": "30d"
+        }
+      ],
+      "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+      "refresh": 2,
+      "skipUrlSync": false,
+      "type": "interval"
+    },
+    "g_constant_var": {
+      "uid": "g_constant_var",
+      "current": {
+        "text": "constant_value",
+        "value": "constant_value"
+      },
+      "hide": 0,
+      "label": null,
+      "name": "global constant var",
+      "options": [
+        {
+          "selected": true,
+          "text": "constant_value",
+          "value": "constant_value"
+        }
+      ],
+      "query": "constant_value",
+      "skipUrlSync": false,
+      "type": "constant"
+    },
+    "g_custom_var":{
+      "uid": "g_custom_var",
+      "allValue": null,
+      "current": {
+        "text": "1",
+        "value": "1"
+      },
+      "hide": 0,
+      "includeAll": true,
+      "label": null,
+      "multi": true,
+      "name": "global custom var",
+      "options": [
+        {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        {
+          "selected": true,
+          "text": "1",
+          "value": "1"
+        },
+        {
+          "selected": false,
+          "text": "2",
+          "value": "2"
+        },
+        {
+          "selected": false,
+          "text": "3",
+          "value": "3"
+        },
+        {
+          "selected": false,
+          "text": "4",
+          "value": "4"
+        },
+        {
+          "selected": false,
+          "text": "5",
+          "value": "5"
+        },
+        {
+          "selected": false,
+          "text": "6",
+          "value": "6"
+        }
+      ],
+      "query": "1, 2, 3, 4, 5, 6",
+      "skipUrlSync": false,
+      "type": "custom"
+    },
+    "g_query_var": {
+      "uid": "g_query_var",
       "allValue": null,
       "current": {
         "text": "fake-data-gen",
@@ -19,7 +161,7 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       "includeAll": true,
       "label": null,
       "multi": true,
-      "name": "query",
+      "name": "global query var",
       "options": [
         {
           "selected": false,

--- a/pkg/api/variables.go
+++ b/pkg/api/variables.go
@@ -1,10 +1,44 @@
 package api
 
-import "github.com/grafana/grafana/pkg/models"
+import (
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/models"
+)
 
 // GetGlobalVariables returns all available global template variables
 // GET /api/variables
 func GetGlobalVariables(c *models.ReqContext) Response {
+	return JSON(200, `
+  [
+    {
+      "uid": "g_interval_var",
+      "name": "GlobalIntervalVar"
+    },
+    {
+      "uid": "g_constant_var",
+      "name": "GlobalConstantVar"
+    },
+    {
+      "uid": "g_custom_var",
+      "name": "GlobalCustomVar"
+    },
+    {
+      "uid": "g_query_var",
+      "name": "GlobalQueryVar"
+    },
+    {
+      "uid": "g_query_var2",
+      "name": "GlobalQueryVar2"
+    }
+  ]
+  `)
+}
+
+// FindGlobalVariables returns all variables matching the uid query param
+// GET /api/variables/find
+func FindGlobalVariables(c *models.ReqContext) Response {
+	log.Info2("uids: %s", c.QueryStrings("uids"))
+
 	return JSON(200, `{ 
     "g_interval_var": {
       "uid": "g_interval_var",
@@ -17,7 +51,7 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       },
       "hide": 0,
       "label": null,
-      "name": "global interval var",
+      "name": "GlobalIntervalVar",
       "options": [
         {
           "selected": true,
@@ -83,7 +117,7 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       },
       "hide": 0,
       "label": null,
-      "name": "global constant var",
+      "name": "GlobalConstantVar",
       "options": [
         {
           "selected": true,
@@ -106,7 +140,7 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       "includeAll": true,
       "label": null,
       "multi": true,
-      "name": "global custom var",
+      "name": "GlobalCustomVar",
       "options": [
         {
           "selected": false,
@@ -161,7 +195,64 @@ func GetGlobalVariables(c *models.ReqContext) Response {
       "includeAll": true,
       "label": null,
       "multi": true,
-      "name": "global query var",
+      "name": "GlobalQueryVar",
+      "options": [
+        {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        {
+          "selected": true,
+          "text": "fake-data-gen",
+          "value": "fake-data-gen"
+        },
+        {
+          "selected": false,
+          "text": "grafana",
+          "value": "grafana"
+        },
+        {
+          "selected": false,
+          "text": "node_exporter",
+          "value": "node_exporter"
+        },
+        {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        {
+          "selected": false,
+          "text": "prometheus-random-data",
+          "value": "prometheus-random-data"
+        }
+      ],
+      "query": "label_values(job)",
+      "refresh": 0,
+      "regex": "",
+      "skipUrlSync": false,
+      "sort": 0,
+      "tagValuesQuery": "",
+      "tags": [],
+      "tagsQuery": "",
+      "type": "query",
+      "useTags": false
+    },
+    "g_query_var2": {
+      "uid": "g_query_var2",
+      "allValue": null,
+      "current": {
+        "text": "fake-data-gen",
+        "value": "fake-data-gen"
+      },
+      "datasource": "gdev-prometheus",
+      "definition": "label_values(job)",
+      "hide": 0,
+      "includeAll": true,
+      "label": null,
+      "multi": true,
+      "name": "GlobalQueryVar2",
       "options": [
         {
           "selected": false,

--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -163,13 +163,6 @@ export class DashboardModel {
         const current = copy.templating.list[i];
         const original = _.find(this.originalTemplating, { name: current.name, type: current.type });
 
-        // extract global model and set current value
-        if (current.globalModel) {
-          current.globalModel.current = current.current;
-          copy.templating.list[i] = current.globalModel;
-          continue;
-        }
-
         if (!original) {
           continue;
         }

--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -164,7 +164,7 @@ export class DashboardModel {
         const original = _.find(this.originalTemplating, { name: current.name, type: current.type });
 
         // if its a global variable we should not override the current value
-        if (current.globalModel) {
+        if (current.type === 'global') {
           continue;
         }
 

--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -163,6 +163,13 @@ export class DashboardModel {
         const current = copy.templating.list[i];
         const original = _.find(this.originalTemplating, { name: current.name, type: current.type });
 
+        // extract global model and set current value
+        if (current.globalModel) {
+          current.globalModel.current = current.current;
+          copy.templating.list[i] = current.globalModel;
+          continue;
+        }
+
         if (!original) {
           continue;
         }

--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -163,6 +163,11 @@ export class DashboardModel {
         const current = copy.templating.list[i];
         const original = _.find(this.originalTemplating, { name: current.name, type: current.type });
 
+        // if its a global variable we should not override the current value
+        if (current.globalModel) {
+          continue;
+        }
+
         if (!original) {
           continue;
         }

--- a/public/app/features/templating/TextBoxVariable.ts
+++ b/public/app/features/templating/TextBoxVariable.ts
@@ -15,13 +15,23 @@ export class TextBoxVariable extends VariableBase implements Variable {
     current: {},
     options: [],
     skipUrlSync: false,
+    globalModel: null,
   };
 
   /** @ngInject */
-  constructor(model, private variableSrv) {
+  constructor(private model, private variableSrv) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/TextBoxVariable.ts
+++ b/public/app/features/templating/TextBoxVariable.ts
@@ -2,8 +2,6 @@ import { Variable, VariableBase, assignModelProperties, variableTypes } from './
 
 export class TextBoxVariable extends VariableBase implements Variable {
   query: string;
-  options: any[];
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'textbox',

--- a/public/app/features/templating/TextBoxVariable.ts
+++ b/public/app/features/templating/TextBoxVariable.ts
@@ -2,7 +2,6 @@ import { Variable, VariableBase, assignModelProperties, variableTypes } from './
 
 export class TextBoxVariable extends VariableBase implements Variable {
   query: string;
-  current: any;
   options: any[];
   skipUrlSync: boolean;
 
@@ -19,19 +18,10 @@ export class TextBoxVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/TextBoxVariable.ts
+++ b/public/app/features/templating/TextBoxVariable.ts
@@ -1,6 +1,6 @@
-import { Variable, assignModelProperties, variableTypes } from './variable';
+import { Variable, VariableBase, assignModelProperties, variableTypes } from './variable';
 
-export class TextBoxVariable implements Variable {
+export class TextBoxVariable extends VariableBase implements Variable {
   query: string;
   current: any;
   options: any[];
@@ -18,13 +18,10 @@ export class TextBoxVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/adhoc_variable.ts
+++ b/public/app/features/templating/adhoc_variable.ts
@@ -16,10 +16,19 @@ export class AdhocVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(model) {
+  constructor(private model) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/adhoc_variable.ts
+++ b/public/app/features/templating/adhoc_variable.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import { Variable, assignModelProperties, variableTypes } from './variable';
+import { Variable, VariableBase, assignModelProperties, variableTypes } from './variable';
 
-export class AdhocVariable implements Variable {
+export class AdhocVariable extends VariableBase implements Variable {
   filters: any[];
   skipUrlSync: boolean;
 
@@ -16,17 +16,14 @@ export class AdhocVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model) {
+  constructor(model) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   setValue(option) {
     return Promise.resolve();
-  }
-
-  getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   updateOptions() {

--- a/public/app/features/templating/adhoc_variable.ts
+++ b/public/app/features/templating/adhoc_variable.ts
@@ -16,19 +16,10 @@ export class AdhocVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model) {
+  constructor(model) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/adhoc_variable.ts
+++ b/public/app/features/templating/adhoc_variable.ts
@@ -3,7 +3,6 @@ import { Variable, VariableBase, assignModelProperties, variableTypes } from './
 
 export class AdhocVariable extends VariableBase implements Variable {
   filters: any[];
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'adhoc',

--- a/public/app/features/templating/all.ts
+++ b/public/app/features/templating/all.ts
@@ -9,6 +9,7 @@ import { DatasourceVariable } from './datasource_variable';
 import { CustomVariable } from './custom_variable';
 import { ConstantVariable } from './constant_variable';
 import { AdhocVariable } from './adhoc_variable';
+import { GlobalVariable } from './global_variable';
 import { TextBoxVariable } from './TextBoxVariable';
 
 coreModule.factory('templateSrv', () => {
@@ -24,4 +25,5 @@ export {
   ConstantVariable,
   AdhocVariable,
   TextBoxVariable,
+  GlobalVariable,
 };

--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -15,13 +15,23 @@ export class ConstantVariable extends VariableBase implements Variable {
     current: {},
     options: [],
     skipUrlSync: false,
+    globalModel: null,
   };
 
   /** @ngInject */
-  constructor(model, private variableSrv) {
+  constructor(private model, private variableSrv) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -3,7 +3,6 @@ import { Variable, assignModelProperties, variableTypes, VariableBase } from './
 export class ConstantVariable extends VariableBase implements Variable {
   query: string;
   options: any[];
-  current: any;
   skipUrlSync: boolean;
 
   defaults = {
@@ -19,19 +18,10 @@ export class ConstantVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -2,8 +2,6 @@ import { Variable, assignModelProperties, variableTypes, VariableBase } from './
 
 export class ConstantVariable extends VariableBase implements Variable {
   query: string;
-  options: any[];
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'constant',

--- a/public/app/features/templating/constant_variable.ts
+++ b/public/app/features/templating/constant_variable.ts
@@ -1,6 +1,6 @@
-import { Variable, assignModelProperties, variableTypes } from './variable';
+import { Variable, assignModelProperties, variableTypes, VariableBase } from './variable';
 
-export class ConstantVariable implements Variable {
+export class ConstantVariable extends VariableBase implements Variable {
   query: string;
   options: any[];
   current: any;
@@ -18,13 +18,10 @@ export class ConstantVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import { Variable, assignModelProperties, variableTypes } from './variable';
+import { Variable, assignModelProperties, variableTypes, VariableBase } from './variable';
 
-export class CustomVariable implements Variable {
+export class CustomVariable extends VariableBase implements Variable {
   query: string;
   options: any;
   includeAll: boolean;
@@ -24,17 +24,14 @@ export class CustomVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   setValue(option) {
     return this.variableSrv.setOptionAsCurrent(this, option);
-  }
-
-  getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   updateOptions() {

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -25,19 +25,10 @@ export class CustomVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
-  }
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -3,11 +3,8 @@ import { Variable, assignModelProperties, variableTypes, VariableBase } from './
 
 export class CustomVariable extends VariableBase implements Variable {
   query: string;
-  options: any;
   includeAll: boolean;
   multi: boolean;
-  current: any;
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'custom',

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -21,13 +21,23 @@ export class CustomVariable extends VariableBase implements Variable {
     multi: false,
     allValue: null,
     skipUrlSync: false,
+    globalModel: null,
   };
 
   /** @ngInject */
-  constructor(model, private variableSrv) {
+  constructor(private model, private variableSrv) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -23,8 +23,9 @@ export class DatasourceVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private datasourceSrv, private variableSrv, private templateSrv) {
+  constructor(model, private datasourceSrv, private variableSrv, private templateSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 1;
   }

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -23,17 +23,19 @@ export class DatasourceVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(model, private datasourceSrv, private variableSrv, private templateSrv) {
+  constructor(private model, private datasourceSrv, private variableSrv, private templateSrv) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 1;
   }
 
   getSaveModel() {
-    this.model = super.getSaveModel();
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
 
-    // don't persist options
+    assignModelProperties(this.model, this, this.defaults);
     this.model.options = [];
     return this.model;
   }

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -4,10 +4,7 @@ import { Variable, VariableBase, containsVariable, assignModelProperties, variab
 export class DatasourceVariable extends VariableBase implements Variable {
   regex: any;
   query: string;
-  options: any;
-  current: any;
   refresh: any;
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'datasource',

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -1,7 +1,7 @@
 import kbn from 'app/core/utils/kbn';
-import { Variable, containsVariable, assignModelProperties, variableTypes } from './variable';
+import { Variable, VariableBase, containsVariable, assignModelProperties, variableTypes } from './variable';
 
-export class DatasourceVariable implements Variable {
+export class DatasourceVariable extends VariableBase implements Variable {
   regex: any;
   query: string;
   options: any;
@@ -23,13 +23,15 @@ export class DatasourceVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private datasourceSrv, private variableSrv, private templateSrv) {
+  constructor(model, private datasourceSrv, private variableSrv, private templateSrv) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 1;
   }
 
   getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
+    this.model = super.getSaveModel();
 
     // don't persist options
     this.model.options = [];

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -66,6 +66,10 @@ export class VariableEditorCtrl {
         return false;
       }
 
+      if ($scope.current.type === 'global') {
+        return true;
+      }
+
       if (!$scope.current.name.match(/^\w+$/)) {
         appEvents.emit('alert-warning', ['Validation', 'Only word and digit characters are allowed in variable names']);
         return false;

--- a/public/app/features/templating/global_variable.ts
+++ b/public/app/features/templating/global_variable.ts
@@ -2,9 +2,7 @@ import _ from 'lodash';
 import { Variable, assignModelProperties, variableTypes, VariableBase } from './variable';
 
 export class GlobalVariable extends VariableBase implements Variable {
-  query: string;
   options: any;
-  current: any;
   uid: string;
 
   defaults = {
@@ -14,15 +12,14 @@ export class GlobalVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(model, private variableSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   getSaveModel() {
     assignModelProperties(this.model, this, this.defaults);
-    console.log('globalVariable.getSaveModel', this.uid);
-    console.log('globalVariable.getSaveModel', this.model);
     return this.model;
   }
 

--- a/public/app/features/templating/global_variable.ts
+++ b/public/app/features/templating/global_variable.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { Variable, assignModelProperties, variableTypes, VariableBase } from './variable';
 
 export class GlobalVariable extends VariableBase implements Variable {
-  options: any;
   uid: string;
 
   defaults = {

--- a/public/app/features/templating/global_variable.ts
+++ b/public/app/features/templating/global_variable.ts
@@ -1,0 +1,54 @@
+import _ from 'lodash';
+import { Variable, assignModelProperties, variableTypes, VariableBase } from './variable';
+
+export class GlobalVariable extends VariableBase implements Variable {
+  query: string;
+  options: any;
+  current: any;
+  uid: string;
+
+  defaults = {
+    type: 'global',
+    uid: '',
+    tags: [],
+  };
+
+  /** @ngInject */
+  constructor(private model, private variableSrv) {
+    super();
+    assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    assignModelProperties(this.model, this, this.defaults);
+    console.log('globalVariable.getSaveModel', this.uid);
+    console.log('globalVariable.getSaveModel', this.model);
+    return this.model;
+  }
+
+  setValue(option) {
+    return this.variableSrv.setOptionAsCurrent(this, option);
+  }
+
+  updateOptions() {
+    return Promise.resolve();
+  }
+
+  dependsOn(variable) {
+    return false;
+  }
+
+  setValueFromUrl(urlValue) {
+    return this.variableSrv.setOptionFromUrl(this, urlValue);
+  }
+
+  getValueForUrl() {
+    return this.current.value;
+  }
+}
+
+variableTypes['global'] = {
+  name: 'Global',
+  ctor: GlobalVariable,
+  description: 'Reference to an global variable',
+};

--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -5,11 +5,9 @@ import { Variable, VariableBase, assignModelProperties, variableTypes } from './
 export class IntervalVariable extends VariableBase implements Variable {
   auto_count: number; // tslint:disable-line variable-name
   auto_min: number; // tslint:disable-line variable-name
-  options: any;
   auto: boolean;
   query: string;
   refresh: number;
-  skipUrlSync: boolean;
 
   defaults = {
     type: 'interval',

--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import kbn from 'app/core/utils/kbn';
-import { Variable, assignModelProperties, variableTypes } from './variable';
+import { Variable, VariableBase, assignModelProperties, variableTypes } from './variable';
 
-export class IntervalVariable implements Variable {
+export class IntervalVariable extends VariableBase implements Variable {
   name: string;
   auto_count: number; // tslint:disable-line variable-name
   auto_min: number; // tslint:disable-line variable-name
@@ -29,14 +29,11 @@ export class IntervalVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private timeSrv, private templateSrv, private variableSrv) {
+  constructor(model, private timeSrv, private templateSrv, private variableSrv) {
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 2;
-  }
-
-  getSaveModel() {
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -3,14 +3,12 @@ import kbn from 'app/core/utils/kbn';
 import { Variable, VariableBase, assignModelProperties, variableTypes } from './variable';
 
 export class IntervalVariable extends VariableBase implements Variable {
-  name: string;
   auto_count: number; // tslint:disable-line variable-name
   auto_min: number; // tslint:disable-line variable-name
   options: any;
   auto: boolean;
   query: string;
   refresh: number;
-  current: any;
   skipUrlSync: boolean;
 
   defaults = {
@@ -30,20 +28,11 @@ export class IntervalVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private timeSrv, private templateSrv, private variableSrv) {
+  constructor(model, private timeSrv, private templateSrv, private variableSrv) {
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 2;
-  }
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -26,14 +26,24 @@ export class IntervalVariable extends VariableBase implements Variable {
     auto_min: '10s',
     auto_count: 30,
     skipUrlSync: false,
+    globalModel: null,
   };
 
   /** @ngInject */
-  constructor(model, private timeSrv, private templateSrv, private variableSrv) {
+  constructor(private model, private timeSrv, private templateSrv, private variableSrv) {
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
     this.refresh = 2;
+  }
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
   }
 
   setValue(option) {

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -119,9 +119,10 @@
 			<h5 class="section-heading">Global Options</h5>
 
 			<div class="gf-form">
-				<span class="gf-form-label width-9">uids</span>
-				<select class="gf-form-input" ng-model="current.uid" ng-options="f.value as f.text for f in globalVariableOptions"
-						 ng-change=""></select>
+				<span class="gf-form-label width-14">Select global variable</span>
+				<div class="gf-form-select-wrapper max-width-20">
+					<select class="gf-form-input" ng-model="current.uid" ng-options="f.value as f.text for f in globalVariableOptions" ng-change=""></select>
+				</div>
 			</div>
 		</div>
 

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -121,7 +121,7 @@
 			<div class="gf-form">
 				<span class="gf-form-label width-9">uids</span>
 				<select class="gf-form-input" ng-model="current.uid" ng-options="f.value as f.text for f in globalVariableOptions"
-						 ng-change="runQuery()"></select>
+						 ng-change=""></select>
 			</div>
 		</div>
 

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -77,7 +77,7 @@
 		<h5 class="section-heading">General</h5>
 		<div class="gf-form-group">
 			<div class="gf-form-inline">
-				<div class="gf-form max-width-19">
+				<div class="gf-form max-width-19" ng-if="current.type !== 'global'">
 					<span class="gf-form-label width-6">Name</span>
 					<input type="text" class="gf-form-input" name="name" placeholder="name" ng-model='current.name' required
 					 ng-pattern="namePattern"></input>
@@ -101,7 +101,7 @@
 					Grafana's global variables</span>
 			</div>
 
-			<div class="gf-form-inline">
+			<div class="gf-form-inline" ng-if="current.type !== 'global'">
 				<div class="gf-form max-width-19">
 					<span class="gf-form-label width-6">Label</span>
 					<input type="text" class="gf-form-input" ng-model='current.label' placeholder="optional display name"></input>
@@ -112,6 +112,16 @@
 						<select class="gf-form-input" ng-model="current.hide" ng-options="f.value as f.text for f in hideOptions"></select>
 					</div>
 				</div>
+			</div>
+		</div>
+
+		<div ng-if="current.type === 'global'" class="gf-form-group">
+			<h5 class="section-heading">Global Options</h5>
+
+			<div class="gf-form">
+				<span class="gf-form-label width-9">uids</span>
+				<select class="gf-form-input" ng-model="current.uid" ng-options="f.value as f.text for f in globalVariableOptions"
+						 ng-change="runQuery()"></select>
 			</div>
 		</div>
 

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -11,7 +11,6 @@ export class QueryVariable extends VariableBase implements Variable {
   query: any;
   regex: any;
   sort: any;
-  options: any;
   refresh: number;
   hide: number;
   multi: boolean;
@@ -20,7 +19,6 @@ export class QueryVariable extends VariableBase implements Variable {
   tagsQuery: string;
   tagValuesQuery: string;
   tags: any[];
-  skipUrlSync: boolean;
   definition: string;
 
   defaults = {

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -12,10 +12,8 @@ export class QueryVariable extends VariableBase implements Variable {
   regex: any;
   sort: any;
   options: any;
-  current: any;
   refresh: number;
   hide: number;
-  name: string;
   multi: boolean;
   includeAll: boolean;
   useTags: boolean;
@@ -50,20 +48,18 @@ export class QueryVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
+  constructor(model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
     // copy model properties to this instance
     super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
+    this.model = super.getSaveModel();
 
-    assignModelProperties(this.model, this, this.defaults);
-    if (this.refresh !== 0) {
+    // if the savemodel is global we dont want to change options.
+    if (this.type !== 'global' && this.refresh !== 0) {
       this.model.options = [];
     }
 

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -50,18 +50,19 @@ export class QueryVariable extends VariableBase implements Variable {
   };
 
   /** @ngInject */
-  constructor(model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
+  constructor(private model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
     // copy model properties to this instance
     super();
-    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   getSaveModel() {
-    // copy back model properties to model
-    this.model = super.getSaveModel();
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
 
-    // remove options
+    assignModelProperties(this.model, this, this.defaults);
     if (this.refresh !== 0) {
       this.model.options = [];
     }

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
 import kbn from 'app/core/utils/kbn';
-import { Variable, containsVariable, assignModelProperties, variableTypes } from './variable';
+import { Variable, VariableBase, containsVariable, variableTypes, assignModelProperties } from './variable';
 
 function getNoneOption() {
   return { text: 'None', value: '', isNone: true };
 }
 
-export class QueryVariable implements Variable {
+export class QueryVariable extends VariableBase implements Variable {
   datasource: any;
   query: any;
   regex: any;
@@ -50,14 +50,16 @@ export class QueryVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
+  constructor(model, private datasourceSrv, private templateSrv, private variableSrv, private timeSrv) {
     // copy model properties to this instance
+    super();
+    this.model = model;
     assignModelProperties(this, model, this.defaults);
   }
 
   getSaveModel() {
     // copy back model properties to model
-    assignModelProperties(this.model, this, this.defaults);
+    this.model = super.getSaveModel();
 
     // remove options
     if (this.refresh !== 0) {

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -46,6 +46,7 @@ export class QueryVariable implements Variable {
     tagValuesQuery: '',
     skipUrlSync: false,
     definition: '',
+    globalModel: null,
   };
 
   /** @ngInject */

--- a/public/app/features/templating/specs/editor_ctrl.test.ts
+++ b/public/app/features/templating/specs/editor_ctrl.test.ts
@@ -25,7 +25,7 @@ describe('VariableEditorCtrl', () => {
         },
       };
 
-      return new VariableEditorCtrl(scope, {}, variableSrv, {});
+      return new VariableEditorCtrl(scope, {}, variableSrv, {}, {});
     });
 
     it('should emit an error', () => {

--- a/public/app/features/templating/specs/variable_srv.test.ts
+++ b/public/app/features/templating/specs/variable_srv.test.ts
@@ -30,6 +30,9 @@ describe('VariableSrv', function(this: any) {
     $location: {
       search: () => {},
     },
+    backendSrv: {
+      get: () => Promise.resolve({}),
+    },
   } as any;
 
   function describeUpdateVariable(desc, fn) {
@@ -45,7 +48,14 @@ describe('VariableSrv', function(this: any) {
         const ds: any = {};
         ds.metricFindQuery = () => Promise.resolve(scenario.queryResult);
 
-        ctx.variableSrv = new VariableSrv(ctx.$rootScope, $q, ctx.$location, ctx.$injector, ctx.templateSrv);
+        ctx.variableSrv = new VariableSrv(
+          ctx.$rootScope,
+          $q,
+          ctx.$location,
+          ctx.$injector,
+          ctx.templateSrv,
+          ctx.backendSrv
+        );
 
         ctx.variableSrv.timeSrv = ctx.timeSrv;
         ctx.datasourceSrv = {
@@ -57,7 +67,7 @@ describe('VariableSrv', function(this: any) {
           return getVarMockConstructor(ctr, model, ctx);
         };
 
-        ctx.variableSrv.init(
+        await ctx.variableSrv.init(
           new DashboardModel({
             templating: { list: [] },
             updateSubmenuVisibility: () => {},

--- a/public/app/features/templating/specs/variable_srv_init.test.ts
+++ b/public/app/features/templating/specs/variable_srv_init.test.ts
@@ -23,6 +23,10 @@ describe('VariableSrv init', function(this: any) {
     $on: () => {},
   };
 
+  const backendSrv = {
+    get: () => Promise.resolve({}),
+  };
+
   let ctx = {} as any;
 
   function describeInitScenario(desc, fn) {
@@ -47,7 +51,7 @@ describe('VariableSrv init', function(this: any) {
           templateSrv,
         };
 
-        ctx.variableSrv = new VariableSrv($rootscope, $q, {}, $injector, templateSrv);
+        ctx.variableSrv = new VariableSrv($rootscope, $q, {}, $injector, templateSrv, backendSrv);
 
         $injector.instantiate = (variable, model) => {
           return getVarMockConstructor(variable, model, ctx);

--- a/public/app/features/templating/specs/variable_srv_init.test.ts
+++ b/public/app/features/templating/specs/variable_srv_init.test.ts
@@ -101,17 +101,27 @@ describe('VariableSrv init', function(this: any) {
         {
           type: 'global',
           uid: 'g_query_var',
-          current: { text: 'global_text', value: 'global_value' },
+          current: { text: 'local_text', value: 'local_value' },
         },
       ];
 
       scenario.globalVariables = {};
-      scenario.globalVariables['g_query_var'] = { uid: 'g_query_var', name: 'GlobalQueryVar', type: 'query' };
+      scenario.globalVariables['g_query_var'] = {
+        uid: 'g_query_var',
+        name: 'GlobalQueryVar',
+        type: 'query',
+        current: { text: 'globalText', value: 'globalValue' },
+      };
     });
 
     it('can return global version', () => {
       expect(scenario.variables[0].type).toBe('query');
       expect(scenario.variables[0].name).toBe('GlobalQueryVar');
+    });
+
+    it('should override current with local value', () => {
+      expect(scenario.variables[0].current.text).toBe('local_text');
+      expect(scenario.variables[0].current.value).toBe('local_value');
     });
   });
 

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -29,9 +29,10 @@ export abstract class VariableBase {
   type: string;
   current: any;
   options = [];
-  tags = [];
+  tags: any[];
   globalModel: any;
   model: any;
+  skipUrlSync: boolean;
   abstract defaults: any;
 
   getSaveModel() {

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -28,9 +28,21 @@ export abstract class VariableBase {
   name: string;
   type: string;
   current: any;
-  globalVariable = false;
   options = [];
   tags = [];
+  globalModel: any;
+  model: any;
+  abstract defaults = {};
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
 }
 
 export let variableTypes = {};

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -31,6 +31,18 @@ export abstract class VariableBase {
   options = [];
   tags = [];
   globalModel: any;
+  model: any;
+  abstract defaults: any;
+
+  getSaveModel() {
+    if (this.globalModel) {
+      this.globalModel.current = this.current;
+      return this.globalModel;
+    }
+
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
 }
 
 export let variableTypes = {};

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -31,18 +31,6 @@ export abstract class VariableBase {
   options = [];
   tags = [];
   globalModel: any;
-  model: any;
-  abstract defaults = {};
-
-  getSaveModel() {
-    if (this.globalModel) {
-      this.globalModel.current = this.current;
-      return this.globalModel;
-    }
-
-    assignModelProperties(this.model, this, this.defaults);
-    return this.model;
-  }
 }
 
 export let variableTypes = {};

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -24,6 +24,15 @@ export interface Variable {
   getSaveModel();
 }
 
+export abstract class VariableBase {
+  name: string;
+  type: string;
+  current: any;
+  globalVariable = false;
+  options = [];
+  tags = [];
+}
+
 export let variableTypes = {};
 export { assignModelProperties };
 

--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -33,7 +33,7 @@ export class VariableSrv {
       .get('/api/variables/find', { uids: uids })
       .then(globalVars => {
         return this.dashboard.templating.list.map(variable => {
-          if (variable.type === 'global') {
+          if (variable.type === 'global' && globalVars[variable.uid]) {
             const copy = _.cloneDeep(variable);
             variable = globalVars[copy.uid];
             variable.globalModel = copy;

--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -35,7 +35,6 @@ export class VariableSrv {
         return this.dashboard.templating.list.map(variable => {
           if (variable.type === 'global') {
             const copy = _.cloneDeep(variable);
-
             variable = globalVars[copy.uid];
             variable.globalModel = copy;
             variable.current = copy.current;

--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -30,7 +30,7 @@ export class VariableSrv {
     const uids = dashboard.templating.list.filter(t => t.type === 'global').map(t => t.uid);
 
     return this.backendSrv
-      .get('/api/variables', { uids: uids })
+      .get('/api/variables/find', { uids: uids })
       .then(globalVars => {
         return this.dashboard.templating.list.map(variable => {
           if (variable.type === 'global') {


### PR DESCRIPTION
Tried two different ways of implementing this.

**A new global variable type that wrapped the the global version.**
At first I thought this would be neat since the rest of grafana shouldnt care about how each variable is implemented but It didnt work out as good as I expected. Turns out there are to many areas Grafana still expect to have direct access to the template json. 

**Loading the global version of a template variable on load and extracting the refference on save.**
This feels much easier to reason about work with. The downside is that the code spreads in different parts of the codebase. I'll try moving the extraction of the global var definition to `getSaveModel`.

Im still not happy with this solution so I keep working on it for a bit.

TODO

* [x] Should support all kinds of variables. 
* [ ] UI for add/edit template variables in dashboard settings
* [x] Add new global variable
* [x] remove global variable
* [ ] Edit current variable.. Still quirky since its not rerendered on the dashboard.
* [ ] Backend for storing template variables
* [ ] Naming.. Im not sure `Global variable` is a good name. 

ref #1959

Ive used this bashscript to create a dashboard with a global variable. 

```bash

curl 'http://admin:admin@localhost:3000/api/dashboards/db/' \
-H 'Accept-Encoding: gzip, deflate, br' \
-H 'X-Grafana-Org-Id: 1' \
-H 'Content-Type: application/json;charset=UTF-8' \
-H 'Accept: application/json, text/plain, */*' \
-H 'Connection: keep-alive' --data-binary '{
"overwrite": true,
"dashboard":{
"annotations":{
"list":[
{
"builtIn":1,
"datasource":"-- Grafana --",
"enable":true,
"hide":true,
"iconColor":"rgba(0, 211, 255, 1)",
"name":"Annotations & Alerts",
"type":"dashboard"
}
]
},
"editable":true,
"gnetId":null,
"graphTooltip":0,
"links":[

],
"panels":[
{
"aliasColors":{

},
"bars":false,
"dashLength":10,
"dashes":false,
"fill":1,
"gridPos":{
"h":9,
"w":12,
"x":0,
"y":0
},
"id":2,
"legend":{
"avg":false,
"current":false,
"max":false,
"min":false,
"show":true,
"total":false,
"values":false
},
"lines":true,
"linewidth":1,
"links":[

],
"nullPointMode":"null",
"percentage":false,
"pointradius":5,
"points":false,
"renderer":"flot",
"seriesOverrides":[

],
"spaceLength":10,
"stack":false,
"steppedLine":false,
"targets":[
{
"expr":"",
"format":"time_series",
"intervalFactor":1,
"refId":"A"
}
],
"thresholds":[

],
"timeFrom":null,
"timeRegions":[

],
"timeShift":null,
"title":"Panel Title",
"tooltip":{
"shared":true,
"sort":0,
"value_type":"individual"
},
"type":"graph",
"xaxis":{
"buckets":null,
"mode":"time",
"name":null,
"show":true,
"values":[

]
},
"yaxes":[
{
"format":"short",
"label":null,
"logBase":1,
"max":null,
"min":null,
"show":true
},
{
"format":"short",
"label":null,
"logBase":1,
"max":null,
"min":null,
"show":true
}
],
"yaxis":{
"align":false,
"alignLevel":null
}
}
],
"schemaVersion":16,
"style":"dark",
"tags":[

],
"templating":{
"list":[
{
"type": "global",
"uid": "g_query_var",
"current": {
"selected": true,
"text": "global_text",
"value": "global_value"
}
},
{
"type": "global",
"uid": "g_custom_var",
"current": {
"selected": true,
"text": "global_text",
"value": "global_value"
}
},
{
"type": "global",
"uid": "g_constant_var",
"current": {
"selected": true,
"text": "global_text",
"value": "global_value"
}
},
{
"type": "global",
"uid": "g_interval_var",
"current": {
"selected": true,
"text": "global_text",
"value": "global_value"
}
}
]
},
"time":{
"from":"now-6h",
"to":"now"
},
"timepicker":{
"refresh_intervals":[
"5s",
"10s",
"30s",
"1m",
"5m",
"15m",
"30m",
"1h",
"2h",
"1d"
],
"time_options":[
"5m",
"15m",
"1h",
"6h",
"12h",
"24h",
"2d",
"7d",
"30d"
]
},
"timezone":"",
"title":"Many template variables",
"uid":"N7Qy7RYmk",
"version":9
},
"message":""
}' --compressed
```

