### PR TITLE
Docs: adds note about removing session storage

### DIFF
--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -172,6 +172,6 @@ this new setting.
 
 ### Session storage is no longer used
 
-In 6.2 we completly removed the session storage since we replaced the previous session implementation with an auth token.
+In 6.2 we completely removed the session storage since we replaced the previous session implementation with an auth token.
 If you are using Auth proxy with LDAP an shared cached is used in Grafana so you might want configure [remote_cache] instead. If not
 Grafana will fallback to using the database as an shared cache.

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -169,3 +169,9 @@ configuration.
 If you're embedding Grafana in a `<frame>`, `<iframe>`, `<embed>` or `<object>` on a different website it will no longer work due to a new setting
 that per default instructs the browser to not allow Grafana to be embedded. Read more [here](/installation/configuration/#allow-embedding) about
 this new setting.
+
+### Session storage is no longer used
+
+In 6.2 we completly removed the session storage since we replaced the previous session implementation with an auth token.
+If you are using Auth proxy with LDAP an shared cached is used in Grafana so you might want configure [remote_cache] instead. If not
+Grafana will fallback to using the database as an shared cache.

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -172,6 +172,6 @@ this new setting.
 
 ### Session storage is no longer used
 
-In 6.2 we completely removed the session storage since we replaced the previous session implementation with an auth token.
+In 6.2 we completely removed the backend session storage since we replaced the previous login session implementation with an auth token.
 If you are using Auth proxy with LDAP an shared cached is used in Grafana so you might want configure [remote_cache] instead. If not
 Grafana will fallback to using the database as an shared cache.

--- a/docs/sources/tutorials/ha_setup.md
+++ b/docs/sources/tutorials/ha_setup.md
@@ -31,7 +31,7 @@ Currently alerting supports a limited form of high availability. Since v4.2.0, a
 ## User sessions
 
 > After Grafana 6.2 you don't need to configure session storage since the database will be used by default.
-> If you want to offload the login session data from the database you can configure [remote_cache]({{< relref "configuration.md" >}}#remote_cache)
+> If you want to offload the login session data from the database you can configure [remote_cache]({{< relref "configuration.md" >}}#remote-cache)
 
 The second thing to consider is how to deal with user sessions and how to configure your load balancer in front of Grafana.
 Grafana supports two ways of storing session data: locally on disk or in a database/cache-server.

--- a/docs/sources/tutorials/ha_setup.md
+++ b/docs/sources/tutorials/ha_setup.md
@@ -30,7 +30,8 @@ Currently alerting supports a limited form of high availability. Since v4.2.0, a
 
 ## User sessions
 
-> Beginning with Grafana v6.0 and above the following only applies when using [Auth Proxy Authentication](/auth/auth-proxy/).
+> After Grafana 6.2 you don't need to configure session storage since the database will be used by default.
+> If you want to offload the login session data from the database you can configure [remote_cache]({{< relref "configuration.md" >}}#remote_cache)
 
 The second thing to consider is how to deal with user sessions and how to configure your load balancer in front of Grafana.
 Grafana supports two ways of storing session data: locally on disk or in a database/cache-server.


### PR DESCRIPTION
closes #17000

During discussions when we removed this feature we decided to keep them in the docs since we dont use versioned docs that much. 