### PR TITLE
Explore: Move back / forward with browser buttons now works

### DIFF
--- a/public/app/core/actions/location.ts
+++ b/public/app/core/actions/location.ts
@@ -1,17 +1,4 @@
 import { LocationUpdate } from 'app/types';
+import { actionCreatorFactory } from 'app/core/redux';
 
-export enum CoreActionTypes {
-  UpdateLocation = 'UPDATE_LOCATION',
-}
-
-export type Action = UpdateLocationAction;
-
-export interface UpdateLocationAction {
-  type: CoreActionTypes.UpdateLocation;
-  payload: LocationUpdate;
-}
-
-export const updateLocation = (location: LocationUpdate): UpdateLocationAction => ({
-  type: CoreActionTypes.UpdateLocation,
-  payload: location,
-});
+export const updateLocation = actionCreatorFactory<LocationUpdate>('UPDATE_LOCATION').create();

--- a/public/app/core/reducers/location.ts
+++ b/public/app/core/reducers/location.ts
@@ -1,7 +1,8 @@
-import { Action, CoreActionTypes } from 'app/core/actions/location';
 import { LocationState } from 'app/types';
 import { renderUrl } from 'app/core/utils/url';
 import _ from 'lodash';
+import { reducerFactory } from 'app/core/redux';
+import { updateLocation } from 'app/core/actions';
 
 export const initialState: LocationState = {
   url: '',
@@ -12,9 +13,10 @@ export const initialState: LocationState = {
   lastUpdated: 0,
 };
 
-export const locationReducer = (state = initialState, action: Action): LocationState => {
-  switch (action.type) {
-    case CoreActionTypes.UpdateLocation: {
+export const locationReducer = reducerFactory<LocationState>(initialState)
+  .addMapper({
+    filter: updateLocation,
+    mapper: (state, action): LocationState => {
       const { path, routeParams, replace } = action.payload;
       let query = action.payload.query || state.query;
 
@@ -31,8 +33,6 @@ export const locationReducer = (state = initialState, action: Action): LocationS
         replace: replace === true,
         lastUpdated: new Date().getTime(),
       };
-    }
-  }
-
-  return state;
-};
+    },
+  })
+  .create();

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -68,5 +68,9 @@ export const getNoPayloadActionCreatorMock = (creator: NoPayloadActionCreator): 
   return mock;
 };
 
+export const mockActionCreator = (creator: ActionCreator<any>) => {
+  return Object.assign(jest.fn(), creator);
+};
+
 // Should only be used by tests
 export const resetAllActionCreatorTypes = () => (allActionCreators.length = 0);

--- a/public/app/features/alerting/AlertRuleList.test.tsx
+++ b/public/app/features/alerting/AlertRuleList.test.tsx
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import { AlertRuleList, Props } from './AlertRuleList';
 import { AlertRule, NavModel } from '../../types';
 import appEvents from '../../core/app_events';
