### PR TITLE
Explore: Support for new LogQL filtering syntax

### DIFF
--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -21,7 +21,7 @@ export interface QueryResultMeta {
   requestId?: string;
 
   // Used in Explore for highlighting
-  search?: string;
+  searchWords?: string[];
 
   // Used in Explore to show limit applied to search result
   limit?: number;

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -188,7 +188,7 @@ export abstract class ExploreDataSourceApi<
   TOptions extends DataSourceJsonData = DataSourceJsonData
 > extends DataSourceApi<TQuery, TOptions> {
   modifyQuery?(query: TQuery, action: QueryFixAction): TQuery;
-  getHighlighterExpression?(query: TQuery): string;
+  getHighlighterExpression?(query: TQuery): string[];
   languageProvider?: any;
 }
 

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -446,7 +446,7 @@ export function processLogSeriesRow(
   const timeLocal = time.format('YYYY-MM-DD HH:mm:ss');
   const logLevel = getLogLevel(message);
   const hasAnsi = hasAnsiCodes(message);
-  const search = series.meta && series.meta.search ? series.meta.search : '';
+  const searchWords = series.meta && series.meta.searchWords ? series.meta.searchWords : [];
 
   return {
     logLevel,
@@ -455,10 +455,10 @@ export function processLogSeriesRow(
     timeLocal,
     uniqueLabels,
     hasAnsi,
+    searchWords,
     entry: hasAnsi ? ansicolor.strip(message) : message,
     raw: message,
     labels: series.labels,
-    searchWords: search ? [search] : [],
     timestamp: ts,
   };
 }

--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -6,7 +6,7 @@ import xss from 'xss';
  * See https://github.com/bvaughn/react-highlight-words#props
  */
 export function findHighlightChunksInText({ searchWords, textToHighlight }) {
-  return findMatchesInText(textToHighlight, searchWords.join(' '));
+  return searchWords.reduce((acc, term) => [...acc, ...findMatchesInText(textToHighlight, term)], []);
 }
 
 const cleanNeedle = (needle: string): string => {

--- a/public/app/features/explore/LogRow.tsx
+++ b/public/app/features/explore/LogRow.tsx
@@ -133,7 +133,7 @@ export class LogRow extends PureComponent<Props, State> {
     const { entry, hasAnsi, raw } = row;
     const previewHighlights = highlighterExpressions && !_.isEqual(highlighterExpressions, row.searchWords);
     const highlights = previewHighlights ? highlighterExpressions : row.searchWords;
-    const needsHighlighter = highlights && highlights.length > 0 && highlights[0].length > 0;
+    const needsHighlighter = highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0;
     const highlightClassName = classnames('logs-row__match-highlight', {
       'logs-row__match-highlight--preview': previewHighlights,
     });

--- a/public/app/features/explore/QueryRow.tsx
+++ b/public/app/features/explore/QueryRow.tsx
@@ -95,7 +95,7 @@ export class QueryRow extends PureComponent<QueryRowProps> {
     const { datasourceInstance } = this.props;
     if (datasourceInstance.getHighlighterExpression) {
       const { exploreId } = this.props;
-      const expressions = [datasourceInstance.getHighlighterExpression(value)];
+      const expressions = datasourceInstance.getHighlighterExpression(value);
       this.props.highlightLogsExpressionAction({ exploreId, expressions });
     }
   }, 500);

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -69,7 +69,7 @@ describe('LokiDatasource', () => {
       const seriesData = res.data[0] as SeriesData;
       expect(seriesData.rows[0][1]).toBe('hello');
       expect(seriesData.meta.limit).toBe(20);
-      expect(seriesData.meta.search).toBe('(?i)foo');
+      expect(seriesData.meta.search).toBe('foo');
       done();
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -61,7 +61,7 @@ describe('LokiDatasource', () => {
       backendSrvMock.datasourceRequest = jest.fn(() => Promise.resolve(testResp));
 
       const options = getQueryOptions<LokiQuery>({
-        targets: [{ expr: 'foo', refId: 'B' }],
+        targets: [{ expr: '{} foo', refId: 'B' }],
       });
 
       const res = await ds.query(options);
@@ -69,7 +69,7 @@ describe('LokiDatasource', () => {
       const seriesData = res.data[0] as SeriesData;
       expect(seriesData.rows[0][1]).toBe('hello');
       expect(seriesData.meta.limit).toBe(20);
-      expect(seriesData.meta.search).toBe('foo');
+      expect(seriesData.meta.searchWords).toEqual(['(?i)foo']);
       done();
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -134,6 +134,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
             const seriesData = logStreamToSeriesData(stream);
             seriesData.refId = refId;
             seriesData.meta = {
+              search: queryTargets[i].regexp,
               limit: this.maxLines,
             };
             series.push(seriesData);
@@ -174,7 +175,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   }
 
   getHighlighterExpression(query: LokiQuery): string {
-    return undefined;
+    return parseQuery(query.expr).regexp;
   }
 
   getTime(date, roundUp) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -6,7 +6,7 @@ import * as dateMath from '@grafana/ui/src/utils/datemath';
 import { addLabelToSelector } from 'app/plugins/datasource/prometheus/add_label_to_query';
 import LanguageProvider from './language_provider';
 import { logStreamToSeriesData } from './result_transformer';
-import { formatQuery, parseQuery } from './query_utils';
+import { formatQuery, parseQuery, getHighlighterExpressionsFromQuery } from './query_utils';
 
 // Types
 import {
@@ -134,7 +134,9 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
             const seriesData = logStreamToSeriesData(stream);
             seriesData.refId = refId;
             seriesData.meta = {
-              search: queryTargets[i].regexp,
+              searchWords: getHighlighterExpressionsFromQuery(
+                formatQuery(queryTargets[i].query, queryTargets[i].regexp)
+              ),
               limit: this.maxLines,
             };
             series.push(seriesData);
@@ -174,8 +176,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     return { ...query, expr: expression };
   }
 
-  getHighlighterExpression(query: LokiQuery): string {
-    return parseQuery(query.expr).regexp;
+  getHighlighterExpression(query: LokiQuery): string[] {
+    return getHighlighterExpressionsFromQuery(query.expr);
   }
 
   getTime(date, roundUp) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -27,6 +27,7 @@ export const DEFAULT_MAX_LINES = 1000;
 const DEFAULT_QUERY_PARAMS = {
   direction: 'BACKWARD',
   limit: DEFAULT_MAX_LINES,
+  regexp: '',
   query: '',
 };
 
@@ -68,13 +69,14 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
   prepareQueryTarget(target: LokiQuery, options: DataQueryRequest<LokiQuery>) {
     const interpolated = this.templateSrv.replace(target.expr);
-    const { query } = parseQuery(interpolated);
+    const { query, regexp } = parseQuery(interpolated);
     const start = this.getTime(options.range.from, false);
     const end = this.getTime(options.range.to, true);
     const refId = target.refId;
     return {
       ...DEFAULT_QUERY_PARAMS,
       query,
+      regexp,
       start,
       end,
       limit: this.maxLines,
@@ -158,7 +160,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
   modifyQuery(query: LokiQuery, action: any): LokiQuery {
     const parsed = parseQuery(query.expr || '');
-    let { selector } = parsed;
+    let { query: selector } = parsed;
     switch (action.type) {
       case 'ADD_FILTER': {
         selector = addLabelToSelector(selector, action.key, action.value);
@@ -167,7 +169,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       default:
         break;
     }
-    const expression = formatQuery(selector, parsed.filter);
+    const expression = formatQuery(selector, parsed.regexp);
     return { ...query, expr: expression };
   }
 

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -4,53 +4,74 @@ describe('parseQuery', () => {
   it('returns empty for empty string', () => {
     expect(parseQuery('')).toEqual({
       query: '',
-      regexp: '',
+      selector: '',
+      filter: '',
     });
   });
 
   it('returns regexp for strings without query', () => {
     expect(parseQuery('test')).toEqual({
-      query: '',
-      regexp: '(?i)test',
+      query: 'test',
+      selector: '',
+      filter: 'test',
     });
   });
 
   it('returns query for strings without regexp', () => {
     expect(parseQuery('{foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '',
+      selector: '{foo="bar"}',
+      filter: '',
     });
   });
 
   it('returns query for strings with query and search string', () => {
     expect(parseQuery('x {foo="bar"}')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '(?i)x',
+      query: '{foo="bar"} |~ "(?i)x"',
+      selector: '{foo="bar"}',
+      filter: 'x',
     });
   });
 
   it('returns query for strings with query and regexp', () => {
     expect(parseQuery('{foo="bar"} x|y')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '(?i)x|y',
+      query: '{foo="bar"} |~ "(?i)x|y"',
+      selector: '{foo="bar"}',
+      filter: 'x|y',
     });
   });
 
   it('returns query for selector with two labels', () => {
     expect(parseQuery('{foo="bar", baz="42"}')).toEqual({
       query: '{foo="bar", baz="42"}',
-      regexp: '',
+      selector: '{foo="bar", baz="42"}',
+      filter: '',
     });
   });
 
   it('returns query and regexp with quantifiers', () => {
     expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '(?i)\\.java:[0-9]{1,5}',
+      query: '{foo="bar"} |~ "(?i)\\.java:[0-9]{1,5}"',
+      selector: '{foo="bar"}',
+      filter: '\\.java:[0-9]{1,5}',
     });
     expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '(?i)\\.java:[0-9]{1,5}',
+      query: '{foo="bar"} |~ "(?i)\\.java:[0-9]{1,5}"',
+      selector: '{foo="bar"}',
+      filter: '\\.java:[0-9]{1,5}',
+    });
+  });
+
+  it('returns query with filter operands as is', () => {
+    expect(parseQuery('{foo="bar"} |= "x|y"')).toEqual({
+      query: '{foo="bar"} |= "x|y"',
+      selector: '{foo="bar"}',
+      filter: '|= "x|y"',
+    });
+    expect(parseQuery('{foo="bar"} |~ "42"')).toEqual({
+      query: '{foo="bar"} |~ "42"',
+      selector: '{foo="bar"}',
+      filter: '|~ "42"',
     });
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -1,77 +1,68 @@
 import { parseQuery } from './query_utils';
+import { LokiExpression } from './types';
 
 describe('parseQuery', () => {
   it('returns empty for empty string', () => {
     expect(parseQuery('')).toEqual({
       query: '',
-      selector: '',
-      filter: '',
-    });
+      regexp: '',
+    } as LokiExpression);
   });
 
   it('returns regexp for strings without query', () => {
     expect(parseQuery('test')).toEqual({
-      query: 'test',
-      selector: '',
-      filter: 'test',
-    });
+      query: '',
+      regexp: 'test',
+    } as LokiExpression);
   });
 
   it('returns query for strings without regexp', () => {
     expect(parseQuery('{foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      selector: '{foo="bar"}',
-      filter: '',
-    });
+      regexp: '',
+    } as LokiExpression);
   });
 
   it('returns query for strings with query and search string', () => {
     expect(parseQuery('x {foo="bar"}')).toEqual({
-      query: '{foo="bar"} |~ "(?i)x"',
-      selector: '{foo="bar"}',
-      filter: 'x',
-    });
+      query: '{foo="bar"}',
+      regexp: '|~ "(?i)x"',
+    } as LokiExpression);
   });
 
   it('returns query for strings with query and regexp', () => {
     expect(parseQuery('{foo="bar"} x|y')).toEqual({
-      query: '{foo="bar"} |~ "(?i)x|y"',
-      selector: '{foo="bar"}',
-      filter: 'x|y',
-    });
+      query: '{foo="bar"}',
+      regexp: '|~ "(?i)x|y"',
+    } as LokiExpression);
   });
 
   it('returns query for selector with two labels', () => {
     expect(parseQuery('{foo="bar", baz="42"}')).toEqual({
       query: '{foo="bar", baz="42"}',
-      selector: '{foo="bar", baz="42"}',
-      filter: '',
-    });
+      regexp: '',
+    } as LokiExpression);
   });
 
   it('returns query and regexp with quantifiers', () => {
     expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
-      query: '{foo="bar"} |~ "(?i)\\.java:[0-9]{1,5}"',
-      selector: '{foo="bar"}',
-      filter: '\\.java:[0-9]{1,5}',
-    });
+      query: '{foo="bar"}',
+      regexp: '|~ "(?i)\\.java:[0-9]{1,5}"',
+    } as LokiExpression);
     expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
