### PR TITLE
OAuth: Support JMES path lookup when retrieving user email

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -366,6 +366,7 @@ client_id = some_id
 client_secret = some_secret
 scopes = user:email
 email_attribute_name = email:primary
+email_attribute_path =
 auth_url =
 token_url =
 api_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -319,6 +319,8 @@
 ;client_id = some_id
 ;client_secret = some_secret
 ;scopes = user:email,read:org
+;email_attribute_name = email:primary
+;email_attribute_path =
 ;auth_url = https://foo.bar/login/oauth/authorize
 ;token_url = https://foo.bar/login/oauth/access_token
 ;api_url = https://foo.bar/user

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -41,6 +41,7 @@ Grafana will attempt to determine the user's e-mail address by querying the OAut
 
 1. Check for the presence of an e-mail address via the `email` field encoded in the OAuth `id_token` parameter.
 2. Check for the presence of an e-mail address using the [JMES path](http://jmespath.org/examples.html) specified via the `email_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the `api_url` configuration option.
+**Note**: Only available in Grafana v6.3+.
 3. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
 4. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
 5. If no e-mail address is found in steps (1-4), then the e-mail address of the user is set to the empty string.

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -40,9 +40,10 @@ Set `api_url` to the resource that returns [OpenID UserInfo](https://connect2id.
 Grafana will attempt to determine the user's e-mail address by querying the OAuth provider as described below in the following order until an e-mail address is found:
 
 1. Check for the presence of an e-mail address via the `email` field encoded in the OAuth `id_token` parameter.
-2. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
-3. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
-4. If no e-mail address is found in steps (1-3), then the e-mail address of the user is set to the empty string.
+2. Check for the presence of an e-mail address using the [JMES path](http://jmespath.org/examples.html) specified via the `email_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the `api_url` configuration option.
+3. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
+4. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
+5. If no e-mail address is found in steps (1-4), then the e-mail address of the user is set to the empty string.
 
 ## Set up OAuth2 with Okta
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -41,7 +41,7 @@ Grafana will attempt to determine the user's e-mail address by querying the OAut
 
 1. Check for the presence of an e-mail address via the `email` field encoded in the OAuth `id_token` parameter.
 2. Check for the presence of an e-mail address using the [JMES path](http://jmespath.org/examples.html) specified via the `email_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the `api_url` configuration option.
-**Note**: Only available in Grafana v6.3+.
+**Note**: Only available in Grafana v6.4+.
 3. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
 4. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
 5. If no e-mail address is found in steps (1-4), then the e-mail address of the user is set to the empty string.

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -310,8 +310,7 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson, userInfoResp []byt
 		emailAddr, emailErr := mail.ParseAddress(data.Upn)
 		if emailErr != nil {
 			s.log.Debug("Failed to parse e-mail address", "email", emailAddr, "err", emailErr.Error())
-		}
-		if emailErr == nil {
+		} else {
 			return emailAddr.Address, nil
 		}
 	}

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -294,12 +294,10 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson, userInfoResp []byt
 	}
 
 	email, err := s.searchJSONForEmail(userInfoResp)
-	if err != nil {
-		s.log.Debug("Failed to search user info JSON response for e-mail", "err", err.Error())
-	} else {
+	if err == nil {
 		return email, nil
 	}
-	s.log.Debug("No e-mail address found when searching user info JSON response")
+	s.log.Debug("Failed to search user info JSON response for e-mail", "err", err.Error())
 
 	emails, ok := data.Attributes[s.emailAttributeName]
 	if ok && len(emails) != 0 {
@@ -308,11 +306,10 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson, userInfoResp []byt
 
 	if data.Upn != "" {
 		emailAddr, emailErr := mail.ParseAddress(data.Upn)
-		if emailErr != nil {
-			s.log.Debug("Failed to parse e-mail address", "email", emailAddr, "err", emailErr.Error())
-		} else {
+		if emailErr == nil {
 			return emailAddr.Address, nil
 		}
+		s.log.Debug("Failed to parse e-mail address", "email", emailAddr, "err", emailErr.Error())
 	}
 
 	return "", errors.New("Failed to extract e-mail address from user info response")

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -85,8 +85,11 @@ func (s *SocialGenericOAuth) IsOrganizationMember(client *http.Client) bool {
 // Returns a non-nil error if the provided JSON response could not be decoded,
 // searched, or if an e-mail address is not found.
 func (s *SocialGenericOAuth) searchJSONForEmail(data []byte) (email string, err error) {
-	if s.emailAttributePath == "" || len(data) == 0 {
-		return "", nil
+	if s.emailAttributePath == "" {
+		return "", errors.New("No e-mail attribute path specified")
+	}
+	if len(data) == 0 {
+		return "", errors.New("Empty user info JSON response provided")
 	}
 	var buf interface{}
 	if err := json.Unmarshal(data, &buf); err != nil {

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -277,7 +277,7 @@ func (s *SocialGenericOAuth) extractToken(data *UserInfoJson, token *oauth2.Toke
 		return false
 	}
 
-	email := s.extractEmail(&UserInfoJson{}, payload)
+	email := s.extractEmail(data, payload)
 	if email == "" {
 		s.log.Debug("No email found in id_token", "json", string(payload), "data", data)
 		return false

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -297,7 +297,9 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson, userInfoResp []byt
 	if err == nil {
 		return email, nil
 	}
-	s.log.Debug("Failed to search user info JSON response for e-mail", "err", err.Error())
+	if s.emailAttributePath != "" {
+		s.log.Debug("Failed to search user info JSON response for e-mail", "err", err.Error())
+	}
 
 	emails, ok := data.Attributes[s.emailAttributeName]
 	if ok && len(emails) != 0 {

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -103,7 +103,7 @@ func (s *SocialGenericOAuth) searchJSONForEmail(data []byte) (email string, err 
 	if ok {
 		return strVal, nil
 	}
-	return "", errors.New(fmt.Sprintf("E-mail not found when searching JSON with provided path: %s", s.emailAttributePath))
+	return "", fmt.Errorf("E-mail not found when searching JSON with provided path: %s", s.emailAttributePath)
 }
 
 func (s *SocialGenericOAuth) FetchPrivateEmail(client *http.Client) (string, error) {

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -100,7 +100,7 @@ func (s *SocialGenericOAuth) searchJSONForEmail(data []byte) (email string, err 
 	if ok {
 		return strVal, nil
 	}
-	return "", errors.New(fmt.Sprintf("E-mail not found when searching JSON with provided path: %s"))
+	return "", errors.New(fmt.Sprintf("E-mail not found when searching JSON with provided path: %s", s.emailAttributePath))
 }
 
 func (s *SocialGenericOAuth) FetchPrivateEmail(client *http.Client) (string, error) {

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -314,7 +314,7 @@ func (s *SocialGenericOAuth) extractEmail(data *UserInfoJson, userInfoResp []byt
 		if emailErr == nil {
 			return emailAddr.Address
 		}
-		s.log.Debug("Failed to parse e-mail address", "email", emailAddr, "err", emailErr.Error())
+		s.log.Debug("Failed to parse e-mail address", "err", emailErr.Error())
 	}
 
 	return ""

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -28,12 +28,14 @@ func TestSearchJSONForEmail(t *testing.T) {
 				UserInfoJSONResponse: []byte{},
 				EmailAttributePath:   "",
 				ExpectedResult:       "",
+				ErrorExpected:        true,
 			},
 			{
 				Name:                 "Given an empty user info JSON response and valid JMES path",
 				UserInfoJSONResponse: []byte{},
 				EmailAttributePath:   "attributes.email",
 				ExpectedResult:       "",
+				ErrorExpected:        true,
 			},
 			{
 				Name: "Given a simple user info JSON response and valid JMES path",
@@ -75,7 +77,7 @@ func TestSearchJSONForEmail(t *testing.T) {
 		for _, test := range tests {
 			provider.emailAttributePath = test.EmailAttributePath
 			Convey(test.Name, func() {
-				actualResult, err := provider.SearchJSONForEmail(test.UserInfoJSONResponse)
+				actualResult, err := provider.searchJSONForEmail(test.UserInfoJSONResponse)
 				So(actualResult, ShouldEqual, test.ExpectedResult)
 				if test.ErrorExpected {
 					So(err, ShouldNotBeNil)

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -1,0 +1,88 @@
+package social
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestSearchJSONForEmail(t *testing.T) {
+	Convey("Given a generic OAuth provider", t, func() {
+		provider := SocialGenericOAuth{}
+
+		tests := []struct {
+			Name                 string
+			UserInfoJSONResponse []byte
+			EmailAttributePath   string
+			ExpectedResult       string
+			ErrorExpected        bool
+		}{
+			{
+				Name:                 "Given an invalid user info JSON response",
+				UserInfoJSONResponse: []byte("{"),
+				EmailAttributePath:   "attributes.email",
+				ExpectedResult:       "",
+				ErrorExpected:        true,
+			},
+			{
+				Name:                 "Given an empty user info JSON response and empty JMES path",
+				UserInfoJSONResponse: []byte{},
+				EmailAttributePath:   "",
+				ExpectedResult:       "",
+			},
+			{
+				Name:                 "Given an empty user info JSON response and valid JMES path",
+				UserInfoJSONResponse: []byte{},
+				EmailAttributePath:   "attributes.email",
+				ExpectedResult:       "",
+			},
+			{
+				Name: "Given a simple user info JSON response and valid JMES path",
+				UserInfoJSONResponse: []byte(`{
+	"attributes": {
+		"email": "grafana@localhost"
+	}
+}`),
+				EmailAttributePath: "attributes.email",
+				ExpectedResult:     "grafana@localhost",
+			},
+			{
+				Name: "Given a user info JSON response with e-mails array and valid JMES path",
+				UserInfoJSONResponse: []byte(`{
+	"attributes": {
+		"emails": ["grafana@localhost", "admin@localhost"]
+	}
+}`),
+				EmailAttributePath: "attributes.emails[0]",
+				ExpectedResult:     "grafana@localhost",
+			},
+			{
+				Name: "Given a nested user info JSON response and valid JMES path",
+				UserInfoJSONResponse: []byte(`{
+	"identities": [
+		{
+			"userId": "grafana@localhost"
+		},
+		{
+			"userId": "admin@localhost"
+		}
+	]
+}`),
+				EmailAttributePath: "identities[0].userId",
+				ExpectedResult:     "grafana@localhost",
+			},
+		}
+
+		for _, test := range tests {
+			provider.emailAttributePath = test.EmailAttributePath
+			Convey(test.Name, func() {
+				actualResult, err := provider.SearchJSONForEmail(test.UserInfoJSONResponse)
+				So(actualResult, ShouldEqual, test.ExpectedResult)
+				if test.ErrorExpected {
+					So(err, ShouldNotBeNil)
+				} else {
+					So(err, ShouldBeNil)
+				}
+			})
+		}
+	})
+}

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -1,41 +1,42 @@
 package social
 
 import (
+	"github.com/grafana/grafana/pkg/infra/log"
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 )
 
 func TestSearchJSONForEmail(t *testing.T) {
 	Convey("Given a generic OAuth provider", t, func() {
-		provider := SocialGenericOAuth{}
+		provider := SocialGenericOAuth{
+			SocialBase: &SocialBase{
+				log: log.New("generic_oauth_test"),
+			},
+		}
 
 		tests := []struct {
 			Name                 string
 			UserInfoJSONResponse []byte
 			EmailAttributePath   string
 			ExpectedResult       string
-			ErrorExpected        bool
 		}{
 			{
 				Name:                 "Given an invalid user info JSON response",
 				UserInfoJSONResponse: []byte("{"),
 				EmailAttributePath:   "attributes.email",
 				ExpectedResult:       "",
-				ErrorExpected:        true,
 			},
 			{
 				Name:                 "Given an empty user info JSON response and empty JMES path",
 				UserInfoJSONResponse: []byte{},
 				EmailAttributePath:   "",
 				ExpectedResult:       "",
-				ErrorExpected:        true,
 			},
 			{
 				Name:                 "Given an empty user info JSON response and valid JMES path",
 				UserInfoJSONResponse: []byte{},
 				EmailAttributePath:   "attributes.email",
 				ExpectedResult:       "",
-				ErrorExpected:        true,
 			},
 			{
 				Name: "Given a simple user info JSON response and valid JMES path",
@@ -77,13 +78,8 @@ func TestSearchJSONForEmail(t *testing.T) {
 		for _, test := range tests {
 			provider.emailAttributePath = test.EmailAttributePath
 			Convey(test.Name, func() {
-				actualResult, err := provider.searchJSONForEmail(test.UserInfoJSONResponse)
+				actualResult := provider.searchJSONForEmail(test.UserInfoJSONResponse)
 				So(actualResult, ShouldEqual, test.ExpectedResult)
-				if test.ErrorExpected {
-					So(err, ShouldNotBeNil)
-				} else {
-					So(err, ShouldBeNil)
-				}
 			})
 		}
 	})

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -72,6 +72,7 @@ func NewOAuthService() {
 			ApiUrl:                       sec.Key("api_url").String(),
 			Enabled:                      sec.Key("enabled").MustBool(),
 			EmailAttributeName:           sec.Key("email_attribute_name").String(),
+			EmailAttributePath:           sec.Key("email_attribute_path").String(),
 			AllowedDomains:               util.SplitString(sec.Key("allowed_domains").String()),
 			HostedDomain:                 sec.Key("hosted_domain").String(),
 			AllowSignup:                  sec.Key("allow_sign_up").MustBool(),
@@ -165,6 +166,7 @@ func NewOAuthService() {
 				apiUrl:               info.ApiUrl,
 				allowSignup:          info.AllowSignup,
 				emailAttributeName:   info.EmailAttributeName,
+				emailAttributePath:   info.EmailAttributePath,
 				teamIds:              sec.Key("team_ids").Ints(","),
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
 			}

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -6,6 +6,7 @@ type OAuthInfo struct {
 	AuthUrl, TokenUrl            string
 	Enabled                      bool
 	EmailAttributeName           string
+	EmailAttributePath           string
 	AllowedDomains               []string
 	HostedDomain                 string
 	ApiUrl                       string


### PR DESCRIPTION
Closes #13353

This PR aims to increase the generality of the generic OAuth provider by allowing users to specify a [JMES Path](http://jmespath.org/) that Grafana will use to search for an e-mail address.