### PR TITLE
Devenv: makes the grafana users default for saml

### DIFF
--- a/devenv/docker/blocks/saml/users.php
+++ b/devenv/docker/blocks/saml/users.php
@@ -3,7 +3,7 @@ $config = array(
     'admin' => array(
         'core:AdminPassword',
     ),
-    'grafana-userpass' => array(
+    'example-userpass' => array(
         'exampleauth:UserPass',
         'saml-admin:grafana' => array(
             'groups' => array('admins'),


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes simplesamlphp use the grafana users per default.


We will have to change the ACS and Entity ID endpoints to get simeplsamlphp to work, but we can't do that until we have added those endpoints to Grafana. To get logout working we need to add the logout endpoint as well.

When sending the request to the idp, it is important that the entity id matches what the idp expects.