### PR TITLE
Fix warning re "state update on unmounted component" happening when l…

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -51,6 +51,7 @@ export class PanelChrome extends PureComponent<Props, State> {
 
   componentWillUnmount() {
     this.props.panel.events.off('refresh', this.onRefresh);
+    this.props.panel.events.off('render', this.onRender);
   }
 
   onRefresh = () => {


### PR DESCRIPTION
How to reproduce:
Select a React panel. Switch to an Angular one.
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in PanelChrome (created by DashboardPanel)
```
Part of #14274