### PR TITLE
Reducing boilerplate code for Redux

### DIFF
--- a/public/app/core/redux/actionCreatorFactory.test.ts
+++ b/public/app/core/redux/actionCreatorFactory.test.ts
@@ -11,7 +11,7 @@ interface Dummy {
   b: boolean;
 }
 
-const setup = payload => {
+const setup = (payload: Dummy) => {
   resetAllActionCreatorTypes();
   const actionCreator = actionCreatorFactory<Dummy>('dummy').create();
   const result = actionCreator(payload);

--- a/public/app/core/redux/actionCreatorFactory.test.ts
+++ b/public/app/core/redux/actionCreatorFactory.test.ts
@@ -1,4 +1,8 @@
-import { actionCreatorFactory, resetAllActionCreatorTypes } from './actionCreatorFactory';
+import {
+  actionCreatorFactory,
+  resetAllActionCreatorTypes,
+  noPayloadActionCreatorFactory,
+} from './actionCreatorFactory';
 
 interface Dummy {
   n: number;
@@ -11,15 +15,14 @@ interface Dummy {
   b: boolean;
 }
 
-const setup = (payload: Dummy) => {
+const setup = (payload?: Dummy) => {
   resetAllActionCreatorTypes();
   const actionCreator = actionCreatorFactory<Dummy>('dummy').create();
+  const noPayloadactionCreator = noPayloadActionCreatorFactory('NoPayload').create();
   const result = actionCreator(payload);
+  const noPayloadResult = noPayloadactionCreator();
 
-  return {
-    actionCreator,
-    result,
-  };
+  return { actionCreator, noPayloadactionCreator, result, noPayloadResult };
 };
 
 describe('actionCreatorFactory', () => {
@@ -46,7 +49,34 @@ describe('actionCreatorFactory', () => {
       setup(payload);
 
       expect(() => {
-        actionCreatorFactory<Dummy>('DuMmY').create();
+        noPayloadActionCreatorFactory('DuMmY').create();
+      }).toThrow();
+    });
+  });
+});
+
+describe('noPayloadActionCreatorFactory', () => {
+  describe('when calling create', () => {
+    it('then it should create correct type string', () => {
+      const { noPayloadResult, noPayloadactionCreator } = setup();
+
+      expect(noPayloadactionCreator.type).toEqual('NoPayload');
+      expect(noPayloadResult.type).toEqual('NoPayload');
+    });
+
+    it('then it should create correct payload', () => {
+      const { noPayloadResult } = setup();
+
+      expect(noPayloadResult.payload).toBeUndefined();
+    });
+  });
+
+  describe('when calling create with existing type', () => {
+    it('then it should throw error', () => {
+      setup();
+
+      expect(() => {
+        actionCreatorFactory<Dummy>('nOpAyLoAd').create();
       }).toThrow();
     });
   });

--- a/public/app/core/redux/actionCreatorFactory.test.ts
+++ b/public/app/core/redux/actionCreatorFactory.test.ts
@@ -46,7 +46,7 @@ describe('actionCreatorFactory', () => {
       setup(payload);
 
       expect(() => {
-        actionCreatorFactory<Dummy>('dummy').create();
+        actionCreatorFactory<Dummy>('DuMmY').create();
       }).toThrow();
     });
   });

--- a/public/app/core/redux/actionCreatorFactory.test.ts
+++ b/public/app/core/redux/actionCreatorFactory.test.ts
@@ -1,0 +1,53 @@
+import { actionCreatorFactory, resetAllActionCreatorTypes } from './actionCreatorFactory';
+
+interface Dummy {
+  n: number;
+  s: string;
+  o: {
+    n: number;
+    s: string;
+    b: boolean;
+  };
+  b: boolean;
+}
+
+const setup = payload => {
+  resetAllActionCreatorTypes();
+  const actionCreator = actionCreatorFactory<Dummy>('dummy').create();
+  const result = actionCreator(payload);
+
+  return {
+    actionCreator,
+    result,
+  };
+};
+
+describe('actionCreatorFactory', () => {
+  describe('when calling create', () => {
+    it('then it should create correct type string', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      const { actionCreator, result } = setup(payload);
+
+      expect(actionCreator.type).toEqual('dummy');
+      expect(result.type).toEqual('dummy');
+    });
+
+    it('then it should create correct payload', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      const { result } = setup(payload);
+
+      expect(result.payload).toEqual(payload);
+    });
+  });
+
+  describe('when calling create with existing type', () => {
+    it('then it should throw error', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      setup(payload);
+
+      expect(() => {
+        actionCreatorFactory<Dummy>('dummy').create();
+      }).toThrow();
+    });
+  });
+});

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -1,0 +1,33 @@
+import { Action } from 'redux';
+
+const allActionCreators: string[] = [];
+
+export interface GrafanaAction<Payload> extends Action {
+  readonly type: string;
+  readonly payload: Payload;
+}
+
+export interface GrafanaActionCreator<Payload> {
+  readonly type: string;
+  (payload: Payload): GrafanaAction<Payload>;
+}
+
+export interface ActionCreatorFactory<Payload> {
+  create: () => GrafanaActionCreator<Payload>;
+}
+
+export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactory<Payload> => {
+  const create = (): GrafanaActionCreator<Payload> => {
+    return Object.assign((payload: Payload): GrafanaAction<Payload> => ({ type, payload }), { type });
+  };
+
+  if (allActionCreators.some(t => type === type)) {
+    throw new Error(`There is already an actionCreator defined with the type ${type}`);
+  }
+
+  allActionCreators.push(type);
+
+  return { create };
+};
+
+export const resetAllActionCreatorTypes = () => (allActionCreators.length = 0);

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -2,23 +2,23 @@ import { Action } from 'redux';
 
 const allActionCreators: string[] = [];
 