-      query: '{foo="bar"} |~ "(?i)\\.java:[0-9]{1,5}"',
-      selector: '{foo="bar"}',
-      filter: '\\.java:[0-9]{1,5}',
-    });
+      query: '{foo="bar"}',
+      regexp: '|~ "(?i)\\.java:[0-9]{1,5}"',
+    } as LokiExpression);
   });
 
   it('returns query with filter operands as is', () => {
     expect(parseQuery('{foo="bar"} |= "x|y"')).toEqual({
-      query: '{foo="bar"} |= "x|y"',
-      selector: '{foo="bar"}',
-      filter: '|= "x|y"',
-    });
+      query: '{foo="bar"}',
+      regexp: '|= "x|y"',
+    } as LokiExpression);
     expect(parseQuery('{foo="bar"} |~ "42"')).toEqual({
-      query: '{foo="bar"} |~ "42"',
-      selector: '{foo="bar"}',
-      filter: '|~ "42"',
-    });
+      query: '{foo="bar"}',
+      regexp: '|~ "42"',
+    } as LokiExpression);
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -1,4 +1,4 @@
-import { parseQuery } from './query_utils';
+import { parseQuery, getHighlighterExpressionsFromQuery } from './query_utils';
 import { LokiExpression } from './types';
 
 describe('parseQuery', () => {
@@ -64,5 +64,24 @@ describe('parseQuery', () => {
       query: '{foo="bar"} |~ "42"',
       regexp: '',
     } as LokiExpression);
+  });
+});
+
+describe('getHighlighterExpressionsFromQuery', () => {
+  it('returns no expressions for empty query', () => {
+    expect(getHighlighterExpressionsFromQuery('')).toEqual([]);
+  });
+  it('returns a single expressions for legacy query', () => {
+    expect(getHighlighterExpressionsFromQuery('{} x')).toEqual(['(?i)x']);
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} x')).toEqual(['(?i)x']);
+  });
+  it('returns an expression for query with filter', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x"')).toEqual(['x']);
+  });
+  it('returns expressions for query with filter chain', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ "y"')).toEqual(['x', 'y']);
+  });
+  it('returns drops expressions for query with negative filter chain', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" != "y"')).toEqual(['x']);
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -26,14 +26,14 @@ describe('parseQuery', () => {
   it('returns query for strings with query and search string', () => {
     expect(parseQuery('x {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '|~ "(?i)x"',
+      regexp: 'x',
     } as LokiExpression);
   });
 
   it('returns query for strings with query and regexp', () => {
     expect(parseQuery('{foo="bar"} x|y')).toEqual({
       query: '{foo="bar"}',
-      regexp: '|~ "(?i)x|y"',
+      regexp: 'x|y',
     } as LokiExpression);
   });
 
@@ -47,11 +47,11 @@ describe('parseQuery', () => {
   it('returns query and regexp with quantifiers', () => {
     expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '|~ "(?i)\\.java:[0-9]{1,5}"',
+      regexp: '\\.java:[0-9]{1,5}',
     } as LokiExpression);
     expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '|~ "(?i)\\.java:[0-9]{1,5}"',
+      regexp: '\\.java:[0-9]{1,5}',
     } as LokiExpression);
   });
 

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -11,8 +11,8 @@ describe('parseQuery', () => {
 
   it('returns regexp for strings without query', () => {
     expect(parseQuery('test')).toEqual({
-      query: '',
-      regexp: 'test',
+      query: 'test',
+      regexp: '',
     } as LokiExpression);
   });
 
@@ -26,14 +26,14 @@ describe('parseQuery', () => {
   it('returns query for strings with query and search string', () => {
     expect(parseQuery('x {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: 'x',
+      regexp: '(?i)x',
     } as LokiExpression);
   });
 
   it('returns query for strings with query and regexp', () => {
     expect(parseQuery('{foo="bar"} x|y')).toEqual({
       query: '{foo="bar"}',
-      regexp: 'x|y',
+      regexp: '(?i)x|y',
     } as LokiExpression);
   });
 
@@ -47,22 +47,22 @@ describe('parseQuery', () => {
   it('returns query and regexp with quantifiers', () => {
     expect(parseQuery('{foo="bar"} \\.java:[0-9]{1,5}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '\\.java:[0-9]{1,5}',
+      regexp: '(?i)\\.java:[0-9]{1,5}',
     } as LokiExpression);
     expect(parseQuery('\\.java:[0-9]{1,5} {foo="bar"}')).toEqual({
       query: '{foo="bar"}',
-      regexp: '\\.java:[0-9]{1,5}',
+      regexp: '(?i)\\.java:[0-9]{1,5}',
     } as LokiExpression);
   });
 
   it('returns query with filter operands as is', () => {
     expect(parseQuery('{foo="bar"} |= "x|y"')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '|= "x|y"',
+      query: '{foo="bar"} |= "x|y"',
+      regexp: '',
     } as LokiExpression);
     expect(parseQuery('{foo="bar"} |~ "42"')).toEqual({
-      query: '{foo="bar"}',
-      regexp: '|~ "42"',
+      query: '{foo="bar"} |~ "42"',
+      regexp: '',
     } as LokiExpression);
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,16 +1,22 @@
 import { LokiExpression } from './types';
 
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
+const caseInsensitive = '(?i)'; // Golang mode modifier for Loki, doesn't work in JavaScript
 export function parseQuery(input: string): LokiExpression {
   input = input || '';
   const match = input.match(selectorRegexp);
-  let query = '';
-  let regexp = input;
+  let query = input;
+  let regexp = '';
 
   if (match) {
-    // Selector
-    query = match[0].trim();
     regexp = input.replace(selectorRegexp, '').trim();
+    // Keep old-style regexp, otherwise take whole query
+    if (regexp && regexp.search(/\|=|\|~|!=|!~/) === -1) {
+      query = match[0].trim();
+      regexp = `${caseInsensitive}${regexp}`;
+    } else {
+      regexp = '';
+    }
   }
 
   return { regexp, query };

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -13,7 +13,9 @@ export function parseQuery(input: string): LokiExpression {
     // Keep old-style regexp, otherwise take whole query
     if (regexp && regexp.search(/\|=|\|~|!=|!~/) === -1) {
       query = match[0].trim();
-      regexp = `${caseInsensitive}${regexp}`;
+      if (!regexp.startsWith(caseInsensitive)) {
+        regexp = `${caseInsensitive}${regexp}`;
+      }
     } else {
       regexp = '';
     }

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,7 +1,6 @@
 import { LokiExpression } from './types';
 
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
-const caseInsensitive = '(?i)'; // Golang mode modifier for Loki, doesn't work in JavaScript
 export function parseQuery(input: string): LokiExpression {
   input = input || '';
   const match = input.match(selectorRegexp);
@@ -12,9 +11,6 @@ export function parseQuery(input: string): LokiExpression {
     // Selector
     query = match[0].trim();
     regexp = input.replace(selectorRegexp, '').trim();
-    if (regexp && regexp.search(/\|=|\|~|!=|!~/) === -1) {
-      regexp = `|~ "${caseInsensitive}${regexp}"`;
-    }
   }
 
   return { regexp, query };

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,20 +1,23 @@
+import { LokiExpression } from './types';
+
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
 const caseInsensitive = '(?i)'; // Golang mode modifier for Loki, doesn't work in JavaScript
-export function parseQuery(input: string) {
+export function parseQuery(input: string): LokiExpression {
   input = input || '';
   const match = input.match(selectorRegexp);
-  let query = '';
-  let regexp = input;
+  let selector = '';
+  let filter = input;
+  let query = input;
 
   if (match) {
-    query = match[0].trim();
-    regexp = input.replace(selectorRegexp, '').trim();
+    selector = match[0].trim();
+    filter = input.replace(selectorRegexp, '').trim();
+    if (filter && filter.search(/\|=|\|~|!=|!~/) === -1) {
+      query = `${selector} |~ "${caseInsensitive}${filter}"`;
+    }
   }
 
-  if (regexp) {
-    regexp = caseInsensitive + regexp;
-  }
-  return { query, regexp };
+  return { selector, filter, query };
 }
 
 export function formatQuery(selector: string, search: string): string {

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -5,19 +5,19 @@ const caseInsensitive = '(?i)'; // Golang mode modifier for Loki, doesn't work i
 export function parseQuery(input: string): LokiExpression {
   input = input || '';
   const match = input.match(selectorRegexp);
-  let selector = '';
-  let filter = input;
-  let query = input;
+  let query = '';
+  let regexp = input;
 
   if (match) {
-    selector = match[0].trim();
-    filter = input.replace(selectorRegexp, '').trim();
-    if (filter && filter.search(/\|=|\|~|!=|!~/) === -1) {
-      query = `${selector} |~ "${caseInsensitive}${filter}"`;
+    // Selector
+    query = match[0].trim();
+    regexp = input.replace(selectorRegexp, '').trim();
+    if (regexp && regexp.search(/\|=|\|~|!=|!~/) === -1) {
+      regexp = `|~ "${caseInsensitive}${regexp}"`;
     }
   }
 
-  return { selector, filter, query };
+  return { regexp, query };
 }
 
 export function formatQuery(selector: string, search: string): string {

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -22,3 +22,9 @@ export interface LokiLogsStreamEntry {
   // Legacy, was renamed to ts
   timestamp?: string;
 }
+
+export interface LokiExpression {
+  selector: string;
+  filter: string;
+  query: string;
+}

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -24,7 +24,6 @@ export interface LokiLogsStreamEntry {
 }
 
 export interface LokiExpression {
-  selector: string;
-  filter: string;
+  regexp: string;
   query: string;
 }


### PR DESCRIPTION
Loki is adding syntax to support chained filtering. See https://github.com/grafana/loki/pull/492.
This PR adapts Grafana to support this.

- Send LogQL-style queries as `query` parameter
- Send legacy queries with `regexp` parameter`
- fixed match highlighting

Notes to reviewer:

Test this with a Loki instance by
1. starting with a selector `{...}` 
2. then add a search term `{...} foo` (legacy format)
3. then try the new syntax `{...} |= "foo"`
4. try a filter chain with negative filters `{...} |= "foo" != "bar"`

Notice how the highlighting should work, even as you type (when syntax is correct).