### PR TITLE
grafana/ui 6.0.0-alpha.0 release version bump

### DIFF
--- a/packages/grafana-ui/CHANGELOG.md
+++ b/packages/grafana-ui/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 1.0.0-alpha.0 (2019-02-21)
+# 6.0.0-alpha.0 (2019-02-22)
+Version update to 6.0.0 to keep @grafana/ui version in sync with [Grafana](https://github.com/grafana/grafana)
 
+# 1.0.0-alpha.0 (2019-02-21)
 First public release
 

--- a/packages/grafana-ui/README.md
+++ b/packages/grafana-ui/README.md
@@ -11,3 +11,7 @@ See [package source](https://github.com/grafana/grafana/tree/master/packages/gra
 `yarn add @grafana/ui`
 
 `npm install @grafana/ui`
+
+## Versioning
+To limit the confusion related to @grafana/ui and Grafana versioning we decided to keep the major version in sync between those two.
+This means, that first version of @grafana/ui is taged with 6.0.0-alpha.0 to keep version in sync with Grafana 6.0 release.

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/ui",
-  "version": "1.0.0-alpha.0",
+  "version": "6.0.0-alpha.0",
   "description": "Grafana Components Library",
   "keywords": [
     "typescript",


### PR DESCRIPTION
To limit the confusion related to @grafana/ui and Grafana versioning we decided to keep the major version in sync between those two.

This means, that first version of @grafana/ui is taged with 6.0.0-alpha.0 to keep version in sync with Grafana 6.0 release.