### PR TITLE
DataPanel: Added missing built-in interval variables to scopedVars

### DIFF
--- a/public/app/features/dashboard/dashgrid/DataPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DataPanel.tsx
@@ -132,9 +132,15 @@ export class DataPanel extends Component<Props, State> {
     try {
       const ds = await this.dataSourceSrv.get(datasource, scopedVars);
 
-      // TODO interpolate variables
       const minInterval = this.props.minInterval || ds.interval;
       const intervalRes = kbn.calculateInterval(timeRange, widthPixels, minInterval);
+
+      // make shallow copy of scoped vars,
+      // and add built in variables interval and interval_ms
+      const scopedVarsWithInterval = Object.assign({}, scopedVars, {
+        __interval: { text: intervalRes.interval, value: intervalRes.interval },
+        __interval_ms: { text: intervalRes.intervalMs.toString(), value: intervalRes.intervalMs },
+      });
 
       const queryOptions: DataQueryOptions = {
         timezone: 'browser',
@@ -146,7 +152,7 @@ export class DataPanel extends Component<Props, State> {
         intervalMs: intervalRes.intervalMs,
         targets: queries,
         maxDataPoints: maxDataPoints || widthPixels,
-        scopedVars: scopedVars || {},
+        scopedVars: scopedVarsWithInterval,
         cacheTimeout: null,
       };
 


### PR DESCRIPTION
For React panels the scopedVars did not contain the built in $__interval and $__interval_ms
variables.

Fixes #16546

