### PR TITLE
Explore: Words in logs are highlighted on keypress

### DIFF
--- a/public/app/features/explore/QueryField.tsx
+++ b/public/app/features/explore/QueryField.tsx
@@ -152,6 +152,9 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
         if (textChanged && invokeParentOnValueChanged) {
           this.executeOnQueryChangeAndExecuteQueries();
         }
+        if (textChanged && !invokeParentOnValueChanged) {
+          this.updateLogsHighlights();
+        }
       }
     });
 
@@ -161,6 +164,13 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
       window.requestAnimationFrame(this.handleTypeahead);
     } else if (!this.resetTimer) {
       this.resetTypeahead();
+    }
+  };
+
+  updateLogsHighlights = () => {
+    const { onQueryChange } = this.props;
+    if (onQueryChange) {
+      onQueryChange(Plain.serialize(this.state.value));
     }
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During this refactor (https://github.com/grafana/grafana/pull/15220) the highlightning of words in log viewer while typing in query field got removed. This PR adds the highlighting back.

**Which issue(s) this PR fixes**:
Fixes: #16277 


