### PR TITLE
Automation: Updates to yarn cli cherrypick & changelog tasks

### DIFF
--- a/scripts/cli/tasks/changelog.ts
+++ b/scripts/cli/tasks/changelog.ts
@@ -14,21 +14,21 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = async ({ milestone }) 
     timeout: 10000,
   });
 
+  if (!/^\d+$/.test(milestone)) {
+    console.log('Use milestone number not title, find number in milestone url');
+    return;
+  }
+
   const res = await client.get('/issues', {
     params: {
       state: 'closed',
       per_page: 100,
       labels: 'add to changelog',
+      milestone: milestone,
     },
   });
 
-  const issues = res.data.filter(item => {
-    if (!item.milestone) {
-      console.log('Item missing milestone', item.number);
-      return false;
-    }
-    return item.milestone.title === milestone;
-  });
+  const issues = res.data;
 
   const bugs = _.sortBy(
     issues.filter(item => {

--- a/scripts/cli/tasks/cherrypick.ts
+++ b/scripts/cli/tasks/cherrypick.ts
@@ -27,13 +27,10 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
       continue;
     }
 
-    console.log(item.number + ' closed_at ' + item.closed_at + ' ' + item.html_url);
+    console.log(`${item.title} (${item.number}) closed_at ${item.closed_at}`);
+    console.log(`\tURL: ${item.closed_at} ${item.html_url}`);
     const issueDetails = await client.get(item.pull_request.url);
-    const commits = await client.get(issueDetails.data.commits_url);
-
-    for (const commit of commits.data) {
-      console.log(commit.commit.message + ' sha: ' + commit.sha);
-    }
+    console.log(`\tMerge sha: ${issueDetails.data.merge_commit_sha}`);
   }
 };
 


### PR DESCRIPTION
cherrypick now prints merge sha only. 

changelog task now filters changelog issues by milestone using api filter instead of doing after api results are in. 