### PR TITLE
stackdriver: change reducer mapping for distribution metrics

### DIFF
--- a/public/app/plugins/datasource/stackdriver/components/Aggregations.test.tsx
+++ b/public/app/plugins/datasource/stackdriver/components/Aggregations.test.tsx
@@ -49,7 +49,8 @@ describe('Aggregations', () => {
       });
       it('', () => {
         const options = wrapper.state().aggOptions[0].options;
-        expect(options.length).toEqual(5);
+
+        expect(options.length).toEqual(10);
         expect(options.map(o => o.value)).toEqual(expect.arrayContaining(['REDUCE_NONE']));
       });
     });

--- a/public/app/plugins/datasource/stackdriver/components/Aggregations.tsx
+++ b/public/app/plugins/datasource/stackdriver/components/Aggregations.tsx
@@ -73,7 +73,7 @@ export class Aggregations extends React.Component<Props, State> {
               value={crossSeriesReducer}
               variables={templateSrv.variables}
               options={aggOptions}
-              placeholder="Select Aggregation"
+              placeholder="Select Reducer"
               className="width-15"
             />
           </div>

--- a/public/app/plugins/datasource/stackdriver/components/Metrics.tsx
+++ b/public/app/plugins/datasource/stackdriver/components/Metrics.tsx
@@ -185,7 +185,7 @@ export class Metrics extends React.Component<Props, State> {
                 },
               ]}
               placeholder="Select Metric"
-              className="width-15"
+              className="width-26"
             />
           </div>
           <div className="gf-form gf-form--grow">

--- a/public/app/plugins/datasource/stackdriver/components/__snapshots__/Aggregations.test.tsx.snap
+++ b/public/app/plugins/datasource/stackdriver/components/__snapshots__/Aggregations.test.tsx.snap
@@ -28,7 +28,7 @@ Array [
             <div
               className="css-0 gf-form-select-box__placeholder"
             >
-              Select Aggregation
+              Select Reducer
             </div>
             <div
               className="css-0"

--- a/public/app/plugins/datasource/stackdriver/components/__snapshots__/QueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/stackdriver/components/__snapshots__/QueryEditor.test.tsx.snap
@@ -72,7 +72,7 @@ Array [
         Metric
       </span>
       <div
-        className="css-0 gf-form-input gf-form-input--form-dropdown width-15"
+        className="css-0 gf-form-input gf-form-input--form-dropdown width-26"
         onKeyDown={[Function]}
       >
         <div
@@ -196,7 +196,7 @@ Array [
             <div
               className="css-0 gf-form-select-box__placeholder"
             >
-              Select Aggregation
+              Select Reducer
             </div>
             <div
               className="css-0"

--- a/public/app/plugins/datasource/stackdriver/constants.ts
+++ b/public/app/plugins/datasource/stackdriver/constants.ts
@@ -189,7 +189,7 @@ export const aggOptions = [
       ValueTypes.BOOL,
       ValueTypes.STRING,
     ],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
   {
     text: 'count true',
@@ -207,25 +207,25 @@ export const aggOptions = [
     text: '99th percentile',
     value: 'REDUCE_PERCENTILE_99',
     valueTypes: [ValueTypes.INT64, ValueTypes.DOUBLE, ValueTypes.MONEY, ValueTypes.DISTRIBUTION],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
   {
     text: '95th percentile',
     value: 'REDUCE_PERCENTILE_95',
     valueTypes: [ValueTypes.INT64, ValueTypes.DOUBLE, ValueTypes.MONEY, ValueTypes.DISTRIBUTION],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
   {
     text: '50th percentile',
     value: 'REDUCE_PERCENTILE_50',
     valueTypes: [ValueTypes.INT64, ValueTypes.DOUBLE, ValueTypes.MONEY, ValueTypes.DISTRIBUTION],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
   {
     text: '5th percentile',
     value: 'REDUCE_PERCENTILE_05',
     valueTypes: [ValueTypes.INT64, ValueTypes.DOUBLE, ValueTypes.MONEY, ValueTypes.DISTRIBUTION],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
 ];
 


### PR DESCRIPTION
- Distribution metrics are now mapped to more reducers when the metric kind is cumulative.
- The width of the metrics dropdown is now much wider.
- Changed the text from Select Aggregation to Select Reducer to be more similar with the UI in Stackdriver.

Closes #15179

