### PR TITLE
use Partial<TOptions> with new PanelTypeChangedHooks

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -30,10 +30,10 @@ export interface PanelEditorProps<T = any> {
  * Called before a panel is initalized
  */
 export type PanelTypeChangedHook<TOptions = any> = (
-  options: TOptions,
+  options: Partial<TOptions>,
   prevPluginId?: string,
   prevOptions?: any
-) => TOptions;
+) => Partial<TOptions>;
 
 export class ReactPanelPlugin<TOptions = any> {
   panel: ComponentClass<PanelProps<TOptions>>;


### PR DESCRIPTION
Simple issue found with #15925

The new PanelTypeChangedHooks should be able to use Partial... otherwise the compiler complains too much
