### PR TITLE
Chore: Update jquery to 3.4.1 in grafana ui

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -23,7 +23,7 @@
     "@types/react-color": "2.17.0",
     "classnames": "2.2.6",
     "d3": "5.9.1",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "lodash": "4.17.11",
     "moment": "2.24.0",
     "papaparse": "4.6.3",


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/17290 missed updating grafana/ui lib 