### PR TITLE
Explore: Adds maxDataPoints to data source query options 

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -141,6 +141,7 @@ export function buildQueryTransaction(
       __interval: { text: interval, value: interval },
       __interval_ms: { text: intervalMs, value: intervalMs },
     },
+    maxDataPoints: queryOptions.maxDataPoints,
   };
 
   return {

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -536,6 +536,7 @@ export function runQueries(exploreId: ExploreId, ignoreUIState = false): ThunkRe
       supportsLogs,
       supportsTable,
       datasourceError,
+      containerWidth,
     } = getState().explore[exploreId];
 
     if (datasourceError) {
@@ -579,6 +580,7 @@ export function runQueries(exploreId: ExploreId, ignoreUIState = false): ThunkRe
             interval,
             format: 'time_series',
             instant: false,
+            maxDataPoints: containerWidth,
           },
           makeTimeSeriesList
         )

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -317,6 +317,7 @@ export interface QueryOptions {
   hinting?: boolean;
   instant?: boolean;
   valueWithRefId?: boolean;
+  maxDataPoints?: number;
 }
 
 export interface QueryTransaction {


### PR DESCRIPTION
**What this PR does / why we need it**:
For some data sources maxDataPoints are used to minimize the amount of rendered pixels. This PR will add maxDataPoints as an option to the datasource query.

**Which issue(s) this PR fixes**:
Fixes: #16490

**Special notes for your reviewer**:

