### PR TITLE
wip: Fix playlists "by tags"

### DIFF
--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -52,8 +52,10 @@ func populateDashboardsByTag(orgID int64, signedInUser *m.SignedInUser, dashboar
 			for _, item := range searchQuery.Result {
 				result = append(result, dtos.PlaylistDashboard{
 					Id:    item.Id,
+					Slug:  item.Slug,
 					Title: item.Title,
 					Uri:   item.Uri,
+					Url:   m.GetDashboardUrl(item.Uid, item.Slug),
 					Order: dashboardTagOrder[tag],
 				})
 			}

--- a/pkg/services/search/models.go
+++ b/pkg/services/search/models.go
@@ -17,6 +17,7 @@ type Hit struct {
 	Title       string   `json:"title"`
 	Uri         string   `json:"uri"`
 	Url         string   `json:"url"`
+	Slug        string   `json:"slug"`
 	Type        HitType  `json:"type"`
 	Tags        []string `json:"tags"`
 	IsStarred   bool     `json:"isStarred"`


### PR DESCRIPTION
When playing playlists "by tags" the API wont return the dashboard url which is needed for the playlist to start. The result will be a black screen and no errors. Adding the Url fixes the playlists but...

Two things we should fix before merge:
1. I added the Url param. I also added the Slug-param, but the Slug is always an empty string (help, please!) so the Urls generated work, but they are not the real canonical urls.
2. "Order" is always set to 1.

Fixes #15656