### PR TITLE
CloudWatch: Fixes error when hiding/disabling queries 

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -149,12 +149,14 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery>
       if (res.results) {
         for (const query of request.queries) {
           const queryRes = res.results[query.refId];
-          for (const series of queryRes.series) {
-            const s = { target: series.name, datapoints: series.points } as any;
-            if (queryRes.meta.unit) {
-              s.unit = queryRes.meta.unit;
+          if (queryRes) {
+            for (const series of queryRes.series) {
+              const s = { target: series.name, datapoints: series.points } as any;
+              if (queryRes.meta.unit) {
+                s.unit = queryRes.meta.unit;
+              }
+              data.push(s);
             }
-            data.push(s);
           }
         }
       }


### PR DESCRIPTION

**What this PR does / why we need it**: #16408 introduced a bug that caused panels using CloudWatch datasource with at least 1 hidden query to throw exceptions. The end-user result is that the panel no longer loads as of 6.2.

**Which issue(s) this PR fixes**:
Fixes #17112

**Special notes for your reviewer**: N/A

