### PR TITLE
Render API supports kiosk mode

### DIFF
--- a/tools/phantomjs/render.js
+++ b/tools/phantomjs/render.js
@@ -12,11 +12,19 @@
       params[parts[1]] = parts[2];
     });
 
-    var usage = "url=<url> png=<filename> width=<width> height=<height> renderKey=<key>";
+    var usage = "url=<url> png=<filename> width=<width> height=<height> renderKey=<key> kiosk=<kioskmode>";
 
     if (!params.url || !params.png ||  !params.renderKey || !params.domain) {
       console.log(usage);
       phantom.exit();
+    }
+
+    if (typeof params.kiosk !== 'undefined') {
+      var param = 'kiosk';
+      if (params.kiosk) {
+        param = param + '=' + params.kiosk;
+      }
+      params.url = params.url + param;
     }
 
     phantom.addCookie({


### PR DESCRIPTION
After upgrading to Grafana 5.4.0, the image generated via the render api always has a sidebar and cannot be removed.
![image](https://user-images.githubusercontent.com/2211648/49448515-06af8280-f814-11e8-8bd7-a513442a0b4c.png)

The dashboard page supports kiosk mode, so I add this parameter to render api. When I call the render api, phantomjs will add the kiosk parameter after the dashboard url.

So I can use this url to render image in kiosk mode.
`https://GRAFANA_HOST/render/dashboard/db/DASHBOARD_NAME?from=FROM&to=TO&width=WIDTH&height=HEIGHT&kiosk=tv`
![image](https://user-images.githubusercontent.com/2211648/49448502-00b9a180-f814-11e8-92cd-7d6004262869.png)
or
`https://GRAFANA_HOST/render/dashboard/db/DASHBOARD_NAME?from=FROM&to=TO&width=WIDTH&height=HEIGHT&kiosk`
![image](https://user-images.githubusercontent.com/2211648/49449357-ab7e8f80-f815-11e8-96a4-5dd054b4b7a1.png)