### PR TITLE
Populate LDAP bind password using environment variable

### DIFF
--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -102,6 +102,12 @@ bind_dn = "cn=admin,dc=grafana,dc=org"
 bind_password = "grafana"
 ```
 
+You can also set the bind password using an environment variable, the variable name is case insensitive and can not contain any dots.
+
+```bash
+bind_password = "${LDAP_BIND}"
+```
+
 #### Single Bind Example
 
 If you can provide a single bind expression that matches all possible users, you can skip the second bind and bind against the user DN directly.

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -155,9 +155,9 @@ func evalEnvVar(value string) string {
 			envValue := os.Getenv(envVar)
 			return envValue
 		})
-	} else {
-		return value
 	}
+	return value
+	
 }
 
 func assertNotEmptyCfg(val interface{}, propName string) error {

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -139,14 +139,14 @@ func readConfig(configFile string) (*Config, error) {
 	}
 
 	for _, server := range result.Servers {
-		envValue := evalBindPwdVariable(server.BindPassword)
+		envValue := evalEnvVar(server.BindPassword)
 		server.BindPassword = envValue
 	}
 
 	return result, nil
 }
 
-func evalBindPasswordVariable(value string) string {
+func evalEnvVar(value string) string {
 	regex := regexp.MustCompile(`\${(\w+)}`)
 	if regex != nil {
 		return regex.ReplaceAllStringFunc(value, func(envVar string) string {

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -2,10 +2,10 @@ package ldap
 
 import (
 	"fmt"
-	"sync"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"golang.org/x/xerrors"
@@ -154,7 +154,7 @@ func evalEnvVar(value string) string {
 			envVar = strings.TrimSuffix(envVar, "}")
 			envValue := os.Getenv(envVar)
 			return envValue
-			})
+		})
 	} else {
 		return value
 	}

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -157,7 +157,7 @@ func evalEnvVar(value string) string {
 		})
 	}
 	return value
-	
+
 }
 
 func assertNotEmptyCfg(val interface{}, propName string) error {

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -148,16 +148,15 @@ func readConfig(configFile string) (*Config, error) {
 
 func evalEnvVar(value string) string {
 	regex := regexp.MustCompile(`\${(\w+)}`)
-	if regex != nil {
-		return regex.ReplaceAllStringFunc(value, func(envVar string) string {
-			envVar = strings.TrimPrefix(envVar, "${")
-			envVar = strings.TrimSuffix(envVar, "}")
-			envValue := os.Getenv(envVar)
-			return envValue
-		})
-	}
-	return value
 
+	if regex != nil {
+		submatch := regex.FindSubmatch([]byte(value))
+
+		match := string(submatch[0])
+	  envValue := os.Getenv(match)
+		return envValue
+  }
+	return value
 }
 
 func assertNotEmptyCfg(val interface{}, propName string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request allows you to populate your LDAP bind password in ldap.toml using an environment variable, a la:`bind_password = "${LDAP_BIND}"`.  

I set this up because I wanted to be able to use a Kubernetes secret mounted as an env variable to a Grafana container, to be usable in the ldap.toml file.

I edited the docs accordingly as well.

**Which issue(s) this PR fixes**:
Fixes #8832

