### PR TITLE
consider adding description to datasource dropdown

### DIFF
--- a/public/app/core/components/Select/DataSourcePicker.tsx
+++ b/public/app/core/components/Select/DataSourcePicker.tsx
@@ -40,12 +40,14 @@ export class DataSourcePicker extends PureComponent<Props> {
       value: ds.name,
       label: ds.name,
       imgUrl: ds.meta.info.logos.small,
+      description: ds.meta.info.description,
     }));
 
     const value = current && {
       label: current.name,
       value: current.name,
       imgUrl: current.meta.info.logos.small,
+      description: current.meta.info.description,
     };
 
     return (


### PR DESCRIPTION
In #16282, it seems nice to have to describe the datasource.  Adding description is easy, but most of them are defined with poor descriptions:

![image](https://user-images.githubusercontent.com/705951/56056781-feaba600-5d11-11e9-8761-7ca446638015.png)
