### PR TITLE
Build: Restore postgres integration tests

### DIFF
--- a/scripts/circle-test-postgres.sh
+++ b/scripts/circle-test-postgres.sh
@@ -12,7 +12,6 @@ function exit_if_fail {
 
 export GRAFANA_TEST_DB=postgres
 
-exit_if_fail go test -v -run="StatsDataAccess" -tags=integration ./pkg/services/sqlstore/...
-#time for d in $(go list ./pkg/...); do
-#  exit_if_fail go test -tags=integration $d
-#done
+time for d in $(go list ./pkg/...); do
+ exit_if_fail go test -tags=integration $d
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like #16667 accidentally disabled running all postgres integration tests in CI. This PR should restore this.