### PR TITLE
redact value for plugin proxy routes

### DIFF
--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -87,7 +87,7 @@ func NewApiPluginProxy(ctx *m.ReqContext, proxyPath string, route *plugins.AppPl
 			}
 
 			for key, value := range headers {
-				log.Trace("setting key %v value %v", key, value[0])
+				log.Trace("setting key %v value <redacted>", key)
 				req.Header.Set(key, value[0])
 			}
 		}


### PR DESCRIPTION
Simple fix for issue #14319 

Alternatively it could output a hash of the value, or another method to mask the value in the log.
