### PR TITLE
Explore: Fix logging query parser for regex with quantifiers

### DIFF
--- a/public/app/plugins/datasource/logging/query_utils.test.ts
+++ b/public/app/plugins/datasource/logging/query_utils.test.ts
@@ -42,4 +42,15 @@ describe('parseQuery', () => {
       regexp: '',
     });
   });
+
+  it('returns query and regexp with quantifiers', () => {
+    expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
+      query: '{foo="bar"}',
+      regexp: '\\.java:[0-9]{1,5}',
+    });
+    expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
+      query: '{foo="bar"}',
+      regexp: '\\.java:[0-9]{1,5}',
+    });
+  });
 });

--- a/public/app/plugins/datasource/logging/query_utils.ts
+++ b/public/app/plugins/datasource/logging/query_utils.ts
@@ -1,11 +1,11 @@
-const selectorRegexp = /{[^{]*}/g;
+const selectorRegexp = /(?:^|\s){[^{]*}/g;
 export function parseQuery(input: string) {
   const match = input.match(selectorRegexp);
   let query = '';
   let regexp = input;
 
   if (match) {
-    query = match[0];
+    query = match[0].trim();
     regexp = input.replace(selectorRegexp, '').trim();
   }
 


### PR DESCRIPTION
- ensure that selectors have to be preceded by whitespace or line beginning
- glacing over the fact that ` {0,1}` could be a valid regexp, but we're using space as query/regexp separators anyway, so I think it's fine for now (if someone wants to use a certain number of spaces they can still fall back to `\s{n,m}`)

Fixes #14250 