### PR TITLE
Dashboard: Enable filtering dashboards in search by current folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "reselect": "4.0.0",
     "rst2html": "github:thoward/rst2html#990cb89",
     "rxjs": "6.4.0",
+    "search-query-parser": "1.5.2",
     "slate": "0.33.8",
     "slate-plain-serializer": "0.5.41",
     "slate-prism": "0.5.0",

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -25,7 +25,7 @@ export function registerAngularDirectives() {
     'query',
     'autoFocus',
     ['onChange', { watchDepth: 'reference' }],
-    ['keyDown', { watchDepth: 'reference' }],
+    ['onKeyDown', { watchDepth: 'reference' }],
   ]);
   react2AngularDirective('tagFilter', TagFilter, [
     'tags',

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -11,6 +11,7 @@ import { MetricSelect } from './components/Select/MetricSelect';
 import AppNotificationList from './components/AppNotifications/AppNotificationList';
 import { ColorPicker, SeriesColorPickerPopoverWithTheme, SecretFormField } from '@grafana/ui';
 import { FunctionEditor } from 'app/plugins/datasource/graphite/FunctionEditor';
+import { SearchField } from './components/search/SearchField';
 
 export function registerAngularDirectives() {
   react2AngularDirective('passwordStrength', PasswordStrength, ['password']);
@@ -20,6 +21,12 @@ export function registerAngularDirectives() {
   react2AngularDirective('pageHeader', PageHeader, ['model', 'noTabs']);
   react2AngularDirective('emptyListCta', EmptyListCTA, ['model']);
   react2AngularDirective('searchResult', SearchResult, []);
+  react2AngularDirective('searchField', SearchField, [
+    'query',
+    'autoFocus',
+    ['onChange', { watchDepth: 'reference' }],
+    ['keyDown', { watchDepth: 'reference' }],
+  ]);
   react2AngularDirective('tagFilter', TagFilter, [
     'tags',
     ['onChange', { watchDepth: 'reference' }],

--- a/public/app/core/components/search/SearchField.tsx
+++ b/public/app/core/components/search/SearchField.tsx
@@ -9,9 +9,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 interface SearchFieldProps extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {
   query: SearchQuery;
   onChange: (query: string) => void;
-
-  // Introducing keyDown prop because passing onKeyDown causes some untraceable exception
-  keyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const getSearchFieldStyles = (theme: GrafanaTheme) => ({
@@ -64,9 +62,15 @@ const getSearchFieldStyles = (theme: GrafanaTheme) => ({
   ),
 });
 
-export const SearchField: React.FunctionComponent<SearchFieldProps> = ({ query, onChange, keyDown, ...inputProps }) => {
+export const SearchField: React.FunctionComponent<SearchFieldProps> = ({
+  query,
+  onChange,
+  onKeyDown,
+  ...inputProps
+}) => {
   const theme = useContext(ThemeContext);
   const styles = getSearchFieldStyles(theme);
+
   return (
     <>
       {/* search-field-wrapper class name left on purpose until we migrate entire search to React */}
@@ -87,7 +91,6 @@ export const SearchField: React.FunctionComponent<SearchFieldProps> = ({ query, 
           spellCheck={false}
           {...inputProps}
           className={styles.input}
-          onKeyDown={keyDown}
         />
 
         <div className={styles.spacer} />

--- a/public/app/core/components/search/SearchField.tsx
+++ b/public/app/core/components/search/SearchField.tsx
@@ -69,7 +69,9 @@ export const SearchField: React.FunctionComponent<SearchFieldProps> = ({ query, 
   const styles = getSearchFieldStyles(theme);
   return (
     <>
-      <div className={styles.wrapper}>
+      {/* search-field-wrapper class name left on purpose until we migrate entire search to React */}
+      {/* based on this class name the GrafanaCtrl (L256) decides whether or not to hide search */}
+      <div className={`${styles.wrapper} search-field-wrapper`}>
         <div className={styles.icon}>
           <i className="fa fa-search" />
         </div>

--- a/public/app/core/components/search/SearchField.tsx
+++ b/public/app/core/components/search/SearchField.tsx
@@ -62,19 +62,14 @@ const getSearchFieldStyles = (theme: GrafanaTheme) => ({
   ),
 });
 
-export const SearchField: React.FunctionComponent<SearchFieldProps> = ({
-  query,
-  onChange,
-  onKeyDown,
-  ...inputProps
-}) => {
+export const SearchField: React.FunctionComponent<SearchFieldProps> = ({ query, onChange, ...inputProps }) => {
   const theme = useContext(ThemeContext);
   const styles = getSearchFieldStyles(theme);
 
   return (
     <>
       {/* search-field-wrapper class name left on purpose until we migrate entire search to React */}
-      {/* based on this class name the GrafanaCtrl (L256) decides whether or not to hide search */}
+      {/* based on it GrafanaCtrl (L256) decides whether or not hide search */}
       <div className={`${styles.wrapper} search-field-wrapper`}>
         <div className={styles.icon}>
           <i className="fa fa-search" />

--- a/public/app/core/components/search/SearchField.tsx
+++ b/public/app/core/components/search/SearchField.tsx
@@ -1,0 +1,95 @@
+import React, { useContext } from 'react';
+import tinycolor from 'tinycolor2';
+import { SearchQuery } from './search';
+import { css, cx } from 'emotion';
+import { ThemeContext, GrafanaTheme, selectThemeVariant } from '@grafana/ui';
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+interface SearchFieldProps extends Omit<React.HTMLAttributes<HTMLInputElement>, 'onChange'> {
+  query: SearchQuery;
+  onChange: (query: string) => void;
+
+  // Introducing keyDown prop because passing onKeyDown causes some untraceable exception
+  keyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+const getSearchFieldStyles = (theme: GrafanaTheme) => ({
+  wrapper: css`
+    width: 100%;
+    height: 55px; /* this variable is not part of GrafanaTheme yet*/
+    display: flex;
+    background-color: ${selectThemeVariant(
+      {
+        light: theme.colors.white,
+        dark: theme.colors.dark4,
+      },
+      theme.type
+    )};
+    position: relative;
+  `,
+  input: css`
+    max-width: 653px;
+    padding: ${theme.spacing.md} ${theme.spacing.md} ${theme.spacing.sm} ${theme.spacing.md};
+    height: 51px;
+    box-sizing: border-box;
+    outline: none;
+    background: ${selectThemeVariant(
+      {
+        light: theme.colors.dark1,
+        dark: theme.colors.black,
+      },
+      theme.type
+    )};
+    background-color: ${selectThemeVariant(
+      {
+        light: tinycolor(theme.colors.white)
+          .lighten(4)
+          .toString(),
+        dark: theme.colors.dark4,
+      },
+      theme.type
+    )};
+    flex-grow: 10;
+  `,
+  spacer: css`
+    flex-grow: 1;
+  `,
+  icon: cx(
+    css`
+      font-size: ${theme.typography.size.lg};
+      padding: ${theme.spacing.md} ${theme.spacing.md} ${theme.spacing.sm} ${theme.spacing.md};
+    `,
+    'pointer'
+  ),
+});
+
+export const SearchField: React.FunctionComponent<SearchFieldProps> = ({ query, onChange, keyDown, ...inputProps }) => {
+  const theme = useContext(ThemeContext);
+  const styles = getSearchFieldStyles(theme);
+  return (
+    <>
+      <div className={styles.wrapper}>
+        <div className={styles.icon}>
+          <i className="fa fa-search" />
+        </div>
+
+        <input
+          type="text"
+          placeholder="Find dashboards by name"
+          value={query.query}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            onChange(event.currentTarget.value);
+          }}
+          tabIndex={1}
+          spellCheck={false}
+          {...inputProps}
+          className={styles.input}
+          onKeyDown={keyDown}
+        />
+
+        <div className={styles.spacer} />
+      </div>
+    </>
+  );
+};

--- a/public/app/core/components/search/search.html
+++ b/public/app/core/components/search/search.html
@@ -35,7 +35,7 @@
           </a>
         </div>
 
-        <tag-filter tags="ctrl.query.tag" tagOptions="ctrl.getTags" onChange="ctrl.onTagFiltersChanged">
+        <tag-filter query="ctrl.query" tagOptions="ctrl.getTags" on-change="ctrl.onTagFiltersChanged">
         </tag-filter>
       </div>
 

--- a/public/app/core/components/search/search.html
+++ b/public/app/core/components/search/search.html
@@ -3,19 +3,13 @@
 
 <div class="search-container" ng-if="ctrl.isOpen">
 
-	<div class="search-field-wrapper">
-		<div class="search-field-icon pointer" ng-click="ctrl.closeSearch()"><i class="fa fa-search"></i></div>
+  <search-field
+    query="ctrl.query"
+    autoFocus="ctrl.giveSearchFocus"
+    onChange="ctrl.onQueryChange"
+    keyDown="ctrl.onKeyDown"
+  />
 
-		<input type="text" placeholder="Find dashboards by name" give-focus="ctrl.giveSearchFocus" tabindex="1"
-						ng-keydown="ctrl.keyDown($event)"
-						ng-model="ctrl.query.query"
-						ng-model-options="{ debounce: 500 }"
-						spellcheck='false'
-						ng-change="ctrl.search()"
-            />
-
-		<div class="search-field-spacer"></div>
-	</div>
 
 	<div class="search-dropdown">
     <div class="search-dropdown__col_1">

--- a/public/app/core/components/search/search.html
+++ b/public/app/core/components/search/search.html
@@ -6,8 +6,8 @@
   <search-field
     query="ctrl.query"
     autoFocus="ctrl.giveSearchFocus"
-    onChange="ctrl.onQueryChange"
-    keyDown="ctrl.onKeyDown"
+    on-change="ctrl.onQueryChange"
+    on-key-down="ctrl.onKeyDown"
   />
 
 

--- a/public/app/core/components/search/search.html
+++ b/public/app/core/components/search/search.html
@@ -35,7 +35,7 @@
           </a>
         </div>
 
-        <tag-filter query="ctrl.query" tagOptions="ctrl.getTags" on-change="ctrl.onTagFiltersChanged">
+        <tag-filter tags="ctrl.query.tags" tagOptions="ctrl.getTags" on-change="ctrl.onTagFiltersChanged">
         </tag-filter>
       </div>
 

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -120,7 +120,7 @@ export class SearchCtrl {
     }, 100);
   }
 
-  onKeyDown(evt) {
+  onKeyDown(evt: KeyboardEvent) {
     if (evt.keyCode === 27) {
       this.closeSearch();
     }
@@ -298,7 +298,10 @@ export class SearchCtrl {
     this.moveSelection(0);
   }
 
-  private getFlattenedResultForNavigation() {
+  private getFlattenedResultForNavigation(): Array<{
+    folderIndex: number;
+    dashboardIndex: number;
+  }> {
     let folderIndex = 0;
 
     return _.flatMap(this.results, s => {

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -273,7 +273,6 @@ export class SearchCtrl {
   };
 
   onTagFiltersChanged = (tags: string[]) => {
-    console.log(tags);
     this.query.tags = tags;
     this.search();
   };

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { debounce } from 'lodash';
 import coreModule from '../../core_module';
 import { SearchSrv } from 'app/core/services/search_srv';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -52,14 +52,13 @@ export class SearchCtrl {
   constructor($scope, private $location, private $timeout, private searchSrv: SearchSrv) {
     appEvents.on('show-dash-search', this.openSearch.bind(this), $scope);
     appEvents.on('hide-dash-search', this.closeSearch.bind(this), $scope);
-    appEvents.on('search-query', this.search.bind(this), $scope);
+    appEvents.on('search-query', debounce(this.search.bind(this), 500), $scope);
 
     this.initialFolderFilterTitle = 'All';
     this.isEditor = contextSrv.isEditor;
     this.hasEditPermissionInFolders = contextSrv.hasEditPermissionInFolders;
     this.onQueryChange = this.onQueryChange.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
-
     this.query = {
       query: '',
       parsedQuery: { text: '' },

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -277,6 +277,7 @@ export class SearchCtrl {
   };
 
   clearSearchFilter() {
+    this.query.query = '';
     this.query.tags = [];
     this.search();
   }

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -60,8 +60,14 @@ export class DashNav extends PureComponent<Props> {
     }
   }
 
-  onOpenSearch = () => {
+  onDahboardNameClick = () => {
     appEvents.emit('show-dash-search');
+  };
+
+  onFolderNameClick = () => {
+    appEvents.emit('show-dash-search', {
+      query: 'folder:current',
+    });
   };
 
   onClose = () => {
@@ -139,12 +145,17 @@ export class DashNav extends PureComponent<Props> {
     return (
       <>
         <div>
-          <a className="navbar-page-btn" onClick={this.onOpenSearch}>
+          <div className="navbar-page-btn">
             {!this.isInFullscreenOrSettings && <i className="gicon gicon-dashboard" />}
-            {haveFolder && <span className="navbar-page-btn--folder">{folderTitle} / </span>}
-            {dashboard.title}
-            <i className="fa fa-caret-down" />
-          </a>
+            {haveFolder && (
+              <span className="navbar-page-btn--folder" onClick={this.onFolderNameClick}>
+                {folderTitle} /{' '}
+              </span>
+            )}
+            <span onClick={this.onDahboardNameClick}>
+              {dashboard.title} <i className="fa fa-caret-down" />
+            </span>
+          </div>
         </div>
         {this.isSettings && <span className="navbar-settings-title">&nbsp;/ Settings</span>}
         <div className="navbar__spacer" />

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -60,14 +60,17 @@ export class DashNav extends PureComponent<Props> {
     }
   }
 
-  onDahboardNameClick = () => {
-    appEvents.emit('show-dash-search');
-  };
-
-  onFolderNameClick = () => {
-    appEvents.emit('show-dash-search', {
-      query: 'folder:current',
-    });
+  onOpenSearch = () => {
+    const { dashboard } = this.props;
+    const haveFolder = dashboard.meta.folderId > 0;
+    appEvents.emit(
+      'show-dash-search',
+      haveFolder
+        ? {
+            query: 'folder:current',
+          }
+        : null
+    );
   };
 
   onClose = () => {
@@ -145,17 +148,11 @@ export class DashNav extends PureComponent<Props> {
     return (
       <>
         <div>
-          <div className="navbar-page-btn">
+          <a className="navbar-page-btn" onClick={this.onOpenSearch}>
             {!this.isInFullscreenOrSettings && <i className="gicon gicon-dashboard" />}
-            {haveFolder && (
-              <span className="navbar-page-btn--folder" onClick={this.onFolderNameClick}>
-                {folderTitle} /{' '}
-              </span>
-            )}
-            <span onClick={this.onDahboardNameClick}>
-              {dashboard.title} <i className="fa fa-caret-down" />
-            </span>
-          </div>
+            {haveFolder && <span className="navbar-page-btn--folder">{folderTitle} / </span>}
+            {dashboard.title} <i className="fa fa-caret-down" />
+          </a>
         </div>
         {this.isSettings && <span className="navbar-settings-title">&nbsp;/ Settings</span>}
         <div className="navbar__spacer" />

--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -19,34 +19,6 @@
 }
 
 // Search
-.search-field-wrapper {
-  width: 100%;
-  height: $navbarHeight;
-  display: flex;
-  background-color: $navbarBackground;
-  position: relative;
-
-  & > input {
-    max-width: 653px;
-    padding: $space-md $space-md $space-sm $space-md;
-    height: 51px;
-    box-sizing: border-box;
-    outline: none;
-    background: $side-menu-bg;
-    background-color: $navbarButtonBackground;
-    flex-grow: 10;
-  }
-}
-
-.search-field-spacer {
-  flex-grow: 1;
-}
-
-.search-field-icon {
-  font-size: $font-size-lg;
-  padding: $space-md $space-md $space-sm $space-md;
-}
-
 .search-dropdown {
   display: flex;
   flex-direction: column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15250,6 +15250,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+search-query-parser@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/search-query-parser/-/search-query-parser-1.5.2.tgz#f6c8c9ecbde439cbbce75110045944c3cb5fe546"
+  integrity sha512-PcvjC0eJMmFIYAxUaeaRVLnPHctzsymtMJUSGKv6xJtctGrunihoCItrQ3AcM5eO7q90pNeIVTrLwuqW0LIzyg==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"


### PR DESCRIPTION
First proposal to solve #14739

It assumes introducing simple query lang to the search (similar to Gmail's) https://github.com/nepsilon/search-query-parser

For now it naively supports `folder:current` keyword only, but I want to expand on this idea a little bit more when working on Search -> React migration. 

The `folder` keyword results in search results from within specified folders. In longer run I would like to be able to add `folder:[current|folder_name|folder_id]` resolving. I assume (not sure if there is a real need for that) but we could in the same manner search for specific tags and enable shareable search queries. But first we have to make sure this is something worth exploring. 

@torkelo I don't want to put too much effort into this ATM, would love to focus on general search rewrite and deliver MVP here only. WDYT?

FYI @Ijin08 

TODO:
- [ ] Add tests
- [x] Add missing pointer cursors on dashboard folder/name