### PR TITLE
Release: Improved cherry pick task

### DIFF
--- a/scripts/cli/tasks/cherrypick.ts
+++ b/scripts/cli/tasks/cherrypick.ts
@@ -23,7 +23,9 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
 
   let commands = '';
 
+  console.log('--------------------------------------------------------------------');
   console.log('Printing PRs with cherry-pick-needed, in ASC merge date order');
+  console.log('--------------------------------------------------------------------');
 
   for (const item of res.data) {
     if (!item.milestone) {
@@ -32,15 +34,13 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
     }
 
     const issueDetails = await client.get(item.pull_request.url);
-    console.log(
-      `* ${item.title}, (#${item.number}), closed_at ${item.closed_at}, merge-sha: ${
-        issueDetails.data.merge_commit_sha
-      }`
-    );
+    console.log(`* ${item.title}, (#${item.number}), merge-sha: ${issueDetails.data.merge_commit_sha}`);
     commands += `git cherry-pick -x ${issueDetails.data.merge_commit_sha}\n`;
   }
 
+  console.log('--------------------------------------------------------------------');
   console.log('Commands (in order of how they should be executed)');
+  console.log('--------------------------------------------------------------------');
   console.log(commands);
 };
 

--- a/scripts/cli/tasks/cherrypick.ts
+++ b/scripts/cli/tasks/cherrypick.ts
@@ -16,10 +16,14 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
     },
   });
 
-  // sort by closed date
+  // sort by closed date ASC
   res.data.sort(function(a, b) {
-    return new Date(b.closed_at).getTime() - new Date(a.closed_at).getTime();
+    return new Date(a.closed_at).getTime() - new Date(b.closed_at).getTime();
   });
+
+  let commands = '';
+
+  console.log('Printing PRs with cherry-pick-needed, in ASC merge date order');
 
   for (const item of res.data) {
     if (!item.milestone) {
@@ -27,11 +31,17 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
       continue;
     }
 
-    console.log(`${item.title} (${item.number}) closed_at ${item.closed_at}`);
-    console.log(`\tURL: ${item.closed_at} ${item.html_url}`);
     const issueDetails = await client.get(item.pull_request.url);
-    console.log(`\tMerge sha: ${issueDetails.data.merge_commit_sha}`);
+    console.log(
+      `* ${item.title}, (#${item.number}), closed_at ${item.closed_at}, merge-sha: ${
+        issueDetails.data.merge_commit_sha
+      }`
+    );
+    commands += `git cherry-pick -x ${issueDetails.data.merge_commit_sha}\n`;
   }
+
+  console.log('Commands (in order of how they should be executed)');
+  console.log(commands);
 };
 
 export const cherryPickTask = new Task<CherryPickOptions>();


### PR DESCRIPTION
Now prints markdown first (no in ASC order), then a list of git commands. 

Example: 

