### PR TITLE
New icon for alert list

### DIFF
--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -74,7 +74,7 @@ function getStateDisplayModel(state: string) {
     case 'alerting': {
       return {
         text: 'ALERTING',
-        iconClass: 'icon-gf icon-gf-critical',
+        iconClass: 'gicon gicon-alert-list-alerting',
         stateClass: 'alert-state-critical',
       };
     }

--- a/public/img/icons_dark_theme/icon_alert_list_alerting.svg
+++ b/public/img/icons_dark_theme/icon_alert_list_alerting.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="64px" height="64px" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#E02F44;}
+</style>
+<g>
+	<g>
+		<path class="st0" d="M32,64c4.6,0,8.2-3.7,8.2-8.2H23.8C23.8,60.3,27.4,64,32,64z"/>
+	</g>
+	<path class="st0" d="M53.5,42.7V32.3c0-12.8-6.7-23.5-15.9-26.7C37.6,2.5,35.1,0,32,0c-3.1,0-5.6,2.5-5.6,5.6
+		c-9.2,3.2-15.9,13.9-15.9,26.7v10.4C8,42.8,6,44.8,6,47.3s2,4.5,4.5,4.6v0h0.1h42.8h0.1v0c2.5,0,4.5-2.1,4.5-4.6
+		C58,44.8,56,42.8,53.5,42.7z"/>
+</g>
+</svg>

--- a/public/img/icons_light_theme/icon_alert_list_alerting.svg
+++ b/public/img/icons_light_theme/icon_alert_list_alerting.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="64px" height="64px" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#c4162a;}
+</style>
+<g>
+	<g>
+		<path class="st0" d="M32,64c4.6,0,8.2-3.7,8.2-8.2H23.8C23.8,60.3,27.4,64,32,64z"/>
+	</g>
+	<path class="st0" d="M53.5,42.7V32.3c0-12.8-6.7-23.5-15.9-26.7C37.6,2.5,35.1,0,32,0c-3.1,0-5.6,2.5-5.6,5.6
+		c-9.2,3.2-15.9,13.9-15.9,26.7v10.4C8,42.8,6,44.8,6,47.3s2,4.5,4.5,4.6v0h0.1h42.8h0.1v0c2.5,0,4.5-2.1,4.5-4.6
+		C58,44.8,56,42.8,53.5,42.7z"/>
+</g>
+</svg>

--- a/public/sass/base/_icons.scss
+++ b/public/sass/base/_icons.scss
@@ -24,6 +24,12 @@
   height: 0.8em;
 }
 
+.gicon-alert-list-alerting {
+  background-image: url('../img/icons_#{$theme-name}_theme/icon_alert_list_alerting.svg');
+  width: 24px;
+  height: 24px;
+}
+
 .gicon-add-annotation {
   background-image: url('../img/icons_#{$theme-name}_theme/icon_add_annotation.svg');
 }


### PR DESCRIPTION
Created red version of alert icon.
Replaced icon for alerting in alert list with new red icon

<img width="1440" alt="Screenshot 2019-05-29 at 09 44 56" src="https://user-images.githubusercontent.com/23470681/58538914-76685e00-81f6-11e9-86ce-7e75dd42b394.png">


fixes #16990