### PR TITLE
allow 90 percent of alertTimeout for rendering to complete vs 50 percent

### DIFF
--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -3,6 +3,7 @@ package alerting
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/imguploader"
@@ -126,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         alertTimeout / 2,
+		Timeout:         time.Duration(float64(alertTimeout) * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,


### PR DESCRIPTION
Currently a long duration query for a panel can cause an alert to be sent without a png included.

When rendering images, the timeout is set to half of the duration of alertTimeout (hardcoded to 30 seconds currently).

This change allows 90% of the alertTime to be used waiting for external rendering to complete, whether it is phantomjs or an outside service.

