### PR TITLE
Add meta-variable for better templating experience

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/template.html
+++ b/public/app/features/dashboard/components/SubMenu/template.html
@@ -4,8 +4,9 @@
       <label class="gf-form-label template-variable" ng-hide="variable.hide === 1">
         {{variable.label || variable.name}}
       </label>
-      <value-select-dropdown ng-if="variable.type !== 'adhoc' && variable.type !== 'textbox'" dashboard="ctrl.dashboard" variable="variable" on-updated="ctrl.variableUpdated(variable)"></value-select-dropdown>
+      <value-select-dropdown ng-if="variable.type !== 'adhoc' && variable.type !== 'textbox' && variable.type !== 'meta'" dashboard="ctrl.dashboard" variable="variable" on-updated="ctrl.variableUpdated(variable)"></value-select-dropdown>
       <input type="text" ng-if="variable.type === 'textbox'" ng-model="variable.query" class="gf-form-input width-12"  ng-blur="variable.current.value != variable.query && variable.updateOptions() && ctrl.variableUpdated(variable);" ng-keydown="$event.keyCode === 13 && variable.current.value != variable.query && variable.updateOptions() && ctrl.variableUpdated(variable);" ></input>
+      <input type="text" ng-if="variable.type === 'meta'" ng-model="variable.query" class="gf-form-input width-12" ng-blur="variable.current.text != variable.query && variable.updateOptions() && ctrl.variableUpdated(variable);" ng-keydown="$event.keyCode === 13 && variable.current.text != variable.query && variable.updateOptions() && ctrl.variableUpdated(variable);" ></input>
     </div>
     <ad-hoc-filters ng-if="variable.type === 'adhoc'" variable="variable" dashboard="ctrl.dashboard"></ad-hoc-filters>
   </div>

--- a/public/app/features/templating/meta_variable.ts
+++ b/public/app/features/templating/meta_variable.ts
@@ -1,0 +1,60 @@
+import { Variable, assignModelProperties, variableTypes, containsVariable } from './variable';
+
+export class MetaVariable implements Variable {
+  query: string;
+  current: any;
+  options: any[];
+  skipUrlSync: boolean;
+
+  defaults = {
+    type: 'meta',
+    name: '',
+    hide: 2,
+    label: '',
+    query: '',
+    current: {},
+    options: [],
+    skipUrlSync: false,
+  };
+
+  /** @ngInject */
+  constructor(private model, private variableSrv, private templateSrv) {
+    assignModelProperties(this, model, this.defaults);
+  }
+
+  getSaveModel() {
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
+
+  setValue(option) {
+    this.variableSrv.setOptionAsCurrent(this, option);
+  }
+
+  updateOptions() {
+    const text = this.query.trim(),
+          value = this.templateSrv.replace(text, this.templateSrv.variables);
+    this.options = [{ text: text, value: value }];
+    this.current = this.options[0];
+    return Promise.resolve();
+  }
+
+  dependsOn(variable) {
+    return containsVariable(this.query, variable.name);
+  }
+
+  setValueFromUrl(urlValue) {
+    this.query = urlValue;
+    return this.variableSrv.setOptionFromUrl(this, urlValue);
+  }
+
+  getValueForUrl() {
+    return this.current.text;
+  }
+}
+
+variableTypes['meta'] = {
+  name: 'Meta',
+  ctor: MetaVariable,
+  description: 'Define a hidden meta variable, where users can use other variables',
+};

--- a/public/app/features/templating/meta_variable.ts
+++ b/public/app/features/templating/meta_variable.ts
@@ -32,8 +32,8 @@ export class MetaVariable implements Variable {
   }
 
   updateOptions() {
-    const text = this.query.trim(),
-          value = this.templateSrv.replace(text, this.templateSrv.variables);
+    const text = this.query.trim();
+    const value = this.templateSrv.replace(text, this.templateSrv.variables);
     this.options = [{ text: text, value: value }];
     this.current = this.options[0];
     return Promise.resolve();

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -193,6 +193,14 @@
       </div>
     </div>
 
+    <div ng-if="current.type === 'meta'" class="gf-form-group">
+      <h5 class="section-heading">Meta options</h5>
+      <div class="gf-form">
+        <span class="gf-form-label">Expression</span>
+        <textarea class="gf-form-input" ng-model='current.query' ng-blur="runQuery()" placeholder='region=~"$region", instance=~"$instance"'></textarea>
+      </div>
+    </div>
+
     <div ng-if="current.type === 'custom'" class="gf-form-group">
       <h5 class="section-heading">Custom Options</h5>
       <div class="gf-form">


### PR DESCRIPTION
Meta-variable allows to reference already declared variables
which gives additional flexibility in queries. 

**What this PR does / why we need it**:
Meta-variable allows to reference already declared variables which gives additional flexibility in queries. For example, create variable `commonFilter` with following content: `region=~"$region", instance=~"$instance"`, where `region` and `instance` were already declared. Then we can use meta-variable in query: `up{$commonFilter}`.

**Which issue(s) this PR fixes**:
Fixes #16582 

