### PR TITLE
Explore: Datasource fixes

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -158,7 +158,9 @@ export function calculateResultsFromQueryTransactions(
   );
   const tableResult = mergeTablesIntoModel(
     new TableModel(),
-    ...queryTransactions.filter(qt => qt.resultType === 'Table' && qt.done && qt.result).map(qt => qt.result)
+    ...queryTransactions
+      .filter(qt => qt.resultType === 'Table' && qt.done && qt.result && qt.result.columns && qt.result.rows)
+      .map(qt => qt.result)
   );
   const logsResult =
     datasource && datasource.mergeStreams

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -57,12 +57,19 @@ export async function getExploreUrl(
     }
   }
 
-  if (exploreDatasource && exploreDatasource.meta.explore) {
+  if (panelDatasource) {
     const range = timeSrv.timeRangeForUrl();
-    const state = {
-      ...exploreDatasource.getExploreState(exploreTargets),
-      range,
-    };
+    let state: Partial<ExploreUrlState> = { range };
+    if (exploreDatasource.getExploreState) {
+      state = { ...state, ...exploreDatasource.getExploreState(exploreTargets) };
+    } else {
+      state = {
+        ...state,
+        datasource: panelDatasource.name,
+        queries: exploreTargets.map(t => ({ ...t, datasource: panelDatasource.name })),
+      };
+    }
+
     const exploreState = JSON.stringify(state);
     url = renderUrl('/explore', { state: exploreState });
   }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -608,9 +608,11 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     // Clone range for query request
     // const queryRange: RawTimeRange = { ...range };
     // const { from, to, raw } = this.timeSrv.timeRange();
-    // Datasource is using `panelId + query.refId` for cancellation logic.
+    // Most datasource is using `panelId + query.refId` for cancellation logic.
     // Using `format` here because it relates to the view panel that the request is for.
-    const panelId = queryOptions.format;
+    // However, some datasources don't use `panelId + query.refId`, but only `panelId`.
+    // Therefore panel id has to be unique.
+    const panelId = `${queryOptions.format}-${query.key}`;
 
     return {
       interval,

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -233,12 +233,7 @@ class MetricsPanelCtrl extends PanelCtrl {
 
   getAdditionalMenuItems() {
     const items = [];
-    if (
-      config.exploreEnabled &&
-      this.contextSrv.isEditor &&
-      this.datasource &&
-      (this.datasource.meta.explore || this.datasource.meta.id === 'mixed')
-    ) {
+    if (config.exploreEnabled && this.contextSrv.isEditor && this.datasource) {
       items.push({
         text: 'Explore',
         click: 'ctrl.explore();',


### PR DESCRIPTION
* Feature: Make it possible to go to Explore mode from panel query editor using the context menu

* Bug fix: Don't try to merge tables if the query request did not return any tables or columns
* Bug fix: Give panelId a unique name since some datasource (Graphite) will cancel ongoing requests that has the same panelId. 