### PR TITLE
Explore: Fix empty result from datasource should render logs container

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -356,7 +356,12 @@ export function seriesDataToLogsModel(seriesData: SeriesData[], intervalMs: numb
     return logsModel;
   }
 
-  return undefined;
+  return {
+    hasUniqueLabels: false,
+    rows: [],
+    meta: [],
+    series: [],
+  };
 }
 
 export function logSeriesToLogsModel(logSeries: SeriesData[]): LogsModel {

--- a/public/app/core/specs/logs_model.test.ts
+++ b/public/app/core/specs/logs_model.test.ts
@@ -333,22 +333,29 @@ describe('LogsParsers', () => {
   });
 });
 
+const emptyLogsModel = {
+  hasUniqueLabels: false,
+  rows: [],
+  meta: [],
+  series: [],
+};
+
 describe('seriesDataToLogsModel', () => {
-  it('given empty series should return undefined', () => {
-    expect(seriesDataToLogsModel([] as SeriesData[], 0)).toBeUndefined();
+  it('given empty series should return empty logs model', () => {
+    expect(seriesDataToLogsModel([] as SeriesData[], 0)).toMatchObject(emptyLogsModel);
   });
 
-  it('given series without correct series name should not be processed', () => {
+  it('given series without correct series name should return empty logs model', () => {
     const series: SeriesData[] = [
       {
         fields: [],
         rows: [],
       },
     ];
-    expect(seriesDataToLogsModel(series, 0)).toBeUndefined();
+    expect(seriesDataToLogsModel(series, 0)).toMatchObject(emptyLogsModel);
   });
 
-  it('given series without a time field should not be processed', () => {
+  it('given series without a time field should return empty logs model', () => {
     const series: SeriesData[] = [
       {
         fields: [
@@ -360,10 +367,10 @@ describe('seriesDataToLogsModel', () => {
         rows: [],
       },
     ];
-    expect(seriesDataToLogsModel(series, 0)).toBeUndefined();
+    expect(seriesDataToLogsModel(series, 0)).toMatchObject(emptyLogsModel);
   });
 
-  it('given series without a string field should not be processed', () => {
+  it('given series without a string field should return empty logs model', () => {
     const series: SeriesData[] = [
       {
         fields: [
@@ -375,7 +382,7 @@ describe('seriesDataToLogsModel', () => {
         rows: [],
       },
     ];
-    expect(seriesDataToLogsModel(series, 0)).toBeUndefined();
+    expect(seriesDataToLogsModel(series, 0)).toMatchObject(emptyLogsModel);
   });
 
   it('given one series should return expected logs model', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make sure to return an empty logs model instead of undefined so that the logs container renders an empty graph and log result in Explore.

**Which issue(s) this PR fixes**:
Fixes #16997
