### PR TITLE
Explore: graphInterval needs to update after query execution 

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -654,6 +654,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
         ...results,
         queryTransactions: nextQueryTransactions,
         showingStartPage: false,
+        graphInterval: queryOptions.intervalMs,
       };
     });
 


### PR DESCRIPTION
* fixes #14364

Noticed something strange that, calculateResultsFromQueryTransactions is called both on transaction start & transaction complete. So the whole get time series from logs is called twice when you change time range. Not sure if this is intended or not. 

