### PR TITLE
Explore: Vendor ansi stripping

### DIFF
--- a/public/app/core/utils/text.test.ts
+++ b/public/app/core/utils/text.test.ts
@@ -1,4 +1,4 @@
-import { findMatchesInText } from './text';
+import { findMatchesInText, stripAnsi } from './text';
 
 describe('findMatchesInText()', () => {
   it('gets no matches for when search and or line are empty', () => {
@@ -31,5 +31,12 @@ describe('findMatchesInText()', () => {
     ]);
     expect(findMatchesInText('foo foo bar', '(')).toEqual([]);
     expect(findMatchesInText('foo foo bar', '(foo|')).toEqual([]);
+  });
+});
+
+describe('stripAnsi()', () => {
+  test('should strip ansi codes', () => {
+    expect(stripAnsi("foo: 'bar'")).toBe("foo: 'bar'");
+    expect(stripAnsi("foo: [32m'bar'[39m")).toBe("foo: 'bar'");
   });
 });

--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -72,3 +72,15 @@ export function sanitize(unsanitizedString: string): string {
 export function hasAnsiCodes(input: string): boolean {
   return /\u001b\[\d{1,2}m/.test(input);
 }
+
+// From npm module ansicolor (import broke phantomjs)
+// https://github.com/xpl/ansicolor/blob/b82360563ed29de444dc7618b9236191e0a77096/ansicolor.js#L370
+const ANSI_REGEX = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]/g;
+
+/**
+ * Strips ANSI codes from a string
+ * @param input a string containing ANSI escape codes.
+ */
+export function stripAnsi(input: string): string {
+  return input.replace(ANSI_REGEX, '');
+}

--- a/public/app/features/explore/LogMessageAnsi.tsx
+++ b/public/app/features/explore/LogMessageAnsi.tsx
@@ -1,4 +1,6 @@
 import React, { PureComponent } from 'react';
+// BEWARE Importing this will break phantomjs-based image rendering.
+// Ok to leave it here for now, until LogMessageAnsi is used in other places than Explore.
 import ansicolor from 'ansicolor';
 
 interface Style {

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -1,4 +1,3 @@
-import ansicolor from 'ansicolor';
 import _ from 'lodash';
 import moment from 'moment';
 
@@ -12,7 +11,7 @@ import {
   LogsStreamLabels,
   LogsMetaKind,
 } from 'app/core/logs_model';
-import { hasAnsiCodes } from 'app/core/utils/text';
+import { hasAnsiCodes, stripAnsi } from 'app/core/utils/text';
 import { DEFAULT_MAX_LINES } from './datasource';
 
 /**
@@ -137,7 +136,7 @@ export function processEntry(
     timeLocal,
     uniqueLabels,
     hasAnsi,
-    entry: hasAnsi ? ansicolor.strip(line) : line,
+    entry: hasAnsi ? stripAnsi(line) : line,
     raw: line,
     labels: parsedLabels,
     searchWords: search ? [search] : [],


### PR DESCRIPTION
- The npm library ansicolor breaks phantomjs-based rendering when
included in any loaded bundles
- this change vendors the parts of ansicolor that the main bundle
includes and which will be loaded to render graphs with phantomjs
- this change leaves ansicolor in the log message renderer because it's
part of the Explore bundle and is not loaded by phantomjs when rendering
dashboard panels

Fixes #15635
