### PR TITLE
Loki: Adds comment explaining usage of RFC3339Nano string

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -310,13 +310,13 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       return {
         ...commontTargetOptons,
         start: timeEpochNs - contextTimeBuffer,
-        end: timeEpochNs,
+        end: row.timestamp, // using RFC3339Nano format to avoid precision loss
         direction,
       };
     } else {
       return {
         ...commontTargetOptons,
-        start: timeEpochNs, // start param in Loki API is inclusive so we'll have to filter out the row that this request is based from
+        start: row.timestamp, // start param in Loki API is inclusive so we'll have to filter out the row that this request is based from
         end: timeEpochNs + contextTimeBuffer,
       };
     }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -310,13 +310,13 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       return {
         ...commontTargetOptons,
         start: timeEpochNs - contextTimeBuffer,
-        end: row.timestamp,
+        end: timeEpochNs,
         direction,
       };
     } else {
       return {
         ...commontTargetOptons,
-        start: row.timestamp, // start param in Loki API is inclusive so we'll have to filter out the row that this request is based from
+        start: timeEpochNs, // start param in Loki API is inclusive so we'll have to filter out the row that this request is based from
         end: timeEpochNs + contextTimeBuffer,
       };
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds comment explaining usage of RFC3339Nano string. Needed since it's not immediately obvious why it's being used.