### PR TITLE
Prometheus: fixes regex ad-hoc filters variables with wildcards

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -215,7 +215,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
       const { key, operator } = filter;
       let { value } = filter;
       if (operator === '=~' || operator === '!~') {
-        value = prometheusSpecialRegexEscape(value);
+        value = prometheusRegularEscape(value);
       }
       return addLabelToQuery(acc, key, value, operator);
     }, expr);


### PR DESCRIPTION
Fixes #14615 

Removes extra escaping for regex filter values when using ad hoc filters for Prometheus. The extra escaping causes queries with regex characters to be invalid.