### PR TITLE
Chore: fix codespell issue with build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,7 @@ jobs:
       - run:
           # Important: all words have to be in lowercase, and separated by "\n".
           name: exclude known exceptions
-          command: 'echo -e "unknwon" > words_to_ignore.txt'
-          command: 'echo -e "Referer" >> words_to_ignore.txt'
-          command: 'echo -e "ErrorString" >> words_to_ignore.txt'
+          command: 'echo -e "unknwon\nreferer\nerrorstring" > words_to_ignore.txt'
       - run:
           name: check documentation spelling errors
           command: 'codespell -I ./words_to_ignore.txt docs/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
         - run:
             name: cache server tests
             command: './scripts/circle-test-cache-servers.sh'
-  
+
   end-to-end-test:
       docker:
         - image: circleci/node:8-browsers
@@ -104,6 +104,8 @@ jobs:
           # Important: all words have to be in lowercase, and separated by "\n".
           name: exclude known exceptions
           command: 'echo -e "unknwon" > words_to_ignore.txt'
+          command: 'echo -e "Referer" >> words_to_ignore.txt'
+          command: 'echo -e "ErrorString" >> words_to_ignore.txt'
       - run:
           name: check documentation spelling errors
           command: 'codespell -I ./words_to_ignore.txt docs/'


### PR DESCRIPTION
The circleci build is currently failing with:
![image](https://user-images.githubusercontent.com/705951/57951841-2b6a5480-78a0-11e9-828e-85acaf76026c.png)

I don't know the best way to solve it...  this is one option