### PR TITLE
RefreshPicker: minor design update

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -55,7 +55,7 @@ export class RefreshPicker extends PureComponent<Props> {
 
     const cssClasses = classNames({
       'refresh-picker': true,
-      'refresh-picker--refreshing': selectedValue.label !== offOption.label,
+      'refresh-picker--off': selectedValue.label === offOption.label,
     });
 
     return (

--- a/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
+++ b/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
@@ -6,6 +6,10 @@
     display: flex;
   }
 
+  .navbar-button--refresh {
+    border-right: 0;
+  }
+
   .gf-form-input--form-dropdown {
     position: static;
   }
@@ -16,9 +20,13 @@
     width: 100%;
   }
 
-  &--refreshing {
+  .select-button-value {
+    color: $orange;
+  }
+
+  &--off {
     .select-button-value {
-      color: $orange;
+      display: none;
     }
   }
 

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -267,8 +267,8 @@ export class DashNav extends PureComponent<Props> {
 
         {!dashboard.timepicker.hidden && (
           <div className="navbar-buttons">
-            <DashNavTimeControls dashboard={dashboard} location={location} updateLocation={updateLocation} />
             <div className="gf-timepicker-nav" ref={element => (this.timePickerEl = element)} />
+            <DashNavTimeControls dashboard={dashboard} location={location} updateLocation={updateLocation} />
           </div>
         )}
       </div>


### PR DESCRIPTION
<img width="375" alt="Screen Shot 2019-04-25 at 21 36 36" src="https://user-images.githubusercontent.com/10999/56763258-3ac71800-67a2-11e9-8c7f-6e77b7d0f213.png">

* Moved back to far right, 
* Do not show "Off" label. 

Fixes #16627