### PR TITLE
return the same panelData unless it changes

### DIFF
--- a/public/app/features/dashboard/dashgrid/DataPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DataPanel.tsx
@@ -44,6 +44,7 @@ export interface State {
   isFirstLoad: boolean;
   loading: LoadingState;
   response: DataQueryResponse;
+  panelData: PanelData;
 }
 
 export class DataPanel extends Component<Props, State> {
@@ -63,6 +64,7 @@ export class DataPanel extends Component<Props, State> {
       response: {
         data: [],
       },
+      panelData: {},
       isFirstLoad: true,
     };
   }
@@ -147,6 +149,7 @@ export class DataPanel extends Component<Props, State> {
       this.setState({
         loading: LoadingState.Done,
         response: resp,
+        panelData: this.getPanelData(resp),
         isFirstLoad: false,
       });
     } catch (err) {
@@ -169,9 +172,7 @@ export class DataPanel extends Component<Props, State> {
     }
   };
 
-  getPanelData = () => {
-    const { response } = this.state;
-
+  getPanelData(response: DataQueryResponse) {
     if (response.data.length > 0 && (response.data[0] as TableData).type === 'table') {
       return {
         tableData: response.data[0] as TableData,
@@ -183,12 +184,11 @@ export class DataPanel extends Component<Props, State> {
       timeSeries: response.data as TimeSeries[],
       tableData: null,
     };
-  };
+  }
 
   render() {
     const { queries } = this.props;
-    const { loading, isFirstLoad } = this.state;
-    const panelData = this.getPanelData();
+    const { loading, isFirstLoad, panelData } = this.state;
 
     // do not render component until we have first data
     if (isFirstLoad && (loading === LoadingState.Loading || loading === LoadingState.NotStarted)) {


### PR DESCRIPTION
fixes #15840

This will process the data 1x for each refresh rather than 3x 😄 It may not be a big deal for this one, but I expect these first react panels will be copied so we should aim for best practice!

I don't know the best style for the GaugePanel changes.  This adds state, but keeps it a PureComponent.  I *think* it could do the same implementing `getDerivedStateFromProps ` but I'm not sure that is a good idea