### PR TITLE
Remove Explore > "New tab" from sidebar

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -147,9 +147,6 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 			SubTitle: "Explore your data",
 			Icon:     "fa fa-rocket",
 			Url:      setting.AppSubUrl + "/explore",
-			Children: []*dtos.NavLink{
-				{Text: "New tab", Icon: "gicon gicon-dashboard-new", Url: setting.AppSubUrl + "/explore"},
-			},
 		})
 	}
 

--- a/public/app/core/components/sidemenu/TopSectionItem.tsx
+++ b/public/app/core/components/sidemenu/TopSectionItem.tsx
@@ -15,7 +15,7 @@ const TopSectionItem: SFC<Props> = props => {
           {link.img && <img src={link.img} />}
         </span>
       </a>
-      {link.children && <SideMenuDropDown link={link} />}
+      <SideMenuDropDown link={link} />
     </div>
   );
 };

--- a/public/app/core/components/sidemenu/__snapshots__/TopSectionItem.test.tsx.snap
+++ b/public/app/core/components/sidemenu/__snapshots__/TopSectionItem.test.tsx.snap
@@ -13,5 +13,8 @@ exports[`Render should render component 1`] = `
       <i />
     </span>
   </a>
+  <SideMenuDropDown
+    link={Object {}}
+  />
 </div>
 `;


### PR DESCRIPTION
- we don't support tabs yet, might as well remove the entry

As seen by @DanCech 