### PR TITLE
Fixed issue with react panel dimensions

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -125,8 +125,8 @@ export class PanelChrome extends PureComponent<Props, State> {
           panelData={panelData}
           timeRange={timeRange}
           options={panel.getOptions(plugin.exports.PanelDefaults)}
-          width={width - 2 * variables.panelHorizontalPadding}
-          height={height - PANEL_HEADER_HEIGHT - variables.panelVerticalPadding}
+          width={width - 2 * variables.panelhorizontalpadding}
+          height={height - PANEL_HEADER_HEIGHT - variables.panelverticalpadding}
           renderCounter={renderCounter}
           onInterpolate={this.onInterpolate}
         />

--- a/public/sass/_variables.scss.d.ts
+++ b/public/sass/_variables.scss.d.ts
@@ -1,6 +1,6 @@
 export interface GrafanaVariables {
-  panelHorizontalPadding: number;
-  panelVerticalPadding: number;
+  panelhorizontalpadding: number;
+  panelverticalpadding: number;
 }
 
 declare const variables: GrafanaVariables;


### PR DESCRIPTION
Prettier lowercased the export for the 2 variables exported from variables.scss so the width & height calculation in PanelChrome did not work. 

