### PR TITLE
Loki: getHighlighterExpressionsFromQuery returns null if filter term is not quoted

### DIFF
--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -71,17 +71,25 @@ describe('getHighlighterExpressionsFromQuery', () => {
   it('returns no expressions for empty query', () => {
     expect(getHighlighterExpressionsFromQuery('')).toEqual([]);
   });
+
   it('returns a single expressions for legacy query', () => {
     expect(getHighlighterExpressionsFromQuery('{} x')).toEqual(['(?i)x']);
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} x')).toEqual(['(?i)x']);
   });
+
   it('returns an expression for query with filter', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x"')).toEqual(['x']);
   });
+
   it('returns expressions for query with filter chain', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ "y"')).toEqual(['x', 'y']);
   });
+
   it('returns drops expressions for query with negative filter chain', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" != "y"')).toEqual(['x']);
+  });
+
+  it('returns null if filter term is not wrapped in double quotes', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= x')).toEqual(null);
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -59,12 +59,19 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
     if (filterEnd === -1) {
       filterTerm = expression.trim();
     } else {
-      filterTerm = expression.substr(0, filterEnd);
+      filterTerm = expression.substr(0, filterEnd).trim();
       expression = expression.substr(filterEnd);
     }
 
     // Unwrap the filter term by removing quotes
-    results.push(filterTerm.replace(/^\s*"/g, '').replace(/"\s*$/g, ''));
+    const quotedTerm = filterTerm.match(/^"((?:[^\\"]|\\")*)"$/);
+
+    if (quotedTerm) {
+      const unwrappedFilterTerm = quotedTerm[1];
+      results.push(unwrappedFilterTerm);
+    } else {
+      return null;
+    }
   }
   return results;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`getHighlighterExpressionsFromQuery` now returns `null` if a filter term supplied in a query isn't wrapped in double quotes.
Needed since a filter term needs to be wrapped in double quotes in order to be valid.

**Which issue(s) this PR fixes**:
Closes #17687
