### PR TITLE
PanelQueryState: check for the same query running

### DIFF
--- a/public/app/features/dashboard/state/PanelQueryState.test.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.test.ts
@@ -34,14 +34,22 @@ describe('PanelQueryState', () => {
     expect(empty.series.length).toBe(0);
     expect(hasRun).toBeFalsy();
 
-    empty = await state.execute(
-      ds,
-      getQueryOptions({ targets: [{ hide: true, refId: 'X' }, { hide: true, refId: 'Y' }, { hide: true, refId: 'Z' }] })
-    );
+    const query = getQueryOptions({
+      targets: [{ hide: true, refId: 'X' }, { hide: true, refId: 'Y' }, { hide: true, refId: 'Z' }],
+    });
+
+    empty = await state.execute(ds, query);
     // should not run any hidden queries'
     expect(state.getActiveRunner()).toBeFalsy();
     expect(empty.series.length).toBe(0);
     expect(hasRun).toBeFalsy();
+
+    // Check for the same query
+    expect(state.isSameQuery(ds, query)).toBeTruthy();
+
+    // Check for differnet queries
+    expect(state.isSameQuery(new MockDataSourceApi('test'), query)).toBeFalsy();
+    expect(state.isSameQuery(ds, getQueryOptions({ targets: [{ refId: 'differnet' }] }))).toBeFalsy();
   });
 });
 

--- a/public/app/features/dashboard/state/PanelQueryState.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.ts
@@ -95,6 +95,7 @@ export class PanelQueryState {
 
   execute(ds: DataSourceApi, req: DataQueryRequest): Promise<PanelData> {
     this.request = req;
+    this.datasource = ds;
 
     // Return early if there are no queries to run
     if (!req.targets.length) {


### PR DESCRIPTION
Fixes #16880

The `isSameQuery` makes sure it is the same datasource, but we never reset it before