### PR TITLE
add startValue to random_walk testdata scenario and random_walk_table

### DIFF
--- a/pkg/tsdb/testdata/scenarios.go
+++ b/pkg/tsdb/testdata/scenarios.go
@@ -251,7 +251,7 @@ func getRandomWalk(query *tsdb.Query, tsdbQuery *tsdb.TsdbQuery) *tsdb.QueryResu
 	series := newSeriesForQuery(query)
 
 	points := make(tsdb.TimeSeriesPoints, 0)
-	walker := rand.Float64() * 100
+	walker := query.Model.Get("startValue").MustFloat64(rand.Float64() * 100)
 
 	for i := int64(0); i < 10000 && timeWalkerMs < to; i++ {
 		points = append(points, tsdb.NewTimePoint(null.FloatFrom(walker), float64(timeWalkerMs)))

--- a/pkg/tsdb/testdata/scenarios_test.go
+++ b/pkg/tsdb/testdata/scenarios_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestTestdataScenarios(t *testing.T) {
 	Convey("random walk ", t, func() {
-		scenario, exist := ScenarioRegistry["random_walk"]
-		So(exist, ShouldBeTrue)
+		scenario, _ := ScenarioRegistry["random_walk"]
 
 		Convey("Should start at the requested value", func() {
 			req := &tsdb.TsdbQuery{
@@ -33,8 +32,7 @@ func TestTestdataScenarios(t *testing.T) {
 	})
 
 	Convey("random walk table", t, func() {
-		scenario, exist := ScenarioRegistry["random_walk_table"]
-		So(exist, ShouldBeTrue)
+		scenario, _ := ScenarioRegistry["random_walk_table"]
 
 		Convey("Should return a table that looks like value/min/max", func() {
 			req := &tsdb.TsdbQuery{

--- a/pkg/tsdb/testdata/scenarios_test.go
+++ b/pkg/tsdb/testdata/scenarios_test.go
@@ -11,27 +11,86 @@ import (
 
 func TestTestdataScenarios(t *testing.T) {
 	Convey("random walk ", t, func() {
-		if scenario, exist := ScenarioRegistry["random_walk"]; exist {
+		scenario, exist := ScenarioRegistry["random_walk"]
+		So(exist, ShouldBeTrue)
 
-			Convey("Should start at the requested value", func() {
-				req := &tsdb.TsdbQuery{
-					TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
-					Queries: []*tsdb.Query{
-						{RefId: "A", IntervalMs: 100, MaxDataPoints: 10, Model: simplejson.New()},
-					},
+		Convey("Should start at the requested value", func() {
+			req := &tsdb.TsdbQuery{
+				TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
+				Queries: []*tsdb.Query{
+					{RefId: "A", IntervalMs: 100, MaxDataPoints: 100, Model: simplejson.New()},
+				},
+			}
+			query := req.Queries[0]
+			query.Model.Set("startValue", 1.234)
+
+			result := scenario.Handler(req.Queries[0], req)
+			points := result.Series[0].Points
+
+			So(result.Series, ShouldNotBeNil)
+			So(points[0][0].Float64, ShouldEqual, 1.234)
+		})
+	})
+
+	Convey("random walk table", t, func() {
+		scenario, exist := ScenarioRegistry["random_walk_table"]
+		So(exist, ShouldBeTrue)
+
+		Convey("Should return a table that looks like value/min/max", func() {
+			req := &tsdb.TsdbQuery{
+				TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
+				Queries: []*tsdb.Query{
+					{RefId: "A", IntervalMs: 100, MaxDataPoints: 100, Model: simplejson.New()},
+				},
+			}
+
+			result := scenario.Handler(req.Queries[0], req)
+			table := result.Tables[0]
+
+			So(len(table.Rows), ShouldBeGreaterThan, 50)
+			for _, row := range table.Rows {
+				value := row[1]
+				min := row[2]
+				max := row[3]
+
+				So(min, ShouldBeLessThan, value)
+				So(max, ShouldBeGreaterThan, value)
+			}
+		})
+
+		Convey("Should return a table with some nil values", func() {
+			req := &tsdb.TsdbQuery{
+				TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
+				Queries: []*tsdb.Query{
+					{RefId: "A", IntervalMs: 100, MaxDataPoints: 100, Model: simplejson.New()},
+				},
+			}
+			query := req.Queries[0]
+			query.Model.Set("withNil", true)
+
+			result := scenario.Handler(req.Queries[0], req)
+			table := result.Tables[0]
+
+			nil1 := false
+			nil2 := false
+			nil3 := false
+
+			So(len(table.Rows), ShouldBeGreaterThan, 50)
+			for _, row := range table.Rows {
+				if row[1] == nil {
+					nil1 = true
 				}
-				query := req.Queries[0]
-				query.Model.Set("startValue", 1.234)
+				if row[2] == nil {
+					nil2 = true
+				}
+				if row[3] == nil {
+					nil3 = true
+				}
+			}
 
-				result := scenario.Handler(req.Queries[0], req)
-				points := result.Series[0].Points
-
-				So(result.Series, ShouldNotBeNil)
-				So(points[0][0].Float64, ShouldEqual, 1.234)
-			})
-
-		} else {
-			t.Fail()
-		}
+			So(nil1, ShouldBeTrue)
+			So(nil2, ShouldBeTrue)
+			So(nil3, ShouldBeTrue)
+		})
 	})
 }

--- a/pkg/tsdb/testdata/scenarios_test.go
+++ b/pkg/tsdb/testdata/scenarios_test.go
@@ -1,0 +1,37 @@
+package testdata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTestdataScenarios(t *testing.T) {
+	Convey("random walk ", t, func() {
+		if scenario, exist := ScenarioRegistry["random_walk"]; exist {
+
+			Convey("Should start at the requested value", func() {
+				req := &tsdb.TsdbQuery{
+					TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
+					Queries: []*tsdb.Query{
+						{RefId: "A", IntervalMs: 100, MaxDataPoints: 10, Model: simplejson.New()},
+					},
+				}
+				query := req.Queries[0]
+				query.Model.Set("startValue", 1.234)
+
+				result := scenario.Handler(req.Queries[0], req)
+				points := result.Series[0].Points
+
+				So(result.Series, ShouldNotBeNil)
+				So(points[0][0].Float64, ShouldEqual, 1.234)
+			})
+
+		} else {
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
In an effort to work on #4355, it would be great to have a test datasource that could be pulled repeatedly to get a continuous stream of data.  the 'random_walk' one is close, but needs to be able to pick up where it stopped in the last request.

This adds:  `startValue` as an optional parameter:

```
	walker := query.Model.Get("startValue").MustFloat64(rand.Float64() * 100)
```