### PR TITLE
Devenv: Add nginx proxy for mac to devenv

### DIFF
--- a/devenv/docker/blocks/nginx_proxy_mac/Dockerfile
+++ b/devenv/docker/blocks/nginx_proxy_mac/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY htpasswd /etc/nginx/htpasswd

--- a/devenv/docker/blocks/nginx_proxy_mac/docker-compose.yaml
+++ b/devenv/docker/blocks/nginx_proxy_mac/docker-compose.yaml
@@ -1,0 +1,11 @@
+# This will proxy all requests for http://localhost:10080/grafana/ to
+# http://localhost:3000 (Grafana running locally)
+#
+# Please note that you'll need to change the root_url in the Grafana configuration:
+# root_url = %(protocol)s://%(domain)s:10080/grafana/
+
+  nginxproxy:
+    build: docker/blocks/nginx_proxy
+    ports:
+      - "10080:10080"
+

--- a/devenv/docker/blocks/nginx_proxy_mac/htpasswd
+++ b/devenv/docker/blocks/nginx_proxy_mac/htpasswd
@@ -1,0 +1,3 @@
+user1:$apr1$1odeeQb.$kwV8D/VAAGUDU7pnHuKoV0
+user2:$apr1$A2kf25r.$6S0kp3C7vIuixS5CL0XA9.
+admin:$apr1$IWn4DoRR$E2ol7fS/dkI18eU4bXnBO1

--- a/devenv/docker/blocks/nginx_proxy_mac/nginx.conf
+++ b/devenv/docker/blocks/nginx_proxy_mac/nginx.conf
@@ -1,0 +1,39 @@
+events { worker_connections 1024; }
+
+http {
+  sendfile on;
+
+  proxy_redirect     off;
+  proxy_set_header   Host $host;
+  proxy_set_header   X-Real-IP $remote_addr;
+  proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header   X-Forwarded-Host $server_name;
+
+  server {
+    listen 10080;
+
+    location /grafana/ {
+      ################################################################
+      # Enable these settings to test with basic auth and an auth proxy header
+      # the htpasswd file contains an admin user with password admin and
+      # user1: grafana and user2: grafana
+      ################################################################
+
+      # auth_basic "Restricted Content";
+      # auth_basic_user_file /etc/nginx/htpasswd;
+
+      ################################################################
+      # To use the auth proxy header, set the following in custom.ini:
+      # [auth.proxy]
+      # enabled = true
+      # header_name = X-WEBAUTH-USER
+      # header_property = username
+      ################################################################
+
+      # proxy_set_header X-WEBAUTH-USER $remote_user;
+
+      # this url works only on mac
+      proxy_pass http://host.docker.internal:3000/;
+    }
+  }
+}


### PR DESCRIPTION
Add mac specific proxy setup because of issues with networking otherwise it is the same os the base one.