### PR TITLE
XSS sanitizer allows class and style attributes

### DIFF
--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -44,9 +44,25 @@ export function findMatchesInText(haystack: string, needle: string): TextMatch[]
   return matches;
 }
 
+const XSSWL = Object.keys(xss.whiteList).reduce((acc, element) => {
+  acc[element] = xss.whiteList[element].concat(['class', 'style']);
+  return acc;
+}, {});
+
+const sanitizeXSS = new xss.FilterXSS({
+  whiteList: XSSWL
+});
+
+/**
+ * Returns string safe from XSS attacks.
+ *
+ * Even though we allow the style-attribute, there's still default filtering applied to it
+ * Info: https://github.com/leizongmin/js-xss#customize-css-filter
+ * Whitelist: https://github.com/leizongmin/js-css-filter/blob/master/lib/default.js
+ */
 export function sanitize (unsanitizedString: string): string {
   try {
-    return xss(unsanitizedString);
+    return sanitizeXSS.process(unsanitizedString);
   } catch (error) {
     console.log('String could not be sanitized', unsanitizedString);
     return unsanitizedString;


### PR DESCRIPTION
Updated xss sanitizer to allow `class` and `style` attributes on html tags.

However, there's still filtering done on the style-attribute to avoid `background-image: url(javascript:alert('XSS'))` and such. Added comment for that since it's a special case in the external lib.