### PR TITLE
Chore: prepare our SQL for cockroach db

### DIFF
--- a/pkg/services/sqlstore/migrations/alert_mig.go
+++ b/pkg/services/sqlstore/migrations/alert_mig.go
@@ -144,7 +144,7 @@ func addAlertMigrations(mg *Migrator) {
 
 	mg.AddMigration("Update uid column values in alert_notification", new(RawSqlMigration).
 		Sqlite("UPDATE alert_notification SET uid=printf('%09d',id) WHERE uid IS NULL;").
-		Postgres("UPDATE alert_notification SET uid=lpad('' || id,9,'0') WHERE uid IS NULL;").
+		Postgres("UPDATE alert_notification SET uid=lpad('' || id::text,9,'0') WHERE uid IS NULL;").
 		Mysql("UPDATE alert_notification SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
 
 	mg.AddMigration("Add unique index alert_notification_org_id_uid", NewAddIndexMigration(alert_notification, &Index{

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -157,7 +157,7 @@ func addDashboardMigration(mg *Migrator) {
 
 	mg.AddMigration("Update uid column values in dashboard", NewRawSqlMigration("").
 		Sqlite("UPDATE dashboard SET uid=printf('%09d',id) WHERE uid IS NULL;").
-		Postgres("UPDATE dashboard SET uid=lpad('' || id,9,'0') WHERE uid IS NULL;").
+		Postgres("UPDATE dashboard SET uid=lpad('' || id::text,9,'0') WHERE uid IS NULL;").
 		Mysql("UPDATE dashboard SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
 
 	mg.AddMigration("Add unique index dashboard_org_id_uid", NewAddIndexMigration(dashboardV2, &Index{

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -110,7 +110,7 @@ func (db *Postgres) IndexCheckSql(tableName, indexName string) (string, []interf
 func (db *Postgres) DropIndexSql(tableName string, index *Index) string {
 	quote := db.Quote
 	idxName := index.XName(tableName)
-	return fmt.Sprintf("DROP INDEX %v", quote(idxName))
+	return fmt.Sprintf("DROP INDEX %v CASCADE", quote(idxName))
 }
 
 func (db *Postgres) UpdateTableSql(tableName string, columns []*Column) string {


### PR DESCRIPTION
This is basically implementation of the https://github.com/grafana/grafana/issues/8900#issuecomment-435437167
points, except for the type conversion bit.

I tried to implement idea mentioned in cockroachdb ticket (see below).
And it is possible, but it complicates things as lot - not only we have to
have 4 SQL statements instead of one, but we would have to copy the column
structure as well - PK, FG, indexes and stuff, plus there will
be additional downtime with this approach.

So idea for this pull is to prepare our SQL as much as possible, so when
cockroachdb will add support for full type conversions, we could easilly add
support for it as well.

* Add `CASCADE` to `DROP INDEX` statement

* Make string conversions explicit

Thanks @Luit

Ref #8900
Ref cockroach/cockroach#9851

