### PR TITLE
InfluxDB: Add support for POST HTTP verb

### DIFF
--- a/docs/sources/features/datasources/influxdb.md
+++ b/docs/sources/features/datasources/influxdb.md
@@ -32,6 +32,7 @@ Name | Description
 *Database* | Name of your influxdb database
 *User* | Name of your database user
 *Password* | Database user's password
+*HTTP mode* | How to query the database (`GET` or `POST` HTTP verb). The `POST` verb allows heavy queries that would return an error using the `GET` verb. Default is `GET`.
 
 Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else stated.
 
@@ -212,4 +213,6 @@ datasources:
     user: grafana
     password: grafana
     url: http://localhost:8086
+    jsonData:
+      httpMode: GET
 ```

--- a/pkg/tsdb/influxdb/influxdb_test.go
+++ b/pkg/tsdb/influxdb/influxdb_test.go
@@ -1,0 +1,77 @@
+package influxdb
+
+import (
+	"io/ioutil"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestInfluxDB(t *testing.T) {
+	Convey("InfluxDB", t, func() {
+		datasource := &models.DataSource{
+			Url:      "http://awesome-influxdb:1337",
+			Database: "awesome-db",
+			JsonData: simplejson.New(),
+		}
+		query := "SELECT awesomeness FROM somewhere"
+		e := &InfluxDBExecutor{
+			QueryParser:    &InfluxdbQueryParser{},
+			ResponseParser: &ResponseParser{},
+		}
+		Convey("createRequest with GET httpMode", func() {
+			req, _ := e.createRequest(datasource, query)
+
+			Convey("as default", func() {
+				So(req.Method, ShouldEqual, "GET")
+			})
+
+			Convey("has a 'q' GET param that equals to query", func() {
+				q := req.URL.Query().Get("q")
+				So(q, ShouldEqual, query)
+			})
+
+			Convey("has an empty body", func() {
+				So(req.Body, ShouldEqual, nil)
+			})
+
+		})
+
+		Convey("createRequest with POST httpMode", func() {
+			datasource.JsonData.Set("httpMode", "POST")
+			req, _ := e.createRequest(datasource, query)
+
+			Convey("method should be POST", func() {
+				So(req.Method, ShouldEqual, "POST")
+			})
+
+			Convey("has no 'q' GET param", func() {
+				q := req.URL.Query().Get("q")
+				So(q, ShouldEqual, "")
+			})
+
+			Convey("has the request as GET param in body", func() {
+				body, _ := ioutil.ReadAll(req.Body)
+				testBodyValues := url.Values{}
+				testBodyValues.Add("q", query)
+				testBody := testBodyValues.Encode()
+				So(string(body[:]), ShouldEqual, testBody)
+			})
+
+		})
+
+		Convey("createRequest with PUT httpMode", func() {
+			datasource.JsonData.Set("httpMode", "PUT")
+			_, err := e.createRequest(datasource, query)
+
+			Convey("should miserably fail", func() {
+				So(err, ShouldEqual, ErrInvalidHttpMode)
+			})
+
+		})
+
+	})
+}

--- a/public/app/plugins/datasource/influxdb/module.ts
+++ b/public/app/plugins/datasource/influxdb/module.ts
@@ -15,7 +15,10 @@ class InfluxConfigCtrl {
   constructor() {
     this.onPasswordReset = createResetHandler(this, PasswordFieldEnum.Password);
     this.onPasswordChange = createChangeHandler(this, PasswordFieldEnum.Password);
+    this.current.jsonData.httpMode = this.current.jsonData.httpMode || 'GET';
   }
+
+  httpMode = [{ name: 'GET', value: 'GET' }, { name: 'POST', value: 'POST' }];
 }
 
 class InfluxAnnotationsQueryCtrl {

--- a/public/app/plugins/datasource/influxdb/partials/config.html
+++ b/public/app/plugins/datasource/influxdb/partials/config.html
@@ -26,6 +26,19 @@
       />
 		</div>
 	</div>
+
+	<div class="gf-form">
+		<label class="gf-form-label width-8">HTTP Method</label>
+		<div class="gf-form-select-wrapper width-8 gf-form-select-wrapper--has-help-icon">
+			<select class="gf-form-input" ng-model="ctrl.current.jsonData.httpMode" ng-options="f.value as f.name for f in ctrl.httpMode"></select>
+      		<info-popover mode="right-absolute">
+        		You can use either <code>GET</code> or <code>POST</code> HTTP method to query your InfluxDB database. The <code>POST</code>
+				method allows you to perform heavy requests (with a lots of <code>WHERE</code> clause) while the <code>GET</code> method
+				will restrict you and return an error if the query is too large.
+      		</info-popover>
+		</div>
+	</div>
+
 </div>
 
 

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -7,7 +7,7 @@ describe('InfluxDataSource', () => {
     backendSrv: {},
     $q: $q,
     templateSrv: new TemplateSrvStub(),
-    instanceSettings: { url: 'url', name: 'influxDb', jsonData: {} },
+    instanceSettings: { url: 'url', name: 'influxDb', jsonData: { httpMode: 'GET' } },
   };
 
   beforeEach(() => {
@@ -23,11 +23,13 @@ describe('InfluxDataSource', () => {
         to: '2018-01-02T00:00:00Z',
       },
     };
-    let requestQuery;
+    let requestQuery, requestMethod, requestData;
 
     beforeEach(async () => {
       ctx.backendSrv.datasourceRequest = req => {
+        requestMethod = req.method;
         requestQuery = req.params.q;
+        requestData = req.data;
         return ctx.$q.when({
           results: [
             {
@@ -48,6 +50,70 @@ describe('InfluxDataSource', () => {
 
     it('should replace $timefilter', () => {
       expect(requestQuery).toMatch('time >= 1514764800000ms and time <= 1514851200000ms');
+    });
+
+    it('should use the HTTP GET method', () => {
+      expect(requestMethod).toBe('GET');
+    });
+
+    it('should not have any data in request body', () => {
+      expect(requestData).toBeNull();
+    });
+  });
+});
+
+describe('InfluxDataSource in POST query mode', () => {
+  const ctx: any = {
+    backendSrv: {},
+    $q: $q,
+    templateSrv: new TemplateSrvStub(),
+    instanceSettings: { url: 'url', name: 'influxDb', jsonData: { httpMode: 'POST' } },
+  };
+
+  beforeEach(() => {
+    ctx.instanceSettings.url = '/api/datasources/proxy/1';
+    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+  });
+
+  describe('When issuing metricFindQuery', () => {
+    const query = 'SELECT max(value) FROM measurement';
+    const queryOptions: any = {};
+    let requestMethod, requestQueryParameter, queryEncoded, requestQuery;
+
+    beforeEach(async () => {
+      ctx.backendSrv.datasourceRequest = req => {
+        requestMethod = req.method;
+        requestQueryParameter = req.params;
+        requestQuery = req.data;
+        return ctx.$q.when({
+          results: [
+            {
+              series: [
+                {
+                  name: 'measurement',
+                  columns: ['max'],
+                  values: [[1]],
+                },
+              ],
+            },
+          ],
+        });
+      };
+
+      queryEncoded = await ctx.ds.serializeParams({ q: query });
+      await ctx.ds.metricFindQuery(query, queryOptions).then(_ => {});
+    });
+
+    it('should have the query form urlencoded', () => {
+      expect(requestQuery).toBe(queryEncoded);
+    });
+
+    it('should use the HTTP POST method', () => {
+      expect(requestMethod).toBe('POST');
+    });
+
+    it('should not have q as a query parameter', () => {
+      expect(requestQueryParameter).not.toHaveProperty('q');
     });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
A new parameter `queryMode` is added to the InfluxDB datasource to provide a way to use POST instead of GET when querying the database. This prevents to get any error when querying the database with an heavy request.
Default configuration is kept to GET for backward compatibility. Tests have been added for this new behaviour.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/10038

**Special notes for your reviewer**:
None at the moment.
