### PR TITLE
Improved error handling when rendering dashboard panels

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -163,12 +163,18 @@ export class DashboardPage extends PureComponent<Props, State> {
         fullscreenPanel: null,
         scrollTop: this.state.rememberScrollTop,
       },
-      () => {
-        dashboard.render();
-      }
+      this.triggerPanelsRendering.bind(this)
     );
 
     this.setPanelFullscreenClass(false);
+  }
+
+  triggerPanelsRendering() {
+    try {
+      this.props.dashboard.render();
+    } catch (err) {
+      this.props.notifyApp(createErrorNotification(`Panel rendering error`, err));
+    }
   }
 
   handleFullscreenPanelNotFound(urlPanelId: string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some panels throw exceptions directly in the sync render path. Which caused main react page to unmount. 

**Which issue(s) this PR fixes**:
Fixes #15913


