### PR TITLE
Loki: Search is now case insensitive

### DIFF
--- a/public/app/core/utils/text.test.ts
+++ b/public/app/core/utils/text.test.ts
@@ -1,4 +1,4 @@
-import { findMatchesInText } from './text';
+import { findMatchesInText, parseFlags } from './text';
 
 describe('findMatchesInText()', () => {
   it('gets no matches for when search and or line are empty', () => {
@@ -31,5 +31,38 @@ describe('findMatchesInText()', () => {
     ]);
     expect(findMatchesInText('foo foo bar', '(')).toEqual([]);
     expect(findMatchesInText('foo foo bar', '(foo|')).toEqual([]);
+  });
+
+  test('should parse and use flags', () => {
+    expect(findMatchesInText(' foo FOO bar ', '(?i)foo')).toEqual([
+      { length: 3, start: 1, text: 'foo', end: 4 },
+      { length: 3, start: 5, text: 'FOO', end: 8 },
+    ]);
+    expect(findMatchesInText(' foo FOO bar ', '(?i)(?-i)foo')).toEqual([{ length: 3, start: 1, text: 'foo', end: 4 }]);
+    expect(findMatchesInText('FOO\nfoobar\nbar', '(?ims)^foo.')).toEqual([
+      { length: 4, start: 0, text: 'FOO\n', end: 4 },
+      { length: 4, start: 4, text: 'foob', end: 8 },
+    ]);
+    expect(findMatchesInText('FOO\nfoobar\nbar', '(?ims)(?-smi)^foo.')).toEqual([]);
+  });
+});
+
+describe('parseFlags()', () => {
+  it('when no flags or text', () => {
+    expect(parseFlags('')).toEqual({ cleaned: '', flags: 'g' });
+    expect(parseFlags('(?is)')).toEqual({ cleaned: '', flags: 'gis' });
+    expect(parseFlags('foo')).toEqual({ cleaned: 'foo', flags: 'g' });
+  });
+
+  it('when flags present', () => {
+    expect(parseFlags('(?i)foo')).toEqual({ cleaned: 'foo', flags: 'gi' });
+    expect(parseFlags('(?ims)foo')).toEqual({ cleaned: 'foo', flags: 'gims' });
+  });
+
+  it('when flags cancel each other', () => {
+    expect(parseFlags('(?i)(?-i)foo')).toEqual({ cleaned: 'foo', flags: 'g' });
+    expect(parseFlags('(?i-i)foo')).toEqual({ cleaned: 'foo', flags: 'g' });
+    expect(parseFlags('(?is)(?-ims)foo')).toEqual({ cleaned: 'foo', flags: 'g' });
+    expect(parseFlags('(?i)(?-i)(?i)foo')).toEqual({ cleaned: 'foo', flags: 'gi' });
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -11,7 +11,7 @@ describe('parseQuery', () => {
   it('returns regexp for strings without query', () => {
     expect(parseQuery('test')).toEqual({
       query: '',
-      regexp: 'test',
+      regexp: '(?i)test',
     });
   });
 
@@ -25,14 +25,14 @@ describe('parseQuery', () => {
   it('returns query for strings with query and search string', () => {
     expect(parseQuery('x {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: 'x',
+      regexp: '(?i)x',
     });
   });
 
   it('returns query for strings with query and regexp', () => {
     expect(parseQuery('{foo="bar"} x|y')).toEqual({
       query: '{foo="bar"}',
-      regexp: 'x|y',
+      regexp: '(?i)x|y',
     });
   });
 
@@ -46,11 +46,11 @@ describe('parseQuery', () => {
   it('returns query and regexp with quantifiers', () => {
     expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '\\.java:[0-9]{1,5}',
+      regexp: '(?i)\\.java:[0-9]{1,5}',
     });
     expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '\\.java:[0-9]{1,5}',
+      regexp: '(?i)\\.java:[0-9]{1,5}',
     });
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,4 +1,5 @@
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
+const caseInsensitive = '(?i)';
 export function parseQuery(input: string) {
   input = input || '';
   const match = input.match(selectorRegexp);
@@ -10,6 +11,9 @@ export function parseQuery(input: string) {
     regexp = input.replace(selectorRegexp, '').trim();
   }
 
+  if (regexp) {
+    regexp = caseInsensitive + regexp;
+  }
   return { query, regexp };
 }
 

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,5 +1,5 @@
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
-const caseInsensitive = '(?i)';
+const caseInsensitive = '(?i)'; // Golang mode modifier for Loki, doesn't work in JavaScript
 export function parseQuery(input: string) {
   input = input || '';
   const match = input.match(selectorRegexp);


### PR DESCRIPTION
**What this PR does / why we need it**:
See #15929

**Which issue(s) this PR fixes**:
Fixes #15929

**Special notes for your reviewer**:
- Users can still disable case insensitive search by adding `(?-i)foo`
- In the future, it might be useful to expose this option via a UI toggle. Even then though, this PR is useful since the default should still be case insensitive.

**Release note**:
```release-note
Loki now searches logs case insensitive by default
```
