### PR TITLE
Loki: fix timestamp field

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -82,6 +82,8 @@ export interface LogsStream {
 export interface LogsStreamEntry {
   line: string;
   ts: string;
+  // Legacy, was renamed to ts
+  timestamp?: string;
 }
 
 export interface LogsStreamLabels {

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -81,7 +81,7 @@ export interface LogsStream {
 
 export interface LogsStreamEntry {
   line: string;
-  timestamp: string;
+  ts: string;
 }
 
 export interface LogsStreamLabels {

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -99,7 +99,7 @@ describe('mergeStreamsToLogs()', () => {
       entries: [
         {
           line: 'WARN boooo',
-          timestamp: '1970-01-01T00:00:00Z',
+          ts: '1970-01-01T00:00:00Z',
         },
       ],
     };
@@ -120,7 +120,7 @@ describe('mergeStreamsToLogs()', () => {
       entries: [
         {
           line: 'WARN boooo',
-          timestamp: '1970-01-01T00:00:01Z',
+          ts: '1970-01-01T00:00:01Z',
         },
       ],
     };
@@ -129,11 +129,11 @@ describe('mergeStreamsToLogs()', () => {
       entries: [
         {
           line: 'INFO 1',
-          timestamp: '1970-01-01T00:00:00Z',
+          ts: '1970-01-01T00:00:00Z',
         },
         {
           line: 'INFO 2',
-          timestamp: '1970-01-01T00:00:02Z',
+          ts: '1970-01-01T00:00:02Z',
         },
       ],
     };

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -116,10 +116,10 @@ export function processEntry(
   uniqueLabels: LogsStreamLabels,
   search: string
 ): LogRow {
-  const { line, timestamp } = entry;
+  const { line, ts } = entry;
   // Assumes unique-ness, needs nanosec precision for timestamp
-  const key = `EK${timestamp}${labels}`;
-  const time = moment(timestamp);
+  const key = `EK${ts}${labels}`;
+  const time = moment(ts);
   const timeEpochMs = time.valueOf();
   const timeFromNow = time.fromNow();
   const timeLocal = time.format('YYYY-MM-DD HH:mm:ss');
@@ -135,7 +135,7 @@ export function processEntry(
     entry: line,
     labels: parsedLabels,
     searchWords: search ? [search] : [],
-    timestamp: timestamp,
+    timestamp: ts,
   };
 }
 

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -116,7 +116,8 @@ export function processEntry(
   uniqueLabels: LogsStreamLabels,
   search: string
 ): LogRow {
-  const { line, ts } = entry;
+  const { line } = entry;
+  const ts = entry.ts || entry.timestamp;
   // Assumes unique-ness, needs nanosec precision for timestamp
   const key = `EK${ts}${labels}`;
   const time = moment(ts);


### PR DESCRIPTION
- timestamp was renamed to `ts` in grafana/loki#152
- renamed here in result transformer and tests

Fixes #14635 
Fixes #14599
