### PR TITLE
fix(explore): Prevent double querying for Prometheus and Loki

### DIFF
--- a/public/app/features/explore/QueryField.tsx
+++ b/public/app/features/explore/QueryField.tsx
@@ -329,11 +329,13 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
       }
 
       return true;
-    } else {
+    } else if (!event.shiftKey) {
+      // Run queries if Shift is not pressed, otherwise pass through
       this.executeOnChangeAndRunQueries();
 
-      return undefined;
+      return true;
     }
+    return undefined;
   };
 
   onKeyDown = (event: KeyboardEvent, change: Change) => {

--- a/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
@@ -12,7 +12,6 @@ import QueryField, { TypeaheadInput, QueryFieldState } from 'app/features/explor
 // dom also includes Element polyfills
 import { getNextCharacter, getPreviousCousin } from 'app/features/explore/utils/dom';
 import BracesPlugin from 'app/features/explore/slate-plugins/braces';
-import RunnerPlugin from 'app/features/explore/slate-plugins/runner';
 
 // Types
 import { LokiQuery } from '../types';
@@ -77,7 +76,6 @@ export interface LokiQueryFieldFormProps extends ExploreQueryFieldProps<ExploreD
 
 export class LokiQueryFieldForm extends React.PureComponent<LokiQueryFieldFormProps> {
   plugins: any[];
-  pluginsSearch: any[];
   modifiedSearch: string;
   modifiedQuery: string;
 
@@ -86,14 +84,11 @@ export class LokiQueryFieldForm extends React.PureComponent<LokiQueryFieldFormPr
 
     this.plugins = [
       BracesPlugin(),
-      RunnerPlugin({ handler: props.onRunQuery }),
       PluginPrism({
         onlyIn: (node: any) => node.type === 'code_block',
         getSyntax: (node: any) => 'promql',
       }),
     ];
-
-    this.pluginsSearch = [RunnerPlugin({ handler: props.onRunQuery })];
   }
 
   loadOptions = (selectedOptions: CascaderOption[]) => {

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -4,7 +4,7 @@
   "id": "loki",
   "category": "logging",
 
-  "metrics": true,
+  "metrics": false,
   "alerting": false,
   "annotations": false,
   "logs": true,

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -12,7 +12,6 @@ import { TypeaheadOutput, HistoryItem } from 'app/types/explore';
 // dom also includes Element polyfills
 import { getNextCharacter, getPreviousCousin } from 'app/features/explore/utils/dom';
 import BracesPlugin from 'app/features/explore/slate-plugins/braces';
-import RunnerPlugin from 'app/features/explore/slate-plugins/runner';
 import QueryField, { TypeaheadInput, QueryFieldState } from 'app/features/explore/QueryField';
 import { PromQuery } from '../types';
 import { CancelablePromise, makePromiseCancelable } from 'app/core/utils/CancelablePromise';
@@ -126,7 +125,6 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
     this.plugins = [
       BracesPlugin(),
-      RunnerPlugin({ handler: props.onRunQuery }),
       PluginPrism({
         onlyIn: (node: any) => node.type === 'code_block',
         getSyntax: (node: any) => 'promql',


### PR DESCRIPTION
- queries were triggered twice because two Enter handlers existed
- removed runner plugin from Loki and Prom query fields (runner plugin
is still being used in azure)
- set loki's mtrics capability to false
    

Fixes #16995

Notes:

Decided to remove runner plugin instead of key handlers in query field because the runner plugin was not obvious enough, leading to this very issue.
    Loki is not a metrics store. Explore was using the `metrics` field in
    the plugin definition to issue a second query run. But Loki shows only
    one result viewer.
