### PR TITLE
Update core:start cli command to watch theme changes again

### DIFF
--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -16,7 +16,7 @@ program
   .description('Starts Grafana front-end in development mode with watch enabled')
   .action(async cmd => {
     await execTask(startTask)({
-      watchThemes: cmd.theme,
+      watchThemes: cmd.watchTheme,
       hot: cmd.hot,
     });
   });


### PR DESCRIPTION
Fixes changes introduced in 73ef864979b4ab21b81c587154bfd5961ade734b. 

Themes were not watched since `--theme` option of `core:start` task was replaced with `--watchTheme`, but old option was passed to the task.