### PR TITLE
SinglestatPanel: Remove background color when value turns null

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -609,6 +609,9 @@ class SingleStatCtrl extends MetricsPanelCtrl {
           } else {
             elem.css('background-color', '');
           }
+        } else {
+          $panelContainer.css('background-color', '');
+          elem.css('background-color', '');
         }
       } else {
         $panelContainer.css('background-color', '');


### PR DESCRIPTION
**What this PR does / why we need it**:
Manages the background color of SinglestatPanel, when getColorForValue() function returns null value, by setting it as ''. This is the case when the data.value of the panel is NaN.

![SinglestatPanelComparison](https://user-images.githubusercontent.com/13367068/59366201-39de4b80-8d3a-11e9-9c04-544f27211020.JPG)

**Which issue(s) this PR fixes**:
Fixes #9747