### PR TITLE
Alerting: Makes timeouts and retries configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -521,11 +521,11 @@ nodata_or_nullvalues = no_data
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 concurrent_render_limit = 5
 
-## Default setting for how long to perform the calculation of alert rule timeout
-execute_caculate_rule_timeout = 30
+## Default setting for alert calculation timeout
+evaluation_timeout_seconds = 30
 
-## Default setting for how long to perform the sending alert timeout
-result_handle_timeout = 30
+## Default setting for alert notification timeout
+notification_timeout_seconds = 30
 
 ## Default setting for max attempts to sending alert notifications
 max_attempts = 3

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -521,6 +521,16 @@ nodata_or_nullvalues = no_data
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 concurrent_render_limit = 5
 
+## Default setting for how long to perform the calculation of alert rule timeout
+execute_caculate_rule_timeout = 30
+
+## Default setting for how long to perform the sending alert timeout
+result_handle_timeout = 30
+
+## Default setting for max attempts to sending alert notifications
+max_attempts = 3
+
+
 #################################### Explore #############################
 [explore]
 # Enable the Explore section

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -521,13 +521,13 @@ nodata_or_nullvalues = no_data
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 concurrent_render_limit = 5
 
-## Default setting for alert calculation timeout
+# Default setting for alert calculation timeout. Default value is 30
 evaluation_timeout_seconds = 30
 
-## Default setting for alert notification timeout
+# Default setting for alert notification timeout. Default value is 30
 notification_timeout_seconds = 30
 
-## Default setting for max attempts to sending alert notifications
+# Default setting for max attempts to sending alert notifications. Default value is 3
 max_attempts = 3
 
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -446,6 +446,16 @@ log_queries =
 # This limit will protect the server from render overloading and make sure notifications are sent out quickly
 ;concurrent_render_limit = 5
 
+
+## Default setting for how long to perform the calculation of alert rule timeout
+;execute_caculate_rule_timeout = 30
+
+## Default setting for how long to perform the sendding alert timeout
+;alert_result_handle_timeout = 30
+
+## Default setting for max attempts to sendding alert notifications
+;max_attempts = 3
+
 #################################### Explore #############################
 [explore]
 # Enable the Explore section

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -447,13 +447,13 @@ log_queries =
 ;concurrent_render_limit = 5
 
 
-## Default setting for alert calculation timeout
+# Default setting for alert calculation timeout. Default value is 30
 ;evaluation_timeout_seconds = 30
 
-## Default setting for alert notification timeout
+# Default setting for alert notification timeout. Default value is 30
 ;notification_timeout_seconds = 30
 
-## Default setting for max attempts to sendding alert notifications
+# Default setting for max attempts to sending alert notifications. Default value is 3
 ;max_attempts = 3
 
 #################################### Explore #############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -447,11 +447,11 @@ log_queries =
 ;concurrent_render_limit = 5
 
 
-## Default setting for how long to perform the calculation of alert rule timeout
-;execute_caculate_rule_timeout = 30
+## Default setting for alert calculation timeout
+;evaluation_timeout_seconds = 30
 
-## Default setting for how long to perform the sendding alert timeout
-;alert_result_handle_timeout = 30
+## Default setting for alert notification timeout
+;notification_timeout_seconds = 30
 
 ## Default setting for max attempts to sendding alert notifications
 ;max_attempts = 3

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -651,17 +651,17 @@ This limit will protect the server from render overloading and make sure notific
 value is `5`.
 
 
-### execute_caculate_rule_timeout 
+### evaluation_timeout_seconds 
 
-Default setting for how long to perform the calculation of alert rule timeout
+Default setting for alert calculation timeout. Default value is `30` 
 
-### result_handle_timeout
+### notification_timeout_seconds
 
-Default setting for how long to perform the sending alert timeout
+Default setting for alert notification timeout. Default value is `30` 
 
 ### max_attempts
 
-Default setting for max attempts to sending alert notifications
+Default setting for max attempts to sending alert notifications. Default value is `3` 
 
 
 ## [panels]

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -650,6 +650,20 @@ Alert notifications can include images, but rendering many images at the same ti
 This limit will protect the server from render overloading and make sure notifications are sent out quickly. Default
 value is `5`.
 
