### PR TITLE
Grafana-CLI: Makes datapath configurable for the data encryption migration

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -19,6 +19,7 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 		cmd := &utils.ContextCommandLine{Context: context}
 
 		cfg := setting.NewCfg()
+
 		cfg.Load(&setting.CommandLineArgs{
 			Config:   cmd.String("config"),
 			HomePath: cmd.String("homepath"),
@@ -93,21 +94,23 @@ var pluginCommands = []cli.Command{
 	},
 }
 
+var dbCommandFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "homepath",
+		Usage: "path to grafana install/home path, defaults to working directory",
+	},
+	cli.StringFlag{
+		Name:  "config",
+		Usage: "path to config file",
+	},
+}
+
 var adminCommands = []cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
 		Action: runDbCommand(resetPasswordCommand),
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "homepath",
-				Usage: "path to grafana install/home path, defaults to working directory",
-			},
-			cli.StringFlag{
-				Name:  "config",
-				Usage: "path to config file",
-			},
-		},
+		Flags:  dbCommandFlags,
 	},
 	{
 		Name:  "data-migration",
@@ -117,6 +120,7 @@ var adminCommands = []cli.Command{
 				Name:   "encrypt-datasource-passwords",
 				Usage:  "Migrates passwords from unsecured fields to secure_json_data field. Return ok unless there is an error. Safe to execute multiple times.",
 				Action: runDbCommand(datamigrations.EncryptDatasourcePaswords),
+				Flags:  dbCommandFlags,
 			},
 		},
 	},

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -16,7 +17,7 @@ var version = "master"
 
 func main() {
 	setupLogging()
-
+	flag.Parse()
 	app := cli.NewApp()
 	app.Name = "Grafana cli"
 	app.Usage = ""


### PR DESCRIPTION
This makes datapath configurable CLI tasks that use the database. Such as reset-admin password and datasource encryption. 

This solution is a bit hacky but we need it for our Hosted Grafana offering sooner than later. I think we can go back to this and think about how we want to solve this in a better way. 