### PR TITLE
Provisioning: Allow escaping literal '$' with '$$' in configs to avoid interpolation

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -45,6 +45,8 @@ datasources:
     password: $PASSWORD
 ```
 
+If you have a literal `$` in your value and want to avoid interpolation, `$$` can be used.
+
 <hr />
 
 ## Configuration Management Tools

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -12,6 +12,7 @@ func TestValues(t *testing.T) {
 	Convey("Values", t, func() {
 		os.Setenv("INT", "1")
 		os.Setenv("STRING", "test")
+		os.Setenv("EMPTYSTRING", "")
 		os.Setenv("BOOL", "true")
 
 		Convey("IntValue", func() {
@@ -62,10 +63,17 @@ func TestValues(t *testing.T) {
 				So(d.Val.Value(), ShouldEqual, "")
 				So(d.Val.Raw, ShouldEqual, "")
 			})
-			Convey("Should pass literal $", func() {
-				unmarshalingTest(`val: mY,Passwo$rd`, d)
+
+			Convey("empty var should have empty value", func() {
+				unmarshalingTest(`val: $EMPTYSTRING`, d)
+				So(d.Val.Value(), ShouldEqual, "")
+				So(d.Val.Raw, ShouldEqual, "$EMPTYSTRING")
+			})
+
+			Convey("$$ should be a literal $ and not expanded", func() {
+				unmarshalingTest(`val: mY,Passwo$$rd`, d)
 				So(d.Val.Value(), ShouldEqual, "mY,Passwo$rd")
-				So(d.Val.Raw, ShouldEqual, "mY,Passwo$rd")
+				So(d.Val.Raw, ShouldEqual, "mY,Passwo$$rd")
 			})
 		})
 
@@ -205,6 +213,7 @@ func TestValues(t *testing.T) {
 		Reset(func() {
 			os.Unsetenv("INT")
 			os.Unsetenv("STRING")
+			os.Unsetenv("EMPTYSTRING")
 			os.Unsetenv("BOOL")
 		})
 	})

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -1,10 +1,11 @@
 package values
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/yaml.v2"
 )
 
 func TestValues(t *testing.T) {
@@ -60,6 +61,11 @@ func TestValues(t *testing.T) {
 				unmarshalingTest(`val: `, d)
 				So(d.Val.Value(), ShouldEqual, "")
 				So(d.Val.Raw, ShouldEqual, "")
+			})
+			Convey("Should pass literal $", func() {
+				unmarshalingTest(`val: mY,Passwo$rd`, d)
+				So(d.Val.Value(), ShouldEqual, "mY,Passwo$rd")
+				So(d.Val.Raw, ShouldEqual, "mY,Passwo$rd")
 			})
 		})
 

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -70,7 +70,13 @@ func TestValues(t *testing.T) {
 				So(d.Val.Raw, ShouldEqual, "$EMPTYSTRING")
 			})
 
-			Convey("$$ should be a literal $ and not expanded", func() {
+			Convey("$$ should be a literal $", func() {
+				unmarshalingTest(`val: $$`, d)
+				So(d.Val.Value(), ShouldEqual, "$")
+				So(d.Val.Raw, ShouldEqual, "$$")
+			})
+
+			Convey("$$ should be a literal $ and not expanded within a string", func() {
 				unmarshalingTest(`val: mY,Passwo$$rd`, d)
 				So(d.Val.Value(), ShouldEqual, "mY,Passwo$rd")
 				So(d.Val.Raw, ShouldEqual, "mY,Passwo$$rd")


### PR DESCRIPTION
fixes #17986