### PR TITLE
Explore: Enable click on name label

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -100,7 +100,7 @@ export class ResultTransformer {
     table.columns.push({ text: 'Time', type: 'time' });
     _.each(sortedLabels, (label, labelIndex) => {
       metricLabels[label] = labelIndex + 1;
-      table.columns.push({ text: label, filterable: !label.startsWith('__') });
+      table.columns.push({ text: label, filterable: true });
     });
     const valueText = resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value';
     table.columns.push({ text: valueText });

--- a/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
@@ -66,11 +66,12 @@ describe('Prometheus Result Transformer', () => {
       ]);
       expect(table.columns).toMatchObject([
         { text: 'Time', type: 'time' },
-        { text: '__name__' },
-        { text: 'instance' },
+        { text: '__name__', filterable: true },
+        { text: 'instance', filterable: true },
         { text: 'job' },
         { text: 'Value' },
       ]);
+      expect(table.columns[4].filterable).toBeUndefined();
     });
 
     it('should column title include refId if response count is more than 2', () => {


### PR DESCRIPTION
- click on the name label in a prometheus table was disabled
- it was disabled because every query used to have a metric which is no
longer true
- this change enables it

Fixes #14654 
