### PR TITLE
docs: Change type of 'tags' in annotationQuery result example to list

### DIFF
--- a/docs/sources/plugins/developing/datasources.md
+++ b/docs/sources/plugins/developing/datasources.md
@@ -163,7 +163,7 @@ Expected result from datasource.annotationQuery:
     "title": "Cluster outage",
     "time": 1457075272576,
     "text": "Joe causes brain split",
-    "tags": "joe, cluster, failure"
+    "tags": ["joe", "cluster", "failure"]
   }
 ]
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the documentation for datasource plugin authors.
 
A datasource plugin must return a list of tags in the 'tags' field of the annotationQuery result (and not a string). Returning a string 'test' would otherwise result in 4 tags in Grafana: 't','e','s','t'.

See for example: https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/testdata/datasource.ts#L83
