### PR TITLE
use explore icon in menu

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -224,7 +224,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       items.push({
         text: 'Explore',
         click: 'ctrl.explore();',
-        icon: 'fa fa-fw fa-rocket',
+        icon: 'gicon gicon-explore',
         shortcut: 'x',
       });
     }


### PR DESCRIPTION
The sidebar got a new icon, but the menu should use the same one:

![image](https://user-images.githubusercontent.com/705951/53861953-9b07bd80-3f9a-11e9-80b5-ccdda32fbfa7.png)
