### PR TITLE
Explore: Improves performance of Logs element by limiting re-rendering

### DIFF
--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -91,6 +91,12 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     return [];
   };
 
+  // Limit re-rendering to when a query is finished executing or when the deduplication strategy changes
+  // for performance reasons.
+  shouldComponentUpdate(nextProps: LogsContainerProps): boolean {
+    return nextProps.loading !== this.props.loading || nextProps.dedupStrategy !== this.props.dedupStrategy;
+  }
+
   render() {
     const {
       exploreId,

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -94,7 +94,11 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
   // Limit re-rendering to when a query is finished executing or when the deduplication strategy changes
   // for performance reasons.
   shouldComponentUpdate(nextProps: LogsContainerProps): boolean {
-    return nextProps.loading !== this.props.loading || nextProps.dedupStrategy !== this.props.dedupStrategy;
+    return (
+      nextProps.loading !== this.props.loading ||
+      nextProps.dedupStrategy !== this.props.dedupStrategy ||
+      nextProps.logsHighlighterExpressions !== this.props.logsHighlighterExpressions
+    );
   }
 
   render() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves performance of Logs element by re-rendering only when query has finished executing or when the de-duplication strategy changes.
Needed as performance was suffering by re-rendering Logs whenever the QueryField's state changed.

**Which issue(s) this PR fixes**:
Closes #17663

**Special notes for your reviewer**:
It's possible I've missed a condition besides a query finishing execution or the de-duplication strategy changing that should prompt a re-render, but it seems to work fine from the testing I did.
