### PR TITLE
PanelModel: expose isInView property to PanelModel

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -233,6 +233,7 @@ export class DashboardGrid extends PureComponent<Props> {
     for (const panel of this.props.dashboard.panels) {
       const panelClasses = classNames({ 'react-grid-item--fullscreen': panel.fullscreen });
       const id = panel.id.toString();
+      panel.isInView = this.isInView(panel);
       panelElements.push(
         <div
           key={id}
@@ -247,7 +248,7 @@ export class DashboardGrid extends PureComponent<Props> {
             dashboard={this.props.dashboard}
             isEditing={panel.isEditing}
             isFullscreen={panel.fullscreen}
-            isInView={this.isInView(panel)}
+            isInView={panel.isInView}
           />
         </div>
       );

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -23,6 +23,7 @@ const notPersistedProperties: { [str: string]: boolean } = {
   events: true,
   fullscreen: true,
   isEditing: true,
+  isInView: true,
   hasRefreshed: true,
   cachedPluginOptions: true,
   plugin: true,
@@ -111,6 +112,7 @@ export class PanelModel {
   // non persisted
   fullscreen: boolean;
   isEditing: boolean;
+  isInView: boolean;
   hasRefreshed: boolean;
   events: Emitter;
   cacheTimeout?: any;


### PR DESCRIPTION
I would like to add an optional sidebar TOC like:
https://london.my-netdata.io/default.html#menu_apps_submenu_swap;theme=slate
![image](https://user-images.githubusercontent.com/705951/56340278-57da6600-6166-11e9-95b7-532e69389ac9.png)

For long dashboards, this will be super helpful.

Now that we are calculating which panels are visible, that should be pretty easy to implement.

This PR takes the simple first step of adding visibility info to the PanelModel so we can expose it from the dashboard.  

We could wait and expose this along with a TOC PR, but I think adding it to the PanelModel is kind of its own concept and I'm not sure about setting panel sate in the render method.
