### PR TITLE
Project: Issue triage doc improvement

### DIFF
--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -53,6 +53,66 @@ The core maintainers of the Grafana project is responsible for categorizing all 
                                                      +------------------+          +--------------+
 ```
 
+## How you can help
+
+There are multiple ways that you can help with the Grafana project, especially without writing a single line of code. Everyone in the Grafana community will be greatly thankful you for helping out with any of the below tasks.
+
+### Answer/ask questions
+
+The [community site](https://community.grafana.com/) is the main channel to be used for asking and answering questions related to the Grafana project. This may be the first place a new or existing Grafana user look/ask for help after they found that the [documentation](https://grafana.com/docs) wasn't answering their questions. It's very important to help new and existing users so that these new users can find proper answers and eventually help out other users and by that keep growing the Grafana community.
+
+Please signup to the Grafana [community site](https://community.grafana.com/) and start help other Grafana users by answering their questions and/or ask for help.
+
+### Report documentation enhancements
+
+If you visit the [documentation site](https://grafana.com/docs) and find typos/error/lack of information please report these by clicking on the `Request doc changes` link found on every page and/or contribute the changes yourself by clicking on `Edit this page` and open a pull request. Everyone in the community will greatly thank you for.
+
+Please read about how documentation issues is triaged [below](#documentation-issue) to understand what kind of documentation may be suitable to request/add.
+
+### Report a security vulnerability
+
+Please review the [security policy](https://github.com/grafana/grafana/security/policy) for more details.
+
+### Report bugs
+
+Report a bug you found when using Grafana by [opening a new bug report](https://github.com/grafana/grafana/issues/new?labels=type%3A+bug&template=1-bug_report.md).
+
+### Request enhancements/new features
+
+Suggest an enhancement or new feature for the Grafana project by [opening a new enhancement issue](https://github.com/grafana/grafana/issues/new?labels=type%3A+feature+request&template=2-feature_request.md).
+
+Alternatively, help make Grafana be better at being accessible to all by [opening a new accessibility issue](https://github.com/grafana/grafana/issues/new?labels=type%3A+accessibility&template=3-accessibility.md).
+
+### Report inaccurate issue information
+
+If you find an issue that have a badly formatted title and/or description, bad language/grammar and/or wrong labels it's important to let the issue author or maintainers know so it can be fixed. See [good practices](#good-practices) regarding basic information for issues below.
+
+### Request closing of issues
+
+The Grafana project have a lot of open issues and the main goal is to only have issues open if their still relevant. If you find an issue that you think already have been resolved or no longer is relevant please report by adding a comment and explain why you think it should be closed including related issues (`#<issue number>`), if applicable, and optionally mention one of the maintainers.
+
+### Investigate issues
+
+See [investigation of issues](#investigation-of-issues).
+
+### Vote on enhancements/bugs
+
+Helping the Grafana project to know which issues are most important by users and the community is crucial for the success of the project. Read more about [prioritizing issues](#4-prioritization-of-issues) for details about how issues are being prioritized. The Grafana project use GitGub issues and reactions for collecting votes on enhancement and bugs.
+
+**Please don't add `+1` issue comments or similar since that will notify everyone that have subscribed to an issue and it doesn't add any useful update, rather it creates a bad .**
+
+If you want to show your interest or importance of an issue, please use [GitHub's reactions](https://help.github.com/en/articles/about-conversations-on-github#reacting-to-ideas-in-comments).
+
+### Report duplicates
+
+If you find two issues describing the same bug/enhancement/feature please add a comment in one of the issue and explain which issues (`#<issue number>`) you think is a duplicate of another issue (`#<issue number>`).
+
+### Suggest ideas for resolving bugs/enhancements
+
+Related to how [issues are being prioritized](#4-prioritization-of-issues) it's important to help anyone that's interested in contributing code for resolving a bug or enhancement. This can be anything from getting started and setup the development environment to reference code and files where changes probably needs to be made and/or suggest ideas on how enhancements may function/be implemented.
+
+Please read about how [help from the community](#5-requesting-help-from-the-community) may be requested when issues being triaged.
+
 ## 1. Find uncategorized issues
 
 To get started with issue triage and finding issues that haven't been triaged you have two alternatives.

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -63,9 +63,9 @@ The easiest and straigt forward way of getting started and finding issues that h
 
 ### Subscribe to all notifications
 
-The more advanced, but recommended way is to subscribe to all notifications from this repository which means that all new issues, pull requests, comments and important status changes are sent to your configure email address. Read this [guide](https://help.github.com/en/articles/watching-and-unwatching-repositories#watching-a-single-repository) for help with setting this up.
+The more advanced, but recommended way is to subscribe to all notifications from this repository which means that all new issues, pull requests, comments and important status changes are sent to your configured email address. Read this [guide](https://help.github.com/en/articles/watching-and-unwatching-repositories#watching-a-single-repository) for help with setting this up.
 
-It's highly recommened that you setup filters to automatically remove emails from the inbox and label/categorize them accordingly to make it easy for you to understand when you need to act upon a notification or where to look for finding issues that haven't been triaged etc.
+It's highly recommended that you setup filters to automatically remove emails from the inbox and label/categorize them accordingly to make it easy for you to understand when you need to act upon a notification or where to look for finding issues that haven't been triaged etc.
 
 Instructions for setting up filters in Gmail can be found [here](#setting-up-gmail-filters). Another alternative is to use [Trailer](https://github.com/ptsochantaris/trailer) or similar software.
 
@@ -107,7 +107,7 @@ In general, if the issue description and title is perceived as a question no mor
 
 To make it easier for everyone to understand and find issues they're searching for it's suggested as a general rule of thumbs to:
 
-* Make sure that issue titles are named to explain the subject of the issue, has a correct spelling and and doesn't include irrelevant information and/or sensitive information.
+* Make sure that issue titles are named to explain the subject of the issue, has a correct spelling and doesn't include irrelevant information and/or sensitive information.
 * Make sure that issue descriptions doesn't include irrelevant information, information from template that haven't been filled out and/or sensitive information.
 * Do your best effort to change title and description or request suggested changes by adding a comment.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some fixes of types and a new section describing how you can help with the Grafana project related to issues.

**Which issue(s) this PR fixes**:
Ref #17648

**Special notes for your reviewer**:
Eventually we may want to move the "how you can help" section to the [contribution guideline](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md), but lets add it here to start with.