### PR TITLE
Prometheus: Preallocate data for Prometheus backend response parsing

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -199,8 +199,9 @@ func parseResponse(value model.Value, query *PrometheusQuery) (*tsdb.QueryResult
 
 	for _, v := range data {
 		series := tsdb.TimeSeries{
-			Name: formatLegend(v.Metric, query),
-			Tags: map[string]string{},
+			Name:   formatLegend(v.Metric, query),
+			Tags:   make(map[string]string, len(v.Metric)),
+			Points: make([]tsdb.TimePoint, 0, len(v.Values)),
 		}
 
 		for k, v := range v.Metric {


### PR DESCRIPTION

**What this PR does / why we need it**:
During Prometheus response processing we already know how many tags and point will be. We can easily preallocate enough items in corresponding map and slice which reduce allocations count.
