### PR TITLE
Refresh picker: Handle empty intervals

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -43,6 +43,11 @@ export class RefreshPicker extends PureComponent<Props> {
       options.unshift(liveOption);
     }
     options.unshift(offOption);
+
+    // Remove the option with the empty string
+    if (this.hasNoIntervals() && intervals[0] === '') {
+      options.pop();
+    }
     return options;
   };
 
@@ -56,7 +61,7 @@ export class RefreshPicker extends PureComponent<Props> {
 
   render() {
     const { onRefresh, intervals, tooltip, value } = this.props;
-    const options = this.intervalsToOptions(this.hasNoIntervals() ? defaultIntervals : intervals);
+    const options = this.intervalsToOptions(intervals);
     const currentValue = value || '';
     const selectedValue = options.find(item => item.value === currentValue) || offOption;
 

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -19,35 +19,21 @@ export interface Props {
 }
 
 export class RefreshPicker extends PureComponent<Props> {
-  static defaultProps = {
-    intervals: defaultIntervals,
-  };
-
   constructor(props: Props) {
     super(props);
   }
 
-  hasNoIntervals = () => {
-    const { intervals } = this.props;
-    // Current implementaion returns an array with length of 1 consisting of
-    // an empty string when auto-refresh is empty in dashboard settings
-    if (!intervals || intervals.length < 1 || (intervals.length === 1 && intervals[0] === '')) {
-      return true;
-    }
-    return false;
-  };
+  intervalsToOptions = (intervals: string[] | undefined): Array<SelectOptionItem<string>> => {
+    const intervalsOrDefault = intervals || defaultIntervals;
+    const options = intervalsOrDefault
+      .filter(str => str !== '')
+      .map(interval => ({ label: interval, value: interval }));
 
-  intervalsToOptions = (intervals: string[] = defaultIntervals): Array<SelectOptionItem<string>> => {
-    const options = intervals.map(interval => ({ label: interval, value: interval }));
     if (this.props.hasLiveOption) {
       options.unshift(liveOption);
     }
-    options.unshift(offOption);
 
-    // Remove the option with the empty string
-    if (this.hasNoIntervals() && intervals[0] === '') {
-      options.pop();
-    }
+    options.unshift(offOption);
     return options;
   };
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #17341

**Special notes for your reviewer**:
`undefined` intervals is handled by default value in `this.intervalsToOptions`.