### PR TITLE
Fix so that correct cache is provided to di registry

### DIFF
--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	"github.com/facebookgo/inject"
-	"github.com/patrickmn/go-cache"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	_ "github.com/grafana/grafana/pkg/extensions"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	_ "github.com/grafana/grafana/pkg/infra/metrics"
 	_ "github.com/grafana/grafana/pkg/infra/remotecache"
@@ -88,7 +88,7 @@ func (g *GrafanaServerImpl) Run() error {
 	if err != nil {
 		return fmt.Errorf("Failed to provide object to the graph: %v", err)
 	}
-	err = serviceGraph.Provide(&inject.Object{Value: cache.New(5*time.Minute, 10*time.Minute)})
+	err = serviceGraph.Provide(&inject.Object{Value: localcache.New(5*time.Minute, 10*time.Minute)})
 	if err != nil {
 		return fmt.Errorf("Failed to provide object to the graph: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix prevents Grafana from crashing after being logged in.

**Which issue(s) this PR fixes**:
Ref #17519 

**Special notes for your reviewer**:

