### PR TITLE
UI Switch: Fix broken UI switches

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import uniqueId from 'lodash/uniqueId';
-import { Input } from '@grafana/ui';
 
 export interface Props {
   label: string;
@@ -39,7 +38,7 @@ export class Switch extends PureComponent<Props, State> {
         <label htmlFor={labelId} className={`gf-form gf-form-switch-container ${className || ''}`}>
           {label && <div className={labelClassName}>{label}</div>}
           <div className={switchClassName}>
-            <Input id={labelId} type="checkbox" checked={checked} onChange={this.internalOnChange} />
+            <input id={labelId} type="checkbox" checked={checked} onChange={this.internalOnChange} />
             <span className="gf-form-switch__slider" />
           </div>
         </label>


### PR DESCRIPTION
Switch component's styling relies on native input's `checked` attribute used in adjacent sibling selector. Because React based Input is wrapped in div, there was no chance for Switch's styling to work