### PR TITLE
Fixed scrollbar not visible initially (only after manual scroll)

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -15,6 +15,7 @@ interface Props {
   scrollTop?: number;
   setScrollTop: (event: any) => void;
   autoHeightMin?: number | string;
+  updateAfterMountMs?: number;
 }
 
 /**
@@ -48,6 +49,20 @@ export class CustomScrollbar extends Component<Props> {
 
   componentDidMount() {
     this.updateScroll();
+
+    // this logic is to make scrollbar visible when content is added body after mount
+    if (this.props.updateAfterMountMs) {
+      setTimeout(() => this.updateAfterMount(), this.props.updateAfterMountMs);
+    }
+  }
+
+  updateAfterMount() {
+    if (this.ref && this.ref.current) {
+      const scrollbar = this.ref.current as any;
+      if (scrollbar.update) {
+        scrollbar.update();
+      }
+    }
   }
 
   componentDidUpdate() {

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -272,6 +272,7 @@ export class DashboardPage extends PureComponent<Props, State> {
             autoHeightMin={'100%'}
             setScrollTop={this.setScrollTop}
             scrollTop={scrollTop}
+            updateAfterMountMs={500}
             className="custom-scrollbar--page"
           >
             {editview && <DashboardSettings dashboard={dashboard} />}

--- a/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
+++ b/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
       hideTracksWhenNotNeeded={false}
       scrollTop={0}
       setScrollTop={[Function]}
+      updateAfterMountMs={500}
     >
       <div
         className="dashboard-container"
@@ -349,6 +350,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
       hideTracksWhenNotNeeded={false}
       scrollTop={0}
       setScrollTop={[Function]}
+      updateAfterMountMs={500}
     >
       <DashboardSettings
         dashboard={

--- a/public/app/features/dashboard/panel_editor/EditorTabBody.tsx
+++ b/public/app/features/dashboard/panel_editor/EditorTabBody.tsx
@@ -118,7 +118,7 @@ export class EditorTabBody extends PureComponent<Props, State> {
           {toolbarItems.map(item => this.renderButton(item))}
         </div>
         <div className="panel-editor__scroll">
-          <CustomScrollbar autoHide={false} scrollTop={scrollTop} setScrollTop={setScrollTop}>
+          <CustomScrollbar autoHide={false} scrollTop={scrollTop} setScrollTop={setScrollTop} updateAfterMountMs={300}>
             <div className="panel-editor__content">
               <FadeIn in={isOpen} duration={200} unmountOnExit={true}>
                 {openView && this.renderOpenView(openView)}


### PR DESCRIPTION
If OS does not support native overlay scrollbar the custom scrollbar did not show even though auto hide 
was turned off. Due to the content being added after initial mount in angular compile that sidestep react. 

Added a delayed update 

Fixes #15711

