### PR TITLE
Fix new datasource search input

### DIFF
--- a/public/app/features/datasources/NewDataSourcePage.tsx
+++ b/public/app/features/datasources/NewDataSourcePage.tsx
@@ -70,6 +70,7 @@ function mapStateToProps(state: StoreState) {
   return {
     navModel: getNavModel(state.navIndex, 'datasources'),
     dataSourceTypes: getDataSourceTypes(state.dataSources),
+    dataSourceTypeSearchQuery: state.dataSources.dataSourceTypeSearchQuery,
     isLoading: state.dataSources.isLoadingDataSources,
   };
 }


### PR DESCRIPTION
This fixes issue that search results were persisted between page navigation while value of the search input was not, resulting in confusing behaviour.

![add_data_source_bug](https://user-images.githubusercontent.com/1014802/53915469-40389980-4060-11e9-8367-700b26183de0.gif)

I did not add any test for this as ideally this should be caught by TS type checker and so not sure if it is a good candidate for unit test. The issue though is that routes are done in Angular calling React dynamically without type checks (I assume) so if anybody thinks this should have a test let me know.

Also did not find an open bug for this (though could have missed it) so I am not sure if I should open one for tracking purposes or not.
