### PR TITLE
Fixed react to angular wrapper watching function expressions

### DIFF
--- a/public/app/core/services/ng_react.ts
+++ b/public/app/core/services/ng_react.ts
@@ -110,20 +110,23 @@ function watchProps(watchDepth, scope, watchExpressions, listener) {
 
   const watchGroupExpressions = [];
 
-  watchExpressions.forEach(expr => {
+  for (const expr of watchExpressions) {
     const actualExpr = getPropExpression(expr);
     const exprWatchDepth = getPropWatchDepth(watchDepth, expr);
+
+    // ignore empty expressions & expressions with functions
+    if (!actualExpr || actualExpr.match(/\(.*\)/) || exprWatchDepth === 'one-time') {
+      continue;
+    }
 
     if (exprWatchDepth === 'collection' && supportsWatchCollection) {
       scope.$watchCollection(actualExpr, listener);
     } else if (exprWatchDepth === 'reference' && supportsWatchGroup) {
       watchGroupExpressions.push(actualExpr);
-    } else if (exprWatchDepth === 'one-time') {
-      //do nothing because we handle our one time bindings after this
     } else {
       scope.$watch(actualExpr, listener, exprWatchDepth !== 'reference');
     }
-  });
+  }
 
   if (watchDepth === 'one-time') {
     listener();


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/16078 fixed a bug in the ng-react wrapper that caused it now to start watching function expressions, which caused infinte digest loop. Added check for function call in watch expression and ignore them. 

fixes #16194

