### PR TITLE
CloudWatch: Fix for dimension value list when changing dimension key

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.ts
@@ -112,6 +112,7 @@ export class CloudWatchQueryParameterCtrl {
         query = $scope.datasource.getDimensionKeys($scope.target.namespace, $scope.target.region);
       } else if (segment.type === 'value') {
         const dimensionKey = $scope.dimSegments[$index - 2].value;
+        delete target.dimensions[dimensionKey];
         query = $scope.datasource.getDimensionValues(
           target.region,
           target.namespace,


### PR DESCRIPTION
Will fix https://github.com/grafana/grafana/issues/15984.

The step to reproduce:

1. input `CacheNodeId` to dimension key field
2. click dimension value field, select `0001` (or other CacheNodeId in list)
3. change dimension key field from `CacheNodeId` to `CacheClusterId`
4. click dimension value field for `CacheClusterId`

At step 4, the dimension value list should be valid `CacheClusterId`.
But, CloudWatch datasource query dimension value for `{"CacheClusterId": "0001"}`, it is invalid dimension, so it failed to get valid dimension value.
It cause this issue.

https://github.com/grafana/grafana/blob/v6.0.2/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.ts#L115-L121