### PR TITLE
docs: improve alert notification channel provisioning

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -273,6 +273,9 @@ notifiers:
     # or
     org_name: Main Org.
     is_default: true
+    send_reminders: true
+    frequency: 1h
+    disable_resolve_message: false
     # See `Supported Settings` section for settings supporter for each
     # alert notification type.
     settings:
@@ -286,7 +289,7 @@ delete_notifiers:
     uid: notifier1
     # either
     org_id: 2
-    # or 
+    # or
     org_name: Main Org.
   - name: notification-channel-2
     # default org_id: 1
@@ -324,6 +327,7 @@ The following sections detail the supported settings for each alert notification
 | Name |
 | ---- |
 | url |
+| autoResolve |
 
 #### Alert notification `kafka`
 
@@ -343,6 +347,7 @@ The following sections detail the supported settings for each alert notification
 | Name |
 | ---- |
 | integrationKey |
+| autoResolve |
 
 #### Alert notification `sensu`
 
@@ -392,6 +397,7 @@ The following sections detail the supported settings for each alert notification
 | ---- |
 | apiKey |
 | apiUrl |
+[ autoClose ]
 
 #### Alert notification `telegram`
 


### PR DESCRIPTION
Adds example of additional default properties for provisioning a notification channel
Adds missing settings for pagerduty, victorops, opsgenie