### PR TITLE
Docs: Documents new features available with Loki data source in Explore

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -92,6 +92,20 @@ Example queries:
 * `{name="kafka"} tsdb-ops.*io:2003`
 * `{instance=~"kafka-[23]",name="kafka"} kafka.server:type=ReplicaManager`
 
+## Live Tailing
+
+To view your logs live as they are added, choose `Live` from the refresh dropdown, and you should see your logs be displayed in real time.
+
+Note: This feature is only available in Grafana v6.3+
+
+## Log Context
+
+When using a search expression as detailed above, you now have the ability to retrieve the context surrounding your filtered results.
+By clicking the `Show Context` link on the filtered rows, you'll be able to investigate the log messages that came before and after the
+log message you're interested in.
+
+Note: This feature is only available in Grafana v6.3+
+
 ## Templating
 
 Template variables are not yet supported by Loki.

--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -96,7 +96,10 @@ Example queries:
 
 To view your logs live as they are added, choose `Live` from the refresh dropdown, and you should see your logs be displayed in real time.
 
-Note: This feature is only available in Grafana v6.3+
+Note that Live Tailing relies on two Websocket connections: one between the browser and the Grafana server, and another between the Grafana server and the Loki server. If you run any reverse proxies, please configure them accordingly.
+
+
+> Note: This feature is only available in Grafana v6.3+
 
 ## Log Context
 
@@ -104,7 +107,7 @@ When using a search expression as detailed above, you now have the ability to re
 By clicking the `Show Context` link on the filtered rows, you'll be able to investigate the log messages that came before and after the
 log message you're interested in.
 
-Note: This feature is only available in Grafana v6.3+
+> Note: This feature is only available in Grafana v6.3+
 
 ## Templating
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents new live tailing and context features for the Loki data source in Explore.
Needed so that the documentation reflects the latest features.

**Which issue(s) this PR fixes**:
Closes #17898