-export interface GrafanaAction<Payload> extends Action {
+export interface ActionOf<Payload> extends Action {
   readonly type: string;
   readonly payload: Payload;
 }
 
-export interface GrafanaActionCreator<Payload> {
+export interface ActionCreator<Payload> {
   readonly type: string;
-  (payload: Payload): GrafanaAction<Payload>;
+  (payload: Payload): ActionOf<Payload>;
 }
 
 export interface ActionCreatorFactory<Payload> {
-  create: () => GrafanaActionCreator<Payload>;
+  create: () => ActionCreator<Payload>;
 }
 
 export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactory<Payload> => {
-  const create = (): GrafanaActionCreator<Payload> => {
-    return Object.assign((payload: Payload): GrafanaAction<Payload> => ({ type, payload }), { type });
+  const create = (): ActionCreator<Payload> => {
+    return Object.assign((payload: Payload): ActionOf<Payload> => ({ type, payload }), { type });
   };
 
   if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -12,13 +12,36 @@ export interface ActionCreator<Payload> {
   (payload: Payload): ActionOf<Payload>;
 }
 
+export interface NoPayloadActionCreator {
+  readonly type: string;
+  (): ActionOf<undefined>;
+}
+
 export interface ActionCreatorFactory<Payload> {
   create: () => ActionCreator<Payload>;
+}
+
+export interface NoPayloadActionCreatorFactory {
+  create: () => NoPayloadActionCreator;
 }
 
 export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactory<Payload> => {
   const create = (): ActionCreator<Payload> => {
     return Object.assign((payload: Payload): ActionOf<Payload> => ({ type, payload }), { type });
+  };
+
+  if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {
+    throw new Error(`There is already an actionCreator defined with the type ${type}`);
+  }
+
+  allActionCreators.push(type);
+
+  return { create };
+};
+
+export const noPayloadActionCreatorFactory = (type: string): NoPayloadActionCreatorFactory => {
+  const create = (): NoPayloadActionCreator => {
+    return Object.assign((): ActionOf<undefined> => ({ type, payload: undefined }), { type });
   };
 
   if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -21,7 +21,7 @@ export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactor
     return Object.assign((payload: Payload): GrafanaAction<Payload> => ({ type, payload }), { type });
   };
 
-  if (allActionCreators.some(t => type === type)) {
+  if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {
     throw new Error(`There is already an actionCreator defined with the type ${type}`);
   }
 
@@ -30,4 +30,5 @@ export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactor
   return { create };
 };
 
+// Should only be used by tests
 export const resetAllActionCreatorTypes = () => (allActionCreators.length = 0);

--- a/public/app/core/redux/index.ts
+++ b/public/app/core/redux/index.ts
@@ -1,0 +1,4 @@
+import { actionCreatorFactory } from './actionCreatorFactory';
+import { reducerFactory } from './reducerFactory';
+
+export { actionCreatorFactory, reducerFactory };

--- a/public/app/core/redux/reducerFactory.test.ts
+++ b/public/app/core/redux/reducerFactory.test.ts
@@ -1,5 +1,5 @@
 import { reducerFactory } from './reducerFactory';
-import { actionCreatorFactory, GrafanaAction } from './actionCreatorFactory';
+import { actionCreatorFactory, ActionOf } from './actionCreatorFactory';
 
 interface DummyReducerState {
   n: number;
@@ -37,7 +37,7 @@ describe('reducerFactory', () => {
     describe('when reducer is called with no state', () => {
       describe('and with an action that the handler can not handle', () => {
         it('then the resulting state should be intial state', () => {
-          const result = dummyReducer(undefined as DummyReducerState, {} as GrafanaAction<any>);
+          const result = dummyReducer(undefined as DummyReducerState, {} as ActionOf<any>);
 
           expect(result).toEqual(dummyReducerIntialState);
         });
@@ -56,7 +56,7 @@ describe('reducerFactory', () => {
     describe('when reducer is called with a state', () => {
       describe('and with an action that the handler can not handle', () => {
         it('then the resulting state should be intial state', () => {
-          const result = dummyReducer(dummyReducerIntialState, {} as GrafanaAction<any>);
+          const result = dummyReducer(dummyReducerIntialState, {} as ActionOf<any>);
 
           expect(result).toEqual(dummyReducerIntialState);
         });

--- a/public/app/core/redux/reducerFactory.test.ts
+++ b/public/app/core/redux/reducerFactory.test.ts
@@ -1,0 +1,99 @@
+import { reducerFactory } from './reducerFactory';
+import { actionCreatorFactory, GrafanaAction } from './actionCreatorFactory';
+
+interface DummyReducerState {
+  n: number;
+  s: string;
+  b: boolean;
+  o: {
+    n: number;
+    s: string;
+    b: boolean;
+  };
+}
+
+const dummyReducerIntialState: DummyReducerState = {
+  n: 1,
+  s: 'One',
+  b: true,
+  o: {
+    n: 2,
+    s: 'two',
+    b: false,
+  },
+};
+
+const dummyActionCreator = actionCreatorFactory<DummyReducerState>('dummy').create();
+
+const dummyReducer = reducerFactory(dummyReducerIntialState)
+  .addHandler({
+    creator: dummyActionCreator,
+    handler: ({ state, action }) => {
+      return { ...state, ...action.payload };
+    },
+  })
+  .create();
+
+describe('reducerFactory', () => {
+  describe('given it is created with a defined handler', () => {
+    describe('when reducer is called with no state', () => {
+      describe('and with an action that the handler can not handle', () => {
+        it('then the resulting state should be intial state', () => {
+          const result = dummyReducer(undefined as DummyReducerState, {} as GrafanaAction<any>);
+
+          expect(result).toEqual(dummyReducerIntialState);
+        });
+      });
+
+      describe('and with an action that the handler can handle', () => {
+        it('then the resulting state should correct', () => {
+          const payload = { n: 10, s: 'ten', b: false, o: { n: 20, s: 'twenty', b: true } };
+          const result = dummyReducer(undefined as DummyReducerState, dummyActionCreator(payload));
+
+          expect(result).toEqual(payload);
+        });
+      });
+    });
+
+    describe('when reducer is called with a state', () => {
+      describe('and with an action that the handler can not handle', () => {
+        it('then the resulting state should be intial state', () => {
+          const result = dummyReducer(dummyReducerIntialState, {} as GrafanaAction<any>);
+
+          expect(result).toEqual(dummyReducerIntialState);
+        });
+      });
+
+      describe('and with an action that the handler can handle', () => {
+        it('then the resulting state should correct', () => {
+          const payload = { n: 10, s: 'ten', b: false, o: { n: 20, s: 'twenty', b: true } };
+          const result = dummyReducer(dummyReducerIntialState, dummyActionCreator(payload));
+
+          expect(result).toEqual(payload);
+        });
+      });
+    });
+  });
+
+  describe('given a handler is added', () => {
+    describe('when a handler with the same creator is added', () => {
+      it('then is should throw', () => {
+        const faultyReducer = reducerFactory(dummyReducerIntialState).addHandler({
+          creator: dummyActionCreator,
+          handler: ({ state, action }) => {
+            return { ...state, ...action.payload };
+          },
+        });
+
+        expect(() => {
+          faultyReducer.addHandler({
+            creator: dummyActionCreator,
+            handler: ({ state }) => {
+              return state;
+            },
+          });
+        }).toThrow();
+      });
+    });
+  });
+});

--- a/public/app/core/redux/reducerFactory.test.ts
+++ b/public/app/core/redux/reducerFactory.test.ts
@@ -26,7 +26,7 @@ const dummyReducerIntialState: DummyReducerState = {
 const dummyActionCreator = actionCreatorFactory<DummyReducerState>('dummy').create();
 
 const dummyReducer = reducerFactory(dummyReducerIntialState)
-  .addHandler({
+  .addMapper({
     filter: dummyActionCreator,
     mapper: (state, action) => ({ ...state, ...action.payload }),
   })
@@ -76,7 +76,7 @@ describe('reducerFactory', () => {
   describe('given a handler is added', () => {
     describe('when a handler with the same creator is added', () => {
       it('then is should throw', () => {
-        const faultyReducer = reducerFactory(dummyReducerIntialState).addHandler({
+        const faultyReducer = reducerFactory(dummyReducerIntialState).addMapper({
           filter: dummyActionCreator,
           mapper: (state, action) => {
             return { ...state, ...action.payload };
@@ -84,7 +84,7 @@ describe('reducerFactory', () => {
         });
 
         expect(() => {
-          faultyReducer.addHandler({
+          faultyReducer.addMapper({
             filter: dummyActionCreator,
             mapper: state => {
               return state;

--- a/public/app/core/redux/reducerFactory.test.ts
+++ b/public/app/core/redux/reducerFactory.test.ts
@@ -27,10 +27,8 @@ const dummyActionCreator = actionCreatorFactory<DummyReducerState>('dummy').crea
 
 const dummyReducer = reducerFactory(dummyReducerIntialState)
   .addHandler({
-    creator: dummyActionCreator,
-    handler: ({ state, action }) => {
-      return { ...state, ...action.payload };
-    },
+    filter: dummyActionCreator,
+    handler: (state, action) => ({ ...state, ...action.payload }),
   })
   .create();
 
@@ -79,16 +77,16 @@ describe('reducerFactory', () => {
     describe('when a handler with the same creator is added', () => {
       it('then is should throw', () => {
         const faultyReducer = reducerFactory(dummyReducerIntialState).addHandler({
-          creator: dummyActionCreator,
-          handler: ({ state, action }) => {
+          filter: dummyActionCreator,
+          handler: (state, action) => {
             return { ...state, ...action.payload };
           },
         });
 
         expect(() => {
           faultyReducer.addHandler({
-            creator: dummyActionCreator,
-            handler: ({ state }) => {
+            filter: dummyActionCreator,
+            handler: state => {
               return state;
             },
           });

--- a/public/app/core/redux/reducerFactory.test.ts
+++ b/public/app/core/redux/reducerFactory.test.ts
@@ -28,7 +28,7 @@ const dummyActionCreator = actionCreatorFactory<DummyReducerState>('dummy').crea
 const dummyReducer = reducerFactory(dummyReducerIntialState)
   .addHandler({
     filter: dummyActionCreator,
-    handler: (state, action) => ({ ...state, ...action.payload }),
+    mapper: (state, action) => ({ ...state, ...action.payload }),
   })
   .create();
 
@@ -78,7 +78,7 @@ describe('reducerFactory', () => {
       it('then is should throw', () => {
         const faultyReducer = reducerFactory(dummyReducerIntialState).addHandler({
           filter: dummyActionCreator,
-          handler: (state, action) => {
+          mapper: (state, action) => {
             return { ...state, ...action.payload };
           },
         });
@@ -86,7 +86,7 @@ describe('reducerFactory', () => {
         expect(() => {
           faultyReducer.addHandler({
             filter: dummyActionCreator,
-            handler: state => {
+            mapper: state => {
               return state;
             },
           });

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,47 +1,45 @@
 import { ActionOf, ActionCreator } from './actionCreatorFactory';
+import { Reducer } from 'redux';
 
 export type Mapper<State, Payload> = (state: State, action: ActionOf<Payload>) => State;
 
-export interface HandlerConfig<State, Payload> {
+export interface MapperConfig<State, Payload> {
   filter: ActionCreator<Payload>;
   mapper: Mapper<State, Payload>;
 }
 
-export interface AddHandler<State> {
-  addHandler: <Payload>(config: HandlerConfig<State, Payload>) => CreateReducer<State>;
+export interface AddMapper<State> {
+  addMapper: <Payload>(config: MapperConfig<State, Payload>) => CreateReducer<State>;
 }
 
-export interface CreateReducer<State> extends AddHandler<State> {
-  create: () => Mapper<State, any>;
+export interface CreateReducer<State> extends AddMapper<State> {
+  create: () => Reducer<State, ActionOf<any>>;
 }
 
-export const reducerFactory = <State>(initialState: State): AddHandler<State> => {
-  const allHandlerConfigs: Array<HandlerConfig<State, any>> = [];
+export const reducerFactory = <State>(initialState: State): AddMapper<State> => {
+  const allMapperConfigs: Array<MapperConfig<State, any>> = [];
 
-  const addHandler = <Payload>(config: HandlerConfig<State, Payload>): CreateReducer<State> => {
-    if (allHandlerConfigs.some(c => c.filter.type === config.filter.type)) {
-      throw new Error(`There is already a handlers defined with the type ${config.filter.type}`);
+  const addMapper = <Payload>(config: MapperConfig<State, Payload>): CreateReducer<State> => {
+    if (allMapperConfigs.some(c => c.filter.type === config.filter.type)) {
+      throw new Error(`There is already a Mappers defined with the type ${config.filter.type}`);
     }
 
-    allHandlerConfigs.push(config);
+    allMapperConfigs.push(config);
 
     return instance;
   };
 
-  const create = () => (state: State = initialState, action: ActionOf<any>): State => {
-    const handlerConfig = allHandlerConfigs.filter(config => config.filter.type === action.type)[0];
+  const create = (): Reducer<State, ActionOf<any>> => (state: State = initialState, action: ActionOf<any>): State => {
+    const mapperConfig = allMapperConfigs.filter(config => config.filter.type === action.type)[0];
 
-    if (handlerConfig) {
-      return handlerConfig.mapper(state, action);
+    if (mapperConfig) {
+      return mapperConfig.mapper(state, action);
     }
 
     return state;
   };
 
-  const instance: CreateReducer<State> = {
-    addHandler,
-    create,
-  };
+  const instance: CreateReducer<State> = { addMapper, create };
 
   return instance;
 };

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,9 +1,9 @@
-import { GrafanaAction, GrafanaActionCreator } from './actionCreatorFactory';
+import { ActionOf, ActionCreator } from './actionCreatorFactory';
 import { Reducer } from 'redux';
 
 export interface HandlerConfig<State, Payload> {
-  filter: GrafanaActionCreator<Payload>;
-  handler: (state: State, action: GrafanaAction<Payload>) => State;
+  filter: ActionCreator<Payload>;
+  handler: (state: State, action: ActionOf<Payload>) => State;
 }
 
 export interface AddHandler<State> {
@@ -11,7 +11,7 @@ export interface AddHandler<State> {
 }
 
 export interface CreateReducer<State> extends AddHandler<State> {
-  create: () => Reducer<State, GrafanaAction<any>>;
+  create: () => Reducer<State, ActionOf<any>>;
 }
 
 export const reducerFactory = <State>(initialState: State): AddHandler<State> => {
@@ -27,8 +27,8 @@ export const reducerFactory = <State>(initialState: State): AddHandler<State> =>
     return instance;
   };
 
-  const create = (): Reducer<State, GrafanaAction<any>> => {
-    const reducer: Reducer<State, GrafanaAction<any>> = (state: State = initialState, action: GrafanaAction<any>) => {
+  const create = (): Reducer<State, ActionOf<any>> => {
+    const reducer: Reducer<State, ActionOf<any>> = (state: State = initialState, action: ActionOf<any>) => {
       const validHandlers = allHandlerConfigs
         .filter(config => config.filter.type === action.type)
         .map(config => config.handler);

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,4 +1,4 @@
-import { ActionOf, ActionCreator, actionCreatorFactory } from './actionCreatorFactory';
+import { ActionOf, ActionCreator } from './actionCreatorFactory';
 import { Reducer } from 'redux';
 
 export type Mapper<State, Payload> = (state: State, action: ActionOf<Payload>) => State;
@@ -17,23 +17,23 @@ export interface CreateReducer<State> extends AddMapper<State> {
 }
 
 export const reducerFactory = <State>(initialState: State): AddMapper<State> => {
-  const allMapperConfigs: Array<MapperConfig<State, any>> = [];
+  const allMappers: { [key: string]: Mapper<State, any> } = {};
 
   const addMapper = <Payload>(config: MapperConfig<State, Payload>): CreateReducer<State> => {
-    if (allMapperConfigs.some(c => c.filter.type === config.filter.type)) {
-      throw new Error(`There is already a Mappers defined with the type ${config.filter.type}`);
+    if (allMappers[config.filter.type]) {
+      throw new Error(`There is already a mapper defined with the type ${config.filter.type}`);
     }
 
-    allMapperConfigs.push(config);
+    allMappers[config.filter.type] = config.mapper;
 
     return instance;
   };
 
   const create = (): Reducer<State, ActionOf<any>> => (state: State = initialState, action: ActionOf<any>): State => {
-    const mapperConfig = allMapperConfigs.filter(config => config.filter.type === action.type)[0];
+    const mapper = allMappers[action.type];
 
-    if (mapperConfig) {
-      return mapperConfig.mapper(state, action);
+    if (mapper) {
+      return mapper(state, action);
     }
 
     return state;
@@ -43,95 +43,3 @@ export const reducerFactory = <State>(initialState: State): AddMapper<State> => 
 
   return instance;
 };
-
-/** Another type of fluent reducerFactory */
-
-export interface FilterWith<State> {
-  filterWith: <Payload>(actionCreator: ActionCreator<Payload>) => MapTo<State, Payload>;
-}
-
-export interface OrFilterWith<State> {
-  orFilterWith: <Payload>(actionCreator: ActionCreator<Payload>) => MapTo<State, Payload>;
-}
-
-export interface MapTo<State, Payload> {
-  mapTo: (mapper: Mapper<State, Payload>) => CreateReducerEx<State>;
-}
-
-export interface CreateReducerEx<State> extends OrFilterWith<State> {
-  create: () => Reducer<State, ActionOf<any>>;
-}
-
-export const reducerFactoryEx = <State>(initialState: State): FilterWith<State> => {
-  const allMapperConfigs: Array<MapperConfig<State, any>> = [];
-
-  const innerMapTo = (actionCreator: ActionCreator<any>, mapper: Mapper<State, any>): CreateReducerEx<State> => {
-    allMapperConfigs.filter(config => config.filter.type === actionCreator.type)[0].mapper = mapper;
-
-    return instance;
-  };
-
-  const filterWith = <Payload>(actionCreator: ActionCreator<Payload>): MapTo<State, Payload> => {
-    if (allMapperConfigs.some(c => c.filter.type === actionCreator.type)) {
-      throw new Error(`There is already a mapper defined with the type ${actionCreator.type}`);
-    }
-
-    allMapperConfigs.push({ filter: actionCreator, mapper: null });
-
-    const mapTo = <Payload>(mapper: Mapper<State, Payload>): CreateReducerEx<State> => {
-      innerMapTo(actionCreator, mapper);
-
-      return instance;
-    };
-
-    return { mapTo };
-  };
-
-  const orFilterWith = <Payload>(actionCreator: ActionCreator<Payload>): MapTo<State, Payload> => {
-    if (allMapperConfigs.some(c => c.filter.type === actionCreator.type)) {
-      throw new Error(`There is already a mapper defined with the type ${actionCreator.type}`);
-    }
-
-    allMapperConfigs.push({ filter: actionCreator, mapper: null });
-
-    const mapTo = <Payload>(mapper: Mapper<State, Payload>): CreateReducerEx<State> => {
-      innerMapTo(actionCreator, mapper);
-
-      return instance;
-    };
-
-    return { mapTo };
-  };
-
-  const create = (): Reducer<State, ActionOf<any>> => (state: State = initialState, action: ActionOf<any>): State => {
-    const mapperConfig = allMapperConfigs.filter(config => config.filter.type === action.type)[0];
-
-    if (mapperConfig) {
-      return mapperConfig.mapper(state, action);
-    }
-
-    return state;
-  };
-
-  const instance = { filterWith, orFilterWith, create };
-
-  return instance;
-};
-
-interface TestState {
-  data: string[];
-}
-
-const initialState: TestState = {
-  data: [],
-};
-
-const dummyActionCreator = actionCreatorFactory<string>('dummyActionCreator').create();
-const dummyActionCreator2 = actionCreatorFactory<number>('dummyActionCreator2').create();
-
-export const reducerFactoryExReducer = reducerFactoryEx<TestState>(initialState)
-  .filterWith(dummyActionCreator)
-  .mapTo((state, action) => ({ ...state, data: state.data.concat(action.payload) }))
-  .orFilterWith(dummyActionCreator2)
-  .mapTo((state, action) => ({ ...state, data: state.data.concat(`${action.payload}`) }))
-  .create();

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,0 +1,55 @@
+import { GrafanaAction, GrafanaActionCreator } from './actionCreatorFactory';
+import { Reducer } from 'redux';
+
+export interface ActionHandler<State, Payload> {
+  state: State;
+  action: GrafanaAction<Payload>;
+}
+
+export interface ActionHandlerConfig<State, Payload> {
+  creator: GrafanaActionCreator<Payload>;
+  handler: (handler: ActionHandler<State, Payload>) => State;
+}
+
+export interface AddActionHandler<State> {
+  addHandler: <Payload>(config: ActionHandlerConfig<State, Payload>) => CreateReducer<State>;
+}
+
+export interface CreateReducer<State> extends AddActionHandler<State> {
+  create: () => Reducer<State, GrafanaAction<any>>;
+}
+
+export const reducerFactory = <State>(initialState: State): AddActionHandler<State> => {
+  const allHandlerConfigs: Array<ActionHandlerConfig<State, any>> = [];
+
+  const addHandler = <Payload>(config: ActionHandlerConfig<State, Payload>): CreateReducer<State> => {
+    if (allHandlerConfigs.some(c => c.creator.type === config.creator.type)) {
+      throw new Error(`There is already a handlers defined with the type ${config.creator.type}`);
+    }
+
+    allHandlerConfigs.push(config);
+
+    return instance;
+  };
+
+  const create = (): Reducer<State, GrafanaAction<any>> => {
+    const reducer: Reducer<State, GrafanaAction<any>> = (state: State = initialState, action: GrafanaAction<any>) => {
+      const validHandlers = allHandlerConfigs
+        .filter(config => config.creator.type === action.type)
+        .map(config => config.handler);
+
+      return validHandlers.reduce((currentState, handler) => {
+        return handler({ state: currentState, action });
+      }, state || initialState);
+    };
+
+    return reducer;
+  };
+
+  const instance: CreateReducer<State> = {
+    addHandler,
+    create,
+  };
+
+  return instance;
+};

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,30 +1,25 @@
 import { GrafanaAction, GrafanaActionCreator } from './actionCreatorFactory';
 import { Reducer } from 'redux';
 
-export interface ActionHandler<State, Payload> {
-  state: State;
-  action: GrafanaAction<Payload>;
+export interface HandlerConfig<State, Payload> {
+  filter: GrafanaActionCreator<Payload>;
+  handler: (state: State, action: GrafanaAction<Payload>) => State;
 }
 
-export interface ActionHandlerConfig<State, Payload> {
-  creator: GrafanaActionCreator<Payload>;
-  handler: (handler: ActionHandler<State, Payload>) => State;
+export interface AddHandler<State> {
+  addHandler: <Payload>(config: HandlerConfig<State, Payload>) => CreateReducer<State>;
 }
 
-export interface AddActionHandler<State> {
-  addHandler: <Payload>(config: ActionHandlerConfig<State, Payload>) => CreateReducer<State>;
-}
-
-export interface CreateReducer<State> extends AddActionHandler<State> {
+export interface CreateReducer<State> extends AddHandler<State> {
   create: () => Reducer<State, GrafanaAction<any>>;
 }
 
-export const reducerFactory = <State>(initialState: State): AddActionHandler<State> => {
-  const allHandlerConfigs: Array<ActionHandlerConfig<State, any>> = [];
+export const reducerFactory = <State>(initialState: State): AddHandler<State> => {
+  const allHandlerConfigs: Array<HandlerConfig<State, any>> = [];
 
-  const addHandler = <Payload>(config: ActionHandlerConfig<State, Payload>): CreateReducer<State> => {
-    if (allHandlerConfigs.some(c => c.creator.type === config.creator.type)) {
-      throw new Error(`There is already a handlers defined with the type ${config.creator.type}`);
+  const addHandler = <Payload>(config: HandlerConfig<State, Payload>): CreateReducer<State> => {
+    if (allHandlerConfigs.some(c => c.filter.type === config.filter.type)) {
+      throw new Error(`There is already a handlers defined with the type ${config.filter.type}`);
     }
 
     allHandlerConfigs.push(config);
@@ -35,11 +30,11 @@ export const reducerFactory = <State>(initialState: State): AddActionHandler<Sta
   const create = (): Reducer<State, GrafanaAction<any>> => {
     const reducer: Reducer<State, GrafanaAction<any>> = (state: State = initialState, action: GrafanaAction<any>) => {
       const validHandlers = allHandlerConfigs
-        .filter(config => config.creator.type === action.type)
+        .filter(config => config.filter.type === action.type)
         .map(config => config.handler);
 
       return validHandlers.reduce((currentState, handler) => {
-        return handler({ state: currentState, action });
+        return handler(currentState, action);
       }, state || initialState);
     };
 

--- a/public/app/core/redux/reducerFactory.ts
+++ b/public/app/core/redux/reducerFactory.ts
@@ -1,4 +1,4 @@
-import { ActionOf, ActionCreator } from './actionCreatorFactory';
+import { ActionOf, ActionCreator, actionCreatorFactory } from './actionCreatorFactory';
 import { Reducer } from 'redux';
 
 export type Mapper<State, Payload> = (state: State, action: ActionOf<Payload>) => State;
@@ -43,3 +43,95 @@ export const reducerFactory = <State>(initialState: State): AddMapper<State> => 
 
   return instance;
 };
+
+/** Another type of fluent reducerFactory */
+
+export interface FilterWith<State> {
+  filterWith: <Payload>(actionCreator: ActionCreator<Payload>) => MapTo<State, Payload>;
+}
+
+export interface OrFilterWith<State> {
+  orFilterWith: <Payload>(actionCreator: ActionCreator<Payload>) => MapTo<State, Payload>;
+}
+
+export interface MapTo<State, Payload> {
+  mapTo: (mapper: Mapper<State, Payload>) => CreateReducerEx<State>;
+}
+
+export interface CreateReducerEx<State> extends OrFilterWith<State> {
+  create: () => Reducer<State, ActionOf<any>>;
+}
+
+export const reducerFactoryEx = <State>(initialState: State): FilterWith<State> => {
+  const allMapperConfigs: Array<MapperConfig<State, any>> = [];
+
+  const innerMapTo = (actionCreator: ActionCreator<any>, mapper: Mapper<State, any>): CreateReducerEx<State> => {
+    allMapperConfigs.filter(config => config.filter.type === actionCreator.type)[0].mapper = mapper;
+
+    return instance;
+  };
+
+  const filterWith = <Payload>(actionCreator: ActionCreator<Payload>): MapTo<State, Payload> => {
+    if (allMapperConfigs.some(c => c.filter.type === actionCreator.type)) {
+      throw new Error(`There is already a mapper defined with the type ${actionCreator.type}`);
+    }
+
+    allMapperConfigs.push({ filter: actionCreator, mapper: null });
+
+    const mapTo = <Payload>(mapper: Mapper<State, Payload>): CreateReducerEx<State> => {
+      innerMapTo(actionCreator, mapper);
+
+      return instance;
+    };
+
+    return { mapTo };
+  };
+
+  const orFilterWith = <Payload>(actionCreator: ActionCreator<Payload>): MapTo<State, Payload> => {
+    if (allMapperConfigs.some(c => c.filter.type === actionCreator.type)) {
+      throw new Error(`There is already a mapper defined with the type ${actionCreator.type}`);
+    }
+
+    allMapperConfigs.push({ filter: actionCreator, mapper: null });
+
+    const mapTo = <Payload>(mapper: Mapper<State, Payload>): CreateReducerEx<State> => {
+      innerMapTo(actionCreator, mapper);
+
+      return instance;
+    };
+
+    return { mapTo };
+  };
+
+  const create = (): Reducer<State, ActionOf<any>> => (state: State = initialState, action: ActionOf<any>): State => {
+    const mapperConfig = allMapperConfigs.filter(config => config.filter.type === action.type)[0];
+
+    if (mapperConfig) {
+      return mapperConfig.mapper(state, action);
+    }
+
+    return state;
+  };
+
+  const instance = { filterWith, orFilterWith, create };
+
+  return instance;
+};
+
+interface TestState {
+  data: string[];
+}
+
+const initialState: TestState = {
+  data: [],
+};
+
+const dummyActionCreator = actionCreatorFactory<string>('dummyActionCreator').create();
+const dummyActionCreator2 = actionCreatorFactory<number>('dummyActionCreator2').create();
+
+export const reducerFactoryExReducer = reducerFactoryEx<TestState>(initialState)
+  .filterWith(dummyActionCreator)
+  .mapTo((state, action) => ({ ...state, data: state.data.concat(action.payload) }))
+  .orFilterWith(dummyActionCreator2)
+  .mapTo((state, action) => ({ ...state, data: state.data.concat(`${action.payload}`) }))
+  .create();

--- a/public/app/features/datasources/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.test.tsx
@@ -5,6 +5,7 @@ import { NavModel } from 'app/types';
 import { DataSourceSettings } from '@grafana/ui/src/types';
 import { LayoutModes } from '../../core/components/LayoutSelector/LayoutSelector';
 import { getMockDataSources } from './__mocks__/dataSourcesMocks';
+import { setDataSourcesSearchQuery, setDataSourcesLayoutMode } from './state/actions';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -13,16 +14,16 @@ const setup = (propOverrides?: object) => {
     loadDataSources: jest.fn(),
     navModel: {
       main: {
-        text: 'Configuration'
+        text: 'Configuration',
       },
       node: {
-        text: 'Data Sources'
-      }
+        text: 'Data Sources',
+      },
     } as NavModel,
     dataSourcesCount: 0,
     searchQuery: '',
-    setDataSourcesSearchQuery: jest.fn(),
-    setDataSourcesLayoutMode: jest.fn(),
+    setDataSourcesSearchQuery,
+    setDataSourcesLayoutMode,
     hasFetched: false,
   };
 

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
@@ -5,6 +5,7 @@ import { NavModel } from 'app/types';
 import { DataSourceSettings } from '@grafana/ui';
 import { getMockDataSource } from '../__mocks__/dataSourcesMocks';
 import { getMockPlugin } from '../../plugins/__mocks__/pluginMocks';
+import { setDataSourceName, setIsDefault } from '../state/actions';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -14,9 +15,9 @@ const setup = (propOverrides?: object) => {
     pageId: 1,
     deleteDataSource: jest.fn(),
     loadDataSource: jest.fn(),
-    setDataSourceName: jest.fn(),
+    setDataSourceName,
     updateDataSource: jest.fn(),
-    setIsDefault: jest.fn(),
+    setIsDefault,
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -8,6 +8,8 @@ import { UpdateLocationAction } from 'app/core/actions/location';
 import { buildNavModel } from './navModel';
 import { DataSourceSettings } from '@grafana/ui/src/types';
 import { Plugin, StoreState } from 'app/types';
+import { actionCreatorFactory } from 'app/core/redux';
+import { ActionOf } from 'app/core/redux/actionCreatorFactory';
 
 export enum ActionTypes {
   LoadDataSources = 'LOAD_DATA_SOURCES',
@@ -22,124 +24,36 @@ export enum ActionTypes {
   SetIsDefault = 'SET_IS_DEFAULT',
 }
 
-interface LoadDataSourcesAction {
-  type: ActionTypes.LoadDataSources;
-  payload: DataSourceSettings[];
-}
+export const dataSourceLoaded = actionCreatorFactory<DataSourceSettings>(ActionTypes.LoadDataSource).create();
 
-interface SetDataSourcesSearchQueryAction {
-  type: ActionTypes.SetDataSourcesSearchQuery;
-  payload: string;
-}
+export const dataSourcesLoaded = actionCreatorFactory<DataSourceSettings[]>(ActionTypes.LoadDataSources).create();
 
-interface SetDataSourcesLayoutModeAction {
-  type: ActionTypes.SetDataSourcesLayoutMode;
-  payload: LayoutMode;
-}
+export const dataSourceMetaLoaded = actionCreatorFactory<Plugin>(ActionTypes.LoadDataSourceMeta).create();
 
-interface LoadDataSourceTypesAction {
-  type: ActionTypes.LoadDataSourceTypes;
-}
+export const dataSourceTypesLoad = actionCreatorFactory(ActionTypes.LoadDataSourceTypes).create();
 
-interface LoadedDataSourceTypesAction {
-  type: ActionTypes.LoadedDataSourceTypes;
-  payload: Plugin[];
-}
+export const dataSourceTypesLoaded = actionCreatorFactory<Plugin[]>(ActionTypes.LoadedDataSourceTypes).create();
 
-interface SetDataSourceTypeSearchQueryAction {
-  type: ActionTypes.SetDataSourceTypeSearchQuery;
-  payload: string;
-}
+export const setDataSourcesSearchQuery = actionCreatorFactory<string>(ActionTypes.SetDataSourcesSearchQuery).create();
 
-interface LoadDataSourceAction {
-  type: ActionTypes.LoadDataSource;
-  payload: DataSourceSettings;
-}
+export const setDataSourcesLayoutMode = actionCreatorFactory<LayoutMode>(ActionTypes.SetDataSourcesLayoutMode).create();
 
-interface LoadDataSourceMetaAction {
-  type: ActionTypes.LoadDataSourceMeta;
-  payload: Plugin;
-}
+export const setDataSourceTypeSearchQuery = actionCreatorFactory<string>(
+  ActionTypes.SetDataSourceTypeSearchQuery
+).create();
 
-interface SetDataSourceNameAction {
-  type: ActionTypes.SetDataSourceName;
-  payload: string;
-}
+export const setDataSourceName = actionCreatorFactory<string>(ActionTypes.SetDataSourceName).create();
 
-interface SetIsDefaultAction {
-  type: ActionTypes.SetIsDefault;
-  payload: boolean;
-}
+export const setIsDefault = actionCreatorFactory<boolean>(ActionTypes.SetIsDefault).create();
 
-const dataSourcesLoaded = (dataSources: DataSourceSettings[]): LoadDataSourcesAction => ({
-  type: ActionTypes.LoadDataSources,
-  payload: dataSources,
-});
-
-const dataSourceLoaded = (dataSource: DataSourceSettings): LoadDataSourceAction => ({
-  type: ActionTypes.LoadDataSource,
-  payload: dataSource,
-});
-
-const dataSourceMetaLoaded = (dataSourceMeta: Plugin): LoadDataSourceMetaAction => ({
-  type: ActionTypes.LoadDataSourceMeta,
-  payload: dataSourceMeta,
-});
-
-const dataSourceTypesLoad = (): LoadDataSourceTypesAction => ({
-  type: ActionTypes.LoadDataSourceTypes,
-});
-
-const dataSourceTypesLoaded = (dataSourceTypes: Plugin[]): LoadedDataSourceTypesAction => ({
-  type: ActionTypes.LoadedDataSourceTypes,
-  payload: dataSourceTypes,
-});
-
-export const setDataSourcesSearchQuery = (searchQuery: string): SetDataSourcesSearchQueryAction => ({
-  type: ActionTypes.SetDataSourcesSearchQuery,
-  payload: searchQuery,
-});
-
-export const setDataSourcesLayoutMode = (layoutMode: LayoutMode): SetDataSourcesLayoutModeAction => ({
-  type: ActionTypes.SetDataSourcesLayoutMode,
-  payload: layoutMode,
-});
-
-export const setDataSourceTypeSearchQuery = (query: string): SetDataSourceTypeSearchQueryAction => ({
-  type: ActionTypes.SetDataSourceTypeSearchQuery,
-  payload: query,
-});
-
-export const setDataSourceName = (name: string) => ({
-  type: ActionTypes.SetDataSourceName,
-  payload: name,
-});
-
-export const setIsDefault = (state: boolean) => ({
-  type: ActionTypes.SetIsDefault,
-  payload: state,
-});
-
-export type Action =
-  | LoadDataSourcesAction
-  | SetDataSourcesSearchQueryAction
-  | SetDataSourcesLayoutModeAction
-  | UpdateLocationAction
-  | LoadDataSourceTypesAction
-  | LoadedDataSourceTypesAction
-  | SetDataSourceTypeSearchQueryAction
-  | LoadDataSourceAction
-  | UpdateNavIndexAction
-  | LoadDataSourceMetaAction
-  | SetDataSourceNameAction
-  | SetIsDefaultAction;
+export type Action = UpdateLocationAction | UpdateNavIndexAction | ActionOf<any>;
 
 type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action>;
 
 export function loadDataSources(): ThunkResult<void> {
   return async dispatch => {
     const response = await getBackendSrv().get('/api/datasources');
-    dispatch(dataSourcesLoaded(response));
+    dataSourcesLoaded(response);
   };
 }
 
@@ -177,7 +91,7 @@ export function addDataSource(plugin: Plugin): ThunkResult<void> {
 
 export function loadDataSourceTypes(): ThunkResult<void> {
   return async dispatch => {
-    dispatch(dataSourceTypesLoad());
+    dispatch(dataSourceTypesLoad({}));
     const result = await getBackendSrv().get('/api/plugins', { enabled: 1, type: 'datasource' });
     dispatch(dataSourceTypesLoaded(result));
   };

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -9,51 +9,42 @@ import { buildNavModel } from './navModel';
 import { DataSourceSettings } from '@grafana/ui/src/types';
 import { Plugin, StoreState } from 'app/types';
 import { actionCreatorFactory } from 'app/core/redux';
-import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+import { ActionOf, noPayloadActionCreatorFactory } from 'app/core/redux/actionCreatorFactory';
 
-export enum ActionTypes {
-  LoadDataSources = 'LOAD_DATA_SOURCES',
-  LoadDataSourceTypes = 'LOAD_DATA_SOURCE_TYPES',
-  LoadedDataSourceTypes = 'LOADED_DATA_SOURCE_TYPES',
-  LoadDataSource = 'LOAD_DATA_SOURCE',
-  LoadDataSourceMeta = 'LOAD_DATA_SOURCE_META',
-  SetDataSourcesSearchQuery = 'SET_DATA_SOURCES_SEARCH_QUERY',
-  SetDataSourcesLayoutMode = 'SET_DATA_SOURCES_LAYOUT_MODE',
-  SetDataSourceTypeSearchQuery = 'SET_DATA_SOURCE_TYPE_SEARCH_QUERY',
-  SetDataSourceName = 'SET_DATA_SOURCE_NAME',
-  SetIsDefault = 'SET_IS_DEFAULT',
-}
+export const dataSourceLoaded = actionCreatorFactory<DataSourceSettings>('LOAD_DATA_SOURCE').create();
 
-export const dataSourceLoaded = actionCreatorFactory<DataSourceSettings>(ActionTypes.LoadDataSource).create();
+export const dataSourcesLoaded = actionCreatorFactory<DataSourceSettings[]>('LOAD_DATA_SOURCES').create();
 
-export const dataSourcesLoaded = actionCreatorFactory<DataSourceSettings[]>(ActionTypes.LoadDataSources).create();
+export const dataSourceMetaLoaded = actionCreatorFactory<Plugin>('LOAD_DATA_SOURCE_META').create();
 
-export const dataSourceMetaLoaded = actionCreatorFactory<Plugin>(ActionTypes.LoadDataSourceMeta).create();
+export const dataSourceTypesLoad = noPayloadActionCreatorFactory('LOAD_DATA_SOURCE_TYPES').create();
 
-export const dataSourceTypesLoad = actionCreatorFactory(ActionTypes.LoadDataSourceTypes).create();
+export const dataSourceTypesLoaded = actionCreatorFactory<Plugin[]>('LOADED_DATA_SOURCE_TYPES').create();
 
-export const dataSourceTypesLoaded = actionCreatorFactory<Plugin[]>(ActionTypes.LoadedDataSourceTypes).create();
+export const setDataSourcesSearchQuery = actionCreatorFactory<string>('SET_DATA_SOURCES_SEARCH_QUERY').create();
 
-export const setDataSourcesSearchQuery = actionCreatorFactory<string>(ActionTypes.SetDataSourcesSearchQuery).create();
+export const setDataSourcesLayoutMode = actionCreatorFactory<LayoutMode>('SET_DATA_SOURCES_LAYOUT_MODE').create();
 
-export const setDataSourcesLayoutMode = actionCreatorFactory<LayoutMode>(ActionTypes.SetDataSourcesLayoutMode).create();
+export const setDataSourceTypeSearchQuery = actionCreatorFactory<string>('SET_DATA_SOURCE_TYPE_SEARCH_QUERY').create();
 
-export const setDataSourceTypeSearchQuery = actionCreatorFactory<string>(
-  ActionTypes.SetDataSourceTypeSearchQuery
-).create();
+export const setDataSourceName = actionCreatorFactory<string>('SET_DATA_SOURCE_NAME').create();
 
-export const setDataSourceName = actionCreatorFactory<string>(ActionTypes.SetDataSourceName).create();
+export const setIsDefault = actionCreatorFactory<boolean>('SET_IS_DEFAULT').create();
 
-export const setIsDefault = actionCreatorFactory<boolean>(ActionTypes.SetIsDefault).create();
-
-export type Action = UpdateLocationAction | UpdateNavIndexAction | ActionOf<any>;
+export type Action =
+  | UpdateLocationAction
+  | UpdateNavIndexAction
+  | ActionOf<DataSourceSettings>
+  | ActionOf<DataSourceSettings[]>
+  | ActionOf<Plugin>
+  | ActionOf<Plugin[]>;
 
 type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action>;
 
 export function loadDataSources(): ThunkResult<void> {
   return async dispatch => {
     const response = await getBackendSrv().get('/api/datasources');
-    dataSourcesLoaded(response);
+    dispatch(dataSourcesLoaded(response));
   };
 }
 
@@ -91,7 +82,7 @@ export function addDataSource(plugin: Plugin): ThunkResult<void> {
 
 export function loadDataSourceTypes(): ThunkResult<void> {
   return async dispatch => {
-    dispatch(dataSourceTypesLoad({}));
+    dispatch(dataSourceTypesLoad());
     const result = await getBackendSrv().get('/api/plugins', { enabled: 1, type: 'datasource' });
     dispatch(dataSourceTypesLoaded(result));
   };

--- a/public/app/features/datasources/state/reducers.test.ts
+++ b/public/app/features/datasources/state/reducers.test.ts
@@ -1,0 +1,137 @@
+import { reducerTester } from 'test/core/redux/reducerTester';
+import { dataSourcesReducer, initialState } from './reducers';
+import {
+  dataSourcesLoaded,
+  dataSourceLoaded,
+  setDataSourcesSearchQuery,
+  setDataSourcesLayoutMode,
+  dataSourceTypesLoad,
+  dataSourceTypesLoaded,
+  setDataSourceTypeSearchQuery,
+  dataSourceMetaLoaded,
+  setDataSourceName,
+  setIsDefault,
+} from './actions';
+import { getMockDataSources, getMockDataSource } from '../__mocks__/dataSourcesMocks';
+import { LayoutModes } from 'app/core/components/LayoutSelector/LayoutSelector';
+import { DataSourcesState } from 'app/types';
+import { PluginMetaInfo } from '@grafana/ui';
+
+const mockPlugin = () => ({
+  defaultNavUrl: 'defaultNavUrl',
+  enabled: true,
+  hasUpdate: true,
+  id: 'id',
+  info: {} as PluginMetaInfo,
+  latestVersion: 'latestVersion',
+  name: 'name',
+  pinned: true,
+  state: 'state',
+  type: 'type',
+  module: {},
+});
+
+describe('dataSourcesReducer', () => {
+  describe('when dataSourcesLoaded is dispatched', () => {
+    it('then state should be correct', () => {
+      const dataSources = getMockDataSources(0);
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(dataSourcesLoaded(dataSources))
+        .thenStateShouldEqual({ ...initialState, hasFetched: true, dataSources, dataSourcesCount: 1 });
+    });
+  });
+
+  describe('when dataSourceLoaded is dispatched', () => {
+    it('then state should be correct', () => {
+      const dataSource = getMockDataSource();
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(dataSourceLoaded(dataSource))
+        .thenStateShouldEqual({ ...initialState, dataSource });
+    });
+  });
+
+  describe('when setDataSourcesSearchQuery is dispatched', () => {
+    it('then state should be correct', () => {
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setDataSourcesSearchQuery('some query'))
+        .thenStateShouldEqual({ ...initialState, searchQuery: 'some query' });
+    });
+  });
+
+  describe('when setDataSourcesLayoutMode is dispatched', () => {
+    it('then state should be correct', () => {
+      const layoutMode: LayoutModes = LayoutModes.Grid;
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setDataSourcesLayoutMode(layoutMode))
+        .thenStateShouldEqual({ ...initialState, layoutMode: LayoutModes.Grid });
+    });
+  });
+
+  describe('when dataSourceTypesLoad is dispatched', () => {
+    it('then state should be correct', () => {
+      const state: DataSourcesState = { ...initialState, dataSourceTypes: [mockPlugin()] };
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, state)
+        .whenActionIsDispatched(dataSourceTypesLoad())
+        .thenStateShouldEqual({ ...initialState, dataSourceTypes: [], isLoadingDataSources: true });
+    });
+  });
+
+  describe('when dataSourceTypesLoaded is dispatched', () => {
+    it('then state should be correct', () => {
+      const dataSourceTypes = [mockPlugin()];
+      const state: DataSourcesState = { ...initialState, isLoadingDataSources: true };
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, state)
+        .whenActionIsDispatched(dataSourceTypesLoaded(dataSourceTypes))
+        .thenStateShouldEqual({ ...initialState, dataSourceTypes, isLoadingDataSources: false });
+    });
+  });
+
+  describe('when setDataSourceTypeSearchQuery is dispatched', () => {
+    it('then state should be correct', () => {
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setDataSourceTypeSearchQuery('type search query'))
+        .thenStateShouldEqual({ ...initialState, dataSourceTypeSearchQuery: 'type search query' });
+    });
+  });
+
+  describe('when dataSourceMetaLoaded is dispatched', () => {
+    it('then state should be correct', () => {
+      const dataSourceMeta = mockPlugin();
+
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(dataSourceMetaLoaded(dataSourceMeta))
+        .thenStateShouldEqual({ ...initialState, dataSourceMeta });
+    });
+  });
+
+  describe('when setDataSourceName is dispatched', () => {
+    it('then state should be correct', () => {
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setDataSourceName('some name'))
+        .thenStateShouldEqual({ ...initialState, dataSource: { name: 'some name' } });
+    });
+  });
+
+  describe('when setIsDefault is dispatched', () => {
+    it('then state should be correct', () => {
+      reducerTester()
+        .givenReducer(dataSourcesReducer, initialState)
+        .whenActionIsDispatched(setIsDefault(true))
+        .thenStateShouldEqual({ ...initialState, dataSource: { isDefault: true } });
+    });
+  });
+});

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -15,7 +15,7 @@ import {
 import { LayoutModes } from 'app/core/components/LayoutSelector/LayoutSelector';
 import { reducerFactory } from 'app/core/redux';
 
-const initialState: DataSourcesState = {
+export const initialState: DataSourcesState = {
   dataSources: [],
   dataSource: {} as DataSourceSettings,
   layoutMode: LayoutModes.List,

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -1,56 +1,87 @@
 import { DataSourcesState, Plugin } from 'app/types';
 import { DataSourceSettings } from '@grafana/ui/src/types';
-import { Action, ActionTypes } from './actions';
+import {
+  dataSourceLoaded,
+  dataSourcesLoaded,
+  setDataSourcesSearchQuery,
+  setDataSourcesLayoutMode,
+  dataSourceTypesLoad,
+  dataSourceTypesLoaded,
+  setDataSourceTypeSearchQuery,
+  dataSourceMetaLoaded,
+  setDataSourceName,
+  setIsDefault,
+} from './actions';
 import { LayoutModes } from 'app/core/components/LayoutSelector/LayoutSelector';
+import { reducerFactory } from 'app/core/redux';
 
 const initialState: DataSourcesState = {
-  dataSources: [] as DataSourceSettings[],
+  dataSources: [],
   dataSource: {} as DataSourceSettings,
   layoutMode: LayoutModes.List,
   searchQuery: '',
   dataSourcesCount: 0,
-  dataSourceTypes: [] as Plugin[],
+  dataSourceTypes: [],
   dataSourceTypeSearchQuery: '',
   hasFetched: false,
   isLoadingDataSources: false,
   dataSourceMeta: {} as Plugin,
 };
 
-export const dataSourcesReducer = (state = initialState, action: Action): DataSourcesState => {
-  switch (action.type) {
-    case ActionTypes.LoadDataSources:
-      return { ...state, hasFetched: true, dataSources: action.payload, dataSourcesCount: action.payload.length };
-
-    case ActionTypes.LoadDataSource:
-      return { ...state, dataSource: action.payload };
-
-    case ActionTypes.SetDataSourcesSearchQuery:
-      return { ...state, searchQuery: action.payload };
-
-    case ActionTypes.SetDataSourcesLayoutMode:
-      return { ...state, layoutMode: action.payload };
-
-    case ActionTypes.LoadDataSourceTypes:
-      return { ...state, dataSourceTypes: [], isLoadingDataSources: true };
-
-    case ActionTypes.LoadedDataSourceTypes:
-      return { ...state, dataSourceTypes: action.payload, isLoadingDataSources: false };
-
-    case ActionTypes.SetDataSourceTypeSearchQuery:
-      return { ...state, dataSourceTypeSearchQuery: action.payload };
-
-    case ActionTypes.LoadDataSourceMeta:
-      return { ...state, dataSourceMeta: action.payload };
-
-    case ActionTypes.SetDataSourceName:
-      return { ...state, dataSource: { ...state.dataSource, name: action.payload } };
-
-    case ActionTypes.SetIsDefault:
-      return { ...state, dataSource: { ...state.dataSource, isDefault: action.payload } };
-  }
-
-  return state;
-};
+export const dataSourcesReducer = reducerFactory(initialState)
+  .addHandler({
+    filter: dataSourcesLoaded,
+    mapper: (state, action) => ({
+      ...state,
+      hasFetched: true,
+      dataSources: action.payload,
+      dataSourcesCount: action.payload.length,
+    }),
+  })
+  .addHandler({
+    filter: dataSourceLoaded,
+    mapper: (state, action) => ({ ...state, dataSource: action.payload }),
+  })
+  .addHandler({
+    filter: setDataSourcesSearchQuery,
+    mapper: (state, action) => ({ ...state, searchQuery: action.payload }),
+  })
+  .addHandler({
+    filter: setDataSourcesLayoutMode,
+    mapper: (state, action) => ({ ...state, layoutMode: action.payload }),
+  })
+  .addHandler({
+    filter: dataSourceTypesLoad,
+    mapper: state => ({ ...state, dataSourceTypes: [], isLoadingDataSources: true }),
+  })
+  .addHandler({
+    filter: dataSourceTypesLoaded,
+    mapper: (state, action) => ({
+      ...state,
+      dataSourceTypes: action.payload,
+      isLoadingDataSources: false,
+    }),
+  })
+  .addHandler({
+    filter: setDataSourceTypeSearchQuery,
+    mapper: (state, action) => ({ ...state, dataSourceTypeSearchQuery: action.payload }),
+  })
+  .addHandler({
+    filter: dataSourceMetaLoaded,
+    mapper: (state, action) => ({ ...state, dataSourceMeta: action.payload }),
+  })
+  .addHandler({
+    filter: setDataSourceName,
+    mapper: (state, action) => ({ ...state, dataSource: { ...state.dataSource, name: action.payload } }),
+  })
+  .addHandler({
+    filter: setIsDefault,
+    mapper: (state, action) => ({
+      ...state,
+      dataSource: { ...state.dataSource, isDefault: action.payload },
+    }),
+  })
+  .create();
 
 export default {
   dataSources: dataSourcesReducer,

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -29,7 +29,7 @@ const initialState: DataSourcesState = {
 };
 
 export const dataSourcesReducer = reducerFactory(initialState)
-  .addHandler({
+  .addMapper({
     filter: dataSourcesLoaded,
     mapper: (state, action) => ({
       ...state,
@@ -38,23 +38,23 @@ export const dataSourcesReducer = reducerFactory(initialState)
       dataSourcesCount: action.payload.length,
     }),
   })
-  .addHandler({
+  .addMapper({
     filter: dataSourceLoaded,
     mapper: (state, action) => ({ ...state, dataSource: action.payload }),
   })
-  .addHandler({
+  .addMapper({
     filter: setDataSourcesSearchQuery,
     mapper: (state, action) => ({ ...state, searchQuery: action.payload }),
   })
-  .addHandler({
+  .addMapper({
     filter: setDataSourcesLayoutMode,
     mapper: (state, action) => ({ ...state, layoutMode: action.payload }),
   })
-  .addHandler({
+  .addMapper({
     filter: dataSourceTypesLoad,
     mapper: state => ({ ...state, dataSourceTypes: [], isLoadingDataSources: true }),
   })
-  .addHandler({
+  .addMapper({
     filter: dataSourceTypesLoaded,
     mapper: (state, action) => ({
       ...state,
@@ -62,19 +62,19 @@ export const dataSourcesReducer = reducerFactory(initialState)
       isLoadingDataSources: false,
     }),
   })
-  .addHandler({
+  .addMapper({
     filter: setDataSourceTypeSearchQuery,
     mapper: (state, action) => ({ ...state, dataSourceTypeSearchQuery: action.payload }),
   })
-  .addHandler({
+  .addMapper({
     filter: dataSourceMetaLoaded,
     mapper: (state, action) => ({ ...state, dataSourceMeta: action.payload }),
   })
-  .addHandler({
+  .addMapper({
     filter: setDataSourceName,
     mapper: (state, action) => ({ ...state, dataSource: { ...state.dataSource, name: action.payload } }),
   })
-  .addHandler({
+  .addMapper({
     filter: setIsDefault,
     mapper: (state, action) => ({
       ...state,

--- a/public/test/core/redux/reducerTester.test.ts
+++ b/public/test/core/redux/reducerTester.test.ts
@@ -1,0 +1,58 @@
+import { reducerFactory, actionCreatorFactory } from 'app/core/redux';
+import { reducerTester } from './reducerTester';
+
+interface DummyState {
+  data: string[];
+}
+
+const initialState: DummyState = {
+  data: [],
+};
+
+const dummyAction = actionCreatorFactory<string>('dummyAction').create();
+
+const mutatingReducer = reducerFactory(initialState)
+  .addMapper({
+    filter: dummyAction,
+    mapper: (state, action) => {
+      state.data.push(action.payload);
+      return state;
+    },
+  })
+  .create();
+
+const okReducer = reducerFactory(initialState)
+  .addMapper({
+    filter: dummyAction,
+    mapper: (state, action) => {
+      return {
+        ...state,
+        data: state.data.concat(action.payload),
+      };
+    },
+  })
+  .create();
+
+describe('reducerTester', () => {
+  describe('when reducer mutates state', () => {
+    it('then it should throw', () => {
+      expect(() => {
+        reducerTester()
+          .givenReducer(mutatingReducer, initialState)
+          .whenActionIsDispatched(dummyAction('some string'))
+          .thenStateShouldEqual({ ...initialState, data: ['some string'] });
+      }).toThrow();
+    });
+  });
+
+  describe('when reducer does not mutate state', () => {
+    it('then it should not throw', () => {
+      expect(() => {
+        reducerTester()
+          .givenReducer(okReducer, initialState)
+          .whenActionIsDispatched(dummyAction('some string'))
+          .thenStateShouldEqual({ ...initialState, data: ['some string'] });
+      }).not.toThrow();
+    });
+  });
+});

--- a/public/test/core/redux/reducerTester.test.ts
+++ b/public/test/core/redux/reducerTester.test.ts
@@ -39,8 +39,7 @@ describe('reducerTester', () => {
       expect(() => {
         reducerTester()
           .givenReducer(mutatingReducer, initialState)
-          .whenActionIsDispatched(dummyAction('some string'))
-          .thenStateShouldEqual({ ...initialState, data: ['some string'] });
+          .whenActionIsDispatched(dummyAction('some string'));
       }).toThrow();
     });
   });
@@ -50,8 +49,7 @@ describe('reducerTester', () => {
       expect(() => {
         reducerTester()
           .givenReducer(okReducer, initialState)
-          .whenActionIsDispatched(dummyAction('some string'))
-          .thenStateShouldEqual({ ...initialState, data: ['some string'] });
+          .whenActionIsDispatched(dummyAction('some string'));
       }).not.toThrow();
     });
   });

--- a/public/test/core/redux/reducerTester.ts
+++ b/public/test/core/redux/reducerTester.ts
@@ -1,0 +1,79 @@
+import { Reducer } from 'redux';
+
+import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+
+export interface Given<State> {
+  givenReducer: (reducer: Reducer<State, ActionOf<any>>, state: State) => When<State>;
+}
+
+export interface When<State> {
+  whenActionIsDispatched: (action: ActionOf<any>) => Then<State>;
+}
+
+export interface Then<State> {
+  thenStateShouldEqual: (state: State) => Then<State>;
+}
+
+interface ObjectType extends Object {
+  [key: string]: any;
+}
+
+const deepFreeze = <T>(obj: T): T => {
+  Object.freeze(obj);
+
+  const isNotException = (object: any, propertyName: any) =>
+    typeof object === 'function'
+      ? propertyName !== 'caller' && propertyName !== 'callee' && propertyName !== 'arguments'
+      : true;
+  const hasOwnProp = Object.prototype.hasOwnProperty;
+
+  if (obj && obj instanceof Object) {
+    const object: ObjectType = obj;
+    Object.getOwnPropertyNames(object).forEach(propertyName => {
+      const objectProperty: any = object[propertyName];
+      if (
+        hasOwnProp.call(object, propertyName) &&
+        isNotException(object, propertyName) &&
+        objectProperty &&
+        (typeof objectProperty === 'object' || typeof objectProperty === 'function') &&
+        Object.isFrozen(objectProperty) === false
+      ) {
+        deepFreeze(objectProperty);
+      }
+    });
+  }
+
+  return obj;
+};
+
+interface ReducerTester<State> extends Given<State>, When<State>, Then<State> {}
+
+export const reducerTester = <State>(): Given<State> => {
+  let reducerUnderTest: Reducer<State, ActionOf<any>> = null;
+  let resultingState: State = null;
+  let initialState: State = null;
+
+  const givenReducer = (reducer: Reducer<State, ActionOf<any>>, state: State): When<State> => {
+    reducerUnderTest = reducer;
+    initialState = { ...state };
+    initialState = deepFreeze(initialState);
+
+    return instance;
+  };
+
+  const whenActionIsDispatched = (action: ActionOf<any>): Then<State> => {
+    resultingState = reducerUnderTest(initialState, action);
+
+    return instance;
+  };
+
+  const thenStateShouldEqual = (state: State): Then<State> => {
+    expect(state).toEqual(resultingState);
+
+    return instance;
+  };
+
+  const instance: ReducerTester<State> = { thenStateShouldEqual, givenReducer, whenActionIsDispatched };
+
+  return instance;
+};


### PR DESCRIPTION
The goal with the POC is to show a way to reduce the amount of boilerplate code used to create a strongly typed redux solution with actions, action creators, reducers and tests.

``+`` Much less boilerplate code
``-`` Non Redux standard api

## New core functionality
### actionCreatorFactory
Used to create an action creator with the following signature 
```typescript
{ type: string , (payload: T): {type: string; payload: T;} }
```
where the ``type`` string will be ensured to be unique and ``T`` is the type supplied to the factory.

#### Example
```typescript
export const someAction = actionCreatorFactory<string>('SOME_ACTION').create();

// later when dispatched
someAction('this rocks!');
```
```typescript
// best practices, always use an interface as type
interface SomeAction { data: string; } 
export const someAction = actionCreatorFactory<SomeAction>('SOME_ACTION').create();

// later when dispatched
someAction({ data: 'best practices' });
```
```typescript
// declaring an action creator with a type string that has already been defined will throw
export const someAction = actionCreatorFactory<string>('SOME_ACTION').create();
export const theAction = actionCreatorFactory<string>('SOME_ACTION').create(); // will throw
```

### noPayloadActionCreatorFactory
Used when you don't need to supply a payload for your action. Will create an action creator with the following signature 
```typescript
{ type: string , (): {type: string; payload: undefined;} }
```
where the ``type`` string will be ensured to be unique.

#### Example
```typescript
export const noPayloadAction = noPayloadActionCreatorFactory('NO_PAYLOAD').create();

// later when dispatched
noPayloadAction();
```
```typescript
// declaring an action creator with a type string that has already been defined will throw
export const noPayloadAction = noPayloadActionCreatorFactory('NO_PAYLOAD').create();
export const noAction = noPayloadActionCreatorFactory('NO_PAYLOAD').create(); // will throw
```

### reducerFactory
Fluent API used to create a reducer. (same as implementing the standard switch statement in Redux)
(there is a similar fluent api to ``reducerFactory`` in the code called ``reducerFactoryEx`` just with another syntax, we should pick the best one 😄if we decide to use this pattern)

#### Example
```typescript
interface ExampleReducerState { data: string[]; }

const intialState: ExampleReducerState = { data: [] };

export const someAction = actionCreatorFactory<string>('SOME_ACTION').create();
export const otherAction = actionCreatorFactory<string[]>('Other_ACTION').create();

export const exampleReducer = reducerFactory<ExampleReducerState>(intialState)
// addMapper is the function that ties an action creator to a state change
.addMapper({ 
    // action creator to filter out which mapper to use
    filter: someAction, 
    // mapper function where the state change occurs
    mapper: (state, action) => ({ ...state, data: state.data.concat(action.payload) }),
  })
// a developer can just chain addMapper functions until reducer is done
.addMapper({
    filter: otherAction,
    mapper: (state, action) => ({ ...state, data: action.payload }),
  })
  .create(); // this will return the reducer
```

#### Typing limitations
There is a challenge left with the mapper function that I can not solve with TypeScript. The signature of a mapper is

```typescript
<State, Payload>(state: State, action: ActionOf<Payload>) => State
```
If you would to return an object that is not of the state type like the following mapper  
```typescript
mapper: (state, action) => ({ nonExistingProperty: ''}),
```
Then you would receive the following compile error
```shell
[ts] Property 'data' is missing in type '{ nonExistingProperty: string; }' but required in type 'ExampleReducerState'. [2741]
```
But if you return an object that is spreading state and add a non existing property type like the following mapper  
```typescript
mapper: (state, action) => ({ ...state, nonExistingProperty: ''}),
```
Then you would not receive any compile error.

If you want to make sure that never happens you can just supply the State type to the mapper callback like the following mapper:
```typescript
mapper: (state, action): ExampleReducerState => ({ ...state, nonExistingProperty: 'kalle' }),
```
Then you would receive the following compile error
```shell
[ts]
Type '{ nonExistingProperty: string; data: string[]; }' is not assignable to type 'ExampleReducerState'.
  Object literal may only specify known properties, and 'nonExistingProperty' does not exist in type 'ExampleReducerState'. [2322]
```

## New test functionality

### reducerTester
Fluent API that simplifies the testing of reducers

#### Example
```typescript
reducerTester()
        .givenReducer(someReducer, initialState)
        .whenActionIsDispatched(someAction('reducer tests'))
        .thenStateShouldEqual({ ...initialState, data: 'reducer tests' });
```