### PR TITLE
Explore: Query rows are now reset when changing data sources

### DIFF
--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -264,7 +264,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         loadingState: LoadingState.NotStarted,
         StartPage,
         showingStartPage: Boolean(StartPage),
-        queryKeys: getQueryKeys(state.queries, datasourceInstance),
+        queryKeys: [],
         supportedModes,
         mode,
       };


### PR DESCRIPTION
**What this PR does / why we need it**:
Query rows are now reset when changing data sources, except when those data sources are compatible.

**Which issue(s) this PR fixes**:
Closes #17861