### PR TITLE
pkg/services/dashboards/dashboard_service.go: simplify return

### DIFF
--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -164,11 +164,7 @@ func (dr *dashboardServiceImpl) updateAlerting(cmd *models.SaveDashboardCommand,
 		User:      dto.User,
 	}
 
-	if err := bus.Dispatch(&alertCmd); err != nil {
-		return err
-	}
-
-	return nil
+	return bus.Dispatch(&alertCmd)
 }
 
 func (dr *dashboardServiceImpl) SaveProvisionedDashboard(dto *SaveDashboardDTO, provisioning *models.DashboardProvisioning) (*models.Dashboard, error) {


### PR DESCRIPTION
Hi @torkelo @xlson,

related to #10381, I fixed a trivial **megacheck** issue.

See,
```
$ gometalinter --vendor --deadline 10m --disable-all --enable=megacheck  ./...
pkg/services/dashboards/dashboard_service.go:167:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
```