### PR TITLE
fix filter for building msi during release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ workflows:
             - backend-lint
             - mysql-integration-test
             - postgres-integration-test
-          filters: *filter-only-master
+          filters: *filter-only-release
 
   build-branches-and-prs:
       jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

circleci release has wrong filter to trigger building MSI

**Special notes for your reviewer**:

the filter name for release was set to master instead of release, causing the release workflow to skip the msi generation process
