### PR TITLE
Styles: Fixed menu hover highlight border

### DIFF
--- a/public/sass/mixins/_mixins.scss
+++ b/public/sass/mixins/_mixins.scss
@@ -335,7 +335,6 @@
 }
 
 @mixin left-brand-border-gradient() {
-  border: none;
   border-image: linear-gradient(rgba(255, 213, 0, 1) 0%, rgba(255, 68, 0, 1) 99%, rgba(255, 68, 0, 1) 100%);
   border-image-slice: 1;
   border-style: solid;


### PR DESCRIPTION
Upgrades to webpack & css optimization caused changes
in production build that removed the left brand
gradient.

Fixes #16430

