### PR TITLE
UI: Adjust padding for HD fullscreen

### DIFF
--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -196,7 +196,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 $side-menu-width: 60px;
 
 // dashboard
-$dashboard-padding: $space-md;
+$dashboard-padding: $space-sm;
 $panel-padding: ${theme.panelPadding}px;
 $panel-header-height: ${theme.panelHeaderHeight}px;
 $panel-header-z-index: 10;

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -199,7 +199,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 $side-menu-width: 60px;
 
 // dashboard
-$dashboard-padding: $space-md;
+$dashboard-padding: $space-sm;
 $panel-padding: 8px;
 $panel-header-height: 28px;
 $panel-header-z-index: 10;


### PR DESCRIPTION
Hi,

In a HD fullscreen dashboard (1080 pixels in height), you are able to put 3 graphs, all 3 being 9 "units" in height.
Unfortunately, a few pixels are then missing here to avoid triggering the vertical scrollbar.

Here is then a fix to give the dashboard a little more space, thus 3 identical graphs can maximize used space in HD fullscreen mode, without triggering the vertical scrollbar.

Thank you 👍 