### PR TITLE
fix for panel height when embedding 

### DIFF
--- a/public/app/features/panel/partials/soloPanel.html
+++ b/public/app/features/panel/partials/soloPanel.html
@@ -1,5 +1,4 @@
-<div class="panel panel--solo" ng-if="panel" style="width: 100%">
+<div class="panel-solo" ng-if="panel">
 	<plugin-component type="panel">
 	</plugin-component>
 </div>
-<div class="clearfix"></div>

--- a/public/sass/base/_type.scss
+++ b/public/sass/base/_type.scss
@@ -199,7 +199,6 @@ small,
 
 mark,
 .mark {
-  padding: 0.2em;
   background: $alert-warning-bg;
 }
 

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -19,16 +19,23 @@ div.flot-text {
 
 .panel {
   height: 100%;
+}
 
-  &--solo {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    margin: 0;
-    .panel-container {
-      border: none;
-      z-index: $zindex-sidemenu + 1;
-    }
+.panel-solo {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  margin: 0;
+  left: 0;
+  top: 0;
+
+  .panel-container {
+    border: none;
+  }
+
+  .panel-menu-toggle,
+  .panel-menu {
+    display: none;
   }
 }
 


### PR DESCRIPTION
fixes #14284

Caused by panel height changes in panel directive (now more css based. before it was more forced via code). 

The issue was related to a media query that was designed for the grid & mobile views. That grid related class should not be used in solo view so decoupling the styles (class names) used for grid panel and solo panel (when it comes to this outer class). In develop branch I have done more changes related to this, so panel class can go away. 
