### PR TITLE
LDAP: Fix for IPA v4.6.4 which does not allow empty attributes in search requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ devenv/docker-compose.yaml
 /conf/provisioning/**/custom.yaml
 /conf/provisioning/**/dev.yaml
 /conf/ldap_dev.toml
+/conf/ldap_freeipa.toml
 profile.cov
 /grafana
 /local

--- a/devenv/docker/blocks/freeipa/docker-compose.yaml
+++ b/devenv/docker/blocks/freeipa/docker-compose.yaml
@@ -1,0 +1,54 @@
+version: '3'
+
+volumes:
+  freeipa_data: {}
+
+services:
+  freeipa:
+    image: freeipa/freeipa-server:fedora-29
+    container_name: freeipa
+    stdin_open: true
+    tty: true
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    hostname: ipa.example.test
+    environment:
+      # - DEBUG_TRACE=1
+      - IPA_SERVER_IP=172.17.0.2
+      - DEBUG_NO_EXIT=1
+      - IPA_SERVER_HOSTNAME=ipa.example.test
+      - PASSWORD=Secret123
+      - HOSTNAME=ipa.example.test
+    command:
+      - --admin-password=Secret123
+      - --ds-password=Secret123
+      - -U
+      - --realm=EXAMPLE.TEST
+    ports:
+      # FreeIPA WebUI
+      - "80:80"
+      - "443:443"
+      # Kerberos
+      - "88:88/udp"
+      - "88:88"
+      - "464:464/udp"
+      - "464:464"
+      # LDAP
+      - "389:389"
+      - "636:636"
+      # DNS
+      # - "53:53/udp"
+      # - "53:53"
+      # NTP
+      - "123:123/udp"
+      # other
+      - "7389:7389"
+      - "9443:9443"
+      - "9444:9444"
+      - "9445:9445"
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - freeipa_data:/data:Z
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/devenv/docker/blocks/freeipa/ldap_freeipa.toml
+++ b/devenv/docker/blocks/freeipa/ldap_freeipa.toml
@@ -1,0 +1,74 @@
+# To troubleshoot and get more log info enable ldap debug logging in grafana.ini
+# [log]
+# filters = ldap:debug
+
+[[servers]]
+# Ldap server host (specify multiple hosts space separated)
+host = "172.17.0.1"
+# Default port is 389 or 636 if use_ssl = true
+port = 389
+# Set to true if ldap server supports TLS
+use_ssl = false
+# Set to true if connect ldap server with STARTTLS pattern (create connection in insecure, then upgrade to secure connection with TLS)
+start_tls = false
+# set to true if you want to skip ssl cert validation
+ssl_skip_verify = false
+# set to the path to your root CA certificate or leave unset to use system defaults
+# root_ca_cert = "/path/to/certificate.crt"
+
+# Search user bind dn
+bind_dn = "uid=admin,cn=users,cn=accounts,dc=example,dc=test"
+# Search user bind password
+# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+bind_password = 'Secret123'
+
+# User search filter, for example "(cn=%s)" or "(sAMAccountName=%s)" or "(uid=%s)"
+search_filter = "(uid=%s)"
+
+# An array of base dns to search through
+search_base_dns = ["cn=users,cn=accounts,dc=example,dc=test"]
+
+# In POSIX LDAP schemas, without memberOf attribute a secondary query must be made for groups.
+# This is done by enabling group_search_filter below. You must also set member_of= "cn"
+# in [servers.attributes] below.
+
+# Users with nested/recursive group membership and an LDAP server that supports LDAP_MATCHING_RULE_IN_CHAIN
+# can set group_search_filter, group_search_filter_user_attribute, group_search_base_dns and member_of
+# below in such a way that the user's recursive group membership is considered.
+#
+# Nested Groups + Active Directory (AD) Example:
+#
+#   AD groups store the Distinguished Names (DNs) of members, so your filter must
+#   recursively search your groups for the authenticating user's DN. For example:
+#
+#     group_search_filter = "(member:1.2.840.113556.1.4.1941:=%s)"
+#     group_search_filter_user_attribute = "distinguishedName"
+#     group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
+#
+#     [servers.attributes]
+#     ...
+#     member_of = "distinguishedName"
+
+## Group search filter, to retrieve the groups of which the user is a member (only set if memberOf attribute is not available)
+# group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+## Group search filter user attribute defines what user attribute gets substituted for %s in group_search_filter.
+## Defaults to the value of username in [server.attributes]
+## Valid options are any of your values in [servers.attributes]
+## If you are using nested groups you probably want to set this and member_of in
+## [servers.attributes] to "distinguishedName"
+# group_search_filter_user_attribute = "distinguishedName"
+## An array of the base DNs to search through for groups. Typically uses ou=groups
+# group_search_base_dns = ["ou=groups,dc=grafana,dc=org"]
+
+# Specify names of the ldap attributes your ldap uses
+[servers.attributes]
+name = "givenName"
+username = "uid"
+member_of = "memberOf"
+# surname = "sn"
+# email =  "mail"
+
+[[servers.group_mappings]]
+# If you want to match all (or no ldap groups) then you can use wildcard
+group_dn = "*"
+org_role = "Viewer"

