### PR TITLE
Set the zIndex higher for the tooltip where the mouse is. 

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -49,11 +49,13 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
     }
   };
 
-  this.renderAndShow = (absoluteTime, innerHtml, pos, xMode) => {
+  this.renderAndShow = (absoluteTime, innerHtml, pos, xMode, primary) => {
     if (xMode === 'time') {
       innerHtml = '<div class="graph-tooltip-time">' + absoluteTime + '</div>' + innerHtml;
     }
     $tooltip.html(innerHtml).place_tt(pos.pageX + 20, pos.pageY);
+    // The primary tooltip should be drawn on top
+    $tooltip.css('zIndex', primary ? 9999 : 9998);
   };
 
   this.getMultiSeriesPlotHoverInfo = function(seriesList, pos) {
@@ -159,7 +161,8 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
   });
 
   elem.bind('plothover', (event, pos, item) => {
-    self.show(pos, item);
+    // This is the graph the mouse is over so it should be drawn on top
+    self.show(pos, item, true);
 
     // broadcast to other graph panels that we are hovering!
     pos.panelRelY = (pos.pageY - elem.offset().top) / elem.height();
@@ -176,7 +179,7 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
     plot.unhighlight();
   };
 
-  this.show = (pos, item) => {
+  this.show = (pos, item, primary) => {
     const plot = elem.data().plot;
     const plotData = plot.getData();
     const xAxes = plot.getXAxes();
@@ -265,7 +268,7 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
         plot.highlight(hoverInfo.index, hoverInfo.hoverIndex);
       }
 
-      self.renderAndShow(absoluteTime, seriesHtml, pos, xMode);
+      self.renderAndShow(absoluteTime, seriesHtml, pos, xMode, primary);
     } else if (item) {
       // single series tooltip
       series = seriesList[item.seriesIndex];
@@ -285,7 +288,7 @@ export default function GraphTooltip(this: any, elem, dashboard, scope, getSerie
 
       group += '<div class="graph-tooltip-value">' + value + '</div>';
 
-      self.renderAndShow(absoluteTime, group, pos, xMode);
+      self.renderAndShow(absoluteTime, group, pos, xMode, primary);
     } else {
       // no hit
       $tooltip.detach();

--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -58,7 +58,7 @@ export class HeatmapTooltip {
     this.tooltip = null;
   }
 
-  show(pos, data) {
+  show(pos, data, primary) {
     if (!this.panel.tooltip.show || !data) {
       return;
     }
@@ -144,6 +144,8 @@ export class HeatmapTooltip {
     }
 
     this.tooltip.html(tooltipHtml);
+    // The primary tooltip should be drawn on top
+    this.tooltip.css('zIndex', primary ? 9999 : 9998);
 
     if (this.panel.tooltip.showHistogram) {
       this.addHistogram(xData);

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -744,7 +744,8 @@ export class HeatmapRenderer {
     } else {
       const pos = this.getEventPos(event, offset);
       this.drawCrosshair(offset.x);
-      this.tooltip.show(pos, this.data);
+      // This is the graph the mouse is over so it should be drawn on top
+      this.tooltip.show(pos, this.data, true);
       this.emitGraphHoverEvent(pos);
     }
   }

--- a/public/sass/components/_tooltip.scss
+++ b/public/sass/components/_tooltip.scss
@@ -102,6 +102,7 @@
   font-weight: 200;
   background-color: $tooltipBackground;
   border-radius: 5px;
+  z-index: 9999;
   max-width: 800px;
   max-height: 600px;
   overflow: hidden;

--- a/public/sass/components/_tooltip.scss
+++ b/public/sass/components/_tooltip.scss
@@ -102,7 +102,6 @@
   font-weight: 200;
   background-color: $tooltipBackground;
   border-radius: 5px;
-  z-index: 9999;
   max-width: 800px;
   max-height: 600px;
   overflow: hidden;


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
This keeps the "primary" tooltip on top of any overlapping tooltips.

**Which issue(s) this PR fixes**:
Fixes #16157 

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
The primary tooltip for the graph underneath the pointer is drawn on top of any other graph's tooltip.
```
