### PR TITLE
fix: Remove tab param from url when leaving edit mode

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -65,7 +65,7 @@ export class DashNav extends PureComponent<Props> {
       });
     } else {
       this.props.updateLocation({
-        query: { panelId: null, edit: null, fullscreen: null },
+        query: { panelId: null, edit: null, fullscreen: null, tab: null },
         partial: true,
       });
     }

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -43,6 +43,7 @@ export class DashboardSrv {
         delete urlParams.fullscreen;
         delete urlParams.edit;
         delete urlParams.panelId;
+        delete urlParams.tab;
         this.$location.search(urlParams);
         return;
       }
@@ -58,6 +59,7 @@ export class DashboardSrv {
       urlParams.edit = true;
     } else {
       delete urlParams.edit;
+      delete urlParams.tab;
     }
 
     if (options.panelId || options.panelId === 0) {


### PR DESCRIPTION
Fixes #15485 

Note that this PR removes the param completely, no matter the value (ie "visualization" as mentioned in the issue).