### PR TITLE
sqlstore: use column name in ORDER BY in GetDashboardAclInfoList()

### DIFF
--- a/pkg/services/sqlstore/dashboard_acl.go
+++ b/pkg/services/sqlstore/dashboard_acl.go
@@ -112,7 +112,7 @@ func GetDashboardAclInfoList(query *m.GetDashboardAclInfoListQuery) error {
 				LEFT JOIN ` + dialect.Quote("user") + ` AS u ON u.id = da.user_id
 				LEFT JOIN team ug on ug.id = da.team_id
 			WHERE d.org_id = ? AND d.id = ? AND da.id IS NOT NULL
-			ORDER BY 1 ASC
+			ORDER BY da.id ASC
 			`
 
 		query.Result = make([]*m.DashboardAclInfoDTO, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your RP as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
One of the queries in `GetDashboardAclInfoList()` has an `ORDER BY` that references a column position, which doesn't play nice with the [Vitess](https://vitess.io/) query parser. We can make a fix on the Vitess side, but I still opened this PR because it's more idiomatic to use `ORDER BY` with column names.