### PR TITLE
Correct table names of sql storage for remotecache

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -101,7 +101,7 @@ func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration
 
 	// insert or update depending on if item already exist
 	if has {
-		sql := `UPDATE cache_data SET data=?, created=?, expire=? WHERE cache_key='?'`
+		sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
 		_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
 	} else {
 		sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/bmizerany/assert"
-
 	"github.com/grafana/grafana/pkg/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
@@ -52,5 +51,22 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 	_, err = db.Get("key4")
 	assert.Equal(t, err, nil)
 	_, err = db.Get("key5")
+	assert.Equal(t, err, nil)
+}
+
+func TestSecondSet(t *testing.T) {
+	var err error
+	sqlstore := sqlstore.InitTestDB(t)
+
+	db := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	obj := &CacheableStruct{String: "hey!"}
+
+	err = db.Set("killa-gorilla", obj, 0)
+	err = db.Set("killa-gorilla", obj, 0)
+
 	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Basically a typo fix for the table names for `remotecache` of sql storage

