### PR TITLE
Search: Make only folder name only open search with current folder filter

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -60,17 +60,14 @@ export class DashNav extends PureComponent<Props> {
     }
   }
 
-  onOpenSearch = () => {
-    const { dashboard } = this.props;
-    const haveFolder = dashboard.meta.folderId > 0;
-    appEvents.emit(
-      'show-dash-search',
-      haveFolder
-        ? {
-            query: 'folder:current',
-          }
-        : null
-    );
+  onDahboardNameClick = () => {
+    appEvents.emit('show-dash-search');
+  };
+
+  onFolderNameClick = () => {
+    appEvents.emit('show-dash-search', {
+      query: 'folder:current',
+    });
   };
 
   onClose = () => {
@@ -148,11 +145,20 @@ export class DashNav extends PureComponent<Props> {
     return (
       <>
         <div>
-          <a className="navbar-page-btn" onClick={this.onOpenSearch}>
+          <div className="navbar-page-btn">
             {!this.isInFullscreenOrSettings && <i className="gicon gicon-dashboard" />}
-            {haveFolder && <span className="navbar-page-btn--folder">{folderTitle} / </span>}
-            {dashboard.title} <i className="fa fa-caret-down" />
-          </a>
+            {haveFolder && (
+              <>
+                <a className="navbar-page-btn__folder" onClick={this.onFolderNameClick}>
+                  {folderTitle}
+                </a>
+                <i className="fa fa-chevron-right navbar-page-btn__folder-icon" />
+              </>
+            )}
+            <a onClick={this.onDahboardNameClick}>
+              {dashboard.title} <i className="fa fa-caret-down navbar-page-btn__search" />
+            </a>
+          </div>
         </div>
         {this.isSettings && <span className="navbar-settings-title">&nbsp;/ Settings</span>}
         <div className="navbar__spacer" />

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -67,11 +67,6 @@
   min-height: $navbarHeight;
   line-height: $navbarHeight;
 
-  .fa-caret-down {
-    font-size: 60%;
-    padding-left: 6px;
-  }
-
   .gicon {
     top: -2px;
     position: relative;
@@ -85,15 +80,30 @@
       display: inline-block;
     }
   }
+}
 
-  &--folder {
-    color: $text-color-weak;
-    display: none;
+.navbar-page-btn__folder {
+  color: $text-color-weak;
+  display: none;
 
-    @include media-breakpoint-up(lg) {
-      display: inline-block;
-    }
+  @include media-breakpoint-up(lg) {
+    display: inline-block;
   }
+}
+
+// element is needed here to override font-awesome specificity
+i.navbar-page-btn__folder-icon {
+  font-size: $font-size-sm;
+  color: $text-color-weak;
+  padding: 0 $space-sm;
+  position: relative;
+  top: -1px;
+}
+
+// element is needed here to override font-awesome specificity
+i.navbar-page-btn__search {
+  font-size: $font-size-xs;
+  padding: 0 $space-xs;
 }
 
 .navbar-buttons {


### PR DESCRIPTION

Having search always open with a current folder filter was a bad idea. We have now changed it so folder name can be clicked separately and only if you click folder name in the dashboard toolbar wil the current folder filter be applied. 

![image](https://user-images.githubusercontent.com/10999/58159536-06e5f200-7c7d-11e9-8b28-41a1be17fce7.png)


Fixes #17207