### PR TITLE
DataSource Plugins: avoid angular injector when only one parameter

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -61,9 +61,13 @@ export class DatasourceSrv {
           return;
         }
 
-        const instance: DataSourceApi = this.$injector.instantiate(dsPlugin.DataSourceClass, {
-          instanceSettings: dsConfig,
-        });
+        // If there is only one constructor argument it is instanceSettings
+        const useAngular = dsPlugin.DataSourceClass.length !== 1;
+        const instance: DataSourceApi = useAngular
+          ? this.$injector.instantiate(dsPlugin.DataSourceClass, {
+              instanceSettings: dsConfig,
+            })
+          : new dsPlugin.DataSourceClass(dsConfig);
 
         instance.components = dsPlugin.components;
         instance.meta = dsConfig.meta;


### PR DESCRIPTION
DataSource instances are all created using: `this.$injector.instantiate(` this requires plugins to package things so that `@ngInject` works.  This adds a lot of unnecessary complications for things that do not want or need angular injections!

I started with adding a flag to say which constructor version to use, but I *think* just just checking that if there is only one constructor argument, then it can be instantiated with new is fine.