### PR TITLE
mark grafana-ui package with Apache license

### DIFF
--- a/packages/grafana-build/package.json
+++ b/packages/grafana-build/package.json
@@ -8,6 +8,6 @@
     "tslint": "echo \"Nothing to do\"",
     "typecheck": "echo \"Nothing to do\""
   },
-  "author": "",
-  "license": "ISC"
+  "author": "Grafana Labs",
+  "license": "Apache-2.0"
 }

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -8,8 +8,8 @@
     "typecheck": "tsc --noEmit",
     "storybook": "start-storybook -p 9001 -c .storybook -s ../../public"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Grafana Labs",
+  "license": "Apache-2.0",
   "dependencies": {
     "@torkelo/react-select": "2.1.1",
     "@types/react-color": "^2.14.0",


### PR DESCRIPTION
I assume the new packages are intended to be released with the same license as grafana itself.  Can you explicilty mark the packages with the license?