### PR TITLE
@grafana/runtime: Expose template service

### DIFF
--- a/packages/grafana-runtime/src/services/TemplateSrv.ts
+++ b/packages/grafana-runtime/src/services/TemplateSrv.ts
@@ -1,0 +1,24 @@
+import { TimeRange, ScopedVars, KeyValue } from '@grafana/ui';
+
+export interface TemplateSrv {
+  variables: any[];
+  init(variables: any[], timeRange?: TimeRange): void;
+  fillVariableValuesForUrl(params: KeyValue<string>, scopedVars?: ScopedVars): void;
+  highlightVariablesAsHtml(text?: string): string;
+  replaceWithText(target: string, scopedVars: ScopedVars): string;
+  replace(target: string, scopedVars?: ScopedVars, format?: string | Function): string;
+  setGrafanaVariable(name: string, value: any): void;
+  updateIndex(): void;
+  updateTimeRange(timeRange: TimeRange): void;
+  variableInitialized(variable: any): void;
+}
+
+let singletonInstance: TemplateSrv;
+
+export function setTemplateSrv(instance: TemplateSrv) {
+  singletonInstance = instance;
+}
+
+export function getTemplateSrv(): TemplateSrv {
+  return singletonInstance;
+}

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './backendSrv';
 export * from './AngularLoader';
 export * from './dataSourceSrv';
 export * from './LocationSrv';
+export * from './TemplateSrv';

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { DashboardRow } from './DashboardRow';
 import { PanelModel } from '../../state/PanelModel';
