### PR TITLE
refactor: move timeInfo to DataRequestInfo

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -224,7 +224,6 @@ export interface DataQueryOptions<TQuery extends DataQuery = DataQuery> {
   timezone: string;
   range: TimeRange;
   rangeRaw: RawTimeRange; // Duplicate of results in range.  will be deprecated eventually
-  timeInfo?: string; // String decription of the time query
   targets: TQuery[];
   panelId: number;
   dashboardId: number;
@@ -239,6 +238,7 @@ export interface DataQueryOptions<TQuery extends DataQuery = DataQuery> {
  * Timestamps when the query starts and stops
  */
 export interface DataRequestInfo extends DataQueryOptions {
+  timeInfo?: string; // The query time description (blue text in the upper right)
   startTime: number;
   endTime?: number;
 }

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -223,7 +223,8 @@ export interface ScopedVars {
 export interface DataQueryOptions<TQuery extends DataQuery = DataQuery> {
   timezone: string;
   range: TimeRange;
-  rangeRaw: RawTimeRange;
+  rangeRaw: RawTimeRange; // Duplicate of results in range.  will be deprecated eventually
+  timeInfo?: string; // String decription of the time query
   targets: TQuery[];
   panelId: number;
   dashboardId: number;

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -28,6 +28,7 @@ export interface QueryRunnerOptions<TQuery extends DataQuery = DataQuery> {
   dashboardId?: number;
   timezone?: string;
   timeRange?: TimeRange;
+  timeInfo?: string; // String description of time range for display
   widthPixels: number;
   minInterval?: string;
   maxDataPoints?: number;
@@ -88,6 +89,7 @@ export class PanelQueryRunner {
       panelId,
       dashboardId,
       timeRange,
+      timeInfo,
       cacheTimeout,
       widthPixels,
       maxDataPoints,
@@ -101,6 +103,7 @@ export class PanelQueryRunner {
       dashboardId,
       range: timeRange,
       rangeRaw: timeRange.raw,
+      timeInfo,
       interval: '',
       intervalMs: 0,
       targets: cloneDeep(queries),


### PR DESCRIPTION
ignore until after #16656 

We should pass the `timeInfo` string (the blue text that shows up in the right hand corner) along with the query request so that anyone listening to the results can also display it.  

A nice side effect is that we will skip one extra react render pass since the timeInfo is not set via state directly