### PR TITLE
Elasticsearch: Support for visualizing logs in Explore 

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -153,6 +153,9 @@ datasources:
       interval: Daily
       timeField: "@timestamp"
       esVersion: 70
+      timeInterval: "10s"
+      logMessageField: message
+      logLevelField: fields.level
 
   - name: gdev-elasticsearch-v7-metricbeat
     type: elasticsearch

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -115,11 +115,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			}
 		}
 
-		if ds.Type == m.DS_ES {
-			dsMap["index"] = ds.Database
-		}
-
-		if ds.Type == m.DS_INFLUXDB {
+		if (ds.Type == m.DS_INFLUXDB) || (ds.Type == m.DS_ES) {
 			dsMap["database"] = ds.Database
 		}
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -240,7 +240,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       const supportsGraph = datasourceInstance.meta.metrics;
       const supportsLogs = datasourceInstance.meta.logs;
 
-      let mode = ExploreMode.Metrics;
+      let mode = state.mode || ExploreMode.Metrics;
       const supportedModes: ExploreMode[] = [];
 
       if (supportsGraph) {

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -7,7 +7,7 @@ import Prism from 'prismjs';
 
 // dom also includes Element polyfills
 import QueryField from 'app/features/explore/QueryField';
-import { ExploreQueryFieldProps, DataSourceStatus } from '@grafana/ui';
+import { ExploreQueryFieldProps } from '@grafana/ui';
 import { ElasticDatasource } from '../datasource';
 import { ElasticsearchOptions, ElasticsearchQuery } from '../types';
 
@@ -42,11 +42,9 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
   componentWillUnmount() {}
 
   componentDidUpdate(prevProps: Props) {
-    const reconnected =
-      prevProps.datasourceStatus === DataSourceStatus.Disconnected &&
-      this.props.datasourceStatus === DataSourceStatus.Connected;
-    if (!reconnected) {
-      return;
+    // if query changed from the outside (i.e. cleared via explore toolbar)
+    if (!this.props.query.isLogsQuery) {
+      this.onChangeQuery('', true);
     }
   }
 

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -54,7 +54,7 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
     // Send text change to parent
     const { query, onChange, onRunQuery } = this.props;
     if (onChange) {
-      const nextQuery: ElasticsearchQuery = { ...query, query: value, context: 'explore', isLogsQuery: true };
+      const nextQuery: ElasticsearchQuery = { ...query, query: value, isLogsQuery: true };
       onChange(nextQuery);
 
       if (override && onRunQuery) {

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -14,6 +14,7 @@ import { ElasticsearchOptions } from '../types';
 export interface ElasticsearchQuery extends DataQuery {
   query: string;
   context: string;
+  isLogsQuery: boolean;
   bucketAggs?: any[];
   metrics?: any[];
   alias?: string;
@@ -44,7 +45,7 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    this.onChangeQuery('');
+    this.onChangeQuery('', true);
   }
 
   componentWillUnmount() {}
@@ -62,7 +63,7 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
     // Send text change to parent
     const { query, onChange, onRunQuery } = this.props;
     if (onChange) {
-      const nextQuery: ElasticsearchQuery = { ...query, query: value, context: 'explore' };
+      const nextQuery: ElasticsearchQuery = { ...query, query: value, context: 'explore', isLogsQuery: true };
       onChange(nextQuery);
 
       if (override && onRunQuery) {

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -9,13 +9,14 @@ import Prism from 'prismjs';
 import QueryField from 'app/features/explore/QueryField';
 import { ExploreQueryFieldProps, DataSourceStatus, DataQuery } from '@grafana/ui';
 import { ElasticDatasource } from '../datasource';
+import { ElasticsearchOptions } from '../types';
 
 export interface ElasticsearchQuery extends DataQuery {
   query: string;
   context: string;
 }
 
-interface Props extends ExploreQueryFieldProps<ElasticDatasource, ElasticsearchQuery> {}
+interface Props extends ExploreQueryFieldProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions> {}
 
 interface State {
   syntaxLoaded: boolean;

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -71,10 +71,7 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
           <div className="gf-form gf-form--grow flex-shrink-1">
             <QueryField
               additionalPlugins={this.plugins}
-              // cleanText={cleanText}
               initialQuery={query.query}
-              // onTypeahead={this.onTypeahead}
-              // onWillApplySuggestion={willApplySuggestion}
               onChange={this.onChangeQuery}
               onRunQuery={this.props.onRunQuery}
               placeholder="Enter a Lucene query"

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -1,0 +1,100 @@
+import _ from 'lodash';
+import React from 'react';
+// @ts-ignore
+import PluginPrism from 'slate-prism';
+// @ts-ignore
+import Prism from 'prismjs';
+
+// dom also includes Element polyfills
+import QueryField from 'app/features/explore/QueryField';
+import { ExploreQueryFieldProps, DataSourceStatus, DataQuery } from '@grafana/ui';
+import { ElasticDatasource } from '../datasource';
+
+export interface ElasticsearchQuery extends DataQuery {
+  query: string;
+  context: string;
+}
+
+interface Props extends ExploreQueryFieldProps<ElasticDatasource, ElasticsearchQuery> {}
+
+interface State {
+  syntaxLoaded: boolean;
+}
+
+class ElasticsearchQueryField extends React.PureComponent<Props, State> {
+  plugins: any[];
+
+  constructor(props: Props, context: React.Context<any>) {
+    super(props, context);
+
+    this.plugins = [
+      PluginPrism({
+        onlyIn: (node: any) => node.type === 'code_block',
+        getSyntax: (node: any) => 'lucene',
+      }),
+    ];
+
+    this.state = {
+      syntaxLoaded: false,
+    };
+  }
+
+  componentDidMount() {
+    this.onChangeQuery('');
+  }
+
+  componentWillUnmount() {}
+
+  componentDidUpdate(prevProps: Props) {
+    const reconnected =
+      prevProps.datasourceStatus === DataSourceStatus.Disconnected &&
+      this.props.datasourceStatus === DataSourceStatus.Connected;
+    if (!reconnected) {
+      return;
+    }
+  }
+
+  onChangeQuery = (value: string, override?: boolean) => {
+    // Send text change to parent
+    const { query, onChange, onRunQuery } = this.props;
+    if (onChange) {
+      const nextQuery: ElasticsearchQuery = { ...query, query: value, context: 'explore' };
+      onChange(nextQuery);
+
+      if (override && onRunQuery) {
+        onRunQuery();
+      }
+    }
+  };
+
+  render() {
+    const { queryResponse, query } = this.props;
+    const { syntaxLoaded } = this.state;
+
+    return (
+      <>
+        <div className="gf-form-inline gf-form-inline--nowrap">
+          <div className="gf-form gf-form--grow flex-shrink-1">
+            <QueryField
+              additionalPlugins={this.plugins}
+              // cleanText={cleanText}
+              initialQuery={query.query}
+              // onTypeahead={this.onTypeahead}
+              // onWillApplySuggestion={willApplySuggestion}
+              onChange={this.onChangeQuery}
+              onRunQuery={this.props.onRunQuery}
+              placeholder="Enter a Lucene query"
+              portalOrigin="elasticsearch"
+              syntaxLoaded={syntaxLoaded}
+            />
+          </div>
+        </div>
+        {queryResponse && queryResponse.error ? (
+          <div className="prom-query-field-info text-error">{queryResponse.error.message}</div>
+        ) : null}
+      </>
+    );
+  }
+}
+
+export default ElasticsearchQueryField;

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -14,6 +14,9 @@ import { ElasticsearchOptions } from '../types';
 export interface ElasticsearchQuery extends DataQuery {
   query: string;
   context: string;
+  bucketAggs?: any[];
+  metrics?: any[];
+  alias?: string;
 }
 
 interface Props extends ExploreQueryFieldProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions> {}

--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -7,18 +7,9 @@ import Prism from 'prismjs';
 
 // dom also includes Element polyfills
 import QueryField from 'app/features/explore/QueryField';
-import { ExploreQueryFieldProps, DataSourceStatus, DataQuery } from '@grafana/ui';
+import { ExploreQueryFieldProps, DataSourceStatus } from '@grafana/ui';
 import { ElasticDatasource } from '../datasource';
-import { ElasticsearchOptions } from '../types';
-
-export interface ElasticsearchQuery extends DataQuery {
-  query: string;
-  context: string;
-  isLogsQuery: boolean;
-  bucketAggs?: any[];
-  metrics?: any[];
-  alias?: string;
-}
+import { ElasticsearchOptions, ElasticsearchQuery } from '../types';
 
 interface Props extends ExploreQueryFieldProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions> {}
 

--- a/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/config_ctrl.ts
@@ -11,6 +11,8 @@ export class ElasticConfigCtrl {
     const defaultMaxConcurrentShardRequests = this.current.jsonData.esVersion >= 70 ? 5 : 256;
     this.current.jsonData.maxConcurrentShardRequests =
       this.current.jsonData.maxConcurrentShardRequests || defaultMaxConcurrentShardRequests;
+    this.current.jsonData.logMessageField = this.current.jsonData.logMessageField || '';
+    this.current.jsonData.logLevelField = this.current.jsonData.logLevelField || '';
   }
 
   indexPatternTypes = [

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -216,7 +216,6 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery> {
   }
 
   testDatasource() {
-    // this.timeSrv.setTime({ from: 'now-1m', to: 'now' }, true);
     // validate that the index exist and has date field
     return this.getFields({ type: 'date' }).then(
       dateFields => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -287,7 +287,6 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
 
       let queryObj;
       if (target.isLogsQuery) {
-        console.log('Logs query!!!');
         target.bucketAggs = [queryDef.defaultBucketAgg()];
         target.metrics = [queryDef.defaultMetricAgg()];
         queryObj = this.queryBuilder.getLogsQuery(target, queryString);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -6,11 +6,10 @@ import { IndexPattern } from './index_pattern';
 import { ElasticQueryBuilder } from './query_builder';
 import { toUtc } from '@grafana/ui/src/utils/moment_wrapper';
 import * as queryDef from './query_def';
-import { ElasticsearchQuery } from './components/ElasticsearchQueryField';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
-import { ElasticsearchOptions } from './types';
+import { ElasticsearchOptions, ElasticsearchQuery } from './types';
 
 export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, ElasticsearchOptions> {
   basicAuth: string;
@@ -287,8 +286,8 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       }
 
       let queryObj;
-      if (target.context && target.context === 'explore') {
-        target.isLogsQuery = true;
+      if (target.isLogsQuery) {
+        console.log('Logs query!!!');
         target.bucketAggs = [queryDef.defaultBucketAgg()];
         target.metrics = [queryDef.defaultMetricAgg()];
         queryObj = this.queryBuilder.getLogsQuery(target, queryString);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1,6 +1,6 @@
 import angular, { IQService } from 'angular';
 import _ from 'lodash';
-import { DataSourceApi, DataSourceInstanceSettings } from '@grafana/ui';
+import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse } from '@grafana/ui';
 import { ElasticResponse } from './elastic_response';
 import { IndexPattern } from './index_pattern';
 import { ElasticQueryBuilder } from './query_builder';
@@ -267,7 +267,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     return angular.toJson(queryHeader);
   }
 
-  query(options) {
+  query(options: DataQueryRequest<ElasticsearchQuery>): Promise<DataQueryResponse> {
     let payload = '';
     const targets = _.cloneDeep(options.targets);
     const sentTargets = [];
@@ -313,11 +313,11 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     }
 
     if (sentTargets.length === 0) {
-      return this.$q.when([]);
+      return Promise.resolve({ data: [] });
     }
 
-    payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf());
-    payload = payload.replace(/\$timeTo/g, options.range.to.valueOf());
+    payload = payload.replace(/\$timeFrom/g, options.range.from.valueOf().toString());
+    payload = payload.replace(/\$timeTo/g, options.range.to.valueOf().toString());
     payload = this.templateSrv.replace(payload, options.scopedVars);
 
     const url = this.getMultiSearchUrl();

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -440,6 +440,8 @@ export class ElasticResponse {
           ...flattened,
         };
 
+        // Note: the order of for...in is arbitrary amd implementation dependant
+        // and should probably not be relied upon.
         for (propName in hit.fields) {
           if (propNames.indexOf(propName) === -1) {
             propNames.push(propName);

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash';
+import flatten from 'app/core/utils/flatten';
 import * as queryDef from './query_def';
 import TableModel from 'app/core/table_model';
+import { SeriesData, DataQueryResponse, toSeriesData, FieldType } from '@grafana/ui';
 
 export class ElasticResponse {
   constructor(private targets, private response) {
@@ -409,5 +411,141 @@ export class ElasticResponse {
     }
 
     return { data: seriesList };
+  }
+
+  getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {
+    const seriesData: SeriesData[] = [];
+    const docs: any[] = [];
+
+    for (let n = 0; n < this.response.responses.length; n++) {
+      const response = this.response.responses[n];
+      if (response.error) {
+        throw this.getErrorFromElasticResponse(this.response, response.error);
+      }
+
+      const hits = response.hits;
+      let propNames: string[] = [];
+      let propName, hit, doc, i;
+
+      for (i = 0; i < hits.hits.length; i++) {
+        hit = hits.hits[i];
+        const flattened = hit._source ? flatten(hit._source, null) : {};
+        doc = {};
+        doc[this.targets[0].timeField] = null;
+        doc = {
+          ...doc,
+          _id: hit._id,
+          _type: hit._type,
+          _index: hit._index,
+          ...flattened,
+        };
+
+        for (propName in hit.fields) {
+          if (propNames.indexOf(propName) === -1) {
+            propNames.push(propName);
+          }
+          doc[propName] = hit.fields[propName];
+        }
+
+        for (propName in doc) {
+          if (propNames.indexOf(propName) === -1) {
+            propNames.push(propName);
+          }
+        }
+
+        doc._source = { ...flattened };
+
+        docs.push(doc);
+      }
+
+      if (docs.length > 0) {
+        propNames = propNames.sort();
+        const series: SeriesData = {
+          fields: [
+            {
+              name: this.targets[0].timeField,
+              type: FieldType.time,
+            },
+          ],
+          rows: [],
+        };
+
+        if (logMessageField) {
+          series.fields.push({
+            name: logMessageField,
+            type: FieldType.string,
+          });
+        } else {
+          series.fields.push({
+            name: '_source',
+            type: FieldType.string,
+          });
+        }
+
+        if (logLevelField) {
+          series.fields.push({
+            name: 'level',
+            type: FieldType.string,
+          });
+        }
+
+        for (const propName of propNames) {
+          if (propName === this.targets[0].timeField || propName === '_source') {
+            continue;
+          }
+
+          series.fields.push({
+            name: propName,
+            type: FieldType.string,
+          });
+        }
+
+        for (const doc of docs) {
+          const row: any[] = [];
+          row.push(doc[this.targets[0].timeField][0]);
+
+          if (logMessageField) {
+            row.push(doc[logMessageField] || '');
+          } else {
+            row.push(JSON.stringify(doc._source, null, 2));
+          }
+
+          if (logLevelField) {
+            row.push(doc[logLevelField] || '');
+          }
+
+          for (const propName of propNames) {
+            if (doc.hasOwnProperty(propName)) {
+              row.push(doc[propName]);
+            } else {
+              row.push(null);
+            }
+          }
+
+          series.rows.push(row);
+        }
+
+        seriesData.push(series);
+      }
+
+      if (response.aggregations) {
+        const aggregations = response.aggregations;
+        const target = this.targets[n];
+        const tmpSeriesList = [];
+        const table = new TableModel();
+
+        this.processBuckets(aggregations, target, tmpSeriesList, table, {}, 0);
+        this.trimDatapoints(tmpSeriesList, target);
+        this.nameSeries(tmpSeriesList, target);
+
+        for (let y = 0; y < tmpSeriesList.length; y++) {
+          const series = toSeriesData(tmpSeriesList[y]);
+          series.labels = {};
+          seriesData.push(series);
+        }
+      }
+    }
+
+    return { data: seriesData };
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -1,11 +1,12 @@
 import coreModule from 'app/core/core_module';
 import _ from 'lodash';
 import * as queryDef from './query_def';
+import { ElasticsearchAggregation } from './types';
 
 export class ElasticMetricAggCtrl {
   /** @ngInject */
   constructor($scope, uiSegmentSrv, $q, $rootScope) {
-    const metricAggs = $scope.target.metrics;
+    const metricAggs: ElasticsearchAggregation[] = $scope.target.metrics;
     $scope.metricAggTypes = queryDef.getMetricAggTypes($scope.esVersion);
     $scope.extendedStats = queryDef.extendedStats;
     $scope.pipelineAggOptions = [];

--- a/public/app/plugins/datasource/elasticsearch/module.ts
+++ b/public/app/plugins/datasource/elasticsearch/module.ts
@@ -1,14 +1,15 @@
+import { DataSourcePlugin } from '@grafana/ui';
 import { ElasticDatasource } from './datasource';
 import { ElasticQueryCtrl } from './query_ctrl';
 import { ElasticConfigCtrl } from './config_ctrl';
+import ElasticsearchQueryField from './components/ElasticsearchQueryField';
 
 class ElasticAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
 }
 
-export {
-  ElasticDatasource as Datasource,
-  ElasticQueryCtrl as QueryCtrl,
-  ElasticConfigCtrl as ConfigCtrl,
-  ElasticAnnotationsQueryCtrl as AnnotationsQueryCtrl,
-};
+export const plugin = new DataSourcePlugin(ElasticDatasource)
+  .setQueryCtrl(ElasticQueryCtrl)
+  .setConfigCtrl(ElasticConfigCtrl)
+  .setExploreLogsQueryField(ElasticsearchQueryField)
+  .setAnnotationQueryCtrl(ElasticAnnotationsQueryCtrl);

--- a/public/app/plugins/datasource/elasticsearch/partials/config.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/config.html
@@ -51,3 +51,16 @@
 		</div>
 	</div>
 </div>
+
+<b>Logs</b>
+
+<div class="gf-form-group">
+	<div class="gf-form max-width-30">
+		<span class="gf-form-label width-11">Message field name</span>
+		<input class="gf-form-input" type="text" ng-model='ctrl.current.jsonData.logMessageField' placeholder="_source" />
+	</div>
+	<div class="gf-form max-width-30">
+		<span class="gf-form-label width-11">Level field name</span>
+		<input class="gf-form-input" type="text" ng-model='ctrl.current.jsonData.logLevelField' placeholder="" />
+	</div>
+</div>

--- a/public/app/plugins/datasource/elasticsearch/plugin.json
+++ b/public/app/plugins/datasource/elasticsearch/plugin.json
@@ -21,6 +21,7 @@
   "alerting": true,
   "annotations": true,
   "metrics": true,
+  "logs": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -367,4 +367,31 @@ export class ElasticQueryBuilder {
 
     return query;
   }
+
+  getLogsQuery(target, querystring) {
+    let query: any = {
+      size: 0,
+      query: {
+        bool: {
+          filter: [{ range: this.getRangeFilter() }],
+        },
+      },
+    };
+
+    if (target.query) {
+      query.query.bool.filter.push({
+        query_string: {
+          analyze_wildcard: true,
+          query: target.query,
+        },
+      });
+    }
+
+    query = this.documentQuery(query, 500);
+
+    return {
+      ...query,
+      aggs: this.build(target, null, querystring).aggs,
+    };
+  }
 }

--- a/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_ctrl.ts
@@ -6,6 +6,7 @@ import angular from 'angular';
 import _ from 'lodash';
 import * as queryDef from './query_def';
 import { QueryCtrl } from 'app/plugins/sdk';
+import { ElasticsearchAggregation } from './types';
 
 export class ElasticQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
@@ -53,7 +54,7 @@ export class ElasticQueryCtrl extends QueryCtrl {
   }
 
   getCollapsedText() {
-    const metricAggs = this.target.metrics;
+    const metricAggs: ElasticsearchAggregation[] = this.target.metrics;
     const bucketAggs = this.target.bucketAggs;
     const metricAggTypes = queryDef.getMetricAggTypes(this.esVersion);
     const bucketAggTypes = queryDef.bucketAggTypes;

--- a/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
@@ -1,20 +1,25 @@
-import angular from 'angular';
+import angular, { IQService } from 'angular';
 import * as dateMath from '@grafana/ui/src/utils/datemath';
 import _ from 'lodash';
 import { ElasticDatasource } from '../datasource';
 import { toUtc, dateTime } from '@grafana/ui/src/utils/moment_wrapper';
+import { BackendSrv } from 'app/core/services/backend_srv';
+import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+import { DataSourceInstanceSettings } from '@grafana/ui';
+import { ElasticsearchOptions } from '../types';
 
 describe('ElasticDatasource', function(this: any) {
-  const backendSrv = {
+  const backendSrv: any = {
     datasourceRequest: jest.fn(),
   };
 
-  const $rootScope = {
+  const $rootScope: any = {
     $on: jest.fn(),
     appEvent: jest.fn(),
   };
 
-  const templateSrv = {
+  const templateSrv: any = {
     replace: jest.fn(text => {
       if (text.startsWith('$')) {
         return `resolvedVariable`;
@@ -25,7 +30,7 @@ describe('ElasticDatasource', function(this: any) {
     getAdhocFilters: jest.fn(() => []),
   };
 
-  const timeSrv = {
+  const timeSrv: any = {
     time: { from: 'now-1h', to: 'now' },
     timeRange: jest.fn(() => {
       return {
@@ -43,18 +48,24 @@ describe('ElasticDatasource', function(this: any) {
     backendSrv,
   } as any;
 
-  function createDatasource(instanceSettings) {
-    instanceSettings.jsonData = instanceSettings.jsonData || {};
-    ctx.ds = new ElasticDatasource(instanceSettings, {}, backendSrv, templateSrv, timeSrv);
+  function createDatasource(instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>) {
+    instanceSettings.jsonData = instanceSettings.jsonData || ({} as ElasticsearchOptions);
+    ctx.ds = new ElasticDatasource(
+      instanceSettings,
+      {} as IQService,
+      backendSrv as BackendSrv,
+      templateSrv as TemplateSrv,
+      timeSrv as TimeSrv
+    );
   }
 
   describe('When testing datasource with index pattern', () => {
     beforeEach(() => {
       createDatasource({
         url: 'http://es.com',
-        index: '[asd-]YYYY.MM.DD',
-        jsonData: { interval: 'Daily', esVersion: '2' },
-      });
+        database: '[asd-]YYYY.MM.DD',
+        jsonData: { interval: 'Daily', esVersion: 2 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
     });
 
     it('should translate index pattern to current day', () => {
@@ -77,9 +88,9 @@ describe('ElasticDatasource', function(this: any) {
     beforeEach(async () => {
       createDatasource({
         url: 'http://es.com',
-        index: '[asd-]YYYY.MM.DD',
-        jsonData: { interval: 'Daily', esVersion: '2' },
-      });
+        database: '[asd-]YYYY.MM.DD',
+        jsonData: { interval: 'Daily', esVersion: 2 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         requestOptions = options;
@@ -148,9 +159,9 @@ describe('ElasticDatasource', function(this: any) {
     beforeEach(() => {
       createDatasource({
         url: 'http://es.com',
-        index: 'test',
-        jsonData: { esVersion: '2' },
-      });
+        database: 'test',
+        jsonData: { esVersion: 2 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         requestOptions = options;
@@ -187,7 +198,11 @@ describe('ElasticDatasource', function(this: any) {
 
   describe('When getting fields', () => {
     beforeEach(() => {
-      createDatasource({ url: 'http://es.com', index: 'metricbeat', jsonData: { esVersion: 50 } });
+      createDatasource({
+        url: 'http://es.com',
+        database: 'metricbeat',
+        jsonData: { esVersion: 50 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         return Promise.resolve({
@@ -279,7 +294,11 @@ describe('ElasticDatasource', function(this: any) {
 
   describe('When getting fields from ES 7.0', () => {
     beforeEach(() => {
-      createDatasource({ url: 'http://es.com', index: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
+      createDatasource({
+        url: 'http://es.com',
+        database: 'genuine.es7._mapping.response',
+        jsonData: { esVersion: 70 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         return Promise.resolve({
@@ -430,9 +449,9 @@ describe('ElasticDatasource', function(this: any) {
     beforeEach(() => {
       createDatasource({
         url: 'http://es.com',
-        index: 'test',
-        jsonData: { esVersion: '5' },
-      });
+        database: 'test',
+        jsonData: { esVersion: 5 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         requestOptions = options;
@@ -473,9 +492,9 @@ describe('ElasticDatasource', function(this: any) {
     beforeEach(() => {
       createDatasource({
         url: 'http://es.com',
-        index: 'test',
-        jsonData: { esVersion: '5' },
-      });
+        database: 'test',
+        jsonData: { esVersion: 5 } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
 
       ctx.backendSrv.datasourceRequest = jest.fn(options => {
         requestOptions = options;

--- a/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
@@ -29,8 +29,8 @@ describe('ElasticDatasource', function(this: any) {
     time: { from: 'now-1h', to: 'now' },
     timeRange: jest.fn(() => {
       return {
-        from: dateMath.parse(this.time.from, false),
-        to: dateMath.parse(this.time.to, true),
+        from: dateMath.parse(timeSrv.time.from, false),
+        to: dateMath.parse(timeSrv.time.to, true),
       };
     }),
     setTime: jest.fn(time => {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -490,4 +490,10 @@ describe('ElasticQueryBuilder', () => {
     const query = builder6x.getTermsQuery({});
     expect(query.aggs['1'].terms.order._key).toBe('asc');
   });
+
+  it('getTermsQuery should request documents and date histogram', () => {
+    const query = builder.getLogsQuery({});
+    expect(query).toHaveProperty('query.bool.filter');
+    expect(query.aggs['2']).toHaveProperty('date_histogram');
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,7 +1,6 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/ui';
 
 export interface ElasticsearchOptions extends DataSourceJsonData {
-  index: string;
   timeField: string;
   esVersion: number;
   interval: string;

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,4 +1,15 @@
-import { DataQuery } from '@grafana/ui';
+import { DataQuery, DataSourceJsonData } from '@grafana/ui';
+
+export interface ElasticsearchOptions extends DataSourceJsonData {
+  index: string;
+  timeField: string;
+  esVersion: number;
+  interval: string;
+  timeInterval: string;
+  maxConcurrentShardRequests: number;
+  logMessageField?: string;
+  logLevelField?: string;
+}
 
 export interface ElasticsearchAggregation {
   id: string;

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -15,14 +15,13 @@ export interface ElasticsearchAggregation {
   id: string;
   type: string;
   settings?: any;
+  field?: string;
 }
 
 export interface ElasticsearchQuery extends DataQuery {
-  context: string;
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
   bucketAggs?: ElasticsearchAggregation[];
-  metricAggs?: ElasticsearchAggregation[];
-  metrics?: any[];
+  metrics?: ElasticsearchAggregation[];
 }

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -6,7 +6,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   esVersion: number;
   interval: string;
   timeInterval: string;
-  maxConcurrentShardRequests: number;
+  maxConcurrentShardRequests?: number;
   logMessageField?: string;
   logLevelField?: string;
 }

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -1,0 +1,14 @@
+import { DataQuery } from '@grafana/ui';
+
+export interface ElasticsearchAggregation {
+  id: string;
+  type: string;
+  settings?: any;
+}
+
+export interface ElasticsearchQuery extends DataQuery {
+  alias?: string;
+  query?: string;
+  bucketAggs?: ElasticsearchAggregation[];
+  metricAggs?: ElasticsearchAggregation[];
+}

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -18,8 +18,11 @@ export interface ElasticsearchAggregation {
 }
 
 export interface ElasticsearchQuery extends DataQuery {
+  context: string;
+  isLogsQuery: boolean;
   alias?: string;
   query?: string;
   bucketAggs?: ElasticsearchAggregation[];
   metricAggs?: ElasticsearchAggregation[];
+  metrics?: any[];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for visualizing logs in Explore using Elasticsearch.

Left to do for MVP:
- [x] Use field settings from datasource settings
- [x] Figure out the best way of sending query from query field to datasource.
- [x] Replace `context` property with something that says that the query is a logs query.
- [x] Logs query should be run when switching to logs mode even though it's empty.
- [x] Try use the `QueryField` without any highlighting or auto-complete to get styling and ctrl+Return/Return to run query. Need to look into why the input field is lagging when input text to it. If lag cannot be removed, lets go for a regular html input field instead with Return handler.
- [x] Add types for elasticsearch options to datasource in similar manner as Influx datasource

**Which issue(s) this PR fixes**:
Closes #16812 

**Special notes for your reviewer**:

