### PR TITLE
Table: fix rotate support and storybook example

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.story.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.story.tsx
@@ -43,7 +43,7 @@ export function makeDummyTable(columnCount: number, rowCount: number): SeriesDat
   };
 }
 
-storiesOf('Alpha/Table', module)
+storiesOf('UI/Table', module)
   .add('Basic Table', () => {
     // NOTE: This example does not seem to survice rotate &
     // Changing fixed headers... but the next one does?
@@ -56,7 +56,7 @@ storiesOf('Alpha/Table', module)
 
     return withFullSizeStory(Table, {
       styles: [],
-      data: simpleTable,
+      data: { ...simpleTable },
       replaceVariables,
       showHeader,
       fixedHeader,

--- a/packages/grafana-ui/src/components/Table/examples.ts
+++ b/packages/grafana-ui/src/components/Table/examples.ts
@@ -162,6 +162,6 @@ export const migratedTestStyles: ColumnStyle[] = [
 
 export const simpleTable = {
   type: 'table',
-  columns: [{ name: 'First' }, { name: 'Second' }, { name: 'Third' }],
+  fields: [{ name: 'First' }, { name: 'Second' }, { name: 'Third' }],
   rows: [[701, 205, 305], [702, 206, 301], [703, 207, 304]],
 };


### PR DESCRIPTION
This PR fixes:
 * avoids error for invalid data
 * fixes width calculation for rotate
 * moves the storybook example out of alpha