### PR TITLE
docs: howto for recreating our debian repositories.

### DIFF
--- a/scripts/build/update_repo/init-deb-repo.sh
+++ b/scripts/build/update_repo/init-deb-repo.sh
@@ -10,3 +10,6 @@ mkdir -p /deb-repo/db   \
 
 aptly repo create -distribution=stable -component=main grafana
 aptly repo create -distribution=beta -component=main beta
+
+aptly publish repo -architectures=amd64,i386,arm64,armhf grafana filesystem:repo:grafana
+aptly publish repo -architectures=amd64,i386,arm64,armhf beta filesystem:repo:grafana


### PR DESCRIPTION
Added missing instruction for how to create the repo
so that and empty i386 arch is added.