### PR TITLE
allow to read organizations from access_token claim for generic_oauth

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -368,6 +368,8 @@ token_url =
 api_url =
 team_ids =
 allowed_organizations =
+# if your OAuth provider do not provide '/orgs' API endpoints to fetch organizations, read them from a field of the 'attributes' claim
+organizations_attribute_name =
 tls_skip_verify_insecure = false
 tls_client_cert =
 tls_client_key =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -324,6 +324,7 @@
 ;api_url = https://foo.bar/user
 ;team_ids =
 ;allowed_organizations =
+;organizations_attribute_name =
 ;tls_skip_verify_insecure = false
 ;tls_client_cert =
 ;tls_client_key =

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -33,6 +33,8 @@ token_url =
 api_url =
 allowed_domains = mycompany.com mycompany.org
 allow_sign_up = true
+# allowed_organizations = grafana
+# organizations_attribute_name = roles
 ```
 
 Set `api_url` to the resource that returns [OpenID UserInfo](https://connect2id.com/products/server/docs/api/userinfo) compatible information.
@@ -43,6 +45,10 @@ Grafana will attempt to determine the user's e-mail address by querying the OAut
 2. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
 3. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
 4. If no e-mail address is found in steps (1-3), then the e-mail address of the user is set to the empty string.
+
+**OPTIONAL:** If you need more granular control over who has access to Grafana, you can configure the `allowed_organizations` setting. In which case, you need:
+* either your OAuth provider provides the `<api_url>/orgs` endpoint
+* or to set an `organizations_attribute_name` so Grafana can fetch the organizations the users belongs to from the token claims.
 
 ## Set up OAuth2 with Okta
 

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -161,12 +161,13 @@ func NewOAuthService() {
 					Config: &config,
 					log:    logger,
 				},
-				allowedDomains:       info.AllowedDomains,
-				apiUrl:               info.ApiUrl,
-				allowSignup:          info.AllowSignup,
-				emailAttributeName:   info.EmailAttributeName,
-				teamIds:              sec.Key("team_ids").Ints(","),
-				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
+				allowedDomains:             info.AllowedDomains,
+				apiUrl:                     info.ApiUrl,
+				allowSignup:                info.AllowSignup,
+				emailAttributeName:         info.EmailAttributeName,
+				organizationsAttributeName: sec.Key("organizations_attribute_name").String(),
+				teamIds:                    sec.Key("team_ids").Ints(","),
+				allowedOrganizations:       util.SplitString(sec.Key("allowed_organizations").String()),
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This allow to use a custom `claim` from the OAuth token in order to define which `organizations` a user belongs to if your OAuth provider don't provide `/orgs` API.

**Which issue(s) this PR fixes**:
N/A
