### PR TITLE
Templating: Custom variable value now escapes all backslashes properly

### DIFF
--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -40,7 +40,7 @@ export class CustomVariable implements Variable {
   updateOptions() {
     // extract options in comma separated string (use backslash to escape wanted commas)
     this.options = _.map(this.query.match(/(?:\\,|[^,])+/g), text => {
-      text = text.replace('\\,', ',');
+      text = text.replace(/\\,/g, ',');
       return { text: text.trim(), value: text.trim() };
     });
 


### PR DESCRIPTION
Closes #15921  

Using regex  /\\,/g for repacing comma