### PR TITLE
Explore: Highlight graph line when hovering over legend item

### DIFF
--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -385,6 +385,10 @@ $panel-grid-placeholder-shadow: 0 0 4px $blue-shade;
 // logs
 $logs-color-unkown: $gray-2;
 
+// Legend
+$legend-hover: $dark-9;
+$legend-active: $dark-10;
+
 // toggle-group
 $button-toggle-group-btn-active-bg: linear-gradient(90deg, #eb7b18, #d44a3a);
 $button-toggle-group-btn-active-shadow: inset 0 0 4px $black;

--- a/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
@@ -372,6 +372,10 @@ $panel-grid-placeholder-shadow: 0 0 4px $blue-light;
 // logs
 $logs-color-unkown: $gray-5;
 
+// Legend
+$legend-hover: $gray-6;
+$legend-active: $gray-5;
+
 // toggle-group
 $button-toggle-group-btn-active-bg: $brand-primary;
 $button-toggle-group-btn-active-shadow: inset 0 0 4px $white;

--- a/public/app/features/explore/Legend.tsx
+++ b/public/app/features/explore/Legend.tsx
@@ -5,17 +5,35 @@ import { TimeSeries } from 'app/core/core';
 interface LegendProps {
   data: TimeSeries[];
   hiddenSeries: Set<string>;
+  onHighlightSeries?: (series: TimeSeries) => void;
+  onUnhighlightSeries?: (series: TimeSeries) => void;
   onToggleSeries?: (series: TimeSeries, exclusive: boolean) => void;
 }
 
 interface LegendItemProps {
   hidden: boolean;
   onClickLabel?: (series: TimeSeries, event: MouseEvent) => void;
+  onHighlightSeries?: (series: TimeSeries) => void;
+  onUnhighlightSeries?: (series: TimeSeries) => void;
   series: TimeSeries;
 }
 
 class LegendItem extends PureComponent<LegendItemProps> {
   onClickLabel = e => this.props.onClickLabel(this.props.series, e);
+
+  onHighlight = (e: MouseEvent) => {
+    const { hidden, series, onHighlightSeries } = this.props;
+    if (!hidden) {
+      onHighlightSeries(series);
+    }
+  };
+
+  onUnhighlight = (e: MouseEvent) => {
+    const { hidden, series, onUnhighlightSeries } = this.props;
+    if (!hidden) {
+      onUnhighlightSeries(series);
+    }
+  };
 
   render() {
     const { hidden, series } = this.props;
@@ -23,7 +41,11 @@ class LegendItem extends PureComponent<LegendItemProps> {
       'graph-legend-series-hidden': hidden,
     });
     return (
-      <div className={`graph-legend-series ${seriesClasses}`}>
+      <div
+        className={`graph-legend-series ${seriesClasses}`}
+        onMouseOver={this.onHighlight}
+        onMouseOut={this.onUnhighlight}
+      >
         <div className="graph-legend-icon">
           <i className="fa fa-minus pointer" style={{ color: series.color }} />
         </div>
@@ -37,6 +59,8 @@ class LegendItem extends PureComponent<LegendItemProps> {
 
 export default class Legend extends PureComponent<LegendProps> {
   static defaultProps = {
+    onHighlightSeries: () => {},
+    onUnhighlightSeries: () => {},
     onToggleSeries: () => {},
   };
 
@@ -47,7 +71,7 @@ export default class Legend extends PureComponent<LegendProps> {
   };
 
   render() {
-    const { data, hiddenSeries } = this.props;
+    const { data, hiddenSeries, onHighlightSeries, onUnhighlightSeries } = this.props;
     const items = data || [];
     return (
       <div className="graph-legend ps">
@@ -57,6 +81,8 @@ export default class Legend extends PureComponent<LegendProps> {
             // Workaround to resolve conflicts since series visibility tracks the alias property
             key={`${series.id}-${i}`}
             onClickLabel={this.onClickLabel}
+            onHighlightSeries={onHighlightSeries}
+            onUnhighlightSeries={onUnhighlightSeries}
             series={series}
           />
         ))}

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -388,6 +388,10 @@ $panel-grid-placeholder-shadow: 0 0 4px $blue-shade;
 // logs
 $logs-color-unkown: $gray-2;
 
+// Legend
+$legend-hover: $dark-9;
+$legend-active: $dark-10;
+
 // toggle-group
 $button-toggle-group-btn-active-bg: linear-gradient(90deg, #eb7b18, #d44a3a);
 $button-toggle-group-btn-active-shadow: inset 0 0 4px $black;

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -375,6 +375,10 @@ $panel-grid-placeholder-shadow: 0 0 4px $blue-light;
 // logs
 $logs-color-unkown: $gray-5;
 
+// Legend
+$legend-hover: $gray-6;
+$legend-active: $gray-5;
+
 // toggle-group
 $button-toggle-group-btn-active-bg: $brand-primary;
 $button-toggle-group-btn-active-shadow: inset 0 0 4px $white;

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -107,6 +107,16 @@
   &--right-y {
     float: right;
   }
+
+  &:active {
+    background: $legend-active;
+    border-radius: 3px;
+  }
+
+  &:hover {
+    background: $legend-hover;
+    border-radius: 3px;
+  }
 }
 
 // Don't move series to the right if legend is on the right as well
@@ -217,6 +227,8 @@
 }
 
 .graph-legend-series-hidden {
+  opacity: 0.4;
+
   .graph-legend-value,
   .graph-legend-alias {
     color: $link-color-disabled;


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reduces opacity of hidden legend item to clearly show which item is selected
- Highlights legend item background on mouse over
- Highlights graph line that corresponds to hovered legend item (technically it reduces opacity of other lines)
- Similar in functionality to Prometheus' UI

![Screen Shot 2019-03-15 at 18 31 17](https://user-images.githubusercontent.com/17552371/54467078-d8b1d680-4750-11e9-9f09-cfc8192ebdab.png)
![Screen Shot 2019-03-15 at 19 16 59](https://user-images.githubusercontent.com/17552371/54468029-00a43880-4757-11e9-8ebd-ad7fedc1afed.png)


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- I know you're refactoring the graph as part of your roadmap, so I focused mainly on the legend
- Let me know if you can think of how to name variables and methods better
- The non-highlighted graph lines have an alpha set of 30% using 8 digit color codes
- Tested in both light and dark modes

**Release note**:
```release-note
Explore: Highlight graph line when hovering over legend item
```
