### PR TITLE
Show folders when dashboards have acceptable permissions

### DIFF
--- a/docs/sources/permissions/dashboard_folder_permissions.md
+++ b/docs/sources/permissions/dashboard_folder_permissions.md
@@ -27,7 +27,8 @@ Permission levels:
 
 ## Restricting Access
 
-The highest permission always wins so if you for example want to hide a folder or dashboard from others you need to remove the **Organization Role** based permission from the Access Control List (ACL).
+The highest permission always wins for dashboards so if you for example want to hide a dashboard from others you need to remove the **Organization Role** based permission from the Access Control List (ACL).
+However in case of folder - restricting its permission will not be enough when dashboards inside are visible to user.
 
 - You cannot override permissions for users with the **Org Admin Role**. Admins always have access to everything.
 - A more specific permission with a lower permission level will not have any effect if a more general rule exists with higher permission level. You need to remove or lower the permission level of the more general rule.

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -202,11 +202,20 @@ func (dash *Dashboard) GenerateUrl() string {
 
 // GetDashboardFolderUrl return the html url for a folder if it's folder, otherwise for a dashboard
 func GetDashboardFolderUrl(isFolder bool, uid string, slug string) string {
+
 	if isFolder {
 		return GetFolderUrl(uid, slug)
 	}
 
 	return GetDashboardUrl(uid, slug)
+}
+
+// GetDashboardFolderUrl return the html url for a folder if it's folder, otherwise for a dashboard
+func GetDashboardFolderUrlForPermission(isFolder bool, uid string, slug string, viewable bool, admin bool) string {
+	if !viewable && !admin {
+		return ""
+	}
+	return GetDashboardFolderUrl(isFolder, uid, slug)
 }
 
 // GetDashboardUrl return the html url for a dashboard

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -93,7 +93,11 @@ func (g *dashboardGuardianImpl) logHasPermissionResult(permission m.PermissionTy
 }
 
 func (g *dashboardGuardianImpl) checkAcl(permission m.PermissionType, acl []*m.DashboardAclInfoDTO) (bool, error) {
-	orgRole := g.user.OrgRole
+	orgOkRoles := []m.RoleType{g.user.OrgRole}
+	if g.user.OrgRole == m.ROLE_EDITOR {
+		orgOkRoles = append(orgOkRoles, m.ROLE_VIEWER)
+	}
+
 	teamAclItems := []*m.DashboardAclInfoDTO{}
 
 	for _, p := range acl {
@@ -105,9 +109,11 @@ func (g *dashboardGuardianImpl) checkAcl(permission m.PermissionType, acl []*m.D
 		}
 
 		// role match
-		if p.Role != nil {
-			if *p.Role == orgRole && p.Permission >= permission {
-				return true, nil
+		for _, orgRole := range orgOkRoles {
+			if p.Role != nil {
+				if *p.Role == orgRole && p.Permission >= permission {
+					return true, nil
+				}
 			}
 		}
 

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -95,9 +95,9 @@ func TestGuardianEditor(t *testing.T) {
 			sc.dashboardPermissionScenario(EDITOR, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// dashboard has viewer role with permission
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_ADMIN, NO_ACCESS)
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_EDIT, NO_ACCESS)
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_VIEW, NO_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_ADMIN, FULL_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_EDIT, EDITOR_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// parent folder has user with permission
 			sc.parentFolderPermissionScenario(USER, m.PERMISSION_ADMIN, FULL_ACCESS)
@@ -115,9 +115,9 @@ func TestGuardianEditor(t *testing.T) {
 			sc.parentFolderPermissionScenario(EDITOR, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// parent folder has viweer role with permission
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_ADMIN, NO_ACCESS)
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_EDIT, NO_ACCESS)
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_VIEW, NO_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_ADMIN, FULL_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_EDIT, EDITOR_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_VIEW, VIEWER_ACCESS)
 		})
 	})
 }

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -85,7 +85,14 @@ func HandleAlertsQuery(query *m.GetAlertsQuery) error {
 		FROM alert
 		INNER JOIN dashboard on dashboard.id = alert.dashboard_id `)
 
-	builder.Write(`WHERE alert.org_id = ?`, query.OrgId)
+	builder.sql.WriteString(`
+		LEFT OUTER JOIN `)
+	builder.buildPermissionsTable(query.User, m.PERMISSION_VIEW)
+	builder.Write(` as permissions ON alert.dashboard_id = permissions.d_id
+		WHERE (permissions.dashboard_count + permissions.folder_count  + permissions.default_count > 0 OR ?) AND alert.org_id= ?`,
+		dialect.BooleanStr(query.User.OrgRole == m.ROLE_ADMIN), query.OrgId)
+
+	builder.Write(` AND alert.org_id = ?`, query.OrgId)
 
 	if len(strings.TrimSpace(query.Query)) > 0 {
 		builder.Write(" AND alert.name "+dialect.LikeStr()+" ?", "%"+query.Query+"%")
@@ -118,10 +125,6 @@ func HandleAlertsQuery(query *m.GetAlertsQuery) error {
 			builder.AddParams(v)
 		}
 		builder.Write(")")
-	}
-
-	if query.User.OrgRole != m.ROLE_ADMIN {
-		builder.writeDashboardPermissionFilter(query.User, m.PERMISSION_VIEW)
 	}
 
 	builder.Write(" ORDER BY name ASC")

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -194,6 +194,7 @@ type DashboardSearchProjection struct {
 	FolderUid   string
 	FolderSlug  string
 	FolderTitle string
+	Viewable    bool
 }
 
 func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error) {
@@ -234,7 +235,7 @@ func SearchDashboards(query *search.FindPersistedDashboardsQuery) error {
 		return err
 	}
 
-	makeQueryResult(query, res)
+	makeQueryResult(query, res, query.SignedInUser.IsGrafanaAdmin)
 
 	return nil
 }
@@ -250,7 +251,7 @@ func getHitType(item DashboardSearchProjection) search.HitType {
 	return hitType
 }
 
-func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []DashboardSearchProjection) {
+func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []DashboardSearchProjection, admin bool) {
 	query.Result = make([]*search.Hit, 0)
 	hits := make(map[int64]*search.Hit)
 
@@ -262,7 +263,7 @@ func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []Dashboard
 				Uid:         item.Uid,
 				Title:       item.Title,
 				Uri:         "db/" + item.Slug,
-				Url:         m.GetDashboardFolderUrl(item.IsFolder, item.Uid, item.Slug),
+				Url:         m.GetDashboardFolderUrlForPermission(item.IsFolder, item.Uid, item.Slug, item.Viewable, admin),
 				Type:        getHitType(item),
 				FolderId:    item.FolderId,
 				FolderUid:   item.FolderUid,

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -184,17 +184,18 @@ func GetDashboard(query *m.GetDashboardQuery) error {
 }
 
 type DashboardSearchProjection struct {
-	Id          int64
-	Uid         string
-	Title       string
-	Slug        string
-	Term        string
-	IsFolder    bool
-	FolderId    int64
-	FolderUid   string
-	FolderSlug  string
-	FolderTitle string
-	Viewable    bool
+	Id             int64
+	Uid            string
+	Title          string
+	Slug           string
+	Term           string
+	IsFolder       bool
+	FolderId       int64
+	FolderUid      string
+	FolderSlug     string
+	FolderTitle    string
+	Viewable       bool
+	FolderViewable bool
 }
 
 func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error) {
@@ -271,7 +272,7 @@ func makeQueryResult(query *search.FindPersistedDashboardsQuery, res []Dashboard
 				Tags:        []string{},
 			}
 
-			if item.FolderId > 0 {
+			if item.FolderId > 0 && item.FolderViewable {
 				hit.FolderUrl = m.GetFolderUrl(item.FolderUid, item.FolderSlug)
 			}
 

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -105,13 +105,14 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				Convey("when the user is given permission to child", func() {
 					testHelperUpdateDashboardAcl(childDash.Id, m.DashboardAcl{DashboardId: childDash.Id, OrgId: 1, UserId: currentUser.Id, Permission: m.PERMISSION_EDIT})
 
-					Convey("should be able to search for child dashboard but not folder", func() {
+					Convey("should be able to search for child dashboard and the folder", func() {
 						query := &search.FindPersistedDashboardsQuery{SignedInUser: &m.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
 						err := SearchDashboards(query)
 						So(err, ShouldBeNil)
-						So(len(query.Result), ShouldEqual, 2)
-						So(query.Result[0].Id, ShouldEqual, childDash.Id)
-						So(query.Result[1].Id, ShouldEqual, dashInRoot.Id)
+						So(len(query.Result), ShouldEqual, 3)
+						So(query.Result[0].Id, ShouldEqual, folder.Id)
+						So(query.Result[1].Id, ShouldEqual, childDash.Id)
+						So(query.Result[2].Id, ShouldEqual, dashInRoot.Id)
 					})
 				})
 

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -16,7 +16,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		Convey("Given one dashboard folder with two dashboards and one dashboard in the root folder", func() {
 			folder := insertTestDashboard("1 test dash folder", 1, 0, true, "prod", "webapp")
 			dashInRoot := insertTestDashboard("test dash 67", 1, 0, false, "prod", "webapp")
-			childDash := insertTestDashboard("test dash 23", 1, folder.Id, false, "prod", "webapp")
+			childDash := insertTestDashboard("test dash 23", 1, folder.Id, false, "prod", "webapp", "detailed")
 			insertTestDashboard("test dash 45", 1, folder.Id, false, "prod")
 
 			currentUser := createUser("viewer", "Viewer", false)
@@ -116,6 +116,16 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						So(query.Result[1].Url, ShouldContainSubstring, childDash.Uid)
 						So(query.Result[2].Id, ShouldEqual, dashInRoot.Id)
 						So(query.Result[2].Url, ShouldContainSubstring, dashInRoot.Uid)
+					})
+
+					Convey("should be able to search (by tags) for child dashboard and the folder", func() {
+						query := &search.FindPersistedDashboardsQuery{Tags: []string{"detailed"}, SignedInUser: &m.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}, Permission: m.PERMISSION_VIEW}
+						err := SearchDashboards(query)
+						So(err, ShouldBeNil)
+						So(len(query.Result), ShouldEqual, 1)
+						So(query.Result[0].Id, ShouldEqual, childDash.Id)
+						So(query.Result[0].Url, ShouldContainSubstring, childDash.Uid)
+						So(query.Result[0].FolderUrl, ShouldBeEmpty)
 					})
 				})
 

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -111,8 +111,11 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 3)
 						So(query.Result[0].Id, ShouldEqual, folder.Id)
+						So(query.Result[0].Url, ShouldBeEmpty)
 						So(query.Result[1].Id, ShouldEqual, childDash.Id)
+						So(query.Result[1].Url, ShouldContainSubstring, childDash.Uid)
 						So(query.Result[2].Id, ShouldEqual, dashInRoot.Id)
+						So(query.Result[2].Url, ShouldContainSubstring, dashInRoot.Uid)
 					})
 				})
 

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -106,7 +106,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					testHelperUpdateDashboardAcl(childDash.Id, m.DashboardAcl{DashboardId: childDash.Id, OrgId: 1, UserId: currentUser.Id, Permission: m.PERMISSION_EDIT})
 
 					Convey("should be able to search for child dashboard and the folder", func() {
-						query := &search.FindPersistedDashboardsQuery{SignedInUser: &m.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
+						query := &search.FindPersistedDashboardsQuery{SignedInUser: &m.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: m.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}, Permission: m.PERMISSION_VIEW}
 						err := SearchDashboards(query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 3)

--- a/pkg/services/sqlstore/search_builder.go
+++ b/pkg/services/sqlstore/search_builder.go
@@ -135,7 +135,8 @@ func (sb *SearchBuilder) buildSelect() {
 			folder.uid as folder_uid,
 			folder.slug as folder_slug,
 			folder.title as folder_title,
-			(permissions.dashboard_count > 0 OR permissions.folder_count > 0 OR permissions.default_count > 0 OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `) as viewable
+			(permissions.dashboard_count > 0 OR permissions.folder_count > 0 OR permissions.default_count > 0 OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `) as viewable,
+			(permissions.folder_count > 0 OR permissions.default_count > 0 OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `) as folder_viewable
 		FROM `)
 }
 

--- a/pkg/services/sqlstore/search_builder.go
+++ b/pkg/services/sqlstore/search_builder.go
@@ -111,9 +111,10 @@ func (sb *SearchBuilder) ToSql() (string, []interface{}) {
 
 	sb.sql.WriteString(`
 		LEFT OUTER JOIN `)
-	sb.buildPermissionsTable()
+	sb.buildPermissionsTable(sb.signedInUser, sb.permission)
 	sb.sql.WriteString(` as permissions ON dashboard.id = permissions.d_id
