### PR TITLE
Infra package for creating distributed lock to make sure functions are executed once even in HA mode. 

### DIFF
--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -28,6 +28,7 @@ import (
 
 	// self registering services
 	_ "github.com/grafana/grafana/pkg/extensions"
+	_ "github.com/grafana/grafana/pkg/infra/serverlock"
 	_ "github.com/grafana/grafana/pkg/metrics"
 	_ "github.com/grafana/grafana/pkg/plugins"
 	_ "github.com/grafana/grafana/pkg/services/alerting"

--- a/pkg/infra/serverlock/migrations.go
+++ b/pkg/infra/serverlock/migrations.go
@@ -1,0 +1,23 @@
+package serverlock
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// AddMigration create database migrations for server lock
+func (sl *ServerLockService) AddMigration(mg *migrator.Migrator) {
+	serverLock := migrator.Table{
+		Name: "server_lock",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "operation_uid", Type: migrator.DB_Text},
+			{Name: "version", Type: migrator.DB_BigInt},
+			{Name: "last_execution", Type: migrator.DB_BigInt, Nullable: false},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"operation_uid"}, Type: migrator.UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create server_lock table", migrator.NewAddTableMigration(serverLock))
+
+	mg.AddMigration("add index server_lock.operation_uid", migrator.NewAddIndexMigration(serverLock, serverLock.Indices[0]))
+}

--- a/pkg/infra/serverlock/migrations.go
+++ b/pkg/infra/serverlock/migrations.go
@@ -8,7 +8,7 @@ func (sl *ServerLockService) AddMigration(mg *migrator.Migrator) {
 		Name: "server_lock",
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
-			{Name: "operation_uid", Type: migrator.DB_Text},
+			{Name: "operation_uid", Type: migrator.DB_NVarchar, Length: 100},
 			{Name: "version", Type: migrator.DB_BigInt},
 			{Name: "last_execution", Type: migrator.DB_BigInt, Nullable: false},
 		},

