### PR TITLE
Only log connection string in dev environment

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -329,7 +329,7 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), Wrap(hs.QueryMetrics))
 		apiRoute.Get("/tsdb/testdata/scenarios", Wrap(GetTestDataScenarios))
 		apiRoute.Get("/tsdb/testdata/gensql", reqGrafanaAdmin, Wrap(GenerateSQLTestData))
-		apiRoute.Get("/tsdb/testdata/random-walk", Wrap(GetTestDataRandomWalk))
+		apiRoute.Get("/tsdb/testdata/random-walk", Wrap(hs.GetTestDataRandomWalk))
 
 		apiRoute.Group("/alerts", func(alertsRoute routing.RouteRegister) {
 			alertsRoute.Post("/test", bind(dtos.AlertTestCommand{}), Wrap(AlertTest))

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -45,7 +45,7 @@ func (hs *HTTPServer) QueryMetrics(c *m.ReqContext, reqDto dtos.MetricRequest) R
 		})
 	}
 
-	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request)
+	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request, hs.Cfg)
 	if err != nil {
 		return Error(500, "Metric request error", err)
 	}
@@ -94,7 +94,7 @@ func GenerateSQLTestData(c *m.ReqContext) Response {
 }
 
 // GET /api/tsdb/testdata/random-walk
