### PR TITLE
Release 6.2.3

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -179,6 +179,31 @@ cookie_samesite = lax
 # set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
 allow_embedding = false
 
+# Set to true if you want to enable http strict transport security (HSTS) response header.
+# This is only sent when HTTPS is enabled in this configuration.
+# HSTS tells browsers that the site should only be accessed using HTTPS.
+# The default will change to true in the next minor release, 6.3.
+strict_transport_security = false
+
+# Sets how long a browser should cache HSTS. Only applied if strict_transport_security is enabled.
+strict_transport_security_max_age_seconds = 86400
+
+# Set to true if to enable HSTS preloading option. Only applied if strict_transport_security is enabled.
+strict_transport_security_preload = false
+
+# Set to true if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled.
+strict_transport_security_subdomains = false
+
+# Set to true to enable the X-Content-Type-Options response header.
+# The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised
+# in the Content-Type headers should not be changed and be followed. The default will change to true in the next minor release, 6.3.
+x_content_type_options = false
+
+# Set to true to enable the X-XSS-Protection header, which tells browsers to stop pages from loading
+# when they detect reflected cross-site scripting (XSS) attacks. The default will change to true in the next minor release, 6.3.
+x_xss_protection = false
+
+
 #################################### Snapshots ###########################
 [snapshots]
 # snapshot sharing options

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -113,9 +113,9 @@ type = database
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0`. Only addr is required.
 # memcache: 127.0.0.1:11211
-connstr =
+;connstr =
 
 #################################### Data proxy ###########################
 [dataproxy]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -109,7 +109,7 @@ log_queries =
 
 # cache connectionstring options
 # database: will use Grafana primary database.
-# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+# redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=0`. Only addr is required.
 # memcache: 127.0.0.1:11211
 ;connstr =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -175,6 +175,30 @@ log_queries =
 # set to true if you want to allow browsers to render Grafana in a <frame>, <iframe>, <embed> or <object>. default is false.
 ;allow_embedding = false
 
