### PR TITLE
Api: Fix auth tokens returning wrong seenAt value

### DIFF
--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -84,6 +84,13 @@ func (server *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID
 			}
 		}
 
+		createdAt := time.Unix(token.CreatedAt, 0)
+		seenAt := time.Unix(token.SeenAt, 0)
+
+		if token.SeenAt == 0 {
+			seenAt = createdAt
+		}
+
 		result = append(result, &dtos.UserToken{
 			Id:                     token.Id,
 			IsActive:               isActive,
@@ -93,8 +100,8 @@ func (server *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID
 			OperatingSystemVersion: osVersion,
 			Browser:                client.UserAgent.Family,
 			BrowserVersion:         browserVersion,
-			CreatedAt:              time.Unix(token.CreatedAt, 0),
-			SeenAt:                 time.Unix(token.SeenAt, 0),
+			CreatedAt:              createdAt,
+			SeenAt:                 seenAt,
 		})
 	}
 

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -124,7 +124,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 					ClientIp:  "127.0.0.2",
 					UserAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
 					CreatedAt: time.Now().Unix(),
-					SeenAt:    time.Now().Unix(),
+					SeenAt:    0,
 				},
 			}
 			sc.userAuthTokenService.GetUserTokensProvider = func(ctx context.Context, userId int64) ([]*m.UserToken, error) {
@@ -154,7 +154,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 			So(resultTwo.Get("isActive").MustBool(), ShouldBeFalse)
 			So(resultTwo.Get("clientIp").MustString(), ShouldEqual, "127.0.0.2")
 			So(resultTwo.Get("createdAt").MustString(), ShouldEqual, time.Unix(tokens[1].CreatedAt, 0).Format(time.RFC3339))
-			So(resultTwo.Get("seenAt").MustString(), ShouldEqual, time.Unix(tokens[1].SeenAt, 0).Format(time.RFC3339))
+			So(resultTwo.Get("seenAt").MustString(), ShouldEqual, time.Unix(tokens[1].CreatedAt, 0).Format(time.RFC3339))
 
 			So(resultTwo.Get("device").MustString(), ShouldEqual, "iPhone")
 			So(resultTwo.Get("browser").MustString(), ShouldEqual, "Mobile Safari")


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes so a non-set seenAt property gets the createdAt value.

**Which issue(s) this PR fixes**:
Fixes #17953 

**Special notes for your reviewer**:

