### PR TITLE
Templating: Correctly display __text in multi-value variable after page reload

### DIFF
--- a/public/app/features/templating/specs/variable_srv.test.ts
+++ b/public/app/features/templating/specs/variable_srv.test.ts
@@ -601,7 +601,7 @@ describe('VariableSrv', function(this: any) {
     it('sets single value as array if multi choice', async () => {
       const [setValueMock, setFromUrl] = setupSetFromUrlTest(ctx, { multi: true });
       await setFromUrl('one');
-      expect(setValueMock).toHaveBeenCalledWith({ text: 'one', value: ['one'] });
+      expect(setValueMock).toHaveBeenCalledWith({ text: ['one'], value: ['one'] });
     });
 
     it('sets both text and value as array if multiple values in url', async () => {

--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -261,7 +261,7 @@ export class VariableSrv {
       if (variable.multi) {
         // In case variable is multiple choice, we cast to array to preserve the same behaviour as when selecting
         // the option directly, which will return even single value in an array.
-        option = { ...option, value: _.castArray(option.value) };
+        option = { text: _.castArray(option.text), value: _.castArray(option.value) };
       }
 
       return variable.setValue(option);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the bug described in #17839: `__value` is displayed after page refresh instead of `__text` when a single item is selected in multi-value variable

**Which issue(s) this PR fixes**:
Fixes #17839