### PR TITLE
Explore: Removes minus button in adhoc query field

### DIFF
--- a/public/app/features/explore/AdHocFilterField.tsx
+++ b/public/app/features/explore/AdHocFilterField.tsx
@@ -156,11 +156,6 @@ export class AdHocFilterField<
                 onValueChanged={this.onValueChanged(index)}
               />
               {index < pairs.length - 1 && <span>&nbsp;AND&nbsp;</span>}
-              {index < pairs.length - 1 && (
-                <button className="gf-form-label gf-form-label--btn" onClick={() => this.onRemoveFilter(index)}>
-                  <i className="fa fa-minus" />
-                </button>
-              )}
               {index === pairs.length - 1 && addFilterButton(this.onAddFilter)}
             </div>
           );


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes minus button in adhoc query field.
We have a solution for removing filters that works when one or multiple filters have been defined and we don't need to have two ways.

**Which issue(s) this PR fixes**:
Closes #17571

**Special notes for your reviewer**:

