### PR TITLE
Build: ignore absence of docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ endif
 # drop down the envs
 devenv-down:
 	@cd devenv; \
-	docker-compose down;
+	test -f docker-compose.yaml && \
+	docker-compose down || exit 0;
 
 # TODO recheck the rules and leave only necessary exclusions
 gosec: scripts/go/bin/gosec


### PR DESCRIPTION
If devenv/docker-compose.yaml file is missing, `devenv-down`
and subsequently `devenv` is not going to work
