### PR TITLE
PagerDuty: No Data as Warning severity option

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -101,6 +101,7 @@ Setting | Description
 ---------- | -----------
 Integration Key | Integration key for PagerDuty.
 Auto resolve incidents | Resolve incidents in PagerDuty once the alert goes back to ok
+Treat No Data as Warning | Alerts in the No Data state will be sent to PagerDuty with a severity of warning instead of critical
 
 ### Webhook
 

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -41,7 +41,7 @@ func init() {
            label="Treat No Data as Warning"
            label-class="width-14"
            checked="ctrl.model.settings.noDataWarn"
-           tooltip="Alerts in the No Data state will be sent to PagerDuty as a warning.">
+           tooltip="Alerts in the No Data state will be sent to PagerDuty with a severity of warning instead of critical.">
         </gf-form-switch>
       </div>
     `,

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -43,13 +43,15 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
 				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
 				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
+				So(pagerdutyNotifier.NoDataWarn, ShouldBeFalse)
 			})
 
 			Convey("settings should trigger incident", func() {
 				json := `
 				{
 		  			"integrationKey": "abcdefgh0123456789",
-					"autoResolve": false
+					"autoResolve": false,
+					"noDataWarn": true
 				}`
 
 				settingsJSON, _ := simplejson.NewJson([]byte(json))
@@ -67,6 +69,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
 				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
 				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
+				So(pagerdutyNotifier.NoDataWarn, ShouldBeTrue)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
Provides the option to reduce the severity of alerts in the No Data state from the default "critical" to "warning".
Adds "[No Data]" to the custom data field on all alerts sent when the state is No Data

Both these changes allow PagerDuty users to create lower severity incidents when there is a data interruption rather than everything being as the highest severity.

**Special notes for your reviewer**:
I am unsure how these notifiers are persisted to storage and if there will be any conflict with existing PagerDuty notifiers that never set the NoDataWarn field.

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
Adds "Treat No Data as Warning" option to PagerDuty notification channels.
```
