### PR TITLE
InfluxDB: Fix HTTP method should default to GET

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -34,7 +34,7 @@ export default class InfluxDatasource {
     this.withCredentials = instanceSettings.withCredentials;
     this.interval = (instanceSettings.jsonData || {}).timeInterval;
     this.responseParser = new ResponseParser();
-    this.httpMode = instanceSettings.jsonData.httpMode;
+    this.httpMode = instanceSettings.jsonData.httpMode || 'GET';
   }
 
   query(options) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a default value when initializating the `InfluxDatasource` object. This ensures that a value is set after updating Grafana.

Tested by updating from v6.1.4 to v6.2.0-beta1 + this commit.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/16929