--- a/devenv/docker/blocks/freeipa/notes.md
+++ b/devenv/docker/blocks/freeipa/notes.md
@@ -1,0 +1,32 @@
+# Notes on FreeIPA LDAP Docker Block
+
+Users have to be created manually. The docker-compose up command takes a few minutes to run.
+
+## Create a user
+
+`docker exec -it freeipa /bin/bash`
+
+To create a user with username: `ldap-viewer` and password: `grafana123`
+
+```bash
+kinit admin
+```
+
+Log in with password `Secret123`
+
+```bash
+ipa user-add ldap-viewer --first ldap --last viewer
+ipa passwd ldap-viewer
+ldappasswd -D uid=ldap-viewer,cn=users,cn=accounts,dc=example,dc=org -w test -a test -s grafana123
+```
+
+## Enabling FreeIPA LDAP in Grafana
+
+Copy the ldap_freeipa.toml file in this folder into your `conf` folder (it is gitignored already). To enable it in the .ini file to get Grafana to use this block:
+
+```ini
+[auth.ldap]
+enabled = true
+config_file = conf/ldap_freeipa.toml
+; allow_sign_up = true
+```

--- a/pkg/login/ldap.go
+++ b/pkg/login/ldap.go
@@ -273,25 +273,28 @@ func (a *ldapAuther) initialBind(username, userPassword string) error {
 	return nil
 }
 
+func appendIfNotEmpty(slice []string, values ...string) []string {
+	for _, v := range values {
+		if v != "" {
+			slice = append(slice, v)
+		}
+	}
+	return slice
+}
+
 func (a *ldapAuther) searchForUser(username string) (*LdapUserInfo, error) {
 	var searchResult *ldap.SearchResult
 	var err error
 
 	for _, searchBase := range a.server.SearchBaseDNs {
 		attributes := make([]string, 0)
-
-		appendIfNotEmpty := func(slice []string, attr string) []string {
-			if attr == "" {
-				return slice
-			}
-			return append(slice, attr)
-		}
-
-		attributes = appendIfNotEmpty(attributes, a.server.Attr.Username)
-		attributes = appendIfNotEmpty(attributes, a.server.Attr.Surname)
-		attributes = appendIfNotEmpty(attributes, a.server.Attr.Email)
-		attributes = appendIfNotEmpty(attributes, a.server.Attr.Name)
-		attributes = appendIfNotEmpty(attributes, a.server.Attr.MemberOf)
+		inputs := a.server.Attr
+		attributes = appendIfNotEmpty(attributes,
+			inputs.Username,
+			inputs.Surname,
+			inputs.Email,
+			inputs.Name,
+			inputs.MemberOf)
 
 		searchReq := ldap.SearchRequest{
 			BaseDN:       searchBase,


### PR DESCRIPTION
Fixes #14432 

A security patch for IPA/FreeIPA v4.6.4 had the side effect of not allowing LDAP searches with empty attributes in the search request. This fix only adds attributes to the search request if they are mapped in the ldap toml file and does not send empty attributes as it currently does.

This PR also includes a simple docker block for FreeIPA so that we can test LDAP issues in the future. An alternative to using the docker-compose block is to use the following docker run command:

```bash
docker run --name freeipa -ti \
--sysctl net.ipv6.conf.all.disable_ipv6=0 \
--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro \
-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-h ipa.example.test \
-p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 \
-p 88:88/udp -p 464:464/udp -p 123:123/udp -p 7389:7389 \
-p 9443:9443 -p 9444:9444 -p 9445:9445 \
-e PASSWORD=Secret123 -e DEBUG_NO_EXIT=1 \
freeipa/freeipa-server:fedora-29 -r EXAMPLE.TEST \
-U --admin-password=Secret123 --ds-password=Secret123
```

To test this PR, you will need to run the above command and then create a user (per default only an admin user is created). To create a user, follow the instructions in the notes.md file included in this PR.