### PR TITLE
devenv: various fixes for Loki docker block

### DIFF
--- a/devenv/docker/blocks/loki/config.yaml
+++ b/devenv/docker/blocks/loki/config.yaml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: http://loki:3100/api/prom/push
+
+scrape_configs:
+- job_name: system
+  entry_parser: raw
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*log
+- job_name: grafana
+  entry_parser: raw
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: grafana
+      __path__: /var/log/grafana/*log

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:master
+    image: grafana/loki:master-3e6a75e
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -13,9 +13,11 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:master
+    image: grafana/promtail:master-3e6a75e
     volumes:
+      - ./docker/blocks/loki/config.yaml:/etc/promtail/docker-config.yaml
       - /var/log:/var/log
+      - ../data/log:/var/log/grafana
     command:
       -config.file=/etc/promtail/docker-config.yaml
     networks:

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -1,24 +1,14 @@
-version: "3"
-
-networks:
   loki:
-
-services:
-  loki:
-    image: grafana/loki:master-3e6a75e
+    image: grafana/loki:master
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
-    networks:
-      - loki
 
   promtail:
-    image: grafana/promtail:master-3e6a75e
+    image: grafana/promtail:master
     volumes:
       - ./docker/blocks/loki/config.yaml:/etc/promtail/docker-config.yaml
       - /var/log:/var/log
       - ../data/log:/var/log/grafana
     command:
       -config.file=/etc/promtail/docker-config.yaml
-    networks:
-      - loki


### PR DESCRIPTION
Temporary locks Loki docker image to a few days old build since current master image doesn't work as expected.
Also adds support for tailing the local Grafana server log