### PR TITLE
Update _navbar.scss for arrow fix

### DIFF
--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -200,11 +200,17 @@
   height: 34px;
   transition: transform 0.1s ease 0.1s;
   color: $text-color;
-
+	display: inline-flex; 
+	align-items: center; 
+	justify-content: center;
+  
   i {
     font-size: $font-size-lg;
     position: relative;
-    top: 2px;
+    margin-left: auto; 
+    margin-right: auto; 
+    left: 0; 
+    right: 0; 
   }
 
   &:hover {


### PR DESCRIPTION
Update `_navbar.scss` to fix nav arrow position into container `.navbar-edit__back-btn`
Back button doesn't look good now if we talk about good UI. 
Arrow need some optical compensation.

![ezgif-1-6b0bed9cfd4f](https://user-images.githubusercontent.com/1700286/56410889-7be19880-6287-11e9-823c-596a2c900bdd.gif)

