### PR TITLE
Docs: Add v6.3 version notes and encryption format information

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -199,6 +199,8 @@ Notification services which need public image access are marked as 'external onl
 
 # Use alert rule tags in notifications {#alert-rule-tags}
 
+> Only available in Grafana v6.3+.
+
 Grafana can include a list of tags (key/value) in the notification.
 It's called alert rule tags to contrast with tags parsed from timeseries.
 It currently supports only the Prometheus Alertmanager notifier.

--- a/docs/sources/features/panels/graph.md
+++ b/docs/sources/features/panels/graph.md
@@ -37,6 +37,8 @@ Repeat a panel for each value of a variable.  Repeating panels are described in 
 
 ### Data link
 
+> Only available in Grafana v6.3+.
+
 Data link in graph settings allows adding dynamic links to the visualization. Those links can link to either other dashboard or to an external URL.
 
 {{< docs-imagebox img="/img/docs/data_link.png"  max-width= "800px" >}}

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -304,7 +304,7 @@ The number of days the keep me logged in / remember me cookie lasts.
 
 ### secret_key
 
-Used for signing some datasource settings like secrets and passwords. Cannot be changed without requiring an update
+Used for signing some datasource settings like secrets and passwords, the encryption format used is AES-256 in CFB mode. Cannot be changed without requiring an update
 to datasource settings to re-encode them.
 
 ### disable_gravatar

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -154,7 +154,7 @@ The default cookie name for storing the auth token is `grafana_session`. you can
 
 ### Ensure encryption of datasource secrets
 
-Datasources store passwords and basic auth passwords in secureJsonData encrypted by default. Existing datasource
+Datasources store passwords and basic auth passwords in secureJsonData encrypted (AES-256 in CFB mode) by default. Existing datasource
 will keep working with unencrypted passwords. If you want to migrate to encrypted storage for your existing datasources
 you can do that by:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds version note for alert rule tags.
Adds version note for graph data links.
Adds information about secret_key and encryption format in use

**Which issue(s) this PR fixes**:
Fixes #17815 
Fixes #17803 

