### PR TITLE
Explore: dont pass all rows to all rows, fixes profiler

### DIFF
--- a/public/app/features/explore/LogLabels.tsx
+++ b/public/app/features/explore/LogLabels.tsx
@@ -69,7 +69,7 @@ export class Stats extends PureComponent<{
 
 class Label extends PureComponent<
   {
-    allRows?: LogRow[];
+    getRows?: () => LogRow[];
     label: string;
     plain?: boolean;
     value: string;
@@ -98,13 +98,14 @@ class Label extends PureComponent<
       if (state.showStats) {
         return { showStats: false, stats: null };
       }
-      const stats = calculateLogsLabelStats(this.props.allRows, this.props.label);
+      const allRows = this.props.getRows();
+      const stats = calculateLogsLabelStats(allRows, this.props.label);
       return { showStats: true, stats };
     });
   };
 
   render() {
-    const { allRows, label, plain, value } = this.props;
+    const { getRows, label, plain, value } = this.props;
     const { showStats, stats } = this.state;
     const tooltip = `${label}: ${value}`;
     return (
@@ -115,12 +116,12 @@ class Label extends PureComponent<
         {!plain && (
           <span title="Filter for label" onClick={this.onClickLabel} className="logs-label__icon fa fa-search-plus" />
         )}
-        {!plain && allRows && <span onClick={this.onClickStats} className="logs-label__icon fa fa-signal" />}
+        {!plain && getRows && <span onClick={this.onClickStats} className="logs-label__icon fa fa-signal" />}
         {showStats && (
           <span className="logs-label__stats">
             <Stats
               stats={stats}
-              rowCount={allRows.length}
+              rowCount={getRows().length}
               label={label}
               value={value}
               onClickClose={this.onClickClose}
@@ -133,15 +134,15 @@ class Label extends PureComponent<
 }
 
 export default class LogLabels extends PureComponent<{
-  allRows?: LogRow[];
+  getRows?: () => LogRow[];
   labels: LogsStreamLabels;
   plain?: boolean;
   onClickLabel?: (label: string, value: string) => void;
 }> {
   render() {
-    const { allRows, labels, onClickLabel, plain } = this.props;
+    const { getRows, labels, onClickLabel, plain } = this.props;
     return Object.keys(labels).map(key => (
-      <Label key={key} allRows={allRows} label={key} value={labels[key]} plain={plain} onClickLabel={onClickLabel} />
+      <Label key={key} getRows={getRows} label={key} value={labels[key]} plain={plain} onClickLabel={onClickLabel} />
     ));
   }
 }


### PR DESCRIPTION
- react profiler seems to evaluate all props of all components down the tree
- this becomes slow when 1000 rows are passed to 1000 rows and their labels
- use getter function instead to ask for rows on demand

Fixes #14362

To test this:

find a logging stream with lots of log lines, then open chrome devtools and choose the react tab. Without this change it will hog your CPU for 2 minutes and the UI becomes unresponsive. 