### PR TITLE
Turn off verbose output from tar extraction when building docker file

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -qq -y tar && \
 
 COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
-RUN mkdir /tmp/grafana && tar xfvz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
+RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
 ARG BASE_IMAGE=debian:stretch-slim
 FROM ${BASE_IMAGE}

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -qq -y tar && \
 
 COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
+# Change to tar xfzv to make tar print every file it extracts
 RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
 ARG BASE_IMAGE=debian:stretch-slim


### PR DESCRIPTION
Fixes #15528
