### PR TITLE
Add tooltips to explore table

### DIFF
--- a/public/app/features/explore/Table.tsx
+++ b/public/app/features/explore/Table.tsx
@@ -40,11 +40,15 @@ export default class Table extends PureComponent<TableProps> {
     const tableModel = data || EMPTY_TABLE;
     const columnNames = tableModel.columns.map(({ text }) => text);
     const columns = tableModel.columns.map(({ filterable, text }) => ({
-      Header: text,
+      Header: () => <span title={text}>{text}</span>,
       accessor: text,
       className: VALUE_REGEX.test(text) ? 'text-right' : '',
       show: text !== 'Time',
-      Cell: row => <span className={filterable ? 'link' : ''}>{row.value}</span>,
+      Cell: row => (
+        <span className={filterable ? 'link' : ''} title={text + ': ' + row.value}>
+          {row.value}
+        </span>
+      ),
     }));
     const noDataText = data ? 'The queries returned no data for a table.' : '';
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds tooltips to header and rows in Explore table so that longer labels are viewable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Let me know if you prefer tooltip for rows without the label prefix

**Release note**:
```release-note
Longer labels are now viewable as a tooltip in the Explore table
```
