### PR TITLE
PanelQueryRunner: add generics and better error handling

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -99,15 +99,9 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (data.state === LoadingState.Error) {
         const { error } = data;
         if (error) {
-          let message = 'Query error';
-          if (error.message) {
-            message = error.message;
-          } else if (error.data && error.data.message) {
-            message = error.data.message;
-          } else if (error.data && error.data.error) {
-            message = error.data.error;
-          } else if (error.status) {
-            message = `Query error: ${error.status} ${error.statusText}`;
+          let message = error.message;
+          if (!message) {
+            message = 'Query error';
           }
 
           if (this.state.errorMessage !== message) {


### PR DESCRIPTION
follow up on comments from @dprokop in #16632

This PR:
1. Makes `QueryRunnerOptions` generic.  I don't know the explore code, but that may be helpful
2. moves complex error handling from `PanelChrome` to `PanelQueryRunner`