### PR TITLE
convert 'login maximum inactive lifetime' to duration

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -265,8 +265,9 @@ editors_can_admin = false
 # Login cookie name
 login_cookie_name = grafana_session
 
-# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
-login_maximum_inactive_lifetime_days = 7
+# The lifetime an authenticated user can be inactive before being required to login at next visit. Default is 168 hours (7 days).
+# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+login_maximum_inactive_lifetime_duration = 168h
 
 # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
 login_maximum_lifetime_days = 30

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -254,7 +254,7 @@
 ;login_cookie_name = grafana_session
 
 # The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
-;login_maximum_inactive_lifetime_days = 7
+;login_maximum_inactive_lifetime_duration = 168h
 
 # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
 ;login_maximum_lifetime_days = 30

--- a/docs/sources/auth/overview.md
+++ b/docs/sources/auth/overview.md
@@ -56,7 +56,7 @@ Example:
 login_cookie_name = grafana_session
 
 # The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
-login_maximum_inactive_lifetime_days = 7
+login_maximum_inactive_lifetime_duration = 168h
 
 # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
 login_maximum_lifetime_days = 30

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -143,7 +143,7 @@ If you have `login_remember_days` configured to 0 (zero) you should change your 
 
 ```ini
 [auth]
-login_maximum_inactive_lifetime_days = 1
+login_maximum_inactive_lifetime_duration = 24h
 login_maximum_lifetime_days = 1
 ```
 

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -390,7 +390,10 @@ func (s *UserAuthTokenService) createdAfterParam() int64 {
 }
 
 func (s *UserAuthTokenService) rotatedAfterParam() int64 {
-	tokenMaxInactiveLifetime := time.Duration(s.Cfg.LoginMaxInactiveLifetimeDays) * 24 * time.Hour
+	tokenMaxInactiveLifetime, err := time.ParseDuration(s.Cfg.LoginMaxInactiveLifetimeDuration)
+	if err != nil {
+		s.log.Error("failed to parse login_maximum_inactive_lifetime_duration", "error", err)
+	}
 	return getTime().Add(-tokenMaxInactiveLifetime).Unix()
 }
 

--- a/pkg/services/auth/auth_token_test.go
+++ b/pkg/services/auth/auth_token_test.go
@@ -497,9 +497,9 @@ func createTestContext(t *testing.T) *testContext {
 	tokenService := &UserAuthTokenService{
 		SQLStore: sqlstore,
 		Cfg: &setting.Cfg{
-			LoginMaxInactiveLifetimeDays: 7,
-			LoginMaxLifetimeDays:         30,
-			TokenRotationIntervalMinutes: 10,
+			LoginMaxInactiveLifetimeDuration: "168h",
+			LoginMaxLifetimeDays:             30,
+			TokenRotationIntervalMinutes:     10,
 		},
 		log: log.New("test-logger"),
 	}

--- a/pkg/services/auth/token_cleanup_test.go
+++ b/pkg/services/auth/token_cleanup_test.go
@@ -13,7 +13,7 @@ func TestUserAuthTokenCleanup(t *testing.T) {
 
 	Convey("Test user auth token cleanup", t, func() {
 		ctx := createTestContext(t)
-		ctx.tokenService.Cfg.LoginMaxInactiveLifetimeDays = 7
+		ctx.tokenService.Cfg.LoginMaxInactiveLifetimeDuration = "168h"
 		ctx.tokenService.Cfg.LoginMaxLifetimeDays = 30
 
 		insertToken := func(token string, prev string, createdAt, rotatedAt int64) {
@@ -27,8 +27,8 @@ func TestUserAuthTokenCleanup(t *testing.T) {
 			return t
 		}
 
-		Convey("should delete tokens where token rotation age is older than or equal 7 days", func() {
-			from := t.Add(-7 * 24 * time.Hour)
+		Convey("should delete tokens where token rotation age is older than or equal 168 hours", func() {
+			from := t.Add(-168 * time.Hour)
 
 			// insert three old tokens that should be deleted
 			for i := 0; i < 3; i++ {
@@ -41,7 +41,7 @@ func TestUserAuthTokenCleanup(t *testing.T) {
 				insertToken(fmt.Sprintf("newA%d", i), fmt.Sprintf("newB%d", i), from.Unix(), from.Unix())
 			}
 
-			affected, err := ctx.tokenService.deleteExpiredTokens(context.Background(), 7*24*time.Hour, 30*24*time.Hour)
+			affected, err := ctx.tokenService.deleteExpiredTokens(context.Background(), 168*time.Hour, 30*24*time.Hour)
 			So(err, ShouldBeNil)
 			So(affected, ShouldEqual, 3)
 		})

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -247,10 +247,10 @@ type Cfg struct {
 	EnterpriseLicensePath            string
 
 	// Auth
-	LoginCookieName              string
-	LoginMaxInactiveLifetimeDays int
-	LoginMaxLifetimeDays         int
-	TokenRotationIntervalMinutes int
+	LoginCookieName                  string
+	LoginMaxInactiveLifetimeDuration string
+	LoginMaxLifetimeDays             int
+	TokenRotationIntervalMinutes     int
 
 	// Dataproxy
 	SendUserHeader bool
@@ -791,7 +791,10 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	if err != nil {
 		return err
 	}
-	cfg.LoginMaxInactiveLifetimeDays = auth.Key("login_maximum_inactive_lifetime_days").MustInt(7)
+	cfg.LoginMaxInactiveLifetimeDuration, err = valueAsString(auth, "login_maximum_inactive_lifetime_duration", "168h")
+	if err != nil {
+		return err
+	}
 
 	LoginMaxLifetimeDays = auth.Key("login_maximum_lifetime_days").MustInt(30)
 	cfg.LoginMaxLifetimeDays = LoginMaxLifetimeDays


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows to set a `login_maximum_inactive_lifetime` that is shorter than 1 day.

**Which issue(s) this PR fixes**:
Fixes #17554

**Special notes for your reviewer**:
