### PR TITLE
Search: Fixes search limits and adds a page parameter

### DIFF
--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -23,7 +23,8 @@ Query parameters:
 - **dashboardIds** – List of dashboard id's to search for
 - **folderIds** – List of folder id's to search in for dashboards
 - **starred** – Flag indicating if only starred Dashboards should be returned
-- **limit** – Limit the number of returned results
+- **limit** – Limit the number of returned results (max 5000)
+- **page** – Use this parameter to access hits beyond limit. Numbering starts on 1. limit param acts as page size.
 
 **Example request for retrieving folders and dashboards of the general folder**:
 

--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -24,7 +24,7 @@ Query parameters:
 - **folderIds** – List of folder id's to search in for dashboards
 - **starred** – Flag indicating if only starred Dashboards should be returned
 - **limit** – Limit the number of returned results (max 5000)
-- **page** – Use this parameter to access hits beyond limit. Numbering starts on 1. limit param acts as page size.
+- **page** – Use this parameter to access hits beyond limit. Numbering starts at 1. limit param acts as page size.
 
 **Example request for retrieving folders and dashboards of the general folder**:
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -325,7 +325,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		// Search
-		apiRoute.Get("/search/", Search)
+		apiRoute.Get("/search/", Wrap(Search))
 
 		// metrics
 		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), Wrap(hs.QueryMetrics))

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -12,7 +12,7 @@ import (
 
 func GetFolders(c *m.ReqContext) Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser)
