### PR TITLE
WIP/POC - Enable declarative way of panel options / editors definition

### DIFF
--- a/packages/grafana-ui/src/components/PanelOptions/BooleanOption.tsx
+++ b/packages/grafana-ui/src/components/PanelOptions/BooleanOption.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Switch } from '../Switch/Switch';
+import { OptionInputAPI } from '../../types/panelOptions';
+
+interface BooleanOptionProps extends OptionInputAPI<boolean> {
+  label: string;
+}
+
+export const BooleanOption: React.FunctionComponent<BooleanOptionProps> = ({ label, value, onChange }) => {
+  return (
+    <Switch
+      label={label}
+      checked={value}
+      onChange={event => {
+        if (event) {
+          onChange((event.target as HTMLInputElement).checked);
+        }
+      }}
+    />
+  );
+};

--- a/packages/grafana-ui/src/components/PanelOptions/NumericInputOption.tsx
+++ b/packages/grafana-ui/src/components/PanelOptions/NumericInputOption.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Input } from '../Input/Input';
+import { FormField } from '../FormField/FormField';
+import { OptionInputAPI } from '../../types/panelOptions';
+
+interface NumericOptionProps extends OptionInputAPI<number> {
+  label: string;
+  float?: boolean;
+}
+
+const NumericOption: React.FunctionComponent<NumericOptionProps> = ({ float, label, value, onChange }) => {
+  return (
+    <FormField
+      label={label}
+      inputEl={
+        <Input
+          type="number"
+          value={value}
+          onChange={event => {
+            if (float) {
+              onChange(parseFloat(event.currentTarget.value));
+            } else {
+              onChange(parseInt((event.currentTarget as HTMLInputElement).value, 10), event);
+            }
+          }}
+        />
+      }
+    />
+  );
+};
+
+export const FloatOption: React.FunctionComponent<NumericOptionProps> = props => <NumericOption {...props} float />;
+export const IntegerOption: React.FunctionComponent<NumericOptionProps> = props => (
+  <NumericOption {...props} float={false} />
+);

--- a/packages/grafana-ui/src/components/PanelOptions/PanelOptionsBuilder.story.tsx
+++ b/packages/grafana-ui/src/components/PanelOptions/PanelOptionsBuilder.story.tsx
@@ -1,0 +1,157 @@
+import { storiesOf } from '@storybook/react';
+import { PanelOptionsUIBuilder } from './PanelOptionsBuilder';
+import React from 'react';
+import { SingleStatValueEditor, SingleStatBaseOptions } from '../SingleStatShared/shared';
+import { BooleanOption } from './BooleanOption';
+import { FloatOption, IntegerOption } from './NumericInputOption';
+import { UseState } from '../../utils/storybook/UseState';
+import { ThresholdsEditor } from '../ThresholdsEditor/ThresholdsEditor';
+import { StatID } from '../../utils/statsCalculator';
+import { ValueMappingsEditor } from '../ValueMappingsEditor/ValueMappingsEditor';
+import { OptionsUIModel, GroupLayoutType, OptionType, OptionUIModel, PanelUIModel } from '../../types/panelOptions';
+import { action } from '@storybook/addon-actions';
+
+const story = storiesOf('Alpha/PanelOptionsUIBuilder', module);
+
+export interface GaugeOptions extends SingleStatBaseOptions {
+  maxValue: number;
+  minValue: number;
+  showThresholdLabels: boolean;
+  showThresholdMarkers: boolean;
+}
+
+const defaultOptions: GaugeOptions = {
+  maxValue: 10,
+  minValue: 0,
+  showThresholdLabels: false,
+  showThresholdMarkers: false,
+  valueOptions: {
+    prefix: '',
+    suffix: '',
+    decimals: null,
+    stat: StatID.mean,
+    unit: 'none',
+  },
+  thresholds: [
+    {
+      index: 0,
+      // @ts-ignore
+      value: null,
+      color: 'green',
+    },
+    {
+      index: 1,
+      value: 80,
+      color: 'red',
+    },
+  ],
+  valueMappings: [],
+};
+
+story.add('default', () => {
+  return (
+    <div>
+      <UseState initialState={defaultOptions}>
+        {(options, updateState) => {
+          return (
+            <PanelOptionsUIBuilder
+              uiModel={GaugeOptionsModel}
+              options={options}
+              onOptionsChange={(key, value) => {
+                const stateUpdate: { [key: string]: any } = {};
+                stateUpdate[key] = value;
+                action('Options changed:')(stateUpdate);
+                updateState({
+                  ...options,
+                  ...stateUpdate,
+                });
+              }}
+            />
+          );
+        }}
+      </UseState>
+    </div>
+  );
+});
+
+const GaugeOptionsModel: OptionsUIModel<GaugeOptions> = {
+  rows: [
+    {
+      columns: 3,
+      content: [
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Gauge',
+          },
+          options: [
+            {
+              type: OptionType.Float,
+              path: 'minValue',
+              component: IntegerOption,
+              label: 'Min value',
+              placeholder: 'Min value',
+            } as OptionUIModel<GaugeOptions, 'minValue'>,
+            {
+              type: OptionType.Float,
+              path: 'maxValue',
+              component: FloatOption,
+              label: 'Max value',
+              placeholder: 'Max value',
+            } as OptionUIModel<GaugeOptions, 'maxValue'>,
+            {
+              type: OptionType.Boolean,
+              path: 'showThresholdLabels',
+              component: BooleanOption,
+              label: 'Show labels',
+            } as OptionUIModel<GaugeOptions, 'showThresholdLabels'>,
+            {
+              type: OptionType.Boolean,
+              path: 'showThresholdMarkers',
+              component: BooleanOption,
+              label: 'Show markers',
+            } as OptionUIModel<GaugeOptions, 'showThresholdMarkers'>,
+          ],
+        } as PanelUIModel,
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Value Settings',
+          },
+          options: [
+            {
+              type: OptionType.Object,
+              path: 'valueOptions',
+              component: SingleStatValueEditor,
+            } as OptionUIModel<GaugeOptions, 'valueOptions'>,
+          ],
+        } as PanelUIModel,
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Thresholds',
+          },
+          options: [
+            {
+              type: OptionType.Array,
+              path: 'thresholds',
+              component: ThresholdsEditor,
+            } as OptionUIModel<GaugeOptions, 'thresholds'>,
+          ],
+        } as PanelUIModel,
+      ],
+    },
+    {
+      columns: 1,
+      content: [
+        {
+          type: OptionType.Object,
+          path: 'valueMappings',
+          component: ValueMappingsEditor,
+          label: 'Min value',
+          placeholder: 'Min value',
+        } as OptionUIModel<GaugeOptions, 'valueMappings'>,
+      ],
+    },
+  ],
+};