-		WHERE (d_count + f_count + c_count + default_count > 0) OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `
+		WHERE (permissions.dashboard_count + permissions.folder_count + permissions.child_count + permissions.default_count > 0) 
+			OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `
 	`)
 
 	sb.sql.WriteString(" ORDER BY dashboard.title ASC" + dialect.Limit(5000))
@@ -134,7 +135,7 @@ func (sb *SearchBuilder) buildSelect() {
 			folder.uid as folder_uid,
 			folder.slug as folder_slug,
 			folder.title as folder_title,
-			(permissions.d_count > 0 OR permissions.f_count > 0 OR permissions.default_count > 0 OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `) as viewable
+			(permissions.dashboard_count > 0 OR permissions.folder_count > 0 OR permissions.default_count > 0 OR ` + dialect.BooleanStr(sb.signedInUser.OrgRole == m.ROLE_ADMIN) + `) as viewable
 		FROM `)
 }
 
@@ -209,46 +210,4 @@ func (sb *SearchBuilder) buildSearchWhereClause() {
 			sb.params = append(sb.params, id)
 		}
 	}
-}
-
-func (sb *SearchBuilder) buildPermissionsTable() {
-	falseStr := dialect.BooleanStr(false)
-	okRoles := []interface{}{sb.signedInUser.OrgRole}
-
-	sb.sql.WriteString(`
-		(
-			SELECT d_id, SUM(CASE WHEN da_did=d_id THEN 1 ELSE 0 END) as d_count,SUM(CASE WHEN da_did=f_id THEN 1 ELSE 0 END) as f_count,
-				SUM(CASE WHEN da_did=child_id THEN 1 ELSE  0 END) as c_count, SUM(CASE WHEN da_did = -1 THEN 1 ELSE 0 END) as default_count
-			FROM (
-			  SELECT d.id as d_id, folder.id as f_id, child_dashboard.id as child_id, da.dashboard_id as da_did
-			  FROM dashboard AS d
-			  LEFT JOIN dashboard folder on folder.id = d.folder_id
-			  LEFT JOIN dashboard child_dashboard on child_dashboard.folder_id = d.id
-			  LEFT JOIN dashboard_acl AS da ON
-	 			  da.dashboard_id = d.id OR
-	 			  da.dashboard_id = d.folder_id OR
-				  da.dashboard_id = child_dashboard.id OR
-	 			  (
-	 				  -- include default permissions -->
-					  da.org_id = -1 AND (
-					    (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
-					    (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
-					  )
-	 			  )
-			  LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
-			  WHERE
-				  d.org_id = ? AND
-				  da.permission >= ? AND
-				  (
-					  da.user_id = ? OR
-					  ugm.user_id = ? OR
-					  da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
-				  )
-      		)
-      		GROUP BY d_id
-		) 
-	`)
-
-	sb.params = append(sb.params, sb.signedInUser.OrgId, sb.permission, sb.signedInUser.UserId, sb.signedInUser.UserId)
-	sb.params = append(sb.params, okRoles...)
 }

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -28,49 +28,43 @@ func (sb *SqlBuilder) AddParams(params ...interface{}) {
 	sb.params = append(sb.params, params...)
 }
 
-func (sb *SqlBuilder) writeDashboardPermissionFilter(user *m.SignedInUser, permission m.PermissionType) {
-
-	if user.OrgRole == m.ROLE_ADMIN {
-		return
-	}
-
+func (sb *SqlBuilder) buildPermissionsTable(user *m.SignedInUser, permission m.PermissionType) {
+	falseStr := dialect.BooleanStr(false)
 	okRoles := []interface{}{user.OrgRole}
 
-	if user.OrgRole == m.ROLE_EDITOR {
-		okRoles = append(okRoles, m.ROLE_VIEWER)
-	}
-
-	falseStr := dialect.BooleanStr(false)
-
-	sb.sql.WriteString(` AND
-	(
-		dashboard.id IN (
-			SELECT distinct d.id AS DashboardId
-			FROM dashboard AS d
-			LEFT JOIN dashboard folder on folder.id = d.folder_id
-			LEFT JOIN dashboard child_dashboard on child_dashboard.folder_id = d.id
-			LEFT JOIN dashboard_acl AS da ON
-	 			da.dashboard_id = d.id OR
-	 			da.dashboard_id = d.folder_id OR
-				da.dashboard_id = child_dashboard.id OR
-	 			(
-	 				-- include default permissions -->
-					da.org_id = -1 AND (
-					  (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
-					  (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
-					)
-	 			)
-			LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
-			WHERE
-				d.org_id = ? AND
-				da.permission >= ? AND
-				(
-					da.user_id = ? OR
-					ugm.user_id = ? OR
-					da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
-				)
-		)
-	)`)
+	sb.sql.WriteString(`
+		(
+			SELECT d_id, SUM(CASE WHEN da_did=d_id THEN 1 ELSE 0 END) as dashboard_count,SUM(CASE WHEN da_did=f_id THEN 1 ELSE 0 END) as folder_count,
+				SUM(CASE WHEN da_did=child_id THEN 1 ELSE  0 END) as child_count, SUM(CASE WHEN da_did = -1 THEN 1 ELSE 0 END) as default_count
+			FROM (
+			  SELECT d.id as d_id, folder.id as f_id, child_dashboard.id as child_id, da.dashboard_id as da_did
+			  FROM dashboard AS d
+			  LEFT JOIN dashboard folder on folder.id = d.folder_id
+			  LEFT JOIN dashboard child_dashboard on child_dashboard.folder_id = d.id
+			  LEFT JOIN dashboard_acl AS da ON
+	 			  da.dashboard_id = d.id OR
+	 			  da.dashboard_id = d.folder_id OR
+				  da.dashboard_id = child_dashboard.id OR
+	 			  (
+	 				  -- include default permissions -->
+					  da.org_id = -1 AND (
+					    (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
+					    (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
+					  )
+	 			  )
+			  LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
+			  WHERE
+				  d.org_id = ? AND
+				  da.permission >= ? AND
+				  (
+					  da.user_id = ? OR
+					  ugm.user_id = ? OR
+					  da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
+				  )
+      		)
+      		GROUP BY d_id
+		) 
+	`)
 
 	sb.params = append(sb.params, user.OrgId, permission, user.UserId, user.UserId)
 	sb.params = append(sb.params, okRoles...)

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -32,6 +32,10 @@ func (sb *SqlBuilder) buildPermissionsTable(user *m.SignedInUser, permission m.P
 	falseStr := dialect.BooleanStr(false)
 	okRoles := []interface{}{user.OrgRole}
 
+	if user.OrgRole == m.ROLE_EDITOR {
+		okRoles = append(okRoles, m.ROLE_VIEWER)
+	}
+
 	sb.sql.WriteString(`
 		(
 			SELECT d_id, SUM(CASE WHEN da_did=d_id THEN 1 ELSE 0 END) as dashboard_count,SUM(CASE WHEN da_did=f_id THEN 1 ELSE 0 END) as folder_count,

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -61,7 +61,7 @@ func (sb *SqlBuilder) buildPermissionsTable(user *m.SignedInUser, permission m.P
 					  ugm.user_id = ? OR
 					  da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
 				  )
-      		)
+      		) as p
       		GROUP BY d_id
 		) 
 	`)


### PR DESCRIPTION
Fixes #12948 issue

Desciption:
I've changed backend code to return also folders that have dashboards with proper permissions. At the same time I'm doing validation of this permissions (fetched from dashboard, its folder or default acls) to decide whether to display url for that folder. As a result folders (without explicit permissions) that are displayed on the list only for their dashboards won't be viewable in folder panel.

I've also noticed inconsistency beetween dashboards search and guardian: editor was also viewer in search but no in guardian

