### PR TITLE
rename Tags to Labels in SeriesData (simple)

### DIFF
--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -51,6 +51,7 @@ export interface TimeSeries {
   target: string;
   datapoints: TimeSeriesPoints;
   unit?: string;
+  tags?: Labels;
 }
 
 export enum NullValueMode {

--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -21,7 +21,7 @@ export interface Field {
   dateFormat?: string; // Source data format
 }
 
-export interface Tags {
+export interface Labels {
   [key: string]: string;
 }
 
@@ -29,7 +29,7 @@ export interface SeriesData {
   name?: string;
   fields: Field[];
   rows: any[][];
-  tags?: Tags;
+  labels?: Labels;
 }
 
 export interface Column {

--- a/packages/grafana-ui/src/utils/processSeriesData.ts
+++ b/packages/grafana-ui/src/utils/processSeriesData.ts
@@ -35,6 +35,7 @@ function convertTimeSeriesToSeriesData(timeSeries: TimeSeries): SeriesData {
       },
     ],
     rows: timeSeries.datapoints,
+    labels: timeSeries.tags,
   };
 }
 


### PR DESCRIPTION
I'm looking at loki and SeriesData... about to post a proposal :)

We added a `Tags` interface to SeriesData, but I think we should rename it to `Labels` so it feels more natural for the prometheus/loki people and I don't think anyone really cares that it is called Tags

