### PR TITLE
fix DataQueryResponse typings

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -1,12 +1,12 @@
 import { TimeRange, RawTimeRange } from './time';
 import { PluginMeta } from './plugin';
-import { TableData, TimeSeries } from './data';
+import { TableData, TimeSeries, SeriesData } from './data';
+
+export type DataQueryResponseData = TimeSeries | TableData | SeriesData | any;
 
 export interface DataQueryResponse {
-  data: DataQueryResponseData;
+  data: DataQueryResponseData[];
 }
-
-export type DataQueryResponseData = TimeSeries[] | [TableData] | any;
 
 export interface DataQuery {
   /**


### PR DESCRIPTION
This updates the response to be more accurate.  It is essentially any[], but the existing types are kinda confusing.  This adds `SeriesData` as a response -- we will eventually need to add something to convert SeriesData to TableData/SeriesData for the angular panels, but this at least has a more accurate signature