### PR TITLE
panel: defensive coding that fixes #15563

### DIFF
--- a/public/app/features/panel/query_editor_row.ts
+++ b/public/app/features/panel/query_editor_row.ts
@@ -14,7 +14,7 @@ export class QueryRowCtrl {
     this.target = this.queryCtrl.target;
     this.panel = this.panelCtrl.panel;
 
-    if (this.hasTextEditMode) {
+    if (this.hasTextEditMode && this.queryCtrl.toggleEditorMode) {
       // expose this function to react parent component
       this.panelCtrl.toggleEditorMode = this.queryCtrl.toggleEditorMode.bind(this.queryCtrl);
     }


### PR DESCRIPTION
If a plugin incorrectly sets toggle text mode to true in the query-editor-row directive, it should not throw an exception. While it is incorrect for the plugin to do so, this used to work in Grafana 5.x.