### PR TITLE
Add shortcuts for toggling panel stack attr

### DIFF
--- a/public/app/core/components/help/help.ts
+++ b/public/app/core/components/help/help.ts
@@ -36,6 +36,7 @@ export class HelpCtrl {
         { keys: ['p', 'd'], description: 'Duplicate Panel' },
         { keys: ['p', 'r'], description: 'Remove Panel' },
         { keys: ['p', 'l'], description: 'Toggle panel legend' },
+        { keys: ['p', 'k'], description: 'Toggle stacking' },
       ],
       'Time Range': [
         { keys: ['t', 'z'], description: 'Zoom out time range' },

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -257,6 +257,16 @@ export class KeybindingSrv {
       }
     });
 
+    // toggle panel stack attr
+    this.bind('p k', () => {
+      if (dashboard.meta.focusPanelId) {
+        const panelRef = dashboard.getPanelById(dashboard.meta.focusPanelId);
+        panelRef.stack = !panelRef.stack;
+        panelRef.fill = 10 - panelRef.fill;
+        panelRef.render();
+      }
+    });
+
     // toggle all panel legends
     this.bind('d l', () => {
       dashboard.toggleLegendsForAll();

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -147,6 +147,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   onInitPanelActions(actions) {
     actions.push({ text: 'Export CSV', click: 'ctrl.exportCsv()' });
     actions.push({ text: 'Toggle legend', click: 'ctrl.toggleLegend()', shortcut: 'p l' });
+    actions.push({ text: 'Toggle stacking', click: 'ctrl.toggleStacking()', shortcut: 'p k' });
   }
 
   issueQueries(datasource) {
@@ -281,6 +282,12 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   toggleLegend() {
     this.panel.legend.show = !this.panel.legend.show;
+    this.render();
+  }
+
+  toggleStacking() {
+    this.panel.stack = !this.panel.stack;
+    this.panel.fill = 10 - this.panel.fill;
     this.render();
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds both a menu item and keyboard shortcut for toggling the stack
attribute on the focused panel. We need it for the types of graphs we analyze. Often we find ourselves needing to compare the stacked and unstacked graph to identify issues.

I used "Toggle legend" as a guide. The shortcut is 'p k', although I personally would prefer just 'k'. This felt more inline with how the other panel specific shortcuts work.

In addition to toggling the stack attr on the panel, it also changes the fill, since most line graphs have low or 0 fill, I decided that a good heuristic would be to "flip" the fill by setting it to 10-fill. I'm open to suggestions or advice though. I'm sure it could be more complicated, but I wanted to keep this initial commit simple.

**Which issue(s) this PR fixes**:
Fixes #10714

**Special notes for your reviewer**:

**Release note**:
```release-note
Added stack/unstack toggle to panel menu and keyboard shortcuts
```