### PR TITLE
Explore: display more meaningful call to action when no datasource configured

### DIFF
--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -98,8 +98,8 @@ export function updateDataSource(dataSource: DataSourceSettings): ThunkResult<vo
 export function deleteDataSource(): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const dataSource = getStore().dataSources.dataSource;
-
     await getBackendSrv().delete(`/api/datasources/${dataSource.id}`);
+    await updateFrontendSettings();
     dispatch(updateLocation({ path: '/datasources' }));
   };
 }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -38,6 +38,7 @@ import { LAST_USED_DATASOURCE_KEY, ensureQueries, DEFAULT_RANGE, DEFAULT_UI_STAT
 import { Emitter } from 'app/core/utils/emitter';
 import { ExploreToolbar } from './ExploreToolbar';
 import { scanStopAction } from './state/actionTypes';
+import { NoDataSourceCallToAction } from './NoDataSourceCallToAction';
 
 interface ExploreProps {
   StartPage?: ComponentClass<ExploreStartPageProps>;
@@ -192,6 +193,14 @@ export class Explore extends React.PureComponent<ExploreProps> {
     }
   };
 
+  renderEmptyState = () => {
+    return (
+      <div className="explore-container">
+        <NoDataSourceCallToAction />
+      </div>
+    );
+  };
+
   render() {
     const {
       StartPage,
@@ -213,9 +222,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
       <div className={exploreClass} ref={this.getRef}>
         <ExploreToolbar exploreId={exploreId} timepickerRef={this.timepickerRef} onChangeTime={this.onChangeTime} />
         {datasourceLoading ? <div className="explore-container">Loading datasource...</div> : null}
-        {datasourceMissing ? (
-          <div className="explore-container">Please add a datasource that supports Explore (e.g., Prometheus).</div>
-        ) : null}
+        {datasourceMissing ? this.renderEmptyState() : null}
 
         {datasourceError && (
           <div className="explore-container">

--- a/public/app/features/explore/NoDataSourceCallToAction.tsx
+++ b/public/app/features/explore/NoDataSourceCallToAction.tsx
@@ -5,13 +5,14 @@ import { ThemeContext, ExtraLargeLinkButton, CallToActionCard } from '@grafana/u
 export const NoDataSourceCallToAction = () => {
   const theme = useContext(ThemeContext);
 
-  const message = 'Please add a datasource that supports Explore (e.g., Prometheus)';
+  const message =
+    'Explore requires at least one data source. Once you have added a data source, you can query it here.';
   const footer = (
     <>
       <i className="fa fa-rocket" />
       <> ProTip: You can also define data sources through configuration files. </>
       <a
-        href="http://docs.grafana.org/administration/provisioning/#datasources?utm_source=grafana_ds_list"
+        href="http://docs.grafana.org/administration/provisioning/#datasources?utm_source=explore"
         target="_blank"
         className="text-link"
       >

--- a/public/app/features/explore/NoDataSourceCallToAction.tsx
+++ b/public/app/features/explore/NoDataSourceCallToAction.tsx
@@ -1,0 +1,42 @@
+import React, { useContext } from 'react';
+import { css } from 'emotion';
+import { ThemeContext, ExtraLargeLinkButton, CallToActionCard } from '@grafana/ui';
+
+export const NoDataSourceCallToAction = () => {
+  const theme = useContext(ThemeContext);
+
+  const message = 'Please add a datasource that supports Explore (e.g., Prometheus)';
+  const footer = (
+    <>
+      <i className="fa fa-rocket" />
+      <> ProTip: You can also define data sources through configuration files. </>
+      <a
+        href="http://docs.grafana.org/administration/provisioning/#datasources?utm_source=grafana_ds_list"
+        target="_blank"
+        className="text-link"
+      >
+        Learn more
+      </a>
+    </>
+  );
+
+  const ctaElement = (
+    <ExtraLargeLinkButton href="/datasources/new" icon="gicon gicon-add-datasources">
+      Add data source
+    </ExtraLargeLinkButton>
+  );
+
+  const cardClassName = css`
+    max-width: ${theme.breakpoints.lg};
+  `;
+
+  return (
+    <CallToActionCard
+      callToActionElement={ctaElement}
+      className={cardClassName}
+      footer={footer}
+      message={message}
+      theme={theme}
+    />
+  );
+};


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/15533

Displays call to action card that allows quick datasource configuration (me and @Ijin08 discussed the placement of the card and decided that left alignment, same as cheatsheet, is the besrt one - any opinion on that @davkal?): 

![image](https://user-images.githubusercontent.com/2376619/55082266-aa61be80-50a1-11e9-8fcc-344896cdde98.png)

Also, fixed issue with DatasourceSrv not being updated after datasource was deleted.