### PR TITLE
auth: /api/login/ping fixes

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -108,8 +108,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/snapshots-delete/:deleteKey", Wrap(DeleteDashboardSnapshotByDeleteKey))
 	r.Delete("/api/snapshots/:key", reqEditorRole, Wrap(DeleteDashboardSnapshot))
 
-	// api renew session based on remember cookie
-	r.Get("/api/login/ping", quota("session"), hs.LoginAPIPing)
+	// api renew session based on cookie
+	r.Get("/api/login/ping", quota("session"), Wrap(hs.LoginAPIPing))
 
 	// authed api
 	r.Group("/api", func(apiRoute routing.RouteRegister) {

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -78,12 +78,13 @@ func tryOAuthAutoLogin(c *m.ReqContext) bool {
 	return false
 }
 
-func (hs *HTTPServer) LoginAPIPing(c *m.ReqContext) Response {
-	if c.IsSignedIn || c.IsAnonymous {
-		return JSON(200, "Logged in")
+func (hs *HTTPServer) LoginAPIPing(c *m.ReqContext) {
+	if c.IsSignedIn || (c.AllowAnonymous && c.IsAnonymous) {
+		c.JsonOK("Logged in")
+		return
 	}
 
-	return Error(401, "Unauthorized", nil)
+	c.JsonApiErr(401, "Unauthorized", nil)
 }
 
 func (hs *HTTPServer) LoginPost(c *m.ReqContext, cmd dtos.LoginCommand) Response {

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -78,13 +78,12 @@ func tryOAuthAutoLogin(c *m.ReqContext) bool {
 	return false
 }
 
-func (hs *HTTPServer) LoginAPIPing(c *m.ReqContext) {
-	if c.IsSignedIn || (c.AllowAnonymous && c.IsAnonymous) {
-		c.JsonOK("Logged in")
-		return
+func (hs *HTTPServer) LoginAPIPing(c *m.ReqContext) Response {
+	if c.IsSignedIn || c.IsAnonymous {
+		return JSON(200, "Logged in")
 	}
 
-	c.JsonApiErr(401, "Unauthorized", nil)
+	return Error(401, "Unauthorized", nil)
 }
 
 func (hs *HTTPServer) LoginPost(c *m.ReqContext, cmd dtos.LoginCommand) Response {


### PR DESCRIPTION
Ref #15067

* Fixes issue with /api/login/ping returning 200 OK even though a 401 unauthorized was intended.
* Signout user if /api/login/ping returns 401 unauthorized:
  * Not sure if this may have any implications so would like feedback