### PR TITLE
Fix numeric value formatting

### DIFF
--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -177,7 +177,7 @@ export class TableRenderer {
           return '-';
         }
 
-        if (_.isString(v) || _.isArray(v)) {
+        if (isNaN(v) || _.isArray(v)) {
           return this.defaultCellFormatter(v, column.style);
         }
 

--- a/public/app/plugins/panel/table/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table/specs/renderer.test.ts
@@ -224,7 +224,12 @@ describe('when rendering table', () => {
       expect(html).toBe('<td>1.230 s</td>');
     });
 
-    it('number style should ignore string values', () => {
+    it('number column should format numeric string values', () => {
+      const html = renderer.renderCell(1, 0, '1230');
+      expect(html).toBe('<td>1.230 s</td>');
+    });
+
+    it('number style should ignore string non-numeric values', () => {
       const html = renderer.renderCell(1, 0, 'asd');
       expect(html).toBe('<td>asd</td>');
     });


### PR DESCRIPTION
I did not found where it broke, but this worked few weeks back.

The problem is that some datasources return number values as string. Eg. https://github.com/Vertamedia/clickhouse-grafana receives UInt64 value from ClickHouse as string.

Therefore if the value was string, the defaultCellFormatter was being applied and such huge value wasn't being formatted to eg. `bits/s`.

This fixes it by checking whether the value is numeric and if so the proper formatter is applied for number-type styles.