### PR TITLE
Add common webpack rule to transpile ES6 libs

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -10,20 +10,16 @@ module.exports = {
     path: path.resolve(__dirname, '../../public/build'),
     filename: '[name].[hash].js',
     // Keep publicPath relative for host.com/grafana/ deployments
-    publicPath: "public/build/",
+    publicPath: 'public/build/',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.es6', '.js', '.json', '.svg'],
-    alias: {
-    },
-    modules: [
-      path.resolve('public'),
-      path.resolve('node_modules')
-    ],
+    alias: {},
+    modules: [path.resolve('public'), path.resolve('node_modules')],
   },
   stats: {
     children: false,
-    warningsFilter: /export .* was not found in/
+    warningsFilter: /export .* was not found in/,
   },
   node: {
     fs: 'empty',
@@ -35,35 +31,58 @@ module.exports = {
         use: [
           {
             loader: 'expose-loader',
-            query: 'jQuery'
+            query: 'jQuery',
           },
           {
             loader: 'expose-loader',
-            query: '$'
-          }
-        ]
+            query: '$',
+          },
+        ],
+      },
+      // Section for node_modules libs that are ES6 and need to be transpiled to ES5. Make sure to use `include` only.
+      {
+        test: /\.js/,
+        include: /node_modules\/ansicolor/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              cacheDirectory: true,
+              babelrc: false,
+              presets: [
+                [
+                  '@babel/preset-env',
+                  {
+                    targets: { browsers: 'last 3 versions' },
+                    useBuiltIns: 'entry',
+                  },
+                ],
+              ],
+            },
+          },
+        ],
       },
       {
         test: /\.html$/,
         exclude: /(index|error)\-template\.html/,
         use: [
-          { loader: 'ngtemplate-loader?relativeTo=' + (path.resolve(__dirname, '../../public')) + '&prefix=public' },
+          { loader: 'ngtemplate-loader?relativeTo=' + path.resolve(__dirname, '../../public') + '&prefix=public' },
           {
             loader: 'html-loader',
             options: {
               attrs: [],
               minimize: true,
               removeComments: false,
-              collapseWhitespace: false
-            }
-          }
-        ]
-      }
-    ]
+              collapseWhitespace: false,
+            },
+          },
+        ],
+      },
+    ],
   },
   plugins: [
     new ForkTsCheckerWebpackPlugin({
       checkSyntacticErrors: true,
     }),
-  ]
+  ],
 };


### PR DESCRIPTION
- Dependencies like `ansicolor` come with ES6 builds, instead of ES5
(our build target)
- current webpack rules have transpilation only for `.ts` files
- this change adds a common rule for `.js` files of `include`-listed
libs

Fixes #15635

This is an alternative to #15738