### PR TITLE
Docs: Explain correct access control model of GCS buckets

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -571,7 +571,7 @@ basic auth password
 Path to JSON key file associated with a Google service account to authenticate and authorize.
 Service Account keys can be created and downloaded from https://console.developers.google.com/permissions/serviceaccounts.
 
-Service Account should have "Storage Object Writer" role.
+Service Account should have "Storage Object Writer" role. The access control model of the bucket needs to be "Set object-level and bucket-level permissions". Grafana itself will make the images public readable.
 
 ### bucket name
 Bucket Name on Google Cloud Storage.


### PR DESCRIPTION
Makes the documentation clearer on how to setup a GCS bucket.

If the bucket has a global permission set, any attempt to set it on the object level will fail with the error message: "Cannot use ACL API to set object policy when object policies are disabled."

---

I had to run grafana from source to debug that issue, because the logs would only show the status code 400 in the error message when the upload failed.