### PR TITLE
Change `.diff-change-group` color to respect theme

### DIFF
--- a/public/sass/pages/_history.scss
+++ b/public/sass/pages/_history.scss
@@ -188,7 +188,7 @@
 
 .diff-change-group {
   width: 100%;
-  color: rgba(223, 224, 225, 0.6);
+  color: $text-color;
   margin-bottom: 14px;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In light theme mode, some text on the **version history compare page** is not readable. This fix will change the following

![before](https://user-images.githubusercontent.com/5479836/55011292-b4d17900-500b-11e9-9f98-f7863afa6043.png)

into,

![after](https://user-images.githubusercontent.com/5479836/55011342-c31f9500-500b-11e9-9f28-6d19b0dbaf07.png)
