### PR TITLE
Explore: Fixes implicit any error in AdHocFilterField.test.tsx

### DIFF
--- a/public/app/features/explore/AdHocFilterField.test.tsx
+++ b/public/app/features/explore/AdHocFilterField.test.tsx
@@ -3,10 +3,11 @@ import { shallow } from 'enzyme';
 
 import { AdHocFilterField, DEFAULT_REMOVE_FILTER_VALUE } from './AdHocFilterField';
 import { AdHocFilter } from './AdHocFilter';
+import { DataSourceApi } from '@grafana/ui';
 import { MockDataSourceApi } from '../../../test/mocks/datasource_srv';
 
 describe('<AdHocFilterField />', () => {
-  let mockDataSourceApi;
+  let mockDataSourceApi: DataSourceApi;
 
   beforeEach(() => {
     mockDataSourceApi = new MockDataSourceApi();


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes implicit any error in AdHocFilterField.test.tsx which was causing frontend tests to fail.