--- a/pkg/infra/serverlock/model.go
+++ b/pkg/infra/serverlock/model.go
@@ -1,0 +1,8 @@
+package serverlock
+
+type serverLock struct {
+	Id            int64
+	OperationUid  string
+	LastExecution int64
+	Version       int64
+}

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -1,0 +1,111 @@
+package serverlock
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func init() {
+	registry.RegisterService(&ServerLockService{})
+}
+
+// ServerLockService allows servers in HA mode to execute function once over in the group
+type ServerLockService struct {
+	SQLStore *sqlstore.SqlStore `inject:""`
+	log      log.Logger
+}
+
+// Init this service
+func (sl *ServerLockService) Init() error {
+	return nil
+}
+
+// OncePerServerGroup try to create a lock for this server and only executes the
+// `fn` function when successful. This should not be used at low internal. But services
+// that needs to be run once every ex 10m.
+func (sl *ServerLockService) OncePerServerGroup(ctx context.Context, actionName string, maxEvery time.Duration, fn func()) error {
+	rowLock, err := sl.getOrCreate(ctx, actionName)
+	if err != nil {
+		return err
+	}
+
+	if rowLock.LastExecution != 0 {
+		lastExeuctionTime := time.Unix(rowLock.LastExecution, 0)
+		if lastExeuctionTime.Unix() > time.Now().Add(-maxEvery).Unix() {
+			return nil
+		}
+	}
+
+	acquiredLock, err := sl.acquireLock(ctx, rowLock, maxEvery)
+	if err != nil {
+		return err
+	}
+
+	if acquiredLock {
+		fn()
+	}
+
+	return nil
+}
+
+func (sl *ServerLockService) acquireLock(ctx context.Context, serverLock *serverLock, maxEvery time.Duration) (bool, error) {
+	var result bool
+
+	err := sl.SQLStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		newVersion := serverLock.Version + 1
+		sql := `UPDATE server_lock SET
+			version = ?,
+			last_execution = ?
+		WHERE
+			id = ? AND version = ?`
+
+		res, err := dbSession.Exec(sql, newVersion, time.Now().Unix(), serverLock.Id, serverLock.Version)
+		if err != nil {
+			return err
+		}
+
+		affected, err := res.RowsAffected()
+		result = affected == 1
+
+		return err
+	})
+
+	return result, err
+}
+
+func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
+	var result *serverLock
+
+	err := sl.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		lockRows := []*serverLock{}
+		err := dbSession.Where("operation_uid = ?", actionName).Find(&lockRows)
+		if err != nil {
+			return err
+		}
+
+		if len(lockRows) > 0 {
+			result = lockRows[0]
+			return nil
+		}
+
+		lockRow := &serverLock{
+			OperationUid:  actionName,
+			LastExecution: 0,
+		}
+
+		_, err = dbSession.Insert(lockRow)
+		if err != nil {
+			return err
+		}
+
+		result = lockRow
+
+		return nil
+	})
+
+	return result, err
+}

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -21,6 +21,7 @@ type ServerLockService struct {
 
 // Init this service
 func (sl *ServerLockService) Init() error {
+	sl.log = log.New("infra.lockservice")
 	return nil
 }
 

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -13,8 +13,6 @@ func init() {
 	registry.RegisterService(&ServerLockService{})
 }
 
-// DistributedLockService
-
 // ServerLockService allows servers in HA mode to claim a lock
 // and execute an function if the server was granted the lock
 type ServerLockService struct {

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -36,7 +36,7 @@ func (sl *ServerLockService) LockAndExecute(ctx context.Context, actionName stri
 		return err
 	}
 
-	// avoid execution if last lock happened less than `matInterval` ago
+	// avoid execution if last lock happened less than `maxInterval` ago
 	if rowLock.LastExecution != 0 {
 		lastExeuctionTime := time.Unix(rowLock.LastExecution, 0)
 		if lastExeuctionTime.Unix() > time.Now().Add(-maxInterval).Unix() {

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -13,7 +13,10 @@ func init() {
 	registry.RegisterService(&ServerLockService{})
 }
 
-// ServerLockService allows servers in HA mode to execute function once over in the group
+// DistributedLockService
+
+// ServerLockService allows servers in HA mode to claim a lock
+// and execute an function if the server was granted the lock
 type ServerLockService struct {
 	SQLStore *sqlstore.SqlStore `inject:""`
 	log      log.Logger
@@ -25,10 +28,10 @@ func (sl *ServerLockService) Init() error {
 	return nil
 }
 
-// OncePerServerGroup try to create a lock for this server and only executes the
+// LockAndExecute try to create a lock for this server and only executes the
 // `fn` function when successful. This should not be used at low internal. But services
 // that needs to be run once every ex 10m.
-func (sl *ServerLockService) OncePerServerGroup(ctx context.Context, actionName string, maxInterval time.Duration, fn func()) error {
+func (sl *ServerLockService) LockAndExecute(ctx context.Context, actionName string, maxInterval time.Duration, fn func()) error {
 	// gets or creates a lockable row
 	rowLock, err := sl.getOrCreate(ctx, actionName)
 	if err != nil {

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -21,19 +21,19 @@ func TestServerLok(t *testing.T) {
 		ctx := context.Background()
 
 		//this time `fn` should be executed
-		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
 
 		//this should not execute `fn`
-		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
-		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
-		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
-		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
 
 		// wait 5 second.
 		<-time.After(atInterval * 2)
 
 		// now `fn` should be executed again
-		err = sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter)
+		err = sl.LockAndExecute(ctx, "test-operation", atInterval, incCounter)
 		So(err, ShouldBeNil)
 		So(counter, ShouldEqual, 2)
 	})

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -13,63 +13,28 @@ import (
 func TestServerLok(t *testing.T) {
 	sl := createTestableServerLock(t)
 
-	Convey("Server lock integration test", t, func() {
+	Convey("Server lock integration tests", t, func() {
+		counter := 0
+		var err error
+		incCounter := func() { counter++ }
+		atInterval := time.Second * 1
+		ctx := context.Background()
 
-		Convey("Check that we can call OncePerServerGroup multiple times without executing callback", func() {
-			counter := 0
-			var err error
+		//this time `fn` should be executed
+		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
 
-			//this time `fn` should be executed
-			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
-			So(err, ShouldBeNil)
+		//this should not execute `fn`
+		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
+		So(sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter), ShouldBeNil)
 
-			//this should not execute `fn`
-			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
-			So(err, ShouldBeNil)
+		// wait 5 second.
+		<-time.After(atInterval * 2)
 
-			//this should not execute `fn`
-			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
-			So(err, ShouldBeNil)
-
-			// wg := sync.WaitGroup{}
-			// for i := 0; i < 3; i++ {
-			// 	wg.Add(1)
-			// 	go func(index int) {
-			// 		defer wg.Done()
-			// 		//sl := createTestableServerLock(t)
-			// 		//<-time.After(time.Second)
-
-			// 		j := 0
-			// 		for {
-			// 			select {
-			// 			case <-time.Tick(time.Second):
-			// 				fmt.Printf("running worker %d loop %d\n", index, j)
-			// 				err := sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*2, func() {
-			// 					counter++
-			// 				})
-
-			// 				if err != nil {
-			// 					t.Errorf("expected. err: %v", err)
-			// 				}
-
-			// 				j++
-			// 				if j > 3 {
-			// 					return
-			// 				}
-			// 			}
-			// 		}
-			// 	}(i)
-			// }
-
-			// wg.Wait()
-
-			// wait 5 second.
-			<-time.After(time.Second * 10)
-
-			// now `fn` should be executed again
-			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
-			So(err, ShouldBeNil)
-			So(counter, ShouldEqual, 2)
-		})
+		// now `fn` should be executed again
+		err = sl.OncePerServerGroup(ctx, "test-operation", atInterval, incCounter)
+		So(err, ShouldBeNil)
+		So(counter, ShouldEqual, 2)
 	})
 }

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -1,0 +1,75 @@
+// +build integration
+
+package serverlock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestServerLok(t *testing.T) {
+	sl := createTestableServerLock(t)
+
+	Convey("Server lock integration test", t, func() {
+
+		Convey("Check that we can call OncePerServerGroup multiple times without executing callback", func() {
+			counter := 0
+			var err error
+
+			//this time `fn` should be executed
+			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
+			So(err, ShouldBeNil)
+
+			//this should not execute `fn`
+			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
+			So(err, ShouldBeNil)
+
+			//this should not execute `fn`
+			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
+			So(err, ShouldBeNil)
+
+			// wg := sync.WaitGroup{}
+			// for i := 0; i < 3; i++ {
+			// 	wg.Add(1)
+			// 	go func(index int) {
+			// 		defer wg.Done()
+			// 		//sl := createTestableServerLock(t)
+			// 		//<-time.After(time.Second)
+
+			// 		j := 0
+			// 		for {
+			// 			select {
+			// 			case <-time.Tick(time.Second):
+			// 				fmt.Printf("running worker %d loop %d\n", index, j)
+			// 				err := sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*2, func() {
+			// 					counter++
+			// 				})
+
+			// 				if err != nil {
+			// 					t.Errorf("expected. err: %v", err)
+			// 				}
+
+			// 				j++
+			// 				if j > 3 {
+			// 					return
+			// 				}
+			// 			}
+			// 		}
+			// 	}(i)
+			// }
+
+			// wg.Wait()
+
+			// wait 5 second.
+			<-time.After(time.Second * 10)
+
+			// now `fn` should be executed again
+			err = sl.OncePerServerGroup(context.Background(), "test-operation", time.Second*5, func() { counter++ })
+			So(err, ShouldBeNil)
+			So(counter, ShouldEqual, 2)
+		})
+	})
+}

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -1,0 +1,57 @@
+package serverlock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/log"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func createTestableServerLock(t *testing.T) *ServerLockService {
+	t.Helper()
+
+	sqlstore := sqlstore.InitTestDB(t)
+
+	return &ServerLockService{
+		SQLStore: sqlstore,
+		log:      log.New("test-logger"),
+	}
+}
+
+func TestServerLock(t *testing.T) {
+	Convey("Server lock", t, func() {
+		sl := createTestableServerLock(t)
+		operationUID := "test-operation"
+
+		first, err := sl.getOrCreate(context.Background(), operationUID)
+		So(err, ShouldBeNil)
+
+		lastExecution := first.LastExecution
+		Convey("trying to create three new row locks", func() {
+			for i := 0; i < 3; i++ {
+				first, err = sl.getOrCreate(context.Background(), operationUID)
+				So(err, ShouldBeNil)
+				So(first.OperationUid, ShouldEqual, operationUID)
+				So(first.Id, ShouldEqual, 1)
+			}
+
+			Convey("Should not create new since lock already exist", func() {
+				So(lastExecution, ShouldEqual, first.LastExecution)
+			})
+		})
+
+		Convey("Should be able to create lock on first row", func() {
+			gotLock, err := sl.acquireLock(context.Background(), first, time.Second*1)
+			So(err, ShouldBeNil)
+			So(gotLock, ShouldBeTrue)
+
+			gotLock, err = sl.acquireLock(context.Background(), first, time.Second*1)
+			So(err, ShouldBeNil)
+			So(gotLock, ShouldBeFalse)
+		})
+	})
+}

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -3,10 +3,8 @@ package serverlock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/grafana/grafana/pkg/log"
-
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -45,11 +43,11 @@ func TestServerLock(t *testing.T) {
 		})
 
 		Convey("Should be able to create lock on first row", func() {
-			gotLock, err := sl.acquireLock(context.Background(), first, time.Second*1)
+			gotLock, err := sl.acquireLock(context.Background(), first)
 			So(err, ShouldBeNil)
 			So(gotLock, ShouldBeTrue)
 
-			gotLock, err = sl.acquireLock(context.Background(), first, time.Second*1)
+			gotLock, err = sl.acquireLock(context.Background(), first)
 			So(err, ShouldBeNil)
 			So(gotLock, ShouldBeFalse)
 		})

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -7,9 +7,8 @@ import (
 	"path"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/serverlock"
-
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
@@ -41,7 +40,7 @@ func (srv *CleanUpService) Run(ctx context.Context) error {
 			srv.cleanUpTmpFiles()
 			srv.deleteExpiredSnapshots()
 			srv.deleteExpiredDashboardVersions()
-			srv.ServerLockService.OncePerServerGroup(ctx, "delete old login attempts", time.Minute*10, func() {
+			srv.ServerLockService.LockAndExecute(ctx, "delete old login attempts", time.Minute*10, func() {
 				srv.deleteOldLoginAttempts()
 			})
 

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -31,6 +31,7 @@ func AddMigrations(mg *Migrator) {
 	addTagMigration(mg)
 	addLoginAttemptMigrations(mg)
 	addUserAuthMigrations(mg)
+	addServerlockMigrations(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/serverlock_migrations.go
+++ b/pkg/services/sqlstore/migrations/serverlock_migrations.go
@@ -1,9 +1,8 @@
-package serverlock
+package migrations
 
 import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 
-// AddMigration create database migrations for server lock
-func (sl *ServerLockService) AddMigration(mg *migrator.Migrator) {
+func addServerlockMigrations(mg *migrator.Migrator) {
 	serverLock := migrator.Table{
 		Name: "server_lock",
 		Columns: []*migrator.Column{

--- a/scripts/circle-test-backend.sh
+++ b/scripts/circle-test-backend.sh
@@ -19,5 +19,5 @@ exit_if_fail time go install ./pkg/cmd/grafana-server
 echo "running go test"
 set -e
 time for d in $(go list ./pkg/...); do
-  exit_if_fail go test -covermode=atomic $d
+  exit_if_fail go test -tags=integration -covermode=atomic $d
 done


### PR DESCRIPTION
This will make it easy for other components to make sure certain functions are only runned once even when Grafana is running in HA mode. 

Some interesting ideas in the PR.
I placed all the code for `serverlock` in the same package instead of using placing database code in the sqlstore package. 

I like the fact that I could make the database model private in this case. 

Spent hours trying to write multi go routines tests that can query/write to the database but failed...
