### PR TITLE
Use correct variable name in fail text

### DIFF
--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -178,7 +178,7 @@
       </p>
       <p>
         1. This could be caused by your reverse proxy settings.<br /><br />
-        2. If you host grafana under subpath make sure your grafana.ini root_path setting includes subpath<br /> <br />
+        2. If you host grafana under subpath make sure your grafana.ini root_url setting includes subpath<br /> <br />
         3. If you have a local dev build make sure you build frontend using: npm run dev, npm run watch, or npm run
         build<br /> <br />
         4. Sometimes restarting grafana-server can help<br />


### PR DESCRIPTION
In my setup I have grafana running behind a reverse proxy. With the basic settings a warning page shows up "If you're seeing this Grafana has failed to load its application files". This page contains some hints how to adjust the grafana.ini to run behind a reverse proxy. 
However the mentioned root_path variable doesn't exist, it is called root_url in the [server] section.

In grafana.ini:

```
# The full public facing url you use in browser, used for redirects and emails
# If you use reverse proxy and sub path specify full url (with sub path)
;root_url = http://localhost:3000
```

In documentation it is also correct: http://docs.grafana.org/installation/behind_proxy/
