### PR TITLE
Check with lowercase

### DIFF
--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -148,7 +148,7 @@ export function loadDataSourceTypes(): ThunkResult<void> {
 export function nameExits(dataSources, name) {
   return (
     dataSources.filter(dataSource => {
-      return dataSource.name === name;
+      return dataSource.name.toLowerCase() === name.toLowerCase();
     }).length > 0
   );
 }


### PR DESCRIPTION
When creating a new datasource, we didn't check against names with lowercase which caused issues with duplicate names. This PR should fix that.

fixes #14467