### PR TITLE
Templating: Correctly display __text in multi-values variable after refresh

### DIFF
--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -194,7 +194,7 @@ export class VariableSrv {
           }),
           text: _.map(selected, val => {
             return val.text;
-          }).join(' + '),
+          }),
         };
       }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the bug described in #17915: Templating: __value's are displayed instead of __text's after variable is updated

**Which issue(s) this PR fixes**:
Fixes #17915

**Special notes for your reviewer**:
Related to #17840 but fixes a different issue