+import { mockActionCreator } from 'app/core/redux';
+import { updateLocation } from 'app/core/actions';
 
 jest.mock('../../core/app_events', () => ({
   emit: jest.fn(),
@@ -12,7 +14,7 @@ const setup = (propOverrides?: object) => {
   const props: Props = {
     navModel: {} as NavModel,
     alertRules: [] as AlertRule[],
-    updateLocation: jest.fn(),
+    updateLocation: mockActionCreator(updateLocation),
     getAlertRulesAsync: jest.fn(),
     setSearchQuery: jest.fn(),
     togglePauseAlertRule: jest.fn(),

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -3,8 +3,9 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { DashboardPage, Props, State, mapStateToProps } from './DashboardPage';
 import { DashboardModel } from '../state';
 import { cleanUpDashboard } from '../state/actions';
-import { getNoPayloadActionCreatorMock, NoPayloadActionCreatorMock } from 'app/core/redux';
+import { getNoPayloadActionCreatorMock, NoPayloadActionCreatorMock, mockActionCreator } from 'app/core/redux';
 import { DashboardRouteInfo, DashboardInitPhase } from 'app/types';
+import { updateLocation } from 'app/core/actions';
 
 jest.mock('app/features/dashboard/components/DashboardSettings/SettingsCtrl', () => ({}));
 
@@ -62,7 +63,7 @@ function dashboardPageScenario(description, scenarioFn: (ctx: ScenarioContext) =
           initPhase: DashboardInitPhase.NotStarted,
           isInitSlow: false,
           initDashboard: jest.fn(),
-          updateLocation: jest.fn(),
+          updateLocation: mockActionCreator(updateLocation),
           notifyApp: jest.fn(),
           cleanUpDashboard: ctx.cleanUpDashboardMock,
           dashboard: null,

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -4,10 +4,9 @@ import { getBackendSrv } from 'app/core/services/backend_srv';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { LayoutMode } from 'app/core/components/LayoutSelector/LayoutSelector';
 import { updateLocation, updateNavIndex, UpdateNavIndexAction } from 'app/core/actions';
-import { UpdateLocationAction } from 'app/core/actions/location';
 import { buildNavModel } from './navModel';
 import { DataSourceSettings } from '@grafana/ui/src/types';
-import { Plugin, StoreState } from 'app/types';
+import { Plugin, StoreState, LocationUpdate } from 'app/types';
 import { actionCreatorFactory } from 'app/core/redux';
 import { ActionOf, noPayloadActionCreatorFactory } from 'app/core/redux/actionCreatorFactory';
 
@@ -32,12 +31,12 @@ export const setDataSourceName = actionCreatorFactory<string>('SET_DATA_SOURCE_N
 export const setIsDefault = actionCreatorFactory<boolean>('SET_IS_DEFAULT').create();
 
 export type Action =
-  | UpdateLocationAction
   | UpdateNavIndexAction
   | ActionOf<DataSourceSettings>
   | ActionOf<DataSourceSettings[]>
   | ActionOf<Plugin>
-  | ActionOf<Plugin[]>;
+  | ActionOf<Plugin[]>
+  | ActionOf<LocationUpdate>;
 
 type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action>;
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -106,7 +106,25 @@ export class Explore extends React.PureComponent<ExploreProps> {
   }
 
   componentDidMount() {
-    this.refreshExplore();
+    const { exploreId, urlState, initialized } = this.props;
+    const { datasource, queries, range = DEFAULT_RANGE, ui = DEFAULT_UI_STATE } = (urlState || {}) as ExploreUrlState;
+    const initialDatasource = datasource || store.get(LAST_USED_DATASOURCE_KEY);
+    const initialQueries: DataQuery[] = ensureQueries(queries);
+    const initialRange = { from: parseTime(range.from), to: parseTime(range.to) };
+    const width = this.el ? this.el.offsetWidth : 0;
+
+    // initialize the whole explore first time we mount and if browser history contains a change in datasource
+    if (!initialized) {
+      this.props.initializeExplore(
+        exploreId,
+        initialDatasource,
+        initialQueries,
+        initialRange,
+        width,
+        this.exploreEvents,
+        ui
+      );
+    }
   }
 
   componentWillUnmount() {
@@ -165,31 +183,9 @@ export class Explore extends React.PureComponent<ExploreProps> {
   };
 
   refreshExplore = () => {
-    const { exploreId, urlState, initialized, refresh } = this.props;
-    const { datasource, queries, range = DEFAULT_RANGE, ui = DEFAULT_UI_STATE } = (urlState || {}) as ExploreUrlState;
-    const initialDatasource = datasource || store.get(LAST_USED_DATASOURCE_KEY);
-    const initialQueries: DataQuery[] = ensureQueries(queries);
-    const initialRange = {
-      from: parseTime(range.from),
-      to: parseTime(range.to),
-    };
-    const width = this.el ? this.el.offsetWidth : 0;
+    const { exploreId, refresh } = this.props;
 
-    // initialize the whole explore first time we mount and if browser history contains a change in datasource
-    if (!initialized || refresh.datasource) {
-      this.props.initializeExplore(
-        exploreId,
-        initialDatasource,
-        initialQueries,
-        initialRange,
-        width,
-        this.exploreEvents,
-        ui
-      );
-      return;
-    }
-
-    if (refresh.queries || refresh.ui || refresh.range) {
+    if (refresh.queries || refresh.ui || refresh.range || refresh.datasource) {
       this.props.refreshExplore(exploreId);
     }
   };

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -89,37 +89,24 @@ export class Explore extends React.PureComponent<ExploreProps> {
    */
   timepickerRef: React.RefObject<TimePicker>;
 
-  constructor(props) {
+  constructor(props: ExploreProps) {
     super(props);
     this.exploreEvents = new Emitter();
     this.timepickerRef = React.createRef();
   }
 
   async componentDidMount() {
-    const { exploreId, initialized, urlState } = this.props;
-    // Don't initialize on split, but need to initialize urlparameters when present
-    if (!initialized) {
-      // Load URL state and parse range
-      const { datasource, queries, range = DEFAULT_RANGE, ui = DEFAULT_UI_STATE } = (urlState || {}) as ExploreUrlState;
-      const initialDatasource = datasource || store.get(LAST_USED_DATASOURCE_KEY);
-      const initialQueries: DataQuery[] = ensureQueries(queries);
-      const initialRange = { from: parseTime(range.from), to: parseTime(range.to) };
-      const width = this.el ? this.el.offsetWidth : 0;
-
-      this.props.initializeExplore(
-        exploreId,
-        initialDatasource,
-        initialQueries,
-        initialRange,
-        width,
-        this.exploreEvents,
-        ui
-      );
-    }
+    this.refreshExplore();
   }
 
   componentWillUnmount() {
     this.exploreEvents.removeAllListeners();
+  }
+
+  componentDidUpdate(prevProps: ExploreProps) {
+    if (prevProps.urlState !== this.props.urlState) {
+      this.refreshExplore();
+    }
   }
 
   getRef = el => {
@@ -167,6 +154,29 @@ export class Explore extends React.PureComponent<ExploreProps> {
 
   onStopScanning = () => {
     this.props.scanStopAction({ exploreId: this.props.exploreId });
+  };
+
+  refreshExplore = () => {
+    const { exploreId, urlState, initialized } = this.props;
+    if (!initialized) {
+      // Don't initialize on split, but need to initialize urlparameters when present
+      // Load URL state and parse range
+      const { datasource, queries, range = DEFAULT_RANGE, ui = DEFAULT_UI_STATE } = (urlState || {}) as ExploreUrlState;
+      const initialDatasource = datasource || store.get(LAST_USED_DATASOURCE_KEY);
+      const initialQueries: DataQuery[] = ensureQueries(queries);
+      const initialRange = { from: parseTime(range.from), to: parseTime(range.to) };
+      const width = this.el ? this.el.offsetWidth : 0;
+
+      this.props.initializeExplore(
+        exploreId,
+        initialDatasource,
+        initialQueries,
+        initialRange,
+        width,
+        this.exploreEvents,
+        ui
+      );
+    }
   };
 
   render() {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -25,7 +25,7 @@ import {
   modifyQueries,
   scanStart,
   setQueries,
-  runQueries,
+  refreshExplore,
 } from './state/actions';
 
 // Types
@@ -35,14 +35,12 @@ import { StoreState } from 'app/types';
 import { LAST_USED_DATASOURCE_KEY, ensureQueries, DEFAULT_RANGE, DEFAULT_UI_STATE } from 'app/core/utils/explore';
 import { Emitter } from 'app/core/utils/emitter';
 import { ExploreToolbar } from './ExploreToolbar';
-import { scanStopAction, updateUIStateAction, changeTimeAction, clearQueriesAction } from './state/actionTypes';
+import { scanStopAction } from './state/actionTypes';
 
 interface ExploreProps {
   StartPage?: ComponentClass<ExploreStartPageProps>;
   changeSize: typeof changeSize;
   changeTime: typeof changeTime;
-  changeTimeAction: typeof changeTimeAction;
-  clearQueriesAction: typeof clearQueriesAction;
   datasourceError: string;
   datasourceInstance: ExploreDataSourceApi;
   datasourceLoading: boolean | null;
@@ -53,7 +51,7 @@ interface ExploreProps {
   modifyQueries: typeof modifyQueries;
   range: RawTimeRange;
   refresh: ExploreRefreshState;
-  runQueries: typeof runQueries;
+  refreshExplore: typeof refreshExplore;
   scanner?: RangeScanner;
   scanning?: boolean;
   scanRange?: RawTimeRange;
@@ -67,7 +65,6 @@ interface ExploreProps {
   supportsTable: boolean | null;
   queryKeys: string[];
   urlState: ExploreUrlState;
-  updateUIStateAction: typeof updateUIStateAction;
 }
 
 /**
@@ -192,27 +189,8 @@ export class Explore extends React.PureComponent<ExploreProps> {
       return;
     }
 
-    // need to refresh time range
-    if (refresh.range) {
-      this.props.changeTimeAction({
-        exploreId,
-        range: initialRange as TimeRange,
-      });
-    }
-
-    // need to refresh ui state
-    if (refresh.ui) {
-      this.props.updateUIStateAction({ ...ui, exploreId });
-    }
-
-    // need to refresh queries
-    if (refresh.queries) {
-      this.props.setQueries(exploreId, initialQueries);
-    }
-
-    // always run queries when refresh is needed
     if (refresh.queries || refresh.ui || refresh.range) {
-      this.props.runQueries(exploreId);
+      this.props.refreshExplore(exploreId);
     }
   };
 
@@ -330,15 +308,12 @@ function mapStateToProps(state: StoreState, { exploreId }) {
 const mapDispatchToProps = {
   changeSize,
   changeTime,
-  changeTimeAction,
-  clearQueriesAction,
   initializeExplore,
   modifyQueries,
-  runQueries,
+  refreshExplore,
   scanStart,
   scanStopAction,
   setQueries,
-  updateUIStateAction,
 };
 
 export default hot(module)(

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -1,7 +1,9 @@
 // Libraries
 import React, { ComponentClass } from 'react';
 import { hot } from 'react-hot-loader';
+// @ts-ignore
 import { connect } from 'react-redux';
+// @ts-ignore
 import _ from 'lodash';
 import { AutoSizer } from 'react-virtualized';
 
@@ -135,7 +137,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
     this.refreshExplore();
   }
 
-  getRef = el => {
+  getRef = (el: any) => {
     this.el = el;
   };
 
@@ -155,7 +157,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
     this.onModifyQueries({ type: 'ADD_FILTER', key, value });
   };
 
-  onModifyQueries = (action, index?: number) => {
+  onModifyQueries = (action: any, index?: number) => {
     const { datasourceInstance } = this.props;
     if (datasourceInstance && datasourceInstance.modifyQuery) {
       const modifier = (queries: DataQuery, modification: any) => datasourceInstance.modifyQuery(queries, modification);
@@ -262,7 +264,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
   }
 }
 
-function mapStateToProps(state: StoreState, { exploreId }) {
+function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
   const explore = state.explore;
   const { split } = explore;
   const item: ExploreItemState = explore[exploreId];

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -32,7 +32,7 @@ import {
 
 // Types
 import { RawTimeRange, TimeRange, DataQuery, ExploreStartPageProps, ExploreDataSourceApi } from '@grafana/ui';
-import { ExploreItemState, ExploreUrlState, RangeScanner, ExploreId, ExploreRefreshState } from 'app/types/explore';
+import { ExploreItemState, ExploreUrlState, RangeScanner, ExploreId, ExploreUpdateState } from 'app/types/explore';
 import { StoreState } from 'app/types';
 import { LAST_USED_DATASOURCE_KEY, ensureQueries, DEFAULT_RANGE, DEFAULT_UI_STATE } from 'app/core/utils/explore';
 import { Emitter } from 'app/core/utils/emitter';
@@ -52,7 +52,7 @@ interface ExploreProps {
   initialized: boolean;
   modifyQueries: typeof modifyQueries;
   range: RawTimeRange;
-  refresh: ExploreRefreshState;
+  update: ExploreUpdateState;
   refreshExplore: typeof refreshExplore;
   scanner?: RangeScanner;
   scanning?: boolean;
@@ -185,9 +185,9 @@ export class Explore extends React.PureComponent<ExploreProps> {
   };
 
   refreshExplore = () => {
-    const { exploreId, refresh } = this.props;
+    const { exploreId, update } = this.props;
 
-    if (refresh.queries || refresh.ui || refresh.range || refresh.datasource) {
+    if (update.queries || update.ui || update.range || update.datasource) {
       this.props.refreshExplore(exploreId);
     }
   };
@@ -282,7 +282,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     supportsTable,
     queryKeys,
     urlState,
-    refresh,
+    update,
   } = item;
   return {
     StartPage,
@@ -299,7 +299,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     supportsTable,
     queryKeys,
     urlState,
-    refresh,
+    update,
   };
 }
 

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -2,10 +2,8 @@ import React, { Component } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 
-import { updateLocation } from 'app/core/actions';
 import { StoreState } from 'app/types';
 import { ExploreId, ExploreUrlState } from 'app/types/explore';
-import { parseUrlState } from 'app/core/utils/explore';
 
 import ErrorBoundary from './ErrorBoundary';
 import Explore from './Explore';
@@ -13,54 +11,30 @@ import { CustomScrollbar } from '@grafana/ui';
 import { initializeExploreSplitAction, resetExploreAction } from './state/actionTypes';
 
 interface WrapperProps {
-  initializeExploreSplitAction: typeof initializeExploreSplitAction;
   split: boolean;
-  updateLocation: typeof updateLocation;
   resetExploreAction: typeof resetExploreAction;
-  urlStates: { [key: string]: string };
+  leftUrlState: ExploreUrlState;
+  rightUrlState: ExploreUrlState;
 }
 
 export class Wrapper extends Component<WrapperProps> {
-  initialSplit: boolean;
-  urlStates: { [key: string]: ExploreUrlState };
-
-  constructor(props: WrapperProps) {
-    super(props);
-    this.urlStates = {};
-    const { left, right } = props.urlStates;
-    if (props.urlStates.left) {
-      this.urlStates.leftState = parseUrlState(left);
-    }
-    if (props.urlStates.right) {
-      this.urlStates.rightState = parseUrlState(right);
-      this.initialSplit = true;
-    }
-  }
-
-  componentDidMount() {
-    if (this.initialSplit) {
-      this.props.initializeExploreSplitAction();
-    }
-  }
-
   componentWillUnmount() {
     this.props.resetExploreAction();
   }
 
   render() {
-    const { split } = this.props;
-    const { leftState, rightState } = this.urlStates;
+    const { split, leftUrlState, rightUrlState } = this.props;
 
     return (
       <div className="page-scrollbar-wrapper">
         <CustomScrollbar autoHeightMin={'100%'} className="custom-scrollbar--page">
           <div className="explore-wrapper">
             <ErrorBoundary>
-              <Explore exploreId={ExploreId.left} urlState={leftState} />
+              <Explore exploreId={ExploreId.left} urlState={leftUrlState} />
             </ErrorBoundary>
             {split && (
               <ErrorBoundary>
-                <Explore exploreId={ExploreId.right} urlState={rightState} />
+                <Explore exploreId={ExploreId.right} urlState={rightUrlState} />
               </ErrorBoundary>
             )}
           </div>
@@ -71,14 +45,12 @@ export class Wrapper extends Component<WrapperProps> {
 }
 
 const mapStateToProps = (state: StoreState) => {
-  const urlStates = state.location.query;
-  const { split } = state.explore;
-  return { split, urlStates };
+  const { split, leftUrlState, rightUrlState } = state.explore;
+  return { split, leftUrlState, rightUrlState };
 };
 
 const mapDispatchToProps = {
   initializeExploreSplitAction,
-  updateLocation,
   resetExploreAction,
 };
 

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -3,18 +3,16 @@ import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 
 import { StoreState } from 'app/types';
-import { ExploreId, ExploreUrlState } from 'app/types/explore';
+import { ExploreId } from 'app/types/explore';
 
 import ErrorBoundary from './ErrorBoundary';
 import Explore from './Explore';
 import { CustomScrollbar } from '@grafana/ui';
-import { initializeExploreSplitAction, resetExploreAction } from './state/actionTypes';
+import { resetExploreAction } from './state/actionTypes';
 
 interface WrapperProps {
   split: boolean;
   resetExploreAction: typeof resetExploreAction;
-  leftUrlState: ExploreUrlState;
-  rightUrlState: ExploreUrlState;
 }
 
 export class Wrapper extends Component<WrapperProps> {
@@ -23,18 +21,18 @@ export class Wrapper extends Component<WrapperProps> {
   }
 
   render() {
-    const { split, leftUrlState, rightUrlState } = this.props;
+    const { split } = this.props;
 
     return (
       <div className="page-scrollbar-wrapper">
         <CustomScrollbar autoHeightMin={'100%'} className="custom-scrollbar--page">
           <div className="explore-wrapper">
             <ErrorBoundary>
-              <Explore exploreId={ExploreId.left} urlState={leftUrlState} />
+              <Explore exploreId={ExploreId.left} />
             </ErrorBoundary>
             {split && (
               <ErrorBoundary>
-                <Explore exploreId={ExploreId.right} urlState={rightUrlState} />
+                <Explore exploreId={ExploreId.right} />
               </ErrorBoundary>
             )}
           </div>
@@ -45,12 +43,11 @@ export class Wrapper extends Component<WrapperProps> {
 }
 
 const mapStateToProps = (state: StoreState) => {
-  const { split, leftUrlState, rightUrlState } = state.explore;
-  return { split, leftUrlState, rightUrlState };
+  const { split } = state.explore;
+  return { split };
 };
 
 const mapDispatchToProps = {
-  initializeExploreSplitAction,
   resetExploreAction,
 };
 

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -24,15 +24,9 @@ import { LogLevel } from 'app/core/logs_model';
  *
  */
 export enum ActionTypes {
-  InitializeExploreSplit = 'explore/INITIALIZE_EXPLORE_SPLIT',
   SplitClose = 'explore/SPLIT_CLOSE',
   SplitOpen = 'explore/SPLIT_OPEN',
   ResetExplore = 'explore/RESET_EXPLORE',
-}
-
-export interface InitializeExploreSplitAction {
-  type: ActionTypes.InitializeExploreSplit;
-  payload: {};
 }
 
 export interface SplitCloseAction {
@@ -260,11 +254,6 @@ export const initializeExploreAction = actionCreatorFactory<InitializeExplorePay
 ).create();
 
 /**
- * Initialize the wrapper split state
- */
-export const initializeExploreSplitAction = noPayloadActionCreatorFactory('explore/INITIALIZE_EXPLORE_SPLIT').create();
-
-/**
  * Display an error that happened during the selection of a datasource
  */
 export const loadDatasourceFailureAction = actionCreatorFactory<LoadDatasourceFailurePayload>(
@@ -411,12 +400,7 @@ export const toggleLogLevelAction = actionCreatorFactory<ToggleLogLevelPayload>(
 export const resetExploreAction = noPayloadActionCreatorFactory('explore/RESET_EXPLORE').create();
 export const queriesImportedAction = actionCreatorFactory<QueriesImportedPayload>('explore/QueriesImported').create();
 
-export type HigherOrderAction =
-  | InitializeExploreSplitAction
-  | SplitCloseAction
-  | SplitOpenAction
-  | ResetExploreAction
-  | ActionOf<any>;
+export type HigherOrderAction = SplitCloseAction | SplitOpenAction | ResetExploreAction | ActionOf<any>;
 
 export type Action =
   | ActionOf<AddQueryRowPayload>

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -148,10 +148,6 @@ export interface RemoveQueryRowPayload {
   index: number;
 }
 
-export interface RunQueriesEmptyPayload {
-  exploreId: ExploreId;
-}
-
 export interface ScanStartPayload {
   exploreId: ExploreId;
   scanner: RangeScanner;
@@ -331,7 +327,6 @@ export const queryTransactionSuccessAction = actionCreatorFactory<QueryTransacti
  */
 export const removeQueryRowAction = actionCreatorFactory<RemoveQueryRowPayload>('explore/REMOVE_QUERY_ROW').create();
 export const runQueriesAction = noPayloadActionCreatorFactory('explore/RUN_QUERIES').create();
-export const runQueriesEmptyAction = actionCreatorFactory<RunQueriesEmptyPayload>('explore/RUN_QUERIES_EMPTY').create();
 
 /**
  * Start a scan for more results using the given scanner.
@@ -419,7 +414,6 @@ export type Action =
   | ActionOf<QueryTransactionStartPayload>
   | ActionOf<QueryTransactionSuccessPayload>
   | ActionOf<RemoveQueryRowPayload>
-  | ActionOf<RunQueriesEmptyPayload>
   | ActionOf<ScanStartPayload>
   | ActionOf<ScanRangePayload>
   | ActionOf<SetQueriesPayload>

--- a/public/app/features/explore/state/actions.test.ts
+++ b/public/app/features/explore/state/actions.test.ts
@@ -1,5 +1,5 @@
 import { refreshExplore } from './actions';
-import { ExploreId, ExploreUrlState, ExploreRefreshState } from 'app/types';
+import { ExploreId, ExploreUrlState, ExploreUpdateState } from 'app/types';
 import { thunkTester } from 'test/core/thunk/thunkTester';
 import { LogsDedupStrategy } from 'app/core/logs_model';
 import {
@@ -11,7 +11,7 @@ import {
 } from './actionTypes';
 import { Emitter } from 'app/core/core';
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
-import { makeInitialRefreshState } from './reducers';
+import { makeInitialUpdateState } from './reducers';
 
 jest.mock('app/features/plugins/datasource_srv', () => ({
   getDatasourceSrv: () => ({
@@ -23,15 +23,15 @@ jest.mock('app/features/plugins/datasource_srv', () => ({
   }),
 }));
 
-const setup = (refreshOverides?: Partial<ExploreRefreshState>) => {
+const setup = (updateOverides?: Partial<ExploreUpdateState>) => {
   const exploreId = ExploreId.left;
   const containerWidth = 1920;
   const eventBridge = {} as Emitter;
   const ui = { dedupStrategy: LogsDedupStrategy.none, showingGraph: false, showingLogs: false, showingTable: false };
   const range = { from: 'now', to: 'now' };
   const urlState: ExploreUrlState = { datasource: 'some-datasource', queries: [], range, ui };
-  const refreshDefaults = makeInitialRefreshState();
-  const refresh = { ...refreshDefaults, ...refreshOverides };
+  const updateDefaults = makeInitialUpdateState();
+  const update = { ...updateDefaults, ...updateOverides };
   const initialState = {
     explore: {
       [exploreId]: {
@@ -39,7 +39,7 @@ const setup = (refreshOverides?: Partial<ExploreRefreshState>) => {
         urlState,
         containerWidth,
         eventBridge,
-        refresh,
+        update,
         datasourceInstance: { name: 'some-datasource' },
         queries: [],
         range,
@@ -60,7 +60,7 @@ const setup = (refreshOverides?: Partial<ExploreRefreshState>) => {
 
 describe('refreshExplore', () => {
   describe('when explore is initialized', () => {
-    describe('and refresh datasource is set', () => {
+    describe('and update datasource is set', () => {
       it('then it should dispatch initializeExplore', () => {
         const { exploreId, ui, range, initialState, containerWidth, eventBridge } = setup({ datasource: true });
 
@@ -84,7 +84,7 @@ describe('refreshExplore', () => {
       });
     });
 
-    describe('and refresh range is set', () => {
+    describe('and update range is set', () => {
       it('then it should dispatch changeTimeAction', () => {
         const { exploreId, range, initialState } = setup({ range: true });
 
@@ -100,7 +100,7 @@ describe('refreshExplore', () => {
       });
     });
 
-    describe('and refresh ui is set', () => {
+    describe('and update ui is set', () => {
       it('then it should dispatch updateUIStateAction', () => {
         const { exploreId, initialState, ui } = setup({ ui: true });
 
@@ -116,7 +116,7 @@ describe('refreshExplore', () => {
       });
     });
 
-    describe('and refresh queries is set', () => {
+    describe('and update queries is set', () => {
       it('then it should dispatch setQueriesAction', () => {
         const { exploreId, initialState } = setup({ queries: true });
 
@@ -133,7 +133,7 @@ describe('refreshExplore', () => {
     });
   });
 
-  describe('when explore is not initialized', () => {
+  describe('when update is not initialized', () => {
     it('then it should not dispatch any actions', () => {
       const exploreId = ExploreId.left;
       const initialState = { explore: { [exploreId]: { initialized: false } } };

--- a/public/app/features/explore/state/actions.test.ts
+++ b/public/app/features/explore/state/actions.test.ts
@@ -1,0 +1,147 @@
+import { refreshExplore } from './actions';
+import { ExploreId, ExploreUrlState, ExploreRefreshState } from 'app/types';
+import { thunkTester } from 'test/core/thunk/thunkTester';
+import { LogsDedupStrategy } from 'app/core/logs_model';
+import {
+  initializeExploreAction,
+  InitializeExplorePayload,
+  changeTimeAction,
+  updateUIStateAction,
+  setQueriesAction,
+} from './actionTypes';
+import { Emitter } from 'app/core/core';
+import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+import { makeInitialRefreshState } from './reducers';
+
+jest.mock('app/features/plugins/datasource_srv', () => ({
+  getDatasourceSrv: () => ({
+    getExternal: jest.fn().mockReturnValue([]),
+    get: jest.fn().mockReturnValue({
+      testDatasource: jest.fn(),
+      init: jest.fn(),
+    }),
+  }),
+}));
+
+const setup = (refreshOverides?: Partial<ExploreRefreshState>) => {
+  const exploreId = ExploreId.left;
+  const containerWidth = 1920;
+  const eventBridge = {} as Emitter;
+  const ui = { dedupStrategy: LogsDedupStrategy.none, showingGraph: false, showingLogs: false, showingTable: false };
+  const range = { from: 'now', to: 'now' };
+  const urlState: ExploreUrlState = { datasource: 'some-datasource', queries: [], range, ui };
+  const refreshDefaults = makeInitialRefreshState();
+  const refresh = { ...refreshDefaults, ...refreshOverides };
+  const initialState = {
+    explore: {
+      [exploreId]: {
+        initialized: true,
+        urlState,
+        containerWidth,
+        eventBridge,
+        refresh,
+        datasourceInstance: { name: 'some-datasource' },
+        queries: [],
+        range,
+        ui,
+      },
+    },
+  };
+
+  return {
+    initialState,
+    exploreId,
+    range,
+    ui,
+    containerWidth,
+    eventBridge,
+  };
+};
+
+describe('refreshExplore', () => {
+  describe('when explore is initialized', () => {
+    describe('and refresh datasource is set', () => {
+      it('then it should dispatch initializeExplore', () => {
+        const { exploreId, ui, range, initialState, containerWidth, eventBridge } = setup({ datasource: true });
+
+        thunkTester(initialState)
+          .givenThunk(refreshExplore)
+          .whenThunkIsDispatched(exploreId)
+          .thenDispatchedActionsAreEqual(dispatchedActions => {
+            const initializeExplore = dispatchedActions[0] as ActionOf<InitializeExplorePayload>;
+            const { type, payload } = initializeExplore;
+
+            expect(type).toEqual(initializeExploreAction.type);
+            expect(payload.containerWidth).toEqual(containerWidth);
+            expect(payload.eventBridge).toEqual(eventBridge);
+            expect(payload.exploreDatasources).toEqual([]);
+            expect(payload.queries.length).toBe(1); // Queries have generated keys hard to expect on
+            expect(payload.range).toEqual(range);
+            expect(payload.ui).toEqual(ui);
+
+            return true;
+          });
+      });
+    });
+
+    describe('and refresh range is set', () => {
+      it('then it should dispatch changeTimeAction', () => {
+        const { exploreId, range, initialState } = setup({ range: true });
+
+        thunkTester(initialState)
+          .givenThunk(refreshExplore)
+          .whenThunkIsDispatched(exploreId)
+          .thenDispatchedActionsAreEqual(dispatchedActions => {
+            expect(dispatchedActions[0].type).toEqual(changeTimeAction.type);
+            expect(dispatchedActions[0].payload).toEqual({ exploreId, range });
+
+            return true;
+          });
+      });
+    });
+
+    describe('and refresh ui is set', () => {
+      it('then it should dispatch updateUIStateAction', () => {
+        const { exploreId, initialState, ui } = setup({ ui: true });
+
+        thunkTester(initialState)
+          .givenThunk(refreshExplore)
+          .whenThunkIsDispatched(exploreId)
+          .thenDispatchedActionsAreEqual(dispatchedActions => {
+            expect(dispatchedActions[0].type).toEqual(updateUIStateAction.type);
+            expect(dispatchedActions[0].payload).toEqual({ ...ui, exploreId });
+
+            return true;
+          });
+      });
+    });
+
+    describe('and refresh queries is set', () => {
+      it('then it should dispatch setQueriesAction', () => {
+        const { exploreId, initialState } = setup({ queries: true });
+
+        thunkTester(initialState)
+          .givenThunk(refreshExplore)
+          .whenThunkIsDispatched(exploreId)
+          .thenDispatchedActionsAreEqual(dispatchedActions => {
+            expect(dispatchedActions[0].type).toEqual(setQueriesAction.type);
+            expect(dispatchedActions[0].payload).toEqual({ exploreId, queries: [] });
+
+            return true;
+          });
+      });
+    });
+  });
+
+  describe('when explore is not initialized', () => {
+    it('then it should not dispatch any actions', () => {
+      const exploreId = ExploreId.left;
+      const initialState = { explore: { [exploreId]: { initialized: false } } };
+
+      thunkTester(initialState)
+        .givenThunk(refreshExplore)
+        .whenThunkIsDispatched(exploreId)
+        .thenThereAreNoDispatchedActions();
+    });
+  });
+});

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -781,35 +781,35 @@ export function refreshExplore(exploreId: ExploreId): ThunkResult<void> {
       return;
     }
 
-    const { urlState, refresh, containerWidth, eventBridge } = itemState;
+    const { urlState, update, containerWidth, eventBridge } = itemState;
     const { datasource, queries, range, ui } = urlState;
     const refreshQueries = queries.map(q => ({ ...q, ...generateEmptyQuery(itemState.queries) }));
     const refreshRange = { from: parseTime(range.from), to: parseTime(range.to) };
 
     // need to refresh datasource
-    if (refresh.datasource) {
+    if (update.datasource) {
       const initialQueries = ensureQueries(queries);
       const initialRange = { from: parseTime(range.from), to: parseTime(range.to) };
       dispatch(initializeExplore(exploreId, datasource, initialQueries, initialRange, containerWidth, eventBridge, ui));
       return;
     }
 
-    if (refresh.range) {
+    if (update.range) {
       dispatch(changeTimeAction({ exploreId, range: refreshRange as TimeRange }));
     }
 
     // need to refresh ui state
-    if (refresh.ui) {
+    if (update.ui) {
       dispatch(updateUIStateAction({ ...ui, exploreId }));
     }
 
     // need to refresh queries
-    if (refresh.queries) {
+    if (update.queries) {
       dispatch(setQueriesAction({ exploreId, queries: refreshQueries }));
     }
 
     // always run queries when refresh is needed
-    if (refresh.queries || refresh.ui || refresh.range) {
+    if (update.queries || update.ui || update.range) {
       dispatch(runQueries(exploreId));
     }
   };

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -1,4 +1,4 @@
-import { itemReducer, makeExploreItemState, exploreReducer, makeInitialRefreshState } from './reducers';
+import { itemReducer, makeExploreItemState, exploreReducer, makeInitialUpdateState } from './reducers';
 import { ExploreId, ExploreItemState, ExploreUrlState } from 'app/types/explore';
 import { reducerTester } from 'test/core/redux/reducerTester';
 import { scanStartAction, scanStopAction } from './actionTypes';
@@ -50,7 +50,7 @@ describe('Explore item reducer', () => {
 });
 
 export const setup = (urlStateOverrides?: any) => {
-  const refresh = makeInitialRefreshState();
+  const update = makeInitialUpdateState();
   const urlStateDefaults: ExploreUrlState = {
     datasource: 'some-datasource',
     queries: [],
@@ -67,7 +67,7 @@ export const setup = (urlStateOverrides?: any) => {
   };
   const urlState: ExploreUrlState = { ...urlStateDefaults, ...urlStateOverrides };
   const serializedUrlState = serializeStateToUrlParam(urlState);
-  const initalState = { split: false, left: { urlState, refresh }, right: { urlState, refresh } };
+  const initalState = { split: false, left: { urlState, update }, right: { urlState, update } };
 
   return {
     initalState,
@@ -117,7 +117,7 @@ describe('Explore reducer', () => {
 
       describe("and query contains a 'left'", () => {
         describe('but urlState is not set in state', () => {
-          it('then it should just add urlState and refresh in state', () => {
+          it('then it should just add urlState and update in state', () => {
             const { initalState, serializedUrlState } = setup();
             const stateWithoutUrlState = { ...initalState, left: { urlState: null } };
             const expectedState = { ...initalState };
@@ -137,7 +137,7 @@ describe('Explore reducer', () => {
         });
 
         describe("but '/explore' is missing in path", () => {
-          it('then it should just add urlState and refresh in state', () => {
+          it('then it should just add urlState and update in state', () => {
             const { initalState, serializedUrlState } = setup();
             const expectedState = { ...initalState };
 
@@ -157,14 +157,14 @@ describe('Explore reducer', () => {
 
         describe("and '/explore' is in path", () => {
           describe('and datasource differs', () => {
-            it('then it should return refresh datasource', () => {
+            it('then it should return update datasource', () => {
               const { initalState, serializedUrlState } = setup();
               const expectedState = {
                 ...initalState,
                 left: {
                   ...initalState.left,
-                  refresh: {
-                    ...initalState.left.refresh,
+                  update: {
+                    ...initalState.left.update,
                     datasource: true,
                   },
                 },
@@ -195,14 +195,14 @@ describe('Explore reducer', () => {
           });
 
           describe('and range differs', () => {
-            it('then it should return refresh range', () => {
+            it('then it should return update range', () => {
               const { initalState, serializedUrlState } = setup();
               const expectedState = {
                 ...initalState,
                 left: {
                   ...initalState.left,
-                  refresh: {
-                    ...initalState.left.refresh,
+                  update: {
+                    ...initalState.left.update,
                     range: true,
                   },
                 },
@@ -236,14 +236,14 @@ describe('Explore reducer', () => {
           });
 
           describe('and queries differs', () => {
-            it('then it should return refresh queries', () => {
+            it('then it should return update queries', () => {
               const { initalState, serializedUrlState } = setup();
               const expectedState = {
                 ...initalState,
                 left: {
                   ...initalState.left,
-                  refresh: {
-                    ...initalState.left.refresh,
+                  update: {
+                    ...initalState.left.update,
                     queries: true,
                   },
                 },
@@ -274,14 +274,14 @@ describe('Explore reducer', () => {
           });
 
           describe('and ui differs', () => {
-            it('then it should return refresh ui', () => {
+            it('then it should return update ui', () => {
               const { initalState, serializedUrlState } = setup();
               const expectedState = {
                 ...initalState,
                 left: {
                   ...initalState.left,
-                  refresh: {
-                    ...initalState.left.refresh,
+                  update: {
+                    ...initalState.left.update,
                     ui: true,
                   },
                 },
@@ -315,7 +315,7 @@ describe('Explore reducer', () => {
           });
 
           describe('and nothing differs', () => {
-            fit('then it should return refresh ui', () => {
+            fit('then it should return update ui', () => {
               const { initalState, serializedUrlState } = setup();
               const expectedState = { ...initalState };
 

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -1,9 +1,12 @@
-import { itemReducer, makeExploreItemState } from './reducers';
-import { ExploreId, ExploreItemState } from 'app/types/explore';
+import { itemReducer, makeExploreItemState, exploreReducer, makeInitialRefreshState } from './reducers';
+import { ExploreId, ExploreItemState, ExploreUrlState } from 'app/types/explore';
 import { reducerTester } from 'test/core/redux/reducerTester';
 import { scanStartAction, scanStopAction } from './actionTypes';
 import { Reducer } from 'redux';
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+import { updateLocation } from 'app/core/actions/location';
+import { LogsDedupStrategy } from 'app/core/logs_model';
+import { serializeStateToUrlParam } from 'app/core/utils/explore';
 
 describe('Explore item reducer', () => {
   describe('scanning', () => {
@@ -42,6 +45,295 @@ describe('Explore item reducer', () => {
           scanner: undefined,
           scanRange: undefined,
         });
+    });
+  });
+});
+
+export const setup = (urlStateOverrides?: any) => {
+  const refresh = makeInitialRefreshState();
+  const urlStateDefaults: ExploreUrlState = {
+    datasource: 'some-datasource',
+    queries: [],
+    range: {
+      from: '',
+      to: '',
+    },
+    ui: {
+      dedupStrategy: LogsDedupStrategy.none,
+      showingGraph: false,
+      showingTable: false,
+      showingLogs: false,
+    },
+  };
+  const urlState: ExploreUrlState = { ...urlStateDefaults, ...urlStateOverrides };
+  const serializedUrlState = serializeStateToUrlParam(urlState);
+  const initalState = { split: false, left: { urlState, refresh }, right: { urlState, refresh } };
+
+  return {
+    initalState,
+    serializedUrlState,
+  };
+};
+
+describe('Explore reducer', () => {
+  describe('when updateLocation is dispatched', () => {
+    describe('and payload does not contain a query', () => {
+      it('then it should just return state', () => {
+        reducerTester()
+          .givenReducer(exploreReducer, {})
+          .whenActionIsDispatched(updateLocation({ query: null }))
+          .thenStateShouldEqual({});
+      });
+    });
+
+    describe('and payload contains a query', () => {
+      describe("but does not contain 'left'", () => {
+        it('then it should just return state', () => {
+          reducerTester()
+            .givenReducer(exploreReducer, {})
+            .whenActionIsDispatched(updateLocation({ query: {} }))
+            .thenStateShouldEqual({});
+        });
+      });
+
+      describe("and query contains a 'right'", () => {
+        it('then it should add split in state', () => {
+          const { initalState, serializedUrlState } = setup();
+          const expectedState = { ...initalState, split: true };
+
+          reducerTester()
+            .givenReducer(exploreReducer, initalState)
+            .whenActionIsDispatched(
+              updateLocation({
+                query: {
+                  left: serializedUrlState,
+                  right: serializedUrlState,
+                },
+              })
+            )
+            .thenStateShouldEqual(expectedState);
+        });
+      });
+
+      describe("and query contains a 'left'", () => {
+        describe('but urlState is not set in state', () => {
+          it('then it should just add urlState and refresh in state', () => {
+            const { initalState, serializedUrlState } = setup();
+            const stateWithoutUrlState = { ...initalState, left: { urlState: null } };
+            const expectedState = { ...initalState };
+
+            reducerTester()
+              .givenReducer(exploreReducer, stateWithoutUrlState)
+              .whenActionIsDispatched(
+                updateLocation({
+                  query: {
+                    left: serializedUrlState,
+                  },
+                  path: '/explore',
+                })
+              )
+              .thenStateShouldEqual(expectedState);
+          });
+        });
+
+        describe("but '/explore' is missing in path", () => {
+          it('then it should just add urlState and refresh in state', () => {
+            const { initalState, serializedUrlState } = setup();
+            const expectedState = { ...initalState };
+
+            reducerTester()
+              .givenReducer(exploreReducer, initalState)
+              .whenActionIsDispatched(
+                updateLocation({
+                  query: {
+                    left: serializedUrlState,
+                  },
+                  path: '/dashboard',
+                })
+              )
+              .thenStateShouldEqual(expectedState);
+          });
+        });
+
+        describe("and '/explore' is in path", () => {
+          describe('and datasource differs', () => {
+            it('then it should return refresh datasource', () => {
+              const { initalState, serializedUrlState } = setup();
+              const expectedState = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  refresh: {
+                    ...initalState.left.refresh,
+                    datasource: true,
+                  },
+                },
+              };
+              const stateWithDifferentDataSource = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  urlState: {
+                    ...initalState.left.urlState,
+                    datasource: 'different datasource',
+                  },
+                },
+              };
+
+              reducerTester()
+                .givenReducer(exploreReducer, stateWithDifferentDataSource)
+                .whenActionIsDispatched(
+                  updateLocation({
+                    query: {
+                      left: serializedUrlState,
+                    },
+                    path: '/explore',
+                  })
+                )
+                .thenStateShouldEqual(expectedState);
+            });
+          });
+
+          describe('and range differs', () => {
+            it('then it should return refresh range', () => {
+              const { initalState, serializedUrlState } = setup();
+              const expectedState = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  refresh: {
+                    ...initalState.left.refresh,
+                    range: true,
+                  },
+                },
+              };
+              const stateWithDifferentDataSource = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  urlState: {
+                    ...initalState.left.urlState,
+                    range: {
+                      from: 'now',
+                      to: 'now-6h',
+                    },
+                  },
+                },
+              };
+
+              reducerTester()
+                .givenReducer(exploreReducer, stateWithDifferentDataSource)
+                .whenActionIsDispatched(
+                  updateLocation({
+                    query: {
+                      left: serializedUrlState,
+                    },
+                    path: '/explore',
+                  })
+                )
+                .thenStateShouldEqual(expectedState);
+            });
+          });
+
+          describe('and queries differs', () => {
+            it('then it should return refresh queries', () => {
+              const { initalState, serializedUrlState } = setup();
+              const expectedState = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  refresh: {
+                    ...initalState.left.refresh,
+                    queries: true,
+                  },
+                },
+              };
+              const stateWithDifferentDataSource = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  urlState: {
+                    ...initalState.left.urlState,
+                    queries: [{ expr: '{__filename__="some.log"}' }],
+                  },
+                },
+              };
+
+              reducerTester()
+                .givenReducer(exploreReducer, stateWithDifferentDataSource)
+                .whenActionIsDispatched(
+                  updateLocation({
+                    query: {
+                      left: serializedUrlState,
+                    },
+                    path: '/explore',
+                  })
+                )
+                .thenStateShouldEqual(expectedState);
+            });
+          });
+
+          describe('and ui differs', () => {
+            it('then it should return refresh ui', () => {
+              const { initalState, serializedUrlState } = setup();
+              const expectedState = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  refresh: {
+                    ...initalState.left.refresh,
+                    ui: true,
+                  },
+                },
+              };
+              const stateWithDifferentDataSource = {
+                ...initalState,
+                left: {
+                  ...initalState.left,
+                  urlState: {
+                    ...initalState.left.urlState,
+                    ui: {
+                      ...initalState.left.urlState.ui,
+                      showingGraph: true,
+                    },
+                  },
+                },
+              };
+
+              reducerTester()
+                .givenReducer(exploreReducer, stateWithDifferentDataSource)
+                .whenActionIsDispatched(
+                  updateLocation({
+                    query: {
+                      left: serializedUrlState,
+                    },
+                    path: '/explore',
+                  })
+                )
+                .thenStateShouldEqual(expectedState);
+            });
+          });
+
+          describe('and nothing differs', () => {
+            fit('then it should return refresh ui', () => {
+              const { initalState, serializedUrlState } = setup();
+              const expectedState = { ...initalState };
+
+              reducerTester()
+                .givenReducer(exploreReducer, initalState)
+                .whenActionIsDispatched(
+                  updateLocation({
+                    query: {
+                      left: serializedUrlState,
+                    },
+                    path: '/explore',
+                  })
+                )
+                .thenStateShouldEqual(expectedState);
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -32,7 +32,6 @@ import {
   queryTransactionStartAction,
   queryTransactionSuccessAction,
   removeQueryRowAction,
-  runQueriesEmptyAction,
   scanRangeAction,
   scanStartAction,
   scanStopAction,
@@ -186,12 +185,6 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         showingStartPage: Boolean(state.StartPage),
         queryKeys: getQueryKeys(queries, state.datasourceInstance),
       };
-    },
-  })
-  .addMapper({
-    filter: runQueriesEmptyAction,
-    mapper: (state): ExploreItemState => {
-      return { ...state, queryTransactions: [] };
     },
   })
   .addMapper({

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -534,7 +534,7 @@ export const updateChildRefreshState = (
   const path = payload.path || '';
   const queryState = payload.query[exploreId] as string;
   if (!queryState) {
-    return { ...state };
+    return state;
   }
 
   const urlState = parseUrlState(queryState);
@@ -581,7 +581,7 @@ export const exploreReducer = (state = initialExploreState, action: HigherOrderA
 
     case updateLocation.type: {
       const { query } = action.payload;
-      if (!query[ExploreId.left]) {
+      if (!query || !query[ExploreId.left]) {
         return state;
       }
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -294,7 +294,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       const { queries, queryTransactions } = state;
       const { modification, index, modifier } = action.payload;
       let nextQueries: DataQuery[];
-      let nextQueryTransactions;
+      let nextQueryTransactions: QueryTransaction[];
       if (index === undefined) {
         // Modify all queries
         nextQueries = queries.map((query, i) => ({

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -9,7 +9,7 @@ import {
   parseUrlState,
   DEFAULT_UI_STATE,
 } from 'app/core/utils/explore';
-import { ExploreItemState, ExploreState, QueryTransaction, ExploreId, ExploreRefreshState } from 'app/types/explore';
+import { ExploreItemState, ExploreState, QueryTransaction, ExploreId, ExploreUpdateState } from 'app/types/explore';
 import { DataQuery } from '@grafana/ui/src/types';
 
 import { HigherOrderAction, ActionTypes } from './actionTypes';
@@ -54,7 +54,7 @@ export const DEFAULT_RANGE = {
 // Millies step for helper bar charts
 const DEFAULT_GRAPH_INTERVAL = 15 * 1000;
 
-export const makeInitialRefreshState = (): ExploreRefreshState => ({
+export const makeInitialUpdateState = (): ExploreUpdateState => ({
   datasource: false,
   queries: false,
   range: false,
@@ -88,7 +88,7 @@ export const makeExploreItemState = (): ExploreItemState => ({
   supportsTable: null,
   queryKeys: [],
   urlState: null,
-  refresh: makeInitialRefreshState(),
+  update: makeInitialUpdateState(),
 });
 
 /**
@@ -208,7 +208,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         initialized: true,
         queryKeys: getQueryKeys(queries, state.datasourceInstance),
         ...ui,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -226,7 +226,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         ...state,
         datasourceError: action.payload.error,
         datasourceLoading: false,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -237,7 +237,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         ...state,
         datasourceMissing: true,
         datasourceLoading: false,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -277,7 +277,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         datasourceError: null,
         logsHighlighterExpressions: undefined,
         queryTransactions: [],
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -332,7 +332,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         ...state,
         queryTransactions,
         showingStartPage: false,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -353,7 +353,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         ...state,
         queryTransactions: nextQueryTransactions,
         showingStartPage: false,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -374,7 +374,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         history,
         queryTransactions,
         showingStartPage: false,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -432,7 +432,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         scanning: false,
         scanRange: undefined,
         scanner: undefined,
-        refresh: makeInitialRefreshState(),
+        update: makeInitialUpdateState(),
       };
     },
   })
@@ -533,7 +533,7 @@ export const updateChildRefreshState = (
   const urlState = parseUrlState(queryState);
   if (!state.urlState || path !== '/explore') {
     // we only want to refresh when browser back/forward
-    return { ...state, urlState, refresh: { datasource: false, queries: false, range: false, ui: false } };
+    return { ...state, urlState, update: { datasource: false, queries: false, range: false, ui: false } };
   }
 
   const datasource = _.isEqual(urlState ? urlState.datasource : '', state.urlState.datasource) === false;
@@ -544,8 +544,8 @@ export const updateChildRefreshState = (
   return {
     ...state,
     urlState,
-    refresh: {
-      ...state.refresh,
+    update: {
+      ...state.update,
       datasource,
       queries,
       range,

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -106,6 +106,10 @@ export interface ExploreState {
    * Explore state of the right area in split view.
    */
   right: ExploreItemState;
+
+  leftUrlState: ExploreUrlState;
+
+  rightUrlState: ExploreUrlState;
 }
 
 export interface ExploreItemState {

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -106,10 +106,6 @@ export interface ExploreState {
    * Explore state of the right area in split view.
    */
   right: ExploreItemState;
-
-  leftUrlState: ExploreUrlState;
-
-  rightUrlState: ExploreUrlState;
 }
 
 export interface ExploreItemState {
@@ -252,6 +248,17 @@ export interface ExploreItemState {
    * Currently hidden log series
    */
   hiddenLogLevels?: LogLevel[];
+
+  urlState: ExploreUrlState;
+
+  refresh: ExploreRefreshState;
+}
+
+export interface ExploreRefreshState {
+  datasource: boolean;
+  queries: boolean;
+  range: boolean;
+  ui: boolean;
 }
 
 export interface ExploreUIState {

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -251,10 +251,10 @@ export interface ExploreItemState {
 
   urlState: ExploreUrlState;
 
-  refresh: ExploreRefreshState;
+  update: ExploreUpdateState;
 }
 
-export interface ExploreRefreshState {
+export interface ExploreUpdateState {
   datasource: boolean;
   queries: boolean;
   range: boolean;

--- a/public/test/core/thunk/thunkTester.ts
+++ b/public/test/core/thunk/thunkTester.ts
@@ -1,0 +1,64 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+
+const mockStore = configureMockStore([thunk]);
+
+export interface ThunkGiven {
+  givenThunk: (thunkFunction: any) => ThunkWhen;
+}
+
+export interface ThunkWhen {
+  whenThunkIsDispatched: (...args: any) => ThunkThen;
+}
+
+export interface ThunkThen {
+  thenDispatchedActionsEqual: (actions: Array<ActionOf<any>>) => ThunkWhen;
+  thenDispatchedActionsAreEqual: (callback: (actions: Array<ActionOf<any>>) => boolean) => ThunkWhen;
+  thenThereAreNoDispatchedActions: () => ThunkWhen;
+}
+
+export const thunkTester = (initialState: any): ThunkGiven => {
+  const store = mockStore(initialState);
+  let thunkUnderTest = null;
+
+  const givenThunk = (thunkFunction: any): ThunkWhen => {
+    thunkUnderTest = thunkFunction;
+
+    return instance;
+  };
+
+  function whenThunkIsDispatched(...args: any): ThunkThen {
+    store.dispatch(thunkUnderTest(...arguments));
+
+    return instance;
+  }
+
+  const thenDispatchedActionsEqual = (actions: Array<ActionOf<any>>): ThunkWhen => {
+    const resultingActions = store.getActions();
+    expect(resultingActions).toEqual(actions);
+
+    return instance;
+  };
+
+  const thenDispatchedActionsAreEqual = (callback: (dispathedActions: Array<ActionOf<any>>) => boolean): ThunkWhen => {
+    const resultingActions = store.getActions();
+    expect(callback(resultingActions)).toBe(true);
+
+    return instance;
+  };
+
+  const thenThereAreNoDispatchedActions = () => {
+    return thenDispatchedActionsEqual([]);
+  };
+
+  const instance = {
+    givenThunk,
+    whenThunkIsDispatched,
+    thenDispatchedActionsEqual,
+    thenDispatchedActionsAreEqual,
+    thenThereAreNoDispatchedActions,
+  };
+
+  return instance;
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to navigate backward and forward in browser using Explore.

**Which issue(s) this PR fixes**:
Fixes #14301

**Special notes for your reviewer**:
Checkout out the branch and try it out
