### PR TITLE
Styling: Aligned page headings

### DIFF
--- a/public/app/features/admin/partials/edit_org.html
+++ b/public/app/features/admin/partials/edit_org.html
@@ -1,7 +1,7 @@
 <page-header model="navModel"></page-header>
 
 <div class="page-container page-body">
-	<h2 class="page-sub-heading">Edit Organization</h2>
+	<h3 class="page-sub-heading">Edit Organization</h3>
 
 	<form name="orgDetailsForm" class="gf-form-group">
 		<div class="gf-form">

--- a/public/app/features/admin/partials/edit_user.html
+++ b/public/app/features/admin/partials/edit_user.html
@@ -2,9 +2,9 @@
 
 <div class="page-container page-body">
 
-	<div class="page-sub-heading">
-		<h2>Edit User</h2>
-	</div>
+
+	<h3 class="page-sub-heading">Edit User</h3>
+
 
 	<form name="userForm" class="gf-form-group">
 			<div class="gf-form">

--- a/public/app/features/admin/partials/new_user.html
+++ b/public/app/features/admin/partials/new_user.html
@@ -2,7 +2,7 @@
 
 <div class="page-container page-body">
 	<div class="page-sub-heading">
-		<h1>Add new user</h1>
+		<h3 class="page-sub-heading">Add new user</h3>
 	</div>
 
 	<form name="userForm" class="gf-form-group">

--- a/public/app/features/folders/FolderSettingsPage.tsx
+++ b/public/app/features/folders/FolderSettingsPage.tsx
@@ -68,7 +68,7 @@ export class FolderSettingsPage extends PureComponent<Props, State> {
     return (
       <Page navModel={navModel}>
         <Page.Contents isLoading={this.state.isLoading}>
-          <h2 className="page-sub-heading">Folder Settings</h2>
+          <h3 className="page-sub-heading">Folder Settings</h3>
 
           <div className="section gf-form-group">
             <form name="folderSettingsForm" onSubmit={this.onSave}>

--- a/public/app/features/folders/__snapshots__/FolderSettingsPage.test.tsx.snap
+++ b/public/app/features/folders/__snapshots__/FolderSettingsPage.test.tsx.snap
@@ -7,11 +7,11 @@ exports[`Render should enable save button 1`] = `
   <PageContents
     isLoading={false}
   >
-    <h2
+    <h3
       className="page-sub-heading"
     >
       Folder Settings
-    </h2>
+    </h3>
     <div
       className="section gf-form-group"
     >
@@ -65,11 +65,11 @@ exports[`Render should render component 1`] = `
   <PageContents
     isLoading={false}
   >
-    <h2
+    <h3
       className="page-sub-heading"
     >
       Folder Settings
-    </h2>
+    </h3>
     <div
       className="section gf-form-group"
     >

--- a/public/app/features/org/partials/invite.html
+++ b/public/app/features/org/partials/invite.html
@@ -2,7 +2,7 @@
 
 <div class="page-container page-body" ng-cloak>
 
-	<h2 class="page-sub-heading">Invite User</h2>
+	<h3 class="page-sub-heading">Invite User</h3>
 
 	<div class="p-b-2">
 		Send invite or add existing Grafana user to the organization

--- a/public/app/features/org/partials/newOrg.html
+++ b/public/app/features/org/partials/newOrg.html
@@ -1,9 +1,9 @@
 <page-header model="navModel"></page-header>
 
 <div class="page-container page-body" ng-form="playlistEditForm">
-	<h2 class="page-sub-heading">
+	<h3 class="page-sub-heading">
 		New Organization
-	</h2>
+	</h3>
 
 	<p class="playlist-description">Each organization contains their own dashboards, data sources and configuration, and cannot be shared between orgs. While users may belong to more than one, multiple organization are most frequently used in multi-tenant deployments. </p>
 

--- a/public/app/features/profile/partials/change_password.html
+++ b/public/app/features/profile/partials/change_password.html
@@ -1,9 +1,9 @@
 <page-header model="navModel"></page-header>
 
 <div class="page-container page-body">
-	<h2 class="page-sub-heading">
+	<h3 class="page-sub-heading">
 		Change your password
-	</h2>
+	</h3>
 
 	<div ng-if="ldapEnabled || authProxyEnabled">
 		You cannot change password when ldap or auth proxy authentication is enabled.

--- a/public/app/plugins/panel/singlestat/mappings.html
+++ b/public/app/plugins/panel/singlestat/mappings.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 <div class="editor-row" ng-if="ctrl.panel.mappingType==1">
-  <h5 class="page-heading">Set value mappings</h5>
+  <h5 class="section-heading">Set value mappings</h5>
   <div class="gf-form-group">
     <div class="gf-form" ng-repeat="map in ctrl.panel.valueMaps">
       <span class="gf-form-label">
@@ -34,7 +34,7 @@
   </div>
 </div>
 <div class="editor-row" ng-if="ctrl.panel.mappingType==2">
-  <h5 class="page-heading">Set range mappings</h5>
+  <h5 class="section-heading">Set range mappings</h5>
   <div class="gf-form-group">
     <div class="gf-form" ng-repeat="rangeMap in ctrl.panel.rangeMaps">
         <span class="gf-form-label">


### PR DESCRIPTION
Aligned headers on profile, admin and configuration pages. Currently headers in the pages have been implemented inconsistently.

This is a pre-step to update text elements to work with the 8px system.
See #15342