### PR TITLE
Fixed issue with AlertList panel links resulting in panel not found errors

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -92,11 +92,12 @@ export class DashboardPage extends PureComponent<Props, State> {
   componentWillUnmount() {
     if (this.props.dashboard) {
       this.props.cleanUpDashboard();
+      this.setPanelFullscreenClass(false);
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { dashboard, editview, urlEdit, urlFullscreen, urlPanelId } = this.props;
+    const { dashboard, editview, urlEdit, urlFullscreen, urlPanelId, urlUid } = this.props;
 
     if (!dashboard) {
       return;
@@ -105,6 +106,12 @@ export class DashboardPage extends PureComponent<Props, State> {
     // if we just got dashboard update title
     if (!prevProps.dashboard) {
       document.title = dashboard.title + ' - Grafana';
+    }
+
+    // Due to the angular -> react url bridge we can ge an update here with new uid before the container unmounts
+    // Can remove this condition after we switch to react router
+    if (prevProps.urlUid !== urlUid) {
+      return;
     }
 
     // handle animation states when opening dashboard settings


### PR DESCRIPTION
**What this PR does / why we need it**:
Angular route changes -> updates redux store before container unmounts so the current dashboard tried to open the alert and could not find the panel. 

**Which issue(s) this PR fixes**:
 Fixes #15680

