### PR TITLE
WIP: Make query response and error available to React query editors

### DIFF
--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -26,6 +26,7 @@ export interface Tags {
 }
 
 export interface SeriesData {
+  refId?: string; // query source refId
   name?: string;
   fields: Field[];
   rows: any[][];
@@ -39,6 +40,7 @@ export interface Column {
 }
 
 export interface TableData {
+  refId?: string; // query ref id
   columns: Column[];
   rows: any[][];
 }
@@ -48,6 +50,7 @@ export type TimeSeriesValue = number | null;
 export type TimeSeriesPoints = TimeSeriesValue[][];
 
 export interface TimeSeries {
+  refId?: string; // query ref id
   target: string;
   datapoints: TimeSeriesPoints;
   unit?: string;

--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -1,6 +1,14 @@
 import { ComponentClass } from 'react';
 import { ReactPanelPlugin } from './panel';
-import { DataQueryOptions, DataQuery, DataQueryResponse, QueryHint, QueryFixAction } from './datasource';
+import {
+  DataQueryOptions,
+  DataQuery,
+  DataQueryResponse,
+  DataQueryResponseData,
+  DataQueryError,
+  QueryHint,
+  QueryFixAction,
+} from './datasource';
 
 export interface DataSourceApi<TQuery extends DataQuery = DataQuery> {
   /**
@@ -52,6 +60,8 @@ export interface QueryEditorProps<DSType extends DataSourceApi, TQuery extends D
   query: TQuery;
   onRunQuery: () => void;
   onChange: (value: TQuery) => void;
+  queryResponse?: DataQueryResponseData[];
+  queryError?: DataQueryError;
 }
 
 export interface ExploreQueryFieldProps<DSType extends DataSourceApi, TQuery extends DataQuery> {


### PR DESCRIPTION
one big (the only I think), missing piece to react query editors #14749 

Big open question is the response should be prefiltered by refId (so only relevant to the query). Currently every sql datasource does this in the query ctrl. Could be good for the framework do to that outside. 

Filtering error on refId is harder as no data source has unified way of returning error by refId as if any query fail everything fails. 