### PR TITLE
fixed logs to time series calculation issue, increased bucket size

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -1,15 +1,15 @@
 import _ from 'lodash';
 
 import { renderUrl } from 'app/core/utils/url';
-import { ExploreState, ExploreUrlState, HistoryItem, QueryTransaction } from 'app/types/explore';
-import { DataQuery, RawTimeRange } from 'app/types/series';
-
-import TableModel, { mergeTablesIntoModel } from 'app/core/table_model';
 import kbn from 'app/core/utils/kbn';
-import colors from 'app/core/utils/colors';
-import TimeSeries from 'app/core/time_series2';
-import { parse as parseDate } from 'app/core/utils/datemath';
 import store from 'app/core/store';
+import colors from 'app/core/utils/colors';
+import { parse as parseDate } from 'app/core/utils/datemath';
+
+import TimeSeries from 'app/core/time_series2';
+import TableModel, { mergeTablesIntoModel } from 'app/core/table_model';
+import { ExploreState, ExploreUrlState, HistoryItem, QueryTransaction } from 'app/types/explore';
+import { DataQuery, RawTimeRange, IntervalValues, DataSourceApi } from 'app/types/series';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',
@@ -170,18 +170,16 @@ export function calculateResultsFromQueryTransactions(
   };
 }
 
-export function getIntervals(
-  range: RawTimeRange,
-  datasource,
-  resolution: number
-): { interval: string; intervalMs: number } {
+export function getIntervals(range: RawTimeRange, datasource: DataSourceApi, resolution: number): IntervalValues {
   if (!datasource || !resolution) {
     return { interval: '1s', intervalMs: 1000 };
   }
+
   const absoluteRange: RawTimeRange = {
     from: parseDate(range.from, false),
     to: parseDate(range.to, true),
   };
+
   return kbn.calculateInterval(absoluteRange, resolution, datasource.interval);
 }
 

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -24,6 +24,7 @@ const PREVIEW_LIMIT = 100;
 
 const graphOptions = {
   series: {
+    stack: true,
     bars: {
       show: true,
       lineWidth: 5,

--- a/public/app/types/index.ts
+++ b/public/app/types/index.ts
@@ -19,6 +19,7 @@ import {
   DataQuery,
   DataQueryResponse,
   DataQueryOptions,
+  IntervalValues,
 } from './series';
 import { PanelProps, PanelOptionsProps } from './panel';
 import { PluginDashboard, PluginMeta, Plugin, PluginsState } from './plugins';
@@ -87,6 +88,7 @@ export {
   AppNotificationTimeout,
   DashboardSearchHit,
   UserState,
+  IntervalValues,
 };
 
 export interface StoreState {

--- a/public/app/types/series.ts
+++ b/public/app/types/series.ts
@@ -19,6 +19,11 @@ export interface TimeRange {
   raw: RawTimeRange;
 }
 
+export interface IntervalValues {
+  interval: string; // 10s,5m
+  intervalMs: number;
+}
+
 export type TimeSeriesValue = string | number | null;
 
 export type TimeSeriesPoints = TimeSeriesValue[][];
@@ -90,6 +95,11 @@ export interface DataQueryOptions {
 
 export interface DataSourceApi {
   /**
+   *  min interval range
+   */
+  interval?: string;
+
+  /**
    * Imports queries from a different datasource
    */
   importQueries?(queries: DataQuery[], originMeta: PluginMeta): Promise<DataQuery[]>;
@@ -97,6 +107,14 @@ export interface DataSourceApi {
    * Initializes a datasource after instantiation
    */
   init?: () => void;
+
+  /**
+   *  Main data query method
+   */
   query(options: DataQueryOptions): Promise<DataQueryResponse>;
+
+  /**
+   *  test data source
+   */
   testDatasource?: () => Promise<any>;
 }


### PR DESCRIPTION
* Fixes #14248, bucket size is now always 10x the explore interval size, so ~10px per bucket
* Think this also fixes stacking issues, enabled stacking and can now no longer see any stacking issues, #14247

