### PR TITLE
fix: Filter out values not supported by Explore yet #15281

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -396,6 +396,10 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
       const expandedQueries = queries.map(query => ({
         ...query,
         expr: this.templateSrv.replace(query.expr, {}, this.interpolateQueryExpr),
+
+        // null out values we don't support in Explore yet
+        legendFormat: null,
+        step: null,
       }));
       state = {
         ...state,


### PR DESCRIPTION
This is one way of solving #15281  - removing the unsupported params from the explore URL.

I'm not sure if its the best place to do this though.

Fixes #15281