### PR TITLE
Explore: Runs query when measurement/field and pairs are selected in logs mode for influx

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.test.tsx
@@ -1,0 +1,53 @@
+import { pairsAreValid } from './InfluxLogsQueryField';
+
+describe('pairsAreValid()', () => {
+  describe('when all pairs are fully defined', () => {
+    it('should return true', () => {
+      const pairs = [
+        {
+          key: 'a',
+          operator: '=',
+          value: '1',
+        },
+        {
+          key: 'b',
+          operator: '!=',
+          value: '2',
+        },
+      ];
+
+      expect(pairsAreValid(pairs as any)).toBe(true);
+    });
+  });
+
+  describe('when no pairs are defined at all', () => {
+    it('should return true', () => {
+      expect(pairsAreValid([])).toBe(true);
+    });
+  });
+
+  describe('when pairs are undefined', () => {
+    it('should return true', () => {
+      expect(pairsAreValid(undefined)).toBe(true);
+    });
+  });
+
+  describe('when one or more pairs are only partially defined', () => {
+    it('should return false', () => {
+      const pairs = [
+        {
+          key: 'a',
+          operator: undefined,
+          value: '1',
+        },
+        {
+          key: 'b',
+          operator: '!=',
+          value: '2',
+        },
+      ];
+
+      expect(pairsAreValid(pairs as any)).toBe(false);
+    });
+  });
+});

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -60,6 +60,10 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     });
   };
 
+  private pairsSet = (pairs: KeyValuePair[]) => {
+    return pairs.length && pairs.reduce((prev, pair) => prev && !!pair.key && !!pair.operator && !!pair.value, true);
+  };
+
   onPairsChanged = (pairs: KeyValuePair[]) => {
     const { query } = this.props;
     const { measurement, field } = this.state;
@@ -77,6 +81,11 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     );
 
     this.props.onChange(queryModel.target);
+
+    // Only run the query if measurement, field, and pairs are all set
+    if (this.pairsSet(pairs) && measurement && field) {
+      this.props.onRunQuery();
+    }
   };
 
   render() {

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -19,6 +19,19 @@ export interface State {
   field: string;
 }
 
+// Helper function for determining if a collection of pairs are valid
+// where a valid pair is either fully defined, or not defined at all, but not partially defined
+export function pairsAreValid(pairs: KeyValuePair[]) {
+  return (
+    !pairs ||
+    pairs.every(pair => {
+      const allDefined = !!(pair.key && pair.operator && pair.value);
+      const allEmpty = pair.key === undefined && pair.operator === undefined && pair.value === undefined;
+      return allDefined || allEmpty;
+    })
+  );
+}
+
 export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
   templateSrv: TemplateSrv = new TemplateSrv();
   state: State = { measurements: [], measurement: null, field: null };
@@ -60,10 +73,6 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     });
   };
 
-  private pairsSet = (pairs: KeyValuePair[]) => {
-    return pairs.length && pairs.reduce((prev, pair) => prev && !!pair.key && !!pair.operator && !!pair.value, true);
-  };
-
   onPairsChanged = (pairs: KeyValuePair[]) => {
     const { query } = this.props;
     const { measurement, field } = this.state;
@@ -82,8 +91,8 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
 
     this.props.onChange(queryModel.target);
 
-    // Only run the query if measurement, field, and pairs are all set
-    if (this.pairsSet(pairs) && measurement && field) {
+    // Only run the query if measurement & field are set, and there are no invalid pairs
+    if (measurement && field && pairsAreValid(pairs)) {
       this.props.onRunQuery();
     }
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
Runs query when measurement/field and pairs are selected in `Logs` mode for InfluxDB in Explore.

**Which issue(s) this PR fixes**:
Fixes #17500

**Special notes for your reviewer**:

