### PR TITLE
added google_tag_manager_id from defaults.ini

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -145,6 +145,9 @@ log_queries =
 # Google Analytics universal tracking code, only enabled if you specify an id here
 ;google_analytics_ua_id =
 
+# Google Tag Manager ID, only enabled if you specify an id here
+;google_tag_manager_id =
+
 #################################### Security ####################################
 [security]
 # default admin user, created on startup


### PR DESCRIPTION
added google_tag_manager_id from defaults.ini to sample.ini

On RHEL for example the parameter is missing in the default configuration file @/etc/grafana/grafana.ini