### PR TITLE
Drilldown: use separate editors for panel and series links

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -6,6 +6,7 @@ import { Portal, List } from '../index';
 
 export interface ContextMenuItem {
   label: string;
+  target?: string;
   icon?: string;
   url?: string;
   onClick?: (event?: React.SyntheticEvent<HTMLElement>) => void;
@@ -88,6 +89,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
             return (
               <a
                 href={item.url}
+                target={item.target || '_self'}
                 className={styles.link}
                 onClick={e => {
                   if (item.onClick) {

--- a/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinkEditor.tsx
+++ b/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinkEditor.tsx
@@ -1,51 +1,15 @@
-// Libraries
-import React, { FC, ChangeEvent, useState } from 'react';
+import React, { FC, useState, ChangeEvent } from 'react';
+import { PanelDrillDownLink } from '../../index';
+import { FormField, Switch } from '../index';
 
-// Components
-import { PanelOptionsGroup, PanelDrillDownLink, FormField, Switch } from '@grafana/ui';
-
-export interface Props {
-  value: PanelDrillDownLink[];
-  onChange: (links: PanelDrillDownLink[]) => void;
-}
-
-export const PanelLinksEditor: FC<Props> = React.memo(({ value, onChange }) => {
-  const onAdd = () => {
-    onChange([...value, { url: '', title: '' }]);
-  };
-
-  const onLinkChanged = (linkIndex: number, newLink: PanelDrillDownLink) => {
-    onChange(
-      value.map((item, listIndex) => {
-        if (linkIndex === listIndex) {
-          return newLink;
-        }
-        return item;
-      })
-    );
-  };
-
-  const onRemove = (link: PanelDrillDownLink) => {
-    onChange(value.filter(item => item !== link));
-  };
-
-  return (
-    <PanelOptionsGroup title="Drilldown links" onAdd={onAdd}>
-      {value.map((link, index) => (
-        <LinkEditor key={index.toString()} index={index} value={link} onChange={onLinkChanged} onRemove={onRemove} />
-      ))}
-    </PanelOptionsGroup>
-  );
-});
-
-export interface LinkEditor {
+export interface DrilldownLinkEditor {
   index: number;
   value: PanelDrillDownLink;
   onChange: (index: number, link: PanelDrillDownLink) => void;
   onRemove: (link: PanelDrillDownLink) => void;
 }
 
-export const LinkEditor: FC<LinkEditor> = React.memo(({ index, value, onChange, onRemove }) => {
+export const DrilldownLinkEditor: FC<DrilldownLinkEditor> = React.memo(({ index, value, onChange, onRemove }) => {
   const [linkUrl, setLinkUrl] = useState(value.url);
   const [title, setTitle] = useState(value.title);
 

--- a/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinkEditor.tsx
+++ b/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinkEditor.tsx
@@ -2,14 +2,14 @@ import React, { FC, useState, ChangeEvent } from 'react';
 import { PanelDrillDownLink } from '../../index';
 import { FormField, Switch } from '../index';
 
-export interface DrilldownLinkEditor {
+interface DrilldownLinkEditorProps {
   index: number;
   value: PanelDrillDownLink;
   onChange: (index: number, link: PanelDrillDownLink) => void;
   onRemove: (link: PanelDrillDownLink) => void;
 }
 
-export const DrilldownLinkEditor: FC<DrilldownLinkEditor> = React.memo(({ index, value, onChange, onRemove }) => {
+export const DrilldownLinkEditor: FC<DrilldownLinkEditorProps> = React.memo(({ index, value, onChange, onRemove }) => {
   const [linkUrl, setLinkUrl] = useState(value.url);
   const [title, setTitle] = useState(value.title);
 

--- a/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinksEditor.tsx
+++ b/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinksEditor.tsx
@@ -1,0 +1,64 @@
+// Libraries
+import React, { FC, useContext } from 'react';
+
+// Components
+import { css } from 'emotion';
+import { PanelDrillDownLink, ThemeContext } from '../../index';
+import { Button, ButtonVariant } from '../index';
+import { DrilldownLinkEditor } from './DrilldownLinkEditor';
+
+export interface Props {
+  value: PanelDrillDownLink[];
+  onChange: (links: PanelDrillDownLink[]) => void;
+}
+
+export const DrilldownLinksEditor: FC<Props> = React.memo(({ value, onChange }) => {
+  const theme = useContext(ThemeContext);
+
+  const onAdd = () => {
+    onChange([...value, { url: '', title: '' }]);
+  };
+
+  const onLinkChanged = (linkIndex: number, newLink: PanelDrillDownLink) => {
+    onChange(
+      value.map((item, listIndex) => {
+        if (linkIndex === listIndex) {
+          return newLink;
+        }
+        return item;
+      })
+    );
+  };
+
+  const onRemove = (link: PanelDrillDownLink) => {
+    onChange(value.filter(item => item !== link));
+  };
+
+  return (
+    <>
+      {value && value.length > 0 && (
+        <div
+          className={css`
+            margin-bottom: ${theme.spacing.sm};
+          `}
+        >
+          {value.map((link, index) => (
+            <DrilldownLinkEditor
+              key={index.toString()}
+              index={index}
+              value={link}
+              onChange={onLinkChanged}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+
+      <Button variant={ButtonVariant.Inverse} icon="fa fa-plus" onClick={() => onAdd()}>
+        Create link
+      </Button>
+    </>
+  );
+});
+
+DrilldownLinksEditor.displayName = 'DrilldownLinksEditor';

--- a/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinksEditor.tsx
+++ b/packages/grafana-ui/src/components/DrilldownLinks/DrilldownLinksEditor.tsx
@@ -7,12 +7,12 @@ import { PanelDrillDownLink, ThemeContext } from '../../index';
 import { Button, ButtonVariant } from '../index';
 import { DrilldownLinkEditor } from './DrilldownLinkEditor';
 
-export interface Props {
+interface DrilldownLinksEditorProps {
   value: PanelDrillDownLink[];
   onChange: (links: PanelDrillDownLink[]) => void;
 }
 
-export const DrilldownLinksEditor: FC<Props> = React.memo(({ value, onChange }) => {
+export const DrilldownLinksEditor: FC<DrilldownLinksEditorProps> = React.memo(({ value, onChange }) => {
   const theme = useContext(ThemeContext);
 
   const onAdd = () => {

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -6,6 +6,7 @@ export { Portal } from './Portal/Portal';
 export { CustomScrollbar } from './CustomScrollbar/CustomScrollbar';
 
 export * from './Button/Button';
+export { ButtonVariant } from './Button/AbstractButton';
 
 // Select
 export { Select, AsyncSelect, SelectOptionItem } from './Select/Select';
@@ -65,3 +66,4 @@ export { ClickOutsideWrapper } from './ClickOutsideWrapper/ClickOutsideWrapper';
 export * from './SingleStatShared/index';
 export { CallToActionCard } from './CallToActionCard/CallToActionCard';
 export { ContextMenu, ContextMenuItem } from './ContextMenu/ContextMenu';
+export { DrilldownLinksEditor } from './DrilldownLinks/DrilldownLinksEditor';

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -8,7 +8,13 @@ import { TagFilter } from './components/TagFilter/TagFilter';
 import { SideMenu } from './components/sidemenu/SideMenu';
 import { MetricSelect } from './components/Select/MetricSelect';
 import AppNotificationList from './components/AppNotifications/AppNotificationList';
-import { ColorPicker, SeriesColorPickerPopoverWithTheme, SecretFormField, ContextMenu } from '@grafana/ui';
+import {
+  ColorPicker,
+  SeriesColorPickerPopoverWithTheme,
+  SecretFormField,
+  ContextMenu,
+  DrilldownLinksEditor,
+} from '@grafana/ui';
 import { FunctionEditor } from 'app/plugins/datasource/graphite/FunctionEditor';
 import { SearchField } from './components/search/SearchField';
 
@@ -77,5 +83,10 @@ export function registerAngularDirectives() {
     'y',
     'items',
     ['onClose', { watchDepth: 'reference', wrapApply: true }],
+  ]);
+
+  react2AngularDirective('drilldownLinksEditor', DrilldownLinksEditor, [
+    'value',
+    ['onChange', { watchDepth: 'reference', wrapApply: true }],
   ]);
 }

--- a/public/app/features/dashboard/panel_editor/GeneralTab.tsx
+++ b/public/app/features/dashboard/panel_editor/GeneralTab.tsx
@@ -4,12 +4,12 @@ import React, { PureComponent } from 'react';
 // Components
 import { getAngularLoader, AngularComponent } from 'app/core/services/AngularLoader';
 import { EditorTabBody } from './EditorTabBody';
-import { PanelLinksEditor } from '../../panel/PanelLinksEditor/PanelLinksEditor';
+import { DrilldownLinksEditor } from '@grafana/ui';
 import './../../panel/GeneralTabCtrl';
 
 // Types
 import { PanelModel } from '../state/PanelModel';
-import { PanelDrillDownLink } from '@grafana/ui';
+import { PanelDrillDownLink, PanelOptionsGroup } from '@grafana/ui';
 
 interface Props {
   panel: PanelModel;
@@ -60,7 +60,9 @@ export class GeneralTab extends PureComponent<Props> {
       <EditorTabBody heading="General" toolbarItems={[]}>
         <>
           <div ref={element => (this.element = element)} />
-          <PanelLinksEditor value={panel.links} onChange={this.onPanelDrillDownLinksChanged} />
+          <PanelOptionsGroup title="Panel links">
+            <DrilldownLinksEditor value={panel.links} onChange={this.onPanelDrillDownLinksChanged} />
+          </PanelOptionsGroup>
         </>
       </EditorTabBody>
     );

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -177,7 +177,7 @@ class GraphElement {
   }
 
   getContextMenuItems = (flotPosition: { x: number; y: number }, item?: FlotDataPoint): ContextMenuItem[] => {
-    const drilldownLinks: PanelDrillDownLink[] = this.panel.links || [];
+    const drilldownLinks: PanelDrillDownLink[] = this.panel.options.drilldownLinks || [];
 
     const items: ContextMenuItem[] = [
       {

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -11,7 +11,7 @@ import { DataProcessor } from './data_processor';
 import { axesEditorComponent } from './axes_editor';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
-import { getColorFromHexRgbOrName, LegacyResponseData, SeriesData } from '@grafana/ui';
+import { getColorFromHexRgbOrName, LegacyResponseData, SeriesData, PanelDrillDownLink } from '@grafana/ui';
 import { getProcessedSeriesData } from 'app/features/dashboard/state/PanelQueryState';
 import { PanelQueryRunnerFormat } from 'app/features/dashboard/state/PanelQueryRunner';
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
@@ -120,6 +120,9 @@ class GraphCtrl extends MetricsPanelCtrl {
     seriesOverrides: [],
     thresholds: [],
     timeRegions: [],
+    options: {
+      drilldownLinks: [],
+    },
   };
 
   /** @ngInject */
@@ -130,6 +133,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel.tooltip, this.panelDefaults.tooltip);
     _.defaults(this.panel.legend, this.panelDefaults.legend);
     _.defaults(this.panel.xaxis, this.panelDefaults.xaxis);
+    _.defaults(this.panel.options, this.panelDefaults.options);
 
     this.dataFormat = PanelQueryRunnerFormat.series;
     this.processor = new DataProcessor(this.panel);
@@ -141,6 +145,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.events.on('data-snapshot-load', this.onDataSnapshotLoad.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
     this.events.on('init-panel-actions', this.onInitPanelActions.bind(this));
+
+    this.onDrilldownLinksChange = this.onDrilldownLinksChange.bind(this);
   }
 
   onInitEditMode() {
@@ -148,6 +154,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.addEditorTab('Axes', axesEditorComponent);
     this.addEditorTab('Legend', 'public/app/plugins/panel/graph/tab_legend.html');
     this.addEditorTab('Thresholds & Time Regions', 'public/app/plugins/panel/graph/tab_thresholds_time_regions.html');
+    this.addEditorTab('Drilldown links', 'public/app/plugins/panel/graph/tab_drilldown_links.html');
     this.subTabIndex = 0;
   }
 
@@ -284,6 +291,13 @@ class GraphCtrl extends MetricsPanelCtrl {
     override.yaxis = info.yaxis;
     this.render();
   };
+
+  onDrilldownLinksChange(drilldownLinks: PanelDrillDownLink[]) {
+    this.panel.updateOptions({
+      ...this.panel.options,
+      drilldownLinks,
+    });
+  }
 
   addSeriesOverride(override) {
     this.panel.seriesOverrides.push(override || {});

--- a/public/app/plugins/panel/graph/tab_drilldown_links.html
+++ b/public/app/plugins/panel/graph/tab_drilldown_links.html
@@ -1,0 +1,4 @@
+<drilldown-links-editor
+  value="ctrl.panel.options.drilldownLinks"
+  on-change="(ctrl.onDrilldownLinksChange)"
+></drilldown-links-editor>


### PR DESCRIPTION
1. Renamed `PanelLinksEditor` to `DrilldownLinksEditor` and moved to grafana/ui
2. Removed PanelOptionsGroup from above, as this ain't part of the editor
2. Introduced visualization drilldown links. These links model is stored in PanelModel.options object under `drilldownLinks` key. I don't like the separation of panel links being available directly on PanelModel and "visualization" links in PanelModel.options object. I was thinking, maybe a simple idea to start with is to have interfaces for "links" options that would hold panel links and drilldown links? Then we could store both of these on PanelModel.options level

Sth like:
```
interface ValueLinks {
 valueLinks: DrilldownLink[], // would hold value specific links, used by i.e. viz
}

interface PanelLinks {
  panelLinks: DrilldownLink[], 
}
```

-  for example ColumnStyles or FieldOptions interface would extend ValueLinks interface to get the links editor
- panel that wants drill down functionality would extend it's options using both of above interfaces
