### PR TITLE
Elasticsearch: Adds support for region annotations

### DIFF
--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -180,6 +180,7 @@ Name | Description
 ------------ | -------------
 Query | You can leave the search query blank or specify a lucene query
 Time | The name of the time field, needs to be date field.
+Time End | Optional name of the time end field, needs to be date field. If set, then annotations will be marked as a regions between time and time-end.
 Text | Event description field.
 Tags | Optional field name to use for event tags (can be an array or a CSV string).
 

--- a/public/app/plugins/datasource/elasticsearch/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/annotations.editor.html
@@ -19,6 +19,10 @@
 			<input type="text" class="gf-form-input max-width-14" ng-model='ctrl.annotation.timeField' placeholder="@timestamp"></input>
 		</div>
 		<div class="gf-form">
+			<span class="gf-form-label">Time End</span>
+			<input type="text" class="gf-form-input max-width-14" ng-model='ctrl.annotation.timeEndField' placeholder=""></input>
+		</div>
+		<div class="gf-form">
 			<span class="gf-form-label">Text</span>
 			<input type="text" class="gf-form-input max-width-14" ng-model='ctrl.annotation.textField' placeholder=""></input>
 		</div>


### PR DESCRIPTION
It is now possible to specify a field containing a region-id in Elasticsearch annotations.
Two annotations events sharing the same region-id will be displayed as a single region
annotation. 
In order to support regions that start or end outside of the displayed time
frame, the region-id field will have to contain the document-id of the start-event

Ref #10589 for Elasticsearch based annotations
