### PR TITLE
cloudwatch: fix for flaky tests

### DIFF
--- a/pkg/tsdb/cloudwatch/get_metric_data_test.go
+++ b/pkg/tsdb/cloudwatch/get_metric_data_test.go
@@ -42,22 +42,29 @@ func TestCloudWatchGetMetricData(t *testing.T) {
 					ReturnData: true,
 				},
 			}
+
 			queryContext := &tsdb.TsdbQuery{
 				TimeRange: tsdb.NewFakeTimeRange("5m", "now", time.Now()),
 			}
 			res, err := parseGetMetricDataQuery(queries, queryContext)
 			So(err, ShouldBeNil)
-			So(*res.MetricDataQueries[0].MetricStat.Metric.Namespace, ShouldEqual, "AWS/EC2")
-			So(*res.MetricDataQueries[0].MetricStat.Metric.MetricName, ShouldEqual, "CPUUtilization")
-			So(*res.MetricDataQueries[0].MetricStat.Metric.Dimensions[0].Name, ShouldEqual, "InstanceId")
-			So(*res.MetricDataQueries[0].MetricStat.Metric.Dimensions[0].Value, ShouldEqual, "i-12345678")
-			So(*res.MetricDataQueries[0].MetricStat.Period, ShouldEqual, 300)
-			So(*res.MetricDataQueries[0].MetricStat.Stat, ShouldEqual, "Average")
-			So(*res.MetricDataQueries[0].Id, ShouldEqual, "id1")
-			So(*res.MetricDataQueries[0].ReturnData, ShouldEqual, true)
-			So(*res.MetricDataQueries[1].Id, ShouldEqual, "id2")
-			So(*res.MetricDataQueries[1].Expression, ShouldEqual, "id1 * 2")
-			So(*res.MetricDataQueries[1].ReturnData, ShouldEqual, true)
+
+			for _, v := range res.MetricDataQueries {
+				if *v.Id == "id1" {
+					So(*v.MetricStat.Metric.Namespace, ShouldEqual, "AWS/EC2")
+					So(*v.MetricStat.Metric.MetricName, ShouldEqual, "CPUUtilization")
+					So(*v.MetricStat.Metric.Dimensions[0].Name, ShouldEqual, "InstanceId")
+					So(*v.MetricStat.Metric.Dimensions[0].Value, ShouldEqual, "i-12345678")
+					So(*v.MetricStat.Period, ShouldEqual, 300)
+					So(*v.MetricStat.Stat, ShouldEqual, "Average")
+					So(*v.Id, ShouldEqual, "id1")
+					So(*v.ReturnData, ShouldEqual, true)
+				} else {
+					So(*v.Id, ShouldEqual, "id2")
+					So(*v.Expression, ShouldEqual, "id1 * 2")
+					So(*v.ReturnData, ShouldEqual, true)
+				}
+			}
 		})
 
 		Convey("can parse cloudwatch response", func() {


### PR DESCRIPTION
The iteration order over maps is not specified and is not guaranteed
to be the same from one iteration to the next. If a map entry that
has not yet been reached is removed during iteration, the corresponding
iteration value will not be produced. If a map entry is created during
iteration, that entry may be produced during the iteration or may be skipped.
The choice may vary for each entry created and from one iteration to
the next. If the map is nil, the number of iterations is 0.

https://golang.org/ref/spec#For_range