### PR TITLE
Explore: Fix datasource selector being empty with single datasource

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -161,11 +161,17 @@ export function initializeExplore(
       },
     });
 
-    if (exploreDatasources.length > 1) {
+    if (exploreDatasources.length >= 1) {
       let instance;
       if (datasource) {
-        instance = await getDatasourceSrv().get(datasource);
-      } else {
+        try {
+          instance = await getDatasourceSrv().get(datasource);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+      // Checking on instance here because requested datasource could be deleted already
+      if (!instance) {
         instance = await getDatasourceSrv().get();
       }
       dispatch(loadDatasource(exploreId, instance));


### PR DESCRIPTION
- The "missing" action was triggered unless the number of datasource >1 :facepalm:
- Made datasource preselection more robust in case the requested datasource is already gone

Fixes #14926 

Urgent: Keeps users from testing Loki in when Loki is single datasource.