### PR TITLE
PanelQueryRunner: add datasource name to queries

### DIFF
--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -127,11 +127,26 @@ export class PanelQueryRunner {
 
     let loadingStateTimeoutId = 0;
 
+    // Quick return when no queries
+    if (!request.targets.length) {
+      const data = state.setEmpty();
+      this.subject.next(data);
+      return data;
+    }
+
     try {
       const ds =
         datasource && (datasource as any).query
           ? (datasource as DataSourceApi)
           : await getDatasourceSrv().get(datasource as string, request.scopedVars);
+
+      // Attach the datasource name to each query
+      request.targets = request.targets.map(query => {
+        if (!query.datasource) {
+          query.datasource = ds.name;
+        }
+        return query;
+      });
 
       const lowerIntervalLimit = minInterval ? templateSrv.replace(minInterval, request.scopedVars) : ds.interval;
       const norm = kbn.calculateInterval(timeRange, widthPixels, lowerIntervalLimit);

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -127,13 +127,6 @@ export class PanelQueryRunner {
 
     let loadingStateTimeoutId = 0;
 
-    // Quick return when no queries
-    if (!request.targets.length) {
-      const data = state.setEmpty();
-      this.subject.next(data);
-      return data;
-    }
-
     try {
       const ds =
         datasource && (datasource as any).query

--- a/public/app/features/dashboard/state/PanelQueryState.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.ts
@@ -140,6 +140,18 @@ export class PanelQueryState {
     return this.data;
   }
 
+  setEmpty(): PanelData {
+    if (!this.request.endTime) {
+      this.request.endTime = Date.now();
+    }
+    return (this.data = {
+      state: LoadingState.Done,
+      series: [],
+      legacy: [],
+      request: this.request,
+    });
+  }
+
   setError(err: any): PanelData {
     if (!this.request.endTime) {
       this.request.endTime = Date.now();

--- a/public/app/features/dashboard/state/PanelQueryState.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.ts
@@ -140,18 +140,6 @@ export class PanelQueryState {
     return this.data;
   }
 
-  setEmpty(): PanelData {
-    if (!this.request.endTime) {
-      this.request.endTime = Date.now();
-    }
-    return (this.data = {
-      state: LoadingState.Done,
-      series: [],
-      legacy: [],
-      request: this.request,
-    });
-  }
-
   setError(err: any): PanelData {
     if (!this.request.endTime) {
       this.request.endTime = Date.now();


### PR DESCRIPTION
This sets the `datasource` attribute on all request queries.  This is helpful later so that the response can know which datasource issued the query.  (empty loads the default)