### PR TITLE
Mixed Datasource: Fix error when one query is disabled

### DIFF
--- a/public/app/plugins/datasource/mixed/datasource.ts
+++ b/public/app/plugins/datasource/mixed/datasource.ts
@@ -13,9 +13,17 @@ class MixedDatasource {
         return this.$q([]);
       }
 
+      const filtered = _.filter(targets, t => {
+        return !t.hide;
+      });
+
+      if (filtered.length === 0) {
+        return { data: [] };
+      }
+
       return this.datasourceSrv.get(dsName).then(ds => {
         const opt = angular.copy(options);
-        opt.targets = targets;
+        opt.targets = filtered;
         return ds.query(opt);
       });
     });


### PR DESCRIPTION
This fixes an error that was thrown when one or several queries
was disabled using the mixed datasources.

Fixes #12977 

![image](https://user-images.githubusercontent.com/1668778/55625994-a1ac6f00-57aa-11e9-8e30-7ddad6ca61de.png)