### PR TITLE
Auth Proxy: Log any error in middleware

### DIFF
--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -31,6 +31,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Check if allowed to continue with this IP
 	if result, err := auth.IsAllowedIP(); !result {
+		ctx.Logger.Error("auth proxy: failed to check whitelisted ip addresses", "error", err)
 		ctx.Handle(407, err.Error(), err.DetailsError)
 		return true
 	}
@@ -38,6 +39,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Try to log in user from various providers
 	id, err := auth.Login()
 	if err != nil {
+		ctx.Logger.Error("auth proxy: failed to login", "error", err)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -45,6 +47,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Get full user info
 	user, err := auth.GetSignedUser(id)
 	if err != nil {
+		ctx.Logger.Error("auth proxy: failed to get signed in user", "error", err)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -55,6 +58,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Remember user data it in cache
 	if err := auth.Remember(id); err != nil {
+		ctx.Logger.Error("auth proxy: failed to store user in cache", "error", err)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -31,7 +31,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Check if allowed to continue with this IP
 	if result, err := auth.IsAllowedIP(); !result {
-		ctx.Logger.Error("auth proxy: failed to check whitelisted ip addresses", "error", err)
+		ctx.Logger.Error("auth proxy: failed to check whitelisted ip addresses", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(407, err.Error(), err.DetailsError)
 		return true
 	}
@@ -39,7 +39,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Try to log in user from various providers
 	id, err := auth.Login()
 	if err != nil {
-		ctx.Logger.Error("auth proxy: failed to login", "error", err)
+		ctx.Logger.Error("auth proxy: failed to login", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -47,7 +47,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Get full user info
 	user, err := auth.GetSignedUser(id)
 	if err != nil {
-		ctx.Logger.Error("auth proxy: failed to get signed in user", "error", err)
+		ctx.Logger.Error("auth proxy: failed to get signed in user", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -58,7 +58,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Remember user data it in cache
 	if err := auth.Remember(id); err != nil {
-		ctx.Logger.Error("auth proxy: failed to store user in cache", "error", err)
+		ctx.Logger.Error("auth proxy: failed to store user in cache", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes so that errors happening in auth proxy middleware is logged.

It isn't good that `ctx.Handle(500, err.Error(), err.DetailsError)` is used on error since that will create a html response with Grafana's server error page. This makes it really hard to understand what error has happened since the error is not logged in Grafana's server log. That's why I've added logging in the mix and `ctx.Handle(500, err.Error(), err.DetailsError)` have been used for a long time in this middleware.

We should refactor auth middlewares so that they can return an error, but that is a future improvement that this PR not solves.

**Which issue(s) this PR fixes**:
Ref #17247 

**Special notes for your reviewer**:
Not sure this can easily be cherry picket into 6.2.x due to changes happened in master.
