### PR TITLE
AuthProxy: Optimistic lock pattern for remote cache Set

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -84,40 +84,41 @@ func (dc *databaseCache) Get(key string) (interface{}, error) {
 }
 
 func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration) error {
-	return dc.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
-		item := &cachedItem{Val: value}
-		data, err := encodeGob(item)
-		if err != nil {
-			return err
-		}
+	item := &cachedItem{Val: value}
+	data, err := encodeGob(item)
+	if err != nil {
+		return err
+	}
 
-		var cacheHit CacheData
-		has, err := session.Where("cache_key = ?", key).Get(&cacheHit)
-		if err != nil {
-			return err
-		}
+	session := dc.SQLStore.NewSession()
+	defer session.Close()
 
-		var expiresInSeconds int64
-		if expire != 0 {
-			expiresInSeconds = int64(expire) / int64(time.Second)
-		}
+	var cacheHit CacheData
+	has, err := session.Where("cache_key = ?", key).Get(&cacheHit)
+	if err != nil {
+		return err
+	}
 
+	var expiresInSeconds int64
+	if expire != 0 {
+		expiresInSeconds = int64(expire) / int64(time.Second)
+	}
+
+	// insert or update depending on if item already exist
+	if has {
+		sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
+		_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
+	} else {
 		// insert or update depending on if item already exist
-		if has {
+		sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
+		_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
+		if err != nil {
 			sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
 			_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
-		} else {
-			sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
-			_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
-			if err != nil {
-				// TODO: check for integrity error
-				sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
-				_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
-			}
 		}
+	}
 
-		return err
-	})
+	return err
 }
 
 func (dc *databaseCache) Delete(key string) error {

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -70,7 +70,10 @@ func (dc *databaseCache) Get(key string) (interface{}, error) {
 	if cacheHit.Expires > 0 {
 		existedButExpired := getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires
 		if existedButExpired {
-			_ = dc.Delete(key) //ignore this error since we will return `ErrCacheItemNotFound` anyway
+			err = dc.Delete(key) //ignore this error since we will return `ErrCacheItemNotFound` anyway
+			if err != nil {
+				dc.log.Debug(err.Error())
+			}
 			return nil, ErrCacheItemNotFound
 		}
 	}

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -108,8 +108,10 @@ func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration
 	sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
 	_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
 	if err != nil {
-		sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
-		_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
+		if dc.SQLStore.Dialect.IsUniqueConstraintViolation(err) {
+			sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
+			_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
+		}
 	}
 
 	return err

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -96,12 +96,6 @@ func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration
 	session := dc.SQLStore.NewSession()
 	defer session.Close()
 
-	var cacheHit CacheData
-	_, err = session.Where("cache_key = ?", key).Get(&cacheHit)
-	if err != nil {
-		return err
-	}
-
 	var expiresInSeconds int64
 	if expire != 0 {
 		expiresInSeconds = int64(expire) / int64(time.Second)

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -109,6 +109,11 @@ func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration
 		} else {
 			sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
 			_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
+			if err != nil {
+				// TODO: check for integrity error
+				sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
+				_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
+			}
 		}
 
 		return err

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -108,7 +108,7 @@ func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration
 	sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
 	_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
 	if err != nil {
-		if dc.SQLStore.Dialect.IsUniqueConstraintViolation(err) {
+		if dc.SQLStore.Dialect.IsUniqueConstraintViolation(err) || dc.SQLStore.Dialect.IsDeadlock(err) {
 			sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
 			_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
 		}

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -72,7 +72,7 @@ func (dc *databaseCache) Get(key string) (interface{}, error) {
 		if existedButExpired {
 			err = dc.Delete(key) //ignore this error since we will return `ErrCacheItemNotFound` anyway
 			if err != nil {
-				dc.log.Debug(err.Error())
+				dc.log.Debug("Deletion of expired key failed: %v", err)
 			}
 			return nil, ErrCacheItemNotFound
 		}

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -48,6 +48,7 @@ type Dialect interface {
 	NoOpSql() string
 
 	IsUniqueConstraintViolation(err error) bool
+	IsDeadlock(err error) bool
 }
 
 func NewDialect(engine *xorm.Engine) Dialect {

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -49,6 +49,7 @@ type Dialect interface {
 
 	IsUniqueConstraintViolation(err error) bool
 	IsDeadlock(err error) bool
+	GetErrorCode(err error) string
 }
 
 func NewDialect(engine *xorm.Engine) Dialect {

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -49,7 +49,6 @@ type Dialect interface {
 
 	IsUniqueConstraintViolation(err error) bool
 	IsDeadlock(err error) bool
-	GetErrorCode(err error) string
 }
 
 func NewDialect(engine *xorm.Engine) Dialect {

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -134,12 +134,20 @@ func (db *Mysql) CleanDB() error {
 	return nil
 }
 
-func (db *Mysql) IsUniqueConstraintViolation(err error) bool {
+func (db *Mysql) isThisError(err error, errcode uint16) bool {
 	if driverErr, ok := err.(*mysql.MySQLError); ok {
-		if driverErr.Number == mysqlerr.ER_DUP_ENTRY {
+		if driverErr.Number == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Mysql) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, mysqlerr.ER_DUP_ENTRY)
+}
+
+func (db *Mysql) IsDeadlock(err error) bool {
+	return db.isThisError(err, mysqlerr.ER_LOCK_DEADLOCK)
 }

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -134,6 +134,13 @@ func (db *Mysql) CleanDB() error {
 	return nil
 }
 
+func (db *Mysql) GetErrorCode(err error) string {
+	if driverErr, ok := err.(*mysql.MySQLError); ok {
+		return strconv.Itoa(int(driverErr.Number))
+	}
+	return ""
+}
+
 func (db *Mysql) isThisError(err error, errcode uint16) bool {
 	if driverErr, ok := err.(*mysql.MySQLError); ok {
 		if driverErr.Number == errcode {

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -134,13 +134,6 @@ func (db *Mysql) CleanDB() error {
 	return nil
 }
 
-func (db *Mysql) GetErrorCode(err error) string {
-	if driverErr, ok := err.(*mysql.MySQLError); ok {
-		return strconv.Itoa(int(driverErr.Number))
-	}
-	return ""
-}
-
 func (db *Mysql) isThisError(err error, errcode uint16) bool {
 	if driverErr, ok := err.(*mysql.MySQLError); ok {
 		if driverErr.Number == errcode {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -138,12 +138,20 @@ func (db *Postgres) CleanDB() error {
 	return nil
 }
 
-func (db *Postgres) IsUniqueConstraintViolation(err error) bool {
+func (db *Postgres) isThisError(err error, errcode string) bool {
 	if driverErr, ok := err.(*pq.Error); ok {
-		if driverErr.Code == "23505" {
+		if string(driverErr.Code) == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Postgres) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, "23505")
+}
+
+func (db *Postgres) IsDeadlock(err error) bool {
+	return db.isThisError(err, "40P01")
 }

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -138,6 +138,13 @@ func (db *Postgres) CleanDB() error {
 	return nil
 }
 
+func (db *Postgres) GetErrorCode(err error) string {
+	if driverErr, ok := err.(*pq.Error); ok {
+		return string(driverErr.Code)
+	}
+	return ""
+}
+
 func (db *Postgres) isThisError(err error, errcode string) bool {
 	if driverErr, ok := err.(*pq.Error); ok {
 		if string(driverErr.Code) == errcode {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -138,13 +138,6 @@ func (db *Postgres) CleanDB() error {
 	return nil
 }
 
-func (db *Postgres) GetErrorCode(err error) string {
-	if driverErr, ok := err.(*pq.Error); ok {
-		return string(driverErr.Code)
-	}
-	return ""
-}
-
 func (db *Postgres) isThisError(err error, errcode string) bool {
 	if driverErr, ok := err.(*pq.Error); ok {
 		if string(driverErr.Code) == errcode {

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -85,12 +85,20 @@ func (db *Sqlite3) CleanDB() error {
 	return nil
 }
 
-func (db *Sqlite3) IsUniqueConstraintViolation(err error) bool {
+func (db *Sqlite3) isThisError(err error, errcode int) bool {
 	if driverErr, ok := err.(sqlite3.Error); ok {
-		if driverErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+		if int(driverErr.ExtendedCode) == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Sqlite3) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, int(sqlite3.ErrConstraintUnique))
+}
+
+func (db *Sqlite3) IsDeadlock(err error) bool {
+	return false // No deadlock
 }

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -85,13 +85,6 @@ func (db *Sqlite3) CleanDB() error {
 	return nil
 }
 
-func (db *Sqlite3) GetErrorCode(err error) string {
-	if driverErr, ok := err.(sqlite3.Error); ok {
-		return string(driverErr.ExtendedCode)
-	}
-	return ""
-}
-
 func (db *Sqlite3) isThisError(err error, errcode int) bool {
 	if driverErr, ok := err.(sqlite3.Error); ok {
 		if int(driverErr.ExtendedCode) == errcode {

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -85,6 +85,13 @@ func (db *Sqlite3) CleanDB() error {
 	return nil
 }
 
+func (db *Sqlite3) GetErrorCode(err error) string {
+	if driverErr, ok := err.(sqlite3.Error); ok {
+		return string(driverErr.ExtendedCode)
+	}
+	return ""
+}
+
 func (db *Sqlite3) isThisError(err error, errcode int) bool {
 	if driverErr, ok := err.(sqlite3.Error); ok {
 		if int(driverErr.ExtendedCode) == errcode {


### PR DESCRIPTION
Fixes #17375

The error can be triggered by enabling authentication proxy, setting `ldap_sync_ttl` to something small and running the load tests using MySQL or PostgreSQL as a database.

The error occurs when one request tries to insert the key to the table after having checked that it does not exist but in the meantime another one has already inserted it.

The solution attempts to insert the key without checking if it's already there and in case of an integrity constrain violation tries to update it instead.

The transaction is removed in order to prevent deadlocks after an integrity constrain violation occurs. However, there were still some deadlocks on MySQL therefore in case of a deadlock an update is attempted.

 If the update also fails the error will be propagated (since it's a cache and it does not harm a lot to end up with a key that is not set) unless it is a deadlock. In that case the error is ignored since most probably somebody else is trying to insert or update the key, so one way or another the key will be set.