### PR TITLE
Chore: remove use of `== false`

### DIFF
--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -20,17 +20,17 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	})
 
 	// Bail if auth proxy is not enabled
-	if auth.IsEnabled() == false {
+	if !auth.IsEnabled() {
 		return false
 	}
 
 	// If the there is no header - we can't move forward
-	if auth.HasHeader() == false {
+	if !auth.HasHeader() {
 		return false
 	}
 
 	// Check if allowed to continue with this IP
-	if result, err := auth.IsAllowedIP(); result == false {
+	if result, err := auth.IsAllowedIP(); !result {
 		ctx.Handle(407, err.Error(), err.DetailsError)
 		return true
 	}

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -92,7 +92,7 @@ func New(options *Options) *AuthProxy {
 func (auth *AuthProxy) IsEnabled() bool {
 
 	// Bail if the setting is not enabled
-	if auth.enabled == false {
+	if !auth.enabled {
 		return false
 	}
 

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -5,12 +5,12 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/toml"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"golang.org/x/xerrors"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 type Config struct {
@@ -68,9 +68,10 @@ func IsEnabled() bool {
 
 // ReloadConfig reads the config from the disc and caches it.
 func ReloadConfig() error {
-	if IsEnabled() == false {
+	if !IsEnabled() {
 		return nil
 	}
+
 	loadingMutex.Lock()
 	defer loadingMutex.Unlock()
 
@@ -82,7 +83,7 @@ func ReloadConfig() error {
 // GetConfig returns the LDAP config if LDAP is enabled otherwise it returns nil. It returns either cached value of
 // the config or it reads it and caches it first.
 func GetConfig() (*Config, error) {
-	if IsEnabled() == false {
+	if !IsEnabled() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Interestingly enough, golint or revive doesn't not prohibit
the use that construction :)

Ref #17035