-	folders, err := s.GetFolders(c.QueryInt("limit"))
+	folders, err := s.GetFolders(c.QueryInt64("limit"))
 
 	if err != nil {
 		return toFolderError(err)

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -213,7 +213,7 @@ type fakeFolderService struct {
 	DeletedFolderUids    []string
 }
 
-func (s *fakeFolderService) GetFolders(limit int) ([]*m.Folder, error) {
+func (s *fakeFolderService) GetFolders(limit int64) ([]*m.Folder, error) {
 	return s.GetFoldersResult, s.GetFoldersError
 }
 

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -23,7 +23,7 @@ func Search(c *m.ReqContext) Response {
 	}
 
 	if limit > 5000 {
-		return Error(422, "Limit is above maxium allowed (5000), use page parameter to access hits beyond 5000", nil)
+		return Error(422, "Limit is above maximum allowed (5000), use page parameter to access hits beyond limit", nil)
 	}
 
 	if c.Query("permission") == "Edit" {

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -18,10 +18,6 @@ func Search(c *m.ReqContext) Response {
 	dashboardType := c.Query("type")
 	permission := m.PERMISSION_VIEW
 
-	if limit == 0 {
-		limit = 1000
-	}
-
 	if limit > 5000 {
 		return Error(422, "Limit is above maximum allowed (5000), use page parameter to access hits beyond limit", nil)
 	}

--- a/pkg/services/dashboards/folder_service.go
+++ b/pkg/services/dashboards/folder_service.go
@@ -9,7 +9,7 @@ import (
 
 // FolderService service for operating on folders
 type FolderService interface {
-	GetFolders(limit int) ([]*models.Folder, error)
+	GetFolders(limit int64) ([]*models.Folder, error)
 	GetFolderByID(id int64) (*models.Folder, error)
 	GetFolderByUID(uid string) (*models.Folder, error)
 	CreateFolder(cmd *models.CreateFolderCommand) error
@@ -25,7 +25,7 @@ var NewFolderService = func(orgId int64, user *models.SignedInUser) FolderServic
 	}
 }
 
-func (dr *dashboardServiceImpl) GetFolders(limit int) ([]*models.Folder, error) {
+func (dr *dashboardServiceImpl) GetFolders(limit int64) ([]*models.Folder, error) {
 	if limit == 0 {
 		limit = 1000
 	}

--- a/pkg/services/dashboards/folder_service.go
+++ b/pkg/services/dashboards/folder_service.go
@@ -26,10 +26,6 @@ var NewFolderService = func(orgId int64, user *models.SignedInUser) FolderServic
 }
 
 func (dr *dashboardServiceImpl) GetFolders(limit int64) ([]*models.Folder, error) {
-	if limit == 0 {
-		limit = 1000
-	}
-
 	searchQuery := search.Query{
 		SignedInUser: dr.user,
 		DashboardIds: make([]int64, 0),

--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -46,7 +46,7 @@ func (s *SearchService) searchHandler(query *Query) error {
 	sort.Sort(hits)
 
 	if int64(len(hits)) > query.Limit {
-		hits = hits[1:query.Limit]
+		hits = hits[0:query.Limit]
 	}
 
 	// sort tags

--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -31,6 +31,7 @@ func (s *SearchService) searchHandler(query *Query) error {
 		FolderIds:    query.FolderIds,
 		Tags:         query.Tags,
 		Limit:        query.Limit,
+		Page:         query.Page,
 		Permission:   query.Permission,
 	}
 
@@ -44,8 +45,8 @@ func (s *SearchService) searchHandler(query *Query) error {
 	// sort main result array
 	sort.Sort(hits)
 
-	if len(hits) > query.Limit {
-		hits = hits[0:query.Limit]
+	if int64(len(hits)) > query.Limit {
+		hits = hits[1:query.Limit]
 	}
 
 	// sort tags

--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -45,10 +45,6 @@ func (s *SearchService) searchHandler(query *Query) error {
 	// sort main result array
 	sort.Sort(hits)
 
-	if int64(len(hits)) > query.Limit {
-		hits = hits[0:query.Limit]
-	}
-
 	// sort tags
 	for _, hit := range hits {
 		sort.Strings(hit.Tags)

--- a/pkg/services/search/models.go
+++ b/pkg/services/search/models.go
@@ -48,7 +48,8 @@ type Query struct {
 	Tags         []string
 	OrgId        int64
 	SignedInUser *models.SignedInUser
-	Limit        int
+	Limit        int64
+	Page         int64
 	IsStarred    bool
 	Type         string
 	DashboardIds []int64
@@ -67,7 +68,8 @@ type FindPersistedDashboardsQuery struct {
 	Type         string
 	FolderIds    []int64
 	Tags         []string
-	Limit        int
+	Limit        int64
+	Page         int64
 	Permission   models.PermissionType
 
 	Result HitList

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -202,7 +202,7 @@ func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSear
 		limit = 1000
 	}
 
-	sb := NewSearchBuilder(query.SignedInUser, limit, query.Permission).
+	sb := NewSearchBuilder(query.SignedInUser, limit, query.Page, query.Permission).
 		WithTags(query.Tags).
 		WithDashboardIdsIn(query.DashboardIds)
 

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -197,12 +197,7 @@ type DashboardSearchProjection struct {
 }
 
 func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error) {
-	limit := query.Limit
-	if limit == 0 {
-		limit = 1000
-	}
-
-	sb := NewSearchBuilder(query.SignedInUser, limit, query.Page, query.Permission).
+	sb := NewSearchBuilder(query.SignedInUser, query.Limit, query.Page, query.Permission).
 		WithTags(query.Tags).
 		WithDashboardIdsIn(query.DashboardIds)
 

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -259,6 +259,35 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(hit.FolderTitle, ShouldEqual, "")
 			})
 
+			Convey("Should be able to limit search", func() {
+				query := search.FindPersistedDashboardsQuery{
+					OrgId:        1,
+					Limit:        1,
+					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
+				}
+
+				err := SearchDashboards(&query)
+				So(err, ShouldBeNil)
+
+				So(len(query.Result), ShouldEqual, 1)
+				So(query.Result[0].Title, ShouldEqual, "1 test dash folder")
+			})
+
+			Convey("Should be able to search beyond limit using paging", func() {
+				query := search.FindPersistedDashboardsQuery{
+					OrgId:        1,
+					Limit:        1,
+					Page:         2,
+					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
+				}
+
+				err := SearchDashboards(&query)
+				So(err, ShouldBeNil)
+
+				So(len(query.Result), ShouldEqual, 1)
+				So(query.Result[0].Title, ShouldEqual, "1 test dash folder")
+			})
+
 			Convey("Should be able to search for a dashboard folder's children", func() {
 				query := search.FindPersistedDashboardsQuery{
 					OrgId:        1,

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -285,7 +285,7 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 1)
-				So(query.Result[0].Title, ShouldEqual, "1 test dash folder")
+				So(query.Result[0].Title, ShouldEqual, "test dash 23")
 			})
 
 			Convey("Should be able to search for a dashboard folder's children", func() {

--- a/pkg/services/sqlstore/search_builder.go
+++ b/pkg/services/sqlstore/search_builder.go
@@ -11,7 +11,8 @@ type SearchBuilder struct {
 	SqlBuilder
 	tags                []string
 	isStarred           bool
-	limit               int
+	limit               int64
+	page                int64
 	signedInUser        *m.SignedInUser
 	whereDashboardIdsIn []int64
 	whereTitle          string
@@ -21,10 +22,11 @@ type SearchBuilder struct {
 	permission          m.PermissionType
 }
 
-func NewSearchBuilder(signedInUser *m.SignedInUser, limit int, permission m.PermissionType) *SearchBuilder {
+func NewSearchBuilder(signedInUser *m.SignedInUser, limit int64, page int64, permission m.PermissionType) *SearchBuilder {
 	searchBuilder := &SearchBuilder{
 		signedInUser: signedInUser,
 		limit:        limit,
+		page:         page,
 		permission:   permission,
 	}
 
@@ -92,8 +94,17 @@ func (sb *SearchBuilder) ToSql() (string, []interface{}) {
 		LEFT OUTER JOIN dashboard folder on folder.id = dashboard.folder_id
 		LEFT OUTER JOIN dashboard_tag on dashboard.id = dashboard_tag.dashboard_id`)
 
-	sb.sql.WriteString(" ORDER BY dashboard.title ASC" + dialect.Limit(5000))
+	// Default to page 1
+	if sb.page < 1 {
+		sb.page = 1
+	}
 
+	// do not allow limits beyond 5000
+	if sb.limit > 5000 {
+		sb.limit = 5000
+	}
+
+	sb.sql.WriteString(" ORDER BY dashboard.title ASC " + dialect.LimitOffset(sb.limit, (sb.page-1)*sb.limit))
 	return sb.sql.String(), sb.params
 }
 
@@ -135,7 +146,7 @@ func (sb *SearchBuilder) buildTagQuery() {
 	// this ends the inner select (tag filtered part)
 	sb.sql.WriteString(`
 		GROUP BY dashboard.id HAVING COUNT(dashboard.id) >= ?
-		ORDER BY dashboard.id` + dialect.Limit(int64(sb.limit)) + `) as ids
+		ORDER BY dashboard.id as ids
 		INNER JOIN dashboard on ids.id = dashboard.id
 	`)
 
@@ -152,7 +163,7 @@ func (sb *SearchBuilder) buildMainQuery() {
 	sb.sql.WriteString(` WHERE `)
 	sb.buildSearchWhereClause()
 
-	sb.sql.WriteString(` ORDER BY dashboard.title` + dialect.Limit(int64(sb.limit)) + `) as ids INNER JOIN dashboard on ids.id = dashboard.id `)
+	sb.sql.WriteString(` ORDER BY dashboard.title) as ids INNER JOIN dashboard on ids.id = dashboard.id `)
 }
 
 func (sb *SearchBuilder) buildSearchWhereClause() {

--- a/pkg/services/sqlstore/search_builder_test.go
+++ b/pkg/services/sqlstore/search_builder_test.go
@@ -14,7 +14,7 @@ func TestSearchBuilder(t *testing.T) {
 			UserId: 1,
 		}
 
-		sb := NewSearchBuilder(signedInUser, 1000, m.PERMISSION_VIEW)
+		sb := NewSearchBuilder(signedInUser, 1000, 0, m.PERMISSION_VIEW)
 
 		Convey("When building a normal search", func() {
 			sql, params := sb.IsStarred().WithTitle("test").ToSql()


### PR DESCRIPTION
This adds a page parameter to search api without adding
any major breaking change.

It does add an API validation error when trying to use a limit beyond 5000. This is a breaking change. We could remove this and have it only in the docs and describe that this is a limit that Grafana will apply silently. 

This is a bit quick and dirty so feedback is welcomed. But I feel we need to fix this asap so large users can have a way to list all dashboards in the API. But I do not want to just remove the limits and leave a potential future DOS attack vector open. 

The big limitation in this partial paging implementation is the lack of page count in the result but to add that we need to do a substantial breaking API change as the current api just returns items without a container object. Opened an issue for a bigger search api update  https://github.com/grafana/grafana/issues/16457

Fixes #16049


