### PR TITLE
Table Panel: delay refresh on the table when navigating 

### DIFF
--- a/public/app/plugins/panel/table/editor.html
+++ b/public/app/plugins/panel/table/editor.html
@@ -34,16 +34,17 @@
 	<div class="section gf-form-group">
 		<h5 class="section-heading">Paging</h5>
     <div class="gf-form">
-      <label class="gf-form-label width-8">Rows per page</label>
+      <label class="gf-form-label width-9">Rows per page</label>
       <input type="number" class="gf-form-input width-7"
                            placeholder="100" data-placement="right"
                                              ng-model="editor.panel.pageSize"
                                              ng-change="editor.render()"
                                              ng-model-onblur>
     </div>
-    <gf-form-switch class="gf-form" label-class="width-8" switch-class="max-width-7" label="Scroll" checked="editor.panel.scroll" on-change="editor.render()"></gf-form-switch>
+    <gf-form-switch class="gf-form" label-class="width-9" switch-class="max-width-7" label="Pause refresh" checked="editor.panel.pagingPausesRefresh" on-change="editor.render()"></gf-form-switch>
+    <gf-form-switch class="gf-form" label-class="width-9" switch-class="max-width-7" label="Scroll" checked="editor.panel.scroll" on-change="editor.render()"></gf-form-switch>
     <div class="gf-form max-width-17">
-      <label class="gf-form-label width-8">Font size</label>
+      <label class="gf-form-label width-9">Font size</label>
       <div class="gf-form-select-wrapper width-7">
         <select class="gf-form-input"
                 ng-model="editor.panel.fontSize"


### PR DESCRIPTION
**What this PR does / why we need it**:

This feature is enabled if the user opts-in with a "Pause refresh" checkbox under "Paging".

Once enabled, if the user has navigated away from page 1 and new data arrives, instead of immediately redrawing and forcing them back to page one, it will show a 'refresh' icon next to the page list.  Upon clicking, *then* it will redraw with the new data.

**Which issue(s) this PR fixes**:
Fixes #14780

(Oops, originally opened this against #16392 instead because I was looking into both issues simultaneously. <g>)
