### PR TITLE
Chore: Remove unused properties in explore

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -75,9 +75,7 @@ export class DataSourcePlugin<
 export interface DataSourcePluginMeta extends PluginMeta {
   builtIn?: boolean; // Is this for all
   metrics?: boolean;
-  tables?: boolean;
   logs?: boolean;
-  explore?: boolean;
   annotations?: boolean;
   alerting?: boolean;
   mixed?: boolean;

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -144,7 +144,6 @@ describe('Explore item reducer', () => {
             meta: {
               metrics: true,
               logs: true,
-              tables: true,
             },
             components: {
               ExploreStartPage: StartPage,
@@ -154,9 +153,6 @@ describe('Explore item reducer', () => {
           const queryKeys: string[] = [];
           const initalState: Partial<ExploreItemState> = {
             datasourceInstance: null,
-            supportsGraph: false,
-            supportsLogs: false,
-            supportsTable: false,
             StartPage: null,
             showingStartPage: false,
             queries,
@@ -164,9 +160,6 @@ describe('Explore item reducer', () => {
           };
           const expectedState = {
             datasourceInstance,
-            supportsGraph: true,
-            supportsLogs: true,
-            supportsTable: true,
             StartPage,
             showingStartPage: true,
             queries,

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -103,9 +103,6 @@ export const makeExploreItemState = (): ExploreItemState => ({
   graphIsLoading: false,
   logIsLoading: false,
   tableIsLoading: false,
-  supportsGraph: null,
-  supportsLogs: null,
-  supportsTable: null,
   queryKeys: [],
   urlState: null,
   update: makeInitialUpdateState(),
@@ -246,7 +243,6 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       // Capabilities
       const supportsGraph = datasourceInstance.meta.metrics;
       const supportsLogs = datasourceInstance.meta.logs;
-      const supportsTable = datasourceInstance.meta.tables;
 
       let mode = ExploreMode.Metrics;
       const supportedModes: ExploreMode[] = [];
@@ -274,9 +270,6 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         graphIsLoading: false,
         logIsLoading: false,
         tableIsLoading: false,
-        supportsGraph,
-        supportsLogs,
-        supportsTable,
         StartPage,
         showingStartPage: Boolean(StartPage),
         queryKeys: getQueryKeys(state.queries, datasourceInstance),

--- a/public/app/plugins/datasource/graphite/plugin.json
+++ b/public/app/plugins/datasource/graphite/plugin.json
@@ -10,7 +10,6 @@
   "metrics": true,
   "alerting": true,
   "annotations": true,
-  "tables": false,
 
   "queryOptions": {
     "maxDataPoints": true,

--- a/public/app/plugins/datasource/influxdb/plugin.json
+++ b/public/app/plugins/datasource/influxdb/plugin.json
@@ -8,7 +8,6 @@
   "metrics": true,
   "annotations": true,
   "alerting": true,
-  "tables": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/input/plugin.json
+++ b/public/app/plugins/datasource/input/plugin.json
@@ -8,7 +8,6 @@
   "alerting": false,
   "annotations": false,
   "logs": false,
-  "explore": false,
 
   "info": {
     "description": "Data source that supports manual table & CSV input",

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -8,8 +8,6 @@
   "alerting": false,
   "annotations": false,
   "logs": true,
-  "explore": true,
-  "tables": false,
 
   "info": {
     "description": "Like Prometheus but for logs. OSS logging solution from Grafana Labs",

--- a/public/app/plugins/datasource/mssql/plugin.json
+++ b/public/app/plugins/datasource/mssql/plugin.json
@@ -19,7 +19,6 @@
   "alerting": true,
   "annotations": true,
   "metrics": true,
-  "tables": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/mysql/plugin.json
+++ b/public/app/plugins/datasource/mysql/plugin.json
@@ -19,7 +19,6 @@
   "alerting": true,
   "annotations": true,
   "metrics": true,
-  "tables": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/opentsdb/plugin.json
+++ b/public/app/plugins/datasource/opentsdb/plugin.json
@@ -8,7 +8,6 @@
   "defaultMatchFormat": "pipe",
   "annotations": true,
   "alerting": true,
-  "tables": false,
 
   "info": {
     "description": "Open source time series database",

--- a/public/app/plugins/datasource/postgres/plugin.json
+++ b/public/app/plugins/datasource/postgres/plugin.json
@@ -19,7 +19,6 @@
   "alerting": true,
   "annotations": true,
   "metrics": true,
-  "tables": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -24,8 +24,6 @@
   "metrics": true,
   "alerting": true,
   "annotations": true,
-  "explore": true,
-  "tables": true,
   "queryOptions": {
     "minInterval": true
   },

--- a/public/app/plugins/datasource/stackdriver/plugin.json
+++ b/public/app/plugins/datasource/stackdriver/plugin.json
@@ -7,7 +7,6 @@
   "metrics": true,
   "alerting": true,
   "annotations": true,
-  "tables": false,
   "queryOptions": {
     "maxDataPoints": true,
     "cacheTimeout": true

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -214,18 +214,6 @@ export interface ExploreItemState {
    * True if table result viewer is expanded. Query runs will contain table queries.
    */
   showingTable: boolean;
-  /**
-   * True if `datasourceInstance` supports graph queries.
-   */
-  supportsGraph: boolean | null;
-  /**
-   * True if `datasourceInstance` supports logs queries.
-   */
-  supportsLogs: boolean | null;
-  /**
-   * True if `datasourceInstance` supports table queries.
-   */
-  supportsTable: boolean | null;
 
   graphIsLoading: boolean;
   logIsLoading: boolean;


### PR DESCRIPTION
This removes unused properties in explore and datasource meta data (tables and explore properties in plugin.json).

As far as I can see nothing of this is in use any longer. 