### PR TITLE
Docs: Update notification services

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -181,7 +181,7 @@ Sensu | `sensu` | yes
 OpsGenie | `opsgenie` | yes
 Threema | `threema` | yes
 Pushover | `pushover` | no
-Telegram | `telegram` | no
+Telegram | `telegram` | yes
 Line | `line` | no
 Prometheus Alertmanager | `prometheus-alertmanager` | no
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -165,25 +165,28 @@ Once these two properties are set, you can send the alerts to Kafka for further 
 
 Notifications can be sent by setting up an incoming webhook in Google Hangouts chat. Configuring such a webhook is described [here](https://developers.google.com/hangouts/chat/how-tos/webhooks).
 
-### All supported notifier
+### All supported notifiers
 
-Name | Type |Support images
+Name | Type | Supports images
 -----|------------ | ------
-Slack | `slack` | yes
-Pagerduty | `pagerduty` | yes
+DingDing | `dingding` | yes, external only
+Discord | `discord` | yes
 Email | `email` | yes
-Webhook | `webhook` | link
-Kafka | `kafka` | no
-Google Hangouts Chat | `googlechat` | yes
-Hipchat | `hipchat` | yes
-VictorOps | `victorops` | yes
-Sensu | `sensu` | yes
-OpsGenie | `opsgenie` | yes
-Threema | `threema` | yes
-Pushover | `pushover` | no
+Google Hangouts Chat | `googlechat` | yes, external only
+Hipchat | `hipchat` | yes, external only
+Kafka | `kafka` | yes, external only
+Line | `line` | yes, external only
+Microsoft Teams | `teams` | yes, external only
+OpsGenie | `opsgenie` | yes, external only
+Pagerduty | `pagerduty` | yes, external only
+Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only
+Pushover | `pushover` | yes
+Sensu | `sensu` | yes, external only
+Slack | `slack` | yes
 Telegram | `telegram` | yes
-Line | `line` | no
-Prometheus Alertmanager | `prometheus-alertmanager` | no
+Threema | `threema` | yes, external only
+VictorOps | `victorops` | yes, external only
+Webhook | `webhook` | yes, external only
 
 # Enable images in notifications {#external-image-store}
 
@@ -192,9 +195,7 @@ Amazon S3, Webdav, Google Cloud Storage and Azure Blob Storage. So to set that u
 
 Be aware that some notifiers requires public access to the image to be able to include it in the notification. So make sure to enable public access to the images. If you're using local image uploader, your Grafana instance need to be accessible by the internet.
 
-Currently only the Email Channels attaches images if no external image store is specified. To include images in alert notifications for other channels then you need to set up an external image store.
-
-This is an optional requirement. You can get Slack and email notifications without setting this up.
+Notification services which need public image access are marked as 'external only'.
 
 # Configure the link back to Grafana from alert notifications
 


### PR DESCRIPTION
The current docs say that the Telegram notification channel does not support images. Because I'm getting graph images sent over that channel, I think the docs are outdated here, especially the sentence:

> Currently only the Email Channels attaches images if no external image store is specified. To include images in alert notifications for other channels then you need to set up an external image store.

If we update the docs, let's get them all right at once. So I'd like to know which other channels besides Telegram support image sending as of today?