### PR TITLE
Datasources with custom time range handling should always take dashboard timezone into consideration

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -31,8 +31,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
 
   this.query = function(options) {
     const graphOptions = {
-      from: this.translateTime(options.rangeRaw.from, false),
-      until: this.translateTime(options.rangeRaw.to, true),
+      from: this.translateTime(options.rangeRaw.from, false, options.timezone),
+      until: this.translateTime(options.rangeRaw.to, true, options.timezone),
       targets: options.targets,
       format: options.format,
       cacheTimeout: options.cacheTimeout || this.cacheTimeout,
@@ -165,9 +165,9 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
         method: 'GET',
         url:
           '/events/get_data?from=' +
-          this.translateTime(options.range.from, false) +
+          this.translateTime(options.range.from, false, options.timezone) +
           '&until=' +
-          this.translateTime(options.range.to, true) +
+          this.translateTime(options.range.to, true, options.timezone) +
           tags,
       });
     } catch (err) {
@@ -179,7 +179,7 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
     return templateSrv.variableExists(target.target);
   };
 
-  this.translateTime = (date, roundUp) => {
+  this.translateTime = (date, roundUp, timezone) => {
     if (_.isString(date)) {
       if (date === 'now') {
         return 'now';
@@ -189,7 +189,7 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
         date = date.replace('M', 'mon');
         return date;
       }
-      date = dateMath.parse(date, roundUp);
+      date = dateMath.parse(date, roundUp, timezone);
     }
 
     // graphite' s from filter is exclusive
@@ -255,8 +255,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
     };
 
     if (options.range) {
-      httpOptions.params.from = this.translateTime(options.range.from, false);
-      httpOptions.params.until = this.translateTime(options.range.to, true);
+      httpOptions.params.from = this.translateTime(options.range.from, false, options.timezone);
+      httpOptions.params.until = this.translateTime(options.range.to, true, options.timezone);
     }
 
     return this.doGraphiteRequest(httpOptions).then(results => {
@@ -280,8 +280,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
     };
 
     if (options.range) {
-      httpOptions.params.from = this.translateTime(options.range.from, false);
-      httpOptions.params.until = this.translateTime(options.range.to, true);
+      httpOptions.params.from = this.translateTime(options.range.from, false, options.timezone);
+      httpOptions.params.until = this.translateTime(options.range.to, true, options.timezone);
     }
 
     return this.doGraphiteRequest(httpOptions).then(results => {
@@ -305,8 +305,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
     };
 
     if (options.range) {
-      httpOptions.params.from = this.translateTime(options.range.from, false);
-      httpOptions.params.until = this.translateTime(options.range.to, true);
+      httpOptions.params.from = this.translateTime(options.range.from, false, options.timezone);
+      httpOptions.params.until = this.translateTime(options.range.to, true, options.timezone);
     }
 
     return this.doGraphiteRequest(httpOptions).then(results => {
@@ -343,8 +343,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
       httpOptions.params.limit = options.limit;
     }
     if (options.range) {
-      httpOptions.params.from = this.translateTime(options.range.from, false);
-      httpOptions.params.until = this.translateTime(options.range.to, true);
+      httpOptions.params.from = this.translateTime(options.range.from, false, options.timezone);
+      httpOptions.params.until = this.translateTime(options.range.to, true, options.timezone);
     }
 
     return this.doGraphiteRequest(httpOptions).then(results => {
@@ -379,8 +379,8 @@ export function GraphiteDatasource(this: any, instanceSettings, $q, backendSrv, 
       httpOptions.params.limit = options.limit;
     }
     if (options.range) {
-      httpOptions.params.from = this.translateTime(options.range.from, false);
-      httpOptions.params.until = this.translateTime(options.range.to, true);
+      httpOptions.params.from = this.translateTime(options.range.from, false, options.timezone);
+      httpOptions.params.until = this.translateTime(options.range.to, true, options.timezone);
     }
 
     return this.doGraphiteRequest(httpOptions).then(results => {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -127,7 +127,7 @@ export default class InfluxDatasource {
       });
     }
 
-    const timeFilter = this.getTimeFilter({ rangeRaw: options.rangeRaw });
+    const timeFilter = this.getTimeFilter({ rangeRaw: options.rangeRaw, timezone: options.timezone });
     let query = options.annotation.query.replace('$timeFilter', timeFilter);
     query = this.templateSrv.replace(query, null, 'regex');
 
@@ -184,7 +184,7 @@ export default class InfluxDatasource {
     }
 
     if (options && options.range) {
-      const timeFilter = this.getTimeFilter({ rangeRaw: options.range });
+      const timeFilter = this.getTimeFilter({ rangeRaw: options.range, timezone: options.timezone });
       query = query.replace('$timeFilter', timeFilter);
     }
 
@@ -291,8 +291,8 @@ export default class InfluxDatasource {
   }
 
   getTimeFilter(options) {
-    const from = this.getInfluxTime(options.rangeRaw.from, false);
-    const until = this.getInfluxTime(options.rangeRaw.to, true);
+    const from = this.getInfluxTime(options.rangeRaw.from, false, options.timezone);
+    const until = this.getInfluxTime(options.rangeRaw.to, true, options.timezone);
     const fromIsAbsolute = from[from.length - 1] === 'ms';
 
     if (until === 'now()' && !fromIsAbsolute) {
@@ -302,7 +302,7 @@ export default class InfluxDatasource {
     return 'time >= ' + from + ' and time <= ' + until;
   }
 
-  getInfluxTime(date, roundUp) {
+  getInfluxTime(date, roundUp, timezone) {
     if (_.isString(date)) {
       if (date === 'now') {
         return 'now()';
@@ -314,7 +314,7 @@ export default class InfluxDatasource {
         const unit = parts[2];
         return 'now() - ' + amount + unit;
       }
-      date = dateMath.parse(date, roundUp);
+      date = dateMath.parse(date, roundUp, timezone);
     }
 
     return date.valueOf() + 'ms';

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -33,8 +33,8 @@ export default class OpenTsDatasource {
 
   // Called once per panel (graph)
   query(options) {
-    const start = this.convertToTSDBTime(options.rangeRaw.from, false);
-    const end = this.convertToTSDBTime(options.rangeRaw.to, true);
+    const start = this.convertToTSDBTime(options.rangeRaw.from, false, options.timezone);
+    const end = this.convertToTSDBTime(options.rangeRaw.to, true, options.timezone);
     const qs = [];
 
     _.each(options.targets, target => {
@@ -86,8 +86,8 @@ export default class OpenTsDatasource {
   }
 
   annotationQuery(options) {
-    const start = this.convertToTSDBTime(options.rangeRaw.from, false);
-    const end = this.convertToTSDBTime(options.rangeRaw.to, true);
+    const start = this.convertToTSDBTime(options.rangeRaw.from, false, options.timezone);
+    const end = this.convertToTSDBTime(options.rangeRaw.to, true, options.timezone);
     const qs = [];
     const eventList = [];
 
@@ -484,12 +484,12 @@ export default class OpenTsDatasource {
     });
   }
 
-  convertToTSDBTime(date, roundUp) {
+  convertToTSDBTime(date, roundUp, timezone) {
     if (date === 'now') {
       return null;
     }
 
-    date = dateMath.parse(date, roundUp);
+    date = dateMath.parse(date, roundUp, timezone);
     return date.valueOf();
   }
 }


### PR DESCRIPTION
Fixes #15284 

This is work in progress, needs some other eyes on this before moving forward.

Right now only fixed this for Graphite datasource, but looking at code seems like at least Influx and opentsdb have the same problem regarding time ranges using now/d. Can be others as well? Prometheus for example don't seem to be problematic since it uses `this.timeSrv.timeRange()` instead of `options.range`.