### PR TITLE
Docker image for ARM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,47 +200,47 @@ jobs:
             - dist/grafana*
 
   grafana-docker-master:
-    docker:
-      - image: docker:stable-git
+    machine:
+      image: circleci/classic:201808-01
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - setup_remote_docker
       - run: docker info
-      - run: cp dist/grafana-latest.linux-x64.tar.gz packaging/docker
+      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - run: cp dist/grafana-latest.linux-*.tar.gz packaging/docker
       - run: cd packaging/docker && ./build-deploy.sh "master-${CIRCLE_SHA1}"
-      - run: rm packaging/docker/grafana-latest.linux-x64.tar.gz
+      - run: rm packaging/docker/grafana-latest.linux-*.tar.gz
       - run: cp enterprise-dist/grafana-enterprise-*.linux-amd64.tar.gz packaging/docker/grafana-latest.linux-x64.tar.gz
       - run: cd packaging/docker && ./build-enterprise.sh "master"
 
 
   grafana-docker-pr:
-    docker:
-      - image: docker:stable-git
+    machine:
+      image: circleci/classic:201808-01
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - setup_remote_docker
       - run: docker info
-      - run: cp dist/grafana-latest.linux-x64.tar.gz packaging/docker
+      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - run: cp dist/grafana-latest.linux-*.tar.gz packaging/docker
       - run: cd packaging/docker && ./build.sh "${CIRCLE_SHA1}"
 
   grafana-docker-release:
-      docker:
-        - image: docker:stable-git
-      steps:
-        - checkout
-        - attach_workspace:
-            at: .
-        - setup_remote_docker
-        - run: docker info
-        - run: cp dist/grafana-latest.linux-x64.tar.gz packaging/docker
-        - run: cd packaging/docker && ./build-deploy.sh "${CIRCLE_TAG}"
-        - run: rm packaging/docker/grafana-latest.linux-x64.tar.gz
-        - run: cp enterprise-dist/grafana-enterprise-*.linux-amd64.tar.gz packaging/docker/grafana-latest.linux-x64.tar.gz
-        - run: cd packaging/docker && ./build-enterprise.sh "${CIRCLE_TAG}"
+    machine:
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: docker info
+      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - run: cp dist/grafana-latest.linux-*.tar.gz packaging/docker
+      - run: cd packaging/docker && ./build-deploy.sh "${CIRCLE_TAG}"
+      - run: rm packaging/docker/grafana-latest.linux-*.tar.gz
+      - run: cp enterprise-dist/grafana-enterprise-*.linux-amd64.tar.gz packaging/docker/grafana-latest.linux-x64.tar.gz
+      - run: cd packaging/docker && ./build-enterprise.sh "${CIRCLE_TAG}"
 
   build-enterprise:
     docker:

