### PR TITLE
Graphite: Fixes issue with seriesByTag & function with variable param

### DIFF
--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -57,4 +57,17 @@ describe('Graphite query model', () => {
       expect(ctx.queryModel.functions[1].params[0]).toBe('#A');
     });
   });
+
+  describe('when query has seriesByTag and highestMax with variable param', () => {
+    beforeEach(() => {
+      ctx.target = { refId: 'A', target: `highestMax(seriesByTag('namespace=asd'), $limit)` };
+      ctx.targets = [ctx.target];
+      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+    });
+
+    it('should add $limit to highestMax function param', () => {
+      expect(ctx.queryModel.segments.length).toBe(0);
+      expect(ctx.queryModel.functions[1].params[0]).toBe('$limit');
+    });
+  });
 });


### PR DESCRIPTION
Query with seriesByTag & a function with a variable param was parsed incorrectly into the view model and hence rendered incorrectly back to the query string. 

Fixes #17696

