### PR TITLE
Bugfix: ensure file permissions in docker image.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -17,13 +17,15 @@ FROM ${BASE_IMAGE}
 ARG GF_UID="472"
 ARG GF_GID="472"
 
+ENV GF_PATHS_CONFIG_DIR="/etc/grafana"
+
 ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+    GF_PATHS_CONFIG="$GF_PATHS_CONFIG_DIR/grafana.ini" \
     GF_PATHS_DATA="/var/lib/grafana" \
     GF_PATHS_HOME="/usr/share/grafana" \
     GF_PATHS_LOGS="/var/log/grafana" \
     GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
-    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+    GF_PATHS_PROVISIONING="$GF_PATHS_CONFIG_DIR/provisioning"
 
 WORKDIR $GF_PATHS_HOME
 
@@ -32,24 +34,28 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=0 /tmp/grafana "$GF_PATHS_HOME"
+RUN groupadd -r -g $GF_GID grafana && \
+    useradd -r -u $GF_UID -g grafana grafana
+
+COPY --chown=grafana:grafana --from=0 /tmp/grafana "$GF_PATHS_HOME"
+
+COPY ./run.sh /run.sh
 
 RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
-    groupadd -r -g $GF_GID grafana && \
-    useradd -r -u $GF_UID -g grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \
     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
-    cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
+    cp "$GF_PATHS_HOME/conf/ldap.toml" "$GF_PATHS_CONFIG_DIR/ldap.toml" && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" && \
-    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS"
+    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" && \
+    find "$GF_PATHS_CONFIG_DIR" -type f -execdir chmod a+r {} \; && \
+    find "$GF_PATHS_CONFIG_DIR" -type d -execdir chmod a+rx {} \; && \
+    chmod a+rx /run.sh
 
 EXPOSE 3000
-
-COPY ./run.sh /run.sh
 
 USER grafana
 ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
Bugfix: ensure file permissions in docker image, includes:
- `/usr/share/grafana` - set owner to *grafana:grafana*
- `/etc/grafana` - add access permission to *grafana* user
- `/run.sh` - add execute permission to *grafana* user.

Add an environment variable `GF_PATHS_CONFIG_DIR=/etc/grafana`.

**NOTICE**
Instructions added in Dockerfile used the `COPY --chown` option, so please use docker *18.03.1-ee-1* or *17.09.0-ce* (according to [docker release notes](https://docs.docker.com/engine/release-notes/)).

This PR aims to fix the issue #14854 