### PR TITLE
Config: Fixes bug where timeouts for alerting was not parsed correctly

### DIFF
--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -3,7 +3,6 @@ package alerting
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/imguploader"

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(setting.AlertingEvaluationTimeout.Seconds()*0.9) * time.Second,
+		Timeout:         setting.AlertingEvaluationTimeout,
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -127,7 +127,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 	renderOpts := rendering.Opts{
 		Width:           1000,
 		Height:          500,
-		Timeout:         time.Duration(setting.AlertingEvaluationTimeout.Seconds() * 0.9),
+		Timeout:         time.Duration(setting.AlertingEvaluationTimeout.Seconds()*0.9) * time.Second,
 		OrgId:           context.Rule.OrgId,
 		OrgRole:         m.ROLE_ADMIN,
 		ConcurrentLimit: setting.AlertingRenderLimit,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -892,9 +892,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	}
 
 	evaluationTimeoutSeconds := alerting.Key("evaluation_timeout_seconds").MustInt64(30)
-	AlertingEvaluationTimeout = time.Duration(time.Second * time.Duration(evaluationTimeoutSeconds))
+	AlertingEvaluationTimeout = time.Second * time.Duration(evaluationTimeoutSeconds)
 	notificationTimeoutSeconds := alerting.Key("notification_timeout_seconds").MustInt64(30)
-	AlertingNotificationTimeout = time.Duration(time.Second * time.Duration(notificationTimeoutSeconds))
+	AlertingNotificationTimeout = time.Second * time.Duration(notificationTimeoutSeconds)
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
 
 	explore := iniFile.Section("explore")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -891,8 +891,10 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 		return err
 	}
 
-	AlertingEvaluationTimeout = alerting.Key("evaluation_timeout_seconds").MustDuration(time.Second * 30)
-	AlertingNotificationTimeout = alerting.Key("notification_timeout_seconds").MustDuration(time.Second * 30)
+	evaluationTimeoutSeconds := alerting.Key("evaluation_timeout_seconds").MustInt64(30)
+	AlertingEvaluationTimeout = time.Duration(time.Second * time.Duration(evaluationTimeoutSeconds))
+	notificationTimeoutSeconds := alerting.Key("notification_timeout_seconds").MustInt64(30)
+	AlertingNotificationTimeout = time.Duration(time.Second * time.Duration(notificationTimeoutSeconds))
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
 
 	explore := iniFile.Section("explore")


### PR DESCRIPTION
Closes: #16663

Fixes how the config is parsed and also how a timeout value is computed in notifier.