### PR TITLE
Proposal for fixing back navigation from running playlist

### DIFF
--- a/public/app/core/actions/location.ts
+++ b/public/app/core/actions/location.ts
@@ -1,4 +1,5 @@
 import { LocationUpdate } from 'app/types';
+import { getPlaylistSrv } from 'app/features/playlist/playlist_srv';
 
 export enum CoreActionTypes {
   UpdateLocation = 'UPDATE_LOCATION',
@@ -11,7 +12,15 @@ export interface UpdateLocationAction {
   payload: LocationUpdate;
 }
 
-export const updateLocation = (location: LocationUpdate): UpdateLocationAction => ({
-  type: CoreActionTypes.UpdateLocation,
-  payload: location,
-});
+export const updateLocation = (location: LocationUpdate) => (dispatch, getState) => {
+  const playlistSrv = getPlaylistSrv();
+
+  if (playlistSrv && playlistSrv.isPlaying) {
+    playlistSrv.handleLocationUpdate(getState().location, location);
+  }
+
+  dispatch({
+    type: CoreActionTypes.UpdateLocation,
+    payload: location,
+  });
+};

--- a/public/app/core/reducers/location.ts
+++ b/public/app/core/reducers/location.ts
@@ -30,6 +30,7 @@ export const locationReducer = (state = initialState, action: Action): LocationS
         routeParams: routeParams || state.routeParams,
         replace: replace === true,
         lastUpdated: new Date().getTime(),
+        state: action.payload.state,
       };
     }
   }

--- a/public/app/core/services/bridge_srv.ts
+++ b/public/app/core/services/bridge_srv.ts
@@ -23,6 +23,7 @@ export class BridgeSrv {
             path: this.$location.path(),
             query: this.$location.search(),
             routeParams: this.$route.current.params,
+            state: this.$location.state(),
           })
         );
       }
@@ -34,6 +35,7 @@ export class BridgeSrv {
           path: this.$location.path(),
           query: this.$location.search(),
           routeParams: this.$route.current.params,
+          state: this.$location.state(),
         })
       );
     });

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -157,7 +157,17 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
     // add missing orgId query param
     const storeState = getState();
     if (!storeState.location.query.orgId) {
-      dispatch(updateLocation({ query: { orgId: storeState.user.orgId }, partial: true, replace: true }));
+      dispatch(
+        updateLocation({
+          query: { orgId: storeState.user.orgId },
+          partial: true,
+          replace: true,
+          // Persisting location state, as dashboard might be running in playlist.
+          // Without this, state will be cleared when initialising dashboard within playlist
+          // making it impossible to stop on navigation out from playlist
+          state: storeState.location.state,
+        })
+      );
     }
 
     // init services

--- a/public/app/features/playlist/playlist_srv.ts
+++ b/public/app/features/playlist/playlist_srv.ts
@@ -7,6 +7,7 @@ import coreModule from '../../core/core_module';
 import appEvents from 'app/core/app_events';
 import locationUtil from 'app/core/utils/location_util';
 import kbn from 'app/core/utils/kbn';
