### PR TITLE
Grafana-CLI: Wrapper for `grafana-cli` within RPM/DEB packages and config/homepath are now global flags

### DIFF
--- a/build.go
+++ b/build.go
@@ -232,6 +232,7 @@ type linuxPackageOptions struct {
 	packageType            string
 	packageArch            string
 	homeDir                string
+	homeBinDir             string
 	binPath                string
 	serverBinPath          string
 	cliBinPath             string
@@ -261,6 +262,7 @@ func createDebPackages() {
 		packageType:            "deb",
 		packageArch:            debPkgArch,
 		homeDir:                "/usr/share/grafana",
+		homeBinDir:             "/usr/share/grafana/bin",
 		binPath:                "/usr/sbin",
 		configDir:              "/etc/grafana",
 		etcDefaultPath:         "/etc/default",
@@ -290,6 +292,7 @@ func createRpmPackages() {
 		packageType:            "rpm",
 		packageArch:            rpmPkgArch,
 		homeDir:                "/usr/share/grafana",
+		homeBinDir:             "/usr/share/grafana/bin",
 		binPath:                "/usr/sbin",
 		configDir:              "/etc/grafana",
 		etcDefaultPath:         "/etc/sysconfig",
@@ -328,10 +331,6 @@ func createPackage(options linuxPackageOptions) {
 	runPrint("mkdir", "-p", filepath.Join(packageRoot, "/usr/lib/systemd/system"))
 	runPrint("mkdir", "-p", filepath.Join(packageRoot, "/usr/sbin"))
 
-	// The grafana-cli binary is exposed through a wrapper to ensure a proper
-	// configuration is in place. To enable that, we need to store the original
-	// binary in a separate location to avoid conflicts.
-	runPrint("cp", "-p", filepath.Join(workingDir, "tmp/bin/"+cliBinary), filepath.Join(packageRoot, options.homeDir, cliBinary))
 	// copy grafana-cli wrapper
 	runPrint("cp", "-p", options.cliBinaryWrapperSrc, filepath.Join(packageRoot, "/usr/sbin/"+cliBinary))
 
@@ -348,6 +347,13 @@ func createPackage(options linuxPackageOptions) {
 	runPrint("cp", "-a", filepath.Join(workingDir, "tmp")+"/.", filepath.Join(packageRoot, options.homeDir))
 	// remove bin path
 	runPrint("rm", "-rf", filepath.Join(packageRoot, options.homeDir, "bin"))
+
+	// create /bin within home
+	runPrint("mkdir", "-p", filepath.Join(packageRoot, options.homeBinDir))
+	// The grafana-cli binary is exposed through a wrapper to ensure a proper
+	// configuration is in place. To enable that, we need to store the original
+	// binary in a separate location to avoid conflicts.
+	runPrint("cp", "-p", filepath.Join(workingDir, "tmp/bin/"+cliBinary), filepath.Join(packageRoot, options.homeBinDir, cliBinary))
 
 	args := []string{
 		"-s", "dir",

--- a/docs/sources/administration/cli.md
+++ b/docs/sources/administration/cli.md
@@ -37,7 +37,7 @@ If running the command returns this error:
 
 then there are two flags that can be used to set homepath and the config file path.
 
-`grafana-cli admin reset-admin-password --homepath "/usr/share/grafana" newpass`
+`grafana-cli --homepath "/usr/share/grafana" admin reset-admin-password newpass`
 
 If you have not lost the admin password then it is better to set in the Grafana UI. If you need to set the password in a script then the [Grafana API](http://docs.grafana.org/http_api/user/#change-password) can be used. Here is an example using curl with basic auth:
 

--- a/packaging/wrappers/grafana-cli
+++ b/packaging/wrappers/grafana-cli
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+# Wrapper for the grafana-cli binary
+# This file serves as a wrapper for the grafana-cli binary. It ensures we set
+# the system-wide Grafana configuration that was bundled with the package as we
+# use the binary.
+
+DEFAULT=/etc/default/grafana
+
+GRAFANA_HOME=/usr/share/grafana
+CONF_DIR=/etc/grafana
+DATA_DIR=/var/lib/grafana
+PLUGINS_DIR=/var/lib/grafana/plugins
+LOG_DIR=/var/log/grafana
+
+CONF_FILE=$CONF_DIR/grafana.ini
+PROVISIONING_CFG_DIR=$CONF_DIR/provisioning
+
+EXECUTABLE=$GRAFANA_HOME/grafana-cli
+
+if [ ! -x $EXECUTABLE ]; then
+ echo "Program not installed or not executable"
+ exit 5
+fi
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+  . "$DEFAULT"
+fi
+
+OPTS="--homepath=${GRAFANA_HOME} \
+      --config=${CONF_FILE} \
+      --pluginsDir=${PLUGINS_DIR} \
+      --optionsString='cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR \
+                        cfg:default.paths.data=${DATA_DIR} \
+                        cfg:default.paths.logs=${LOG_DIR} \
+                        cfg:default.paths.plugins=${PLUGINS_DIR}'"
+
+eval $EXECUTABLE "$OPTS" "$@"

--- a/packaging/wrappers/grafana-cli
+++ b/packaging/wrappers/grafana-cli
@@ -16,7 +16,7 @@ LOG_DIR=/var/log/grafana
 CONF_FILE=$CONF_DIR/grafana.ini
 PROVISIONING_CFG_DIR=$CONF_DIR/provisioning
 
-EXECUTABLE=$GRAFANA_HOME/grafana-cli
+EXECUTABLE=$GRAFANA_HOME/bin/grafana-cli
 
 if [ ! -x $EXECUTABLE ]; then
  echo "Program not installed or not executable"

--- a/packaging/wrappers/grafana-cli
+++ b/packaging/wrappers/grafana-cli
@@ -31,7 +31,7 @@ fi
 OPTS="--homepath=${GRAFANA_HOME} \
       --config=${CONF_FILE} \
       --pluginsDir=${PLUGINS_DIR} \
-      --optionsString='cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR \
+      --configOverrides='cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR \
                         cfg:default.paths.data=${DATA_DIR} \
                         cfg:default.paths.logs=${LOG_DIR} \
                         cfg:default.paths.plugins=${PLUGINS_DIR}'"

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -17,6 +17,7 @@ import (
 func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore.SqlStore) error) func(context *cli.Context) {
 	return func(context *cli.Context) {
 		cmd := &utils.ContextCommandLine{Context: context}
+		debug := cmd.GlobalBool("debug")
 
 		cfg := setting.NewCfg()
 
@@ -27,7 +28,9 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 			Args:     append(configOptions, cmd.Args()...), // tailing arguments have precedence over the options string
 		})
 
-		cfg.LogConfigSources()
+		if debug {
+			cfg.LogConfigSources()
+		}
 
 		engine := &sqlstore.SqlStore{}
 		engine.Cfg = cfg

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/color"
@@ -19,10 +20,11 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 
 		cfg := setting.NewCfg()
 
+		configOptions := strings.Split(cmd.GlobalString("optionsString"), " ")
 		cfg.Load(&setting.CommandLineArgs{
-			Args:     context.Args(),
 			Config:   cmd.ConfigFile(),
 			HomePath: cmd.HomePath(),
+			Args:     append(configOptions, cmd.Args()...), // tailing arguments have precedence over the options string
 		})
 
 		cfg.LogConfigSources()

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -20,9 +20,9 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 		cfg := setting.NewCfg()
 
 		cfg.Load(&setting.CommandLineArgs{
-			Config:   cmd.String("config"),
-			HomePath: cmd.String("homepath"),
 			Args:     context.Args(),
+			Config:   cmd.ConfigFile(),
+			HomePath: cmd.HomePath(),
 		})
 
 		cfg.LogConfigSources()
@@ -95,23 +95,11 @@ var pluginCommands = []cli.Command{
 	},
 }
 
-var dbCommandFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "homepath",
-		Usage: "path to grafana install/home path, defaults to working directory",
-	},
-	cli.StringFlag{
-		Name:  "config",
-		Usage: "path to config file",
-	},
-}
-
 var adminCommands = []cli.Command{
 	{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
 		Action: runDbCommand(resetPasswordCommand),
-		Flags:  dbCommandFlags,
 	},
 	{
 		Name:  "data-migration",
@@ -121,7 +109,6 @@ var adminCommands = []cli.Command{
 				Name:   "encrypt-datasource-passwords",
 				Usage:  "Migrates passwords from unsecured fields to secure_json_data field. Return ok unless there is an error. Safe to execute multiple times.",
 				Action: runDbCommand(datamigrations.EncryptDatasourcePaswords),
-				Flags:  dbCommandFlags,
 			},
 		},
 	},

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -21,7 +21,7 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 
 		cfg := setting.NewCfg()
 
-		configOptions := strings.Split(cmd.GlobalString("optionsString"), " ")
+		configOptions := strings.Split(cmd.GlobalString("configOverrides"), " ")
 		cfg.Load(&setting.CommandLineArgs{
 			Config:   cmd.ConfigFile(),
 			HomePath: cmd.HomePath(),

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -51,6 +51,14 @@ func main() {
 			Name:  "debug, d",
 			Usage: "enable debug logging",
 		},
+		cli.StringFlag{
+			Name:  "homepath",
+			Usage: "path to grafana install/home path, defaults to working directory",
+		},
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "path to config file",
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -52,7 +52,7 @@ func main() {
 			Usage: "enable debug logging",
 		},
 		cli.StringFlag{
-			Name:  "optionsString",
+			Name:  "configOverrides",
 			Usage: "configuration options to override defaults as a string. e.g. cfg:default.paths.log=/dev/null",
 		},
 		cli.StringFlag{

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -52,6 +52,10 @@ func main() {
 			Usage: "enable debug logging",
 		},
 		cli.StringFlag{
+			Name:  "optionsString",
+			Usage: "configuration options to override defaults as a string. e.g. cfg:default.paths.log=/dev/null",
+		},
+		cli.StringFlag{
 			Name:  "homepath",
 			Usage: "path to grafana install/home path, defaults to working directory",
 		},

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -55,5 +55,5 @@ func (c *ContextCommandLine) PluginURL() string {
 }
 
 func (c *ContextCommandLine) OptionsString() string {
-	return c.GlobalString("optionsString")
+	return c.GlobalString("configOverrides")
 }

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -53,3 +53,7 @@ func (c *ContextCommandLine) RepoDirectory() string {
 func (c *ContextCommandLine) PluginURL() string {
 	return c.GlobalString("pluginUrl")
 }
+
+func (c *ContextCommandLine) OptionsString() string {
+	return c.GlobalString("optionsString")
+}

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -38,6 +38,10 @@ func (c *ContextCommandLine) Application() *cli.App {
 	return c.App
 }
 
+func (c *ContextCommandLine) HomePath() string { return c.GlobalString("homepath") }
+
+func (c *ContextCommandLine) ConfigFile() string { return c.GlobalString("config") }
+
 func (c *ContextCommandLine) PluginDirectory() string {
 	return c.GlobalString("pluginsDir")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user impact in the title. The PR title is used in the changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:

When our users install the *nix packed version of grafana (via RPM or deb), tendency is to use the services and scripts installed as part of the package for grafana-server. These leverage the default configuration options by specifying several default paths.

This introduces a similar approach for the grafana-cli binary. We expose it through a wrapper to ensure a proper configuration is in place. 

To enable that, we tuck away into the `/usr/share/grafana` (default grafana home) directory the original binary (grafana-cli) and then use a bash script named grafana-cli as the wrapper.

In addition to that, this PR also:

- Makes the `--config` and `--homepath` flags global. Which allow us to significantly simplify the wrapper logic. 
- Adds a new  `--optionsString` which allow us to override default configuration options as a string. A thing to note is that this was and is still supported by passing these arguments as trailing args to the command, with the particularity that the trailing arguments take precedence over the flag to allow for backward compatibility. That means:

```bash
$ ./bin/darwin-amd64/grafana-cli -d --optionsString="cfg:default.paths.data=/dev/nullX cfg:default.paths.logs=/dev/nullX" --config=/dev/null admin reset-admin-password 1234 cfg:default.paths.plugins=/dev/nullY cfg:default.paths.logs=/dev/nullY
INFO[06-20|14:33:00] Config loaded from                       logger=settings file=/Users/josueabreu/go/src/github.com/grafana/grafana/conf/defaults.ini
INFO[06-20|14:33:00] Config loaded from                       logger=settings file=/dev/null
INFO[06-20|14:33:00] Config overridden from command line      logger=settings arg="default.paths.data=/dev/nullX"
INFO[06-20|14:33:00] Config overridden from command line      logger=settings arg="default.paths.logs=/dev/nullY"
INFO[06-20|14:33:00] Config overridden from command line      logger=settings arg="default.paths.plugins=/dev/nullY"
INFO[06-20|14:33:00] Path Home                                logger=settings path=/Users/josueabreu/go/src/github.com/grafana/grafana
INFO[06-20|14:33:00] Path Data                                logger=settings path=/dev/nullX
INFO[06-20|14:33:00] Path Logs                                logger=settings path=/dev/nullY
INFO[06-20|14:33:00] Path Plugins                             logger=settings path=/dev/nullY
INFO[06-20|14:33:00] Path Provisioning                        logger=settings path=/Users/josueabreu/go/src/github.com/grafana/grafana/conf/provisioning
INFO[06-20|14:33:00] App mode production                      logger=settings
INFO[06-20|14:33:00] Connecting to DB                         logger=sqlstore dbtype=sqlite3
INFO[06-20|14:33:00] Starting DB migration                    logger=migrator

Error: New password is too short

NAME:
   Grafana cli admin reset-admin-password - reset-admin-password <new password>

USAGE:
   Grafana cli admin reset-admin-password [arguments...
```
- Logs the paths configured as part of the command run to provide some feedback for the user if the `--debug` global flag is used

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->