### PR TITLE
grafanaui: ban importing from @grafana/ui in grafana ui files

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "storybook:build": "cd packages/grafana-ui && yarn storybook:build",
     "themes:generate": "ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/generateSassVariableFiles.ts",
     "prettier:check": "prettier --list-different \"**/*.{ts,tsx,scss}\"",
+    "gui:tslint": "tslint -c ./packages/grafana-ui/tslint.json --project ./packages/grafana-ui/tsconfig.json",
     "gui:build": "ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/index.ts gui:build",
     "gui:releasePrepare": "ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/index.ts gui:release",
     "gui:publish": "cd packages/grafana-ui/dist && npm publish --access public",

--- a/packages/grafana-ui/tslint.json
+++ b/packages/grafana-ui/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tslint.json"
+  "extends": "../../tslint.json",
+  "rules": {
+    "import-blacklist": [true, ["^@grafana/ui.*"]]
+  }
 }


### PR DESCRIPTION
Added tslint rule to ban imports like `from '@grafana/ui'`, `from '@grafana/ui/...'` in graffana ui's files. Importing in such way makes rollup being unable to bundle the package.

fyi @ryantxu 