+import { LocationUpdate } from 'app/types';
 
 export class PlaylistSrv {
   private cancelPromise: any;
@@ -45,6 +46,7 @@ export class PlaylistSrv {
     this.$timeout(() => {
       const stripedUrl = locationUtil.stripBaseFromUrl(dash.url);
       this.$location.url(stripedUrl + '?' + toUrlParams(filteredParams));
+      this.$location.state({ playlistRunning: true });
       this.$location.replace();
     });
 
@@ -92,6 +94,27 @@ export class PlaylistSrv {
 
     appEvents.emit('playlist-stopped');
   }
+
+  handleLocationUpdate = (location: LocationUpdate, nextLocation: LocationUpdate) => {
+    // Stop playlist when navigating from playlist to anywhere else
+    if (
+      location.state &&
+      location.state.playlistRunning &&
+      (nextLocation.state === null || (nextLocation.state && !nextLocation.state.playlistRunning))
+    ) {
+      this.stop();
+    }
+  };
+}
+
+let singleton;
+
+export function setPlaylistSrv(srv: PlaylistSrv) {
+  singleton = srv;
+}
+
+export function getPlaylistSrv(): PlaylistSrv {
+  return singleton;
 }
 
 coreModule.service('playlistSrv', PlaylistSrv);

--- a/public/app/features/playlist/playlist_srv.ts
+++ b/public/app/features/playlist/playlist_srv.ts
@@ -45,6 +45,7 @@ export class PlaylistSrv {
     this.$timeout(() => {
       const stripedUrl = locationUtil.stripBaseFromUrl(dash.url);
       this.$location.url(stripedUrl + '?' + toUrlParams(filteredParams));
+      this.$location.replace();
     });
 
     this.index++;

--- a/public/app/features/playlist/playlists_ctrl.ts
+++ b/public/app/features/playlist/playlists_ctrl.ts
@@ -6,7 +6,11 @@ export class PlaylistsCtrl {
   navModel: any;
 
   /** @ngInject */
-  constructor(private $scope, private backendSrv, navModelSrv) {
+  constructor(private $scope, private backendSrv, navModelSrv, playlistSrv) {
+    if (playlistSrv.isPlaying) {
+      playlistSrv.stop();
+    }
+
     this.navModel = navModelSrv.getNav('dashboards', 'playlists', 0);
 
     backendSrv.get('/api/playlists').then(result => {

--- a/public/app/features/playlist/playlists_ctrl.ts
+++ b/public/app/features/playlist/playlists_ctrl.ts
@@ -6,11 +6,7 @@ export class PlaylistsCtrl {
   navModel: any;
 
   /** @ngInject */
-  constructor(private $scope, private backendSrv, navModelSrv, playlistSrv) {
-    if (playlistSrv.isPlaying) {
-      playlistSrv.stop();
-    }
-
+  constructor(private $scope, private backendSrv, navModelSrv) {
     this.navModel = navModelSrv.getNav('dashboards', 'playlists', 0);
 
     backendSrv.get('/api/playlists').then(result => {

--- a/public/app/features/playlist/specs/playlist_srv.test.ts
+++ b/public/app/features/playlist/specs/playlist_srv.test.ts
@@ -96,4 +96,29 @@ describe('PlaylistSrv', () => {
     expect(hrefMock).toHaveBeenCalledTimes(3);
     expect(hrefMock).toHaveBeenLastCalledWith(initialUrl);
   });
+
+  it('should stop playlist when navigating out of it', async () => {
+    await srv.start(1);
+    expect(srv.isPlaying).toBeTruthy();
+
+    srv.handleLocationUpdate(
+      {
+        state: { playlistRunning: true },
+      },
+      { state: {} }
+    );
+
+    expect(srv.isPlaying).toBeFalsy();
+
+    await srv.start(1);
+    expect(srv.isPlaying).toBeTruthy();
+
+    srv.handleLocationUpdate(
+      {
+        state: { playlistRunning: true },
+      },
+      { state: null }
+    );
+    expect(srv.isPlaying).toBeFalsy();
+  });
 });

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -18,6 +18,7 @@ import { configureStore } from 'app/store/configureStore';
 
 // Types
 import { KioskUrlValue } from 'app/types';
+import { PlaylistSrv, setPlaylistSrv } from 'app/features/playlist/playlist_srv';
 
 export class GrafanaCtrl {
   /** @ngInject */
@@ -32,6 +33,7 @@ export class GrafanaCtrl {
     timeSrv: TimeSrv,
     datasourceSrv: DatasourceSrv,
     keybindingSrv: KeybindingSrv,
+    playlistSrv: PlaylistSrv,
     angularLoader: AngularLoader
   ) {
     // make angular loader service available to react components
@@ -40,6 +42,8 @@ export class GrafanaCtrl {
     setDatasourceSrv(datasourceSrv);
     setTimeSrv(timeSrv);
     setKeybindingSrv(keybindingSrv);
+    setKeybindingSrv(keybindingSrv);
+    setPlaylistSrv(playlistSrv);
     configureStore();
 
     $scope.init = () => {

--- a/public/app/types/location.ts
+++ b/public/app/types/location.ts
@@ -7,6 +7,9 @@ export interface LocationUpdate {
    * If true this will replace url state (ie cause no new browser history)
    */
   replace?: boolean;
+  state?: {
+    playlistRunning?: boolean;
+  };
 }
 
 export interface LocationState {
@@ -16,6 +19,9 @@ export interface LocationState {
   routeParams: UrlQueryMap;
   replace: boolean;
   lastUpdated: number;
+  state?: {
+    playlistRunning?: boolean;
+  };
 }
 
 export type UrlQueryValue = string | number | boolean | string[] | number[] | boolean[];


### PR DESCRIPTION
Fixes #15701

@torkelo this is a quick proposal. Not sure if it's the right one- instead of creating new history entries when changing dashboards, the url is being replaced. Also, when going back to playlists list (meaning initialising PlaylistCtrl) I'm stopping the PlaylistSrv if it's playing not to cycle through dashboards anymore.

Not sure if replace vs history push is a huge issue for users. They can always navigate back through dashboards using playlist navigation instead of back button. 

WDYT?