### PR TITLE
CLI: Search perf test data

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "typecheck": "tsc --noEmit",
     "jest": "jest --notify --watch",
     "e2e-tests": "jest --runInBand --config=jest.config.e2e.js",
-    "api-tests": "jest --notify --watch --config=tests/api/jest.js",
+    "api-tests": "jest --notify --watch --config=devenv/e2e-api-tests/jest.js",
     "storybook": "cd packages/grafana-ui && yarn storybook",
     "storybook:build": "cd packages/grafana-ui && yarn storybook:build",
     "themes:generate": "ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/generateSassVariableFiles.ts",

--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -20,7 +20,6 @@ func addDashboardAclMigrations(mg *Migrator) {
 			{Cols: []string{"dashboard_id"}},
 			{Cols: []string{"dashboard_id", "user_id"}, Type: UniqueIndex},
 			{Cols: []string{"dashboard_id", "team_id"}, Type: UniqueIndex},
-			{Cols: []string{"org_id"}},
 		},
 	}
 
@@ -47,7 +46,4 @@ INSERT INTO dashboard_acl
 	`
 
 	mg.AddMigration("save default acl rules in dashboard_acl table", NewRawSqlMigration(rawSQL))
-
-	// Add index for org_id
-	mg.AddMigration("add unique index dashboard_acl_org_id", NewAddIndexMigration(dashboardAclV1, dashboardAclV1.Indices[3]))
 }

--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -20,6 +20,7 @@ func addDashboardAclMigrations(mg *Migrator) {
 			{Cols: []string{"dashboard_id"}},
 			{Cols: []string{"dashboard_id", "user_id"}, Type: UniqueIndex},
 			{Cols: []string{"dashboard_id", "team_id"}, Type: UniqueIndex},
+			{Cols: []string{"org_id"}},
 		},
 	}
 
@@ -46,4 +47,7 @@ INSERT INTO dashboard_acl
 	`
 
 	mg.AddMigration("save default acl rules in dashboard_acl table", NewRawSqlMigration(rawSQL))
+
+	// Add index for org_id
+	mg.AddMigration("add unique index dashboard_acl_org_id", NewAddIndexMigration(dashboardAclV1, dashboardAclV1.Indices[3]))
 }

--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -7,6 +7,7 @@ import { releaseTask } from './tasks/grafanaui.release';
 import { changelogTask } from './tasks/changelog';
 import { cherryPickTask } from './tasks/cherrypick';
 import { precommitTask } from './tasks/precommit';
+import { searchTestDataSetupTask } from './tasks/searchTestDataSetup';
 
 program.option('-d, --depreciate <scripts>', 'Inform about npm script deprecation', v => v.split(','));
 
@@ -70,6 +71,14 @@ program
   .description('Executes checks')
   .action(async cmd => {
     await execTask(precommitTask)({});
+  });
+
+program
+  .command('searchTestData')
+  .option('-c, --count <number_of_dashboards>', 'Specify number of dashboards')
+  .description('Setup test data for search')
+  .action(async cmd => {
+    await execTask(searchTestDataSetupTask)({ count: cmd.count });
   });
 
 program.parse(process.argv);

--- a/scripts/cli/tasks/searchTestDataSetup.ts
+++ b/scripts/cli/tasks/searchTestDataSetup.ts
@@ -1,0 +1,117 @@
+import axios from 'axios';
+import _ from 'lodash';
+import { Task, TaskRunner } from './task';
+
+interface SearchTestDataSetupOptions {
+  count: number;
+}
+
+const client = axios.create({
+  baseURL: 'http://localhost:3000/api',
+  auth: {
+    username: 'admin',
+    password: 'admin2',
+  },
+});
+
+export async function getUser(user): Promise<any> {
+  console.log('Creating user ' + user.name);
+  const search = await client.get('/users/search', {
+    params: { query: user.login },
+  });
+
+  if (search.data.totalCount === 1) {
+    user.id = search.data.users[0].id;
+    return user;
+  }
+
+  const rsp = await client.post('/admin/users', user);
+  user.id = rsp.data.id;
+  return user;
+}
+
+export async function getTeam(team: any): Promise<any> {
+  // delete if exists
+  const teams = await client.get('/teams/search');
+  for (const existing of teams.data.teams) {
+    if (existing.name === team.name) {
+      console.log('Team exists, deleting');
+      await client.delete('/teams/' + existing.id);
+    }
+  }
+
+  console.log('Creating team ' + team.name);
+  const teamRsp = await client.post(`/teams`, team);
+  team.id = teamRsp.data.teamId;
+  return team;
+}
+
+export async function addToTeam(team: any, user: any): Promise<any> {
+  const members = await client.get(`/teams/${team.id}/members`);
+  console.log(`Adding user ${user.name} to team ${team.name}`);
+  await client.post(`/teams/${team.id}/members`, { userId: user.id });
+}
+
+export async function setDashboardAcl(dashboardId: any, aclList: any) {
+  console.log('Setting Dashboard ACL ' + dashboardId);
+  await client.post(`/dashboards/id/${dashboardId}/permissions`, { items: aclList });
+}
+
+const searchTestDataSetupRunnner: TaskRunner<SearchTestDataSetupOptions> = async ({ count }) => {
+  const user1 = await getUser({
+    name: 'searchTestUser1',
+    email: 'searchTestUser@team.com',
+    login: 'searchTestUser1',
+    password: '12345',
+  });
+
+  const team1 = await getTeam({ name: 'searchTestTeam1', email: 'searchtestdata@team.com' });
+  addToTeam(team1, user1);
+
+  // create or update folder
+  const folder: any = {
+    uid: 'search-test-data',
+    title: 'Search test data folder',
+    version: 1,
+  };
+
+  try {
+    await client.delete(`/folders/${folder.uid}`);
+  } catch (err) {}
+
+  console.log('Creating folder');
+
+  const rsp = await client.post(`/folders`, folder);
+  folder.id = rsp.data.id;
+  folder.url = rsp.data.url;
+
+  await setDashboardAcl(folder.id, []);
+
+  console.log('Creating dashboards');
+
+  const dashboards: any = [];
+
+  for (let i = 0; i < count; i++) {
+    const dashboard: any = {
+      uid: 'search-test-dash-' + i.toString().padStart(5, '0'),
+      title: 'Search test dash ' + i.toString().padStart(5, '0'),
+    };
+
+    const rsp = await client.post(`/dashboards/db`, {
+      dashboard: dashboard,
+      folderId: folder.id,
+      overwrite: true,
+    });
+
+    dashboard.id = rsp.data.id;
+    dashboard.url = rsp.data.url;
+
+    console.log('Created dashboard ' + dashboard.title);
+    dashboards.push(dashboard);
+    await setDashboardAcl(dashboard.id, [{ userId: 0, teamId: team1.id, permission: 4 }]);
+  }
+};
+
+export const searchTestDataSetupTask = new Task<SearchTestDataSetupOptions>();
+searchTestDataSetupTask.setName('Search test data setup');
+searchTestDataSetupTask.setRunner(searchTestDataSetupRunnner);


### PR DESCRIPTION
Adds new yarn cli command

```
yarn cli searchTestData -c 100
```

will create a 100 dashboards each with one team ACL entry (that has one user member). 

When adding 10000 dashboards and login with the searchTestUser1 user the search is unusably slow and in some cases grafana stops responding and I cannot do full page reload / login. 

