### PR TITLE
Add strictNullChecks for TypeScript

### DIFF
--- a/public/app/core/components/json_explorer/helpers.ts
+++ b/public/app/core/components/json_explorer/helpers.ts
@@ -34,7 +34,7 @@ export function getObjectName(object: object): string {
 
   const funcNameRegex = /function ([^(]*)/;
   const results = funcNameRegex.exec(object.constructor.toString());
-  if (results && results.length > 1) {
+  if (results !== null && results.length > 1) {
     return results[1];
   } else {
     return '';

--- a/public/app/features/templating/datasource_variable.ts
+++ b/public/app/features/templating/datasource_variable.ts
@@ -61,7 +61,7 @@ export class DatasourceVariable implements Variable {
         continue;
       }
 
-      if (regex && !regex.exec(source.name)) {
+      if (regex && regex.exec(source.name) === null) {
         continue;
       }
 

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -166,7 +166,7 @@ export class QueryVariable implements Variable {
 
       if (regex) {
         matches = regex.exec(value);
-        if (!matches) {
+        if (matches === null) {
           continue;
         }
         if (matches.length > 1) {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -187,7 +187,7 @@ export class TemplateSrv {
   getVariableName(expression) {
     this.regex.lastIndex = 0;
     const match = this.regex.exec(expression);
-    if (!match) {
+    if (match === null) {
       return null;
     }
     const variableName = match.slice(1).find(match => match !== undefined);

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -188,7 +188,7 @@ export default class GraphiteQuery {
       _.each(targetsByRefId, (t, id) => {
         if (id !== refId) {
           const match = nestedSeriesRefRegex.exec(t.target);
-          const count = match && match.length ? match.length - 1 : 0;
+          const count = match !== null && match.length ? match.length - 1 : 0;
           refCount += count;
         }
       });

--- a/public/app/plugins/panel/graph/time_region_manager.ts
+++ b/public/app/plugins/panel/graph/time_region_manager.ts
@@ -233,7 +233,7 @@ export class TimeRegionManager {
     const result: any = { h: null, m: null };
     const match = timeRegex.exec(str);
 
-    if (!match) {
+    if (match === null) {
       return result;
     }
 

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -3,11 +3,11 @@
 echo -e "Collecting code stats (typescript errors & more)"
 
 
-ERROR_COUNT_LIMIT=2350
+ERROR_COUNT_LIMIT=3222
 DIRECTIVES_LIMIT=172
 CONTROLLERS_LIMIT=139
 
-ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --noImplicitAny true | grep -oP 'Found \K(\d+)')"
+ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --noImplicitAny true --strictNullChecks true | grep -oP 'Found \K(\d+)')"
 DIRECTIVES="$(grep -r -o  directive public/app/**/*  | wc -l)"
 CONTROLLERS="$(grep -r -oP 'class .*Ctrl' public/app/**/*  | wc -l)"
 


### PR DESCRIPTION
I'd like to propose to start using `strictNullChecks`

Consider this snippet for example:

```ts
function matchSeriesOverride(aliasOrRegex: string, seriesAlias: string) {
  if (!aliasOrRegex) {
    return false;
  }
```

`aliasOrRegex` is typed as `string`. But I don't know whether the `if (!aliasOrRegex) {` condition is outdated or not. Was it meant as 1) `aliasOrRegex` is `null`/`undefined` which should never happen now or 2) meant as `aliasOrRegex` is `''`?

This change should increase code readability in long term.