### PR TITLE
docker: block for loki

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -152,4 +152,10 @@ datasources:
       authType: credentials
       defaultRegion: eu-west-2
 
+  - name: gdev-loki
+    type: loki
+    access: proxy
+    url: http://localhost:3100
+    editable: false
+
 

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+networks:
+  loki:
+
+services:
+  loki:
+    image: grafana/loki:master
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - loki
+
+  promtail:
+    image: grafana/promtail:master
+    volumes:
+      - /var/log:/var/log
+    command:
+      -config.file=/etc/promtail/docker-config.yaml
+    networks:
+      - loki


### PR DESCRIPTION
Simple docker block for loki. It ingests log files from your local `/var/log` directory.

No auth and the url should be http://localhost:3100
