### PR TITLE
Feature: Adds redux action logging toggle from url params

### DIFF
--- a/public/app/core/actions/application.ts
+++ b/public/app/core/actions/application.ts
@@ -1,0 +1,3 @@
+import { noPayloadActionCreatorFactory } from 'app/core/redux';
+
+export const toggleLogActions = noPayloadActionCreatorFactory('TOGGLE_LOG_ACTIONS').create();

--- a/public/app/core/middlewares/application.ts
+++ b/public/app/core/middlewares/application.ts
@@ -1,0 +1,27 @@
+import { Store, Dispatch } from 'redux';
+import { StoreState } from 'app/types/store';
+import { ActionOf } from '../redux/actionCreatorFactory';
+import { toggleLogActions } from '../actions/application';
+
+export const toggleLogActionsMiddleware = (store: Store<StoreState>) => (next: Dispatch) => (action: ActionOf<any>) => {
+  const isLogActionsAction = action.type === toggleLogActions.type;
+  if (isLogActionsAction) {
+    return next(action);
+  }
+
+  const logActionsTrue =
+    window && window.location && window.location.search && window.location.search.indexOf('logActions=true') !== -1;
+  const logActionsFalse =
+    window && window.location && window.location.search && window.location.search.indexOf('logActions=false') !== -1;
+  const logActions = store.getState().application.logActions;
+
+  if (logActionsTrue && !logActions) {
+    store.dispatch(toggleLogActions());
+  }
+
+  if (logActionsFalse && logActions) {
+    store.dispatch(toggleLogActions());
+  }
+
+  return next(action);
+};

--- a/public/app/core/reducers/application.ts
+++ b/public/app/core/reducers/application.ts
@@ -1,0 +1,17 @@
+import { ApplicationState } from 'app/types/application';
+import { reducerFactory } from 'app/core/redux';
+import { toggleLogActions } from '../actions/application';
+
+export const initialState: ApplicationState = {
+  logActions: false,
+};
+
+export const applicationReducer = reducerFactory<ApplicationState>(initialState)
+  .addMapper({
+    filter: toggleLogActions,
+    mapper: (state): ApplicationState => ({
+      ...state,
+      logActions: !state.logActions,
+    }),
+  })
+  .create();

--- a/public/app/core/reducers/index.ts
+++ b/public/app/core/reducers/index.ts
@@ -1,9 +1,11 @@
 import { navIndexReducer as navIndex } from './navModel';
 import { locationReducer as location } from './location';
 import { appNotificationsReducer as appNotifications } from './appNotification';
+import { applicationReducer as application } from './application';
 
 export default {
   navIndex,
   location,
   appNotifications,
+  application,
 };

--- a/public/app/types/application.ts
+++ b/public/app/types/application.ts
@@ -1,0 +1,3 @@
+export interface ApplicationState {
+  logActions: boolean;
+}

--- a/public/app/types/store.ts
+++ b/public/app/types/store.ts
@@ -13,6 +13,7 @@ import { OrganizationState } from './organization';
 import { AppNotificationsState } from './appNotifications';
 import { PluginsState } from './plugins';
 import { NavIndex } from '@grafana/ui';
+import { ApplicationState } from './application';
 
 export interface StoreState {
   navIndex: NavIndex;
@@ -29,6 +30,7 @@ export interface StoreState {
   appNotifications: AppNotificationsState;
   user: UserState;
   plugins: PluginsState;
+  application: ApplicationState;
 }
 
 /*


### PR DESCRIPTION
**What this PR does / why we need it**:
With live tailing introduced in Explore we now have a lot of actions dispatching and the Redux Dev Tools doesn't cope with the amount and rate of actions and crashes. This PR turns on redux action logging when you add `logActions=true` in the url and turns it off if you refresh the page or add `logActions=false` in the url.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

