### PR TITLE
Graph: fixed png rendering with legend to the right

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -120,6 +120,10 @@
 
 // fix for phantomjs
 .body--phantomjs {
+  .graph-panel {
+    display: -webkit-box;
+  }
+
   .graph-panel--legend-right {
     .graph-legend {
       display: block;


### PR DESCRIPTION
Upgraded autoprefixer changed the way flexbox prefixing is done

Before with autoprefixer 6.4.0

```css
.graph-panel {
  display: -webkit-box;
  display: -ms-flexbox;
  display: flex;
  -webkit-box-orient: vertical;
  -webkit-box-direction: normal;
      -ms-flex-direction: column;
          flex-direction: column;
  height: 100%; }
```

With autoprefixer 9
```css
.graph-panel {
  display: -webkit-box;
  display: -webkit-flex;
  display: -ms-flexbox;
  display: flex;
  -webkit-box-orient: vertical;
  -webkit-box-direction: normal;
  -webkit-flex-direction: column;
      -ms-flex-direction: column;
          flex-direction: column;
  height: 100%; }
```

Major difference is the new prefix display: -webkit-flex; after the display: -webkit-box; 

This addition of the newer prefix standard caused the legend to the right to stop working. 

Fixes #16443