### PR TITLE
devenv: add slow reverse proxy

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -13,6 +13,11 @@ datasources:
     access: proxy
     url: http://localhost:9090
 
+  - name: gdev-slow-prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:3011
+
   - name: gdev-testdata
     type: testdata
     isDefault: true

--- a/devenv/docker/blocks/slow_proxy/Dockerfile
+++ b/devenv/docker/blocks/slow_proxy/Dockerfile
@@ -1,0 +1,7 @@
+
+FROM golang:latest 
+ADD main.go /
+WORKDIR /
+RUN go build -o main . 
+EXPOSE 3011
+ENTRYPOINT ["/main"]

--- a/devenv/docker/blocks/slow_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/slow_proxy/docker-compose.yaml
@@ -1,0 +1,7 @@
+  slow_proxy:
+    build: docker/blocks/slow_proxy
+    network_mode: host
+    ports:
+      - "3011:3011"
+    environment:
+      ORIGIN_SERVER: "http://localhost:9090/"

--- a/devenv/docker/blocks/slow_proxy/main.go
+++ b/devenv/docker/blocks/slow_proxy/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"time"
+)
+
+func main() {
+	origin := os.Getenv("ORIGIN_SERVER")
+	if origin == "" {
+		origin = "http://localhost:9090/"
+	}
+
+	sleep := time.Minute
+
+	originURL, _ := url.Parse(origin)
+	proxy := httputil.NewSingleHostReverseProxy(originURL)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("sleeping for %s then proxying request: %s", sleep.String(), r.RequestURI)
+		<-time.After(sleep)
+		proxy.ServeHTTP(w, r)
+	})
+
+	log.Fatal(http.ListenAndServe(":3011", nil))
+}


### PR DESCRIPTION
this can be useful when testing timeouts etc
in the dataproxy

ref #16923