### PR TITLE
Build: crcmod speedups rsync to gcp for deploy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
 
   deploy-enterprise-master:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.0
+      - image: grafana/grafana-ci-deploy:1.2.1
     steps:
       - attach_workspace:
           at: .
@@ -345,7 +345,7 @@ jobs:
 
   deploy-enterprise-release:
     docker:
-    - image: grafana/grafana-ci-deploy:1.2.0
+    - image: grafana/grafana-ci-deploy:1.2.1
     steps:
       - checkout
       - attach_workspace:
@@ -378,7 +378,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.0
+      - image: grafana/grafana-ci-deploy:1.2.1
     steps:
       - attach_workspace:
           at: .
@@ -409,7 +409,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.0
+      - image: grafana/grafana-ci-deploy:1.2.1
     steps:
       - checkout
       - attach_workspace:

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -10,7 +10,7 @@ FROM circleci/python:2.7-stretch
 
 USER root
 
-RUN pip install awscli && \
+RUN pip install -U awscli crcmod && \
     curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-222.0.0-linux-x86_64.tar.gz | \
       tar xvzf - -C /opt && \
     apt update && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_version="1.2.0"
+_version="1.2.1"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates of our deb and rpm repositories is done using `gsutil rsync` and has gotten pretty slow as it expects crcmod to be installed for sha comparission. 

This installs crcmod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #15641

<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
NONE
```