### PR TITLE
SeriesData: fix TableData conversion in toLegacyResponseData

### DIFF
--- a/packages/grafana-ui/src/utils/processSeriesData.test.ts
+++ b/packages/grafana-ui/src/utils/processSeriesData.test.ts
@@ -6,7 +6,7 @@ import {
   guessFieldTypes,
   guessFieldTypeFromValue,
 } from './processSeriesData';
-import { FieldType, TimeSeries } from '../types/data';
+import { FieldType, TimeSeries, SeriesData, TableData } from '../types/data';
 import { dateTime } from './moment_wrapper';
 
 describe('toSeriesData', () => {
@@ -98,5 +98,26 @@ describe('SerisData backwards compatibility', () => {
     const roundtrip = toLegacyResponseData(series) as TimeSeries;
     expect(isTableData(roundtrip)).toBeTruthy();
     expect(roundtrip).toMatchObject(table);
+  });
+
+  it('converts SeriesData to TableData to series and back again', () => {
+    const series: SeriesData = {
+      refId: 'Z',
+      meta: {
+        somethign: 8,
+      },
+      fields: [
+        { name: 'T', type: FieldType.time }, // first
+        { name: 'N', type: FieldType.number, filterable: true },
+        { name: 'S', type: FieldType.string, filterable: true },
+      ],
+      rows: [[1, 100, '1'], [2, 200, '2'], [3, 300, '3']],
+    };
+    const table = toLegacyResponseData(series) as TableData;
+    expect(table.meta).toBe(series.meta);
+    expect(table.refId).toBe(series.refId);
+
+    const names = table.columns.map(c => c.text);
+    expect(names).toEqual(['T', 'N', 'S']);
   });
 });

--- a/packages/grafana-ui/src/utils/processSeriesData.ts
+++ b/packages/grafana-ui/src/utils/processSeriesData.ts
@@ -4,7 +4,7 @@ import isString from 'lodash/isString';
 import isBoolean from 'lodash/isBoolean';
 
 // Types
-import { SeriesData, Field, TimeSeries, FieldType, TableData } from '../types/index';
+import { SeriesData, Field, TimeSeries, FieldType, TableData, Column } from '../types/index';
 import { isDateTime } from './moment_wrapper';
 
 function convertTableToSeriesData(table: TableData): SeriesData {
@@ -171,14 +171,12 @@ export const toLegacyResponseData = (series: SeriesData): TimeSeries | TableData
 
   return {
     columns: fields.map(f => {
-      return {
-        text: f.name,
-        filterable: f.filterable,
-        unit: f.unit,
-        refId: series.refId,
-        meta: series.meta,
-      };
+      const { name, ...column } = f;
+      (column as Column).text = name;
+      return column as Column;
     }),
+    refId: series.refId,
+    meta: series.meta,
     rows,
   };
 };


### PR DESCRIPTION
The current `toLegacyResponseData` does not properly convert SeriesData to TableData for toLegacyResponseData.  This only effects datasources that write SeriesData and panels that expect data in TableData

I found this working with a  new unpublished datasource and https://github.com/NatelEnergy/grafana-discrete-panel

