### PR TITLE
Teams: show proper label for each auth provider

### DIFF
--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -22,11 +22,27 @@ func GetTeamMembers(c *m.ReqContext) Response {
 		member.Labels = []string{}
 
 		if setting.IsEnterprise && setting.LDAPEnabled && member.External {
-			member.Labels = append(member.Labels, "LDAP")
+			authProvider := GetAuthProviderName(member.AuthModule)
+			member.Labels = append(member.Labels, authProvider)
 		}
 	}
 
 	return JSON(200, query.Result)
+}
+
+func GetAuthProviderName(authModule string) string {
+	switch authModule {
+	case "oauth_github":
+		return "GitHub"
+	case "oauth_google":
+		return "Google"
+	case "ldap":
+		return "LDAP"
+	case "":
+		return "LDAP"
+	default:
+		return "OAuth"
+	}
 }
 
 // POST /api/teams/:teamId/members

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -21,7 +21,7 @@ func GetTeamMembers(c *m.ReqContext) Response {
 		member.AvatarUrl = dtos.GetGravatarUrl(member.Email)
 		member.Labels = []string{}
 
-		if setting.IsEnterprise && setting.LDAPEnabled && member.External {
+		if setting.IsEnterprise && member.External {
 			authProvider := GetAuthProviderLabel(member.AuthModule)
 			member.Labels = append(member.Labels, authProvider)
 		}

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -22,7 +22,7 @@ func GetTeamMembers(c *m.ReqContext) Response {
 		member.Labels = []string{}
 
 		if setting.IsEnterprise && setting.LDAPEnabled && member.External {
-			authProvider := GetAuthProviderName(member.AuthModule)
+			authProvider := GetAuthProviderLabel(member.AuthModule)
 			member.Labels = append(member.Labels, authProvider)
 		}
 	}
@@ -30,15 +30,17 @@ func GetTeamMembers(c *m.ReqContext) Response {
 	return JSON(200, query.Result)
 }
 
-func GetAuthProviderName(authModule string) string {
+func GetAuthProviderLabel(authModule string) string {
 	switch authModule {
 	case "oauth_github":
 		return "GitHub"
 	case "oauth_google":
 		return "Google"
-	case "ldap":
-		return "LDAP"
-	case "":
+	case "oauth_gitlab":
+		return "GitLab"
+	case "oauth_grafana_com", "oauth_grafananet":
+		return "grafana.com"
+	case "ldap", "":
 		return "LDAP"
 	default:
 		return "OAuth"

--- a/pkg/models/team_member.go
+++ b/pkg/models/team_member.go
@@ -17,7 +17,6 @@ type TeamMember struct {
 	TeamId     int64
 	UserId     int64
 	External   bool // Signals that the membership has been created by an external systems, such as LDAP
-	AuthModule string
 	Permission PermissionType
 
 	Created time.Time

--- a/pkg/models/team_member.go
+++ b/pkg/models/team_member.go
@@ -17,6 +17,7 @@ type TeamMember struct {
 	TeamId     int64
 	UserId     int64
 	External   bool // Signals that the membership has been created by an external systems, such as LDAP
+	AuthModule string
 	Permission PermissionType
 
 	Created time.Time
@@ -68,6 +69,7 @@ type TeamMemberDTO struct {
 	TeamId     int64          `json:"teamId"`
 	UserId     int64          `json:"userId"`
 	External   bool           `json:"-"`
+	AuthModule string         `json:"auth_module"`
 	Email      string         `json:"email"`
 	Login      string         `json:"login"`
 	AvatarUrl  string         `json:"avatarUrl"`


### PR DESCRIPTION
This PR related to https://github.com/grafana/grafana-enterprise/issues/59
After adding support of team sync with providers other than LDAP we need to fix labels in team members view:

![Screenshot from 2019-07-02 10-41-57](https://user-images.githubusercontent.com/4932851/60493681-0b5aed00-9cb6-11e9-9e21-3c89f1c4bcdc.png)

So this PR adds own label for each known auth provider, like GitHub, Google, etc:

![Screenshot from 2019-07-02 10-43-35](https://user-images.githubusercontent.com/4932851/60493778-40ffd600-9cb6-11e9-85b3-19964dd85601.png)
