### PR TITLE
Prometheus: Correctly escape '|' literals in interpolated PromQL variables

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -701,7 +701,7 @@ export function prometheusRegularEscape(value) {
 
 export function prometheusSpecialRegexEscape(value) {
   if (typeof value === 'string') {
-    return prometheusRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()]/g, '\\\\$&'));
+    return prometheusRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
   }
   return value;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Correctly escapes `|` characters when sending Prometheus queries with interpolated multi-value or include-all variables.

**Which issue(s) this PR fixes**:

Fixes #16840

**Special notes for your reviewer**:

Added tests for 'interpolateQueryExpr' which should possibly be private, but is difficult to
test due to TemplateSrv calling it. Took the approach used in the MySQL tests and tested the interpolation directly.
