### PR TITLE
Panel: Fully escape html in drilldown links (was only sanitized before) 

### DIFF
--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -101,3 +101,11 @@ export function sanitize(unsanitizedString: string): string {
 export function hasAnsiCodes(input: string): boolean {
   return /\u001b\[\d{1,2}m/.test(input);
 }
+
+export function htmlToText(str: string): string {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -102,7 +102,7 @@ export function hasAnsiCodes(input: string): boolean {
   return /\u001b\[\d{1,2}m/.test(input);
 }
 
-export function htmlToText(str: string): string {
+export function escapeHtml(str: string): string {
   return String(str)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import Remarkable from 'remarkable';
+import { sanitize as XSSsanitize } from 'app/core/utils/text';
 
 import config from 'app/core/config';
 import { profiler } from 'app/core/core';
@@ -267,11 +268,11 @@ export class PanelCtrl {
         const info = linkSrv.getPanelLinkAnchorInfo(link, this.panel.scopedVars);
         html +=
           '<li><a class="panel-menu-link" href="' +
-          info.href +
+          XSSsanitize(info.href) +
           '" target="' +
-          info.target +
+          XSSsanitize(info.target) +
           '">' +
-          info.title +
+          XSSsanitize(info.title) +
           '</a></li>';
       }
       html += '</ul>';

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Remarkable from 'remarkable';
-import { sanitize, htmlToText } from 'app/core/utils/text';
+import { sanitize, escapeHtml } from 'app/core/utils/text';
 
 import config from 'app/core/config';
 import { profiler } from 'app/core/core';
@@ -269,11 +269,11 @@ export class PanelCtrl {
 
         html +=
           '<li><a class="panel-menu-link" href="' +
-          htmlToText(info.href) +
+          escapeHtml(info.href) +
           '" target="' +
-          htmlToText(info.target) +
+          escapeHtml(info.target) +
           '">' +
-          htmlToText(info.title) +
+          escapeHtml(info.title) +
           '</a></li>';
       }
       html += '</ul>';

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Remarkable from 'remarkable';
-import { sanitize } from 'app/core/utils/text';
+import { sanitize, htmlToText } from 'app/core/utils/text';
 
 import config from 'app/core/config';
 import { profiler } from 'app/core/core';
@@ -259,7 +259,8 @@ export class PanelCtrl {
     const interpolatedMarkdown = templateSrv.replace(markdown, this.panel.scopedVars);
     let html = '<div class="markdown-html">';
 
-    html += new Remarkable().render(interpolatedMarkdown);
+    const md = new Remarkable().render(interpolatedMarkdown);
+    html += config.disableSanitizeHtml ? md : sanitize(md);
 
     if (this.panel.links && this.panel.links.length > 0) {
       html += '<ul>';
@@ -268,17 +269,17 @@ export class PanelCtrl {
 
         html +=
           '<li><a class="panel-menu-link" href="' +
-          info.href +
+          htmlToText(info.href) +
           '" target="' +
-          info.target +
+          htmlToText(info.target) +
           '">' +
-          info.title +
+          htmlToText(info.title) +
           '</a></li>';
       }
       html += '</ul>';
     }
 
     html += '</div>';
-    return config.disableSanitizeHtml ? html : sanitize(html);
+    return html;
   }
 }

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Remarkable from 'remarkable';
-import { sanitize as XSSsanitize } from 'app/core/utils/text';
+import { sanitize } from 'app/core/utils/text';
 
 import config from 'app/core/config';
 import { profiler } from 'app/core/core';
@@ -255,7 +255,6 @@ export class PanelCtrl {
     }
 
     const linkSrv: LinkSrv = this.$injector.get('linkSrv');
-    const sanitize: any = this.$injector.get('$sanitize');
     const templateSrv: TemplateSrv = this.$injector.get('templateSrv');
     const interpolatedMarkdown = templateSrv.replace(markdown, this.panel.scopedVars);
     let html = '<div class="markdown-html">';
@@ -266,19 +265,20 @@ export class PanelCtrl {
       html += '<ul>';
       for (const link of this.panel.links) {
         const info = linkSrv.getPanelLinkAnchorInfo(link, this.panel.scopedVars);
+
         html +=
           '<li><a class="panel-menu-link" href="' +
-          XSSsanitize(info.href) +
+          info.href +
           '" target="' +
-          XSSsanitize(info.target) +
+          info.target +
           '">' +
-          XSSsanitize(info.title) +
+          info.title +
           '</a></li>';
       }
       html += '</ul>';
     }
 
     html += '</div>';
-    return sanitize(html);
+    return config.disableSanitizeHtml ? html : sanitize(html);
   }
 }

--- a/public/app/plugins/panel/text/module.ts
+++ b/public/app/plugins/panel/text/module.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { PanelCtrl } from 'app/plugins/sdk';
 import Remarkable from 'remarkable';
-import { sanitize } from 'app/core/utils/text';
+import { sanitize, escapeHtml } from 'app/core/utils/text';
 import config from 'app/core/config';
 import { auto, ISCEService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
@@ -77,12 +77,8 @@ export class TextPanelCtrl extends PanelCtrl {
   }
 
   renderText(content: string) {
-    content = content
-      .replace(/&/g, '&amp;')
-      .replace(/>/g, '&gt;')
-      .replace(/</g, '&lt;')
-      .replace(/\n/g, '<br/>');
-    this.updateContent(content);
+    const safeContent = escapeHtml(content).replace(/\n/g, '<br/>');
+    this.updateContent(safeContent);
   }
 
   renderMarkdown(content: string) {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #17718
**Special notes for your reviewer**:
It is now handled the same way as in the text panel.
