### PR TITLE
Add legend sorting

### DIFF
--- a/public/app/plugins/panel/graph/Legend/Legend.tsx
+++ b/public/app/plugins/panel/graph/Legend/Legend.tsx
@@ -46,6 +46,13 @@ interface LegendSortProps {
   sortDesc?: boolean;
 }
 
+const legendCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+  ignorePunctuation: true,
+  caseFirst: 'upper',
+});
+
 export type GraphLegendProps = LegendProps &
   LegendDisplayProps &
   LegendValuesProps &
@@ -100,6 +107,11 @@ export class GraphLegend extends PureComponent<GraphLegendProps, LegendState> {
       if (this.props.sortDesc) {
         seriesList = seriesList.reverse();
       }
+    } else {
+      // if no special sorting is enabled, sorting by the metric alias alphabetically
+      seriesList = seriesList.sort((a, b) => {
+        return legendCollator.compare(String(a.alias), String(b.alias));
+      });
     }
     return seriesList;
   }


### PR DESCRIPTION
Sort legend, both list and table style, by alias name with natural sorting unless some other
sorting have been selected by clicking on the legend table header.