### PR TITLE
Generic timeseries tooltip

### DIFF
--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,19 +1,16 @@
 import React, { PureComponent, CSSProperties } from 'react';
 import withTimeSeriesTooltip, {
   TimeSeriesTooltipProps,
-  InjectedTooltipProps,
+  InjectedTimeSeriesTooltipProps,
   TimeSeriesTooltipState,
 } from './TimeSeriesTooltip';
 import { TimeSeriesVM } from 'app/types';
 
-interface GraphTooltipSpecificProps {}
+export interface GraphTooltipProps extends TimeSeriesTooltipProps {}
 
-interface GraphTooltipSpecificState {}
+export interface GraphTooltipState extends TimeSeriesTooltipState {}
 
-export type GraphTooltipProps = TimeSeriesTooltipProps & GraphTooltipSpecificProps;
-export type GraphTooltipState = TimeSeriesTooltipState & GraphTooltipSpecificState;
-
-export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedTooltipProps, GraphTooltipState> {
+export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedTimeSeriesTooltipProps, GraphTooltipState> {
   constructor(props) {
     super(props);
   }

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -3,33 +3,39 @@ import { TimeSeriesVM } from 'app/types';
 import { FlotHoverItem } from 'app/types/events';
 import { PlotHoverInfoItem } from './utils';
 import { TimeAxisTooltipProps } from './TimeAxisTooltip';
-import TimeSeriesTooltip, { InjectedTimeSeriesTooltipProps, TimeSeriesTooltipProps } from './TimeSeriesTooltip';
+import TimeSeriesTooltip, { TimeSeriesTooltipProps } from './TimeSeriesTooltip';
 
 export interface GraphTooltipContentProps {
   formatDate: (time, format?) => string;
 }
 
-type ComponentProps = GraphTooltipContentProps & InjectedTimeSeriesTooltipProps;
+export type GraphTooltipProps = GraphTooltipContentProps & TimeSeriesTooltipProps & TimeAxisTooltipProps;
 
-export class GraphTooltipContent extends PureComponent<ComponentProps> {
+export class GraphTooltip extends PureComponent<GraphTooltipProps> {
   render() {
-    const { series, hoverInfo, item, timestamp, formatDate } = this.props;
-    let timeFormat = 'YYYY-MM-DD HH:mm:ss';
-    if (series && series.length && series[0].stats.hasMsResolution) {
-      timeFormat += '.SSS';
-    }
-    const absoluteTime = formatDate(timestamp, timeFormat);
-    const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
-    const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (
-      <TooltipSeries key={index} hoverItem={hoverItem} seriesList={series} item={item} />
-    ));
+    return (
+      <TimeSeriesTooltip {...this.props}>
+        {(series, item, timestamp, hoverInfo) => {
+          let timeFormat = 'YYYY-MM-DD HH:mm:ss';
+          if (series && series.length && series[0].stats.hasMsResolution) {
+            timeFormat += '.SSS';
+          }
+          const absoluteTime = this.props.formatDate(timestamp, timeFormat);
 
-    return [
-      <div className="graph-tooltip-time timeseries-tooltip-time" key="time">
-        {absoluteTime}
-      </div>,
-      ...seriesItems,
-    ];
+          const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
+          const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (
+            <TooltipSeries key={index} hoverItem={hoverItem} seriesList={series} item={item} />
+          ));
+
+          return [
+            <div className="graph-tooltip-time timeseries-tooltip-time" key="time">
+              {absoluteTime}
+            </div>,
+            ...seriesItems,
+          ];
+        }}
+      </TimeSeriesTooltip>
+    );
   }
 }
 
@@ -58,26 +64,6 @@ class TooltipSeries extends PureComponent<TooltipSeriesProps> {
         </div>
         <div className="graph-tooltip-value">{value}</div>
       </div>
-    );
-  }
-}
-
-export type GraphTooltipProps = GraphTooltipContentProps & TimeSeriesTooltipProps & TimeAxisTooltipProps;
-
-export class GraphTooltip extends PureComponent<GraphTooltipProps> {
-  render() {
-    return (
-      <TimeSeriesTooltip {...this.props}>
-        {(series, item, timestamp, hoverInfo) => (
-          <GraphTooltipContent
-            {...this.props}
-            series={series}
-            item={item}
-            timestamp={timestamp}
-            hoverInfo={hoverInfo}
-          />
-        )}
-      </TimeSeriesTooltip>
     );
   }
 }

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,14 +1,14 @@
 import React, { PureComponent, CSSProperties } from 'react';
 import { TimeSeriesVM } from 'app/types';
 import { FlotHoverItem } from 'app/types/events';
