### PR TITLE
refactor: move queryRunner to panelModel

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -37,7 +37,7 @@ export class DashboardPanel extends PureComponent<Props, State> {
   element: HTMLElement;
   specialPanels = {};
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -150,7 +150,7 @@ export class DashboardPanel extends PureComponent<Props, State> {
   };
 
   renderReactPanel() {
-    const { dashboard, panel, isFullscreen, isEditing } = this.props;
+    const { dashboard, panel, isFullscreen } = this.props;
     const { plugin } = this.state;
 
     return (
@@ -165,7 +165,6 @@ export class DashboardPanel extends PureComponent<Props, State> {
               panel={panel}
               dashboard={dashboard}
               isFullscreen={isFullscreen}
-              isEditing={isEditing}
               width={width}
               height={height}
             />

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -32,7 +32,6 @@ export interface Props {
   dashboard: DashboardModel;
   plugin: PanelPlugin;
   isFullscreen: boolean;
-  isEditing: boolean;
   width: number;
   height: number;
 }

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -113,12 +113,17 @@ export class PanelChrome extends PureComponent<Props, State> {
         this.clearErrorState();
       }
 
-      // Save the query response into the panel
-      if (data.state === LoadingState.Done && this.props.dashboard.snapshot) {
-        this.props.panel.snapshotData = data.series;
+      if (data.state === LoadingState.Done) {
+        // If we are doing a snapshot save data in panel model
+        if (this.props.dashboard.snapshot) {
+          this.props.panel.snapshotData = data.series;
+        }
+        if (this.state.isFirstLoad) {
+          this.setState({ isFirstLoad: false });
+        }
       }
 
-      this.setState({ data, isFirstLoad: false });
+      this.setState({ data });
     },
   };
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -93,17 +93,21 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   // Updates the response with information from the stream
+  // The next is outside a react synthetic event so setState is not batched
+  // So in this context we can only do a single call to setState
   panelDataObserver = {
     next: (data: PanelData) => {
+      let { errorMessage, isFirstLoad } = this.state;
+
       if (data.state === LoadingState.Error) {
         const { error } = data;
         if (error) {
           if (this.state.errorMessage !== error.message) {
-            this.setState({ errorMessage: error.message });
+            errorMessage = error.message;
           }
         }
       } else {
-        this.clearErrorState();
+        errorMessage = null;
       }
 
       if (data.state === LoadingState.Done) {
@@ -112,11 +116,11 @@ export class PanelChrome extends PureComponent<Props, State> {
           this.props.panel.snapshotData = data.series;
         }
         if (this.state.isFirstLoad) {
-          this.setState({ isFirstLoad: false });
+          isFirstLoad = false;
         }
       }
 
-      this.setState({ data });
+      this.setState({ isFirstLoad, errorMessage, data });
     },
   };
 
@@ -181,12 +185,6 @@ export class PanelChrome extends PureComponent<Props, State> {
       this.setState({ errorMessage: message });
     }
   };
-
-  clearErrorState() {
-    if (this.state.errorMessage) {
-      this.setState({ errorMessage: null });
-    }
-  }
 
   get isVisible() {
     return !this.props.dashboard.otherPanelInFullscreen(this.props.panel);

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -98,16 +98,9 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (data.state === LoadingState.Error) {
         const { error } = data;
         if (error) {
-          let message = error.message;
-          if (!message) {
-            message = 'Query error';
+          if (this.state.errorMessage !== error.message) {
+            this.setState({ errorMessage: error.message });
           }
-
-          if (this.state.errorMessage !== message) {
-            this.setState({ errorMessage: message });
-          }
-          // this event is used by old query editors
-          this.props.panel.events.emit('data-error', error);
         }
       } else {
         this.clearErrorState();

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -10,6 +10,8 @@ import { DataQuery, Threshold, ScopedVars, DataQueryResponseData } from '@grafan
 import { PanelPlugin } from 'app/types';
 import config from 'app/core/config';
 
+import { PanelQueryRunner } from './PanelQueryRunner';
+
 export interface GridPos {
   x: number;
   y: number;
@@ -25,6 +27,7 @@ const notPersistedProperties: { [str: string]: boolean } = {
   hasRefreshed: true,
   cachedPluginOptions: true,
   plugin: true,
+  queryRunner: true,
 };
 
 // For angular panels we need to clean up properties when changing type
@@ -115,6 +118,7 @@ export class PanelModel {
   cachedPluginOptions?: any;
   legend?: { show: boolean };
   plugin?: PanelPlugin;
+  queryRunner?: PanelQueryRunner;
 
   constructor(model: any) {
     this.events = new Emitter();

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -125,6 +125,8 @@ export class PanelQueryRunner {
       return this.data;
     }
 
+    let loadingStateTimeoutId = 0;
+
     try {
       const ds = options.ds ? options.ds : await getDatasourceSrv().get(datasource, request.scopedVars);
 
@@ -141,18 +143,12 @@ export class PanelQueryRunner {
       request.intervalMs = norm.intervalMs;
 
       // Send a loading status event on slower queries
-      setTimeout(() => {
-        if (!request.endTime) {
-          this.data = {
-            ...this.data,
-            state: LoadingState.Loading,
-            request,
-          };
-          this.subject.next(this.data);
-        }
+      loadingStateTimeoutId = window.setTimeout(() => {
+        this.publishUpdate({ state: LoadingState.Loading });
       }, delayStateNotification || 100);
 
       const resp = await ds.query(request);
+
       request.endTime = Date.now();
 
       // Make sure the response is in a supported format
@@ -166,15 +162,16 @@ export class PanelQueryRunner {
           })
         : undefined;
 
-      // The Result
-      this.data = {
+      // Make sure the delayed loading state timeout is cleared
+      clearTimeout(loadingStateTimeoutId);
+
+      // Publish the result
+      return this.publishUpdate({
         state: LoadingState.Done,
         series,
         legacy,
         request,
-      };
-      this.subject.next(this.data);
-      return this.data;
+      });
     } catch (err) {
       const error = err as DataQueryError;
       if (!error.message) {
@@ -191,14 +188,25 @@ export class PanelQueryRunner {
         error.message = message;
       }
 
-      this.data = {
-        ...this.data, // ?? Should we keep existing data, or clear it ???
+      // Make sure the delayed loading state timeout is cleared
+      clearTimeout(loadingStateTimeoutId);
+
+      return this.publishUpdate({
         state: LoadingState.Error,
         error: error,
-      };
-      this.subject.next(this.data);
-      return this.data;
+      });
     }
+  }
+
+  publishUpdate(update: Partial<PanelData>): PanelData {
+    this.data = {
+      ...this.data,
+      ...update,
+    };
+
+    this.subject.next(this.data);
+
+    return this.data;
   }
 }
 

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -39,6 +39,7 @@ export interface QueryRunnerOptions<TQuery extends DataQuery = DataQuery> {
 export enum PanelQueryRunnerFormat {
   series = 'series',
   legacy = 'legacy',
+  both = 'both',
 }
 
 export class PanelQueryRunner {
@@ -62,6 +63,9 @@ export class PanelQueryRunner {
     }
 
     if (format === PanelQueryRunnerFormat.legacy) {
+      this.sendLegacy = true;
+    } else if (format === PanelQueryRunnerFormat.both) {
+      this.sendSeries = true;
       this.sendLegacy = true;
     } else {
       this.sendSeries = true;

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -145,7 +145,7 @@ export class PanelQueryRunner {
       // Send a loading status event on slower queries
       loadingStateTimeoutId = window.setTimeout(() => {
         this.publishUpdate({ state: LoadingState.Loading });
-      }, delayStateNotification || 100);
+      }, delayStateNotification || 500);
 
       const resp = await ds.query(request);
 


### PR DESCRIPTION
This:
* moves queryRunner to panelModel
* changes QueriesTab to subscribe() to events and passes them to QueryEditorRow rather than use panel.event.on()