### PR TITLE
User enumeration via password reset

### DIFF
--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -25,7 +25,8 @@ func SendResetPasswordEmail(c *m.ReqContext, form dtos.SendResetPasswordEmailFor
 
 	emailCmd := m.SendResetPasswordEmailCommand{User: userQuery.Result}
 	if err := bus.Dispatch(&emailCmd); err != nil {
-		return Error(500, "Failed to send email", err)
+		c.Logger.Error("Failed to send password reset email for ", "user", userQuery.LoginOrEmail)
+		return Error(200, "Email sent", err)
 	}
 
 	return Success("Email sent")

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -26,7 +26,7 @@ func SendResetPasswordEmail(c *m.ReqContext, form dtos.SendResetPasswordEmailFor
 	emailCmd := m.SendResetPasswordEmailCommand{User: userQuery.Result}
 	if err := bus.Dispatch(&emailCmd); err != nil {
 		c.Logger.Error("Failed to send password reset email for ", "user", userQuery.LoginOrEmail)
-		return Error(200, "Email sent", err)
+		return Error(500, "Email sent", err)
 	}
 
 	return Success("Email sent")


### PR DESCRIPTION
Our pen testers flagged up the different email notification message that appears when asking for password resets. The client has a different response if the user exists or doesn't exist. 

While this would be a slow way to find valid users and possibly fairly small issue it would be nice if it was addressed. 

I have made a small change, feel free to include your own take on it if mine doesn't follow the guidelines/coding styles close enough.

