### PR TITLE
Use isolated modules for ts-jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,4 +23,5 @@ module.exports = {
     "./public/test/jest-setup.ts"
   ],
   "snapshotSerializers": ["enzyme-to-json/serializer"],
+  "globals": { "ts-jest": { "isolatedModules": true } },
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Speedup running tests with jest. This will skip type checking, but should be fine since we already do this in the webpack build step.