### PR TITLE
Linkedin heatmap POC

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -14,6 +14,9 @@ export interface PanelProps<T = any> {
   width: number;
   height: number;
   replaceVariables: InterpolateFunction;
+  targets?: any[];
+  onCustomQuery?: any;
+  customQuery?: string;
 }
 
 export interface PanelData {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -39,6 +39,7 @@ export interface State {
   timeInfo?: string;
   timeRange?: TimeRange;
   errorMessage: string | null;
+  customQuery?: string;
 }
 
 export class PanelChrome extends PureComponent<Props, State> {
@@ -119,6 +120,11 @@ export class PanelChrome extends PureComponent<Props, State> {
     }
   };
 
+  onCustomQuery = (query: string) => {
+    console.log('issue query:', query);
+    this.setState({ customQuery: query });
+  };
+
   clearErrorState() {
     if (this.state.errorMessage) {
       this.setState({ errorMessage: null });
@@ -142,7 +148,14 @@ export class PanelChrome extends PureComponent<Props, State> {
     return this.hasPanelSnapshot ? snapshotDataToPanelData(this.props.panel) : null;
   }
 
-  renderPanelPlugin(loading: LoadingState, panelData: PanelData, width: number, height: number): JSX.Element {
+  renderPanelPlugin(
+    loading: LoadingState,
+    panelData: PanelData,
+    width: number,
+    height: number,
+    targets?,
+    onCustomQuery?
+  ): JSX.Element {
     const { panel, plugin } = this.props;
     const { timeRange, renderCounter } = this.state;
     const PanelComponent = plugin.exports.reactPanel.panel;
@@ -164,6 +177,8 @@ export class PanelChrome extends PureComponent<Props, State> {
           height={height - PANEL_HEADER_HEIGHT - config.theme.panelPadding.vertical}
           renderCounter={renderCounter}
           replaceVariables={this.replaceVariables}
+          targets={targets}
+          onCustomQuery={onCustomQuery}
         />
       </div>
     );
@@ -171,7 +186,7 @@ export class PanelChrome extends PureComponent<Props, State> {
 
   renderPanelBody = (width: number, height: number): JSX.Element => {
     const { panel } = this.props;
-    const { refreshCounter, timeRange } = this.state;
+    const { refreshCounter, timeRange, customQuery } = this.state;
     const { datasource, targets } = panel;
     return (
       <>
@@ -187,9 +202,10 @@ export class PanelChrome extends PureComponent<Props, State> {
             scopedVars={panel.scopedVars}
             onDataResponse={this.onDataResponse}
             onError={this.onDataError}
+            customQuery={customQuery}
           >
             {({ loading, panelData }) => {
-              return this.renderPanelPlugin(loading, panelData, width, height);
+              return this.renderPanelPlugin(loading, panelData, width, height, targets, this.onCustomQuery);
             }}
           </DataPanel>
         ) : (

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -22,6 +22,7 @@ import * as dashListPanel from 'app/plugins/panel/dashlist/module';
 import * as pluginsListPanel from 'app/plugins/panel/pluginlist/module';
 import * as alertListPanel from 'app/plugins/panel/alertlist/module';
 import * as heatmapPanel from 'app/plugins/panel/heatmap/module';
+import * as linkedinHeatmapPanel from 'app/plugins/panel/linkedin-heatmap/module';
 import * as tablePanel from 'app/plugins/panel/table/module';
 import * as table2Panel from 'app/plugins/panel/table2/module';
 import * as singlestatPanel from 'app/plugins/panel/singlestat/module';
@@ -62,6 +63,7 @@ const builtInPlugins = {
   'app/plugins/panel/gettingstarted/module': gettingStartedPanel,
   'app/plugins/panel/gauge/module': gaugePanel,
   'app/plugins/panel/bargauge/module': barGaugePanel,
+  'app/plugins/panel/linkedin-heatmap/module': linkedinHeatmapPanel,
 };
 
 export default builtInPlugins;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -170,6 +170,8 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
           responseListLength: responseList.length,
           refId: activeTargets[index].refId,
           valueWithRefId: activeTargets[index].valueWithRefId,
+          xAxisLabel: activeTargets[index].xAxisLabel,
+          yAxisLabel: activeTargets[index].yAxisLabel,
         };
         const series = this.resultTransformer.transform(response, transformerOptions);
         result = [...result, ...series];

--- a/public/app/plugins/datasource/prometheus/partials/query.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/query.editor.html
@@ -41,7 +41,7 @@
 
     <div class="gf-form gf-form--grow">
       <label class="gf-form-label width-5">Format</label>
-      <div class="gf-form-select-wrapper width-8">
+      <div class="gf-form-select-wrapper width-12">
         <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats"
           ng-change="ctrl.refresh()"></select>
       </div>
@@ -52,6 +52,21 @@
           <i class="fa fa-share-square-o"></i>
         </a>
       </label>
+    </div>
+  </div>
+  <div class="gf-form-inline" ng-if="ctrl.target.format === 'linkedin_heatmap'">
+    <div class="gf-form">
+      <label class="gf-form-label width-8">X aixs label</label>
+      <input type="text" class="gf-form-input width-8" ng-model="ctrl.target.xAxisLabel"
+        spellcheck='false' ng-model-onblur ng-change="ctrl.refreshMetricData()"
+      />
+    </div>
+    <div class="gf-form gf-form--grow">
+      <label class="gf-form-label width-8">Y aixs label</label>
+      <input type="text" class="gf-form-input width-8" ng-model="ctrl.target.yAxisLabel"
+        spellcheck='false' ng-model-onblur ng-change="ctrl.refreshMetricData()"
+      />
+      <label class="gf-form-label gf-form-label--grow"></label>
     </div>
   </div>
 </query-editor-row>

--- a/public/app/plugins/datasource/prometheus/query_ctrl.ts
+++ b/public/app/plugins/datasource/prometheus/query_ctrl.ts
@@ -35,6 +35,7 @@ class PrometheusQueryCtrl extends QueryCtrl {
       { text: 'Time series', value: 'time_series' },
       { text: 'Table', value: 'table' },
       { text: 'Heatmap', value: 'heatmap' },
+      { text: 'LinkedIn Heatmap', value: 'linkedin_heatmap' },
     ];
 
     this.instant = false;

--- a/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export class HeatmapCanvas extends React.Component<any> {
+  canvas: HTMLCanvasElement | null = null;
+
+  componentDidUpdate() {
+    this.draw();
+  }
+
+  componentDidMount() {
+    this.draw();
+  }
+
+  draw() {
+    if (this.canvas === null) {
+      return;
+    }
+
+    const { width, height, data } = this.props;
+
+    if (!width || !height) {
+      return;
+    }
+
+    const ctx = this.canvas.getContext('2d');
+    console.log(this.props);
+    // for (let i = 0; i < width; i++) {
+    //   for (let j = 0; j < height; j++) {
+    //     const colorJitter = Math.round(Math.random() * 100);
+    //     ctx.fillStyle = `rgb(200,${colorJitter},0)`;
+    //     ctx.fillRect(i, j, 1, 1);
+    //   }
+    // }
+    const pointWidth = Math.floor(width / data.length);
+    const pointHeight = Math.floor(height / data.length);
+    console.log(pointWidth, pointHeight);
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      for (let j = 0; j < row.length; j++) {
+        const value = row[j];
+        ctx.fillStyle = `rgb(200,${value},0)`;
+        ctx.fillRect(i * pointWidth, j * pointHeight, pointWidth, pointHeight);
+      }
+    }
+  }
+
+  render() {
+    const { width, height } = this.props;
+    return <canvas className="linkedin-heatmap-canvas" ref={e => (this.canvas = e)} width={width} height={height} />;
+  }
+}

--- a/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { getColorFromHexRgbOrName } from '@grafana/ui/src/utils';
 
 interface HeatmapCanvasProps {
   width: number;
   height: number;
   data: number[][];
   labels: string[];
-  valueToColor?: (value: number) => string;
+  thresholds: any[];
   onPointHover?: (value: number, labels: string[]) => void;
   onPointClick?: (labels: string[]) => void;
 }
@@ -102,6 +103,17 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
     this.draw();
   }
 
+  valueToColor = (value: number) => {
+    const thresholds = this.props.thresholds;
+    let color = getColorFromHexRgbOrName(thresholds[0].color);
+    for (const threshold of thresholds) {
+      if (value > threshold.value) {
+        color = getColorFromHexRgbOrName(threshold.color);
+      }
+    }
+    return color;
+  };
+
   draw() {
     if (this.canvas === null) {
       return;
@@ -126,11 +138,7 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
       const row = data[i];
       for (let j = 0; j < row.length; j++) {
         const value = row[j];
-        if (this.props.valueToColor) {
-          ctx.fillStyle = this.props.valueToColor(value);
-        } else {
-          ctx.fillStyle = `rgb(200,${value},0)`;
-        }
+        ctx.fillStyle = this.valueToColor(value);
         ctx.fillRect(i * pointSize, j * pointSize, pointSize, pointSize);
       }
     }

--- a/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
@@ -34,6 +34,13 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
     if (!this.ctx) {
       return;
     }
+    console.log(event);
+    if (event.ctrlKey) {
+      return this.zoomCanvas(event);
+    }
+    if (event.shiftKey) {
+      return this.resetZoom();
+    }
     const x = event.layerX;
     const y = event.layerY;
     const pointLabels = this.getPointLabels(x, y);
@@ -50,6 +57,7 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
     const x = event.layerX;
     const y = event.layerY;
     // const pixel = this.ctx.getImageData(x, y, 1, 1);
+    // console.log(pixel);
     // const pixelData = pixel.data;
     const pointLabels = this.getPointLabels(x, y);
     const pointValue = this.getPointValue(x, y);
@@ -73,6 +81,25 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
       return null;
     }
     return this.props.data[yIndex][xIndex];
+  }
+
+  zoomCanvas(event) {
+    const { width, height } = this.props;
+    const x = event.layerX;
+    const y = event.layerY;
+    // this.ctx.save();
+    this.ctx.clearRect(0, 0, width, height);
+    this.ctx.translate(-x, -y);
+    this.ctx.scale(2, 2);
+    this.draw();
+    // this.ctx.restore();
+  }
+
+  resetZoom() {
+    const { width, height } = this.props;
+    this.ctx.clearRect(0, 0, width, height);
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this.draw();
   }
 
   draw() {

--- a/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
@@ -37,7 +37,8 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
     const x = event.layerX;
     const y = event.layerY;
     const pointLabels = this.getPointLabels(x, y);
-    if (this.props.onPointHover) {
+    const pointValue = this.getPointValue(x, y);
+    if (this.props.onPointHover && pointValue !== null) {
       this.props.onPointClick(pointLabels);
     }
   };
@@ -54,7 +55,7 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
     const pointValue = this.getPointValue(x, y);
     // console.log(pointLabels, pointValue);
 
-    if (this.props.onPointHover && pointValue) {
+    if (this.props.onPointHover) {
       this.props.onPointHover(pointValue, pointLabels);
     }
   };
@@ -81,7 +82,7 @@ export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
 
     const { width, height, data } = this.props;
 
-    if (!width || !height) {
+    if (!width || !height || !data) {
       return;
     }
 

--- a/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/HeatmapCanvas.tsx
@@ -1,7 +1,19 @@
 import React from 'react';
 
-export class HeatmapCanvas extends React.Component<any> {
+interface HeatmapCanvasProps {
+  width: number;
+  height: number;
+  data: number[][];
+  labels: string[];
+  valueToColor?: (value: number) => string;
+  onPointHover?: (value: number, labels: string[]) => void;
+  onPointClick?: (labels: string[]) => void;
+}
+
+export class HeatmapCanvas extends React.PureComponent<HeatmapCanvasProps> {
   canvas: HTMLCanvasElement | null = null;
+  ctx: CanvasRenderingContext2D;
+  pointSize: number;
 
   componentDidUpdate() {
     this.draw();
@@ -9,6 +21,57 @@ export class HeatmapCanvas extends React.Component<any> {
 
   componentDidMount() {
     this.draw();
+    this.canvas.addEventListener('mousemove', this.handleMouseMove);
+    this.canvas.addEventListener('click', this.handleMouseClick);
+  }
+
+  componentWillUnmount() {
+    this.canvas.removeEventListener('mousemove', this.handleMouseMove);
+    this.canvas.removeEventListener('click', this.handleMouseClick);
+  }
+
+  handleMouseClick = event => {
+    if (!this.ctx) {
+      return;
+    }
+    const x = event.layerX;
+    const y = event.layerY;
+    const pointLabels = this.getPointLabels(x, y);
+    if (this.props.onPointHover) {
+      this.props.onPointClick(pointLabels);
+    }
+  };
+
+  handleMouseMove = event => {
+    if (!this.ctx) {
+      return;
+    }
+    const x = event.layerX;
+    const y = event.layerY;
+    // const pixel = this.ctx.getImageData(x, y, 1, 1);
+    // const pixelData = pixel.data;
+    const pointLabels = this.getPointLabels(x, y);
+    const pointValue = this.getPointValue(x, y);
+    // console.log(pointLabels, pointValue);
+
+    if (this.props.onPointHover && pointValue) {
+      this.props.onPointHover(pointValue, pointLabels);
+    }
+  };
+
+  getPointLabels(x: number, y: number): string[] {
+    const xIndex = Math.floor(x / this.pointSize);
+    const yIndex = Math.floor(y / this.pointSize);
+    return [this.props.labels[xIndex], this.props.labels[yIndex]];
+  }
+
+  getPointValue(x: number, y: number): number {
+    const xIndex = Math.floor(x / this.pointSize);
+    const yIndex = Math.floor(y / this.pointSize);
+    if (xIndex >= this.props.data.length || yIndex >= this.props.data.length) {
+      return null;
+    }
+    return this.props.data[yIndex][xIndex];
   }
 
   draw() {
@@ -22,29 +85,31 @@ export class HeatmapCanvas extends React.Component<any> {
       return;
     }
 
-    const ctx = this.canvas.getContext('2d');
+    console.log('drawing canvas');
     console.log(this.props);
-    // for (let i = 0; i < width; i++) {
-    //   for (let j = 0; j < height; j++) {
-    //     const colorJitter = Math.round(Math.random() * 100);
-    //     ctx.fillStyle = `rgb(200,${colorJitter},0)`;
-    //     ctx.fillRect(i, j, 1, 1);
-    //   }
-    // }
-    const pointWidth = Math.floor(width / data.length);
-    const pointHeight = Math.floor(height / data.length);
-    console.log(pointWidth, pointHeight);
+    const ctx = this.canvas.getContext('2d');
+    this.ctx = ctx;
+    const pointWidth = Math.max(Math.floor(width / data.length), 1);
+    const pointHeight = Math.max(Math.floor(height / data.length), 1);
+    const pointSize = Math.min(pointWidth, pointHeight);
+    this.pointSize = pointSize;
+    // console.log(pointWidth, pointHeight);
     for (let i = 0; i < data.length; i++) {
       const row = data[i];
       for (let j = 0; j < row.length; j++) {
         const value = row[j];
-        ctx.fillStyle = `rgb(200,${value},0)`;
-        ctx.fillRect(i * pointWidth, j * pointHeight, pointWidth, pointHeight);
+        if (this.props.valueToColor) {
+          ctx.fillStyle = this.props.valueToColor(value);
+        } else {
+          ctx.fillStyle = `rgb(200,${value},0)`;
+        }
+        ctx.fillRect(i * pointSize, j * pointSize, pointSize, pointSize);
       }
     }
   }
 
   render() {
+    console.log('rendering canvas component');
     const { width, height } = this.props;
     return <canvas className="linkedin-heatmap-canvas" ref={e => (this.canvas = e)} width={width} height={height} />;
   }

--- a/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
@@ -1,0 +1,58 @@
+// Libraries
+import React, { PureComponent } from 'react';
+
+// Services & Utils
+import { config } from 'app/core/config';
+
+// Components
+import { Gauge } from '@grafana/ui';
+import { HeatmapCanvas } from './HeatmapCanvas';
+
+// Types
+import { LHeatmapOptions } from './types';
+import { DisplayValue, PanelProps } from '@grafana/ui';
+
+export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>> {
+  renderValue = (value: DisplayValue, width: number, height: number): JSX.Element => {
+    const { options } = this.props;
+
+    return (
+      <Gauge
+        value={value}
+        width={width}
+        height={height}
+        thresholds={options.thresholds}
+        showThresholdLabels={options.showThresholdLabels}
+        showThresholdMarkers={options.showThresholdMarkers}
+        minValue={options.minValue}
+        maxValue={options.maxValue}
+        theme={config.theme}
+      />
+    );
+  };
+
+  getProcessedValues = (): DisplayValue[] => {
+    return [];
+  };
+
+  render() {
+    console.log(this.props);
+    const { height, width, panelData } = this.props;
+    const heatmapData = panelData.timeSeries[0][0];
+    const labels = panelData.timeSeries[0][1];
+    return (
+      <div className="linkedin-heatmap-poc">
+        <HeatmapCanvas data={heatmapData} labels={labels} width={width} height={height} />
+      </div>
+      // <Graph
+      //   timeSeries={vmSeries}
+      //   timeRange={timeRange}
+      //   showLines={showLines}
+      //   showPoints={showPoints}
+      //   showBars={showBars}
+      //   width={width}
+      //   height={height}
+      // />
+    );
+  }
+}

--- a/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 
 // Services & Utils
 import { config } from 'app/core/config';
+import { getColorFromHexRgbOrName } from '@grafana/ui/src/utils';
 
 // Components
 import { Gauge } from '@grafana/ui';
@@ -12,7 +13,43 @@ import { HeatmapCanvas } from './HeatmapCanvas';
 import { LHeatmapOptions } from './types';
 import { DisplayValue, PanelProps } from '@grafana/ui';
 
-export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>> {
+interface LHeatmapPanelState {
+  pointValue: number;
+  pointLabels: string[];
+}
+
+export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LHeatmapPanelState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pointValue: null,
+      pointLabels: [],
+    };
+  }
+
+  handlePointHover = (value: number, labels: string[]) => {
+    // console.log(labels, value);
+    this.setState({
+      pointValue: value,
+      pointLabels: labels,
+    });
+  };
+
+  handlePointClick = (labels: string[]) => {
+    console.log('click on', labels);
+  };
+
+  valueToColor = (value: number) => {
+    const thresholds = this.props.options.thresholds;
+    let color = getColorFromHexRgbOrName(thresholds[0].color);
+    for (const threshold of thresholds) {
+      if (value > threshold.value) {
+        color = getColorFromHexRgbOrName(threshold.color);
+      }
+    }
+    return color;
+  };
+
   renderValue = (value: DisplayValue, width: number, height: number): JSX.Element => {
     const { options } = this.props;
 
@@ -36,13 +73,26 @@ export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>> {
   };
 
   render() {
-    console.log(this.props);
     const { height, width, panelData } = this.props;
     const heatmapData = panelData.timeSeries[0][0];
     const labels = panelData.timeSeries[0][1];
     return (
       <div className="linkedin-heatmap-poc">
-        <HeatmapCanvas data={heatmapData} labels={labels} width={width} height={height} />
+        <HeatmapCanvas
+          width={width}
+          height={height - 40}
+          data={heatmapData}
+          labels={labels}
+          valueToColor={this.valueToColor}
+          onPointHover={this.handlePointHover}
+          onPointClick={this.handlePointClick}
+        />
+        <div className="linkedin-heatmap-value-container" style={{ padding: '8px' }}>
+          <span>
+            {this.state.pointLabels[0]} - {this.state.pointLabels[1]}
+          </span>
+          <span style={{ marginLeft: '8px' }}>{this.state.pointValue}</span>
+        </div>
       </div>
       // <Graph
       //   timeSeries={vmSeries}

--- a/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
@@ -1,17 +1,20 @@
 // Libraries
+import _ from 'lodash';
 import React, { PureComponent } from 'react';
 
 // Services & Utils
 import { config } from 'app/core/config';
+import { processTimeSeries } from '@grafana/ui/src/utils';
 import { getColorFromHexRgbOrName } from '@grafana/ui/src/utils';
 
 // Components
-import { Gauge } from '@grafana/ui';
+import { Gauge, Graph, TimeSeriesVMs } from '@grafana/ui';
 import { HeatmapCanvas } from './HeatmapCanvas';
 
 // Types
 import { LHeatmapOptions } from './types';
 import { DisplayValue, PanelProps } from '@grafana/ui';
+import { NullValueMode } from '@grafana/ui/src/types';
 
 interface LHeatmapPanelState {
   pointValue: number;
@@ -19,6 +22,10 @@ interface LHeatmapPanelState {
 }
 
 export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LHeatmapPanelState> {
+  heatmapData: any;
+  labels: any;
+  customQuery: string;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -37,6 +44,15 @@ export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LH
 
   handlePointClick = (labels: string[]) => {
     console.log('click on', labels);
+    const target = this.props.targets[0];
+    const query = target.expr;
+    const interpolatedLabels = [`${target.xAxisLabel}="${labels[0]}"`, `${target.yAxisLabel}="${labels[1]}"`];
+    const modifiedQuery = addLabelsToPromQuery(query, interpolatedLabels);
+    console.log(query, modifiedQuery);
+    if (this.props.onCustomQuery) {
+      this.customQuery = modifiedQuery;
+      this.props.onCustomQuery(modifiedQuery);
+    }
   };
 
   valueToColor = (value: number) => {
@@ -73,36 +89,63 @@ export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LH
   };
 
   render() {
-    const { height, width, panelData } = this.props;
-    const heatmapData = panelData.timeSeries[0][0];
-    const labels = panelData.timeSeries[0][1];
+    // console.log(this.props);
+    const { height, width, panelData, timeRange } = this.props;
+    const data = panelData.timeSeries[0];
+    let heatmapData, labels, vmSeries: TimeSeriesVMs;
+    if (!data || (data && !_.isArray(data))) {
+      heatmapData = this.heatmapData;
+      labels = this.labels;
+      vmSeries = processTimeSeries({
+        timeSeries: panelData.timeSeries,
+        nullValueMode: NullValueMode.Ignore,
+      });
+    } else {
+      heatmapData = data[0];
+      labels = data[1];
+      this.heatmapData = heatmapData;
+      this.labels = labels;
+    }
+    const pointValue = this.state.pointValue || 'null';
+
     return (
       <div className="linkedin-heatmap-poc">
-        <HeatmapCanvas
-          width={width}
-          height={height - 40}
-          data={heatmapData}
-          labels={labels}
-          valueToColor={this.valueToColor}
-          onPointHover={this.handlePointHover}
-          onPointClick={this.handlePointClick}
-        />
+        <div style={{ display: 'flex' }}>
+          <HeatmapCanvas
+            width={width / 2}
+            height={height - 40}
+            data={heatmapData}
+            labels={labels}
+            valueToColor={this.valueToColor}
+            onPointHover={this.handlePointHover}
+            onPointClick={this.handlePointClick}
+          />
+          {vmSeries && (
+            <div className="linkedin-heatmap-graph-container" style={{ width: width / 2, height: height / 2 }}>
+              <Graph timeSeries={vmSeries} timeRange={timeRange} showLines={true} width={width / 2} height={height} />
+            </div>
+          )}
+        </div>
         <div className="linkedin-heatmap-value-container" style={{ padding: '8px' }}>
           <span>
             {this.state.pointLabels[0]} - {this.state.pointLabels[1]}
           </span>
-          <span style={{ marginLeft: '8px' }}>{this.state.pointValue}</span>
+          <span style={{ marginLeft: '8px' }}>{pointValue}</span>
         </div>
       </div>
-      // <Graph
-      //   timeSeries={vmSeries}
-      //   timeRange={timeRange}
-      //   showLines={showLines}
-      //   showPoints={showPoints}
-      //   showBars={showBars}
-      //   width={width}
-      //   height={height}
-      // />
     );
   }
+}
+
+function addLabelsToPromQuery(query: string, labels: string[]) {
+  const selectorOpenIndex = query.indexOf('{');
+  const selectorCloseIndex = query.indexOf('}');
+  if (selectorOpenIndex < 0) {
+    return query;
+  }
+  const labelsStr = labels.join(',');
+  if (selectorCloseIndex - selectorOpenIndex === 1) {
+    return query.slice(0, selectorOpenIndex + 1) + labelsStr + query.slice(selectorCloseIndex);
+  }
+  return query.slice(0, selectorOpenIndex + 1) + labelsStr + ',' + query.slice(selectorOpenIndex + 1);
 }

--- a/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanel.tsx
@@ -3,17 +3,15 @@ import _ from 'lodash';
 import React, { PureComponent } from 'react';
 
 // Services & Utils
-import { config } from 'app/core/config';
 import { processTimeSeries } from '@grafana/ui/src/utils';
-import { getColorFromHexRgbOrName } from '@grafana/ui/src/utils';
 
 // Components
-import { Gauge, Graph, TimeSeriesVMs } from '@grafana/ui';
+import { Graph, TimeSeriesVMs } from '@grafana/ui';
 import { HeatmapCanvas } from './HeatmapCanvas';
 
 // Types
 import { LHeatmapOptions } from './types';
-import { DisplayValue, PanelProps } from '@grafana/ui';
+import { PanelProps } from '@grafana/ui';
 import { NullValueMode } from '@grafana/ui/src/types';
 
 interface LHeatmapPanelState {
@@ -83,42 +81,9 @@ export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LH
     }
   };
 
-  valueToColor = (value: number) => {
-    const thresholds = this.props.options.thresholds;
-    let color = getColorFromHexRgbOrName(thresholds[0].color);
-    for (const threshold of thresholds) {
-      if (value > threshold.value) {
-        color = getColorFromHexRgbOrName(threshold.color);
-      }
-    }
-    return color;
-  };
-
-  renderValue = (value: DisplayValue, width: number, height: number): JSX.Element => {
-    const { options } = this.props;
-
-    return (
-      <Gauge
-        value={value}
-        width={width}
-        height={height}
-        thresholds={options.thresholds}
-        showThresholdLabels={options.showThresholdLabels}
-        showThresholdMarkers={options.showThresholdMarkers}
-        minValue={options.minValue}
-        maxValue={options.maxValue}
-        theme={config.theme}
-      />
-    );
-  };
-
-  getProcessedValues = (): DisplayValue[] => {
-    return [];
-  };
-
   render() {
     // console.log(this.props);
-    const { height, width, timeRange } = this.props;
+    const { height, width, timeRange, options } = this.props;
     const pointValue = this.state.pointValue || 'null';
 
     return (
@@ -129,7 +94,7 @@ export class LHeatmapPanel extends PureComponent<PanelProps<LHeatmapOptions>, LH
             height={height - 40}
             data={this.state.heatmapData}
             labels={this.state.labels}
-            valueToColor={this.valueToColor}
+            thresholds={options.thresholds}
             onPointHover={this.handlePointHover}
             onPointClick={this.handlePointClick}
           />

--- a/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanelEditor.tsx
+++ b/public/app/plugins/panel/linkedin-heatmap/LHeatmapPanelEditor.tsx
@@ -1,0 +1,47 @@
+// Libraries
+import React, { PureComponent } from 'react';
+import {
+  PanelEditorProps,
+  ThresholdsEditor,
+  Threshold,
+  PanelOptionsGrid,
+  ValueMappingsEditor,
+  ValueMapping,
+} from '@grafana/ui';
+
+import { LHeatmapOptions } from './types';
+import { SingleStatValueOptions } from '../singlestat2/types';
+
+export class LHeatmapPanelEditor extends PureComponent<PanelEditorProps<LHeatmapOptions>> {
+  onThresholdsChanged = (thresholds: Threshold[]) =>
+    this.props.onOptionsChange({
+      ...this.props.options,
+      thresholds,
+    });
+
+  onValueMappingsChanged = (valueMappings: ValueMapping[]) =>
+    this.props.onOptionsChange({
+      ...this.props.options,
+      valueMappings,
+    });
+
+  onValueOptionsChanged = (valueOptions: SingleStatValueOptions) =>
+    this.props.onOptionsChange({
+      ...this.props.options,
+      valueOptions,
+    });
+
+  render() {
+    const { options } = this.props;
+
+    return (
+      <>
+        <PanelOptionsGrid>
+          <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
+        </PanelOptionsGrid>
+
+        <ValueMappingsEditor onChange={this.onValueMappingsChanged} valueMappings={options.valueMappings} />
+      </>
+    );
+  }
+}

--- a/public/app/plugins/panel/linkedin-heatmap/module.ts
+++ b/public/app/plugins/panel/linkedin-heatmap/module.ts
@@ -1,0 +1,10 @@
+import { ReactPanelPlugin } from '@grafana/ui';
+
+import { LHeatmapPanelEditor } from './LHeatmapPanelEditor';
+import { LHeatmapPanel } from './LHeatmapPanel';
+import { LHeatmapOptions, defaults } from './types';
+
+export const reactPanel = new ReactPanelPlugin<LHeatmapOptions>(LHeatmapPanel);
+
+reactPanel.setEditor(LHeatmapPanelEditor);
+reactPanel.setDefaults(defaults);

--- a/public/app/plugins/panel/linkedin-heatmap/plugin.json
+++ b/public/app/plugins/panel/linkedin-heatmap/plugin.json
@@ -1,0 +1,20 @@
+{
+  "type": "panel",
+  "name": "LinkedIn Heatmap",
+  "id": "linkedin-heatmap",
+
+  "dataFormats": ["time_series"],
+
+  "info": {
+    "description": "Heatmap Panel for Grafana",
+    "author": {
+      "name": "Grafana Project",
+      "url": "https://grafana.com"
+    },
+    "logos": {},
+    "links": [
+      { "name": "Brendan Gregg - Heatmaps", "url": "http://www.brendangregg.com/heatmaps.html" },
+      { "name": "Brendan Gregg - Latency Heatmaps", "url": " http://www.brendangregg.com/HeatMaps/latency.html" }
+    ]
+  }
+}

--- a/public/app/plugins/panel/linkedin-heatmap/types.ts
+++ b/public/app/plugins/panel/linkedin-heatmap/types.ts
@@ -1,0 +1,6 @@
+export type LHeatmapOptions = any;
+
+export const defaults: LHeatmapOptions = {
+  valueMappings: [],
+  thresholds: [{ index: 0, value: -Infinity, color: 'green' }, { index: 1, value: 80, color: 'red' }],
+};


### PR DESCRIPTION
Use `promLinkedinHeatmap` test data gen from this PR: https://github.com/grafana/fake-data-gen/pull/13

Dummy implementation of the linkedin heatmap. Click on the point in order to load graph for the particular labels. Ctrl+click for zoom and Shift+click for reset zoom. Zoom is very dummy and scaled heatmap doesn't correspond real data when you hover over a point.

Query should look like `irate(counters_packets{}[5m])` with empty `{}` even if it doesn't contain labels. This is due to dummy implementation of loading graph data - panel modifies original query and adds labels from point you clicked on, so result time series query will look like `irate(counters_packets{src="switch_182",dst="switch_16"}[5m])`

![Screenshot from 2019-03-22 11-36-15](https://user-images.githubusercontent.com/4932851/54810262-b828d580-4c96-11e9-9265-f77b3dd8d63b.png)

![Screenshot from 2019-03-22 11-31-24](https://user-images.githubusercontent.com/4932851/54810039-10130c80-4c96-11e9-88be-9cde1d4d2867.png)

Panel JSON:
```json
{
  "datasource": "LinkedIn Heatmap Data",
  "gridPos": {
    "h": 18,
    "w": 24,
    "x": 0,
    "y": 0
  },
  "id": 3,
  "options": {
    "thresholds": [
      {
        "color": "rgb(145, 157, 143)",
        "index": 0,
        "value": null
      },
      {
        "color": "#56A64B",
        "index": 1,
        "value": 1
      },
      {
        "color": "#F2CC0C",
        "index": 2,
        "value": 30
      },
      {
        "color": "#C4162A",
        "index": 3,
        "value": 50
      }
    ],
    "valueMappings": []
  },
  "targets": [
    {
      "expr": "irate(counters_packets{}[5m])",
      "format": "linkedin_heatmap",
      "instant": true,
      "interval": "",
      "intervalFactor": 1,
      "legendFormat": "{{src}} - {{dst}}",
      "refId": "A",
      "xAxisLabel": "src",
      "yAxisLabel": "dst"
    }
  ],
  "timeFrom": null,
  "timeShift": null,
  "title": "Panel Title",
  "type": "linkedin-heatmap"
}
```
