### PR TITLE
Use package libfontconfig1, instead of libfontconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 WORKDIR $GF_PATHS_HOME
 
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -qq -y libfontconfig ca-certificates && \
+    apt-get install -qq -y libfontconfig1 ca-certificates && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/build.go
+++ b/build.go
@@ -270,7 +270,7 @@ func createDebPackages() {
 		defaultFileSrc: "packaging/deb/default/grafana-server",
 		systemdFileSrc: "packaging/deb/systemd/grafana-server.service",
 
-		depends: []string{"adduser", "libfontconfig"},
+		depends: []string{"adduser", "libfontconfig1"},
 	})
 }
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -27,7 +27,7 @@ installation.
 
 ```bash
 wget <debian package url>
-sudo apt-get install -y adduser libfontconfig
+sudo apt-get install -y adduser libfontconfig1
 sudo dpkg -i grafana_<version>_amd64.deb
 ```
 
@@ -35,7 +35,7 @@ Example:
 
 ```bash
 wget https://dl.grafana.com/oss/release/grafana_5.4.2_amd64.deb
-sudo apt-get install -y adduser libfontconfig
+sudo apt-get install -y adduser libfontconfig1
 sudo dpkg -i grafana_5.4.2_amd64.deb
 ```
 

--- a/docs/sources/reference/sharing.md
+++ b/docs/sources/reference/sharing.md
@@ -39,7 +39,7 @@ Click a panel title to open the panel menu, then click share in the panel menu t
 
 ### Direct Link Rendered Image
 
-You also get a link to service side rendered PNG of the panel. Useful if you want to share an image of the panel. Please note that for OSX and Windows, you will need to ensure that a `phantomjs` binary is available under `tools/phantomjs/phantomjs`. For Linux, a `phantomjs` binary is included - however, you should ensure that any requisite libraries (e.g. libfontconfig) are available.
+You also get a link to service side rendered PNG of the panel. Useful if you want to share an image of the panel. Please note that for OSX and Windows, you will need to ensure that a `phantomjs` binary is available under `tools/phantomjs/phantomjs`. For Linux, a `phantomjs` binary is included - however, you should ensure that any requisite libraries (e.g. libfontconfig1) are available.
 
 Example of a link to a server-side rendered PNG:
 

--- a/packaging/conf/nfpm.yaml
+++ b/packaging/conf/nfpm.yaml
@@ -11,7 +11,7 @@ provides:
 - grafana-cli
 depends:
 - adduser
-- libfontconfig
+- libfontconfig1
 maintainer: "<contact@grafana.com>"
 description: |
   Grafana

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 WORKDIR $GF_PATHS_HOME
 
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -qq -y libfontconfig ca-certificates curl && \
+    apt-get install -qq -y libfontconfig1 ca-certificates curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the correct package name. The package ```libfontconfig``` does not exist at Debian and Ubuntu: 
```
vagrant@debian-8:~$ apt search libfontconfig
Sorting... Done
Full Text Search... Done
libfontconfig1/oldstable,oldstable 2.11.0-6.3+deb8u1 amd64
  generic font configuration library - runtime

libfontconfig1-dbg/oldstable,oldstable 2.11.0-6.3+deb8u1 amd64
  generic font configuration library - debugging symbols

libfontconfig1-dev/oldstable,oldstable 2.11.0-6.3+deb8u1 amd64
  generic font configuration library - development
```

The installation only works because ```apt``` automatically corrects the package name:
```
vagrant@debian-8:~$ sudo apt install libfontconfig
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'libfontconfig1' instead of 'libfontconfig'
The following extra packages will be installed:
  fontconfig-config fonts-dejavu-core
The following NEW packages will be installed:
  fontconfig-config fonts-dejavu-core libfontconfig1
0 upgraded, 3 newly installed, 0 to remove and 94 not upgraded.
Need to get 0 B/1,650 kB of archives.
After this operation, 3,879 kB of additional disk space will be used.
Do you want to continue? [Y/n]
```

**Special notes for your reviewer**:
The dependency has already been correctly configured in the following file:
* https://github.com/grafana/grafana/blob/master/scripts/build/ci-build/Dockerfile#L86