### PR TITLE
Update development section README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,24 @@ Notice: If you are using Docker for MacOS, be sure to set the memory limit to be
 
 ### Dev config
 
-Create a custom.ini in the conf directory to override default configuration options.
+The environment uses `./conf/default.ini` for settings. Create `./conf/custom.ini` file in the `conf` directory to override default configuration options.
 You only need to add the options you want to override. Config files are applied in the order of:
 
 1. grafana.ini
 1. custom.ini
 
-In your custom.ini uncomment (remove the leading `;`) sign. And set `app_mode = development`.
+In your custom.ini uncomment (remove the leading `;`) sign. And add `app_mode = development`. For api development one can add `[auth.anonymous]` for easy access to api calls.
+
+Example config `cat custom.ini`:
+```
+app_mode = development
+
+[auth.anonymous]
+# enable anonymous access (for easy api development)
+enabled = true
+```
+
+Learn more about Grafana config options in the [Configuration section](/installation/configuration/)
 
 ### Running tests
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Would like to update the development section of the readme to be a bit easier to get started for development.

- auth anonymous
- app_mode = development

If possible, explain what `app_mode = development` setting do in a one liner above.
found this description in https://github.com/grafana/grafana/blame/5445e47fd568b48facfa7cea071769563ab78185/docs/sources/alerting/rules.md#L130
```
If you want to log raw query sent to your TSDB and raw response in log you also have to set grafana.ini option `app_mode` to
`development`
```

Should one always use `app_mode = development` for development? 
Is it reloading of the application or is it more logging or maybe both?

Related issues:
- Create DEVELOPMENT.md : https://github.com/grafana/grafana/issues/10062