+# Set to true if you want to enable http strict transport security (HSTS) response header.
+# This is only sent when HTTPS is enabled in this configuration.
+# HSTS tells browsers that the site should only be accessed using HTTPS.
+# The default version will change to true in the next minor release, 6.3.
+;strict_transport_security = false
+
+# Sets how long a browser should cache HSTS. Only applied if strict_transport_security is enabled.
+;strict_transport_security_max_age_seconds = 86400
+
+# Set to true if to enable HSTS preloading option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_preload = false
+
+# Set to true if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled.
+;strict_transport_security_subdomains = false
+
+# Set to true to enable the X-Content-Type-Options response header.
+# The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised
+# in the Content-Type headers should not be changed and be followed. The default will change to true in the next minor release, 6.3.
+;x_content_type_options = false
+
+# Set to true to enable the X-XSS-Protection header, which tells browsers to stop pages from loading
+# when they detect reflected cross-site scripting (XSS) attacks. The default will change to true in the next minor release, 6.3.
+;x_xss_protection = false
+
 #################################### Snapshots ###########################
 [snapshots]
 # snapshot sharing options

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -320,6 +320,30 @@ When `false`, the HTTP header `X-Frame-Options: deny` will be set in Grafana HTT
 browsers to not allow rendering Grafana in a `<frame>`, `<iframe>`, `<embed>` or `<object>`. The main goal is to
 mitigate the risk of [Clickjacking](https://www.owasp.org/index.php/Clickjacking). Default is `false`.
 
+### strict_transport_security
+
+Set to `true` if you want to enable http `Strict-Transport-Security` (HSTS) response header. This is only sent when HTTPS is enabled in this configuration. HSTS tells browsers that the site should only be accessed using HTTPS. The default value is `false` until the next minor release, `6.3`.
+
+### strict_transport_security_max_age_seconds
+
+Sets how long a browser should cache HSTS in seconds. Only applied if strict_transport_security is enabled. The default value is `86400`.
+
+### strict_transport_security_preload
+
+Set to `true` if to enable HSTS `preloading` option. Only applied if strict_transport_security is enabled. The default value is `false`.
+
+### strict_transport_security_subdomains
+
+Set to `true` if to enable the HSTS includeSubDomains option. Only applied if strict_transport_security is enabled. The default value is `false`.
+
+### x_content_type_options
+
+Set to `true` to enable the X-Content-Type-Options response header. The X-Content-Type-Options response HTTP header is a marker used by the server to indicate that the MIME types advertised in the Content-Type headers should not be changed and be followed. The default value is `false` until the next minor release, `6.3`.
+
+### x_xss_protection
+
+Set to `false` to disable the X-XSS-Protection header, which tells browsers to stop pages from loading when they detect reflected cross-site scripting (XSS) attacks. The default value is `false` until the next minor release, `6.3`.
+
 <hr />
 
 ## [users]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "company": "Grafana Labs"
   },
   "name": "grafana",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -354,7 +354,7 @@ func addOAuthPassThruAuth(c *m.ReqContext, req *http.Request) {
 	// If the tokens are not the same, update the entry in the DB
 	if token.AccessToken != authInfoQuery.Result.OAuthAccessToken {
 		updateAuthCommand := &m.UpdateAuthInfoCommand{
-			UserId:     authInfoQuery.Result.Id,
+			UserId:     authInfoQuery.Result.UserId,
 			AuthModule: authInfoQuery.Result.AuthModule,
 			AuthId:     authInfoQuery.Result.AuthId,
 			OAuthToken: token,

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -19,11 +19,14 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 		cmd := &utils.ContextCommandLine{Context: context}
 
 		cfg := setting.NewCfg()
+
 		cfg.Load(&setting.CommandLineArgs{
 			Config:   cmd.String("config"),
 			HomePath: cmd.String("homepath"),
 			Args:     flag.Args(),
 		})
+
+		cfg.LogConfigSources()
 
 		engine := &sqlstore.SqlStore{}
 		engine.Cfg = cfg
@@ -93,21 +96,23 @@ var pluginCommands = []cli.Command{
 	},
 }
 
+var dbCommandFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "homepath",
+		Usage: "path to grafana install/home path, defaults to working directory",
+	},
+	cli.StringFlag{
+		Name:  "config",
+		Usage: "path to config file",
+	},
+}
+
 var adminCommands = []cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
 		Action: runDbCommand(resetPasswordCommand),
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "homepath",
-				Usage: "path to grafana install/home path, defaults to working directory",
-			},
-			cli.StringFlag{
-				Name:  "config",
-				Usage: "path to config file",
-			},
-		},
+		Flags:  dbCommandFlags,
 	},
 	{
 		Name:  "data-migration",
@@ -117,6 +122,7 @@ var adminCommands = []cli.Command{
 				Name:   "encrypt-datasource-passwords",
 				Usage:  "Migrates passwords from unsecured fields to secure_json_data field. Return ok unless there is an error. Safe to execute multiple times.",
 				Action: runDbCommand(datamigrations.EncryptDatasourcePaswords),
+				Flags:  dbCommandFlags,
 			},
 		},
 	},

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -17,6 +18,7 @@ var version = "master"
 func main() {
 	setupLogging()
 
+	flag.Parse()
 	app := cli.NewApp()
 	app.Name = "Grafana cli"
 	app.Usage = ""

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -70,7 +70,10 @@ func (dc *databaseCache) Get(key string) (interface{}, error) {
 	if cacheHit.Expires > 0 {
 		existedButExpired := getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires
 		if existedButExpired {
-			_ = dc.Delete(key) //ignore this error since we will return `ErrCacheItemNotFound` anyway
+			err = dc.Delete(key) //ignore this error since we will return `ErrCacheItemNotFound` anyway
+			if err != nil {
+				dc.log.Debug("Deletion of expired key failed: %v", err)
+			}
 			return nil, ErrCacheItemNotFound
 		}
 	}
@@ -84,35 +87,40 @@ func (dc *databaseCache) Get(key string) (interface{}, error) {
 }
 
 func (dc *databaseCache) Set(key string, value interface{}, expire time.Duration) error {
-	return dc.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
-		item := &cachedItem{Val: value}
-		data, err := encodeGob(item)
-		if err != nil {
-			return err
-		}
+	item := &cachedItem{Val: value}
+	data, err := encodeGob(item)
+	if err != nil {
+		return err
+	}
 
-		var cacheHit CacheData
-		has, err := session.Where("cache_key = ?", key).Get(&cacheHit)
-		if err != nil {
-			return err
-		}
+	session := dc.SQLStore.NewSession()
+	defer session.Close()
 
-		var expiresInSeconds int64
-		if expire != 0 {
-			expiresInSeconds = int64(expire) / int64(time.Second)
-		}
+	var expiresInSeconds int64
+	if expire != 0 {
+		expiresInSeconds = int64(expire) / int64(time.Second)
+	}
 
-		// insert or update depending on if item already exist
-		if has {
+	// attempt to insert the key
+	sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
+	_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
+	if err != nil {
+		// attempt to update if a unique constrain violation or a deadlock (for MySQL) occurs
+		// if the update fails propagate the error
+		// which eventually will result in a key that is not finally set
+		// but since it's a cache does not harm a lot
+		if dc.SQLStore.Dialect.IsUniqueConstraintViolation(err) || dc.SQLStore.Dialect.IsDeadlock(err) {
 			sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
 			_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
-		} else {
-			sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
-			_, err = session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
+			if err != nil && dc.SQLStore.Dialect.IsDeadlock(err) {
+				// most probably somebody else is upserting the key
+				// so it is safe enough not to propagate this error
+				return nil
+			}
 		}
+	}
 
-		return err
-	})
+	return err
 }
 
 func (dc *databaseCache) Delete(key string) error {

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -1,9 +1,13 @@
 package remotecache
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
 	redis "gopkg.in/redis.v2"
 )
 
@@ -13,12 +17,47 @@ type redisStorage struct {
 	c *redis.Client
 }
 
-func newRedisStorage(opts *setting.RemoteCacheOptions) *redisStorage {
-	opt := &redis.Options{
-		Network: "tcp",
-		Addr:    opts.ConnStr,
+// parseRedisConnStr parses k=v pairs in csv and builds a redis Options object
+func parseRedisConnStr(connStr string) (*redis.Options, error) {
+	keyValueCSV := strings.Split(connStr, ",")
+	options := &redis.Options{Network: "tcp"}
+	for _, rawKeyValue := range keyValueCSV {
+		keyValueTuple := strings.Split(rawKeyValue, "=")
+		if len(keyValueTuple) != 2 {
+			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
+		}
+		connKey := keyValueTuple[0]
+		connVal := keyValueTuple[1]
+		switch connKey {
+		case "addr":
+			options.Addr = connVal
+		case "password":
+			options.Password = connVal
+		case "db":
+			i, err := strconv.ParseInt(connVal, 10, 64)
+			if err != nil {
+				return nil, errutil.Wrap("value for db in redis connection string must be a number", err)
+			}
+			options.DB = i
+		case "pool_size":
+			i, err := strconv.Atoi(connVal)
+			if err != nil {
+				return nil, errutil.Wrap("value for pool_size in redis connection string must be a number", err)
+			}
+			options.PoolSize = i
+		default:
+			return nil, fmt.Errorf("unrecorgnized option '%v' in redis connection string", connVal)
+		}
 	}
-	return &redisStorage{c: redis.NewClient(opt)}
+	return options, nil
+}
+
+func newRedisStorage(opts *setting.RemoteCacheOptions) (*redisStorage, error) {
+	opt, err := parseRedisConnStr(opts.ConnStr)
+	if err != nil {
+		return nil, err
+	}
+	return &redisStorage{c: redis.NewClient(opt)}, nil
 }
 
 // Set sets value to given key in session.
@@ -28,7 +67,6 @@ func (s *redisStorage) Set(key string, val interface{}, expires time.Duration) e
 	if err != nil {
 		return err
 	}
-
 	status := s.c.SetEx(key, expires, string(value))
 	return status.Err()
 }

--- a/pkg/infra/remotecache/redis_storage_integration_test.go
+++ b/pkg/infra/remotecache/redis_storage_integration_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRedisCacheStorage(t *testing.T) {
 
-	opts := &setting.RemoteCacheOptions{Name: redisCacheType, ConnStr: "localhost:6379"}
+	opts := &setting.RemoteCacheOptions{Name: redisCacheType, ConnStr: "addr=localhost:6379"}
 	client := createTestClient(t, opts, nil)
 	runTestsForClient(t, client)
 }

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -91,7 +91,7 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 
 func createClient(opts *setting.RemoteCacheOptions, sqlstore *sqlstore.SqlStore) (CacheStorage, error) {
 	if opts.Name == redisCacheType {
-		return newRedisStorage(opts), nil
+		return newRedisStorage(opts)
 	}
 
 	if opts.Name == memcachedCacheType {

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -311,7 +311,7 @@ func (auth *AuthProxy) Remember(id int64) *Error {
 		return nil
 	}
 
-	expiration := time.Duration(-auth.cacheTTL) * time.Minute
+	expiration := time.Duration(auth.cacheTTL) * time.Minute
 
 	err = auth.store.Set(key, id, expiration)
 	if err != nil {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -241,7 +242,32 @@ func AddDefaultResponseHeaders() macaron.Handler {
 			if !setting.AllowEmbedding {
 				AddXFrameOptionsDenyHeader(w)
 			}
+
+			AddSecurityHeaders(w)
 		})
+	}
+}
+
+// AddSecurityHeaders adds various HTTP(S) response headers that enable various security protections behaviors in the client's browser.
+func AddSecurityHeaders(w macaron.ResponseWriter) {
+	if setting.Protocol == setting.HTTPS && setting.StrictTransportSecurity {
+		strictHeader := "Strict-Transport-Security"
+		w.Header().Add(strictHeader, fmt.Sprintf("max-age=%v", setting.StrictTransportSecurityMaxAge))
+		if setting.StrictTransportSecurityPreload {
+			w.Header().Add(strictHeader, "preload")
+		}
+		if setting.StrictTransportSecuritySubDomains {
+			w.Header().Add(strictHeader, "includeSubDomains")
+		}
+	}
+
+	if setting.ContentTypeProtectionHeader {
+		w.Header().Add("X-Content-Type-Options", "nosniff")
+	}
+
+	if setting.XSSProtectionHeader {
+		w.Header().Add("X-XSS-Protection", "1")
+		w.Header().Add("X-XSS-Protection", "mode=block")
 	}
 }
 

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -48,6 +48,7 @@ type Dialect interface {
 	NoOpSql() string
 
 	IsUniqueConstraintViolation(err error) bool
+	IsDeadlock(err error) bool
 }
 
 func NewDialect(engine *xorm.Engine) Dialect {

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -134,12 +134,20 @@ func (db *Mysql) CleanDB() error {
 	return nil
 }
 
-func (db *Mysql) IsUniqueConstraintViolation(err error) bool {
+func (db *Mysql) isThisError(err error, errcode uint16) bool {
 	if driverErr, ok := err.(*mysql.MySQLError); ok {
-		if driverErr.Number == mysqlerr.ER_DUP_ENTRY {
+		if driverErr.Number == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Mysql) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, mysqlerr.ER_DUP_ENTRY)
+}
+
+func (db *Mysql) IsDeadlock(err error) bool {
+	return db.isThisError(err, mysqlerr.ER_LOCK_DEADLOCK)
 }

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -138,12 +138,20 @@ func (db *Postgres) CleanDB() error {
 	return nil
 }
 
-func (db *Postgres) IsUniqueConstraintViolation(err error) bool {
+func (db *Postgres) isThisError(err error, errcode string) bool {
 	if driverErr, ok := err.(*pq.Error); ok {
-		if driverErr.Code == "23505" {
+		if string(driverErr.Code) == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Postgres) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, "23505")
+}
+
+func (db *Postgres) IsDeadlock(err error) bool {
+	return db.isThisError(err, "40P01")
 }

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -85,12 +85,20 @@ func (db *Sqlite3) CleanDB() error {
 	return nil
 }
 
-func (db *Sqlite3) IsUniqueConstraintViolation(err error) bool {
+func (db *Sqlite3) isThisError(err error, errcode int) bool {
 	if driverErr, ok := err.(sqlite3.Error); ok {
-		if driverErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+		if int(driverErr.ExtendedCode) == errcode {
 			return true
 		}
 	}
 
 	return false
+}
+
+func (db *Sqlite3) IsUniqueConstraintViolation(err error) bool {
+	return db.isThisError(err, int(sqlite3.ErrConstraintUnique))
+}
+
+func (db *Sqlite3) IsDeadlock(err error) bool {
+	return false // No deadlock
 }

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -216,8 +216,8 @@ func UpdateAuthInfo(cmd *m.UpdateAuthInfoCommand) error {
 			UserId:     cmd.UserId,
 			AuthModule: cmd.AuthModule,
 		}
-
-		_, err := sess.Update(authUser, cond)
+		upd, err := sess.Update(authUser, cond)
+		sqlog.Debug("Updated user_auth", "user_id", cmd.UserId, "auth_module", cmd.AuthModule, "rows", upd)
 		return err
 	})
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -86,14 +86,20 @@ var (
 	EnforceDomain      bool
 
 	// Security settings.
-	SecretKey                        string
-	DisableGravatar                  bool
-	EmailCodeValidMinutes            int
-	DataProxyWhiteList               map[string]bool
-	DisableBruteForceLoginProtection bool
-	CookieSecure                     bool
-	CookieSameSite                   http.SameSite
-	AllowEmbedding                   bool
+	SecretKey                         string
+	DisableGravatar                   bool
+	EmailCodeValidMinutes             int
+	DataProxyWhiteList                map[string]bool
+	DisableBruteForceLoginProtection  bool
+	CookieSecure                      bool
+	CookieSameSite                    http.SameSite
+	AllowEmbedding                    bool
+	XSSProtectionHeader               bool
+	ContentTypeProtectionHeader       bool
+	StrictTransportSecurity           bool
+	StrictTransportSecurityMaxAge     int
+	StrictTransportSecurityPreload    bool
+	StrictTransportSecuritySubDomains bool
 
 	// Snapshots
 	ExternalSnapshotUrl   string
@@ -692,6 +698,13 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	}
 
 	AllowEmbedding = security.Key("allow_embedding").MustBool(false)
+
+	ContentTypeProtectionHeader = security.Key("x_content_type_options").MustBool(false)
+	XSSProtectionHeader = security.Key("x_xss_protection").MustBool(false)
+	StrictTransportSecurity = security.Key("strict_transport_security").MustBool(false)
+	StrictTransportSecurityMaxAge = security.Key("strict_transport_security_max_age_seconds").MustInt(86400)
+	StrictTransportSecurityPreload = security.Key("strict_transport_security_preload").MustBool(false)
+	StrictTransportSecuritySubDomains = security.Key("strict_transport_security_subdomains").MustBool(false)
 
 	// read snapshots settings
 	snapshots := iniFile.Section("snapshots")


### PR DESCRIPTION
  # Features / Enhancements
  * **AuthProxy**: Optimistic lock pattern for remote cache Set. [#17485](https://github.com/grafana/grafana/pull/17485), [@papagian](https://github.com/papagian)
  * **HTTPServer**: Options for returning new headers X-Content-Type-Options,  X-XSS-Protection and Strict-Transport-Security. [#17522](https://github.com/grafana/grafana/pull/17522), [@kylebrandt](https://github.com/kylebrandt)

  # Bug Fixes
  * **Auth Proxy**: Fix non-negative cache TTL. [#17495](https://github.com/grafana/grafana/pull/17495), [@kylebrandt](https://github.com/kylebrandt)
  * **Grafana-CLI**: Fix receiving configuration flags from the command line. [#17606](https://github.com/grafana/grafana/pull/17606), [@gotjosh](https://github.com/gotjosh)
  * **OAuth**: Fix for wrong user token updated on OAuth refresh in DS proxy. [#17541](https://github.com/grafana/grafana/pull/17541), [@redbaron](https://github.com/redbaron)
  * **remote_cache**: Fix redis. [#17483](https://github.com/grafana/grafana/pull/17483), [@kylebrandt](https://github.com/kylebrandt)