### PR TITLE
Fix: report the correct value before failing

### DIFF
--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -16,7 +16,7 @@ if [ $ERROR_COUNT -gt $ERROR_COUNT_LIMIT ]; then
 fi
 
 if [ $DIRECTIVES -gt $DIRECTIVES_LIMIT ]; then
-  echo -e "Directive count $ERROR_COUNT exceeded $DIRECTIVES_LIMIT so failing build"
+  echo -e "Directive count $DIRECTIVES exceeded $DIRECTIVES_LIMIT so failing build"
 	exit -1
 fi
 


### PR DESCRIPTION
Currently reporting the TS errors when failing for directives:
```
Executing './scripts/ci-frontend-metrics.sh'
Collecting code stats (typescript errors & more)
Directive count 6926 exceeded 173 so failing build
'./scripts/ci-frontend-metrics.sh' returned 255.
```