### PR TITLE
Removed dashboard variables + minor things

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -228,15 +228,15 @@ exports[`Render should render with base threshold 1`] = `
                                 "regular": 400,
                                 "semibold": 500,
                               },
-                              "zIndex": Object {
-                                "dropdown": "1000",
-                                "modal": "1050",
-                                "modalBackdrop": "1040",
-                                "navbarFixed": "1020",
-                                "sidemenu": "1025",
-                                "tooltip": "1030",
-                                "typeahead": "1060",
-                              },
+                            },
+                            "zIndex": Object {
+                              "dropdown": "1000",
+                              "modal": "1050",
+                              "modalBackdrop": "1040",
+                              "navbarFixed": "1020",
+                              "sidemenu": "1025",
+                              "tooltip": "1030",
+                              "typeahead": "1060",
                             },
                           }
                         }
@@ -385,15 +385,15 @@ exports[`Render should render with base threshold 1`] = `
                                       "regular": 400,
                                       "semibold": 500,
                                     },
-                                    "zIndex": Object {
-                                      "dropdown": "1000",
-                                      "modal": "1050",
-                                      "modalBackdrop": "1040",
-                                      "navbarFixed": "1020",
-                                      "sidemenu": "1025",
-                                      "tooltip": "1030",
-                                      "typeahead": "1060",
-                                    },
+                                  },
+                                  "zIndex": Object {
+                                    "dropdown": "1000",
+                                    "modal": "1050",
+                                    "modalBackdrop": "1040",
+                                    "navbarFixed": "1020",
+                                    "sidemenu": "1025",
+                                    "tooltip": "1030",
+                                    "typeahead": "1060",
                                   },
                                 }
                               }

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`Render should render with base threshold 1`] = `
                             "typography": Object {
                               "fontFamily": Object {
                                 "monospace": "Menlo, Monaco, Consolas, 'Courier New', monospace",
-                                "sansSerif": "'Roboto', Helvetica, Arial, sans-serif",
+                                "sansSerif": "'Roboto', 'Helvetica  Neue', Arial, sans-serif",
                               },
                               "heading": Object {
                                 "h1": "28px",
@@ -339,7 +339,7 @@ exports[`Render should render with base threshold 1`] = `
                                   "typography": Object {
                                     "fontFamily": Object {
                                       "monospace": "Menlo, Monaco, Consolas, 'Courier New', monospace",
-                                      "sansSerif": "'Roboto', Helvetica, Arial, sans-serif",
+                                      "sansSerif": "'Roboto', 'Helvetica Neue', Arial, sans-serif",
                                     },
                                     "heading": Object {
                                       "h1": "28px",

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`Render should render with base threshold 1`] = `
                             "typography": Object {
                               "fontFamily": Object {
                                 "monospace": "Menlo, Monaco, Consolas, 'Courier New', monospace",
-                                "sansSerif": "'Roboto', 'Helvetica  Neue', Arial, sans-serif",
+                                "sansSerif": "'Roboto', 'Helvetica Neue', Arial, sans-serif",
                               },
                               "heading": Object {
                                 "h1": "28px",

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -211,6 +211,10 @@ exports[`Render should render with base threshold 1`] = `
                                 "sm": 1.1,
                                 "xs": 1,
                               },
+                              "link": Object {
+                                "decoration": "none",
+                                "hoverDecoration": "none",
+                              },
                               "size": Object {
                                 "base": "13px",
                                 "lg": "18px",
@@ -223,6 +227,15 @@ exports[`Render should render with base threshold 1`] = `
                                 "light": 300,
                                 "regular": 400,
                                 "semibold": 500,
+                              },
+                              "zIndex": Object {
+                                "dropdown": "1000",
+                                "modal": "1050",
+                                "modalBackdrop": "1040",
+                                "navbarFixed": "1020",
+                                "sidemenu": "1025",
+                                "tooltip": "1030",
+                                "typeahead": "1060",
                               },
                             },
                           }
@@ -355,6 +368,10 @@ exports[`Render should render with base threshold 1`] = `
                                       "sm": 1.1,
                                       "xs": 1,
                                     },
