### PR TITLE
Loki: Hide empty labels column

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -77,6 +77,7 @@ export interface LogsMetaItem {
 }
 
 export interface LogsModel {
+  hasUniqueLabels: boolean;
   id: string; // Identify one logs result from another
   meta?: LogsMetaItem[];
   rows: LogRowModel[];

--- a/public/app/features/explore/LogRow.tsx
+++ b/public/app/features/explore/LogRow.tsx
@@ -13,7 +13,7 @@ interface Props {
   highlighterExpressions?: string[];
   row: LogRowModel;
   showDuplicates: boolean;
-  showLabels: boolean | null; // Tristate: null means auto
+  showLabels: boolean;
   showLocalTime: boolean;
   showUtc: boolean;
   getRows: () => LogRowModel[];

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -169,6 +169,7 @@ export default class Logs extends PureComponent<Props, State> {
     const { deferLogs, renderAll, showLabels, showLocalTime, showUtc } = this.state;
     const { dedupStrategy } = this.props;
     const hasData = data && data.rows && data.rows.length > 0;
+    const hasLabel = hasData && dedupedData.hasUniqueLabels;
     const dedupCount = dedupedData.rows.reduce((sum, row) => sum + row.duplicates, 0);
     const showDuplicates = dedupStrategy !== LogsDedupStrategy.none && dedupCount > 0;
     const meta = [...data.meta];
@@ -247,7 +248,7 @@ export default class Logs extends PureComponent<Props, State> {
                 highlighterExpressions={highlighterExpressions}
                 row={row}
                 showDuplicates={showDuplicates}
-                showLabels={showLabels}
+                showLabels={showLabels && hasLabel}
                 showLocalTime={showLocalTime}
                 showUtc={showUtc}
                 onClickLabel={onClickLabel}
@@ -262,7 +263,7 @@ export default class Logs extends PureComponent<Props, State> {
                 getRows={getRows}
                 row={row}
                 showDuplicates={showDuplicates}
-                showLabels={showLabels}
+                showLabels={showLabels && hasLabel}
                 showLocalTime={showLocalTime}
                 showUtc={showUtc}
                 onClickLabel={onClickLabel}

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -175,6 +175,8 @@ export function mergeStreamsToLogs(streams: LogsStream[], limit = DEFAULT_MAX_LI
     .reverse()
     .value();
 
+  const hasUniqueLabels = sortedRows && sortedRows.some(row => Object.keys(row.uniqueLabels).length > 0);
+
   // Meta data to display in status
   const meta: LogsMetaItem[] = [];
   if (_.size(commonLabels) > 0) {
@@ -194,6 +196,7 @@ export function mergeStreamsToLogs(streams: LogsStream[], limit = DEFAULT_MAX_LI
 
   return {
     id,
+    hasUniqueLabels,
     meta,
     rows: sortedRows,
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
- With the change to fixed size columns for labels in #15737, the column will still show up even if there are no labels
- Also removed the showLabels tristate option that was missed in #15982

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
Loki: Hide empty labels column
```