### PR TITLE
rename stat to show in UI

### DIFF
--- a/public/app/plugins/panel/singlestat2/SingleStatValueEditor.tsx
+++ b/public/app/plugins/panel/singlestat2/SingleStatValueEditor.tsx
@@ -50,7 +50,7 @@ export class SingleStatValueEditor extends PureComponent<Props> {
     return (
       <PanelOptionsGroup title="Value">
         <div className="gf-form">
-          <FormLabel width={labelWidth}>Stat</FormLabel>
+          <FormLabel width={labelWidth}>Show</FormLabel>
           <StatsPicker
             width={12}
             placeholder="Choose Stat"


### PR DESCRIPTION
Perhaps my smallest PR yet... but worth its own issue.

The name 'stat' has always bothered me in the single stat configuration.  Can we call it 'Show' instead?

![image](https://user-images.githubusercontent.com/705951/54856214-94758780-4cb6-11e9-955b-5a9dbf17bc07.png)
