### PR TITLE
Build: Upgrades to golang 1.12.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ version: 2
 jobs:
   mysql-integration-test:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.4
       - image: circleci/mysql:5.6-ram
         environment:
           MYSQL_ROOT_PASSWORD: rootpass
@@ -39,7 +39,7 @@ jobs:
 
   postgres-integration-test:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.4
       - image: circleci/postgres:9.3-ram
         environment:
           POSTGRES_USER: grafanatest
@@ -58,7 +58,7 @@ jobs:
 
   cache-server-test:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.4
       - image: circleci/redis:4-alpine
       - image: memcached
     working_directory: /go/src/github.com/grafana/grafana
@@ -88,7 +88,7 @@ jobs:
 
   backend-lint:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.4
         environment:
           # we need CGO because of go-sqlite3
           CGO_ENABLED: 1
@@ -120,7 +120,7 @@ jobs:
 
   test-backend:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.4
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout
@@ -130,7 +130,7 @@ jobs:
 
   build-all:
     docker:
-     - image: grafana/build-container:1.2.4
+     - image: grafana/build-container:1.2.6
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout
@@ -174,7 +174,7 @@ jobs:
 
   build:
     docker:
-     - image: grafana/build-container:1.2.4
+     - image: grafana/build-container:1.2.6
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout
@@ -243,7 +243,7 @@ jobs:
 
   build-enterprise:
     docker:
-     - image: grafana/build-container:1.2.4
+     - image: grafana/build-container:1.2.6
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout
@@ -275,7 +275,7 @@ jobs:
 
   build-all-enterprise:
     docker:
-    - image: grafana/build-container:1.2.4
+    - image: grafana/build-container:1.2.6
     working_directory: /go/src/github.com/grafana/grafana
     steps:
     - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Golang build container
-FROM golang:1.11.5
+FROM golang:1.12.4
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -407,8 +407,15 @@ func GetDashboardVersion(c *m.ReqContext) Response {
 	}
 
 	dashVersionMeta := &m.DashboardVersionMeta{
-		DashboardVersion: *query.Result,
-		CreatedBy:        creator,
+		Id:            query.Result.Id,
+		DashboardId:   query.Result.DashboardId,
+		Data:          query.Result.Data,
+		ParentVersion: query.Result.ParentVersion,
+		RestoredFrom:  query.Result.RestoredFrom,
+		Version:       query.Result.Version,
+		Created:       query.Result.Created,
+		Message:       query.Result.Message,
+		CreatedBy:     creator,
 	}
 
 	return JSON(200, dashVersionMeta)

--- a/pkg/models/dashboard_version.go
+++ b/pkg/models/dashboard_version.go
@@ -32,8 +32,15 @@ type DashboardVersion struct {
 // associated with the UserIds, overriding the field with the same name from
 // the DashboardVersion model.
 type DashboardVersionMeta struct {
-	DashboardVersion
-	CreatedBy string `json:"createdBy"`
+	Id            int64            `json:"id"`
+	DashboardId   int64            `json:"dashboardId"`
+	ParentVersion int              `json:"parentVersion"`
+	RestoredFrom  int              `json:"restoredFrom"`
+	Version       int              `json:"version"`
+	Created       time.Time        `json:"created"`
+	Message       string           `json:"message"`
+	Data          *simplejson.Json `json:"data"`
+	CreatedBy     string           `json:"createdBy"`
 }
 
 // DashboardVersionDTO represents a dashboard version, without the dashboard

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update   && \
 # base image to crossbuild grafana
 FROM ubuntu:14.04
 
-ENV GOVERSION=1.11.5 \
+ENV GOVERSION=1.12.4 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=10.14.2

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_version="1.2.4"
+_version="1.2.6"
 _tag="grafana/build-container:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
1.12.4 fixes the cgo build issues we had with 1.12.3
Just need to wait for circle ci to add a golang container for 1.12.4