### PR TITLE
Fixed scrolling issue that caused scroll to be locked to bottom

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -42,11 +42,7 @@ export class CustomScrollbar extends Component<Props> {
     const ref = this.ref.current;
 
     if (ref && !isNil(this.props.scrollTop)) {
-      if (this.props.scrollTop > 10000) {
-        ref.scrollToBottom();
-      } else {
-        ref.scrollTop(this.props.scrollTop);
-      }
+      ref.scrollTop(this.props.scrollTop);
     }
   }
 


### PR DESCRIPTION
big dashboards with scrollTop > 10000 caused scrolling to be locked to the bottom after hitting the bottom. 

Fixes #15712

