### PR TITLE
Fix variable name typo - `EmbeddedImage`

### DIFF
--- a/emails/templates/alert_notification.html
+++ b/emails/templates/alert_notification.html
@@ -91,8 +91,8 @@
             [[if ne .ImageLink "" ]]
               <img src="[[.ImageLink]]" alt="Alerting Panel"/>
             [[end]]
-            [[if ne .EmbededImage "" ]]
-              <img src="cid:[[.EmbededImage]]" alt="Alerting Panel"/>
+            [[if ne .EmbeddedImage "" ]]
+              <img src="cid:[[.EmbeddedImage]]" alt="Alerting Panel"/>
             [[end]]
           </td>
         </tr>

--- a/pkg/services/alerting/notifiers/email.go
+++ b/pkg/services/alerting/notifiers/email.go
@@ -76,17 +76,17 @@ func (this *EmailNotifier) Notify(evalContext *alerting.EvalContext) error {
 		SendEmailCommand: m.SendEmailCommand{
 			Subject: evalContext.GetNotificationTitle(),
 			Data: map[string]interface{}{
-				"Title":        evalContext.GetNotificationTitle(),
-				"State":        evalContext.Rule.State,
-				"Name":         evalContext.Rule.Name,
-				"StateModel":   evalContext.GetStateModel(),
-				"Message":      evalContext.Rule.Message,
-				"Error":        error,
-				"RuleUrl":      ruleUrl,
-				"ImageLink":    "",
-				"EmbededImage": "",
-				"AlertPageUrl": setting.AppUrl + "alerting",
-				"EvalMatches":  evalContext.EvalMatches,
+				"Title":         evalContext.GetNotificationTitle(),
+				"State":         evalContext.Rule.State,
+				"Name":          evalContext.Rule.Name,
+				"StateModel":    evalContext.GetStateModel(),
+				"Message":       evalContext.Rule.Message,
+				"Error":         error,
+				"RuleUrl":       ruleUrl,
+				"ImageLink":     "",
+				"EmbeddedImage": "",
+				"AlertPageUrl":  setting.AppUrl + "alerting",
+				"EvalMatches":   evalContext.EvalMatches,
 			},
 			To:           this.Addresses,
 			Template:     "alert_notification.html",
@@ -100,7 +100,7 @@ func (this *EmailNotifier) Notify(evalContext *alerting.EvalContext) error {
 		file, err := os.Stat(evalContext.ImageOnDiskPath)
 		if err == nil {
 			cmd.EmbededFiles = []string{evalContext.ImageOnDiskPath}
-			cmd.Data["EmbededImage"] = file.Name()
+			cmd.Data["EmbeddedImage"] = file.Name()
 		}
 	}
 

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -39,7 +39,7 @@ func TestEmailIntegrationTest(t *testing.T) {
 					"RuleUrl":       "http://localhost:3000/dashboard/db/graphite-dashboard",
 					"ImageLink":     "http://localhost:3000/render/dashboard-solo/db/graphite-dashboard?panelId=1&from=1471008499616&to=1471012099617&width=1000&height=500",
 					"AlertPageUrl":  "http://localhost:3000/alerting",
-					"EmbededImage":  "test.png",
+					"EmbeddedImage": "test.png",
 					"EvalMatches": []map[string]string{
 						{
 							"Metric": "desktop",

--- a/public/emails/alert_notification.html
+++ b/public/emails/alert_notification.html
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width" />
-	
+
 <style>body {
 width: 100% !important; min-width: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; margin: 0; padding: 0;
 }
@@ -297,8 +297,8 @@ text-decoration: underline;
             {{if ne .ImageLink "" }}
               <img src="{{.ImageLink}}" alt="Alerting Panel" style="outline: none !important; text-decoration: none !important; -ms-interpolation-mode: bicubic; width: auto; clear: both; display: block; border: 0;" align="left" />
             {{end}}
-            {{if ne .EmbededImage "" }}
-              <img src="cid:{{.EmbededImage}}" alt="Alerting Panel" style="outline: none !important; text-decoration: none !important; -ms-interpolation-mode: bicubic; width: auto; clear: both; display: block; border: 0;" align="left" />
+            {{if ne .EmbeddedImage "" }}
+              <img src="cid:{{.EmbeddedImage}}" alt="Alerting Panel" style="outline: none !important; text-decoration: none !important; -ms-interpolation-mode: bicubic; width: auto; clear: both; display: block; border: 0;" align="left" />
             {{end}}
           </td>
         </tr>
@@ -339,11 +339,11 @@ text-decoration: underline;
 
 
 
-								
+
 							</td>
 						</tr>
 					</table>
-					
+
 					<table class="footer center" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: center; color: #999999; margin-top: 20px; padding: 0;" bgcolor="#2e2e2e">
 						<tr style="vertical-align: top; padding: 0;" align="left">
 							<td class="wrapper last" style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; position: relative; color: #222222; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0; padding: 10px 20px 0px 0px;" align="left" valign="top">


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the variable name from `EmbededImage` to `EmbeddedImage` in Alert notification templates