### PR TITLE
global settings: add auto_count option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -194,6 +194,8 @@ snapshot_remove_expired = true
 [dashboards]
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
 versions_to_keep = 20
+# Set step count value for auto option (applied for interval type variables)
+auto_count = 30
 
 #################################### Users ###############################
 [users]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -189,6 +189,8 @@ log_queries =
 [dashboards]
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
 ;versions_to_keep = 20
+# Set step count value for auto option (applied for interval type variables)
+;auto_count = 30
 
 #################################### Users ###############################
 [users]

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -709,6 +709,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	// read dashboard settings
 	dashboards := iniFile.Section("dashboards")
 	DashboardVersionsToKeep = dashboards.Key("versions_to_keep").MustInt(20)
+	DashboardAutoCount = dashboards.Key("auto_count").MustInt(30)
 
 	//  read data source proxy white list
 	DataProxyWhiteList = make(map[string]bool)

--- a/public/app/features/templating/interval_variable.ts
+++ b/public/app/features/templating/interval_variable.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import setting from 'setting';
 import kbn from 'app/core/utils/kbn';
 import { Variable, assignModelProperties, variableTypes } from './variable';
 
@@ -24,7 +25,7 @@ export class IntervalVariable implements Variable {
     query: '1m,10m,30m,1h,6h,12h,1d,7d,14d,30d',
     auto: false,
     auto_min: '10s',
-    auto_count: 30,
+    auto_count: setting.DashboardAutoCount,
     skipUrlSync: false,
   };
 


### PR DESCRIPTION
This PR added new global config option **auto_count** under [dashboards] subsection to be able to set its value for all dashboard globally in one place.

