### PR TITLE
PanelModel: Clear queryRunner on destroy

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -87,10 +87,7 @@ describe('PanelModel', () => {
     });
 
     describe('when changing panel type', () => {
-      let panelQueryRunner: any;
-
       beforeEach(() => {
-        panelQueryRunner = model.getQueryRunner();
         model.changePlugin(getPanelPlugin({ id: 'graph' }));
         model.alert = { id: 2 };
       });
@@ -109,9 +106,9 @@ describe('PanelModel', () => {
         expect(model.alert).toBe(undefined);
       });
 
-      it('getQueryRunner() should return same instance after plugin change', () => {
-        const sameQueryRunner = model.getQueryRunner();
-        expect(panelQueryRunner).toBe(sameQueryRunner);
+      it('panelQueryRunner should be cleared', () => {
+        const panelQueryRunner = (model as any).queryRunner;
+        expect(panelQueryRunner).toBeFalsy();
       });
     });
 
@@ -131,18 +128,27 @@ describe('PanelModel', () => {
       });
     });
 
-    describe('when changing to react panel', () => {
+    describe('when changing to react panel from angular panel', () => {
+      let panelQueryRunner: any;
+
       const onPanelTypeChanged = jest.fn();
       const reactPlugin = getPanelPlugin({ id: 'react' }).setPanelChangeHandler(onPanelTypeChanged as any);
 
       beforeEach(() => {
         model.changePlugin(reactPlugin);
+        panelQueryRunner = model.getQueryRunner();
       });
 
       it('should call react onPanelTypeChanged', () => {
         expect(onPanelTypeChanged.mock.calls.length).toBe(1);
         expect(onPanelTypeChanged.mock.calls[0][1]).toBe('table');
         expect(onPanelTypeChanged.mock.calls[0][2].thresholds).toBeDefined();
+      });
+
+      it('getQueryRunner() should return same instance after changing to another react panel', () => {
+        model.changePlugin(getPanelPlugin({ id: 'react2' }));
+        const sameQueryRunner = model.getQueryRunner();
+        expect(panelQueryRunner).toBe(sameQueryRunner);
       });
     });
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -336,6 +336,7 @@ export class PanelModel {
 
     if (this.queryRunner) {
       this.queryRunner.destroy();
+      this.queryRunner = null;
     }
   }
 }

--- a/public/app/features/dashboard/state/PanelQueryState.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.ts
@@ -41,7 +41,7 @@ export class PanelQueryState {
   sendLegacy = false;
 
   // A promise for the running query
-  private executor?: Promise<PanelData>;
+  private executor?: Promise<PanelData> = null;
   private rejector = (reason?: any) => {};
   private datasource: DataSourceApi = {} as any;
 


### PR DESCRIPTION
Fixes issue when changing panel type from angular to react 