### PR TITLE
Use Dropbox's zxcvbn package to calculate password strength

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,8 @@
     "tether": "1.4.5",
     "tether-drop": "https://github.com/torkelo/drop/tarball/master",
     "tinycolor2": "1.4.1",
-    "xss": "1.0.3"
+    "xss": "1.0.3",
+    "zxcvbn": "4.4.2"
   },
   "resolutions": {
     "caniuse-db": "1.0.30000772"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/react-transition-group": "2.0.16",
     "@types/react-virtualized": "9.18.12",
     "@types/react-window": "1.7.0",
+    "@types/zxcvbn": "4.4.0",
     "angular-mocks": "1.6.6",
     "autoprefixer": "9.5.0",
     "axios": "0.18.0",

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -21,7 +21,7 @@ export class PasswordStrength extends React.Component<Props, any> {
 
     const passwordScore = zxcvbn(password).score;
 
-    if (passwordScore == 2) {
+    if (passwordScore <= 2) {
       strengthText = 'strength: you can do better.';
       strengthClass = 'password-strength-ok';
     }

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 
 export interface Props {
   password: string;
 }
 
-export class PasswordStrength extends React.Component<Props, any> {
+export class PasswordStrength extends PureComponent<Props, any> {
   constructor(props: Props) {
     super(props);
 
@@ -33,8 +33,8 @@ export class PasswordStrength extends React.Component<Props, any> {
 
   render() {
     const { password } = this.props;
-    let strengthText = 'strength: strong like a bull.';
-    let strengthClass = 'password-strength-good';
+    let strengthText = 'strong like a bull.';
+    let strengthClassModifier = 'good';
 
     if (!password) {
       return null;
@@ -43,18 +43,18 @@ export class PasswordStrength extends React.Component<Props, any> {
     const passwordScore = this.state.getScore(password);
 
     if (passwordScore <= 2) {
-      strengthText = 'strength: you can do better.';
-      strengthClass = 'password-strength-ok';
+      strengthText = 'you can do better.';
+      strengthClassModifier = 'ok';
     }
 
     if (passwordScore <= 1) {
-      strengthText = 'strength: weak sauce.';
-      strengthClass = 'password-strength-bad';
+      strengthText = 'weak sauce.';
+      strengthClassModifier = 'bad';
     }
 
     return (
-      <div className={`password-strength small ${strengthClass}`}>
-        <em>{strengthText}</em>
+      <div className={`password-strength small password-strength-${strengthClassModifier}`}>
+        <em>strength: {strengthText}</em>
       </div>
     );
   }

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import zxcvbn from 'zxcvbn';
 
 export interface Props {
   password: string;
@@ -18,12 +19,14 @@ export class PasswordStrength extends React.Component<Props, any> {
       return null;
     }
 
-    if (password.length <= 8) {
+    const passwordScore = zxcvbn(password).score;
+
+    if (passwordScore <= 2) {
       strengthText = 'strength: you can do better.';
       strengthClass = 'password-strength-ok';
     }
 
-    if (password.length < 4) {
+    if (passwordScore < 1) {
       strengthText = 'strength: weak sauce.';
       strengthClass = 'password-strength-bad';
     }

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import zxcvbn from 'zxcvbn';
 
 export interface Props {
   password: string;
@@ -8,6 +7,28 @@ export interface Props {
 export class PasswordStrength extends React.Component<Props, any> {
   constructor(props: Props) {
     super(props);
+
+    this.state = {
+      getScore(password: string) {
+        if (password.length < 4) {
+          return 1;
+        }
+        if (password.length < 8) {
+          return 2;
+        }
+        return 3;
+      },
+    };
+  }
+
+  componentDidMount() {
+    import(/* webpackChunkName: "zxcvbn" */ 'zxcvbn').then(zxcvbn => {
+      this.setState({
+        getScore(password: string) {
+          return zxcvbn.default(password).score;
+        },
+      });
+    });
   }
 
   render() {
@@ -19,7 +40,7 @@ export class PasswordStrength extends React.Component<Props, any> {
       return null;
     }
 
-    const passwordScore = zxcvbn(password).score;
+    const passwordScore = this.state.getScore(password);
 
     if (passwordScore <= 2) {
       strengthText = 'strength: you can do better.';

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -21,12 +21,12 @@ export class PasswordStrength extends React.Component<Props, any> {
 
     const passwordScore = zxcvbn(password).score;
 
-    if (passwordScore <= 2) {
+    if (passwordScore == 2) {
       strengthText = 'strength: you can do better.';
       strengthClass = 'password-strength-ok';
     }
 
-    if (passwordScore < 1) {
+    if (passwordScore <= 1) {
       strengthText = 'strength: weak sauce.';
       strengthClass = 'password-strength-bad';
     }

--- a/public/app/core/components/PasswordStrength.tsx
+++ b/public/app/core/components/PasswordStrength.tsx
@@ -4,7 +4,11 @@ export interface Props {
   password: string;
 }
 
-export class PasswordStrength extends PureComponent<Props, any> {
+export interface State {
+  getScore(password: string): number;
+}
+
+export class PasswordStrength extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/public/app/core/specs/PasswordStrength.test.tsx
+++ b/public/app/core/specs/PasswordStrength.test.tsx
@@ -5,7 +5,7 @@ import { PasswordStrength } from '../components/PasswordStrength';
 
 describe('PasswordStrength', () => {
   it('should have class bad if using weak password', () => {
-    const wrapper = shallow(<PasswordStrength password="asdaasdda" />);
+    const wrapper = shallow(<PasswordStrength password="aaaaaaa" />);
     expect(wrapper.find('.password-strength-bad')).toHaveLength(1);
   });
 

--- a/public/app/core/specs/PasswordStrength.test.tsx
+++ b/public/app/core/specs/PasswordStrength.test.tsx
@@ -4,18 +4,18 @@ import { shallow } from 'enzyme';
 import { PasswordStrength } from '../components/PasswordStrength';
 
 describe('PasswordStrength', () => {
-  it('should have class bad if length below 4', () => {
-    const wrapper = shallow(<PasswordStrength password="asd" />);
+  it('should have class bad if using weak password', () => {
+    const wrapper = shallow(<PasswordStrength password="asdaasdda" />);
     expect(wrapper.find('.password-strength-bad')).toHaveLength(1);
   });
 
-  it('should have class ok if length below 8', () => {
-    const wrapper = shallow(<PasswordStrength password="asdasd" />);
+  it('should have class ok if using average password', () => {
+    const wrapper = shallow(<PasswordStrength password="ok-password2" />);
     expect(wrapper.find('.password-strength-ok')).toHaveLength(1);
   });
 
-  it('should have class good if length above 8', () => {
-    const wrapper = shallow(<PasswordStrength password="asdaasdda" />);
+  it('should have class good if using strong password or passphrase', () => {
+    const wrapper = shallow(<PasswordStrength password="grape-acoustic-feature-abuse-gaze" />);
     expect(wrapper.find('.password-strength-good')).toHaveLength(1);
   });
 });

--- a/public/app/core/specs/PasswordStrength.test.tsx
+++ b/public/app/core/specs/PasswordStrength.test.tsx
@@ -4,18 +4,47 @@ import { shallow } from 'enzyme';
 import { PasswordStrength } from '../components/PasswordStrength';
 
 describe('PasswordStrength', () => {
-  it('should have class bad if using weak password', () => {
-    const wrapper = shallow(<PasswordStrength password="aaaaaaa" />);
-    expect(wrapper.find('.password-strength-bad')).toHaveLength(1);
+  describe('Using length', () => {
+    it('should have class bad if using weak password', () => {
+      const wrapper = shallow(<PasswordStrength password="asd" />);
+      expect(wrapper.find('.password-strength-bad')).toHaveLength(1);
+    });
+
+    it('should have class ok if using average password', () => {
+      const wrapper = shallow(<PasswordStrength password="asdasd" />);
+      expect(wrapper.find('.password-strength-ok')).toHaveLength(1);
+    });
+
+    it('should have class good if using strong password or passphrase', () => {
+      const wrapper = shallow(<PasswordStrength password="asdaasdda" />);
+      expect(wrapper.find('.password-strength-good')).toHaveLength(1);
+    });
   });
 
-  it('should have class ok if using average password', () => {
-    const wrapper = shallow(<PasswordStrength password="ok-password2" />);
-    expect(wrapper.find('.password-strength-ok')).toHaveLength(1);
-  });
+  describe('Using zxcvbn', () => {
+    // zxcvbn is dynamically imported due to its size
+    // wait for the dynamic import to resolve
+    const waitForPromises = () => new Promise(resolve => process.nextTick(resolve));
 
-  it('should have class good if using strong password or passphrase', () => {
-    const wrapper = shallow(<PasswordStrength password="grape-acoustic-feature-abuse-gaze" />);
-    expect(wrapper.find('.password-strength-good')).toHaveLength(1);
+    it('should have class bad if using weak password', async () => {
+      const wrapper = shallow(<PasswordStrength password="aaaaaaa" />);
+      await waitForPromises();
+
+      expect(wrapper.find('.password-strength-bad')).toHaveLength(1);
+    });
+
+    it('should have class ok if using average password', async () => {
+      const wrapper = shallow(<PasswordStrength password="ok-password2" />);
+      await waitForPromises();
+
+      expect(wrapper.find('.password-strength-ok')).toHaveLength(1);
+    });
+
+    it('should have class good if using strong password or passphrase', async () => {
+      const wrapper = shallow(<PasswordStrength password="grape-acoustic-feature-abuse-gaze" />);
+      await waitForPromises();
+
+      expect(wrapper.find('.password-strength-good')).toHaveLength(1);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,6 +2657,11 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
+"@types/zxcvbn@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.0.tgz#fbc1d941cc6d9d37d18405c513ba6b294f89b609"
+  integrity sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -18299,3 +18304,8 @@ zone.js@0.7.8:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.8.tgz#4f3fe8834d44597f2639053a0fa438df34fffded"
   integrity sha1-Tz/og01EWX8mOQU6D6Q43zT//e0=
+
+zxcvbn@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
Previous password strength was solely base on password length. 

It's now using Dropbox's library to calculate password strength.

More info: https://www.npmjs.com/package/zxcvbn

> More secure: policies often fail both ways, allowing weak passwords (P@ssword1) and disallowing strong passwords.

Fixes #12910. 