### PR TITLE
Alerting: Adjust label for send on all alerts to default 

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -27,7 +27,7 @@ can configure and setup a new Notification Channel.
 You specify a name and a type, and type specific options. You can also test the notification to make
 sure it's setup correctly.
 
-### Send on all alerts
+### Default (send on all alerts)
 
 When checked, this option will notify for all alert rules - existing and new.
 

--- a/public/app/features/alerting/partials/notification_edit.html
+++ b/public/app/features/alerting/partials/notification_edit.html
@@ -20,7 +20,7 @@
       </div>
       <gf-form-switch
           class="gf-form"
-          label="Send on all alerts"
+          label="Default (send on all alerts)"
           label-class="width-14"
           checked="ctrl.model.isDefault"
           tooltip="Use this notification for all alerts">


### PR DESCRIPTION
I spent 5m looking for how to disable default for Alert channel

![image](https://user-images.githubusercontent.com/327717/56046698-1ef45880-5d44-11e9-96b7-87aa3f51a606.png)

Then I found it's hidden under this 

![image](https://user-images.githubusercontent.com/327717/56046716-29165700-5d44-11e9-9948-ff4315aed34e.png)

The naming should IMO be same. When I see `default` label, I look for how to disable `is default`.