### PR TITLE
Build: Fix for renamed package for armv6.

### DIFF
--- a/build.go
+++ b/build.go
@@ -361,6 +361,7 @@ func createPackage(options linuxPackageOptions) {
 	fmt.Printf("pkgArch is set to '%s', generated arch is '%s'\n", pkgArch, options.packageArch)
 	if pkgArch == "armv6" {
 		name += "-rpi"
+		args = append(args, "--replaces", "grafana")
 	}
 	args = append(args, "--name", name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames the raspbery pi 1 package correctly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
