### PR TITLE
add ScopedVars to props.replaceVariables()

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -1,8 +1,9 @@
 import { ComponentClass } from 'react';
 import { TimeSeries, LoadingState, TableData } from './data';
 import { TimeRange } from './time';
+import { ScopedVars } from './datasource';
 
-export type InterpolateFunction = (value: string, format?: string | Function) => string;
+export type InterpolateFunction = (value: string, scopedVars?: ScopedVars, format?: string | Function) => string;
 
 export interface PanelProps<T = any> {
   panelData: PanelData;

--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -27,7 +27,7 @@ describe('PanelChrome', () => {
     expect(out).toBe('hello AAA');
   });
 
-  it('It should prefer the diret variables', () => {
+  it('But it should prefer the local variable value', () => {
     const extra = { aaa: { text: '???', value: 'XXX' } };
     const out = chrome.replaceVariables('hello $aaa and $bbb', extra);
     expect(out).toBe('hello XXX and BBB');

--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -1,0 +1,35 @@
+import { PanelChrome } from './PanelChrome';
+
+jest.mock('sass/_variables.generated.scss', () => ({
+  panelhorizontalpadding: 10,
+  panelVerticalPadding: 10,
+}));
+
+describe('PanelChrome', () => {
+  let chrome: PanelChrome;
+
+  beforeEach(() => {
+    chrome = new PanelChrome({
+      panel: {
+        scopedVars: {
+          aaa: { value: 'AAA', text: 'upperA' },
+          bbb: { value: 'BBB', text: 'upperB' },
+        },
+      },
+      dashboard: {},
+      plugin: {},
+      isFullscreen: false,
+    });
+  });
+
+  it('Should replace a panel variable', () => {
+    const out = chrome.replaceVariables('hello $aaa');
+    expect(out).toBe('hello AAA');
+  });
+
+  it('It should prefer the diret variables', () => {
+    const extra = { aaa: { text: '???', value: 'XXX' } };
+    const out = chrome.replaceVariables('hello $aaa and $bbb', extra);
+    expect(out).toBe('hello XXX and BBB');
+  });
+});

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -19,6 +19,7 @@ import { profiler } from 'app/core/profiler';
 import { DashboardModel, PanelModel } from '../state';
 import { PanelPlugin } from 'app/types';
 import { DataQueryResponse, TimeRange, LoadingState, PanelData, DataQueryError } from '@grafana/ui';
+import { ScopedVars } from '@grafana/ui';
 
 import variables from 'sass/_variables.generated.scss';
 import templateSrv from 'app/features/templating/template_srv';
@@ -85,8 +86,13 @@ export class PanelChrome extends PureComponent<Props, State> {
     });
   };
 
-  replaceVariables = (value: string, format?: string) => {
-    return templateSrv.replace(value, this.props.panel.scopedVars, format);
+  replaceVariables = (value: string, extraVars?: ScopedVars, format?: string) => {
+    let vars = this.props.panel.scopedVars;
+    if (extraVars) {
+      vars = vars ? { ...vars, ...extraVars } : extraVars;
+    }
+    console.log('VARiables', vars);
+    return templateSrv.replace(value, vars, format);
   };
 
   onDataResponse = (dataQueryResponse: DataQueryResponse) => {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -91,7 +91,6 @@ export class PanelChrome extends PureComponent<Props, State> {
     if (extraVars) {
       vars = vars ? { ...vars, ...extraVars } : extraVars;
     }
-    console.log('VARiables', vars);
     return templateSrv.replace(value, vars, format);
   };
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -1,7 +1,7 @@
 import kbn from 'app/core/utils/kbn';
 import _ from 'lodash';
 import { variableRegex } from 'app/features/templating/variable';
-import { TimeRange } from '@grafana/ui/src';
+import { TimeRange, ScopedVars } from '@grafana/ui/src';
 
 function luceneEscape(value) {
   return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');
@@ -220,7 +220,7 @@ export class TemplateSrv {
     return values;
   }
 
-  replace(target, scopedVars?, format?) {
+  replace(target: string, scopedVars?: ScopedVars, format?: string | Function) {
     if (!target) {
       return target;
     }


### PR DESCRIPTION
While working on #15811, I found that we sometimes need to pass in local ScopedVars.  The table view needs to pass in values for each row.  

This exposes lets you pass in scopedVars and merges them with the panel.scopedVars

