### PR TITLE
avoid ProvisioningService startup error with custom Dockerfile

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -2,6 +2,17 @@ ARG GRAFANA_VERSION="latest"
 
 FROM grafana/grafana:${GRAFANA_VERSION}
 
+USER root
+
+# Add default provisioning service paths
+RUN mkdir -p /etc/grafana/provisioning/notifiers && \
+    mkdir -p /etc/grafana/provisioning/datasources && \
+    mkdir -p /etc/grafana/provisioning/dashboards && \
+    chmod -R 755 /etc/grafana/provisioning
+
+# Assert permissions for default configuration path
+RUN chown -R grafana:grafana /etc/grafana/
+
 USER grafana
 
 ARG GF_INSTALL_PLUGINS=""

--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -5,9 +5,9 @@ FROM grafana/grafana:${GRAFANA_VERSION}
 USER root
 
 # Add default provisioning service paths
-RUN mkdir -p /etc/grafana/provisioning/notifiers && \
-    mkdir -p /etc/grafana/provisioning/datasources && \
-    mkdir -p /etc/grafana/provisioning/dashboards && \
+RUN mkdir -p /etc/grafana/provisioning/notifiers     \
+             /etc/grafana/provisioning/datasources   \
+             /etc/grafana/provisioning/dashboards && \
     chmod -R 755 /etc/grafana/provisioning
 
 # Assert permissions for default configuration path


### PR DESCRIPTION
The default directories looked for during ProvisioningService startup must exist in order for the service to start cleanly. This change modifies the example Dockerfile referenced by the
custom Dockerfile build documentation. (http://docs.grafana.org/installation/docker/#building-a-custom-grafana-image-with-pre-installed-plugins)


Fixes #16305

**Note** - This does not modify any files in the CI build paths as it is an example Dockerfile that is referenced in the documentation only. For testing, a Docker container was built locally and it was confirmed to resolve the issue. The Dockerfile was also checked with a linter, and no problems were identified with the contributed change. 

**Release note**:

```release-note
**Docker**: Custom Dockerfile example includes ProvisioningService config paths.
```
