### PR TITLE
docs: loki provisioning

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -113,7 +113,25 @@ apiVersion: 1
 datasources:
   - name: Loki
     type: loki
+    access: proxy
     url: http://localhost:3100
+    jsonData:
+      maxLines: 1000
+```
+
+Here's another with basic auth:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://localhost:3100
+    basicAuth: true
+    basicAuthUser: my_user
+    basicAuthPassword: test_password
     jsonData:
       maxLines: 1000
 ```


### PR DESCRIPTION
Adds required proxy access and a basic auth example.

Fixes #16187 

Hoping that we can link to Grafana documenation instead of to https://github.com/grafana/loki/blob/master/docs/grafana-provisioning.md from https://github.com/grafana/loki/blob/master/docs/usage.md to minimize spreading configuration in different places.