### PR TITLE
Pickers with min-width instead of width

### DIFF
--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -84,7 +84,7 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
   render() {
     const { onCancel } = this.props;
     const newItem = this.state;
-    const pickerClassName = 'width-20';
+    const pickerClassName = 'min-width-20';
     const isValid = this.isValid();
     return (
       <div className="gf-form-inline cta-form">

--- a/public/app/core/components/Picker/UserPicker.tsx
+++ b/public/app/core/components/Picker/UserPicker.tsx
@@ -40,7 +40,7 @@ export class UserPicker extends Component<Props, State> {
       .then(result => {
         return result.map(user => ({
           id: user.userId,
-          label: `${user.login} - ${user.email}`,
+          label: user.login === user.email ? user.login : `${user.login} - ${user.email}`,
           avatarUrl: user.avatarUrl,
           login: user.login,
         }));

--- a/public/app/features/teams/TeamMembers.tsx
+++ b/public/app/features/teams/TeamMembers.tsx
@@ -115,7 +115,7 @@ export class TeamMembers extends PureComponent<Props, State> {
             </button>
             <h5>Add Team Member</h5>
             <div className="gf-form-inline">
-              <UserPicker onSelected={this.onUserSelected} className="width-30" />
+              <UserPicker onSelected={this.onUserSelected} className="min-width-30" />
               {this.state.newTeamMember && (
                 <button className="btn btn-success gf-form-btn" type="submit" onClick={this.onAddUserToTeam}>
                   Add to team

--- a/public/app/features/teams/__snapshots__/TeamMembers.test.tsx.snap
+++ b/public/app/features/teams/__snapshots__/TeamMembers.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Render should render component 1`] = `
         className="gf-form-inline"
       >
         <UserPicker
-          className="width-30"
+          className="min-width-30"
           onSelected={[Function]}
         />
       </div>
@@ -152,7 +152,7 @@ exports[`Render should render team members 1`] = `
         className="gf-form-inline"
       >
         <UserPicker
-          className="width-30"
+          className="min-width-30"
           onSelected={[Function]}
         />
       </div>
@@ -372,7 +372,7 @@ exports[`Render should render team members when sync enabled 1`] = `
         className="gf-form-inline"
       >
         <UserPicker
-          className="width-30"
+          className="min-width-30"
           onSelected={[Function]}
         />
       </div>

--- a/public/sass/utils/_widths.scss
+++ b/public/sass/utils/_widths.scss
@@ -20,6 +20,12 @@
 }
 
 @for $i from 1 through 30 {
+  .min-width-#{$i} {
+    min-width: ($spacer * $i) - $gf-form-margin !important;
+  }
+}
+
+@for $i from 1 through 30 {
   .offset-width-#{$i} {
     margin-left: ($spacer * $i) !important;
   }


### PR DESCRIPTION
Today we set a fixed width to our User- and Team-pickers to avoid them jumping around depending on the length of the content. This is not good when user name is very long, then the picker can override other form components and buttons.

- Switching to min-width
- Make sure user picker only writes the login of the user if the login equals email. Ie avoid 'john.doe@internet.email.address - john.doe@internet.email.address'

Fixes #14341