### PR TITLE
Rename PanelEditorProps.onChange to onOptionsChange 

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -22,7 +22,7 @@ export interface PanelData {
 
 export interface PanelEditorProps<T = any> {
   options: T;
-  updateOptions: (options: T) => void;
+  onOptionsChange: (options: T) => void;
 }
 
 export class ReactPanelPlugin<TOptions = any> {

--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -22,7 +22,7 @@ export interface PanelData {
 
 export interface PanelEditorProps<T = any> {
   options: T;
-  onChange: (options: T) => void;
+  updateOptions: (options: T) => void;
 }
 
 export class ReactPanelPlugin<TOptions = any> {

--- a/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
@@ -66,7 +66,7 @@ export class VisualizationTab extends PureComponent<Props, State> {
       const PanelEditor = plugin.exports.reactPanel.editor;
 
       if (PanelEditor) {
-        return <PanelEditor options={this.getReactPanelOptions()} updateOptions={this.onPanelOptionsChanged} />;
+        return <PanelEditor options={this.getReactPanelOptions()} onOptionsChange={this.onPanelOptionsChanged} />;
       }
     }
 

--- a/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
@@ -66,7 +66,7 @@ export class VisualizationTab extends PureComponent<Props, State> {
       const PanelEditor = plugin.exports.reactPanel.editor;
 
       if (PanelEditor) {
-        return <PanelEditor options={this.getReactPanelOptions()} onChange={this.onPanelOptionsChanged} />;
+        return <PanelEditor options={this.getReactPanelOptions()} updateOptions={this.onPanelOptionsChanged} />;
       }
     }
 

--- a/public/app/plugins/panel/gauge/GaugeOptionsBox.tsx
+++ b/public/app/plugins/panel/gauge/GaugeOptionsBox.tsx
@@ -10,14 +10,17 @@ import { GaugeOptions } from './types';
 
 export class GaugeOptionsBox extends PureComponent<PanelEditorProps<GaugeOptions>> {
   onToggleThresholdLabels = () =>
-    this.props.updateOptions({ ...this.props.options, showThresholdLabels: !this.props.options.showThresholdLabels });
+    this.props.onOptionsChange({ ...this.props.options, showThresholdLabels: !this.props.options.showThresholdLabels });
 
   onToggleThresholdMarkers = () =>
-    this.props.updateOptions({ ...this.props.options, showThresholdMarkers: !this.props.options.showThresholdMarkers });
+    this.props.onOptionsChange({
+      ...this.props.options,
+      showThresholdMarkers: !this.props.options.showThresholdMarkers,
+    });
 
-  onMinValueChange = ({ target }) => this.props.updateOptions({ ...this.props.options, minValue: target.value });
+  onMinValueChange = ({ target }) => this.props.onOptionsChange({ ...this.props.options, minValue: target.value });
 
-  onMaxValueChange = ({ target }) => this.props.updateOptions({ ...this.props.options, maxValue: target.value });
+  onMaxValueChange = ({ target }) => this.props.onOptionsChange({ ...this.props.options, maxValue: target.value });
 
   render() {
     const { options } = this.props;

--- a/public/app/plugins/panel/gauge/GaugeOptionsBox.tsx
+++ b/public/app/plugins/panel/gauge/GaugeOptionsBox.tsx
@@ -10,14 +10,14 @@ import { GaugeOptions } from './types';
 
 export class GaugeOptionsBox extends PureComponent<PanelEditorProps<GaugeOptions>> {
   onToggleThresholdLabels = () =>
-    this.props.onChange({ ...this.props.options, showThresholdLabels: !this.props.options.showThresholdLabels });
+    this.props.updateOptions({ ...this.props.options, showThresholdLabels: !this.props.options.showThresholdLabels });
 
   onToggleThresholdMarkers = () =>
-    this.props.onChange({ ...this.props.options, showThresholdMarkers: !this.props.options.showThresholdMarkers });
+    this.props.updateOptions({ ...this.props.options, showThresholdMarkers: !this.props.options.showThresholdMarkers });
 
-  onMinValueChange = ({ target }) => this.props.onChange({ ...this.props.options, minValue: target.value });
+  onMinValueChange = ({ target }) => this.props.updateOptions({ ...this.props.options, minValue: target.value });
 
-  onMaxValueChange = ({ target }) => this.props.onChange({ ...this.props.options, maxValue: target.value });
+  onMaxValueChange = ({ target }) => this.props.updateOptions({ ...this.props.options, maxValue: target.value });
 
   render() {
     const { options } = this.props;

--- a/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
@@ -14,31 +14,31 @@ import { GaugeOptions, SingleStatValueOptions } from './types';
 
 export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOptions>> {
   onThresholdsChanged = (thresholds: Threshold[]) =>
-    this.props.updateOptions({
+    this.props.onOptionsChange({
       ...this.props.options,
       thresholds,
     });
 
   onValueMappingsChanged = (valueMappings: ValueMapping[]) =>
-    this.props.updateOptions({
+    this.props.onOptionsChange({
       ...this.props.options,
       valueMappings,
     });
 
   onValueOptionsChanged = (valueOptions: SingleStatValueOptions) =>
-    this.props.updateOptions({
+    this.props.onOptionsChange({
       ...this.props.options,
       valueOptions,
     });
 
   render() {
-    const { updateOptions, options } = this.props;
+    const { onOptionsChange, options } = this.props;
 
     return (
       <>
         <PanelOptionsGrid>
           <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
-          <GaugeOptionsBox updateOptions={updateOptions} options={options} />
+          <GaugeOptionsBox onOptionsChange={onOptionsChange} options={options} />
           <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
         </PanelOptionsGrid>
 

--- a/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
@@ -14,31 +14,31 @@ import { GaugeOptions, SingleStatValueOptions } from './types';
 
 export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOptions>> {
   onThresholdsChanged = (thresholds: Threshold[]) =>
-    this.props.onChange({
+    this.props.updateOptions({
       ...this.props.options,
       thresholds,
     });
 
   onValueMappingsChanged = (valueMappings: ValueMapping[]) =>
-    this.props.onChange({
+    this.props.updateOptions({
       ...this.props.options,
       valueMappings,
     });
 
   onValueOptionsChanged = (valueOptions: SingleStatValueOptions) =>
-    this.props.onChange({
+    this.props.updateOptions({
       ...this.props.options,
       valueOptions,
     });
 
   render() {
-    const { onChange, options } = this.props;
+    const { updateOptions, options } = this.props;
 
     return (
       <>
         <PanelOptionsGrid>
           <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
-          <GaugeOptionsBox onChange={onChange} options={options} />
+          <GaugeOptionsBox updateOptions={updateOptions} options={options} />
           <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
         </PanelOptionsGrid>
 

--- a/public/app/plugins/panel/graph2/GraphPanelEditor.tsx
+++ b/public/app/plugins/panel/graph2/GraphPanelEditor.tsx
@@ -8,15 +8,15 @@ import { Options } from './types';
 
 export class GraphPanelEditor extends PureComponent<PanelEditorProps<Options>> {
   onToggleLines = () => {
-    this.props.updateOptions({ ...this.props.options, showLines: !this.props.options.showLines });
+    this.props.onOptionsChange({ ...this.props.options, showLines: !this.props.options.showLines });
   };
 
   onToggleBars = () => {
-    this.props.updateOptions({ ...this.props.options, showBars: !this.props.options.showBars });
+    this.props.onOptionsChange({ ...this.props.options, showBars: !this.props.options.showBars });
   };
 
   onTogglePoints = () => {
-    this.props.updateOptions({ ...this.props.options, showPoints: !this.props.options.showPoints });
+    this.props.onOptionsChange({ ...this.props.options, showPoints: !this.props.options.showPoints });
   };
 
   render() {

--- a/public/app/plugins/panel/graph2/GraphPanelEditor.tsx
+++ b/public/app/plugins/panel/graph2/GraphPanelEditor.tsx
@@ -8,15 +8,15 @@ import { Options } from './types';
 
 export class GraphPanelEditor extends PureComponent<PanelEditorProps<Options>> {
   onToggleLines = () => {
-    this.props.onChange({ ...this.props.options, showLines: !this.props.options.showLines });
+    this.props.updateOptions({ ...this.props.options, showLines: !this.props.options.showLines });
   };
 
   onToggleBars = () => {
-    this.props.onChange({ ...this.props.options, showBars: !this.props.options.showBars });
+    this.props.updateOptions({ ...this.props.options, showBars: !this.props.options.showBars });
   };
 
   onTogglePoints = () => {
-    this.props.onChange({ ...this.props.options, showPoints: !this.props.options.showPoints });
+    this.props.updateOptions({ ...this.props.options, showPoints: !this.props.options.showPoints });
   };
 
   render() {


### PR DESCRIPTION
part of #15734

This renames `onChange` to `updateOptions`

I think it looks bad in VisualizationTab.tsx, but everywhere else makes more sense.

Alternative names I think make sense:
 * updatePanelOptions
 * setPanelOptions
 * setOptions

And if we think this really needs an `onChange` prefix:
 * onChangeOptions
