### PR TITLE
Improve usability of forms, better showing disabled metrics

### DIFF
--- a/public/sass/_variables.light.scss
+++ b/public/sass/_variables.light.scss
@@ -56,7 +56,7 @@ $page-bg: $gray-7;
 $body-color: $gray-1;
 $text-color: $gray-1;
 $text-color-strong: $dark-2;
-$text-color-weak: $gray-2;
+$text-color-weak: $gray-3;
 $text-color-faint: $gray-4;
 $text-color-emphasis: $dark-5;
 


### PR DESCRIPTION
WHAT
* Use gray-3 instead of gray-2 for text-color-weak in "light" theme

WHY
* Difficult to know which metric is "disabled" - disabled row is too similarly colored to the "enabled" row while viewing Grafana in "light" theme

MORE
* See attachment illustrating improvement in this PR description
![grafana-pr-gray3-lightmode](https://user-images.githubusercontent.com/704698/52510809-62024600-2bb2-11e9-9651-6525abda7293.png)
