### PR TITLE
InfluxDB: Fix tag names with periods in alert evaluation

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -18,7 +18,7 @@ var (
 )
 
 func init() {
-	legendFormat = regexp.MustCompile(`\[\[(\w+?)*\]\]*|\$\s*(\w+?)*`)
+	legendFormat = regexp.MustCompile(`\[\[(\w+)(\.\w+)*\]\]*|\$\s*(\w+?)*`)
 }
 
 func (rp *ResponseParser) Parse(response *Response, query *Query) *tsdb.QueryResult {

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -75,7 +75,10 @@ func TestInfluxdbResponseParser(t *testing.T) {
 							{
 								Name:    "cpu.upc",
 								Columns: []string{"time", "mean", "sum"},
-								Tags:    map[string]string{"datacenter": "America"},
+								Tags:    map[string]string{
+									"datacenter": "America",
+									"dc.region.name": "Northeast",
+								},
 								Values: [][]interface{}{
 									{json.Number("111"), json.Number("222"), json.Number("333")},
 								},
@@ -158,6 +161,13 @@ func TestInfluxdbResponseParser(t *testing.T) {
 					result := parser.Parse(response, query)
 
 					So(result.Series[0].Name, ShouldEqual, "alias America")
+				})
+
+				Convey("tag alias with periods", func() {
+					query := &Query{Alias: "alias [[tag_dc.region.name]]"}
+					result := parser.Parse(response, query)
+
+					So(result.Series[0].Name, ShouldEqual, "alias Northeast")
 				})
 			})
 		})

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -75,8 +75,8 @@ func TestInfluxdbResponseParser(t *testing.T) {
 							{
 								Name:    "cpu.upc",
 								Columns: []string{"time", "mean", "sum"},
-								Tags:    map[string]string{
-									"datacenter": "America",
+								Tags: map[string]string{
+									"datacenter":     "America",
 									"dc.region.name": "Northeast",
 								},
 								Values: [][]interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:

This updates the regex that replaces values in influxDB series aliases so that it can handle tag names with periods in them when using the square bracket syntax (e.g. `[[tag_foo.bar.baz]]`).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #9148 

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note

```
