### PR TITLE
Panels: fix loading panels with non-array targets

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -3,9 +3,10 @@ import { PanelModel } from './PanelModel';
 describe('PanelModel', () => {
   describe('when creating new panel model', () => {
     let model;
+    let modelJson;
 
     beforeEach(() => {
-      model = new PanelModel({
+      modelJson = {
         type: 'table',
         showColumns: true,
         targets: [{ refId: 'A' }, { noRefId: true }],
@@ -23,7 +24,8 @@ describe('PanelModel', () => {
             },
           ],
         },
-      });
+      };
+      model = new PanelModel(modelJson);
     });
 
     it('should apply defaults', () => {
@@ -36,6 +38,15 @@ describe('PanelModel', () => {
 
     it('should add missing refIds', () => {
       expect(model.targets[1].refId).toBe('B');
+    });
+
+    it("shouldn't break panel with non-array targets", () => {
+      modelJson.targets = {
+        0: { refId: 'A' },
+        foo: { bar: 'baz' },
+      };
+      model = new PanelModel(modelJson);
+      expect(model.targets[0].refId).toBe('A');
     });
 
     it('getSaveModel should remove defaults', () => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -126,7 +126,8 @@ export class PanelModel {
 
   ensureQueryIds() {
     if (this.targets) {
-      for (const query of this.targets) {
+      for (let i = 0; i < this.targets.length; i++) {
+        const query = this.targets[i];
         if (!query.refId) {
           query.refId = this.getNextQueryLetter();
         }

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -125,9 +125,8 @@ export class PanelModel {
   }
 
   ensureQueryIds() {
-    if (this.targets) {
-      for (let i = 0; i < this.targets.length; i++) {
-        const query = this.targets[i];
+    if (this.targets && _.isArray(this.targets)) {
+      for (const query of this.targets) {
         if (!query.refId) {
           query.refId = this.getNextQueryLetter();
         }


### PR DESCRIPTION
This PR fixes #15993
Bug happens when panel has not array-like `targets` object (this may be true for non-metrics panel). Root cause - `ensureQueryIds()` function in `PanelModel` module iterates over targets with `for ... of` loop which can handle any iterable types (objects as well).
https://github.com/grafana/grafana/blob/9e7d1f42753495254c7a9220161b0818decbf58a/public/app/features/dashboard/state/PanelModel.ts#L129
I suggest to use normal `for ...` loop and iterate only over array elements.