### PR TITLE
Alerting: Notification channel http api fixes

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -261,6 +261,10 @@ func UpdateAlertNotification(c *m.ReqContext, cmd m.UpdateAlertNotificationComma
 		return Error(500, "Failed to update alert notification", err)
 	}
 
+	if cmd.Result == nil {
+		return Error(404, "Alert notification not found", nil)
+	}
+
 	return JSON(200, dtos.NewAlertNotification(cmd.Result))
 }
 
@@ -270,6 +274,10 @@ func UpdateAlertNotificationByUID(c *m.ReqContext, cmd m.UpdateAlertNotification
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		return Error(500, "Failed to update alert notification", err)
+	}
+
+	if cmd.Result == nil {
+		return Error(404, "Alert notification not found", nil)
 	}
 
 	return JSON(200, dtos.NewAlertNotification(cmd.Result))

--- a/pkg/models/alert_notifications.go
+++ b/pkg/models/alert_notifications.go
@@ -39,7 +39,7 @@ type AlertNotification struct {
 }
 
 type CreateAlertNotificationCommand struct {
-	Uid                   string           `json:"-"`
+	Uid                   string           `json:"uid"`
 	Name                  string           `json:"name"  binding:"Required"`
 	Type                  string           `json:"type"  binding:"Required"`
 	SendReminder          bool             `json:"sendReminder"`

--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -382,6 +382,8 @@ func UpdateAlertNotificationWithUid(cmd *m.UpdateAlertNotificationWithUidCommand
 		return err
 	}
 
+	cmd.Result = updateNotification.Result
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes so it's possible to create new notification channel and providing uid.
Fixes better error/result handling when updating a notifcation channel.

Fixes #16372 
Ref #16219 #16012