-func GetTestDataRandomWalk(c *m.ReqContext) Response {
+func (hs *HTTPServer) GetTestDataRandomWalk(c *m.ReqContext) Response {
 	from := c.Query("from")
 	to := c.Query("to")
 	intervalMs := c.QueryInt64("intervalMs")
@@ -112,7 +112,7 @@ func GetTestDataRandomWalk(c *m.ReqContext) Response {
 		DataSource: dsInfo,
 	})
 
-	resp, err := tsdb.HandleRequest(context.Background(), dsInfo, request)
+	resp, err := tsdb.HandleRequest(context.Background(), dsInfo, request, hs.Cfg)
 	if err != nil {
 		return Error(500, "Metric request error", err)
 	}

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"github.com/grafana/grafana/pkg/setting"
 	"os/exec"
 	"path"
 	"time"
@@ -90,7 +91,7 @@ func (p *DataSourcePlugin) spawnSubProcess() error {
 
 	plugin := raw.(datasource.DatasourcePlugin)
 
-	tsdb.RegisterTsdbQueryEndpoint(p.Id, func(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+	tsdb.RegisterTsdbQueryEndpoint(p.Id, func(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 		return wrapper.NewDatasourcePluginWrapper(p.log, plugin), nil
 	})
 

--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -112,7 +112,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 	req := c.getRequestForAlertRule(getDsInfo.Result, timeRange)
 	result := make(tsdb.TimeSeriesSlice, 0)
 
-	resp, err := c.HandleRequest(context.Ctx, getDsInfo.Result, req)
+	resp, err := c.HandleRequest(context.Ctx, getDsInfo.Result, req, context.Cfg)
 	if err != nil {
 		if err == gocontext.DeadlineExceeded {
 			return nil, fmt.Errorf("Alert execution exceeded the timeout")

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -2,6 +2,7 @@ package conditions
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/setting"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -168,7 +169,7 @@ func (ctx *queryConditionTestContext) exec() (*alerting.ConditionResult, error) 
 
 	ctx.condition = condition
 
-	condition.HandleRequest = func(context context.Context, dsInfo *m.DataSource, req *tsdb.TsdbQuery) (*tsdb.Response, error) {
+	condition.HandleRequest = func(context context.Context, dsInfo *m.DataSource, req *tsdb.TsdbQuery, cfg *setting.Cfg) (*tsdb.Response, error) {
 		return &tsdb.Response{
 			Results: map[string]*tsdb.QueryResult{
 				"A": {Series: ctx.series},

--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -19,6 +19,7 @@ import (
 
 type AlertingService struct {
 	RenderService rendering.Service `inject:""`
+	Cfg           *setting.Cfg      `inject:""`
 
 	execQueue chan *Job
 	//clock         clock.Clock
@@ -166,7 +167,7 @@ func (e *AlertingService) processJob(attemptID int, attemptChan chan int, cancel
 	span := opentracing.StartSpan("alert execution")
 	alertCtx = opentracing.ContextWithSpan(alertCtx, span)
 
-	evalContext := NewEvalContext(alertCtx, job.Rule)
+	evalContext := NewEvalContext(alertCtx, job.Rule, e.Cfg)
 	evalContext.Ctx = alertCtx
 
 	go func() {

--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -31,9 +31,10 @@ type EvalContext struct {
 	PrevAlertState  m.AlertStateType
 
 	Ctx context.Context
+	Cfg *setting.Cfg
 }
 
-func NewEvalContext(alertCtx context.Context, rule *Rule) *EvalContext {
+func NewEvalContext(alertCtx context.Context, rule *Rule, cfg *setting.Cfg) *EvalContext {
 	return &EvalContext{
 		Ctx:            alertCtx,
 		StartTime:      time.Now(),
@@ -42,6 +43,7 @@ func NewEvalContext(alertCtx context.Context, rule *Rule) *EvalContext {
 		EvalMatches:    make([]*EvalMatch, 0),
 		log:            log.New("alerting.evalContext"),
 		PrevAlertState: rule.State,
+		Cfg:            cfg,
 	}
 }
 

--- a/pkg/services/alerting/test_notification.go
+++ b/pkg/services/alerting/test_notification.go
@@ -3,6 +3,7 @@ package alerting
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/null"
@@ -54,7 +55,7 @@ func createTestEvalContext(cmd *NotificationTestCommand) *EvalContext {
 		State:       m.AlertStateAlerting,
 	}
 
-	ctx := NewEvalContext(context.Background(), testRule)
+	ctx := NewEvalContext(context.Background(), testRule, &setting.Cfg{})
 	if cmd.Settings.Get("uploadImage").MustBool(true) {
 		ctx.ImagePublicUrl = "https://grafana.com/assets/img/blog/mixed_styles.png"
 	}

--- a/pkg/services/alerting/test_rule.go
+++ b/pkg/services/alerting/test_rule.go
@@ -3,6 +3,7 @@ package alerting
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -50,7 +51,7 @@ func handleAlertTestCommand(cmd *AlertTestCommand) error {
 func testAlertRule(rule *Rule) *EvalContext {
 	handler := NewEvalHandler()
 
-	context := NewEvalContext(context.Background(), rule)
+	context := NewEvalContext(context.Background(), rule, &setting.Cfg{})
 	context.IsTestRun = true
 
 	handler.Eval(context)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -200,6 +200,8 @@ var (
 type Cfg struct {
 	Raw *ini.File
 
+	Env string
+
 	// HTTP Server Settings
 	AppUrl    string
 	AppSubUrl string
@@ -571,6 +573,8 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	}
 
 	Env = iniFile.Section("").Key("app_mode").MustString("development")
+	cfg.Env = Env
+
 	InstanceName = iniFile.Section("").Key("instance_name").MustString("unknown_instance_name")
 	PluginsPath = makeAbsolute(iniFile.Section("paths").Key("plugins").String(), HomePath)
 	cfg.ProvisioningPath = makeAbsolute(iniFile.Section("paths").Key("provisioning").String(), HomePath)

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -3,6 +3,7 @@ package azuremonitor
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/log"
@@ -21,7 +22,7 @@ type AzureMonitorExecutor struct {
 }
 
 // NewAzureMonitorExecutor initializes a http client
-func NewAzureMonitorExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewAzureMonitorExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -44,7 +44,7 @@ type DatasourceInfo struct {
 	SecretKey string
 }
 
-func NewCloudWatchExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewCloudWatchExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &CloudWatchExecutor{}, nil
 }
 

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -3,6 +3,7 @@ package elasticsearch
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -19,7 +20,7 @@ var (
 )
 
 // NewElasticsearchExecutor creates a new elasticsearch executor
-func NewElasticsearchExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewElasticsearchExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &ElasticsearchExecutor{}, nil
 }
 

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -24,7 +24,7 @@ type GraphiteExecutor struct {
 	HttpClient *http.Client
 }
 
-func NewGraphiteExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewGraphiteExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &GraphiteExecutor{}, nil
 }
 

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -23,7 +23,7 @@ type InfluxDBExecutor struct {
 	//HttpClient     *http.Client
 }
 
-func NewInfluxDBExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewInfluxDBExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &InfluxDBExecutor{
 		QueryParser:    &InfluxdbQueryParser{},
 		ResponseParser: &ResponseParser{},

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"strconv"
 
 	_ "github.com/denisenkom/go-mssqldb"
@@ -17,14 +18,16 @@ func init() {
 	tsdb.RegisterTsdbQueryEndpoint("mssql", newMssqlQueryEndpoint)
 }
 
-func newMssqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newMssqlQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.mssql")
 
 	cnnstr, err := generateConnectionString(datasource)
 	if err != nil {
 		return nil, err
 	}
-	logger.Debug("getEngine", "connection", cnnstr)
+	if cfg.Env == setting.DEV {
+		logger.Debug("getEngine", "connection", cnnstr)
+	}
 
 	config := tsdb.SqlQueryEndpointConfiguration{
 		DriverName:        "mssql",

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"reflect"
 	"strconv"
 	"strings"
@@ -18,7 +19,7 @@ func init() {
 	tsdb.RegisterTsdbQueryEndpoint("mysql", newMysqlQueryEndpoint)
 }
 
-func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newMysqlQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.mysql")
 
 	protocol := "tcp"
@@ -44,7 +45,9 @@ func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 		cnnstr += "&tls=" + tlsConfigString
 	}
 
-	logger.Debug("getEngine", "connection", cnnstr)
+	if cfg.Env == setting.DEV {
+		logger.Debug("getEngine", "connection", cnnstr)
+	}
 
 	config := tsdb.SqlQueryEndpointConfiguration{
 		DriverName:        "mysql",

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -24,7 +24,7 @@ import (
 type OpenTsdbExecutor struct {
 }
 
-func NewOpenTsdbExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewOpenTsdbExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &OpenTsdbExecutor{}, nil
 }
 

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-xorm/core"
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
@@ -15,11 +16,13 @@ func init() {
 	tsdb.RegisterTsdbQueryEndpoint("postgres", newPostgresQueryEndpoint)
 }
 
-func newPostgresQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newPostgresQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.postgres")
 
 	cnnstr := generateConnectionString(datasource)
-	logger.Debug("getEngine", "connection", cnnstr)
+	if cfg.Env == setting.DEV {
+		logger.Debug("getEngine", "connection", cnnstr)
+	}
 
 	config := tsdb.SqlQueryEndpointConfiguration{
 		DriverName:        "postgres",

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"regexp"
 	"strings"
 	"time"
@@ -36,7 +37,7 @@ func (bat basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return bat.Transport.RoundTrip(req)
 }
 
-func NewPrometheusExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewPrometheusExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	transport, err := dsInfo.GetHttpTransport()
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/query_endpoint.go
+++ b/pkg/tsdb/query_endpoint.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/models"
 )
@@ -13,15 +14,15 @@ type TsdbQueryEndpoint interface {
 
 var registry map[string]GetTsdbQueryEndpointFn
 
-type GetTsdbQueryEndpointFn func(dsInfo *models.DataSource) (TsdbQueryEndpoint, error)
+type GetTsdbQueryEndpointFn func(dsInfo *models.DataSource, cfg *setting.Cfg) (TsdbQueryEndpoint, error)
 
 func init() {
 	registry = make(map[string]GetTsdbQueryEndpointFn)
 }
 
-func getTsdbQueryEndpointFor(dsInfo *models.DataSource) (TsdbQueryEndpoint, error) {
+func getTsdbQueryEndpointFor(dsInfo *models.DataSource, cfg *setting.Cfg) (TsdbQueryEndpoint, error) {
 	if fn, exists := registry[dsInfo.Type]; exists {
-		executor, err := fn(dsInfo)
+		executor, err := fn(dsInfo, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/request.go
+++ b/pkg/tsdb/request.go
@@ -2,14 +2,15 @@ package tsdb
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/models"
 )
 
-type HandleRequestFunc func(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error)
+type HandleRequestFunc func(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery, cfg *setting.Cfg) (*Response, error)
 
-func HandleRequest(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error) {
-	endpoint, err := getTsdbQueryEndpointFor(dsInfo)
+func HandleRequest(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery, cfg *setting.Cfg) (*Response, error) {
+	endpoint, err := getTsdbQueryEndpointFor(dsInfo, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -47,7 +47,7 @@ type StackdriverExecutor struct {
 }
 
 // NewStackdriverExecutor initializes a http client
-func NewStackdriverExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewStackdriverExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/testdata/testdata.go
+++ b/pkg/tsdb/testdata/testdata.go
@@ -2,6 +2,7 @@ package testdata
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -13,7 +14,7 @@ type TestDataExecutor struct {
 	log log.Logger
 }
 
-func NewTestDataExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewTestDataExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &TestDataExecutor{
 		DataSource: dsInfo,
 		log:        log.New("tsdb.testdata"),


### PR DESCRIPTION
Closes: #16001 
Check for env before logging. I went for using `session.Cfg` object instead of global variable thats why there are lots of changes where the setting needed to be propagated though not sure if it was right choice for something like `Env`.