### PR TITLE
FormField: Changed to render prop

### DIFF
--- a/packages/grafana-ui/src/components/FormField/FormField.test.tsx
+++ b/packages/grafana-ui/src/components/FormField/FormField.test.tsx
@@ -16,20 +16,22 @@ const setup = (propOverrides?: Partial<Props>) => {
 };
 
 describe('FormField', () => {
-  it('should render component with default inputEl', () => {
+  it('should render component with default inputRender', () => {
     const wrapper = setup();
 
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render component with custom inputEl', () => {
+  it('should render component with custom inputRender', () => {
     const wrapper = setup({
-      inputEl: (
-        <>
-          <span>Input</span>
-          <button>Ok</button>
-        </>
-      ),
+      inputRender: () => {
+        return (
+          <>
+            <span>Input</span>
+            <button>Ok</button>
+          </>
+        );
+      },
     });
 
     expect(wrapper).toMatchSnapshot();

--- a/packages/grafana-ui/src/components/FormField/FormField.tsx
+++ b/packages/grafana-ui/src/components/FormField/FormField.tsx
@@ -7,7 +7,7 @@ export interface Props extends InputHTMLAttributes<HTMLInputElement> {
   tooltip?: PopperContent<any>;
   labelWidth?: number;
   inputWidth?: number;
-  inputEl?: React.ReactNode;
+  inputRender?: () => React.ReactNode;
 }
 
 const defaultProps = {
@@ -24,7 +24,7 @@ export const FormField: FunctionComponent<Props> = ({
   tooltip,
   labelWidth,
   inputWidth,
-  inputEl,
+  inputRender,
   ...inputProps
 }) => {
   return (
@@ -32,7 +32,8 @@ export const FormField: FunctionComponent<Props> = ({
       <FormLabel width={labelWidth} tooltip={tooltip}>
         {label}
       </FormLabel>
-      {inputEl || <input type="text" className={`gf-form-input width-${inputWidth}`} {...inputProps} />}
+      {inputRender && inputRender()}
+      {!inputRender && <input type="text" className={`gf-form-input width-${inputWidth}`} {...inputProps} />}
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/SecretFormFied/SecretFormField.tsx
+++ b/packages/grafana-ui/src/components/SecretFormFied/SecretFormField.tsx
@@ -1,5 +1,5 @@
 import { omit } from 'lodash';
-import React, { InputHTMLAttributes, FunctionComponent } from 'react';
+import React, { InputHTMLAttributes, FC } from 'react';
 import { FormField } from '..';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
@@ -27,7 +27,7 @@ const defaultProps = {
  * form field. This is used for passwords or anything that is encrypted on the server and is later returned encrypted
  * to the user (like datasource passwords).
  */
-export const SecretFormField: FunctionComponent<Props> = ({
+export const SecretFormField: FC<Props> = ({
   label,
   labelWidth,
   inputWidth,
@@ -36,35 +36,31 @@ export const SecretFormField: FunctionComponent<Props> = ({
   placeholder,
   ...inputProps
 }: Props) => {
-  return (
-    <FormField
-      label={label!}
-      labelWidth={labelWidth}
-      inputEl={
-        isConfigured ? (
-          <>
-            <input
-              type="text"
-              className={`gf-form-input width-${inputWidth! - 2}`}
-              disabled={true}
-              value="configured"
-              {...omit(inputProps, 'value')}
-            />
-            <button className="btn btn-secondary gf-form-btn" onClick={onReset}>
-              reset
-            </button>
-          </>
-        ) : (
-          <input
-            type="password"
-            className={`gf-form-input width-${inputWidth}`}
-            placeholder={placeholder}
-            {...inputProps}
-          />
-        )
-      }
-    />
-  );
+  const inputRender = () => {
+    return isConfigured ? (
+      <>
+        <input
+          type="text"
+          className={`gf-form-input width-${inputWidth! - 2}`}
+          disabled={true}
+          value="configured"
+          {...omit(inputProps, 'value')}
+        />
+        <button className="btn btn-secondary gf-form-btn" onClick={onReset}>
+          reset
+        </button>
+      </>
+    ) : (
+      <input
+        type="password"
+        className={`gf-form-input width-${inputWidth}`}
+        placeholder={placeholder}
+        {...inputProps}
+      />
+    );
+  };
+
+  return <FormField label={label!} labelWidth={labelWidth} inputRender={inputRender} />;
 };
 
 SecretFormField.defaultProps = defaultProps;


### PR DESCRIPTION
Changed inputEl to a more traditional render function prop. Passing React.Nodes directly as children is not something I have seen elsewhere, but do not know if that is a good/bad practice or not :)