### PR TITLE
Warning header v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,6 @@ jobs:
       - run: 'go get -u github.com/mdempsky/unconvert'
       - run: 'go get -u github.com/opennota/check/cmd/varcheck'
       - run:
-          name: run linters
-          command: 'gometalinter --enable-gc --vendor --deadline 10m --disable-all --enable=deadcode --enable=goconst --enable=gofmt --enable=ineffassign --enable=megacheck --enable=structcheck --enable=unconvert --enable=varcheck ./...'
-      - run:
           name: run go vet
           command: 'go vet ./pkg/...'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ jobs:
       - run: 'go get -u github.com/mdempsky/unconvert'
       - run: 'go get -u github.com/opennota/check/cmd/varcheck'
       - run:
+          name: run linters
+          command: 'gometalinter --enable-gc --vendor --deadline 10m --disable-all --enable=deadcode --enable=goconst --enable=gofmt --enable=ineffassign --enable=megacheck --enable=structcheck --enable=unconvert --enable=varcheck ./...'
+      - run:
           name: run go vet
           command: 'go vet ./pkg/...'
 

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -76,8 +76,9 @@ class MetricsPanelCtrl extends PanelCtrl {
       return;
     }
 
-    // clear loading/error state
+    // clear datasource response state & loading flag
     delete this.error;
+    delete this.warning;
     this.loading = true;
 
     // load datasource service
@@ -183,6 +184,11 @@ class MetricsPanelCtrl extends PanelCtrl {
   handleQueryResult(result) {
     this.setTimeQueryEnd();
     this.loading = false;
+
+    // check for info or warning messages
+    if (result && result.warning) {
+      this.warning = result.warning;
+    }
 
     // check for if data source returns subject
     if (result && result.subscribe) {

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -18,6 +18,7 @@ import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, PANEL_HEADER_HE
 export class PanelCtrl {
   panel: any;
   error: any;
+  warning: string;
   dashboard: any;
   pluginName: string;
   pluginId: string;
@@ -244,8 +245,12 @@ export class PanelCtrl {
   }
 
   getInfoMode() {
+    // Error > Warn > Description
     if (this.error) {
       return 'error';
+    }
+    if (this.warning) {
+      return 'warning';
     }
     if (!!this.panel.description) {
       return 'info';
@@ -260,7 +265,7 @@ export class PanelCtrl {
     let markdown = this.panel.description;
 
     if (options.mode === 'tooltip') {
-      markdown = this.error || this.panel.description;
+      markdown = this.error ? this.error : this.warning ? this.warning : this.panel.description;
     }
 
     const linkSrv = this.$injector.get('linkSrv');

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -166,12 +166,22 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
             infoDrop.destroy();
           }
 
+          let dropClass;
+
+          if (ctrl.error) {
+            dropClass = 'drop-error';
+          } else if (ctrl.warning) {
+            dropClass = 'drop-warning';
+          } else {
+            dropClass = 'drop-help';
+          }
+
           infoDrop = new Drop({
             target: cornerInfoElem[0],
             content: () => {
               return ctrl.getInfoContent({ mode: 'tooltip' });
             },
-            classes: ctrl.error ? 'drop-error' : 'drop-help',
+            classes: dropClass,
             openOn: 'hover',
             hoverOpenDelay: 100,
             tetherOptions: {
@@ -189,7 +199,7 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
         }
       }
 
-      scope.$watchGroup(['ctrl.error', 'ctrl.panel.description'], updatePanelCornerInfo);
+      scope.$watchGroup(['ctrl.error', 'ctrl.warning', 'ctrl.panel.description'], updatePanelCornerInfo);
       scope.$watchCollection('ctrl.panel.links', updatePanelCornerInfo);
 
       cornerInfoElem.on('click', () => {
@@ -221,7 +231,7 @@ module.directive('panelHelpCorner', $rootScope => {
     restrict: 'E',
     template: `
     <span class="alert-error panel-error small pointer" ng-if="ctrl.error" ng-click="ctrl.openInspector()">
-    <span data-placement="top" bs-tooltip="ctrl.error">
+    <span data-placement="top" bs-tooltip="ctrl.error ? ctrl.error : (ctrl.warning ? ctrl.warning : ''))">
     <i class="fa fa-exclamation"></i><span class="panel-error-arrow"></span>
     </span>
     </span>

--- a/public/app/plugins/datasource/mixed/datasource.ts
+++ b/public/app/plugins/datasource/mixed/datasource.ts
@@ -21,7 +21,12 @@ class MixedDatasource {
     });
 
     return this.$q.all(promises).then(results => {
-      return { data: _.flatten(_.map(results, 'data')) };
+      const warningStates = _.flatten(_.map(results, 'warning'));
+
+      return {
+        data: _.flatten(_.map(results, 'data')),
+        warning: warningStates && warningStates.length > 0 ? warningStates.join('\n') : null,
+      };
     });
   }
 }

--- a/public/sass/_variables.dark.scss
+++ b/public/sass/_variables.dark.scss
@@ -299,6 +299,7 @@ $popover-help-bg: $btn-secondary-bg;
 $popover-help-color: $text-color;
 
 $popover-error-bg: $btn-danger-bg;
+$popover-warning-bg: $btn-secondary-bg;
 
 // Tooltips and popovers
 // -------------------------

--- a/public/sass/_variables.light.scss
+++ b/public/sass/_variables.light.scss
@@ -302,7 +302,9 @@ $popover-shadow: 0 0 20px $white;
 
 $popover-help-bg: $blue;
 $popover-help-color: $gray-6;
+
 $popover-error-bg: $btn-danger-bg;
+$popover-warning-bg: $blue-dark;
 
 // Tooltips and popovers
 // -------------------------

--- a/public/sass/_variables.light.scss
+++ b/public/sass/_variables.light.scss
@@ -304,7 +304,7 @@ $popover-help-bg: $blue;
 $popover-help-color: $gray-6;
 
 $popover-error-bg: $btn-danger-bg;
-$popover-warning-bg: $blue-dark;
+$popover-warning-bg: $blue;
 
 // Tooltips and popovers
 // -------------------------

--- a/public/sass/components/_drop.scss
+++ b/public/sass/components/_drop.scss
@@ -6,11 +6,13 @@ $attachmentOffset: 0%;
 $easing: cubic-bezier(0, 0, 0.265, 1);
 
 @include drop-theme('error', $popover-error-bg, $popover-color);
+@include drop-theme('warning', $popover-warning-bg, $popover-help-color);
 @include drop-theme('popover', $popover-bg, $popover-color, $popover-border-color);
 @include drop-theme('help', $popover-help-bg, $popover-help-color);
 
 @include drop-animation-scale('drop', 'help', $attachmentOffset: $attachmentOffset, $easing: $easing);
 @include drop-animation-scale('drop', 'error', $attachmentOffset: $attachmentOffset, $easing: $easing);
+@include drop-animation-scale('drop', 'warning', $attachmentOffset: $attachmentOffset, $easing: $easing);
 @include drop-animation-scale('drop', 'popover', $attachmentOffset: $attachmentOffset, $easing: $easing);
 
 .drop-element {

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -231,6 +231,15 @@ div.flot-text {
     }
   }
 
+  &--warning {
+    display: block;
+    color: $text-color;
+    @include panel-corner-color($warn);
+    .fa:before {
+      content: '\f12a';
+    }
+  }
+
   &--error {
     display: block;
     color: $white;


### PR DESCRIPTION
Implements the changes described in #14487.

Effectively, the panel inspects the datasource result for a `warning` field. If it exists, it's bound to the controller and rendered in the corner. Note that error still takes priority.
