### PR TITLE
POC: change click behavior on graph legend

### DIFF
--- a/public/app/plugins/panel/graph/Legend/Legend.tsx
+++ b/public/app/plugins/panel/graph/Legend/Legend.tsx
@@ -6,6 +6,7 @@ import { LegendItem, LEGEND_STATS } from './LegendSeriesItem';
 
 interface LegendProps {
   seriesList: TimeSeries[];
+  onSeriesClick?: (series: TimeSeries) => void; // Optionally passed in externally
   optionalClass?: string;
 }
 
@@ -169,6 +170,7 @@ export class GraphLegend extends PureComponent<GraphLegendProps, LegendState> {
       avg,
       current,
       total,
+      onSeriesClick,
     } = this.props;
     const seriesValuesProps = { values, min, max, avg, current, total };
     const hiddenSeries = this.state.hiddenSeries;
@@ -189,7 +191,7 @@ export class GraphLegend extends PureComponent<GraphLegendProps, LegendState> {
     const legendProps: LegendComponentProps = {
       seriesList: seriesList,
       hiddenSeries: hiddenSeries,
-      onToggleSeries: this.onToggleSeries,
+      onToggleSeries: onSeriesClick ? onSeriesClick : this.onToggleSeries,
       onToggleAxis: this.props.onToggleAxis,
       onToggleSort: this.props.onToggleSort,
       onColorChange: this.props.onColorChange,

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -12,7 +12,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import moment from 'moment';
 import { tickStep } from 'app/core/utils/ticks';
-import { appEvents, coreModule, updateLegendValues } from 'app/core/core';
+import { appEvents, coreModule, updateLegendValues, TimeSeries } from 'app/core/core';
 import GraphTooltip from './graph_tooltip';
 import { ThresholdManager } from './threshold_manager';
 import { TimeRegionManager } from './time_region_manager';
@@ -75,6 +75,10 @@ class GraphElement {
     }
   }
 
+  onSeriesDrilldown = (series: TimeSeries) => {
+    alert('TODO change the URL and add template for: ' + series.alias);
+  };
+
   onRender(renderData) {
     this.data = renderData || this.data;
     if (!this.data) {
@@ -95,7 +99,7 @@ class GraphElement {
     }
 
     const { values, min, max, avg, current, total } = this.panel.legend;
-    const { alignAsTable, rightSide, sideWidth, sort, sortDesc, hideEmpty, hideZero } = this.panel.legend;
+    const { alignAsTable, rightSide, sideWidth, sort, sortDesc, hideEmpty, hideZero, clickAction } = this.panel.legend;
     const legendOptions = { alignAsTable, rightSide, sideWidth, sort, sortDesc, hideEmpty, hideZero };
     const valueOptions = { values, min, max, avg, current, total };
     const legendProps: GraphLegendProps = {
@@ -103,6 +107,7 @@ class GraphElement {
       hiddenSeries: this.ctrl.hiddenSeries,
       ...legendOptions,
       ...valueOptions,
+      onSeriesClick: clickAction === 'drilldown' ? this.onSeriesDrilldown : null,
       onToggleSeries: this.ctrl.onToggleSeries,
       onToggleSort: this.ctrl.onToggleSort,
       onColorChange: this.ctrl.onColorChange,

--- a/public/app/plugins/panel/graph/tab_legend.html
+++ b/public/app/plugins/panel/graph/tab_legend.html
@@ -70,4 +70,32 @@
 			checked="ctrl.panel.legend.hideZero" on-change="ctrl.render()">
 		</gf-form-switch>
 	</div>
+
+	<div class="section gf-form-group">
+		<h5 class="section-heading">Interaction</h5>
+		<div class="gf-form">
+			<label class="gf-form-label width-5">Click</label>
+			<span class="gf-form-select-wrapper">
+				<select 
+					type="text" 
+					class="gf-form-input max-width-12"
+					ng-model="ctrl.panel.legend.clickAction"
+					ng-change="ctrl.render()"
+					placeholder="Toggle Visibility"
+					>
+					<option value="toggle">Toggle Visibility</option>
+					<option value="drilldown">Drilldown Link</option>
+				</select>
+			</span>
+		</div>
+	</div>
+
+
+	<div class="editor-row" ng-if="ctrl.panel.legend.clickAction === 'drilldown'">
+		<h4>Drilldown Link</h4>
+		TODO... make it only allow one and add a template variable
+		<panel-links-editor panel="ctrl.panel"></panel-links-editor>
+	</div>
+	
 </div>
+


### PR DESCRIPTION
Currently when you click on the series in a legend, it toggles visibility.  It would be nice to let that do something else, like update the query.  

This PR explores how that could happen.

1. Add an option under Graph Legend.  The default value is to 'Toggle Visibility':
![image](https://user-images.githubusercontent.com/705951/56168801-1b094600-5f91-11e9-8d0c-b90bdd687852.png)

2. Selecting 'Drilldown Link' adds something like the existing panel drilldown link with the only changes being:
* there is only one (can not add/remove)
* make it clear what variable name you will set from the clicked series
![image](https://user-images.githubusercontent.com/705951/56168933-7c311980-5f91-11e9-8d4f-b9b0ff5310a8.png)

3. The click behavior is changed in the legend when this is configured.

4. Would be nice to have a tooltip on the legend that matches existing panel drilldowns.
 

