### PR TITLE
Add pointer cursor to colorpicker

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/_ColorPicker.scss
+++ b/packages/grafana-ui/src/components/ColorPicker/_ColorPicker.scss
@@ -167,6 +167,7 @@ $arrowSize: 15px;
   color: inherit;
   padding: 0;
   border-radius: 10px;
+  cursor: pointer;
 }
 
 .sp-replacer:hover,


### PR DESCRIPTION
I think we should have a pointer cursor on the color dot to explicitly show that this is something you can click on. 