### PR TITLE
[WIP] Chore: Refactor part of datasources sql

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -50,21 +50,15 @@ func GetDataSources(c *m.ReqContext) Response {
 }
 
 func GetDataSourceById(c *m.ReqContext) Response {
-	query := m.GetDataSourceByIdQuery{
-		Id:    c.ParamsInt64(":id"),
-		OrgId: c.OrgId,
-	}
-
-	if err := bus.Dispatch(&query); err != nil {
+	ds, err := c.DatasourceService.GetDataSourceById(c.ParamsInt64(":id"), c.OrgId)
+	if err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}
 		return Error(500, "Failed to query datasources", err)
 	}
 
-	ds := query.Result
 	dtos := convertModelToDtos(ds)
-
 	return JSON(200, &dtos)
 }
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -66,6 +67,7 @@ type HTTPServer struct {
 	QuotaService        *quota.QuotaService      `inject:""`
 	RemoteCacheService  *remotecache.RemoteCache `inject:""`
 	ProvisioningService ProvisioningService      `inject:""`
+	SqlStore            *sqlstore.SqlStore       `inject:""`
 }
 
 func (hs *HTTPServer) Init() error {
@@ -238,6 +240,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m.Use(middleware.GetContextHandler(
 		hs.AuthTokenService,
 		hs.RemoteCacheService,
+		hs.SqlStore,
 	))
 	m.Use(middleware.OrgRedirect())
 

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
+type DatasourceService interface {
+	GetDataSourceById(id int64, orgId int64) (*DataSource, error)
+}
+
 type ReqContext struct {
 	*macaron.Context
 	*SignedInUser
@@ -19,6 +23,8 @@ type ReqContext struct {
 	AllowAnonymous bool
 	SkipCache      bool
 	Logger         log.Logger
+
+	DatasourceService DatasourceService
 }
 
 // Handle handles and logs error by given status.

--- a/pkg/services/datasources/datasources_service.go
+++ b/pkg/services/datasources/datasources_service.go
@@ -1,0 +1,29 @@
+package datasources
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+type datasourceSql interface {
+	GetDataSourceById(id int64, orgId int64) (*models.DataSource, error)
+}
+
+type datasourceService struct {
+	sqlStore *sqlstore.SqlStore
+	sql      datasourceSql
+	ctx      context.Context
+}
+
+func NewDatasourceService(ctx context.Context, sqlStore *sqlstore.SqlStore) *datasourceService {
+	ds := &datasourceService{}
+	ds.ctx = ctx
+	ds.sql = &datasourceSqlImpl{sqlStore: sqlStore, ctx: ds.ctx}
+	return ds
+}
+
+func (ds *datasourceService) GetDataSourceById(id int64, orgId int64) (*models.DataSource, error) {
+	return ds.sql.GetDataSourceById(id, orgId)
+}

--- a/pkg/services/datasources/sql.go
+++ b/pkg/services/datasources/sql.go
@@ -1,0 +1,211 @@
+package datasources
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+
+	"github.com/go-xorm/xorm"
+
+	"github.com/grafana/grafana/pkg/components/securejsondata"
+	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type datasourceSqlImpl struct {
+	sqlStore *sqlstore.SqlStore
+	ctx      context.Context
+}
+
+func (ds *datasourceSqlImpl) GetDataSourceById(id int64, orgId int64) (*models.DataSource, error) {
+	var datasource *models.DataSource
+	err := ds.sqlStore.WithTransactionalDbSession(ds.ctx, func(sess *sqlstore.DBSession) error {
+
+		metrics.M_DB_DataSource_QueryById.Inc()
+
+		datasource = &models.DataSource{OrgId: orgId, Id: id}
+		has, err := ds.sqlStore.Engine.Get(datasource)
+
+		if err != nil {
+			return err
+		}
+
+		if !has {
+			return models.ErrDataSourceNotFound
+		}
+
+		return nil
+	})
+
+	return datasource, err
+}
+
+func (ds *datasourceSqlImpl) GetDataSourceByName(query *models.GetDataSourceByNameQuery) error {
+	datasource := models.DataSource{OrgId: query.OrgId, Name: query.Name}
+	has, err := ds.sqlStore.Engine.Get(&datasource)
+
+	if !has {
+		return models.ErrDataSourceNotFound
+	}
+
+	query.Result = &datasource
+	return err
+}
+
+func (ds *datasourceSqlImpl) GetDataSources(query *models.GetDataSourcesQuery) error {
+	sess := ds.sqlStore.Engine.Limit(5000, 0).Where("org_id=?", query.OrgId).Asc("name")
+
+	query.Result = make([]*models.DataSource, 0)
+	return sess.Find(&query.Result)
+}
+
+func (ds *datasourceSqlImpl) GetAllDataSources(query *models.GetAllDataSourcesQuery) error {
+	sess := ds.sqlStore.Engine.Limit(5000, 0).Asc("name")
+
+	query.Result = make([]*models.DataSource, 0)
+	return sess.Find(&query.Result)
+}
+
+func (ds *datasourceSqlImpl) DeleteDataSourceById(cmd *models.DeleteDataSourceByIdCommand) error {
+	return ds.sqlStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		var rawSql = "DELETE FROM data_source WHERE id=? and org_id=?"
+		result, err := sess.Exec(rawSql, cmd.Id, cmd.OrgId)
+		affected, _ := result.RowsAffected()
+		cmd.DeletedDatasourcesCount = affected
+		return err
+	})
+}
+
+func (ds *datasourceSqlImpl) DeleteDataSourceByName(cmd *models.DeleteDataSourceByNameCommand) error {
+	return ds.sqlStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		var rawSql = "DELETE FROM data_source WHERE name=? and org_id=?"
+		result, err := sess.Exec(rawSql, cmd.Name, cmd.OrgId)
+		affected, _ := result.RowsAffected()
+		cmd.DeletedDatasourcesCount = affected
+		return err
+	})
+}
+
+func (ds *datasourceSqlImpl) AddDataSource(cmd *models.AddDataSourceCommand) error {
+	return ds.sqlStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		existing := models.DataSource{OrgId: cmd.OrgId, Name: cmd.Name}
+		has, _ := sess.Get(&existing)
+
+		if has {
+			return models.ErrDataSourceNameExists
+		}
+
+		if cmd.JsonData == nil {
+			cmd.JsonData = simplejson.New()
+		}
+
+		ds := &models.DataSource{
+			OrgId:             cmd.OrgId,
+			Name:              cmd.Name,
+			Type:              cmd.Type,
+			Access:            cmd.Access,
+			Url:               cmd.Url,
+			User:              cmd.User,
+			Password:          cmd.Password,
+			Database:          cmd.Database,
+			IsDefault:         cmd.IsDefault,
+			BasicAuth:         cmd.BasicAuth,
+			BasicAuthUser:     cmd.BasicAuthUser,
+			BasicAuthPassword: cmd.BasicAuthPassword,
+			WithCredentials:   cmd.WithCredentials,
+			JsonData:          cmd.JsonData,
+			SecureJsonData:    securejsondata.GetEncryptedJsonData(cmd.SecureJsonData),
+			Created:           time.Now(),
+			Updated:           time.Now(),
+			Version:           1,
+			ReadOnly:          cmd.ReadOnly,
+		}
+
+		if _, err := sess.Insert(ds); err != nil {
+			return err
+		}
+		if err := updateIsDefaultFlag(ds, sess); err != nil {
+			return err
+		}
+
+		cmd.Result = ds
+		return nil
+	})
+}
+
+func updateIsDefaultFlag(ds *models.DataSource, sess *sqlstore.DBSession) error {
+	// Handle is default flag
+	if ds.IsDefault {
+		rawSql := "UPDATE data_source SET is_default=? WHERE org_id=? AND id <> ?"
+		if _, err := sess.Exec(rawSql, false, ds.OrgId, ds.Id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ds *datasourceSqlImpl) UpdateDataSource(cmd *models.UpdateDataSourceCommand) error {
+	return ds.sqlStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		if cmd.JsonData == nil {
+			cmd.JsonData = simplejson.New()
+		}
+
+		ds := &models.DataSource{
+			Id:                cmd.Id,
+			OrgId:             cmd.OrgId,
+			Name:              cmd.Name,
+			Type:              cmd.Type,
+			Access:            cmd.Access,
+			Url:               cmd.Url,
+			User:              cmd.User,
+			Password:          cmd.Password,
+			Database:          cmd.Database,
+			IsDefault:         cmd.IsDefault,
+			BasicAuth:         cmd.BasicAuth,
+			BasicAuthUser:     cmd.BasicAuthUser,
+			BasicAuthPassword: cmd.BasicAuthPassword,
+			WithCredentials:   cmd.WithCredentials,
+			JsonData:          cmd.JsonData,
+			SecureJsonData:    securejsondata.GetEncryptedJsonData(cmd.SecureJsonData),
+			Updated:           time.Now(),
+			ReadOnly:          cmd.ReadOnly,
+			Version:           cmd.Version + 1,
+		}
+
+		sess.UseBool("is_default")
+		sess.UseBool("basic_auth")
+		sess.UseBool("with_credentials")
+		sess.UseBool("read_only")
+		// Make sure password are zeroed out if empty. We do this as we want to migrate passwords from
+		// plain text fields to SecureJsonData.
+		sess.MustCols("password")
+		sess.MustCols("basic_auth_password")
+
+		var updateSession *xorm.Session
+		if cmd.Version != 0 {
+			// the reason we allow cmd.version > db.version is make it possible for people to force
+			// updates to datasources using the datasource.yaml file without knowing exactly what version
+			// a datasource have in the db.
+			updateSession = sess.Where("id=? and org_id=? and version < ?", ds.Id, ds.OrgId, ds.Version)
+
+		} else {
+			updateSession = sess.Where("id=? and org_id=?", ds.Id, ds.OrgId)
+		}
+
+		affected, err := updateSession.Update(ds)
+		if err != nil {
+			return err
+		}
+
+		if affected == 0 {
+			return models.ErrDataSourceUpdatingOldVersion
+		}
+
+		err = updateIsDefaultFlag(ds, sess)
+
+		cmd.Result = ds
+		return err
+	})
+}

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -162,7 +162,7 @@ func createTestSnapshot(sqlstore *SqlStore, key string, expires int64) *m.Dashbo
 	// Set expiry date manually - to be able to create expired snapshots
 	if expires < 0 {
 		expireDate := time.Now().Add(time.Second * time.Duration(expires))
-		_, err = sqlstore.engine.Exec("UPDATE dashboard_snapshot SET expires = ? WHERE id = ?", expireDate, cmd.Result.Id)
+		_, err = sqlstore.Engine.Exec("UPDATE dashboard_snapshot SET expires = ? WHERE id = ?", expireDate, cmd.Result.Id)
 		So(err, ShouldBeNil)
 	}
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -52,7 +52,7 @@ type SqlStore struct {
 	CacheService *cache.CacheService `inject:""`
 
 	dbCfg           DatabaseConfig
-	engine          *xorm.Engine
+	Engine          *xorm.Engine
 	log             log.Logger
 	Dialect         migrator.Dialect
 	skipEnsureAdmin bool
@@ -60,12 +60,12 @@ type SqlStore struct {
 
 // NewSession returns a new DBSession
 func (ss *SqlStore) NewSession() *DBSession {
-	return &DBSession{Session: ss.engine.NewSession()}
+	return &DBSession{Session: ss.Engine.NewSession()}
 }
 
 // WithDbSession calls the callback with an session attached to the context.
 func (ss *SqlStore) WithDbSession(ctx context.Context, callback dbTransactionFunc) error {
-	sess, err := startSession(ctx, ss.engine, false)
+	sess, err := startSession(ctx, ss.Engine, false)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (ss *SqlStore) WithTransactionalDbSession(ctx context.Context, callback dbT
 }
 
 func (ss *SqlStore) inTransactionWithRetryCtx(ctx context.Context, callback dbTransactionFunc, retry int) error {
-	sess, err := startSession(ctx, ss.engine, true)
+	sess, err := startSession(ctx, ss.Engine, true)
 	if err != nil {
 		return err
 	}
@@ -126,8 +126,8 @@ func (ss *SqlStore) Init() error {
 		return fmt.Errorf("Fail to connect to database: %v", err)
 	}
 
-	ss.engine = engine
-	ss.Dialect = migrator.NewDialect(ss.engine)
+	ss.Engine = engine
+	ss.Dialect = migrator.NewDialect(ss.Engine)
 
 	// temporarily still set global var
 	x = engine
@@ -386,8 +386,8 @@ func InitTestDB(t *testing.T) *SqlStore {
 		t.Fatalf("Failed to init test database: %v", err)
 	}
 
-	sqlstore.engine.DatabaseTZ = time.UTC
-	sqlstore.engine.TZLocation = time.UTC
+	sqlstore.Engine.DatabaseTZ = time.UTC
+	sqlstore.Engine.TZLocation = time.UTC
 
 	return sqlstore
 }

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-xorm/xorm"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	sqlite3 "github.com/mattn/go-sqlite3"
@@ -14,53 +15,18 @@ func (ss *SqlStore) InTransaction(ctx context.Context, fn func(ctx context.Conte
 }
 
 func (ss *SqlStore) inTransactionWithRetry(ctx context.Context, fn func(ctx context.Context) error, retry int) error {
-	sess, err := startSession(ctx, ss.engine, true)
-	if err != nil {
-		return err
-	}
-
-	defer sess.Close()
-
-	withValue := context.WithValue(ctx, ContextSessionName, sess)
-
-	err = fn(withValue)
-
-	// special handling of database locked errors for sqlite, then we can retry 3 times
-	if sqlError, ok := err.(sqlite3.Error); ok && retry < 5 {
-		if sqlError.Code == sqlite3.ErrLocked {
-			sess.Rollback()
-			time.Sleep(time.Millisecond * time.Duration(10))
-			ss.log.Info("Database table locked, sleeping then retrying", "retry", retry)
-			return ss.inTransactionWithRetry(ctx, fn, retry+1)
-		}
-	}
-
-	if err != nil {
-		sess.Rollback()
-		return err
-	}
-
-	if err = sess.Commit(); err != nil {
-		return err
-	}
-
-	if len(sess.events) > 0 {
-		for _, e := range sess.events {
-			if err = bus.Publish(e); err != nil {
-				ss.log.Error("Failed to publish event after commit", err)
-			}
-		}
-	}
-
-	return nil
+	return inTransactionWithRetryCtx(ss.Engine, ctx, func(sess *DBSession) error {
+		withValue := context.WithValue(ctx, ContextSessionName, sess)
+		return fn(withValue)
+	}, retry)
 }
 
 func inTransactionWithRetry(callback dbTransactionFunc, retry int) error {
-	return inTransactionWithRetryCtx(context.Background(), callback, retry)
+	return inTransactionWithRetryCtx(x, context.Background(), callback, retry)
 }
 
-func inTransactionWithRetryCtx(ctx context.Context, callback dbTransactionFunc, retry int) error {
-	sess, err := startSession(ctx, x, true)
+func inTransactionWithRetryCtx(engine *xorm.Engine, ctx context.Context, callback dbTransactionFunc, retry int) error {
+	sess, err := startSession(ctx, engine, true)
 	if err != nil {
 		return err
 	}
@@ -102,5 +68,5 @@ func inTransaction(callback dbTransactionFunc) error {
 }
 
 func inTransactionCtx(ctx context.Context, callback dbTransactionFunc) error {
-	return inTransactionWithRetryCtx(ctx, callback, 0)
+	return inTransactionWithRetryCtx(x, ctx, callback, 0)
 }


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/17038

I tried separating some sql statements from sqlstore and put it into service package. I chose datasource at is has small surface.

Regarding transaction, my assumption is that transaction should defined by the top most code, so http handler or job or cli command. So if you use different service calls in a handler you should be able to wrap them inside a transaction. So most of the code should be wrapped in transaction but should also pass on any existing transaction from outer scope.

This means that services should be either scoped/created per top level transaction (like http request) or should allow passing context with transaction to every function (that contains code that could be put in a transaction). Here I create the service in a middleware and bind it to transaction that is automatically created on each request.