### PR TITLE
Lazyload panels

### DIFF
--- a/public/app/core/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/public/app/core/components/CustomScrollbar/CustomScrollbar.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
-import Scrollbars from 'react-custom-scrollbars';
+import Scrollbars, { ScrollbarProps } from 'react-custom-scrollbars';
 
-interface Props {
+interface Props extends ScrollbarProps {
   customClassName?: string;
   autoHide?: boolean;
   autoHideTimeout?: number;
@@ -30,6 +30,7 @@ class CustomScrollbar extends PureComponent<Props> {
         autoHeight={true}
         autoHeightMin={'inherit'}
         autoHeightMax={'inherit'}
+        onScroll={() => {console.log('scrolling');}}
         renderTrackHorizontal={props => <div {...props} className="track-horizontal" />}
         renderTrackVertical={props => <div {...props} className="track-vertical" />}
         renderThumbHorizontal={props => <div {...props} className="thumb-horizontal" />}

--- a/public/app/features/dashboard/dashboard_migration.ts
+++ b/public/app/features/dashboard/dashboard_migration.ts
@@ -428,7 +428,7 @@ export class DashboardMigrator {
           w: GRID_COLUMN_COUNT,
           h: rowGridHeight,
         };
-        rowPanelModel = new PanelModel(rowPanel);
+        rowPanelModel = new PanelModel(rowPanel, this.dashboard);
         nextRowId++;
         yPos++;
       }
@@ -458,7 +458,7 @@ export class DashboardMigrator {
         if (rowPanelModel && rowPanel.collapsed) {
           rowPanelModel.panels.push(panel);
         } else {
-          this.dashboard.panels.push(new PanelModel(panel));
+          this.dashboard.panels.push(new PanelModel(panel, this.dashboard));
         }
       }
 

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -7,6 +7,7 @@ import { DashboardModel } from '../dashboard_model';
 import { PanelModel } from '../panel_model';
 import classNames from 'classnames';
 import sizeMe from 'react-sizeme';
+import CustomScrollbar from '../../../core/components/CustomScrollbar/CustomScrollbar';
 
 let lastGridWidth = 1200;
 let ignoreNextWidthChange = false;
@@ -19,6 +20,7 @@ function GridWrapper({
   onDragStop,
   onResize,
   onResizeStop,
+  onScroll,
   onWidthChange,
   className,
   isResizable,
@@ -38,26 +40,30 @@ function GridWrapper({
   }
 
   return (
-    <ReactGridLayout
-      width={lastGridWidth}
-      className={className}
-      isDraggable={isDraggable}
-      isResizable={isResizable}
-      measureBeforeMount={false}
-      containerPadding={[0, 0]}
-      useCSSTransforms={false}
-      margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}
-      cols={GRID_COLUMN_COUNT}
-      rowHeight={GRID_CELL_HEIGHT}
-      draggableHandle=".grid-drag-handle"
-      layout={layout}
-      onResize={onResize}
-      onResizeStop={onResizeStop}
-      onDragStop={onDragStop}
-      onLayoutChange={onLayoutChange}
+    <CustomScrollbar
+      onScroll={onScroll}
     >
-      {children}
-    </ReactGridLayout>
+      <ReactGridLayout
+        width={lastGridWidth}
+        className={className}
+        isDraggable={isDraggable}
+        isResizable={isResizable}
+        measureBeforeMount={false}
+        containerPadding={[0, 0]}
+        useCSSTransforms={false}
+        margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}
+        cols={GRID_COLUMN_COUNT}
+        rowHeight={GRID_CELL_HEIGHT}
+        draggableHandle=".grid-drag-handle"
+        layout={layout}
+        onResize={onResize}
+        onResizeStop={onResizeStop}
+        onDragStop={onDragStop}
+        onLayoutChange={onLayoutChange}
+      >
+          {children}
+      </ReactGridLayout>
+    </CustomScrollbar>
   );
 }
 
@@ -87,6 +93,18 @@ export class DashboardGrid extends React.Component<DashboardGridProps> {
     dashboard.on('view-mode-changed', this.onViewModeChanged.bind(this));
     dashboard.on('row-collapsed', this.triggerForceUpdate.bind(this));
     dashboard.on('row-expanded', this.triggerForceUpdate.bind(this));
+
+    this.refreshOnScroll  = this.refreshOnScroll.bind(this);
+    // $('.scroll-canvas--dashboard').on('scroll', this.refreshOnScroll);
+  }
+
+  refreshOnScroll() {
+    console.log('bound');
+    for (const panel of this.props.dashboard.panels) {
+      if (panel.skippedLastRefresh) {
+        panel.refresh();
+      }
+    }
   }
 
   buildLayout() {
@@ -197,6 +215,7 @@ export class DashboardGrid extends React.Component<DashboardGridProps> {
         onLayoutChange={this.onLayoutChange}
         onWidthChange={this.onWidthChange}
         onDragStop={this.onDragStop}
+        onScroll={this.refreshOnScroll}
         onResize={this.onResize}
         onResizeStop={this.onResizeStop}
         isFullscreen={this.props.dashboard.meta.fullscreen}

--- a/public/app/features/dashboard/settings/settings.html
+++ b/public/app/features/dashboard/settings/settings.html
@@ -55,6 +55,13 @@
 		</folder-picker>
 		<gf-form-switch class="gf-form" label="Editable" tooltip="Uncheck, then save and reload to disable all dashboard editing" checked="ctrl.dashboard.editable" label-class="width-7">
 		</gf-form-switch>
+		<gf-form-switch
+		  class="gf-form"
+		  label="LazyLoad on scroll"
+		  tooltip="Load panels as they become visible"
+		  checked="ctrl.dashboard.lazyLoad"
+		  label-class="width-11">
+		</gf-form-switch>
 	</div>
 
 	<gf-time-picker-settings dashboard="ctrl.dashboard"></gf-time-picker-settings>

--- a/public/app/features/dashboard/specs/DashboardRow.test.tsx
+++ b/public/app/features/dashboard/specs/DashboardRow.test.tsx
@@ -14,7 +14,7 @@ describe('DashboardRow', () => {
       },
     };
 
-    panel = new PanelModel({ collapsed: false });
+    panel = new PanelModel({ collapsed: false }, dashboardMock);
     wrapper = shallow(<DashboardRow panel={panel} dashboard={dashboardMock} />);
   });
 
@@ -42,7 +42,7 @@ describe('DashboardRow', () => {
 
   it('should have zero actions when cannot edit', () => {
     dashboardMock.meta.canEdit = false;
-    panel = new PanelModel({ collapsed: false });
+    panel = new PanelModel({ collapsed: false }, dashboardMock);
     wrapper = shallow(<DashboardRow panel={panel} dashboard={dashboardMock} />);
     expect(wrapper.find('.dashboard-row__actions .pointer')).toHaveLength(0);
   });

--- a/public/app/features/dashboard/specs/change_tracker.test.ts
+++ b/public/app/features/dashboard/specs/change_tracker.test.ts
@@ -93,7 +93,7 @@ describe('ChangeTracker', () => {
   });
 
   it('Should ignore panel repeats', () => {
-    dash.panels.push(new PanelModel({ repeatPanelId: 10 }));
+    dash.panels.push(new PanelModel({ repeatPanelId: 10 }, new DashboardModel({}, {})));
     expect(tracker.hasChanges()).toBe(false);
   });
 });

--- a/public/app/features/dashboard/specs/panel_model.test.ts
+++ b/public/app/features/dashboard/specs/panel_model.test.ts
@@ -1,5 +1,5 @@
-import _ from 'lodash';
 import { PanelModel } from '../panel_model';
+import { DashboardModel } from '../dashboard_model';
 
 describe('PanelModel', () => {
   describe('when creating new panel model', () => {
@@ -9,7 +9,7 @@ describe('PanelModel', () => {
       model = new PanelModel({
         type: 'table',
         showColumns: true,
-      });
+      }, new DashboardModel({}, {}));
     });
 
     it('should apply defaults', () => {

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -55,7 +55,7 @@ const replacePanel = (dashboard: DashboardModel, newPanel: PanelModel, oldPanel:
   const deletedPanel = dashboard.panels.splice(index, 1);
   dashboard.events.emit('panel-removed', deletedPanel);
 
-  newPanel = new PanelModel(newPanel);
+  newPanel = new PanelModel(newPanel, dashboard);
   newPanel.id = oldPanel.id;
 
   dashboard.panels.splice(index, 0, newPanel);

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -2,6 +2,7 @@ import angular from 'angular';
 import $ from 'jquery';
 import Drop from 'tether-drop';
 import baron from 'baron';
+import { debounce } from 'lodash';
 
 const module = angular.module('grafana.directives');
 
@@ -200,9 +201,29 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
       elem.on('mouseenter', mouseEnter);
       elem.on('mouseleave', mouseLeave);
 
+      ctrl.panel.isPanelVisible = () => {
+        const position = panelContainer[0].getBoundingClientRect();
+        return (0 < position.top) && (position.top < window.innerHeight);
+      };
+
+      $document.bind('scroll', debounce(() => {
+        if (ctrl.panel.skippedLastRefresh) {
+          ctrl.refresh();
+        }
+      }, 250));
+
+      const refreshOnScroll = () => {
+        if (ctrl.panel.skippedLastRefresh) {
+          ctrl.refresh();
+        }
+      };
+
+      $document.on('scroll', refreshOnScroll);
+
       scope.$on('$destroy', () => {
         elem.off();
         cornerInfoElem.off();
+        $document.off('scroll', refreshOnScroll);
 
         if (infoDrop) {
           infoDrop.destroy();

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -2,7 +2,6 @@ import angular from 'angular';
 import $ from 'jquery';
 import Drop from 'tether-drop';
 import baron from 'baron';
-import { debounce } from 'lodash';
 
 const module = angular.module('grafana.directives');
 
@@ -206,24 +205,9 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
         return (0 < position.top) && (position.top < window.innerHeight);
       };
 
-      $document.bind('scroll', debounce(() => {
-        if (ctrl.panel.skippedLastRefresh) {
-          ctrl.refresh();
-        }
-      }, 250));
-
-      const refreshOnScroll = () => {
-        if (ctrl.panel.skippedLastRefresh) {
-          ctrl.refresh();
-        }
-      };
-
-      $document.on('scroll', refreshOnScroll);
-
       scope.$on('$destroy', () => {
         elem.off();
         cornerInfoElem.off();
-        $document.off('scroll', refreshOnScroll);
 
         if (infoDrop) {
           infoDrop.destroy();

--- a/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
@@ -1,3 +1,5 @@
+import { DashboardModel } from '../../dashboard/dashboard_model';
+
 jest.mock('app/core/core', () => ({}));
 jest.mock('app/core/config', () => {
   return {
@@ -71,7 +73,7 @@ function setupController() {
     colors: [],
   };
 
-  MetricsPanelCtrl.prototype.panel = new PanelModel({ type: 'test' });
+  MetricsPanelCtrl.prototype.panel = new PanelModel({ type: 'test' }, new DashboardModel({}, {}));
 
   return new MetricsPanelCtrl(scope, injectorStub);
 }

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -47,7 +47,7 @@ export function ControllerTestContext(this: any) {
       self.$location = $location;
       self.$browser = $browser;
       self.$q = $q;
-      self.panel = new PanelModel({ type: 'test' });
+      self.panel = new PanelModel({ type: 'test' }, self.dashboard);
       self.dashboard = { meta: {} };
       self.isUtc = false;
       self.dashboard.isTimezoneUtc = () => {


### PR DESCRIPTION
I tried to resurrect lazyloading.

References here https://github.com/grafana/grafana/pull/7452 https://github.com/grafana/grafana/issues/5216 https://github.com/grafana/grafana/issues/8365 https://github.com/grafana/grafana/issues/8500

What I was not very sure of is that now as `refresh()` is moved to PanelModel I had to pass DashboardModel as well. Appreciate your review!