### PR TITLE
Graphite: Fixed issue with using series ref and series by tag

### DIFF
--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -98,7 +98,7 @@ export default class GraphiteQuery {
         this.functions.push(innerFunc);
         break;
       case 'series-ref':
-        if (this.segments.length > 0) {
+        if (this.segments.length > 0 || this.getSeriesByTagFuncIndex() >= 0) {
           this.addFunctionParameter(func, astNode.value);
         } else {
           this.segments.push(astNode);

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -44,4 +44,16 @@ describe('Graphite query model', () => {
       expect(ctx.queryModel.target.targetFull).toBeDefined();
     });
   });
+
+  describe('when query seriesByTag and series ref', () => {
+    beforeEach(() => {
+      ctx.target = { refId: 'A', target: `group(seriesByTag('namespace=asd'), #A)` };
+      ctx.targets = [ctx.target];
+      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+    });
+
+    it('should keep group function series ref', () => {
+      expect(ctx.queryModel.functions[1].params[0]).toBe('#A');
+    });
+  });
 });

--- a/public/app/plugins/datasource/graphite/specs/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/query_ctrl.test.ts
@@ -24,7 +24,6 @@ describe('GraphiteQueryCtrl', () => {
   beforeEach(() => {
     GraphiteQueryCtrl.prototype.target = ctx.target;
     GraphiteQueryCtrl.prototype.datasource = ctx.datasource;
-
     GraphiteQueryCtrl.prototype.panelCtrl = ctx.panelCtrl;
 
     ctx.ctrl = new GraphiteQueryCtrl(
@@ -81,22 +80,6 @@ describe('GraphiteQueryCtrl', () => {
 
     it('should add function and remove select metric link', () => {
       expect(ctx.ctrl.segments.length).toBe(0);
-    });
-  });
-
-  describe('when initializing target without metric expression and only function', () => {
-    beforeEach(() => {
-      ctx.ctrl.target.target = 'asPercent(#A, #B)';
-      ctx.ctrl.datasource.metricFindQuery = () => Promise.resolve([]);
-      ctx.ctrl.parseTarget();
-    });
-
-    it('should not add select metric segment', () => {
-      expect(ctx.ctrl.segments.length).toBe(1);
-    });
-
-    it('should add second series ref as param', () => {
-      expect(ctx.ctrl.queryModel.functions[0].params.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
Fixes #15237

Removed some smarts that places first series-ref in the metric segments, but this is actually not needed, and messes with tagged queries that do not have a metric path. 