### PR TITLE
fix: When loki is default data source, datasource is passed as undefi…

### DIFF
--- a/public/app/features/dashboard/dashgrid/QueryOptions.tsx
+++ b/public/app/features/dashboard/dashgrid/QueryOptions.tsx
@@ -94,7 +94,7 @@ export class QueryOptions extends PureComponent<Props, State> {
 
   renderOptions() {
     const { datasource, panel } = this.props;
-    const { queryOptions } = datasource.meta;
+    const queryOptions = datasource && datasource.meta ? datasource.meta.queryOptions : undefined;
 
     if (!queryOptions) {
       return null;


### PR DESCRIPTION
QueryOptions throws if datasource is undefined (and it's undefined when Loki is default datasource).

Fixes #14667 