### PR TITLE
Chore: Bump ts-node to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "terser-webpack-plugin": "1.2.3",
     "ts-jest": "24.0.1",
     "ts-loader": "5.3.3",
-    "ts-node": "8.0.2",
+    "ts-node": "8.1.0",
     "tslib": "1.9.3",
     "tslint": "5.14.0",
     "tslint-loader": "3.5.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
       "app": ["app"],
       "sass": ["sass"]
     },
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "preserveSymlinks": true
   },
   "include": [
     "public/app/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16947,10 +16947,10 @@ ts-loader@5.3.3:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-ts-node@8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.0.2.tgz#9ecdf8d782a0ca4c80d1d641cbb236af4ac1b756"
-  integrity sha512-MosTrinKmaAcWgO8tqMjMJB22h+sp3Rd1i4fdoWY4mhBDekOwIAKI/bzmRi7IcbCmjquccYg2gcF6NBkLgr0Tw==
+ts-node@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.1.0.tgz#8c4b37036abd448577db22a061fd7a67d47e658e"
+  integrity sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==
   dependencies:
     arg "^4.1.0"
     diff "^3.1.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps ts-node to 8.1.0 and to do that we have to set `preserveSymlinks` to `true` in tsconfig - info about that in #15974

**Which issue(s) this PR fixes**:
Fixes #15974
