### PR TITLE
run db tests in all packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
         - run: cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h 127.0.0.1 -P 3306 -u root -prootpass
         - run:
             name: mysql integration tests
-            command: 'GRAFANA_TEST_DB=mysql go test ./pkg/services/sqlstore/... ./pkg/tsdb/mysql/... '
+            command: './scripts/circle-test-mysql.sh'
 
   postgres-integration-test:
     docker:
@@ -54,7 +54,7 @@ jobs:
         - run: 'PGPASSWORD=grafanatest psql -p 5432 -h 127.0.0.1 -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql'
         - run:
             name: postgres integration tests
-            command: 'GRAFANA_TEST_DB=postgres go test ./pkg/services/sqlstore/... ./pkg/tsdb/postgres/...'
+            command: './scripts/circle-test-postgres.sh'
 
   codespell:
     docker:

--- a/scripts/circle-test-mysql.sh
+++ b/scripts/circle-test-mysql.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+function exit_if_fail {
+    command=$@
+    echo "Executing '$command'"
+    eval $command
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "'$command' returned $rc."
+        exit $rc
+    fi
+}
+
+export GRAFANA_TEST_DB=mysql
+
+time for d in $(go list ./pkg/...); do
+  exit_if_fail go test -tags=integration $d
+done

--- a/scripts/circle-test-postgres.sh
+++ b/scripts/circle-test-postgres.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+function exit_if_fail {
+    command=$@
+    echo "Executing '$command'"
+    eval $command
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "'$command' returned $rc."
+        exit $rc
+    fi
+}
+
+export GRAFANA_TEST_DB=postgres
+
+time for d in $(go list ./pkg/...); do
+  exit_if_fail go test -tags=integration $d
+done


### PR DESCRIPTION
Since we want to move away from having all sql code in sqlstore we either need to include the path to all places invoking sql code or test everything. 

I favor this since its an easier solution even though it might take a little bit longer to run. 
(Turns out it takes about as long to run all tests as just a few)