### PR TITLE
Explore: Changes LogsContainer from a PureComponent to a Component

### DIFF
--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 import {
@@ -53,7 +53,7 @@ interface LogsContainerProps {
   stopLive: typeof changeRefreshIntervalAction;
 }
 
-export class LogsContainer extends PureComponent<LogsContainerProps> {
+export class LogsContainer extends Component<LogsContainerProps> {
   onChangeTime = (absRange: AbsoluteTimeRange) => {
     const { exploreId, timeZone, changeTime } = this.props;
     const range = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the `LogsContainer` React component from a `PureComponent` to a regular `Component`, since `shouldComponentUpdate()` has been implemented.