### PR TITLE
API: Add a new endpoint to get dashboard by ID 

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -291,6 +291,9 @@ func (hs *HTTPServer) registerRoutes() {
 			dashboardRoute.Get("/db/:slug", Wrap(hs.GetDashboard))
 			dashboardRoute.Delete("/db/:slug", Wrap(DeleteDashboardBySlug))
 
+			dashboardRoute.Get("/id/:id", Wrap(hs.GetDashboard))
+			dashboardRoute.Delete("/id/:id", Wrap(DeleteDashboardByID))
+
 			dashboardRoute.Post("/calculate-diff", bind(dtos.CalculateDiffOptions{}), Wrap(CalculateDashboardDiff))
 
 			dashboardRoute.Post("/db", bind(m.SaveDashboardCommand{}), Wrap(hs.PostDashboard))

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -49,7 +49,7 @@ func dashboardGuardianResponse(err error) Response {
 }
 
 func (hs *HTTPServer) GetDashboard(c *m.ReqContext) Response {
-	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, c.Params(":uid"))
+	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), c.ParamsInt64(":id"), c.Params(":uid"))
 	if rsp != nil {
 		return rsp
 	}
@@ -180,8 +180,12 @@ func DeleteDashboardByUID(c *m.ReqContext) Response {
 	return deleteDashboard(c)
 }
 
+func DeleteDashboardByID(c *m.ReqContext) Response {
+	return deleteDashboard(c)
+}
+
 func deleteDashboard(c *m.ReqContext) Response {
-	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), 0, c.Params(":uid"))
+	dash, rsp := getDashboardHelper(c.OrgId, c.Params(":slug"), c.ParamsInt64(":id"), c.Params(":uid"))
 	if rsp != nil {
 		return rsp
 	}


### PR DESCRIPTION
Located at api/dashboards/id/:id

The dashboards api already support searching by UID and Slug
For people using tracing, it will ease troubleshooting since we only have IDs

**What this PR does / why we need it**:
As DashboardIDs are something that are returned as part of the responses (and the only available field in opentracing), It would make sense that it receives the same amount of love than `slug` and `uid` api-wise

This is a simple endpoint, extending getDashboard, to return the same response as /uid/ or db/:slug

An other idea was to have a way to route something like `/d/id/:id` in the frontend to the corresponding, but I'm quite bad at that, so I'll keep this PR for the API since I feel it has no downside to have it as is :)
