### PR TITLE
OAuth: Fix for wrong user token updated on OAuth refresh in DS proxy

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -354,7 +354,7 @@ func addOAuthPassThruAuth(c *m.ReqContext, req *http.Request) {
 	// If the tokens are not the same, update the entry in the DB
 	if token.AccessToken != authInfoQuery.Result.OAuthAccessToken {
 		updateAuthCommand := &m.UpdateAuthInfoCommand{
-			UserId:     authInfoQuery.Result.Id,
+			UserId:     authInfoQuery.Result.UserId,
 			AuthModule: authInfoQuery.Result.AuthModule,
 			AuthId:     authInfoQuery.Result.AuthId,
 			OAuthToken: token,

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -241,8 +241,8 @@ func UpdateAuthInfo(cmd *models.UpdateAuthInfoCommand) error {
 			UserId:     cmd.UserId,
 			AuthModule: cmd.AuthModule,
 		}
-
-		_, err := sess.Update(authUser, cond)
+		upd, err := sess.Update(authUser, cond)
+		sqlog.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_module", cmd.AuthModule, "rows", upd)
 		return err
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When DS proxy is configured with `oauthPassThru: true` flag it takes care of refreshing the token. New token is then persisted into `user_auth` table, but wrong `user_id` was used. as a result either no users are updated or wrong user receives a token.


**Special notes for your reviewer**:

It might be seen as a security issue, but given that it is triggered by an undocumented flag it is probably not.