### PR TITLE
Explore: Fixes crash when parsing date math string with whitespace

### DIFF
--- a/packages/grafana-ui/src/utils/datemath.test.ts
+++ b/packages/grafana-ui/src/utils/datemath.test.ts
@@ -129,5 +129,10 @@ describe('DateMath', () => {
       const date = dateMath.parseDateMath('2', dateTime([2014, 1, 5]));
       expect(date).toEqual(undefined);
     });
+
+    it('should strip whitespace from string', () => {
+      const date = dateMath.parseDateMath(' - 2d', dateTime([2014, 1, 5]));
+      expect(date!.valueOf()).toEqual(dateTime([2014, 1, 3]).valueOf());
+    });
   });
 });

--- a/packages/grafana-ui/src/utils/datemath.ts
+++ b/packages/grafana-ui/src/utils/datemath.ts
@@ -87,12 +87,13 @@ export function isValid(text: string | DateTime): boolean {
  */
 // TODO: Had to revert Andrejs `time: moment.Moment` to `time: any`
 export function parseDateMath(mathString: string, time: any, roundUp?: boolean): DateTime | undefined {
+  const strippedMathString = mathString.replace(/\s/g, '');
   const dateTime = time;
   let i = 0;
-  const len = mathString.length;
+  const len = strippedMathString.length;
 
   while (i < len) {
-    const c = mathString.charAt(i++);
+    const c = strippedMathString.charAt(i++);
     let type;
     let num;
     let unit;
@@ -107,19 +108,19 @@ export function parseDateMath(mathString: string, time: any, roundUp?: boolean):
       return undefined;
     }
 
-    if (isNaN(parseInt(mathString.charAt(i), 10))) {
+    if (isNaN(parseInt(strippedMathString.charAt(i), 10))) {
       num = 1;
-    } else if (mathString.length === 2) {
-      num = mathString.charAt(i);
+    } else if (strippedMathString.length === 2) {
+      num = strippedMathString.charAt(i);
     } else {
       const numFrom = i;
-      while (!isNaN(parseInt(mathString.charAt(i), 10))) {
+      while (!isNaN(parseInt(strippedMathString.charAt(i), 10))) {
         i++;
         if (i > 10) {
           return undefined;
         }
       }
-      num = parseInt(mathString.substring(numFrom, i), 10);
+      num = parseInt(strippedMathString.substring(numFrom, i), 10);
     }
 
     if (type === 0) {
@@ -128,7 +129,7 @@ export function parseDateMath(mathString: string, time: any, roundUp?: boolean):
         return undefined;
       }
     }
-    unit = mathString.charAt(i++);
+    unit = strippedMathString.charAt(i++);
 
     if (!includes(units, unit)) {
       return undefined;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where date math strings with spaces caused an error to be thrown.

**Which issue(s) this PR fixes**:
Fixes: #16257

**Special notes for your reviewer**:

