### PR TITLE
Build: fixes missing shebang in release tagging script.

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # abort if we get any error
 set -e
@@ -33,8 +33,9 @@ echo "press [y] to push the tags"
 
 read -n 1 confirm
 
-if [ "${confirm}" == "y" ]; then 
+if [ "${confirm}" == "y" ]; then
     git push origin "${_branch}" --tags
-else 
+else
+    git tag -d "${_tag}"
     echo "Abort! "
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

An incorrect shebang meant that this script would be parsed by the default shell. This works well if the default shell is bash, but not zsh.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**: