### PR TITLE
Explore: Add back datasource prop to query coming from angular query editors

### DIFF
--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -35,7 +35,7 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
 
     const loader = getAngularLoader();
     const template = '<plugin-component type="query-ctrl"> </plugin-component>';
-    const target = { ...initialQuery };
+    const target = { datasource: datasource.name, ...initialQuery };
     const scopeProps = {
       ctrl: {
         datasource,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a regression introduced in #16959 which removed datasource property from changed query for angular query editors having the result of loading explore URL's without datasource loaded the default query in query editor and Explore. 

**Which issue(s) this PR fixes**:
Ref #16808 

**Special notes for your reviewer**:

