### PR TITLE
Remove the jump effect on run query button

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -944,7 +944,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
           <div className="navbar-buttons relative">
             <button className="btn navbar-button navbar-button--primary" onClick={this.onSubmit}>
               Run Query{' '}
-              {loading ? <i className="fa fa-spinner fa-spin run-icon" /> : <i className="fa fa-level-down run-icon" />}
+              {loading ? <i className="fa fa-spinner fa-fw fa-spin run-icon" /> : <i className="fa fa-level-down fa-fw run-icon" />}
             </button>
           </div>
         </div>

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -160,7 +160,7 @@
   }
 
   .run-icon {
-    margin-left: 0.5em;
+    margin-left: 0.25em;
     transform: rotate(90deg);
   }
 


### PR DESCRIPTION
Fixes #14326

Caused by the return and loading spinner icons having different widths. Used `fa-fw` helper class to ensure fixed width on icons. Also, made the spacing between icon and button label slightly smaller, as the rotated `fa-level-down` icon used as return icon has significantly smaller width compared to the loading spinner and it looked oddly too far from the label as compared to timepicker's icon.
