### PR TITLE
Viewers with viewers_can_edit should be able to access /explore

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,7 +11,6 @@ import (
 
 func (hs *HTTPServer) registerRoutes() {
 	reqSignedIn := middleware.ReqSignedIn
-	reqViewersCanEditOrEditorRole := middleware.ReqViewersCanEditOrEditorRole
 	reqGrafanaAdmin := middleware.ReqGrafanaAdmin
 	reqEditorRole := middleware.ReqEditorRole
 	reqOrgAdmin := middleware.ReqOrgAdmin
@@ -74,7 +73,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboards/", reqSignedIn, hs.Index)
 	r.Get("/dashboards/*", reqSignedIn, hs.Index)
 
-	r.Get("/explore", reqSignedIn, reqViewersCanEditOrEditorRole, hs.Index)
+	r.Get("/explore", reqSignedIn, middleware.EnsureEditorOrViewerCanEdit, hs.Index)
 
 	r.Get("/playlists/", reqSignedIn, hs.Index)
 	r.Get("/playlists/*", reqSignedIn, hs.Index)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,6 +11,7 @@ import (
 
 func (hs *HTTPServer) registerRoutes() {
 	reqSignedIn := middleware.ReqSignedIn
+	reqViewersCanEditOrEditorRole := middleware.ReqViewersCanEditOrEditorRole
 	reqGrafanaAdmin := middleware.ReqGrafanaAdmin
 	reqEditorRole := middleware.ReqEditorRole
 	reqOrgAdmin := middleware.ReqOrgAdmin
@@ -73,7 +74,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboards/", reqSignedIn, hs.Index)
 	r.Get("/dashboards/*", reqSignedIn, hs.Index)
 
-	r.Get("/explore", reqEditorRole, hs.Index)
+	r.Get("/explore", reqSignedIn, reqViewersCanEditOrEditorRole, hs.Index)
 
 	r.Get("/playlists/", reqSignedIn, hs.Index)
 	r.Get("/playlists/*", reqSignedIn, hs.Index)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strings"
 
-	"gopkg.in/macaron.v1"
+	macaron "gopkg.in/macaron.v1"
 
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
@@ -50,6 +50,26 @@ func notAuthorized(c *m.ReqContext) {
 	c.SetCookie("redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, setting.AppSubUrl+"/", nil, false, true)
 
 	c.Redirect(setting.AppSubUrl + "/login")
+}
+
+func ViewersCanEditOrRoleAuth(roles ...m.RoleType) macaron.Handler {
+	return func(c *m.ReqContext) {
+		ok := false
+		if setting.ViewersCanEdit == true {
+			ok = true
+		}
+		if ok == false {
+			for _, role := range roles {
+				if role == c.OrgRole {
+					ok = true
+					break
+				}
+			}
+		}
+		if !ok {
+			accessForbidden(c)
+		}
+	}
 }
 
 func RoleAuth(roles ...m.RoleType) macaron.Handler {

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -52,23 +52,9 @@ func notAuthorized(c *m.ReqContext) {
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 
-func ViewersCanEditOrRoleAuth(roles ...m.RoleType) macaron.Handler {
-	return func(c *m.ReqContext) {
-		ok := false
-		if setting.ViewersCanEdit == true {
-			ok = true
-		}
-		if ok == false {
-			for _, role := range roles {
-				if role == c.OrgRole {
-					ok = true
-					break
-				}
-			}
-		}
-		if !ok {
-			accessForbidden(c)
-		}
+func EnsureEditorOrViewerCanEdit(c *m.ReqContext) {
+	if !c.SignedInUser.HasRole(m.ROLE_EDITOR) && !setting.ViewersCanEdit {
+		accessForbidden(c)
 	}
 }
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -17,11 +17,10 @@ import (
 )
 
 var (
-	ReqGrafanaAdmin               = Auth(&AuthOptions{ReqSignedIn: true, ReqGrafanaAdmin: true})
-	ReqSignedIn                   = Auth(&AuthOptions{ReqSignedIn: true})
-	ReqEditorRole                 = RoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
-	ReqOrgAdmin                   = RoleAuth(m.ROLE_ADMIN)
-	ReqViewersCanEditOrEditorRole = ViewersCanEditOrRoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
+	ReqGrafanaAdmin = Auth(&AuthOptions{ReqSignedIn: true, ReqGrafanaAdmin: true})
+	ReqSignedIn     = Auth(&AuthOptions{ReqSignedIn: true})
+	ReqEditorRole   = RoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
+	ReqOrgAdmin     = RoleAuth(m.ROLE_ADMIN)
 )
 
 func GetContextHandler(ats m.UserTokenService) macaron.Handler {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	ReqGrafanaAdmin = Auth(&AuthOptions{ReqSignedIn: true, ReqGrafanaAdmin: true})
-	ReqSignedIn     = Auth(&AuthOptions{ReqSignedIn: true})
-	ReqEditorRole   = RoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
-	ReqOrgAdmin     = RoleAuth(m.ROLE_ADMIN)
+	ReqGrafanaAdmin               = Auth(&AuthOptions{ReqSignedIn: true, ReqGrafanaAdmin: true})
+	ReqSignedIn                   = Auth(&AuthOptions{ReqSignedIn: true})
+	ReqEditorRole                 = RoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
+	ReqOrgAdmin                   = RoleAuth(m.ROLE_ADMIN)
+	ReqViewersCanEditOrEditorRole = ViewersCanEditOrRoleAuth(m.ROLE_EDITOR, m.ROLE_ADMIN)
 )
 
 func GetContextHandler(ats m.UserTokenService) macaron.Handler {


### PR DESCRIPTION
The /explore route in the backend should check if the `viewers_can_edit` setting is set or not.


Fixes #15773