+
+### execute_caculate_rule_timeout 
+
+Default setting for how long to perform the calculation of alert rule timeout
+
+### result_handle_timeout
+
+Default setting for how long to perform the sending alert timeout
+
+### max_attempts
+
+Default setting for max attempts to sending alert notifications
+
+
 ## [panels]
 
 ### enable_alpha

--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -157,7 +157,7 @@ func (e *AlertingService) processJob(attemptID int, attemptChan chan int, cancel
 		}
 	}()
 
-	alertCtx, cancelFn := context.WithTimeout(context.Background(), setting.AlertingEvaluationTimeout*time.Second)
+	alertCtx, cancelFn := context.WithTimeout(context.Background(), setting.AlertingEvaluationTimeout)
 	cancelChan <- cancelFn
 	span := opentracing.StartSpan("alert execution")
 	alertCtx = opentracing.ContextWithSpan(alertCtx, span)
@@ -202,7 +202,7 @@ func (e *AlertingService) processJob(attemptID int, attemptChan chan int, cancel
 		}
 
 		// create new context with timeout for notifications
-		resultHandleCtx, resultHandleCancelFn := context.WithTimeout(context.Background(), setting.AlertingNotificationTimeout*time.Second)
+		resultHandleCtx, resultHandleCancelFn := context.WithTimeout(context.Background(), setting.AlertingNotificationTimeout)
 		cancelChan <- resultHandleCancelFn
 
 		// override the context used for evaluation with a new context for notifications.

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -23,8 +23,8 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				originAlertTimeout := alertTimeout
-				alertTimeout = 2 * time.Second
+				originAlertTimeout := time.Second * time.Duration(engine.alertingEvaluationTimeoutSeconds)
+				alertTimeout := 2 * time.Second
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -23,8 +23,6 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				originAlertTimeout := time.Second * 30
-				alertTimeout := 2 * time.Second
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 
@@ -39,7 +37,6 @@ func TestEngineTimeouts(t *testing.T) {
 				So(resultHandler.ResultHandleSucceed, ShouldEqual, true)
 
 				// initialize for other tests.
-				alertTimeout = originAlertTimeout
 				engine.resultHandler = &FakeResultHandler{}
 			})
 		})

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -23,6 +23,7 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
+				engine.alertingEvaluationTimeoutSeconds = 30
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 
@@ -37,6 +38,7 @@ func TestEngineTimeouts(t *testing.T) {
 				So(resultHandler.ResultHandleSucceed, ShouldEqual, true)
 
 				// initialize for other tests.
+				engine.alertingEvaluationTimeoutSeconds = 2
 				engine.resultHandler = &FakeResultHandler{}
 			})
 		})

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -23,7 +23,7 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				originAlertTimeout := time.Second * time.Duration(engine.alertingEvaluationTimeoutSeconds)
+				originAlertTimeout := time.Second * 30
 				alertTimeout := 2 * time.Second
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -11,21 +11,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestEngineTimeouts(t *testing.T) {
 	Convey("Alerting engine timeout tests", t, func() {
 		engine := NewEngine()
-		engine.alertingNotificationTimeoutSeconds = 30
-		engine.alertingMaxAttempts = 3
+		setting.AlertingNotificationTimeout = 30 * time.Second
+		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
 
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				engine.alertingEvaluationTimeoutSeconds = 30
+				setting.AlertingEvaluationTimeout = 30 * time.Second
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 
@@ -40,7 +41,7 @@ func TestEngineTimeouts(t *testing.T) {
 				So(resultHandler.ResultHandleSucceed, ShouldEqual, true)
 
 				// initialize for other tests.
-				engine.alertingEvaluationTimeoutSeconds = 2
+				setting.AlertingEvaluationTimeout = 2 * time.Second
 				engine.resultHandler = &FakeResultHandler{}
 			})
 		})

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -18,7 +18,7 @@ import (
 func TestEngineTimeouts(t *testing.T) {
 	Convey("Alerting engine timeout tests", t, func() {
 		engine := NewEngine()
-		setting.AlertingNotificationTimeout = 30
+		setting.AlertingNotificationTimeout = 30 * time.Second
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
@@ -26,7 +26,7 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				setting.AlertingEvaluationTimeout = 30
+				setting.AlertingEvaluationTimeout = 30 * time.Second
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 
@@ -41,7 +41,7 @@ func TestEngineTimeouts(t *testing.T) {
 				So(resultHandler.ResultHandleSucceed, ShouldEqual, true)
 
 				// initialize for other tests.
-				setting.AlertingEvaluationTimeout = 2
+				setting.AlertingEvaluationTimeout = 2 * time.Second
 				engine.resultHandler = &FakeResultHandler{}
 			})
 		})

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -17,6 +17,8 @@ import (
 func TestEngineTimeouts(t *testing.T) {
 	Convey("Alerting engine timeout tests", t, func() {
 		engine := NewEngine()
+		engine.alertingNotificationTimeoutSeconds = 30
+		engine.alertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -18,7 +18,7 @@ import (
 func TestEngineTimeouts(t *testing.T) {
 	Convey("Alerting engine timeout tests", t, func() {
 		engine := NewEngine()
-		setting.AlertingNotificationTimeout = 30 * time.Second
+		setting.AlertingNotificationTimeout = 30
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
@@ -26,7 +26,7 @@ func TestEngineTimeouts(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {
 				// reduce alert timeout to test quickly
-				setting.AlertingEvaluationTimeout = 30 * time.Second
+				setting.AlertingEvaluationTimeout = 30
 				transportTimeoutInterval := 2 * time.Second
 				serverBusySleepDuration := 1 * time.Second
 
@@ -41,7 +41,7 @@ func TestEngineTimeouts(t *testing.T) {
 				So(resultHandler.ResultHandleSucceed, ShouldEqual, true)
 
 				// initialize for other tests.
-				setting.AlertingEvaluationTimeout = 2 * time.Second
+				setting.AlertingEvaluationTimeout = 2
 				engine.resultHandler = &FakeResultHandler{}
 			})
 		})

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -45,9 +45,9 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("error + not last attempt -> retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(0)
 
-				for i := 1; i < alertMaxAttempts; i++ {
+				for i := 1; i < engine.alertingMaxAttempts; i++ {
 					attemptChan := make(chan int, 1)
-					cancelChan := make(chan context.CancelFunc, alertMaxAttempts)
+					cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
 
 					engine.processJob(i, attemptChan, cancelChan, job)
 					nextAttemptID, more := <-attemptChan
@@ -61,9 +61,9 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("error + last attempt -> no retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(0)
 				attemptChan := make(chan int, 1)
-				cancelChan := make(chan context.CancelFunc, alertMaxAttempts)
+				cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
 
-				engine.processJob(alertMaxAttempts, attemptChan, cancelChan, job)
+				engine.processJob(engine.alertingMaxAttempts, attemptChan, cancelChan, job)
 				nextAttemptID, more := <-attemptChan
 
 				So(nextAttemptID, ShouldEqual, 0)
@@ -74,7 +74,7 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("no error -> no retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(1)
 				attemptChan := make(chan int, 1)
-				cancelChan := make(chan context.CancelFunc, alertMaxAttempts)
+				cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
 
 				engine.processJob(1, attemptChan, cancelChan, job)
 				nextAttemptID, more := <-attemptChan
@@ -88,7 +88,7 @@ func TestEngineProcessJob(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 
 			Convey("never success -> max retries number", func() {
-				expectedAttempts := alertMaxAttempts
+				expectedAttempts := engine.alertingMaxAttempts
 				evalHandler := NewFakeEvalHandler(0)
 				engine.evalHandler = evalHandler
 
@@ -106,7 +106,7 @@ func TestEngineProcessJob(t *testing.T) {
 			})
 
 			Convey("some errors before success -> some retries", func() {
-				expectedAttempts := int(math.Ceil(float64(alertMaxAttempts) / 2))
+				expectedAttempts := int(math.Ceil(float64(engine.alertingMaxAttempts) / 2))
 				evalHandler := NewFakeEvalHandler(expectedAttempts)
 				engine.evalHandler = evalHandler
 

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
+	"time"
 )
 
 type FakeEvalHandler struct {
@@ -37,9 +39,9 @@ func (handler *FakeResultHandler) Handle(evalContext *EvalContext) error {
 func TestEngineProcessJob(t *testing.T) {
 	Convey("Alerting engine job processing", t, func() {
 		engine := NewEngine()
-		engine.alertingEvaluationTimeoutSeconds = 30
-		engine.alertingNotificationTimeoutSeconds = 30
-		engine.alertingMaxAttempts = 3
+		setting.AlertingEvaluationTimeout = 30 * time.Second
+		setting.AlertingNotificationTimeout = 30 * time.Second
+		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
 
@@ -48,9 +50,9 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("error + not last attempt -> retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(0)
 
-				for i := 1; i < engine.alertingMaxAttempts; i++ {
+				for i := 1; i < setting.AlertingMaxAttempts; i++ {
 					attemptChan := make(chan int, 1)
-					cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
+					cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
 					engine.processJob(i, attemptChan, cancelChan, job)
 					nextAttemptID, more := <-attemptChan
@@ -64,9 +66,9 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("error + last attempt -> no retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(0)
 				attemptChan := make(chan int, 1)
-				cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
+				cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
-				engine.processJob(engine.alertingMaxAttempts, attemptChan, cancelChan, job)
+				engine.processJob(setting.AlertingMaxAttempts, attemptChan, cancelChan, job)
 				nextAttemptID, more := <-attemptChan
 
 				So(nextAttemptID, ShouldEqual, 0)
@@ -77,7 +79,7 @@ func TestEngineProcessJob(t *testing.T) {
 			Convey("no error -> no retry", func() {
 				engine.evalHandler = NewFakeEvalHandler(1)
 				attemptChan := make(chan int, 1)
-				cancelChan := make(chan context.CancelFunc, engine.alertingMaxAttempts)
+				cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
 				engine.processJob(1, attemptChan, cancelChan, job)
 				nextAttemptID, more := <-attemptChan
@@ -91,7 +93,7 @@ func TestEngineProcessJob(t *testing.T) {
 		Convey("Should trigger as many retries as needed", func() {
 
 			Convey("never success -> max retries number", func() {
-				expectedAttempts := engine.alertingMaxAttempts
+				expectedAttempts := setting.AlertingMaxAttempts
 				evalHandler := NewFakeEvalHandler(0)
 				engine.evalHandler = evalHandler
 
@@ -109,7 +111,7 @@ func TestEngineProcessJob(t *testing.T) {
 			})
 
 			Convey("some errors before success -> some retries", func() {
-				expectedAttempts := int(math.Ceil(float64(engine.alertingMaxAttempts) / 2))
+				expectedAttempts := int(math.Ceil(float64(setting.AlertingMaxAttempts) / 2))
 				evalHandler := NewFakeEvalHandler(expectedAttempts)
 				engine.evalHandler = evalHandler
 

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
+	"time"
 )
 
 type FakeEvalHandler struct {
@@ -38,8 +39,8 @@ func (handler *FakeResultHandler) Handle(evalContext *EvalContext) error {
 func TestEngineProcessJob(t *testing.T) {
 	Convey("Alerting engine job processing", t, func() {
 		engine := NewEngine()
-		setting.AlertingEvaluationTimeout = 30
-		setting.AlertingNotificationTimeout = 30
+		setting.AlertingEvaluationTimeout = 30 * time.Second
+		setting.AlertingNotificationTimeout = 30 * time.Second
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -37,6 +37,9 @@ func (handler *FakeResultHandler) Handle(evalContext *EvalContext) error {
 func TestEngineProcessJob(t *testing.T) {
 	Convey("Alerting engine job processing", t, func() {
 		engine := NewEngine()
+		engine.alertingEvaluationTimeoutSeconds = 30
+		engine.alertingNotificationTimeoutSeconds = 30
+		engine.alertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}
 

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
-	"time"
 )
 
 type FakeEvalHandler struct {
@@ -39,8 +38,8 @@ func (handler *FakeResultHandler) Handle(evalContext *EvalContext) error {
 func TestEngineProcessJob(t *testing.T) {
 	Convey("Alerting engine job processing", t, func() {
 		engine := NewEngine()
-		setting.AlertingEvaluationTimeout = 30 * time.Second
-		setting.AlertingNotificationTimeout = 30 * time.Second
+		setting.AlertingEvaluationTimeout = 30
+		setting.AlertingNotificationTimeout = 30
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
 		job := &Job{Running: true, Rule: &Rule{}}

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(float64(setting.AlertingEvaluationTimeoutSeconds) * 0.9),
+		Timeout:         time.Duration(float64(setting.AlertingEvaluationTimeout) * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(float64(alertTimeout) * 0.9),
+		Timeout:         time.Duration(float64(setting.AlertingExcuteCaculateTimeout) * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(float64(setting.AlertingExcuteCaculateTimeout) * 0.9),
+		Timeout:         time.Duration(float64(setting.AlertingEvaluationTimeoutSeconds) * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(float64(setting.AlertingEvaluationTimeout) * 0.9),
+		Timeout:         time.Duration(setting.AlertingEvaluationTimeout.Seconds() * 0.9),
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -179,9 +179,9 @@ var (
 	AlertingErrorOrTimeout     string
 	AlertingNoDataOrNullValues string
 
-	AlertingEvaluationTimeoutSeconds   int
-	AlertingNotificationTimeoutSeconds int
-	AlertingMaxAttempts                int
+	AlertingEvaluationTimeout   time.Duration
+	AlertingNotificationTimeout time.Duration
+	AlertingMaxAttempts         int
 
 	// Explore UI
 	ExploreEnabled bool
@@ -764,9 +764,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AlertingErrorOrTimeout = alerting.Key("error_or_timeout").MustString("alerting")
 	AlertingNoDataOrNullValues = alerting.Key("nodata_or_nullvalues").MustString("no_data")
 
-	AlertingEvaluationTimeoutSeconds = alerting.Key("evaluation_timeout_seconds").MustInt()
-	AlertingNotificationTimeoutSeconds = alerting.Key("notification_timeout_seconds").MustInt()
-	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt()
+	AlertingEvaluationTimeout = alerting.Key("evaluation_timeout_seconds").MustDuration(time.Second * 30)
+	AlertingNotificationTimeout = alerting.Key("notification_timeout_seconds").MustDuration(time.Second * 30)
+	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -179,7 +179,11 @@ var (
 	AlertingErrorOrTimeout     string
 	AlertingNoDataOrNullValues string
 
-	// Explore UI
+    AlertingExcuteCaculateTimeout int
+    AlertingResultHandleTimeout int
+    AlertingMaxAttempts int
+
+// Explore UI
 	ExploreEnabled bool
 
 	// logger
@@ -759,6 +763,11 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AlertingRenderLimit = alerting.Key("concurrent_render_limit").MustInt(5)
 	AlertingErrorOrTimeout = alerting.Key("error_or_timeout").MustString("alerting")
 	AlertingNoDataOrNullValues = alerting.Key("nodata_or_nullvalues").MustString("no_data")
+
+	AlertingExcuteCaculateTimeout = alerting.Key("execute_caculate_rule_timeout").MustInt()
+	AlertingResultHandleTimeout = alerting.Key("result_handle_timeout").MustInt()
+	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt()
+
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -179,11 +179,11 @@ var (
 	AlertingErrorOrTimeout     string
 	AlertingNoDataOrNullValues string
 
-    AlertingExcuteCaculateTimeout int
-    AlertingResultHandleTimeout int
-    AlertingMaxAttempts int
+	AlertingEvaluationTimeoutSeconds   int
+	AlertingNotificationTimeoutSeconds int
+	AlertingMaxAttempts                int
 
-// Explore UI
+	// Explore UI
 	ExploreEnabled bool
 
 	// logger
@@ -764,10 +764,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	AlertingErrorOrTimeout = alerting.Key("error_or_timeout").MustString("alerting")
 	AlertingNoDataOrNullValues = alerting.Key("nodata_or_nullvalues").MustString("no_data")
 
-	AlertingExcuteCaculateTimeout = alerting.Key("execute_caculate_rule_timeout").MustInt()
-	AlertingResultHandleTimeout = alerting.Key("result_handle_timeout").MustInt()
+	AlertingEvaluationTimeoutSeconds = alerting.Key("evaluation_timeout_seconds").MustInt()
+	AlertingNotificationTimeoutSeconds = alerting.Key("notification_timeout_seconds").MustInt()
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt()
-
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)


### PR DESCRIPTION
**What this PR does / why we need it**:

Make alertTimeout and alertMaxAttempts configurable in the config file

**Which issue(s) this PR fixes**:

Fixes #16240 


**Release note**:

Make alertTimeout and alertMaxAttempts configurable in the config file
