### PR TITLE
build: upgrade jquery to 3.4.0

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -23,7 +23,7 @@
     "@types/react-color": "2.17.0",
     "classnames": "2.2.6",
     "d3": "5.9.1",
-    "jquery": "3.3.1",
+    "jquery": "3.4.0",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "papaparse": "4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10011,11 +10011,6 @@ jest@24.6.0:
     import-local "^2.0.0"
     jest-cli "^24.6.0"
 
-jquery@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
-
 jquery@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"


### PR DESCRIPTION
CVE-2019-5428
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
A prototype pollution vulnerability exists in jQuery versions < 3.4.0 that
allows an attacker to inject properties on Object.prototype.

https://nvd.nist.gov/vuln/detail/CVE-2019-5428