### PR TITLE
Fix: Break redirect loop if oauth_auto_login = true and OAuth login fails

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -93,6 +93,26 @@ func (sc *scenarioContext) fakeReqWithParams(method, url string, queryParams map
 	return sc
 }
 
+func (sc *scenarioContext) fakeReqNoAssertions(method, url string) *scenarioContext {
+	sc.resp = httptest.NewRecorder()
+	req, _ := http.NewRequest(method, url, nil)
+	sc.req = req
+
+	return sc
+}
+
+func (sc *scenarioContext) fakeReqNoAssertionsWithCookie(method, url string, cookie http.Cookie) *scenarioContext {
+	sc.resp = httptest.NewRecorder()
+	http.SetCookie(sc.resp, &cookie)
+
+	req, _ := http.NewRequest(method, url, nil)
+	req.Header = http.Header{"Cookie": sc.resp.Header()["Set-Cookie"]}
+
+	sc.req = req
+
+	return sc
+}
+
 type scenarioContext struct {
 	m                    *macaron.Macaron
 	context              *m.ReqContext

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -21,8 +21,10 @@ const (
 	LoginErrorCookieName = "login_error"
 )
 
+var setIndexViewData = (*HTTPServer).setIndexViewData
+
 func (hs *HTTPServer) LoginView(c *models.ReqContext) {
-	viewData, err := hs.setIndexViewData(c)
+	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
 		c.Handle(500, "Failed to get settings", err)
 		return

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -23,6 +23,10 @@ const (
 
 var setIndexViewData = (*HTTPServer).setIndexViewData
 
+var getViewIndex = func() string {
+	return ViewIndex
+}
+
 func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
@@ -45,7 +49,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	if loginError, ok := tryGetEncryptedCookie(c, LoginErrorCookieName); ok {
 		deleteCookie(c, LoginErrorCookieName)
 		viewData.Settings["loginError"] = loginError
-		c.HTML(200, ViewIndex, viewData)
+		c.HTML(200, getViewIndex(), viewData)
 		return
 	}
 

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -45,6 +45,8 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	if loginError, ok := tryGetEncryptedCookie(c, LoginErrorCookieName); ok {
 		deleteCookie(c, LoginErrorCookieName)
 		viewData.Settings["loginError"] = loginError
+		c.HTML(200, ViewIndex, viewData)
+		return
 	}
 
 	if tryOAuthAutoLogin(c) {

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -47,6 +47,10 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	viewData.Settings["samlEnabled"] = hs.Cfg.SAMLEnabled
 
 	if loginError, ok := tryGetEncryptedCookie(c, LoginErrorCookieName); ok {
+		//this cookie is only set whenever an OAuth login fails
+		//therefore the loginError should be passed to the view data
+		//and the view should return immediately before attempting
+		//to login again via OAuth and enter to a redirect loop
 		deleteCookie(c, LoginErrorCookieName)
 		viewData.Settings["loginError"] = loginError
 		c.HTML(200, getViewIndex(), viewData)

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -30,6 +30,18 @@ func resetSetIndexViewData() {
 	setIndexViewData = (*HTTPServer).setIndexViewData
 }
 
+func mockViewIndex() {
+	getViewIndex = func() string {
+		return "index-template"
+	}
+}
+
+func resetViewIndex() {
+	getViewIndex = func() string {
+		return ViewIndex
+	}
+}
+
 func getBody(resp *httptest.ResponseRecorder) (string, error) {
 	responseData, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -41,6 +53,9 @@ func getBody(resp *httptest.ResponseRecorder) (string, error) {
 func TestLoginErrorCookieApiEndpoint(t *testing.T) {
 	mockSetIndexViewData()
 	defer resetSetIndexViewData()
+
+	mockViewIndex()
+	defer resetViewIndex()
 
 	sc := setupScenarioContext("/login")
 	hs := &HTTPServer{

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/hex"
+	"errors"
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func mockSetIndexViewData() {
+	setIndexViewData = func(*HTTPServer, *models.ReqContext) (*dtos.IndexViewData, error) {
+		data := &dtos.IndexViewData{
+			User:     &dtos.CurrentUser{},
+			Settings: map[string]interface{}{},
+			NavTree:  []*dtos.NavLink{},
+		}
+		return data, nil
+	}
+}
+
+func resetSetIndexViewData() {
+	setIndexViewData = (*HTTPServer).setIndexViewData
+}
+
+func getBody(resp *httptest.ResponseRecorder) (string, error) {
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(responseData), nil
+}
+
+func TestLoginErrorCookieApiEndpoint(t *testing.T) {
+	mockSetIndexViewData()
+	defer resetSetIndexViewData()
+
+	sc := setupScenarioContext("/login")
+	hs := &HTTPServer{
+		Cfg: setting.NewCfg(),
+	}
+
+	sc.defaultHandler = Wrap(func(w http.ResponseWriter, c *models.ReqContext) {
+		hs.LoginView(c)
+	})
+
+	setting.OAuthService = &setting.OAuther{}
+	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
+	setting.LoginCookieName = "grafana_session"
+	setting.SecretKey = "login_testing"
+
+	setting.OAuthService = &setting.OAuther{}
+	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
+	setting.OAuthService.OAuthInfos["github"] = &setting.OAuthInfo{
+		ClientId:     "fake",
+		ClientSecret: "fakefake",
+		Enabled:      true,
+		AllowSignup:  true,
+		Name:         "github",
+	}
+	setting.OAuthAutoLogin = true
+
+	oauthError := errors.New("User not a member of one of the required organizations")
+	encryptedError, _ := util.Encrypt([]byte(oauthError.Error()), setting.SecretKey)
+	cookie := http.Cookie{
+		Name:     LoginErrorCookieName,
+		MaxAge:   60,
+		Value:    hex.EncodeToString(encryptedError),
+		HttpOnly: true,
+		Path:     setting.AppSubUrl + "/",
+		Secure:   hs.Cfg.CookieSecure,
+		SameSite: hs.Cfg.CookieSameSite,
+	}
+	sc.m.Get(sc.url, sc.defaultHandler)
+	sc.fakeReqNoAssertionsWithCookie("GET", sc.url, cookie).exec()
+	assert.Equal(t, sc.resp.Code, 200)
+
+	responseString, err := getBody(sc.resp)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(responseString, oauthError.Error()))
+}
+
+func TestLoginOAuthRedirect(t *testing.T) {
+	mockSetIndexViewData()
+	defer resetSetIndexViewData()
+
+	sc := setupScenarioContext("/login")
+	hs := &HTTPServer{
+		Cfg: setting.NewCfg(),
+	}
+
+	sc.defaultHandler = Wrap(func(c *models.ReqContext) {
+		hs.LoginView(c)
+	})
+
+	setting.OAuthService = &setting.OAuther{}
+	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
+	setting.OAuthService.OAuthInfos["github"] = &setting.OAuthInfo{
+		ClientId:     "fake",
+		ClientSecret: "fakefake",
+		Enabled:      true,
+		AllowSignup:  true,
+		Name:         "github",
+	}
+	setting.OAuthAutoLogin = true
+	sc.m.Get(sc.url, sc.defaultHandler)
+	sc.fakeReqNoAssertions("GET", sc.url).exec()
+
+	assert.Equal(t, sc.resp.Code, 307)
+	location, ok := sc.resp.Header()["Location"]
+	assert.True(t, ok)
+	assert.Equal(t, location[0], "/login/github")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
Break redirect loop if `oauth_auto_login` is enabled but OAuth login fails.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17623

**Special notes for your reviewer**:
The redirect loop can occur whenever the OAuth login fails and not only when the user does not belong to the allowed organisations as described in the issue. 
My solution does not introduce an new `auto-login-error` query parameter as it is suggested because the `login_error` cookie is only set when the OAuth login fails for any reason
https://github.com/grafana/grafana/blob/master//pkg/api/login_oauth.go#L236
and therefore the `LoginView` should return immediately if such a cookie exists instead of trying to login via OAuth again (if `oauth_auto_login` is enabled).

