### PR TITLE
Streaming: support streaming in MetricsPanelCtrl

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -129,25 +129,36 @@ class MetricsPanelCtrl extends PanelCtrl {
       if (data.state === LoadingState.Error) {
         this.loading = false;
         this.processDataError(data.error);
-      } else if (data.state === LoadingState.Done) {
-        this.loading = false;
+        return;
+      }
 
-        // The result should already be processed, but just in case
-        if (!data.legacy) {
-          data.legacy = data.series.map(v => {
-            if (isSeriesData(v)) {
-              return toLegacyResponseData(v);
-            }
-            return v;
-          });
-        }
+      this.loading = false;
 
-        // Make the results look like they came directly from a <6.2 datasource request
-        // NOTE: any object other than 'data' is no longer supported supported
-        this.handleQueryResult({
-          data: data.legacy,
+      // The result should already be processed, but just in case
+      if (!data.legacy) {
+        data.legacy = data.series.map(v => {
+          if (isSeriesData(v)) {
+            return toLegacyResponseData(v);
+          }
+          return v;
         });
       }
+
+      if (data.request) {
+        const { range, timeInfo } = data.request;
+        if (range) {
+          this.range = range;
+        }
+        if (timeInfo) {
+          this.timeInfo = timeInfo;
+        }
+      }
+
+      // Make the results look like they came directly from a <6.2 datasource request
+      // NOTE: any object other than 'data' is no longer supported supported
+      this.handleQueryResult({
+        data: data.legacy,
+      });
     },
   };
 

--- a/public/app/plugins/datasource/testdata/dashboards/streaming.json
+++ b/public/app/plugins/datasource/testdata/dashboards/streaming.json
@@ -14,7 +14,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.2.0-pre"
+      "version": "6.3.0-pre"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
     },
     {
       "type": "panel",
@@ -49,13 +55,104 @@
   "links": [],
   "panels": [
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "streaming_client",
+          "stream": {
+            "noise": 2.2,
+            "speed": 100,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Angular Graph",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "datasource": "${DS_TESTDATA_DB}",
       "description": "",
       "gridPos": {
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 7
       },
       "id": 2,
       "links": [],
@@ -108,7 +205,7 @@
     "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
-  "title": "Simple Streaming Example",
-  "uid": "TXSTREZ",
+  "title": "Streaming Data",
+  "uid": "GaA8BumZz",
   "version": 2
 }

--- a/public/app/plugins/datasource/testdata/dashboards/streaming.json
+++ b/public/app/plugins/datasource/testdata/dashboards/streaming.json
@@ -205,7 +205,7 @@
     "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "",
-  "title": "Streaming Data",
-  "uid": "GaA8BumZz",
-  "version": 2
+  "title": "Simple Streaming Example",
+  "uid": "TXSTREZ",
+  "version": 3
 }


### PR DESCRIPTION
This fixes MetricsPanelCtrl so that streaming works.  Specifically it:
* does not ignore responses when except when: `data.state === LoadingState.Done`
* updates the time range & info from response 
* Updates the dashboard in testdata with the angular graph 


If #17037 seems OK, apply that instead (this will be included)
