### PR TITLE
reuse TimeSeries/flot calculations

### DIFF
--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -212,7 +212,8 @@ export default class TimeSeries {
     this.stats = viewModel.stats;
     this.allIsNull = viewModel.allIsNull;
     this.allIsZero = viewModel.allIsZero;
-
+    this.color = viewModel.color;
+    // ignore the .label
     return viewModel.data;
   }
 


### PR DESCRIPTION
There is likely a reason this was not done before, but...  it seems odd to have two copies of some very specific flot point processing.  I noticed this while looking at #15733

This PR uses the utility function in grafana/ui within time_series2 rather than its own (I assume the original) implementation.

Basic testing seems to work, but since this is super widely used, it deserves extra attention :)

