### PR TITLE
iOS login button should be enabled when using browser autofill

### DIFF
--- a/public/app/core/core.ts
+++ b/public/app/core/core.ts
@@ -1,5 +1,6 @@
 import './directives/dash_class';
 import './directives/dropdown_typeahead';
+import './directives/autofill_event_fix';
 import './directives/metric_segment';
 import './directives/misc';
 import './directives/ng_model_on_blur';

--- a/public/app/core/directives/autofill_event_fix.ts
+++ b/public/app/core/directives/autofill_event_fix.ts
@@ -1,0 +1,35 @@
+﻿import coreModule from '../core_module';
+
+/** @ngInject */
+export function autofillEventFix($compile) {
+  return {
+    link: ($scope: any, elem: any) => {
+      const input = elem[0];
+      const dispatchChangeEvent = () => {
+        const event = new Event('change');
+        return input.dispatchEvent(event);
+      };
+      const onAnimationStart = ({ animationName }: AnimationEvent) => {
+        switch (animationName) {
+          case 'onAutoFillStart':
+            return dispatchChangeEvent();
+          case 'onAutoFillCancel':
+            return dispatchChangeEvent();
+        }
+        return null;
+      };
+
+      // const onChange = (evt: Event) => console.log(evt);
+
+      input.addEventListener('animationstart', onAnimationStart);
+      // input.addEventListener('change', onChange);
+
+      $scope.$on('$destroy', () => {
+        input.removeEventListener('animationstart', onAnimationStart);
+        // input.removeEventListener('change', onChange);
+      });
+    }
+  };
+}
+
+coreModule.directive('autofillEventFix', autofillEventFix);

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -9,7 +9,7 @@
         <form name="loginForm" class="login-form-group gf-form-group" ng-hide="disableLoginForm">
           <div class="login-form">
             <input type="text" name="username" class="gf-form-input login-form-input" required ng-model='formModel.user' placeholder={{loginHint}}
-              autofocus>
+              autofocus autofill-event-fix>
           </div>
           <div class="login-form">
             <input type="password" name="password" class="gf-form-input login-form-input" required ng-model="formModel.password" id="inputPassword"

--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -32,6 +32,7 @@
 @import 'utils/angular';
 @import 'utils/spacings';
 @import 'utils/widths';
+@import 'utils/hacks';
 
 // LAYOUTS
 @import 'layout/lists';

--- a/public/sass/utils/_hacks.scss
+++ b/public/sass/utils/_hacks.scss
@@ -1,0 +1,11 @@
+﻿// <3: https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
+// sass-lint:disable no-empty-rulesets
+@keyframes onAutoFillStart {  from {/**/}  to {/**/}}
+@keyframes onAutoFillCancel {  from {/**/}  to {/**/}}
+input:-webkit-autofill {
+  animation-name: onAutoFillStart;
+  transition: transform 1ms;
+}
+input:not(:-webkit-autofill) {
+  animation-name: onAutoFillCancel;
+}


### PR DESCRIPTION
Fixes #12133

**This needs to be tested more**

Background: There's no change event triggered when autofill is used in Chrome on iOS. More info in #12133.

Solution: When autofill is used, start a css animation, listen for that one and manually trigger the change event. The downside is that this will trigger a change-event twice on all other devices than Chrome + iOS.
