### PR TITLE
build: Fixed incorrect permissions for repo folders in ci-deploy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
 
   deploy-enterprise-master:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.1
+      - image: grafana/grafana-ci-deploy:1.2.2
     steps:
       - attach_workspace:
           at: .
@@ -347,7 +347,7 @@ jobs:
 
   deploy-enterprise-release:
     docker:
-    - image: grafana/grafana-ci-deploy:1.2.1
+    - image: grafana/grafana-ci-deploy:1.2.2
     steps:
       - checkout
       - attach_workspace:
@@ -380,7 +380,7 @@ jobs:
 
   deploy-master:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.1
+      - image: grafana/grafana-ci-deploy:1.2.2
     steps:
       - attach_workspace:
           at: .
@@ -411,7 +411,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.1
+      - image: grafana/grafana-ci-deploy:1.2.2
     steps:
       - checkout
       - attach_workspace:

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -18,7 +18,9 @@ RUN pip install -U awscli crcmod && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \
-    ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+    ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud && \
+    mkdir -p /deb-repo /rpm-repo && \
+    chown circleci:circleci /deb-repo /rpm-repo
 
 COPY --from=0 /go/bin/aptly /usr/local/bin/aptly
 

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_version="1.2.1"
+_version="1.2.2"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes permissions for folders needed by ci-deploy to be able to update the deb and rpm repos. This was fixed in 1.2.0 but did not end up in master and therefor broke when 1.2.1 was released.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```