### PR TITLE
fix min/max config in singlestat sparklines

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -552,9 +552,10 @@ class SingleStatCtrl extends MetricsPanelCtrl {
             fill: 1,
             lineWidth: 1,
             fillColor: getColorFromHexRgbOrName(panel.sparkline.fillColor, config.theme.type),
+            zero: false,
           },
         },
-        yaxes: {
+        yaxis: {
           show: false,
           min: panel.sparkline.ymin,
           max: panel.sparkline.ymax,


### PR DESCRIPTION
**What this PR does / why we need it**:
I should have tested #17527 yesterday better. Turns out jquery.plot ["defaults [zero] to true for filled lines and bars"](https://github.com/flot/flot/blob/master/API.md#customizing-the-data-series), which means "zero" needs to be explicitly set to false. Also, there was a misspelling in the options (`yaxes` instead of `yaxis`)

![out](https://user-images.githubusercontent.com/102791/59350044-66369f80-8d1b-11e9-9619-fb7c9abd43da.gif)
