### PR TITLE
Fix: No refresh button in playlists

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -53,6 +53,7 @@ export class RefreshPicker extends PureComponent<Props> {
     const selectedValue = options.find(item => item.value === currentValue) || offOption;
 
     const cssClasses = classNames({
+      'navbar-button--refresh-picker': true,
       'refresh-picker': true,
       'refresh-picker--refreshing': selectedValue.label !== offOption.label,
     });

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -266,7 +266,7 @@ export class DashNav extends PureComponent<Props> {
         </div>
 
         {!dashboard.timepicker.hidden && (
-          <div className="navbar-buttons">
+          <div className="navbar-buttons navbar-buttons--time-controls">
             <DashNavTimeControls dashboard={dashboard} location={location} updateLocation={updateLocation} />
             <div className="gf-timepicker-nav" ref={element => (this.timePickerEl = element)} />
           </div>

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -266,7 +266,7 @@ export class DashNav extends PureComponent<Props> {
         </div>
 
         {!dashboard.timepicker.hidden && (
-          <div className="navbar-buttons navbar-buttons--time-controls">
+          <div className="navbar-buttons">
             <DashNavTimeControls dashboard={dashboard} location={location} updateLocation={updateLocation} />
             <div className="gf-timepicker-nav" ref={element => (this.timePickerEl = element)} />
           </div>

--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -17,7 +17,7 @@
   }
 
   .navbar-button--zoom,
-  .navbar-button--refresh {
+  .navbar-button--refresh-picker {
     display: none;
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
Right now there's only half of the refresh picker shown in the playlists.

![Screenshot 2019-04-23 15 57 44](https://user-images.githubusercontent.com/224493/56586761-92b62100-65e0-11e9-8c79-afe5b183098c.png)

This PR hides the button completely.
![Screenshot 2019-04-23 15 59 57](https://user-images.githubusercontent.com/224493/56586914-df99f780-65e0-11e9-89af-a743728216ee.png)
