### PR TITLE
Alerting: new min_interval_seconds options to enforce a minimum eval frequency

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -506,6 +506,9 @@ notification_timeout_seconds = 30
 # Default setting for max attempts to sending alert notifications. Default value is 3
 max_attempts = 3
 
+# Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
+min_interval_seconds = 100
+
 
 #################################### Explore #############################
 [explore]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -507,7 +507,7 @@ notification_timeout_seconds = 30
 max_attempts = 3
 
 # Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
-min_interval_seconds = 100
+min_interval_seconds = 60
 
 
 #################################### Explore #############################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -507,7 +507,7 @@ notification_timeout_seconds = 30
 max_attempts = 3
 
 # Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
-min_interval_seconds = 60
+min_interval_seconds = 1
 
 
 #################################### Explore #############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -437,6 +437,10 @@ log_queries =
 # Default setting for max attempts to sending alert notifications. Default value is 3
 ;max_attempts = 3
 
+# Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
+;min_interval_seconds = 0
+
+
 #################################### Explore #############################
 [explore]
 # Enable the Explore section

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -438,7 +438,7 @@ log_queries =
 ;max_attempts = 3
 
 # Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
-;min_interval_seconds = 0
+;min_interval_seconds = 60
 
 
 #################################### Explore #############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -438,7 +438,7 @@ log_queries =
 ;max_attempts = 3
 
 # Makes it possible to enforce a minimal interval between evaluations, to reduce load on the backend
-;min_interval_seconds = 60
+;min_interval_seconds = 1
 
 
 #################################### Explore #############################

--- a/docs/sources/alerting/rules.md
+++ b/docs/sources/alerting/rules.md
@@ -48,6 +48,7 @@ panels as well in a future release.
 ### Name & Evaluation interval
 
 Here you can specify the name of the alert rule and how often the scheduler should evaluate the alert rule.
+Note: A minimum interval can be specified in the `alerting.min_interval_seconds` config field, to set a minimum time between evaluations.
 
 ### For
 

--- a/pkg/services/alerting/scheduler.go
+++ b/pkg/services/alerting/scheduler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type schedulerImpl struct {
@@ -62,7 +63,13 @@ func (s *schedulerImpl) Tick(tickTime time.Time, execQueue chan *Job) {
 			continue
 		}
 
-		if now%job.Rule.Frequency == 0 {
+		// Check the job frequency against the minimum interval required
+		interval := job.Rule.Frequency
+		if interval < setting.AlertingMinInterval {
+			interval = setting.AlertingMinInterval
+		}
+
+		if now%interval == 0 {
 			if job.Offset > 0 {
 				job.OffsetWait = true
 			} else {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -184,6 +184,7 @@ var (
 	AlertingEvaluationTimeout   time.Duration
 	AlertingNotificationTimeout time.Duration
 	AlertingMaxAttempts         int
+	AlertingMinInterval         int64
 
 	// Explore UI
 	ExploreEnabled bool
@@ -895,6 +896,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	notificationTimeoutSeconds := alerting.Key("notification_timeout_seconds").MustInt64(30)
 	AlertingNotificationTimeout = time.Second * time.Duration(notificationTimeoutSeconds)
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
+	AlertingMinInterval = alerting.Key("min_interval_seconds").MustInt64(0)
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -896,7 +896,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	notificationTimeoutSeconds := alerting.Key("notification_timeout_seconds").MustInt64(30)
 	AlertingNotificationTimeout = time.Second * time.Duration(notificationTimeoutSeconds)
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
-	AlertingMinInterval = alerting.Key("min_interval_seconds").MustInt64(0)
+	AlertingMinInterval = alerting.Key("min_interval_seconds").MustInt64(60)
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -896,7 +896,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	notificationTimeoutSeconds := alerting.Key("notification_timeout_seconds").MustInt64(30)
 	AlertingNotificationTimeout = time.Second * time.Duration(notificationTimeoutSeconds)
 	AlertingMaxAttempts = alerting.Key("max_attempts").MustInt(3)
-	AlertingMinInterval = alerting.Key("min_interval_seconds").MustInt64(60)
+	AlertingMinInterval = alerting.Key("min_interval_seconds").MustInt64(1)
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)


### PR DESCRIPTION
Fixes: #14447

It will allow operator to force alerting scheduler to honor a minimum frequency when Tick() is called