### PR TITLE
Extending redux framework for higher order actions and reducers

### DIFF
--- a/public/app/core/redux/actionCreatorFactory.test.ts
+++ b/public/app/core/redux/actionCreatorFactory.test.ts
@@ -2,6 +2,8 @@ import {
   actionCreatorFactory,
   resetAllActionCreatorTypes,
   noPayloadActionCreatorFactory,
+  higherOrderActionCreatorFactory,
+  noPayloadHigherOrderActionCreatorFactory,
 } from './actionCreatorFactory';
 
 interface Dummy {
@@ -15,14 +17,29 @@ interface Dummy {
   b: boolean;
 }
 
-const setup = (payload?: Dummy) => {
+const setup = (payload?: Dummy, id?: string) => {
   resetAllActionCreatorTypes();
   const actionCreator = actionCreatorFactory<Dummy>('dummy').create();
   const noPayloadactionCreator = noPayloadActionCreatorFactory('NoPayload').create();
+  const higherOrderActionCreator = higherOrderActionCreatorFactory<Dummy>('higher-order-dummy').create();
+  const noPayloadHigherOrderActionCreator = noPayloadHigherOrderActionCreatorFactory(
+    'no-payload-higher-order'
+  ).create();
   const result = actionCreator(payload);
   const noPayloadResult = noPayloadactionCreator();
+  const higherOrderResult = higherOrderActionCreator(id)(payload);
+  const noPayloadHigherOrderResult = noPayloadHigherOrderActionCreator(id)();
 
-  return { actionCreator, noPayloadactionCreator, result, noPayloadResult };
+  return {
+    actionCreator,
+    noPayloadactionCreator,
+    higherOrderActionCreator,
+    noPayloadHigherOrderActionCreator,
+    result,
+    noPayloadResult,
+    higherOrderResult,
+    noPayloadHigherOrderResult,
+  };
 };
 
 describe('actionCreatorFactory', () => {
@@ -77,6 +94,77 @@ describe('noPayloadActionCreatorFactory', () => {
 
       expect(() => {
         actionCreatorFactory<Dummy>('nOpAyLoAd').create();
+      }).toThrow();
+    });
+  });
+});
+
+describe('higherOrderActionCreatorFactory', () => {
+  describe('when calling create', () => {
+    it('then it should create correct type string', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      const { higherOrderActionCreator, higherOrderResult } = setup(payload);
+
+      expect(higherOrderActionCreator.type).toEqual('higher-order-dummy');
+      expect(higherOrderResult.type).toEqual('higher-order-dummy');
+    });
+
+    it('then it should create correct payload', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      const { higherOrderResult } = setup(payload);
+
+      expect(higherOrderResult.payload).toEqual(payload);
+    });
+
+    it('then it should create correct id', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      const { higherOrderResult } = setup(payload, 'SomeId');
+
+      expect(higherOrderResult.id).toEqual('SomeId');
+    });
+  });
+
+  describe('when calling create with existing type', () => {
+    it('then it should throw error', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      setup(payload);
+
+      expect(() => {
+        higherOrderActionCreatorFactory('DuMmY').create();
+      }).toThrow();
+    });
+  });
+});
+
+describe('noPayloadHigherOrderActionCreatorFactory', () => {
+  describe('when calling create', () => {
+    it('then it should create correct type string', () => {
+      const { noPayloadHigherOrderActionCreator, noPayloadHigherOrderResult } = setup();
+
+      expect(noPayloadHigherOrderActionCreator.type).toEqual('no-payload-higher-order');
+      expect(noPayloadHigherOrderResult.type).toEqual('no-payload-higher-order');
+    });
+
+    it('then it should create correct payload', () => {
+      const { noPayloadHigherOrderResult } = setup();
+
+      expect(noPayloadHigherOrderResult.payload).toBeUndefined();
+    });
+
+    it('then it should create correct id', () => {
+      const { noPayloadHigherOrderResult } = setup({} as Dummy, 'SomeId');
+
+      expect(noPayloadHigherOrderResult.id).toEqual('SomeId');
+    });
+  });
+
+  describe('when calling create with existing type', () => {
+    it('then it should throw error', () => {
+      const payload = { n: 1, b: true, s: 'dummy', o: { n: 1, b: true, s: 'dummy' } };
+      setup(payload);
+
+      expect(() => {
+        noPayloadHigherOrderActionCreatorFactory('DuMmY').create();
       }).toThrow();
     });
   });

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -4,6 +4,7 @@ const allActionCreators: string[] = [];
 
 export interface ActionOf<Payload> extends Action {
   readonly type: string;
+  readonly id?: string; // used by higher order actions, always undefined for lower order actions
   readonly payload: Payload;
 }
 
@@ -12,9 +13,19 @@ export interface ActionCreator<Payload> {
   (payload: Payload): ActionOf<Payload>;
 }
 
+export interface HigherOrderActionCreator<Payload> {
+  readonly type: string;
+  (id: string): ActionCreator<Payload>;
+}
+
 export interface NoPayloadActionCreator {
   readonly type: string;
   (): ActionOf<undefined>;
+}
+
+export interface NoPayloadHigherOrderActionCreator {
+  readonly type: string;
+  (id: string): NoPayloadActionCreator;
 }
 
 export interface ActionCreatorFactory<Payload> {
@@ -23,6 +34,14 @@ export interface ActionCreatorFactory<Payload> {
 
 export interface NoPayloadActionCreatorFactory {
   create: () => NoPayloadActionCreator;
+}
+
+export interface HigherOrderActionCreatorFactory<Payload> {
+  create: () => HigherOrderActionCreator<Payload>;
+}
+
+export interface NoPayloadHigherOrderActionCreatorFactory {
+  create: () => NoPayloadHigherOrderActionCreator;
 }
 
 export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactory<Payload> => {
@@ -42,6 +61,42 @@ export const actionCreatorFactory = <Payload>(type: string): ActionCreatorFactor
 export const noPayloadActionCreatorFactory = (type: string): NoPayloadActionCreatorFactory => {
   const create = (): NoPayloadActionCreator => {
     return Object.assign((): ActionOf<undefined> => ({ type, payload: undefined }), { type });
+  };
+
+  if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {
+    throw new Error(`There is already an actionCreator defined with the type ${type}`);
+  }
+
+  allActionCreators.push(type);
+
+  return { create };
+};
+
+export const higherOrderActionCreatorFactory = <Payload>(type: string): HigherOrderActionCreatorFactory<Payload> => {
+  const create = (): HigherOrderActionCreator<Payload> => {
+    return Object.assign(
+      (id: string): ActionCreator<Payload> =>
+        Object.assign((payload: Payload): ActionOf<Payload> => ({ type, payload, id }), { type, id }),
+      { type }
+    );
+  };
+
+  if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {
+    throw new Error(`There is already an actionCreator defined with the type ${type}`);
+  }
+
+  allActionCreators.push(type);
+
+  return { create };
+};
+
+export const noPayloadHigherOrderActionCreatorFactory = (type: string): NoPayloadHigherOrderActionCreatorFactory => {
+  const create = (): NoPayloadHigherOrderActionCreator => {
+    return Object.assign(
+      (id: string): NoPayloadActionCreator =>
+        Object.assign((): ActionOf<undefined> => ({ type, payload: undefined, id }), { type, id }),
+      { type }
+    );
   };
 
   if (allActionCreators.some(t => (t && type ? t.toLocaleUpperCase() === type.toLocaleUpperCase() : false))) {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -18,7 +18,15 @@ import TableContainer from './TableContainer';
 import TimePicker, { parseTime } from './TimePicker';
 
 // Actions
-import { changeSize, changeTime, initializeExplore, modifyQueries, scanStart, setQueries } from './state/actions';
+import {
+  changeSize,
+  changeTime,
+  initializeExplore,
+  modifyQueries,
+  scanStart,
+  setQueries,
+  scanStop,
+} from './state/actions';
 
 // Types
 import { RawTimeRange, TimeRange, DataQuery, ExploreStartPageProps, ExploreDataSourceApi } from '@grafana/ui';
@@ -27,7 +35,6 @@ import { StoreState } from 'app/types';
 import { LAST_USED_DATASOURCE_KEY, ensureQueries, DEFAULT_RANGE, DEFAULT_UI_STATE } from 'app/core/utils/explore';
 import { Emitter } from 'app/core/utils/emitter';
 import { ExploreToolbar } from './ExploreToolbar';
-import { scanStopAction } from './state/actionTypes';
 
 interface ExploreProps {
   StartPage?: ComponentClass<ExploreStartPageProps>;
@@ -46,7 +53,7 @@ interface ExploreProps {
   scanning?: boolean;
   scanRange?: RawTimeRange;
   scanStart: typeof scanStart;
-  scanStopAction: typeof scanStopAction;
+  scanStop: typeof scanStop;
   setQueries: typeof setQueries;
   split: boolean;
   showingStartPage?: boolean;
@@ -166,7 +173,8 @@ export class Explore extends React.PureComponent<ExploreProps> {
   };
 
   onStopScanning = () => {
-    this.props.scanStopAction(this.props.exploreId)();
+    const { scanStop, exploreId } = this.props;
+    scanStop(exploreId);
   };
 
   render() {
@@ -282,7 +290,7 @@ const mapDispatchToProps = {
   initializeExplore,
   modifyQueries,
   scanStart,
-  scanStopAction,
+  scanStop,
   setQueries,
 };
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -166,7 +166,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
   };
 
   onStopScanning = () => {
-    this.props.scanStopAction({ exploreId: this.props.exploreId });
+    this.props.scanStopAction(this.props.exploreId)();
   };
 
   render() {

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -46,10 +46,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
 
   hangleToggleLogLevel = (hiddenLogLevels: Set<LogLevel>) => {
     const { exploreId } = this.props;
-    this.props.toggleLogLevelAction({
-      exploreId,
-      hiddenLogLevels,
-    });
+    this.props.toggleLogLevelAction(exploreId)({ hiddenLogLevels });
   };
 
   render() {

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -7,10 +7,9 @@ import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { LogsModel, LogsDedupStrategy, LogLevel } from 'app/core/logs_model';
 import { StoreState } from 'app/types';
 
-import { toggleLogs, changeDedupStrategy } from './state/actions';
+import { toggleLogs, changeDedupStrategy, toggleLogLevel } from './state/actions';
 import Logs from './Logs';
 import Panel from './Panel';
-import { toggleLogLevelAction } from 'app/features/explore/state/actionTypes';
 import { deduplicatedLogsSelector, exploreItemUIStateSelector } from 'app/features/explore/state/selectors';
 
 interface LogsContainerProps {
@@ -28,7 +27,7 @@ interface LogsContainerProps {
   scanRange?: RawTimeRange;
   showingLogs: boolean;
   toggleLogs: typeof toggleLogs;
-  toggleLogLevelAction: typeof toggleLogLevelAction;
+  toggleLogLevel: typeof toggleLogLevel;
   changeDedupStrategy: typeof changeDedupStrategy;
   dedupStrategy: LogsDedupStrategy;
   hiddenLogLevels: Set<LogLevel>;
@@ -46,7 +45,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
 
   hangleToggleLogLevel = (hiddenLogLevels: Set<LogLevel>) => {
     const { exploreId } = this.props;
-    this.props.toggleLogLevelAction(exploreId)({ hiddenLogLevels });
+    this.props.toggleLogLevel(exploreId, hiddenLogLevels);
   };
 
   render() {
@@ -121,7 +120,7 @@ function mapStateToProps(state: StoreState, { exploreId }) {
 const mapDispatchToProps = {
   toggleLogs,
   changeDedupStrategy,
-  toggleLogLevelAction,
+  toggleLogLevel,
 };
 
 export default hot(module)(

--- a/public/app/features/explore/QueryRow.tsx
+++ b/public/app/features/explore/QueryRow.tsx
@@ -82,7 +82,7 @@ export class QueryRow extends PureComponent<QueryRowProps> {
 
   onClickRemoveButton = () => {
     const { exploreId, index } = this.props;
-    this.props.removeQueryRowAction({ exploreId, index });
+    this.props.removeQueryRowAction(exploreId)({ index });
   };
 
   updateLogsHighlights = _.debounce((value: DataQuery) => {
@@ -90,7 +90,7 @@ export class QueryRow extends PureComponent<QueryRowProps> {
     if (datasourceInstance.getHighlighterExpression) {
       const { exploreId } = this.props;
       const expressions = [datasourceInstance.getHighlighterExpression(value)];
-      this.props.highlightLogsExpressionAction({ exploreId, expressions });
+      this.props.highlightLogsExpressionAction(exploreId)({ expressions });
     }
   }, 500);
 

--- a/public/app/features/explore/QueryRow.tsx
+++ b/public/app/features/explore/QueryRow.tsx
@@ -9,14 +9,20 @@ import QueryEditor from './QueryEditor';
 import QueryTransactionStatus from './QueryTransactionStatus';
 
 // Actions
-import { changeQuery, modifyQueries, runQueries, addQueryRow } from './state/actions';
+import {
+  changeQuery,
+  modifyQueries,
+  runQueries,
+  addQueryRow,
+  highlightLogsExpression,
+  removeQueryRow,
+} from './state/actions';
 
 // Types
 import { StoreState } from 'app/types';
 import { RawTimeRange, DataQuery, ExploreDataSourceApi, QueryHint, QueryFixAction } from '@grafana/ui';
 import { QueryTransaction, HistoryItem, ExploreItemState, ExploreId } from 'app/types/explore';
 import { Emitter } from 'app/core/utils/emitter';
-import { highlightLogsExpressionAction, removeQueryRowAction } from './state/actionTypes';
 
 function getFirstHintFromTransactions(transactions: QueryTransaction[]): QueryHint {
   const transaction = transactions.find(qt => qt.hints && qt.hints.length > 0);
@@ -32,7 +38,7 @@ interface QueryRowProps {
   className?: string;
   exploreId: ExploreId;
   datasourceInstance: ExploreDataSourceApi;
-  highlightLogsExpressionAction: typeof highlightLogsExpressionAction;
+  highlightLogsExpression: typeof highlightLogsExpression;
   history: HistoryItem[];
   index: number;
   query: DataQuery;
@@ -40,7 +46,7 @@ interface QueryRowProps {
   queryTransactions: QueryTransaction[];
   exploreEvents: Emitter;
   range: RawTimeRange;
-  removeQueryRowAction: typeof removeQueryRowAction;
+  removeQueryRow: typeof removeQueryRow;
   runQueries: typeof runQueries;
 }
 
@@ -82,7 +88,7 @@ export class QueryRow extends PureComponent<QueryRowProps> {
 
   onClickRemoveButton = () => {
     const { exploreId, index } = this.props;
-    this.props.removeQueryRowAction(exploreId)({ index });
+    this.props.removeQueryRow(exploreId, index);
   };
 
   updateLogsHighlights = _.debounce((value: DataQuery) => {
@@ -90,7 +96,7 @@ export class QueryRow extends PureComponent<QueryRowProps> {
     if (datasourceInstance.getHighlighterExpression) {
       const { exploreId } = this.props;
       const expressions = [datasourceInstance.getHighlighterExpression(value)];
-      this.props.highlightLogsExpressionAction(exploreId)({ expressions });
+      this.props.highlightLogsExpression(exploreId, expressions);
     }
   }, 500);
 
@@ -163,9 +169,9 @@ function mapStateToProps(state: StoreState, { exploreId, index }) {
 const mapDispatchToProps = {
   addQueryRow,
   changeQuery,
-  highlightLogsExpressionAction,
+  highlightLogsExpression,
   modifyQueries,
-  removeQueryRowAction,
+  removeQueryRow,
   runQueries,
 };
 

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -25,45 +25,6 @@ import {
 } from 'app/core/redux/actionCreatorFactory';
 import { LogLevel } from 'app/core/logs_model';
 
-/**  Higher order actions
- *
- */
-export enum ActionTypes {
-  InitializeExploreSplit = 'explore/INITIALIZE_EXPLORE_SPLIT',
-  SplitClose = 'explore/SPLIT_CLOSE',
-  SplitOpen = 'explore/SPLIT_OPEN',
-  ResetExplore = 'explore/RESET_EXPLORE',
-}
-
-export interface InitializeExploreSplitAction {
-  type: ActionTypes.InitializeExploreSplit;
-  id?: string;
-  payload: {};
-}
-
-export interface SplitCloseAction {
-  type: ActionTypes.SplitClose;
-  id?: string;
-  payload: {};
-}
-
-export interface SplitOpenAction {
-  type: ActionTypes.SplitOpen;
-  id?: string;
-  payload: {
-    itemState: ExploreItemState;
-  };
-}
-
-export interface ResetExploreAction {
-  type: ActionTypes.ResetExplore;
-  id?: string;
-  payload: {};
-}
-
-/**  Lower order actions
- *
- */
 export interface AddQueryRowPayload {
   index: number;
   query: DataQuery;
@@ -369,13 +330,6 @@ export const resetExploreAction = noPayloadActionCreatorFactory('explore/RESET_E
 export const queriesImportedAction = higherOrderActionCreatorFactory<QueriesImportedPayload>(
   'explore/QueriesImported'
 ).create();
-
-export type HigherOrderAction =
-  | InitializeExploreSplitAction
-  | SplitCloseAction
-  | SplitOpenAction
-  | ResetExploreAction
-  | ActionOf<any>;
 
 export type Action =
   | ActionOf<AddQueryRowPayload>

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -288,7 +288,6 @@ export const splitCloseAction = noPayloadActionCreatorFactory('explore/SPLIT_CLO
  * The copy keeps all query modifications but wipes the query results.
  */
 export const splitOpenAction = actionCreatorFactory<SplitOpenPayload>('explore/SPLIT_OPEN').create();
-export const stateSaveAction = noPayloadActionCreatorFactory('explore/STATE_SAVE').create();
 
 /**
  * Update state of Explores UI elements (panels visiblity and deduplication  strategy)

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -9,7 +9,6 @@ import {
   QueryFixAction,
 } from '@grafana/ui/src/types';
 import {
-  ExploreId,
   ExploreItemState,
   HistoryItem,
   RangeScanner,
@@ -17,7 +16,13 @@ import {
   QueryTransaction,
   ExploreUIState,
 } from 'app/types/explore';
-import { actionCreatorFactory, noPayloadActionCreatorFactory, ActionOf } from 'app/core/redux/actionCreatorFactory';
+import {
+  actionCreatorFactory,
+  noPayloadActionCreatorFactory,
+  ActionOf,
+  higherOrderActionCreatorFactory,
+  noPayloadHigherOrderActionCreatorFactory,
+} from 'app/core/redux/actionCreatorFactory';
 import { LogLevel } from 'app/core/logs_model';
 
 /**  Higher order actions
@@ -32,16 +37,19 @@ export enum ActionTypes {
 
 export interface InitializeExploreSplitAction {
   type: ActionTypes.InitializeExploreSplit;
+  id?: string;
   payload: {};
 }
 
 export interface SplitCloseAction {
   type: ActionTypes.SplitClose;
+  id?: string;
   payload: {};
 }
 
 export interface SplitOpenAction {
   type: ActionTypes.SplitOpen;
+  id?: string;
   payload: {
     itemState: ExploreItemState;
   };
@@ -49,6 +57,7 @@ export interface SplitOpenAction {
 
 export interface ResetExploreAction {
   type: ActionTypes.ResetExplore;
+  id?: string;
   payload: {};
 }
 
@@ -56,40 +65,30 @@ export interface ResetExploreAction {
  *
  */
 export interface AddQueryRowPayload {
-  exploreId: ExploreId;
   index: number;
   query: DataQuery;
 }
 
 export interface ChangeQueryPayload {
-  exploreId: ExploreId;
   query: DataQuery;
   index: number;
   override: boolean;
 }
 
 export interface ChangeSizePayload {
-  exploreId: ExploreId;
   width: number;
   height: number;
 }
 
 export interface ChangeTimePayload {
-  exploreId: ExploreId;
   range: TimeRange;
 }
 
-export interface ClearQueriesPayload {
-  exploreId: ExploreId;
-}
-
 export interface HighlightLogsExpressionPayload {
-  exploreId: ExploreId;
   expressions: string[];
 }
 
 export interface InitializeExplorePayload {
-  exploreId: ExploreId;
   containerWidth: number;
   eventBridge: Emitter;
   exploreDatasources: DataSourceSelectItem[];
@@ -99,21 +98,14 @@ export interface InitializeExplorePayload {
 }
 
 export interface LoadDatasourceFailurePayload {
-  exploreId: ExploreId;
   error: string;
 }
 
-export interface LoadDatasourceMissingPayload {
-  exploreId: ExploreId;
-}
-
 export interface LoadDatasourcePendingPayload {
-  exploreId: ExploreId;
   requestedDatasourceName: string;
 }
 
 export interface LoadDatasourceSuccessPayload {
-  exploreId: ExploreId;
   StartPage?: any;
   datasourceInstance: any;
   history: HistoryItem[];
@@ -125,55 +117,39 @@ export interface LoadDatasourceSuccessPayload {
 }
 
 export interface ModifyQueriesPayload {
-  exploreId: ExploreId;
   modification: QueryFixAction;
   index: number;
   modifier: (query: DataQuery, modification: QueryFixAction) => DataQuery;
 }
 
 export interface QueryTransactionFailurePayload {
-  exploreId: ExploreId;
   queryTransactions: QueryTransaction[];
 }
 
 export interface QueryTransactionStartPayload {
-  exploreId: ExploreId;
   resultType: ResultType;
   rowIndex: number;
   transaction: QueryTransaction;
 }
 
 export interface QueryTransactionSuccessPayload {
-  exploreId: ExploreId;
   history: HistoryItem[];
   queryTransactions: QueryTransaction[];
 }
 
 export interface RemoveQueryRowPayload {
-  exploreId: ExploreId;
   index: number;
 }
 
-export interface RunQueriesEmptyPayload {
-  exploreId: ExploreId;
-}
-
 export interface ScanStartPayload {
-  exploreId: ExploreId;
   scanner: RangeScanner;
 }
 
 export interface ScanRangePayload {
-  exploreId: ExploreId;
   range: RawTimeRange;
 }
 
-export interface ScanStopPayload {
-  exploreId: ExploreId;
-}
-
 export interface SetQueriesPayload {
-  exploreId: ExploreId;
   queries: DataQuery[];
 }
 
@@ -181,73 +157,51 @@ export interface SplitOpenPayload {
   itemState: ExploreItemState;
 }
 
-export interface ToggleTablePayload {
-  exploreId: ExploreId;
-}
-
-export interface ToggleGraphPayload {
-  exploreId: ExploreId;
-}
-
-export interface ToggleLogsPayload {
-  exploreId: ExploreId;
-}
-
-export interface UpdateUIStatePayload extends Partial<ExploreUIState> {
-  exploreId: ExploreId;
-}
+export interface UpdateUIStatePayload extends Partial<ExploreUIState> {}
 
 export interface UpdateDatasourceInstancePayload {
-  exploreId: ExploreId;
   datasourceInstance: DataSourceApi;
 }
 
 export interface ToggleLogLevelPayload {
-  exploreId: ExploreId;
   hiddenLogLevels: Set<LogLevel>;
 }
 
 export interface QueriesImportedPayload {
-  exploreId: ExploreId;
   queries: DataQuery[];
 }
 
 /**
  * Adds a query row after the row with the given index.
  */
-export const addQueryRowAction = actionCreatorFactory<AddQueryRowPayload>('explore/ADD_QUERY_ROW').create();
-
-/**
- * Loads a new datasource identified by the given name.
- */
-export const changeDatasourceAction = noPayloadActionCreatorFactory('explore/CHANGE_DATASOURCE').create();
+export const addQueryRowAction = higherOrderActionCreatorFactory<AddQueryRowPayload>('explore/ADD_QUERY_ROW').create();
 
 /**
  * Query change handler for the query row with the given index.
  * If `override` is reset the query modifications and run the queries. Use this to set queries via a link.
  */
-export const changeQueryAction = actionCreatorFactory<ChangeQueryPayload>('explore/CHANGE_QUERY').create();
+export const changeQueryAction = higherOrderActionCreatorFactory<ChangeQueryPayload>('explore/CHANGE_QUERY').create();
 
 /**
  * Keep track of the Explore container size, in particular the width.
  * The width will be used to calculate graph intervals (number of datapoints).
  */
-export const changeSizeAction = actionCreatorFactory<ChangeSizePayload>('explore/CHANGE_SIZE').create();
+export const changeSizeAction = higherOrderActionCreatorFactory<ChangeSizePayload>('explore/CHANGE_SIZE').create();
 
 /**
  * Change the time range of Explore. Usually called from the Timepicker or a graph interaction.
  */
-export const changeTimeAction = actionCreatorFactory<ChangeTimePayload>('explore/CHANGE_TIME').create();
+export const changeTimeAction = higherOrderActionCreatorFactory<ChangeTimePayload>('explore/CHANGE_TIME').create();
 
 /**
  * Clear all queries and results.
  */
-export const clearQueriesAction = actionCreatorFactory<ClearQueriesPayload>('explore/CLEAR_QUERIES').create();
+export const clearQueriesAction = noPayloadHigherOrderActionCreatorFactory('explore/CLEAR_QUERIES').create();
 
 /**
  * Highlight expressions in the log results
  */
-export const highlightLogsExpressionAction = actionCreatorFactory<HighlightLogsExpressionPayload>(
+export const highlightLogsExpressionAction = higherOrderActionCreatorFactory<HighlightLogsExpressionPayload>(
   'explore/HIGHLIGHT_LOGS_EXPRESSION'
 ).create();
 
@@ -255,7 +209,7 @@ export const highlightLogsExpressionAction = actionCreatorFactory<HighlightLogsE
  * Initialize Explore state with state from the URL and the React component.
  * Call this only on components for with the Explore state has not been initialized.
  */
-export const initializeExploreAction = actionCreatorFactory<InitializeExplorePayload>(
+export const initializeExploreAction = higherOrderActionCreatorFactory<InitializeExplorePayload>(
   'explore/INITIALIZE_EXPLORE'
 ).create();
 
@@ -267,21 +221,21 @@ export const initializeExploreSplitAction = noPayloadActionCreatorFactory('explo
 /**
  * Display an error that happened during the selection of a datasource
  */
-export const loadDatasourceFailureAction = actionCreatorFactory<LoadDatasourceFailurePayload>(
+export const loadDatasourceFailureAction = higherOrderActionCreatorFactory<LoadDatasourceFailurePayload>(
   'explore/LOAD_DATASOURCE_FAILURE'
 ).create();
 
 /**
  * Display an error when no datasources have been configured
  */
-export const loadDatasourceMissingAction = actionCreatorFactory<LoadDatasourceMissingPayload>(
+export const loadDatasourceMissingAction = noPayloadHigherOrderActionCreatorFactory(
   'explore/LOAD_DATASOURCE_MISSING'
 ).create();
 
 /**
  * Start the async process of loading a datasource to display a loading indicator
  */
-export const loadDatasourcePendingAction = actionCreatorFactory<LoadDatasourcePendingPayload>(
+export const loadDatasourcePendingAction = higherOrderActionCreatorFactory<LoadDatasourcePendingPayload>(
   'explore/LOAD_DATASOURCE_PENDING'
 ).create();
 
@@ -290,35 +244,35 @@ export const loadDatasourcePendingAction = actionCreatorFactory<LoadDatasourcePe
  * run datasource-specific code. Existing queries are imported to the new datasource if an importer exists,
  * e.g., Prometheus -> Loki queries.
  */
-export const loadDatasourceSuccessAction = actionCreatorFactory<LoadDatasourceSuccessPayload>(
+export const loadDatasourceSuccessAction = higherOrderActionCreatorFactory<LoadDatasourceSuccessPayload>(
   'explore/LOAD_DATASOURCE_SUCCESS'
 ).create();
 
 /**
  * Action to modify a query given a datasource-specific modifier action.
- * @param exploreId Explore area
  * @param modification Action object with a type, e.g., ADD_FILTER
  * @param index Optional query row index. If omitted, the modification is applied to all query rows.
  * @param modifier Function that executes the modification, typically `datasourceInstance.modifyQueries`.
  */
-export const modifyQueriesAction = actionCreatorFactory<ModifyQueriesPayload>('explore/MODIFY_QUERIES').create();
+export const modifyQueriesAction = higherOrderActionCreatorFactory<ModifyQueriesPayload>(
+  'explore/MODIFY_QUERIES'
+).create();
 
 /**
  * Mark a query transaction as failed with an error extracted from the query response.
  * The transaction will be marked as `done`.
  */
-export const queryTransactionFailureAction = actionCreatorFactory<QueryTransactionFailurePayload>(
+export const queryTransactionFailureAction = higherOrderActionCreatorFactory<QueryTransactionFailurePayload>(
   'explore/QUERY_TRANSACTION_FAILURE'
 ).create();
 
 /**
  * Start a query transaction for the given result type.
- * @param exploreId Explore area
  * @param transaction Query options and `done` status.
  * @param resultType Associate the transaction with a result viewer, e.g., Graph
  * @param rowIndex Index is used to associate latency for this transaction with a query row
  */
-export const queryTransactionStartAction = actionCreatorFactory<QueryTransactionStartPayload>(
+export const queryTransactionStartAction = higherOrderActionCreatorFactory<QueryTransactionStartPayload>(
   'explore/QUERY_TRANSACTION_START'
 ).create();
 
@@ -326,42 +280,41 @@ export const queryTransactionStartAction = actionCreatorFactory<QueryTransaction
  * Complete a query transaction, mark the transaction as `done` and store query state in URL.
  * If the transaction was started by a scanner, it keeps on scanning for more results.
  * Side-effect: the query is stored in localStorage.
- * @param exploreId Explore area
  * @param transactionId ID
  * @param result Response from `datasourceInstance.query()`
  * @param latency Duration between request and response
  * @param queries Queries from all query rows
  * @param datasourceId Origin datasource instance, used to discard results if current datasource is different
  */
-export const queryTransactionSuccessAction = actionCreatorFactory<QueryTransactionSuccessPayload>(
+export const queryTransactionSuccessAction = higherOrderActionCreatorFactory<QueryTransactionSuccessPayload>(
   'explore/QUERY_TRANSACTION_SUCCESS'
 ).create();
 
 /**
  * Remove query row of the given index, as well as associated query results.
  */
-export const removeQueryRowAction = actionCreatorFactory<RemoveQueryRowPayload>('explore/REMOVE_QUERY_ROW').create();
-export const runQueriesAction = noPayloadActionCreatorFactory('explore/RUN_QUERIES').create();
-export const runQueriesEmptyAction = actionCreatorFactory<RunQueriesEmptyPayload>('explore/RUN_QUERIES_EMPTY').create();
+export const removeQueryRowAction = higherOrderActionCreatorFactory<RemoveQueryRowPayload>(
+  'explore/REMOVE_QUERY_ROW'
+).create();
+export const runQueriesEmptyAction = noPayloadHigherOrderActionCreatorFactory('explore/RUN_QUERIES_EMPTY').create();
 
 /**
  * Start a scan for more results using the given scanner.
- * @param exploreId Explore area
  * @param scanner Function that a) returns a new time range and b) triggers a query run for the new range
  */
-export const scanStartAction = actionCreatorFactory<ScanStartPayload>('explore/SCAN_START').create();
-export const scanRangeAction = actionCreatorFactory<ScanRangePayload>('explore/SCAN_RANGE').create();
+export const scanStartAction = higherOrderActionCreatorFactory<ScanStartPayload>('explore/SCAN_START').create();
+export const scanRangeAction = higherOrderActionCreatorFactory<ScanRangePayload>('explore/SCAN_RANGE').create();
 
 /**
  * Stop any scanning for more results.
  */
-export const scanStopAction = actionCreatorFactory<ScanStopPayload>('explore/SCAN_STOP').create();
+export const scanStopAction = noPayloadHigherOrderActionCreatorFactory('explore/SCAN_STOP').create();
 
 /**
  * Reset queries to the given queries. Any modifications will be discarded.
  * Use this action for clicks on query examples. Triggers a query run.
  */
-export const setQueriesAction = actionCreatorFactory<SetQueriesPayload>('explore/SET_QUERIES').create();
+export const setQueriesAction = higherOrderActionCreatorFactory<SetQueriesPayload>('explore/SET_QUERIES').create();
 
 /**
  * Close the split view and save URL state.
@@ -379,37 +332,43 @@ export const stateSaveAction = noPayloadActionCreatorFactory('explore/STATE_SAVE
 /**
  * Update state of Explores UI elements (panels visiblity and deduplication  strategy)
  */
-export const updateUIStateAction = actionCreatorFactory<UpdateUIStatePayload>('explore/UPDATE_UI_STATE').create();
+export const updateUIStateAction = higherOrderActionCreatorFactory<UpdateUIStatePayload>(
+  'explore/UPDATE_UI_STATE'
+).create();
 
 /**
  * Expand/collapse the table result viewer. When collapsed, table queries won't be run.
  */
-export const toggleTableAction = actionCreatorFactory<ToggleTablePayload>('explore/TOGGLE_TABLE').create();
+export const toggleTableAction = noPayloadHigherOrderActionCreatorFactory('explore/TOGGLE_TABLE').create();
 
 /**
  * Expand/collapse the graph result viewer. When collapsed, graph queries won't be run.
  */
-export const toggleGraphAction = actionCreatorFactory<ToggleGraphPayload>('explore/TOGGLE_GRAPH').create();
+export const toggleGraphAction = noPayloadHigherOrderActionCreatorFactory('explore/TOGGLE_GRAPH').create();
 
 /**
  * Expand/collapse the logs result viewer. When collapsed, log queries won't be run.
  */
-export const toggleLogsAction = actionCreatorFactory<ToggleLogsPayload>('explore/TOGGLE_LOGS').create();
+export const toggleLogsAction = noPayloadHigherOrderActionCreatorFactory('explore/TOGGLE_LOGS').create();
 
 /**
  * Updates datasource instance before datasouce loading has started
  */
-export const updateDatasourceInstanceAction = actionCreatorFactory<UpdateDatasourceInstancePayload>(
+export const updateDatasourceInstanceAction = higherOrderActionCreatorFactory<UpdateDatasourceInstancePayload>(
   'explore/UPDATE_DATASOURCE_INSTANCE'
 ).create();
 
-export const toggleLogLevelAction = actionCreatorFactory<ToggleLogLevelPayload>('explore/TOGGLE_LOG_LEVEL').create();
+export const toggleLogLevelAction = higherOrderActionCreatorFactory<ToggleLogLevelPayload>(
+  'explore/TOGGLE_LOG_LEVEL'
+).create();
 
 /**
  * Resets state for explore.
  */
 export const resetExploreAction = noPayloadActionCreatorFactory('explore/RESET_EXPLORE').create();
-export const queriesImportedAction = actionCreatorFactory<QueriesImportedPayload>('explore/QueriesImported').create();
+export const queriesImportedAction = higherOrderActionCreatorFactory<QueriesImportedPayload>(
+  'explore/QueriesImported'
+).create();
 
 export type HigherOrderAction =
   | InitializeExploreSplitAction
@@ -423,11 +382,9 @@ export type Action =
   | ActionOf<ChangeQueryPayload>
   | ActionOf<ChangeSizePayload>
   | ActionOf<ChangeTimePayload>
-  | ActionOf<ClearQueriesPayload>
   | ActionOf<HighlightLogsExpressionPayload>
   | ActionOf<InitializeExplorePayload>
   | ActionOf<LoadDatasourceFailurePayload>
-  | ActionOf<LoadDatasourceMissingPayload>
   | ActionOf<LoadDatasourcePendingPayload>
   | ActionOf<LoadDatasourceSuccessPayload>
   | ActionOf<ModifyQueriesPayload>
@@ -435,14 +392,10 @@ export type Action =
   | ActionOf<QueryTransactionStartPayload>
   | ActionOf<QueryTransactionSuccessPayload>
   | ActionOf<RemoveQueryRowPayload>
-  | ActionOf<RunQueriesEmptyPayload>
   | ActionOf<ScanStartPayload>
   | ActionOf<ScanRangePayload>
   | ActionOf<SetQueriesPayload>
   | ActionOf<SplitOpenPayload>
-  | ActionOf<ToggleTablePayload>
-  | ActionOf<ToggleGraphPayload>
-  | ActionOf<ToggleLogsPayload>
   | ActionOf<UpdateDatasourceInstancePayload>
   | ActionOf<QueriesImportedPayload>
   | ActionOf<ToggleLogLevelPayload>;

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -65,9 +65,15 @@ import {
   toggleLogsAction,
   toggleTableAction,
   updateUIStateAction,
+  toggleLogLevelAction,
+  ToggleLogLevelPayload,
+  HighlightLogsExpressionPayload,
+  highlightLogsExpressionAction,
+  removeQueryRowAction,
+  RemoveQueryRowPayload,
 } from './actionTypes';
 import { ActionOf, NoPayloadHigherOrderActionCreator } from 'app/core/redux/actionCreatorFactory';
-import { LogsDedupStrategy } from 'app/core/logs_model';
+import { LogsDedupStrategy, LogLevel } from 'app/core/logs_model';
 
 type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action>;
 
@@ -765,4 +771,31 @@ export const changeDedupStrategy = (exploreId, dedupStrategy: LogsDedupStrategy)
   return dispatch => {
     dispatch(updateExploreUIState(exploreId, { dedupStrategy }));
   };
+};
+
+/**
+ * Toggles log level in graph
+ */
+export const toggleLogLevel = (
+  exploreId: ExploreId,
+  hiddenLogLevels: Set<LogLevel>
+): ActionOf<ToggleLogLevelPayload> => {
+  return toggleLogLevelAction(exploreId)({ hiddenLogLevels });
+};
+
+/**
+ * Highlight expressions in the log results
+ */
+export const highlightLogsExpression = (
+  exploreId: ExploreId,
+  expressions: string[]
+): ActionOf<HighlightLogsExpressionPayload> => {
+  return highlightLogsExpressionAction(exploreId)({ expressions });
+};
+
+/**
+ * Remove query row of the given index, as well as associated query results.
+ */
+export const removeQueryRow = (exploreId: ExploreId, index: number): ActionOf<RemoveQueryRowPayload> => {
+  return removeQueryRowAction(exploreId)({ index });
 };

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -618,6 +618,17 @@ export function scanStart(exploreId: ExploreId, scanner: RangeScanner): ThunkRes
 }
 
 /**
+ * Stops a scan.
+ * @param exploreId Explore area
+ * @param scanner Function that a) returns a new time range and b) triggers a query run for the new range
+ */
+export function scanStop(exploreId: ExploreId): ThunkResult<void> {
+  return dispatch => {
+    dispatch(scanStopAction(exploreId)());
+  };
+}
+
+/**
  * Reset queries to the given queries. Any modifications will be discarded.
  * Use this action for clicks on query examples. Triggers a query run.
  */

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -17,7 +17,7 @@ describe('Explore item reducer', () => {
 
       reducerTester()
         .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
-        .whenActionIsDispatched(scanStartAction({ exploreId: ExploreId.left, scanner }))
+        .whenActionIsDispatched(scanStartAction(ExploreId.left)({ scanner }))
         .thenStateShouldEqual({
           ...makeExploreItemState(),
           scanning: true,
@@ -35,7 +35,7 @@ describe('Explore item reducer', () => {
 
       reducerTester()
         .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
-        .whenActionIsDispatched(scanStopAction({ exploreId: ExploreId.left }))
+        .whenActionIsDispatched(scanStopAction(ExploreId.left)())
         .thenStateShouldEqual({
           ...makeExploreItemState(),
           scanning: false,

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -91,7 +91,7 @@ export const initialExploreState: ExploreState = {
  * Reducer for an Explore area, to be used by the global Explore reducer.
  */
 export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemState)
-  .addMapper({
+  .addHigherOrderMapper({
     filter: addQueryRowAction,
     mapper: (state, action): ExploreItemState => {
       const { queries, queryTransactions } = state;
@@ -120,7 +120,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: changeQueryAction,
     mapper: (state, action): ExploreItemState => {
       const { queries, queryTransactions } = state;
@@ -142,7 +142,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: changeSizeAction,
     mapper: (state, action): ExploreItemState => {
       const { range, datasourceInstance } = state;
@@ -155,13 +155,13 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, containerWidth, queryIntervals };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: changeTimeAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, range: action.payload.range };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: clearQueriesAction,
     mapper: (state): ExploreItemState => {
       const queries = ensureQueries();
@@ -174,14 +174,14 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: highlightLogsExpressionAction,
     mapper: (state, action): ExploreItemState => {
       const { expressions } = action.payload;
       return { ...state, logsHighlighterExpressions: expressions };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: initializeExploreAction,
     mapper: (state, action): ExploreItemState => {
       const { containerWidth, eventBridge, exploreDatasources, queries, range, ui } = action.payload;
@@ -198,32 +198,32 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: updateDatasourceInstanceAction,
     mapper: (state, action): ExploreItemState => {
       const { datasourceInstance } = action.payload;
       return { ...state, datasourceInstance, queryKeys: getQueryKeys(state.queries, datasourceInstance) };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: loadDatasourceFailureAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, datasourceError: action.payload.error, datasourceLoading: false };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: loadDatasourceMissingAction,
     mapper: (state): ExploreItemState => {
       return { ...state, datasourceMissing: true, datasourceLoading: false };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: loadDatasourcePendingAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, datasourceLoading: true, requestedDatasourceName: action.payload.requestedDatasourceName };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: loadDatasourceSuccessAction,
     mapper: (state, action): ExploreItemState => {
       const { containerWidth, range } = state;
@@ -256,7 +256,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: modifyQueriesAction,
     mapper: (state, action): ExploreItemState => {
       const { queries, queryTransactions } = state;
@@ -297,14 +297,14 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: queryTransactionFailureAction,
     mapper: (state, action): ExploreItemState => {
       const { queryTransactions } = action.payload;
       return { ...state, queryTransactions, showingStartPage: false };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: queryTransactionStartAction,
     mapper: (state, action): ExploreItemState => {
       const { queryTransactions } = state;
@@ -320,7 +320,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, queryTransactions: nextQueryTransactions, showingStartPage: false };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: queryTransactionSuccessAction,
     mapper: (state, action): ExploreItemState => {
       const { datasourceInstance, queryIntervals } = state;
@@ -334,7 +334,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, ...results, history, queryTransactions, showingStartPage: false };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: removeQueryRowAction,
     mapper: (state, action): ExploreItemState => {
       const { datasourceInstance, queries, queryIntervals, queryTransactions, queryKeys } = state;
@@ -365,25 +365,25 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: runQueriesEmptyAction,
     mapper: (state): ExploreItemState => {
       return { ...state, queryTransactions: [] };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: scanRangeAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, scanRange: action.payload.range };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: scanStartAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, scanning: true, scanner: action.payload.scanner };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: scanStopAction,
     mapper: (state): ExploreItemState => {
       const { queryTransactions } = state;
@@ -397,7 +397,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: setQueriesAction,
     mapper: (state, action): ExploreItemState => {
       const { queries } = action.payload;
@@ -408,13 +408,13 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: updateUIStateAction,
     mapper: (state, action): ExploreItemState => {
       return { ...state, ...action.payload };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: toggleGraphAction,
     mapper: (state): ExploreItemState => {
       const showingGraph = !state.showingGraph;
@@ -426,7 +426,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, queryTransactions: nextQueryTransactions };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: toggleLogsAction,
     mapper: (state): ExploreItemState => {
       const showingLogs = !state.showingLogs;
@@ -438,7 +438,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, queryTransactions: nextQueryTransactions };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: toggleTableAction,
     mapper: (state): ExploreItemState => {
       const showingTable = !state.showingTable;
@@ -457,7 +457,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return { ...state, ...results, queryTransactions: nextQueryTransactions };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: queriesImportedAction,
     mapper: (state, action): ExploreItemState => {
       const { queries } = action.payload;
@@ -468,7 +468,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       };
     },
   })
-  .addMapper({
+  .addHigherOrderMapper({
     filter: toggleLogLevelAction,
     mapper: (state, action): ExploreItemState => {
       const { hiddenLogLevels } = action.payload;
@@ -503,12 +503,10 @@ export const exploreReducer = (state = initialExploreState, action: HigherOrderA
     }
   }
 
-  if (action.payload) {
-    const { exploreId } = action.payload as any;
-    if (exploreId !== undefined) {
-      const exploreItemState = state[exploreId];
-      return { ...state, [exploreId]: itemReducer(exploreItemState, action) };
-    }
+  if (action.id) {
+    const exploreId = action.id;
+    const exploreItemState = state[exploreId];
+    return { ...state, [exploreId]: itemReducer(exploreItemState, action) };
   }
 
   return state;


### PR DESCRIPTION
Closes #15565 

## New core functionality

### higherOrderActionCreatorFactory

Used to create an action creator with the following signature
```typescript
{ type: string , (id: string) => (payload: T): {type: string; id:string; payload: T;} }
```

#### Example

```typescript
export const higherOrderAction = higherOrderActionCreatorFactory<string>('HIGHER_ORDER_ACTION').create();

// later when dispatched
higherOrderAction('SomeId')('this rocks!'); // this results in the following action => {type:'HIGHER_ORDER_ACTION', id: 'SomeId', payload: 'this rocks!'}
```

```typescript
// declaring an action creator with a type string that has already been defined will throw
export const someAction = higherOrderActionCreatorFactory<string>('SOME_ACTION').create();
export const theAction = higherOrderActionCreatorFactory<string>('SOME_ACTION').create(); // will throw
```

### noPayloadHigherOrderActionCreatorFactory

Used to create an action creator with the following signature
```typescript
{ type: string , (id: string) => (): {type: string; id:string; payload: undefined;} }
```

#### Example

```typescript
export const noPayloadHigherOrderAction = noPayloadHigherOrderActionCreatorFactory('NO_PAYLOAD_HIGHER_ORDER_ACTION').create();

// later when dispatched
noPayloadHigherOrderAction('SomeId')(); // this results in the following action => {type:'NO_PAYLOAD_HIGHER_ORDER_ACTION', id: 'SomeId', payload: undefined}
```

```typescript
// declaring an action creator with a type string that has already been defined will throw
export const someAction = noPayloadHigherOrderActionCreatorFactory('SOME_ACTION').create();
export const theAction = noPayloadHigherOrderActionCreatorFactory('SOME_ACTION').create(); // will throw
```

## Updated Core functionality

### reducerFactory
reducerFactory has 2 new functions that can be called ``addHigherOrderMapper``and ``addReducer``.


### addHigherOrderMapper
Use ``addHigherOrderMapper`` when you wish to filter for a higher order action instead of a regular action 

```typescript
const lowerOrderActionCreator = actionCreatorFactory<number>('lower-order').create();
const higherOrderAction = higherOrderActionCreatorFactory<string>('higher-order').create();

const reducer = reducerFactory(childReducerIntialState)
// addHigherOrderMapper is the function that ties a higher order action creator to a state change
  .addHigherOrderMapper({
    // action creator to filter out which mapper to use
    filter: higherOrderAction,
    // mapper function where the state change occurs
    mapper: (state, action) => ({ ...state, name: action.payload }),
  })
// a developer can just chain addMapper/addHigherOrderMapper functions until reducer is done
 .addMapper({ 
    // action creator to filter out which mapper to use
    filter: lowerOrderActionCreator, 
    // mapper function where the state change occurs
    mapper: (state, action) => ({ ...state, age: action.payload }),
  })
  .create();
```

### addReducer
Use ``addReducer`` when you wish to redirect part of the state to another reducer

#### Example
Let's say we have the following need in a contrived state tree

```
 | - numberOfPosts
 | - [id:n]
        | - title
        | - content
 | - [id:n + 1]
        | - title
        | - content
```

To make this work in our application we could use 2 reducers for this, one parent reducer that contains ``numberOfPosts`` and all the "child states" and one child reducer that operates on child state like ``title`` and ``content``
```typescript
interface ChildState {
  title: string;
  content: string;
}

const initialChildState: ChildState = {
  title: null,
  content: null,
};

const higherOrderAction = higherOrderActionCreatorFactory<ChildState>('higher-order').create();

const childReducer = reducerFactory(initialChildState)
  .addHigherOrderMapper({
    filter: higherOrderAction,
    mapper: (state, action) => ({ ...state, title: action.payload.title, content: action.payload.content }),
  })
  .create();

interface ParentState {
  numberOfPosts: number;
  [key: string]: ChildState | number;
}

const initialParentState: ParentState = {
  numberOfPosts: 0,
};

const lowerOrderAction = actionCreatorFactory<ParentState>('lower-order').create();

const parentReducer = reducerFactory(initialParentState)
  .addMapper({
    filter: lowerOrderAction,
    mapper: (state, action) => ({ ...state, numberOfPosts: action.payload.numberOfPosts }),
  })
  .addReducer(childReducer) // by adding the childReducer here the reducer factory will check any action that is not lowerOrderAction and if that action has an id it is passed on to the childReducer
  .create();
```
