### PR TITLE
Build: detect packages changes based on the git diff

### DIFF
--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -19,8 +19,10 @@ GIT_SHA=$(parse_git_hash)
 echo "Commit: ${GIT_SHA}"
 echo "Current lerna.json version: ${PACKAGE_VERSION}"
 
-# count packages that changed
-count=`npx lerna changed --loglevel silent | awk '{c++} END {print c}'`
+# check if there were any changes to packages between current and previous commit
+count=`git diff HEAD~1..HEAD --name-only -- packages | awk '{c++} END {print c}'`
+
+
 
 if [ -z $count ]; then
   echo "No changes in packages, skipping packages publishing"


### PR DESCRIPTION
`lerna changed` depends on git tag. Since we are not tagging releases on master branch, Lerna's change detection is useless for now. This PR introduces packages change detection based on git diff on consecutive commits (that's safe because of squash commits that we use). 

Ref: https://github.com/grafana/grafana/pull/18062#issuecomment-510891884