### PR TITLE
Plugins: replace dataFormats list with skipDataQuery flag in plugin.json

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -7,18 +7,9 @@ import { PluginMeta, GrafanaPlugin } from './plugin';
 export type InterpolateFunction = (value: string, scopedVars?: ScopedVars, format?: string | Function) => string;
 
 export interface PanelPluginMeta extends PluginMeta {
+  skipDataQuery?: boolean;
   hideFromList?: boolean;
   sort: number;
-
-  // if length>0 the query tab will show up
-  // Before 6.2 this could be table and/or series, but 6.2+ supports both transparently
-  // so it will be deprecated soon
-  dataFormats?: PanelDataFormat[];
-}
-
-export enum PanelDataFormat {
-  Table = 'table',
-  TimeSeries = 'time_series',
 }
 
 export interface PanelData {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	"github.com/grafana/grafana/pkg/util"
 	"strconv"
+
+	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
@@ -154,15 +155,15 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 		}
 
 		panels[panel.Id] = map[string]interface{}{
-			"module":       panel.Module,
-			"baseUrl":      panel.BaseUrl,
-			"name":         panel.Name,
-			"id":           panel.Id,
-			"info":         panel.Info,
-			"hideFromList": panel.HideFromList,
-			"sort":         getPanelSort(panel.Id),
-			"dataFormats":  panel.DataFormats,
-			"state":        panel.State,
+			"module":        panel.Module,
+			"baseUrl":       panel.BaseUrl,
+			"name":          panel.Name,
+			"id":            panel.Id,
+			"info":          panel.Info,
+			"hideFromList":  panel.HideFromList,
+			"sort":          getPanelSort(panel.Id),
+			"skipDataQuery": panel.SkipDataQuery,
+			"state":         panel.State,
 		}
 	}
 

