### PR TITLE
Disable query should trigger refresh

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -166,6 +166,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
 
   onDisableQuery = () => {
     this.props.query.hide = !this.props.query.hide;
+    this.onExecuteQuery();
     this.forceUpdate();
   };
 


### PR DESCRIPTION
The eye icon did not trigger a query execution (So no update in panel)