### PR TITLE
best choice

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -31,7 +31,7 @@ func Register(descriptor *Descriptor) {
 func GetServices() []*Descriptor {
 	slice := getServicesWithOverrides()
 
-	sort.Slice(slice, func(i, j int) bool {
+	sort.SliceStable(slice, func(i, j int) bool {
 		return slice[i].InitPriority > slice[j].InitPriority
 	})
 
@@ -68,7 +68,7 @@ func getServicesWithOverrides() []*Descriptor {
 }
 
 // Service interface is the lowest common shape that services
-// are expected to forfill to be started within Grafana.
+// are expected to to fulfilled and to be started within Grafana.
 type Service interface {
 
 	// Init is called by Grafana main process which gives the service


### PR DESCRIPTION


**What this PR does / why we need it**:
The sort `sort.Slice` is not guaranteed to be stable. For a stable sort, use SliceStable `sort.SliceStable`. And I added the comment to understand the code logic.

