### PR TITLE
Fix: input elements autofill background

### DIFF
--- a/public/sass/pages/_login.scss
+++ b/public/sass/pages/_login.scss
@@ -33,9 +33,9 @@ textarea:-webkit-autofill:focus,
 select:-webkit-autofill,
 select:-webkit-autofill:hover,
 select:-webkit-autofill:focus {
-  -webkit-box-shadow: 0 0 0px 1000px $black inset !important;
-  -webkit-text-fill-color: #fbfbfb !important;
-  box-shadow: 0 0 0px 1000px $black inset;
+  -webkit-box-shadow: 0 0 0px 1000px $input-bg inset !important;
+  -webkit-text-fill-color: $input-color !important;
+  box-shadow: 0 0 0px 1000px $input-bg inset;
 }
 
 .login-form-group {


### PR DESCRIPTION
**What this PR does / why we need it**:

If the password is saved in browser, the autofill background color of input elements is hardcoded to black. This will break in light theme. This change will fix the background color of autofill input elements in light theme.

***Before***,

![before-1](https://user-images.githubusercontent.com/5479836/55231686-6b6e6d00-5249-11e9-836b-0c6fa67758bb.png)
![before-2](https://user-images.githubusercontent.com/5479836/55231701-732e1180-5249-11e9-8dbd-5557e79a9fc8.png)

***After the change***,

![after-1](https://user-images.githubusercontent.com/5479836/55231722-7c1ee300-5249-11e9-9289-4895535000d3.png)
![after-2](https://user-images.githubusercontent.com/5479836/55231731-7fb26a00-5249-11e9-936e-5591718806d0.png)

