### PR TITLE
Chore: Add prometheus basic auth proxy

### DIFF
--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/Dockerfile
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY htpasswd /etc/nginx/htpasswd

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
@@ -1,0 +1,6 @@
+# This will proxy all requests for http://localhost:10090 to
+# http://prometheus:9090 (Prometheus inside the docker compose)
+
+  nginxproxy:
+    build: docker/blocks/nginx_proxy
+    network_mode: host

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/htpasswd
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/htpasswd
@@ -1,0 +1,1 @@
+prom:$apr1$bfu32njz$HHDDTjaeWHDzQs2UMXP.C1

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/nginx.conf
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/nginx.conf
@@ -1,0 +1,34 @@
+events { }
+
+http {
+  server {
+
+    listen 10090;
+
+    location / {
+
+      # Removes any Access-Control-Allow-Origin from Prometheus itself. When accessing from browser, having * or
+      # multiple values is not allowed in some cases
+      proxy_hide_header Access-Control-Allow-Origin;
+
+      # Allow the origin access. This is kinda wildcard but for browser it seems more strict and is needed for
+      # withCredentials requests.
+      add_header Access-Control-Allow-Origin $http_origin;
+
+      # When using withCredentials requests this must be true.
+      add_header Access-Control-Allow-Credentials true;
+
+      # Ask for basic auth except for pre flight OPTIONS request.
+      limit_except OPTIONS {
+        ################################################################
+        # The htpasswd file contains user:
+        # prom: test
+        ################################################################
+        auth_basic "prom";
+        auth_basic_user_file /etc/nginx/htpasswd;
+      }
+
+      proxy_pass http://prometheus:9090/;
+    }
+  }
+}


### PR DESCRIPTION
As Prometheus does not have basic auth itself, to test it you need a proxy which is this PR. It adds a new service into devenv docker-compose files that can be used.