### PR TITLE
fix(panels/graph): Default option name for spaceLength was accidentally changed

### DIFF
--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -73,7 +73,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     // length of a dash
     dashLength: 10,
     // length of space between two dashes
-    paceLength: 10,
+    spaceLength: 10,
     // show hide points
     points: false,
     // point radius in pixels


### PR DESCRIPTION
Fixes a mistake in https://github.com/grafana/grafana/commit/dac02d3d737870005c14321b02a32549c48520e6 where spaceLength was accitdentially changed to paceLength in panel defaults. 