### PR TITLE
Tweak datetime picker layout for mobile

### DIFF
--- a/public/sass/components/_timepicker.scss
+++ b/public/sass/components/_timepicker.scss
@@ -20,9 +20,12 @@
   display: flex;
   flex-direction: column;
   position: absolute;
+  left: 20px;
   right: 20px;
   top: $navbarHeight;
-  width: 550px;
+  @include media-breakpoint-up(md) {
+    width: 550px;
+  }
 
   .popover-box {
     max-width: 100%;


### PR DESCRIPTION
On smaller screens fixes this
![image](https://user-images.githubusercontent.com/327717/50565970-ac331480-0d34-11e9-94a5-a0d0ca4ae3e3.png)

into this

![image](https://user-images.githubusercontent.com/327717/50565993-cff65a80-0d34-11e9-88a4-81074bb37de1.png)
