### PR TITLE
Making sure we do not pass a long invalid queries and save to state

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -538,6 +538,7 @@ export function runQueries(exploreId: ExploreId) {
 
     if (!hasNonEmptyQuery(modifiedQueries)) {
       dispatch({ type: ActionTypes.RunQueriesEmpty, payload: { exploreId } });
+      dispatch(stateSave()); // Remember to saves to state and update location
       return;
     }
 

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -173,8 +173,9 @@ export default class LokiLanguageProvider extends LanguageProvider {
         })
       );
     }
+    // Return a cleaned LokiQuery
     return queries.map(query => ({
-      ...query,
+      refId: query.refId,
       expr: '',
     }));
   }


### PR DESCRIPTION
- Changed so that we clear LokiDataQuery from anything but refId and expr (this works but is it Ok @davkal)
- Make sure we save state and update location for empty queries as well

This PR doesn't solve the infinite loop issue but rather makes sure that we don't show an explore view with a Loki datasource with an invalid query.

