### PR TITLE
Grafana-CLI: Fix receiving configuration flags from the command line

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -19,11 +19,14 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 		cmd := &utils.ContextCommandLine{Context: context}
 
 		cfg := setting.NewCfg()
+
 		cfg.Load(&setting.CommandLineArgs{
 			Config:   cmd.String("config"),
 			HomePath: cmd.String("homepath"),
 			Args:     flag.Args(),
 		})
+
+		cfg.LogConfigSources()
 
 		engine := &sqlstore.SqlStore{}
 		engine.Cfg = cfg
@@ -93,21 +96,23 @@ var pluginCommands = []cli.Command{
 	},
 }
 
+var dbCommandFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "homepath",
+		Usage: "path to grafana install/home path, defaults to working directory",
+	},
+	cli.StringFlag{
+		Name:  "config",
+		Usage: "path to config file",
+	},
+}
+
 var adminCommands = []cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
 		Action: runDbCommand(resetPasswordCommand),
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "homepath",
-				Usage: "path to grafana install/home path, defaults to working directory",
-			},
-			cli.StringFlag{
-				Name:  "config",
-				Usage: "path to config file",
-			},
-		},
+		Flags:  dbCommandFlags,
 	},
 	{
 		Name:  "data-migration",
@@ -117,6 +122,7 @@ var adminCommands = []cli.Command{
 				Name:   "encrypt-datasource-passwords",
 				Usage:  "Migrates passwords from unsecured fields to secure_json_data field. Return ok unless there is an error. Safe to execute multiple times.",
 				Action: runDbCommand(datamigrations.EncryptDatasourcePaswords),
+				Flags:  dbCommandFlags,
 			},
 		},
 	},

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -17,6 +18,7 @@ var version = "master"
 func main() {
 	setupLogging()
 
+	flag.Parse()
 	app := cli.NewApp()
 	app.Name = "Grafana cli"
 	app.Usage = ""


### PR DESCRIPTION
grafana-cli should allow configuration overrides to be received from the command line. e.g.

```
grafana-cli admin reset-password cfg:default.paths.logs=custom/log/directory/
```

Seems like we missed the inclusion of `flag.Parse` as we run the command,  to be able to consume them.

Additionally, it'll be useful for the user to know whenever these are being overridden or not - hence the addition of logging the configuration to be used as we run the command.

Additionally, it'll be useful for the user to know whenever these are being overridden or not - hence the addition of logging the configuration to be used as we run the command and extends support for the flags `--config` and `--homepath` to every subcommand within the admin top-level command

![Screenshot 2019-06-16 at 14 42 58 copy](https://user-images.githubusercontent.com/231583/59593972-d44bdf80-90ea-11e9-9be0-fe5a187af6cd.png)


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Essentially, this Fixes #12638 but https://github.com/grafana/grafana/pull/17596 also provides further optimisations. 
