### PR TITLE
Color picker is not opening when setting threshold colors#16019

### DIFF
--- a/public/app/plugins/panel/graph/thresholds_form.ts
+++ b/public/app/plugins/panel/graph/thresholds_form.ts
@@ -26,6 +26,8 @@ export class ThresholdFormCtrl {
     this.panel.thresholds.push({
       value: undefined,
       colorMode: 'critical',
+      lineColor: '#000000',
+      fillColor: '#000000',
       op: 'gt',
       fill: true,
       line: true,


### PR DESCRIPTION
**What this PR does / why we need it:**
 Fixes #16019 

**Special Notes**
Do i need to  use different colors for dark and light theme? Presently i initialised fillColor and lineColor to '#000000' in all cases