### PR TITLE
SeriesData Field: remove color

### DIFF
--- a/packages/grafana-ui/src/types/data.ts
+++ b/packages/grafana-ui/src/types/data.ts
@@ -47,7 +47,6 @@ export interface Field {
   unit?: string;
   dateFormat?: string; // Source data format
   decimals?: number | null; // Significant digits (for display)
-  color?: string;
   min?: number | null;
   max?: number | null;
 }

--- a/packages/grafana-ui/src/utils/displayValue.test.ts
+++ b/packages/grafana-ui/src/utils/displayValue.test.ts
@@ -18,7 +18,7 @@ describe('Process simple display values', () => {
     getDisplayProcessor(),
 
     // Add a simple option that is not used (uses a different base class)
-    getDisplayProcessor({ field: { color: '#FFF' } }),
+    getDisplayProcessor({ field: { min: 0, max: 100 } }),
 
     // Add a simple option that is not used (uses a different base class)
     getDisplayProcessor({ field: { unit: 'locale' } }),

--- a/packages/grafana-ui/src/utils/displayValue.ts
+++ b/packages/grafana-ui/src/utils/displayValue.ts
@@ -42,7 +42,7 @@ export function getDisplayProcessor(options?: DisplayValueOptions): DisplayProce
 
     return (value: any) => {
       const { mappings, thresholds, theme } = options;
-      let color = field.color;
+      let color;
 
       let text = _.toString(value);
       let numeric = toNumber(value);
@@ -76,7 +76,7 @@ export function getDisplayProcessor(options?: DisplayValueOptions): DisplayProce
           const { decimals, scaledDecimals } = getDecimalsForValue(value, field.decimals);
           text = formatFunc(numeric, decimals, scaledDecimals, options.isUtc);
         }
-        if (thresholds && thresholds.length > 0) {
+        if (thresholds && thresholds.length) {
           color = getColorFromThreshold(numeric, thresholds, theme);
         }
       }


### PR DESCRIPTION
Currently there is a `color` value on Field.  I think we should remove it and later put something back that has a more clear way to say where the color comes from.  It could be:
 * hardcoded
 * thresholds
 * based on scale (like d3) 
 * maybe set opacity (like histogram)

See also:
 #16925