### PR TITLE
Fix issue with Max value in Gauge

### DIFF
--- a/public/vendor/flot/jquery.flot.gauge.js
+++ b/public/vendor/flot/jquery.flot.gauge.js
@@ -935,16 +935,7 @@
                         }
                     },
                     values: [
-                        {
-                            value: 50,
-                            color: "lightgreen"
-                        }, {
-                            value: 80,
-                            color: "yellow"
-                        }, {
-                            value: 100,
-                            color: "red"
-                        }
+                      
                     ]
                 }
             }


### PR DESCRIPTION
If you increase max value from 100 to anything above the Gauge would look very weirdly (see screenshot). Turns out it was the default threshold values in flot.gauge. These has been causing issues before as they're almost impossible to get rid of (?). My proposal is to get rid of them. I've tested with angular gauges and could see that this caused an issue.


![screenshot 2019-02-11 at 14 18 51](https://user-images.githubusercontent.com/946275/52572476-2d8fc380-2e18-11e9-8983-9d5a3df3abd6.png)
