### PR TITLE
16996 check for table indicating keys

### DIFF
--- a/public/app/plugins/panel/table/specs/transformers.test.ts
+++ b/public/app/plugins/panel/table/specs/transformers.test.ts
@@ -108,7 +108,6 @@ describe('when transforming time series table', () => {
         {
           type: 'foo',
           columns: [{ text: 'Time' }, { text: 'Label Key 1' }, { text: 'Value' }],
-          rows: [[time, 'Label Value 1', 42]],
         },
       ];
 

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -158,8 +158,7 @@ transformers['table'] = {
     if (!data || data.length === 0) {
       return;
     }
-
-    const noTableIndex = _.findIndex(data, d => d.type !== 'table');
+    const noTableIndex = _.findIndex(data, d => 'columns' in d && 'rows' in d);
     if (noTableIndex > -1) {
       throw {
         message: `Result of query #${String.fromCharCode(

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -159,7 +159,7 @@ transformers['table'] = {
       return;
     }
     const noTableIndex = _.findIndex(data, d => 'columns' in d && 'rows' in d);
-    if (noTableIndex > -1) {
+    if (noTableIndex < 0) {
       throw {
         message: `Result of query #${String.fromCharCode(
           65 + noTableIndex


### PR DESCRIPTION
Fixes #16996 

@torkelo I figured it would be adequate to check for keys that would indicate that the obj is a table if the type will not be set.