### PR TITLE
TestData: add dashboards to datasource

### DIFF
--- a/public/app/plugins/datasource/testdata/dashboards/streaming.json
+++ b/public/app/plugins/datasource/testdata/dashboards/streaming.json
@@ -1,0 +1,114 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_TESTDATA_DB",
+      "label": "TestData DB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "testdata",
+      "pluginName": "TestData DB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.2.0-pre"
+    },
+    {
+      "type": "panel",
+      "id": "graph2",
+      "name": "React Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "testdata",
+      "name": "TestData DB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "${DS_TESTDATA_DB}",
+      "description": "",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "graph": {
+          "showBars": false,
+          "showLines": true,
+          "showPoints": false
+        },
+        "legend": {
+          "asTable": true,
+          "decimals": 2,
+          "isVisible": true,
+          "placement": "right",
+          "stats": ["last"]
+        },
+        "series": {}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "streaming_client",
+          "stream": {
+            "noise": 10,
+            "speed": 100,
+            "spread": 20,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Simple dummy streaming example",
+      "type": "graph2"
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "",
+  "title": "Simple Streaming Example",
+  "uid": "TXSTREZ",
+  "version": 2
+}

--- a/public/app/plugins/datasource/testdata/plugin.json
+++ b/public/app/plugins/datasource/testdata/plugin.json
@@ -20,5 +20,13 @@
       "small": "../../../../img/grafana_icon.svg",
       "large": "../../../../img/grafana_icon.svg"
     }
-  }
+  },
+
+  "includes": [
+    {
+      "type": "dashboard",
+      "name": "Streaming Example",
+      "path": "dashboards/streaming.json"
+    }
+  ]
 }


### PR DESCRIPTION
In an ongoing effort to have *something* in grafana use the important plugin features, this adds a dashboard to the TestData source:

![image](https://user-images.githubusercontent.com/705951/57103984-11474880-6cdc-11e9-8a79-19badf61b91e.png)

I don't actually care what the dashboard is, but I added on to show off streaming:
![image](https://user-images.githubusercontent.com/705951/57103959-ff65a580-6cdb-11e9-8859-5884c2c1d32f.png)

it depends on the alpha `graph2` panel, so maybe we want something else.





