### PR TITLE
Show folder name under dashboard title

### DIFF
--- a/public/app/plugins/panel/dashlist/editor.html
+++ b/public/app/plugins/panel/dashlist/editor.html
@@ -22,15 +22,17 @@
       <input type="text" class="gf-form-input" placeholder="title query" ng-model="ctrl.panel.query" ng-change="ctrl.refresh()" ng-model-onblur>
     </div>
 
-    <div class="gf-form">
-      <folder-picker  initial-folder-id="ctrl.panel.folderId"
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <folder-picker  initial-folder-id="ctrl.panel.folderId"
 											on-change="ctrl.onFolderChange($folder)"
                       label-class="width-6"
                       initial-title="'All'"
                       enable-reset="true">
-			</folder-picker>
+      </folder-picker>
+      </div>
+      <gf-form-switch class="gf-form" label="Folder names" label-class="width-9" ng-show="ctrl.showFolderNameOption" checked="ctrl.panel.showFolderName" on-change="ctrl.refresh()"></gf-form-switch>
     </div>
-
     <div class="gf-form">
       <span class="gf-form-label width-6">Tags</span>
       <bootstrap-tagsinput ng-model="ctrl.panel.tags" tagclass="label label-tag" placeholder="add tags" on-tags-updated="ctrl.refresh()">

--- a/public/app/plugins/panel/dashlist/module.html
+++ b/public/app/plugins/panel/dashlist/module.html
@@ -6,8 +6,13 @@
       </h6>
       <div class="dashlist-item" ng-repeat="dash in group.list">
         <a class="dashlist-link dashlist-link-{{dash.type}}" href="{{dash.url}}">
-          <span class="dashlist-title">
-            {{dash.title}}
+          <span class="dashlist-link-body">
+            <span class="dashlist-title">
+              {{dash.title}}
+            </span>
+            <div class="dashlist-folder-title" ng-if="dash.folderTitle && ctrl.panel.showFolderName">
+              {{dash.folderTitle}}
+            </div>
           </span>
           <span class="dashlist-star" ng-click="ctrl.starDashboard(dash, $event)">
             <i class="fa" ng-class="{'fa-star': dash.isStarred, 'fa-star-o': dash.isStarred === false}"></i>

--- a/public/app/plugins/panel/dashlist/module.ts
+++ b/public/app/plugins/panel/dashlist/module.ts
@@ -8,6 +8,7 @@ class DashListCtrl extends PanelCtrl {
 
   groups: any[];
   modes: any[];
+  showFolderNameOption: boolean;
 
   panelDefaults = {
     query: '',
@@ -18,6 +19,7 @@ class DashListCtrl extends PanelCtrl {
     starred: true,
     headings: true,
     folderId: null,
+    showFolderName: false,
   };
 
   /** @ngInject */
@@ -38,6 +40,7 @@ class DashListCtrl extends PanelCtrl {
       { list: [], show: false, header: 'Recently viewed dashboards' },
       { list: [], show: false, header: 'Search' },
     ];
+    this.showFolderNameOption = _.isNull(this.panel.folderId);
 
     // update capability
     if (this.panel.mode) {
@@ -138,6 +141,8 @@ class DashListCtrl extends PanelCtrl {
 
   onFolderChange(folder: any) {
     this.panel.folderId = folder.id;
+    this.panel.showFolderName = false;
+    this.showFolderNameOption = _.isNull(folder.id);
     this.refresh();
   }
 }

--- a/public/sass/components/_panel_dashlist.scss
+++ b/public/sass/components/_panel_dashlist.scss
@@ -10,6 +10,11 @@
 
 .dashlist-link {
   @include list-item();
+  display: flex;
+  flex-grow: 1;
+  height: 37px;
+  white-space: nowrap;
+  padding: 0px;
 
   .fa {
     padding-top: 3px;
@@ -17,9 +22,31 @@
 
   .dashlist-star {
     float: right;
+    padding: 10px;
   }
 
   .fa-star {
     color: $orange;
   }
+
+  .dashlist-link-body {
+    flex: 1 1 auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0 10px;
+  }
+}
+
+.dashlist-title {
+  color: $list-item-link-color;
+}
+
+.dashlist-folder-title {
+  color: $text-color-weak;
+  font-size: $font-size-xs;
+  line-height: 11px;
+  position: relative;
+  top: -1px;
 }


### PR DESCRIPTION
#13995

- Displaying folder name below dashboard title in Dash List panel.
- Toggle switch to hide/display folder name.
- Saving folder title display state in panel model against a boolean 'showFolderName'.
- CSS changes to auto-adjust display of dashboards with/without folder name.

![home](https://user-images.githubusercontent.com/46553842/51585412-45ea7d80-1eff-11e9-8316-90df7781e1f1.PNG)

![options1](https://user-images.githubusercontent.com/46553842/51585413-45ea7d80-1eff-11e9-8d2d-66b963d4614e.PNG)

![options2](https://user-images.githubusercontent.com/46553842/51585414-46831400-1eff-11e9-9ea6-518ac39ff3e8.PNG)

![options3](https://user-images.githubusercontent.com/46553842/51585416-46831400-1eff-11e9-9b3e-d961a1a76870.PNG)



