### PR TITLE
AppPlugin: add an init function

### DIFF
--- a/packages/grafana-ui/src/types/app.ts
+++ b/packages/grafana-ui/src/types/app.ts
@@ -27,13 +27,11 @@ export class AppPlugin extends GrafanaPlugin<AppPluginMeta> {
   angularPages?: { [component: string]: any };
 
   /**
-   * Called after the module has loaded, meta has been set
-   * and before the app is used.
-   *
-   * This can modify any existing settings and/or force a singleton instance
+   * Called after the module has loaded, and before the app is used.
+   * This function may be called multiple times on the same instance.
    */
-  init(): AppPlugin {
-    return this;
+  init(meta: AppPluginMeta) {
+    this.meta = meta;
   }
 
   /**

--- a/packages/grafana-ui/src/types/app.ts
+++ b/packages/grafana-ui/src/types/app.ts
@@ -29,10 +29,9 @@ export class AppPlugin extends GrafanaPlugin<AppPluginMeta> {
   /**
    * Called after the module has loaded, and before the app is used.
    * This function may be called multiple times on the same instance.
+   * The first time, `this.meta` will be undefined
    */
-  init(meta: AppPluginMeta) {
-    this.meta = meta;
-  }
+  init(meta: AppPluginMeta) {}
 
   /**
    * Set the component displayed under:

--- a/packages/grafana-ui/src/types/app.ts
+++ b/packages/grafana-ui/src/types/app.ts
@@ -27,6 +27,16 @@ export class AppPlugin extends GrafanaPlugin<AppPluginMeta> {
   angularPages?: { [component: string]: any };
 
   /**
+   * Called after the module has loaded, meta has been set
+   * and before the app is used.
+   *
+   * This can modify any existing settings and/or force a singleton instance
+   */
+  init(): AppPlugin {
+    return this;
+  }
+
+  /**
    * Set the component displayed under:
    *   /a/${plugin-id}/*
    */

--- a/public/app/features/plugins/plugin_loader.test.ts
+++ b/public/app/features/plugins/plugin_loader.test.ts
@@ -3,10 +3,11 @@ import { importAppPlugin } from './plugin_loader';
 
 class MyCustomApp extends AppPlugin {
   initWasCalled = false;
+  calledTwice = false;
 
-  init() {
+  init(meta: AppPluginMeta) {
     this.initWasCalled = true;
-    return this;
+    this.calledTwice = this.meta === meta;
   }
 }
 const app = new MyCustomApp();
@@ -35,7 +36,13 @@ describe('Load App', () => {
     // expect(v.plugin).toBe(app);
 
     const loaded = await importAppPlugin(meta);
-    expect(loaded.meta).toBe(meta);
+    expect(loaded).toBe(app);
+    expect(app.meta).toBe(meta);
     expect(app.initWasCalled).toBeTruthy();
+    expect(app.calledTwice).toBeFalsy();
+
+    const again = await importAppPlugin(meta);
+    expect(again).toBe(app);
+    expect(app.calledTwice).toBeTruthy();
   });
 });

--- a/public/app/features/plugins/plugin_loader.test.ts
+++ b/public/app/features/plugins/plugin_loader.test.ts
@@ -1,3 +1,18 @@
+// Use the real plugin_loader (stubbed by default)
+jest.unmock('app/features/plugins/plugin_loader');
+
+(global as any).ace = {
+  define: jest.fn(),
+};
+
+jest.mock('app/core/core', () => {
+  return {
+    coreModule: {
+      directive: jest.fn(),
+    },
+  };
+});
+
 /* tslint:disable:import-blacklist */
 import System from 'systemjs/dist/system.js';
 

--- a/public/app/features/plugins/plugin_loader.test.ts
+++ b/public/app/features/plugins/plugin_loader.test.ts
@@ -1,0 +1,35 @@
+import { AppPluginMeta, PluginMetaInfo, PluginType, AppPlugin } from '@grafana/ui';
+import { importAppPlugin } from './plugin_loader';
+
+class MyCustomApp extends AppPlugin {
+  initWasCalled = false;
+
+  init() {
+    this.initWasCalled = true;
+    return this;
+  }
+}
+const app = new MyCustomApp();
+
+jest.mock('plugins/my/app', () => ({
+  module: () => {
+    return app;
+  },
+}));
+
+describe('Load App', () => {
+  it('should call init and set meta', async () => {
+    const meta: AppPluginMeta = {
+      id: 'test-app',
+      module: 'plugins/my/app',
+      baseUrl: 'xxx',
+      info: {} as PluginMetaInfo,
+      type: PluginType.app,
+      name: 'test',
+    };
+
+    const loaded = await importAppPlugin(meta);
+    expect(loaded.meta).toBe(meta);
+    expect(app.initWasCalled).toBeTruthy();
+  });
+});

--- a/public/app/features/plugins/plugin_loader.test.ts
+++ b/public/app/features/plugins/plugin_loader.test.ts
@@ -11,22 +11,28 @@ class MyCustomApp extends AppPlugin {
 }
 const app = new MyCustomApp();
 
-jest.mock('plugins/my/app', () => ({
-  module: () => {
-    return app;
-  },
-}));
+// Need to import a path that has a real export
+const modulePath = 'app/plugins/app/example-app/module';
+jest.mock(modulePath, () => {
+  return {
+    plugin: app,
+  };
+});
 
 describe('Load App', () => {
   it('should call init and set meta', async () => {
     const meta: AppPluginMeta = {
       id: 'test-app',
-      module: 'plugins/my/app',
+      module: modulePath,
       baseUrl: 'xxx',
       info: {} as PluginMetaInfo,
       type: PluginType.app,
       name: 'test',
     };
+
+    // // Check that we mocked the import OK
+    // const v = await System.import(modulePath);
+    // expect(v.plugin).toBe(app);
 
     const loaded = await importAppPlugin(meta);
     expect(loaded.meta).toBe(meta);

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -183,7 +183,7 @@ export function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
     const plugin = pluginExports.plugin ? (pluginExports.plugin as AppPlugin) : new AppPlugin();
     plugin.meta = meta;
     plugin.setComponentsFromLegacyExports(pluginExports);
-    return plugin;
+    return plugin.init();
   });
 }
 

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -181,9 +181,9 @@ export function importDataSourcePlugin(meta: DataSourcePluginMeta): Promise<Data
 export function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
   return importPluginModule(meta.module).then(pluginExports => {
     const plugin = pluginExports.plugin ? (pluginExports.plugin as AppPlugin) : new AppPlugin();
-    plugin.meta = meta;
     plugin.setComponentsFromLegacyExports(pluginExports);
-    return plugin.init();
+    plugin.init(meta);
+    return plugin;
   });
 }
 

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -183,6 +183,7 @@ export function importAppPlugin(meta: PluginMeta): Promise<AppPlugin> {
     const plugin = pluginExports.plugin ? (pluginExports.plugin as AppPlugin) : new AppPlugin();
     plugin.setComponentsFromLegacyExports(pluginExports);
     plugin.init(meta);
+    plugin.meta = meta;
     return plugin;
   });
 }


### PR DESCRIPTION
This is a simple proposal to have an init() function that gets called before the app gets used.

I am looking for a way to get a callback with the app settings (meta) before it is used.

finally got the test to work using:
```
jest.unmock('app/features/plugins/plugin_loader');
```