### PR TITLE
Correct 6.2.3 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.3.0 (unreleased)
 
-# 6.2.3 (2018-06-17)
+# 6.2.3 (2019-06-17)
 
 ### Known issues
 * **grafana-cli**: The argument `--pluginsDir` is not working.


### PR DESCRIPTION
**Changelog date correction**:

Just a correction to the changelog date of 6.2.3, not a big deal ;)
