### PR TITLE
OAuth: return github teams as a part of user info (enable team sync)

### DIFF
--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -34,7 +34,7 @@ ldap_sync_ttl = 60
 # Example `whitelist = 192.168.1.1, 192.168.1.0/24, 2001::23, 2001::0/120`
 whitelist =
 # Optionally define more headers to sync other user attributes
-# Example `headers = Name:X-WEBAUTH-NAME Email:X-WEBAUTH-EMAIL`
+# Example `headers = Name:X-WEBAUTH-NAME Email:X-WEBAUTH-EMAIL Groups:X-WEBAUTH-GROUPS`
 headers =
 ```
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -171,6 +171,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 		Login:      userInfo.Login,
 		Email:      userInfo.Email,
 		OrgRoles:   map[int64]m.RoleType{},
+		Groups:     userInfo.Groups,
 	}
 
 	if userInfo.Role != "" {

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -53,14 +53,9 @@ func (s *SocialGithub) IsTeamMember(client *http.Client) bool {
 		return false
 	}
 
-	teamMembershipIds := make([]int, len(teamMemberships))
-	for i, team := range teamMemberships {
-		teamMembershipIds[i] = team.Id
-	}
-
 	for _, teamId := range s.teamIds {
-		for _, membershipId := range teamMembershipIds {
-			if teamId == membershipId {
+		for _, membership := range teamMemberships {
+			if teamId == membership.Id {
 				return true
 			}
 		}
@@ -138,15 +133,7 @@ func (s *SocialGithub) FetchTeamMemberships(client *http.Client) ([]GithubTeam, 
 			return nil, fmt.Errorf("Error getting team memberships: %s", err)
 		}
 
-		newRecords := len(records)
-		existingRecords := len(teams)
-		tempTeams := make([]GithubTeam, (newRecords + existingRecords))
-		copy(tempTeams, teams)
-		teams = tempTeams
-
-		for i, record := range records {
-			teams[i] = record
-		}
+		teams = append(teams, records...)
 
 		url, hasMore = s.HasMoreRecords(response.Headers)
 	}

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -20,6 +20,7 @@ type BasicUserInfo struct {
 	Login   string
 	Company string
 	Role    string
+	Groups  []string
 }
 
 type SocialConnector interface {

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -246,13 +247,17 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 		return 0, newError("Auth proxy header property invalid", nil)
 	}
 
-	for _, field := range []string{"Name", "Email", "Login"} {
+	for _, field := range []string{"Name", "Email", "Login", "Groups"} {
 		if auth.headers[field] == "" {
 			continue
 		}
 
 		if val := auth.ctx.Req.Header.Get(auth.headers[field]); val != "" {
-			reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(val)
+			if field == "Groups" {
+				extUser.Groups = util.SplitString(val)
+			} else {
+				reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(val)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is basic POC for getting teams from github and passing it to `ExternalUserInfo.Groups`. This achieves team sync feature for OAuth.
https://github.com/grafana/grafana-enterprise/issues/59
Based on https://github.com/grafana/grafana-private-mirror/pull/4

Github team should be specified by URL (for example, `https://github.com/orgs/grafana/teams/grafana-labs-core-devs`), but maybe it's better to use `org@slug` form, like `@grafana/grafana-labs-core-devs`.