### PR TITLE
AppPlugin: remove /edit from the URL

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -233,7 +233,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 
 			if len(appLink.Children) > 0 && c.OrgRole == m.ROLE_ADMIN {
 				appLink.Children = append(appLink.Children, &dtos.NavLink{Divider: true})
-				appLink.Children = append(appLink.Children, &dtos.NavLink{Text: "Plugin Config", Icon: "gicon gicon-cog", Url: setting.AppSubUrl + "/plugins/" + plugin.Id + "/edit"})
+				appLink.Children = append(appLink.Children, &dtos.NavLink{Text: "Plugin Config", Icon: "gicon gicon-cog", Url: setting.AppSubUrl + "/plugins/" + plugin.Id + "/"})
 			}
 
 			if len(appLink.Children) > 0 {


### PR DESCRIPTION
In #16586 we removed `/edit` from the plugin pages, but it is still used when you have an enabled app:

![image](https://user-images.githubusercontent.com/705951/57337937-44c11300-70e0-11e9-8d99-395bb7907f86.png)
