### PR TITLE
Configuration: Improve session_lifetime comments

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -141,7 +141,7 @@ cookie_name = grafana_sess
 # If you use session in https only, default is false
 cookie_secure = false
 
-# Session life time, default is 86400
+# Session life time, default is 86400 (means 86400 seconds or 24 hours)
 session_life_time = 86400
 gc_interval_time = 86400
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -132,7 +132,7 @@ log_queries =
 # If you use session in https only, default is false
 ;cookie_secure = false
 
-# Session life time, default is 86400
+# Session life time, default is 86400 (means 86400 seconds or 24 hours)
 ;session_life_time = 86400
 
 #################################### Data proxy ###########################


### PR DESCRIPTION
Hi, 

**What this PR does / why we need it**:
Just adding a unit in the comment of session_life_time directive.
It's trivial, but I cannot unseen it, so here's the PR ;-)


**Special notes for your reviewer**:
I assume it was seconds. Feel free to correct if I was wrong.


Regards,