### PR TITLE
support three letter hex color strings

### DIFF
--- a/packages/grafana-ui/src/utils/namedColorsPalette.test.ts
+++ b/packages/grafana-ui/src/utils/namedColorsPalette.test.ts
@@ -59,6 +59,8 @@ describe('colors', () => {
     it('returns color if specified as hex or rgb/a', () => {
       expect(getColorFromHexRgbOrName('ff0000')).toBe('ff0000');
       expect(getColorFromHexRgbOrName('#ff0000')).toBe('#ff0000');
+      expect(getColorFromHexRgbOrName('#FF0000')).toBe('#FF0000');
+      expect(getColorFromHexRgbOrName('#CCC')).toBe('#CCC');
       expect(getColorFromHexRgbOrName('rgb(0,0,0)')).toBe('rgb(0,0,0)');
       expect(getColorFromHexRgbOrName('rgba(0,0,0,1)')).toBe('rgba(0,0,0,1)');
     });

--- a/packages/grafana-ui/src/utils/namedColorsPalette.ts
+++ b/packages/grafana-ui/src/utils/namedColorsPalette.ts
@@ -73,7 +73,7 @@ export const getColorDefinition = (hex: string, theme: GrafanaThemeType): ColorD
 };
 
 const isHex = (color: string) => {
-  const hexRegex = /^((0x){0,1}|#{0,1})([0-9A-F]{8}|[0-9A-F]{6})$/gi;
+  const hexRegex = /^((0x){0,1}|#{0,1})([0-9A-F]{8}|[0-9A-F]{6}|[0-9A-F]{3})$/gi;
   return hexRegex.test(color);
 };
 


### PR DESCRIPTION
While migrating some things to v6, I hit these dramatic errors in the console:
![image](https://user-images.githubusercontent.com/705951/52505252-c5cf4380-2b9f-11e9-970f-88482f778c17.png)


I would also recommend returning `undefined` rather than throwing an error in: `getColorFromHexRgbOrName`
 
