### PR TITLE
Do not override default `hide` attribute for variables

### DIFF
--- a/public/app/features/templating/TextBoxVariable.ts
+++ b/public/app/features/templating/TextBoxVariable.ts
@@ -9,7 +9,7 @@ export class TextBoxVariable implements Variable {
   defaults = {
     type: 'textbox',
     name: '',
-    hide: 2,
+    hide: 0,
     label: '',
     query: '',
     current: {},

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -163,7 +163,6 @@ export class VariableEditorCtrl {
         type: $scope.current.type,
       });
       $scope.current.name = old.name;
-      $scope.current.hide = old.hide;
       $scope.current.label = old.label;
 
       const oldIndex = _.indexOf(this.variables, old);


### PR DESCRIPTION
Some variables like `constant` or `textBox` are configured to be hidden by default but this setting is ignored.

**What this PR does / why we need it**:
This PR removes override of `hide` attribute when creating variable since some types are preconfigured to be hidden by default

**Which issue(s) this PR fixes**:
Fixes #16695 