### PR TITLE
Fix panel time overrides not being applied fully

### DIFF
--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -143,12 +143,9 @@ export function applyPanelTimeOverrides(panel: PanelModel, timeRange: TimeRange)
     const timeShift = '-' + timeShiftInterpolated;
     newTimeData.timeInfo += ' timeshift ' + timeShift;
     newTimeData.timeRange = {
-      from: dateMath.parseDateMath(timeShift, timeRange.from, false),
-      to: dateMath.parseDateMath(timeShift, timeRange.to, true),
-      raw: {
-        from: timeRange.from,
-        to: timeRange.to,
-      },
+      from: dateMath.parseDateMath(timeShift, newTimeData.timeRange.from, false),
+      to: dateMath.parseDateMath(timeShift, newTimeData.timeRange.to, true),
+      raw: newTimeData.timeRange.raw,
     };
   }
 


### PR DESCRIPTION
fix #14726

When both relative and time shift were applied, only time shift was taken into consideration.

@torkelo regarding `raw: RawTimeRange` field in `TimeRange` object - how should it behave actually?   I see it's either a `Moment` object or a `string` but I cannot figure out which type should be applied in what circumstances.

I guess we need to write some tests for `applyPanelTimeOverrides` util