### PR TITLE
Chore: Show drilldown links in React panels

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
@@ -48,7 +48,7 @@ export class PanelHeaderCorner extends Component<Props> {
     const remarkableInterpolatedMarkdown = new Remarkable().render(interpolatedMarkdown);
 
     return (
-      <div className="markdown-html">
+      <div className="panel-info-content markdown-html">
         <div dangerouslySetInnerHTML={{ __html: remarkableInterpolatedMarkdown }} />
         {panel.links && panel.links.length > 0 && (
           <ul className="text-left">
@@ -71,7 +71,7 @@ export class PanelHeaderCorner extends Component<Props> {
   renderCornerType(infoMode: InfoMode, content: string | JSX.Element) {
     const theme = infoMode === InfoMode.Error ? 'error' : 'info';
     return (
-      <Tooltip content={content} placement="bottom-start" theme={theme}>
+      <Tooltip content={content} placement="top-start" theme={theme}>
         <div className={`panel-info-corner panel-info-corner--${infoMode.toLowerCase()}`}>
           <i className="fa" />
           <span className="panel-info-corner-inner" />
@@ -91,7 +91,7 @@ export class PanelHeaderCorner extends Component<Props> {
       return this.renderCornerType(infoMode, this.props.error);
     }
 
-    if (infoMode === InfoMode.Info) {
+    if (infoMode === InfoMode.Info || infoMode === InfoMode.Links) {
       return this.renderCornerType(infoMode, this.getInfoContent());
     }
 

--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -167,6 +167,15 @@ $panel-header-no-title-zindex: 1;
   }
 }
 
+.panel-info-content {
+  a {
+    color: $white;
+    &:hover {
+      color: darken($white, 10%);
+    }
+  }
+}
+
 .panel-time-info {
   font-weight: $font-weight-semi-bold;
   float: right;


### PR DESCRIPTION
This PR addresses a small part of #15990.

It displays drilldown links in the top-left corner of React panels the same way they are displayed e.g. in Graph panel:

![image](https://user-images.githubusercontent.com/1216874/57946195-072c6900-78dc-11e9-9f6e-b3a55115c602.png)
![image](https://user-images.githubusercontent.com/1216874/57946126-df3d0580-78db-11e9-84e4-c33130315e24.png)

#### Specific changes

* Show links in the top-left corner tooltip even when the panel description prop is not available
* Show the tooltip at `top-start` at instead of `bottom-start` for consistent positioning with older panels
* Show links in white color, also for consistency with older panels

