### PR TITLE
graph2 should use ReactPanelPlugin from @grafana/ui

### DIFF
--- a/public/app/plugins/panel/graph2/module.tsx
+++ b/public/app/plugins/panel/graph2/module.tsx
@@ -1,4 +1,8 @@
-import { GraphPanel } from './GraphPanel';
-import { GraphPanelEditor } from './GraphPanelEditor';
+import { ReactPanelPlugin } from '@grafana/ui';
 
-export { GraphPanel as Panel, GraphPanelEditor as PanelOptions };
+import { GraphPanelEditor } from './GraphPanelEditor';
+import { GraphPanel } from './GraphPanel';
+import { Options } from './types';
+
+export const reactPanel = new ReactPanelPlugin<Options>(GraphPanel);
+reactPanel.setEditor(GraphPanelEditor);


### PR DESCRIPTION
graph2 doesn't work - needs to use the ReactPanelPlugin from @grafana/ui