--- a/packages/grafana-ui/src/components/PanelOptions/PanelOptionsBuilder.tsx
+++ b/packages/grafana-ui/src/components/PanelOptions/PanelOptionsBuilder.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { PanelOptionsGrid, PanelOptionsGroup } from '../../components/index';
+import { OptionsUIModel, isOptionModel, isOptionsPanelModel, isSelectOption } from '../../types/panelOptions';
+
+interface PanelOptionsBilderProps<TOptions> {
+  uiModel: OptionsUIModel<TOptions>;
+  options: TOptions;
+  onOptionsChange: <K extends keyof TOptions>(key: K, value: TOptions[K]) => void;
+}
+
+export function PanelOptionsUIBuilder<TOptions extends { [key: string]: any }>(
+  props: PanelOptionsBilderProps<TOptions>
+) {
+  const { uiModel, options } = props;
+  return (
+    <>
+      {uiModel.rows.map(r => {
+        return (
+          <div>
+            <PanelOptionsGrid cols={r.columns}>
+              <>
+                {r.content.map(c => {
+                  if (isOptionModel(c)) {
+                    if (!c.component) {
+                      return null;
+                    }
+                    return React.createElement(c.component, {
+                      value: options[c.path],
+                      onChange: (value: any) => props.onOptionsChange(c.path, value),
+                    });
+                  } else {
+                    if (isOptionsPanelModel(c)) {
+                      return (
+                        <PanelOptionsGroup title={c.groupOptions.title}>
+                          {c.options.map(o => {
+                            if (isSelectOption(o)) {
+                              return React.createElement(o.component as any, {
+                                value: options[o.path],
+                                options: o.options,
+                                onChange: (value: any) => props.onOptionsChange(o.path, value),
+                                label: o.label,
+                                placeholder: o.placeholder,
+                              });
+                            }
+                            return React.createElement(o.component as any, {
+                              value: options[o.path],
+                              onChange: (value: any) => props.onOptionsChange(o.path, value),
+                              label: o.label,
+                              placeholder: o.placeholder,
+                            });
+                          })}
+                        </PanelOptionsGroup>
+                      );
+                    } else {
+                      return <h1>asd</h1>;
+                    }
+                  }
+                })}
+              </>
+            </PanelOptionsGrid>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/grafana-ui/src/components/PanelOptionsGrid/PanelOptionsGrid.tsx
+++ b/packages/grafana-ui/src/components/PanelOptionsGrid/PanelOptionsGrid.tsx
@@ -1,10 +1,23 @@
-import React, { SFC } from 'react';
+import React, { SFC, useContext } from 'react';
+import { ThemeContext } from '../../themes/ThemeContext';
+import { css } from 'emotion';
 
 interface Props {
   cols?: number;
   children: JSX.Element[] | JSX.Element;
 }
 
-export const PanelOptionsGrid: SFC<Props> = ({ children }) => {
-  return <div className="panel-options-grid">{children}</div>;
+const getStyles = (columns = 3, breakpoint: string) => css`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  grid-row-gap: 10px;
+  grid-column-gap: 10px;
+  @media screen and (min-width: ${breakpoint}) {
+    grid-template-columns: repeat(${columns}, 1fr);
+  }
+`;
+
+export const PanelOptionsGrid: SFC<Props> = ({ cols, children }) => {
+  const theme = useContext(ThemeContext);
+  return <div className={getStyles(cols, theme.breakpoints.lg)}>{children}</div>;
 };

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -42,6 +42,7 @@ export class RefreshPicker extends PureComponent<Props> {
   onChangeSelect = (item: SelectOptionItem<string>) => {
     const { onIntervalChanged } = this.props;
     if (onIntervalChanged) {
+      // @ts-ignore
       onIntervalChanged(item.value);
     }
   };

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -33,13 +33,13 @@ export class RefreshPicker extends PureComponent<Props> {
     return false;
   };
 
-  intervalsToOptions = (intervals: string[] = defaultIntervals): SelectOptionItem[] => {
+  intervalsToOptions = (intervals: string[] = defaultIntervals): Array<SelectOptionItem<string>> => {
     const options = intervals.map(interval => ({ label: interval, value: interval }));
     options.unshift(offOption);
     return options;
   };
 
-  onChangeSelect = (item: SelectOptionItem) => {
+  onChangeSelect = (item: SelectOptionItem<string>) => {
     const { onIntervalChanged } = this.props;
     if (onIntervalChanged) {
       onIntervalChanged(item.value);

--- a/packages/grafana-ui/src/components/Select/ButtonSelect.story.tsx
+++ b/packages/grafana-ui/src/components/Select/ButtonSelect.story.tsx
@@ -12,9 +12,9 @@ const ButtonSelectStories = storiesOf('UI/Select/ButtonSelect', module);
 ButtonSelectStories.addDecorator(withCenteredStory).addDecorator(withKnobs);
 
 ButtonSelectStories.add('default', () => {
-  const intialState: SelectOptionItem = { label: 'A label', value: 'A value' };
-  const value = object<SelectOptionItem>('Selected Value:', intialState);
-  const options = object<SelectOptionItem[]>('Options:', [
+  const intialState: SelectOptionItem<string> = { label: 'A label', value: 'A value' };
+  const value = object<SelectOptionItem<string>>('Selected Value:', intialState);
+  const options = object<Array<SelectOptionItem<string>>>('Options:', [
     intialState,
     { label: 'Another label', value: 'Another value' },
   ]);

--- a/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
@@ -27,23 +27,23 @@ const ButtonComponent = (buttonProps: ButtonComponentProps) => (props: any) => {
   );
 };
 
-export interface Props {
+export interface Props<T> {
   className: string | undefined;
-  options: SelectOptionItem[];
-  value: SelectOptionItem;
+  options: Array<SelectOptionItem<T>>;
+  value: SelectOptionItem<T>;
   label?: string;
   iconClass?: string;
   components?: any;
   maxMenuHeight?: number;
-  onChange: (item: SelectOptionItem) => void;
+  onChange: (item: SelectOptionItem<T>) => void;
   tooltipContent?: PopperContent<any>;
   isMenuOpen?: boolean;
   onOpenMenu?: () => void;
   onCloseMenu?: () => void;
 }
 
-export class ButtonSelect extends PureComponent<Props> {
-  onChange = (item: SelectOptionItem) => {
+export class ButtonSelect<T> extends PureComponent<Props<T>> {
+  onChange = (item: SelectOptionItem<T>) => {
     const { onChange } = this.props;
     onChange(item);
   };

--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -20,22 +20,22 @@ import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { PopperContent } from '@grafana/ui/src/components/Tooltip/PopperController';
 import { Tooltip } from '@grafana/ui';
 
-export interface SelectOptionItem {
+export interface SelectOptionItem<T> {
   label?: string;
-  value?: any;
+  value?: T;
   imgUrl?: string;
   description?: string;
   [key: string]: any;
 }
 
-export interface CommonProps {
+export interface CommonProps<T> {
   defaultValue?: any;
-  getOptionLabel?: (item: SelectOptionItem) => string;
-  getOptionValue?: (item: SelectOptionItem) => string;
-  onChange: (item: SelectOptionItem) => {} | void;
+  getOptionLabel?: (item: SelectOptionItem<T>) => string;
+  getOptionValue?: (item: SelectOptionItem<T>) => string;
+  onChange: (item: SelectOptionItem<T>) => {} | void;
   placeholder?: string;
   width?: number;
-  value?: SelectOptionItem;
+  value?: SelectOptionItem<T>;
   className?: string;
   isDisabled?: boolean;
   isSearchable?: boolean;
@@ -55,13 +55,13 @@ export interface CommonProps {
   onCloseMenu?: () => void;
 }
 
-export interface SelectProps {
-  options: SelectOptionItem[];
+export interface SelectProps<T> {
+  options: Array<SelectOptionItem<T>>;
 }
 
-interface AsyncProps {
+interface AsyncProps<T> {
   defaultOptions: boolean;
-  loadOptions: (query: string) => Promise<SelectOptionItem[]>;
+  loadOptions: (query: string) => Promise<Array<SelectOptionItem<T>>>;
   loadingMessage?: () => string;
 }
 
@@ -95,7 +95,7 @@ export const MenuList = (props: any) => {
   );
 };
 
-export class Select extends PureComponent<CommonProps & SelectProps> {
+export class Select<T> extends PureComponent<CommonProps<T> & SelectProps<T>> {
   static defaultProps = {
     width: null,
     className: '',
@@ -201,7 +201,7 @@ export class Select extends PureComponent<CommonProps & SelectProps> {
   }
 }
 
-export class AsyncSelect extends PureComponent<CommonProps & AsyncProps> {
+export class AsyncSelect<T> extends PureComponent<CommonProps<T> & AsyncProps<T>> {
   static defaultProps = {
     width: null,
     className: '',

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatValueEditor.tsx
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatValueEditor.tsx
@@ -18,39 +18,39 @@ import { SingleStatValueOptions } from './shared';
 const labelWidth = 6;
 
 export interface Props {
-  options: SingleStatValueOptions;
+  value: SingleStatValueOptions;
   onChange: (valueOptions: SingleStatValueOptions) => void;
 }
 
 export class SingleStatValueEditor extends PureComponent<Props> {
-  onUnitChange = (unit: SelectOptionItem) => this.props.onChange({ ...this.props.options, unit: unit.value });
+  onUnitChange = (unit: SelectOptionItem<string>) => this.props.onChange({ ...this.props.value, unit: unit.value });
 
   onStatsChange = (stats: string[]) => {
     const stat = stats[0] || StatID.mean;
-    this.props.onChange({ ...this.props.options, stat });
+    this.props.onChange({ ...this.props.value, stat });
   };
 
   onDecimalChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!isNaN(parseInt(event.target.value, 10))) {
       this.props.onChange({
-        ...this.props.options,
+        ...this.props.value,
         decimals: parseInt(event.target.value, 10),
       });
     } else {
       this.props.onChange({
-        ...this.props.options,
+        ...this.props.value,
         decimals: null,
       });
     }
   };
 
   onPrefixChange = (event: ChangeEvent<HTMLInputElement>) =>
-    this.props.onChange({ ...this.props.options, prefix: event.target.value });
+    this.props.onChange({ ...this.props.value, prefix: event.target.value });
   onSuffixChange = (event: ChangeEvent<HTMLInputElement>) =>
-    this.props.onChange({ ...this.props.options, suffix: event.target.value });
+    this.props.onChange({ ...this.props.value, suffix: event.target.value });
 
   render() {
-    const { stat, unit, decimals, prefix, suffix } = this.props.options;
+    const { stat, unit, decimals, prefix, suffix } = this.props.value;
 
     let decimalsString = '';
     if (decimals !== null && decimals !== undefined && Number.isFinite(decimals as number)) {

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatValueEditor.tsx
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatValueEditor.tsx
@@ -23,6 +23,7 @@ export interface Props {
 }
 
 export class SingleStatValueEditor extends PureComponent<Props> {
+  // @ts-ignore
   onUnitChange = (unit: SelectOptionItem<string>) => this.props.onChange({ ...this.props.value, unit: unit.value });
 
   onStatsChange = (stats: string[]) => {

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -54,12 +54,12 @@ export class StatsPicker extends PureComponent<Props> {
     }
   };
 
-  onSelectionChange = (item: SelectOptionItem) => {
+  onSelectionChange = (item: SelectOptionItem<string>) => {
     const { onChange } = this.props;
     if (isArray(item)) {
       onChange(item.map(v => v.value));
     } else {
-      onChange([item.value]);
+      onChange(item.value ? [item.value] : []);
     }
   };
 
@@ -73,7 +73,7 @@ export class StatsPicker extends PureComponent<Props> {
       };
     });
 
-    const value: SelectOptionItem[] = options.filter(option => stats.find(stat => option.value === stat));
+    const value: Array<SelectOptionItem<string>> = options.filter(option => stats.find(stat => option.value === stat));
 
     return (
       <Select

--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.story.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.story.tsx
@@ -8,9 +8,9 @@ const ThresholdsEditorStories = storiesOf('UI/ThresholdsEditor', module);
 const thresholds = [{ index: 0, value: -Infinity, color: 'green' }, { index: 1, value: 50, color: 'red' }];
 
 ThresholdsEditorStories.add('default', () => {
-  return <ThresholdsEditor thresholds={[]} onChange={action('Thresholds changed')} />;
+  return <ThresholdsEditor value={[]} onChange={action('Thresholds changed')} />;
 });
 
 ThresholdsEditorStories.add('with thresholds', () => {
-  return <ThresholdsEditor thresholds={thresholds} onChange={action('Thresholds changed')} />;
+  return <ThresholdsEditor value={thresholds} onChange={action('Thresholds changed')} />;
 });

--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -6,7 +6,7 @@ import { colors } from '../../utils';
 const setup = (propOverrides?: Partial<Props>) => {
   const props: Props = {
     onChange: jest.fn(),
-    thresholds: [],
+    value: [],
   };
 
   Object.assign(props, propOverrides);
@@ -58,7 +58,7 @@ describe('Add threshold', () => {
 
   it('should add another threshold above a first', () => {
     const { instance } = setup({
-      thresholds: [{ index: 0, value: -Infinity, color: colors[0] }, { index: 1, value: 50, color: colors[2] }],
+      value: [{ index: 0, value: -Infinity, color: colors[0] }, { index: 1, value: 50, color: colors[2] }],
     });
 
     instance.onAddThreshold(2);
@@ -72,7 +72,7 @@ describe('Add threshold', () => {
 
   it('should add another threshold between first and second index', () => {
     const { instance } = setup({
-      thresholds: [
+      value: [
         { index: 0, value: -Infinity, color: colors[0] },
         { index: 1, value: 50, color: colors[2] },
         { index: 2, value: 75, color: colors[3] },
@@ -97,7 +97,7 @@ describe('Remove threshold', () => {
       { index: 1, value: 50, color: '#EAB839' },
       { index: 2, value: 75, color: '#6ED0E0' },
     ];
-    const { instance } = setup({ thresholds });
+    const { instance } = setup({ value: thresholds });
 
     instance.onRemoveThreshold(thresholds[0]);
 
@@ -110,7 +110,7 @@ describe('Remove threshold', () => {
       { index: 1, value: 50, color: '#EAB839' },
       { index: 2, value: 75, color: '#6ED0E0' },
     ];
-    const { instance } = setup({ thresholds });
+    const { instance } = setup({ value: thresholds });
 
     instance.onRemoveThreshold(thresholds[1]);
 
@@ -128,7 +128,7 @@ describe('change threshold value', () => {
       { index: 1, value: 50, color: '#EAB839' },
       { index: 2, value: 75, color: '#6ED0E0' },
     ];
-    const { instance } = setup({ thresholds });
+    const { instance } = setup({ value: thresholds });
 
     const mockEvent = ({ target: { value: '12' } } as any) as ChangeEvent<HTMLInputElement>;
 

--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.tsx
@@ -7,7 +7,7 @@ import { ThemeContext } from '../../themes';
 import { getColorFromHexRgbOrName } from '../../utils';
 
 export interface Props {
-  thresholds: Threshold[];
+  value: Threshold[];
   onChange: (thresholds: Threshold[]) => void;
 }
 
@@ -19,10 +19,10 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const addDefaultThreshold = this.props.thresholds.length === 0;
+    const addDefaultThreshold = this.props.value.length === 0;
     const thresholds: Threshold[] = addDefaultThreshold
       ? [{ index: 0, value: -Infinity, color: colors[0] }]
-      : props.thresholds;
+      : props.value;
     this.state = { thresholds };
 
     if (addDefaultThreshold) {

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -231,8 +231,10 @@ export class TimePicker extends PureComponent<Props, State> {
     ];
   };
 
-  onSelectChanged = (item: SelectOptionItem) => {
+  onSelectChanged = (item: SelectOptionItem<TimeOption>) => {
     const { isTimezoneUtc, onChange, timezone } = this.props;
+
+    // @ts-ignore
     onChange(mapTimeOptionToTimeRange(item.value, isTimezoneUtc, timezone));
   };
 
@@ -264,6 +266,7 @@ export class TimePicker extends PureComponent<Props, State> {
     const options = this.mapTimeOptionsToSelectOptionItems(selectTimeOptions);
     const rangeString = mapTimeRangeToRangeString(value);
     const isAbsolute = moment.isMoment(value.raw.to);
+
     return (
       <div className="time-picker">
         <div className="time-picker-buttons">

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
@@ -126,6 +126,7 @@ export default class MappingRow extends PureComponent<Props, State> {
             isSearchable={false}
             options={mappingOptions}
             value={mappingOptions.find(o => o.value === type)}
+            // @ts-ignore
             onChange={type => this.onMappingTypeChange(type.value)}
             width={7}
           />

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.story.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.story.tsx
@@ -6,5 +6,5 @@ import { ValueMappingsEditor } from './ValueMappingsEditor';
 const ValueMappingsEditorStories = storiesOf('UI/ValueMappingsEditor', module);
 
 ValueMappingsEditorStories.add('default', () => {
-  return <ValueMappingsEditor valueMappings={[]} onChange={action('Mapping changed')} />;
+  return <ValueMappingsEditor value={[]} onChange={action('Mapping changed')} />;
 });

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.test.tsx
@@ -7,7 +7,7 @@ import { MappingType } from '../../types';
 const setup = (propOverrides?: object) => {
   const props: Props = {
     onChange: jest.fn(),
-    valueMappings: [
+    value: [
       { id: 1, operator: '', type: MappingType.ValueToText, value: '20', text: 'Ok' },
       { id: 2, operator: '', type: MappingType.RangeToText, from: '21', to: '30', text: 'Meh' },
     ],

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
@@ -5,7 +5,7 @@ import { MappingType, ValueMapping } from '../../types';
 import { PanelOptionsGroup } from '../PanelOptionsGroup/PanelOptionsGroup';
 
 export interface Props {
-  valueMappings: ValueMapping[];
+  value: ValueMapping[];
   onChange: (valueMappings: ValueMapping[]) => void;
 }
 
@@ -18,7 +18,7 @@ export class ValueMappingsEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const mappings = props.valueMappings;
+    const mappings = props.value;
 
     this.state = {
       valueMappings: mappings,

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -49,3 +49,7 @@ export { VizRepeater } from './VizRepeater/VizRepeater';
 export { ClickOutsideWrapper } from './ClickOutsideWrapper/ClickOutsideWrapper';
 export * from './SingleStatShared/shared';
 export { CallToActionCard } from './CallToActionCard/CallToActionCard';
+
+export { PanelOptionsUIBuilder } from './PanelOptions/PanelOptionsBuilder';
+export { BooleanOption } from './PanelOptions/BooleanOption';
+export { FloatOption, IntegerOption } from './PanelOptions/NumericInputOption';

--- a/packages/grafana-ui/src/types/index.ts
+++ b/packages/grafana-ui/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './data';
 export * from './time';
 export * from './panel';
+export * from './panelOptions';
 export * from './plugin';
 export * from './datasource';
 export * from './theme';

--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -2,6 +2,7 @@ import { ComponentClass } from 'react';
 import { LoadingState, SeriesData } from './data';
 import { TimeRange } from './time';
 import { ScopedVars, DataRequestInfo, DataQueryError, LegacyResponseData } from './datasource';
+import { OptionsUIModel } from './panelOptions';
 
 export type InterpolateFunction = (value: string, scopedVars?: ScopedVars, format?: string | Function) => string;
 
@@ -54,7 +55,7 @@ export type PanelTypeChangedHandler<TOptions = any> = (
 
 export class ReactPanelPlugin<TOptions = any> {
   panel: ComponentClass<PanelProps<TOptions>>;
-  editor?: ComponentClass<PanelEditorProps<TOptions>>;
+  editor?: ComponentClass<PanelEditorProps<TOptions>> | OptionsUIModel<TOptions>;
   defaults?: TOptions;
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
@@ -63,7 +64,7 @@ export class ReactPanelPlugin<TOptions = any> {
     this.panel = panel;
   }
 
-  setEditor(editor: ComponentClass<PanelEditorProps<TOptions>>) {
+  setEditor(editor: ComponentClass<PanelEditorProps<TOptions>> | OptionsUIModel<TOptions>) {
     this.editor = editor;
     return this;
   }

--- a/packages/grafana-ui/src/types/panelOptions.tsx
+++ b/packages/grafana-ui/src/types/panelOptions.tsx
@@ -1,0 +1,181 @@
+import { SelectOptionItem } from '../components/Select/Select';
+
+/**
+ * Option editors, i.e. BooleanOption have to comply to OptionInputAPI.
+ * OptionInputAPI represents UI elements that allow value modification, name it string, boolean, complex object, whatever
+ */
+
+export interface OptionInputAPI<T> {
+  value: T;
+  onChange: (value: T, event?: React.SyntheticEvent<HTMLElement>) => void;
+}
+
+export interface OptionsRowModel<TOptions> {
+  columns: number;
+  content: Array<OptionUIModel<TOptions, any> | GroupLayoutUIModel<any>>;
+}
+export interface OptionsUIModel<TOptions> {
+  rows: Array<OptionsRowModel<TOptions>>;
+}
+
+export enum OptionType {
+  Text = 'text',
+  Float = 'float',
+  Integer = 'integer',
+  Boolean = 'boolean',
+  Object = 'object',
+  Array = 'array',
+}
+
+/**
+ * Introducing this interface to make sure component for manipulating given option
+ * handles the type that's specific for that option.
+ * i.e. for maxValue: number we expect the component to accept value property of that type
+ * and onChange handler that exposes modified value of that type.
+ *
+ * onChange has to accept event property as well. Exposing event as a second argument is purposeful.
+ * Driver for that is that the primary expected output from InputAPI component is it's modified value rather than the event object.
+ * But, event is also very important in certain cases, hence we need to keep it in the API.
+ */
+export interface OptionUIComponentProps<T> extends OptionInputAPI<T> {}
+
+export interface SelectOptionUIComponentProps<T> extends OptionInputAPI<SelectOptionItem<T>> {
+  options: Array<SelectOptionItem<T>>;
+}
+
+interface AbstractOptionUIModel<ComponentProps, P> {
+  type: OptionType;
+  /**
+   * Name of the options object property
+   * i.e. for GaugeOptions type:
+   * export const defaults: GaugeOptions = {
+   *   minValue: 0,
+   *   maxValue: 100,
+   *   ...
+   * }
+   * it could be 'minValue'
+   * Question: Should we name it option instead of path?
+   */
+  path: P;
+  /**
+   * Keeping component as optional on purpose to enable default components for simple types,
+   * i.e. number
+   */
+  component?: React.ComponentType<ComponentProps>;
+  label?: string;
+  placeholder?: string;
+}
+
+export interface OptionUIModel<TOptions, TKey extends keyof TOptions>
+  extends AbstractOptionUIModel<OptionUIComponentProps<TOptions[TKey]>, TKey> {}
+
+type LazySelectOptions<O> = () => Promise<O[]>;
+
+export interface SelectOptionUIModel<TOptions, TKey extends keyof TOptions>
+  extends AbstractOptionUIModel<SelectOptionUIComponentProps<TOptions[TKey]>, TKey> {
+  options: Array<SelectOptionItem<TOptions[TKey]>> | LazySelectOptions<SelectOptionItem<TOptions[TKey]>>;
+}
+
+export enum GroupLayoutType {
+  Panel = 'panel',
+  Fieldset = 'fieldset',
+}
+
+export interface GroupLayoutUIModel<K> {
+  type: GroupLayoutType;
+
+  /**
+   * Represents options of a given layout
+   */
+  groupOptions: K;
+
+  /**
+   * Represents panel options that belong to a given layout group
+   */
+  options: Array<OptionUIModel<any, any> | SelectOptionUIModel<any, any>>;
+}
+
+/**
+ * Represents a container for a group of options.
+ * Panel UI for options is characterised by a title with a gradient background
+ * Use it for grouping related options:
+ *
+ *      ++++++++++++++++++++++++++++++++++++++
+ *      + Panel title                        +
+ *      ++++++++++++++++++++++++++++++++++++++
+ *      + Option 1                    on/off +
+ *      + Option 2                    on/off +
+ *      + ...                                +
+ *      + ...                                +
+ *      ++++++++++++++++++++++++++++++++++++++
+ *
+ */
+export interface PanelUIModel extends GroupLayoutUIModel<{ title: string }> {}
+
+/**
+ * Represents a group of options
+ * Fieldset UI does not have any characteristic UI elements. It's basically a group of options
+ * with a title:
+ *
+ *      ++++++++++++++++++++++++++++++++++++++
+ *      * Fieldset title                     *
+ *      *                                    *
+ *      + Option 1                    on/off +
+ *      + Option 2                    on/off +
+ *      + ...                                +
+ *      ++++++++++++++++++++++++++++++++++++++
+ */
+export interface FieldsetUIModel
+  extends GroupLayoutUIModel<{
+    legend: string;
+  }> {} // legend property name inspired by https://www.w3schools.com/tags/tag_legend.asp
+
+/**
+ * Below are typeguards used by PanelOptionsBuilder components
+ */
+export function isOptionsUIModel(model: any): model is OptionsUIModel<any> {
+  return (model as OptionsUIModel<any>).rows !== undefined;
+}
+export function isOptionModel(
+  option: OptionUIModel<any, any> | GroupLayoutUIModel<any>
+): option is OptionUIModel<any, any> {
+  return (option as OptionUIModel<any, any>).path !== undefined;
+}
+
+export function isOptionsPanelModel(ui: PanelUIModel | FieldsetUIModel): ui is PanelUIModel {
+  return (ui as PanelUIModel).groupOptions.title !== undefined;
+}
+
+export function isSelectOption(
+  option: OptionUIModel<any, any> | SelectOptionUIModel<any, any>
+): option is SelectOptionUIModel<any, any> {
+  return (option as SelectOptionUIModel<any, any>).options !== undefined;
+}
+
+// // const uiOptionModel = new UIModel<GaugeOptions>()
+// //   .addRow(/*{row config }*/)
+// //     .addColumn()
+// //       .addPanel('Basic settings') // Creates
+// //         .useStatsPicker('Show', 'valueMappings.stats')
+// //         .useUnitPicker('Unit', 'valueMappings.unit')
+// //         .useDecimalsInput('Decimals', 'valueMappings.decimals')
+// //         .useTextInput('Prefix', 'valueMappings.prefix')
+// //         .useTextInput('Suffix', 'valueMappings.suffix')
+// //         .addBooleanOption('Title', 'option.path')
+// //         .addSelectOption('Title', 'option.path', )
+// //       .endPanel()
+// //     .endColumn()
+// //     .addColumn()
+// //       .addPanel('Gauge')
+// //         .useNumber('Min value', 'minValue')
+// //         .useNumber('Max value', 'maxValue')
+// //         .useToggle('Show labels', 'showThresholdLabels')
+// //         .useToggle('Show markers', 'showThresholdMarkers')
+// //       .endPanel()
+// //     .endColumn()
+// //     .addColumn()
+// //       .addPanel('Threshold')
+// //         .useThresholdEditor('thresholds')
+// //       .endPanel()
+// //     .endColumn()
+// //   .endRow();

--- a/packages/grafana-ui/src/utils/string.ts
+++ b/packages/grafana-ui/src/utils/string.ts
@@ -43,7 +43,7 @@ export function stringToMs(str: string): number {
   }
 }
 
-export function getIntervalFromString(strInterval: string): SelectOptionItem {
+export function getIntervalFromString(strInterval: string): SelectOptionItem<number> {
   return {
     label: strInterval,
     value: stringToMs(strInterval),

--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -61,7 +61,7 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
     this.setState({ teamId: team && !Array.isArray(team) ? team.id : 0 });
   };
 
-  onPermissionChanged = (permission: SelectOptionItem) => {
+  onPermissionChanged = (permission: SelectOptionItem<PermissionLevel>) => {
     this.setState({ permission: permission.value });
   };
 

--- a/public/app/core/components/Select/DataSourcePicker.tsx
+++ b/public/app/core/components/Select/DataSourcePicker.tsx
@@ -28,7 +28,7 @@ export class DataSourcePicker extends PureComponent<Props> {
     super(props);
   }
 
-  onChange = (item: SelectOptionItem) => {
+  onChange = (item: SelectOptionItem<string>) => {
     const ds = this.props.datasources.find(ds => ds.name === item.value);
     this.props.onChange(ds);
   };

--- a/public/app/core/components/Select/MetricSelect.tsx
+++ b/public/app/core/components/Select/MetricSelect.tsx
@@ -6,7 +6,7 @@ import { Variable } from 'app/types/templates';
 
 export interface Props {
   onChange: (value: string) => void;
-  options: SelectOptionItem[];
+  options: Array<SelectOptionItem<string>>;
   isSearchable: boolean;
   value: string;
   placeholder?: string;
@@ -15,7 +15,7 @@ export interface Props {
 }
 
 interface State {
-  options: any[];
+  options: Array<SelectOptionItem<string>>;
 }
 
 export class MetricSelect extends React.Component<Props, State> {

--- a/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
@@ -19,6 +19,7 @@ import { DashboardModel } from '../state';
 import { PanelPlugin } from 'app/types/plugins';
 import { VizPickerSearch } from './VizPickerSearch';
 import PluginStateinfo from 'app/features/plugins/PluginStateInfo';
+import { PanelOptionsUIBuilder, isOptionsUIModel, OptionsUIModel } from '@grafana/ui';
 
 interface Props {
   panel: PanelModel;
@@ -68,7 +69,24 @@ export class VisualizationTab extends PureComponent<Props, State> {
       const PanelEditor = plugin.reactPlugin.editor;
 
       if (PanelEditor) {
-        return <PanelEditor options={this.getReactPanelOptions()} onOptionsChange={this.onPanelOptionsChanged} />;
+        if (isOptionsUIModel(PanelEditor)) {
+          return (
+            <PanelOptionsUIBuilder
+              uiModel={PanelEditor as OptionsUIModel<any>}
+              options={this.getReactPanelOptions()}
+              onOptionsChange={(key, value) => {
+                const optionsUpdate: { [key: string]: any } = {};
+                optionsUpdate[key as string] = value;
+                this.onPanelOptionsChanged({
+                  ...this.getReactPanelOptions(),
+                  ...optionsUpdate,
+                });
+              }}
+            />
+          );
+        } else {
+          return <PanelEditor options={this.getReactPanelOptions()} onOptionsChange={this.onPanelOptionsChanged} />;
+        }
       }
     }
 

--- a/public/app/features/teams/TeamMemberRow.test.tsx
+++ b/public/app/features/teams/TeamMemberRow.test.tsx
@@ -80,7 +80,7 @@ describe('Functions', () => {
     };
     const { instance } = setup({ member });
     const permission = TeamPermissionLevel.Admin;
-    const item: SelectOptionItem = { value: permission };
+    const item: SelectOptionItem<TeamPermissionLevel> = { value: permission };
     const expectedTeamMemeber = { ...member, permission };
 
     instance.onPermissionChange(item, member);

--- a/public/app/features/teams/TeamMemberRow.tsx
+++ b/public/app/features/teams/TeamMemberRow.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { DeleteButton, Select, SelectOptionItem } from '@grafana/ui';
 
-import { TeamMember, teamsPermissionLevels } from 'app/types';
+import { TeamMember, teamsPermissionLevels, TeamPermissionLevel } from 'app/types';
 import { WithFeatureToggle } from 'app/core/components/WithFeatureToggle';
 import { updateTeamMember, removeTeamMember } from './state/actions';
 import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
@@ -27,7 +27,7 @@ export class TeamMemberRow extends PureComponent<Props> {
     this.props.removeTeamMember(member.userId);
   }
 
-  onPermissionChange = (item: SelectOptionItem, member: TeamMember) => {
+  onPermissionChange = (item: SelectOptionItem<TeamPermissionLevel>, member: TeamMember) => {
     const permission = item.value;
     const updatedTeamMember = { ...member, permission };
 

--- a/public/app/plugins/datasource/input/InputQueryEditor.tsx
+++ b/public/app/plugins/datasource/input/InputQueryEditor.tsx
@@ -29,7 +29,7 @@ export class InputQueryEditor extends PureComponent<Props, State> {
     this.setState({ text });
   }
 
-  onSourceChange = (item: SelectOptionItem) => {
+  onSourceChange = (item: SelectOptionItem<string>) => {
     const { datasource, query, onChange, onRunQuery } = this.props;
     let data: SeriesData[] | undefined = undefined;
     if (item.value === 'panel') {

--- a/public/app/plugins/datasource/stackdriver/components/Alignments.tsx
+++ b/public/app/plugins/datasource/stackdriver/components/Alignments.tsx
@@ -8,7 +8,7 @@ import { SelectOptionItem } from '@grafana/ui';
 export interface Props {
   onChange: (perSeriesAligner) => void;
   templateSrv: TemplateSrv;
-  alignOptions: SelectOptionItem[];
+  alignOptions: Array<SelectOptionItem<string>>;
   perSeriesAligner: string;
 }
 

--- a/public/app/plugins/datasource/stackdriver/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/stackdriver/components/QueryEditor.tsx
@@ -25,7 +25,7 @@ export interface Props {
 }
 
 interface State extends StackdriverQuery {
-  alignOptions: SelectOptionItem[];
+  alignOptions: Array<SelectOptionItem<string>>;
   lastQuery: string;
   lastQueryError: string;
   [key: string]: any;

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -40,7 +40,7 @@ export class QueryEditor extends PureComponent<Props> {
     this.setState({ scenarioList: scenarioList, current: current });
   }
 
-  onScenarioChange = (item: SelectOptionItem) => {
+  onScenarioChange = (item: SelectOptionItem<string>) => {
     this.props.onChange({
       ...this.props.query,
       scenarioId: item.value,

--- a/public/app/plugins/panel/bargauge/BarGaugePanelEditor.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanelEditor.tsx
@@ -46,7 +46,7 @@ export class BarGaugePanelEditor extends PureComponent<PanelEditorProps<BarGauge
     return (
       <>
         <PanelOptionsGrid>
-          <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
+          <SingleStatValueEditor onChange={this.onValueOptionsChanged} value={options.valueOptions} />
           <PanelOptionsGroup title="Gauge">
             <FormField label="Min value" labelWidth={8} onChange={this.onMinValueChange} value={options.minValue} />
             <FormField label="Max value" labelWidth={8} onChange={this.onMaxValueChange} value={options.maxValue} />

--- a/public/app/plugins/panel/bargauge/BarGaugePanelEditor.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanelEditor.tsx
@@ -71,10 +71,10 @@ export class BarGaugePanelEditor extends PureComponent<PanelEditorProps<BarGauge
               />
             </div>
           </PanelOptionsGroup>
-          <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
+          <ThresholdsEditor onChange={this.onThresholdsChanged} value={options.thresholds} />
         </PanelOptionsGrid>
 
-        <ValueMappingsEditor onChange={this.onValueMappingsChanged} valueMappings={options.valueMappings} />
+        <ValueMappingsEditor onChange={this.onValueMappingsChanged} value={options.valueMappings} />
       </>
     );
   }

--- a/public/app/plugins/panel/bargauge/types.ts
+++ b/public/app/plugins/panel/bargauge/types.ts
@@ -6,13 +6,13 @@ export interface BarGaugeOptions extends SingleStatBaseOptions {
   displayMode: 'basic' | 'lcd' | 'gradient';
 }
 
-export const displayModes: SelectOptionItem[] = [
+export const displayModes: Array<SelectOptionItem<string>> = [
   { value: 'gradient', label: 'Gradient' },
   { value: 'lcd', label: 'Retro LCD' },
   { value: 'basic', label: 'Basic' },
 ];
 
-export const orientationOptions: SelectOptionItem[] = [
+export const orientationOptions: Array<SelectOptionItem<VizOrientation>> = [
   { value: VizOrientation.Horizontal, label: 'Horizontal' },
   { value: VizOrientation.Vertical, label: 'Vertical' },
 ];

--- a/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
@@ -39,7 +39,7 @@ export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOption
     return (
       <>
         <PanelOptionsGrid>
-          <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
+          <SingleStatValueEditor onChange={this.onValueOptionsChanged} value={options.valueOptions} />
           <GaugeOptionsBox onOptionsChange={onOptionsChange} options={options} />
           <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
         </PanelOptionsGrid>

--- a/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
@@ -41,10 +41,10 @@ export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOption
         <PanelOptionsGrid>
           <SingleStatValueEditor onChange={this.onValueOptionsChanged} value={options.valueOptions} />
           <GaugeOptionsBox onOptionsChange={onOptionsChange} options={options} />
-          <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
+          <ThresholdsEditor onChange={this.onThresholdsChanged} value={options.thresholds} />
         </PanelOptionsGrid>
 
-        <ValueMappingsEditor onChange={this.onValueMappingsChanged} valueMappings={options.valueMappings} />
+        <ValueMappingsEditor onChange={this.onValueMappingsChanged} value={options.valueMappings} />
       </>
     );
   }

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,10 +1,106 @@
-import { ReactPanelPlugin, sharedSingleStatMigrationCheck, sharedSingleStatOptionsCheck } from '@grafana/ui';
-import { GaugePanelEditor } from './GaugePanelEditor';
+import {
+  ReactPanelPlugin,
+  sharedSingleStatMigrationCheck,
+  sharedSingleStatOptionsCheck,
+  GroupLayoutType,
+  OptionType,
+  OptionUIModel,
+  PanelUIModel,
+  SingleStatValueEditor,
+  ThresholdsEditor,
+  ValueMappingsEditor,
+  BooleanOption,
+  IntegerOption,
+  FloatOption,
+} from '@grafana/ui';
+// import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
 
+const getGaugePanelOptionsUIModel = () => ({
+  rows: [
+    {
+      columns: 3,
+      content: [
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Gauge',
+          },
+          options: [
+            {
+              type: OptionType.Float,
+              path: 'minValue',
+              component: IntegerOption,
+              label: 'Min value',
+              placeholder: 'Min value',
+            } as OptionUIModel<GaugeOptions, 'minValue'>,
+            {
+              type: OptionType.Float,
+              path: 'maxValue',
+              component: FloatOption,
+              label: 'Max value',
+              placeholder: 'Max value',
+            } as OptionUIModel<GaugeOptions, 'maxValue'>,
+            {
+              type: OptionType.Boolean,
+              path: 'showThresholdLabels',
+              component: BooleanOption,
+              label: 'Show labels',
+            } as OptionUIModel<GaugeOptions, 'showThresholdLabels'>,
+            {
+              type: OptionType.Boolean,
+              path: 'showThresholdMarkers',
+              component: BooleanOption,
+              label: 'Show markers',
+            } as OptionUIModel<GaugeOptions, 'showThresholdMarkers'>,
+          ],
+        } as PanelUIModel,
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Value Settings',
+          },
+          options: [
+            {
+              type: OptionType.Object,
+              path: 'valueOptions',
+              component: SingleStatValueEditor,
+            } as OptionUIModel<GaugeOptions, 'valueOptions'>,
+          ],
+        } as PanelUIModel,
+        {
+          type: GroupLayoutType.Panel,
+          groupOptions: {
+            title: 'Thresholds',
+          },
+          options: [
+            {
+              type: OptionType.Array,
+              path: 'thresholds',
+              component: ThresholdsEditor,
+            } as OptionUIModel<GaugeOptions, 'thresholds'>,
+          ],
+        } as PanelUIModel,
+      ],
+    },
+    {
+      columns: 1,
+      content: [
+        {
+          type: OptionType.Object,
+          path: 'valueMappings',
+          component: ValueMappingsEditor,
+          label: 'Min value',
+          placeholder: 'Min value',
+        } as OptionUIModel<GaugeOptions, 'valueMappings'>,
+      ],
+    },
+  ],
+});
+
 export const reactPanel = new ReactPanelPlugin<GaugeOptions>(GaugePanel)
   .setDefaults(defaults)
-  .setEditor(GaugePanelEditor)
+  .setEditor(getGaugePanelOptionsUIModel())
   .setPanelChangeHandler(sharedSingleStatOptionsCheck)
   .setMigrationHandler(sharedSingleStatMigrationCheck);

--- a/public/app/plugins/panel/piechart/PieChartPanelEditor.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanelEditor.tsx
@@ -30,7 +30,7 @@ export class PieChartPanelEditor extends PureComponent<PanelEditorProps<PieChart
     return (
       <>
         <PanelOptionsGrid>
-          <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
+          <SingleStatValueEditor onChange={this.onValueOptionsChanged} value={options.valueOptions} />
           <PieChartOptionsBox onOptionsChange={onOptionsChange} options={options} />
         </PanelOptionsGrid>
 

--- a/public/app/plugins/panel/piechart/PieChartPanelEditor.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanelEditor.tsx
@@ -34,7 +34,7 @@ export class PieChartPanelEditor extends PureComponent<PanelEditorProps<PieChart
           <PieChartOptionsBox onOptionsChange={onOptionsChange} options={options} />
         </PanelOptionsGrid>
 
-        <ValueMappingsEditor onChange={this.onValueMappingsChanged} valueMappings={options.valueMappings} />
+        <ValueMappingsEditor onChange={this.onValueMappingsChanged} value={options.valueMappings} />
       </>
     );
   }

--- a/public/app/plugins/panel/singlestat2/FontSizeEditor.tsx
+++ b/public/app/plugins/panel/singlestat2/FontSizeEditor.tsx
@@ -20,11 +20,13 @@ const fontSizeOptions = percents.map(v => {
 });
 
 export class FontSizeEditor extends PureComponent<Props> {
-  setPrefixFontSize = (v: SelectOptionItem) => this.props.onChange({ ...this.props.options, prefixFontSize: v.value });
+  setPrefixFontSize = (v: SelectOptionItem<string>) =>
+    this.props.onChange({ ...this.props.options, prefixFontSize: v.value });
 
-  setValueFontSize = (v: SelectOptionItem) => this.props.onChange({ ...this.props.options, valueFontSize: v.value });
+  setValueFontSize = (v: SelectOptionItem<string>) =>
+    this.props.onChange({ ...this.props.options, valueFontSize: v.value });
 
-  setPostfixFontSize = (v: SelectOptionItem) =>
+  setPostfixFontSize = (v: SelectOptionItem<string>) =>
     this.props.onChange({ ...this.props.options, postfixFontSize: v.value });
 
   render() {

--- a/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
+++ b/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
@@ -47,7 +47,7 @@ export class SingleStatEditor extends PureComponent<PanelEditorProps<SingleStatO
     return (
       <>
         <PanelOptionsGrid>
-          <SingleStatValueEditor onChange={this.onValueOptionsChanged} options={options.valueOptions} />
+          <SingleStatValueEditor onChange={this.onValueOptionsChanged} value={options.valueOptions} />
           <FontSizeEditor options={options} onChange={this.props.onOptionsChange} />
           <ColoringEditor options={options} onChange={this.props.onOptionsChange} />
           <SparklineEditor options={options.sparkline} onChange={this.onSparklineChanged} />

--- a/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
+++ b/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
@@ -52,10 +52,10 @@ export class SingleStatEditor extends PureComponent<PanelEditorProps<SingleStatO
           <ColoringEditor options={options} onChange={this.props.onOptionsChange} />
           <SparklineEditor options={options.sparkline} onChange={this.onSparklineChanged} />
 
-          <ThresholdsEditor onChange={this.onThresholdsChanged} thresholds={options.thresholds} />
+          <ThresholdsEditor onChange={this.onThresholdsChanged} value={options.thresholds} />
         </PanelOptionsGrid>
 
-        <ValueMappingsEditor onChange={this.onValueMappingsChanged} valueMappings={options.valueMappings} />
+        <ValueMappingsEditor onChange={this.onValueMappingsChanged} value={options.valueMappings} />
       </>
     );
   }

--- a/public/app/plugins/panel/text2/TextPanelEditor.tsx
+++ b/public/app/plugins/panel/text2/TextPanelEditor.tsx
@@ -5,16 +5,17 @@ import React, { PureComponent, ChangeEvent } from 'react';
 import { PanelEditorProps, PanelOptionsGroup, Select, SelectOptionItem } from '@grafana/ui';
 
 // Types
-import { TextOptions } from './types';
+import { TextOptions, TextMode } from './types';
 
 export class TextPanelEditor extends PureComponent<PanelEditorProps<TextOptions>> {
-  modes: SelectOptionItem[] = [
+  modes: Array<SelectOptionItem<TextMode>> = [
     { value: 'markdown', label: 'Markdown' },
     { value: 'text', label: 'Text' },
     { value: 'html', label: 'HTML' },
   ];
 
-  onModeChange = (item: SelectOptionItem) => this.props.onOptionsChange({ ...this.props.options, mode: item.value });
+  onModeChange = (item: SelectOptionItem<TextMode>) =>
+    this.props.onOptionsChange({ ...this.props.options, mode: item.value });
 
   onContentChange = (evt: ChangeEvent<HTMLTextAreaElement>) => {
     this.props.onOptionsChange({ ...this.props.options, content: (event.target as any).value });

--- a/public/app/plugins/panel/text2/types.ts
+++ b/public/app/plugins/panel/text2/types.ts
@@ -1,5 +1,6 @@
+export type TextMode = 'html' | 'markdown' | 'text';
 export interface TextOptions {
-  mode: 'html' | 'markdown' | 'text';
+  mode: TextMode;
   content: string;
 }
 


### PR DESCRIPTION
Based on https://github.com/grafana/grafana/pull/16718

*This is a heavy POC/WIP* 

The idea behind this PR is to enable declarative way of panel editors definition. Core typings are available in `panelOptions.ts`. Based on options UI model the PanelOptionsUIBuilder component will create options editor. For now there are only simple option inputs implemented: BooleanOption, Numeric(Integer/Float)Option. 

Major proposed change is OptionInputAPI interface that would enforce all option editor components to have a common API (value/onChange). Some steps in this direction are already taken (see ThresholdsEditor, ValueMappingsEditor).

To see the proposed JSON model for options UI take a look at `panel/gauge/module.tsx`. Gauge panel options editor is now rendered from options JSON model using a very primitive (yet) PanelOptionsUIBuilder component

Next step is to implement and API to make the model creation easy. The draft shape will be sth more or less like:

```ts
 const MyPanelOptionModel = new OptionsEditorUIModel<PanelOptions>()
   .addRow(/*{row config, i.e. number of column }*/)
     .addColumn()
       .addPanel('Basic settings') // Creates
         .useStatsPicker('Show', 'stats')
         .useUnitPicker('Unit', 'unit')
         .useDecimalsInput('Decimals', 'decimals')
         .useTextInput('Prefix', 'prefix')
         .useTextInput('Suffix', 'suffix')
         .addSelectOption('Font size', 'fontSize', /*[...options]*/ )
       .endPanel()
     .endColumn()
     .addColumn()
       .addPanel('Gauge')
         .useNumber('Min value', 'minValue')
         .useNumber('Max value', 'maxValue')
         .useToggle('Show labels', 'showThresholdLabels')
         .useToggle('Show markers', 'showThresholdMarkers')
       .endPanel()
     .endColumn()
     .addColumn()
       .addPanel('Threshold')
         .useThresholdEditor('thresholds')
       .endPanel()
     .endColumn()
   .endRow();
```

TODO: 
- [ ] Implement basic options UI elements (i.e. TextOption, SelectOption...)
- [ ] Implement API for options UI model creation
- [ ] Implement PanelOptionsUIBuilder components to render options edito layout/panels/etc
- [ ] Make it panel independent (no *Panel* in naming convention)