### PR TITLE
remove check on axis.used in flot

### DIFF
--- a/public/vendor/flot/jquery.flot.js
+++ b/public/vendor/flot/jquery.flot.js
@@ -931,13 +931,13 @@ Licensed under the MIT license.
             var res = {}, i, axis;
             for (i = 0; i < xaxes.length; ++i) {
                 axis = xaxes[i];
-                if (axis && axis.used)
+                if (axis)
                     res["x" + axis.n] = axis.c2p(pos.left);
             }
 
             for (i = 0; i < yaxes.length; ++i) {
                 axis = yaxes[i];
-                if (axis && axis.used)
+                if (axis)
                     res["y" + axis.n] = axis.c2p(pos.top);
             }
 


### PR DESCRIPTION
It looks like the issue is with a subtle behavior of the underlying flot plotting library. If a graph has no data, the axes are considered unused and no positions are returned in the click event. These positions are being used to render the popup. I've removed the check on `axis.used` and we get the desired result of the editor dialog appearing at the location of the annotation. 

Fixes #13765