### PR TITLE
Fix setState on unmounted component in Loki and Prometheus QueryField

### DIFF
--- a/public/app/core/utils/CancelablePromise.ts
+++ b/public/app/core/utils/CancelablePromise.ts
@@ -1,0 +1,22 @@
+// https://github.com/facebook/react/issues/5465
+
+export interface CancelablePromise<T> {
+  promise: Promise<T>;
+  cancel: () => void;
+}
+
+export const makePromiseCancelable = <T>(promise: Promise<T>): CancelablePromise<T> => {
+  let hasCanceled_ = false;
+
+  const wrappedPromise = new Promise<T>((resolve, reject) => {
+    promise.then(val => (hasCanceled_ ? reject({ isCanceled: true }) : resolve(val)));
+    promise.catch(error => (hasCanceled_ ? reject({ isCanceled: true }) : reject(error)));
+  });
+
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      hasCanceled_ = true;
+    },
+  };
+};


### PR DESCRIPTION
Added possibility to make promise cancelable (Ref: https://github.com/facebook/react/issues/5465). I think of this as a temporary solution, to avoid `hasMounted` approach to the underlying issue. 

Thing is, redux state changes cause QueryRow to unmount making the QueryField component to be reinitialised. I haven't figured out yet what's the exact state change that causes the components up in the tree to completely re-render. Also, I think that the language provider initialization could be performed in redux instead of `*QueryField` componenent. I'm gonna prepare an issue about that with some suggestions.


