### PR TITLE
Plugins: Fix how datemath utils are exposed to plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -106,7 +106,7 @@ exposeToPlugin('app/core/services/backend_srv', {
 });
 
 exposeToPlugin('app/plugins/sdk', sdk);
-exposeToPlugin('@grafana/ui/src/utils/datemath', datemath);
+exposeToPlugin('app/core/utils/datemath', datemath);
 exposeToPlugin('app/core/utils/file_export', fileExport);
 exposeToPlugin('app/core/utils/flatten', flatten);
 exposeToPlugin('app/core/utils/kbn', kbn);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a regression accidentally introduced by #16890 so that datemath utils are exposed to plugins in a backward-compatible way.

**Which issue(s) this PR fixes**:
Fixes #16962 

**Special notes for your reviewer**:

