### PR TITLE
Explore: Adds ability to remove filter from <AdHocFilterField /> key dropdown

### DIFF
--- a/public/app/features/explore/AdHocFilterField.test.tsx
+++ b/public/app/features/explore/AdHocFilterField.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AdHocFilterField, DEFAULT_REMOVE_FILTER_VALUE } from './AdHocFilterField';
+import { AdHocFilter } from './AdHocFilter';
+import { MockDataSourceApi } from '../../../test/mocks/datasource_srv';
+
+describe('<AdHocFilterField />', () => {
+  let mockDataSourceApi;
+
+  beforeEach(() => {
+    mockDataSourceApi = new MockDataSourceApi();
+  });
+
+  it('should initially have no filters', () => {
+    const mockOnPairsChanged = jest.fn();
+    const wrapper = shallow(<AdHocFilterField datasource={mockDataSourceApi} onPairsChanged={mockOnPairsChanged} />);
+    expect(wrapper.state('pairs')).toEqual([]);
+    expect(wrapper.find(AdHocFilter).exists()).toBeFalsy();
+  });
+
+  it('should add <AdHocFilter /> when onAddFilter is invoked', () => {
+    const mockOnPairsChanged = jest.fn();
+    const wrapper = shallow(<AdHocFilterField datasource={mockDataSourceApi} onPairsChanged={mockOnPairsChanged} />);
+    expect(wrapper.state('pairs')).toEqual([]);
+    wrapper
+      .find('button')
+      .first()
+      .simulate('click');
+    expect(wrapper.find(AdHocFilter).exists()).toBeTruthy();
+  });
+
+  it(`should remove the relavant filter when the '${DEFAULT_REMOVE_FILTER_VALUE}' key is selected`, () => {
+    const mockOnPairsChanged = jest.fn();
+    const wrapper = shallow(<AdHocFilterField datasource={mockDataSourceApi} onPairsChanged={mockOnPairsChanged} />);
+    expect(wrapper.state('pairs')).toEqual([]);
+
+    wrapper
+      .find('button')
+      .first()
+      .simulate('click');
+    expect(wrapper.find(AdHocFilter).exists()).toBeTruthy();
+
+    wrapper.find(AdHocFilter).prop('onKeyChanged')(DEFAULT_REMOVE_FILTER_VALUE);
+    expect(wrapper.find(AdHocFilter).exists()).toBeFalsy();
+  });
+
+  it('it should call onPairsChanged when a filter is removed', async () => {
+    const mockOnPairsChanged = jest.fn();
+    const wrapper = shallow(<AdHocFilterField datasource={mockDataSourceApi} onPairsChanged={mockOnPairsChanged} />);
+    expect(wrapper.state('pairs')).toEqual([]);
+
+    wrapper
+      .find('button')
+      .first()
+      .simulate('click');
+    expect(wrapper.find(AdHocFilter).exists()).toBeTruthy();
+
+    wrapper.find(AdHocFilter).prop('onKeyChanged')(DEFAULT_REMOVE_FILTER_VALUE);
+    expect(wrapper.find(AdHocFilter).exists()).toBeFalsy();
+
+    expect(mockOnPairsChanged.mock.calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds ability to remove filter from `<AdHocFilterField />` key dropdown
- Adds tests to validate behavior
- Query now reruns when filter is removed
- Changes `<AdHocFilterField />` such that after a measurement and field have been chosen,
just a `+` button is displayed, rather than an empty `<AdHocFilter />`

Needed to make UX more user-friendly.

**Which issue(s) this PR fixes**:
Closes #17544
Closes #17497

**Special notes for your reviewer**:

