### PR TITLE
Prometheus: Fix regression after adding support for tracing headers

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -72,6 +72,7 @@ export class PrometheusDatasource implements DataSourceApi<PromQuery> {
     options = _.defaults(options || {}, {
       url: this.url + url,
       method: this.httpMethod,
+      headers: {},
     });
 
     if (options.method === 'GET') {

--- a/public/app/plugins/datasource/prometheus/specs/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/metric_find_query.test.ts
@@ -57,6 +57,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: 'proxied/api/v1/labels',
         silent: true,
+        headers: {},
       });
     });
 
@@ -75,6 +76,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: 'proxied/api/v1/label/resource/values',
         silent: true,
+        headers: {},
       });
     });
 
@@ -97,6 +99,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
+        headers: {},
       });
     });
 
@@ -121,6 +124,7 @@ describe('PrometheusMetricFindQuery', () => {
           'metric{label1="foo", label2="bar", label3="baz"}'
         )}&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
+        headers: {},
       });
     });
 
@@ -145,6 +149,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
+        headers: {},
       });
     });
 
@@ -163,6 +168,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: 'proxied/api/v1/label/__name__/values',
         silent: true,
+        headers: {},
       });
     });
 
@@ -190,6 +196,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url: `proxied/api/v1/query?query=metric&time=${raw.to.unix()}`,
         requestId: undefined,
+        headers: {},
       });
     });
 
@@ -217,6 +224,7 @@ describe('PrometheusMetricFindQuery', () => {
           'up{job="job1"}'
         )}&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
+        headers: {},
       });
     });
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a regression introduced by #16724 when datasource is configured
to use HTTP method POST and testing the datasource which results in an
'options.headers is undefined'. Same error probably happens if datasource
is configured to use basic auth and testing datasource.

**Which issue(s) this PR fixes**:
Ref #16724

**Special notes for your reviewer**:

