### PR TITLE
Build: Fix final prompt for @grafana/ui npm publish confirmation

### DIFF
--- a/scripts/cli/tasks/grafanaui.build.ts
+++ b/scripts/cli/tasks/grafanaui.build.ts
@@ -7,7 +7,7 @@ import { Task, TaskRunner } from './task';
 
 let distDir, cwd;
 
-const clean = useSpinner<void>('Cleaning', async () => await execa('npm', ['run', 'clean']));
+export const clean = useSpinner<void>('Cleaning', async () => await execa('npm', ['run', 'clean']));
 
 const compile = useSpinner<void>('Compiling sources', () => execa('tsc', ['-p', './tsconfig.build.json']));
 


### PR DESCRIPTION
Fixes issue of the final confirmation prompt (the one to confirm the actual npm publish) being invisible, making it impossible to release by anyone but me.

Also, before the release is created I'm assuring previous release bundle is remove (otherwise tests and checks would fail)