### PR TITLE
Chore: Add task to warn about FocusConvey tests

### DIFF
--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -593,7 +593,7 @@ func TestMySQL(t *testing.T) {
 				So(queryResult.Series[0].Points[0][1].Float64, ShouldEqual, float64(tInitial.UnixNano()/1e6))
 			})
 
-			FocusConvey("When doing a metric query using epoch (int32) as time column and value column (int32) should return metric with time in milliseconds", func() {
+			Convey("When doing a metric query using epoch (int32) as time column and value column (int32) should return metric with time in milliseconds", func() {
 				query := &tsdb.TsdbQuery{
 					Queries: []*tsdb.Query{
 						{

--- a/scripts/grunt/default_task.js
+++ b/scripts/grunt/default_task.js
@@ -1,52 +1,68 @@
 // Lint and build CSS
-module.exports = function (grunt) {
+module.exports = function(grunt) {
   'use strict';
 
+  // prettier-ignore
   grunt.registerTask('default', [
     'clean:build',
     'phantomjs',
-    'webpack:dev',
+    'webpack:dev'
   ]);
 
+  // prettier-ignore
   grunt.registerTask('test', [
     'sasslint',
     'tslint',
     'typecheck',
-    "exec:jest",
-    'no-only-tests'
+    'exec:jest',
+    'no-only-tests',
+    'no-focus-convey-tests'
   ]);
 
+  // prettier-ignore
   grunt.registerTask('tslint', [
     'newer:exec:tslintPackages',
-    'newer:exec:tslintRoot',
+    'newer:exec:tslintRoot'
   ]);
 
+  // prettier-ignore
   grunt.registerTask('typecheck', [
     'newer:exec:typecheckPackages',
-    'newer:exec:typecheckRoot',
+    'newer:exec:typecheckRoot'
   ]);
 
+  // prettier-ignore
   grunt.registerTask('precommit', [
     'newer:sasslint',
     'typecheck',
     'tslint',
-    'no-only-tests'
+    'no-only-tests',
+    'no-focus-convey-tests'
   ]);
 
-  grunt.registerTask('no-only-tests', function () {
+  grunt.registerTask('no-only-tests', function() {
     var files = grunt.file.expand(
-      'public/**/*@(_specs|\.test)\.@(ts|js|tsx|jsx)',
-      'packages/grafana-ui/**/*@(_specs|\.test)\.@(ts|js|tsx|jsx)'
+      'public/**/*@(_specs|.test).@(ts|js|tsx|jsx)',
+      'packages/grafana-ui/**/*@(_specs|.test).@(ts|js|tsx|jsx)'
     );
+    grepFiles(files, '.only(', 'found only statement in test: ');
+  });
 
-    files.forEach(function (spec) {
+  grunt.registerTask('no-focus-convey-tests', function() {
+    var files = grunt.file.expand('pkg/**/*_test.go');
+    grepFiles(files, 'FocusConvey(', 'found FocusConvey statement in test: ');
+  });
+
+  function grepFiles(files, pattern, errorMessage) {
+    files.forEach(function(spec) {
       var rows = grunt.file.read(spec).split('\n');
-      rows.forEach(function (row) {
-        if (row.indexOf('.only(') > 0) {
+      rows.forEach(function(row) {
+        if (row.indexOf(pattern) > 0) {
           grunt.log.errorlns(row);
-          grunt.fail.warn('found only statement in test: ' + spec);
+          grunt.fail.warn(errorMessage + spec);
         }
       });
     });
-  });
+  }
 };
+


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/16328

Same thing as with `.only` test just for go convey. Seems to be pretty quick so should not make the checks much slower and probably makes sense to have them in one place.