### PR TITLE
adds auth example for the cli cherrypick task

### DIFF
--- a/scripts/cli/tasks/cherrypick.ts
+++ b/scripts/cli/tasks/cherrypick.ts
@@ -7,6 +7,10 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
   let client = axios.create({
     baseURL: 'https://api.github.com/repos/grafana/grafana',
     timeout: 10000,
+    // auth: {
+    //   username: '<username>',
+    //   password: '<personal access token>',
+    // },
   });
 
   const res = await client.get('/issues', {


### PR DESCRIPTION
In case of rate limiting issues a personal access token needs to be used for generating list of PR's to be  cherrypicked.
