### PR TITLE
Suggest add-apt-repository to install APT repos

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -41,16 +41,16 @@ sudo dpkg -i grafana_5.4.2_amd64.deb
 
 ## APT Repository
 
-Create a file `/etc/apt/sources.list.d/grafana.list` and add the following to it.
+Instal the repository for stable releases
 
 ```bash
-deb https://packages.grafana.com/oss/deb stable main
+sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
 ```
 
 There is a separate repository if you want beta releases.
 
 ```bash
-deb https://packages.grafana.com/oss/deb beta main
+sudo add-apt-repository "deb https://packages.grafana.com/oss/deb beta main"
 ```
 
 Use the above line even if you are on Ubuntu or another Debian version. Then add our gpg key. This allows you to install signed packages.

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -41,7 +41,7 @@ sudo dpkg -i grafana_5.4.2_amd64.deb
 
 ## APT Repository
 
-Instal the repository for stable releases
+Install the repository for stable releases
 
 ```bash
 sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"


### PR DESCRIPTION
This is a small change to documentation.

It proposes users to install Grafana's APT repositories automatically, 
instead of "create a file with the content below".


Feel free to propose or change the phrasing

Let me know if you  have any feedback.
