### PR TITLE
Chore: reintroduce gosec

### DIFF
--- a/pkg/services/notifications/codes.go
+++ b/pkg/services/notifications/codes.go
@@ -1,7 +1,7 @@
 package notifications
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // #nosec
 	"encoding/hex"
 	"fmt"
 	"time"

--- a/scripts/backend-lint.sh
+++ b/scripts/backend-lint.sh
@@ -15,7 +15,7 @@ go get -u github.com/alecthomas/gometalinter
 go get -u github.com/jgautheron/goconst/cmd/goconst
 go get -u honnef.co/go/tools/cmd/staticcheck
 go get -u github.com/mgechev/revive
-#go get -u github.com/securego/gosec/cmd/gosec/...
+go get -u github.com/securego/gosec/cmd/gosec/...
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # use gometalinter when lints are not available in golangci or
@@ -39,7 +39,7 @@ exit_if_fail go vet ./pkg/...
 exit_if_fail revive -formatter stylish -config ./scripts/revive.toml
 
 # TODO recheck the rules and leave only necessary exclusions
-# exit_if_fail gosec -quiet \
-#  -exclude=G104,G107,G201,G202,G204,G301,G304,G401,G402,G501 \
-#  -conf=./scripts/gosec.json \
-#  ./pkg/...
+exit_if_fail gosec -quiet \
+ -exclude=G104,G107,G201,G202,G204,G301,G304,G401,G402,G501 \
+ -conf=./scripts/gosec.json \
+ ./pkg/...


### PR DESCRIPTION
It seems gosec memory issue was recently fixed.
We should be good to go again

Ref securego/gosec#307