### PR TITLE
@grafana/data: export dateMath and rangeUtil

### DIFF
--- a/packages/grafana-ui/src/utils/index.ts
+++ b/packages/grafana-ui/src/utils/index.ts
@@ -19,5 +19,12 @@ export * from './fieldCache';
 export * from './moment_wrapper';
 export * from './slate';
 
-// Names are too general to export
-// rangeutils, datemath
+// Names are too general to export globally
+
+import * as dateMath from './datemath';
+import * as rangeUtil from './rangeutil';
+
+export const utils = {
+  dateMath: dateMath,
+  rangeUtil: rangeUtil,
+};

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -8,10 +8,11 @@ import { TimeRange } from '@grafana/ui';
 
 // Utils
 import { isString as _isString } from 'lodash';
-import * as rangeUtil from '@grafana/ui/src/utils/rangeutil';
-import * as dateMath from '@grafana/ui/src/utils/datemath';
 import appEvents from 'app/core/app_events';
 import config from 'app/core/config';
+
+import { utils } from '@grafana/ui';
+const { dateMath, rangeUtil } = utils;
 
 // Services
 import templateSrv from 'app/features/templating/template_srv';


### PR DESCRIPTION
This should be done *after* #17952 and is currently a proof-of-concept hoping to solicit ideas, improvements

`dateMath` is a widely used feature in plugins, but in the current version it is not exported in the module.  We can access it using:
```
import * as dateMath from '@grafana/ui/src/utils/datemath';
```

BUT, IIUC, that does not import the module, it imports the code and re-compiles/duplicates it.  Maybe that is OK, but there must be some way to export the functions with a namespace.

I explored various ways to `export * as dateMath`, but did not find anything great.  This PR is a potential pattern we could use for things like this


