### PR TITLE
Devenv:LDAP: couple simplifications for LDAP

### DIFF
--- a/devenv/docker/blocks/openldap/Dockerfile
+++ b/devenv/docker/blocks/openldap/Dockerfile
@@ -19,6 +19,8 @@ EXPOSE 389
 
 VOLUME ["/etc/ldap", "/var/lib/ldap"]
 
+COPY ldap.conf /etc/ldap.dist/ldap.conf
+
 COPY modules/ /etc/ldap.dist/modules
 COPY prepopulate/ /etc/ldap.dist/prepopulate
 

--- a/devenv/docker/blocks/openldap/docker-compose.yaml
+++ b/devenv/docker/blocks/openldap/docker-compose.yaml
@@ -1,4 +1,5 @@
   openldap:
+    container_name: ldap
     build: docker/blocks/openldap
     environment:
       SLAPD_PASSWORD: grafana

--- a/devenv/docker/blocks/openldap/entrypoint.sh
+++ b/devenv/docker/blocks/openldap/entrypoint.sh
@@ -49,10 +49,6 @@ EOF
         dc_string="$dc_string,dc=$dc_part"
     done
 
-    base_string="BASE ${dc_string:1}"
-
-    sed -i "s/^#BASE.*/${base_string}/g" /etc/ldap/ldap.conf
-
     if [[ -n "$SLAPD_CONFIG_PASSWORD" ]]; then
         password_hash=`slappasswd -s "${SLAPD_CONFIG_PASSWORD}"`
 

--- a/devenv/docker/blocks/openldap/ldap.conf
+++ b/devenv/docker/blocks/openldap/ldap.conf
@@ -1,0 +1,16 @@
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+BASE dc=grafana,dc=org
+#URI	ldap://ldap.example.com ldap://ldap-master.example.com:666
+
+SIZELIMIT	1000
+#TIMELIMIT	15
+#DEREF		never
+
+# TLS certificates (needed for GnuTLS)
+TLS_CACERT	/etc/ssl/certs/ca-certificates.crt

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/codegangsta/cli v1.20.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/denisenkom/go-mssqldb v0.0.0-20190315220205-a8ed825ac853
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/inject v0.0.0-20180706035515-f23751cae28b

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -261,6 +261,7 @@ func (server *Server) getSearchRequest(
 	return &ldap.SearchRequest{
 		BaseDN:       base,
 		Scope:        ldap.ScopeWholeSubtree,
+		SizeLimit:    1000,
 		DerefAliases: ldap.NeverDerefAliases,
 		Attributes:   attributes,
 		Filter:       filter,


### PR DESCRIPTION
* Add LDAP config instead sed use

* Add container name

* Add SizeLimit option to client and to server.
  Probably useless at this point, but it's better to have it then otherwise