### PR TITLE
QueryEditors: Toggle edit mode now always work on slower computers

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -161,7 +161,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     // give angular time to compile
     setTimeout(() => {
       this.setState({ hasTextEditMode: !!this.angularScope.toggleEditorMode });
-    }, 10);
+    }, 100);
   }
 
   onToggleCollapse = () => {


### PR DESCRIPTION
Closes #16393 
I'm sure you guys are working towards a better solution for the angular <-> react interplay, but incase you wanted this hacky tweak, I already had it in a branch :).