### PR TITLE
Add Flapping Alerts report

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -341,6 +341,7 @@ func (hs *HTTPServer) registerRoutes() {
 			alertsRoute.Get("/:alertId", ValidateOrgAlert, Wrap(GetAlert))
 			alertsRoute.Get("/", Wrap(GetAlerts))
 			alertsRoute.Get("/states-for-dashboard", Wrap(GetAlertStatesForDashboard))
+			alertsRoute.Get("/top", Wrap(GetTopAlerts))
 		})
 
 		apiRoute.Get("/alert-notifications", Wrap(GetAlertNotifications))

--- a/pkg/models/alert.go
+++ b/pkg/models/alert.go
@@ -247,3 +247,25 @@ type ValidateDashboardAlertsCommand struct {
 	Dashboard *Dashboard
 	User      *SignedInUser
 }
+
+type TopAlertsDTO struct {
+	Id            int64  `json:"id"`
+	Name          string `json:"name"`
+	AlertCount    int64  `json:"alertCount"`
+	LatestAlert   int64  `json:"latestAlert"`
+	DashboardId   int64  `json:"dashboardId"`
+	DashboardUid  string `json:"dashboardUid"`
+	DashboardSlug string `json:"dashboardSlug"`
+	PanelId       int64  `json:"panelId"`
+	Url           string `json:"url"`
+}
+
+type GetTopAlertsQuery struct {
+	From        int64
+	To          int64
+	OrgId       int64
+	DashboardId int64
+	Limit       int64
+
+	Result []*TopAlertsDTO
+}

--- a/public/app/plugins/panel/alertlist/module.html
+++ b/public/app/plugins/panel/alertlist/module.html
@@ -26,6 +26,31 @@
     </ol>
   </section>
 
+  <section ng-if="ctrl.panel.show === 'top'">
+    <ol class="alert-rule-list">
+      <li class="alert-rule-item" ng-repeat="alert in ctrl.topAlerts">
+        <div class="alert-rule-item__icon {{alert.stateModel.stateClass}}">
+          <i class="{{alert.stateModel.iconClass}}"></i>
+        </div>
+        <div class="alert-rule-item__body">
+          <div class="alert-rule-item__header">
+            <p class="alert-rule-item__name">
+              <a href="{{alert.url}}?panelId={{alert.panelId}}&fullscreen&edit&tab=alert">
+                {{alert.name}}
+              </a>
+            </p>
+            <div class="alert-rule-item__text">
+              <span class="alert-rule-item__info">Count: {{alert.alertCount}}</span>
+            </div>
+          </div>
+        </div>
+        <div class="alert-rule-item__time">
+          <span>{{alert.latestAlertDate}}</span>
+        </div>
+      </li>
+    </ol>
+  </section>
+
   <section ng-if="ctrl.panel.show === 'changes'">
     <ol class="alert-rule-list">
       <li class="alert-rule-item" ng-repeat="al in ctrl.alertHistory">


### PR DESCRIPTION
Add a report API and Alert List panel extension to show the list of alerts which have triggered the most number of times recently. It help to locate and fix those nasty flapping alerts.