### PR TITLE
Fix check for UTC timezone

### DIFF
--- a/public/app/features/api-keys/ApiKeysPage.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.tsx
@@ -171,7 +171,7 @@ export class ApiKeysPage extends PureComponent<Props, any> {
     format = format || 'YYYY-MM-DD HH:mm:ss';
     const timezone = getTimeZone(store.getState().user);
 
-    return timezone.isUtc ? date.utc().format(format) : date.format(format);
+    return timezone === 'utc' ? date.utc().format(format) : date.format(format);
   }
 
   renderAddApiKeyForm() {


### PR DESCRIPTION
getTimeZone() no longer returns an object, but a string

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:
This issue was introduced by merging https://github.com/grafana/grafana/pull/17678 because it was out of sync with the master (`getTimeZone()` modifications had already been merged in the master)