### PR TITLE
Change queries to query

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueriesTab.tsx
+++ b/public/app/features/dashboard/panel_editor/QueriesTab.tsx
@@ -193,7 +193,7 @@ export class QueriesTab extends PureComponent<Props, State> {
 
     return (
       <EditorTabBody
-        heading="Queries to"
+        heading="Query"
         renderToolbar={this.renderToolbar}
         toolbarItems={[queryInspector, dsHelp]}
         setScrollTop={this.setScrollTop}


### PR DESCRIPTION
The heading `Queries to` has bothered me for a while.... what about:
![image](https://user-images.githubusercontent.com/705951/56004334-91e7cb80-5c7f-11e9-96ad-5467a1787724.png)

or maybe "Data Source"