### PR TITLE
Plugins: move datasource specific meta into DataSourcePluginMeta

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -68,6 +68,24 @@ export class DataSourcePlugin<TOptions = {}, TQuery extends DataQuery = DataQuer
   }
 }
 
+export interface DataSourcePluginMeta extends PluginMeta {
+  builtIn?: boolean; // Is this for all
+  metrics?: boolean;
+  tables?: boolean;
+  logs?: boolean;
+  explore?: boolean;
+  annotations?: boolean;
+  mixed?: boolean;
+  hasQueryHelp?: boolean;
+  queryOptions?: PluginMetaQueryOptions;
+}
+
+interface PluginMetaQueryOptions {
+  cacheTimeout?: boolean;
+  maxDataPoints?: boolean;
+  minInterval?: boolean;
+}
+
 export interface DataSourcePluginComponents<TOptions = {}, TQuery extends DataQuery = DataQuery> {
   QueryCtrl?: any;
   ConfigCtrl?: any;
@@ -137,7 +155,11 @@ export interface DataSourceApi<TQuery extends DataQuery = DataQuery> {
    * we attach the components to this instance for easy access
    */
   components?: DataSourcePluginComponents;
-  meta?: PluginMeta;
+
+  /**
+   * static information about the datasource
+   */
+  meta?: DataSourcePluginMeta;
 }
 
 export interface ExploreDataSourceApi<TQuery extends DataQuery = DataQuery> extends DataSourceApi {
@@ -340,7 +362,7 @@ export interface DataSourceInstanceSettings {
   id: number;
   type: string;
   name: string;
-  meta: PluginMeta;
+  meta: DataSourcePluginMeta;
   url?: string;
   jsonData: { [str: string]: any };
   username?: string;
@@ -359,6 +381,6 @@ export interface DataSourceInstanceSettings {
 export interface DataSourceSelectItem {
   name: string;
   value: string | null;
-  meta: PluginMeta;
+  meta: DataSourcePluginMeta;
   sort: string;
 }

--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -24,23 +24,6 @@ export interface PluginMeta {
   // Filled in by the backend
   jsonData?: { [str: string]: any };
   enabled?: boolean;
-
-  // Datasource-specific
-  builtIn?: boolean;
-  metrics?: boolean;
-  tables?: boolean;
-  logs?: boolean;
-  explore?: boolean;
-  annotations?: boolean;
-  mixed?: boolean;
-  hasQueryHelp?: boolean;
-  queryOptions?: PluginMetaQueryOptions;
-}
-
-interface PluginMetaQueryOptions {
-  cacheTimeout?: boolean;
-  maxDataPoints?: boolean;
-  minInterval?: boolean;
 }
 
 export enum PluginIncludeType {

--- a/public/app/features/plugins/specs/datasource_srv.test.ts
+++ b/public/app/features/plugins/specs/datasource_srv.test.ts
@@ -1,7 +1,7 @@
 import config from 'app/core/config';
 import 'app/features/plugins/datasource_srv';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
-import { PluginMeta } from '@grafana/ui/src/types';
+import { PluginMeta, DataSourcePluginMeta } from '@grafana/ui/src/types';
 
 // Datasource variable $datasource with current value 'BBB'
 const templateSrv = {
@@ -26,14 +26,14 @@ describe('datasource_srv', () => {
           id: 1,
           type: 'b',
           name: 'buildIn',
-          meta: { builtIn: true } as PluginMeta,
+          meta: { builtIn: true } as DataSourcePluginMeta,
           jsonData: {},
         },
         nonBuildIn: {
           id: 2,
           type: 'e',
           name: 'external1',
-          meta: { builtIn: false } as PluginMeta,
+          meta: { builtIn: false } as DataSourcePluginMeta,
           jsonData: {},
         },
         nonExplore: {


### PR DESCRIPTION
Currently `PluginMeta` contains a bunch of types that are only valid for DataSources. This moves the types to a datasource specific flavor