### PR TITLE
Minor 6.3.0 beta1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.4.0 (unreleased)
 
-# 6.3.0-beta1
+# 6.3.0-beta1 (2019-07-10)
 ### Features / Enhancements
 * **Alerting**: Add tags to alert rules. [#10989](https://github.com/grafana/grafana/pull/10989), [@Thib17](https://github.com/Thib17)
 * **Alerting**: Attempt to send email notifications to all given email addresses. [#16881](https://github.com/grafana/grafana/pull/16881), [@zhulongcheng](https://github.com/zhulongcheng)

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -16,6 +16,9 @@ Further documentation can be found at http://docs.grafana.org/installation/docke
 
 ## Changelog
 
+### v6.3.0-beta1
+* Docker: Switch base image to ubuntu:latest from debian:stretch to avoid security issues.
+
 ### v5.4.3
 * Build and publish docker images for armv7 and arm64 #14617, thx @johanneswuerbach
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -16,6 +16,15 @@ Further documentation can be found at http://docs.grafana.org/installation/docke
 
 ## Changelog
 
+### v5.4.3
+* Build and publish docker images for armv7 and arm64 #14617, thx @johanneswuerbach
+
+### v5.3.2
+* adds curl back into the docker image for utility. #13794
+
+### v5.3.0-beta1
+* Make it possible to set a specific plugin url #12861, thx ClementGautier
+
 ### v5.1.5, v5.2.0-beta2
 * Fix: config keys ending with _FILE are not respected [#170](https://github.com/grafana/grafana-docker/issues/170)
 


### PR DESCRIPTION
A couple of very minor changes around documentation about the 6.3.0-beta1 release. Refer to each commit for the individual change.

One thing to note (and that I certainly would love help with) is that the Docker hub documentation seems to be out of sync with the current one. It claims to be generated source code repository but it doesn't appear so:

![Screenshot 2019-07-10 at 18 32 04](https://user-images.githubusercontent.com/231583/60990792-1ad6d780-a341-11e9-87b6-3eb21c06de02.png)

Any thoughts? The base image change from 6.3.0-beta1 seems like quite an important one for our users so ideally, I would love to get it documented asap. 