### PR TITLE
Make the gauge panel behave identical to 6.0

### DIFF
--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -33,7 +33,7 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
   };
 
   getProcessedValues = (): DisplayValue[] => {
-    return getSingleStatValues(this.props);
+    return [getSingleStatValues(this.props)[0]];
   };
 
   render() {


### PR DESCRIPTION
The gauge panel uses a vis-repeater that has been added since 6.0.  Since gauge is not an alpha panel, this just shows the first element so it is identical to 6.0 behavior.

Except it now will show the first result from a table query.


