### PR TITLE
Explore: Fix log stats with long labels

### DIFF
--- a/public/app/features/explore/LogLabelStats.tsx
+++ b/public/app/features/explore/LogLabelStats.tsx
@@ -11,7 +11,9 @@ function LogLabelStatsRow(logLabelStatsModel: LogLabelStatsModel) {
   return (
     <div className={className}>
       <div className="logs-stats-row__label">
-        <div className="logs-stats-row__value">{value}</div>
+        <div className="logs-stats-row__value" title={value}>
+          {value}
+        </div>
         <div className="logs-stats-row__count">{count}</div>
         <div className="logs-stats-row__percent">{percent}</div>
       </div>

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -299,6 +299,8 @@ $column-horizontal-spacing: 10px;
 
   &__value {
     flex: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   &__count,


### PR DESCRIPTION
**What this PR does / why we need it**:
- Properly ellipsis long labels in log stats popup window
- Adds a tooltip to show full label

Before:
![Screen Shot 2019-03-16 at 00 22 31](https://user-images.githubusercontent.com/17552371/54471415-88556b80-4786-11e9-800e-b828fcbab0b6.png)

After:
![Screen Shot 2019-03-16 at 00 53 30](https://user-images.githubusercontent.com/17552371/54471416-88556b80-4786-11e9-8e31-82f9e31b4484.png)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note

```
