### PR TITLE
Explore: Logging graph shows area hint when limit was hit

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -66,6 +66,7 @@ export interface LogsMetaItem {
 
 export interface LogsModel {
   id: string; // Identify one logs result from another
+  limited?: boolean; // Result count has reached limit
   meta?: LogsMetaItem[];
   rows: LogRow[];
   series?: TimeSeries[];

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -186,8 +186,11 @@ export function mergeStreamsToLogs(streams: LogsStream[], limit = DEFAULT_LIMIT)
     });
   }
 
+  const limited = sortedRows.length === limit;
+
   return {
     id,
+    limited,
     meta,
     rows: sortedRows,
   };

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -112,6 +112,15 @@
     flex-wrap: wrap;
   }
 
+  .graph-markings-label {
+    position: absolute;
+    left: 10px;
+    top: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .explore-panel__loader {
     height: 2px;
     position: relative;
@@ -380,6 +389,17 @@
       border-radius: $border-radius;
       justify-content: space-between;
       box-shadow: $popover-shadow;
+    }
+
+    .logs-limit-label {
+      font-size: $font-size-sm;
+      text-align: center;
+      color: $text-color-weak;
+      transition: color 0.5s ease-out;
+
+      &:hover {
+        color: $text-color;
+      }
     }
 
     .logs-row-labels {


### PR DESCRIPTION
Queries for logs are limited in result rows (typically 1000).
On busy systems that limited row range only spans a couple of minutes.
This change adds a visual area marker to logging graph to show that we could not return rows for that time due to a query limit being hit.

<img width="1240" alt="screenshot 2018-12-03 at 18 11 30" src="https://user-images.githubusercontent.com/859729/49389554-e6ee6080-f726-11e8-83fe-f50c4fbdaa03.png">


TODO

- [x] Display help message behind marked area

Fixes #14244 

