### PR TITLE
Add interval variables as default scopedVars in the template filter

### DIFF
--- a/public/app/core/filters/filters.ts
+++ b/public/app/core/filters/filters.ts
@@ -44,7 +44,11 @@ function interpolateTemplateVars(templateSrv: TemplateSrv) {
   const filterFunc: any = (text: string, scope: any) => {
     let scopedVars;
     if (scope.ctrl) {
-      scopedVars = (scope.ctrl.panel || scope.ctrl.row).scopedVars;
+      scopedVars = {
+        __interval: { text: scope.ctrl.interval, value: scope.ctrl.interval },
+        __interval_ms: { text: scope.ctrl.intervalMs, value: scope.ctrl.intervalMs },
+        ...(scope.ctrl.panel || scope.ctrl.row).scopedVars,
+      };
     } else {
       scopedVars = scope.row.scopedVars;
     }


### PR DESCRIPTION
Fixes #15645

Here's a demo 😄

![#15645](https://user-images.githubusercontent.com/9457739/57350255-5f6ca980-712b-11e9-91ac-e95fe6247b9f.gif)