### PR TITLE
Chore: Build grafana-cli when running bra run

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,6 +1,7 @@
 [run]
 init_cmds = [
-  ["go", "run", "build.go", "-dev", "build-server"],
+  ["go", "run", "build.go", "-dev", "build-cli"],
+	["go", "run", "build.go", "-dev", "build-server"],
 	["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]
 watch_all = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds grafana-cli when running `bra run`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For some reason this was removed in https://github.com/grafana/grafana/commit/059719104f341ec650b339c245cbab5d79b50046. Not sure if there are something I'm missing here why it's not a good idea to build the cli when `bra run` starts up?