### PR TITLE
Explore: fix loading indicator z-index on panel container

### DIFF
--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -135,7 +135,6 @@
     position: absolute;
     animation: loader 2s cubic-bezier(0.17, 0.67, 0.83, 0.67);
     animation-iteration-count: 100;
-    z-index: 2;
     background: $blue;
   }
 


### PR DESCRIPTION
- existing z-index placed the loading indicator above dropdowns of the panel children
- removed z-index for natural ordering

Fixes #14668 