### PR TITLE
Removes unnecessary warnings from webpack output about missing exports

### DIFF
--- a/scripts/webpack/IgnoreNotFoundExportPlugin.js
+++ b/scripts/webpack/IgnoreNotFoundExportPlugin.js
@@ -1,0 +1,22 @@
+// https://github.com/TypeStrong/ts-loader/issues/653#issuecomment-390889335
+
+const ModuleDependencyWarning = require("webpack/lib/ModuleDependencyWarning")
+
+module.exports = class IgnoreNotFoundExportPlugin {
+    apply(compiler) {
+        const messageRegExp = /export '.*'( \(reexported as '.*'\))? was not found in/
+        function doneHook(stats) {
+            stats.compilation.warnings = stats.compilation.warnings.filter(function(warn) {
+                if (warn instanceof ModuleDependencyWarning && messageRegExp.test(warn.message)) {
+                    return false
+                }
+                return true;
+            })
+        }
+        if (compiler.hooks) {
+            compiler.hooks.done.tap("IgnoreNotFoundExportPlugin", doneHook)
+        } else {
+            compiler.plugin("done", doneHook)
+        }
+    }
+}

--- a/scripts/webpack/webpack.hot.js
+++ b/scripts/webpack/webpack.hot.js
@@ -7,6 +7,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const IgnoreNotFoundExportPlugin = require("./IgnoreNotFoundExportPlugin.js");
 
 module.exports = merge(common, {
   entry: {
@@ -111,5 +112,6 @@ module.exports = merge(common, {
         NODE_ENV: JSON.stringify('development'),
       },
     }),
+    new IgnoreNotFoundExportPlugin(),
   ],
 });


### PR DESCRIPTION
This should not break anything as `ForkTsCheckerWebpackPlugin` takes care of type checking. And the webpack's output is not bloated with unnecessary information.
