### PR TITLE
Removed icons from plugin component and updated snapshots

### DIFF
--- a/public/app/features/plugins/PluginListItem.tsx
+++ b/public/app/features/plugins/PluginListItem.tsx
@@ -7,24 +7,12 @@ interface Props {
 
 const PluginListItem: FC<Props> = props => {
   const { plugin } = props;
-  let icon;
-
-  if (plugin.type === 'datasource') {
-    icon = 'gicon gicon-datasources';
-  } else if (plugin.type === 'panel') {
-    icon = 'icon-gf icon-gf-panel';
-  } else {
-    icon = 'icon-gf icon-gf-apps';
-  }
 
   return (
     <li className="card-item-wrapper">
       <a className="card-item" href={`plugins/${plugin.id}/`}>
         <div className="card-item-header">
-          <div className="card-item-type">
-            <i className={icon} />
-            {plugin.type}
-          </div>
+          <div className="card-item-type">{plugin.type}</div>
           {plugin.hasUpdate && (
             <div className="card-item-notice">
               <span bs-tooltip="plugin.latestVersion">Update available!</span>

--- a/public/app/features/plugins/__snapshots__/PluginListItem.test.tsx.snap
+++ b/public/app/features/plugins/__snapshots__/PluginListItem.test.tsx.snap
@@ -14,9 +14,6 @@ exports[`Render should render component 1`] = `
       <div
         className="card-item-type"
       >
-        <i
-          className="icon-gf icon-gf-panel"
-        />
         panel
       </div>
     </div>
@@ -63,9 +60,6 @@ exports[`Render should render has plugin section 1`] = `
       <div
         className="card-item-type"
       >
-        <i
-          className="icon-gf icon-gf-panel"
-        />
         panel
       </div>
       <div


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes icons from the plugins elements in the plugins page.

**Which issue(s) this PR fixes**:
Fixes #16833

**Special notes for your reviewer**:

