### PR TITLE
Explore: Instance data now loads when entering explore view from a panel

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -581,6 +581,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       const expandedQueries = queries.map(query => ({
         ...query,
         expr: this.templateSrv.replace(query.expr, {}, this.interpolateQueryExpr),
+        context: 'explore',
 
         // null out values we don't support in Explore yet
         legendFormat: null,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where instance data was not loading when entering explore view from a panel.

**Which issue(s) this PR fixes**:
Closes #17457
