### PR TITLE
Build: specify build flag for `docker-compose up`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ devenv: devenv-down
 	(rm -rf docker-compose.yaml; exit 1)
 
 	@cd devenv; \
-	docker-compose up -d
+	docker-compose up -d --build
 endif
 
 # drop down the envs


### PR DESCRIPTION
Otherwise changed data will not get refreshed to the previous
state.

Which I think is not evident (unless you are familar with docker-compose).
and therefore error-prone (at least it did for me)
