### PR TITLE
Auth Proxy: Resolve database is locked errors

### DIFF
--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -54,7 +54,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	ctx.IsSignedIn = true
 
 	// Remember user data it in cache
-	if err := auth.Remember(); err != nil {
+	if err := auth.Remember(id); err != nil {
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -298,21 +298,18 @@ func (auth *AuthProxy) GetSignedUser(userID int64) (*models.SignedInUser, *Error
 }
 
 // Remember user in cache
-func (auth *AuthProxy) Remember() *Error {
+func (auth *AuthProxy) Remember(id int64) *Error {
+	key := auth.getKey()
 
-	// Make sure we do not rewrite the expiration time
-	if auth.InCache() {
+	// Check if user already in cache
+	userID, _ := auth.store.Get(key)
+	if userID != nil {
 		return nil
 	}
 
-	var (
-		key        = auth.getKey()
-		value, _   = auth.GetUserIDViaCache()
-		expiration = time.Duration(-auth.cacheTTL) * time.Minute
+	expiration := time.Duration(-auth.cacheTTL) * time.Minute
 
-		err = auth.store.Set(key, value, expiration)
-	)
-
+	err := auth.store.Set(key, id, expiration)
 	if err != nil {
 		return newError(err.Error(), nil)
 	}

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -302,16 +302,20 @@ func (auth *AuthProxy) Remember(id int64) *Error {
 	key := auth.getKey()
 
 	// Check if user already in cache
-	userID, _ := auth.store.Get(key)
+	userID, err := auth.store.Get(key)
+	if err != nil && err != remotecache.ErrCacheItemNotFound {
+		return newError("failed to lookup user in cache", err)
+	}
+
 	if userID != nil {
 		return nil
 	}
 
 	expiration := time.Duration(-auth.cacheTTL) * time.Minute
 
-	err := auth.store.Set(key, id, expiration)
+	err = auth.store.Set(key, id, expiration)
 	if err != nil {
-		return newError(err.Error(), nil)
+		return newError("failed to store user in cache", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The change was originally made in #16950, but that change
was too big to cherry pick. That's why this PR needs to be merged into v6.2.x branch. 
This change adds a major database
performance improvement since the number of selects to fetch
a cached item is drastically decreased and by that removes
sqlite database is locked errors.

**After these changes:**
```
> ./run.sh -d 15m -v 20 -c auth_proxy_test -u http://127.0.0.1:10080/grafana

          /\      |‾‾|  /‾‾/  /‾/   
     /\  /  \     |  |_/  /  / /    
    /  \/    \    |      |  /  ‾‾\  
   /          \   |  |‾\  \ | (_) | 
  / __________ \  |__|  \__\ \___/ .io

  execution: local
     output: -
     script: src/auth_proxy_test.js

    duration: 15m0s, iterations: -
         vus: 20,    max: 20

    done [==========================================================] 15m0s / 15m0s

    █ auth proxy test

      █ batch proxy requests

        ✓ response status is 200

    checks.....................: 100.00% ✓ 209400 ✗ 0
    data_received..............: 5.9 GB  6.6 MB/s
    data_sent..................: 65 MB   72 kB/s
    group_duration.............: avg=20.63s   min=1.64s  med=20.83s max=30.65s  p(90)=24.73s  p(95)=27.02s
    http_req_blocked...........: avg=542.55µs min=890ns  med=2.97µs max=1s      p(90)=4.36µs  p(95)=389.18µs
    http_req_connecting........: avg=506.42µs min=0s     med=0s     max=1s      p(90)=0s      p(95)=277.16µs
    http_req_duration..........: avg=1.32s    min=1.46ms med=1.36s  max=4.69s   p(90)=1.77s   p(95)=1.96s
    http_req_receiving.........: avg=53.28µs  min=9.69µs med=42µs   max=25.18ms p(90)=58.31µs p(95)=67.34µs
    http_req_sending...........: avg=56.55µs  min=6.55µs med=22.7µs max=55.69ms p(90)=35.69µs p(95)=67.24µs
    http_req_tls_handshaking...: avg=0s       min=0s     med=0s     max=0s      p(90)=0s      p(95)=0s
    http_req_waiting...........: avg=1.32s    min=1.4ms  med=1.36s  max=4.69s   p(90)=1.77s   p(95)=1.96s
    http_reqs..................: 212036  235.595539/s
    iteration_duration.........: avg=25.57s   min=5.64µs med=25.85s max=35.65s  p(90)=29.75s  p(95)=32.02s
    iterations.................: 690     0.766667/s
    vus........................: 20      min=20   max=20
    vus_max....................: 20      min=20   max=20
```

**Before these changes:**
```
> ./run.sh -d 15m -v 20 -c auth_proxy_test -u http://127.0.0.1:10080/grafana

          /\      |‾‾|  /‾‾/  /‾/   
     /\  /  \     |  |_/  /  / /    
    /  \/    \    |      |  /  ‾‾\  
   /          \   |  |‾\  \ | (_) | 
  / __________ \  |__|  \__\ \___/ .io

  execution: local
     output: -
     script: src/auth_proxy_test.js

    duration: 15m0s, iterations: -
         vus: 20,    max: 20

    done [==========================================================] 1m49.1s / 15m0s

    █ auth proxy test

      █ batch proxy requests

        ✗ response status is 200
         ↳  45% — ✓ 5730 / ✗ 6870

    checks.....................: 45.47% ✓ 5730 ✗ 6870
    data_received..............: 177 MB 1.6 MB/s
    data_sent..................: 4.0 MB 36 kB/s
    group_duration.............: avg=40.84s   min=3.11s  med=39.27s  max=47.36s  p(90)=47.27s  p(95)=47.34s
    http_req_blocked...........: avg=6.15ms   min=850ns  med=3.01µs  max=1.06s   p(90)=5.63µs  p(95)=3.1ms
    http_req_connecting........: avg=6.12ms   min=0s     med=0s      max=1.01s   p(90)=0s      p(95)=2.85ms
    http_req_duration..........: avg=2.47s    min=2.68ms med=2.19s   max=11.37s  p(90)=5.09s   p(95)=6s
    http_req_receiving.........: avg=49.68µs  min=7.56µs med=39.66µs max=26.82ms p(90)=56.6µs  p(95)=64.96µs
    http_req_sending...........: avg=168.36µs min=6.01µs med=23.11µs max=30.52ms p(90)=39.18µs p(95)=108.77µs
    http_req_tls_handshaking...: avg=0s       min=0s     med=0s      max=0s      p(90)=0s      p(95)=0s
    http_req_waiting...........: avg=2.47s    min=2.58ms med=2.19s   max=11.37s  p(90)=5.09s   p(95)=6s
    http_reqs..................: 15142  138.748067/s
    iteration_duration.........: avg=44.78s   min=49ms   med=44.17s  max=52.38s  p(90)=52.26s  p(95)=52.34s
    iterations.................: 42     0.384851/s
    vus........................: 20     min=20 max=20
    vus_max....................: 20     min=20 max=20
```

**Which issue(s) this PR fixes**:
Fixes #17247 