### PR TITLE
Panel: Pass transparency prop down to React panels

### DIFF
--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -31,6 +31,7 @@ export interface PanelProps<T = any> {
   options: T;
   onOptionsChange: (options: T) => void;
   renderCounter: number;
+  transparent: boolean;
   width: number;
   height: number;
   replaceVariables: InterpolateFunction;

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -254,6 +254,7 @@ export class PanelChrome extends PureComponent<Props, State> {
             data={data}
             timeRange={data.request ? data.request.range : this.timeSrv.timeRange()}
             options={panel.getOptions()}
+            transparent={panel.transparent}
             width={width - theme.panelPadding * 2}
             height={innerPanelHeight}
             renderCounter={renderCounter}


### PR DESCRIPTION
I raised a question of passing down the transparency prop in https://github.com/grafana/grafana/issues/15990#issuecomment-488026454.

My thoughts on why this is useful are the same as for passing the theme information - the component content should be able to adjust its appearance based on the appearance of its surrounding.
