### PR TITLE
Explore: Logging label stats

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -45,6 +45,13 @@ export interface LogRow {
   uniqueLabels?: LogsStreamLabels;
 }
 
+export interface LogsLabelStat {
+  active?: boolean;
+  count: number;
+  proportion: number;
+  value: string;
+}
+
 export enum LogsMetaKind {
   Number,
   String,
@@ -86,6 +93,22 @@ export enum LogsDedupStrategy {
   exact = 'exact',
   numbers = 'numbers',
   signature = 'signature',
+}
+
+export function calculateLogsLabelStats(rows: LogRow[], label: string): LogsLabelStat[] {
+  // Consider only rows that have the given label
+  const rowsWithLabel = rows.filter(row => row.labels[label] !== undefined);
+  const rowCount = rowsWithLabel.length;
+
+  // Get label value counts for eligible rows
+  const countsByValue = _.countBy(rowsWithLabel, row => (row as LogRow).labels[label]);
+  const sortedCounts = _.chain(countsByValue)
+    .map((count, value) => ({ count, value, proportion: count / rowCount }))
+    .sortBy('count')
+    .reverse()
+    .value();
+
+  return sortedCounts;
 }
 
 const isoDateRegexp = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-6]\d[,\.]\d+([+-][0-2]\d:[0-5]\d|Z)/g;

