### PR TITLE
Update grafana-ui version to 6.2.0-alpha.0

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/ui",
-  "version": "6.0.1-alpha.0",
+  "version": "6.2.0-alpha.0",
   "description": "Grafana Components Library",
   "keywords": [
     "typescript",


### PR DESCRIPTION
Version bump after grafana-ui@6.2.0-alpha.0 release