### PR TITLE
Propagate event to onChange prop in Switch component

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -14,8 +14,7 @@ export interface Props {
 export interface State {
   id: any;
 }
-
-export class Switch extends PureComponent<Props, State> {
+ export class Switch extends PureComponent<Props, State> {
   state = {
     id: _.uniqueId(),
   };
@@ -23,7 +22,7 @@ export class Switch extends PureComponent<Props, State> {
   internalOnChange = (event: React.FormEvent<HTMLInputElement>) => {
     event.stopPropagation();
 
-    this.props.onChange();
+    this.props.onChange(event);
   };
 
   render() {


### PR DESCRIPTION
The `onChange` property was called without passing event object to it in Switch component. This caused e.g. Explore's switches not to work.