### PR TITLE
Moved delete button in Dashboard settings

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/template.html
+++ b/public/app/features/dashboard/components/DashboardSettings/template.html
@@ -16,9 +16,6 @@
 		<button class="btn btn-inverse" ng-click="ctrl.openSaveAsModal()" ng-show="ctrl.canSaveAs">
 			Save As...
 		</button>
-		<button class="btn btn-danger" ng-click="ctrl.deleteDashboard()" ng-show="ctrl.canDelete">
-			Delete
-		</button>
 	</div>
 </aside>
 
@@ -70,6 +67,11 @@
 			<select ng-model="ctrl.dashboard.graphTooltip" class='gf-form-input' ng-options="f.value as f.text for f in [{value: 0, text: 'Default'}, {value: 1, text: 'Shared crosshair'},{value: 2, text: 'Shared Tooltip'}]"></select>
 		</div>
 	</div>
+	<div class="gf-form-button-row">
+	  <button class="btn btn-danger" ng-click="ctrl.deleteDashboard()" ng-show="ctrl.canDelete">
+		  Delete Dashboard
+	  </button>
+  </div>
 </div>
 
 <div class="dashboard-settings__content" ng-if="ctrl.viewId === 'annotations'" ng-include="'public/app/features/annotations/partials/editor.html'">


### PR DESCRIPTION
Moved delete button from sidebar to general tab in Dashboard settings and renamed it.

<img width="1381" alt="Screenshot 2019-03-13 at 10 33 19" src="https://user-images.githubusercontent.com/23470681/54268510-a1d69780-457b-11e9-8fcb-4414e082290d.png">

fixes #15965
