### PR TITLE
azuremonitor: revert to clearing chained dropdowns

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -10,7 +10,7 @@
     <div class="gf-form" ng-if="ctrl.target.queryType === 'Azure Monitor' || ctrl.target.queryType === 'Azure Log Analytics'">
       <label class="gf-form-label query-keyword width-9">Subscription</label>
       <gf-form-dropdown model="ctrl.target.subscription" allow-custom="true" lookup-text="true"
-        get-options="ctrl.subscriptions" on-change="ctrl.onSubscriptionChange()" css-class="min-width-12">
+        get-options="ctrl.getSubscriptions($query)" on-change="ctrl.onSubscriptionChange()" css-class="min-width-12">
       </gf-form-dropdown>
     </div>
     <div class="gf-form gf-form--grow">

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -10,7 +10,7 @@
     <div class="gf-form" ng-if="ctrl.target.queryType === 'Azure Monitor' || ctrl.target.queryType === 'Azure Log Analytics'">
       <label class="gf-form-label query-keyword width-9">Subscription</label>
       <gf-form-dropdown model="ctrl.target.subscription" allow-custom="true" lookup-text="true"
-        get-options="ctrl.getSubscriptions($query)" on-change="ctrl.onSubscriptionChange()" css-class="min-width-12">
+        get-options="ctrl.getSubscriptions()" on-change="ctrl.onSubscriptionChange()" css-class="min-width-12">
       </gf-form-dropdown>
     </div>
     <div class="gf-form gf-form--grow">

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -197,12 +197,26 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
       if (!this.target.subscription && this.subscriptions.length > 0) {
         this.target.subscription = this.subscriptions[0].value;
       }
+
+      return this.subscriptions;
     });
   }
 
   onSubscriptionChange() {
     if (this.target.queryType === 'Azure Log Analytics') {
       return this.getWorkspaces();
+    }
+
+    if (this.target.queryType === 'Azure Monitor') {
+      this.target.azureMonitor.resourceGroup = this.defaultDropdownValue;
+      this.target.azureMonitor.metricDefinition = this.defaultDropdownValue;
+      this.target.azureMonitor.resourceName = this.defaultDropdownValue;
+      this.target.azureMonitor.metricName = this.defaultDropdownValue;
+      this.target.azureMonitor.aggregation = '';
+      this.target.azureMonitor.timeGrains = [];
+      this.target.azureMonitor.timeGrain = '';
+      this.target.azureMonitor.dimensions = [];
+      this.target.azureMonitor.dimension = '';
     }
   }
 
@@ -279,6 +293,12 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
   }
 
   onResourceGroupChange() {
+    this.target.azureMonitor.metricDefinition = this.defaultDropdownValue;
+    this.target.azureMonitor.resourceName = this.defaultDropdownValue;
+    this.target.azureMonitor.metricName = this.defaultDropdownValue;
+    this.target.azureMonitor.aggregation = '';
+    this.target.azureMonitor.timeGrains = [];
+    this.target.azureMonitor.timeGrain = '';
     this.target.azureMonitor.dimensions = [];
     this.target.azureMonitor.dimension = '';
   }
@@ -286,11 +306,18 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
   onMetricDefinitionChange() {
     this.target.azureMonitor.resourceName = this.defaultDropdownValue;
     this.target.azureMonitor.metricName = this.defaultDropdownValue;
+    this.target.azureMonitor.aggregation = '';
+    this.target.azureMonitor.timeGrains = [];
+    this.target.azureMonitor.timeGrain = '';
     this.target.azureMonitor.dimensions = [];
     this.target.azureMonitor.dimension = '';
   }
 
   onResourceNameChange() {
+    this.target.azureMonitor.metricName = this.defaultDropdownValue;
+    this.target.azureMonitor.aggregation = '';
+    this.target.azureMonitor.timeGrains = [];
+    this.target.azureMonitor.timeGrain = '';
     this.target.azureMonitor.dimensions = [];
     this.target.azureMonitor.dimension = '';
   }
@@ -312,6 +339,7 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
         this.target.azureMonitor.aggOptions = metadata.supportedAggTypes || [metadata.primaryAggType];
         this.target.azureMonitor.aggregation = metadata.primaryAggType;
         this.target.azureMonitor.timeGrains = [{ text: 'auto', value: 'auto' }].concat(metadata.supportedTimeGrains);
+        this.target.azureMonitor.timeGrain = 'auto';
 
         this.target.azureMonitor.dimensions = metadata.dimensions;
         if (metadata.dimensions.length > 0) {


### PR DESCRIPTION
Fixes #17211 

Also, now triggers getting subscriptions every time the subscriptions dropdown is clicked rather than just the first time when the query editor is loaded. It is apparently common to add subscriptions while building a dashboard.