### PR TITLE
Documentation: fix grammar in query hint, tests, and documentation

### DIFF
--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -67,7 +67,7 @@ The autocomplete menu can be trigger by pressing Ctrl + Space. The Autocomplete 
 
 Suggestions can appear under the query field - click on them to update your query with the suggested change.
 
-* For counters (monotonously increasing metrics), a rate function will be suggested.
+* For counters (monotonically increasing metrics), a rate function will be suggested.
 * For buckets, a histogram function will be suggested.
 * For recording rules, possible to expand the rules.
 

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -26,7 +26,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: any): 
     });
   }
 
-  // Check for monotony on series (table results are being ignored here)
+  // Check for monotonicity on series (table results are being ignored here)
   if (series && series.length > 0) {
     series.forEach(s => {
       const datapoints: number[][] = s.datapoints;
@@ -43,7 +43,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: any): 
         });
         if (increasing && monotonic) {
           const simpleMetric = query.trim().match(/^\w+$/);
-          let label = 'Time series is monotonously increasing.';
+          let label = 'Time series is monotonically increasing.';
           let fix;
           if (simpleMetric) {
             fix = {

--- a/public/app/plugins/datasource/prometheus/specs/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/query_hints.test.ts
@@ -9,7 +9,7 @@ describe('getQueryHints()', () => {
     expect(getQueryHints('', [{ datapoints: [] }])).toEqual(null);
   });
 
-  it('returns no hint for a monotonously decreasing series', () => {
+  it('returns no hint for a monotonically decreasing series', () => {
     const series = [{ datapoints: [[23, 1000], [22, 1001]] }];
     const hints = getQueryHints('metric', series);
     expect(hints).toEqual(null);
@@ -21,12 +21,12 @@ describe('getQueryHints()', () => {
     expect(hints).toEqual(null);
   });
 
-  it('returns a rate hint for a monotonously increasing series', () => {
+  it('returns a rate hint for a monotonically increasing series', () => {
     const series = [{ datapoints: [[23, 1000], [24, 1001]] }];
     const hints = getQueryHints('metric', series);
     expect(hints.length).toBe(1);
     expect(hints[0]).toMatchObject({
-      label: 'Time series is monotonously increasing.',
+      label: 'Time series is monotonically increasing.',
       fix: {
         action: {
           type: 'ADD_RATE',
@@ -36,13 +36,13 @@ describe('getQueryHints()', () => {
     });
   });
 
-  it('returns no rate hint for a monotonously increasing series that already has a rate', () => {
+  it('returns no rate hint for a monotonically increasing series that already has a rate', () => {
     const series = [{ datapoints: [[23, 1000], [24, 1001]] }];
     const hints = getQueryHints('rate(metric[1m])', series);
     expect(hints).toEqual(null);
   });
 
-  it('returns a rate hint w/o action for a complex monotonously increasing series', () => {
+  it('returns a rate hint w/o action for a complex monotonically increasing series', () => {
     const series = [{ datapoints: [[23, 1000], [24, 1001]] }];
     const hints = getQueryHints('sum(metric)', series);
     expect(hints.length).toBe(1);
@@ -50,12 +50,12 @@ describe('getQueryHints()', () => {
     expect(hints[0].fix).toBeUndefined();
   });
 
-  it('returns a rate hint for a monotonously increasing series with missing data', () => {
+  it('returns a rate hint for a monotonically increasing series with missing data', () => {
     const series = [{ datapoints: [[23, 1000], [null, 1001], [24, 1002]] }];
     const hints = getQueryHints('metric', series);
     expect(hints.length).toBe(1);
     expect(hints[0]).toMatchObject({
-      label: 'Time series is monotonously increasing.',
+      label: 'Time series is monotonically increasing.',
       fix: {
         action: {
           type: 'ADD_RATE',


### PR DESCRIPTION
This PR fixes the use of "monotonously" when "monotonically" is intended, in the Explore query hint, related tests, and documentation.