### PR TITLE
Refactor: fix rangeutil import (avoid  from '@grafana/data/src/utils/rangeutil)

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/time.ts
+++ b/packages/grafana-ui/src/components/TimePicker/time.ts
@@ -1,7 +1,15 @@
-import { TimeRange, TIME_FORMAT, RawTimeRange, TimeZone } from '@grafana/data';
-import { describeTimeRange } from '@grafana/data/src/utils/rangeutil';
-import { dateMath } from '@grafana/data';
-import { isDateTime, dateTime, DateTime, toUtc } from '@grafana/data';
+import {
+  TimeRange,
+  TIME_FORMAT,
+  RawTimeRange,
+  TimeZone,
+  rangeUtil,
+  dateMath,
+  isDateTime,
+  dateTime,
+  DateTime,
+  toUtc,
+} from '@grafana/data';
 
 export const rawToTimeRange = (raw: RawTimeRange, timeZone?: TimeZone): TimeRange => {
   const from = stringToDateTimeType(raw.from, false, timeZone);
@@ -32,7 +40,7 @@ export const stringToDateTimeType = (value: string | DateTime, roundUp?: boolean
 };
 
 export const mapTimeRangeToRangeString = (timeRange: RawTimeRange): string => {
-  return describeTimeRange(timeRange);
+  return rangeUtil.describeTimeRange(timeRange);
 };
 
 export const isValidTimeString = (text: string) => dateMath.isValid(text);

--- a/public/app/features/dashboard/panel_editor/QueryOptions.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryOptions.tsx
@@ -2,12 +2,19 @@
 import React, { PureComponent, ChangeEvent, FocusEvent } from 'react';
 
 // Utils
-import { isValidTimeSpan } from '@grafana/data/src/utils/rangeutil';
+import { rangeUtil } from '@grafana/data';
 
 // Components
-import { DataSourceSelectItem, EventsWithValidation, Input, InputStatus, Switch, ValidationEvents } from '@grafana/ui';
+import {
+  DataSourceSelectItem,
+  EventsWithValidation,
+  Input,
+  InputStatus,
+  Switch,
+  ValidationEvents,
+  FormLabel,
+} from '@grafana/ui';
 import { DataSourceOption } from './DataSourceOption';
-import { FormLabel } from '@grafana/ui';
 
 // Types
 import { PanelModel } from '../state';
@@ -19,7 +26,7 @@ const timeRangeValidationEvents: ValidationEvents = {
         if (!value) {
           return true;
         }
-        return isValidTimeSpan(value);
+        return rangeUtil.isValidTimeSpan(value);
       },
       errorMessage: 'Not a valid timespan',
     },


### PR DESCRIPTION
There are still two places that import:
```
import { describeTimeRange } from '@grafana/data/src/utils/rangeutil';
```
This creates an invalid package.  See also #17971


For example in: https://github.com/grafana/simple-json-datasource/pull/129
```
✔ Linting
 FAIL  src/datasource.test.ts
  ● Test suite failed to run

    Cannot find module '@grafana/data/src/utils/rangeutil' from 'index.development.js'

    However, Jest was able to find:
    	'./datasource.test.ts'
    	'./datasource.ts'
```