### PR TITLE
Explore logs styling

### DIFF
--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -54,7 +54,11 @@ export class Settings {
   }
 }
 
-const bootData = (window as any).grafanaBootData || { settings: {} };
+const bootData = (window as any).grafanaBootData || {
+  settings: {},
+  user: {},
+};
+
 const options = bootData.settings;
 options.bootData = bootData;
 

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { TimeSeries } from 'app/core/core';
-import colors from 'app/core/utils/colors';
+import colors, { getThemeColor } from 'app/core/utils/colors';
 
 export enum LogLevel {
   crit = 'critical',
@@ -22,7 +22,7 @@ export const LogLevelColor = {
   [LogLevel.info]: colors[0],
   [LogLevel.debug]: colors[5],
   [LogLevel.trace]: colors[2],
-  [LogLevel.unkown]: '#ddd',
+  [LogLevel.unkown]: getThemeColor('#8e8e8e', '#dde4ed'),
 };
 
 export interface LogSearchMatch {

--- a/public/app/core/utils/colors.ts
+++ b/public/app/core/utils/colors.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import tinycolor from 'tinycolor2';
+import config from 'app/core/config';
 
 export const PALETTE_ROWS = 4;
 export const PALETTE_COLUMNS = 14;
@@ -88,6 +89,10 @@ export function hexToHsl(color) {
 
 export function hslToHex(color) {
   return tinycolor(color).toHexString();
+}
+
+export function getThemeColor(dark: string, light: string): string {
+  return config.bootData.user.lightTheme ? light : dark;
 }
 
 export let sortedColors = sortColorsByHue(colors);

--- a/public/sass/_variables.dark.scss
+++ b/public/sass/_variables.dark.scss
@@ -350,3 +350,6 @@ $diff-json-icon: $gray-7;
 
 //Submenu
 $variable-option-bg: $blue-dark;
+
+// logs
+$logs-color-unkown: $gray-2;

--- a/public/sass/_variables.light.scss
+++ b/public/sass/_variables.light.scss
@@ -359,3 +359,6 @@ $diff-json-icon: $gray-4;
 
 //Submenu
 $variable-option-bg: $blue-light;
+
+// logs
+$logs-color-unkown: $gray-5;

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -78,6 +78,7 @@ $column-horizontal-spacing: 10px;
 
 .logs-row__labels {
   max-width: 20%;
+  line-height: 1.2;
 }
 
 .logs-row__message {
@@ -187,10 +188,6 @@ $column-horizontal-spacing: 10px;
   border-radius: $border-radius;
   justify-content: space-between;
   box-shadow: $popover-shadow;
-}
-
-.logs-row__labels {
-  line-height: 1.2;
 }
 
 .logs-stats__info {

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -64,10 +64,11 @@ $column-horizontal-spacing: 10px;
     display: table-cell;
     padding-right: $column-horizontal-spacing;
     vertical-align: middle;
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;
 
     &:first-child {
       padding-left: $column-horizontal-spacing - 2px;
-      // border-left: 2px solid transparent;
     }
 
     &:last-child {
@@ -76,14 +77,7 @@ $column-horizontal-spacing: 10px;
   }
 
   &:hover {
-    > div {
-      // border-left: 2px solid $blue;
-      background: $page-bg;
-    }
-  }
-
-  &:nth-child(odd) {
-    // background: $page-bg;
+    background: $page-bg;
   }
 }
 

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -67,7 +67,7 @@ $column-horizontal-spacing: 10px;
 
     &:first-child {
       padding-left: $column-horizontal-spacing - 2px;
-      border-left: 2px solid transparent;
+      // border-left: 2px solid transparent;
     }
 
     &:last-child {
@@ -76,13 +76,14 @@ $column-horizontal-spacing: 10px;
   }
 
   &:hover {
-    > div:first-child {
-      border-left: 2px solid $blue;
+    > div {
+      // border-left: 2px solid $blue;
+      background: $page-bg;
     }
   }
 
   &:nth-child(odd) {
-    background: $page-bg;
+    // background: $page-bg;
   }
 }
 
@@ -116,15 +117,16 @@ $column-horizontal-spacing: 10px;
 
 .logs-row__level {
   position: relative;
-  width: 12px;
+  // width: 12px;
 
   &::after {
     content: '';
     display: block;
-    width: 12px;
-    height: 12px;
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    width: 3px;
     background-color: $gray-2;
-    border-radius: 50%;
   }
 
   &--critical,

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -54,7 +54,6 @@ $column-horizontal-spacing: 10px;
   font-size: 12px;
   display: table;
   table-layout: fixed;
-  margin: 0 -(nth($panel-padding, 2));
 }
 
 .logs-row {
@@ -66,14 +65,6 @@ $column-horizontal-spacing: 10px;
     vertical-align: middle;
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
-
-    &:first-child {
-      padding-left: $column-horizontal-spacing - 2px;
-    }
-
-    &:last-child {
-      padding-left: $column-horizontal-spacing;
-    }
   }
 
   &:hover {
@@ -111,7 +102,6 @@ $column-horizontal-spacing: 10px;
 
 .logs-row__level {
   position: relative;
-  // width: 12px;
 
   &::after {
     content: '';
@@ -120,7 +110,7 @@ $column-horizontal-spacing: 10px;
     top: 1px;
     bottom: 1px;
     width: 3px;
-    background-color: $gray-2;
+    background-color: $logs-color-unkown;
   }
 
   &--critical,

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -1,3 +1,5 @@
+$column-horizontal-spacing: 10px;
+
 .logs-panel-controls {
   display: flex;
   background-color: $page-bg;
@@ -52,6 +54,7 @@
   font-size: 12px;
   display: table;
   table-layout: fixed;
+  margin: 0 -(nth($panel-padding, 2));
 }
 
 .logs-row {
@@ -59,8 +62,20 @@
 
   > div {
     display: table-cell;
-    padding-left: 10px;
-    border: 1px solid transparent;
+    padding-right: $column-horizontal-spacing;
+    vertical-align: middle;
+
+    &:first-child {
+      padding-left: $column-horizontal-spacing;
+    }
+
+    &:last-child {
+      padding-left: $column-horizontal-spacing;
+    }
+  }
+
+  &:nth-child(odd) {
+    background: $page-bg;
   }
 }
 
@@ -93,36 +108,55 @@
 }
 
 .logs-row__level {
-  background-color: transparent;
   position: relative;
-  width: 3px;
-  padding: 0 !important;
+  width: 12px;
+
+  &::after {
+    content: '';
+    display: block;
+    width: 12px;
+    height: 12px;
+    background-color: $gray-2;
+    border-radius: 50%;
+  }
 
   &--critical,
   &--crit {
-    background-color: #705da0;
+    &::after {
+      background-color: #705da0;
+    }
   }
 
   &--error,
   &--err {
-    background-color: #e24d42;
+    &::after {
+      background-color: #e24d42;
+    }
   }
 
   &--warning,
   &--warn {
-    background-color: #eab839;
+    &::after {
+      background-color: #eab839;
+    }
   }
 
   &--info {
-    background-color: #7eb26d;
+    &::after {
+      background-color: #7eb26d;
+    }
   }
 
   &--debug {
-    background-color: #1f78c1;
+    &::after {
+      background-color: #1f78c1;
+    }
   }
 
   &--trace {
-    background-color: #6ed0e0;
+    &::after {
+      background-color: #6ed0e0;
+    }
   }
 }
 

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -66,11 +66,18 @@ $column-horizontal-spacing: 10px;
     vertical-align: middle;
 
     &:first-child {
-      padding-left: $column-horizontal-spacing;
+      padding-left: $column-horizontal-spacing - 2px;
+      border-left: 2px solid transparent;
     }
 
     &:last-child {
       padding-left: $column-horizontal-spacing;
+    }
+  }
+
+  &:hover {
+    > div:first-child {
+      border-left: 2px solid $blue;
     }
   }
 
@@ -137,7 +144,7 @@ $column-horizontal-spacing: 10px;
   &--warning,
   &--warn {
     &::after {
-      background-color: #eab839;
+      background-color: $warn;
     }
   }
 


### PR DESCRIPTION
fixes the spacing between levels introduced in #14352 

and adds a subtle hover effect. Would like to try different hover effects / backgrounds / borders, but not sure I have time to spend on this. Feel the look of the logs rows is still ugly (especially labels), but making minor progress here. 

I did experiment with adding a transform: scale(1.005) to the over effect, it has a really good effect of making the row/time/level standout but make the hover effect when you move the mouse around more distracting, so did not include that. 

![image](https://user-images.githubusercontent.com/10999/49591561-0bd51480-f96f-11e8-9fd8-4bb616b87322.png)
