### PR TITLE
CloudWatch: Use default alias if there is no alias for metrics

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -228,5 +228,9 @@ func formatAlias(query *CloudWatchQuery, stat string, dimensions map[string]stri
 		return in
 	})
 
+	if string(result) == "" {
+		return metricName + "_" + stat
+	}
+
 	return string(result)
 }


### PR DESCRIPTION
Fixes #16605 