### PR TITLE
Plugins: expose rxjs matching 6.4.0

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -88,12 +88,6 @@ exposeToPlugin('slate-plain-serializer', slatePlain);
 exposeToPlugin('react', react);
 exposeToPlugin('react-dom', reactDom);
 
-// backward compatible path
-exposeToPlugin('vendor/npm/rxjs/Rx', {
-  Subject: Subject,
-  Observable: Observable,
-});
-
 exposeToPlugin('app/features/dashboard/impression_store', {
   impressions: impressionSrv,
   __esModule: true,

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -75,6 +75,10 @@ exposeToPlugin('angular', angular);
 exposeToPlugin('d3', d3);
 exposeToPlugin('rxjs/Subject', Subject);
 exposeToPlugin('rxjs/Observable', Observable);
+exposeToPlugin('rxjs', {
+  Subject: Subject,
+  Observable: Observable,
+});
 
 // Experimental modules
 exposeToPlugin('prismjs', prismjs);


### PR DESCRIPTION
We currently export rxjs in a few ways, but none of them let you use the same devDepenency as grafnana:
```
    "rxjs": "6.4.0",
```

I also removed the presumably even older (but almost matching) imports:
```
exposeToPlugin('vendor/npm/rxjs/Rx', {
  Subject: Subject,
  Observable: Observable,
});
```

This lets plugin developer import things using:
```
import {Subject, Unsubscribable, PartialObserver} from 'rxjs';
```
The same way we do in master
