### PR TITLE
Support OAuth providers that are not RFC6749 compliant

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -335,6 +335,7 @@ tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =
 tls_client_ca =
+broken_auth_header_provider = false
 
 #################################### Basic Auth ##########################
 [auth.basic]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -335,7 +335,7 @@ tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =
 tls_client_ca =
-broken_auth_header_provider = false
+send_client_credentials_via_post = false
 
 #################################### Basic Auth ##########################
 [auth.basic]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -283,6 +283,7 @@ log_queries =
 ;tls_client_cert =
 ;tls_client_key =
 ;tls_client_ca =
+;broken_auth_header_provider = false
 
 #################################### Grafana.com Auth ####################
 [auth.grafana_com]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -283,7 +283,10 @@ log_queries =
 ;tls_client_cert =
 ;tls_client_key =
 ;tls_client_ca =
-;broken_auth_header_provider = false
+
+; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+;send_client_credentials_via_post = false
 
 #################################### Grafana.com Auth ####################
 [auth.grafana_com]

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -17,7 +17,7 @@ can find examples using Okta, BitBucket, OneLogin and Azure.
 
 This callback URL must match the full HTTP address that you use in your browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
 
-You may have to set the `root_url` option of `[server]` for the callback URL to be 
+You may have to set the `root_url` option of `[server]` for the callback URL to be
 correct. For example in case you are serving Grafana behind a proxy.
 
 Example config:
@@ -207,6 +207,17 @@ allowed_organizations =
     scopes = openid email name
     auth_url = https://<your domain>.my.centrify.com/OAuth2/Authorize/<Application ID>
     token_url = https://<your domain>.my.centrify.com/OAuth2/Token/<Application ID>
