### PR TITLE
Azure Monitor: Application insights query editor now renders correctly

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -108,17 +108,18 @@
         <gf-form-dropdown model="ctrl.target.azureLogAnalytics.workspace" allow-custom="true" lookup-text="true"
           get-options="ctrl.workspaces" on-change="ctrl.refresh()" css-class="min-width-12">
         </gf-form-dropdown>
-      <div class="gf-form">
-        <div class="width-1"></div>
-      </div>
-      <div class="gf-form">
-        <button class="btn btn-primary width-10" ng-click="ctrl.refresh()">Run</button>
-      </div>
-      <div class="gf-form">
-        <label class="gf-form-label">(Run Query: Shift+Enter, Trigger Suggestion: Ctrl+Space)</label>
-      </div>
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
+        <div class="gf-form">
+          <div class="width-1"></div>
+        </div>
+        <div class="gf-form">
+          <button class="btn btn-primary width-10" ng-click="ctrl.refresh()">Run</button>
+        </div>
+        <div class="gf-form">
+          <label class="gf-form-label">(Run Query: Shift+Enter, Trigger Suggestion: Ctrl+Space)</label>
+        </div>
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
A missing closing div tag meant that the Application Insights section in the query editor was hidden by an ng-if expression for the html section above it.

Fixes #17040 