### PR TITLE
Explore: Logging query live preview of matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,18 +108,9 @@
     "precommit": "lint-staged && grunt precommit"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.scss": [
-      "prettier --write",
-      "git add"
-    ],
-    "*pkg/**/*.go": [
-      "gofmt -w -s",
-      "git add"
-    ]
+    "*.{ts,tsx}": ["prettier --write", "git add"],
+    "*.scss": ["prettier --write", "git add"],
+    "*pkg/**/*.go": ["gofmt -w -s", "git add"]
   },
   "prettier": {
     "trailingComma": "es5",
@@ -156,7 +147,7 @@
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.5.0",
     "react-grid-layout": "0.16.6",
-    "react-highlight-words": "^0.10.0",
+    "react-highlight-words": "0.11.0",
     "react-popper": "^0.7.5",
     "react-redux": "^5.0.7",
     "react-select": "2.1.0",

--- a/public/app/core/utils/text.test.ts
+++ b/public/app/core/utils/text.test.ts
@@ -16,9 +16,20 @@ describe('findMatchesInText()', () => {
     expect(findMatchesInText(' foo ', 'foo')).toEqual([{ length: 3, start: 1, text: 'foo', end: 4 }]);
   });
 
-  expect(findMatchesInText(' foo foo bar ', 'foo|bar')).toEqual([
-    { length: 3, start: 1, text: 'foo', end: 4 },
-    { length: 3, start: 5, text: 'foo', end: 8 },
-    { length: 3, start: 9, text: 'bar', end: 12 },
-  ]);
+  test('should find all matches for a complete regex', () => {
+    expect(findMatchesInText(' foo foo bar ', 'foo|bar')).toEqual([
+      { length: 3, start: 1, text: 'foo', end: 4 },
+      { length: 3, start: 5, text: 'foo', end: 8 },
+      { length: 3, start: 9, text: 'bar', end: 12 },
+    ]);
+  });
+
+  test('not fail on incomplete regex', () => {
+    expect(findMatchesInText(' foo foo bar ', 'foo|')).toEqual([
+      { length: 3, start: 1, text: 'foo', end: 4 },
+      { length: 3, start: 5, text: 'foo', end: 8 },
+    ]);
+    expect(findMatchesInText('foo foo bar', '(')).toEqual([]);
+    expect(findMatchesInText('foo foo bar', '(foo|')).toEqual([]);
+  });
 });

--- a/public/app/plugins/datasource/logging/datasource.ts
+++ b/public/app/plugins/datasource/logging/datasource.ts
@@ -117,6 +117,10 @@ export default class LoggingDatasource {
     return { ...query, expr: expression };
   }
 
+  getHighlighterExpression(query: DataQuery): string {
+    return parseQuery(query.expr).regexp;
+  }
+
   getTime(date, roundUp) {
     if (_.isString(date)) {
       date = dateMath.parse(date, roundUp);

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -164,6 +164,7 @@ export interface ExploreState {
   graphResult?: any[];
   history: HistoryItem[];
   initialQueries: DataQuery[];
+  logsHighlighterExpressions?: string[];
   logsResult?: LogsModel;
   queryTransactions: QueryTransaction[];
   range: RawTimeRange;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -308,7 +308,7 @@
     }
 
     .logs-row-match-highlight--preview {
-      background-color: lighten($typeahead-selected-color, 70%);
+      background-color: rgba($typeahead-selected-color, 0.2);
       border-bottom-style: dotted;
     }
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -307,6 +307,11 @@
       background-color: rgba($typeahead-selected-color, 0.1);
     }
 
+    .logs-row-match-highlight--preview {
+      background-color: lighten($typeahead-selected-color, 70%);
+      border-bottom-style: dotted;
+    }
+
     .logs-row-level {
       background-color: transparent;
       margin: 2px 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6230,10 +6230,10 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
-highlight-words-core@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.0.tgz#232bec301cbf2a4943d335dc748ce70e9024f3b1"
-  integrity sha512-nu5bMsWIgpsrlXEMNKSvbJMeUPhFxCOVT28DnI8UCVfhm3e98LC8oeyMNrc7E18+QQ4l/PvbeN7ojyN4XsmBdA==
+highlight-words-core@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.2.tgz#1eff6d7d9f0a22f155042a00791237791b1eeaaa"
+  integrity sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -11285,12 +11285,12 @@ react-grid-layout@0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
-react-highlight-words@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/react-highlight-words/-/react-highlight-words-0.10.0.tgz#2e905c76c11635237f848ecad00600f1b6f6f4a8"
-  integrity sha512-/5jh6a8pir3baCOMC5j88MBmNciSwG5bXWNAAtbtDb3WYJoGn82e2zLCQFnghIBWod1h5y6/LRO8TS6ERbN5aQ==
+react-highlight-words@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-highlight-words/-/react-highlight-words-0.11.0.tgz#4f3c2039a8fd275f3ab795e59946b0324d8e6bee"
+  integrity sha512-b+fgdQXNjX6RwHfiBYn6qH2D2mJEDNLuxdsqRseIiQffoCAoj7naMQ5EktUkmo9Bh1mXq/aMpJbdx7Lf2PytcQ==
   dependencies:
-    highlight-words-core "^1.1.0"
+    highlight-words-core "^1.2.0"
     prop-types "^15.5.8"
 
 react-hot-loader@^4.3.6:


### PR DESCRIPTION
A logging query has a selector part and a regexp. The regexp matches are highlighted when results return.
This change adds live preview to matches when modifying the regexp in a search field.

- delegate retrieval of match query to datasource
- datasource returns search expressions to be used to highlight a live preview of matches
- logs row now takes preview highlights
- logs row renders preview highlights with dotted line to distinguish from query run matches (solid line)
- fix react-highlight-words version to ensure custom chunk matcher
- custom chunk matcher can now also take incomplete regexps, eg, `(level` without inifinte looping
- perf: debounce of live preview to 500ms
- perf: only top 100 rows get the live preview
- preview is only supported with one query row (multiple rows semantic makes this tricky: regexp for row n should only filter results for query n)

Fixes #14253 