### PR TITLE
Build(devenv): correct the context issue

### DIFF
--- a/devenv/docker/blocks/multiple-openldap/admins-ldap-server.Dockerfile
+++ b/devenv/docker/blocks/multiple-openldap/admins-ldap-server.Dockerfile
@@ -19,11 +19,11 @@ EXPOSE 389
 
 VOLUME ["/etc/ldap", "/var/lib/ldap"]
 
-COPY modules/ /etc/ldap.dist/modules
-COPY prepopulate/ /etc/ldap.dist/prepopulate
+COPY admins-ldap-server/modules/ /etc/ldap.dist/modules
+COPY admins-ldap-server/prepopulate/ /etc/ldap.dist/prepopulate
 
-COPY ../entrypoint.sh /entrypoint.sh
-COPY ../prepopulate.sh /prepopulate.sh
+COPY ./entrypoint.sh /entrypoint.sh
+COPY ./prepopulate.sh /prepopulate.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/devenv/docker/blocks/multiple-openldap/docker-compose.yaml
+++ b/devenv/docker/blocks/multiple-openldap/docker-compose.yaml
@@ -1,5 +1,7 @@
   admins-openldap:
-    build: docker/blocks/multiple-openldap/admins-ldap-server
+    build: 
+      context: docker/blocks/multiple-openldap
+      dockerfile: ./admins-ldap-server.Dockerfile
     environment:
       SLAPD_PASSWORD: grafana
       SLAPD_DOMAIN: grafana.org
@@ -8,7 +10,9 @@
       - "389:389"
 
   openldap:
-    build: docker/blocks/multiple-openldap/ldap-server
+    build: 
+      context: docker/blocks/multiple-openldap
+      dockerfile: ./ldap-server.Dockerfile
     environment:
       SLAPD_PASSWORD: grafana
       SLAPD_DOMAIN: grafana.org

--- a/devenv/docker/blocks/multiple-openldap/ldap-server.Dockerfile
+++ b/devenv/docker/blocks/multiple-openldap/ldap-server.Dockerfile
@@ -19,11 +19,11 @@ EXPOSE 389
 
 VOLUME ["/etc/ldap", "/var/lib/ldap"]
 
-COPY modules/ /etc/ldap.dist/modules
-COPY prepopulate/ /etc/ldap.dist/prepopulate
+COPY ldap-server/modules/ /etc/ldap.dist/modules
+COPY ldap-server/prepopulate/ /etc/ldap.dist/prepopulate
 
-COPY ../entrypoint.sh /entrypoint.sh
-COPY ../prepopulate.sh /prepopulate.sh
+COPY ./entrypoint.sh /entrypoint.sh
+COPY ./prepopulate.sh /prepopulate.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
With the previous configuration `docker-compose build` was always failing.
This moves the dockerfiles in the parent dir and changes paths as a result.

Ref moby/moby#2745
