### PR TITLE
v6.2.1 cherry picks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ workflows:
             - backend-lint
             - mysql-integration-test
             - postgres-integration-test
-          filters: *filter-only-master
+          filters: *filter-only-release
 
   build-branches-and-prs:
       jobs:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "company": "Grafana Labs"
   },
   "name": "grafana",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "eventemitter3": "2.0.3",
     "file-saver": "1.3.8",
     "immutable": "3.8.2",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "mousetrap": "1.6.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -23,7 +23,7 @@
     "@types/react-color": "2.17.0",
     "classnames": "2.2.6",
     "d3": "5.9.1",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "papaparse": "4.6.3",

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -11,8 +11,9 @@ import { DisplayValue, Themeable, TimeSeriesValue, Threshold, VizOrientation } f
 const MIN_VALUE_HEIGHT = 18;
 const MAX_VALUE_HEIGHT = 50;
 const MIN_VALUE_WIDTH = 50;
-const MAX_VALUE_WIDTH = 100;
-const LINE_HEIGHT = 1.5;
+const MAX_VALUE_WIDTH = 150;
+const TITLE_LINE_HEIGHT = 1.5;
+const VALUE_LINE_HEIGHT = 1;
 
 export interface Props extends Themeable {
   height: number;
@@ -227,7 +228,7 @@ function calculateTitleDimensions(props: Props): TitleDimensions {
     return {
       fontSize: 14,
       width: width,
-      height: 14 * LINE_HEIGHT,
+      height: 14 * TITLE_LINE_HEIGHT,
       placement: 'below',
     };
   }
@@ -238,7 +239,7 @@ function calculateTitleDimensions(props: Props): TitleDimensions {
     const titleHeight = Math.max(Math.min(height * maxTitleHeightRatio, MAX_VALUE_HEIGHT), 17);
 
     return {
-      fontSize: titleHeight / LINE_HEIGHT,
+      fontSize: titleHeight / TITLE_LINE_HEIGHT,
       width: 0,
       height: titleHeight,
       placement: 'above',
@@ -251,7 +252,7 @@ function calculateTitleDimensions(props: Props): TitleDimensions {
   const titleHeight = Math.max(height * maxTitleHeightRatio, MIN_VALUE_HEIGHT);
 
   return {
-    fontSize: titleHeight / LINE_HEIGHT,
+    fontSize: titleHeight / TITLE_LINE_HEIGHT,
     height: 0,
     width: Math.min(Math.max(width * maxTitleWidthRatio, 50), 200),
     placement: 'left',
@@ -485,7 +486,7 @@ export function getValueColor(props: Props): string {
  * Only exported to for unit test
  */
 function getValueStyles(value: string, color: string, width: number, height: number): CSSProperties {
-  const heightFont = height / LINE_HEIGHT;
+  const heightFont = height / VALUE_LINE_HEIGHT;
   const guess = width / (value.length * 1.1);
   const fontSize = Math.min(Math.max(guess, 14), heightFont);
 
@@ -495,6 +496,15 @@ function getValueStyles(value: string, color: string, width: number, height: num
     width: `${width}px`,
     display: 'flex',
     alignItems: 'center',
-    fontSize: fontSize.toFixed(2) + 'px',
+    lineHeight: VALUE_LINE_HEIGHT,
+    fontSize: fontSize.toFixed(4) + 'px',
   };
 }
+
+// function getTextWidth(text: string): number {
+//   const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"));
+//   var context = canvas.getContext("2d");
+//   context.font = "'Roboto', 'Helvetica Neue', Arial, sans-serif";
+//   var metrics = context.measureText(text);
+//   return metrics.width;
+// }

--- a/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
@@ -18,8 +18,9 @@ exports[`BarGauge Render with basic options should render 1`] = `
         "alignItems": "center",
         "color": "#73BF69",
         "display": "flex",
-        "fontSize": "27.27px",
+        "fontSize": "27.2727px",
         "height": "300px",
+        "lineHeight": 1,
         "paddingLeft": "10px",
         "width": "60px",
       }

--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -58,7 +58,7 @@ export class Gauge extends PureComponent<Props> {
     if (length > 12) {
       return FONT_SCALE - (length * 5) / 110;
     }
-    return FONT_SCALE - (length * 5) / 100;
+    return FONT_SCALE - (length * 5) / 101;
   }
 
   draw() {
@@ -78,7 +78,8 @@ export class Gauge extends PureComponent<Props> {
     const gaugeWidthReduceRatio = showThresholdLabels ? 1.5 : 1;
     const gaugeWidth = Math.min(dimension / 5.5, 40) / gaugeWidthReduceRatio;
     const thresholdMarkersWidth = gaugeWidth / 5;
-    const fontSize = Math.min(dimension / 5.5, 100) * (value.text !== null ? this.getFontScale(value.text.length) : 1);
+    const fontSize = Math.min(dimension / 4, 100) * (value.text !== null ? this.getFontScale(value.text.length) : 1);
+
     const thresholdLabelFontSize = fontSize / 2.5;
 
     const options: any = {

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
@@ -1,0 +1,126 @@
+package datamigrations
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fatih/color"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+var (
+	datasourceTypes = []string{
+		"mysql",
+		"influxdb",
+		"elasticsearch",
+		"graphite",
+		"prometheus",
+		"opentsdb",
+	}
+)
+
+// EncryptDatasourcePaswords migrates un-encrypted secrets on datasources
+// to the secureJson Column.
+func EncryptDatasourcePaswords(c utils.CommandLine, sqlStore *sqlstore.SqlStore) error {
+	return sqlStore.WithDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+		passwordsUpdated, err := migrateColumn(session, "password")
+		if err != nil {
+			return err
+		}
+
+		basicAuthUpdated, err := migrateColumn(session, "basic_auth_password")
+		if err != nil {
+			return err
+		}
+
+		logger.Info("\n")
+		if passwordsUpdated > 0 {
+			logger.Infof("%s Encrypted password field for %d datasources \n", color.GreenString("✔"), passwordsUpdated)
+		}
+
+		if basicAuthUpdated > 0 {
+			logger.Infof("%s Encrypted basic_auth_password field for %d datasources \n", color.GreenString("✔"), basicAuthUpdated)
+		}
+
+		if passwordsUpdated == 0 && basicAuthUpdated == 0 {
+			logger.Infof("%s All datasources secrets are allready encrypted\n", color.GreenString("✔"))
+		}
+
+		logger.Info("\n")
+
+		logger.Warn("Warning: Datasource provisioning files need to be manually changed to prevent overwriting of " +
+			"the data during provisioning. See https://grafana.com/docs/installation/upgrading/#upgrading-to-v6-2 for " +
+			"details")
+		return nil
+	})
+}
+
+func migrateColumn(session *sqlstore.DBSession, column string) (int, error) {
+	var rows []map[string]string
+
+	session.Cols("id", column, "secure_json_data")
+	session.Table("data_source")
+	session.In("type", datasourceTypes)
+	session.Where(column + " IS NOT NULL AND " + column + " != ''")
+	err := session.Find(&rows)
+
+	if err != nil {
+		return 0, errutil.Wrapf(err, "failed to select column: %s", column)
+	}
+
+	rowsUpdated, err := updateRows(session, rows, column)
+	return rowsUpdated, errutil.Wrapf(err, "failed to update column: %s", column)
+}
+
+func updateRows(session *sqlstore.DBSession, rows []map[string]string, passwordFieldName string) (int, error) {
+	var rowsUpdated int
+
+	for _, row := range rows {
+		newSecureJSONData, err := getUpdatedSecureJSONData(row, passwordFieldName)
+		if err != nil {
+			return 0, err
+		}
+
+		data, err := json.Marshal(newSecureJSONData)
+		if err != nil {
+			return 0, errutil.Wrap("marshaling newSecureJsonData failed", err)
+		}
+
+		newRow := map[string]interface{}{"secure_json_data": data, passwordFieldName: ""}
+		session.Table("data_source")
+		session.Where("id = ?", row["id"])
+		// Setting both columns while having value only for secure_json_data should clear the [passwordFieldName] column
+		session.Cols("secure_json_data", passwordFieldName)
+
+		_, err = session.Update(newRow)
+		if err != nil {
+			return 0, err
+		}
+
+		rowsUpdated++
+	}
+	return rowsUpdated, nil
+}
+
+func getUpdatedSecureJSONData(row map[string]string, passwordFieldName string) (map[string]interface{}, error) {
+	encryptedPassword, err := util.Encrypt([]byte(row[passwordFieldName]), setting.SecretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var secureJSONData map[string]interface{}
+
+	if err := json.Unmarshal([]byte(row["secure_json_data"]), &secureJSONData); err != nil {
+		return nil, err
+	}
+
+	jsonFieldName := util.ToCamelCase(passwordFieldName)
+	secureJSONData[jsonFieldName] = encryptedPassword
+	return secureJSONData, nil
+}

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
@@ -1,0 +1,67 @@
+package datamigrations
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/commands/commandstest"
+	"github.com/grafana/grafana/pkg/components/securejsondata"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPasswordMigrationCommand(t *testing.T) {
+	//setup datasources with password, basic_auth and none
+	sqlstore := sqlstore.InitTestDB(t)
+	session := sqlstore.NewSession()
+	defer session.Close()
+
+	datasources := []*models.DataSource{
+		{Type: "influxdb", Name: "influxdb", Password: "foobar"},
+		{Type: "graphite", Name: "graphite", BasicAuthPassword: "foobar"},
+		{Type: "prometheus", Name: "prometheus", SecureJsonData: securejsondata.GetEncryptedJsonData(map[string]string{})},
+	}
+
+	// set required default values
+	for _, ds := range datasources {
+		ds.Created = time.Now()
+		ds.Updated = time.Now()
+		ds.SecureJsonData = securejsondata.GetEncryptedJsonData(map[string]string{})
+	}
+
+	_, err := session.Insert(&datasources)
+	assert.Nil(t, err)
+
+	//run migration
+	err = EncryptDatasourcePaswords(&commandstest.FakeCommandLine{}, sqlstore)
+	assert.Nil(t, err)
+
+	//verify that no datasources still have password or basic_auth
+	var dss []*models.DataSource
+	err = session.SQL("select * from data_source").Find(&dss)
+	assert.Nil(t, err)
+	assert.Equal(t, len(dss), 3)
+
+	for _, ds := range dss {
+		sj := ds.SecureJsonData.Decrypt()
+
+		if ds.Name == "influxdb" {
+			assert.Equal(t, ds.Password, "")
+			v, exist := sj["password"]
+			assert.True(t, exist)
+			assert.Equal(t, v, "foobar", "expected password to be moved to securejson")
+		}
+
+		if ds.Name == "graphite" {
+			assert.Equal(t, ds.BasicAuthPassword, "")
+			v, exist := sj["basicAuthPassword"]
+			assert.True(t, exist)
+			assert.Equal(t, v, "foobar", "expected basic_auth_password to be moved to securejson")
+		}
+
+		if ds.Name == "prometheus" {
+			assert.Equal(t, len(sj), 0)
+		}
+	}
+}

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -14,13 +14,14 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	m "github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 )
 
-func validateInput(c CommandLine, pluginFolder string) error {
+func validateInput(c utils.CommandLine, pluginFolder string) error {
 	arg := c.Args().First()
 	if arg == "" {
 		return errors.New("please specify plugin to install")
@@ -46,7 +47,7 @@ func validateInput(c CommandLine, pluginFolder string) error {
 	return nil
 }
 
-func installCommand(c CommandLine) error {
+func installCommand(c utils.CommandLine) error {
 	pluginFolder := c.PluginDirectory()
 	if err := validateInput(c, pluginFolder); err != nil {
 		return err
@@ -60,7 +61,7 @@ func installCommand(c CommandLine) error {
 
 // InstallPlugin downloads the plugin code as a zip file from the Grafana.com API
 // and then extracts the zip into the plugins directory.
-func InstallPlugin(pluginName, version string, c CommandLine) error {
+func InstallPlugin(pluginName, version string, c utils.CommandLine) error {
 	pluginFolder := c.PluginDirectory()
 	downloadURL := c.PluginURL()
 	if downloadURL == "" {

--- a/pkg/cmd/grafana-cli/commands/listremote_command.go
+++ b/pkg/cmd/grafana-cli/commands/listremote_command.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
-func listremoteCommand(c CommandLine) error {
+func listremoteCommand(c utils.CommandLine) error {
 	plugin, err := s.ListAllPlugins(c.RepoDirectory())
 
 	if err != nil {

--- a/pkg/cmd/grafana-cli/commands/listversions_command.go
+++ b/pkg/cmd/grafana-cli/commands/listversions_command.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
-func validateVersionInput(c CommandLine) error {
+func validateVersionInput(c utils.CommandLine) error {
 	arg := c.Args().First()
 	if arg == "" {
 		return errors.New("please specify plugin to list versions for")
@@ -16,7 +17,7 @@ func validateVersionInput(c CommandLine) error {
 	return nil
 }
 
-func listversionsCommand(c CommandLine) error {
+func listversionsCommand(c utils.CommandLine) error {
 	if err := validateVersionInput(c); err != nil {
 		return err
 	}

--- a/pkg/cmd/grafana-cli/commands/ls_command.go
+++ b/pkg/cmd/grafana-cli/commands/ls_command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	m "github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
 var ls_getPlugins func(path string) []m.InstalledPlugin = s.GetLocalPlugins
@@ -31,7 +32,7 @@ var validateLsCommand = func(pluginDir string) error {
 	return nil
 }
 
-func lsCommand(c CommandLine) error {
+func lsCommand(c utils.CommandLine) error {
 	pluginDir := c.PluginDirectory()
 	if err := validateLsCommand(pluginDir); err != nil {
 		return err

--- a/pkg/cmd/grafana-cli/commands/remove_command.go
+++ b/pkg/cmd/grafana-cli/commands/remove_command.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	services "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
 var removePlugin func(pluginPath, id string) error = services.RemoveInstalledPlugin
 
-func removeCommand(c CommandLine) error {
+func removeCommand(c utils.CommandLine) error {
 	pluginPath := c.PluginDirectory()
 
 	plugin := c.Args().First()

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -6,13 +6,15 @@ import (
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 const AdminUserId = 1
 
-func resetPasswordCommand(c CommandLine) error {
+func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) error {
 	newPassword := c.Args().First()
 
 	password := models.Password(newPassword)

--- a/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
@@ -4,6 +4,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	m "github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 	"github.com/hashicorp/go-version"
 )
 
@@ -27,7 +28,7 @@ func ShouldUpgrade(installed string, remote m.Plugin) bool {
 	return false
 }
 
-func upgradeAllCommand(c CommandLine) error {
+func upgradeAllCommand(c utils.CommandLine) error {
 	pluginsDir := c.PluginDirectory()
 
 	localPlugins := s.GetLocalPlugins(pluginsDir)

--- a/pkg/cmd/grafana-cli/commands/upgrade_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command.go
@@ -4,9 +4,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	s "github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
-func upgradeCommand(c CommandLine) error {
+func upgradeCommand(c utils.CommandLine) error {
 	pluginsDir := c.PluginDirectory()
 	pluginName := c.Args().First()
 

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -1,4 +1,4 @@
-package commands
+package utils
 
 import (
 	"github.com/codegangsta/cli"
@@ -22,30 +22,30 @@ type CommandLine interface {
 	PluginURL() string
 }
 
-type contextCommandLine struct {
+type ContextCommandLine struct {
 	*cli.Context
 }
 
-func (c *contextCommandLine) ShowHelp() {
+func (c *ContextCommandLine) ShowHelp() {
 	cli.ShowCommandHelp(c.Context, c.Command.Name)
 }
 
-func (c *contextCommandLine) ShowVersion() {
+func (c *ContextCommandLine) ShowVersion() {
 	cli.ShowVersion(c.Context)
 }
 
-func (c *contextCommandLine) Application() *cli.App {
+func (c *ContextCommandLine) Application() *cli.App {
 	return c.App
 }
 
-func (c *contextCommandLine) PluginDirectory() string {
+func (c *ContextCommandLine) PluginDirectory() string {
 	return c.GlobalString("pluginsDir")
 }
 
-func (c *contextCommandLine) RepoDirectory() string {
+func (c *ContextCommandLine) RepoDirectory() string {
 	return c.GlobalString("repo")
 }
 
-func (c *contextCommandLine) PluginURL() string {
+func (c *ContextCommandLine) PluginURL() string {
 	return c.GlobalString("pluginUrl")
 }

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -54,7 +54,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	ctx.IsSignedIn = true
 
 	// Remember user data it in cache
-	if err := auth.Remember(); err != nil {
+	if err := auth.Remember(id); err != nil {
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}

--- a/pkg/middleware/auth_proxy.go
+++ b/pkg/middleware/auth_proxy.go
@@ -31,6 +31,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Check if allowed to continue with this IP
 	if result, err := auth.IsAllowedIP(); result == false {
+		ctx.Logger.Error("auth proxy: failed to check whitelisted ip addresses", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(407, err.Error(), err.DetailsError)
 		return true
 	}
@@ -38,6 +39,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Try to get user id from various sources
 	id, err := auth.GetUserID()
 	if err != nil {
+		ctx.Logger.Error("auth proxy: failed to login", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -45,6 +47,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 	// Get full user info
 	user, err := auth.GetSignedUser(id)
 	if err != nil {
+		ctx.Logger.Error("auth proxy: failed to get signed in user", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}
@@ -55,6 +58,7 @@ func initContextWithAuthProxy(store *remotecache.RemoteCache, ctx *m.ReqContext,
 
 	// Remember user data it in cache
 	if err := auth.Remember(id); err != nil {
+		ctx.Logger.Error("auth proxy: failed to store user in cache", "message", err.Error(), "error", err.DetailsError)
 		ctx.Handle(500, err.Error(), err.DetailsError)
 		return true
 	}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -88,12 +88,12 @@ func (ss *SqlStore) inTransactionWithRetryCtx(ctx context.Context, callback dbTr
 
 	err = callback(sess)
 
-	// special handling of database locked errors for sqlite, then we can retry 3 times
+	// special handling of database locked errors for sqlite, then we can retry 5 times
 	if sqlError, ok := err.(sqlite3.Error); ok && retry < 5 {
-		if sqlError.Code == sqlite3.ErrLocked {
+		if sqlError.Code == sqlite3.ErrLocked || sqlError.Code == sqlite3.ErrBusy {
 			sess.Rollback()
 			time.Sleep(time.Millisecond * time.Duration(10))
-			sqlog.Info("Database table locked, sleeping then retrying", "retry", retry)
+			sqlog.Info("Database locked, sleeping then retrying", "error", err, "retry", retry)
 			return ss.inTransactionWithRetryCtx(ctx, callback, retry+1)
 		}
 	}

--- a/pkg/util/errutil/errors.go
+++ b/pkg/util/errutil/errors.go
@@ -1,11 +1,28 @@
 package errutil
 
-import "golang.org/x/xerrors"
+import (
+	"fmt"
+
+	"golang.org/x/xerrors"
+)
 
 // Wrap is a simple wrapper around Errorf that is doing error wrapping. You can read how that works in
 // https://godoc.org/golang.org/x/xerrors#Errorf but its API is very implicit which is a reason for this wrapper.
 // There is also a discussion (https://github.com/golang/go/issues/29934) where many comments make arguments for such
 // wrapper so hopefully it will be added in the standard lib later.
 func Wrap(message string, err error) error {
+	if err == nil {
+		return nil
+	}
 	return xerrors.Errorf("%v: %w", message, err)
+}
+
+// Wrapf is a simple wrapper around Errorf that is doing error wrapping
+// Wrapf allows you to send a format and args instead of just a message.
+func Wrapf(err error, message string, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	return Wrap(fmt.Sprintf(message, a...), err)
 }

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -65,4 +66,20 @@ func GetAgeString(t time.Time) string {
 	}
 
 	return "< 1m"
+}
+
+// ToCamelCase changes kebab case, snake case or mixed strings to camel case. See unit test for examples.
+func ToCamelCase(str string) string {
+	var finalParts []string
+	parts := strings.Split(str, "_")
+
+	for _, part := range parts {
+		finalParts = append(finalParts, strings.Split(part, "-")...)
+	}
+
+	for index, part := range finalParts[1:] {
+		finalParts[index+1] = strings.Title(part)
+	}
+
+	return strings.Join(finalParts, "")
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -37,3 +37,12 @@ func TestDateAge(t *testing.T) {
 		So(GetAgeString(time.Now().Add(-time.Hour*24*409)), ShouldEqual, "1y")
 	})
 }
+
+func TestToCamelCase(t *testing.T) {
+	Convey("ToCamelCase", t, func() {
+		So(ToCamelCase("kebab-case-string"), ShouldEqual, "kebabCaseString")
+		So(ToCamelCase("snake_case_string"), ShouldEqual, "snakeCaseString")
+		So(ToCamelCase("mixed-case_string"), ShouldEqual, "mixedCaseString")
+		So(ToCamelCase("alreadyCamelCase"), ShouldEqual, "alreadyCamelCase")
+	})
+}

--- a/public/app/features/explore/Table.tsx
+++ b/public/app/features/explore/Table.tsx
@@ -26,7 +26,7 @@ export default class Table extends PureComponent<TableProps> {
         if (e.target) {
           const link = e.target as HTMLElement;
           if (link.className === 'link') {
-            const columnKey = column.Header;
+            const columnKey = column.Header().props.title;
             const rowValue = rowInfo.row[columnKey];
             this.props.onClickCell(columnKey, rowValue);
           }

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -11,6 +11,8 @@ import TimeSeries from 'app/core/time_series2';
 import { MetricsPanelCtrl } from 'app/plugins/sdk';
 import { GrafanaThemeType, getValueFormat, getColorFromHexRgbOrName, isTableData } from '@grafana/ui';
 
+const BASE_FONT_SIZE = 38;
+
 class SingleStatCtrl extends MetricsPanelCtrl {
   static templateUrl = 'module.html';
 
@@ -384,10 +386,11 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       return valueString;
     }
 
-    function getSpan(className, fontSize, applyColoring, value) {
+    function getSpan(className, fontSizePercent, applyColoring, value) {
       value = $sanitize(templateSrv.replace(value, data.scopedVars));
       value = applyColoring ? applyColoringThresholds(value) : value;
-      return '<span class="' + className + '" style="font-size:' + fontSize + '">' + value + '</span>';
+      const pixelSize = (parseInt(fontSizePercent, 10) / 100) * BASE_FONT_SIZE;
+      return '<span class="' + className + '" style="font-size:' + pixelSize + 'px">' + value + '</span>';
     }
 
     function getBigValueHtml() {

--- a/public/sass/components/_panel_singlestat.scss
+++ b/public/sass/components/_panel_singlestat.scss
@@ -6,17 +6,13 @@
 }
 
 .singlestat-panel-value-container {
-  // line-height 0 is imporant here as the font-size is on this
-  // level but overriden one level deeper and but the line-height: is still
-  // based on the base font size on this level. Using line-height: 0 fixes that
-  line-height: 0;
   display: table-cell;
   vertical-align: middle;
   text-align: center;
   position: relative;
   z-index: 1;
   font-weight: $font-weight-semi-bold;
-  font-size: 38px;
+  line-height: 1;
 }
 
 // Helps

--- a/yarn.lock
+++ b/yarn.lock
@@ -10048,10 +10048,10 @@ jest@24.6.0:
     import-local "^2.0.0"
     jest-cli "^24.6.0"
 
-jquery@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.1"


### PR DESCRIPTION
Changes going into v6.2.1 release:
* Explore: Fixes so clicking in a Prometheus Table the query is filtered by clicked value, (#17083), merge-sha: fdd421e24c38e92c9ea67d326ad56d00563713bb                                                                                                    
* fix filter for building msi during release, (#17236), merge-sha: 972df40af8b2af356de17ba08b6df628c61797ac                                                                                                                                                 
* Singlestat: Fixes issue with value placement and line wraps, (#17249), merge-sha: 6acc7d37dad262a5f0a2442b2ec80c29fcdd1151
* Update: Update jQuery to 3.4.1 to fix issue on iOS 10 based browers as well as Chrome 53.x , (#17290), merge-sha: df6a4914c4eca3ae87068df3ca29ad9eb101f03c
* CLI: Add command to migrate all datasources to use encrypted password fields , (#17118), merge-sha: 151b24b95fb52a777533c9fd76db48ae8967a74e
* Chore: Update jquery to 3.4.1 in grafana ui, (#17295), merge-sha: 3dda812f12653479084c567cbf63fa83be2a0659
* Gauge/BarGauge: Improvements to auto value font size , (#17292), merge-sha: 5358c5fe6b0a966dcfe0495b47b06d18155ed647

Backports:
* Auth Proxy: Resolve database is locked errors (#17274)
* Auth Proxy: Log any error in middleware (#17296)
* Database: Retry transaction if sqlite returns busy error (#17297)
* Backport parts of #17065