### PR TITLE
Frontend: Fix for Json tree component not working

### DIFF
--- a/public/app/core/components/jsontree/jsontree.ts
+++ b/public/app/core/components/jsontree/jsontree.ts
@@ -11,12 +11,18 @@ coreModule.directive('jsonTree', [
         rootName: '@',
       },
       link: (scope: any, elem) => {
-        const jsonExp = new JsonExplorer(scope.object, 3, {
-          animateOpen: true,
+        let expansionLevel = scope.startExpanded;
+        if (scope.startExpanded === "true" ) {
+          expansionLevel = 2;
+        }else if (scope.startExpanded === "false") {
+          expansionLevel = 1;
+        }
+        const jsonObject = { [scope.rootName]: scope.object};
+        const jsonExp = new JsonExplorer(jsonObject, expansionLevel, {
+          animateOpen: true ,
         });
-
         const html = jsonExp.render(true);
-        elem.replaceAll(html);
+        elem.append(html);
       },
     };
   },

--- a/public/app/core/components/jsontree/jsontree.ts
+++ b/public/app/core/components/jsontree/jsontree.ts
@@ -12,14 +12,14 @@ coreModule.directive('jsonTree', [
       },
       link: (scope: any, elem) => {
         let expansionLevel = scope.startExpanded;
-        if (scope.startExpanded === "true" ) {
+        if (scope.startExpanded === 'true') {
           expansionLevel = 2;
-        }else if (scope.startExpanded === "false") {
+        } else if (scope.startExpanded === 'false') {
           expansionLevel = 1;
         }
-        const jsonObject = { [scope.rootName]: scope.object};
+        const jsonObject = { [scope.rootName]: scope.object };
         const jsonExp = new JsonExplorer(jsonObject, expansionLevel, {
-          animateOpen: true ,
+          animateOpen: true,
         });
         const html = jsonExp.render(true);
         elem.append(html);


### PR DESCRIPTION
 Fixes [16607](https://github.com/grafana/grafana/issues/16607)

Json tree is not working in latest code of grafana

1. **elem.replaceAll** method is being wrongly used. Using **elem.append** instead of elem.replaceAll.
2. rootName is not being considered, so created a new object which uses rootName
3. JsonExplorer has open parameter which takes number. Since previously, json tree used boolean for startExpanded , gave support for it. If a user gives number for startExpanded instead of true/false, it takes corresponding number as level;