### PR TITLE
Create only one submit button in variable form

### DIFF
--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -317,8 +317,8 @@
 		</div>
 
 		<div class="gf-form-button-row p-y-0">
-			<button type="submit" class="btn btn-success" ng-show="mode === 'edit'" ng-click="update();">Update</button>
-			<button type="submit" class="btn btn-success" ng-show="mode === 'new'" ng-click="add();">Add</button>
+			<button type="submit" class="btn btn-success" ng-if="mode === 'edit'" ng-click="update();">Update</button>
+			<button type="submit" class="btn btn-success" ng-if="mode === 'new'" ng-click="add();">Add</button>
 		</div>
 
 	</form>


### PR DESCRIPTION
Previously, if I was adding a new variable to a dashboard and hit the
Enter key to submit the form (instead of clicking on the "Add" button) I
would be redirected to the variables list but my new variable wouldn't
appear.

This is because activating the form would activate the first submit
button in the DOM, which was always "Update" even though it might be
hidden. Then update() would be called instead of add() and the variable
would not be created.

This change will make the edit mode determine the submit button's
presence in the DOM rather than its visibility. So hitting return to
submit the form will activate the correct button because the wrong
button won't exist.