### PR TITLE
Docs feedback: installation/debian.md

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -41,6 +41,11 @@ sudo dpkg -i grafana_5.4.2_amd64.deb
 
 ## APT Repository
 
+The command `add-apt-repository` isn't a default app on Debian 9 and requires
+```bash
+apt-get install -y software-properties-common
+```
+
 Install the repository for stable releases
 
 ```bash
@@ -56,7 +61,7 @@ sudo add-apt-repository "deb https://packages.grafana.com/oss/deb beta main"
 Use the above line even if you are on Ubuntu or another Debian version. Then add our gpg key. This allows you to install signed packages.
 
 ```bash
-curl https://packages.grafana.com/gpg.key | sudo apt-key add -
+sudo wget -q -O - https://packages.grafana.com/gpg.key | apt-key add -
 ```
 
 Update your Apt repositories and install Grafana


### PR DESCRIPTION
Changed `curl` commands to default available command `wget` on Debian and other Debian Distros.
Added necessary package to use `add-apt-repository`

Closes #17129

