### PR TITLE
sqlstore: clean quota and user_auth_tokens when removing users

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -528,6 +528,8 @@ func deleteUserInTransaction(sess *DBSession, cmd *m.DeleteUserCommand) error {
 		"DELETE FROM preferences WHERE user_id = ?",
 		"DELETE FROM team_member WHERE user_id = ?",
 		"DELETE FROM user_auth WHERE user_id = ?",
+		"DELETE FROM user_auth_token WHERE user_id = ?",
+		"DELETE FROM quota WHERE user_id = ?",
 	}
 
 	for _, sql := range deletes {


### PR DESCRIPTION
issue #17392

not sure if user_auth_token is the right table for this issue? Also don't know about quota ... but sounded like something that should also be cleaned?