### PR TITLE
MSI: Generate sha256sum during MSI build process in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,6 +588,7 @@ jobs:
           root: .
           paths:
             - dist/grafana-*.msi
+            - dist/grafana-*.msi.sha256
 
   store-build-artifacts:
     docker:

--- a/scripts/build/ci-msi-build/ci-msi-build-oss.sh
+++ b/scripts/build/ci-msi-build/ci-msi-build-oss.sh
@@ -24,5 +24,11 @@ python3 generator/build.py "$@"
 chmod a+x /tmp/scratch/*.msi
 echo "MSI: Copy to $WORKING_DIRECTORY/dist"
 cp /tmp/scratch/*.msi $WORKING_DIRECTORY/dist
+echo "MSI: Generate SHA256"
+MSI_FILE=`ls $WORKING_DIRECTORY/dist/*.msi`
+SHA256SUM=`sha256sum $MSI_FILE | cut -f1 -d' '`
+echo $SHA256SUM > $MSI_FILE.sha256
+echo "MSI: SHA256 file content:"
+cat $MSI_FILE.sha256
 echo "MSI: contents of $WORKING_DIRECTORY/dist"
 ls -al $WORKING_DIRECTORY/dist


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds generation of the sha256 file for MSI builds.

**Which issue(s) this PR fixes**:
Fixes #17085

**Special notes for your reviewer**:

