### PR TITLE
ManageDashboards: Fix for checkboxes not appearing properly Firefox 

### DIFF
--- a/public/sass/components/_switch.scss
+++ b/public/sass/components/_switch.scss
@@ -94,6 +94,7 @@ input:checked + .gf-form-switch__slider::before {
     opacity: 0;
     width: 0;
     height: 0;
+    appearance: none;
   }
 
   &--transparent {


### PR DESCRIPTION
fixed #15854 , 
Checkbox width and height as 0px is not being respected in firefox.
Added appearance:none property to fix it