### PR TITLE
Explore: Introduces storage keys for last used data source on per-orgId basis

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -53,6 +53,7 @@ export const DEFAULT_UI_STATE = {
 const MAX_HISTORY_ITEMS = 100;
 
 export const LAST_USED_DATASOURCE_KEY = 'grafana.explore.datasource';
+export const lastUsedDatasourceKeyForOrgId = (orgId: number) => `${LAST_USED_DATASOURCE_KEY}.${orgId}`;
 
 /**
  * Returns an Explore-URL that contains a panel's queries and the dashboard time range.

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -41,11 +41,11 @@ import {
 } from 'app/types/explore';
 import { StoreState } from 'app/types';
 import {
-  LAST_USED_DATASOURCE_KEY,
   ensureQueries,
   DEFAULT_RANGE,
   DEFAULT_UI_STATE,
   getTimeRangeFromUrl,
+  lastUsedDatasourceKeyForOrgId,
 } from 'app/core/utils/explore';
 import { Emitter } from 'app/core/utils/emitter';
 import { ExploreToolbar } from './ExploreToolbar';
@@ -307,7 +307,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
   } = item;
 
   const { datasource, queries, range: urlRange, mode: urlMode, ui } = (urlState || {}) as ExploreUrlState;
-  const initialDatasource = datasource || store.get(`${LAST_USED_DATASOURCE_KEY}.${state.user.orgId}`);
+  const initialDatasource = datasource || store.get(lastUsedDatasourceKeyForOrgId(state.user.orgId));
   const initialQueries: DataQuery[] = ensureQueries(queries);
   const initialRange = urlRange ? getTimeRangeFromUrl(urlRange, timeZone).raw : DEFAULT_RANGE;
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -307,7 +307,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
   } = item;
 
   const { datasource, queries, range: urlRange, mode: urlMode, ui } = (urlState || {}) as ExploreUrlState;
-  const initialDatasource = datasource || store.get(LAST_USED_DATASOURCE_KEY);
+  const initialDatasource = datasource || store.get(`${LAST_USED_DATASOURCE_KEY}.${state.user.orgId}`);
   const initialQueries: DataQuery[] = ensureQueries(queries);
   const initialRange = urlRange ? getTimeRangeFromUrl(urlRange, timeZone).raw : DEFAULT_RANGE;
 

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -6,13 +6,13 @@ import store from 'app/core/store';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { Emitter } from 'app/core/core';
 import {
-  LAST_USED_DATASOURCE_KEY,
   ensureQueries,
   generateEmptyQuery,
   parseUrlState,
   getTimeRange,
   getTimeRangeFromUrl,
   generateNewKeyAndAddRefIdIfMissing,
+  lastUsedDatasourceKeyForOrgId,
 } from 'app/core/utils/explore';
 
 // Types
@@ -271,7 +271,7 @@ export const loadDatasourceReady = (
   const history = store.getObject(historyKey, []);
   // Save last-used datasource
 
-  store.set(`${LAST_USED_DATASOURCE_KEY}.${orgId}`, instance.name);
+  store.set(lastUsedDatasourceKeyForOrgId(orgId), instance.name);
 
   return loadDatasourceReadyAction({
     exploreId,

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -104,6 +104,7 @@ export function changeDatasource(exploreId: ExploreId, datasource: string): Thun
 
     const currentDataSourceInstance = getState().explore[exploreId].datasourceInstance;
     const queries = getState().explore[exploreId].queries;
+    const orgId = getState().user.orgId;
 
     dispatch(updateDatasourceInstanceAction({ exploreId, datasourceInstance: newDataSourceInstance }));
 
@@ -113,7 +114,7 @@ export function changeDatasource(exploreId: ExploreId, datasource: string): Thun
       dispatch(changeRefreshInterval(exploreId, offOption.value));
     }
 
-    await dispatch(loadDatasource(exploreId, newDataSourceInstance));
+    await dispatch(loadDatasource(exploreId, newDataSourceInstance, orgId));
     dispatch(runQueries(exploreId));
   };
 }
@@ -263,12 +264,14 @@ export function initializeExplore(
  */
 export const loadDatasourceReady = (
   exploreId: ExploreId,
-  instance: DataSourceApi
+  instance: DataSourceApi,
+  orgId: number
 ): ActionOf<LoadDatasourceReadyPayload> => {
   const historyKey = `grafana.explore.history.${instance.meta.id}`;
   const history = store.getObject(historyKey, []);
   // Save last-used datasource
-  store.set(LAST_USED_DATASOURCE_KEY, instance.name);
+
+  store.set(`${LAST_USED_DATASOURCE_KEY}.${orgId}`, instance.name);
 
   return loadDatasourceReadyAction({
     exploreId,
@@ -346,7 +349,7 @@ export const reconnectDatasource = (exploreId: ExploreId): ThunkResult<void> => 
 /**
  * Main action to asynchronously load a datasource. Dispatches lots of smaller actions for feedback.
  */
-export function loadDatasource(exploreId: ExploreId, instance: DataSourceApi): ThunkResult<void> {
+export function loadDatasource(exploreId: ExploreId, instance: DataSourceApi, orgId: number): ThunkResult<void> {
   return async (dispatch, getState) => {
     const datasourceName = instance.name;
 
@@ -373,7 +376,7 @@ export function loadDatasource(exploreId: ExploreId, instance: DataSourceApi): T
       return;
     }
 
-    dispatch(loadDatasourceReady(exploreId, instance));
+    dispatch(loadDatasourceReady(exploreId, instance, orgId));
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the last used data source was stored in local storage using the key `grafana.explore.datasource`, but without any specification as to which organization it was associated with. This PR fixes the issue by setting keys in the format `grafana.explore.datasource.${orgId}`, where `orgId` is the organization the user is currently switched to. This way the last data source used can be recovered on a per-organization basis.

**Which issue(s) this PR fixes**:
Closes #17903 
