### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Choose this option to build on platforms other than linux/amd64 and/or not have 
 
 The resulting image will be tagged as `grafana/grafana:dev`
 
-Notice: If you are using Docker for MacOS, be sure to let limit of Memory bigger than 2 GiB, otherwize you may faild at `grunt build`
+Notice: If you are using Docker for MacOS, be sure to let limit of Memory bigger than 2 GiB (at docker -> Perferences -> Advanced), otherwize you may faild at `grunt build`
 
 ### Dev config
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Choose this option to build on platforms other than linux/amd64 and/or not have 
 
 The resulting image will be tagged as `grafana/grafana:dev`
 
+Notice: If you are using Docker for MacOS, be sure to let limit of Memory bigger than 2 GiB, otherwize you may faild at `grunt build`
+
 ### Dev config
 
 Create a custom.ini in the conf directory to override default configuration options.


### PR DESCRIPTION
add notice to MacOS Docker user, if docker  memory limit is less than 2GiB, build process may fail when run ./node_modules/.bin/grunt build

no issue link to this pr