### PR TITLE
Fix Datasource Update to no User/Password

### DIFF
--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -180,7 +180,7 @@ func UpdateDataSource(cmd *m.UpdateDataSourceCommand) error {
 			updateSession = sess.Where("id=? and org_id=?", ds.Id, ds.OrgId)
 		}
 
-		affected, err := updateSession.Update(ds)
+		affected, err := updateSession.AllCols().Omit("created").Update(ds)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -164,11 +164,6 @@ func UpdateDataSource(cmd *m.UpdateDataSourceCommand) error {
 			Version:           cmd.Version + 1,
 		}
 
-		sess.UseBool("is_default")
-		sess.UseBool("basic_auth")
-		sess.UseBool("with_credentials")
-		sess.UseBool("read_only")
-
 		var updateSession *xorm.Session
 		if cmd.Version != 0 {
 			// the reason we allow cmd.version > db.version is make it possible for people to force


### PR DESCRIPTION
Until now it was not possible to update a datasource that has a database with a user and password to one without user and password. When clearing the user and passowrd input field from a already existing datasource and hit the submit button the user and password reappears in the input field. The only way was to create a new datasource without adding user and passowrd for anonymous loggin. So I chanced the SQL updated function such that all fields (also empty fileds) gets updated.