### PR TITLE
Expose onQueryChange to angular plugins

### DIFF
--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -43,6 +43,9 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
           this.props.onQueryChange(target);
           this.props.onExecuteQuery();
         },
+        onQueryChange: () => {
+          this.props.onQueryChange(target);
+        },
         events: exploreEvents,
         panel: { datasource, targets: [target] },
         dashboard: {},


### PR DESCRIPTION
A proposal for https://github.com/grafana/grafana/issues/15718, an issue we run into with explore since the plugin we use does not auto-query 