### PR TITLE
TestDataDatasource: add an empty ConfigEditor

### DIFF
--- a/public/app/plugins/datasource/testdata/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/testdata/ConfigEditor.tsx
@@ -1,0 +1,15 @@
+// Libraries
+import React, { PureComponent } from 'react';
+
+import { DataSourcePluginOptionsEditorProps } from '@grafana/ui';
+
+type Props = DataSourcePluginOptionsEditorProps<any>;
+
+/**
+ * Empty Config Editor -- settings to save
+ */
+export class ConfigEditor extends PureComponent<Props> {
+  render() {
+    return <div />;
+  }
+}

--- a/public/app/plugins/datasource/testdata/module.tsx
+++ b/public/app/plugins/datasource/testdata/module.tsx
@@ -1,6 +1,7 @@
 import { DataSourcePlugin } from '@grafana/ui';
 import { TestDataDatasource } from './datasource';
 import { TestDataQueryCtrl } from './query_ctrl';
+import { ConfigEditor } from './ConfigEditor';
 
 class TestDataAnnotationsQueryCtrl {
   annotation: any;
@@ -9,5 +10,6 @@ class TestDataAnnotationsQueryCtrl {
 }
 
 export const plugin = new DataSourcePlugin(TestDataDatasource)
+  .setConfigEditor(ConfigEditor)
   .setQueryCtrl(TestDataQueryCtrl)
   .setAnnotationQueryCtrl(TestDataAnnotationsQueryCtrl);


### PR DESCRIPTION
Loading testdata currently adds a warning message to the console:
<img  src="https://user-images.githubusercontent.com/705951/57116562-c8f34f00-6d0a-11e9-8ccd-08eb2f262a4f.png">

This just registers an empty editor to avoid the warning