### PR TITLE
Fix typo s/Applicaiton/Application/ in error messages

### DIFF
--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -37,7 +37,7 @@ export function getAppPluginPageError(meta: AppPluginMeta) {
     return 'Plugin must be an app';
   }
   if (!meta.enabled) {
-    return 'Applicaiton Not Enabled';
+    return 'Application Not Enabled';
   }
   return null;
 }

--- a/public/app/features/plugins/plugin_page_ctrl.ts
+++ b/public/app/features/plugins/plugin_page_ctrl.ts
@@ -35,7 +35,7 @@ export class AppPageCtrl {
       return;
     }
     if (app.type !== 'app' || !app.enabled) {
-      this.$rootScope.appEvent('alert-error', ['Applicaiton Not Enabled', '']);
+      this.$rootScope.appEvent('alert-error', ['Application Not Enabled', '']);
       this.navModel = this.navModelSrv.getNotFoundNav();
       return;
     }


### PR DESCRIPTION
Fixes a typo in the word "Applicaiton" found in two strings.