### PR TITLE
build: enterprise release co project.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,7 @@ jobs:
     docker:
     - image: grafana/grafana-ci-deploy:1.2.0
     steps:
+      - checkout
       - attach_workspace:
          at: .
       - run:


### PR DESCRIPTION
In the v6.0.0-beta1 release in ci the enterprise release step
failed due to not having the neccessary scripts available
as it wasn't checking out the project from git.

This PR rectifies that.