### PR TITLE
Security: Bump jQuery to 3.4.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "eventemitter3": "2.0.3",
     "file-saver": "1.3.8",
     "immutable": "3.8.2",
-    "jquery": "3.3.1",
+    "jquery": "3.4.0",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "mousetrap": "1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10016,6 +10016,11 @@ jquery@3.3.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
   integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
+jquery@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
+  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"


### PR DESCRIPTION
> edit: the CVE was marked as duplicate of CVE-2019-11358

Ref: https://nvd.nist.gov/vuln/detail/CVE-2019-5428
Closes #16745

