### PR TITLE
Explore: Adds Live option for supported datasources

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
     "react-window": "1.7.1",
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
+    "redux-observable": "1.1.0",
     "redux-thunk": "2.3.0",
     "remarkable": "1.7.1",
     "reselect": "4.0.0",

--- a/packages/grafana-ui/src/components/Button/AbstractButton.tsx
+++ b/packages/grafana-ui/src/components/Button/AbstractButton.tsx
@@ -75,6 +75,12 @@ const getButtonStyles = (theme: GrafanaTheme, size: ButtonSize, variant: ButtonV
       iconDistance = theme.spacing.xs;
       height = theme.height.sm;
       break;
+    case ButtonSize.Medium:
+      padding = `${theme.spacing.sm} ${theme.spacing.md}`;
+      fontSize = theme.typography.size.md;
+      iconDistance = theme.spacing.sm;
+      height = theme.height.md;
+      break;
     case ButtonSize.Large:
       padding = `${theme.spacing.md} ${theme.spacing.lg}`;
       fontSize = theme.typography.size.lg;

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { ButtonSelect } from '../Select/ButtonSelect';
 
 export const offOption = { label: 'Off', value: '' };
-const liveOption = { label: 'Live', value: 'LIVE' };
+export const liveOption = { label: 'Live', value: 'LIVE' };
 export const defaultIntervals = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 export const isLive = (refreshInterval: string): boolean => refreshInterval === liveOption.value;
 

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -63,6 +63,7 @@ export class RefreshPicker extends PureComponent<Props> {
     const cssClasses = classNames({
       'refresh-picker': true,
       'refresh-picker--off': selectedValue.label === offOption.label,
+      'refresh-picker--live': selectedValue === liveOption,
     });
 
     return (
@@ -74,7 +75,7 @@ export class RefreshPicker extends PureComponent<Props> {
             </button>
           </Tooltip>
           <ButtonSelect
-            className="navbar-button--attached btn--radius-left-0"
+            className="navbar-button--attached btn--radius-left-0$"
             value={selectedValue}
             label={selectedValue.label}
             options={options}

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -5,7 +5,9 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { ButtonSelect } from '../Select/ButtonSelect';
 
 export const offOption = { label: 'Off', value: '' };
+const liveOption = { label: 'Live', value: 'LIVE' };
 export const defaultIntervals = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
+export const isLive = (refreshInterval: string): boolean => refreshInterval === liveOption.value;
 
 export interface Props {
   intervals?: string[];
@@ -13,6 +15,7 @@ export interface Props {
   onIntervalChanged: (interval: string) => void;
   value?: string;
   tooltip: string;
+  hasLiveOption?: boolean;
 }
 
 export class RefreshPicker extends PureComponent<Props> {
@@ -36,6 +39,9 @@ export class RefreshPicker extends PureComponent<Props> {
 
   intervalsToOptions = (intervals: string[] = defaultIntervals): Array<SelectOptionItem<string>> => {
     const options = intervals.map(interval => ({ label: interval, value: interval }));
+    if (this.props.hasLiveOption) {
+      options.unshift(liveOption);
+    }
     options.unshift(offOption);
     return options;
   };

--- a/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
+++ b/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
@@ -30,7 +30,25 @@
     }
   }
 
+  &--live {
+    .select-button-value {
+      animation: liveText 2s infinite;
+    }
+  }
+
   @include media-breakpoint-up(sm) {
     display: block;
+  }
+}
+
+@keyframes liveText {
+  0% {
+    color: $orange;
+  }
+  50% {
+    color: $yellow;
+  }
+  100% {
+    color: $orange;
   }
 }

--- a/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
@@ -74,7 +74,7 @@ export class ButtonSelect<T> extends PureComponent<Props<T>> {
         isSearchable={false}
         options={options}
         onChange={this.onChange}
-        defaultValue={value}
+        value={value}
         maxMenuHeight={maxMenuHeight}
         components={combinedComponents}
         className="gf-form-select-box-button-select"

--- a/packages/grafana-ui/src/components/SetInterval/SetInterval.tsx
+++ b/packages/grafana-ui/src/components/SetInterval/SetInterval.tsx
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
-import { interval, Subscription, empty, Subject } from 'rxjs';
+import { interval, Subscription, empty, Subject, of } from 'rxjs';
 import { tap, switchMap } from 'rxjs/operators';
+import _ from 'lodash';
 
 import { stringToMs } from '../../utils/string';
+import { isLive } from '../RefreshPicker/RefreshPicker';
 
 interface Props {
   func: () => any; // TODO
@@ -24,6 +26,9 @@ export class SetInterval extends PureComponent<Props> {
     this.subscription = this.propsSubject
       .pipe(
         switchMap(props => {
+          if (isLive(props.interval)) {
+            return of({});
+          }
           return props.loading ? empty() : interval(stringToMs(props.interval));
         }),
         tap(() => this.props.func())
@@ -32,7 +37,11 @@ export class SetInterval extends PureComponent<Props> {
     this.propsSubject.next(this.props);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
+    if (_.isEqual(prevProps, this.props)) {
+      return;
+    }
+
     this.propsSubject.next(this.props);
   }
 

--- a/packages/grafana-ui/src/components/SetInterval/SetInterval.tsx
+++ b/packages/grafana-ui/src/components/SetInterval/SetInterval.tsx
@@ -1,5 +1,5 @@
 import { PureComponent } from 'react';
-import { interval, Subscription, empty, Subject, of } from 'rxjs';
+import { interval, Subscription, Subject, of, NEVER } from 'rxjs';
 import { tap, switchMap } from 'rxjs/operators';
 import _ from 'lodash';
 
@@ -29,7 +29,7 @@ export class SetInterval extends PureComponent<Props> {
           if (isLive(props.interval)) {
             return of({});
           }
-          return props.loading ? empty() : interval(stringToMs(props.interval));
+          return props.loading ? NEVER : interval(stringToMs(props.interval));
         }),
         tap(() => this.props.func())
       )

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -160,6 +160,8 @@ export abstract class DataSourceApi<
 
   convertToStreamTargets?(options: DataQueryRequest<TQuery>): Array<{ url: string; refId: string }>;
 
+  resultToSeriesData?(data: any, refId?: string): SeriesData;
+
   /**
    * Test & verify datasource settings & connection details
    */

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -160,7 +160,7 @@ export abstract class DataSourceApi<
 
   convertToStreamTargets?(options: DataQueryRequest<TQuery>): Array<{ url: string; refId: string }>;
 
-  resultToSeriesData?(data: any, refId?: string): SeriesData;
+  resultToSeriesData?(data: any, refId: string): SeriesData[];
 
   /**
    * Test & verify datasource settings & connection details

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -84,6 +84,7 @@ export interface DataSourcePluginMeta extends PluginMeta {
   category?: string;
   queryOptions?: PluginMetaQueryOptions;
   sort?: number;
+  supportsStreaming?: boolean;
 }
 
 interface PluginMetaQueryOptions {
@@ -156,6 +157,8 @@ export abstract class DataSourceApi<
    * Main metrics / data query action
    */
   abstract query(options: DataQueryRequest<TQuery>, observer?: DataStreamObserver): Promise<DataQueryResponse>;
+
+  convertToStreamTargets?(options: DataQueryRequest<TQuery>): Array<{ url: string; refId: string }>;
 
   /**
    * Test & verify datasource settings & connection details

--- a/packages/grafana-ui/src/utils/moment_wrapper.ts
+++ b/packages/grafana-ui/src/utils/moment_wrapper.ts
@@ -43,6 +43,9 @@ export interface DateTimeLocale {
 
 export interface DateTimeDuration {
   asHours: () => number;
+  hours: () => number;
+  minutes: () => number;
+  seconds: () => number;
 }
 
 export interface DateTime extends Object {

--- a/public/app/features/explore/ElapsedTime.tsx
+++ b/public/app/features/explore/ElapsedTime.tsx
@@ -1,8 +1,20 @@
 import React, { PureComponent } from 'react';
+import { toDuration } from '@grafana/ui/src/utils/moment_wrapper';
 
 const INTERVAL = 150;
 
-export default class ElapsedTime extends PureComponent<any, any> {
+export interface Props {
+  time?: number;
+  renderCount?: number;
+  className?: string;
+  humanize?: boolean;
+}
+
+export interface State {
+  elapsed: number;
+}
+
+export default class ElapsedTime extends PureComponent<Props, State> {
   offset: number;
   timer: number;
 
@@ -21,10 +33,15 @@ export default class ElapsedTime extends PureComponent<any, any> {
     this.setState({ elapsed });
   };
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     if (nextProps.time) {
       clearInterval(this.timer);
     } else if (this.props.time) {
+      this.start();
+    }
+
+    if (nextProps.renderCount) {
+      clearInterval(this.timer);
       this.start();
     }
   }
@@ -39,8 +56,16 @@ export default class ElapsedTime extends PureComponent<any, any> {
 
   render() {
     const { elapsed } = this.state;
-    const { className, time } = this.props;
+    const { className, time, humanize } = this.props;
     const value = (time || elapsed) / 1000;
-    return <span className={`elapsed-time ${className}`}>{value.toFixed(1)}s</span>;
+    let displayValue = `${value.toFixed(1)}s`;
+    if (humanize) {
+      const duration = toDuration(elapsed);
+      const hours = duration.hours();
+      const minutes = duration.minutes();
+      const seconds = duration.seconds();
+      displayValue = hours ? `${hours}h ${minutes}m ${seconds}s` : minutes ? ` ${minutes}m ${seconds}s` : `${seconds}s`;
+    }
+    return <span className={`elapsed-time ${className}`}>{displayValue}</span>;
   }
 }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -87,6 +87,7 @@ interface ExploreProps {
   initialUI: ExploreUIState;
   queryErrors: DataQueryError[];
   mode: ExploreMode;
+  isLive: boolean;
 }
 
 /**
@@ -315,6 +316,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     update,
     queryErrors,
     mode,
+    isLive,
   } = item;
 
   const { datasource, queries, range: urlRange, ui } = (urlState || {}) as ExploreUrlState;
@@ -340,6 +342,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     initialUI,
     queryErrors,
     mode,
+    isLive,
   };
 }
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -237,11 +237,8 @@ export class Explore extends React.PureComponent<ExploreProps> {
       queryKeys,
       queryErrors,
       mode,
-      isLive,
     } = this.props;
-    const splitClass = split ? 'explore explore-split' : 'explore';
-    const exploreClass = isLive ? `${splitClass} explore-live` : splitClass;
-    const exploreContainerClass = isLive ? 'explore-container explore-live' : 'explore-container';
+    const exploreClass = split ? 'explore explore-split' : 'explore';
 
     return (
       <div className={exploreClass} ref={this.getRef}>
@@ -259,7 +256,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
         </FadeIn>
 
         {datasourceInstance && (
-          <div className={exploreContainerClass}>
+          <div className="explore-container">
             <QueryRows exploreEvents={this.exploreEvents} exploreId={exploreId} queryKeys={queryKeys} />
             <ErrorContainer queryErrors={queryErrors} />
             <AutoSizer onResize={this.onResize} disableHeight>

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -237,8 +237,11 @@ export class Explore extends React.PureComponent<ExploreProps> {
       queryKeys,
       queryErrors,
       mode,
+      isLive,
     } = this.props;
-    const exploreClass = split ? 'explore explore-split' : 'explore';
+    const splitClass = split ? 'explore explore-split' : 'explore';
+    const exploreClass = isLive ? `${splitClass} explore-live` : splitClass;
+    const exploreContainerClass = isLive ? 'explore-container explore-live' : 'explore-container';
 
     return (
       <div className={exploreClass} ref={this.getRef}>
@@ -256,7 +259,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
         </FadeIn>
 
         {datasourceInstance && (
-          <div className="explore-container">
+          <div className={exploreContainerClass}>
             <QueryRows exploreEvents={this.exploreEvents} exploreId={exploreId} queryKeys={queryKeys} />
             <ErrorContainer queryErrors={queryErrors} />
             <AutoSizer onResize={this.onResize} disableHeight>

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -73,6 +73,7 @@ interface StateProps {
   supportedModeOptions: Array<SelectOptionItem<ExploreMode>>;
   selectedModeOption: SelectOptionItem<ExploreMode>;
   hasLiveOption: boolean;
+  isLive: boolean;
 }
 
 interface DispatchProps {
@@ -136,6 +137,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
       supportedModeOptions,
       selectedModeOption,
       hasLiveOption,
+      isLive,
     } = this.props;
 
     return (
@@ -205,9 +207,11 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
               </div>
             ) : null}
             <div className="explore-toolbar-content-item timepicker">
-              <ClickOutsideWrapper onClick={this.onCloseTimePicker}>
-                <TimePicker ref={timepickerRef} range={range} isUtc={timeZone.isUtc} onChangeTime={onChangeTime} />
-              </ClickOutsideWrapper>
+              {!isLive && (
+                <ClickOutsideWrapper onClick={this.onCloseTimePicker}>
+                  <TimePicker ref={timepickerRef} range={range} isUtc={timeZone.isUtc} onChangeTime={onChangeTime} />
+                </ClickOutsideWrapper>
+              )}
 
               <RefreshPicker
                 onIntervalChanged={this.onChangeRefreshInterval}
@@ -219,21 +223,25 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
               {refreshInterval && <SetInterval func={this.onRunQuery} interval={refreshInterval} loading={loading} />}
             </div>
 
-            <div className="explore-toolbar-content-item">
-              <button className="btn navbar-button" onClick={this.onClearAll}>
-                Clear All
-              </button>
-            </div>
-            <div className="explore-toolbar-content-item">
-              {createResponsiveButton({
-                splitted,
-                title: 'Run Query',
-                onClick: this.onRunQuery,
-                buttonClassName: 'navbar-button--secondary',
-                iconClassName: loading ? 'fa fa-spinner fa-fw fa-spin run-icon' : 'fa fa-level-down fa-fw run-icon',
-                iconSide: IconSide.right,
-              })}
-            </div>
+            {!isLive && (
+              <>
+                <div className="explore-toolbar-content-item">
+                  <button className="btn navbar-button" onClick={this.onClearAll}>
+                    Clear All
+                  </button>
+                </div>
+                <div className="explore-toolbar-content-item">
+                  {createResponsiveButton({
+                    splitted,
+                    title: 'Run Query',
+                    onClick: this.onRunQuery,
+                    buttonClassName: 'navbar-button--secondary',
+                    iconClassName: loading ? 'fa fa-spinner fa-fw fa-spin run-icon' : 'fa fa-level-down fa-fw run-icon',
+                    iconSide: IconSide.right,
+                  })}
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -255,6 +263,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     tableIsLoading,
     supportedModes,
     mode,
+    isLive,
   } = exploreItem;
   const selectedDatasource = datasourceInstance
     ? exploreDatasources.find(datasource => datasource.name === datasourceInstance.name)
@@ -301,6 +310,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     supportedModeOptions,
     selectedModeOption,
     hasLiveOption,
+    isLive,
   };
 };
 

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -39,15 +39,20 @@ const createResponsiveButton = (options: {
   buttonClassName?: string;
   iconClassName?: string;
   iconSide?: IconSide;
+  disabled?: boolean;
 }) => {
   const defaultOptions = {
     iconSide: IconSide.left,
   };
   const props = { ...options, defaultOptions };
-  const { title, onClick, buttonClassName, iconClassName, splitted, iconSide } = props;
+  const { title, onClick, buttonClassName, iconClassName, splitted, iconSide, disabled } = props;
 
   return (
-    <button className={`btn navbar-button ${buttonClassName ? buttonClassName : ''}`} onClick={onClick}>
+    <button
+      className={`btn navbar-button ${buttonClassName ? buttonClassName : ''}`}
+      onClick={onClick}
+      disabled={disabled || false}
+    >
       {iconClassName && iconSide === IconSide.left ? <i className={`${iconClassName}`} /> : null}
       <span className="btn-title">{!splitted ? title : ''}</span>
       {iconClassName && iconSide === IconSide.right ? <i className={`${iconClassName}`} /> : null}
@@ -203,6 +208,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
                   onClick: split,
                   iconClassName: 'fa fa-fw fa-columns icon-margin-right',
                   iconSide: IconSide.left,
+                  disabled: isLive,
                 })}
               </div>
             ) : null}
@@ -223,25 +229,22 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
               {refreshInterval && <SetInterval func={this.onRunQuery} interval={refreshInterval} loading={loading} />}
             </div>
 
-            {!isLive && (
-              <>
-                <div className="explore-toolbar-content-item">
-                  <button className="btn navbar-button" onClick={this.onClearAll}>
-                    Clear All
-                  </button>
-                </div>
-                <div className="explore-toolbar-content-item">
-                  {createResponsiveButton({
-                    splitted,
-                    title: 'Run Query',
-                    onClick: this.onRunQuery,
-                    buttonClassName: 'navbar-button--secondary',
-                    iconClassName: loading ? 'fa fa-spinner fa-fw fa-spin run-icon' : 'fa fa-level-down fa-fw run-icon',
-                    iconSide: IconSide.right,
-                  })}
-                </div>
-              </>
-            )}
+            <div className="explore-toolbar-content-item">
+              <button className="btn navbar-button" onClick={this.onClearAll}>
+                Clear All
+              </button>
+            </div>
+            <div className="explore-toolbar-content-item">
+              {createResponsiveButton({
+                splitted,
+                title: 'Run Query',
+                onClick: this.onRunQuery,
+                buttonClassName: 'navbar-button--secondary',
+                iconClassName:
+                  loading && !isLive ? 'fa fa-spinner fa-fw fa-spin run-icon' : 'fa fa-level-down fa-fw run-icon',
+                iconSide: IconSide.right,
+              })}
+            </div>
           </div>
         </div>
       </div>

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -72,6 +72,7 @@ interface StateProps {
   refreshInterval: string;
   supportedModeOptions: Array<SelectOptionItem<ExploreMode>>;
   selectedModeOption: SelectOptionItem<ExploreMode>;
+  hasLiveOption: boolean;
 }
 
 interface DispatchProps {
@@ -134,6 +135,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
       split,
       supportedModeOptions,
       selectedModeOption,
+      hasLiveOption,
     } = this.props;
 
     return (
@@ -212,6 +214,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
                 onRefresh={this.onRunQuery}
                 value={refreshInterval}
                 tooltip="Refresh"
+                hasLiveOption={hasLiveOption}
               />
               {refreshInterval && <SetInterval func={this.onRunQuery} interval={refreshInterval} loading={loading} />}
             </div>
@@ -257,6 +260,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     ? exploreDatasources.find(datasource => datasource.name === datasourceInstance.name)
     : undefined;
   const loading = graphIsLoading || logIsLoading || tableIsLoading;
+  const hasLiveOption = datasourceInstance && datasourceInstance.convertToStreamTargets ? true : false;
 
   const supportedModeOptions: Array<SelectOptionItem<ExploreMode>> = [];
   let selectedModeOption = null;
@@ -296,6 +300,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     refreshInterval,
     supportedModeOptions,
     selectedModeOption,
+    hasLiveOption,
   };
 };
 

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -11,7 +11,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     label: logs-rows-live;
     display: flex;
     flex-flow: column nowrap;
-    height: 70vh;
+    height: 65vh;
     overflow-y: auto;
     :first-child {
       margin-top: auto !important;
@@ -88,7 +88,14 @@ class LiveLogs extends PureComponent<Props, State> {
               </div>
             );
           })}
-          <div ref={element => (this.liveEndDiv = element)} />
+          <div
+            ref={element => {
+              this.liveEndDiv = element;
+              if (this.liveEndDiv) {
+                this.liveEndDiv.scrollIntoView(false);
+              }
+            }}
+          />
         </div>
         <div className={cx([styles.logsRowsIndicator])}>
           <span>

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -1,0 +1,69 @@
+import React, { PureComponent } from 'react';
+import { LogsModel, LogRowModel } from 'app/core/logs_model';
+
+export const rowSorter = (a: LogRowModel, b: LogRowModel) => a.timeEpochMs - b.timeEpochMs;
+
+export interface Props {
+  logsResult?: LogsModel;
+}
+
+export interface State {
+  prevRows: LogRowModel[];
+}
+
+export class LiveLogs extends PureComponent<Props, State> {
+  private liveEndDiv: HTMLDivElement = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { prevRows: props.logsResult ? props.logsResult.rows : [] };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const prevRows: LogRowModel[] = prevProps.logsResult ? prevProps.logsResult.rows : [];
+    const rows: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
+
+    if (prevRows !== rows) {
+      this.setState({
+        prevRows,
+      });
+    }
+
+    if (this.liveEndDiv) {
+      this.liveEndDiv.scrollIntoView(false);
+    }
+  }
+
+  render() {
+    const { prevRows } = this.state;
+    const rows: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
+    const freshRows = rows.filter(row => !prevRows.includes(row)).sort(rowSorter);
+    const oldRows = prevRows.filter(row => rows.includes(row)).sort(rowSorter);
+
+    return (
+      <div className="logs-rows live">
+        {oldRows.map((row, index) => {
+          return (
+            <div className="logs-row old" key={`${row.timeEpochMs}-${index}`}>
+              <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
+                {row.timeLocal}
+              </div>
+              <div className="logs-row__message">{row.entry}</div>
+            </div>
+          );
+        })}
+        {freshRows.map((row, index) => {
+          return (
+            <div className="logs-row fresh" key={`${row.timeEpochMs}-${index}`}>
+              <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
+                {row.timeLocal}
+              </div>
+              <div className="logs-row__message">{row.entry}</div>
+            </div>
+          );
+        })}
+        <div ref={element => (this.liveEndDiv = element)} />
+      </div>
+    );
+  }
+}

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { LogsModel, LogRowModel } from 'app/core/logs_model';
+import ElapsedTime from './ElapsedTime';
 
 export const rowSorter = (a: LogRowModel, b: LogRowModel) => a.timeEpochMs - b.timeEpochMs;
 
@@ -9,6 +10,7 @@ export interface Props {
 
 export interface State {
   prevRows: LogRowModel[];
+  renderCount: number;
 }
 
 export class LiveLogs extends PureComponent<Props, State> {
@@ -16,7 +18,7 @@ export class LiveLogs extends PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = { prevRows: props.logsResult ? props.logsResult.rows : [] };
+    this.state = { prevRows: props.logsResult ? props.logsResult.rows : [], renderCount: 0 };
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -26,6 +28,7 @@ export class LiveLogs extends PureComponent<Props, State> {
     if (prevRows !== rows) {
       this.setState({
         prevRows,
+        renderCount: this.state.renderCount + 1,
       });
     }
 
@@ -35,35 +38,43 @@ export class LiveLogs extends PureComponent<Props, State> {
   }
 
   render() {
-    const { prevRows } = this.state;
+    const { prevRows, renderCount } = this.state;
     const rows: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
     const freshRows = rows.filter(row => !prevRows.includes(row)).sort(rowSorter);
     const oldRows = prevRows.filter(row => rows.includes(row)).sort(rowSorter);
 
     return (
-      <div className="logs-rows live">
-        {oldRows.map((row, index) => {
-          return (
-            <div className="logs-row old" key={`${row.timeEpochMs}-${index}`}>
-              <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
-                {row.timeLocal}
+      <>
+        <div className="logs-rows live">
+          {oldRows.map((row, index) => {
+            return (
+              <div className="logs-row old" key={`${row.timeEpochMs}-${index}`}>
+                <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
+                  {row.timeLocal}
+                </div>
+                <div className="logs-row__message">{row.entry}</div>
               </div>
-              <div className="logs-row__message">{row.entry}</div>
-            </div>
-          );
-        })}
-        {freshRows.map((row, index) => {
-          return (
-            <div className="logs-row fresh" key={`${row.timeEpochMs}-${index}`}>
-              <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
-                {row.timeLocal}
+            );
+          })}
+          {freshRows.map((row, index) => {
+            return (
+              <div className="logs-row fresh" key={`${row.timeEpochMs}-${index}`}>
+                <div className="logs-row__localtime" title={`${row.timestamp} (${row.timeFromNow})`}>
+                  {row.timeLocal}
+                </div>
+                <div className="logs-row__message">{row.entry}</div>
               </div>
-              <div className="logs-row__message">{row.entry}</div>
-            </div>
-          );
-        })}
-        <div ref={element => (this.liveEndDiv = element)} />
-      </div>
+            );
+          })}
+          <div ref={element => (this.liveEndDiv = element)} />
+        </div>
+        <div className="explore-panel__loader explore-panel__loader--active" />
+        <div>
+          <span>
+            Last line received: <ElapsedTime renderCount={renderCount} humanize={true} /> ago
+          </span>
+        </div>
+      </>
     );
   }
 }

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -11,7 +11,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     label: logs-rows-live;
     display: flex;
     flex-flow: column nowrap;
-    height: 75vh;
+    height: 70vh;
     overflow-y: auto;
     :first-child {
       margin-top: auto !important;
@@ -98,7 +98,7 @@ class LiveLogs extends PureComponent<Props, State> {
             onClick={this.props.stopLive}
             size={ButtonSize.Medium}
             variant={ButtonVariant.Transparent}
-            icon="fa fa-square"
+            style={{ color: theme.colors.orange }}
           >
             Stop Live
           </LinkButton>

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -5,8 +5,6 @@ import { Themeable, withTheme, GrafanaTheme, selectThemeVariant } from '@grafana
 import { LogsModel, LogRowModel } from 'app/core/logs_model';
 import ElapsedTime from './ElapsedTime';
 
-const rowSorter = (a: LogRowModel, b: LogRowModel) => a.timeEpochMs - b.timeEpochMs;
-
 const getStyles = (theme: GrafanaTheme) => ({
   logsRowsLive: css`
     label: logs-rows-live;
@@ -38,7 +36,6 @@ export interface Props extends Themeable {
 }
 
 export interface State {
-  prevRows: LogRowModel[];
   renderCount: number;
 }
 
@@ -47,7 +44,7 @@ class LiveLogs extends PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = { prevRows: props.logsResult ? props.logsResult.rows : [], renderCount: 0 };
+    this.state = { renderCount: 0 };
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -56,7 +53,6 @@ class LiveLogs extends PureComponent<Props, State> {
 
     if (prevRows !== rows) {
       this.setState({
-        prevRows,
         renderCount: this.state.renderCount + 1,
       });
     }
@@ -68,15 +64,9 @@ class LiveLogs extends PureComponent<Props, State> {
 
   render() {
     const { theme } = this.props;
-    const { prevRows, renderCount } = this.state;
+    const { renderCount } = this.state;
     const styles = getStyles(theme);
-    const rows: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
-    const freshRows = rows
-      .filter(row => !prevRows.includes(row))
-      .map(row => ({ ...row, fresh: true }))
-      .sort(rowSorter);
-    const oldRows = prevRows.filter(row => rows.includes(row)).sort(rowSorter);
-    const rowsToRender = oldRows.concat(freshRows);
+    const rowsToRender: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
 
     return (
       <>

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import { css, cx } from 'emotion';
-import { Themeable, withTheme, GrafanaTheme, selectThemeVariant } from '@grafana/ui';
+import { Themeable, withTheme, GrafanaTheme, selectThemeVariant, LinkButton } from '@grafana/ui';
 
 import { LogsModel, LogRowModel } from 'app/core/logs_model';
 import ElapsedTime from './ElapsedTime';
+import { ButtonSize, ButtonVariant } from '@grafana/ui/src/components/Button/AbstractButton';
 
 const getStyles = (theme: GrafanaTheme) => ({
   logsRowsLive: css`
@@ -27,12 +28,15 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   logsRowsIndicator: css`
     font-size: ${theme.typography.size.md};
-    padding: ${theme.spacing.gutter} 0;
+    padding: ${theme.spacing.sm} 0;
+    display: flex;
+    align-items: center;
   `,
 });
 
 export interface Props extends Themeable {
   logsResult?: LogsModel;
+  stopLive: () => void;
 }
 
 export interface State {
@@ -86,10 +90,18 @@ class LiveLogs extends PureComponent<Props, State> {
           })}
           <div ref={element => (this.liveEndDiv = element)} />
         </div>
-        <div className="logs-rows-indicator">
+        <div className={cx([styles.logsRowsIndicator])}>
           <span>
             Last line received: <ElapsedTime renderCount={renderCount} humanize={true} /> ago
           </span>
+          <LinkButton
+            onClick={this.props.stopLive}
+            size={ButtonSize.Medium}
+            variant={ButtonVariant.Transparent}
+            icon="fa fa-square"
+          >
+            Stop Live
+          </LinkButton>
         </div>
       </>
     );

--- a/public/app/features/explore/LogRow.tsx
+++ b/public/app/features/explore/LogRow.tsx
@@ -228,7 +228,6 @@ export class LogRow extends PureComponent<Props, State> {
           const styles = this.state.showContext
             ? cx(logRowStyles, getLogRowWithContextStyles(theme, this.state).row)
             : logRowStyles;
-          console.log(styles);
           return (
             <div className={`logs-row ${this.props.className}`}>
               {showDuplicates && (

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -13,7 +13,7 @@ import {
 } from '@grafana/ui';
 
 import { ExploreId, ExploreItemState } from 'app/types/explore';
-import { LogsModel, LogsDedupStrategy } from 'app/core/logs_model';
+import { LogsModel, LogsDedupStrategy, LogRowModel } from 'app/core/logs_model';
 import { StoreState } from 'app/types';
 
 import { changeDedupStrategy, changeTime } from './state/actions';
@@ -90,7 +90,6 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
   render() {
     const {
       exploreId,
-
       loading,
       logsHighlighterExpressions,
       logsResult,
@@ -109,7 +108,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
 
     if (isLive) {
       return (
-        <Panel label="Logs" loading={false} isOpen={showingLogs} onToggle={this.onClickLogsButton}>
+        <Panel label="Logs" loading={false} isOpen>
           <LiveLogsWithTheme logsResult={logsResult} stopLive={this.onStopLive} />
         </Panel>
       );
@@ -146,7 +145,16 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
 function mapStateToProps(state: StoreState, { exploreId }) {
   const explore = state.explore;
   const item: ExploreItemState = explore[exploreId];
-  const { logsHighlighterExpressions, logsResult, logIsLoading, scanning, scanRange, range, datasourceInstance, isLive } = item;
+  const {
+    logsHighlighterExpressions,
+    logsResult,
+    logIsLoading,
+    scanning,
+    scanRange,
+    range,
+    datasourceInstance,
+    isLive,
+  } = item;
   const loading = logIsLoading;
   const { dedupStrategy } = exploreItemUIStateSelector(item);
   const hiddenLogLevels = new Set(item.hiddenLogLevels);

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -19,10 +19,11 @@ import { StoreState } from 'app/types';
 import { changeDedupStrategy, changeTime } from './state/actions';
 import Logs from './Logs';
 import Panel from './Panel';
-import { toggleLogLevelAction } from 'app/features/explore/state/actionTypes';
+import { toggleLogLevelAction, changeRefreshIntervalAction } from 'app/features/explore/state/actionTypes';
 import { deduplicatedLogsSelector, exploreItemUIStateSelector } from 'app/features/explore/state/selectors';
 import { getTimeZone } from '../profile/state/selectors';
 import { LiveLogsWithTheme } from './LiveLogs';
+import { offOption } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
 
 interface LogsContainerProps {
   datasourceInstance: DataSourceApi | null;
@@ -45,6 +46,7 @@ interface LogsContainerProps {
   width: number;
   changeTime: typeof changeTime;
   isLive: boolean;
+  stopLive: typeof changeRefreshIntervalAction;
 }
 
 export class LogsContainer extends PureComponent<LogsContainerProps> {
@@ -56,6 +58,11 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     };
 
     changeTime(exploreId, range);
+  };
+
+  onStopLive = () => {
+    const { exploreId } = this.props;
+    this.props.stopLive({ exploreId, refreshInterval: offOption.value });
   };
 
   handleDedupStrategyChange = (dedupStrategy: LogsDedupStrategy) => {
@@ -103,7 +110,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     if (isLive) {
       return (
         <Panel label="Logs" loading={false} isOpen={showingLogs} onToggle={this.onClickLogsButton}>
-          <LiveLogsWithTheme logsResult={logsResult} />
+          <LiveLogsWithTheme logsResult={logsResult} stopLive={this.onStopLive} />
         </Panel>
       );
     }
@@ -166,6 +173,7 @@ const mapDispatchToProps = {
   changeDedupStrategy,
   toggleLogLevelAction,
   changeTime,
+  stopLive: changeRefreshIntervalAction,
 };
 
 export default hot(module)(

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -22,7 +22,7 @@ import Panel from './Panel';
 import { toggleLogLevelAction } from 'app/features/explore/state/actionTypes';
 import { deduplicatedLogsSelector, exploreItemUIStateSelector } from 'app/features/explore/state/selectors';
 import { getTimeZone } from '../profile/state/selectors';
-import { LiveLogs } from './LiveLogs';
+import { LiveLogsWithTheme } from './LiveLogs';
 
 interface LogsContainerProps {
   datasourceInstance: DataSourceApi | null;
@@ -103,7 +103,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     if (isLive) {
       return (
         <Panel label="Logs" loading={false} isOpen={showingLogs} onToggle={this.onClickLogsButton}>
-          <LiveLogs logsResult={logsResult} />
+          <LiveLogsWithTheme logsResult={logsResult} />
         </Panel>
       );
     }

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -120,7 +120,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
 
     if (isLive) {
       return (
-        <div>
+        <div className="logs-rows live">
           {this.oldRows.map((row, index) => {
             return (
               <div className="logs-row old" key={`${row.timeEpochMs}-${index}`}>

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -101,7 +101,11 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     } = this.props;
 
     if (isLive) {
-      return <LiveLogs logsResult={logsResult} />;
+      return (
+        <Panel label="Logs" loading={false} isOpen={showingLogs} onToggle={this.onClickLogsButton}>
+          <LiveLogs logsResult={logsResult} />
+        </Panel>
+      );
     }
 
     return (

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -91,11 +91,7 @@ import { LogsDedupStrategy } from 'app/core/logs_model';
 import { getTimeZone } from 'app/features/profile/state/selectors';
 import { isDateTime } from '@grafana/ui/src/utils/moment_wrapper';
 import { toDataQueryError } from 'app/features/dashboard/state/PanelQueryState';
-import {
-  startSubscriptionsAction,
-  stopSubscriptionAction,
-  subscriptionDataReceivedAction,
-} from 'app/features/explore/state/epics';
+import { startSubscriptionsAction, subscriptionDataReceivedAction } from 'app/features/explore/state/epics';
 
 /**
  * Updates UI state and save it to the URL
@@ -594,7 +590,6 @@ function runQueriesForType(
         startSubscriptionsAction({
           exploreId,
           dataReceivedActionCreator: subscriptionDataReceivedAction,
-          stopsActionCreator: stopSubscriptionAction,
         })
       );
     }

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -597,7 +597,6 @@ function runQueriesForType(
           stopsActionCreator: stopSubscriptionAction,
         })
       );
-      return;
     }
 
     const datasourceId = datasourceInstance.meta.id;

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -588,25 +588,22 @@ function runQueriesForType(
     const { datasourceInstance, eventBridge, queries, queryIntervals, range, scanning, history } = getState().explore[
       exploreId
     ];
-    const datasourceId = datasourceInstance.meta.id;
-    const transaction = buildQueryTransaction(queries, resultType, queryOptions, range, queryIntervals, scanning);
-    dispatch(queryStartAction({ exploreId, resultType, rowIndex: 0, transaction }));
-    try {
+
+    if (resultType === 'Logs' && datasourceInstance.convertToStreamTargets) {
       dispatch(
         startSubscriptionsAction({
-          targets: [
-            {
-              url:
-                'api/datasources/proxy/19/api/prom/tail?query=%7B__filename__' +
-                '%3D%22%2Fvar%2Flog%2Fpods%2F00002425-61c9-11e9-9c9b-42010a8a0079%2Ftsdb-gw%2F0.log%22%7D',
-              refId: 'A',
-            },
-          ],
           exploreId,
           dataReceivedActionCreator: subscriptionDataReceivedAction,
           stopsActionCreator: stopSubscriptionAction,
         })
       );
+      return;
+    }
+
+    const datasourceId = datasourceInstance.meta.id;
+    const transaction = buildQueryTransaction(queries, resultType, queryOptions, range, queryIntervals, scanning);
+    dispatch(queryStartAction({ exploreId, resultType, rowIndex: 0, transaction }));
+    try {
       const now = Date.now();
       const response = await datasourceInstance.query(transaction.options);
       eventBridge.emit('data-received', response.data || []);

--- a/public/app/features/explore/state/epics.test.ts
+++ b/public/app/features/explore/state/epics.test.ts
@@ -35,7 +35,7 @@ const setup = (options: any = {}) => {
         refId,
       },
     ],
-    resultToSeriesData: data => data,
+    resultToSeriesData: data => [data],
   };
   const itemState = makeExploreItemState();
   const explore: Partial<ExploreState> = {

--- a/public/app/features/explore/state/epics.test.ts
+++ b/public/app/features/explore/state/epics.test.ts
@@ -9,6 +9,7 @@ import {
   SubscriptionDataReceivedPayload,
   startSubscriptionAction,
   startSubscriptionEpic,
+  limitMessageRatePayloadAction,
 } from './epics';
 import { makeExploreItemState } from './reducers';
 import { epicTester } from 'test/core/redux/epicTester';
@@ -110,11 +111,25 @@ describe('startSubscriptionEpic', () => {
           )
           .thenNoActionsWhereDispatched()
           .whenWebSocketReceivesData({ data: [1, 2, 3] })
-          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+          .thenResultingActionsEqual(
+            limitMessageRatePayloadAction({
+              exploreId,
+              data: { data: [1, 2, 3] } as any,
+              dataReceivedActionCreator,
+            })
+          )
           .whenWebSocketReceivesData({ data: [4, 5, 6] })
           .thenResultingActionsEqual(
-            dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-            dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+            limitMessageRatePayloadAction({
+              exploreId,
+              data: { data: [1, 2, 3] } as any,
+              dataReceivedActionCreator,
+            }),
+            limitMessageRatePayloadAction({
+              exploreId,
+              data: { data: [4, 5, 6] } as any,
+              dataReceivedActionCreator,
+            })
           );
       });
     });
@@ -145,10 +160,22 @@ describe('startSubscriptionEpic', () => {
           )
           .thenNoActionsWhereDispatched()
           .whenWebSocketReceivesData({ data: [1, 2, 3] })
-          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+          .thenResultingActionsEqual(
+            limitMessageRatePayloadAction({
+              exploreId,
+              data: { data: [1, 2, 3] } as any,
+              dataReceivedActionCreator,
+            })
+          )
           .whenActionIsDispatched(resetExploreAction())
           .whenWebSocketReceivesData({ data: [4, 5, 6] })
-          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+          .thenResultingActionsEqual(
+            limitMessageRatePayloadAction({
+              exploreId,
+              data: { data: [1, 2, 3] } as any,
+              dataReceivedActionCreator,
+            })
+          );
       });
     });
 
@@ -168,10 +195,22 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(updateDatasourceInstanceAction({ exploreId, datasourceInstance: null }))
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            );
         });
       });
 
@@ -190,14 +229,28 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(
               updateDatasourceInstanceAction({ exploreId: ExploreId.right, datasourceInstance: null })
             )
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
             .thenResultingActionsEqual(
-              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              }),
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [4, 5, 6] } as any,
+                dataReceivedActionCreator,
+              })
             );
         });
       });
@@ -220,10 +273,22 @@ describe('startSubscriptionEpic', () => {
               )
               .thenNoActionsWhereDispatched()
               .whenWebSocketReceivesData({ data: [1, 2, 3] })
-              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .thenResultingActionsEqual(
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                })
+              )
               .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId, refreshInterval: '10s' }))
               .whenWebSocketReceivesData({ data: [4, 5, 6] })
-              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+              .thenResultingActionsEqual(
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                })
+              );
           });
         });
 
@@ -242,12 +307,26 @@ describe('startSubscriptionEpic', () => {
               )
               .thenNoActionsWhereDispatched()
               .whenWebSocketReceivesData({ data: [1, 2, 3] })
-              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .thenResultingActionsEqual(
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                })
+              )
               .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId, refreshInterval: liveOption.value }))
               .whenWebSocketReceivesData({ data: [4, 5, 6] })
               .thenResultingActionsEqual(
-                dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                }),
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [4, 5, 6] } as any,
+                  dataReceivedActionCreator,
+                })
               );
           });
         });
@@ -268,12 +347,26 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.right, refreshInterval: '10s' }))
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
             .thenResultingActionsEqual(
-              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              }),
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [4, 5, 6] } as any,
+                dataReceivedActionCreator,
+              })
             );
         });
       });
@@ -295,10 +388,22 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(clearQueriesAction({ exploreId }))
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            );
         });
       });
 
@@ -317,12 +422,26 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(clearQueriesAction({ exploreId: ExploreId.right }))
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
             .thenResultingActionsEqual(
-              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              }),
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [4, 5, 6] } as any,
+                dataReceivedActionCreator,
+              })
             );
         });
       });
@@ -344,7 +463,13 @@ describe('startSubscriptionEpic', () => {
             )
             .thenNoActionsWhereDispatched()
             .whenWebSocketReceivesData({ data: [1, 2, 3] })
-            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .thenResultingActionsEqual(
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              })
+            )
             .whenActionIsDispatched(
               startSubscriptionAction({
                 url: webSocketUrl,
@@ -355,8 +480,16 @@ describe('startSubscriptionEpic', () => {
             )
             .whenWebSocketReceivesData({ data: [4, 5, 6] })
             .thenResultingActionsEqual(
-              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [1, 2, 3] } as any,
+                dataReceivedActionCreator,
+              }),
+              limitMessageRatePayloadAction({
+                exploreId,
+                data: { data: [4, 5, 6] } as any,
+                dataReceivedActionCreator,
+              })
               // This looks like we haven't stopped the subscription but we actually started the same again
             );
         });
@@ -376,7 +509,13 @@ describe('startSubscriptionEpic', () => {
               )
               .thenNoActionsWhereDispatched()
               .whenWebSocketReceivesData({ data: [1, 2, 3] })
-              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .thenResultingActionsEqual(
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                })
+              )
               .whenActionIsDispatched(
                 startSubscriptionAction({
                   url: webSocketUrl,
@@ -387,9 +526,21 @@ describe('startSubscriptionEpic', () => {
               )
               .whenWebSocketReceivesData({ data: [4, 5, 6] })
               .thenResultingActionsEqual(
-                dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
-                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any }),
-                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [1, 2, 3] } as any,
+                  dataReceivedActionCreator,
+                }),
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [4, 5, 6] } as any,
+                  dataReceivedActionCreator,
+                }),
+                limitMessageRatePayloadAction({
+                  exploreId,
+                  data: { data: [4, 5, 6] } as any,
+                  dataReceivedActionCreator,
+                })
               );
           });
         });

--- a/public/app/features/explore/state/epics.test.ts
+++ b/public/app/features/explore/state/epics.test.ts
@@ -1,0 +1,399 @@
+import { liveOption } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
+import { DataSourceApi, DataQuery } from '@grafana/ui/src/types/datasource';
+
+import { ExploreId, ExploreState } from 'app/types';
+import { actionCreatorFactory } from 'app/core/redux/actionCreatorFactory';
+import {
+  startSubscriptionsEpic,
+  startSubscriptionsAction,
+  SubscriptionDataReceivedPayload,
+  startSubscriptionAction,
+  startSubscriptionEpic,
+} from './epics';
+import { makeExploreItemState } from './reducers';
+import { epicTester } from 'test/core/redux/epicTester';
+import {
+  resetExploreAction,
+  updateDatasourceInstanceAction,
+  changeRefreshIntervalAction,
+  clearQueriesAction,
+} from './actionTypes';
+
+const setup = (options: any = {}) => {
+  const url = '/api/datasources/proxy/20/api/prom/tail?query=%7Bfilename%3D%22%2Fvar%2Flog%2Fdocker.log%22%7D';
+  const webSocketUrl = 'ws://localhost' + url;
+  const refId = options.refId || 'A';
+  const exploreId = ExploreId.left;
+  const datasourceInstance: DataSourceApi = options.datasourceInstance || {
+    id: 1337,
+    query: jest.fn(),
+    name: 'test',
+    testDatasource: jest.fn(),
+    convertToStreamTargets: () => [
+      {
+        url,
+        refId,
+      },
+    ],
+    resultToSeriesData: data => data,
+  };
+  const itemState = makeExploreItemState();
+  const explore: Partial<ExploreState> = {
+    [exploreId]: {
+      ...itemState,
+      datasourceInstance,
+      refreshInterval: options.refreshInterval || liveOption.value,
+      queries: [{} as DataQuery],
+    },
+  };
+  const state: any = {
+    explore,
+  };
+
+  return { url, state, refId, webSocketUrl, exploreId };
+};
+
+const dataReceivedActionCreator = actionCreatorFactory<SubscriptionDataReceivedPayload>('test').create();
+
+describe('startSubscriptionsEpic', () => {
+  describe('when startSubscriptionsAction is dispatched', () => {
+    describe('and datasource supports convertToStreamTargets', () => {
+      describe('and explore is Live', () => {
+        it('then correct actions should be dispatched', () => {
+          const { state, refId, webSocketUrl, exploreId } = setup();
+
+          epicTester(startSubscriptionsEpic, state)
+            .whenActionIsDispatched(startSubscriptionsAction({ exploreId, dataReceivedActionCreator }))
+            .thenResultingActionsEqual(
+              startSubscriptionAction({
+                exploreId,
+                refId,
+                url: webSocketUrl,
+                dataReceivedActionCreator,
+              })
+            );
+        });
+      });
+
+      describe('and explore is not Live', () => {
+        it('then no actions should be dispatched', () => {
+          const { state, exploreId } = setup({ refreshInterval: '10s' });
+
+          epicTester(startSubscriptionsEpic, state)
+            .whenActionIsDispatched(startSubscriptionsAction({ exploreId, dataReceivedActionCreator }))
+            .thenNoActionsWhereDispatched();
+        });
+      });
+    });
+
+    describe('and datasource does not support streaming', () => {
+      it('then no actions should be dispatched', () => {
+        const { state, exploreId } = setup({ datasourceInstance: {} });
+
+        epicTester(startSubscriptionsEpic, state)
+          .whenActionIsDispatched(startSubscriptionsAction({ exploreId, dataReceivedActionCreator }))
+          .thenNoActionsWhereDispatched();
+      });
+    });
+  });
+});
+
+describe('startSubscriptionEpic', () => {
+  describe('when startSubscriptionAction is dispatched', () => {
+    describe('and datasource supports resultToSeriesData', () => {
+      it('then correct actions should be dispatched', () => {
+        const { state, webSocketUrl, refId, exploreId } = setup();
+
+        epicTester(startSubscriptionEpic, state)
+          .whenActionIsDispatched(
+            startSubscriptionAction({ url: webSocketUrl, refId, exploreId, dataReceivedActionCreator })
+          )
+          .thenNoActionsWhereDispatched()
+          .whenWebSocketReceivesData({ data: [1, 2, 3] })
+          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+          .whenWebSocketReceivesData({ data: [4, 5, 6] })
+          .thenResultingActionsEqual(
+            dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+            dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+          );
+      });
+    });
+
+    describe('and datasource does not support resultToSeriesData', () => {
+      it('then no actions should be dispatched', () => {
+        const { state, webSocketUrl, refId, exploreId } = setup({ datasourceInstance: {} });
+
+        epicTester(startSubscriptionEpic, state)
+          .whenActionIsDispatched(
+            startSubscriptionAction({ url: webSocketUrl, refId, exploreId, dataReceivedActionCreator })
+          )
+          .thenNoActionsWhereDispatched()
+          .whenWebSocketReceivesData({ data: [1, 2, 3] })
+          .thenNoActionsWhereDispatched();
+      });
+    });
+  });
+
+  describe('when an subscription is active', () => {
+    describe('and resetExploreAction is dispatched', () => {
+      it('then subscription should be unsubscribed', () => {
+        const { state, webSocketUrl, refId, exploreId } = setup();
+
+        epicTester(startSubscriptionEpic, state)
+          .whenActionIsDispatched(
+            startSubscriptionAction({ url: webSocketUrl, refId, exploreId, dataReceivedActionCreator })
+          )
+          .thenNoActionsWhereDispatched()
+          .whenWebSocketReceivesData({ data: [1, 2, 3] })
+          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+          .whenActionIsDispatched(resetExploreAction())
+          .whenWebSocketReceivesData({ data: [4, 5, 6] })
+          .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+      });
+    });
+
+    describe('and updateDatasourceInstanceAction is dispatched', () => {
+      describe('and exploreId matches the websockets', () => {
+        it('then subscription should be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(updateDatasourceInstanceAction({ exploreId, datasourceInstance: null }))
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+        });
+      });
+
+      describe('and exploreId does not match the websockets', () => {
+        it('then subscription should not be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(
+              updateDatasourceInstanceAction({ exploreId: ExploreId.right, datasourceInstance: null })
+            )
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(
+              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+            );
+        });
+      });
+    });
+
+    describe('and changeRefreshIntervalAction is dispatched', () => {
+      describe('and exploreId matches the websockets', () => {
+        describe('and refreshinterval is not "Live"', () => {
+          it('then subscription should be unsubscribed', () => {
+            const { state, webSocketUrl, refId, exploreId } = setup();
+
+            epicTester(startSubscriptionEpic, state)
+              .whenActionIsDispatched(
+                startSubscriptionAction({
+                  url: webSocketUrl,
+                  refId,
+                  exploreId,
+                  dataReceivedActionCreator,
+                })
+              )
+              .thenNoActionsWhereDispatched()
+              .whenWebSocketReceivesData({ data: [1, 2, 3] })
+              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId, refreshInterval: '10s' }))
+              .whenWebSocketReceivesData({ data: [4, 5, 6] })
+              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+          });
+        });
+
+        describe('and refreshinterval is "Live"', () => {
+          it('then subscription should not be unsubscribed', () => {
+            const { state, webSocketUrl, refId, exploreId } = setup();
+
+            epicTester(startSubscriptionEpic, state)
+              .whenActionIsDispatched(
+                startSubscriptionAction({
+                  url: webSocketUrl,
+                  refId,
+                  exploreId,
+                  dataReceivedActionCreator,
+                })
+              )
+              .thenNoActionsWhereDispatched()
+              .whenWebSocketReceivesData({ data: [1, 2, 3] })
+              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId, refreshInterval: liveOption.value }))
+              .whenWebSocketReceivesData({ data: [4, 5, 6] })
+              .thenResultingActionsEqual(
+                dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              );
+          });
+        });
+      });
+
+      describe('and exploreId does not match the websockets', () => {
+        it('then subscription should not be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.right, refreshInterval: '10s' }))
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(
+              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+            );
+        });
+      });
+    });
+
+    describe('and clearQueriesAction is dispatched', () => {
+      describe('and exploreId matches the websockets', () => {
+        it('then subscription should be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(clearQueriesAction({ exploreId }))
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }));
+        });
+      });
+
+      describe('and exploreId does not match the websockets', () => {
+        it('then subscription should not be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(clearQueriesAction({ exploreId: ExploreId.right }))
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(
+              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+            );
+        });
+      });
+    });
+
+    describe('and startSubscriptionAction is dispatched', () => {
+      describe('and exploreId and refId matches the websockets', () => {
+        it('then subscription should be unsubscribed', () => {
+          const { state, webSocketUrl, refId, exploreId } = setup();
+
+          epicTester(startSubscriptionEpic, state)
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .thenNoActionsWhereDispatched()
+            .whenWebSocketReceivesData({ data: [1, 2, 3] })
+            .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+            .whenActionIsDispatched(
+              startSubscriptionAction({
+                url: webSocketUrl,
+                refId,
+                exploreId,
+                dataReceivedActionCreator,
+              })
+            )
+            .whenWebSocketReceivesData({ data: [4, 5, 6] })
+            .thenResultingActionsEqual(
+              dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+              dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              // This looks like we haven't stopped the subscription but we actually started the same again
+            );
+        });
+
+        describe('and exploreId or refId does not match the websockets', () => {
+          it('then subscription should not be unsubscribed and another websocket is started', () => {
+            const { state, webSocketUrl, refId, exploreId } = setup();
+
+            epicTester(startSubscriptionEpic, state)
+              .whenActionIsDispatched(
+                startSubscriptionAction({
+                  url: webSocketUrl,
+                  refId,
+                  exploreId,
+                  dataReceivedActionCreator,
+                })
+              )
+              .thenNoActionsWhereDispatched()
+              .whenWebSocketReceivesData({ data: [1, 2, 3] })
+              .thenResultingActionsEqual(dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }))
+              .whenActionIsDispatched(
+                startSubscriptionAction({
+                  url: webSocketUrl,
+                  refId: 'B',
+                  exploreId,
+                  dataReceivedActionCreator,
+                })
+              )
+              .whenWebSocketReceivesData({ data: [4, 5, 6] })
+              .thenResultingActionsEqual(
+                dataReceivedActionCreator({ exploreId, data: { data: [1, 2, 3] } as any }),
+                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any }),
+                dataReceivedActionCreator({ exploreId, data: { data: [4, 5, 6] } as any })
+              );
+          });
+        });
+      });
+    });
+  });
+});

--- a/public/app/features/explore/state/epics.ts
+++ b/public/app/features/explore/state/epics.ts
@@ -1,5 +1,5 @@
 import { Epic } from 'redux-observable';
-import { webSocket } from 'rxjs/webSocket';
+import { EMPTY } from 'rxjs';
 import { map, takeUntil, mergeMap, tap, filter } from 'rxjs/operators';
 
 import { StoreState, ExploreId } from 'app/types';
@@ -11,9 +11,9 @@ import {
   changeRefreshIntervalAction,
   clearQueriesAction,
 } from './actionTypes';
-import { EMPTY } from 'rxjs';
 import { isLive } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
 import { SeriesData } from '@grafana/ui/src/types/data';
+import { EpicDependencies } from 'app/store/configureStore';
 
 const convertToWebSocketUrl = (url: string) => {
   const protocol = window.location.protocol === 'https' ? 'wss://' : 'ws://';
@@ -80,11 +80,15 @@ export const startSubscriptionsEpic: Epic<ActionOf<any>, ActionOf<any>, StoreSta
   );
 };
 
-export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = (action$, state$) => {
+export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDependencies> = (
+  action$,
+  state$,
+  { getWebSocket }
+) => {
   return action$.ofType(startSubscriptionAction.type).pipe(
     mergeMap((action: ActionOf<StartSubscriptionPayload>) => {
       const { url, exploreId, refId, dataReceivedActionCreator } = action.payload;
-      return webSocket(url).pipe(
+      return getWebSocket(url).pipe(
         takeUntil(
           action$
             .ofType(

--- a/public/app/features/explore/state/epics.ts
+++ b/public/app/features/explore/state/epics.ts
@@ -125,7 +125,7 @@ export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreStat
           const { datasourceInstance } = state$.value.explore[exploreId];
 
           if (!datasourceInstance || !datasourceInstance.resultToSeriesData) {
-            return []; //do nothing if datasource does not support streaming
+            return [null]; //do nothing if datasource does not support streaming
           }
 
           return datasourceInstance

--- a/public/app/features/explore/state/epics.ts
+++ b/public/app/features/explore/state/epics.ts
@@ -150,7 +150,7 @@ export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreStat
 
 export const limitMessageRateEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDependencies> = action$ => {
   return action$.ofType(limitMessageRatePayloadAction.type).pipe(
-    throttleTime(5),
+    throttleTime(1),
     map((action: ActionOf<LimitMessageRatePayload>) => {
       const { exploreId, data, dataReceivedActionCreator } = action.payload;
       return dataReceivedActionCreator({ exploreId, data });

--- a/public/app/features/explore/state/epics.ts
+++ b/public/app/features/explore/state/epics.ts
@@ -5,7 +5,12 @@ import { map, takeUntil, mergeMap, tap, filter } from 'rxjs/operators';
 import { StoreState, ExploreId } from 'app/types';
 import { ActionOf, ActionCreator, actionCreatorFactory } from '../../../core/redux/actionCreatorFactory';
 import { config } from '../../../core/config';
-import { updateDatasourceInstanceAction, resetExploreAction, changeRefreshIntervalAction } from './actionTypes';
+import {
+  updateDatasourceInstanceAction,
+  resetExploreAction,
+  changeRefreshIntervalAction,
+  clearQueriesAction,
+} from './actionTypes';
 import { EMPTY } from 'rxjs';
 import { isLive } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
 import { SeriesData } from '@grafana/ui/src/types/data';
@@ -86,7 +91,8 @@ export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreStat
               startSubscriptionAction.type,
               resetExploreAction.type,
               updateDatasourceInstanceAction.type,
-              changeRefreshIntervalAction.type
+              changeRefreshIntervalAction.type,
+              clearQueriesAction.type
             )
             .pipe(
               filter(action => {
@@ -100,6 +106,10 @@ export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreStat
 
                 if (action.type === changeRefreshIntervalAction.type && action.payload.exploreId === exploreId) {
                   return !isLive(action.payload.refreshInterval); // stops subscriptions if user changes refresh interval away from 'Live'
+                }
+
+                if (action.type === clearQueriesAction.type && action.payload.exploreId === exploreId) {
+                  return true; // stops subscriptions if user clears all queries
                 }
 
                 return action.payload.exploreId === exploreId && action.payload.refId === refId;

--- a/public/app/features/explore/state/epics.ts
+++ b/public/app/features/explore/state/epics.ts
@@ -1,0 +1,123 @@
+import { Epic } from 'redux-observable';
+import { webSocket } from 'rxjs/webSocket';
+import { map, takeUntil, mergeMap, tap, filter } from 'rxjs/operators';
+
+import { StoreState, ExploreId } from 'app/types';
+import { ActionOf, ActionCreator, actionCreatorFactory } from '../../../core/redux/actionCreatorFactory';
+import { config } from '../../../core/config';
+import { updateDatasourceInstanceAction, resetExploreAction } from './actionTypes';
+
+const getWebSocketUrl = (options: any) => {
+  const protocol = window.location.protocol === 'https' ? 'wss://' : 'ws://';
+  let backend = `${protocol}${window.location.host}${config.appSubUrl}`;
+  if (!backend.endsWith('/')) {
+    backend += '/';
+  }
+  return `${backend}${options.url}`;
+};
+
+export interface StartSubscriptionsPayload {
+  targets: any[];
+  exploreId: ExploreId;
+  dataReceivedActionCreator: ActionCreator<SubscriptionDataReceivedPayload>;
+  stopsActionCreator: ActionCreator<StopSubscriptionPayload>;
+  pauseActionCreator?: ActionCreator<PauseSubscriptionPayload>;
+  playActionCreator?: ActionCreator<PauseSubscriptionPayload>;
+}
+
+export const startSubscriptionsAction = actionCreatorFactory<StartSubscriptionsPayload>(
+  'explore/START_SUBSCRIPTIONS'
+).create();
+
+export interface StartSubscriptionPayload {
+  url: string;
+  refId: string;
+  exploreId: ExploreId;
+  dataReceivedActionCreator: ActionCreator<SubscriptionDataReceivedPayload>;
+  stopsActionCreator: ActionCreator<StopSubscriptionPayload>;
+  pauseActionCreator?: ActionCreator<PauseSubscriptionPayload>;
+  playActionCreator?: ActionCreator<PauseSubscriptionPayload>;
+}
+
+export const startSubscriptionAction = actionCreatorFactory<StartSubscriptionPayload>(
+  'explore/START_SUBSCRIPTION'
+).create();
+
+export interface StopSubscriptionPayload {
+  refId: string;
+  exploreId: ExploreId;
+}
+
+export const stopSubscriptionAction = actionCreatorFactory<StopSubscriptionPayload>(
+  'explore/STOP_SUBSCRIPTION'
+).create();
+
+export interface PauseSubscriptionPayload extends StopSubscriptionPayload {}
+export interface PlaySubscriptionPayload extends StopSubscriptionPayload {}
+
+export interface SubscriptionDataReceivedPayload {
+  data: any;
+  exploreId: ExploreId;
+}
+
+export const subscriptionDataReceivedAction = actionCreatorFactory<SubscriptionDataReceivedPayload>(
+  'explore/SUBSCRIPTION_DATA_RECEIVED'
+).create();
+
+export const startSubscriptionsEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = action$ => {
+  return action$.ofType(startSubscriptionsAction.type).pipe(
+    mergeMap((action: ActionOf<StartSubscriptionsPayload>) => {
+      const {
+        targets,
+        exploreId,
+        dataReceivedActionCreator,
+        stopsActionCreator,
+        pauseActionCreator,
+        playActionCreator,
+      } = action.payload;
+      return targets.map(target => {
+        return startSubscriptionAction({
+          url: getWebSocketUrl(target),
+          refId: target.refId,
+          exploreId,
+          dataReceivedActionCreator,
+          stopsActionCreator,
+          pauseActionCreator,
+          playActionCreator,
+        });
+      });
+    })
+  );
+};
+
+export const startSubscriptionEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = action$ => {
+  return action$.ofType(startSubscriptionAction.type).pipe(
+    mergeMap((action: ActionOf<StartSubscriptionPayload>) => {
+      const { url, exploreId, refId, dataReceivedActionCreator, stopsActionCreator } = action.payload;
+      return webSocket(url).pipe(
+        takeUntil(
+          action$
+            .ofType(
+              startSubscriptionAction.type,
+              stopsActionCreator.type,
+              resetExploreAction.type,
+              updateDatasourceInstanceAction.type
+            )
+            .pipe(
+              filter(action => {
+                if (action.type === resetExploreAction.type || action.type === updateDatasourceInstanceAction.type) {
+                  return true; // stops all subscriptions if user navigates away from explore or changes data source
+                }
+
+                return action.payload.exploreId === exploreId && action.payload.refId === refId;
+              }),
+              tap(value => console.log('Stopping subscription', value))
+            )
+        ),
+        map(data => {
+          return dataReceivedActionCreator({ data, exploreId });
+        })
+      );
+    })
+  );
+};

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -55,6 +55,7 @@ import {
 import { updateLocation } from 'app/core/actions/location';
 import { LocationUpdate } from 'app/types';
 import TableModel from 'app/core/table_model';
+import { isLive } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
 
 export const DEFAULT_RANGE = {
   from: 'now-6h',
@@ -184,9 +185,13 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
     filter: changeRefreshIntervalAction,
     mapper: (state, action): ExploreItemState => {
       const { refreshInterval } = action.payload;
+      const live = isLive(refreshInterval);
       return {
         ...state,
         refreshInterval: refreshInterval,
+        graphIsLoading: live ? true : false,
+        tableIsLoading: live ? true : false,
+        logIsLoading: live ? true : false,
       };
     },
   })
@@ -376,18 +381,21 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
   .addMapper({
     filter: querySuccessAction,
     mapper: (state, action): ExploreItemState => {
-      const { queryIntervals } = state;
+      const { queryIntervals, refreshInterval } = state;
       const { result, resultType, latency } = action.payload;
       const results = calculateResultsFromQueryTransactions(result, resultType, queryIntervals.intervalMs);
+      const live = isLive(refreshInterval);
+
       return {
         ...state,
         graphResult: resultType === 'Graph' ? results.graphResult : state.graphResult,
         tableResult: resultType === 'Table' ? results.tableResult : state.tableResult,
         logsResult: resultType === 'Logs' ? results.logsResult : state.logsResult,
         latency,
-        graphIsLoading: false,
-        logIsLoading: false,
-        tableIsLoading: false,
+        graphIsLoading: live ? true : false,
+        logIsLoading: live ? true : false,
+        tableIsLoading: live ? true : false,
+        showingStartPage: false,
         update: makeInitialUpdateState(),
       };
     },

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -68,6 +68,24 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     return this.backendSrv.datasourceRequest(req);
   }
 
+  convertToStreamTargets = (options: DataQueryRequest<LokiQuery>): Array<{ url: string; refId: string }> => {
+    return options.targets
+      .filter(target => target.expr && !target.hide)
+      .map(target => {
+        const interpolated = this.templateSrv.replace(target.expr);
+        const { query, regexp } = parseQuery(interpolated);
+        const refId = target.refId;
+        const baseUrl = this.instanceSettings.url;
+        const params = serializeParams({ query, regexp });
+        const url = `${baseUrl}/api/prom/tail?${params}`;
+
+        return {
+          url,
+          refId,
+        };
+      });
+  };
+
   prepareQueryTarget(target: LokiQuery, options: DataQueryRequest<LokiQuery>) {
     const interpolated = this.templateSrv.replace(target.expr);
     const { query, regexp } = parseQuery(interpolated);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -86,10 +86,22 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       });
   };
 
-  resultToSeriesData = (data: any, refId?: string): SeriesData => {
-    const seriesData = logStreamToSeriesData(data);
-    seriesData.refId = refId;
-    return seriesData;
+  resultToSeriesData = (data: any, refId: string): SeriesData[] => {
+    const toSeriesData = (stream: any, refId: string) => ({
+      ...logStreamToSeriesData(stream),
+      refId,
+    });
+
+    if (data.streams) {
+      // new Loki API purposed in https://github.com/grafana/loki/pull/590
+      const series: SeriesData[] = [];
+      for (const stream of data.streams || []) {
+        series.push(toSeriesData(stream, refId));
+      }
+      return series;
+    }
+
+    return [toSeriesData(data, refId)];
   };
 
   prepareQueryTarget(target: LokiQuery, options: DataQueryRequest<LokiQuery>) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -86,6 +86,12 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       });
   };
 
+  resultToSeriesData = (data: any, refId?: string): SeriesData => {
+    const seriesData = logStreamToSeriesData(data);
+    seriesData.refId = refId;
+    return seriesData;
+  };
+
   prepareQueryTarget(target: LokiQuery, options: DataQueryRequest<LokiQuery>) {
     const interpolated = this.templateSrv.replace(target.expr);
     const { query, regexp } = parseQuery(interpolated);

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -15,7 +15,7 @@ import usersReducers from 'app/features/users/state/reducers';
 import userReducers from 'app/features/profile/state/reducers';
 import organizationReducers from 'app/features/org/state/reducers';
 import { setStore } from './store';
-import { startSubscriptionsEpic, startSubscriptionEpic } from 'app/features/explore/state/epics';
+import { startSubscriptionsEpic, startSubscriptionEpic, limitMessageRateEpic } from 'app/features/explore/state/epics';
 import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
 
 const rootReducers = {
@@ -37,7 +37,7 @@ export function addRootReducer(reducers) {
   Object.assign(rootReducers, ...reducers);
 }
 
-export const rootEpic: any = combineEpics(startSubscriptionsEpic, startSubscriptionEpic);
+export const rootEpic: any = combineEpics(startSubscriptionsEpic, startSubscriptionEpic, limitMessageRateEpic);
 
 export interface EpicDependencies {
   getWebSocket: <T>(urlConfigOrSource: string) => WebSocketSubject<T>;

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -16,6 +16,7 @@ import userReducers from 'app/features/profile/state/reducers';
 import organizationReducers from 'app/features/org/state/reducers';
 import { setStore } from './store';
 import { startSubscriptionsEpic, startSubscriptionEpic } from 'app/features/explore/state/epics';
+import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
 
 const rootReducers = {
   ...sharedReducers,
@@ -38,7 +39,15 @@ export function addRootReducer(reducers) {
 
 export const rootEpic: any = combineEpics(startSubscriptionsEpic, startSubscriptionEpic);
 
-const epicMiddleware = createEpicMiddleware();
+export interface EpicDependencies {
+  getWebSocket: <T>(urlConfigOrSource: string) => WebSocketSubject<T>;
+}
+
+const dependencies: EpicDependencies = {
+  getWebSocket: webSocket,
+};
+
+const epicMiddleware = createEpicMiddleware({ dependencies });
 
 export function configureStore() {
   const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -259,9 +259,12 @@ export interface ExploreItemState {
   update: ExploreUpdateState;
 
   queryErrors: DataQueryError[];
+
   latency: number;
   supportedModes: ExploreMode[];
   mode: ExploreMode;
+
+  isLive: boolean;
 }
 
 export interface ExploreUpdateState {

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -337,10 +337,14 @@ $column-horizontal-spacing: 10px;
 
 .logs-row.fresh {
   color: $text-color;
-  background-color: $blue-faint;
-  transition: background-color 500ms ease-in-out;
+  background-color: $blue-light, 20%;
 }
 
 .logs-row.old {
   opacity: 0.8;
+}
+
+.logs-rows-indicator {
+  font-size: $font-size-md;
+  padding: $space-sm 0;
 }

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -323,3 +323,21 @@ $column-horizontal-spacing: 10px;
     background: $blue;
   }
 }
+
+.logs-row.fresh {
+  color: $text-color;
+  background-color: $blue-faint;
+  transition: background-color 500ms ease-in-out;
+  width: 100%;
+  display: flex;
+  flex-flow: row;
+  flex: auto;
+}
+
+.logs-row.old {
+  opacity: 0.9;
+  width: 100%;
+  display: flex;
+  flex-flow: row;
+  flex: auto;
+}

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -323,28 +323,3 @@ $column-horizontal-spacing: 10px;
     background: $blue;
   }
 }
-
-.logs-rows.live {
-  display: flex;
-  flex-flow: column nowrap;
-  height: 75vh;
-  overflow-y: auto;
-}
-
-.logs-rows.live > :first-child {
-  margin-top: auto !important;
-}
-
-.logs-row.fresh {
-  color: $text-color;
-  background-color: $blue-light, 20%;
-}
-
-.logs-row.old {
-  opacity: 0.8;
-}
-
-.logs-rows-indicator {
-  font-size: $font-size-md;
-  padding: $space-sm 0;
-}

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -327,7 +327,7 @@ $column-horizontal-spacing: 10px;
 .logs-rows.live {
   display: flex;
   flex-flow: column nowrap;
-  height: 80vh;
+  height: 75vh;
   overflow-y: auto;
 }
 

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -324,20 +324,21 @@ $column-horizontal-spacing: 10px;
   }
 }
 
+.logs-rows.live {
+  display: flex;
+  flex-direction: column;
+  height: 80vh;
+  overflow-y: scroll;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+}
+
 .logs-row.fresh {
   color: $text-color;
   background-color: $blue-faint;
   transition: background-color 500ms ease-in-out;
-  width: 100%;
-  display: flex;
-  flex-flow: row;
-  flex: auto;
 }
 
 .logs-row.old {
-  opacity: 0.9;
-  width: 100%;
-  display: flex;
-  flex-flow: row;
-  flex: auto;
+  opacity: 0.8;
 }

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -326,11 +326,13 @@ $column-horizontal-spacing: 10px;
 
 .logs-rows.live {
   display: flex;
-  flex-direction: column;
+  flex-flow: column nowrap;
   height: 80vh;
-  overflow-y: scroll;
-  flex: 1 1 auto;
-  justify-content: flex-end;
+  overflow-y: auto;
+}
+
+.logs-rows.live > :first-child {
+  margin-top: auto !important;
 }
 
 .logs-row.fresh {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -138,7 +138,13 @@
 }
 
 .explore {
+  display: flex;
   flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.explore.explore-live {
+  flex-direction: column-reverse;
 }
 
 .explore + .explore {
@@ -146,7 +152,14 @@
 }
 
 .explore-container {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
   padding: $dashboard-padding;
+}
+
+.explore-container.explore-live {
+  flex-direction: column-reverse;
 }
 
 .explore-wrapper {

--- a/public/test/core/redux/epicTester.ts
+++ b/public/test/core/redux/epicTester.ts
@@ -1,0 +1,60 @@
+import { Epic, ActionsObservable, StateObservable } from 'redux-observable';
+import { Subject } from 'rxjs';
+import { WebSocketSubject } from 'rxjs/webSocket';
+
+import { ActionOf } from 'app/core/redux/actionCreatorFactory';
+import { StoreState } from 'app/types/store';
+import { EpicDependencies } from 'app/store/configureStore';
+
+export const epicTester = (
+  epic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDependencies>,
+  state?: StoreState
+) => {
+  const resultingActions: Array<ActionOf<any>> = [];
+  const action$ = new Subject<ActionOf<any>>();
+  const state$ = new Subject<StoreState>();
+  const actionObservable$ = new ActionsObservable(action$);
+  const stateObservable$ = new StateObservable(state$, state || ({} as StoreState));
+  const websockets$: Array<Subject<any>> = [];
+  const dependencies: EpicDependencies = {
+    getWebSocket: () => {
+      const webSocket$ = new Subject<any>();
+      websockets$.push(webSocket$);
+      return webSocket$ as WebSocketSubject<any>;
+    },
+  };
+  epic(actionObservable$, stateObservable$, dependencies).subscribe({ next: action => resultingActions.push(action) });
+
+  const whenActionIsDispatched = (action: ActionOf<any>) => {
+    action$.next(action);
+
+    return instance;
+  };
+
+  const whenWebSocketReceivesData = (data: any) => {
+    websockets$.forEach(websocket$ => websocket$.next(data));
+
+    return instance;
+  };
+
+  const thenResultingActionsEqual = (...actions: Array<ActionOf<any>>) => {
+    expect(resultingActions).toEqual(actions);
+
+    return instance;
+  };
+
+  const thenNoActionsWhereDispatched = () => {
+    expect(resultingActions).toEqual([]);
+
+    return instance;
+  };
+
+  const instance = {
+    whenActionIsDispatched,
+    whenWebSocketReceivesData,
+    thenResultingActionsEqual,
+    thenNoActionsWhereDispatched,
+  };
+
+  return instance;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14735,6 +14735,11 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-observable@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-1.1.0.tgz#323a8fe53e89fdb519be2807b55f08e21c13e6f1"
+  integrity sha512-G0nxgmTZwTK3Z3KoQIL8VQu9n0YCUwEP3wc3zxKQ8zAZm+iYkoZvBqAnBJfLi4EsD1E64KR4s4jFH/dFXpV9Og==
+
 redux-thunk@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a very rough initial live tailing for Loki draft PR, there is no error handling for the websocket right now for instance.
Needs loads of UX feedback and UX mockups to get this to a great user experience.

**Which issue(s) this PR fixes**:
Closes #16666 

**Special notes for your reviewer**:
- Does not work if you use `yarn start:hot`
- Adds a new `Live` option to the RefreshPicker for datasources that support live streaming (i.e. Loki)

** Try out different WebSocket scenarios **
To turn on WebSockets you need to change RefreshPicker to `Live` option
DevTools => Network => WS is your debug friend
![image](https://user-images.githubusercontent.com/562238/57700278-ec4ac200-7659-11e9-826d-0360e452dc53.png)
 
- Changing datasource => previous websocket subscriptions should not receive any new messages 
- Turning off `Live` option in RefreshPicker  => previous websocket subscriptions should not receive any new messages 
- Changing `Live` option in RefreshPicker to other interval  => previous websocket subscriptions should not receive any new messages 
- Navigating away from Explore => previous websocket subscriptions should not receive any new messages 