### PR TITLE
Fixed data source selection in explore

### DIFF
--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -123,7 +123,7 @@ export interface LoadDatasourcePendingAction {
   type: ActionTypes.LoadDatasourcePending;
   payload: {
     exploreId: ExploreId;
-    datasourceId: number;
+    datasourceName: string;
   };
 }
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -185,7 +185,7 @@ const itemReducer = (state, action: Action): ExploreItemState => {
     }
 
     case ActionTypes.LoadDatasourcePending: {
-      return { ...state, datasourceLoading: true, requestedDatasourceId: action.payload.datasourceId };
+      return { ...state, datasourceLoading: true, requestedDatasourceName: action.payload.datasourceName };
     }
 
     case ActionTypes.LoadDatasourceSuccess: {
@@ -217,6 +217,7 @@ const itemReducer = (state, action: Action): ExploreItemState => {
         supportsTable,
         datasourceLoading: false,
         datasourceMissing: false,
+        datasourceError: null,
         logsHighlighterExpressions: undefined,
         modifiedQueries: initialQueries.slice(),
         queryTransactions: [],

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -186,7 +186,7 @@ export interface ExploreItemState {
    * Allows the selection to be discarded if something went wrong during the asynchronous
    * loading of the datasource.
    */
-  requestedDatasourceId?: number;
+  requestedDatasourceName?: string;
   /**
    * Time range for this Explore. Managed by the time picker and used by all query runs.
    */


### PR DESCRIPTION
fixes #14938

* The datasourceError was not cleared on data source change success. 
* Also fixed bug where datasourceId was assigned pluginId but used as instance id, switched this to datasourceName which is what we refer to in url & panel models. 