### PR TITLE
Add options in graph panel to display top-n series

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -38,6 +38,7 @@ class GraphElement {
   panel: any;
   plot: any;
   sortedSeries: any[];
+  originData: any[];
   data: any[];
   panelWidth: number;
   eventManager: EventManager;
@@ -76,7 +77,9 @@ class GraphElement {
   }
 
   onRender(renderData) {
-    this.data = renderData || this.data;
+    this.originData = renderData || this.originData;
+    // data could be altered for displaying top series. Keep originData unaltered
+    this.data = this.originData;
     if (!this.data) {
       return;
     }
@@ -85,6 +88,20 @@ class GraphElement {
     this.buildFlotPairs(this.data);
     const graphHeight = this.elem.height();
     updateLegendValues(this.data, this.panel, graphHeight);
+
+    // Top series order
+    // 0: original, 1: ascending, -1: descending
+    if (this.panel.topSeries.order !== 0) {
+      const order = this.panel.topSeries.order;
+      const orderBy = this.panel.topSeries.orderBy;
+
+      this.data = _.sortBy(this.data, s => s.stats[orderBy] * order);
+    }
+
+    // Top series limit
+    if (this.panel.topSeries.limit > 0) {
+      this.data = this.data.slice(0, this.panel.topSeries.limit);
+    }
 
     if (!this.panel.legend.show) {
       if (this.legendElem.hasChildNodes()) {

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -104,6 +104,11 @@ class GraphCtrl extends MetricsPanelCtrl {
       shared: true,
       sort: 0,
     },
+    // top series
+    topSeries: {
+      order: 0,
+      orderBy: 'avg',
+    },
     // time overrides
     timeFrom: null,
     timeShift: null,
@@ -125,6 +130,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel.tooltip, this.panelDefaults.tooltip);
     _.defaults(this.panel.legend, this.panelDefaults.legend);
     _.defaults(this.panel.xaxis, this.panelDefaults.xaxis);
+    _.defaults(this.panel.topSeries, this.panelDefaults.topSeries);
 
     this.processor = new DataProcessor(this.panel);
 

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -138,6 +138,38 @@
       </div>
     </div>
   </div>
+
+  <div class="section gf-form-group">
+    <h5 class="section-heading">Top Series</h5>
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <label class="gf-form-label width-4">Order</label>
+        <div class="gf-form-select-wrapper max-width-8">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.panel.topSeries.order"
+            ng-options="f.value as f.text for f in [{text: 'Original', value: 0}, {text: 'Ascending', value: 1}, {text: 'Descending', value: -1}]"
+            ng-change="ctrl.render()"
+          ></select>
+        </div>
+      </div>
+      <div class="gf-form">
+        <label class="gf-form-label width-3">By</label>
+        <div class="gf-form-select-wrapper max-width-8">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.panel.topSeries.orderBy"
+            ng-options="f for f in ['min', 'max', 'avg', 'current', 'total']"
+            ng-change="ctrl.render()"
+          ></select>
+        </div>
+      </div>
+    </div>
+    <div class="gf-form">
+      <label class="gf-form-label width-4">Limit</label>
+      <input type="number" class="gf-form-input width-8" placeholder="value" bs-tooltip="'Limit number of series for displaying top series'" data-placement="right" ng-model="ctrl.panel.topSeries.limit" ng-change="ctrl.render()" ng-model-onblur>
+    </div>
+  </div>
 </div>
 
 <div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:

I know some datasources have capabilities to sort and limit the output series to create top-n series graph, but it's still not supported wiht many datasources (ex. Influxdb, Gnocchi).

I think it would be useful if graph panel has the capabilities to display top-n series regardless underlying datasource is supported or not. I saw many people requested this feature.

In order for displaying top-n series, I add 3 options in the new created Top Series selection.

- Order: Sort order for series. (original, ascending, descending)
- By: Which aggregated value the sort is based on. (min, max, avg, current, total)
- Limit: Number of series to be limited to display in graph. (number)

For example, you can set Order = "Descending", By = "avg" and Limit = 5 to display top 5 series based on average value in the selected time range.

<img width="876" alt="Screen Shot 2019-03-23 at 11 03 34 PM" src="https://user-images.githubusercontent.com/47791281/54868537-6d0edf80-4dc8-11e9-8b7d-05b16919101b.png">
<img width="869" alt="Screen Shot 2019-03-23 at 11 04 23 PM" src="https://user-images.githubusercontent.com/47791281/54868545-8021af80-4dc8-11e9-919a-83af4d4620de.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2167

