### PR TITLE
Elasticsearch: Fix empty query (via template variable) should be sent as wildcard

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -257,9 +257,9 @@ export class ElasticDatasource {
         target.alias = this.templateSrv.replace(target.alias, options.scopedVars, 'lucene');
       }
 
-      let queryString = this.templateSrv.replace(target.query || '*', options.scopedVars, 'lucene');
+      let queryString = this.templateSrv.replace(target.query, options.scopedVars, 'lucene');
       // Elasticsearch queryString should always be '*' if empty string
-      if (queryString === '') {
+      if (!queryString || queryString === '') {
         queryString = '*';
       }
       const queryObj = this.queryBuilder.build(target, adhocFilters, queryString);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -257,7 +257,11 @@ export class ElasticDatasource {
         target.alias = this.templateSrv.replace(target.alias, options.scopedVars, 'lucene');
       }
 
-      const queryString = this.templateSrv.replace(target.query || '*', options.scopedVars, 'lucene');
+      let queryString = this.templateSrv.replace(target.query || '*', options.scopedVars, 'lucene');
+      // Elasticsearch queryString should always be '*' if empty string
+      if (queryString === '') {
+        queryString = '*';
+      }
       const queryObj = this.queryBuilder.build(target, adhocFilters, queryString);
       const esQuery = angular.toJson(queryObj);
 


### PR DESCRIPTION
… issue that appears when passing raw data from variables.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
Elasticsearch requires an * when an empty query is requested (default to all).  Grafana captures this requirement in several places.  However, when submitted via a raw variable (ie: ${Variable:raw}), the templateSrv converts this to an empty string.  Elasticsearch will therefore return no results.  Since this is Elasticsearch specific, this PR provides a simple sanity check after templateSrv processes the query.  If the result is '', it is replaced with a '*'.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17442 

**Special notes for your reviewer**:
