### PR TITLE
Prometheus: Adds tracing headers for Prometheus datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -59,6 +59,15 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     return query.expr;
   }
 
+  _addTracingHeaders(httpOptions: any, options: any) {
+    httpOptions.headers = options.headers || {};
+    const proxyMode = !this.url.match(/^http/);
+    if (proxyMode) {
+      httpOptions.headers['X-Dashboard-Id'] = options.dashboardId;
+      httpOptions.headers['X-Panel-Id'] = options.panelId;
+    }
+  }
+
   _request(url, data?, options?: any) {
     options = _.defaults(options || {}, {
       url: this.url + url,
@@ -75,9 +84,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
           }).join('&');
       }
     } else {
-      options.headers = {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      };
+      options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
       options.transformRequest = data => {
         return $.param(data);
       };
@@ -89,9 +96,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     }
 
     if (this.basicAuth) {
-      options.headers = {
-        Authorization: this.basicAuth,
-      };
+      options.headers.Authorization = this.basicAuth;
     }
 
     return this.backendSrv.datasourceRequest(options);
@@ -233,6 +238,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     const adjusted = alignRange(start, end, query.step);
     query.start = adjusted.start;
     query.end = adjusted.end;
+    this._addTracingHeaders(query, options);
 
     return query;
   }
@@ -261,7 +267,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     if (this.queryTimeout) {
       data['timeout'] = this.queryTimeout;
     }
-    return this._request(url, data, { requestId: query.requestId });
+    return this._request(url, data, { requestId: query.requestId, headers: query.headers });
   }
 
   performInstantQuery(query, time) {
@@ -273,7 +279,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     if (this.queryTimeout) {
       data['timeout'] = this.queryTimeout;
     }
-    return this._request(url, data, { requestId: query.requestId });
+    return this._request(url, data, { requestId: query.requestId, headers: query.headers });
   }
 
   performSuggestQuery(query, cache = false) {

--- a/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
@@ -1232,4 +1232,27 @@ describe('PrometheusDatasource for POST', () => {
       expect(results.data[0].target).toBe('test{job="testjob"}');
     });
   });
+
+  describe('When querying prometheus via check headers X-Dashboard-Id and X-Panel-Id', () => {
+    const options = { dashboardId: 1, panelId: 2 };
+
+    const httpOptions = {
+      headers: {},
+    };
+
+    it('with proxy access tracing headers should be added', () => {
+      ctx.ds = new PrometheusDatasource(instanceSettings, q, backendSrv as any, templateSrv, timeSrv);
+      ctx.ds._addTracingHeaders(httpOptions, options);
+      expect(httpOptions.headers['X-Dashboard-Id']).toBe(1);
+      expect(httpOptions.headers['X-Panel-Id']).toBe(2);
+    });
+
+    it('with direct access tracing headers should not be added', () => {
+      instanceSettings.url = 'http://127.0.0.1:8000';
+      ctx.ds = new PrometheusDatasource(instanceSettings, q, backendSrv as any, templateSrv, timeSrv);
+      ctx.ds._addTracingHeaders(httpOptions, options);
+      expect(httpOptions.headers['X-Dashboard-Id']).toBe(undefined);
+      expect(httpOptions.headers['X-Panel-Id']).toBe(undefined);
+    });
+  });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Headers that should be added to prometheus datasource:
- X-Dashboard-Id
- X-Panel-Id

Those 2 headers already exist in the graphite dashboard, so it is good to
have it in the prometheus datasource as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
