### PR TITLE
Explore: Hide empty duplicates column in logs viewer

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -64,7 +64,7 @@ interface Props {
 interface State {
   deferLogs: boolean;
   renderAll: boolean;
-  showLabels: boolean | null; // Tristate: null means auto
+  showLabels: boolean;
   showLocalTime: boolean;
   showUtc: boolean;
 }
@@ -76,7 +76,7 @@ export default class Logs extends PureComponent<Props, State> {
   state = {
     deferLogs: true,
     renderAll: false,
-    showLabels: null,
+    showLabels: false,
     showLocalTime: true,
     showUtc: false,
   };
@@ -166,12 +166,11 @@ export default class Logs extends PureComponent<Props, State> {
       return null;
     }
 
-    const { deferLogs, renderAll, showLocalTime, showUtc } = this.state;
-    let { showLabels } = this.state;
+    const { deferLogs, renderAll, showLabels, showLocalTime, showUtc } = this.state;
     const { dedupStrategy } = this.props;
     const hasData = data && data.rows && data.rows.length > 0;
-    const showDuplicates = dedupStrategy !== LogsDedupStrategy.none;
     const dedupCount = dedupedData.rows.reduce((sum, row) => sum + row.duplicates, 0);
+    const showDuplicates = dedupStrategy !== LogsDedupStrategy.none && dedupCount > 0;
     const meta = [...data.meta];
 
     if (dedupStrategy !== LogsDedupStrategy.none) {
@@ -186,16 +185,6 @@ export default class Logs extends PureComponent<Props, State> {
     const processedRows = dedupedData.rows;
     const firstRows = processedRows.slice(0, PREVIEW_LIMIT);
     const lastRows = processedRows.slice(PREVIEW_LIMIT);
-
-    // Check for labels
-    if (showLabels === null) {
-      if (hasData) {
-        showLabels = data.rows.some(row => _.size(row.uniqueLabels) > 0);
-      } else {
-        showLabels = true;
-      }
-    }
-
     const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
 
     // React profiler becomes unusable if we pass all rows to all rows and their labels, using getter instead

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -173,7 +173,7 @@ $column-horizontal-spacing: 10px;
 
 .logs-row__duplicates {
   text-align: right;
-  width: 4.5em;
+  width: 4em;
 }
 
 .logs-row__field-highlight {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Hides the duplicates column when empty (dedup count == 0)
- Shortens column width slightly
- Hides labels column by default per https://github.com/grafana/grafana/issues/15073#issuecomment-458101289

**Which issue(s) this PR fixes**:
Fixes #15915

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
