### PR TITLE
TablePanel: Select desired link tooltip placement

### DIFF
--- a/public/app/plugins/panel/table/column_options.html
+++ b/public/app/plugins/panel/table/column_options.html
@@ -172,6 +172,12 @@
       <input type="text" class="gf-form-input width-29" ng-model="style.linkTooltip" ng-blur="editor.render()" ng-model-onblur
           data-placement="right">
     </div>
+    <div class="gf-form">
+      <label class="gf-form-label width-9">Tooltip Placement</label>
+      <div class="gf-form-select-wrapper width-10">
+        <select class="gf-form-input" ng-model="style.linkTooltipPlacement" ng-options="c.value as c.text for c in editor.tooltipPlacements" ng-change="editor.render()"></select>
+      </div>
+    </div>
     <gf-form-switch class="gf-form" label-class="width-9" label="Open in new tab" checked="style.linkTargetBlank"></gf-form-switch>
   </div>
 

--- a/public/app/plugins/panel/table/column_options.ts
+++ b/public/app/plugins/panel/table/column_options.ts
@@ -14,6 +14,7 @@ export class ColumnOptionsCtrl {
   getColumnNames: any;
   activeStyleIndex: number;
   mappingTypes: any;
+  tooltipPlacements: any;
 
   /** @ngInject */
   constructor($scope: any) {
@@ -44,6 +45,12 @@ export class ColumnOptionsCtrl {
       { text: 'YYYY-MM-DD', value: 'YYYY-MM-DD' },
     ];
     this.mappingTypes = [{ text: 'Value to text', value: 1 }, { text: 'Range to text', value: 2 }];
+    this.tooltipPlacements = [
+      { text: 'Right', value: 'right' },
+      { text: 'Left', value: 'left' },
+      { text: 'Top', value: 'top' },
+      { text: 'Bottom', value: 'bottom' },
+    ];
 
     this.getColumnNames = () => {
       if (!this.panelCtrl.table) {

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -270,12 +270,15 @@ export class TableRenderer {
 
       const cellLink = this.templateSrv.replace(column.style.linkUrl, scopedVars, encodeURIComponent);
       const cellLinkTooltip = this.templateSrv.replace(column.style.linkTooltip, scopedVars);
+      const cellLinkTooltipPlacement =
+        column.style.linkTooltipPlacement !== undefined ? column.style.linkTooltipPlacement : 'right';
       const cellTarget = column.style.linkTargetBlank ? '_blank' : '';
 
       cellClasses.push('table-panel-cell-link');
 
       columnHtml += `
-        <a href="${cellLink}" target="${cellTarget}" data-link-tooltip data-original-title="${cellLinkTooltip}" data-placement="right"${textStyle}>
+        <a href="${cellLink}" target="${cellTarget}" data-link-tooltip data-original-title="${cellLinkTooltip}"
+           data-placement="${cellLinkTooltipPlacement}"${textStyle}>
           ${value}
         </a>
       `;

--- a/public/app/plugins/panel/table/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table/specs/renderer.test.ts
@@ -292,7 +292,7 @@ describe('when rendering table', () => {
       const expectedHtml = `
         <td class="table-panel-cell-link">
           <a href="/dashboard?param=host1&param_1=1230&param_2=40"
-            target="_blank" data-link-tooltip data-original-title="host1 1230 my.host.org" data-placement="left">
+            target="_blank" data-link-tooltip data-original-title="host1 1230 my.host.com" data-placement="left">
             host1
           </a>
         </td>

--- a/public/app/plugins/panel/table/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table/specs/renderer.test.ts
@@ -77,6 +77,7 @@ describe('when rendering table', () => {
           link: true,
           linkUrl: '/dashboard?param=$__cell&param_1=$__cell_1&param_2=$__cell_2',
           linkTooltip: '$__cell $__cell_1 $__cell_6',
+          linkTooltipPlacement: 'left',
           linkTargetBlank: true,
         },
         {
@@ -291,7 +292,7 @@ describe('when rendering table', () => {
       const expectedHtml = `
         <td class="table-panel-cell-link">
           <a href="/dashboard?param=host1&param_1=1230&param_2=40"
-            target="_blank" data-link-tooltip data-original-title="host1 1230 my.host.com" data-placement="right">
+            target="_blank" data-link-tooltip data-original-title="host1 1230 my.host.org" data-placement="left">
             host1
           </a>
         </td>


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes table panel link tooltip placement configurable - select desired placement: top, bottom, left, right; defaults to right.

**Which issue(s) this PR fixes**:
Fixes #16217
