### PR TITLE
14814 - Pivot by labels feature

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -74,6 +74,7 @@ export class ResultTransformer {
       datapoints: dps,
       query: options.query,
       target: metricLabel,
+      labels: metricData.metric,
     };
   }
 

--- a/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
@@ -145,10 +145,25 @@ describe('Prometheus Result Transformer', () => {
 
       const result = ctx.resultTransformer.transform({ data: response }, options);
       expect(result).toEqual([
-        { target: '1', datapoints: [[10, 1445000010000], [10, 1445000020000], [0, 1445000030000]] },
-        { target: '2', datapoints: [[10, 1445000010000], [0, 1445000020000], [30, 1445000030000]] },
-        { target: '3', datapoints: [[10, 1445000010000], [0, 1445000020000], [10, 1445000030000]] },
-      ]);
+        { datapoints: [[10, 1445000010000], [10, 1445000020000], [0, 1445000030000]], labels: {
+            __name__: "test",
+            job: "testjob",
+            le: "1"
+          },
+          query: undefined, target: "1" },
+        {datapoints: [[10, 1445000010000], [0, 1445000020000], [30, 1445000030000]], labels: {
+            __name__: "test",
+            job: "testjob",
+            le: "2"
+          },
+          query: undefined, target: "2" },
+        { datapoints: [[10, 1445000010000], [0, 1445000020000], [10, 1445000030000]], labels: {
+            __name__: "test",
+            job: "testjob",
+            le: "3"
+          },
+          query: undefined, target: "3"}
+        ]);
     });
 
     it('should handle missing datapoints', () => {
@@ -203,7 +218,11 @@ describe('Prometheus Result Transformer', () => {
       };
 
       const result = ctx.resultTransformer.transform({ data: response }, options);
-      expect(result).toEqual([{ target: 'test{job="testjob"}', datapoints: [[10, 0], [10, 1000], [0, 2000]] }]);
+      expect(result).toEqual([{datapoints: [[10, 0], [10, 1000], [0, 2000]], labels: {
+          job: "testjob"
+        },
+        query: undefined, target: "test{job=\"testjob\"}"}
+      ]);
     });
 
     it('should fill timeseries with null values', () => {
@@ -227,7 +246,9 @@ describe('Prometheus Result Transformer', () => {
       };
 
       const result = ctx.resultTransformer.transform({ data: response }, options);
-      expect(result).toEqual([{ target: 'test{job="testjob"}', datapoints: [[null, 0], [10, 1000], [0, 2000]] }]);
+      expect(result).toEqual([{datapoints: [[null, 0], [10, 1000], [0, 2000]], labels: {
+          job: "testjob"
+        }, query: undefined, target: "test{job=\"testjob\"}"}]);
     });
 
     it('should align null values with step', () => {
@@ -251,8 +272,10 @@ describe('Prometheus Result Transformer', () => {
       };
 
       const result = ctx.resultTransformer.transform({ data: response }, options);
-      expect(result).toEqual([
-        { target: 'test{job="testjob"}', datapoints: [[null, 0], [null, 2000], [10, 4000], [null, 6000], [10, 8000]] },
+      expect(result).toEqual([{ datapoints: [[null, 0], [null, 2000], [10, 4000], [null, 6000], [10, 8000]], labels: {
+          job: "testjob"
+        },
+        query: undefined, target: "test{job=\"testjob\"}"}
       ]);
     });
   });

--- a/public/app/plugins/panel/table/editor.html
+++ b/public/app/plugins/panel/table/editor.html
@@ -1,11 +1,19 @@
 <div class="editor-row">
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Data</h5>
-    <div class="gf-form">
+    <div class="gf-form-inline">
       <label class="gf-form-label width-10">Table Transform</label>
-      <div class="gf-form-select-wrapper max-width-15">
+      <div class="gf-form-select-wrapper max-width-15 gf-form">
         <select class="gf-form-input" ng-model="editor.panel.transform" ng-options="k as v.description for (k, v) in editor.transformers" ng-change="editor.transformChanged()"></select>
       </div>
+      <div class="gf-form" ng-show="editor.canSetPivots">
+				<label class="gf-form-label">
+					Info
+					<info-popover mode="right-normal">
+						Choose this feature if labels are returned by the datasource and alias is set.
+					</info-popover>
+				</label>
+			</div>
     </div>
     <div class="gf-form-inline">
       <div class="gf-form">
@@ -27,6 +35,20 @@
 						{{editor.columnsHelpMessage}}
 					</info-popover>
 				</label>
+			</div>
+    </div>
+    <div class="gf-form-inline" ng-show="editor.canSetPivots">
+      <div class="gf-form">
+        <label class="gf-form-label width-10">Pivot By</label>
+      </div>
+			<div class="gf-form" ng-repeat="pivot in editor.panel.pivots">
+				<label class="gf-form-label">
+					<i class="pointer fa fa-remove" ng-click="editor.removePivot(pivot)"></i>
+					<span>{{pivot.text}}</span>
+				</label>
+			</div>
+			<div class="gf-form">
+				<metric-segment segment="editor.addPivotSegment" get-options="editor.getPivotOptions()" on-change="editor.addPivot()"></metric-segment>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
* #14814 
* Implementation
1. Added a new table transform "Time series pivot by label" , powered by label data from the data source.
2. Added UI segment to choose and add pivot columns.
3. Saving pivots in Panel model against the property "pivots".
4. Modified Elasticsearch response to return props as labels.
5. Modified Prometheus response to return metric data as labels.
6. Added labels information in time series.

* To do
1. Tests
