### PR TITLE
JSON header property support for Auth Proxy

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -368,6 +368,7 @@ enabled = true
 enabled = false
 header_name = X-WEBAUTH-USER
 header_property = username
+json_header_property = preferred_username
 auto_sign_up = true
 ldap_sync_ttl = 60
 whitelist =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -326,6 +326,7 @@ log_queries =
 ;header_property = username
 ;auto_sign_up = true
 ;ldap_sync_ttl = 60
+;json_header_property = preferred_username
 ;whitelist = 192.168.1.1, 192.168.2.1
 ;headers = Email:X-User-Email, Name:X-User-Name
 

--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -25,6 +25,8 @@ enabled = true
 header_name = X-WEBAUTH-USER
 # HTTP Header property, defaults to `username` but can also be `email`
 header_property = username
+# JSON string HTTP Header property for the JSON key that will contain the user as a value.
+json_header_property = preferred_username
 # Set to `true` to enable auto sign up of users who do not exist in Grafana DB. Defaults to `true`.
 auto_sign_up = true
 # If combined with Grafana LDAP integration define sync interval

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -130,14 +130,15 @@ var (
 	AnonymousOrgRole string
 
 	// Auth proxy settings
-	AuthProxyEnabled        bool
-	AuthProxyHeaderName     string
-	AuthProxyHeaderProperty string
-	AuthProxyAutoSignUp     bool
-	AuthProxyLdapSyncTtl    int
-	AuthProxyWhitelist      string
-	AuthProxyHeaders        map[string]string
-
+	AuthProxyEnabled            bool
+	AuthProxyHeaderName         string
+	AuthProxyHeaderProperty     string
+	AuthProxyJsonHeaderProperty string
+	AuthProxyAutoSignUp         bool
+	AuthProxyLdapSyncTtl        int
+	AuthProxyWhitelist          string
+	AuthProxyHeaders            map[string]string
+	
 	// Basic Auth
 	BasicAuthEnabled bool
 
@@ -693,6 +694,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AuthProxyEnabled = authProxy.Key("enabled").MustBool(false)
 	AuthProxyHeaderName = authProxy.Key("header_name").String()
 	AuthProxyHeaderProperty = authProxy.Key("header_property").String()
+	AuthProxyJsonHeaderProperty = authProxy.Key("json_header_property").String()
 	AuthProxyAutoSignUp = authProxy.Key("auto_sign_up").MustBool(true)
 	AuthProxyLdapSyncTtl = authProxy.Key("ldap_sync_ttl").MustInt()
 	AuthProxyWhitelist = authProxy.Key("whitelist").String()


### PR DESCRIPTION
Some API gateway components (like this: https://github.com/nokia/kong-oidc) add logged in user as a JSON string in a header instead of a separate header containing only the username. This addition allows the Auth Proxy to fetch username from the specified JSON key in a header.
