### PR TITLE
InputDatasource: don't crash describing an empty dataset

### DIFF
--- a/public/app/plugins/datasource/input/InputDatasource.test.ts
+++ b/public/app/plugins/datasource/input/InputDatasource.test.ts
@@ -1,4 +1,4 @@
-import InputDatasource from './InputDatasource';
+import InputDatasource, { describeSeriesData } from './InputDatasource';
 import { InputQuery, InputOptions } from './types';
 import { readCSV, DataSourceInstanceSettings, PluginMeta } from '@grafana/ui';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
@@ -30,5 +30,19 @@ describe('InputDatasource', () => {
         expect(series.rows).toEqual(data[0].rows);
       });
     });
+  });
+
+  test('SeriesData descriptions', () => {
+    expect(describeSeriesData([])).toEqual('');
+    expect(describeSeriesData(null)).toEqual('');
+    expect(
+      describeSeriesData([
+        {
+          name: 'x',
+          fields: [{ name: 'a' }],
+          rows: [],
+        },
+      ])
+    ).toEqual('1 Fields, 0 Rows');
   });
 });

--- a/public/app/plugins/datasource/input/InputDatasource.ts
+++ b/public/app/plugins/datasource/input/InputDatasource.ts
@@ -17,28 +17,14 @@ export class InputDatasource extends DataSourceApi<InputQuery, InputOptions> {
     this.data = instanceSettings.jsonData.data ? instanceSettings.jsonData.data : [];
   }
 
-  getDescription(data: SeriesData[]): string {
-    if (!data) {
-      return '';
-    }
-    if (data.length > 1) {
-      const count = data.reduce((acc, series) => {
-        return acc + series.rows.length;
-      }, 0);
-      return `${data.length} Series, ${count} Rows`;
-    }
-    const series = data[0];
-    return `${series.fields.length} Fields, ${series.rows.length} Rows`;
-  }
-
   /**
    * Convert a query to a simple text string
    */
   getQueryDisplayText(query: InputQuery): string {
     if (query.data) {
-      return 'Panel Data: ' + this.getDescription(query.data);
+      return 'Panel Data: ' + describeSeriesData(query.data);
     }
-    return `Shared Data From: ${this.name} (${this.getDescription(this.data)})`;
+    return `Shared Data From: ${this.name} (${describeSeriesData(this.data)})`;
   }
 
   metricFindQuery(query: string, options?: any) {
@@ -94,6 +80,23 @@ export class InputDatasource extends DataSourceApi<InputQuery, InputOptions> {
       });
     });
   }
+}
+
+export function describeSeriesData(data: SeriesData[]): string {
+  if (!data || !data.length) {
+    return '';
+  }
+  if (data.length > 1) {
+    const count = data.reduce((acc, series) => {
+      return acc + series.rows.length;
+    }, 0);
+    return `${data.length} Series, ${count} Rows`;
+  }
+  const series = data[0];
+  if (!series.fields) {
+    return 'Missing Fields';
+  }
+  return `${series.fields.length} Fields, ${series.rows.length} Rows`;
 }
 
 export default InputDatasource;

--- a/public/app/plugins/datasource/input/InputQueryEditor.tsx
+++ b/public/app/plugins/datasource/input/InputQueryEditor.tsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 // Types
-import { InputDatasource } from './InputDatasource';
+import { InputDatasource, describeSeriesData } from './InputDatasource';
 import { InputQuery, InputOptions } from './types';
 
 import { FormLabel, Select, QueryEditorProps, SelectOptionItem, SeriesData, TableInputCSV, toCSV } from '@grafana/ui';
@@ -80,10 +80,10 @@ export class InputQueryEditor extends PureComponent<Props, State> {
 
           <div className="btn btn-link">
             {query.data ? (
-              datasource.getDescription(query.data)
+              describeSeriesData(query.data)
             ) : (
               <a href={`datasources/edit/${id}/`}>
-                {name}: {datasource.getDescription(datasource.data)} &nbsp;&nbsp;
+                {name}: {describeSeriesData(datasource.data)} &nbsp;&nbsp;
                 <i className="fa fa-pencil-square-o" />
               </a>
             )}


### PR DESCRIPTION
The InputDatasource currently crashes when asked to describe an array with null values