--- a/public/app/core/specs/logs_model.test.ts
+++ b/public/app/core/specs/logs_model.test.ts
@@ -1,4 +1,4 @@
-import { dedupLogRows, LogsDedupStrategy, LogsModel } from '../logs_model';
+import { calculateLogsLabelStats, dedupLogRows, LogsDedupStrategy, LogsModel } from '../logs_model';
 
 describe('dedupLogRows()', () => {
   test('should return rows as is when dedup is set to none', () => {
@@ -102,6 +102,59 @@ describe('dedupLogRows()', () => {
       {
         duplicates: 3,
         entry: 'WARN test 1.2323423 on [xxx]',
+      },
+    ]);
+  });
+});
+
+describe('calculateLogsLabelStats()', () => {
+  test('should return no stats for empty rows', () => {
+    expect(calculateLogsLabelStats([], '')).toEqual([]);
+  });
+
+  test('should return no stats of label is not found', () => {
+    const rows = [
+      {
+        entry: 'foo 1',
+        labels: {
+          foo: 'bar',
+        },
+      },
+    ];
+
+    expect(calculateLogsLabelStats(rows as any, 'baz')).toEqual([]);
+  });
+
+  test('should return stats for found labels', () => {
+    const rows = [
+      {
+        entry: 'foo 1',
+        labels: {
+          foo: 'bar',
+        },
+      },
+      {
+        entry: 'foo 0',
+        labels: {
+          foo: 'xxx',
+        },
+      },
+      {
+        entry: 'foo 2',
+        labels: {
+          foo: 'bar',
+        },
+      },
+    ];
+
+    expect(calculateLogsLabelStats(rows as any, 'foo')).toMatchObject([
+      {
+        value: 'bar',
+        count: 2,
+      },
+      {
+        value: 'xxx',
+        count: 1,
       },
     ]);
   });

--- a/public/app/features/explore/LogLabels.tsx
+++ b/public/app/features/explore/LogLabels.tsx
@@ -1,0 +1,164 @@
+import _ from 'lodash';
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+
+import { LogsStreamLabels, LogRow } from 'app/core/logs_model';
+
+interface FieldStat {
+  active?: boolean;
+  value: string;
+  count: number;
+  proportion: number;
+}
+
+function calculateStats(rows: LogRow[], label: string): FieldStat[] {
+  // Consider only rows that have the given label
+  const rowsWithLabel = rows.filter(row => row.labels[label] !== undefined);
+  const rowCount = rowsWithLabel.length;
+
+  // Get label value counts for eligible rows
+  const countsByValue = _.countBy(rowsWithLabel, row => (row as LogRow).labels[label]);
+  const sortedCounts = _.chain(countsByValue)
+    .map((count, value) => ({ count, value, proportion: count / rowCount }))
+    .sortBy('count')
+    .reverse()
+    .value();
+
+  return sortedCounts;
+}
+
+function StatsRow({ active, count, proportion, value }: FieldStat) {
+  const percent = `${Math.round(proportion * 100)}%`;
+  const barStyle = { width: percent };
+  const className = classnames('logs-stats-row', { 'logs-stats-row--active': active });
+
+  return (
+    <div className={className}>
+      <div className="logs-stats-row__label">
+        <div className="logs-stats-row__value">{value}</div>
+        <div className="logs-stats-row__count">{count}</div>
+        <div className="logs-stats-row__percent">{percent}</div>
+      </div>
+      <div className="logs-stats-row__bar">
+        <div className="logs-stats-row__innerbar" style={barStyle} />
+      </div>
+    </div>
+  );
+}
+
+const STATS_ROW_LIMIT = 5;
+class Stats extends PureComponent<{
+  stats: FieldStat[];
+  label: string;
+  value: string;
+  rowCount: number;
+  onClickClose: () => void;
+}> {
+  render() {
+    const { label, rowCount, stats, value, onClickClose } = this.props;
+    const topRows = stats.slice(0, STATS_ROW_LIMIT);
+    let activeRow = topRows.find(row => row.value === value);
+    let otherRows = stats.slice(STATS_ROW_LIMIT);
+    const insertActiveRow = !activeRow;
+    // Remove active row from other to show extra
+    if (insertActiveRow) {
+      activeRow = otherRows.find(row => row.value === value);
+      otherRows = otherRows.filter(row => row.value !== value);
+    }
+    const otherCount = otherRows.reduce((sum, row) => sum + row.count, 0);
+    const topCount = topRows.reduce((sum, row) => sum + row.count, 0);
+    const total = topCount + otherCount;
+    const otherProportion = otherCount / total;
+
+    return (
+      <>
+        <div className="logs-stats__info">
+          {label}: {total} of {rowCount} rows have that label
+          <span className="logs-stats__icon fa fa-window-close" onClick={onClickClose} />
+        </div>
+        {topRows.map(stat => <StatsRow key={stat.value} {...stat} active={stat.value === value} />)}
+        {insertActiveRow && <StatsRow key={activeRow.value} {...activeRow} active />}
+        {otherCount > 0 && <StatsRow key="__OTHERS__" count={otherCount} value="Other" proportion={otherProportion} />}
+      </>
+    );
+  }
+}
+
+class Label extends PureComponent<
+  {
+    allRows?: LogRow[];
+    label: string;
+    plain?: boolean;
+    value: string;
+    onClickLabel?: (label: string, value: string) => void;
+  },
+  { showStats: boolean; stats: FieldStat[] }
+> {
+  state = {
+    stats: null,
+    showStats: false,
+  };
+
+  onClickClose = () => {
+    this.setState({ showStats: false });
+  };
+
+  onClickLabel = () => {
+    const { onClickLabel, label, value } = this.props;
+    if (onClickLabel) {
+      onClickLabel(label, value);
+    }
+  };
+
+  onClickStats = () => {
+    this.setState(state => {
+      if (state.showStats) {
+        return { showStats: false, stats: null };
+      }
+      const stats = calculateStats(this.props.allRows, this.props.label);
+      return { showStats: true, stats };
+    });
+  };
+
+  render() {
+    const { allRows, label, plain, value } = this.props;
+    const { showStats, stats } = this.state;
+    const tooltip = `${label}: ${value}`;
+    return (
+      <span className="logs-label">
+        <span className="logs-label__value" title={tooltip}>
+          {value}
+        </span>
+        {!plain && (
+          <span title="Filter for label" onClick={this.onClickLabel} className="logs-label__icon fa fa-search-plus" />
+        )}
+        {!plain && allRows && <span onClick={this.onClickStats} className="logs-label__icon fa fa-signal" />}
+        {showStats && (
+          <span className="logs-label__stats">
+            <Stats
+              stats={stats}
+              rowCount={allRows.length}
+              label={label}
+              value={value}
+              onClickClose={this.onClickClose}
+            />
+          </span>
+        )}
+      </span>
+    );
+  }
+}
+
+export default class LogLabels extends PureComponent<{
+  allRows?: LogRow[];
+  labels: LogsStreamLabels;
+  plain?: boolean;
+  onClickLabel?: (label: string, value: string) => void;
+}> {
+  render() {
+    const { allRows, labels, onClickLabel, plain } = this.props;
+    return Object.keys(labels).map(key => (
+      <Label key={key} allRows={allRows} label={key} value={labels[key]} plain={plain} onClickLabel={onClickLabel} />
+    ));
+  }
+}

--- a/public/app/features/explore/LogLabels.tsx
+++ b/public/app/features/explore/LogLabels.tsx
@@ -2,32 +2,9 @@ import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 
-import { LogsStreamLabels, LogRow } from 'app/core/logs_model';
+import { calculateLogsLabelStats, LogsLabelStat, LogsStreamLabels, LogRow } from 'app/core/logs_model';
 
-interface FieldStat {
-  active?: boolean;
-  value: string;
-  count: number;
-  proportion: number;
-}
-
-function calculateStats(rows: LogRow[], label: string): FieldStat[] {
-  // Consider only rows that have the given label
-  const rowsWithLabel = rows.filter(row => row.labels[label] !== undefined);
-  const rowCount = rowsWithLabel.length;
-
-  // Get label value counts for eligible rows
-  const countsByValue = _.countBy(rowsWithLabel, row => (row as LogRow).labels[label]);
-  const sortedCounts = _.chain(countsByValue)
-    .map((count, value) => ({ count, value, proportion: count / rowCount }))
-    .sortBy('count')
-    .reverse()
-    .value();
-
-  return sortedCounts;
-}
-
-function StatsRow({ active, count, proportion, value }: FieldStat) {
+function StatsRow({ active, count, proportion, value }: LogsLabelStat) {
   const percent = `${Math.round(proportion * 100)}%`;
   const barStyle = { width: percent };
   const className = classnames('logs-stats-row', { 'logs-stats-row--active': active });
@@ -48,7 +25,7 @@ function StatsRow({ active, count, proportion, value }: FieldStat) {
 
 const STATS_ROW_LIMIT = 5;
 class Stats extends PureComponent<{
-  stats: FieldStat[];
+  stats: LogsLabelStat[];
   label: string;
   value: string;
   rowCount: number;
@@ -92,7 +69,7 @@ class Label extends PureComponent<
     value: string;
     onClickLabel?: (label: string, value: string) => void;
   },
-  { showStats: boolean; stats: FieldStat[] }
+  { showStats: boolean; stats: LogsLabelStat[] }
 > {
   state = {
     stats: null,
@@ -115,7 +92,7 @@ class Label extends PureComponent<
       if (state.showStats) {
         return { showStats: false, stats: null };
       }
-      const stats = calculateStats(this.props.allRows, this.props.label);
+      const stats = calculateLogsLabelStats(this.props.allRows, this.props.label);
       return { showStats: true, stats };
     });
   };

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -369,17 +369,87 @@
       padding: 0 2px;
       background-color: $btn-inverse-bg;
       border-radius: $border-radius;
-      margin-right: 4px;
-      overflow: hidden;
+      margin: 0 4px 2px 0;
       text-overflow: ellipsis;
       white-space: nowrap;
+      position: relative;
+    }
+
+    .logs-label__icon {
+      border-left: $panel-border;
+      padding: 0 2px;
+      cursor: pointer;
+      margin-left: 2px;
+    }
+
+    .logs-label__stats {
+      position: absolute;
+      top: 1.25em;
+      left: -10px;
+      z-index: 100;
+      background-color: $page-bg;
+      border: $panel-border;
+      padding: 10px;
+      border-radius: $border-radius;
+      justify-content: space-between;
     }
 
     .logs-row-labels {
       line-height: 1.2;
+    }
 
-      .logs-label {
-        cursor: pointer;
+    .logs-stats__info {
+      margin-bottom: $spacer / 2;
+    }
+
+    .logs-stats__icon {
+      margin-left: 0.5em;
+      cursor: pointer;
+    }
+
+    .logs-stats-row {
+      margin: $spacer/1.75 0;
+
+      &--active {
+        color: $blue;
+        position: relative;
+      }
+
+      &--active:after {
+        display: inline;
+        content: '*';
+        position: absolute;
+        top: 0;
+        left: -0.75em;
+      }
+
+      &__label {
+        display: flex;
+      }
+
+      &__value {
+        flex: 1;
+      }
+
+      &__count,
+      &__percent {
+        text-align: right;
+        margin-left: 0.5em;
+      }
+
+      &__percent {
+        width: 3em;
+      }
+
+      &__bar,
+      &__innerbar {
+        height: 4px;
+        overflow: hidden;
+        background: $text-color-faint;
+      }
+
+      &__innerbar {
+        background-color: $blue;
       }
     }
   }

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -392,6 +392,7 @@
       padding: 10px;
       border-radius: $border-radius;
       justify-content: space-between;
+      box-shadow: $card-shadow;
     }
 
     .logs-row-labels {
@@ -420,11 +421,12 @@
         content: '*';
         position: absolute;
         top: 0;
-        left: -0.75em;
+        left: -8px;
       }
 
       &__label {
         display: flex;
+        margin-bottom: 1px;
       }
 
       &__value {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -387,12 +387,13 @@
       top: 1.25em;
       left: -10px;
       z-index: 100;
-      background-color: $page-bg;
-      border: $panel-border;
+      background-color: $popover-bg;
+      color: $popover-color;
+      border: 1px solid $popover-border-color;
       padding: 10px;
       border-radius: $border-radius;
       justify-content: space-between;
-      box-shadow: $card-shadow;
+      box-shadow: $popover-shadow;
     }
 
     .logs-row-labels {


### PR DESCRIPTION
- added filter and stats icons to log stream labels
- removed click handler from label itself
- click on stats icon calculates label value distribution across loaded logs lines
- show stats in hover
- stats have indicator which value is the current one
- showing top 5 values for the given label
- if selected value is not among top 5, it is added
- summing up remaining label value distribution as Other

Use case 1 of #14252 

