### PR TITLE
Graph: Fixed auto decimals in legend values

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/valueFormats.test.ts
@@ -1,29 +1,38 @@
 import { toFixed, getValueFormat } from './valueFormats';
 
-describe('kbn.toFixed and negative decimals', () => {
-  it('should treat as zero decimals', () => {
-    const str = toFixed(186.123, -2);
-    expect(str).toBe('186');
+describe('valueFormats', () => {
+  describe('toFixed and negative decimals', () => {
+    it('should treat as zero decimals', () => {
+      const str = toFixed(186.123, -2);
+      expect(str).toBe('186');
+    });
   });
-});
 
-describe('kbn ms format when scaled decimals is null do not use it', () => {
-  it('should use specified decimals', () => {
-    const str = getValueFormat('ms')(10000086.123, 1, null);
-    expect(str).toBe('2.8 hour');
+  describe('ms format when scaled decimals is null do not use it', () => {
+    it('should use specified decimals', () => {
+      const str = getValueFormat('ms')(10000086.123, 1, null);
+      expect(str).toBe('2.8 hour');
+    });
   });
-});
 
-describe('kbn kbytes format when scaled decimals is null do not use it', () => {
-  it('should use specified decimals', () => {
-    const str = getValueFormat('kbytes')(10000000, 3, null);
-    expect(str).toBe('9.537 GiB');
+  describe('kbytes format when scaled decimals is null do not use it', () => {
+    it('should use specified decimals', () => {
+      const str = getValueFormat('kbytes')(10000000, 3, null);
+      expect(str).toBe('9.537 GiB');
+    });
   });
-});
 
-describe('kbn deckbytes format when scaled decimals is null do not use it', () => {
-  it('should use specified decimals', () => {
-    const str = getValueFormat('deckbytes')(10000000, 3, null);
-    expect(str).toBe('10.000 GB');
+  describe('deckbytes format when scaled decimals is null do not use it', () => {
+    it('should use specified decimals', () => {
+      const str = getValueFormat('deckbytes')(10000000, 3, null);
+      expect(str).toBe('10.000 GB');
+    });
+  });
+
+  describe('ms format when scaled decimals is 0', () => {
+    it('should use scaledDecimals and add 3', () => {
+      const str = getValueFormat('ms')(1200, 0, 0);
+      expect(str).toBe('1.200 s');
+    });
   });
 });

--- a/packages/grafana-ui/src/utils/valueFormats/valueFormats.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/valueFormats.ts
@@ -56,17 +56,15 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
 
 export function toFixedScaled(
   value: number,
-  decimals?: DecimalCount,
-  scaledDecimals?: DecimalCount,
-  additionalDecimals?: DecimalCount,
+  decimals: DecimalCount,
+  scaledDecimals: DecimalCount,
+  additionalDecimals: number,
   ext?: string
 ) {
-  if (scaledDecimals) {
-    if (additionalDecimals) {
-      return toFixed(value, scaledDecimals + additionalDecimals) + ext;
-    } else {
-      return toFixed(value, scaledDecimals) + ext;
-    }
+  if (scaledDecimals === null || scaledDecimals === undefined) {
+    return toFixed(value, decimals) + ext;
+  } else {
+    return toFixed(value, scaledDecimals + additionalDecimals) + ext;
   }
 
   return toFixed(value, decimals) + ext;


### PR DESCRIPTION
Graph legend did not get the correct auto decimals for scaled units like ms, s etc . 

Fixes #16448


