### PR TITLE
cleanup plugin versions

### DIFF
--- a/public/app/features/plugins/partials/plugin_edit.html
+++ b/public/app/features/plugins/partials/plugin_edit.html
@@ -25,7 +25,7 @@
       </div>
 
       <aside class="page-sidebar">
-        <section class="page-sidebar-section">
+        <section class="page-sidebar-section" ng-if="ctrl.model.info.version">
           <h4>Version</h4>
           <span>{{ctrl.model.info.version}}</span>
           <div ng-show="ctrl.model.hasUpdate">
@@ -54,7 +54,7 @@
             </li>
           </ul>
         </section>
-        <section class="page-sidebar-section">
+        <section class="page-sidebar-section" ng-if="ctrl.model.info.links">
           <h5>Links</h4>
           <ul class="ui-list">
             <li ng-repeat="link in ctrl.model.info.links">

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -16,7 +16,6 @@
     "logos": {
       "small": "img/amazon-web-services.png",
       "large": "img/amazon-web-services.png"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/plugin.json
+++ b/public/app/plugins/datasource/elasticsearch/plugin.json
@@ -14,10 +14,7 @@
       "small": "img/elasticsearch.svg",
       "large": "img/elasticsearch.svg"
     },
-    "links": [
-      {"name": "elastic.co", "url": "https://www.elastic.co/products/elasticsearch"}
-    ],
-    "version": "5.0.0"
+    "links": [{ "name": "elastic.co", "url": "https://www.elastic.co/products/elasticsearch" }]
   },
 
   "alerting": true,

--- a/public/app/plugins/datasource/graphite/plugin.json
+++ b/public/app/plugins/datasource/graphite/plugin.json
@@ -31,7 +31,6 @@
         "name": "Graphite 1.1 Release",
         "url": "https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/"
       }
-    ],
-    "version": "5.0.0"
+    ]
   }
 }

--- a/public/app/plugins/datasource/influxdb/plugin.json
+++ b/public/app/plugins/datasource/influxdb/plugin.json
@@ -22,7 +22,6 @@
     "logos": {
       "small": "img/influxdb_logo.svg",
       "large": "img/influxdb_logo.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/datasource/mysql/plugin.json
+++ b/public/app/plugins/datasource/mysql/plugin.json
@@ -12,8 +12,7 @@
     "logos": {
       "small": "img/mysql_logo.svg",
       "large": "img/mysql_logo.svg"
-    },
-    "version": "5.0.0"
+    }
   },
 
   "alerting": true,

--- a/public/app/plugins/datasource/opentsdb/plugin.json
+++ b/public/app/plugins/datasource/opentsdb/plugin.json
@@ -18,7 +18,6 @@
     "logos": {
       "small": "img/opentsdb_logo.png",
       "large": "img/opentsdb_logo.png"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/datasource/postgres/plugin.json
+++ b/public/app/plugins/datasource/postgres/plugin.json
@@ -12,8 +12,7 @@
     "logos": {
       "small": "img/postgresql_logo.svg",
       "large": "img/postgresql_logo.svg"
-    },
-    "version": "5.0.0"
+    }
   },
 
   "alerting": true,

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -42,7 +42,6 @@
         "name": "Prometheus",
         "url": "https://prometheus.io/"
       }
-    ],
-    "version": "5.0.0"
+    ]
   }
 }

--- a/public/app/plugins/panel/alertlist/plugin.json
+++ b/public/app/plugins/panel/alertlist/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-singlestat-panel.svg",
       "large": "img/icn-singlestat-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/dashlist/plugin.json
+++ b/public/app/plugins/panel/dashlist/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/graph/plugin.json
+++ b/public/app/plugins/panel/graph/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-graph-panel.svg",
       "large": "img/icn-graph-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -18,7 +18,6 @@
     "links": [
       { "name": "Brendan Gregg - Heatmaps", "url": "http://www.brendangregg.com/heatmaps.html" },
       { "name": "Brendan Gregg - Latency Heatmaps", "url": " http://www.brendangregg.com/HeatMaps/latency.html" }
-    ],
-    "version": "5.0.0"
+    ]
   }
 }

--- a/public/app/plugins/panel/pluginlist/plugin.json
+++ b/public/app/plugins/panel/pluginlist/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-dashlist-panel.svg",
       "large": "img/icn-dashlist-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/singlestat/plugin.json
+++ b/public/app/plugins/panel/singlestat/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-singlestat-panel.svg",
       "large": "img/icn-singlestat-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -14,7 +14,6 @@
     "logos": {
       "small": "img/icn-table-panel.svg",
       "large": "img/icn-table-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -13,7 +13,6 @@
     "logos": {
       "small": "img/icn-text-panel.svg",
       "large": "img/icn-text-panel.svg"
-    },
-    "version": "5.0.0"
+    }
   }
 }


### PR DESCRIPTION
Removes version 5.0.0 from many of the plugins.  Since they are builtin, I don't think we need an explicit version.

This also cleans up the display so it does not show headings where there are no values.

![image](https://user-images.githubusercontent.com/705951/53864384-2f751e80-3fa1-11e9-8269-90fa565a05a6.png)

vs:

![image](https://user-images.githubusercontent.com/705951/53864430-4ca9ed00-3fa1-11e9-84d0-5e6d134d7088.png)