+                                    "link": Object {
+                                      "decoration": "none",
+                                      "hoverDecoration": "none",
+                                    },
                                     "size": Object {
                                       "base": "13px",
                                       "lg": "18px",
@@ -367,6 +384,15 @@ exports[`Render should render with base threshold 1`] = `
                                       "light": 300,
                                       "regular": 400,
                                       "semibold": 500,
+                                    },
+                                    "zIndex": Object {
+                                      "dropdown": "1000",
+                                      "modal": "1050",
+                                      "modalBackdrop": "1040",
+                                      "navbarFixed": "1020",
+                                      "sidemenu": "1025",
+                                      "tooltip": "1030",
+                                      "typeahead": "1060",
                                     },
                                   },
                                 }

--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -195,6 +195,10 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 // sidemenu
 $side-menu-width: 60px;
 
+// dashboard
+$dashboard-padding: $space-md $space-md 0 $space-md;
+$panel-padding: 0 $space-md $space-sm $space-md;
+
 // tabs
 $tabs-padding: 10px 15px 9px;
 

--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -196,7 +196,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 $side-menu-width: 60px;
 
 // dashboard
-$dashboard-padding: $space-md $space-md 0 $space-md;
+$dashboard-padding: $space-md;
 $panel-padding: 0 $space-md $space-sm $space-md;
 
 // tabs

--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -110,7 +110,6 @@ $font-size-h4: ${theme.typography.heading.h4} !default;
 $font-size-h5: ${theme.typography.heading.h5} !default;
 $font-size-h6: ${theme.typography.heading.h6} !default;
 
-$headings-font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $headings-line-height: ${theme.typography.lineHeight.sm} !default;
 
 // Components
@@ -130,8 +129,8 @@ $page-sidebar-margin: 56px;
 
 // Links
 // -------------------------
-$link-decoration: none !default;
-$link-hover-decoration: none !default;
+$link-decoration: ${theme.typography.link.decoration} !default;
+$link-hover-decoration: ${theme.typography.link.hoverDecoration} !default;
 
 // Tables
 //
@@ -166,13 +165,13 @@ $form-icon-danger: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www
 // -------------------------
 // Used for a bird's eye view of components dependent on the z-axis
 // Try to avoid customizing these :)
-$zindex-dropdown: 1000;
-$zindex-navbar-fixed: 1020;
-$zindex-sidemenu: 1025;
-$zindex-tooltip: 1030;
-$zindex-modal-backdrop: 1040;
-$zindex-modal: 1050;
-$zindex-typeahead: 1060;
+$zindex-dropdown: ${theme.zIndex.dropdown};
+$zindex-navbar-fixed: ${theme.zIndex.navbarFixed};
+$zindex-sidemenu: ${theme.zIndex.sidemenu};
+$zindex-tooltip: ${theme.zIndex.tooltip};
+$zindex-modal-backdrop: ${theme.zIndex.modalBackdrop};
+$zindex-modal: ${theme.zIndex.modal};
+$zindex-typeahead: ${theme.zIndex.typeahead};
 
 // Buttons
 //
@@ -195,12 +194,6 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 
 // sidemenu
 $side-menu-width: 60px;
-
-// dashboard
-$dashboard-padding: 10px * 2;
-$panel-horizontal-padding: 10;
-$panel-vertical-padding: 5;
-$panel-padding: 0px $panel-horizontal-padding + 0px $panel-vertical-padding + 0px $panel-horizontal-padding + 0px;
 
 // tabs
 $tabs-padding: 10px 15px 9px;

--- a/packages/grafana-ui/src/themes/default.ts
+++ b/packages/grafana-ui/src/themes/default.ts
@@ -4,7 +4,7 @@ const theme: GrafanaThemeCommons = {
   name: 'Grafana Default',
   typography: {
     fontFamily: {
-      sansSerif: "'Roboto', Helvetica, Arial, sans-serif",
+      sansSerif: "'Roboto', 'Helvetica Neue', Arial, sans-serif",
       monospace: "Menlo, Monaco, Consolas, 'Courier New', monospace",
     },
     size: {
@@ -33,6 +33,10 @@ const theme: GrafanaThemeCommons = {
       sm: 1.1,
       md: 4 / 3,
       lg: 1.5,
+    },
+    link: {
+      decoration: 'none',
+      hoverDecoration: 'none',
     },
   },
   breakpoints: {
@@ -65,6 +69,15 @@ const theme: GrafanaThemeCommons = {
   panelPadding: {
     horizontal: 10,
     vertical: 5,
+  },
+  zIndex: {
+    dropdown: '1000',
+    navbarFixed: '1020',
+    sidemenu: '1025',
+    tooltip: '1030',
+    modalBackdrop: '1040',
+    modal: '1050',
+    typeahead: '1060',
   },
 };
 

--- a/packages/grafana-ui/src/types/theme.ts
+++ b/packages/grafana-ui/src/types/theme.ts
@@ -46,6 +46,10 @@ export interface GrafanaThemeCommons {
       h5: string;
       h6: string;
     };
+    link: {
+      decoration: string;
+      hoverDecoration: string;
+    };
   };
   spacing: {
     d: string;
@@ -70,6 +74,15 @@ export interface GrafanaThemeCommons {
   panelPadding: {
     horizontal: number;
     vertical: number;
+  };
+  zIndex: {
+    dropdown: string;
+    navbarFixed: string;
+    sidemenu: string;
+    tooltip: string;
+    modalBackdrop: string;
+    modal: string;
+    typeahead: string;
   };
 }
 

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -199,7 +199,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 $side-menu-width: 60px;
 
 // dashboard
-$dashboard-padding: $space-md $space-md 0 $space-md;
+$dashboard-padding: $space-md;
 $panel-padding: 0 $space-md $space-sm $space-md;
 
 // tabs

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -90,7 +90,7 @@ $grid-gutter-width: 30px !default;
 // Typography
 // -------------------------
 
-$font-family-sans-serif: 'Roboto', Helvetica, Arial, sans-serif;
+$font-family-sans-serif: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
 $font-family-monospace: Menlo, Monaco, Consolas, 'Courier New', monospace;
 
 $font-size-root: 14px !default;
@@ -113,7 +113,6 @@ $font-size-h4: 18px !default;
 $font-size-h5: 16px !default;
 $font-size-h6: 14px !default;
 
-$headings-font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $headings-line-height: 1.1 !default;
 
 // Components
@@ -198,12 +197,6 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 
 // sidemenu
 $side-menu-width: 60px;
-
-// dashboard
-$dashboard-padding: 10px * 2;
-$panel-horizontal-padding: 10;
-$panel-vertical-padding: 5;
-$panel-padding: 0px $panel-horizontal-padding + 0px $panel-vertical-padding + 0px $panel-horizontal-padding + 0px;
 
 // tabs
 $tabs-padding: 10px 15px 9px;

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -198,6 +198,10 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 // sidemenu
 $side-menu-width: 60px;
 
+// dashboard
+$dashboard-padding: $space-md $space-md 0 $space-md;
+$panel-padding: 0 $space-md $space-sm $space-md;
+
 // tabs
 $tabs-padding: 10px 15px 9px;
 

--- a/public/sass/base/_type.scss
+++ b/public/sass/base/_type.scss
@@ -110,7 +110,6 @@ h6,
 .h5,
 .h6 {
   margin-bottom: $space-sm;
-  font-family: $headings-font-family;
   font-weight: $font-weight-regular;
   line-height: $headings-line-height;
   color: $headings-color;

--- a/public/sass/components/_panel_editor.scss
+++ b/public/sass/components/_panel_editor.scss
@@ -9,14 +9,14 @@
 
   &--edit {
     height: 40%;
-    margin: 0 $space-md;
+    margin: 0 $dashboard-padding;
   }
 
   &--view {
     flex: 1 1 0;
     height: 90%;
-    margin: 0 $space-md;
-    padding-top: $space-md;
+    margin: 0 $dashboard-padding;
+    padding-top: $dashboard-padding;
   }
 }
 
@@ -80,7 +80,7 @@
   }
 
   .submenu-controls {
-    padding: 0 $space-md $space-sm $space-md;
+    padding: 0 $dashboard-padding $space-sm $dashboard-padding;
   }
 
   .search-container {

--- a/public/sass/components/_panel_editor.scss
+++ b/public/sass/components/_panel_editor.scss
@@ -9,14 +9,14 @@
 
   &--edit {
     height: 40%;
-    margin: 0 $dashboard-padding;
+    margin: 0 $space-md;
   }
 
   &--view {
     flex: 1 1 0;
     height: 90%;
-    margin: 0 $dashboard-padding;
-    padding-top: $dashboard-padding;
+    margin: 0 $space-md;
+    padding-top: $space-md;
   }
 }
 
@@ -80,11 +80,7 @@
   }
 
   .submenu-controls {
-    padding: 0 $dashboard-padding $space-sm $dashboard-padding;
-  }
-
-  .panel-editor-container__panel {
-    margin: 0 $dashboard-padding;
+    padding: 0 $space-md $space-sm $space-md;
   }
 
   .search-container {

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -3,8 +3,7 @@ $column-horizontal-spacing: 10px;
 .logs-panel-options {
   display: flex;
   background-color: $page-bg;
-  padding: $panel-padding;
-  padding-top: 10px;
+  padding: $space-sm $space-md $space-sm $space-md;
   border-radius: $border-radius;
   margin: $space-md 0 $space-sm;
   border: $panel-border;

--- a/public/sass/components/_tabbed_view.scss
+++ b/public/sass/components/_tabbed_view.scss
@@ -13,7 +13,7 @@
 .tabbed-view-header {
   box-shadow: $page-header-shadow;
   border-bottom: 1px solid $page-header-border-color;
-  padding: 0 $dashboard-padding;
+  padding: 0 $space-md;
   @include clearfix();
 }
 

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -1,5 +1,5 @@
 .dashboard-container {
-  padding: $dashboard-padding $dashboard-padding 0 $dashboard-padding;
+  padding: $space-md $space-md 0 $space-md;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -78,7 +78,7 @@ div.flot-text {
 }
 
 .panel-content {
-  padding: $panel-padding;
+  padding: 0 $space-md $space-sm $space-md;
   height: calc(100% - 27px);
   position: relative;
 
@@ -260,7 +260,6 @@ div.flot-text {
 }
 
 .dashboard-header {
-  font-family: $headings-font-family;
   font-size: $font-size-h3;
   text-align: center;
   overflow: hidden;
@@ -271,10 +270,6 @@ div.flot-text {
     @include brand-bottom-border();
     padding: 0.5rem 0.5rem 0.2rem 0.5rem;
   }
-}
-
-.panel-full-edit {
-  padding-top: $dashboard-padding;
 }
 
 .dashboard-loading {

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -1,5 +1,5 @@
 .dashboard-container {
-  padding: $dashboard-padding;
+  padding: $dashboard-padding $dashboard-padding 0 $dashboard-padding;
   width: 100%;
   height: 100%;
   box-sizing: border-box;

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -1,5 +1,5 @@
 .dashboard-container {
-  padding: $space-md $space-md 0 $space-md;
+  padding: $dashboard-padding;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
@@ -78,7 +78,7 @@ div.flot-text {
 }
 
 .panel-content {
-  padding: 0 $space-md $space-sm $space-md;
+  padding: $panel-padding;
   height: calc(100% - 27px);
   position: relative;
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -156,7 +156,7 @@
 }
 
 .explore-container {
-  padding: $space-md;
+  padding: $dashboard-padding;
 }
 
 .explore-wrapper {
@@ -172,7 +172,7 @@
 }
 
 .explore-panel__body {
-  padding: 0 $space-md $space-sm $space-md;
+  padding: $panel-padding;
 }
 
 .explore-panel__header {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -31,7 +31,7 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   height: auto;
-  padding: 0 $space-md;
+  padding: 0 $dashboard-padding;
   border-bottom: 1px solid #0000;
   transition-duration: 0.35s;
   transition-timing-function: ease-in-out;
@@ -91,7 +91,7 @@
 }
 
 .explore-toolbar-content-item:first-child {
-  padding-left: $space-md;
+  padding-left: $dashboard-spacer;
   margin-right: auto;
 }
 
@@ -142,7 +142,7 @@
 @media only screen and (max-width: 544px) {
   .explore-toolbar-header-title {
     .navbar-page-btn {
-      margin-left: $space-md;
+      margin-left: $dashboard-padding;
     }
   }
 }

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -31,7 +31,7 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   height: auto;
-  padding: 0 $dashboard-padding;
+  padding: 0 $space-md;
   border-bottom: 1px solid #0000;
   transition-duration: 0.35s;
   transition-timing-function: ease-in-out;
@@ -91,7 +91,7 @@
 }
 
 .explore-toolbar-content-item:first-child {
-  padding-left: $dashboard-padding;
+  padding-left: $space-md;
   margin-right: auto;
 }
 
@@ -142,7 +142,7 @@
 @media only screen and (max-width: 544px) {
   .explore-toolbar-header-title {
     .navbar-page-btn {
-      margin-left: $dashboard-padding;
+      margin-left: $space-md;
     }
   }
 }
@@ -156,7 +156,7 @@
 }
 
 .explore-container {
-  padding: $dashboard-padding;
+  padding: $space-md;
 }
 
 .explore-wrapper {
@@ -172,16 +172,14 @@
 }
 
 .explore-panel__body {
-  padding: $panel-padding;
+  padding: 0 $space-md $space-sm $space-md;
 }
 
 .explore-panel__header {
-  padding: $panel-padding;
-  padding-top: 5px;
-  padding-bottom: 0;
+  padding: $space-sm $space-md 0 $space-md;
   display: flex;
   cursor: pointer;
-  margin-bottom: 5px;
+  margin-bottom: $space-sm;
   transition: all 0.1s linear;
 }
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -91,7 +91,7 @@
 }
 
 .explore-toolbar-content-item:first-child {
-  padding-left: $dashboard-spacer;
+  padding-left: $dashboard-padding;
   margin-right: auto;
 }
 


### PR DESCRIPTION
Removed dashboard variables. I choose to make panel padding slightly bigger. 
Before:
<img width="685" alt="Screenshot 2019-03-20 at 10 02 08" src="https://user-images.githubusercontent.com/23470681/54671936-47978280-4af7-11e9-853c-63d65a2f1289.png">
After:
<img width="702" alt="Screenshot 2019-03-20 at 10 01 21" src="https://user-images.githubusercontent.com/23470681/54671970-54b47180-4af7-11e9-8607-6f84fe585ca0.png">

Removed headings-font-family variable. Didn't make much sense to have both Helvetica and Helvetica Neue. Grafana just uses Helvetica Neue now(if it ever is used).
Created theme variables for links and z-index. 
Removed unused class in _panel_editor and _dashboard.