### PR TITLE
LDAP: Adds bind before searching LDAP for non-login cases.

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -31,9 +31,9 @@ type IConnection interface {
 type IServer interface {
 	Login(*models.LoginUserQuery) (*models.ExternalUserInfo, error)
 	Users([]string) ([]*models.ExternalUserInfo, error)
+	Bind() error
 	UserBind(string, string) error
 	Dial() error
-	Bind() error
 	Close()
 }
 
@@ -44,6 +44,9 @@ type Server struct {
 	log        log.Logger
 }
 
+// Bind authenticates the connection with the LDAP server
+// - with the username and password setup in the config
+// - or, anonymously
 func (server *Server) Bind() error {
 	if server.shouldAuthAdmin() {
 		if err := server.AuthAdmin(); err != nil {
@@ -395,7 +398,7 @@ func (server *Server) shouldAuthAdmin() bool {
 	return server.Config.BindPassword != ""
 }
 
-// UserBind authentificates user in LDAP
+// UserBind authenticates the connection with the LDAP server
 func (server *Server) UserBind(username, password string) error {
 	err := server.userBind(username, password)
 	if err != nil {
@@ -425,7 +428,7 @@ func (server *Server) AuthAdmin() error {
 	return nil
 }
 
-// userBind is helper for several types of LDAP authentification
+// userBind authenticates the connection with the LDAP server
 func (server *Server) userBind(path, password string) error {
 	err := server.Connection.Bind(path, password)
 	if err != nil {

--- a/pkg/services/ldap/ldap_login_test.go
+++ b/pkg/services/ldap/ldap_login_test.go
@@ -19,7 +19,7 @@ func TestLDAPLogin(t *testing.T) {
 	}
 
 	Convey("Login()", t, func() {
-		Convey("Should get invalid credentials when auth fails", func() {
+		Convey("Should get invalid credentials when userBind fails", func() {
 			connection := &MockConnection{}
 			entry := ldap.Entry{}
 			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -145,7 +145,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 	})
 
 	Convey("shouldAuthAdmin()", t, func() {
-		Convey("it should require admin auth", func() {
+		Convey("it should require admin userBind", func() {
 			server := &Server{
 				Config: &ServerConfig{
 					BindPassword: "test",
@@ -156,7 +156,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 			So(result, ShouldBeTrue)
 		})
 
-		Convey("it should not require admin auth", func() {
+		Convey("it should not require admin userBind", func() {
 			server := &Server{
 				Config: &ServerConfig{
 					BindPassword: "",

--- a/pkg/services/ldap/ldap_test.go
+++ b/pkg/services/ldap/ldap_test.go
@@ -102,7 +102,7 @@ func TestPublicAPI(t *testing.T) {
 		})
 	})
 
-	Convey("Auth()", t, func() {
+	Convey("UserBind()", t, func() {
 		Convey("Should use provided DN and password", func() {
 			connection := &MockConnection{}
 			var actualUsername, actualPassword string
@@ -119,7 +119,7 @@ func TestPublicAPI(t *testing.T) {
 			}
 
 			dn := "cn=user,ou=users,dc=grafana,dc=org"
-			err := server.Auth(dn, "pwd")
+			err := server.UserBind(dn, "pwd")
 
 			So(err, ShouldBeNil)
 			So(actualUsername, ShouldEqual, dn)
@@ -141,7 +141,7 @@ func TestPublicAPI(t *testing.T) {
 				},
 				log: log.New("test-logger"),
 			}
-			err := server.Auth("user", "pwd")
+			err := server.UserBind("user", "pwd")
 			So(err, ShouldEqual, expected)
 		})
 	})

--- a/pkg/services/multildap/multildap.go
+++ b/pkg/services/multildap/multildap.go
@@ -109,6 +109,10 @@ func (multiples *MultiLDAP) User(login string) (
 
 		defer server.Close()
 
+		if err := server.Bind(); err != nil {
+			return nil, err
+		}
+
 		users, err := server.Users(search)
 		if err != nil {
 			return nil, err
@@ -141,6 +145,10 @@ func (multiples *MultiLDAP) Users(logins []string) (
 		}
 
 		defer server.Close()
+
+		if err := server.Bind(); err != nil {
+			return nil, err
+		}
 
 		users, err := server.Users(logins)
 		if err != nil {

--- a/pkg/services/multildap/testing.go
+++ b/pkg/services/multildap/testing.go
@@ -11,11 +11,14 @@ type MockLDAP struct {
 	loginCalledTimes int
 	closeCalledTimes int
 	usersCalledTimes int
+	bindCalledTimes  int
 
 	dialErrReturn error
 
 	loginErrReturn error
 	loginReturn    *models.ExternalUserInfo
+
+	bindErrReturn error
 
 	usersErrReturn   error
 	usersFirstReturn []*models.ExternalUserInfo
@@ -40,8 +43,8 @@ func (mock *MockLDAP) Users([]string) ([]*models.ExternalUserInfo, error) {
 	return mock.usersRestReturn, mock.usersErrReturn
 }
 
-// Auth test fn
-func (mock *MockLDAP) Auth(string, string) error {
+// UserBind test fn
+func (mock *MockLDAP) UserBind(string, string) error {
 	return nil
 }
 
@@ -54,6 +57,11 @@ func (mock *MockLDAP) Dial() error {
 // Close test fn
 func (mock *MockLDAP) Close() {
 	mock.closeCalledTimes = mock.closeCalledTimes + 1
+}
+
+func (mock *MockLDAP) Bind() error {
+	mock.bindCalledTimes++
+	return mock.bindErrReturn
 }
 
 // MockMultiLDAP represents testing struct for multildap testing


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds implicit bind for search except when using LDAP in the Login flow.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
