### PR TITLE
Explore: Handle datasources with long names better in ds picker

### DIFF
--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -22,6 +22,11 @@
   .ds-picker {
     min-width: 200px;
     max-width: 200px;
+
+    .gf-form-select-box__img-value {
+      max-width: 150px;
+      overflow: hidden;
+    }
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a max width to the inner content of ds picker to handle datasources with long names better. Note that when having metrics/logs switcher a datasource with long name got render behind the switch buttons and that's why this change is needed.

Before:
![image](https://user-images.githubusercontent.com/1668778/58716082-90599a80-83c8-11e9-8994-5580e571dddf.png)

![image](https://user-images.githubusercontent.com/1668778/58716297-03fba780-83c9-11e9-9517-b06fb8a93198.png)

After:
![image](https://user-images.githubusercontent.com/1668778/58716094-93ed2180-83c8-11e9-9e0e-9593e768e529.png)

![image](https://user-images.githubusercontent.com/1668778/58716329-1544b400-83c9-11e9-9c77-9bb23015ec89.png)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Think we may have to address this problem for ds picker in a better way in the future.