### PR TITLE
TablePanel: fix annotations display

### DIFF
--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -94,8 +94,12 @@ class TablePanelCtrl extends MetricsPanelCtrl {
           panel: this.panel,
           range: this.range,
         })
-        .then(annotations => {
-          return { data: annotations };
+        .then((anno: any) => {
+          this.loading = false;
+          this.dataRaw = anno;
+          this.pageIndex = 0;
+          this.render();
+          return { data: this.dataRaw }; // Not used
         });
     }
 


### PR DESCRIPTION
Fixes #17639 

This was caused by the new query runner.  The table panel skips the query runner when the transformation is set to 'annotations'