-import withTimeSeriesTooltip, { InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
+import TimeSeriesTooltip, { TimeSeriesTooltipProps, InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
 import { PlotHoverInfoItem } from './utils';
 
-export interface GraphTooltipProps extends InjectedTimeSeriesTooltipProps {
+export interface GraphTooltipProps extends TimeSeriesTooltipProps {
   formatDate: (time, format?) => string;
 }
 
-export class GraphTooltip extends PureComponent<GraphTooltipProps> {
+export class GraphTooltipContent extends PureComponent<GraphTooltipProps & InjectedTimeSeriesTooltipProps> {
   render() {
     const { series, hoverInfo, item, timestamp, formatDate } = this.props;
     let timeFormat = 'YYYY-MM-DD HH:mm:ss';
@@ -59,4 +59,23 @@ class TooltipSeries extends PureComponent<TooltipSeriesProps> {
   }
 }
 
-export default withTimeSeriesTooltip(GraphTooltip);
+export class GraphTooltip extends PureComponent<GraphTooltipProps> {
+  render() {
+    return (
+      <TimeSeriesTooltip
+        {...this.props}
+        render={(series, item, timestamp, hoverInfo) => (
+          <GraphTooltipContent
+            {...this.props}
+            series={series}
+            item={item}
+            timestamp={timestamp}
+            hoverInfo={hoverInfo}
+          />
+        )}
+      />
+    );
+  }
+}
+
+export default GraphTooltip;

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -23,7 +23,7 @@ export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedTool
     const timeFormat = 'YYYY-MM-DD HH:mm:ss';
     // const time = this.props.position.x;
     const time = this.props.timestamp;
-    const absoluteTime = this.props.dateFormat(time, timeFormat);
+    const absoluteTime = this.props.formatDate(time, timeFormat);
     const seriesItems = this.props.series.map((series, index) => <TooltipSeries key={index} {...series} />);
 
     return [

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -22,11 +22,12 @@ export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedGrap
 
   render() {
     // console.log('render <GraphTooltip />');
-    const { series, item, timestamp } = this.props;
+    const { series, hoverInfo, item, timestamp } = this.props;
     const timeFormat = 'YYYY-MM-DD HH:mm:ss';
     // const time = this.props.position.x;
     const absoluteTime = this.props.formatDate(timestamp, timeFormat);
-    const seriesItems = this.props.hoverInfo.map((hoverItem, index) => (
+    const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
+    const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (
       <TooltipSeries key={index} hoverItem={hoverItem} seriesList={series} item={item} />
     ));
 

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -62,9 +62,8 @@ class TooltipSeries extends PureComponent<TooltipSeriesProps> {
 export class GraphTooltip extends PureComponent<GraphTooltipProps> {
   render() {
     return (
-      <TimeSeriesTooltip
-        {...this.props}
-        render={(series, item, timestamp, hoverInfo) => (
+      <TimeSeriesTooltip {...this.props}>
+        {(series, item, timestamp, hoverInfo) => (
           <GraphTooltipContent
             {...this.props}
             series={series}
@@ -73,7 +72,7 @@ export class GraphTooltip extends PureComponent<GraphTooltipProps> {
             hoverInfo={hoverInfo}
           />
         )}
-      />
+      </TimeSeriesTooltip>
     );
   }
 }

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,8 +1,8 @@
 import React, { PureComponent, CSSProperties } from 'react';
-import withTimeSeriesTooltip, { InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
 import { TimeSeriesVM } from 'app/types';
-import { PlotHoverInfoItem } from './utils';
 import { FlotHoverItem } from 'app/types/events';
+import withTimeSeriesTooltip, { InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
+import { PlotHoverInfoItem } from './utils';
 
 export interface GraphTooltipProps extends InjectedTimeSeriesTooltipProps {
   formatDate: (time, format?) => string;
@@ -11,7 +11,10 @@ export interface GraphTooltipProps extends InjectedTimeSeriesTooltipProps {
 export class GraphTooltip extends PureComponent<GraphTooltipProps> {
   render() {
     const { series, hoverInfo, item, timestamp, formatDate } = this.props;
-    const timeFormat = 'YYYY-MM-DD HH:mm:ss';
+    let timeFormat = 'YYYY-MM-DD HH:mm:ss';
+    if (series && series.length && series[0].stats.hasMsResolution) {
+      timeFormat += '.SSS';
+    }
     const absoluteTime = formatDate(timestamp, timeFormat);
     const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
     const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, CSSProperties } from 'react';
-import { TimeSeriesVM } from 'app/types';
+// import { TimeSeriesVM } from 'app/types';
 import { FlotHoverItem } from 'app/types/events';
 import { PlotHoverInfoItem } from './utils';
 import { TimeAxisTooltipProps } from './TimeAxisTooltip';
@@ -12,55 +12,59 @@ export interface GraphTooltipContentProps {
 export type GraphTooltipProps = GraphTooltipContentProps & TimeSeriesTooltipProps & TimeAxisTooltipProps;
 
 export class GraphTooltip extends PureComponent<GraphTooltipProps> {
+  renderGraphTooltip = (seriesList, item: FlotHoverItem, timestamp: number, hoverInfo: PlotHoverInfoItem[]) => {
+    let timeFormat = 'YYYY-MM-DD HH:mm:ss';
+    if (seriesList && seriesList.length && seriesList[0].stats.hasMsResolution) {
+      timeFormat += '.SSS';
+    }
+    const absoluteTime = this.props.formatDate(timestamp, timeFormat);
+
+    const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
+    const seriesItems = hoverInfoFiltered.map((hoverItem, index) => {
+      const series = seriesList[hoverItem.index];
+      const value = series.formatValue(hoverItem.value);
+      const highlightItem = item && hoverItem.index === item.seriesIndex;
+      return (
+        <TooltipSeries
+          key={index}
+          label={hoverItem.label}
+          color={hoverItem.color}
+          value={value}
+          highlight={highlightItem}
+        />
+      );
+    });
+
+    return [
+      <div className="graph-tooltip-time timeseries-tooltip-time" key="time">
+        {absoluteTime}
+      </div>,
+      ...seriesItems,
+    ];
+  };
+
   render() {
-    return (
-      <TimeSeriesTooltip {...this.props}>
-        {(series, item, timestamp, hoverInfo) => {
-          let timeFormat = 'YYYY-MM-DD HH:mm:ss';
-          if (series && series.length && series[0].stats.hasMsResolution) {
-            timeFormat += '.SSS';
-          }
-          const absoluteTime = this.props.formatDate(timestamp, timeFormat);
-
-          const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
-          const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (
-            <TooltipSeries key={index} hoverItem={hoverItem} seriesList={series} item={item} />
-          ));
-
-          return [
-            <div className="graph-tooltip-time timeseries-tooltip-time" key="time">
-              {absoluteTime}
-            </div>,
-            ...seriesItems,
-          ];
-        }}
-      </TimeSeriesTooltip>
-    );
+    return <TimeSeriesTooltip {...this.props}>{this.renderGraphTooltip}</TimeSeriesTooltip>;
   }
 }
 
 interface TooltipSeriesProps {
-  seriesList: TimeSeriesVM[] | any;
-  hoverItem: PlotHoverInfoItem;
-  item: FlotHoverItem;
+  label: string;
+  color: string;
+  value: string;
+  highlight?: boolean;
 }
 
 class TooltipSeries extends PureComponent<TooltipSeriesProps> {
   render() {
-    const { seriesList, hoverItem, item } = this.props;
-    const series = seriesList[hoverItem.index];
-    const value = series.formatValue(hoverItem.value);
-    const highlightItem = item && hoverItem.index === item.seriesIndex;
-
-    const iconStyle: CSSProperties = {
-      color: hoverItem.color,
-    };
+    const { label, color, value, highlight } = this.props;
+    const iconStyle: CSSProperties = { color };
 
     return (
-      <div className={`graph-tooltip-list-item ${highlightItem && 'graph-tooltip-list-item--highlight'}`}>
+      <div className={`graph-tooltip-list-item ${highlight && 'graph-tooltip-list-item--highlight'}`}>
         <div className="graph-tooltip-series-name">
           <i className="fa fa-minus" style={iconStyle} />
-          &nbsp;{hoverItem.label}:
+          &nbsp;{label}:
         </div>
         <div className="graph-tooltip-value">{value}</div>
       </div>

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,0 +1,57 @@
+import React, { PureComponent, CSSProperties } from 'react';
+import withTimeSeriesTooltip, {
+  TimeSeriesTooltipProps,
+  InjectedTooltipProps,
+  TimeSeriesTooltipState,
+} from './TimeSeriesTooltip';
+import { TimeSeriesVM } from 'app/types';
+
+interface GraphTooltipSpecificProps {}
+
+interface GraphTooltipSpecificState {}
+
+export type GraphTooltipProps = TimeSeriesTooltipProps & GraphTooltipSpecificProps;
+export type GraphTooltipState = TimeSeriesTooltipState & GraphTooltipSpecificState;
+
+export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedTooltipProps, GraphTooltipState> {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    // console.log('render <GraphTooltip />');
+    const timeFormat = 'YYYY-MM-DD HH:mm:ss';
+    // const time = this.props.position.x;
+    const time = this.props.timestamp;
+    const absoluteTime = this.props.dateFormat(time, timeFormat);
+    const seriesItems = this.props.series.map((series, index) => <TooltipSeries key={index} {...series} />);
+
+    return [
+      <div className="graph-tooltip-time timeseries-tooltip-time" key="time">
+        {absoluteTime}
+      </div>,
+      ...seriesItems,
+    ];
+  }
+}
+
+type TooltipSeriesProps = TimeSeriesVM;
+
+class TooltipSeries extends PureComponent<TooltipSeriesProps> {
+  render() {
+    const iconStyle: CSSProperties = {
+      color: this.props.color,
+    };
+
+    return (
+      <div className="graph-tooltip-list-item">
+        <div className="graph-tooltip-series-name">
+          <i className="fa fa-minus" style={iconStyle} />
+          &nbsp;{this.props.label}:
+        </div>
+      </div>
+    );
+  }
+}
+
+export default withTimeSeriesTooltip(GraphTooltip);

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,31 +1,18 @@
 import React, { PureComponent, CSSProperties } from 'react';
-import withTimeSeriesTooltip, {
-  TimeSeriesTooltipProps,
-  InjectedTimeSeriesTooltipProps,
-  TimeSeriesTooltipState,
-} from './TimeSeriesTooltip';
+import withTimeSeriesTooltip, { InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
 import { TimeSeriesVM } from 'app/types';
 import { PlotHoverInfoItem } from './utils';
 import { FlotHoverItem } from 'app/types/events';
-import { InjectedTimeAxisTooltipProps } from './TimeAxisTooltip';
 
-export interface GraphTooltipProps extends TimeSeriesTooltipProps {}
+export interface GraphTooltipProps extends InjectedTimeSeriesTooltipProps {
+  formatDate: (time, format?) => string;
+}
 
-export interface GraphTooltipState extends TimeSeriesTooltipState {}
-
-type InjectedGraphTooltipProps = InjectedTimeSeriesTooltipProps & InjectedTimeAxisTooltipProps;
-
-export class GraphTooltip extends PureComponent<GraphTooltipProps & InjectedGraphTooltipProps, GraphTooltipState> {
-  constructor(props) {
-    super(props);
-  }
-
+export class GraphTooltip extends PureComponent<GraphTooltipProps> {
   render() {
-    // console.log('render <GraphTooltip />');
-    const { series, hoverInfo, item, timestamp } = this.props;
+    const { series, hoverInfo, item, timestamp, formatDate } = this.props;
     const timeFormat = 'YYYY-MM-DD HH:mm:ss';
-    // const time = this.props.position.x;
-    const absoluteTime = this.props.formatDate(timestamp, timeFormat);
+    const absoluteTime = formatDate(timestamp, timeFormat);
     const hoverInfoFiltered = hoverInfo.filter(hoverItem => !hoverItem.hidden);
     const seriesItems = hoverInfoFiltered.map((hoverItem, index) => (
       <TooltipSeries key={index} hoverItem={hoverItem} seriesList={series} item={item} />
@@ -48,7 +35,6 @@ interface TooltipSeriesProps {
 
 class TooltipSeries extends PureComponent<TooltipSeriesProps> {
   render() {
-    // console.log(this.props);
     const { seriesList, hoverItem, item } = this.props;
     const series = seriesList[hoverItem.index];
     const value = series.formatValue(hoverItem.value);

--- a/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/GraphTooltip.tsx
@@ -1,14 +1,17 @@
 import React, { PureComponent, CSSProperties } from 'react';
 import { TimeSeriesVM } from 'app/types';
 import { FlotHoverItem } from 'app/types/events';
-import TimeSeriesTooltip, { TimeSeriesTooltipProps, InjectedTimeSeriesTooltipProps } from './TimeSeriesTooltip';
 import { PlotHoverInfoItem } from './utils';
+import { TimeAxisTooltipProps } from './TimeAxisTooltip';
+import TimeSeriesTooltip, { InjectedTimeSeriesTooltipProps, TimeSeriesTooltipProps } from './TimeSeriesTooltip';
 
-export interface GraphTooltipProps extends TimeSeriesTooltipProps {
+export interface GraphTooltipContentProps {
   formatDate: (time, format?) => string;
 }
 
-export class GraphTooltipContent extends PureComponent<GraphTooltipProps & InjectedTimeSeriesTooltipProps> {
+type ComponentProps = GraphTooltipContentProps & InjectedTimeSeriesTooltipProps;
+
+export class GraphTooltipContent extends PureComponent<ComponentProps> {
   render() {
     const { series, hoverInfo, item, timestamp, formatDate } = this.props;
     let timeFormat = 'YYYY-MM-DD HH:mm:ss';
@@ -58,6 +61,8 @@ class TooltipSeries extends PureComponent<TooltipSeriesProps> {
     );
   }
 }
+
+export type GraphTooltipProps = GraphTooltipContentProps & TimeSeriesTooltipProps & TimeAxisTooltipProps;
 
 export class GraphTooltip extends PureComponent<GraphTooltipProps> {
   render() {

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -1,0 +1,221 @@
+import React, { PureComponent, CSSProperties } from 'react';
+import ReactDOM from 'react-dom';
+import { GraphHoverPosition, GraphHoverEvent, FlotPosition } from 'app/types/events';
+import { Subtract } from 'app/types/utils';
+import { appEvents } from 'app/core/core';
+
+export interface TimeAxisTooltipProps {
+  chartElem: any;
+  panelId: number;
+  sharedTooltip?: boolean;
+  /** Event which tooltip is showing on. Default is 'plothover' */
+  hoverEvent?: string;
+  /** Use CSS transform: translate() for positioning tooltip. If false, top/left will be used instead. */
+  useCSSTransforms?: boolean;
+  formatDate: (time, format?) => string;
+  /** Function converting timestamp into offset on chart */
+  getOffset: (x) => number;
+  onMouseleave?: (event?) => void;
+}
+
+export interface TimeAxisTooltipState {
+  show: boolean;
+  position?: GraphHoverPosition;
+  tooltipPosition?: { x: number; y: number };
+}
+
+const defaultPosition: GraphHoverPosition = {
+  pageX: 0,
+  pageY: 0,
+  x: 0,
+  y: 0,
+};
+
+export interface InjectedTimeAxisTooltipProps {
+  position: GraphHoverPosition;
+}
+
+interface TooltipSize {
+  width: number;
+  height: number;
+}
+
+const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
+  return class TimeAxisTooltip extends PureComponent<Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps, TimeAxisTooltipState> {
+    appRoot: HTMLElement;
+    tooltipContainer: HTMLElement;
+    tooltipElem: HTMLElement;
+    size: TooltipSize;
+
+    static defaultProps: Partial<TimeAxisTooltipProps> = {
+      hoverEvent: 'plothover',
+      useCSSTransforms: true,
+      sharedTooltip: false,
+    };
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        show: false,
+        position: defaultPosition,
+        tooltipPosition: { x: 0, y: 0 },
+      };
+
+      this.appRoot = document.body;
+      this.tooltipContainer = document.body;
+    }
+
+    getTooltipRef = ref => {
+      this.tooltipElem = ref;
+    };
+
+    componentDidMount() {
+      // this.appRoot = document.getElementsByClassName('dashboard-container')[0];
+      this.bindEvents();
+    }
+
+    componentWillUnmount() {
+      this.unbindEvents();
+    }
+
+    bindEvents() {
+      this.props.chartElem.on(this.props.hoverEvent, this.handleHoverEvent);
+      this.props.chartElem.on('mouseleave', this.handleMouseleave);
+      appEvents.on('graph-hover', this.handleGraphHoverEvent);
+      appEvents.on('graph-hover-clear', this.handleHoverClear);
+    }
+
+    unbindEvents() {
+      this.props.chartElem.off(this.props.hoverEvent);
+      this.props.chartElem.off('mouseleave');
+      appEvents.off('graph-hover', this.handleGraphHoverEvent);
+      appEvents.off('graph-hover-clear', this.handleHoverClear);
+    }
+
+    handleHoverEvent = (event, position: FlotPosition, item) => {
+      // console.log(position);
+      this.show(position);
+    };
+
+    handleGraphHoverEvent = (event: GraphHoverEvent) => {
+      // ignore if we are the emitter
+      if (!this.props.sharedTooltip || this.props.panelId === event.panel.id) {
+        if (this.state.show) {
+          this.hide();
+        }
+        return;
+      }
+      const position = { ...event.pos };
+      const elemOffset = this.getElemOffset();
+      position.pageX = this.props.getOffset(position.x) + elemOffset.left;
+      // console.log(event.pos.pageX);
+      this.show(position);
+    };
+
+    handleMouseleave = event => {
+      this.hide();
+      this.props.onMouseleave(event);
+    };
+
+    handleHoverClear = () => {
+      this.hide();
+    };
+
+    show(position: GraphHoverPosition) {
+      const tooltipPosition = this.calculatePosition(this.state.position);
+      if (tooltipPosition.x < 0 || tooltipPosition.y < 0) {
+        this.setState({ show: false });
+      }
+      this.setState({
+        show: true,
+        position: position,
+        tooltipPosition: tooltipPosition,
+      });
+    }
+
+    hide() {
+      this.setState({ show: false });
+    }
+
+    calculatePosition(hoverEventPos: GraphHoverPosition): { x: number; y: number } {
+      const elemHeight = this.props.chartElem[0].clientHeight;
+      const elemWidth = this.props.chartElem[0].clientWidth;
+      const elemOffset = this.getElemOffset();
+      // const positionOffset = this.props.getOffset(hoverEventPos.x);
+      // console.log(hoverEventPos.x, positionOffset);
+      const tooltipSize = this.size || this.getTooltipSize();
+
+      // Restrict tooltip position
+      let x = hoverEventPos.pageX;
+      if (x + tooltipSize.width > elemWidth + elemOffset.left) {
+        x = elemWidth + elemOffset.left - tooltipSize.width;
+      }
+      if (x < elemOffset.left) {
+        x = elemOffset.left;
+      }
+
+      let y = elemHeight + elemOffset.top;
+      const appRootHeight = this.getAppRootHeight();
+      if (y + tooltipSize.height > appRootHeight) {
+        y = appRootHeight - tooltipSize.height;
+      }
+
+      // Make some CPU throttling
+      // for (let index = 0; index < 5000000; index++) {
+      //   Math.sqrt(Math.random());
+      // }
+
+      return { x, y };
+    }
+
+    getTooltipSize(): TooltipSize {
+      const size = {
+        width: this.tooltipElem && this.tooltipElem.clientWidth,
+        height: this.tooltipElem && this.tooltipElem.clientHeight,
+      };
+      if (size.height && size.width) {
+        this.size = size;
+      }
+      return {
+        width: size.width || 0,
+        height: size.height || 0,
+      };
+    }
+
+    getAppRootHeight() {
+      return (this.appRoot && this.appRoot.clientHeight) || 0;
+    }
+
+    getElemOffset(): { left: number; top: number } {
+      // TODO: make it working for both JQuery and HTML elements
+      const offset = this.props.chartElem.offset();
+      return offset;
+    }
+
+    render() {
+      const tooltipPos = this.state.tooltipPosition;
+      const tooltipStyle: CSSProperties = this.props.useCSSTransforms
+        ? {
+          transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
+        }
+        : {
+          left: tooltipPos.x,
+          top: tooltipPos.y,
+        };
+
+      if (!this.state.show) {
+        tooltipStyle.display = 'none';
+      }
+
+      const tooltipNode = (
+        <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
+          <WrappedComponent position={this.state.position} {...this.props} />
+        </div>
+      );
+      return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);
+    }
+  };
+};
+
+export default withTimeAxisTooltip;

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -4,6 +4,8 @@ import { GraphHoverPosition, GraphHoverEvent, FlotPosition } from 'app/types/eve
 import { Subtract } from 'app/types/utils';
 import { appEvents } from 'app/core/core';
 
+const TOOLTIP_OFFSET = 20;
+
 export interface TimeAxisTooltipProps {
   chartElem: any;
   panelId: number;
@@ -41,7 +43,10 @@ interface TooltipSize {
 }
 
 const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
-  return class TimeAxisTooltip extends PureComponent<Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps, TimeAxisTooltipState> {
+  return class TimeAxisTooltip extends PureComponent<
+    Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps,
+    TimeAxisTooltipState
+  > {
     appRoot: HTMLElement;
     tooltipContainer: HTMLElement;
     tooltipElem: HTMLElement;
@@ -147,7 +152,7 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       const tooltipSize = this.size || this.getTooltipSize();
 
       // Restrict tooltip position
-      let x = hoverEventPos.pageX;
+      let x = hoverEventPos.pageX + TOOLTIP_OFFSET;
       if (x + tooltipSize.width > elemWidth + elemOffset.left) {
         x = elemWidth + elemOffset.left - tooltipSize.width;
       }
@@ -197,12 +202,12 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       const tooltipPos = this.state.tooltipPosition;
       const tooltipStyle: CSSProperties = this.props.useCSSTransforms
         ? {
-          transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
-        }
+            transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
+          }
         : {
-          left: tooltipPos.x,
-          top: tooltipPos.y,
-        };
+            left: tooltipPos.x,
+            top: tooltipPos.y,
+          };
 
       if (!this.state.show) {
         tooltipStyle.display = 'none';

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -2,7 +2,6 @@ import React, { PureComponent, ReactNode, CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
 import { appEvents } from 'app/core/core';
 import { GraphHoverPosition, GraphHoverEvent, FlotPosition, FlotHoverItem } from 'app/types/events';
-// import { Subtract } from 'app/types/utils';
 
 const TOOLTIP_OFFSET = 20;
 
@@ -30,13 +29,6 @@ export interface TimeAxisTooltipState {
   item?: FlotHoverItem;
 }
 
-const defaultPosition: GraphHoverPosition = {
-  pageX: 0,
-  pageY: 0,
-  x: 0,
-  y: 0,
-};
-
 export interface InjectedTimeAxisTooltipProps {
   position: GraphHoverPosition;
   item: FlotHoverItem;
@@ -47,13 +39,16 @@ interface TooltipSize {
   height: number;
 }
 
-/**
- * Finally, withTimeAxisTooltip(WrappedComponent) should have all props that TimeAxisTooltip has and props passed into
- * WrappedComponent, but without injected props.
- */
-// export type WithTimeAxisTooltipProps<P> = Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps;
+const defaultPosition: GraphHoverPosition = {
+  pageX: 0,
+  pageY: 0,
+  x: 0,
+  y: 0,
+};
 
-class TimeAxisTooltip extends PureComponent<TimeAxisTooltipProps & TimeAxisTooltipRenderProps, TimeAxisTooltipState> {
+type ComponentProps = TimeAxisTooltipProps & TimeAxisTooltipRenderProps;
+
+export class TimeAxisTooltip extends PureComponent<ComponentProps, TimeAxisTooltipState> {
   appRoot: HTMLElement;
   tooltipContainer: HTMLElement;
   tooltipElem: HTMLElement;

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -108,13 +108,12 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
 
     handleGraphHoverEvent = (event: GraphHoverEvent) => {
       // ignore if we are the emitter
-      if (!this.props.sharedTooltip || this.props.panelId === event.panel.id) {
+      if (!this.props.sharedTooltip || this.props.panelId === event.panel.id || this.isElemHidden()) {
         return;
       }
       const position = { ...event.pos };
       const elemOffset = this.getElemOffset();
       position.pageX = this.props.getOffset(position.x) + elemOffset.left;
-      // console.log(event.pos.pageX);
       this.show(position);
     };
 
@@ -198,6 +197,14 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       return offset;
     }
 
+    isElemHidden(): boolean {
+      const { chartElem } = this.props;
+      if (chartElem && chartElem[0]) {
+        return chartElem[0].clientWidth === 0 || chartElem[0].clientHeight === 0;
+      }
+      return false;
+    }
+
     render() {
       // Cut the own component props and pass through the rest.
       const {
@@ -212,15 +219,12 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       } = this.props as TimeAxisTooltipProps;
 
       const tooltipPos = this.state.tooltipPosition;
-      const tooltipStyle: CSSProperties = this.props.useCSSTransforms
-        ? {
-            transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
-          }
-        : {
-            left: tooltipPos.x,
-            top: tooltipPos.y,
-          };
-
+      let tooltipStyle: CSSProperties;
+      if (this.props.useCSSTransforms) {
+        tooltipStyle = { transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)` };
+      } else {
+        tooltipStyle = { left: tooltipPos.x, top: tooltipPos.y };
+      }
       if (!this.state.show) {
         tooltipStyle.display = 'none';
       }

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -106,9 +106,6 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
     handleGraphHoverEvent = (event: GraphHoverEvent) => {
       // ignore if we are the emitter
       if (!this.props.sharedTooltip || this.props.panelId === event.panel.id) {
-        if (this.state.show) {
-          this.hide();
-        }
         return;
       }
       const position = { ...event.pos };
@@ -148,7 +145,6 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       const elemWidth = this.props.chartElem[0].clientWidth;
       const elemOffset = this.getElemOffset();
       // const positionOffset = this.props.getOffset(hoverEventPos.x);
-      // console.log(hoverEventPos.x, positionOffset);
       const tooltipSize = this.size || this.getTooltipSize();
 
       // Restrict tooltip position
@@ -163,7 +159,7 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       let y = elemHeight + elemOffset.top;
       const appRootHeight = this.getAppRootHeight();
       if (y + tooltipSize.height > appRootHeight) {
-        y = appRootHeight - tooltipSize.height;
+        y = tooltipSize.height ? appRootHeight - tooltipSize.height : 0;
       }
 
       // Make some CPU throttling
@@ -211,6 +207,10 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
 
       if (!this.state.show) {
         tooltipStyle.display = 'none';
+      }
+      if (!this.size) {
+        // Hide tooltip on its initial position (it cannot be calculated properly due to tooltip size equals 0)
+        tooltipStyle.opacity = 0;
       }
 
       const tooltipNode = (

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent, CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
-import { GraphHoverPosition, GraphHoverEvent, FlotPosition } from 'app/types/events';
+import { GraphHoverPosition, GraphHoverEvent, FlotPosition, FlotHoverItem } from 'app/types/events';
 import { Subtract } from 'app/types/utils';
 import { appEvents } from 'app/core/core';
 
@@ -24,6 +24,7 @@ export interface TimeAxisTooltipState {
   show: boolean;
   position?: GraphHoverPosition;
   tooltipPosition?: { x: number; y: number };
+  item?: FlotHoverItem;
 }
 
 const defaultPosition: GraphHoverPosition = {
@@ -35,6 +36,7 @@ const defaultPosition: GraphHoverPosition = {
 
 export interface InjectedTimeAxisTooltipProps {
   position: GraphHoverPosition;
+  item?: FlotHoverItem;
 }
 
 interface TooltipSize {
@@ -98,9 +100,8 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       appEvents.off('graph-hover-clear', this.handleHoverClear);
     }
 
-    handleHoverEvent = (event, position: FlotPosition, item) => {
-      // console.log(position);
-      this.show(position);
+    handleHoverEvent = (event, position: FlotPosition, item: FlotHoverItem) => {
+      this.show(position, item);
     };
 
     handleGraphHoverEvent = (event: GraphHoverEvent) => {
@@ -124,7 +125,7 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       this.hide();
     };
 
-    show(position: GraphHoverPosition) {
+    show(position: GraphHoverPosition, item?: FlotHoverItem) {
       const tooltipPosition = this.calculatePosition(this.state.position);
       if (tooltipPosition.x < 0 || tooltipPosition.y < 0) {
         this.setState({ show: false });
@@ -133,6 +134,7 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
         show: true,
         position: position,
         tooltipPosition: tooltipPosition,
+        item: item,
       });
     }
 
@@ -215,7 +217,7 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
 
       const tooltipNode = (
         <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
-          <WrappedComponent position={this.state.position} {...this.props} />
+          <WrappedComponent position={this.state.position} item={this.state.item} {...this.props} />
         </div>
       );
       return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -1,8 +1,8 @@
-import React, { PureComponent, CSSProperties } from 'react';
+import React, { PureComponent, ReactNode, CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
 import { appEvents } from 'app/core/core';
 import { GraphHoverPosition, GraphHoverEvent, FlotPosition, FlotHoverItem } from 'app/types/events';
-import { Subtract } from 'app/types/utils';
+// import { Subtract } from 'app/types/utils';
 
 const TOOLTIP_OFFSET = 20;
 
@@ -17,6 +17,10 @@ export interface TimeAxisTooltipProps {
   /** Function converting timestamp into offset on chart */
   getOffset: (x) => number;
   onMouseleave?: (event?) => void;
+}
+
+interface TimeAxisTooltipRenderProps {
+  render: (position: GraphHoverPosition, item: FlotHoverItem) => ReactNode;
 }
 
 export interface TimeAxisTooltipState {
@@ -47,195 +51,181 @@ interface TooltipSize {
  * Finally, withTimeAxisTooltip(WrappedComponent) should have all props that TimeAxisTooltip has and props passed into
  * WrappedComponent, but without injected props.
  */
-export type WithTimeAxisTooltipProps<P> = Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps;
+// export type WithTimeAxisTooltipProps<P> = Subtract<P, InjectedTimeAxisTooltipProps> & TimeAxisTooltipProps;
 
-const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
-  return class TimeAxisTooltip extends PureComponent<WithTimeAxisTooltipProps<P>, TimeAxisTooltipState> {
-    appRoot: HTMLElement;
-    tooltipContainer: HTMLElement;
-    tooltipElem: HTMLElement;
-    size: TooltipSize;
+class TimeAxisTooltip extends PureComponent<TimeAxisTooltipProps & TimeAxisTooltipRenderProps, TimeAxisTooltipState> {
+  appRoot: HTMLElement;
+  tooltipContainer: HTMLElement;
+  tooltipElem: HTMLElement;
+  size: TooltipSize;
 
-    static defaultProps: Partial<TimeAxisTooltipProps> = {
-      hoverEvent: 'plothover',
-      useCSSTransforms: true,
-      sharedTooltip: false,
+  static defaultProps: Partial<TimeAxisTooltipProps> = {
+    hoverEvent: 'plothover',
+    useCSSTransforms: true,
+    sharedTooltip: false,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      show: false,
+      position: defaultPosition,
+      tooltipPosition: { x: 0, y: 0 },
     };
 
-    constructor(props) {
-      super(props);
+    this.appRoot = document.body;
+    this.tooltipContainer = document.body;
+  }
 
-      this.state = {
-        show: false,
-        position: defaultPosition,
-        tooltipPosition: { x: 0, y: 0 },
-      };
+  getTooltipRef = ref => {
+    this.tooltipElem = ref;
+  };
 
-      this.appRoot = document.body;
-      this.tooltipContainer = document.body;
+  componentDidMount() {
+    // this.appRoot = document.getElementsByClassName('dashboard-container')[0];
+    this.bindEvents();
+  }
+
+  componentWillUnmount() {
+    this.unbindEvents();
+  }
+
+  bindEvents() {
+    this.props.chartElem.on(this.props.hoverEvent, this.handleHoverEvent);
+    this.props.chartElem.on('mouseleave', this.handleMouseleave);
+    appEvents.on('graph-hover', this.handleGraphHoverEvent);
+    appEvents.on('graph-hover-clear', this.handleHoverClear);
+  }
+
+  unbindEvents() {
+    this.props.chartElem.off(this.props.hoverEvent);
+    this.props.chartElem.off('mouseleave');
+    appEvents.off('graph-hover', this.handleGraphHoverEvent);
+    appEvents.off('graph-hover-clear', this.handleHoverClear);
+  }
+
+  handleHoverEvent = (event, position: FlotPosition, item?: FlotHoverItem) => {
+    this.show(position, item);
+  };
+
+  handleGraphHoverEvent = (event: GraphHoverEvent) => {
+    // ignore if we are the emitter
+    if (!this.props.sharedTooltip || this.props.panelId === event.panel.id || this.isElemHidden()) {
+      return;
     }
+    const position = { ...event.pos };
+    const elemOffset = this.getElemOffset();
+    position.pageX = this.props.getOffset(position.x) + elemOffset.left;
+    this.show(position);
+  };
 
-    getTooltipRef = ref => {
-      this.tooltipElem = ref;
-    };
+  handleMouseleave = event => {
+    this.hide();
+    this.props.onMouseleave(event);
+  };
 
-    componentDidMount() {
-      // this.appRoot = document.getElementsByClassName('dashboard-container')[0];
-      this.bindEvents();
-    }
+  handleHoverClear = () => {
+    this.hide();
+  };
 
-    componentWillUnmount() {
-      this.unbindEvents();
-    }
-
-    bindEvents() {
-      this.props.chartElem.on(this.props.hoverEvent, this.handleHoverEvent);
-      this.props.chartElem.on('mouseleave', this.handleMouseleave);
-      appEvents.on('graph-hover', this.handleGraphHoverEvent);
-      appEvents.on('graph-hover-clear', this.handleHoverClear);
-    }
-
-    unbindEvents() {
-      this.props.chartElem.off(this.props.hoverEvent);
-      this.props.chartElem.off('mouseleave');
-      appEvents.off('graph-hover', this.handleGraphHoverEvent);
-      appEvents.off('graph-hover-clear', this.handleHoverClear);
-    }
-
-    handleHoverEvent = (event, position: FlotPosition, item?: FlotHoverItem) => {
-      this.show(position, item);
-    };
-
-    handleGraphHoverEvent = (event: GraphHoverEvent) => {
-      // ignore if we are the emitter
-      if (!this.props.sharedTooltip || this.props.panelId === event.panel.id || this.isElemHidden()) {
-        return;
-      }
-      const position = { ...event.pos };
-      const elemOffset = this.getElemOffset();
-      position.pageX = this.props.getOffset(position.x) + elemOffset.left;
-      this.show(position);
-    };
-
-    handleMouseleave = event => {
-      this.hide();
-      this.props.onMouseleave(event);
-    };
-
-    handleHoverClear = () => {
-      this.hide();
-    };
-
-    show(position: GraphHoverPosition, item?: FlotHoverItem) {
-      const tooltipPosition = this.calculatePosition(this.state.position);
-      if (tooltipPosition.x < 0 || tooltipPosition.y < 0) {
-        this.setState({ show: false });
-      }
-      this.setState({
-        show: true,
-        position: position,
-        tooltipPosition: tooltipPosition,
-        item: item,
-      });
-    }
-
-    hide() {
+  show(position: GraphHoverPosition, item?: FlotHoverItem) {
+    const tooltipPosition = this.calculatePosition(this.state.position);
+    if (tooltipPosition.x < 0 || tooltipPosition.y < 0) {
       this.setState({ show: false });
     }
+    this.setState({
+      show: true,
+      position: position,
+      tooltipPosition: tooltipPosition,
+      item: item,
+    });
+  }
 
-    calculatePosition(hoverEventPos: GraphHoverPosition): { x: number; y: number } {
-      const elemHeight = this.props.chartElem[0].clientHeight;
-      const elemWidth = this.props.chartElem[0].clientWidth;
-      const elemOffset = this.getElemOffset();
-      // const positionOffset = this.props.getOffset(hoverEventPos.x);
-      const tooltipSize = this.size || this.getTooltipSize();
+  hide() {
+    this.setState({ show: false });
+  }
 
-      // Restrict tooltip position
-      let x = hoverEventPos.pageX + TOOLTIP_OFFSET;
-      if (x + tooltipSize.width > elemWidth + elemOffset.left) {
-        x = elemWidth + elemOffset.left - tooltipSize.width;
-      }
-      if (x < elemOffset.left) {
-        x = elemOffset.left;
-      }
+  calculatePosition(hoverEventPos: GraphHoverPosition): { x: number; y: number } {
+    const elemHeight = this.props.chartElem[0].clientHeight;
+    const elemWidth = this.props.chartElem[0].clientWidth;
+    const elemOffset = this.getElemOffset();
+    // const positionOffset = this.props.getOffset(hoverEventPos.x);
+    const tooltipSize = this.size || this.getTooltipSize();
 
-      let y = elemHeight + elemOffset.top;
-      const appRootHeight = this.getAppRootHeight();
-      if (y + tooltipSize.height > appRootHeight) {
-        y = tooltipSize.height ? appRootHeight - tooltipSize.height : 0;
-      }
-
-      return { x, y };
+    // Restrict tooltip position
+    let x = hoverEventPos.pageX + TOOLTIP_OFFSET;
+    if (x + tooltipSize.width > elemWidth + elemOffset.left) {
+      x = elemWidth + elemOffset.left - tooltipSize.width;
+    }
+    if (x < elemOffset.left) {
+      x = elemOffset.left;
     }
 
-    getTooltipSize(): TooltipSize {
-      const size = {
-        width: this.tooltipElem && this.tooltipElem.clientWidth,
-        height: this.tooltipElem && this.tooltipElem.clientHeight,
-      };
-      if (size.height && size.width) {
-        this.size = size;
-      }
-      return {
-        width: size.width || 0,
-        height: size.height || 0,
-      };
+    let y = elemHeight + elemOffset.top;
+    const appRootHeight = this.getAppRootHeight();
+    if (y + tooltipSize.height > appRootHeight) {
+      y = tooltipSize.height ? appRootHeight - tooltipSize.height : 0;
     }
 
-    getAppRootHeight() {
-      return (this.appRoot && this.appRoot.clientHeight) || 0;
+    return { x, y };
+  }
+
+  getTooltipSize(): TooltipSize {
+    const size = {
+      width: this.tooltipElem && this.tooltipElem.clientWidth,
+      height: this.tooltipElem && this.tooltipElem.clientHeight,
+    };
+    if (size.height && size.width) {
+      this.size = size;
+    }
+    return {
+      width: size.width || 0,
+      height: size.height || 0,
+    };
+  }
+
+  getAppRootHeight() {
+    return (this.appRoot && this.appRoot.clientHeight) || 0;
+  }
+
+  getElemOffset(): { left: number; top: number } {
+    // TODO: make it working for both JQuery and HTML elements
+    const offset = this.props.chartElem.offset();
+    return offset;
+  }
+
+  isElemHidden(): boolean {
+    const { chartElem } = this.props;
+    if (chartElem && chartElem[0]) {
+      return chartElem[0].clientWidth === 0 || chartElem[0].clientHeight === 0;
+    }
+    return false;
+  }
+
+  render() {
+    const tooltipPos = this.state.tooltipPosition;
+    let tooltipStyle: CSSProperties;
+    if (this.props.useCSSTransforms) {
+      tooltipStyle = { transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)` };
+    } else {
+      tooltipStyle = { left: tooltipPos.x, top: tooltipPos.y };
+    }
+    if (!this.state.show) {
+      tooltipStyle.display = 'none';
+    }
+    if (!this.size) {
+      // Hide tooltip on its initial position (it cannot be calculated properly due to tooltip size equals 0)
+      tooltipStyle.opacity = 0;
     }
 
-    getElemOffset(): { left: number; top: number } {
-      // TODO: make it working for both JQuery and HTML elements
-      const offset = this.props.chartElem.offset();
-      return offset;
-    }
+    const tooltipNode = (
+      <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
+        {this.props.render(this.state.position, this.state.item)}
+      </div>
+    );
+    return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);
+  }
+}
 
-    isElemHidden(): boolean {
-      const { chartElem } = this.props;
-      if (chartElem && chartElem[0]) {
-        return chartElem[0].clientWidth === 0 || chartElem[0].clientHeight === 0;
-      }
-      return false;
-    }
-
-    render() {
-      // Cut the own component props and pass through the rest.
-      const {
-        chartElem,
-        getOffset,
-        hoverEvent,
-        onMouseleave,
-        panelId,
-        sharedTooltip,
-        useCSSTransforms,
-        ...passThroughProps
-      } = this.props as TimeAxisTooltipProps;
-
-      const tooltipPos = this.state.tooltipPosition;
-      let tooltipStyle: CSSProperties;
-      if (this.props.useCSSTransforms) {
-        tooltipStyle = { transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)` };
-      } else {
-        tooltipStyle = { left: tooltipPos.x, top: tooltipPos.y };
-      }
-      if (!this.state.show) {
-        tooltipStyle.display = 'none';
-      }
-      if (!this.size) {
-        // Hide tooltip on its initial position (it cannot be calculated properly due to tooltip size equals 0)
-        tooltipStyle.opacity = 0;
-      }
-
-      const tooltipNode = (
-        <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
-          <WrappedComponent position={this.state.position} item={this.state.item} {...passThroughProps} />
-        </div>
-      );
-      return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);
-    }
-  };
-};
-
-export default withTimeAxisTooltip;
+export default TimeAxisTooltip;

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -1,8 +1,8 @@
 import React, { PureComponent, CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
+import { appEvents } from 'app/core/core';
 import { GraphHoverPosition, GraphHoverEvent, FlotPosition, FlotHoverItem } from 'app/types/events';
 import { Subtract } from 'app/types/utils';
-import { appEvents } from 'app/core/core';
 
 const TOOLTIP_OFFSET = 20;
 
@@ -164,11 +164,6 @@ const withTimeAxisTooltip = <P extends InjectedTimeAxisTooltipProps>(WrappedComp
       if (y + tooltipSize.height > appRootHeight) {
         y = tooltipSize.height ? appRootHeight - tooltipSize.height : 0;
       }
-
-      // Make some CPU throttling
-      // for (let index = 0; index < 5000000; index++) {
-      //   Math.sqrt(Math.random());
-      // }
 
       return { x, y };
     }

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -20,7 +20,7 @@ export interface TimeAxisTooltipProps {
 }
 
 interface TimeAxisTooltipRenderProps {
-  render: (position: GraphHoverPosition, item: FlotHoverItem) => ReactNode;
+  children: (position: GraphHoverPosition, item: FlotHoverItem) => ReactNode;
 }
 
 export interface TimeAxisTooltipState {
@@ -221,7 +221,7 @@ class TimeAxisTooltip extends PureComponent<TimeAxisTooltipProps & TimeAxisToolt
 
     const tooltipNode = (
       <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
-        {this.props.render(this.state.position, this.state.item)}
+        {this.props.children(this.state.position, this.state.item)}
       </div>
     );
     return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);

--- a/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeAxisTooltip.tsx
@@ -9,7 +9,7 @@ const TOOLTIP_OFFSET = 20;
  * Since component render is expensive operation, it makes sense to call it only with a reasonable interval.
  * Inside this interval, tooltip is only moving and do not re-renders content.
  */
-const TOOLTIP_UPDATE_INTERVAL = 100;
+const TOOLTIP_RENDER_INTERVAL = 50;
 
 export interface TimeAxisTooltipProps {
   chartElem: any;
@@ -19,6 +19,7 @@ export interface TimeAxisTooltipProps {
   hoverEvent?: string;
   /** Use CSS transform: translate() for positioning tooltip. If false, top/left will be used instead. */
   useCSSTransforms?: boolean;
+  renderInterval?: number;
   /** Function converting timestamp into offset on chart */
   getOffset: (x) => number;
   onMouseleave?: (event?) => void;
@@ -65,6 +66,7 @@ export class TimeAxisTooltip extends PureComponent<ComponentProps, TimeAxisToolt
     hoverEvent: 'plothover',
     useCSSTransforms: true,
     sharedTooltip: false,
+    renderInterval: TOOLTIP_RENDER_INTERVAL,
   };
 
   constructor(props) {
@@ -142,7 +144,7 @@ export class TimeAxisTooltip extends PureComponent<ComponentProps, TimeAxisToolt
     // interval by changing CSS styles directly. This makes tooltip movement smoother, especially on
     // large dashboards with shared tooltip enabled.
     const interval = performance.now() - this.lastRenderTS;
-    if (interval > TOOLTIP_UPDATE_INTERVAL || !this.state.show) {
+    if (interval > this.props.renderInterval || !this.state.show) {
       this.lastRenderTS = performance.now();
       this.setState({
         show: true,

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -1,0 +1,194 @@
+import React, { PureComponent, CSSProperties } from 'react';
+import ReactDOM from 'react-dom';
+import { TimeSeriesVM } from 'app/types';
+import { GraphHoverPosition, GraphHoverEvent } from 'app/types/events';
+import { appEvents } from 'app/core/core';
+import { getMultiSeriesPlotHoverInfo } from './utils';
+
+export interface TimeSeriesTooltipProps {
+  series: TimeSeriesVM[];
+  chartElem: any;
+  dateFormat: (time, format) => string;
+  hoverEvent?: string;
+  useCSSTransforms?: boolean;
+}
+
+export interface TimeSeriesTooltipState {
+  show: boolean;
+  position?: GraphHoverPosition;
+  tooltipPosition?: { x: number; y: number };
+}
+
+const defaultPosition: GraphHoverPosition = {
+  pageX: 0,
+  x: 0,
+};
+
+export interface InjectedTooltipProps {
+  timestamp: number;
+}
+
+interface TooltipSize {
+  width: number;
+  height: number;
+}
+
+const withTimeSeriesTooltip = <P extends InjectedTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
+  return class TimeSeriesTooltip extends PureComponent<TimeSeriesTooltipProps, TimeSeriesTooltipState> {
+    appRoot: HTMLElement;
+    tooltipContainer: HTMLElement;
+    tooltipElem: HTMLElement;
+    size: TooltipSize;
+
+    static defaultProps: Partial<TimeSeriesTooltipProps> = {
+      hoverEvent: 'plothover',
+      useCSSTransforms: true,
+    };
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        show: false,
+        position: defaultPosition,
+        tooltipPosition: { x: 0, y: 0 },
+      };
+
+      this.appRoot = document.body;
+      this.tooltipContainer = document.body;
+    }
+
+    getTooltipRef = ref => {
+      this.tooltipElem = ref;
+    };
+
+    componentDidMount() {
+      // this.appRoot = document.getElementsByClassName('dashboard-container')[0];
+      this.bindEvents();
+    }
+
+    componentWillUnmount() {
+      this.unbindEvents();
+    }
+
+    bindEvents() {
+      this.props.chartElem.on(this.props.hoverEvent, this.handleHoverEvent);
+      this.props.chartElem.on('mouseleave', this.handleMouseleave);
+      appEvents.on('graph-hover', this.handleGraphHoverEvent);
+      appEvents.on('graph-hover-clear', this.handleMouseleave);
+    }
+
+    unbindEvents() {
+      this.props.chartElem.off(this.props.hoverEvent);
+      this.props.chartElem.off('mouseleave');
+      appEvents.off('graph-hover', this.handleGraphHoverEvent);
+      appEvents.off('graph-hover-clear', this.handleMouseleave);
+    }
+
+    handleHoverEvent = (event, position: GraphHoverPosition, item) => {
+      this.show(position);
+    };
+
+    handleGraphHoverEvent = (event: GraphHoverEvent) => {
+      this.show(event.pos);
+    };
+
+    handleMouseleave = () => {
+      this.hide();
+    };
+
+    show(position: GraphHoverPosition) {
+      const tooltipPosition = this.calculatePosition(this.state.position);
+      this.setState({
+        show: true,
+        position: position,
+        tooltipPosition: tooltipPosition,
+      });
+    }
+
+    hide() {
+      this.setState({ show: false });
+    }
+
+    calculatePosition(hoverEventPos: GraphHoverPosition): { x: number; y: number } {
+      const elemHeight = this.props.chartElem[0].clientHeight;
+      const elemWidth = this.props.chartElem[0].clientWidth;
+      const elemOffset = this.getElemOffset();
+      const tooltipSize = this.size || this.getTooltipSize();
+
+      let x = hoverEventPos.pageX;
+      if (x + tooltipSize.width > elemWidth + elemOffset.left) {
+        x = elemWidth + elemOffset.left - tooltipSize.width;
+      }
+      if (x < elemOffset.left) {
+        x = elemOffset.left;
+      }
+
+      let y = elemHeight + elemOffset.top;
+      const appRootHeight = this.getAppRootHeight();
+      if (y + tooltipSize.height > appRootHeight) {
+        y = appRootHeight - tooltipSize.height;
+      }
+
+      // Make some CPU throttling
+      // for (let index = 0; index < 5000000; index++) {
+      //   Math.sqrt(Math.random());
+      // }
+
+      return { x, y };
+    }
+
+    getTooltipSize(): TooltipSize {
+      const size = {
+        width: this.tooltipElem && this.tooltipElem.clientWidth,
+        height: this.tooltipElem && this.tooltipElem.clientHeight,
+      };
+      if (size.height && size.width) {
+        this.size = size;
+      }
+      return {
+        width: size.width || 0,
+        height: size.height || 0,
+      };
+    }
+
+    getAppRootHeight() {
+      return (this.appRoot && this.appRoot.clientHeight) || 0;
+    }
+
+    getElemOffset(): { left: number; top: number } {
+      // TODO: make it working for both JQuery and HTML elements
+      const offset = this.props.chartElem.offset();
+      return offset;
+    }
+
+    render() {
+      const tooltipPos = this.state.tooltipPosition;
+      const tooltipStyle: CSSProperties = this.props.useCSSTransforms
+        ? {
+            transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
+          }
+        : {
+            left: tooltipPos.x,
+            top: tooltipPos.y,
+          };
+
+      if (!this.state.show) {
+        tooltipStyle.display = 'none';
+      }
+
+      const panelOptions = { tooltip: {}, legend: {} };
+      const seriesHoverInfo = getMultiSeriesPlotHoverInfo(this.props.series, this.state.position, panelOptions);
+      // console.log(seriesHoverInfo);
+
+      const tooltipNode = (
+        <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
+          <WrappedComponent timestamp={seriesHoverInfo.time} {...this.props} />
+        </div>
+      );
+      return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);
+    }
+  };
+};
+
+export default withTimeSeriesTooltip;

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -96,16 +96,14 @@ export class TimeSeriesTooltip extends PureComponent<ComponentProps> {
     }
   }
 
+  renderChildren = (position, item) => {
+    this.calculateHoverInfo(position);
+    const seriesHoverInfo = this.seriesHoverInfo;
+    return this.props.children(this.props.series, item, seriesHoverInfo.time, seriesHoverInfo);
+  };
+
   render() {
-    return (
-      <TimeAxisTooltip {...this.props}>
-        {(position, item) => {
-          this.calculateHoverInfo(position);
-          const seriesHoverInfo = this.seriesHoverInfo;
-          return this.props.children(this.props.series, item, seriesHoverInfo.time, seriesHoverInfo);
-        }}
-      </TimeAxisTooltip>
-    );
+    return <TimeAxisTooltip {...this.props}>{this.renderChildren}</TimeAxisTooltip>;
   }
 }
 

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -31,7 +31,7 @@ interface PanelOptions {
     hideZero?: boolean;
   };
   tooltip?: {
-    value_type?: string;
+    value_type?: 'individual' | 'cumulative';
     shared?: boolean;
   };
 }
@@ -57,7 +57,9 @@ const withTimeSeriesTooltip = <P extends InjectedTimeSeriesTooltipProps>(Wrapped
       this.props.onUnhighlight();
       for (let i = 0; i < series.length; i++) {
         const hoverInfo = seriesHoverInfo[i];
-        this.props.onHighlight(hoverInfo.index, hoverInfo.hoverIndex);
+        if (!hoverInfo.hidden) {
+          this.props.onHighlight(hoverInfo.index, hoverInfo.hoverIndex);
+        }
       }
     }
 

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -2,12 +2,14 @@ import React, { PureComponent } from 'react';
 import { TimeSeriesVM } from 'app/types';
 import { Subtract } from 'app/types/utils';
 import { GraphHoverPosition } from 'app/types/events';
-import { getMultiSeriesPlotHoverInfo } from './utils';
+import { getMultiSeriesPlotHoverInfo, PlotHoverInfo } from './utils';
 import withTimeAxisTooltip, { TimeAxisTooltipProps } from './TimeAxisTooltip';
 
 export interface TimeSeriesTooltipProps extends TimeAxisTooltipProps {
   series: TimeSeriesVM[];
   panelOptions?: PanelOptions;
+  onHighlight?: (series, datapoint) => void;
+  onUnhighlight?: () => void;
 }
 
 export interface TimeSeriesTooltipState {
@@ -46,6 +48,15 @@ const withTimeSeriesTooltip = <P extends InjectedTimeSeriesTooltipProps>(Wrapped
       super(props);
     }
 
+    highlightPoints(seriesHoverInfo: PlotHoverInfo) {
+      const { series } = this.props;
+      this.props.onUnhighlight();
+      for (let i = 0; i < series.length; i++) {
+        const hoverInfo = seriesHoverInfo[i];
+        this.props.onHighlight(hoverInfo.index, hoverInfo.hoverIndex);
+      }
+    }
+
     render() {
       const { position, ...props } = this.props as any;
       const panelOptions = {
@@ -54,6 +65,10 @@ const withTimeSeriesTooltip = <P extends InjectedTimeSeriesTooltipProps>(Wrapped
         tooltipValueType: this.props.panelOptions.tooltip.value_type,
       };
       const seriesHoverInfo = getMultiSeriesPlotHoverInfo(props.series, position, panelOptions);
+      // console.log(props.series);
+      if (this.props.onHighlight && this.props.onUnhighlight) {
+        this.highlightPoints(seriesHoverInfo);
+      }
       return <WrappedComponent position={position} timestamp={seriesHoverInfo.time} {...props} />;
     }
   }

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -1,10 +1,10 @@
+import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import { TimeSeriesVM } from 'app/types';
+import { FlotHoverItem } from 'app/types/events';
 import { Subtract } from 'app/types/utils';
 import { getMultiSeriesPlotHoverInfo, PlotHoverInfo } from './utils';
 import withTimeAxisTooltip, { InjectedTimeAxisTooltipProps } from './TimeAxisTooltip';
-import { FlotHoverItem } from 'app/types/events';
-import _ from 'lodash';
 
 export interface TimeSeriesTooltipProps extends InjectedTimeAxisTooltipProps {
   series: TimeSeriesVM[];
@@ -73,8 +73,7 @@ const withTimeSeriesTooltip = <P extends InjectedTimeSeriesTooltipProps>(Wrapped
     }
 
     sortHoverInfo(seriesHoverInfo) {
-      // Dynamically reorder the hovercard for the current time point if the
-      // option is enabled.
+      // Dynamically reorder the hovercard for the current time point if the option is enabled.
       if (this.props.sort === 2) {
         seriesHoverInfo.sort((a, b) => {
           return b.value - a.value;

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -2,11 +2,10 @@ import _ from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 import { TimeSeriesVM } from 'app/types';
 import { FlotHoverItem } from 'app/types/events';
-// import { Subtract } from 'app/types/utils';
 import { getMultiSeriesPlotHoverInfo, PlotHoverInfo } from './utils';
 import TimeAxisTooltip, { TimeAxisTooltipProps, InjectedTimeAxisTooltipProps } from './TimeAxisTooltip';
 
-export interface TimeSeriesTooltipProps extends TimeAxisTooltipProps {
+export interface TimeSeriesTooltipProps {
   series: TimeSeriesVM[];
   allSeriesMode?: boolean;
   hideEmpty?: boolean;
@@ -34,15 +33,9 @@ export interface InjectedTimeSeriesTooltipProps {
   hoverInfo: PlotHoverInfo;
 }
 
-/**
- * withTimeSeriesTooltip(WrappedComponent) should have all props that TimeSeriesTooltip has and props passed into
- * WrappedComponent, but without injected props.
- */
-// export type WithTimeSeriesTooltipProps = InjectedTimeSeriesTooltipProps & TimeSeriesTooltipProps;
+type ComponentProps = TimeSeriesTooltipProps & TimeSeriesTooltipRenderProps & InjectedTimeAxisTooltipProps;
 
-class TimeSeriesTooltip extends PureComponent<
-  TimeSeriesTooltipProps & InjectedTimeAxisTooltipProps & TimeSeriesTooltipRenderProps
-> {
+class TimeSeriesTooltip extends PureComponent<ComponentProps> {
   seriesHoverInfo: PlotHoverInfo | null;
   calculateHoverInfo: () => void;
 
@@ -109,7 +102,9 @@ class TimeSeriesTooltip extends PureComponent<
   }
 }
 
-class WithTimeSeriesTooltip extends PureComponent<TimeSeriesTooltipProps & TimeSeriesTooltipRenderProps> {
+type WithTimeSeriesTooltipProps = TimeSeriesTooltipProps & TimeSeriesTooltipRenderProps & TimeAxisTooltipProps;
+
+class WithTimeSeriesTooltip extends PureComponent<WithTimeSeriesTooltipProps> {
   render() {
     return (
       <TimeAxisTooltip {...this.props}>

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -24,7 +24,7 @@ export interface TimeSeriesTooltipProps extends TimeAxisTooltipProps {
 }
 
 interface TimeSeriesTooltipRenderProps {
-  render: (series: TimeSeriesVM[], item: FlotHoverItem, timestamp: number, hoverInfo: PlotHoverInfo) => ReactNode;
+  children: (series: TimeSeriesVM[], item: FlotHoverItem, timestamp: number, hoverInfo: PlotHoverInfo) => ReactNode;
 }
 
 export interface InjectedTimeSeriesTooltipProps {
@@ -105,17 +105,16 @@ class TimeSeriesTooltip extends PureComponent<
     const { series, item } = this.props;
     this.calculateHoverInfo();
     const seriesHoverInfo = this.seriesHoverInfo;
-    return this.props.render(series, item, seriesHoverInfo.time, seriesHoverInfo);
+    return this.props.children(series, item, seriesHoverInfo.time, seriesHoverInfo);
   }
 }
 
 class WithTimeSeriesTooltip extends PureComponent<TimeSeriesTooltipProps & TimeSeriesTooltipRenderProps> {
   render() {
     return (
-      <TimeAxisTooltip
-        {...this.props}
-        render={(position, item) => <TimeSeriesTooltip {...this.props} position={position} item={item} />}
-      />
+      <TimeAxisTooltip {...this.props}>
+        {(position, item) => <TimeSeriesTooltip {...this.props} position={position} item={item} />}
+      </TimeAxisTooltip>
     );
   }
 }

--- a/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
+++ b/public/app/core/components/TimeSeriesTooltip/TimeSeriesTooltip.tsx
@@ -1,22 +1,13 @@
-import React, { PureComponent, CSSProperties } from 'react';
-import ReactDOM from 'react-dom';
+import React, { PureComponent } from 'react';
 import { TimeSeriesVM } from 'app/types';
-import { GraphHoverPosition, GraphHoverEvent, FlotPosition } from 'app/types/events';
-import { appEvents } from 'app/core/core';
+import { Subtract } from 'app/types/utils';
+import { GraphHoverPosition } from 'app/types/events';
 import { getMultiSeriesPlotHoverInfo } from './utils';
+import withTimeAxisTooltip, { TimeAxisTooltipProps } from './TimeAxisTooltip';
 
-export interface TimeSeriesTooltipProps {
+export interface TimeSeriesTooltipProps extends TimeAxisTooltipProps {
   series: TimeSeriesVM[];
-  chartElem: any;
-  panelId: number;
   panelOptions?: PanelOptions;
-  sharedTooltip?: boolean;
-  hoverEvent?: string;
-  useCSSTransforms?: boolean;
-  formatDate: (time, format?) => string;
-  /** Function converting timestamp into offset on chart */
-  getOffset: (x) => number;
-  onMouseleave?: (event?) => void;
 }
 
 export interface TimeSeriesTooltipState {
@@ -25,14 +16,7 @@ export interface TimeSeriesTooltipState {
   tooltipPosition?: { x: number; y: number };
 }
 
-const defaultPosition: GraphHoverPosition = {
-  pageX: 0,
-  pageY: 0,
-  x: 0,
-  y: 0,
-};
-
-export interface InjectedTooltipProps {
+export interface InjectedTimeSeriesTooltipProps {
   timestamp: number;
 }
 
@@ -46,22 +30,12 @@ interface PanelOptions {
   };
 }
 
-interface TooltipSize {
-  width: number;
-  height: number;
-}
-
-const withTimeSeriesTooltip = <P extends InjectedTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
-  return class TimeSeriesTooltip extends PureComponent<TimeSeriesTooltipProps, TimeSeriesTooltipState> {
-    appRoot: HTMLElement;
-    tooltipContainer: HTMLElement;
-    tooltipElem: HTMLElement;
-    size: TooltipSize;
-
+const withTimeSeriesTooltip = <P extends InjectedTimeSeriesTooltipProps>(WrappedComponent: React.ComponentType<P>) => {
+  class TimeSeriesTooltip extends PureComponent<
+    Subtract<P, InjectedTimeSeriesTooltipProps> & TimeSeriesTooltipProps,
+    TimeSeriesTooltipState
+  > {
     static defaultProps: Partial<TimeSeriesTooltipProps> = {
-      hoverEvent: 'plothover',
-      useCSSTransforms: true,
-      sharedTooltip: false,
       panelOptions: {
         legend: {},
         tooltip: {},
@@ -70,175 +44,21 @@ const withTimeSeriesTooltip = <P extends InjectedTooltipProps>(WrappedComponent:
 
     constructor(props) {
       super(props);
-
-      this.state = {
-        show: false,
-        position: defaultPosition,
-        tooltipPosition: { x: 0, y: 0 },
-      };
-
-      this.appRoot = document.body;
-      this.tooltipContainer = document.body;
-    }
-
-    getTooltipRef = ref => {
-      this.tooltipElem = ref;
-    };
-
-    componentDidMount() {
-      // this.appRoot = document.getElementsByClassName('dashboard-container')[0];
-      this.bindEvents();
-    }
-
-    componentWillUnmount() {
-      this.unbindEvents();
-    }
-
-    bindEvents() {
-      this.props.chartElem.on(this.props.hoverEvent, this.handleHoverEvent);
-      this.props.chartElem.on('mouseleave', this.handleMouseleave);
-      appEvents.on('graph-hover', this.handleGraphHoverEvent);
-      appEvents.on('graph-hover-clear', this.handleHoverClear);
-    }
-
-    unbindEvents() {
-      this.props.chartElem.off(this.props.hoverEvent);
-      this.props.chartElem.off('mouseleave');
-      appEvents.off('graph-hover', this.handleGraphHoverEvent);
-      appEvents.off('graph-hover-clear', this.handleHoverClear);
-    }
-
-    handleHoverEvent = (event, position: FlotPosition, item) => {
-      // console.log(position);
-      this.show(position);
-    };
-
-    handleGraphHoverEvent = (event: GraphHoverEvent) => {
-      // ignore if we are the emitter
-      if (!this.props.sharedTooltip || this.props.panelId === event.panel.id) {
-        if (this.state.show) {
-          this.hide();
-        }
-        return;
-      }
-      const position = { ...event.pos };
-      const elemOffset = this.getElemOffset();
-      position.pageX = this.props.getOffset(position.x) + elemOffset.left;
-      // console.log(event.pos.pageX);
-      this.show(position);
-    };
-
-    handleMouseleave = event => {
-      this.hide();
-      this.props.onMouseleave(event);
-    };
-
-    handleHoverClear = () => {
-      this.hide();
-    };
-
-    show(position: GraphHoverPosition) {
-      const tooltipPosition = this.calculatePosition(this.state.position);
-      if (tooltipPosition.x < 0 || tooltipPosition.y < 0) {
-        this.setState({ show: false });
-      }
-      this.setState({
-        show: true,
-        position: position,
-        tooltipPosition: tooltipPosition,
-      });
-    }
-
-    hide() {
-      this.setState({ show: false });
-    }
-
-    calculatePosition(hoverEventPos: GraphHoverPosition): { x: number; y: number } {
-      const elemHeight = this.props.chartElem[0].clientHeight;
-      const elemWidth = this.props.chartElem[0].clientWidth;
-      const elemOffset = this.getElemOffset();
-      // const positionOffset = this.props.getOffset(hoverEventPos.x);
-      // console.log(hoverEventPos.x, positionOffset);
-      const tooltipSize = this.size || this.getTooltipSize();
-
-      // Restrict tooltip position
-      let x = hoverEventPos.pageX;
-      if (x + tooltipSize.width > elemWidth + elemOffset.left) {
-        x = elemWidth + elemOffset.left - tooltipSize.width;
-      }
-      if (x < elemOffset.left) {
-        x = elemOffset.left;
-      }
-
-      let y = elemHeight + elemOffset.top;
-      const appRootHeight = this.getAppRootHeight();
-      if (y + tooltipSize.height > appRootHeight) {
-        y = appRootHeight - tooltipSize.height;
-      }
-
-      // Make some CPU throttling
-      // for (let index = 0; index < 5000000; index++) {
-      //   Math.sqrt(Math.random());
-      // }
-
-      return { x, y };
-    }
-
-    getTooltipSize(): TooltipSize {
-      const size = {
-        width: this.tooltipElem && this.tooltipElem.clientWidth,
-        height: this.tooltipElem && this.tooltipElem.clientHeight,
-      };
-      if (size.height && size.width) {
-        this.size = size;
-      }
-      return {
-        width: size.width || 0,
-        height: size.height || 0,
-      };
-    }
-
-    getAppRootHeight() {
-      return (this.appRoot && this.appRoot.clientHeight) || 0;
-    }
-
-    getElemOffset(): { left: number; top: number } {
-      // TODO: make it working for both JQuery and HTML elements
-      const offset = this.props.chartElem.offset();
-      return offset;
     }
 
     render() {
-      const tooltipPos = this.state.tooltipPosition;
-      const tooltipStyle: CSSProperties = this.props.useCSSTransforms
-        ? {
-            transform: `translate(${tooltipPos.x}px, ${tooltipPos.y}px)`,
-          }
-        : {
-            left: tooltipPos.x,
-            top: tooltipPos.y,
-          };
-
-      if (!this.state.show) {
-        tooltipStyle.display = 'none';
-      }
-
+      const { position, ...props } = this.props as any;
       const panelOptions = {
         hideEmpty: this.props.panelOptions.legend.hideEmpty,
         hideZero: this.props.panelOptions.legend.hideZero,
         tooltipValueType: this.props.panelOptions.tooltip.value_type,
       };
-      const seriesHoverInfo = getMultiSeriesPlotHoverInfo(this.props.series, this.state.position, panelOptions);
-      // console.log(seriesHoverInfo);
-
-      const tooltipNode = (
-        <div className="graph-tooltip grafana-tooltip timeseries-tooltip" style={tooltipStyle} ref={this.getTooltipRef}>
-          <WrappedComponent timestamp={seriesHoverInfo.time} {...this.props} />
-        </div>
-      );
-      return ReactDOM.createPortal(tooltipNode, this.tooltipContainer);
+      const seriesHoverInfo = getMultiSeriesPlotHoverInfo(props.series, position, panelOptions);
+      return <WrappedComponent position={position} timestamp={seriesHoverInfo.time} {...props} />;
     }
-  };
+  }
+
+  return withTimeAxisTooltip(TimeSeriesTooltip);
 };
 
 export default withTimeSeriesTooltip;

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -138,7 +138,7 @@ export function getMultiSeriesPlotHoverInfo(
       value: value,
       hoverIndex: hoverIndex,
       color: series.color,
-      label: series.aliasEscaped,
+      label: series.alias,
       time: pointTime,
       distance: hoverDistance,
       index: i,

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -1,5 +1,4 @@
 import { FlotPosition } from 'app/types/events';
-// import { TimeSeriesVM } from 'app/types';
 
 export function findHoverIndexFromDataPoints(posX, series, last) {
   const ps = series.datapoints.pointsize;

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -1,4 +1,5 @@
 import { FlotPosition } from 'app/types/events';
+// import { TimeSeriesVM } from 'app/types';
 
 export function findHoverIndexFromDataPoints(posX, series, last) {
   const ps = series.datapoints.pointsize;
@@ -43,7 +44,7 @@ interface GetPlotHoverInfoOptions {
   tooltipValueType?: 'individual' | string;
 }
 
-interface PlotHoverInfoItem {
+export interface PlotHoverInfoItem {
   value: number;
   hidden?: boolean;
   hoverIndex?: number;

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -43,7 +43,11 @@ interface GetPlotHoverInfoOptions {
   tooltipValueType?: 'individual' | string;
 }
 
-export function getMultiSeriesPlotHoverInfo(seriesList: any[], pos: FlotPosition, options: GetPlotHoverInfoOptions) {
+interface PlotHoverInfo extends Array<any> {
+  time: number;
+}
+
+export function getMultiSeriesPlotHoverInfo(seriesList: any[], pos: FlotPosition, options: GetPlotHoverInfoOptions): PlotHoverInfo {
   let value, i, series, hoverIndex, hoverDistance, pointTime, yaxis;
   // 3 sub-arrays, 1st for hidden series, 2nd for left yaxis, 3rd for right yaxis.
   let results: any = [[], [], []];

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -1,0 +1,127 @@
+export function findHoverIndexFromDataPoints(posX, series, last) {
+  const ps = series.datapoints.pointsize;
+  const initial = last * ps;
+  const len = series.datapoints.points.length;
+  let j;
+  for (j = initial; j < len; j += ps) {
+    // Special case of a non stepped line, highlight the very last point just before a null point
+    if (
+      (!series.lines.steps && series.datapoints.points[initial] != null && series.datapoints.points[j] == null) ||
+      //normal case
+      series.datapoints.points[j] > posX
+    ) {
+      return Math.max(j - ps, 0) / ps;
+    }
+  }
+  return j / ps - 1;
+}
+
+export function findHoverIndexFromData(posX, series) {
+  let lower = 0;
+  let upper = series.data.length - 1;
+  let middle;
+  while (true) {
+    if (lower > upper) {
+      return Math.max(upper, 0);
+    }
+    middle = Math.floor((lower + upper) / 2);
+    if (series.data[middle][0] === posX) {
+      return middle;
+    } else if (series.data[middle][0] < posX) {
+      lower = middle + 1;
+    } else {
+      upper = middle - 1;
+    }
+  }
+}
+
+export function getMultiSeriesPlotHoverInfo(seriesList, pos, panel) {
+  let value, i, series, hoverIndex, hoverDistance, pointTime, yaxis;
+  // 3 sub-arrays, 1st for hidden series, 2nd for left yaxis, 3rd for right yaxis.
+  let results: any = [[], [], []];
+
+  //now we know the current X (j) position for X and Y values
+  let lastValue = 0; //needed for stacked values
+
+  let minDistance, minTime;
+
+  for (i = 0; i < seriesList.length; i++) {
+    series = seriesList[i];
+
+    if (!series.data.length || (panel.legend.hideEmpty && series.allIsNull)) {
+      // Init value so that it does not brake series sorting
+      results[0].push({ hidden: true, value: 0 });
+      continue;
+    }
+
+    if (!series.data.length || (panel.legend.hideZero && series.allIsZero)) {
+      // Init value so that it does not brake series sorting
+      results[0].push({ hidden: true, value: 0 });
+      continue;
+    }
+
+    if (series.hideTooltip) {
+      results[0].push({ hidden: true, value: 0 });
+      continue;
+    }
+
+    hoverIndex = findHoverIndexFromData(pos.x, series);
+    hoverDistance = pos.x - series.data[hoverIndex][0];
+    pointTime = series.data[hoverIndex][0];
+
+    // Take the closest point before the cursor, or if it does not exist, the closest after
+    if (
+      !minDistance ||
+      (hoverDistance >= 0 && (hoverDistance < minDistance || minDistance < 0)) ||
+      (hoverDistance < 0 && hoverDistance > minDistance)
+    ) {
+      minDistance = hoverDistance;
+      minTime = pointTime;
+    }
+
+    if (series.stack) {
+      if (panel.tooltip.value_type === 'individual') {
+        value = series.data[hoverIndex][1];
+      } else if (!series.stack) {
+        value = series.data[hoverIndex][1];
+      } else {
+        lastValue += series.data[hoverIndex][1];
+        value = lastValue;
+      }
+    } else {
+      value = series.data[hoverIndex][1];
+    }
+
+    // Highlighting multiple Points depending on the plot type
+    if (series.lines.steps || series.stack) {
+      // stacked and steppedLine plots can have series with different length.
+      // Stacked series can increase its length on each new stacked serie if null points found,
+      // to speed the index search we begin always on the last found hoverIndex.
+      hoverIndex = findHoverIndexFromDataPoints(pos.x, series, hoverIndex);
+    }
+
+    // Be sure we have a yaxis so that it does not brake series sorting
+    yaxis = 0;
+    if (series.yaxis) {
+      yaxis = series.yaxis.n || series.yaxis;
+    }
+
+    results[yaxis].push({
+      value: value,
+      hoverIndex: hoverIndex,
+      color: series.color,
+      label: series.aliasEscaped,
+      time: pointTime,
+      distance: hoverDistance,
+      index: i,
+    });
+  }
+
+  // Contat the 3 sub-arrays
+  results = results[0].concat(results[1], results[2]);
+
+  // Time of the point closer to pointer
+  results.time = minTime;
+
+  return results;
+}

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -1,3 +1,5 @@
+import { FlotPosition } from 'app/types/events';
+
 export function findHoverIndexFromDataPoints(posX, series, last) {
   const ps = series.datapoints.pointsize;
   const initial = last * ps;
@@ -35,7 +37,13 @@ export function findHoverIndexFromData(posX, series) {
   }
 }
 
-export function getMultiSeriesPlotHoverInfo(seriesList, pos, panel) {
+interface GetPlotHoverInfoOptions {
+  hideEmpty?: boolean;
+  hideZero?: boolean;
+  tooltipValueType?: 'individual' | string;
+}
+
+export function getMultiSeriesPlotHoverInfo(seriesList: any[], pos: FlotPosition, options: GetPlotHoverInfoOptions) {
   let value, i, series, hoverIndex, hoverDistance, pointTime, yaxis;
   // 3 sub-arrays, 1st for hidden series, 2nd for left yaxis, 3rd for right yaxis.
   let results: any = [[], [], []];
@@ -48,13 +56,13 @@ export function getMultiSeriesPlotHoverInfo(seriesList, pos, panel) {
   for (i = 0; i < seriesList.length; i++) {
     series = seriesList[i];
 
-    if (!series.data.length || (panel.legend.hideEmpty && series.allIsNull)) {
+    if (!series.data.length || (options.hideEmpty && series.allIsNull)) {
       // Init value so that it does not brake series sorting
       results[0].push({ hidden: true, value: 0 });
       continue;
     }
 
-    if (!series.data.length || (panel.legend.hideZero && series.allIsZero)) {
+    if (!series.data.length || (options.hideZero && series.allIsZero)) {
       // Init value so that it does not brake series sorting
       results[0].push({ hidden: true, value: 0 });
       continue;
@@ -80,7 +88,7 @@ export function getMultiSeriesPlotHoverInfo(seriesList, pos, panel) {
     }
 
     if (series.stack) {
-      if (panel.tooltip.value_type === 'individual') {
+      if (options.tooltipValueType === 'individual') {
         value = series.data[hoverIndex][1];
       } else if (!series.stack) {
         value = series.data[hoverIndex][1];

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -41,7 +41,7 @@ export function findHoverIndexFromData(posX, series): number {
 interface GetPlotHoverInfoOptions {
   hideEmpty?: boolean;
   hideZero?: boolean;
-  tooltipValueType?: 'individual' | string;
+  valueType?: 'individual' | 'cumulative';
 }
 
 export interface PlotHoverInfoItem {
@@ -108,7 +108,7 @@ export function getMultiSeriesPlotHoverInfo(
     }
 
     if (series.stack) {
-      if (options.tooltipValueType === 'individual') {
+      if (options.valueType === 'individual') {
         value = series.data[hoverIndex][1];
       } else if (!series.stack) {
         value = series.data[hoverIndex][1];

--- a/public/app/core/components/TimeSeriesTooltip/utils.ts
+++ b/public/app/core/components/TimeSeriesTooltip/utils.ts
@@ -18,7 +18,7 @@ export function findHoverIndexFromDataPoints(posX, series, last) {
   return j / ps - 1;
 }
 
-export function findHoverIndexFromData(posX, series) {
+export function findHoverIndexFromData(posX, series): number {
   let lower = 0;
   let upper = series.data.length - 1;
   let middle;
@@ -43,11 +43,26 @@ interface GetPlotHoverInfoOptions {
   tooltipValueType?: 'individual' | string;
 }
 
-interface PlotHoverInfo extends Array<any> {
+interface PlotHoverInfoItem {
+  value: number;
+  hidden?: boolean;
+  hoverIndex?: number;
+  color?: string;
+  label?: string;
+  time?: number;
+  distance?: number;
+  index: number;
+}
+
+export interface PlotHoverInfo extends Array<PlotHoverInfoItem> {
   time: number;
 }
 
-export function getMultiSeriesPlotHoverInfo(seriesList: any[], pos: FlotPosition, options: GetPlotHoverInfoOptions): PlotHoverInfo {
+export function getMultiSeriesPlotHoverInfo(
+  seriesList: any[],
+  pos: FlotPosition,
+  options: GetPlotHoverInfoOptions
+): PlotHoverInfo {
   let value, i, series, hoverIndex, hoverDistance, pointTime, yaxis;
   // 3 sub-arrays, 1st for hidden series, 2nd for left yaxis, 3rd for right yaxis.
   let results: any = [[], [], []];

--- a/public/app/features/dashboard/dashboard_model.ts
+++ b/public/app/features/dashboard/dashboard_model.ts
@@ -576,6 +576,8 @@ export class DashboardModel {
   removePanel(panel: PanelModel) {
     const index = _.indexOf(this.panels, panel);
     this.panels.splice(index, 1);
+    // This should be invoked in order to emit 'panel-teardown', remove panel listeners and execute onPanelTeardown()
+    panel.destroy();
     this.events.emit('panel-removed', panel);
   }
 

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -325,17 +325,20 @@ class GraphElement {
   }
 
   renderTooltip() {
-    // console.log(this);
+    // console.log('renderTooltip', this.ctrl.otherPanelInFullscreenMode());
     const sharedTooltip = this.dashboard.sharedTooltipModeEnabled() && !this.dashboard.sharedCrosshairModeOnly();
     const tooltipProps: GraphTooltipProps = {
-      series: this.sortedSeries,
+      series: this.plot.getData(this.sortedSeries),
       chartElem: this.elem,
       panelId: this.panel.id,
       sharedTooltip: sharedTooltip,
       getOffset: x => this.getOffset(x),
       formatDate: (time, format) => this.ctrl.dashboard.formatDate(time, format),
       onMouseleave: () => this.onTooltipClear(),
+      onHighlight: (series, datapoint) => this.plot.highlight(series, datapoint),
+      onUnhighlight: () => this.plot.unhighlight(),
     };
+    // console.log(this.plot.getData(this.sortedSeries));
     const tooltipReactElem = React.createElement(GraphTooltipReact, tooltipProps);
     ReactDOM.render(tooltipReactElem, this.tooltipElem);
   }

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -325,7 +325,6 @@ class GraphElement {
   }
 
   renderTooltip() {
-    // console.log('renderTooltip', this.ctrl.otherPanelInFullscreenMode());
     const sharedTooltip = this.dashboard.sharedTooltipModeEnabled() && !this.dashboard.sharedCrosshairModeOnly();
     const tooltipProps = {
       series: this.plot.getData(this.sortedSeries),
@@ -343,7 +342,6 @@ class GraphElement {
       onHighlight: (series, datapoint) => this.plot.highlight(series, datapoint),
       onUnhighlight: () => this.plot.unhighlight(),
     };
-    // console.log(this.plot.getData(this.sortedSeries));
     const tooltipReactElem = React.createElement(GraphTooltipReact, tooltipProps);
     ReactDOM.render(tooltipReactElem, this.tooltipElem);
   }

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -325,6 +325,10 @@ class GraphElement {
   }
 
   renderTooltip() {
+    if (!this.plot) {
+      return;
+    }
+
     const sharedTooltip = this.dashboard.sharedTooltipModeEnabled() && !this.dashboard.sharedCrosshairModeOnly();
     const tooltipProps = {
       series: this.plot.getData(this.sortedSeries),

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -334,6 +334,15 @@ class GraphElement {
       sharedTooltip: sharedTooltip,
       allSeriesMode: this.panel.tooltip.shared,
       sort: this.panel.tooltip.sort,
+      panelOptions: {
+        tooltip: {
+          value_type: this.panel.tooltip.value_type,
+        },
+        legend: {
+          hideEmpty: this.panel.legend.hideEmpty,
+          hideZero: this.panel.legend.hideZero,
+        },
+      },
       getOffset: x => this.getOffset(x),
       formatDate: (time, format) => this.ctrl.dashboard.formatDate(time, format),
       onMouseleave: () => this.onTooltipClear(),

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -26,7 +26,6 @@ import ReactDOM from 'react-dom';
 import { Legend, GraphLegendProps } from './Legend/Legend';
 // import { TimeSeriesTooltip, TimeSeriesTooltipProps } from 'app/core/components/TimeSeriesTooltip/TimeSeriesTooltip';
 import GraphTooltipReact, { GraphTooltipProps } from 'app/core/components/TimeSeriesTooltip/GraphTooltip';
-
 import { GraphCtrl } from './module';
 
 class GraphElement {
@@ -310,13 +309,23 @@ class GraphElement {
   }
 
   renderTooltip() {
+    // console.log(this);
     const tooltipProps: GraphTooltipProps = {
       series: this.sortedSeries,
       chartElem: this.elem,
+      panelId: this.panel.id,
+      showSharedTooltip: this.dashboard.sharedTooltipModeEnabled(),
+      getOffset: x => this.getOffset(x),
       dateFormat: this.ctrl.dashboard.formatDate.bind(this.ctrl.dashboard),
     };
     const tooltipReactElem = React.createElement(GraphTooltipReact, tooltipProps);
     ReactDOM.render(tooltipReactElem, this.tooltipElem);
+  }
+
+  getOffset(x) {
+    // const offset = this.plot.p2c({ x });
+    const offset = this.plot.pointOffset({ x });
+    return offset && offset.left;
   }
 
   buildFlotPairs(data) {

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -332,6 +332,8 @@ class GraphElement {
       chartElem: this.elem,
       panelId: this.panel.id,
       sharedTooltip: sharedTooltip,
+      allSeriesMode: this.panel.tooltip.shared,
+      sort: this.panel.tooltip.sort,
       getOffset: x => this.getOffset(x),
       formatDate: (time, format) => this.ctrl.dashboard.formatDate(time, format),
       onMouseleave: () => this.onTooltipClear(),

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -24,6 +24,8 @@ import config from 'app/core/config';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Legend, GraphLegendProps } from './Legend/Legend';
+// import { TimeSeriesTooltip, TimeSeriesTooltipProps } from 'app/core/components/TimeSeriesTooltip/TimeSeriesTooltip';
+import GraphTooltipReact, { GraphTooltipProps } from 'app/core/components/TimeSeriesTooltip/GraphTooltip';
 
 import { GraphCtrl } from './module';
 
@@ -41,6 +43,7 @@ class GraphElement {
   thresholdManager: ThresholdManager;
   timeRegionManager: TimeRegionManager;
   legendElem: HTMLElement;
+  tooltipElem: HTMLElement;
 
   constructor(private scope, private elem, private timeSrv) {
     this.ctrl = scope.ctrl;
@@ -69,6 +72,7 @@ class GraphElement {
     // get graph legend element
     if (this.elem && this.elem.parent) {
       this.legendElem = this.elem.parent().find('.graph-legend')[0];
+      this.tooltipElem = this.elem.parent().find('.graph-tooltip')[0];
     }
   }
 
@@ -121,7 +125,7 @@ class GraphElement {
       return;
     }
 
-    this.tooltip.show(evt.pos);
+    // this.tooltip.show(evt.pos);
   }
 
   onPanelTeardown() {
@@ -138,6 +142,7 @@ class GraphElement {
     this.elem.remove();
 
     ReactDOM.unmountComponentAtNode(this.legendElem);
+    ReactDOM.unmountComponentAtNode(this.tooltipElem);
   }
 
   onGraphHoverClear(event, info) {
@@ -301,6 +306,17 @@ class GraphElement {
 
     this.sortedSeries = this.sortSeries(this.data, this.panel);
     this.callPlot(options, true);
+    this.renderTooltip();
+  }
+
+  renderTooltip() {
+    const tooltipProps: GraphTooltipProps = {
+      series: this.sortedSeries,
+      chartElem: this.elem,
+      dateFormat: this.ctrl.dashboard.formatDate.bind(this.ctrl.dashboard),
+    };
+    const tooltipReactElem = React.createElement(GraphTooltipReact, tooltipProps);
+    ReactDOM.render(tooltipReactElem, this.tooltipElem);
   }
 
   buildFlotPairs(data) {

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -25,7 +25,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Legend, GraphLegendProps } from './Legend/Legend';
 // import { TimeSeriesTooltip, TimeSeriesTooltipProps } from 'app/core/components/TimeSeriesTooltip/TimeSeriesTooltip';
-import GraphTooltipReact, { GraphTooltipProps } from 'app/core/components/TimeSeriesTooltip/GraphTooltip';
+import GraphTooltipReact from 'app/core/components/TimeSeriesTooltip/GraphTooltip';
 import { GraphCtrl } from './module';
 
 class GraphElement {
@@ -327,22 +327,16 @@ class GraphElement {
   renderTooltip() {
     // console.log('renderTooltip', this.ctrl.otherPanelInFullscreenMode());
     const sharedTooltip = this.dashboard.sharedTooltipModeEnabled() && !this.dashboard.sharedCrosshairModeOnly();
-    const tooltipProps: GraphTooltipProps = {
+    const tooltipProps = {
       series: this.plot.getData(this.sortedSeries),
       chartElem: this.elem,
       panelId: this.panel.id,
       sharedTooltip: sharedTooltip,
       allSeriesMode: this.panel.tooltip.shared,
       sort: this.panel.tooltip.sort,
-      panelOptions: {
-        tooltip: {
-          value_type: this.panel.tooltip.value_type,
-        },
-        legend: {
-          hideEmpty: this.panel.legend.hideEmpty,
-          hideZero: this.panel.legend.hideZero,
-        },
-      },
+      valueType: this.panel.tooltip.value_type,
+      hideEmpty: this.panel.legend.hideEmpty,
+      hideZero: this.panel.legend.hideZero,
       getOffset: x => this.getOffset(x),
       formatDate: (time, format) => this.ctrl.dashboard.formatDate(time, format),
       onMouseleave: () => this.onTooltipClear(),

--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -159,7 +159,7 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
   });
 
   elem.bind('plothover', (event, pos, item) => {
-    self.show(pos, item);
+    // self.show(pos, item);
 
     // broadcast to other graph panels that we are hovering!
     pos.panelRelY = (pos.pageY - elem.offset().top) / elem.height();

--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -162,7 +162,7 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
     // self.show(pos, item);
 
     // broadcast to other graph panels that we are hovering!
-    pos.panelRelY = (pos.pageY - elem.offset().top) / elem.height();
+    // pos.panelRelY = (pos.pageY - elem.offset().top) / elem.height();
     appEvents.emit('graph-hover', { pos: pos, panel: panel });
   });
 

--- a/public/app/plugins/panel/graph/template.ts
+++ b/public/app/plugins/panel/graph/template.ts
@@ -6,6 +6,9 @@ const template = `
   <div class="graph-legend">
     <div class="graph-legend-content" graph-legend></div>
   </div>
+
+  <div class="graph-tooltip">
+  </div>
 </div>
 `;
 

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -31,7 +31,7 @@ export interface GraphHoverEvent {
   panel: PanelModel;
 }
 
-export type FlotPoint = [number, number];
+export type FlotPoint = [number, number, number];
 
 export interface FlotHoverItem {
   /** The point with format [ts, value], e.g. [0, 2] */

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -1,0 +1,19 @@
+import { PanelModel } from 'app/features/dashboard/panel_model';
+
+export interface GraphHoverPosition {
+  pageX: number;
+  pageY?: number;
+  x: number;
+  x1?: number;
+  y?: number;
+  y1?: number;
+  y2?: number;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  panelRelY?: number;
+}
+
+export interface GraphHoverEvent {
+  pos: GraphHoverPosition;
+  panel: PanelModel;
+}

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -1,16 +1,29 @@
 import { PanelModel } from 'app/features/dashboard/panel_model';
 
-export interface GraphHoverPosition {
-  pageX: number;
-  pageY?: number;
-  x: number;
-  x1?: number;
-  y?: number;
-  y1?: number;
-  y2?: number;
-  ctrlKey?: boolean;
-  metaKey?: boolean;
+export interface GraphHoverPosition extends FlotPosition {
+  /** Relative Y coordinate (percent of chart height) */
   panelRelY?: number;
+}
+
+export interface FlotPosition {
+  /** Global screen X coordinate */
+  pageX: number;
+  /** Global screen Y coordinate */
+  pageY: number;
+  /** x coordinate for the first X axis */
+  x: number;
+  /** x coordinate for the 1st X axis */
+  x1?: number;
+  /** y coordinate for the first Y axis */
+  y: number;
+  /** y coordinate for the 1st X axis */
+  y1?: number;
+  /** y coordinate for the 2nd X axis (if present) */
+  y2?: number;
+  /** Is Ctrl key pressed */
+  ctrlKey?: boolean;
+  /** Is meta key pressed */
+  metaKey?: boolean;
 }
 
 export interface GraphHoverEvent {

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -30,3 +30,20 @@ export interface GraphHoverEvent {
   pos: GraphHoverPosition;
   panel: PanelModel;
 }
+
+export type FlotPoint = [number, number];
+
+export interface FlotHoverItem {
+  /** The point with format [ts, value], e.g. [0, 2] */
+  datapoint: FlotPoint;
+  /** The index of the point in the data array */
+  dataIndex: number;
+  /** The series object */
+  series: any;
+  /** The index of the series */
+  seriesIndex: number;
+  /** The global screen coordinates of the point */
+  pageX: number;
+  /** The global screen coordinates of the point */
+  pageY: number;
+}

--- a/public/app/types/series.ts
+++ b/public/app/types/series.ts
@@ -52,6 +52,7 @@ export interface TimeSeriesStats {
   count: number;
   allIsNull: boolean;
   allIsZero: boolean;
+  hasMsResolution: boolean;
 }
 
 export enum NullValueMode {

--- a/public/app/types/utils.ts
+++ b/public/app/types/utils.ts
@@ -1,0 +1,3 @@
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export type Subtract<T, K> = Omit<T, keyof K>;

--- a/public/app/viz/state/timeSeries.ts
+++ b/public/app/viz/state/timeSeries.ts
@@ -32,6 +32,7 @@ export function getTimeSeriesVMs({ timeSeries, nullValueMode }: Options): TimeSe
     let timeStep = Number.MAX_VALUE;
     let allIsNull = true;
     let allIsZero = true;
+    let hasMsResolution = false;
 
     const ignoreNulls = nullValueMode === NullValueMode.Ignore;
     const nullAsZero = nullValueMode === NullValueMode.AsZero;
@@ -53,6 +54,13 @@ export function getTimeSeriesVMs({ timeSeries, nullValueMode }: Options): TimeSe
         const currentStep = currentTime - previousTime;
         if (currentStep < timeStep) {
           timeStep = currentStep;
+        }
+      }
+
+      if (currentTime !== null) {
+        const timestamp = currentTime.toString();
+        if (timestamp.length === 13 && timestamp % 1000 !== 0) {
+          hasMsResolution = true;
         }
       }
 
@@ -160,6 +168,7 @@ export function getTimeSeriesVMs({ timeSeries, nullValueMode }: Options): TimeSe
         first,
         allIsZero,
         allIsNull,
+        hasMsResolution,
       },
     };
   });

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -460,3 +460,14 @@
 .thresholds-form-disabled {
   filter: blur(3px);
 }
+
+.graph-tooltip-container {
+  position: fixed;
+  z-index: 100;
+}
+
+.timeseries-tooltip {
+  position: absolute;
+  top: 0;
+  left: 0;
+}


### PR DESCRIPTION
This is an initial implementation of #14085.
Now it implements tooltip for the graph panel with the same features as a previous one.

### Design goals
The main goal is to make tooltip more abstracted from the graph panel and potentially reusable for the other panels which work with time-sereis data. The second goal is split it out into small parts, each with its own independent functions. It allows inheriting more specific components from more general. Also, components should work with a new interface to time series view models - [TimeSeriesVM](https://github.com/grafana/grafana/blob/master/public/app/types/series.ts#L63).

### Components
#### TimeAxisTooltip 
Created by `withTimeAxisTooltip()` HOC. Implements generic behaviour for time-based tooltips.

```ts
interface TimeAxisTooltipProps {
chartElem: any;
panelId: number;
sharedTooltip?: boolean;
hoverEvent?: string; // Event which tooltip is showing on. Default is 'plothover'
useCSSTransforms?: boolean;
getOffset: (x) => number; // Function converting timestamp into offset on chart
onMouseleave?: (event?) => void;
}
```

Components gets `chartElem` and subscribes to hover event. Default hover event is `plothover`, triggered by the `flot.js` library, but may be any event (not implemented yet) with mouse coordinates, like `mousemove`. Also, components listen to global `graph-hover` event (which now is triggering by the panel when user hovers a mouse over the chart) and shows shared tooltip if it's enabled. Position for shared tooltip is calculated through the `getOffset()` function, passed in component props.

Component doesn't take series or any other data related to event. The main purpose of this component is to display tooltip in the appropriate place and inject few props (`position` and `item` from the plothover event) into the underlying component.

#### TimeSeriesTooltip
Created by `withTimeSeriesTooltip()` HOC. Implements behaviour for time-series tooltips. This component takes `series` and other related params (allSeriesMode, hideEmpty, hideZero, etc) and calculates "series hover info" - information about hovered series and datapoint. Alongside with this, components calls `onHighlight()` and `onUnhighlight()` callbacks for highlighting hovered points on the chart. Component injects `series`, `hoverInfo` and `item` (from plothover event, if present) into wrapped component.

#### GraphTooltip
Component which implements graph panel tooltip itself. Just controls how to present information about series on the TimeSeriesTooltip.

So a quick summary looks like:

* **TimeAxisTooltip** - handles hover events and controls tooltip position
* **TimeSeriesTooltip** - makes time series-related calculations (hover info)
* **GraphTooltip** - renders tooltip content

### Pitfalls
Generic `TimeAxisTooltip` component still rely on flot hover event:

```ts
handleHoverEvent = (event, position: FlotPosition, item?: FlotHoverItem) => {
```

it should be improved and can handle different events, like `mousemove` or `mouseover`, which have no `position` argument.

High order components with _Injector_ pattern look a bit tricky to use. [Here's](https://medium.com/@jrwebdev/react-higher-order-component-patterns-in-typescript-42278f7590fb) a good article about types usage in HOCs.

### Improvements
Tooltip placement was changed - now it doesn't change Y position (pinned to the bottom of graph) and X position is restricted by the panel bounds. 
I also added throttling for the series hover info calculation. Too frequent calculation of this info may cause a lot of re-renders and eventually lags in tooltip, especially with shared tooltips. So reasonable default throttling make sense in this case.
Tooltip now positioned with `transform: translate()` CSS property by default - it's faster and smoother than `top, left` approach (this can be changed by `useCSSTransforms` property).

Let's discuss it. Any thoughts appreciated.

