### PR TITLE
Improve PostgreSQL Query Editor if using different Schemas

### DIFF
--- a/public/app/plugins/datasource/postgres/meta_query.ts
+++ b/public/app/plugins/datasource/postgres/meta_query.ts
@@ -151,8 +151,7 @@ table_schema IN (
 
   buildDatatypeQuery(column: string) {
     let query = 'SELECT udt_name FROM information_schema.columns WHERE ';
-    query += this.buildSchemaConstraint();
-    query += ' AND table_name = ' + this.quoteIdentAsLiteral(this.target.table);
+    query += this.buildTableConstraint(this.target.table);
     query += ' AND column_name = ' + this.quoteIdentAsLiteral(column);
     return query;
   }


### PR DESCRIPTION
This PR fixes a bug where the datatype of a column could not be determined if one accesses a table on a non-default schema with the fully-qualified name "schemaname.tablename". This results in not applying a $__timeFilter by default, which might lead to a crashing browser/tab since all data from the table is now requested, downloaded, and processed instead of only the data for the selected time range.

Looks like this function was missed in the refactorings in ad26a31 and e07513b.