### PR TITLE
Update export_import.md

### DIFF
--- a/docs/sources/reference/export_import.md
+++ b/docs/sources/reference/export_import.md
@@ -107,3 +107,5 @@ it as usual and then update the data source option in the metrics tab so that th
 data source. Another alternative is to open the json file in a a text editor and update the data source properties
 to value that matches a name of your data source.
 
+## Note
+In Grafana v5.3.4+ the export modal has new checkbox for sharing for external use (other instances). If the checkbox is not checked then the `__inputs` section will not be included in the exported JSON file.


### PR DESCRIPTION
Grafana v5.3.4 shows a new checkbox in the export modal "Export for sharing externally". If the checkbox is not checked then the `__inputs` section wont be included into the exported JSON file, would be great to add such note into the [documentation ](http://docs.grafana.org/reference/export_import/)for others to avoid confusions.

Related to: https://github.com/grafana/grafana/issues/14216
