### PR TITLE
Improvement: Grafana release process minor improvements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,8 @@ module.exports = {
   "roots": [
     "<rootDir>/public/app",
     "<rootDir>/public/test",
-    "<rootDir>/packages"
+    "<rootDir>/packages",
+    "<rootDir>/scripts",
   ],
   "testRegex": "(\\.|/)(test)\\.(jsx?|tsx?)$",
   "moduleFileExtensions": [

--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -6,6 +6,7 @@ import { buildTask } from './tasks/grafanaui.build';
 import { releaseTask } from './tasks/grafanaui.release';
 import { changelogTask } from './tasks/changelog';
 import { cherryPickTask } from './tasks/cherrypick';
+import { closeMilestoneTask } from './tasks/closeMilestone';
 import { precommitTask } from './tasks/precommit';
 import { searchTestDataSetupTask } from './tasks/searchTestDataSetup';
 
@@ -64,6 +65,21 @@ program
   .description('Helps find commits to cherry pick')
   .action(async cmd => {
     await execTask(cherryPickTask)({});
+  });
+
+program
+  .command('close-milestone')
+  .option('-m, --milestone <milestone>', 'Specify milestone')
+  .description('Helps ends a milestone by removing the cherry-pick label and closing it')
+  .action(async cmd => {
+    if (!cmd.milestone) {
+      console.log('Please specify milestone, example: -m <milestone id from github milestone URL>');
+      return;
+    }
+
+    await execTask(closeMilestoneTask)({
+      milestone: cmd.milestone,
+    });
   });
 
 program

--- a/scripts/cli/tasks/changelog.ts
+++ b/scripts/cli/tasks/changelog.ts
@@ -1,18 +1,14 @@
-import axios from 'axios';
 import _ from 'lodash';
 import { Task, TaskRunner } from './task';
-
-const githubGrafanaUrl = 'https://github.com/grafana/grafana';
+import GithubClient from '../utils/githubClient';
 
 interface ChangelogOptions {
   milestone: string;
 }
 
 const changelogTaskRunner: TaskRunner<ChangelogOptions> = async ({ milestone }) => {
-  const client = axios.create({
-    baseURL: 'https://api.github.com/repos/grafana/grafana',
-    timeout: 10000,
-  });
+  const githubClient = new GithubClient();
+  const client = githubClient.client;
 
   if (!/^\d+$/.test(milestone)) {
     console.log('Use milestone number not title, find number in milestone url');
@@ -67,6 +63,7 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = async ({ milestone }) 
 };
 
 function getMarkdownLineForIssue(item: any) {
+  const githubGrafanaUrl = 'https://github.com/grafana/grafana';
   let markdown = '';
   const title = item.title.replace(/^([^:]*)/, (match, g1) => {
     return `**${g1}**`;

--- a/scripts/cli/tasks/changelog.ts
+++ b/scripts/cli/tasks/changelog.ts
@@ -45,13 +45,20 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = async ({ milestone }) 
 
   const notBugs = _.sortBy(issues.filter(item => !bugs.find(bug => bug === item)), 'title');
 
-  let markdown = '### Features / Enhancements\n';
+  let markdown = '';
+
+  if (notBugs.length > 0) {
+    markdown = '### Features / Enhancements\n';
+  }
 
   for (const item of notBugs) {
     markdown += getMarkdownLineForIssue(item);
   }
 
-  markdown += '\n### Bug Fixes\n';
+  if (bugs.length > 0) {
+    markdown += '\n### Bug Fixes\n';
+  }
+
   for (const item of bugs) {
     markdown += getMarkdownLineForIssue(item);
   }

--- a/scripts/cli/tasks/cherrypick.ts
+++ b/scripts/cli/tasks/cherrypick.ts
@@ -1,17 +1,11 @@
 import { Task, TaskRunner } from './task';
-import axios from 'axios';
+import GithubClient from '../utils/githubClient';
 
 interface CherryPickOptions {}
 
 const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
-  let client = axios.create({
-    baseURL: 'https://api.github.com/repos/grafana/grafana',
-    timeout: 10000,
-    // auth: {
-    //   username: '<username>',
-    //   password: '<personal access token>',
-    // },
-  });
+  const githubClient = new GithubClient();
+  const client = githubClient.client;
 
   const res = await client.get('/issues', {
     params: {

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -14,6 +14,8 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
     return;
   }
 
+  const cherryPickLabel = 'cherry-pick needed';
+
   const client = axios.create({
     baseURL: 'https://api.github.com/repos/grafana/grafana',
     timeout: 10000,
@@ -22,8 +24,6 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
       password: gitHubToken,
     },
   });
-
-  const cherryPickLabel = 'cherry-pick needed';
 
   if (!/^\d+$/.test(milestone)) {
     console.log('Use milestone number not title, find number in milestone url');
@@ -59,12 +59,14 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
   }
 
   for (const issue of issuesRes.data) {
+    // the reason for using stdout.write is for achieving 'action -> result' on
+    // the same line
     process.stdout.write(`🔧removing label from issue #${issue.number} 🗑...`);
     const resDelete = await client.delete(`/issues/${issue.number}/labels/${cherryPickLabel}`, {});
     if (resDelete.status === 200) {
       process.stdout.write('done ✅\n');
     } else {
-      console.log('failed ❌\n');
+      console.log('failed ❌');
     }
   }
 

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -1,8 +1,5 @@
 import axios from 'axios';
-import _ from 'lodash';
 import { Task, TaskRunner } from './task';
-
-// const githubGrafanaUrl = 'https://github.com/grafana/grafana';
 
 interface CloseMilestoneOptions {
   milestone: string;

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -1,29 +1,15 @@
-import axios from 'axios';
 import { Task, TaskRunner } from './task';
+import GithubClient from '../utils/githubClient';
 
 interface CloseMilestoneOptions {
   milestone: string;
 }
 
 const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ milestone }) => {
-  const gitHubUsername = process.env.GITHUB_USERNAME;
-  const gitHubToken = process.env.GITHUB_ACCESS_TOKEN;
-
-  if (!gitHubUsername || !gitHubToken) {
-    console.log('the close milestone operation needs a GITHUB_USERNAME and GITHUB_ACCESS_TOKEN environment variables');
-    return;
-  }
+  const githubClient = new GithubClient(true);
 
   const cherryPickLabel = 'cherry-pick needed';
-
-  const client = axios.create({
-    baseURL: 'https://api.github.com/repos/grafana/grafana',
-    timeout: 10000,
-    auth: {
-      username: gitHubUsername,
-      password: gitHubToken,
-    },
-  });
+  const client = githubClient.client;
 
   if (!/^\d+$/.test(milestone)) {
     console.log('Use milestone number not title, find number in milestone url');

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -10,7 +10,7 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
   const gitHubToken = process.env.GITHUB_ACCESS_TOKEN;
 
   if (!gitHubUsername || !gitHubToken) {
-    console.log('the close milestone operation needs a GITHUB_USERNAME and  GITHUB_ACCESS_TOKEN environment variables');
+    console.log('the close milestone operation needs a GITHUB_USERNAME and GITHUB_ACCESS_TOKEN environment variables');
     return;
   }
 
@@ -30,11 +30,11 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
     return;
   }
 
-  const res = await client.get(`/milestones/${milestone}`, {});
+  const milestoneRes = await client.get(`/milestones/${milestone}`, {});
 
-  const milestoneData = res.data;
+  const milestoneState = milestoneRes.data.state;
 
-  if (milestoneData.state === 'closed') {
+  if (milestoneState === 'closed') {
     console.log('milestone already closed. ✅');
     return;
   }

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -1,0 +1,93 @@
+import axios from 'axios';
+import _ from 'lodash';
+import { Task, TaskRunner } from './task';
+
+// const githubGrafanaUrl = 'https://github.com/grafana/grafana';
+
+interface CloseMilestoneOptions {
+  milestone: string;
+}
+
+const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ milestone }) => {
+  const gitHubUsername = process.env.GITHUB_USERNAME;
+  const gitHubToken = process.env.GITHUB_ACCESS_TOKEN;
+
+  if (!gitHubUsername || !gitHubToken) {
+    console.log(
+      'the close milestone operation needs a GITHUB_USERNAME and \
+    GITHUB_ACCESS_TOKEN environment variables'
+    );
+    return;
+  }
+
+  const client = axios.create({
+    baseURL: 'https://api.github.com/repos/grafana/grafana',
+    timeout: 10000,
+    auth: {
+      username: gitHubUsername,
+      password: gitHubToken,
+    },
+  });
+
+  const cherryPickLabel = 'cherry-pick needed';
+
+  if (!/^\d+$/.test(milestone)) {
+    console.log('Use milestone number not title, find number in milestone url');
+    return;
+  }
+
+  const res = await client.get(`/milestones/${milestone}`, {});
+
+  const milestoneData = res.data;
+
+  if (milestoneData.state === 'closed') {
+    console.log('milestone already closed. ✅');
+    return;
+  }
+
+  console.log('fetching issues/PRs of the milestone ⏬');
+
+  // Get all the issues/PRs with the label cherry-pick
+  // Every pull request is actually an issue
+  const issuesRes = await client.get('/issues', {
+    params: {
+      state: 'closed',
+      labels: cherryPickLabel,
+      per_page: 100,
+      milestone: milestone,
+    },
+  });
+
+  if (issuesRes.data.length < 1) {
+    console.log('no issues to remove label from');
+  } else {
+    console.log(`found ${issuesRes.data.length} issues to remove the cherry-pick label from 🔎`);
+  }
+
+  for (const issue of issuesRes.data) {
+    process.stdout.write(`🔧removing label from issue #${issue.number} 🗑...`);
+    const resDelete = await client.delete(`/issues/${issue.number}/labels/${cherryPickLabel}`, {});
+    if (resDelete.status === 200) {
+      process.stdout.write('done ✅\n');
+    } else {
+      console.log('failed ❌\n');
+    }
+  }
+
+  console.log(`cleaned up ${issuesRes.data.length} issues/prs ⚡️`);
+
+  const resClose = await client.patch(`/milestones/${milestone}`, {
+    state: 'closed',
+  });
+
+  if (resClose.status === 200) {
+    console.log('milestone closed 🙌');
+  } else {
+    console.log('failed to close the milestone, response:');
+    console.log(resClose);
+  }
+};
+
+export const closeMilestoneTask = new Task<CloseMilestoneOptions>();
+closeMilestoneTask.setName('Close Milestone generator task');
+closeMilestoneTask.setRunner(closeMilestoneTaskRunner);

--- a/scripts/cli/tasks/closeMilestone.ts
+++ b/scripts/cli/tasks/closeMilestone.ts
@@ -13,10 +13,7 @@ const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ mil
   const gitHubToken = process.env.GITHUB_ACCESS_TOKEN;
 
   if (!gitHubUsername || !gitHubToken) {
-    console.log(
-      'the close milestone operation needs a GITHUB_USERNAME and \
-    GITHUB_ACCESS_TOKEN environment variables'
-    );
+    console.log('the close milestone operation needs a GITHUB_USERNAME and  GITHUB_ACCESS_TOKEN environment variables');
     return;
   }
 

--- a/scripts/cli/utils/githubClient.test.ts
+++ b/scripts/cli/utils/githubClient.test.ts
@@ -1,0 +1,66 @@
+import GithubClient from './githubClient';
+
+const fakeClient = jest.fn();
+
+beforeEach(() => {
+  delete process.env.GITHUB_USERNAME;
+  delete process.env.GITHUB_ACCESS_TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.GITHUB_USERNAME;
+  delete process.env.GITHUB_ACCESS_TOKEN;
+});
+
+describe('GithubClient', () => {
+  it('should initialise a GithubClient', () => {
+    const github = new GithubClient();
+    expect(github).toBeInstanceOf(GithubClient);
+  });
+
+  describe('#client', () => {
+    it('it should contain a client', () => {
+      const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
+
+      const github = new GithubClient();
+      const client = github.client;
+
+      expect(spy).toHaveBeenCalledWith({
+        baseURL: 'https://api.github.com/repos/grafana/grafana',
+        timeout: 10000,
+      });
+      expect(client).toEqual(fakeClient);
+    });
+
+    describe('when the credentials are required', () => {
+      it('should create the client when the credentials are defined', () => {
+        const username = 'grafana';
+        const token = 'averysecureaccesstoken';
+
+        process.env.GITHUB_USERNAME = username;
+        process.env.GITHUB_ACCESS_TOKEN = token;
+
+        const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
+
+        const github = new GithubClient(true);
+        const client = github.client;
+
+        expect(spy).toHaveBeenCalledWith({
+          baseURL: 'https://api.github.com/repos/grafana/grafana',
+          timeout: 10000,
+          auth: { username, password: token },
+        });
+
+        expect(client).toEqual(fakeClient);
+      });
+
+      describe('when the credentials are not defined', () => {
+        it('should throw an error', () => {
+          expect(() => {
+            new GithubClient(true);
+          }).toThrow(/operation needs a GITHUB_USERNAME and GITHUB_ACCESS_TOKEN environment variables/);
+        });
+      });
+    });
+  });
+});

--- a/scripts/cli/utils/githubClient.ts
+++ b/scripts/cli/utils/githubClient.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+const baseURL = 'https://api.github.com/repos/grafana/grafana';
+
+// Encapsulates the creation of a client for the Github API
+//
+// Two key things:
+// 1. You can specify whenever you want the credentials to be required or not when imported.
+// 2. If the the credentials are available as part of the environment, even if
+// they're not required - the library will use them. This allows us to overcome
+// any API rate limiting imposed without authentication.
+
+class GithubClient {
+  client: AxiosInstance;
+
+  constructor(required = false) {
+    const username = process.env.GITHUB_USERNAME;
+    const token = process.env.GITHUB_ACCESS_TOKEN;
+
+    const clientConfig: AxiosRequestConfig = {
+      baseURL: baseURL,
+      timeout: 10000,
+    };
+
+    if (required && !username && !token) {
+      throw new Error('operation needs a GITHUB_USERNAME and GITHUB_ACCESS_TOKEN environment variables');
+    }
+
+    if (username && token) {
+      clientConfig.auth = { username: username, password: token };
+    }
+
+    this.client = this.createClient(clientConfig);
+  }
+
+  private createClient(clientConfig: AxiosRequestConfig) {
+    return axios.create(clientConfig);
+  }
+}
+
+export default GithubClient;


### PR DESCRIPTION
I've done a Grafana release once per day this week. During the process, I've identified tiny wins that can help avoid confusion by being a bit more explicit and streamlining the process. On top of this, I've contributed back whatever has not been documented on the release document itself.

Quite frankly, while this is far from a fully automated process it's a small move of the gauge in that direction. Quite sure there are other similar wins, I just chose the ones I could do in the shortest amount of time. 

~~1. b7f15e9 looks like:~~ no longer included due to conflicting with copy/paste of commands.

<img width="1303" alt="Screenshot 2019-06-18 at 16 27 47" src="https://user-images.githubusercontent.com/231583/59759532-33932680-9288-11e9-9dc5-6b54fe3c5810.png">


2. 50678e8 Is fairly explicit

3. a1e19d8 looks like:

![Screenshot 2019-06-19 at 11 46 53](https://user-images.githubusercontent.com/231583/59759506-22e2b080-9288-11e9-9297-58b591c7f5f5.png)

TODO
- [x] update the documentation to include 3. as a step
- [x] create a follow up issue to encapsulate actions and functions related with GitHub within the client.  https://github.com/grafana/grafana/issues/17734