### PR TITLE
DataProxy: Restore Set-Cookie header after proxy request

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -101,8 +101,14 @@ func (proxy *DataSourceProxy) HandleRequest() {
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(proxy.ctx.Req.Request.Header))
 
+	originalSetCookie := proxy.ctx.Resp.Header().Get("Set-Cookie")
+
 	reverseProxy.ServeHTTP(proxy.ctx.Resp, proxy.ctx.Req.Request)
 	proxy.ctx.Resp.Header().Del("Set-Cookie")
+
+	if originalSetCookie != "" {
+		proxy.ctx.Resp.Header().Set("Set-Cookie", originalSetCookie)
+	}
 }
 
 func (proxy *DataSourceProxy) addTraceFromHeaderValue(span opentracing.Span, headerName string, tagName string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If Grafana rotates the user's auth token during a request to the data source proxy it will set the `Set-Cookie` header with new auth token in response before proxying the request to the datasource. 

Before this fix the `Set-Cookie` response header was cleared after the proxied request was finished to make sure that proxied datasources cannot affect cookies in users browsers. This had the consequence of accidentally also clearing the new auth token set in `Set-Cookie` header, at least that is the idea to the reported problems in referenced issue.

With this fix the original `Set-Cookie` value in response header is now restored after the proxied datasource request is finished. The existing logic of clearing `Set-Cookie` response header from proxied request have been left intact.

**Which issue(s) this PR fixes**:
Fixes #16757

**Special notes for your reviewer**:

