### PR TITLE
Fix general tab typos

### DIFF
--- a/public/app/features/panel/partials/general_tab.html
+++ b/public/app/features/panel/partials/general_tab.html
@@ -22,7 +22,7 @@
   <div class="panel-option-section__body">
     <div class="section">
       <div class="gf-form">
-        <span class="gf-form-label width-9">Repat</span>
+        <span class="gf-form-label width-9">Repeat</span>
         <dash-repeat-option panel="ctrl.panel"></dash-repeat-option>
       </div>
       <div class="gf-form" ng-show="ctrl.panel.repeat">
@@ -42,7 +42,7 @@
 </div>
 
 <div class="panel-option-section">
-  <div class="panel-option-section__header">Drildown Links</div>
+  <div class="panel-option-section__header">Drilldown Links</div>
   <div class="panel-option-section__body">
     <panel-links-editor panel="ctrl.panel"></panel-links-editor>
   </div>


### PR DESCRIPTION
Fix two typos on panel "General" tab.