--- a/build.go
+++ b/build.go
@@ -164,6 +164,8 @@ func makeLatestDistCopies() {
 		"_amd64.deb":          "dist/grafana_latest_amd64.deb",
 		".x86_64.rpm":         "dist/grafana-latest-1.x86_64.rpm",
 		".linux-amd64.tar.gz": "dist/grafana-latest.linux-x64.tar.gz",
+		".linux-armv7.tar.gz": "dist/grafana-latest.linux-armv7.tar.gz",
+		".linux-arm64.tar.gz": "dist/grafana-latest.linux-arm64.tar.gz",
 	}
 
 	for _, file := range files {

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stretch-slim
+ARG BASE_IMAGE=debian:stretch-slim
+FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
 
@@ -10,7 +11,8 @@ COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
 RUN mkdir /tmp/grafana && tar xfvz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
-FROM debian:stretch-slim
+ARG BASE_IMAGE=debian:stretch-slim
+FROM ${BASE_IMAGE}
 
 ARG GF_UID="472"
 ARG GF_GID="472"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -13,13 +13,37 @@ fi
 
 echo "Building ${_docker_repo}:${_grafana_version}"
 
-docker build \
-	--tag "${_docker_repo}:${_grafana_version}" \
-	--no-cache=true .
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# Build grafana image for a specific arch
+docker_build () {
+	base_image=$1
+	grafana_tgz=$2
+	tag=$3
+
+  docker build \
+		--build-arg BASE_IMAGE=${base_image} \
+		--build-arg GRAFANA_TGZ=${grafana_tgz} \
+		--tag "${tag}" \
+		--no-cache=true .
+}
+
+# Tag docker images of all architectures
+docker_tag_all () {
+	repo=$1
+	tag=$2
+	docker tag "${_docker_repo}:${_grafana_version}" "${repo}:${tag}"
+	docker tag "${_docker_repo}-arm32v7-linux:${_grafana_version}" "${repo}-arm32v7-linux:${tag}"
+	docker tag "${_docker_repo}-arm64v8-linux:${_grafana_version}" "${repo}-arm64v8-linux:${tag}"
+}
+
+docker_build "debian:stretch-slim" "grafana-latest.linux-x64.tar.gz" "${_docker_repo}:${_grafana_version}"
+docker_build "arm32v7/debian:stretch-slim" "grafana-latest.linux-armv7.tar.gz" "${_docker_repo}-arm32v7-linux:${_grafana_version}"
+docker_build "arm64v8/debian:stretch-slim" "grafana-latest.linux-arm64.tar.gz" "${_docker_repo}-arm64v8-linux:${_grafana_version}"
 
 # Tag as 'latest' for official release; otherwise tag as grafana/grafana:master
 if echo "$_grafana_tag" | grep -q "^v"; then
-	docker tag "${_docker_repo}:${_grafana_version}" "${_docker_repo}:latest"
+	docker_tag_all "${_docker_repo}" "latest"
 else
-	docker tag "${_docker_repo}:${_grafana_version}" "grafana/grafana:master"
+	docker_tag_all "grafana/grafana" "master"
 fi

--- a/packaging/docker/push_to_docker_hub.sh
+++ b/packaging/docker/push_to_docker_hub.sh
@@ -12,13 +12,34 @@ else
 	_docker_repo=${2:-grafana/grafana-dev}
 fi
 
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 echo "pushing ${_docker_repo}:${_grafana_version}"
-docker push "${_docker_repo}:${_grafana_version}"
+
+
+docker_push_all () {
+	repo=$1
+	tag=$2
+
+	# Push each image individually
+	docker push "${repo}:${tag}"
+	docker push "${repo}-arm32v7-linux:${tag}"
+	docker push "${repo}-arm64v8-linux:${tag}"
+
+	# Create and push a multi-arch manifest
+	docker manifest create "${repo}:${tag}" \
+		"${repo}:${tag}" \
+  	"${repo}-arm32v7-linux:${tag}" \
+		"${repo}-arm64v8-linux:${tag}"
+
+	docker manifest push "${repo}:${tag}"
+}
+
+docker_push_all "${_docker_repo}" "${_grafana_version}"
 
 if echo "$_grafana_tag" | grep -q "^v" && echo "$_grafana_tag" | grep -vq "beta"; then
 	echo "pushing ${_docker_repo}:latest"
-	docker push "${_docker_repo}:latest"
+	docker_push_all "${_docker_repo}" "latest"
 elif echo "$_grafana_tag" | grep -q "master"; then
-	echo "pushing grafana/grafana:master"
-	docker push grafana/grafana:master
+	docker_push_all "grafana/grafana" "master"
 fi

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -8,6 +8,8 @@ set -e
 
 EXTRA_OPTS="$@"
 
+CCARMV7=arm-linux-gnueabihf-gcc
+CCARM64=aarch64-linux-gnu-gcc
 CCX64=/tmp/x86_64-centos6-linux-gnu/bin/x86_64-centos6-linux-gnu-gcc
 
 GOPATH=/go
@@ -25,6 +27,9 @@ else
 fi
 
 echo "Build arguments: $OPT"
+
+go run build.go -goarch armv7 -cc ${CCARMV7} ${OPT} build
+go run build.go -goarch arm64 -cc ${CCARM64} ${OPT} build
 
 CC=${CCX64} go run build.go ${OPT} build
 
@@ -44,3 +49,5 @@ source /etc/profile.d/rvm.sh
 
 echo "Packaging"
 go run build.go -goos linux -pkg-arch amd64 ${OPT} package-only latest
+go run build.go -goos linux -pkg-arch armv7 ${OPT} package-only latest
+go run build.go -goos linux -pkg-arch arm64 ${OPT} package-only latest


### PR DESCRIPTION
Build and push docker images for armv7 and arm64.

Fixes https://github.com/grafana/grafana/issues/13186

**Building**
The ARM images are building using `binfmt_misc`, which is the same mechanism also used by Docker for Mac to support building ARM images, some details are here https://www.ecliptik.com/Cross-Building-and-Running-Multi-Arch-Docker-Images/

While the circle docker executor doesn't natively support building ARM images, the machine executor has almost all the necessary dependencies pre-installed and allows privileged execution, which is required to setup `binfmt_misc`

The setup itself is done via`docker run --privileged linuxkit/binfmt:v0.6`, which is the same script also used inside Docker for Mac. (Source https://github.com/linuxkit/linuxkit/tree/master/pkg/binfmt)

As the default machine image is fairly old and `binfmt_misc` requires a Kernel 4.8+, use a more recent machine image https://circleci.com/docs/2.0/configuration-reference/#machine

**Publishing**
The two ARM images would be published to `grafana/grafana-arm32v7-linux:TAG` and `grafana/grafana-arm64v8-linux:TAG` (release images) and `grafana/grafana-dev-arm32v7-linux:TAG` and `grafana/grafana-dev-arm64v8-linux:TAG` (dev images), so those 4 docker hub repositories would need to be created.

To simplify image consumption a multi-arch manifest is created using https://docs.docker.com/edge/engine/reference/commandline/manifest/, which allows `docker pull grafana/grafana` to pull the respective amd64, arm32 and arm64 image automatically.

**Test**

Build images locally and pushed them to my registry using:
```
./build.sh multi-test johanneswuerbach/grafana-dev
./push_to_docker_hub.sh multi-test johanneswuerbach/grafana-dev
```

Using them on macOS via Docker for Mac:
```
docker pull johanneswuerbach/grafana-dev:multi-test && docker run --rm -it johanneswuerbach/grafana-dev:multi-test -v
multi-test: Pulling from johanneswuerbach/grafana-dev
Digest: sha256:9073e733b641910d0e016df4e239e2161835f72e407663a49d16597cfe5afdde
Status: Image is up to date for johanneswuerbach/grafana-dev:multi-test
Version 5.5.0-pre1 (commit: 0f535a8, branch: arm-image)
```

Using them on a Raspberry Pi 3:
```
$ docker pull johanneswuerbach/grafana-dev:multi-test && docker run --rm -it johanneswuerbach/grafana-dev:multi-test -v
multi-test: Pulling from johanneswuerbach/grafana-dev
Digest: sha256:9073e733b641910d0e016df4e239e2161835f72e407663a49d16597cfe5afdde
Status: Image is up to date for johanneswuerbach/grafana-dev:multi-test
Version 5.5.0-pre1 (commit: 0f535a8, branch: arm-image)
```

while the current `latest` fails as expected:

```
$ docker pull grafana/grafana && docker run --rm -it grafana/grafana
Using default tag: latest
latest: Pulling from grafana/grafana
Digest: sha256:b9a31857e86e9cf43552605bd7f3c990c123f8792ab6bea8f499db1a1bdb7d53
Status: Downloaded newer image for grafana/grafana:latest
standard_init_linux.go:190: exec user process caused "exec format error"
```

Feedback more then welcome :-)