### PR TITLE
Dashboard: force update after dashboard resize

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -163,6 +163,7 @@ export class DashboardGrid extends PureComponent<Props> {
     for (const panel of this.props.dashboard.panels) {
       panel.resizeDone();
     }
+    this.forceUpdate();
   };
 
   onViewModeChanged = () => {


### PR DESCRIPTION
fixes #17806 

This calls `forceUpdate()` after the dashboard width changes, that then updates the `isInView` property for each panel.

Is there a better way?  I guess we could add something to the state, but I don't know if that is better

