### PR TITLE
Expose influxdbPlugin to 3rd party plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -28,6 +28,9 @@ import builtInPlugins from './built_in_plugins';
 import * as d3 from 'd3';
 import * as grafanaUI from '@grafana/ui';
 
+// Built-in plugins exposed for extension
+import * as influxdbPlugin from 'app/plugins/datasource/influxdb/module';
+
 // rxjs
 import { Observable, Subject } from 'rxjs';
 
@@ -112,6 +115,9 @@ exposeToPlugin('app/core/core', {
   contextSrv: contextSrv,
   __esModule: true,
 });
+
+// Built-in plugins exposed for extension
+exposeToPlugin('app/plugins/datasource/influxdb/module', influxdbPlugin);
 
 import 'vendor/flot/jquery.flot';
 import 'vendor/flot/jquery.flot.selection';


### PR DESCRIPTION
I need to write a 3rd party plugin that customizes the influxdbPlugin (e.g. with custom querying), and I imagine others may want to do the same.  Without exposing this plugin as the other basic modules are, it makes it difficult to reuse the built-in plugin. It's clearly not desirable to copy/paste the existing plugin.  I found it's also undesirable to build my own fork of grafana because of the absolute references in golang to other components in grafana/grafana.

I'm afraid I don't see an existing issue for this. I can open one if desired. 