### PR TITLE
renames usage state metric for auth_token

### DIFF
--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -59,15 +59,15 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 	metrics["stats.provisioned_dashboards.count"] = statsQuery.Result.ProvisionedDashboards
 	metrics["stats.snapshots.count"] = statsQuery.Result.Snapshots
 	metrics["stats.teams.count"] = statsQuery.Result.Teams
-	metrics["stats.total_sessions.count"] = statsQuery.Result.Sessions
+	metrics["stats.total_auth_token.count"] = statsQuery.Result.AuthTokens
 
 	userCount := statsQuery.Result.Users
-	avgSessionsPerUser := statsQuery.Result.Sessions
+	avgAuthTokensPerUser := statsQuery.Result.AuthTokens
 	if userCount != 0 {
-		avgSessionsPerUser = avgSessionsPerUser / userCount
+		avgAuthTokensPerUser = avgAuthTokensPerUser / userCount
 	}
 
-	metrics["stats.avg_sessions_per_user.count"] = avgSessionsPerUser
+	metrics["stats.avg_auth_token_per_user.count"] = avgAuthTokensPerUser
 
 	dsStats := models.GetDataSourceStatsQuery{}
 	if err := uss.Bus.Dispatch(&dsStats); err != nil {

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -45,7 +45,7 @@ func TestMetrics(t *testing.T) {
 				ProvisionedDashboards: 12,
 				Snapshots:             13,
 				Teams:                 14,
-				Sessions:              15,
+				AuthTokens:            15,
 			}
 			getSystemStatsQuery = query
 			return nil
@@ -229,8 +229,8 @@ func TestMetrics(t *testing.T) {
 				So(metrics.Get("stats.provisioned_dashboards.count").MustInt(), ShouldEqual, getSystemStatsQuery.Result.ProvisionedDashboards)
 				So(metrics.Get("stats.snapshots.count").MustInt(), ShouldEqual, getSystemStatsQuery.Result.Snapshots)
 				So(metrics.Get("stats.teams.count").MustInt(), ShouldEqual, getSystemStatsQuery.Result.Teams)
-				So(metrics.Get("stats.total_sessions.count").MustInt64(), ShouldEqual, 15)
-				So(metrics.Get("stats.avg_sessions_per_user.count").MustInt64(), ShouldEqual, 5)
+				So(metrics.Get("stats.total_auth_token.count").MustInt64(), ShouldEqual, 15)
+				So(metrics.Get("stats.avg_auth_token_per_user.count").MustInt64(), ShouldEqual, 5)
 
 				So(metrics.Get("stats.ds."+models.DS_ES+".count").MustInt(), ShouldEqual, 9)
 				So(metrics.Get("stats.ds."+models.DS_PROMETHEUS+".count").MustInt(), ShouldEqual, 10)

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -15,7 +15,7 @@ type SystemStats struct {
 	FolderPermissions     int64
 	Folders               int64
 	ProvisionedDashboards int64
-	Sessions              int64
+	AuthTokens            int64
 }
 
 type DataSourceStats struct {

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -75,7 +75,7 @@ func GetSystemStats(query *m.GetSystemStatsQuery) error {
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_provisioning") + `) AS provisioned_dashboards,`)
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_snapshot") + `) AS snapshots,`)
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("team") + `) AS teams,`)
-	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("user_auth_token") + `) AS sessions`)
+	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("user_auth_token") + `) AS auth_tokens`)
 
 	var stats m.SystemStats
 	_, err := x.SQL(sb.GetSqlString(), sb.params...).Get(&stats)


### PR DESCRIPTION
as noted, sessions might not be a good name for this metrics.
while devices would be a better name for users I think we should
align the name with the code as much as possible. The ui listing
all auth_tokens per user should probarbly say "devices" instead