### PR TITLE
Add CircleCI step trigger-docs-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,6 +605,17 @@ jobs:
       - store_artifacts:
           path: ./dist
 
+  trigger-docs-update:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+      - run:
+          name: Trigger Docs update
+          command: |
+            curl -s -u "$DOCS_CIRCLE_TOKEN:" \
+              -d build_parameters[CIRCLE_JOB]=pull-submodule-changes \
+              https://circleci.com/api/v1.1/project/github/grafana/docs.grafana.com/tree/staging
+
 workflows:
   version: 2
   build-master:
@@ -671,6 +682,10 @@ workflows:
       - end-to-end-test:
           requires:
             - grafana-docker-master
+          filters: *filter-only-master
+      - trigger-docs-update:
+          requires:
+            - end-to-end-test
           filters: *filter-only-master
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,12 +609,19 @@ jobs:
     docker:
       - image: circleci/python:3.6.8
     steps:
+      - checkout
       - run:
           name: Trigger Docs update
           command: |
-            curl -s -u "$DOCS_CIRCLE_TOKEN:" \
-              -d build_parameters[CIRCLE_JOB]=pull-submodule-changes \
-              https://circleci.com/api/v1.1/project/github/grafana/docs.grafana.com/tree/staging
+            if git diff --name-only HEAD^ | grep -q "^docs"; then
+              echo "Build URL:"
+              curl -s -u "$DOCS_CIRCLE_TOKEN:" \
+                -d build_parameters[CIRCLE_JOB]=pull-submodule-changes \
+                https://circleci.com/api/v1.1/project/github/grafana/docs.grafana.com/tree/staging \
+              | jq .build_url
+            else
+              echo "-- no changes to docs files --"
+            fi
 
 workflows:
   version: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

When commits are pushed to master, I want to trigger a job in the new documentation site's CI/CD to pull changes to documentation content and publish them to staging. I will test how this works for a few days/weeks before going to production.

The new docs staging site: http://staging.docs.grafana.com.s3-website-us-west-2.amazonaws.com/
Repo (private) for the new docs site: https://github.com/grafana/docs.grafana.com

The curl command triggers the `pull-submodule-changes` job defined in the `docs.grafana.com` repository (the new docs site, work in progress). This job runs `scripts/git-pull-changes-from-
upstream.sh` which pulls the `grafana/grafana` repo and checks for updates in any files under `docs/` before building and publishing the docs site.

1. A commit is pushed to `grafana/grafana` branch `master` on GitHub.
2. CircleCI runs the `build-master` workflow for `grafana/grafana`.
3. The `trigger-docs-update` job in `grafana/grafana` triggers the `pull-submodule-changes` CircleCI job for the `grafana/docs.grafana.com` project.
4. The `pull-submodule-changes` job pulls `grafana/grafana` master branch in a Git submodule, checks if any files under `docs/` have changed.
5. If there are any changes, the new Git submodule revision is committed to `docs.grafana.com` modules and pushed to the master branch on GitHub.
6. This triggers CI/CD in the `docs.grafana.com` project to build and publish the new docs site.

**Special notes for your reviewer**:

I'm not experienced with this and I would like someone to validate logic and best practices and look for potential problems.

Is this the right place in the CI/CD workflow to add the job? Will the commit be merged into master by the time the `pull-submodule-changes` job runs? Or should I add a check in `git-pull-changes-from-upstream.sh` to wait for the `build-master` workflow to finish successfully?

I also need to define the `DOCS_CIRCLE_TOKEN` environment variable in the `grafana/grafana` project on CircleCI before merging this PR.