### PR TITLE
Playlist: Fix loading dashboards by tag

### DIFF
--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -55,7 +55,7 @@ func populateDashboardsByTag(orgID int64, signedInUser *m.SignedInUser, dashboar
 					Slug:  item.Slug,
 					Title: item.Title,
 					Uri:   item.Uri,
-					Url:   m.GetDashboardUrl(item.Uid, item.Slug),
+					Url:   item.Url,
 					Order: dashboardTagOrder[tag],
 				})
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes playlists based on tags working again.

**Which issue(s) this PR fixes**:
Fixes #16704 

**Special notes for your reviewer**:

