### PR TITLE
Auth: Duplicate API Key Name Handle With Useful HTTP Code

### DIFF
--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -68,7 +68,10 @@ func (hs *HTTPServer) AddAPIKey(c *models.ReqContext, cmd models.AddApiKeyComman
 		if err == models.ErrInvalidApiKeyExpiration {
 			return Error(400, err.Error(), nil)
 		}
-		return Error(500, "Failed to add API key", err)
+		if err.Error() == models.ErrDuplicateApiKey.Error() {
+			return Error(409, "API Key Name Must Be Unique", nil)
+		}
+		return Error(500, "Failed to add API", err)
 	}
 
 	result := &dtos.NewApiKeyResult{

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -68,8 +68,8 @@ func (hs *HTTPServer) AddAPIKey(c *models.ReqContext, cmd models.AddApiKeyComman
 		if err == models.ErrInvalidApiKeyExpiration {
 			return Error(400, err.Error(), nil)
 		}
-		if err.Error() == models.ErrDuplicateApiKey.Error() {
-			return Error(409, "API Key Name Must Be Unique", nil)
+		if err == models.ErrDuplicateApiKey {
+			return Error(409, err.Error(), nil)
 		}
 		return Error(500, "Failed to add API", err)
 	}

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -71,7 +71,7 @@ func (hs *HTTPServer) AddAPIKey(c *models.ReqContext, cmd models.AddApiKeyComman
 		if err == models.ErrDuplicateApiKey {
 			return Error(409, err.Error(), nil)
 		}
-		return Error(500, "Failed to add API", err)
+		return Error(500, "Failed to add API Key", err)
 	}
 
 	result := &dtos.NewApiKeyResult{

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -68,8 +68,8 @@ func (hs *HTTPServer) AddAPIKey(c *models.ReqContext, cmd models.AddApiKeyComman
 		if err == models.ErrInvalidApiKeyExpiration {
 			return Error(400, err.Error(), nil)
 		}
-		if err == models.ErrDuplicateApiKey {
-			return Error(409, err.Error(), nil)
+		if err.Error() == models.ErrDuplicateApiKey.Error() {
+			return Error(409, "API Key Name Must Be Unique", nil)
 		}
 		return Error(500, "Failed to add API", err)
 	}

--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -7,7 +7,7 @@ import (
 
 var ErrInvalidApiKey = errors.New("Invalid API Key")
 var ErrInvalidApiKeyExpiration = errors.New("Negative value for SecondsToLive")
-var ErrDuplicateApiKey = errors.New("UNIQUE constraint failed: api_key.org_id, api_key.name")
+var ErrDuplicateApiKey = errors.New("API Key Organization ID And Name Must Be Unique")
 
 type ApiKey struct {
 	Id      int64

--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -7,6 +7,7 @@ import (
 
 var ErrInvalidApiKey = errors.New("Invalid API Key")
 var ErrInvalidApiKeyExpiration = errors.New("Negative value for SecondsToLive")
+var ErrDuplicateApiKey = errors.New("UNIQUE constraint failed: api_key.org_id, api_key.name")
 
 type ApiKey struct {
 	Id      int64

--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -7,7 +7,7 @@ import (
 
 var ErrInvalidApiKey = errors.New("Invalid API Key")
 var ErrInvalidApiKeyExpiration = errors.New("Negative value for SecondsToLive")
-var ErrDuplicateApiKey = errors.New("API Key Organization ID And Name Must Be Unique")
+var ErrDuplicateApiKey = errors.New("UNIQUE constraint failed: api_key.org_id, api_key.name")
 
 type ApiKey struct {
 	Id      int64

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -37,6 +37,12 @@ func DeleteApiKeyCtx(ctx context.Context, cmd *models.DeleteApiKeyCommand) error
 
 func AddApiKey(cmd *models.AddApiKeyCommand) error {
 	return inTransaction(func(sess *DBSession) error {
+		key := models.ApiKey{OrgId: cmd.OrgId, Name: cmd.Name}
+		exists, _ := sess.Get(&key)
+		if exists {
+			return models.ErrDuplicateApiKey
+		}
+
 		updated := timeNow()
 		var expires *int64 = nil
 		if cmd.SecondsToLive > 0 {

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -56,6 +56,9 @@ func AddApiKey(cmd *models.AddApiKeyCommand) error {
 		}
 
 		if _, err := sess.Insert(&t); err != nil {
+			if dialect.IsUniqueConstraintViolation((err)) {
+				return models.ErrDuplicateApiKey
+			}
 			return err
 		}
 		cmd.Result = &t

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -56,9 +56,6 @@ func AddApiKey(cmd *models.AddApiKeyCommand) error {
 		}
 
 		if _, err := sess.Insert(&t); err != nil {
-			if dialect.IsUniqueConstraintViolation((err)) {
-				return models.ErrDuplicateApiKey
-			}
 			return err
 		}
 		cmd.Result = &t

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -115,3 +115,23 @@ func TestApiKeyDataAccess(t *testing.T) {
 		})
 	})
 }
+
+func TestApiKeyErrors(t *testing.T) {
+	mockTimeNow()
+	defer resetTimeNow()
+
+	t.Run("Testing API Duplicate Key Errors", func(t *testing.T) {
+		InitTestDB(t)
+		t.Run("Given saved api key", func(t *testing.T) {
+			cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate", Key: "asd"}
+			err := AddApiKey(&cmd)
+			assert.Nil(t, err)
+
+			t.Run("Add API Key with existing Org ID and Name", func(t *testing.T) {
+				cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate", Key: "asd"}
+				err = AddApiKey(&cmd)
+				assert.EqualError(t, err, models.ErrDuplicateApiKey.Error())
+			})
+		})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
adds useful http status code & message when trying to create api key 
with same name as another existing api key
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17447 