```
❯ yarn cli cherrypick
yarn run v1.13.0
$ ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/index.ts cherrypick
Running Cherry pick task task
  Printing PRs with cherry-pick-needed, in ASC merge date order
  * Plugins: Support templated urls in plugin routes, (#16599), closed_at 2019-05-07T16:55:40Z, merge-sha: b07d0b1026753dea12acbf2272e6bfb14a41d8e6
  * Plugins: Update beta notice style, (#16928), closed_at 2019-05-07T22:58:04Z, merge-sha: b08cf1e7ac84b111a30616c2b0477a08ac820bff
  * AppPlugin: remove /edit from the URL, (#16934), closed_at 2019-05-08T07:38:41Z, merge-sha: 17ce1273ca2d275deedc937fefd336ee23cfe9a8
  * InfluxDB: Fix HTTP method should default to GET, (#16949), closed_at 2019-05-08T11:02:40Z, merge-sha: e7a9afe9833f608bc4a7fdb16f6adcc2df52132e
  * Singlestat: fixed centering issue for very small panels, (#16944), closed_at 2019-05-08T15:21:18Z, merge-sha: e97853abc9fe26ce3bbb1ba1d782c735067f2afc
  * Dashboard: Fixes blank dashboard after window resize with panel without title, (#16942), closed_at 2019-05-08T15:21:47Z, merge-sha: f58ab7945b51920c4675aa40b8df613a852b471b
  * GettingStarted: Fixes layout issues, (#16941), closed_at 2019-05-08T15:22:27Z, merge-sha: a9e01d8b04aaceac29a03599181a00cb0cd8cd36
  * Plugins: Fix how datemath utils are exposed to plugins, (#16976), closed_at 2019-05-09T13:27:54Z, merge-sha: 0c1530c7a89ba3321a24567a28a511cd13a6c407
  * GettingStarted: convert to react panel plugin, (#16985), closed_at 2019-05-10T05:48:32Z, merge-sha: f617cd8975338644f94d001f7e34d20cd0bb3b68
  * Docker: Prevent a permission denied error when writing files to the default provisioning directory, (#16831), closed_at 2019-05-10T07:03:18Z, merge-sha: 5e44f001fba392bed706b16761250b5112b354de
  * Panels: Fixes panel error tooltip not showing, (#16993), closed_at 2019-05-10T09:35:56Z, merge-sha: 5573d285824f4634c7a598cc94463cf53429b402
  * Explore: Makes it possible to zoom in Explore/Loki/Graph without exception, (#16991), closed_at 2019-05-10T10:10:33Z, merge-sha: d5a35f3631a46f513d7c4cd3b94f68060c9c5d77
  * Explore: Fix empty result from datasource should render logs container, (#16999), closed_at 2019-05-10T10:45:27Z, merge-sha: 8eb78ea931b582ddef948baad818b336793887ef
  * Gauge: Adds background shade to gauge track and improves height usage, (#17019), closed_at 2019-05-13T11:18:15Z, merge-sha: 597c380ead0c5a3d75845e4210eab3cfe337432b
  * Dashboard: show refresh button in first kiosk(tv) mode, (#17032), closed_at 2019-05-13T13:49:55Z, merge-sha: 3ce2f3b58db29340e3ec29fecab15bed0ba6f6a7
  * Dashboard: Fixes scrolling issues for Edge browser, (#17033), closed_at 2019-05-14T05:36:20Z, merge-sha: 1001cd7ac37a71f7935b6bfaa7a399a8ae7e4ff2
  * Search: Scroll issue in dashboard search in latest Chrome, (#17054), closed_at 2019-05-14T09:08:37Z, merge-sha: ceb21bd653adf7d88bbfba50218976b71a9f389a
  * Azure Monitor: Application insights query editor now renders correctly, (#17057), closed_at 2019-05-14T12:27:48Z, merge-sha: 4bc1a66fe41450fc8744f5713eacb8e76c47235c
  * Dashboard: Fixes lazy loading & expanding collapsed rows on mobile, (#17055), closed_at 2019-05-14T12:41:25Z, merge-sha: 74a31bd9b47f3c8663b08d9d164aa9d41393e4b4
  * Gauge: Fixes orientation issue after switching from BarGauge to Gauge, (#17064), closed_at 2019-05-14T14:33:48Z, merge-sha: 68ad93f4108225c1c751b7812f4dbdcbfa80c962
  * Panels: Fixed alert icon position in panel header, (#17070), closed_at 2019-05-14T16:47:36Z, merge-sha: 238a929262a2f332420e908885d5430dfadae331
  * Support publishing MSI to grafana.com, (#17073), closed_at 2019-05-15T08:58:26Z, merge-sha: d0ea98f6bd8087bfaae5d9deb72753f5596ece8c
  * Remotecache: Avoid race condition in Set causing error on insert. , (#17082), closed_at 2019-05-15T09:24:05Z, merge-sha: aed3d0d3adabfdae096aef0116530e365316e586
  Commands (in order of how they should be executed)
  git cherry-pick -x b07d0b1026753dea12acbf2272e6bfb14a41d8e6
  git cherry-pick -x b08cf1e7ac84b111a30616c2b0477a08ac820bff
  git cherry-pick -x 17ce1273ca2d275deedc937fefd336ee23cfe9a8
  git cherry-pick -x e7a9afe9833f608bc4a7fdb16f6adcc2df52132e
  git cherry-pick -x e97853abc9fe26ce3bbb1ba1d782c735067f2afc
  git cherry-pick -x f58ab7945b51920c4675aa40b8df613a852b471b
  git cherry-pick -x a9e01d8b04aaceac29a03599181a00cb0cd8cd36
  git cherry-pick -x 0c1530c7a89ba3321a24567a28a511cd13a6c407
  git cherry-pick -x f617cd8975338644f94d001f7e34d20cd0bb3b68
  git cherry-pick -x 5e44f001fba392bed706b16761250b5112b354de
  git cherry-pick -x 5573d285824f4634c7a598cc94463cf53429b402
  git cherry-pick -x d5a35f3631a46f513d7c4cd3b94f68060c9c5d77
  git cherry-pick -x 8eb78ea931b582ddef948baad818b336793887ef
  git cherry-pick -x 597c380ead0c5a3d75845e4210eab3cfe337432b
  git cherry-pick -x 3ce2f3b58db29340e3ec29fecab15bed0ba6f6a7
  git cherry-pick -x 1001cd7ac37a71f7935b6bfaa7a399a8ae7e4ff2
  git cherry-pick -x ceb21bd653adf7d88bbfba50218976b71a9f389a
  git cherry-pick -x 4bc1a66fe41450fc8744f5713eacb8e76c47235c
  git cherry-pick -x 74a31bd9b47f3c8663b08d9d164aa9d41393e4b4
  git cherry-pick -x 68ad93f4108225c1c751b7812f4dbdcbfa80c962
  git cherry-pick -x 238a929262a2f332420e908885d5430dfadae331
  git cherry-pick -x d0ea98f6bd8087bfaae5d9deb72753f5596ece8c
  git cherry-pick -x aed3d0d3adabfdae096aef0116530e365316e586
```