+import { setTemplateSrv } from '@grafana/runtime';
+import TemplateSrv from 'app/features/templating/template_srv';
 
 describe('DashboardRow', () => {
   let wrapper, panel, dashboardMock;
-
+  setTemplateSrv(new TemplateSrv());
   beforeEach(() => {
     dashboardMock = {
       toggleRow: jest.fn(),

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { PanelModel } from '../../state/PanelModel';
 import { DashboardModel } from '../../state/DashboardModel';
-import templateSrv from 'app/features/templating/template_srv';
+import { getTemplateSrv } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 
 export interface DashboardRowProps {
@@ -79,7 +79,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
       'fa-chevron-right': this.state.collapsed,
     });
 
-    const title = templateSrv.replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
+    const title = getTemplateSrv().replaceWithText(this.props.panel.title, this.props.panel.scopedVars);
     const count = this.props.panel.panels ? this.props.panel.panels.length : 0;
     const panels = count === 1 ? 'panel' : 'panels';
     const canEdit = this.props.dashboard.meta.canEdit === true;

--- a/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.test.ts
+++ b/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.test.ts
@@ -1,8 +1,14 @@
 import config from 'app/core/config';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
 import { ShareModalCtrl } from './ShareModalCtrl';
+import { setTemplateSrv } from '@grafana/runtime';
 
 describe('ShareModalCtrl', () => {
+  const templateSrv = {
+    fillVariableValuesForUrl: () => {},
+  };
+  setTemplateSrv(templateSrv as any);
+
   const ctx = {
     timeSrv: {
       timeRange: () => {
@@ -22,9 +28,7 @@ describe('ShareModalCtrl', () => {
         },
       },
     },
-    templateSrv: {
-      fillVariableValuesForUrl: () => {},
-    },
+    templateSrv,
   } as any;
 
   (window as any).Intl.DateTimeFormat = () => {
@@ -49,7 +53,7 @@ describe('ShareModalCtrl', () => {
       {},
       ctx.timeSrv,
       ctx.templateSrv,
-      new LinkSrv({}, ctx.stimeSrv)
+      new LinkSrv(ctx.stimeSrv)
     );
   });
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -1,8 +1,10 @@
 import { PanelChrome } from './PanelChrome';
+import { setTemplateSrv } from '@grafana/runtime';
+import TemplateSrv from 'app/features/templating/template_srv';
 
 describe('PanelChrome', () => {
   let chrome: PanelChrome;
-
+  setTemplateSrv(new TemplateSrv());
   beforeEach(() => {
     chrome = new PanelChrome({
       panel: {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -12,13 +12,13 @@ import { getTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { applyPanelTimeOverrides, calculateInnerPanelHeight } from 'app/features/dashboard/utils/panel';
 import { profiler } from 'app/core/profiler';
 import { getProcessedSeriesData } from '../state/PanelQueryState';
-import templateSrv from 'app/features/templating/template_srv';
 import config from 'app/core/config';
 
 // Types
 import { DashboardModel, PanelModel } from '../state';
 import { LoadingState, PanelData, PanelPlugin } from '@grafana/ui';
 import { ScopedVars } from '@grafana/ui';
+import { getTemplateSrv } from '@grafana/runtime';
 
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
 
@@ -207,7 +207,7 @@ export class PanelChrome extends PureComponent<Props, State> {
     if (extraVars) {
       vars = vars ? { ...vars, ...extraVars } : extraVars;
     }
-    return templateSrv.replace(value, vars, format);
+    return getTemplateSrv().replace(value, vars, format);
   };
 
   onPanelError = (message: string) => {

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -5,7 +5,7 @@ import { ScopedVars } from '@grafana/ui';
 
 import PanelHeaderCorner from './PanelHeaderCorner';
 import { PanelHeaderMenu } from './PanelHeaderMenu';
-import templateSrv from 'app/features/templating/template_srv';
+import { getTemplateSrv } from '@grafana/runtime';
 
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -72,7 +72,7 @@ export class PanelHeader extends Component<Props, State> {
 
   render() {
     const { panel, dashboard, timeInfo, scopedVars, error, isFullscreen } = this.props;
-    const title = templateSrv.replaceWithText(panel.title, scopedVars);
+    const title = getTemplateSrv().replaceWithText(panel.title, scopedVars);
 
     const panelHeaderClass = classNames({
       'panel-header': true,

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
@@ -3,9 +3,9 @@ import Remarkable from 'remarkable';
 import { Tooltip, ScopedVars } from '@grafana/ui';
 
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import templateSrv from 'app/features/templating/template_srv';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { getTemplateSrv } from '@grafana/runtime';
 
 enum InfoMode {
   Error = 'Error',
@@ -43,7 +43,8 @@ export class PanelHeaderCorner extends Component<Props> {
   getInfoContent = (): JSX.Element => {
     const { panel } = this.props;
     const markdown = panel.description;
-    const linkSrv = new LinkSrv(templateSrv, this.timeSrv);
+    const templateSrv = getTemplateSrv();
+    const linkSrv = new LinkSrv(this.timeSrv);
     const interpolatedMarkdown = templateSrv.replace(markdown, panel.scopedVars);
     const remarkableInterpolatedMarkdown = new Remarkable().render(interpolatedMarkdown);
 

--- a/public/app/features/dashboard/state/PanelQueryRunner.test.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.test.ts
@@ -8,6 +8,8 @@ import {
   ScopedVars,
 } from '@grafana/ui/src/types';
 import { dateTime } from '@grafana/ui/src/utils/moment_wrapper';
+import { setTemplateSrv } from '@grafana/runtime';
+import TemplateSrv from 'app/features/templating/template_srv';
 
 jest.mock('app/core/services/backend_srv');
 
@@ -92,6 +94,7 @@ function describeQueryRunnerScenario(description: string, scenarioFn: ScenarioFn
 }
 
 describe('PanelQueryRunner', () => {
+  setTemplateSrv(new TemplateSrv());
   describeQueryRunnerScenario('simple scenario', ctx => {
     it('should set requestId on request', async () => {
       expect(ctx.queryCalledWith.requestId).toBe('Q100');

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -6,7 +6,7 @@ import { Subject, Unsubscribable, PartialObserver } from 'rxjs';
 // Services & Utils
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import kbn from 'app/core/utils/kbn';
-import templateSrv from 'app/features/templating/template_srv';
+import { getTemplateSrv } from '@grafana/runtime';
 import { PanelQueryState } from './PanelQueryState';
 
 // Types
@@ -144,7 +144,7 @@ export class PanelQueryRunner {
         return query;
       });
 
-      const lowerIntervalLimit = minInterval ? templateSrv.replace(minInterval, request.scopedVars) : ds.interval;
+      const lowerIntervalLimit = minInterval ? getTemplateSrv().replace(minInterval, request.scopedVars) : ds.interval;
       const norm = kbn.calculateInterval(timeRange, widthPixels, lowerIntervalLimit);
 
       // make shallow copy of scoped vars,

--- a/public/app/features/dashboard/utils/panel.test.ts
+++ b/public/app/features/dashboard/utils/panel.test.ts
@@ -2,6 +2,8 @@ import { TimeRange } from '@grafana/ui';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { advanceTo, clear } from 'jest-date-mock';
 import { dateTime, DateTime } from '@grafana/ui/src/utils/moment_wrapper';
+import { setTemplateSrv } from '@grafana/runtime';
+import TemplateSrv from 'app/features/templating/template_srv';
 
 const dashboardTimeRange: TimeRange = {
   from: dateTime([2019, 1, 11, 12, 0]),
@@ -14,7 +16,7 @@ const dashboardTimeRange: TimeRange = {
 
 describe('applyPanelTimeOverrides', () => {
   const fakeCurrentDate = dateTime([2019, 1, 11, 14, 0, 0]).toDate();
-
+  setTemplateSrv(new TemplateSrv());
   beforeAll(() => {
     advanceTo(fakeCurrentDate);
   });

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -14,7 +14,7 @@ import appEvents from 'app/core/app_events';
 import config from 'app/core/config';
 
 // Services
-import templateSrv from 'app/features/templating/template_srv';
+import { getTemplateSrv } from '@grafana/runtime';
 
 // Constants
 import { LS_PANEL_COPY_KEY, PANEL_BORDER } from 'app/core/constants';
@@ -113,7 +113,7 @@ export function applyPanelTimeOverrides(panel: PanelModel, timeRange: TimeRange)
   };
 
   if (panel.timeFrom) {
-    const timeFromInterpolated = templateSrv.replace(panel.timeFrom, panel.scopedVars);
+    const timeFromInterpolated = getTemplateSrv().replace(panel.timeFrom, panel.scopedVars);
     const timeFromInfo = rangeUtil.describeTextRange(timeFromInterpolated);
     if (timeFromInfo.invalid) {
       newTimeData.timeInfo = 'invalid time override';
@@ -135,7 +135,7 @@ export function applyPanelTimeOverrides(panel: PanelModel, timeRange: TimeRange)
   }
 
   if (panel.timeShift) {
-    const timeShiftInterpolated = templateSrv.replace(panel.timeShift, panel.scopedVars);
+    const timeShiftInterpolated = getTemplateSrv().replace(panel.timeShift, panel.scopedVars);
     const timeShiftInfo = rangeUtil.describeTextRange(timeShiftInterpolated);
     if (timeShiftInfo.invalid) {
       newTimeData.timeInfo = 'invalid timeshift';

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -1,10 +1,14 @@
 import angular from 'angular';
 import _ from 'lodash';
 import kbn from 'app/core/utils/kbn';
+import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 export class LinkSrv {
+  private templateSrv: TemplateSrv;
   /** @ngInject */
-  constructor(private templateSrv, private timeSrv) {}
+  constructor(private timeSrv) {
+    this.templateSrv = getTemplateSrv();
+  }
 
   getLinkUrl(link) {
     const url = this.templateSrv.replace(link.url || '');

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -1,5 +1,6 @@
 import { LinkSrv } from '../link_srv';
 import _ from 'lodash';
+import { setTemplateSrv } from '@grafana/runtime';
 
 jest.mock('angular', () => {
   const AngularJSMock = require('test/mocks/angular');
@@ -9,10 +10,11 @@ jest.mock('angular', () => {
 describe('linkSrv', () => {
   let linkSrv;
   const templateSrvMock = {};
+  setTemplateSrv(templateSrvMock as any);
   const timeSrvMock = {};
 
   beforeEach(() => {
-    linkSrv = new LinkSrv(templateSrvMock, timeSrvMock);
+    linkSrv = new LinkSrv(timeSrvMock);
   });
 
   describe('when appending query strings', () => {

--- a/public/app/features/templating/all.ts
+++ b/public/app/features/templating/all.ts
@@ -1,7 +1,7 @@
 import './editor_ctrl';
 import coreModule from 'app/core/core_module';
 
-import templateSrv from './template_srv';
+import { TemplateSrv } from './template_srv';
 import { VariableSrv } from './variable_srv';
 import { IntervalVariable } from './interval_variable';
 import { QueryVariable } from './query_variable';
@@ -11,9 +11,7 @@ import { ConstantVariable } from './constant_variable';
 import { AdhocVariable } from './adhoc_variable';
 import { TextBoxVariable } from './TextBoxVariable';
 
-coreModule.factory('templateSrv', () => {
-  return templateSrv;
-});
+coreModule.service('templateSrv', TemplateSrv);
 
 export {
   VariableSrv,

--- a/public/app/features/templating/specs/variable_srv.test.ts
+++ b/public/app/features/templating/specs/variable_srv.test.ts
@@ -4,8 +4,22 @@ import { DashboardModel } from '../../dashboard/state/DashboardModel';
 import $q from 'q';
 import { dateTime } from '@grafana/ui/src/utils/moment_wrapper';
 import { CustomVariable } from '../custom_variable';
+import { setTemplateSrv } from '@grafana/runtime';
 
 describe('VariableSrv', function(this: any) {
+  const templateSrv = {
+    setGrafanaVariable: jest.fn(),
+    init: vars => {
+      this.variables = vars;
+    },
+    updateIndex: () => {},
+    replace: str =>
+      str.replace(this.regex, match => {
+        return match;
+      }),
+  };
+  setTemplateSrv(templateSrv as any);
+
   const ctx = {
     datasourceSrv: {},
     timeSrv: {
@@ -19,20 +33,10 @@ describe('VariableSrv', function(this: any) {
     $injector: {
       instantiate: (ctr, obj) => new ctr(obj.model),
     },
-    templateSrv: {
-      setGrafanaVariable: jest.fn(),
-      init: vars => {
-        this.variables = vars;
-      },
-      updateIndex: () => {},
-      replace: str =>
-        str.replace(this.regex, match => {
-          return match;
-        }),
-    },
     $location: {
       search: () => {},
     },
+    templateSrv,
   } as any;
 
   function describeUpdateVariable(desc, fn) {
@@ -48,7 +52,7 @@ describe('VariableSrv', function(this: any) {
         const ds: any = {};
         ds.metricFindQuery = () => Promise.resolve(scenario.queryResult);
 
-        ctx.variableSrv = new VariableSrv($q, ctx.$location, ctx.$injector, ctx.templateSrv, ctx.timeSrv);
+        ctx.variableSrv = new VariableSrv($q, ctx.$location, ctx.$injector, ctx.timeSrv);
 
         ctx.variableSrv.timeSrv = ctx.timeSrv;
         ctx.datasourceSrv = {
@@ -625,7 +629,7 @@ describe('VariableSrv', function(this: any) {
 });
 
 function setupSetFromUrlTest(ctx, model = {}) {
-  const variableSrv = new VariableSrv($q, ctx.$location, ctx.$injector, ctx.templateSrv, ctx.timeSrv);
+  const variableSrv = new VariableSrv($q, ctx.$location, ctx.$injector, ctx.timeSrv);
   const finalModel = {
     type: 'custom',
     options: ['one', 'two', 'three'].map(v => ({ text: v, value: v })),

--- a/public/app/features/templating/specs/variable_srv_init.test.ts
+++ b/public/app/features/templating/specs/variable_srv_init.test.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { VariableSrv } from '../variable_srv';
 import { DashboardModel } from '../../dashboard/state/DashboardModel';
 import $q from 'q';
+import { setTemplateSrv } from '@grafana/runtime';
 
 describe('VariableSrv init', function(this: any) {
   const templateSrv = {
@@ -17,6 +18,7 @@ describe('VariableSrv init', function(this: any) {
         return match;
       }),
   };
+  setTemplateSrv(templateSrv as any);
 
   const timeSrv = {
     timeRange: () => {
@@ -50,7 +52,7 @@ describe('VariableSrv init', function(this: any) {
         };
 
         // @ts-ignore
-        ctx.variableSrv = new VariableSrv($q, {}, $injector, templateSrv, timeSrv);
+        ctx.variableSrv = new VariableSrv($q, {}, $injector, timeSrv);
 
         $injector.instantiate = (variable, model) => {
           return getVarMockConstructor(variable, model, ctx);

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -2,12 +2,13 @@ import kbn from 'app/core/utils/kbn';
 import _ from 'lodash';
 import { variableRegex } from 'app/features/templating/variable';
 import { TimeRange, ScopedVars } from '@grafana/ui/src';
+import { TemplateSrv as TemplateService } from '@grafana/runtime';
 
 function luceneEscape(value) {
   return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');
 }
 
-export class TemplateSrv {
+export class TemplateSrv implements TemplateService {
   variables: any[];
 
   private regex = variableRegex;
@@ -194,7 +195,7 @@ export class TemplateSrv {
     return name && this.index[name] !== void 0;
   }
 
-  highlightVariablesAsHtml(str) {
+  highlightVariablesAsHtml(str?: string) {
     if (!str || !_.isString(str)) {
       return str;
     }
@@ -320,4 +321,5 @@ export class TemplateSrv {
   }
 }
 
-export default new TemplateSrv();
+// coreModule.service('templateSrv', TemplateSrv);
+export default TemplateSrv;

--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -6,25 +6,23 @@ import _ from 'lodash';
 import coreModule from 'app/core/core_module';
 import { variableTypes } from './variable';
 import { Graph } from 'app/core/utils/dag';
-import { TemplateSrv } from 'app/features/templating/template_srv';
+
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 
 // Types
 import { TimeRange } from '@grafana/ui/src';
+import { TemplateSrv, getTemplateSrv } from '@grafana/runtime';
 
 export class VariableSrv {
+  private templateSrv: TemplateSrv;
   dashboard: DashboardModel;
   variables: any[];
 
   /** @ngInject */
-  constructor(
-    private $q,
-    private $location,
-    private $injector,
-    private templateSrv: TemplateSrv,
-    private timeSrv: TimeSrv
-  ) {}
+  constructor(private $q, private $location, private $injector, private timeSrv: TimeSrv) {
+    this.templateSrv = getTemplateSrv();
+  }
 
   init(dashboard: DashboardModel) {
     this.dashboard = dashboard;

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -16,11 +16,12 @@ import { KeybindingSrv, setKeybindingSrv } from 'app/core/services/keybindingSrv
 import { AngularLoader, setAngularLoader } from 'app/core/services/AngularLoader';
 import { configureStore } from 'app/store/configureStore';
 
-import { LocationUpdate, setLocationSrv } from '@grafana/runtime';
+import { LocationUpdate, setLocationSrv, setTemplateSrv } from '@grafana/runtime';
 import { updateLocation } from 'app/core/actions';
 
 // Types
 import { KioskUrlValue } from 'app/types';
+import { TemplateSrv } from 'app/features/templating/template_srv';
 
 export class GrafanaCtrl {
   /** @ngInject */
@@ -33,12 +34,14 @@ export class GrafanaCtrl {
     bridgeSrv,
     backendSrv: BackendSrv,
     timeSrv: TimeSrv,
+    templateSrv: TemplateSrv,
     datasourceSrv: DatasourceSrv,
     keybindingSrv: KeybindingSrv,
     angularLoader: AngularLoader
   ) {
     // make angular loader service available to react components
     setAngularLoader(angularLoader);
+    setTemplateSrv(templateSrv);
     setBackendSrv(backendSrv);
     setDataSourceSrv(datasourceSrv);
     setTimeSrv(timeSrv);


### PR DESCRIPTION
@torkelo @ryantxu decided to move TemplateSrv to grafana/runtime as a part of links work. 

There are couple of issues/questions about the approach of exposing services from grafana/runtime that I'd like to discuss with you tomorrow. I.e. whether or not we should use `getXXXSrv` instead of using Angular's dependency injection, see https://github.com/grafana/grafana/pull/17459/files#diff-4468324e53509e365e2af108e45884c5R9. This has some pros and cons, but I feel like in a long run this could be our way of getting rid of services injection at all.