### PR TITLE
Prometheus: Fix when adding label for metrics which contains colons in Explore

### DIFF
--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -30,8 +30,12 @@ export function addLabelToQuery(query: string, key: string, value: string, opera
     const insideSelector = isPositionInsideChars(query, offset, '{', '}');
     // Handle "sum by (key) (metric)"
     const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;
+
+    // check for colon as as "word boundary" symbol
+    const isColonBounded = word.endsWith(':');
+
     previousWord = word;
-    if (!insideSelector && !previousWordIsKeyWord && builtInWords.indexOf(word) === -1) {
+    if (!insideSelector && !isColonBounded && !previousWordIsKeyWord && builtInWords.indexOf(word) === -1) {
       return `${word}{}`;
     }
     return word;

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -29,6 +29,9 @@ describe('addLabelToQuery()', () => {
       'foo{bar="baz",instance="my-host.com:9100"}'
     );
     expect(addLabelToQuery('foo:metric:rate1m', 'bar', 'baz')).toBe('foo:metric:rate1m{bar="baz"}');
+    expect(addLabelToQuery('avg(foo:metric:rate1m{a="b"})', 'bar', 'baz')).toBe(
+      'avg(foo:metric:rate1m{a="b",bar="baz"})'
+    );
     expect(addLabelToQuery('foo{list="a,b,c"}', 'bar', 'baz')).toBe('foo{bar="baz",list="a,b,c"}');
   });
 


### PR DESCRIPTION
The main problem with colons in metric name is that colon is considered as a "not a word character" by \b. The simplest solution here is just to handle this situation by checking matched word - exclude one with colon at the end.

Fixes #14475