### PR TITLE
HTTP Server: Flag serve_from_sub_path as available in 6.3

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -155,6 +155,7 @@ callback URL to be correct).
 > case add the subpath to the end of this URL setting.
 
 ### serve_from_sub_path
+> Available in 6.3 and above
 
 Serve Grafana from subpath specified in `root_url` setting. By
 default it is set to `false` for compatibility reasons.


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to PR #17048. Addresses https://github.com/grafana/grafana/pull/17048#issuecomment-503618222

Flag the new serve_from_sub_path option as available in 6.3 to avoid confusion with the live docs referring to a feature which doesn't yet exist in any released version.