### PR TITLE
Chore: Update the Grafana version to 6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "company": "Grafana Labs"
   },
   "name": "grafana",
-  "version": "6.3.0-pre",
+  "version": "6.4.0-pre",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"


### PR DESCRIPTION
We're about to release 6.3, is time for master to reflect the next version. 