### PR TITLE
Explore: Clear queries when switching between metrics and logs

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -122,6 +122,7 @@ export function changeDatasource(exploreId: ExploreId, datasource: string): Thun
  */
 export function changeMode(exploreId: ExploreId, mode: ExploreMode): ThunkResult<void> {
   return dispatch => {
+    dispatch(clearQueries(exploreId));
     dispatch(changeModeAction({ exploreId, mode }));
     dispatch(runQueries(exploreId));
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
This will clear the existing queries when switching between metrics and logs. In the future we may want to reuse the measurement and field from existing query and/or use a solution for loading certain queries from history (local storage), but this change is needed as a first step.

**Which issue(s) this PR fixes**:
Closes #17496 

**Special notes for your reviewer**:

