### PR TITLE
fix: prevent datasource json data stored as nil

### DIFF
--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -38,10 +38,6 @@ func GetDataSourceById(query *m.GetDataSourceByIdQuery) error {
 		return m.ErrDataSourceNotFound
 	}
 
-	if datasource.JsonData == nil {
-		datasource.JsonData = simplejson.New()
-	}
-
 	query.Result = &datasource
 	return err
 }
@@ -54,10 +50,6 @@ func GetDataSourceByName(query *m.GetDataSourceByNameQuery) error {
 		return m.ErrDataSourceNotFound
 	}
 
-	if datasource.JsonData == nil {
-		datasource.JsonData = simplejson.New()
-	}
-
 	query.Result = &datasource
 	return err
 }
@@ -66,36 +58,14 @@ func GetDataSources(query *m.GetDataSourcesQuery) error {
 	sess := x.Limit(5000, 0).Where("org_id=?", query.OrgId).Asc("name")
 
 	query.Result = make([]*m.DataSource, 0)
-	err := sess.Find(&query.Result)
-	if err != nil {
-		return err
-	}
-
-	for _, ds := range query.Result {
-		if ds.JsonData == nil {
-			ds.JsonData = simplejson.New()
-		}
-	}
-
-	return nil
+	return sess.Find(&query.Result)
 }
 
 func GetAllDataSources(query *m.GetAllDataSourcesQuery) error {
 	sess := x.Limit(5000, 0).Asc("name")
 
 	query.Result = make([]*m.DataSource, 0)
-	err := sess.Find(&query.Result)
-	if err != nil {
-		return err
-	}
-
-	for _, ds := range query.Result {
-		if ds.JsonData == nil {
-			ds.JsonData = simplejson.New()
-		}
-	}
-
-	return nil
+	return sess.Find(&query.Result)
 }
 
 func DeleteDataSourceById(cmd *m.DeleteDataSourceByIdCommand) error {

--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -130,4 +130,7 @@ func addDataSourceMigration(mg *Migrator) {
 
 	const migrateLoggingToLoki = `UPDATE data_source SET type = 'loki' WHERE type = 'logging'`
 	mg.AddMigration("Migrate logging ds to loki ds", NewRawSqlMigration(migrateLoggingToLoki))
+
+	const setEmptyJSONWhereNullJSON = `UPDATE data_source SET json_data = '{}' WHERE json_data is null`
+	mg.AddMigration("Update json_data with nulls", NewRawSqlMigration(setEmptyJSONWhereNullJSON))
 }


### PR DESCRIPTION
Fixes #14239 

Should we add a database migration converting all null jsonData to `{}` as well/instead?