### PR TITLE
Alerting - Fix img rendering and/or uploading timeout preventing to send alerts notifications

### DIFF
--- a/pkg/components/imguploader/azureblobuploader.go
+++ b/pkg/components/imguploader/azureblobuploader.go
@@ -54,7 +54,7 @@ func (az *AzureBlobUploader) Upload(ctx context.Context, imageDiskPath string) (
 	randomFileName := util.GetRandomString(30) + ".png"
 	// upload image
 	az.log.Debug("Uploading image to azure_blob", "container_name", az.container_name, "blob_name", randomFileName)
-	resp, err := blob.FileUpload(az.container_name, randomFileName, file)
+	resp, err := blob.FileUpload(ctx, az.container_name, randomFileName, file)
 	if err != nil {
 		return "", err
 	}
@@ -157,7 +157,7 @@ func copyHeadersToRequest(req *http.Request, headers map[string]string) {
 	}
 }
 
-func (c *StorageClient) FileUpload(container, blobName string, body io.Reader) (*http.Response, error) {
+func (c *StorageClient) FileUpload(ctx context.Context, container, blobName string, body io.Reader) (*http.Response, error) {
 	blobName = escape(blobName)
 	extension := strings.ToLower(path.Ext(blobName))
 	contentType := mime.TypeByExtension(extension)
@@ -170,6 +170,9 @@ func (c *StorageClient) FileUpload(container, blobName string, body io.Reader) (
 	)
 	if err != nil {
 		return nil, err
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 
 	copyHeadersToRequest(req, map[string]string{

--- a/pkg/components/imguploader/s3uploader.go
+++ b/pkg/components/imguploader/s3uploader.go
@@ -83,8 +83,7 @@ func (u *S3Uploader) Upload(ctx context.Context, imageDiskPath string) (string, 
 		Body:        file,
 		ContentType: aws.String("image/png"),
 	}
-	_, err = svc.PutObject(params)
-	if err != nil {
+	if _, err = svc.PutObjectWithContext(ctx, params); err != nil {
 		return "", err
 	}
 	return image_url, nil

--- a/pkg/components/imguploader/webdavuploader.go
+++ b/pkg/components/imguploader/webdavuploader.go
@@ -59,7 +59,9 @@ func (u *WebdavUploader) Upload(ctx context.Context, pa string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
 	if u.username != "" {
 		req.SetBasicAuth(u.username, u.password)
 	}

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -51,7 +51,7 @@ func (n *notificationService) SendIfNeeded(ectx *EvalContext) error {
 		var uploadCtxCancel func()
 		uploadEvalCtx.Ctx, uploadCtxCancel = context.WithTimeout(ectx.Ctx, setting.AlertingNotificationTimeout/2)
 		// Try to upload the image without consuming all the time allocated for EvalContext
-		if err = n.uploadImage(&uploadEvalCtx); err != nil {
+		if err = n.renderAndUploadImage(&uploadEvalCtx); err != nil {
 			n.log.Error("Failed to upload alert panel image.", "error", err)
 		}
 		uploadCtxCancel()
@@ -120,7 +120,7 @@ func (n *notificationService) sendNotifications(evalContext *EvalContext, notifi
 	return nil
 }
 
-func (n *notificationService) uploadImage(context *EvalContext) (err error) {
+func (n *notificationService) renderAndUploadImage(context *EvalContext) (err error) {
 	uploader, err := imguploader.NewImageUploader()
 	if err != nil {
 		return err


### PR DESCRIPTION
The alerting process uses a context with a timeout set to `setting.AlertingNotificationTimeout`. But when img upload is activated, the upload will use the exact same context which can lead to an unpleasant situation:

- `(n *notificationService) SendIfNeeded(context *EvalContext) error` starts
- img upload times out (could be rendering or upload, meaning the context is cancelled)
- then `n.sendNotifications(context, notifierStates)` proceeds and try to send alerts with the same context
- context is already cancelled because of the upload (or rendering) timeout which will prevent sending the alert notifications

The idea here is to limit the time allocated to the rendering/upload section to prevent it to use all the time allocated for sending the alert notifications by creating a sub context with a timeout set at half the duration of the initial duration (`setting.AlertingNotificationTimeout/2`). This way even if the img process fails, there is still time to try to send the alert notifications without the img.

While poking around, I noticed that some of the img uploaders were not using the ctx at all ! So in addition, I fixed:
- s3uploader: the aws sdk does provide methods with context support
- webdavuploader: update `req` to use `ctx`
- azureblobuploader: update `req` to use `ctx` thru `FileUpload()` method

We are still working on the rendering section which could use some context improvements too.
