### PR TITLE
Make alertTimeout and alertMaxAttempts configurable in the config file

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -521,6 +521,16 @@ nodata_or_nullvalues = no_data
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 concurrent_render_limit = 5
 
+## Default setting for how long to perform the calculation of alert rule timeout
+execute_caculate_rule_timeout = 30
+
+## Default setting for how long to perform the sending alert timeout
+result_handle_timeout = 30
+
+## Default setting for max attempts to sending alert notifications
+max_attempts = 3
+
+
 #################################### Explore #############################
 [explore]
 # Enable the Explore section

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -446,6 +446,16 @@ log_queries =
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 ;concurrent_render_limit = 5
 
+
+## Default setting for how long to perform the calculation of alert rule timeout
+;execute_caculate_rule_timeout = 30
+
+## Default setting for how long to perform the sendding alert timeout
+;alert_result_handle_timeout = 30
+
+## Default setting for max attempts to sendding alert notifications
+;max_attempts = 3
+
 #################################### Explore #############################
 [explore]
 # Enable the Explore section

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -650,6 +650,20 @@ Alert notifications can include images, but rendering many images at the same ti
 This limit will protect the server from render overloading and make sure notifications are sent out quickly. Default
 value is `5`.
 
+
+### execute_caculate_rule_timeout 
+
+Default setting for how long to perform the calculation of alert rule timeout
+
+### result_handle_timeout
+
+Default setting for how long to perform the sending alert timeout
+
+### max_attempts
+
+Default setting for max attempts to sending alert notifications
+
+
 ## [panels]
 
 ### enable_alpha

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(float64(alertTimeout) * 0.9),
+		Timeout:         time.Duration(float64(setting.AlertingExcuteCaculateTimeout) * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -179,7 +179,11 @@ var (
 	AlertingErrorOrTimeout     string
 	AlertingNoDataOrNullValues string
 
-	// Explore UI
+    AlertingExcuteCaculateTimeout int
+    AlertingResultHandleTimeout int
+    AlertingMaxAttempts int
+
+// Explore UI
 	ExploreEnabled bool
 
 	// logger
@@ -759,6 +763,11 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AlertingRenderLimit = alerting.Key("concurrent_render_limit").MustInt(5)
 	AlertingErrorOrTimeout = alerting.Key("error_or_timeout").MustString("alerting")
 	AlertingNoDataOrNullValues = alerting.Key("nodata_or_nullvalues").MustString("no_data")
+
+	AlertingExcuteCaculateTimeout = alerting.Key("execute_caculate_rule_timeout").MustInt()
+	AlertingResultHandleTimeout = alerting.Key("result_handle_timeout").MustInt()
+	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt()
+
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)


### PR DESCRIPTION
**What this PR does / why we need it**:

Make alertTimeout and alertMaxAttempts configurable in the config file

**Which issue(s) this PR fixes**:

Fixes #16240 


**Release note**:

Make alertTimeout and alertMaxAttempts configurable in the config file
