### PR TITLE
http: remove dualstack since its deprecated

### DIFF
--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -27,7 +27,6 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -17,7 +17,6 @@ var grafanaComProxyTransport = &http.Transport{
 	Dial: (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}).Dial,
 	TLSHandshakeTimeout: 10 * time.Second,
 }

--- a/pkg/cmd/grafana-cli/services/services.go
+++ b/pkg/cmd/grafana-cli/services/services.go
@@ -32,7 +32,6 @@ func Init(version string, skipTLSVerify bool) {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,

--- a/pkg/components/imguploader/webdavuploader.go
+++ b/pkg/components/imguploader/webdavuploader.go
@@ -25,8 +25,7 @@ type WebdavUploader struct {
 var netTransport = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	Dial: (&net.Dialer{
-		Timeout:   60 * time.Second,
-		DualStack: true,
+		Timeout: 60 * time.Second,
 	}).Dial,
 	TLSHandshakeTimeout: 5 * time.Second,
 }

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -61,7 +61,6 @@ func (ds *DataSource) GetHttpTransport() (*http.Transport, error) {
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).Dial,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -32,8 +32,7 @@ var netTransport = &http.Transport{
 	},
 	Proxy: http.ProxyFromEnvironment,
 	Dial: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		DualStack: true,
+		Timeout: 30 * time.Second,
 	}).Dial,
 	TLSHandshakeTimeout: 5 * time.Second,
 }

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -15,8 +15,7 @@ import (
 var netTransport = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
 	Dial: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		DualStack: true,
+		Timeout: 30 * time.Second,
 	}).Dial,
 	TLSHandshakeTimeout: 5 * time.Second,
 }


### PR DESCRIPTION
Deprecated: Fast Fallback is enabled by default. To
disable, set FallbackDelay to a negative value.

https://golang.org/src/net/dial.go

I stumble upon this when reading `net/http` code for another issue.