### PR TITLE
TestDataDatasource: add the query refId to each result

### DIFF
--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -61,12 +61,14 @@ export class TestDataDatasource implements DataSourceApi<TestDataQuery> {
             continue;
           }
 
-          for (const table of results.tables || []) {
-            data.push(table as TableData);
+          for (const t of results.tables || []) {
+            const table = t as TableData;
+            table.refId = query.refId;
+            data.push(table);
           }
 
           for (const series of results.series || []) {
-            data.push({ target: series.name, datapoints: series.points });
+            data.push({ target: series.name, datapoints: series.points, refId: query.refId });
           }
         }
 


### PR DESCRIPTION
Simple change useful for testing streaming stuff...  this links to query to the result