### PR TITLE
Dashboard data access: Keep deleted dashboards versions for better backups, closes #9235

### DIFF
--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -314,7 +314,6 @@ func DeleteDashboard(cmd *m.DeleteDashboardCommand) error {
 			"DELETE FROM star WHERE dashboard_id = ? ",
 			"DELETE FROM dashboard WHERE id = ?",
 			"DELETE FROM playlist_item WHERE type = 'dashboard_by_id' AND value = ?",
-			"DELETE FROM dashboard_version WHERE dashboard_id = ?",
 			"DELETE FROM annotation WHERE dashboard_id = ?",
 			"DELETE FROM dashboard_provisioning WHERE dashboard_id = ?",
 		}

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -97,6 +97,14 @@ func TestDashboardDataAccess(t *testing.T) {
 				})
 
 				So(err, ShouldBeNil)
+
+				versionQuery := m.GetDashboardVersionQuery{
+					DashboardId: dash.Id,
+					Version:     dash.Version,
+				}
+
+				err = getDashboardVersionRecord(&versionQuery)
+				So(err, ShouldBeNil)
 			})
 
 			Convey("Should retry generation of uid once if it fails.", func() {
@@ -457,4 +465,21 @@ func moveDashboard(orgId int64, dashboard *simplejson.Json, newFolderId int64) *
 	So(err, ShouldBeNil)
 
 	return cmd.Result
+}
+
+func getDashboardVersionRecord(query *m.GetDashboardVersionQuery) error {
+	version := m.DashboardVersion{}
+	has, err := x.Where("dashboard_version.dashboard_id=? AND dashboard_version.version=?", query.DashboardId, query.Version).Get(&version)
+
+	if err != nil {
+		return err
+	}
+
+	if !has {
+		return m.ErrDashboardVersionNotFound
+	}
+
+	version.Data.Set("id", version.DashboardId)
+	query.Result = &version
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently got hit by an issue similar to described in #9235 - one of our teams accidentally deleted a dashboard while trying to only delete a variable.

There is a good discussion in #9235 however, various UI/UX improvements aside, I believe we would all benefit from this relatively easy fix - just keeping all dashboard versions intact even upon dashboards deletion. This makes recovery from simple accidents like described above a painless 2-minute job.

**Which issue(s) this PR fixes**:
Fixes #9235.

**Special notes for your reviewer**:

Run tests for just this change: `GO111MODULE=on go test -v ./pkg/... -run TestDashboardDataAccess`


Thanks for the great work you're putting in!