### PR TITLE
Chore: Mocks plugin loader for DataSourceSettingsPage tests

### DIFF
--- a/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
@@ -8,6 +8,12 @@ import { setDataSourceName, setIsDefault } from '../state/actions';
 
 const pluginMock = new DataSourcePlugin({} as DataSourceConstructor<any>);
 
+jest.mock('app/features/plugins/plugin_loader', () => {
+  return {
+    importDataSourcePlugin: () => Promise.resolve(pluginMock),
+  };
+});
+
 const setup = (propOverrides?: object) => {
   const props: Props = {
     navModel: {} as NavModel,


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly mocks the plugin loader in DataSourceSettingsPage tests and by that removes console the following console logs:

```
PASS  public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
  ● Console

    console.log public/app/features/datasources/settings/DataSourceSettingsPage.tsx:72
      Failed to import plugin module TypeError: plugin_loader_1.importDataSourcePlugin is not a function
          at DataSourceSettingsPage.<anonymous> (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSettingsPage.tsx:70:30)
          at step (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:133:27)
          at Object.next (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:114:57)
          at /home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:107:75
          at new Promise (<anonymous>)
          at Object.__awaiter (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:103:16)
          at DataSourceSettingsPage.Object.<anonymous>.DataSourceSettingsPage.loadPlugin (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSe
ttingsPage.tsx:74:24)
          at DataSourceSettingsPage.<anonymous> (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSettingsPage.tsx:87:20)
          at step (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:133:27)
          at Object.next (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:114:57)
          at fulfilled (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:104:62)
          at process._tickCallback (internal/process/next_tick.js:68:7)
    console.log public/app/features/datasources/settings/DataSourceSettingsPage.tsx:72
      Failed to import plugin module TypeError: plugin_loader_1.importDataSourcePlugin is not a function
          at DataSourceSettingsPage.<anonymous> (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSettingsPage.tsx:70:30)
          at step (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:133:27)
          at Object.next (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:114:57)
          at /home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:107:75
          at new Promise (<anonymous>)
          at Object.__awaiter (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:103:16)
          at DataSourceSettingsPage.Object.<anonymous>.DataSourceSettingsPage.loadPlugin (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSe
ttingsPage.tsx:74:24)
          at DataSourceSettingsPage.<anonymous> (/home/marcus/go/src/github.com/grafana/grafana/public/app/features/datasources/settings/DataSourceSettingsPage.tsx:87:20)
          at step (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:133:27)
          at Object.next (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:114:57)
          at fulfilled (/home/marcus/go/src/github.com/grafana/grafana/node_modules/tslib/tslib.js:104:62)
          at process._tickCallback (internal/process/next_tick.js:68:7)
```