+    ```
+
+## Set up OAuth2 with non-compliant providers
+
+Some OAuth2 providers might not support `client_id` and `client_secret` passed via Basic Authentication HTTP header, which
+results in `invalid_client` error. To allow Grafana to authenticate via these type of providers, the client identifiers must be
+send via POST body, which can be enabled via the following settings:
+
+    ```bash
+    [auth.generic_oauth]
+    send_client_credentials_via_post = true
     ```
 
 <hr>

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,20 +1,21 @@
 package setting
 
 type OAuthInfo struct {
-	ClientId, ClientSecret string
-	Scopes                 []string
-	AuthUrl, TokenUrl      string
-	Enabled                bool
-	EmailAttributeName     string
-	AllowedDomains         []string
-	HostedDomain           string
-	ApiUrl                 string
-	AllowSignup            bool
-	Name                   string
-	TlsClientCert          string
-	TlsClientKey           string
-	TlsClientCa            string
-	TlsSkipVerify          bool
+	ClientId, ClientSecret   string
+	Scopes                   []string
+	AuthUrl, TokenUrl        string
+	Enabled                  bool
+	EmailAttributeName       string
+	AllowedDomains           []string
+	HostedDomain             string
+	ApiUrl                   string
+	AllowSignup              bool
+	Name                     string
+	TlsClientCert            string
+	TlsClientKey             string
+	TlsClientCa              string
+	TlsSkipVerify            bool
+	BrokenAuthHeaderProvider bool
 }
 
 type OAuther struct {

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,21 +1,21 @@
 package setting
 
 type OAuthInfo struct {
-	ClientId, ClientSecret   string
-	Scopes                   []string
-	AuthUrl, TokenUrl        string
-	Enabled                  bool
-	EmailAttributeName       string
-	AllowedDomains           []string
-	HostedDomain             string
-	ApiUrl                   string
-	AllowSignup              bool
-	Name                     string
-	TlsClientCert            string
-	TlsClientKey             string
-	TlsClientCa              string
-	TlsSkipVerify            bool
-	BrokenAuthHeaderProvider bool
+	ClientId, ClientSecret       string
+	Scopes                       []string
+	AuthUrl, TokenUrl            string
+	Enabled                      bool
+	EmailAttributeName           string
+	AllowedDomains               []string
+	HostedDomain                 string
+	ApiUrl                       string
+	AllowSignup                  bool
+	Name                         string
+	TlsClientCert                string
+	TlsClientKey                 string
+	TlsClientCa                  string
+	TlsSkipVerify                bool
+	SendClientCredentialsViaPost bool
 }
 
 type OAuther struct {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -79,7 +79,7 @@ func NewOAuthService() {
 			TlsClientKey:             sec.Key("tls_client_key").String(),
 			TlsClientCa:              sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:            sec.Key("tls_skip_verify_insecure").MustBool(),
-			BrokenAuthHeaderProvider: sec.Key("broken_auth_header_provider").MustBool(),
+			BrokenAuthHeaderProvider: sec.Key("send_client_credentials_via_post").MustBool(),
 		}
 
 		if !info.Enabled {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -63,26 +63,32 @@ func NewOAuthService() {
 	for _, name := range allOauthes {
 		sec := setting.Raw.Section("auth." + name)
 		info := &setting.OAuthInfo{
-			ClientId:           sec.Key("client_id").String(),
-			ClientSecret:       sec.Key("client_secret").String(),
-			Scopes:             util.SplitString(sec.Key("scopes").String()),
-			AuthUrl:            sec.Key("auth_url").String(),
-			TokenUrl:           sec.Key("token_url").String(),
-			ApiUrl:             sec.Key("api_url").String(),
-			Enabled:            sec.Key("enabled").MustBool(),
-			EmailAttributeName: sec.Key("email_attribute_name").String(),
-			AllowedDomains:     util.SplitString(sec.Key("allowed_domains").String()),
-			HostedDomain:       sec.Key("hosted_domain").String(),
-			AllowSignup:        sec.Key("allow_sign_up").MustBool(),
-			Name:               sec.Key("name").MustString(name),
-			TlsClientCert:      sec.Key("tls_client_cert").String(),
-			TlsClientKey:       sec.Key("tls_client_key").String(),
-			TlsClientCa:        sec.Key("tls_client_ca").String(),
-			TlsSkipVerify:      sec.Key("tls_skip_verify_insecure").MustBool(),
+			ClientId:                 sec.Key("client_id").String(),
+			ClientSecret:             sec.Key("client_secret").String(),
+			Scopes:                   util.SplitString(sec.Key("scopes").String()),
+			AuthUrl:                  sec.Key("auth_url").String(),
+			TokenUrl:                 sec.Key("token_url").String(),
+			ApiUrl:                   sec.Key("api_url").String(),
+			Enabled:                  sec.Key("enabled").MustBool(),
+			EmailAttributeName:       sec.Key("email_attribute_name").String(),
+			AllowedDomains:           util.SplitString(sec.Key("allowed_domains").String()),
+			HostedDomain:             sec.Key("hosted_domain").String(),
+			AllowSignup:              sec.Key("allow_sign_up").MustBool(),
+			Name:                     sec.Key("name").MustString(name),
+			TlsClientCert:            sec.Key("tls_client_cert").String(),
+			TlsClientKey:             sec.Key("tls_client_key").String(),
+			TlsClientCa:              sec.Key("tls_client_ca").String(),
+			TlsSkipVerify:            sec.Key("tls_skip_verify_insecure").MustBool(),
+			BrokenAuthHeaderProvider: sec.Key("broken_auth_header_provider").MustBool(),
 		}
 
 		if !info.Enabled {
 			continue
+		}
+
+		// handle the clients that do not properly support Basic auth headers and require passing client_id/client_secret via POST payload
+		if info.BrokenAuthHeaderProvider {
+			oauth2.RegisterBrokenAuthHeaderProvider(info.TokenUrl)
 		}
 
 		if name == "grafananet" {

--- a/pkg/social/social.go
+++ b/pkg/social/social.go
@@ -63,23 +63,23 @@ func NewOAuthService() {
 	for _, name := range allOauthes {
 		sec := setting.Raw.Section("auth." + name)
 		info := &setting.OAuthInfo{
-			ClientId:                 sec.Key("client_id").String(),
-			ClientSecret:             sec.Key("client_secret").String(),
-			Scopes:                   util.SplitString(sec.Key("scopes").String()),
-			AuthUrl:                  sec.Key("auth_url").String(),
-			TokenUrl:                 sec.Key("token_url").String(),
-			ApiUrl:                   sec.Key("api_url").String(),
-			Enabled:                  sec.Key("enabled").MustBool(),
-			EmailAttributeName:       sec.Key("email_attribute_name").String(),
-			AllowedDomains:           util.SplitString(sec.Key("allowed_domains").String()),
-			HostedDomain:             sec.Key("hosted_domain").String(),
-			AllowSignup:              sec.Key("allow_sign_up").MustBool(),
-			Name:                     sec.Key("name").MustString(name),
-			TlsClientCert:            sec.Key("tls_client_cert").String(),
-			TlsClientKey:             sec.Key("tls_client_key").String(),
-			TlsClientCa:              sec.Key("tls_client_ca").String(),
-			TlsSkipVerify:            sec.Key("tls_skip_verify_insecure").MustBool(),
-			BrokenAuthHeaderProvider: sec.Key("send_client_credentials_via_post").MustBool(),
+			ClientId:                     sec.Key("client_id").String(),
+			ClientSecret:                 sec.Key("client_secret").String(),
+			Scopes:                       util.SplitString(sec.Key("scopes").String()),
+			AuthUrl:                      sec.Key("auth_url").String(),
+			TokenUrl:                     sec.Key("token_url").String(),
+			ApiUrl:                       sec.Key("api_url").String(),
+			Enabled:                      sec.Key("enabled").MustBool(),
+			EmailAttributeName:           sec.Key("email_attribute_name").String(),
+			AllowedDomains:               util.SplitString(sec.Key("allowed_domains").String()),
+			HostedDomain:                 sec.Key("hosted_domain").String(),
+			AllowSignup:                  sec.Key("allow_sign_up").MustBool(),
+			Name:                         sec.Key("name").MustString(name),
+			TlsClientCert:                sec.Key("tls_client_cert").String(),
+			TlsClientKey:                 sec.Key("tls_client_key").String(),
+			TlsClientCa:                  sec.Key("tls_client_ca").String(),
+			TlsSkipVerify:                sec.Key("tls_skip_verify_insecure").MustBool(),
+			SendClientCredentialsViaPost: sec.Key("send_client_credentials_via_post").MustBool(),
 		}
 
 		if !info.Enabled {
@@ -87,7 +87,7 @@ func NewOAuthService() {
 		}
 
 		// handle the clients that do not properly support Basic auth headers and require passing client_id/client_secret via POST payload
-		if info.BrokenAuthHeaderProvider {
+		if info.SendClientCredentialsViaPost {
 			oauth2.RegisterBrokenAuthHeaderProvider(info.TokenUrl)
 		}
 


### PR DESCRIPTION
Fixes #14562, as per which, Grafana is not able to use some OAuth providers that are not [RFC6749](https://tools.ietf.org/html/rfc6749#section-2.3.1) compliant because they do not support `client_id` and `client_secret` passed via Basic Authentication HTTP header. 

Grafana uses [golang.org/x/oauth2](https://github.com/golang/oauth2) library for OAuth authentication. The library already maintains a [list of providers that are consider to be broken ](https://github.com/golang/oauth2/blob/master/internal/token.go#L94) and uses POST body payload instead of HTTP headers when using them.

Anyhow, there are some other (usually internal) providers that also do not work with Grafana. To solve the issue while using these providers, the idea is to allow mark them as broken an then use [oauth2.BrokenAuthHeaderProvider](https://github.com/golang/oauth2/blob/master/oauth2.go#L37) to append them to the broken provider list.

As part of the PR, I'm introducing new `broken_auth_header_provider` setting for `auth.generic_oauth`. The setting is `false` by default not to break any clients the users have already configured, while setting it to `true` would trigger the behavior mentioned above.

Please let me know if you prefer naming `broken_auth_header_provider`  somehow differently. Also, I was not entirely sure whether it's better to call `RegisterBrokenAuthHeaderProvider()` inside `social.go`, or if `login_oauth.go` would be a better place. If so, just let me know and I'll move it.

Thanks.