### PR TITLE
Tech: Update jQuery to 3.4.1 to fix issue on iOS 10 based browsers as well as Chrome 53.x 

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "fast-text-encoding": "^1.0.0",
     "file-saver": "1.3.8",
     "immutable": "3.8.2",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "mousetrap": "1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10138,10 +10138,10 @@ jest@24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
-jquery@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects the issue of Grafana not loading on certain browsers
**Which issue(s) this PR fixes**:

Fixes #17289

**Special notes for your reviewer**:
Updates jQuery to 3.4.1 (from 3.4.0) to fix the jQuery bug: https://blog.jquery.com/2019/05/01/jquery-3-4-1-triggering-focus-events-in-ie-and-finding-root-elements-in-ios-10/

