### PR TITLE
Makes the clickable side menu header look great in light theme again

### DIFF
--- a/public/app/core/components/sidemenu/SideMenuDropDown.tsx
+++ b/public/app/core/components/sidemenu/SideMenuDropDown.tsx
@@ -10,7 +10,7 @@ const SideMenuDropDown: FC<Props> = props => {
   return (
     <ul className="dropdown-menu dropdown-menu--sidemenu" role="menu">
       <li className="side-menu-header">
-        <a href={link.url}>
+        <a className="side-menu-header-link" href={link.url}>
           <span className="sidemenu-item-text">{link.text}</span>
         </a>
       </li>

--- a/public/app/core/components/sidemenu/__snapshots__/SideMenuDropDown.test.tsx.snap
+++ b/public/app/core/components/sidemenu/__snapshots__/SideMenuDropDown.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`Render should render children 1`] = `
   <li
     className="side-menu-header"
   >
-    <a>
+    <a
+      className="side-menu-header-link"
+    >
       <span
         className="sidemenu-item-text"
       >
@@ -51,7 +53,9 @@ exports[`Render should render component 1`] = `
   <li
     className="side-menu-header"
   >
-    <a>
+    <a
+      className="side-menu-header-link"
+    >
       <span
         className="sidemenu-item-text"
       >

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -149,10 +149,17 @@
   color: #ebedf2;
 }
 
-.side-menu-header > a {
+.side-menu-header-link {
   // Removes left-brand-border-gradient from link
+  color: #ebedf2 !important;
   border: none !important;
   padding: 0 !important;
+}
+
+.dropdown-menu--sidemenu > li > .side-menu-header-link:hover {
+  // Makes sure it looks good on light theme
+  color: #fff !important;
+  background-color: $side-menu-item-hover-bg !important;
 }
 
 .sidemenu-subtitle {


### PR DESCRIPTION
- Fixes #15406

### Before

![image](https://user-images.githubusercontent.com/562238/51727807-f8d8e980-206d-11e9-96e4-b1303248df06.png)

#### On hover
![image](https://user-images.githubusercontent.com/562238/51727830-1312c780-206e-11e9-9b81-6c1b98d9b600.png)

### After

![image](https://user-images.githubusercontent.com/562238/51727710-80722880-206d-11e9-9d18-a1951328f1f3.png)

#### On hover
![image](https://user-images.githubusercontent.com/562238/51727866-45242980-206e-11e9-8882-9f7f90612873.png)

#### Dark theme still looks great
![image](https://user-images.githubusercontent.com/562238/51727758-b7e0d500-206d-11e9-9f12-65cff524df06.png)

