### PR TITLE
Alerting: Don't include non-existing image in MS Teams notifications

### DIFF
--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -78,6 +78,15 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 		message = evalContext.Rule.Message
 	}
 
+	images := ""
+	if evalContext.ImagePublicUrl != "" {
+		images = []map[string]interface{}{
+			{
+				"image": evalContext.ImagePublicUrl
+			}
+		}
+	}
+
 	body := map[string]interface{}{
 		"@type":    "MessageCard",
 		"@context": "http://schema.org/extensions",
@@ -90,11 +99,7 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 			{
 				"title": "Details",
 				"facts": fields,
-				"images": []map[string]interface{}{
-					{
-						"image": evalContext.ImagePublicUrl,
-					},
-				},
+				"images": images,
 				"text": message,
 			},
 		},

--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -78,13 +78,11 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 		message = evalContext.Rule.Message
 	}
 
-	images := ""
+	images := make([]map[string]interface{}, 0)
 	if evalContext.ImagePublicUrl != "" {
-		images = []map[string]interface{}{
-			{
-				"image": evalContext.ImagePublicUrl,
-			},
-		}
+		images = append(images, map[string]interface{}{
+			"image": evalContext.ImagePublicUrl,
+		})
 	}
 
 	body := map[string]interface{}{

--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -82,8 +82,8 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if evalContext.ImagePublicUrl != "" {
 		images = []map[string]interface{}{
 			{
-				"image": evalContext.ImagePublicUrl
-			}
+				"image": evalContext.ImagePublicUrl,
+			},
 		}
 	}
 
@@ -97,10 +97,10 @@ func (this *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"themeColor": evalContext.GetStateModel().Color,
 		"sections": []map[string]interface{}{
 			{
-				"title": "Details",
-				"facts": fields,
+				"title":  "Details",
+				"facts":  fields,
 				"images": images,
-				"text": message,
+				"text":   message,
 			},
 		},
 		"potentialAction": []map[string]interface{}{


### PR DESCRIPTION
If an image section is included in the JSON payload for MS Teams alerts
when no image URL exists, rendering of the alert in the client fails.
This change makes sure that an image section is only included in the
JSON payload if an image URL exists.

Closes #16082

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #16082

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
MS Teams notifier: Include image switch setting is now honored when creating alert messages. 
```
