### PR TITLE
fix multiple piechart instances bug

### DIFF
--- a/public/vendor/flot/jquery.flot.pie.js
+++ b/public/vendor/flot/jquery.flot.pie.js
@@ -73,6 +73,7 @@ More detail and specific examples can be found in the included HTML file.
 			centerLeft = null,
 			centerTop = null,
 			processed = false,
+			options = null,
 			ctx = null;
 
 		// interactive variables


### PR DESCRIPTION
This PR fixes a [bug in piechart-panel](https://github.com/grafana/piechart-panel/issues/155) which was caused by bug in `flot.pie`.
Bug was caused by modifiyng `options` variable without declaration, so `options` was treated as a global, so it led to rewriting this variabe by another piechart instance.