### PR TITLE
Explore: Fix label and history suggestions

### DIFF
--- a/public/app/plugins/datasource/logging/language_provider.test.ts
+++ b/public/app/plugins/datasource/logging/language_provider.test.ts
@@ -8,9 +8,10 @@ describe('Language completion provider', () => {
   };
 
   describe('empty query suggestions', () => {
-    it('returns default suggestions on emtpty context', () => {
+    it('returns no suggestions on emtpty context', () => {
       const instance = new LanguageProvider(datasource);
-      const result = instance.provideCompletionItems({ text: '', prefix: '', wrapperClasses: [] });
+      const value = Plain.deserialize('');
+      const result = instance.provideCompletionItems({ text: '', prefix: '', value, wrapperClasses: [] });
       expect(result.context).toBeUndefined();
       expect(result.refresher).toBeUndefined();
       expect(result.suggestions.length).toEqual(0);
@@ -37,6 +38,32 @@ describe('Language completion provider', () => {
           ],
         },
       ]);
+    });
+
+    it('returns no suggestions within regexp', () => {
+      const instance = new LanguageProvider(datasource);
+      const value = Plain.deserialize('{} ()');
+      const range = value.selection.merge({
+        anchorOffset: 4,
+      });
+      const valueWithSelection = value.change().select(range).value;
+      const history = [
+        {
+          query: { refId: '1', expr: '{app="foo"}' },
+        },
+      ];
+      const result = instance.provideCompletionItems(
+        {
+          text: '',
+          prefix: '',
+          value: valueWithSelection,
+          wrapperClasses: [],
+        },
+        { history }
+      );
+      expect(result.context).toBeUndefined();
+      expect(result.refresher).toBeUndefined();
+      expect(result.suggestions.length).toEqual(0);
     });
   });
 

--- a/public/app/plugins/datasource/logging/syntax.ts
+++ b/public/app/plugins/datasource/logging/syntax.ts
@@ -1,0 +1,28 @@
+/* tslint:disable max-line-length */
+
+const tokenizer = {
+  comment: {
+    pattern: /(^|[^\n])#.*/,
+    lookbehind: true,
+  },
+  'context-labels': {
+    pattern: /(^|\s)\{[^}]*(?=})/,
+    lookbehind: true,
+    inside: {
+      'label-key': {
+        pattern: /[a-z_]\w*(?=\s*(=|!=|=~|!~))/,
+        alias: 'attr-name',
+      },
+      'label-value': {
+        pattern: /"(?:\\.|[^\\"])*"/,
+        greedy: true,
+        alias: 'attr-value',
+      },
+    },
+  },
+  // number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
+  operator: new RegExp(`/&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?`, 'i'),
+  punctuation: /[{}`,.]/,
+};
+
+export default tokenizer;


### PR DESCRIPTION
- fork promql's tokenizer (need to specify that labels context can only follow beginning of line or whitespace)
- remove unneeded syntax features
- only present history items when field is empty

Fixes #14245 