### PR TITLE
Build: Removes e2e-tests from Grafana master workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,10 +662,6 @@ workflows:
             - mysql-integration-test
             - postgres-integration-test
           filters: *filter-only-master
-      - end-to-end-test:
-          requires:
-            - grafana-docker-master
-          filters: *filter-only-master
   release:
     jobs:
       - build-all:


### PR DESCRIPTION
*What this PR does / why we need it**:
Removes e2e-tests from Grafana master workflow

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

