### PR TITLE
Alerting: Notification channel http api fixes

### DIFF
--- a/docs/sources/http_api/alerting_notification_channels.md
+++ b/docs/sources/http_api/alerting_notification_channels.md
@@ -152,6 +152,7 @@ Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 {
+  "uid": "new-alert-notification", // optional
   "name": "new alert notification",  //Required
   "type":  "email", //Required
   "isDefault": false,
@@ -170,7 +171,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "uid": "cIBgcSjkk",
+  "uid": "new-alert-notification",
   "name": "new alert notification",
   "type": "email",
   "isDefault": false,
@@ -198,6 +199,7 @@ Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 {
+  "uid": "new-alert-notification", // optional
   "name": "new alert notification",  //Required
   "type":  "email", //Required
   "isDefault": false,
@@ -217,7 +219,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "uid": "cIBgcSjkk",
+  "uid": "new-alert-notification",
   "name": "new alert notification",
   "type": "email",
   "isDefault": false,
@@ -247,7 +249,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 {
   "id": 1,
-  "uid": "cIBgcSjkk",
+  "uid": "new-alert-notification", // optional
   "name": "new alert notification",  //Required
   "type":  "email", //Required
   "isDefault": false,
@@ -267,7 +269,7 @@ Content-Type: application/json
 
 {
   "id": 1,
-  "uid": "cIBgcSjkk",
+  "uid": "new-alert-notification",
   "name": "new alert notification",
   "type": "email",
   "isDefault": false,

--- a/pkg/models/alert_notifications.go
+++ b/pkg/models/alert_notifications.go
@@ -54,6 +54,7 @@ type CreateAlertNotificationCommand struct {
 
 type UpdateAlertNotificationCommand struct {
 	Id                    int64            `json:"id"  binding:"Required"`
+	Uid                   string           `json:"uid"`
 	Name                  string           `json:"name"  binding:"Required"`
 	Type                  string           `json:"type"  binding:"Required"`
 	SendReminder          bool             `json:"sendReminder"`
@@ -68,6 +69,7 @@ type UpdateAlertNotificationCommand struct {
 
 type UpdateAlertNotificationWithUidCommand struct {
 	Uid                   string           `json:"-"`
+	NewUid                string           `json:"uid"`
 	Name                  string           `json:"name"  binding:"Required"`
 	Type                  string           `json:"type"  binding:"Required"`
 	SendReminder          bool             `json:"sendReminder"`

--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -317,6 +317,10 @@ func UpdateAlertNotification(cmd *m.UpdateAlertNotificationCommand) error {
 		current.SendReminder = cmd.SendReminder
 		current.DisableResolveMessage = cmd.DisableResolveMessage
 
+		if cmd.Uid != "" {
+			current.Uid = cmd.Uid
+		}
+
 		if current.SendReminder {
 			if cmd.Frequency == "" {
 				return m.ErrNotificationFrequencyNotFound
@@ -356,8 +360,13 @@ func UpdateAlertNotificationWithUid(cmd *m.UpdateAlertNotificationWithUidCommand
 		return fmt.Errorf("Cannot update, alert notification uid %s doesn't exist", cmd.Uid)
 	}
 
+	if cmd.NewUid == "" {
+		cmd.NewUid = cmd.Uid
+	}
+
 	updateNotification := &m.UpdateAlertNotificationCommand{
 		Id:                    current.Id,
+		Uid:                   cmd.NewUid,
 		Name:                  cmd.Name,
 		Type:                  cmd.Type,
 		SendReminder:          cmd.SendReminder,


### PR DESCRIPTION
**What this PR does / why we need it**:
Some additional fixes after #16219 was merged.

Fix so that uid can be changed when updating notification channels through the http api.
Update documentation

**Which issue(s) this PR fixes**:
Fixes #16012

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note

```
