### PR TITLE
Search: Scroll issue in dashboard search in latest Chrome

### DIFF
--- a/public/sass/components/_search.scss
+++ b/public/sass/components/_search.scss
@@ -31,6 +31,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  height: 100%; // Chrome 74 needs this to make the element scrollable
 
   .search-item--indent {
     margin-left: 14px;
@@ -256,10 +257,6 @@
     max-width: 700px;
     height: 260px;
     align-items: flex-start;
-  }
-
-  .search-dropdown__col_1 {
-    height: 100%;
   }
 
   .search-filter-box {


### PR DESCRIPTION
**What this PR does / why we need it**:
Mobile users with latest Chrome are not able to scroll in dashboard search.

**Which issue(s) this PR fixes**:
Fixes #16981

**Special notes for your reviewer**:
Confirmed working in chrome 74 on osx and chrome 74 on android.
