### PR TITLE
Explore: Make sure line graphs get different colors

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -3,8 +3,10 @@ import { PluginMeta } from './plugin';
 import { TableData, TimeSeries } from './data';
 
 export interface DataQueryResponse {
-  data: TimeSeries[] | [TableData] | any;
+  data: DataQueryResponseData;
 }
+
+export type DataQueryResponseData = TimeSeries[] | [TableData] | any;
 
 export interface DataQuery {
   /**

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -597,7 +597,8 @@ function runQueriesForType(
         const res = await datasourceInstance.query(transaction.options);
         eventBridge.emit('data-received', res.data || []);
         const latency = Date.now() - now;
-        const results = resultGetter ? resultGetter(res.data) : res.data;
+        const { queryTransactions } = getState().explore[exploreId];
+        const results = resultGetter ? resultGetter(res.data, transaction, queryTransactions) : res.data;
         dispatch(queryTransactionSuccess(exploreId, transaction.id, results, latency, queries, datasourceId));
       } catch (response) {
         eventBridge.emit('data-error', response);

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -322,6 +322,8 @@ export interface QueryTransaction {
 
 export type RangeScanner = () => RawTimeRange;
 
+export type ResultGetter = (result: any, transaction: QueryTransaction, allTransactions: QueryTransaction[]) => any;
+
 export interface TextMatch {
   text: string;
   start: number;

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -11,7 +11,7 @@ import {
   ExploreStartPageProps,
 } from '@grafana/ui';
 
-import { Emitter } from 'app/core/core';
+import { Emitter, TimeSeries } from 'app/core/core';
 import { LogsModel, LogsDedupStrategy, LogLevel } from 'app/core/logs_model';
 import TableModel from 'app/core/table_model';
 
@@ -327,7 +327,7 @@ export type ResultGetter = (
   result: DataQueryResponseData,
   transaction: QueryTransaction,
   allTransactions: QueryTransaction[]
-) => any;
+) => TimeSeries;
 
 export interface TextMatch {
   text: string;

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -4,6 +4,7 @@ import {
   RawTimeRange,
   TimeRange,
   DataQuery,
+  DataQueryResponseData,
   DataSourceSelectItem,
   DataSourceApi,
   QueryHint,
@@ -322,7 +323,11 @@ export interface QueryTransaction {
 
 export type RangeScanner = () => RawTimeRange;
 
-export type ResultGetter = (result: any, transaction: QueryTransaction, allTransactions: QueryTransaction[]) => any;
+export type ResultGetter = (
+  result: DataQueryResponseData,
+  transaction: QueryTransaction,
+  allTransactions: QueryTransaction[]
+) => any;
 
 export interface TextMatch {
   text: string;


### PR DESCRIPTION
- lines for graphs from different query rows end up in different
transactions
- within each transaction the color distribution resets leading to color
overlap
- this change takes existing transaction colors into account

Fixes #15607 