### PR TITLE
Updated url query param encoding to exctly match angular encoding

### DIFF
--- a/public/app/core/specs/url.test.ts
+++ b/public/app/core/specs/url.test.ts
@@ -14,3 +14,12 @@ describe('toUrlParams', () => {
     expect(url).toBe('server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=');
   });
 });
+
+describe('toUrlParams', () => {
+  it('should encode the same way as angularjs', () => {
+    const url = toUrlParams({
+      server: ':@',
+    });
+    expect(url).toBe('server=:@');
+  });
+});

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -84,7 +84,7 @@ export async function getExploreUrl(
     }
 
     const exploreState = JSON.stringify(state);
-    url = renderUrl('/explore', { state: exploreState });
+    url = renderUrl('/explore', { left: exploreState });
   }
   return url;
 }

--- a/public/app/core/utils/url.ts
+++ b/public/app/core/utils/url.ts
@@ -11,6 +11,16 @@ export function renderUrl(path: string, query: UrlQueryMap | undefined): string 
   return path;
 }
 
+export function encodeURIComponentAsAngularJS(val, pctEncodeSpaces) {
+  return encodeURIComponent(val).
+             replace(/%40/gi, '@').
+             replace(/%3A/gi, ':').
+             replace(/%24/g, '$').
+             replace(/%2C/gi, ',').
+             replace(/%3B/gi, ';').
+             replace(/%20/g, (pctEncodeSpaces ? '%20' : '+'));
+}
+
 export function toUrlParams(a) {
   const s = [];
   const rbracket = /\[\]$/;
@@ -22,9 +32,9 @@ export function toUrlParams(a) {
   const add = (k, v) => {
     v = typeof v === 'function' ? v() : v === null ? '' : v === undefined ? '' : v;
     if (typeof v !== 'boolean') {
-      s[s.length] = encodeURIComponent(k) + '=' + encodeURIComponent(v);
+      s[s.length] = encodeURIComponentAsAngularJS(k, true) + '=' + encodeURIComponentAsAngularJS(v, true);
     } else {
-      s[s.length] = encodeURIComponent(k);
+      s[s.length] = encodeURIComponentAsAngularJS(k, true);
     }
   };
 


### PR DESCRIPTION
Fixes the location update loop found in #15015 and parts of the issue in #15011 

There was a mismatch in how our redux store encodes the query parameters and how angular does it so the url sync between angular <-> redux url state was messed up. 

However this fix does not solve the issues in the above linked issues. 