### PR TITLE
Docs: Clarifies from which version the Patch VERB is available

### DIFF
--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -195,6 +195,7 @@ Content-Type: application/json
 ```
 
 ## Patch Annotation
+> This setting is available in Grafana 6.0.0-beta2 and above.
 
 `PATCH /api/annotations/:id`
 

--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -195,7 +195,7 @@ Content-Type: application/json
 ```
 
 ## Patch Annotation
-> This setting is available in Grafana 6.0.0-beta2 and above.
+> This is available in Grafana 6.0.0-beta2 and above.
 
 `PATCH /api/annotations/:id`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When the Patch VERB was introduced it seems we forgot to add from which version the Patch can be used.

**Which issue(s) this PR fixes**:
Closes: #17508

**Special notes for your reviewer**:

