### PR TITLE
serverlock: run tests async should be more linear time wise

### DIFF
--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -22,14 +22,11 @@ func TestServerLok(t *testing.T) {
 	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
 
 	//this should not execute `fn`
-	for i := 0; i < 4; i++ {
-		go func() {
-			assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
-		}()
-	}
+	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
 
-	// wait 1.5 second.
-	<-time.After(time.Second*1 + time.Second/2)
+	// wait 2 second.
+	<-time.After(time.Second * 2)
 
 	// now `fn` should be executed again
 	err := sl.LockAndExecute(ctx, "test-operation", atInterval, fn)

--- a/scripts/circle-test-mysql.sh
+++ b/scripts/circle-test-mysql.sh
@@ -12,7 +12,6 @@ function exit_if_fail {
 
 export GRAFANA_TEST_DB=mysql
 
-go test -tags=integration -count=1 ./pkg/infra/serverlock/...
-# time for d in $(go list ./pkg/...); do
-#   exit_if_fail go test -tags=integration $d
-# done
+time for d in $(go list ./pkg/...); do
+  exit_if_fail go test -tags=integration $d
+done

--- a/scripts/circle-test-mysql.sh
+++ b/scripts/circle-test-mysql.sh
@@ -12,6 +12,7 @@ function exit_if_fail {
 
 export GRAFANA_TEST_DB=mysql
 
-time for d in $(go list ./pkg/...); do
-  exit_if_fail go test -tags=integration $d
-done
+go test -tags=integration -count=1 ./pkg/infra/serverlock/...
+# time for d in $(go list ./pkg/...); do
+#   exit_if_fail go test -tags=integration $d
+# done


### PR DESCRIPTION
should fix the flaky tests in serverlock. 