### PR TITLE
Add patterns to no-only-tests grunt task

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -161,7 +161,7 @@ describe('change threshold value', () => {
 });
 
 describe('on blur threshold value', () => {
-  it.only('should resort rows and update indexes', () => {
+  it('should resort rows and update indexes', () => {
     const { instance } = setup();
     const thresholds = [
       { index: 0, value: -Infinity, color: '#7EB26D' },

--- a/scripts/grunt/default_task.js
+++ b/scripts/grunt/default_task.js
@@ -34,14 +34,17 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('no-only-tests', function () {
-    var files = grunt.file.expand('public/**/*_specs\.ts', 'public/**/*_specs\.js');
+    var files = grunt.file.expand(
+      'public/**/*@(_specs|\.test)\.@(ts|js|tsx|jsx)',
+      'packages/grafana-ui/**/*@(_specs|\.test)\.@(ts|js|tsx|jsx)'
+    );
 
     files.forEach(function (spec) {
       var rows = grunt.file.read(spec).split('\n');
       rows.forEach(function (row) {
         if (row.indexOf('.only(') > 0) {
           grunt.log.errorlns(row);
-          grunt.fail.warn('found only statement in test: ' + spec)
+          grunt.fail.warn('found only statement in test: ' + spec);
         }
       });
     });


### PR DESCRIPTION
The grunt task worked only on old `_spec` file names and only in `/public`. It already found a usage of `only` in grafana-ui.