### PR TITLE
Show predefined time ranges as first in timepicker on small screens

### DIFF
--- a/public/sass/components/_timepicker.scss
+++ b/public/sass/components/_timepicker.scss
@@ -13,13 +13,18 @@
 }
 
 .gf-timepicker-dropdown {
-  position: absolute;
-  top: $navbarHeight;
-  right: 0;
-  padding: 10px 20px;
   background-color: $page-bg;
   border-radius: 0 0 0 4px;
   box-shadow: $search-shadow;
+  display: flex;
+  flex-direction: column-reverse;
+  padding: 10px 20px;
+  position: absolute;
+  right: 0;
+  top: $navbarHeight;
+  @include media-breakpoint-up(md) {
+    flex-direction: column;
+  }
 }
 
 .gf-timepicker-absolute-section {


### PR DESCRIPTION
For small screens show predefined time ranges first.

Currently the datetime picker with those little calendars was displayed first but it's hard to use on mobile. Predefined ranges are more desired as first there I believe.