### PR TITLE
added optional label functionality to legend format in prometheus datasource

### DIFF
--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -75,6 +75,11 @@ Name | Description
 
 For details of *metric names*, *label names* and *label values* are please refer to the [Prometheus documentation](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 
+### Legend format
+
+If you have mixed cardinality in a panel, you can use the '||' operator in your legend format pattern to ignore labels that aren't available on the metric.
+Here's a sample of an optional label `{{ - || hostname }}` it takes the format `{{ <separator token if desired> || <label name> }}`
+
 
 #### Using interval and range variables
 

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -137,11 +137,19 @@ func formatLegend(metric model.Metric, query *PrometheusQuery) string {
 		labelName := strings.Replace(string(in), "{{", "", 1)
 		labelName = strings.Replace(labelName, "}}", "", 1)
 		labelName = strings.TrimSpace(labelName)
-		if val, exists := metric[model.LabelName(labelName)]; exists {
-			return []byte(val)
-		}
+		if strings.Contains(labelName, "||") {
+			parts := strings.SplitN(labelName, "||", 2)
+			if val, exists := metric[model.LabelName(parts[1])]; exists {
+				return []byte(parts[0] + string(val))
+			}
+			return []byte("")
+		} else {
+			if val, exists := metric[model.LabelName(labelName)]; exists {
+				return []byte(val)
+			}
 
-		return in
+			return in
+		}
 	})
 
 	return string(result)

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -157,8 +157,17 @@ export class ResultTransformer {
   renderTemplate(aliasPattern, aliasData) {
     const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
     return aliasPattern.replace(aliasRegex, (match, g1) => {
-      if (aliasData[g1]) {
-        return aliasData[g1];
+      if (g1.includes('||')) {
+        const parts = g1.split('||');
+        if (aliasData[parts[1]]) {
+          return parts[0] + aliasData[parts[1]];
+        } else {
+          return '';
+        }
+      } else {
+        if (aliasData[g1]) {
+          return aliasData[g1];
+        }
       }
       return g1;
     });


### PR DESCRIPTION
This PR adds support for cleanly rendering optional labels
This is handy if you have a single query that returns mixed cardinality metrics. This is what it looks like rendered: 
![image](https://user-images.githubusercontent.com/977415/50070185-1aa39e80-019b-11e9-85a1-f21e418da9b3.png)

This is especially useful for templated dashboards where each graph might have slightly different cardinality, but you want to be able to easily generate them.

Also this is more a proof of concept than anything, if you'd rather see a different syntax or richer capabilities, please comment and I'll attempt to implement.