### PR TITLE
Build: consistently reference go binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_FILES := ./pkg/...
 all: deps build
 
 deps-go:
-	go run build.go setup
+	$(GO) run build.go setup
 
 deps-js: node_modules
 
@@ -16,15 +16,15 @@ deps: deps-js
 
 build-go:
 	@echo "build go files"
-	GO111MODULE=on go run build.go build
+	$(GO) run build.go build
 
 build-server:
 	@echo "build server"
-	GO111MODULE=on go run build.go build-server
+	$(GO) run build.go build-server
 
 build-cli:
 	@echo "build in CI environment"
-	GO111MODULE=on go run build.go build-cli
+	$(GO) run build.go build-cli
 
 build-js:
 	@echo "build frontend"
@@ -35,7 +35,7 @@ build: build-go build-js
 build-docker-dev:
 	@echo "build development container"
 	@echo "\033[92mInfo:\033[0m the frontend code is expected to be built already."
-	GO111MODULE=on go run build.go -goos linux -pkg-arch amd64 ${OPT} build pkg-archive latest
+	$(GO) run build.go -goos linux -pkg-arch amd64 ${OPT} build pkg-archive latest
 	cp dist/grafana-latest.linux-x64.tar.gz packaging/docker
 	cd packaging/docker && docker build --tag grafana/grafana:dev .
 
@@ -45,7 +45,7 @@ build-docker-full:
 
 test-go:
 	@echo "test backend"
-	GO111MODULE=on go test -v ./pkg/...
+	$(GO) test -v ./pkg/...
 
 test-js:
 	@echo "test frontend"
@@ -107,7 +107,7 @@ golangci-lint: scripts/go/bin/golangci-lint
 
 go-vet:
 	@echo "lint via go vet"
-	@go vet $(GO_FILES)
+	@$(GO) vet $(GO_FILES)
 
 lint-go: go-vet golangci-lint revive revive-alerting gosec
 


### PR DESCRIPTION
Before this applied, go binary is referenced inconsistently in makefile.
Sometimes with go modules enabled and sometimes not, sometimes through
a variable and sometimes not.

This change makes all the references in makefile consistent