### PR TITLE
PanelEditor: Fix queries tab now showing, wrong skipDataQuery logic

### DIFF
--- a/public/app/features/dashboard/panel_editor/PanelEditor.tsx
+++ b/public/app/features/dashboard/panel_editor/PanelEditor.tsx
@@ -105,7 +105,7 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
     ];
 
     // handle panels that do not have queries tab
-    if (!plugin.meta.skipDataQuery) {
+    if (plugin.meta.skipDataQuery) {
       // remove queries tab
       tabs.shift();
       // switch tab


### PR DESCRIPTION
The logic was flipped in https://github.com/grafana/grafana/pull/16984 , it removed queries tab from all data panels and not the other way around :) 