### PR TITLE
use replaceVariables rather than onInterpolate

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -12,7 +12,7 @@ export interface PanelProps<T = any> {
   renderCounter: number;
   width: number;
   height: number;
-  onInterpolate: InterpolateFunction;
+  replaceVariables: InterpolateFunction;
 }
 
 export interface PanelData {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -85,7 +85,7 @@ export class PanelChrome extends PureComponent<Props, State> {
     });
   };
 
-  onInterpolate = (value: string, format?: string) => {
+  replaceVariables = (value: string, format?: string) => {
     return templateSrv.replace(value, this.props.panel.scopedVars, format);
   };
 
@@ -158,7 +158,7 @@ export class PanelChrome extends PureComponent<Props, State> {
           width={width - 2 * variables.panelhorizontalpadding}
           height={height - PANEL_HEADER_HEIGHT - variables.panelverticalpadding}
           renderCounter={renderCounter}
-          onInterpolate={this.onInterpolate}
+          replaceVariables={this.replaceVariables}
         />
       </div>
     );

--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -15,11 +15,11 @@ interface Props extends PanelProps<GaugeOptions> {}
 
 export class GaugePanel extends PureComponent<Props> {
   render() {
-    const { panelData, width, height, onInterpolate, options } = this.props;
+    const { panelData, width, height, replaceVariables, options } = this.props;
     const { valueOptions } = options;
 
-    const prefix = onInterpolate(valueOptions.prefix);
-    const suffix = onInterpolate(valueOptions.suffix);
+    const prefix = replaceVariables(valueOptions.prefix);
+    const suffix = replaceVariables(valueOptions.suffix);
     let value: TimeSeriesValue;
 
     if (panelData.timeSeries) {


### PR DESCRIPTION
Following discussion in #15734

Since `onInterpolate` is not an event, it should not start with `on`

Since I need to dig into the source to find out that `interpolate` is how you you replace variables in the text, I think it should be called `replaceVariables` (or similar)

I'm not sure about: InterpolateFunction.  It is a function signature without any expected behavior, so maybe "interpolate" is fine.  In general, I would expect interpolate to be a numeric function though  https://en.wikipedia.org/wiki/Interpolation


