### PR TITLE
Prevent password reset when login form is disabled or either LDAP or Auth Proxy is enabled

### DIFF
--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -4,10 +4,18 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 func SendResetPasswordEmail(c *m.ReqContext, form dtos.SendResetPasswordEmailForm) Response {
+	if setting.LdapEnabled || setting.AuthProxyEnabled {
+		return Error(401, "Not allowed to reset password when LDAP or Auth Proxy is enabled", nil)
+	}
+	if setting.DisableLoginForm {
+		return Error(401, "Not allowed to reset password when login form is disabled", nil)
+	}
+
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: form.UserOrEmail}
 
 	if err := bus.Dispatch(&userQuery); err != nil {

--- a/public/app/core/controllers/reset_password_ctrl.ts
+++ b/public/app/core/controllers/reset_password_ctrl.ts
@@ -1,4 +1,5 @@
 import coreModule from '../core_module';
+import config from 'app/core/config';
 
 export class ResetPasswordCtrl {
   /** @ngInject */
@@ -6,6 +7,9 @@ export class ResetPasswordCtrl {
     contextSrv.sidemenu = false;
     $scope.formModel = {};
     $scope.mode = 'send';
+    $scope.ldapEnabled = config.ldapEnabled;
+    $scope.authProxyEnabled = config.authProxyEnabled;
+    $scope.disableLoginForm = config.disableLoginForm;
 
     const params = $location.search();
     if (params.code) {

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -22,7 +22,7 @@
             <button type="submit" class="btn btn-large p-x-2 btn-inverse btn-loading" ng-if="loggingIn">
               Logging In<span>.</span><span>.</span><span>.</span>
             </button>
-            <div class="small login-button-forgot-password">
+            <div class="small login-button-forgot-password" ng-hide="ldapEnabled || authProxyEnabled">
               <a href="user/password/send-reset-email">
                 Forgot your password?
               </a>

--- a/public/app/partials/reset_password.html
+++ b/public/app/partials/reset_password.html
@@ -3,7 +3,14 @@
 <div class="page-container page-body">
 	<div class="signup">
 		<h3 class="p-b-1">Reset password</h3>
-		<form name="sendResetForm" class="login-form gf-form-group" ng-show="mode === 'send'">
+
+		<div ng-if="ldapEnabled || authProxyEnabled">
+			You cannot reset password when LDAP or Auth Proxy authentication is enabled.
+		</div>
+		<div ng-if="disableLoginForm">
+			You cannot reset password when login form is disabled.
+		</div>
+		<form name="sendResetForm" class="login-form gf-form-group" ng-show="mode === 'send'" ng-hide="ldapEnabled || authProxyEnabled || disableLoginForm">
 			<div class="gf-form">
 					<span class="gf-form-label width-7">User</span>
 					<input type="text" name="username" class="gf-form-input max-width-14" required ng-model='formModel.userOrEmail' placeholder="email or username">


### PR DESCRIPTION
Hello, team! Thank you for a great tool!

I have discovered an unreliable behavior when either LDAP or Auth Proxy is enabled, or login form is disabled. In case user gets registered with SSO or LDAP, his/her account gets a random password so user is forces to authenticate with SSO next time. Before my pull request, it was possible to request password reset and obtain access to account bypassing SSO.

This pull request disabled password reset for all these cases.

Fixes #14246