### PR TITLE
add PromQL keyword for adhoc filter

### DIFF
--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const keywords = 'by|without|on|ignoring|group_left|group_right';
+const keywords = 'by|without|on|ignoring|group_left|group_right|bool|or|and|unless';
 
 // Duplicate from mode-prometheus.js, which can't be used in tests due to global ace not being loaded.
 const builtInWords = [


### PR DESCRIPTION
Ad-hoc filter doesn't work which include `or` in the query.
Some PromQL keywords are not included in the list, I add it.