### PR TITLE
SAML: Show SAML login button even if OAuth is disabled

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -182,6 +182,10 @@ func initContextWithBasicAuth(ctx *models.ReqContext, orgId int64) bool {
 }
 
 func initContextWithToken(authTokenService models.UserTokenService, ctx *models.ReqContext, orgID int64) bool {
+	if setting.LoginCookieName == "" {
+		return false
+	}
+
 	rawToken := ctx.GetCookie(setting.LoginCookieName)
 	if rawToken == "" {
 		return false

--- a/public/app/partials/login.html
+++ b/public/app/partials/login.html
@@ -45,6 +45,10 @@
           </div>
         </div>
         <div class="clearfix"></div>
+        <a class="btn btn-medium btn-service btn-service--github login-btn" href="login/saml" target="_self" ng-if="samlEnabled">
+          <i class="btn-service-icon fa fa-key"></i>
+          Sign in with SAML
+        </a>
         <div class="login-oauth text-center" ng-show="oauthEnabled">
           <a class="btn btn-medium btn-service btn-service--google login-btn" href="login/google" target="_self" ng-if="oauth.google">
             <i class="btn-service-icon fa fa-google"></i>
@@ -67,10 +71,6 @@
             ng-if="oauth.generic_oauth">
             <i class="btn-service-icon fa fa-sign-in"></i>
             Sign in with {{oauth.generic_oauth.name}}
-          </a>
-          <a class="btn btn-medium btn-service btn-service--github login-btn" href="login/saml" target="_self" ng-if="samlEnabled">
-            <i class="btn-service-icon fa fa-key"></i>
-            Sign in with SAML
           </a>
         </div>
         <div class="login-signup-box" ng-show="!disableUserSignUp">


### PR DESCRIPTION
**What this PR does / why we need it**: 
Move the SAML login button outside of the `div` that holds all the "Login with X" where X is an OAuth provider. This `div` is conditionally shown on whenever OAuth is enabled or not which is completely independent of SAML. 

**Special notes for your reviewer**:

I decided to include another small change that is needed to make the SAML tests work. I currently suspect that there's a bug in the Go standard library that requires this. I'm including it here as this is the quickest way to get out there but I'm happy to pull it apart as I investigate a more about it.