### PR TITLE
Auth: SAML login button.

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -30,7 +30,7 @@ export class GrafanaBootConfig {
   authProxyEnabled = false;
   exploreEnabled = false;
   ldapEnabled = false;
-  samlEnabled: false;
+  samlEnabled = false;
   oauth: any;
   disableUserSignUp = false;
   loginHint: any;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -30,6 +30,7 @@ export class GrafanaBootConfig {
   authProxyEnabled = false;
   exploreEnabled = false;
   ldapEnabled = false;
+  samlEnabled: false;
   oauth: any;
   disableUserSignUp = false;
   loginHint: any;

--- a/pkg/models/saml.go
+++ b/pkg/models/saml.go
@@ -1,0 +1,5 @@
+package models
+
+type IsSAMLEnabledCommand struct {
+	Result bool
+}

--- a/public/app/core/controllers/login_ctrl.ts
+++ b/public/app/core/controllers/login_ctrl.ts
@@ -20,6 +20,7 @@ export class LoginCtrl {
     $scope.oauthEnabled = _.keys(config.oauth).length > 0;
     $scope.ldapEnabled = config.ldapEnabled;
     $scope.authProxyEnabled = config.authProxyEnabled;
+    $scope.samlEnabled = config.samlEnabled;
 
     $scope.disableLoginForm = config.disableLoginForm;
     $scope.disableUserSignUp = config.disableUserSignUp;

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -68,6 +68,10 @@
             <i class="btn-service-icon fa fa-sign-in"></i>
             Sign in with {{oauth.generic_oauth.name}}
           </a>
+          <a class="btn btn-medium btn-service btn-service--github login-btn" href="login/saml" target="_self" ng-if="samlEnabled">
+            <i class="btn-service-icon fa fa-key"></i>
+            Sign in with SAML
+          </a>
         </div>
         <div class="login-signup-box" ng-show="!disableUserSignUp">
           <div class="login-signup-title p-r-1">


### PR DESCRIPTION
**What this PR does / why we need it**:

SAML Enabled check and login button. Needed for Enterprise saml auth support.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

