### PR TITLE
Bring back plugins page styles

### DIFF
--- a/public/sass/_grafana.scss
+++ b/public/sass/_grafana.scss
@@ -113,5 +113,6 @@
 @import 'pages/styleguide';
 @import 'pages/errorpage';
 @import 'pages/explore';
+@import 'pages/plugins';
 @import 'old_responsive';
 @import 'components/view_states.scss';

--- a/public/sass/pages/_plugins.scss
+++ b/public/sass/pages/_plugins.scss
@@ -1,0 +1,31 @@
+.get-more-plugins-link {
+  color: $gray-3;
+  font-size: $font-size-sm;
+  position: relative;
+  top: 1.2rem;
+
+  &:hover {
+    color: $link-hover-color;
+  }
+
+  img {
+    vertical-align: top;
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  .get-more-plugins-link {
+    display: none;
+  }
+}
+
+.plugin-info-list-item {
+  white-space: nowrap;
+  max-width: $page-sidebar-width;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  img {
+    width: 16px;
+  }
+}


### PR DESCRIPTION
Plugins' page css was removed in https://github.com/grafana/grafana/commit/09dbd6b1a6dd8b2866b289ca592c76e2da3c0078#diff-7b3eede9d5fbd295dd1542f17204a45c

I'm bringing it back, as plugins page styling is broken due to that change.

FYI @Ijin08 