### PR TITLE
SQLStore: use bool pointer instead of string

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -147,9 +147,7 @@ type SearchUsersQuery struct {
 	Limit      int
 	AuthModule string
 
-	// We have to use string not bool, since there is cases when
-	// we don't care if user is disabled or not
-	IsDisabled string
+	IsDisabled *bool
 
 	Result SearchUserQueryResult
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -456,14 +456,9 @@ func SearchUsers(query *models.SearchUsersQuery) error {
 		whereParams = append(whereParams, queryWithWildcards, queryWithWildcards, queryWithWildcards)
 	}
 
-	if query.IsDisabled != "" {
-		param, err := strconv.ParseBool(query.IsDisabled)
-		if err != nil {
-			return err
-		}
-
+	if query.IsDisabled != nil {
 		whereConditions = append(whereConditions, "is_disabled = ?")
-		whereParams = append(whereParams, param)
+		whereParams = append(whereParams, query.IsDisabled)
 	}
 
 	if query.AuthModule != "" {

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -194,7 +194,8 @@ func TestUserDataAccess(t *testing.T) {
 					}
 				})
 
-				query := models.SearchUsersQuery{IsDisabled: "false"}
+				isDisabled := false
+				query := models.SearchUsersQuery{IsDisabled: &isDisabled}
 				err := SearchUsers(&query)
 				So(err, ShouldBeNil)
 
@@ -293,7 +294,8 @@ func TestUserDataAccess(t *testing.T) {
 					err := BatchDisableUsers(&disableCmd)
 					So(err, ShouldBeNil)
 
-					query := &models.SearchUsersQuery{IsDisabled: "true"}
+					isDisabled := true
+					query := &models.SearchUsersQuery{IsDisabled: &isDisabled}
 					err = SearchUsers(query)
 
 					So(err, ShouldBeNil)
@@ -319,7 +321,8 @@ func TestUserDataAccess(t *testing.T) {
 					err := BatchDisableUsers(&disableCmd)
 					So(err, ShouldBeNil)
 
-					query := &models.SearchUsersQuery{IsDisabled: "false"}
+					isDisabled := false
+					query := &models.SearchUsersQuery{IsDisabled: &isDisabled}
 					err = SearchUsers(query)
 
 					So(err, ShouldBeNil)


### PR DESCRIPTION
Follow-up for 8e0f091f1481adc70fba4dda2570b77ca45b3d01