### PR TITLE
Explore: Fix scanning for logs

### DIFF
--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -1,0 +1,42 @@
+import { Action, ActionTypes } from './actionTypes';
+import { itemReducer, makeExploreItemState } from './reducers';
+import { ExploreId } from 'app/types/explore';
+
+describe('Explore item reducer', () => {
+  describe('scanning', () => {
+    test('should start scanning', () => {
+      let state = makeExploreItemState();
+      const action: Action = {
+        type: ActionTypes.ScanStart,
+        payload: {
+          exploreId: ExploreId.left,
+          scanner: jest.fn(),
+        },
+      };
+      state = itemReducer(state, action);
+      expect(state.scanning).toBeTruthy();
+      expect(state.scanner).toBe(action.payload.scanner);
+    });
+    test('should stop scanning', () => {
+      let state = makeExploreItemState();
+      const start: Action = {
+        type: ActionTypes.ScanStart,
+        payload: {
+          exploreId: ExploreId.left,
+          scanner: jest.fn(),
+        },
+      };
+      state = itemReducer(state, start);
+      expect(state.scanning).toBeTruthy();
+      const action: Action = {
+        type: ActionTypes.ScanStop,
+        payload: {
+          exploreId: ExploreId.left,
+        },
+      };
+      state = itemReducer(state, action);
+      expect(state.scanning).toBeFalsy();
+      expect(state.scanner).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -20,7 +20,7 @@ const DEFAULT_GRAPH_INTERVAL = 15 * 1000;
 /**
  * Returns a fresh Explore area state
  */
-const makeExploreItemState = (): ExploreItemState => ({
+export const makeExploreItemState = (): ExploreItemState => ({
   StartPage: undefined,
   containerWidth: 0,
   datasourceInstance: null,
@@ -48,7 +48,7 @@ const makeExploreItemState = (): ExploreItemState => ({
 /**
  * Global Explore state that handles multiple Explore areas and the split state
  */
-const initialExploreState: ExploreState = {
+export const initialExploreState: ExploreState = {
   split: null,
   left: makeExploreItemState(),
   right: makeExploreItemState(),
@@ -57,7 +57,7 @@ const initialExploreState: ExploreState = {
 /**
  * Reducer for an Explore area, to be used by the global Explore reducer.
  */
-const itemReducer = (state, action: Action): ExploreItemState => {
+export const itemReducer = (state, action: Action): ExploreItemState => {
   switch (action.type) {
     case ActionTypes.AddQueryRow: {
       const { initialQueries, modifiedQueries, queryTransactions } = state;
@@ -360,13 +360,19 @@ const itemReducer = (state, action: Action): ExploreItemState => {
     }
 
     case ActionTypes.ScanStart: {
-      return { ...state, scanning: true };
+      return { ...state, scanning: true, scanner: action.payload.scanner };
     }
 
     case ActionTypes.ScanStop: {
       const { queryTransactions } = state;
       const nextQueryTransactions = queryTransactions.filter(qt => qt.scanning && !qt.done);
-      return { ...state, queryTransactions: nextQueryTransactions, scanning: false, scanRange: undefined };
+      return {
+        ...state,
+        queryTransactions: nextQueryTransactions,
+        scanning: false,
+        scanRange: undefined,
+        scanner: undefined,
+      };
     }
 
     case ActionTypes.SetQueries: {


### PR DESCRIPTION
- Redux migration caused the scanner to not be set
- this change adds the setting/unsetting of the scanner in the reducer
- added test

Fixes #14997 