### PR TITLE
Explore: Query row using character refId instead of number

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -226,7 +226,7 @@ export function generateKey(index = 0): string {
   return `Q-${Date.now()}-${Math.random()}-${index}`;
 }
 
-export function generateEmptyQuery(queries: DataQuery[], index = 0): { refId: string; key: string } {
+export function generateEmptyQuery(queries: DataQuery[], index = 0): DataQuery {
   return { refId: getNextRefIdLetter(queries), key: generateKey(index) };
 }
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -23,6 +23,7 @@ import {
   ResultGetter,
 } from 'app/types/explore';
 import { LogsDedupStrategy } from 'app/core/logs_model';
+import { getNextQueryLetter } from './query';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',
@@ -225,12 +226,8 @@ export function generateKey(index = 0): string {
   return `Q-${Date.now()}-${Math.random()}-${index}`;
 }
 
-export function generateRefId(index = 0): string {
-  return `${index + 1}`;
-}
-
-export function generateEmptyQuery(index = 0): { refId: string; key: string } {
-  return { refId: generateRefId(index), key: generateKey(index) };
+export function generateEmptyQuery(queries: DataQuery[], index = 0): { refId: string; key: string } {
+  return { refId: getNextQueryLetter(queries), key: generateKey(index) };
 }
 
 /**
@@ -238,9 +235,9 @@ export function generateEmptyQuery(index = 0): { refId: string; key: string } {
  */
 export function ensureQueries(queries?: DataQuery[]): DataQuery[] {
   if (queries && typeof queries === 'object' && queries.length > 0) {
-    return queries.map((query, i) => ({ ...query, ...generateEmptyQuery(i) }));
+    return queries.map((query, i) => ({ ...query, ...generateEmptyQuery(queries, i) }));
   }
-  return [{ ...generateEmptyQuery() }];
+  return [{ ...generateEmptyQuery(queries) }];
 }
 
 /**

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -23,7 +23,7 @@ import {
   ResultGetter,
 } from 'app/types/explore';
 import { LogsDedupStrategy } from 'app/core/logs_model';
-import { getNextQueryLetter } from './query';
+import { getNextRefIdLetter } from './query';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',
@@ -227,7 +227,7 @@ export function generateKey(index = 0): string {
 }
 
 export function generateEmptyQuery(queries: DataQuery[], index = 0): { refId: string; key: string } {
-  return { refId: getNextQueryLetter(queries), key: generateKey(index) };
+  return { refId: getNextRefIdLetter(queries), key: generateKey(index) };
 }
 
 /**

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -9,6 +9,7 @@ import store from 'app/core/store';
 import { parse as parseDate } from 'app/core/utils/datemath';
 import { colors } from '@grafana/ui';
 import TableModel, { mergeTablesIntoModel } from 'app/core/table_model';
+import { getNextRefIdChar } from './query';
 
 // Types
 import { RawTimeRange, IntervalValues, DataQuery, DataSourceApi } from '@grafana/ui';
@@ -23,7 +24,6 @@ import {
   ResultGetter,
 } from 'app/types/explore';
 import { LogsDedupStrategy } from 'app/core/logs_model';
-import { getNextRefIdChar } from './query';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -23,7 +23,7 @@ import {
   ResultGetter,
 } from 'app/types/explore';
 import { LogsDedupStrategy } from 'app/core/logs_model';
-import { getNextRefIdLetter } from './query';
+import { getNextRefIdChar } from './query';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',
@@ -227,7 +227,7 @@ export function generateKey(index = 0): string {
 }
 
 export function generateEmptyQuery(queries: DataQuery[], index = 0): DataQuery {
-  return { refId: getNextRefIdLetter(queries), key: generateKey(index) };
+  return { refId: getNextRefIdChar(queries), key: generateKey(index) };
 }
 
 /**

--- a/public/app/core/utils/query.test.ts
+++ b/public/app/core/utils/query.test.ts
@@ -1,0 +1,30 @@
+import { DataQuery } from '@grafana/ui';
+import { getNextRefIdChar } from './query';
+
+const dataQueries: DataQuery[] = [
+  {
+    refId: 'A',
+  },
+  {
+    refId: 'B',
+  },
+  {
+    refId: 'C',
+  },
+  {
+    refId: 'D',
+  },
+  {
+    refId: 'E',
+  },
+];
+
+describe('Get next refId char', () => {
+  it('should return next char', () => {
+    expect(getNextRefIdChar(dataQueries)).toEqual('F');
+  });
+
+  it('should get first char', () => {
+    expect(getNextRefIdChar([])).toEqual('A');
+  });
+});

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { DataQuery } from '@grafana/ui/';
 
-export const getNextRefIdLetter = (queries: DataQuery[]): string => {
+export const getNextRefIdChar = (queries: DataQuery[]): string => {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
   return _.find(letters, refId => {

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import { DataQuery } from '@grafana/ui/';
+
+export const getNextQueryLetter = (queries: DataQuery[]): string => {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  return _.find(letters, refId => {
+    return _.every(queries, other => {
+      return other.refId !== refId;
+    });
+  });
+};

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { DataQuery } from '@grafana/ui/';
 
-export const getNextQueryLetter = (queries: DataQuery[]): string => {
+export const getNextRefIdLetter = (queries: DataQuery[]): string => {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
   return _.find(letters, refId => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { Emitter } from 'app/core/utils/emitter';
 import { DataQuery, TimeSeries, Threshold, ScopedVars, PanelTypeChangedHook } from '@grafana/ui';
 import { TableData } from '@grafana/ui/src';
+import { getNextQueryLetter } from '../../../core/utils/query';
 
 export interface GridPos {
   x: number;
@@ -128,7 +129,7 @@ export class PanelModel {
     if (this.targets) {
       for (const query of this.targets) {
         if (!query.refId) {
-          query.refId = this.getNextQueryLetter();
+          query.refId = getNextQueryLetter(this.targets);
         }
       }
     }
@@ -266,18 +267,8 @@ export class PanelModel {
 
   addQuery(query?: Partial<DataQuery>) {
     query = query || { refId: 'A' };
-    query.refId = this.getNextQueryLetter();
+    query.refId = getNextQueryLetter(this.targets);
     this.targets.push(query as DataQuery);
-  }
-
-  getNextQueryLetter(): string {
-    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-    return _.find(letters, refId => {
-      return _.every(this.targets, other => {
-        return other.refId !== refId;
-      });
-    });
   }
 
   changeQuery(query: DataQuery, index: number) {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -1,11 +1,13 @@
 // Libraries
 import _ from 'lodash';
 
-// Types
+// Utils
 import { Emitter } from 'app/core/utils/emitter';
+import { getNextRefIdLetter } from 'app/core/utils/query';
+
+// Types
 import { DataQuery, TimeSeries, Threshold, ScopedVars, PanelTypeChangedHook } from '@grafana/ui';
 import { TableData } from '@grafana/ui/src';
-import { getNextRefIdLetter } from '../../../core/utils/query';
 
 export interface GridPos {
   x: number;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { Emitter } from 'app/core/utils/emitter';
 import { DataQuery, TimeSeries, Threshold, ScopedVars, PanelTypeChangedHook } from '@grafana/ui';
 import { TableData } from '@grafana/ui/src';
-import { getNextQueryLetter } from '../../../core/utils/query';
+import { getNextRefIdLetter } from '../../../core/utils/query';
 
 export interface GridPos {
   x: number;
@@ -129,7 +129,7 @@ export class PanelModel {
     if (this.targets) {
       for (const query of this.targets) {
         if (!query.refId) {
-          query.refId = getNextQueryLetter(this.targets);
+          query.refId = getNextRefIdLetter(this.targets);
         }
       }
     }
@@ -267,7 +267,7 @@ export class PanelModel {
 
   addQuery(query?: Partial<DataQuery>) {
     query = query || { refId: 'A' };
-    query.refId = getNextQueryLetter(this.targets);
+    query.refId = getNextRefIdLetter(this.targets);
     this.targets.push(query as DataQuery);
   }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 // Utils
 import { Emitter } from 'app/core/utils/emitter';
-import { getNextRefIdLetter } from 'app/core/utils/query';
+import { getNextRefIdChar } from 'app/core/utils/query';
 
 // Types
 import { DataQuery, TimeSeries, Threshold, ScopedVars, PanelTypeChangedHook } from '@grafana/ui';
@@ -131,7 +131,7 @@ export class PanelModel {
     if (this.targets) {
       for (const query of this.targets) {
         if (!query.refId) {
-          query.refId = getNextRefIdLetter(this.targets);
+          query.refId = getNextRefIdChar(this.targets);
         }
       }
     }
@@ -269,7 +269,7 @@ export class PanelModel {
 
   addQuery(query?: Partial<DataQuery>) {
     query = query || { refId: 'A' };
-    query.refId = getNextRefIdLetter(this.targets);
+    query.refId = getNextRefIdChar(this.targets);
     this.targets.push(query as DataQuery);
   }
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -127,7 +127,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       const { query, index } = action.payload;
 
       // Override path: queries are completely reset
-      const nextQuery: DataQuery = { ...query, ...generateEmptyQuery(index) };
+      const nextQuery: DataQuery = { ...query, ...generateEmptyQuery(state.queries) };
       const nextQueries = [...queries];
       nextQueries[index] = nextQuery;
 
@@ -267,7 +267,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         // Modify all queries
         nextQueries = queries.map((query, i) => ({
           ...modifier({ ...query }, modification),
-          ...generateEmptyQuery(i),
+          ...generateEmptyQuery(state.queries),
         }));
         // Discard all ongoing transactions
         nextQueryTransactions = [];
@@ -276,7 +276,9 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         nextQueries = queries.map((query, i) => {
           // Synchronize all queries with local query cache to ensure consistency
           // TODO still needed?
-          return i === index ? { ...modifier({ ...query }, modification), ...generateEmptyQuery(i) } : query;
+          return i === index
+            ? { ...modifier({ ...query }, modification), ...generateEmptyQuery(state.queries) }
+            : query;
         });
         nextQueryTransactions = queryTransactions
           // Consume the hint corresponding to the action


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where query rows had a number as refId instead of a char.
**Which issue(s) this PR fixes**:
Fixes #15573 

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```
