### PR TITLE
UX: Improve Grafana usage for smaller screens

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
+++ b/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
@@ -30,7 +30,7 @@
     }
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-up(sm) {
     display: block;
   }
 }

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Render should render with base threshold 1`] = `
                             },
                             "breakpoints": Object {
                               "lg": "992px",
-                              "md": "768px",
+                              "md": "769px",
                               "sm": "544px",
                               "xl": "1200px",
                               "xs": "0",
@@ -272,7 +272,7 @@ exports[`Render should render with base threshold 1`] = `
                                   },
                                   "breakpoints": Object {
                                     "lg": "992px",
-                                    "md": "768px",
+                                    "md": "769px",
                                     "sm": "544px",
                                     "xl": "1200px",
                                     "xs": "0",

--- a/packages/grafana-ui/src/themes/default.ts
+++ b/packages/grafana-ui/src/themes/default.ts
@@ -42,7 +42,7 @@ const theme: GrafanaThemeCommons = {
   breakpoints: {
     xs: '0',
     sm: '544px',
-    md: '768px',
+    md: '769px', // 1 more than regular ipad in portrait
     lg: '992px',
     xl: '1200px',
   },

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -38,9 +38,9 @@ const createResponsiveButton = (options: {
 
   return (
     <button className={`btn navbar-button ${buttonClassName ? buttonClassName : ''}`} onClick={onClick}>
-      {iconClassName && iconSide === IconSide.left ? <i className={`${iconClassName} icon-margin-right`} /> : null}
+      {iconClassName && iconSide === IconSide.left ? <i className={`${iconClassName}`} /> : null}
       <span className="btn-title">{!splitted ? title : ''}</span>
-      {iconClassName && iconSide === IconSide.right ? <i className={`${iconClassName} icon-margin-left`} /> : null}
+      {iconClassName && iconSide === IconSide.right ? <i className={`${iconClassName}`} /> : null}
     </button>
   );
 };
@@ -172,7 +172,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
             </div>
 
             <div className="explore-toolbar-content-item">
-              <button className="btn navbar-button navbar-button--no-icon" onClick={this.onClearAll}>
+              <button className="btn navbar-button" onClick={this.onClearAll}>
                 Clear All
               </button>
             </div>

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -67,7 +67,7 @@ $spacers: (
 $grid-breakpoints: (
   xs: 0,
   sm: 544px,
-  md: 768px,
+  md: 769px,
   lg: 992px,
   xl: 1200px,
 ) !default;

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -9,6 +9,11 @@
   transition-duration: 350ms;
   transition-timing-function: ease-in-out;
   transition-property: box-shadow, border-bottom;
+
+  @include media-breakpoint-up(md) {
+    padding-left: $dashboard-padding;
+    margin-left: 0;
+  }
 }
 
 @mixin navbar-alt-look() {
@@ -75,13 +80,18 @@
     opacity: 0.75;
     margin-right: 10px;
     display: none;
+
+    @include media-breakpoint-up(md) {
+      display: inline-block;
+    }
   }
 
   &--folder {
     color: $text-color-weak;
+    display: none;
 
-    @include media-breakpoint-down(md) {
-      display: none;
+    @include media-breakpoint-up(lg) {
+      display: inline-block;
     }
   }
 }
@@ -170,17 +180,11 @@
   &--secondary {
     @include buttonBackground($btn-secondary-bg, $btn-secondary-bg-hl);
   }
-}
 
-@include media-breakpoint-up(sm) {
-  .navbar {
-    padding-left: 20px;
-    margin-left: 0;
-  }
-
-  .navbar-page-btn {
-    .gicon {
-      display: inline-block;
+  @include media-breakpoint-down(lg) {
+    .btn-title {
+      margin-left: $space-xs;
+      display: none;
     }
   }
 }

--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -262,7 +262,7 @@
   background: $panel-bg;
 }
 
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-up(md) {
   .search-container {
     left: $side-menu-width;
   }

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -1,3 +1,5 @@
+$mobile-menu-breakpoint: md;
+
 .sidemenu {
   position: fixed;
   display: flex;
@@ -17,7 +19,7 @@
     display: none;
   }
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-up($mobile-menu-breakpoint) {
     background: $side-menu-bg;
     height: auto;
     box-shadow: $side-menu-shadow;
@@ -46,7 +48,7 @@
 .sidemenu__bottom {
   display: none;
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-up($mobile-menu-breakpoint) {
     display: block;
   }
 }
@@ -55,7 +57,7 @@
   position: relative;
   @include left-brand-border();
 
-  @include media-breakpoint-up(sm) {
+  @include media-breakpoint-up($mobile-menu-breakpoint) {
     &.active,
     &:hover {
       background-color: $side-menu-item-hover-bg;
@@ -214,10 +216,10 @@ li.sidemenu-org-switcher {
   }
 }
 
-@include media-breakpoint-down(xs) {
+@include media-breakpoint-down(sm) {
   .sidemenu-open--xs {
     li {
-      font-size: $font-size-lg;
+      font-size: $font-size-md;
     }
 
     .sidemenu {
@@ -283,7 +285,6 @@ li.sidemenu-org-switcher {
       position: unset;
       width: 100%;
       float: none;
-      margin-top: $space-sm;
       margin-bottom: $space-sm;
 
       > li > a {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -31,11 +31,15 @@
   flex-flow: row wrap;
   justify-content: flex-start;
   height: auto;
-  padding: 0 $dashboard-padding;
+  padding: 0 $dashboard-padding 0 50px;
   border-bottom: 1px solid #0000;
   transition-duration: 0.35s;
   transition-timing-function: ease-in-out;
   transition-property: box-shadow, border-bottom;
+
+  @include media-breakpoint-up(md) {
+    padding-left: $dashboard-padding;
+  }
 }
 
 .explore-toolbar-item {
@@ -65,11 +69,6 @@
   font-size: 18px;
   min-height: 55px;
   line-height: 55px;
-  justify-content: space-between;
-  margin-left: $space-xl;
-}
-
-.explore-toolbar-header {
   justify-content: space-between;
   align-items: center;
 }
@@ -126,24 +125,10 @@
   }
 }
 
-@media only screen and (max-width: 803px) {
-  .btn-title {
-    display: none;
-  }
-}
-
 @media only screen and (max-width: 702px) {
   .explore-toolbar-content-item:first-child {
     padding-left: 2px;
     margin-right: 0;
-  }
-}
-
-@media only screen and (max-width: 544px) {
-  .explore-toolbar-header-title {
-    .navbar-page-btn {
-      margin-left: $dashboard-padding;
-    }
   }
 }
 


### PR DESCRIPTION
This improves Grafana for smaller screens. 

The mobile menu mode (that hides sidemenu and switches to mobile menu) breakpoint was on lower(sm) but the dashboard grid breakpoint to switch to mobile (stacked panels) view is on md. 

This PR changes to that the mobile view (hide sidemenu + mobile view) now is enabled when lower(md) ie lower than 768px same as dashboard grid. 

Also contains some minor fixes & refactorings to align responsive behavior between dashboard nav and explore. 

Fixes #16402