### PR TITLE
In Table Panel, renders epoch string as date if date column style

### DIFF
--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -91,7 +91,14 @@ export class TableRenderer {
         if (_.isArray(v)) {
           v = v[0];
         }
+
+        // if is an epoch (numeric string and len > 12)
+        if (_.isString(v) && !isNaN(v) && v.length > 12) {
+          v = parseInt(v, 10);
+        }
+
         let date = moment(v);
+
         if (this.isUtc) {
           date = date.utc();
         }

--- a/public/app/plugins/panel/table/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table/specs/renderer.test.ts
@@ -186,6 +186,21 @@ describe('when rendering table', () => {
       expect(html).toBe('<td>2014-01-01T06:06:06Z</td>');
     });
 
+    it('time column with epoch as string should be formatted', () => {
+      const html = renderer.renderCell(0, 0, '1388556366666');
+      expect(html).toBe('<td>2014-01-01T06:06:06Z</td>');
+    });
+
+    it('time column with RFC2822 date as string should be formatted', () => {
+      const html = renderer.renderCell(0, 0, 'Sat, 01 Dec 2018 01:00:00 GMT');
+      expect(html).toBe('<td>2018-12-01T01:00:00Z</td>');
+    });
+
+    it('time column with ISO date as string should be formatted', () => {
+      const html = renderer.renderCell(0, 0, '2018-12-01T01:00:00Z');
+      expect(html).toBe('<td>2018-12-01T01:00:00Z</td>');
+    });
+
     it('undefined time column should be rendered as -', () => {
       const html = renderer.renderCell(0, 0, undefined);
       expect(html).toBe('<td>-</td>');


### PR DESCRIPTION
fixes #14484.

If an the column value is an epoch string e.g. `'1544912676544'` and the Date column style is chosen then converts to integer before trying to convert it to date.
