### PR TITLE
Grafana-CLI: Fix receiving flags via command line 

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"flag"
 	"os"
 
 	"github.com/codegangsta/cli"
@@ -23,7 +22,7 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 		cfg.Load(&setting.CommandLineArgs{
 			Config:   cmd.String("config"),
 			HomePath: cmd.String("homepath"),
-			Args:     flag.Args(),
+			Args:     context.Args(),
 		})
 
 		cfg.LogConfigSources()

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"runtime"
@@ -18,13 +17,13 @@ var version = "master"
 func main() {
 	setupLogging()
 
-	flag.Parse()
 	app := cli.NewApp()
 	app.Name = "Grafana cli"
 	app.Usage = ""
 	app.Author = "Grafana Project"
 	app.Email = "https://github.com/grafana/grafana"
 	app.Version = version
+
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "pluginsDir",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:

`grafana-cli` uses the third-party library to define the flags and not the standard library. Using `flag.Parse` conflicts with the defined flags from our third-party library.

In the case where `flag.Parse` is used, the CLI assumes that definitions provided are not needed and will not define them; producing errors of the kind `flag provided but not defined --example-flag`.

Using the context to read any arguments (including flags) is the recommended approach by the third-party library.

**Which issue(s) this PR fixes**: #17613
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17613

**Special notes for your reviewer**:

The original approach taken as part of #17596 was discarded due not functioning correctly on an internal implementation described by @bergquist. He was 100% correct as I was using `Tail()` to retrieve the list of the arguments from the command-line. 

After a [revision of the documentation for the library](https://github.com/urfave/cli/blob/693af58b4d51b8fcc7f9d89576da170765980581/context.go#L200-L207), I noticed that the `Tail()` pull all **but** the first argument thus always omitting one argument from the command line (we want all of them) - the use of `context.Args()` works as expected:

```bash
$ grafana-cli admin data-migration encrypt-datasource-passwords cfg:default.paths.data=/dev/null cfg:default.paths.logs=/dev/null
EROR[06-17|16:22:03] Failed to detect generated javascript files in public/build logger=settings
INFO[06-17|16:22:03] Config loaded from                       logger=settings file=/path/grafana/conf/defaults.ini
INFO[06-17|16:22:03] Config overridden from command line      logger=settings arg="default.paths.data=/dev/null"
INFO[06-17|16:22:03] Config overridden from command line      logger=settings arg="default.paths.logs=/dev/null"
```