### PR TITLE
Release: 6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "company": "Grafana Labs"
   },
   "name": "grafana",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"

--- a/public/app/core/specs/ticks.test.ts
+++ b/public/app/core/specs/ticks.test.ts
@@ -22,4 +22,13 @@ describe('ticks', () => {
       expect(dec.scaledDecimals).toBe(3);
     });
   });
+
+  describe('getStringPrecision()', () => {
+    it('"3.12" should return 2', () => {
+      expect(ticks.getStringPrecision('3.12')).toBe(2);
+    });
+    it('"asd" should return 0', () => {
+      expect(ticks.getStringPrecision('asd.asd')).toBe(0);
+    });
+  });
 });

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -141,6 +141,7 @@ export function buildQueryTransaction(
       __interval: { text: interval, value: interval },
       __interval_ms: { text: intervalMs, value: intervalMs },
     },
+    maxDataPoints: queryOptions.maxDataPoints,
   };
 
   return {

--- a/public/app/core/utils/ticks.ts
+++ b/public/app/core/utils/ticks.ts
@@ -201,6 +201,10 @@ export function getPrecision(num: number): number {
  * Get decimal precision of number stored as a string ("3.14" => 2)
  */
 export function getStringPrecision(num: string): number {
+  if (isNaN((num as unknown) as number)) {
+    return 0;
+  }
+
   const dotIndex = num.indexOf('.');
   if (dotIndex === -1) {
     return 0;

--- a/public/app/features/dashboard/dashgrid/DataPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DataPanel.tsx
@@ -136,9 +136,15 @@ export class DataPanel extends Component<Props, State> {
     try {
       const ds = await this.dataSourceSrv.get(datasource, scopedVars);
 
-      // TODO interpolate variables
       const minInterval = this.props.minInterval || ds.interval;
       const intervalRes = kbn.calculateInterval(timeRange, widthPixels, minInterval);
+
+      // make shallow copy of scoped vars,
+      // and add built in variables interval and interval_ms
+      const scopedVarsWithInterval = Object.assign({}, scopedVars, {
+        __interval: { text: intervalRes.interval, value: intervalRes.interval },
+        __interval_ms: { text: intervalRes.intervalMs.toString(), value: intervalRes.intervalMs },
+      });
 
       const queryOptions: DataQueryOptions = {
         timezone: 'browser',
@@ -150,7 +156,7 @@ export class DataPanel extends Component<Props, State> {
         intervalMs: intervalRes.intervalMs,
         targets: queries,
         maxDataPoints: maxDataPoints || widthPixels,
-        scopedVars: scopedVars || {},
+        scopedVars: scopedVarsWithInterval,
         cacheTimeout: null,
       };
 

--- a/public/app/features/dashboard/panel_editor/QueryInspector.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryInspector.tsx
@@ -39,14 +39,20 @@ export class QueryInspector extends PureComponent<Props, State> {
 
   componentDidMount() {
     const { panel } = this.props;
-    panel.events.on('refresh', this.onPanelRefresh);
+
     appEvents.on('ds-request-response', this.onDataSourceResponse);
+    appEvents.on('ds-request-error', this.onRequestError);
+
+    panel.events.on('refresh', this.onPanelRefresh);
     panel.refresh();
   }
 
   componentWillUnmount() {
     const { panel } = this.props;
+
     appEvents.off('ds-request-response', this.onDataSourceResponse);
+    appEvents.on('ds-request-error', this.onRequestError);
+
     panel.events.off('refresh', this.onPanelRefresh);
   }
 
@@ -71,6 +77,10 @@ export class QueryInspector extends PureComponent<Props, State> {
         response: {},
       },
     }));
+  };
+
+  onRequestError = (err: any) => {
+    this.onDataSourceResponse(err);
   };
 
   onDataSourceResponse = (response: any = {}) => {

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -199,6 +199,15 @@ export interface QueriesImportedPayload {
   queries: DataQuery[];
 }
 
+export interface LoadExploreDataSourcesPayload {
+  exploreId: ExploreId;
+  exploreDatasources: DataSourceSelectItem[];
+}
+
+export interface RunQueriesPayload {
+  exploreId: ExploreId;
+}
+
 /**
  * Adds a query row after the row with the given index.
  */
@@ -323,7 +332,8 @@ export const queryTransactionSuccessAction = actionCreatorFactory<QueryTransacti
  * Remove query row of the given index, as well as associated query results.
  */
 export const removeQueryRowAction = actionCreatorFactory<RemoveQueryRowPayload>('explore/REMOVE_QUERY_ROW').create();
-export const runQueriesAction = noPayloadActionCreatorFactory('explore/RUN_QUERIES').create();
+
+export const runQueriesAction = actionCreatorFactory<RunQueriesPayload>('explore/RUN_QUERIES').create();
 
 /**
  * Start a scan for more results using the given scanner.

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -525,7 +525,7 @@ export function runQueries(exploreId: ExploreId, ignoreUIState = false) {
     // but we're using the datasource interval limit for now
     const interval = datasourceInstance.interval;
 
-    dispatch(runQueriesAction());
+    dispatch(runQueriesAction({ exploreId }));
     // Keep table queries first since they need to return quickly
     if ((ignoreUIState || showingTable) && supportsTable) {
       dispatch(

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -513,6 +513,7 @@ export function runQueries(exploreId: ExploreId, ignoreUIState = false) {
       supportsGraph,
       supportsLogs,
       supportsTable,
+      containerWidth,
     } = getState().explore[exploreId];
 
     if (!hasNonEmptyQuery(queries)) {
@@ -551,6 +552,7 @@ export function runQueries(exploreId: ExploreId, ignoreUIState = false) {
             interval,
             format: 'time_series',
             instant: false,
+            maxDataPoints: containerWidth,
           },
           makeTimeSeriesList
         )

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -12,7 +12,14 @@ import {
 import { ExploreItemState, ExploreState, QueryTransaction, ExploreId, ExploreUpdateState } from 'app/types/explore';
 import { DataQuery } from '@grafana/ui/src/types';
 
-import { HigherOrderAction, ActionTypes, SplitCloseActionPayload, splitCloseAction } from './actionTypes';
+import {
+  HigherOrderAction,
+  ActionTypes,
+  SplitCloseActionPayload,
+  splitCloseAction,
+  runQueriesAction,
+} from './actionTypes';
+
 import { reducerFactory } from 'app/core/redux';
 import {
   addQueryRowAction,
@@ -158,14 +165,8 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
   .addMapper({
     filter: changeSizeAction,
     mapper: (state, action): ExploreItemState => {
-      const { range, datasourceInstance } = state;
-      let interval = '1s';
-      if (datasourceInstance && datasourceInstance.interval) {
-        interval = datasourceInstance.interval;
-      }
       const containerWidth = action.payload.width;
-      const queryIntervals = getIntervals(range, interval, containerWidth);
-      return { ...state, containerWidth, queryIntervals };
+      return { ...state, containerWidth };
     },
   })
   .addMapper({
@@ -250,7 +251,6 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
   .addMapper({
     filter: loadDatasourceSuccessAction,
     mapper: (state, action): ExploreItemState => {
-      const { containerWidth, range } = state;
       const {
         StartPage,
         datasourceInstance,
@@ -260,11 +260,9 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         supportsLogs,
         supportsTable,
       } = action.payload;
-      const queryIntervals = getIntervals(range, datasourceInstance.interval, containerWidth);
 
       return {
         ...state,
-        queryIntervals,
         StartPage,
         datasourceInstance,
         history,
@@ -514,6 +512,21 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return {
         ...state,
         hiddenLogLevels: Array.from(hiddenLogLevels),
+      };
+    },
+  })
+  .addMapper({
+    filter: runQueriesAction,
+    mapper: (state): ExploreItemState => {
+      const { range, datasourceInstance, containerWidth } = state;
+      let interval = '1s';
+      if (datasourceInstance && datasourceInstance.interval) {
+        interval = datasourceInstance.interval;
+      }
+      const queryIntervals = getIntervals(range, interval, containerWidth);
+      return {
+        ...state,
+        queryIntervals,
       };
     },
   })

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -594,7 +594,8 @@ export class HeatmapRenderer {
       yGridSize = Math.floor((this.yScale(1) - this.yScale(base)) / splitFactor);
     }
 
-    this.cardWidth = xGridSize - this.cardPadding * 2;
+    const cardWidth = xGridSize - this.cardPadding * 2;
+    this.cardWidth = Math.max(cardWidth, MIN_CARD_SIZE);
     this.cardHeight = yGridSize ? yGridSize - this.cardPadding * 2 : 0;
   }
 
@@ -611,16 +612,13 @@ export class HeatmapRenderer {
   }
 
   getCardWidth(d) {
-    let w;
+    let w = this.cardWidth;
     if (this.xScale(d.x) < 0) {
       // Cut card left to prevent overlay
-      const cuttedWidth = this.xScale(d.x) + this.cardWidth;
-      w = cuttedWidth > 0 ? cuttedWidth : 0;
+      w = this.xScale(d.x) + this.cardWidth;
     } else if (this.xScale(d.x) + this.cardWidth > this.chartWidth) {
       // Cut card right to prevent overlay
       w = this.chartWidth - this.xScale(d.x) - this.cardPadding;
-    } else {
-      w = this.cardWidth;
     }
 
     // Card width should be MIN_CARD_SIZE at least, but cut cards shouldn't be displayed

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -316,6 +316,7 @@ export interface QueryOptions {
   hinting?: boolean;
   instant?: boolean;
   valueWithRefId?: boolean;
+  maxDataPoints?: number;
 }
 
 export interface QueryTransaction {


### PR DESCRIPTION
DataPanel: Added missing built-in interval variables to scopedVars (16556) closed_at 2019-04-12T16:07:01Z
  	URL: 2019-04-12T16:07:01Z https://github.com/grafana/grafana/pull/16556
  	Merge sha: 6a315bd09dc2def94d7663d4c1cf3e0466b5fb21
QueryInspector: Now shows error responses again (16514) closed_at 2019-04-12T08:01:51Z
  	URL: 2019-04-12T08:01:51Z https://github.com/grafana/grafana/pull/16514
  	Merge sha: e44d049a8e01795b04c9a8cbd372f2d1ab168ac9
Explore: Adds maxDataPoints to data source query options  (16513) closed_at 2019-04-11T11:57:05Z
  	URL: 2019-04-11T11:57:05Z https://github.com/grafana/grafana/pull/16513
  	Merge sha: e5c1cbabb115e626e19a9414a7dd3ec65591003b
Explore: Fixes so intervals are recalculated on run query (16510) closed_at 2019-04-11T11:56:09Z
  	URL: 2019-04-11T11:56:09Z https://github.com/grafana/grafana/pull/16510
	  	Merge sha: 1341f4517a3a67c58c8d4bca2b184fb3dea735f7
Fix: heatmap is empty if panel is too narrow (#16378) (16460) closed_at 2019-04-10T08:11:17Z
  	URL: 2019-04-10T08:11:17Z https://github.com/grafana/grafana/pull/16460
  	Merge sha: 180772f169800153589a28356abd1c81ea1be23f

Version bumped to 6.1.4