### PR TITLE
Database: Fixed slow permission query in folder/dashboard search

### DIFF
--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -45,31 +45,48 @@ func (sb *SqlBuilder) writeDashboardPermissionFilter(user *m.SignedInUser, permi
 	sb.sql.WriteString(` AND
 	(
 		dashboard.id IN (
-			SELECT distinct d.id AS DashboardId
-			FROM dashboard AS d
-			 	LEFT JOIN dashboard folder on folder.id = d.folder_id
-			    LEFT JOIN dashboard_acl AS da ON
-	 			da.dashboard_id = d.id OR
-	 			da.dashboard_id = d.folder_id OR
-	 			(
-	 				-- include default permissions -->
-					da.org_id = -1 AND (
-					  (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
-					  (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
-					)
-	 			)
-				LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
-			WHERE
-				d.org_id = ? AND
-				da.permission >= ? AND
-				(
-					da.user_id = ? OR
-					ugm.user_id = ? OR
-					da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
-				)
+			SELECT distinct DashboardId from (
+				SELECT d.id AS DashboardId
+					FROM dashboard AS d
+					LEFT JOIN dashboard AS folder on folder.id = d.folder_id
+					LEFT JOIN dashboard_acl AS da ON
+						da.dashboard_id = d.id OR
+						da.dashboard_id = d.folder_id
+					LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
+					WHERE
+						d.org_id = ? AND
+						da.permission >= ? AND
+						(
+							da.user_id = ? OR
+							ugm.user_id = ? OR
+							da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
+						)
+				UNION
+				SELECT d.id AS DashboardId
+					FROM dashboard AS d
+					LEFT JOIN dashboard AS folder on folder.id = d.folder_id
+					LEFT JOIN dashboard_acl AS da ON
+						(
+							-- include default permissions -->
+							da.org_id = -1 AND (
+							  (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
+							  (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
+							)
+						)
+					WHERE
+						d.org_id = ? AND
+						da.permission >= ? AND
+						(
+							da.user_id = ? OR
+							da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
+						)
+			) AS a
 		)
 	)`)
 
 	sb.params = append(sb.params, user.OrgId, permission, user.UserId, user.UserId)
+	sb.params = append(sb.params, okRoles...)
+
+	sb.params = append(sb.params, user.OrgId, permission, user.UserId)
 	sb.params = append(sb.params, okRoles...)
 }

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -1,0 +1,345 @@
+package sqlstore
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSqlBuilder(t *testing.T) {
+	t.Run("writeDashboardPermissionFilter", func(t *testing.T) {
+		t.Run("user ACL", func(t *testing.T) {
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{User: true, Permission: models.PERMISSION_VIEW},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_VIEW},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{User: true, Permission: models.PERMISSION_VIEW},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_EDIT},
+				shouldNotFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{User: true, Permission: models.PERMISSION_EDIT},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_EDIT},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{User: true, Permission: models.PERMISSION_VIEW},
+				Search{RequiredPermission: models.PERMISSION_VIEW},
+				shouldNotFind,
+			)
+		})
+
+		t.Run("role ACL", func(t *testing.T) {
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Role: models.ROLE_VIEWER, Permission: models.PERMISSION_VIEW},
+				Search{UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_VIEW},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Role: models.ROLE_VIEWER, Permission: models.PERMISSION_VIEW},
+				Search{UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_EDIT},
+				shouldNotFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Role: models.ROLE_EDITOR, Permission: models.PERMISSION_VIEW},
+				Search{UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_VIEW},
+				shouldNotFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Role: models.ROLE_EDITOR, Permission: models.PERMISSION_VIEW},
+				Search{UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_VIEW},
+				shouldNotFind,
+			)
+		})
+
+		t.Run("team ACL", func(t *testing.T) {
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Team: true, Permission: models.PERMISSION_VIEW},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_VIEW},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Team: true, Permission: models.PERMISSION_VIEW},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_EDIT},
+				shouldNotFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Team: true, Permission: models.PERMISSION_EDIT},
+				Search{UserFromACL: true, RequiredPermission: models.PERMISSION_EDIT},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{},
+				&DashboardPermission{Team: true, Permission: models.PERMISSION_EDIT},
+				Search{UserFromACL: false, RequiredPermission: models.PERMISSION_EDIT},
+				shouldNotFind,
+			)
+		})
+
+		t.Run("defaults for user ACL", func(t *testing.T) {
+			test(t,
+				DashboardProps{},
+				nil,
+				Search{OrgId: -1, UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_VIEW},
+				shouldNotFind,
+			)
+
+			test(t,
+				DashboardProps{OrgId: -1},
+				nil,
+				Search{OrgId: -1, UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_VIEW},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{OrgId: -1},
+				nil,
+				Search{OrgId: -1, UsersOrgRole: models.ROLE_EDITOR, RequiredPermission: models.PERMISSION_EDIT},
+				shouldFind,
+			)
+
+			test(t,
+				DashboardProps{OrgId: -1},
+				nil,
+				Search{OrgId: -1, UsersOrgRole: models.ROLE_VIEWER, RequiredPermission: models.PERMISSION_EDIT},
+				shouldNotFind,
+			)
+		})
+	})
+}
+
+var shouldFind = true
+var shouldNotFind = false
+
+type DashboardProps struct {
+	OrgId int64
+}
+
+type DashboardPermission struct {
+	User       bool
+	Team       bool
+	Role       models.RoleType
+	Permission models.PermissionType
+}
+
+type Search struct {
+	UsersOrgRole       models.RoleType
+	UserFromACL        bool
+	RequiredPermission models.PermissionType
+	OrgId              int64
+}
+
+type dashboardResponse struct {
+	Id int64
+}
+
+func test(t *testing.T, dashboardProps DashboardProps, dashboardPermission *DashboardPermission, search Search, shouldFind bool) {
+	// Will also cleanup the db
+	_ = os.Setenv("GRAFANA_TEST_DB", "postgres")
+	sqlStore := InitTestDB(t)
+
+	dashboard, err := createDummyDashboard(dashboardProps)
+	if !assert.Equal(t, nil, err) {
+		return
+	}
+
+	var aclUserId int64
+	if dashboardPermission != nil {
+		aclUserId, err = createDummyAcl(dashboardPermission, search, dashboard.Id)
+		if !assert.Equal(t, nil, err) {
+			return
+		}
+	}
+	dashboards, err := getDashboards(sqlStore, search, aclUserId)
+	if !assert.Equal(t, nil, err) {
+		return
+	}
+
+	if shouldFind {
+		if assert.Equal(t, 1, len(dashboards), "Should return one dashboard") {
+			assert.Equal(t, dashboards[0].Id, dashboard.Id, "Should return created dashboard")
+		}
+	} else {
+		assert.Equal(t, 0, len(dashboards), "Should node return any dashboard")
+	}
+}
+
+func createDummyUser() (*models.User, error) {
+	uid := rand.Intn(9999999)
+	createUserCmd := &models.CreateUserCommand{
+		Email:          string(uid) + "@example.com",
+		Login:          string(uid),
+		Name:           string(uid),
+		Company:        "",
+		OrgName:        "",
+		Password:       string(uid),
+		EmailVerified:  true,
+		IsAdmin:        false,
+		SkipOrgSetup:   false,
+		DefaultOrgRole: string(models.ROLE_VIEWER),
+	}
+	err := CreateUser(context.Background(), createUserCmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createUserCmd.Result, nil
+}
+
+func createDummyTeam() (*models.Team, error) {
+	cmd := &models.CreateTeamCommand{
+		// Does not matter in this tests actually
+		OrgId: 1,
+		Name:  "test",
+		Email: "test@example.com",
+	}
+	err := CreateTeam(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cmd.Result, nil
+}
+
+func createDummyDashboard(dashboardProps DashboardProps) (*models.Dashboard, error) {
+	json, err := simplejson.NewJson([]byte(`{"schemaVersion":17,"title":"gdev dashboards","uid":"","version":1}`))
+	saveDashboardCmd := &models.SaveDashboardCommand{
+		Dashboard:    json,
+		UserId:       0,
+		Overwrite:    false,
+		Message:      "",
+		RestoredFrom: 0,
+		PluginId:     "",
+		FolderId:     0,
+		IsFolder:     false,
+		UpdatedAt:    time.Time{},
+	}
+	if dashboardProps.OrgId != 0 {
+		saveDashboardCmd.OrgId = dashboardProps.OrgId
+	} else {
+		saveDashboardCmd.OrgId = 1
+	}
+
+	err = SaveDashboard(saveDashboardCmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return saveDashboardCmd.Result, nil
+}
+
+func createDummyAcl(dashboardPermission *DashboardPermission, search Search, dashboardId int64) (int64, error) {
+	acl := &models.DashboardAcl{
+		OrgId:       1,
+		Created:     time.Now(),
+		Updated:     time.Now(),
+		Permission:  dashboardPermission.Permission,
+		DashboardId: dashboardId,
+	}
+
+	var user *models.User
+	var err error
+	if dashboardPermission.User {
+		user, err = createDummyUser()
+		if err != nil {
+			return 0, err
+		}
+
+		acl.UserId = user.Id
+	}
+
+	if dashboardPermission.Team {
+		team, err := createDummyTeam()
+		if err != nil {
+			return 0, err
+		}
+		if search.UserFromACL {
+			user, err = createDummyUser()
+			if err != nil {
+				return 0, err
+			}
+			addTeamMemberCmd := &models.AddTeamMemberCommand{
+				UserId: user.Id,
+				OrgId:  1,
+				TeamId: team.Id,
+			}
+			err = AddTeamMember(addTeamMemberCmd)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		acl.TeamId = team.Id
+	}
+
+	if len(string(dashboardPermission.Role)) > 0 {
+		acl.Role = &dashboardPermission.Role
+	}
+
+	updateAclCmd := &models.UpdateDashboardAclCommand{
+		DashboardId: dashboardId,
+		Items:       []*models.DashboardAcl{acl},
+	}
+	err = UpdateDashboardAcl(updateAclCmd)
+	if user != nil {
+		return user.Id, err
+	} else {
+		return 0, err
+	}
+}
+
+func getDashboards(sqlStore *SqlStore, search Search, aclUserId int64) ([]*dashboardResponse, error) {
+	builder := &SqlBuilder{}
+	signedInUser := &models.SignedInUser{
+		UserId: 9999999999,
+	}
+
+	if search.OrgId == 0 {
+		signedInUser.OrgId = 1
+	} else {
+		signedInUser.OrgId = search.OrgId
+	}
+
+	if len(string(search.UsersOrgRole)) > 0 {
+		signedInUser.OrgRole = search.UsersOrgRole
+	} else {
+		signedInUser.OrgRole = models.ROLE_VIEWER
+	}
+	if search.UserFromACL {
+		signedInUser.UserId = aclUserId
+	}
+
+	var res []*dashboardResponse
+	builder.Write("SELECT * FROM dashboard WHERE true")
+	builder.writeDashboardPermissionFilter(signedInUser, search.RequiredPermission)
+	err := sqlStore.engine.SQL(builder.GetSqlString(), builder.params...).Find(&res)
+	return res, err
+}

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -228,7 +228,8 @@ func createDummyTeam() (*models.Team, error) {
 }
 
 func createDummyDashboard(dashboardProps DashboardProps) (*models.Dashboard, error) {
-	json, err := simplejson.NewJson([]byte(`{"schemaVersion":17,"title":"gdev dashboards","uid":"","version":1}`))
+	json, _ := simplejson.NewJson([]byte(`{"schemaVersion":17,"title":"gdev dashboards","uid":"","version":1}`))
+
 	saveDashboardCmd := &models.SaveDashboardCommand{
 		Dashboard:    json,
 		UserId:       0,
@@ -246,7 +247,7 @@ func createDummyDashboard(dashboardProps DashboardProps) (*models.Dashboard, err
 		saveDashboardCmd.OrgId = 1
 	}
 
-	err = SaveDashboard(saveDashboardCmd)
+	err := SaveDashboard(saveDashboardCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -309,9 +310,8 @@ func createDummyAcl(dashboardPermission *DashboardPermission, search Search, das
 	err = UpdateDashboardAcl(updateAclCmd)
 	if user != nil {
 		return user.Id, err
-	} else {
-		return 0, err
 	}
+	return 0, err
 }
 
 func getDashboards(sqlStore *SqlStore, search Search, aclUserId int64) ([]*dashboardResponse, error) {

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -3,7 +3,6 @@ package sqlstore
 import (
 	"context"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -163,7 +162,6 @@ type dashboardResponse struct {
 
 func test(t *testing.T, dashboardProps DashboardProps, dashboardPermission *DashboardPermission, search Search, shouldFind bool) {
 	// Will also cleanup the db
-	_ = os.Setenv("GRAFANA_TEST_DB", "postgres")
 	sqlStore := InitTestDB(t)
 
 	dashboard, err := createDummyDashboard(dashboardProps)


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/17336

The issue seems to be in one join that adds default permissions that creates N x N row that needs to be filtered (for ~9k dashboards that is around 80m rows). Moving the default permissions to separate select and union-ing them seems to fix the issue while preserving the same results. The UI is still not supper snappy but it seems more of an issue of rendering too many dashboards in the search. I think we could just limit returned dashboards quite a bit.

explain analyze before:
```
"Unique  (cost=1383690.10..1383785.98 rows=9550 width=4) (actual time=32111.894..32113.638 rows=9551 loops=1)"
"  ->  Sort  (cost=1383690.10..1383738.04 rows=19176 width=4) (actual time=32111.893..32112.383 rows=9553 loops=1)"
"        Sort Key: d.id"
"        Sort Method: quicksort  Memory: 832kB"
"        ->  Hash Left Join  (cost=2490.09..1382326.02 rows=19176 width=4) (actual time=22.440..32101.798 rows=9553 loops=1)"
"              Hash Cond: (d.folder_id = folder.id)"
"              Filter: ((da.dashboard_id = d.id) OR (da.dashboard_id = d.folder_id) OR ((da.org_id = '-1'::integer) AND (((folder.id IS NOT NULL) AND (NOT folder.has_acl)) OR ((folder.id IS NULL) AND (NOT d.has_acl)))))"
"              Rows Removed by Filter: 90906416"
"              ->  Nested Loop  (cost=1887.21..1142251.46 rows=91159577 width=29) (actual time=8.669..16795.006 rows=90915969 loops=1)"
"                    ->  Index Scan using dashboard_pkey1 on dashboard d  (cost=0.29..686.43 rows=9550 width=13) (actual time=0.006..24.889 rows=9551 loops=1)"
"                          Filter: (org_id = 1)"
"                    ->  Materialize  (cost=1886.93..2035.14 rows=9546 width=16) (actual time=0.001..0.475 rows=9519 loops=9551)"
"                          ->  Merge Left Join  (cost=1886.93..1987.41 rows=9546 width=16) (actual time=8.658..13.496 rows=9519 loops=1)"
"                                Merge Cond: (da.team_id = ugm.team_id)"
"                                Filter: ((da.user_id = 1) OR (ugm.user_id = 1) OR ((da.role)::text = 'Viewer'::text))"
"                                Rows Removed by Filter: 9518"
"                                ->  Sort  (cost=1811.71..1859.21 rows=18999 width=39) (actual time=8.634..9.761 rows=19037 loops=1)"
"                                      Sort Key: da.team_id"
"                                      Sort Method: quicksort  Memory: 2256kB"
"                                      ->  Seq Scan on dashboard_acl da  (cost=0.00..461.49 rows=18999 width=39) (actual time=0.008..5.796 rows=19037 loops=1)"
"                                            Filter: (permission >= 1)"
"                                ->  Sort  (cost=75.21..77.91 rows=1080 width=16) (actual time=0.017..0.018 rows=1 loops=1)"
"                                      Sort Key: ugm.team_id"
"                                      Sort Method: quicksort  Memory: 25kB"
"                                      ->  Seq Scan on team_member ugm  (cost=0.00..20.80 rows=1080 width=16) (actual time=0.010..0.011 rows=1 loops=1)"
"              ->  Hash  (cost=483.50..483.50 rows=9550 width=5) (actual time=3.851..3.851 rows=9551 loops=1)"
"                    Buckets: 16384  Batches: 1  Memory Usage: 474kB"
"                    ->  Seq Scan on dashboard folder  (cost=0.00..483.50 rows=9550 width=5) (actual time=0.007..2.415 rows=9551 loops=1)"
"Planning Time: 0.422 ms"
"Execution Time: 32114.044 ms"
```

after:
```
"HashAggregate  (cost=51663.40..51665.40 rows=200 width=4) (actual time=62.122..63.198 rows=9551 loops=1)"
"  Group Key: d.id"
"  ->  HashAggregate  (cost=51231.94..51423.70 rows=19176 width=4) (actual time=58.638..60.376 rows=9551 loops=1)"
"        Group Key: d.id"
"        ->  Append  (cost=48960.62..51184.00 rows=19176 width=4) (actual time=41.872..56.794 rows=9552 loops=1)"
"              ->  Merge Left Join  (cost=48960.62..49156.70 rows=19141 width=4) (actual time=41.872..46.071 rows=9517 loops=1)"
"                    Merge Cond: (da.team_id = ugm.team_id)"
"                    Filter: ((da.user_id = 2) OR (ugm.user_id = 2) OR ((da.role)::text = 'Viewer'::text))"
"                    Rows Removed by Filter: 9518"
"                    ->  Sort  (cost=48885.41..48980.65 rows=38097 width=27) (actual time=41.852..42.920 rows=19035 loops=1)"
"                          Sort Key: da.team_id"
"                          Sort Method: quicksort  Memory: 1661kB"
"                          ->  Nested Loop  (cost=0.65..45986.72 rows=38097 width=27) (actual time=0.115..39.421 rows=19035 loops=1)"
"                                ->  Seq Scan on dashboard d  (cost=0.00..507.38 rows=9550 width=12) (actual time=0.005..2.358 rows=9551 loops=1)"
"                                      Filter: (org_id = 1)"
"                                ->  Bitmap Heap Scan on dashboard_acl da  (cost=0.65..4.72 rows=4 width=31) (actual time=0.003..0.003 rows=2 loops=9551)"
"                                      Recheck Cond: ((dashboard_id = d.id) OR (dashboard_id = d.folder_id))"
"                                      Filter: (permission >= 1)"
"                                      Heap Blocks: exact=9518"
"                                      ->  BitmapOr  (cost=0.65..0.65 rows=4 width=0) (actual time=0.002..0.002 rows=0 loops=9551)"
"                                            ->  Bitmap Index Scan on ""IDX_dashboard_acl_dashboard_id""  (cost=0.00..0.33 rows=2 width=0) (actual time=0.001..0.001 rows=2 loops=9551)"
"                                                  Index Cond: (dashboard_id = d.id)"
"                                            ->  Bitmap Index Scan on ""IDX_dashboard_acl_dashboard_id""  (cost=0.00..0.33 rows=2 width=0) (actual time=0.001..0.001 rows=0 loops=9551)"
"                                                  Index Cond: (dashboard_id = d.folder_id)"
"                    ->  Sort  (cost=75.21..77.91 rows=1080 width=16) (actual time=0.012..0.012 rows=1 loops=1)"
"                          Sort Key: ugm.team_id"
"                          Sort Method: quicksort  Memory: 25kB"
"                          ->  Seq Scan on team_member ugm  (cost=0.00..20.80 rows=1080 width=16) (actual time=0.005..0.005 rows=1 loops=1)"
"              ->  Nested Loop  (cost=602.88..1739.66 rows=35 width=4) (actual time=3.514..9.936 rows=35 loops=1)"
"                    ->  Seq Scan on dashboard_acl da_1  (cost=0.00..603.98 rows=1 width=0) (actual time=0.011..2.126 rows=1 loops=1)"
"                          Filter: ((permission >= 1) AND (org_id = '-1'::integer) AND ((user_id = 2) OR ((role)::text = 'Viewer'::text)))"
"                          Rows Removed by Filter: 19036"
"                    ->  Hash Left Join  (cost=602.88..1135.33 rows=35 width=4) (actual time=3.501..7.804 rows=35 loops=1)"
"                          Hash Cond: (d_1.folder_id = folder.id)"
"                          Filter: (((folder.id IS NOT NULL) AND (NOT folder.has_acl)) OR ((folder.id IS NULL) AND (NOT d_1.has_acl)))"
"                          Rows Removed by Filter: 9516"
"                          ->  Seq Scan on dashboard d_1  (cost=0.00..507.38 rows=9550 width=13) (actual time=0.003..2.072 rows=9551 loops=1)"
"                                Filter: (org_id = 1)"
"                          ->  Hash  (cost=483.50..483.50 rows=9550 width=5) (actual time=3.481..3.481 rows=9551 loops=1)"
"                                Buckets: 16384  Batches: 1  Memory Usage: 474kB"
"                                ->  Seq Scan on dashboard folder  (cost=0.00..483.50 rows=9550 width=5) (actual time=0.002..2.242 rows=9551 loops=1)"
"Planning Time: 0.527 ms"
"Execution Time: 63.711 ms"
```

TODO:
- [x] a bit of testing whether the output is really the same for other ACL setup (teams, users, roles etc)
- [ ] benchmark test maybe will probably need a bit of help from @markelog