### PR TITLE
QueryEditors: pass PanelData and filtered PanelData to each editor

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -2,6 +2,7 @@ import { ComponentClass } from 'react';
 import { TimeRange } from './time';
 import { PluginMeta } from './plugin';
 import { TableData, TimeSeries, SeriesData } from './data';
+import { PanelData } from './panel';
 
 export class DataSourcePlugin<TQuery extends DataQuery = DataQuery> {
   DataSourceClass: DataSourceConstructor<TQuery>;
@@ -140,8 +141,8 @@ export interface QueryEditorProps<DSType extends DataSourceApi, TQuery extends D
   query: TQuery;
   onRunQuery: () => void;
   onChange: (value: TQuery) => void;
-  queryResponse?: SeriesData[];
-  queryError?: DataQueryError;
+  panelData: PanelData; // The current panel data
+  queryResponse?: PanelData; // data filtered to only this query.  Includes the error.
 }
 
 export enum DataSourceStatus {

--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.test.ts
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.test.ts
@@ -1,0 +1,45 @@
+import { PanelData, LoadingState, DataQueryRequest } from '@grafana/ui';
+import { filterPanelDataToQuery } from './QueryEditorRow';
+
+function makePretendRequest(requestId: string, subRequests?: DataQueryRequest[]): DataQueryRequest {
+  return {
+    requestId,
+    // subRequests,
+  } as DataQueryRequest;
+}
+
+describe('filterPanelDataToQuery', () => {
+  const data = {
+    state: LoadingState.Done,
+    series: [
+      { refId: 'A', fields: [{ name: 'AAA' }], rows: [], meta: {} },
+      { refId: 'B', fields: [{ name: 'B111' }], rows: [], meta: {} },
+      { refId: 'B', fields: [{ name: 'B222' }], rows: [], meta: {} },
+      { refId: 'B', fields: [{ name: 'B333' }], rows: [], meta: {} },
+      { refId: 'C', fields: [{ name: 'CCCC' }], rows: [], meta: { requestId: 'sub3' } },
+    ],
+    error: {
+      refId: 'B',
+      message: 'Error!!',
+    },
+    request: makePretendRequest('111', [
+      makePretendRequest('sub1'),
+      makePretendRequest('sub2'),
+      makePretendRequest('sub3'),
+    ]),
+  } as PanelData;
+
+  it('should not have an error unless the refId matches', () => {
+    const panelData = filterPanelDataToQuery(data, 'A');
+    expect(panelData.series.length).toBe(1);
+    expect(panelData.series[0].refId).toBe('A');
+    expect(panelData.error).toBeUndefined();
+  });
+
+  it('should match the error to the query', () => {
+    const panelData = filterPanelDataToQuery(data, 'B');
+    expect(panelData.series.length).toBe(3);
+    expect(panelData.series[0].refId).toBe('B');
+    expect(panelData.error!.refId).toBe('B');
+  });
+});


### PR DESCRIPTION
this changes the signature of QueryEditors to pass in panelData (with full properties) rather than just series and error:
```
-  queryResponse?: SeriesData[];
-  queryError?: DataQueryError;
+  panelData: PanelData; // The current panel data
+  queryResponse?: PanelData; // data filtered to only this query.  Includes the error.
```

This change does not seem to affect anything in the code, so that makes me a little concerned :)

This becomes more important for #16676 and #16660 -- both need more info in the editor

