### PR TITLE
Datasources: Add pattern validation for time input on datasource config pages

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/config.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/config.html
@@ -36,7 +36,14 @@
 	<div class="gf-form-inline">
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Min time interval</span>
-			<input type="text" class="gf-form-input width-6 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="10s"></input>
+			<input
+        type="text"
+        class="gf-form-input width-6 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.timeInterval"
+        spellcheck='false'
+        placeholder="10s"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
 			<info-popover mode="right-absolute">
 				A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example <code>1m</code> if your data is written every minute.

--- a/public/app/plugins/datasource/mssql/partials/config.html
+++ b/public/app/plugins/datasource/mssql/partials/config.html
@@ -82,7 +82,14 @@
 	<div class="gf-form-inline">
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Min time interval</span>
-			<input type="text" class="gf-form-input width-6 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="1m"></input>
+			<input
+        type="text"
+        class="gf-form-input width-6 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.timeInterval"
+        spellcheck='false'
+        placeholder="1m"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
 			<info-popover mode="right-absolute">
 				A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example <code>1m</code> if your data is written every minute.

--- a/public/app/plugins/datasource/mysql/partials/config.html
+++ b/public/app/plugins/datasource/mysql/partials/config.html
@@ -82,7 +82,14 @@
 	<div class="gf-form-inline">
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Min time interval</span>
-			<input type="text" class="gf-form-input width-6 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="1m"></input>
+			<input
+        type="text"
+        class="gf-form-input width-6 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.timeInterval"
+        spellcheck='false'
+        placeholder="1m"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
 			<info-popover mode="right-absolute">
 				A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example <code>1m</code> if your data is written every minute.

--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -96,7 +96,14 @@
 	<div class="gf-form-inline">
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Min time interval</span>
-			<input type="text" class="gf-form-input width-6 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="1m"></input>
+			<input
+        type="text"
+        class="gf-form-input width-6 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.timeInterval"
+        spellcheck='false'
+        placeholder="1m"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
 			<info-popover mode="right-absolute">
 				A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example <code>1m</code> if your data is written every minute.

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -5,7 +5,14 @@
   <div class="gf-form-inline">
     <div class="gf-form">
       <span class="gf-form-label width-8">Scrape interval</span>
-      <input type="text" class="gf-form-input width-8 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.timeInterval" spellcheck='false' placeholder="15s"></input>
+      <input
+        type="text"
+        class="gf-form-input width-8 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.timeInterval"
+        spellcheck='false'
+        placeholder="15s"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
       <info-popover mode="right-absolute">
         Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for the
         Prometheus step query parameter.
@@ -16,7 +23,14 @@
   <div class="gf-form-inline">
     <div class="gf-form">
       <span class="gf-form-label width-8">Query timeout</span>
-      <input type="text" class="gf-form-input width-8 gf-form-input--has-help-icon" ng-model="ctrl.current.jsonData.queryTimeout" spellcheck='false' placeholder="60s"></input>
+      <input
+        type="text"
+        class="gf-form-input width-8 gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.queryTimeout"
+        spellcheck="false"
+        placeholder="60s"
+        ng-pattern="/^\d+[Mwdhmsy]$/"
+      ></input>
       <info-popover mode="right-absolute">
         Set the Prometheus query timeout.
       </info-popover>


### PR DESCRIPTION
Closes: #15703

Adds pattern validation in configuration screens where time input needs to have unit. As mentioned in the issue this is only frontend validation as there are issues with defining validation for datasources.

@xlson let me know if this is enough for this particular issue or if you think we should strive for more robust solution.