### PR TITLE
 Security: Prevent CSV formula injection attack when exporting data

### DIFF
--- a/public/app/core/specs/file_export.test.ts
+++ b/public/app/core/specs/file_export.test.ts
@@ -92,6 +92,7 @@ describe('file_export', () => {
           [0x123, 'some string with \n in the middle', 10.01, false],
           [0b1011, 'some string with ; in the middle', -12.34, true],
           [123, 'some string with ;; in the middle', -12.34, true],
+          [1234, '=a bogus formula  ', '-and another', '+another', '@ref'],
         ],
       };
 
@@ -108,7 +109,8 @@ describe('file_export', () => {
         '501;"some string with "" at the end""";0.01;false\r\n' +
         '291;"some string with \n in the middle";10.01;false\r\n' +
         '11;"some string with ; in the middle";-12.34;true\r\n' +
-        '123;"some string with ;; in the middle";-12.34;true';
+        '123;"some string with ;; in the middle";-12.34;true\r\n' +
+        '1234;"\'=a bogus formula";"\'-and another";"\'+another";"\'@ref"';
 
       expect(returnedText).toBe(expectedText);
     });

--- a/public/app/core/utils/file_export.ts
+++ b/public/app/core/utils/file_export.ts
@@ -17,7 +17,11 @@ function csvEscaped(text) {
     return text;
   }
 
-  return text.split(QUOTE).join(QUOTE + QUOTE);
+  return text
+    .split(QUOTE)
+    .join(QUOTE + QUOTE)
+    .replace(/^([-+=@])/, "'$1")
+    .replace(/\s+$/, '');
 }
 
 const domParser = new DOMParser();


### PR DESCRIPTION
This PR mitigates the vulnerability described at https://www.owasp.org/index.php/CSV_Injection whereby a malicious user can craft a query that results in CSV output which would be interpreted as a function by spreadsheet software.

It prevents this attack by prepending any string value starting with `-`, `+`, `=`, or `@` with a single quote, which is used in spreadsheet applications to signify that the cell content is plain text and should not be interpreted as a formula or reference.

It also strips trailing whitespace from all text values per the OWASP recommendation.