--- a/pkg/plugins/panel_plugin.go
+++ b/pkg/plugins/panel_plugin.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type PanelPlugin struct {
 	FrontendPluginBase
-	DataFormats []string `json:"dataFormats"`
+	SkipDataQuery bool `json:"skipDataQuery"`
 }
 
 func (p *PanelPlugin) Load(decoder *json.Decoder, pluginDir string) error {
@@ -14,10 +14,6 @@ func (p *PanelPlugin) Load(decoder *json.Decoder, pluginDir string) error {
 
 	if err := p.registerPlugin(pluginDir); err != nil {
 		return err
-	}
-
-	if p.DataFormats == nil {
-		p.DataFormats = []string{"time_series", "table"}
 	}
 
 	Panels[p.Id] = p

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -222,7 +222,7 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   get wantsQueryExecution() {
-    return this.props.plugin.meta.dataFormats.length > 0 && !this.hasPanelSnapshot;
+    return !(this.props.plugin.meta.skipDataQuery || this.hasPanelSnapshot);
   }
 
   renderPanel(width: number, height: number): JSX.Element {

--- a/public/app/features/dashboard/dashgrid/PanelPluginNotFound.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelPluginNotFound.tsx
@@ -49,7 +49,6 @@ export function getPanelPluginNotFound(id: string): PanelPlugin {
     type: PluginType.panel,
     module: '',
     baseUrl: '',
-    dataFormats: [],
     info: {
       author: {
         name: '',

--- a/public/app/features/dashboard/panel_editor/PanelEditor.tsx
+++ b/public/app/features/dashboard/panel_editor/PanelEditor.tsx
@@ -105,7 +105,7 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
     ];
 
     // handle panels that do not have queries tab
-    if (plugin.meta.dataFormats.length === 0) {
+    if (!plugin.meta.skipDataQuery) {
       // remove queries tab
       tabs.shift();
       // switch tab

--- a/public/app/features/plugins/__mocks__/pluginMocks.ts
+++ b/public/app/features/plugins/__mocks__/pluginMocks.ts
@@ -1,4 +1,4 @@
-import { PanelPluginMeta, PluginMeta, PluginType, PanelDataFormat, PanelPlugin, PanelProps } from '@grafana/ui';
+import { PanelPluginMeta, PluginMeta, PluginType, PanelPlugin, PanelProps } from '@grafana/ui';
 import { ComponentType } from 'enzyme';
 
 export const getMockPlugins = (amount: number): PluginMeta[] => {
@@ -46,7 +46,6 @@ export const getPanelPlugin = (
     type: PluginType.panel,
     name: options.id,
     sort: options.sort || 1,
-    dataFormats: [PanelDataFormat.TimeSeries],
     info: {
       author: {
         name: options.id + 'name',

--- a/public/app/plugins/panel/alertlist/plugin.json
+++ b/public/app/plugins/panel/alertlist/plugin.json
@@ -3,7 +3,7 @@
   "name": "Alert List",
   "id": "alertlist",
 
-  "dataFormats": [],
+  "skipDataQuery": true,
 
   "info": {
     "description": "Shows list of alerts and their current status",

--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -4,8 +4,6 @@
   "id": "bargauge",
   "state": "beta",
 
-  "dataFormats": ["time_series"],
-
   "info": {
     "author": {
       "name": "Grafana Project",

--- a/public/app/plugins/panel/dashlist/plugin.json
+++ b/public/app/plugins/panel/dashlist/plugin.json
@@ -3,7 +3,7 @@
   "name": "Dashboard list",
   "id": "dashlist",
 
-  "dataFormats": [],
+  "skipDataQuery": true,
 
   "info": {
     "description": "List of dynamic links to other dashboards",

--- a/public/app/plugins/panel/gauge/plugin.json
+++ b/public/app/plugins/panel/gauge/plugin.json
@@ -3,8 +3,6 @@
   "name": "Gauge",
   "id": "gauge",
 
-  "dataFormats": ["time_series"],
-
   "info": {
     "author": {
       "name": "Grafana Project",

--- a/public/app/plugins/panel/graph/plugin.json
+++ b/public/app/plugins/panel/graph/plugin.json
@@ -3,8 +3,6 @@
   "name": "Graph",
   "id": "graph",
 
-  "dataFormats": ["time_series", "table"],
-
   "info": {
     "description": "Graph Panel for Grafana",
     "author": {

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -3,8 +3,6 @@
   "name": "Heatmap",
   "id": "heatmap",
 
-  "dataFormats": ["time_series"],
-
   "info": {
     "description": "Heatmap Panel for Grafana",
     "author": {

--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -4,8 +4,6 @@
   "id": "piechart",
   "state": "alpha",
 
-  "dataFormats": ["time_series"],
-
   "info": {
     "author": {
       "name": "Grafana Project",

--- a/public/app/plugins/panel/pluginlist/plugin.json
+++ b/public/app/plugins/panel/pluginlist/plugin.json
@@ -3,7 +3,7 @@
   "name": "Plugin list",
   "id": "pluginlist",
 
-  "dataFormats": [],
+  "skipDataQuery": true,
 
   "info": {
     "description": "Plugin List for Grafana",

--- a/public/app/plugins/panel/singlestat/plugin.json
+++ b/public/app/plugins/panel/singlestat/plugin.json
@@ -3,8 +3,6 @@
   "name": "Singlestat",
   "id": "singlestat",
 
-  "dataFormats": ["time_series", "table"],
-
   "info": {
     "description": "Singlestat Panel for Grafana",
     "author": {

--- a/public/app/plugins/panel/singlestat2/plugin.json
+++ b/public/app/plugins/panel/singlestat2/plugin.json
@@ -4,8 +4,6 @@
   "id": "singlestat2",
   "state": "alpha",
 
-  "dataFormats": ["time_series", "table"],
-
   "info": {
     "description": "Singlestat Panel for Grafana",
     "author": {

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -3,8 +3,6 @@
   "name": "Table",
   "id": "table",
 
-  "dataFormats": ["table", "time_series"],
-
   "info": {
     "description": "Table Panel for Grafana",
     "author": {

--- a/public/app/plugins/panel/table2/plugin.json
+++ b/public/app/plugins/panel/table2/plugin.json
@@ -4,8 +4,6 @@
   "id": "table2",
   "state": "alpha",
 
-  "dataFormats": ["table"],
-
   "info": {
     "author": {
       "name": "Grafana Project",

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -3,7 +3,7 @@
   "name": "Text",
   "id": "text",
 
-  "dataFormats": [],
+  "skipDataQuery": true,
 
   "info": {
     "author": {

--- a/public/app/plugins/panel/text2/plugin.json
+++ b/public/app/plugins/panel/text2/plugin.json
@@ -4,7 +4,7 @@
   "id": "text2",
   "state": "alpha",
 
-  "dataFormats": [],
+  "skipDataQuery": true,
 
   "info": {
     "author": {


### PR DESCRIPTION
in 6.0, a flag for `dataFormats:[time_series, table]` was added.  It gets used to include or hide the query editor.  

Now that we are moving all data to a single structure, this does not make much sense.

Lets replace it with a flag to say if it wants query data or not.  I made it a `skip` flag so you have to set it explicitly and it defaults to on