### PR TITLE
only use SeriesData[] in react panels

### DIFF
--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -14,8 +14,8 @@ export enum FieldType {
 }
 
 export interface QueryResponseData {
-  refId?: string;
-  meta?: any; // Already used by query editors... but not sure what type!
+  refId?: string; // Matches the query target refId
+  meta?: any; // Already used by query editors... but not sure its options
 }
 
 export interface Field {

--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -13,6 +13,11 @@ export enum FieldType {
   other = 'other', // Object, Array, etc
 }
 
+export interface QueryResponseData {
+  refId?: string;
+  meta?: any; // Already used by query editors... but not sure what type!
+}
+
 export interface Field {
   name: string; // The column name
   type?: FieldType;
@@ -25,7 +30,7 @@ export interface Labels {
   [key: string]: string;
 }
 
-export interface SeriesData {
+export interface SeriesData extends QueryResponseData {
   name?: string;
   fields: Field[];
   rows: any[][];
@@ -38,7 +43,7 @@ export interface Column {
   unit?: string;
 }
 
-export interface TableData {
+export interface TableData extends QueryResponseData {
   columns: Column[];
   rows: any[][];
 }
@@ -47,7 +52,7 @@ export type TimeSeriesValue = number | null;
 
 export type TimeSeriesPoints = TimeSeriesValue[][];
 
-export interface TimeSeries {
+export interface TimeSeries extends QueryResponseData {
   target: string;
   datapoints: TimeSeriesPoints;
   unit?: string;

--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -13,9 +13,15 @@ export enum FieldType {
   other = 'other', // Object, Array, etc
 }
 
-export interface QueryResponseData {
-  refId?: string; // Matches the query target refId
-  meta?: any; // Already used by query editors... but not sure its options
+export interface QueryResultBase {
+  /**
+   * Matches the query target refId
+   */
+  refId?: string;
+  /**
+   * Used by some backend datasources to communicate back info about the execution (generated sql, timing)
+   */
+  meta?: any;
 }
 
 export interface Field {
@@ -30,7 +36,7 @@ export interface Labels {
   [key: string]: string;
 }
 
-export interface SeriesData extends QueryResponseData {
+export interface SeriesData extends QueryResultBase {
   name?: string;
   fields: Field[];
   rows: any[][];
@@ -43,7 +49,7 @@ export interface Column {
   unit?: string;
 }
 
-export interface TableData extends QueryResponseData {
+export interface TableData extends QueryResultBase {
   columns: Column[];
   rows: any[][];
 }
@@ -52,7 +58,7 @@ export type TimeSeriesValue = number | null;
 
 export type TimeSeriesPoints = TimeSeriesValue[][];
 
-export interface TimeSeries extends QueryResponseData {
+export interface TimeSeries extends QueryResultBase {
   target: string;
   datapoints: TimeSeriesPoints;
   unit?: string;

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -44,6 +44,7 @@ export interface DataQueryError {
   message?: string;
   status?: string;
   statusText?: string;
+  refId?: string;
 }
 
 export interface ScopedVar {

--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -1,6 +1,14 @@
 import { ComponentClass } from 'react';
 import { ReactPanelPlugin } from './panel';
-import { DataQueryOptions, DataQuery, DataQueryResponse, QueryHint, QueryFixAction } from './datasource';
+import {
+  DataQueryOptions,
+  DataQuery,
+  DataQueryResponse,
+  QueryHint,
+  QueryFixAction,
+  DataQueryError,
+} from './datasource';
+import { SeriesData } from './data';
 
 export interface DataSourceApi<TQuery extends DataQuery = DataQuery> {
   /**
@@ -52,6 +60,8 @@ export interface QueryEditorProps<DSType extends DataSourceApi, TQuery extends D
   query: TQuery;
   onRunQuery: () => void;
   onChange: (value: TQuery) => void;
+  queryResponse?: SeriesData[];
+  queryError?: DataQueryError;
 }
 
 export enum DatasourceStatus {

--- a/packages/grafana-ui/src/utils/processSeriesData.ts
+++ b/packages/grafana-ui/src/utils/processSeriesData.ts
@@ -17,6 +17,8 @@ function convertTableToSeriesData(table: TableData): SeriesData {
       return f;
     }),
     rows: table.rows,
+    refId: table.refId,
+    meta: table.meta,
   };
 }
 
@@ -36,6 +38,8 @@ function convertTimeSeriesToSeriesData(timeSeries: TimeSeries): SeriesData {
     ],
     rows: timeSeries.datapoints,
     labels: timeSeries.tags,
+    refId: timeSeries.refId,
+    meta: timeSeries.meta,
   };
 }
 
@@ -168,6 +172,8 @@ export const toLegacyResponseData = (series: SeriesData): TimeSeries | TableData
         target: fields[0].name || series.name,
         datapoints: rows,
         unit: fields[0].unit,
+        refId: series.refId,
+        meta: series.meta,
       } as TimeSeries;
     }
   }
@@ -178,6 +184,8 @@ export const toLegacyResponseData = (series: SeriesData): TimeSeries | TableData
         text: f.name,
         filterable: f.filterable,
         unit: f.unit,
+        refId: series.refId,
+        meta: series.meta,
       };
     }),
     rows,

--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -128,10 +128,18 @@ export class DashboardPanel extends PureComponent<Props, State> {
   };
 
   renderReactPanel() {
-    const { dashboard, panel, isFullscreen } = this.props;
+    const { dashboard, panel, isFullscreen, isEditing } = this.props;
     const { plugin } = this.state;
 
-    return <PanelChrome plugin={plugin} panel={panel} dashboard={dashboard} isFullscreen={isFullscreen} />;
+    return (
+      <PanelChrome
+        plugin={plugin}
+        panel={panel}
+        dashboard={dashboard}
+        isFullscreen={isFullscreen}
+        isEditing={isEditing}
+      />
+    );
   }
 
   renderAngularPanel() {

--- a/public/app/features/dashboard/dashgrid/DataPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DataPanel.tsx
@@ -8,7 +8,6 @@ import kbn from 'app/core/utils/kbn';
 // Types
 import {
   DataQueryOptions,
-  DataQueryResponse,
   DataQueryError,
   LoadingState,
   SeriesData,
@@ -36,14 +35,13 @@ export interface Props {
   maxDataPoints?: number;
   scopedVars?: ScopedVars;
   children: (r: RenderProps) => JSX.Element;
-  onDataResponse?: (data: DataQueryResponse) => void;
+  onDataResponse?: (data?: SeriesData[]) => void;
   onError: (message: string, error: DataQueryError) => void;
 }
 
 export interface State {
   isFirstLoad: boolean;
   loading: LoadingState;
-  response: DataQueryResponse;
   data?: SeriesData[];
 }
 
@@ -80,9 +78,6 @@ export class DataPanel extends Component<Props, State> {
 
     this.state = {
       loading: LoadingState.NotStarted,
-      response: {
-        data: [],
-      },
       isFirstLoad: true,
     };
   }
@@ -160,14 +155,15 @@ export class DataPanel extends Component<Props, State> {
         return;
       }
 
+      // Make sure the data is SeriesData[]
+      const data = getProcessedSeriesData(resp.data);
       if (onDataResponse) {
-        onDataResponse(resp);
+        onDataResponse(data);
       }
 
       this.setState({
+        data,
         loading: LoadingState.Done,
-        response: resp,
-        data: getProcessedSeriesData(resp.data),
         isFirstLoad: false,
       });
     } catch (err) {

--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -31,8 +31,8 @@ interface State {
   datasource: DataSourceApi | null;
   isCollapsed: boolean;
   hasTextEditMode: boolean;
-  queryError?: DataQueryError;
-  queryResponse?: SeriesData[];
+  queryError: DataQueryError | null;
+  queryResponse: SeriesData[] | null;
 }
 
 export class QueryEditorRow extends PureComponent<Props, State> {
@@ -45,6 +45,8 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     isCollapsed: false,
     loadedDataSourceValue: undefined,
     hasTextEditMode: false,
+    queryError: null,
+    queryResponse: null,
   };
 
   componentDidMount() {
@@ -71,7 +73,11 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     if (this.angularQueryEditor) {
       // for some reason this needs to be done in next tick
       setTimeout(this.angularQueryEditor.digest);
-    } else {
+      return;
+    }
+
+    // if error relates to this query store it in state and pass it on to query editor
+    if (error.refId === this.props.query.refId) {
       this.setState({ queryError: error });
     }
   };
@@ -85,10 +91,12 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     }
   };
 
-  // Only used by the React Editors
+  // Only used by the React Query Editors
   onSeriesDataReceived = (data: SeriesData[]) => {
     if (!this.angularQueryEditor) {
-      this.setState({ queryResponse: data });
+      // only pass series related to this query to query editor
+      const filterByRefId = data.filter(series => series.refId === this.props.query.refId);
+      this.setState({ queryResponse: filterByRefId, queryError: null });
     }
   };
 

--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -11,7 +11,7 @@ import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 // Types
 import { PanelModel } from '../state/PanelModel';
-import { DataQuery, DataSourceApi, TimeRange } from '@grafana/ui';
+import { DataQuery, DataSourceApi, TimeRange, DataQueryError, SeriesData } from '@grafana/ui';
 import { DashboardModel } from '../state/DashboardModel';
 
 interface Props {
@@ -31,6 +31,8 @@ interface State {
   datasource: DataSourceApi | null;
   isCollapsed: boolean;
   hasTextEditMode: boolean;
+  queryError?: DataQueryError;
+  queryResponse?: SeriesData[];
 }
 
 export class QueryEditorRow extends PureComponent<Props, State> {
@@ -50,19 +52,32 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     this.props.panel.events.on('refresh', this.onPanelRefresh);
     this.props.panel.events.on('data-error', this.onPanelDataError);
     this.props.panel.events.on('data-received', this.onPanelDataReceived);
+    this.props.panel.events.on('series-data-received', this.onSeriesDataReceived);
   }
 
   componentWillUnmount() {
     this.props.panel.events.off('refresh', this.onPanelRefresh);
     this.props.panel.events.off('data-error', this.onPanelDataError);
     this.props.panel.events.off('data-received', this.onPanelDataReceived);
+    this.props.panel.events.off('series-data-received', this.onSeriesDataReceived);
 
     if (this.angularQueryEditor) {
       this.angularQueryEditor.destroy();
     }
   }
 
-  onPanelDataError = () => {
+  onPanelDataError = (error: DataQueryError) => {
+    // Some query controllers listen to data error events and need a digest
+    if (this.angularQueryEditor) {
+      // for some reason this needs to be done in next tick
+      setTimeout(this.angularQueryEditor.digest);
+    } else {
+      this.setState({ queryError: error });
+    }
+  };
+
+  // Only used by angular plugins
+  onPanelDataReceived = () => {
     // Some query controllers listen to data error events and need a digest
     if (this.angularQueryEditor) {
       // for some reason this needs to be done in next tick
@@ -70,11 +85,10 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     }
   };
 
-  onPanelDataReceived = () => {
-    // Some query controllers listen to data error events and need a digest
-    if (this.angularQueryEditor) {
-      // for some reason this needs to be done in next tick
-      setTimeout(this.angularQueryEditor.digest);
+  // Only used by the React Editors
+  onSeriesDataReceived = (data: SeriesData[]) => {
+    if (!this.angularQueryEditor) {
+      this.setState({ queryResponse: data });
     }
   };
 
@@ -152,7 +166,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
 
   renderPluginEditor() {
     const { query, onChange } = this.props;
-    const { datasource } = this.state;
+    const { datasource, queryResponse, queryError } = this.state;
 
     if (datasource.pluginExports.QueryCtrl) {
       return <div ref={element => (this.element = element)} />;
@@ -160,7 +174,16 @@ export class QueryEditorRow extends PureComponent<Props, State> {
 
     if (datasource.pluginExports.QueryEditor) {
       const QueryEditor = datasource.pluginExports.QueryEditor;
-      return <QueryEditor query={query} datasource={datasource} onChange={onChange} onRunQuery={this.onRunQuery} />;
+      return (
+        <QueryEditor
+          query={query}
+          datasource={datasource}
+          onChange={onChange}
+          onRunQuery={this.onRunQuery}
+          queryResponse={queryResponse}
+          queryError={queryError}
+        />
+      );
     }
 
     return <div>Data source plugin does not export any Query Editor component</div>;


### PR DESCRIPTION
This aims to remove `QueryResponseData` from react panels, and instead use SeriesData[].  This extends/replaces some of the work in #16233

Since some of the data is passed around via event.emit, this adds a new event that matches the data format with the angular vs react styles.  These events only fire when editing:
```
      // Angular query editors expect TimeSeries|TableData
      events.emit('data-received', data.map(v => toLegacyResponseData(v)));

      // Notify react query editors
      events.emit('series-data-received', data);
```

This also adds the property `refId` and `meta` to TableData | TimeSeries | SeriesData.  I'm not really sure what meta is and how it is expected to be used, but we can improve that in another issue

