### PR TITLE
grafana/toolkit: update the way config is being passed to jest-cli

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin/tests.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/tests.ts
@@ -10,10 +10,15 @@ export interface PluginTestOptions {
 export const testPlugin = useSpinner<PluginTestOptions>('Running tests', async ({ updateSnapshot, coverage }) => {
   const testConfig = jestConfig();
 
-  testConfig.updateSnapshot = updateSnapshot;
-  testConfig.coverage = coverage;
+  const cliConfig = {
+    config: JSON.stringify(testConfig),
+    updateSnapshot,
+    coverage,
+    passWithNoTests: true,
+  };
 
-  const results = await jestCLI.runCLI(testConfig as any, [process.cwd()]);
+  // @ts-ignore
+  const results = await jestCLI.runCLI(cliConfig, [process.cwd()]);
 
   if (results.results.numFailedTests > 0 || results.results.numFailedTestSuites > 0) {
     throw new Error('Tests failed');

--- a/packages/grafana-toolkit/src/config/jest.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import fs = require('fs');
 
-const whitelistedJestConfigOverrides = ['snapshotSerializers'];
+const whitelistedJestConfigOverrides = ['snapshotSerializers', 'moduleNameMapper'];
 
 export const jestConfig = () => {
   const jestConfigOverrides = require(path.resolve(process.cwd(), 'package.json')).jest;
@@ -23,17 +23,21 @@ export const jestConfig = () => {
   const defaultJestConfig = {
     preset: 'ts-jest',
     verbose: false,
-    transform: {
-      '^.+\\.(ts|tsx)$': 'ts-jest',
-    },
     moduleDirectories: ['node_modules', 'src'],
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
     setupFiles,
     globals: { 'ts-jest': { isolatedModules: true } },
     coverageReporters: ['json-summary', 'text', 'lcov'],
     collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/node_modules/**', '!**/vendor/**'],
-    updateSnapshot: false,
-    passWithNoTests: true,
+
+    testMatch: [
+      '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/src/**/*.{spec,test,jest}.{js,jsx,ts,tsx}',
+    ],
+    transformIgnorePatterns: [
+      '[/\\\\\\\\]node_modules[/\\\\\\\\].+\\\\.(js|jsx|ts|tsx)$',
+      '^.+\\\\.module\\\\.(css|sass|scss)$',
+    ],
   };
 
   return {


### PR DESCRIPTION
@ryantxu this fixes the issue @briangann encountered when migrating Dynatrace datasource. I have updated the way config is being passed to jest-cli, and also enables `moduleNameMapper` config via `jest` key in package.json. Thanks to that config plugin author is able to make `grafana/*` imports to resolve from grafana-sdk-mocks.