### PR TITLE
Graphite: Fix for issue with alias function being moved last

### DIFF
--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -131,18 +131,6 @@ export default class GraphiteQuery {
 
   addFunction(newFunc) {
     this.functions.push(newFunc);
-    this.moveAliasFuncLast();
-  }
-
-  moveAliasFuncLast() {
-    const aliasFunc: any = _.find(this.functions, func => {
-      return func.def.name.startsWith('alias');
-    });
-
-    if (aliasFunc) {
-      this.functions = _.without(this.functions, aliasFunc);
-      this.functions.push(aliasFunc);
-    }
   }
 
   addFunctionParameter(func, value) {


### PR DESCRIPTION
Fixes #17099

To fix this I sadly had to remove the mostly nice feature where alias function is moved last, but looks like that is not always the right thing and knowing when it will cause issues seemed complicated so I opted to remove this feature instead. 