### PR TITLE
TestData: add option to increase the number of test streams

### DIFF
--- a/public/app/plugins/datasource/testdata/StreamHandler.ts
+++ b/public/app/plugins/datasource/testdata/StreamHandler.ts
@@ -18,6 +18,7 @@ export const defaultQuery: StreamingQuery = {
   speed: 250, // ms
   spread: 3.5,
   noise: 2.2,
+  bands: 1,
 };
 
 type StreamWorkers = {
@@ -42,7 +43,7 @@ export class StreamHandler {
       // set stream option defaults
       query.stream = defaults(query.stream, defaultQuery);
       // create stream key
-      const key = req.dashboardId + '/' + req.panelId + '/' + query.refId;
+      const key = req.dashboardId + '/' + req.panelId + '/' + query.refId + '@' + query.stream.bands;
 
       if (this.workers[key]) {
         const existing = this.workers[key];
@@ -146,7 +147,7 @@ export class StreamWorker {
 export class SignalWorker extends StreamWorker {
   value: number;
 
-  bands = 25;
+  bands = 1;
 
   constructor(key: string, query: TestDataQuery, request: DataQueryRequest, observer: DataStreamObserver) {
     super(key, query, request, observer);
@@ -154,6 +155,8 @@ export class SignalWorker extends StreamWorker {
       this.stream.series = [this.initBuffer(query.refId)];
       this.looper();
     }, 10);
+
+    this.bands = query.stream.bands ? query.stream.bands : 0;
   }
 
   nextRow = (time: number) => {

--- a/public/app/plugins/datasource/testdata/partials/query.editor.html
+++ b/public/app/plugins/datasource/testdata/partials/query.editor.html
@@ -43,7 +43,7 @@
 				<select
 				  ng-model="ctrl.target.stream.type"
 				  class="gf-form-input"
-					ng-options="type for type in ['signal','logs', 'fetch']"
+				  ng-options="type for type in ['signal','logs', 'fetch']"
 				  ng-change="ctrl.streamChanged()" />
 				</select>
 			</div>
@@ -76,6 +76,16 @@
 				ng-model="ctrl.target.stream.noise"
 				min="0"
 				step="0.1"
+				ng-change="ctrl.streamChanged()" />
+		</div>
+		<div class="gf-form" ng-if="ctrl.target.stream.type === 'signal'">
+			<label class="gf-form-label query-keyword">Bands</label>
+			<input type="number"
+				class="gf-form-input width-5"
+				placeholder="bands"
+				ng-model="ctrl.target.stream.bands"
+				min="0"
+				step="1"
 				ng-change="ctrl.streamChanged()" />
 		</div>
 		<div class="gf-form gf-form--grow" ng-if="ctrl.target.stream.type === 'fetch'">

--- a/public/app/plugins/datasource/testdata/types.ts
+++ b/public/app/plugins/datasource/testdata/types.ts
@@ -18,6 +18,7 @@ export interface StreamingQuery {
   speed: number;
   spread: number;
   noise: number; // wiggle around the signal for min/max
+  bands?: number; // number of bands around the middle van
   buffer?: number;
   url?: string; // the Fetch URL
 }


### PR DESCRIPTION
This PR adds an option to test data that lets you bump up how man values (series) are added in the streaming response.  Each 'band' adds something above and below the last signal

![bands2](https://user-images.githubusercontent.com/705951/60223991-8a26d480-9835-11e9-95ed-fa7a88f5c257.gif)
