### PR TITLE
build: fix integer overflow in pkg/tsdb tests on 32bit platforms

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -107,19 +107,19 @@ func TestAzureMonitorDatasource(t *testing.T) {
 				So(len(res.Series[0].Points), ShouldEqual, 5)
 
 				So(res.Series[0].Points[0][0].Float64, ShouldEqual, 2.0875)
-				So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1549620780000)
+				So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1549620780000))
 
 				So(res.Series[0].Points[1][0].Float64, ShouldEqual, 2.1525)
-				So(res.Series[0].Points[1][1].Float64, ShouldEqual, 1549620840000)
+				So(res.Series[0].Points[1][1].Float64, ShouldEqual, int64(1549620840000))
 
 				So(res.Series[0].Points[2][0].Float64, ShouldEqual, 2.155)
-				So(res.Series[0].Points[2][1].Float64, ShouldEqual, 1549620900000)
+				So(res.Series[0].Points[2][1].Float64, ShouldEqual, int64(1549620900000))
 
 				So(res.Series[0].Points[3][0].Float64, ShouldEqual, 3.6925)
-				So(res.Series[0].Points[3][1].Float64, ShouldEqual, 1549620960000)
+				So(res.Series[0].Points[3][1].Float64, ShouldEqual, int64(1549620960000))
 
 				So(res.Series[0].Points[4][0].Float64, ShouldEqual, 2.44)
-				So(res.Series[0].Points[4][1].Float64, ShouldEqual, 1549621020000)
+				So(res.Series[0].Points[4][1].Float64, ShouldEqual, int64(1549621020000))
 			})
 
 			Convey("when data from query aggregated as total to one time series", func() {
@@ -139,7 +139,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(res.Series[0].Points[0][0].Float64, ShouldEqual, 8.26)
-				So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1549718940000)
+				So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1549718940000))
 			})
 
 			Convey("when data from query aggregated as maximum to one time series", func() {
@@ -159,7 +159,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(res.Series[0].Points[0][0].Float64, ShouldEqual, 3.07)
-				So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1549722360000)
+				So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1549722360000))
 			})
 
 			Convey("when data from query aggregated as minimum to one time series", func() {
@@ -179,7 +179,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(res.Series[0].Points[0][0].Float64, ShouldEqual, 1.51)
-				So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1549723380000)
+				So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1549723380000))
 			})
 
 			Convey("when data from query aggregated as Count to one time series", func() {
@@ -199,7 +199,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(res.Series[0].Points[0][0].Float64, ShouldEqual, 4)
-				So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1549723440000)
+				So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1549723440000))
 			})
 
 			Convey("when data from query aggregated as total and has dimension filter", func() {

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -162,7 +162,7 @@ func TestMSSQL(t *testing.T) {
 				So(column[19].(time.Time), ShouldEqual, dt.Truncate(time.Minute))
 				So(column[20].(time.Time), ShouldEqual, dt.Truncate(24*time.Hour))
 				So(column[21].(time.Time), ShouldEqual, time.Date(1, 1, 1, dt.Hour(), dt.Minute(), dt.Second(), dt.Nanosecond(), time.UTC))
-				So(column[22].(time.Time), ShouldEqual, dt2.In(time.FixedZone("UTC", int(-7*time.Hour))))
+				So(column[22].(time.Time), ShouldEqual, dt2.In(time.FixedZone("UTC-7", int(-7*60*60))))
 			})
 		})
 

--- a/pkg/tsdb/stackdriver/stackdriver_test.go
+++ b/pkg/tsdb/stackdriver/stackdriver_test.go
@@ -236,13 +236,13 @@ func TestStackdriver(t *testing.T) {
 
 				Convey("timestamps should be in ascending order", func() {
 					So(res.Series[0].Points[0][0].Float64, ShouldEqual, 0.05)
-					So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1536670020000)
+					So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1536670020000))
 
 					So(res.Series[0].Points[1][0].Float64, ShouldEqual, 1.05)
-					So(res.Series[0].Points[1][1].Float64, ShouldEqual, 1536670080000)
+					So(res.Series[0].Points[1][1].Float64, ShouldEqual, int64(1536670080000))
 
 					So(res.Series[0].Points[2][0].Float64, ShouldEqual, 1.0666666666667)
-					So(res.Series[0].Points[2][1].Float64, ShouldEqual, 1536670260000)
+					So(res.Series[0].Points[2][1].Float64, ShouldEqual, int64(1536670260000))
 				})
 			})
 
@@ -365,9 +365,9 @@ func TestStackdriver(t *testing.T) {
 				}
 
 				Convey("timestamps should be in ascending order", func() {
-					So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1536668940000)
-					So(res.Series[0].Points[1][1].Float64, ShouldEqual, 1536669000000)
-					So(res.Series[0].Points[2][1].Float64, ShouldEqual, 1536669060000)
+					So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1536668940000))
+					So(res.Series[0].Points[1][1].Float64, ShouldEqual, int64(1536669000000))
+					So(res.Series[0].Points[2][1].Float64, ShouldEqual, int64(1536669060000))
 				})
 
 				Convey("bucket bounds should be correct", func() {
@@ -410,8 +410,8 @@ func TestStackdriver(t *testing.T) {
 				}
 
 				Convey("timestamps should be in ascending order", func() {
-					So(res.Series[0].Points[0][1].Float64, ShouldEqual, 1550859086000)
-					So(res.Series[0].Points[1][1].Float64, ShouldEqual, 1550859146000)
+					So(res.Series[0].Points[0][1].Float64, ShouldEqual, int64(1550859086000))
+					So(res.Series[0].Points[1][1].Float64, ShouldEqual, int64(1550859146000))
 				})
 
 				Convey("bucket bounds should be correct", func() {

--- a/pkg/tsdb/time_range_test.go
+++ b/pkg/tsdb/time_range_test.go
@@ -70,11 +70,11 @@ func TestTimeRange(t *testing.T) {
 
 			res, err := tr.ParseFrom()
 			So(err, ShouldBeNil)
-			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, 1474973725473)
+			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, int64(1474973725473))
 
 			res, err = tr.ParseTo()
 			So(err, ShouldBeNil)
-			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, 1474975757930)
+			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, int64(1474975757930))
 		})
 
 		Convey("Cannot parse asdf", func() {


### PR DESCRIPTION
Several pkg/tsdb tests fail to compile on 32bit platforms due to
integer overflow.