### PR TITLE
docs: Fix indentation level for OAuth2 config

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -217,10 +217,10 @@ Some OAuth2 providers might not support `client_id` and `client_secret` passed v
 results in `invalid_client` error. To allow Grafana to authenticate via these type of providers, the client identifiers must be
 send via POST body, which can be enabled via the following settings:
 
-    ```bash
-    [auth.generic_oauth]
-    send_client_credentials_via_post = true
-    ```
+```bash
+[auth.generic_oauth]
+send_client_credentials_via_post = true
+```
 
 <hr>
 


### PR DESCRIPTION
Fix the indentation level of config snippet at the end of document - [http://docs.grafana.org/auth/generic-oauth/](http://docs.grafana.org/auth/generic-oauth/)

From,

![pre](https://user-images.githubusercontent.com/5479836/54044138-32b41880-41f4-11e9-8b00-53452ac57754.png)

To,

![post](https://user-images.githubusercontent.com/5479836/54044047-0b5d4b80-41f4-11e9-9d62-84d402b4dc01.png)
