### PR TITLE
Explore: Log highlights only update when user stops typing

### DIFF
--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 import {
@@ -52,7 +52,7 @@ interface LogsContainerProps {
   absoluteRange: AbsoluteTimeRange;
 }
 
-export class LogsContainer extends Component<LogsContainerProps> {
+export class LogsContainer extends PureComponent<LogsContainerProps> {
   onChangeTime = (absoluteRange: AbsoluteTimeRange) => {
     const { exploreId, updateTimeRange } = this.props;
 
@@ -85,19 +85,6 @@ export class LogsContainer extends Component<LogsContainerProps> {
 
     return [];
   };
-
-  // Limit re-rendering to when a query is finished executing or when the deduplication strategy changes
-  // for performance reasons.
-  shouldComponentUpdate(nextProps: LogsContainerProps): boolean {
-    return (
-      nextProps.loading !== this.props.loading ||
-      nextProps.dedupStrategy !== this.props.dedupStrategy ||
-      nextProps.logsHighlighterExpressions !== this.props.logsHighlighterExpressions ||
-      nextProps.hiddenLogLevels !== this.props.hiddenLogLevels ||
-      nextProps.scanning !== this.props.scanning ||
-      nextProps.isLive !== this.props.isLive
-    );
-  }
 
   render() {
     const {

--- a/public/app/features/explore/QueryField.tsx
+++ b/public/app/features/explore/QueryField.tsx
@@ -19,6 +19,7 @@ import { makeFragment, makeValue } from '@grafana/ui';
 import PlaceholdersBuffer from './PlaceholdersBuffer';
 
 export const TYPEAHEAD_DEBOUNCE = 100;
+export const HIGHLIGHT_WAIT = 500;
 
 function getSuggestionByIndex(suggestions: CompletionItemGroup[], index: number): CompletionItem {
   // Flatten suggestion groups
@@ -77,11 +78,13 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
   plugins: any[];
   resetTimer: any;
   mounted: boolean;
+  updateHighlightsTimer: any;
 
   constructor(props: QueryFieldProps, context: Context<any>) {
     super(props, context);
 
     this.placeholdersBuffer = new PlaceholdersBuffer(props.initialQuery || '');
+    this.updateHighlightsTimer = _.debounce(this.updateLogsHighlights, HIGHLIGHT_WAIT);
 
     // Base plugins
     this.plugins = [ClearPlugin(), NewlinePlugin(), ...(props.additionalPlugins || [])].filter(p => p);
@@ -152,7 +155,7 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
           this.executeOnChangeAndRunQueries();
         }
         if (textChanged && !invokeParentOnValueChanged) {
-          this.updateLogsHighlights();
+          this.updateHighlightsTimer();
         }
       }
     });
@@ -168,6 +171,7 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
 
   updateLogsHighlights = () => {
     const { onChange } = this.props;
+
     if (onChange) {
       onChange(Plain.serialize(this.state.value));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a debounce such that updating the log highlights only occurs after the user stops typing for a period of time.
- Reverts performance enhancements made to LogsContainer as they are no
longer needed, and complicated things.

Needed to improve performance.

**Which issue(s) this PR fixes**:
Closes #17818

