### PR TITLE
Develop keep panel settings when switching visualizations

### DIFF
--- a/public/app/features/dashboard/panel_model.ts
+++ b/public/app/features/dashboard/panel_model.ts
@@ -55,6 +55,12 @@ const mustKeepProps: { [str: string]: boolean } = {
   cachedPluginOptions: true,
 };
 
+// Keep current option value when switching visualization
+const keepLatestProps: { [str: string]: boolean } = {
+  title: true,
+  description: true,
+};
+
 const defaults: any = {
   gridPos: { x: 0, y: 0, h: 3, w: 6 },
   datasource: null,
@@ -209,11 +215,11 @@ export class PanelModel {
 
   restorePanelOptions(pluginId: string) {
     const currentOptions = this.getPanelOptions();
-    const prevOptions = this.cachedPluginOptions[pluginId];
+    const prevOptions = this.cachedPluginOptions[pluginId] || {};
     const newOptions = Object.keys(prevOptions).reduce((acc, currKey: string) => {
       return {
         ...acc,
-        [currKey]: currentOptions[currKey] || prevOptions[currKey],
+        [currKey]: keepLatestProps[currKey] ? currentOptions[currKey] : prevOptions[currKey],
       };
     }, {});
 

--- a/public/app/features/dashboard/specs/panel_model.test.ts
+++ b/public/app/features/dashboard/specs/panel_model.test.ts
@@ -1,0 +1,54 @@
+import _ from 'lodash';
+import { PanelModel } from '../panel_model';
+
+describe('PanelModel', () => {
+  describe('when creating new panel model', () => {
+    let model;
+
+    beforeEach(() => {
+      model = new PanelModel({
+        type: 'table',
+        showColumns: true,
+      });
+    });
+
+    it('should apply defaults', () => {
+      expect(model.gridPos.h).toBe(3);
+    });
+
+    it('should set model props on instance', () => {
+      expect(model.showColumns).toBe(true);
+    });
+
+    it('getSaveModel should remove defaults', () => {
+      const saveModel = model.getSaveModel();
+      expect(saveModel.gridPos).toBe(undefined);
+    });
+
+    it('getSaveModel should remove nonPersistedProperties', () => {
+      const saveModel = model.getSaveModel();
+      expect(saveModel.events).toBe(undefined);
+    });
+
+    describe('when changing panel type', () => {
+      beforeEach(() => {
+        model.changeType('graph', true);
+        model.alert = { id: 2 };
+      });
+
+      it('should remove table properties but keep core props', () => {
+        expect(model.showColumns).toBe(undefined);
+      });
+
+      it('should restore table properties when changing back', () => {
+        model.changeType('table', true);
+        expect(model.showColumns).toBe(true);
+      });
+
+      it('should remove alert rule when changing type that does not support it', () => {
+        model.changeType('table', true);
+        expect(model.alert).toBe(undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
* When switching visualization, we should remember the options in case the user switch back #14274