### PR TITLE
Refactor: use data rather than series in stream callback

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -309,9 +309,9 @@ export interface DataStreamState {
   request: DataQueryRequest;
 
   /**
-   * Series data may not be known yet
+   * Data may not be known yet
    */
-  series?: DataFrame[];
+  data?: DataFrame[];
 
   /**
    * Error in stream (but may still be running)

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -11,7 +11,7 @@ import ErrorBoundary from 'app/core/components/ErrorBoundary/ErrorBoundary';
 import { getTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { applyPanelTimeOverrides, calculateInnerPanelHeight } from 'app/features/dashboard/utils/panel';
 import { profiler } from 'app/core/profiler';
-import { getProcessedDataFrame } from '../state/PanelQueryState';
+import { getProcessedDataFrames } from '../state/PanelQueryState';
 import templateSrv from 'app/features/templating/template_srv';
 import config from 'app/core/config';
 
@@ -71,7 +71,7 @@ export class PanelChrome extends PureComponent<Props, State> {
       this.setState({
         data: {
           state: LoadingState.Done,
-          series: getProcessedDataFrame(panel.snapshotData),
+          series: getProcessedDataFrames(panel.snapshotData),
         },
         isFirstLoad: false,
       });

--- a/public/app/features/dashboard/state/PanelQueryRunner.test.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.test.ts
@@ -168,7 +168,7 @@ describe('PanelQueryRunner', () => {
       streamState = {
         state: LoadingState.Streaming,
         key: 'test-stream-1',
-        series: [
+        data: [
           {
             rows: [],
             fields: [],

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -34,7 +34,7 @@ export interface QueryRunnerOptions<
 }
 
 export enum PanelQueryRunnerFormat {
-  series = 'series',
+  frames = 'frames',
   legacy = 'legacy',
   both = 'both',
 }
@@ -57,7 +57,7 @@ export class PanelQueryRunner {
    * Listen for updates to the PanelData.  If a query has already run for this panel,
    * the results will be immediatly passed to the observer
    */
-  subscribe(observer: PartialObserver<PanelData>, format = PanelQueryRunnerFormat.series): Unsubscribable {
+  subscribe(observer: PartialObserver<PanelData>, format = PanelQueryRunnerFormat.frames): Unsubscribable {
     if (!this.subject) {
       this.subject = new Subject(); // Delay creating a subject until someone is listening
     }
@@ -65,10 +65,10 @@ export class PanelQueryRunner {
     if (format === PanelQueryRunnerFormat.legacy) {
       this.state.sendLegacy = true;
     } else if (format === PanelQueryRunnerFormat.both) {
-      this.state.sendSeries = true;
+      this.state.sendFrames = true;
       this.state.sendLegacy = true;
     } else {
-      this.state.sendSeries = true;
+      this.state.sendFrames = true;
     }
 
     // Send the last result

--- a/public/app/features/dashboard/state/PanelQueryState.test.ts
+++ b/public/app/features/dashboard/state/PanelQueryState.test.ts
@@ -1,4 +1,4 @@
-import { toDataQueryError, PanelQueryState, getProcessedDataFrame } from './PanelQueryState';
+import { toDataQueryError, PanelQueryState, getProcessedDataFrames } from './PanelQueryState';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { LoadingState } from '@grafana/data';
 import { DataQueryResponse } from '@grafana/ui';
@@ -65,7 +65,7 @@ describe('getProcessedDataFrame', () => {
       target: '',
       datapoints: [[100, 1], [200, 2]],
     };
-    const data = getProcessedDataFrame([null, input1, input2, null, null]);
+    const data = getProcessedDataFrames([null, input1, input2, null, null]);
     expect(data.length).toBe(2);
     expect(data[0].fields[0].name).toBe(input1.target);
     expect(data[0].rows).toBe(input1.datapoints);
@@ -83,10 +83,10 @@ describe('getProcessedDataFrame', () => {
   });
 
   it('supports null values from query OK', () => {
-    expect(getProcessedDataFrame([null, null, null, null])).toEqual([]);
-    expect(getProcessedDataFrame(undefined)).toEqual([]);
-    expect(getProcessedDataFrame((null as unknown) as any[])).toEqual([]);
-    expect(getProcessedDataFrame([])).toEqual([]);
+    expect(getProcessedDataFrames([null, null, null, null])).toEqual([]);
+    expect(getProcessedDataFrames(undefined)).toEqual([]);
+    expect(getProcessedDataFrames((null as unknown) as any[])).toEqual([]);
+    expect(getProcessedDataFrames([])).toEqual([]);
   });
 });
 
@@ -129,7 +129,7 @@ describe('stream handling', () => {
       state: LoadingState.Loading,
       key: 'C',
       request: state.request, // From the same request
-      series: [makeSeriesStub('C')],
+      data: [makeSeriesStub('C')],
       unsubscribe: () => {},
     });
     expect(state.streams.length).toBe(1);
@@ -146,7 +146,7 @@ describe('stream handling', () => {
       state: LoadingState.Loading,
       key: 'D',
       request: state.request, // From the same request
-      series: [makeSeriesStub('D')],
+      data: [makeSeriesStub('D')],
       unsubscribe: () => {},
     });
     expect(state.streams.length).toBe(2);
@@ -163,7 +163,7 @@ describe('stream handling', () => {
       state: LoadingState.Loading,
       key: 'C', // The key to replace previous index 2
       request: state.request, // From the same request
-      series: [makeSeriesStub('X')],
+      data: [makeSeriesStub('X')],
       unsubscribe: () => {},
     });
     expect(state.streams.length).toBe(2);
@@ -181,7 +181,7 @@ describe('stream handling', () => {
         ...state.request,
         requestId: 'XXX', // Different request and id
       } as any,
-      series: [makeSeriesStub('C')],
+      data: [makeSeriesStub('C')],
       unsubscribe: () => {},
     });
 

--- a/public/app/features/explore/state/epics/runQueriesBatchEpic.test.ts
+++ b/public/app/features/explore/state/epics/runQueriesBatchEpic.test.ts
@@ -189,7 +189,7 @@ describe('runQueriesBatchEpic', () => {
             )
             .whenQueryObserverReceivesEvent({
               state: LoadingState.Done,
-              series: null,
+              data: null,
               delta,
               key: 'some key',
               request: {} as DataQueryRequest,

--- a/public/app/features/explore/state/epics/runQueriesBatchEpic.ts
+++ b/public/app/features/explore/state/epics/runQueriesBatchEpic.ts
@@ -104,8 +104,8 @@ export const runQueriesBatchEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState>
         // observer subscription, handles datasourceInstance.query observer events and pushes that forward
         const streamSubscription = streamHandler.subscribe({
           next: event => {
-            const { state, error, series, delta } = event;
-            if (!series && !delta && !error) {
+            const { state, error, data, delta } = event;
+            if (!data && !delta && !error) {
               return;
             }
 

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -3,7 +3,7 @@ import { DataQueryResponse, DataQueryResponseData } from '@grafana/ui';
 import { TableData, isTableData, LogsModel, toDataFrame, guessFieldTypes, TimeSeries } from '@grafana/data';
 
 import { ExploreItemState, ExploreMode } from 'app/types/explore';
-import { getProcessedDataFrame } from 'app/features/dashboard/state/PanelQueryState';
+import { getProcessedDataFrames } from 'app/features/dashboard/state/PanelQueryState';
 import TableModel, { mergeTablesIntoModel } from 'app/core/table_model';
 import { sortLogsResult } from 'app/core/utils/explore';
 import { dataFrameToLogsModel } from 'app/core/logs_model';
@@ -101,7 +101,7 @@ export class ResultProcessor {
   };
 
   private makeTimeSeriesList = (rawData: any[]) => {
-    const dataList = getProcessedDataFrame(rawData);
+    const dataList = getProcessedDataFrames(rawData);
     const dataProcessor = new DataProcessor({ xaxis: {}, aliasColors: [] }); // Hack before we use GraphSeriesXY instead
     const timeSeries = dataProcessor.getSeriesList({ dataList });
 

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -156,7 +156,7 @@ class MetricsPanelCtrl extends PanelCtrl {
           data: data.legacy,
         });
       } else {
-        this.handleDataFrame(data.series);
+        this.handleDataFrames(data.series);
       }
     },
   };
@@ -215,7 +215,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     });
   }
 
-  handleDataFrame(data: DataFrame[]) {
+  handleDataFrames(data: DataFrame[]) {
     if (this.dashboard && this.dashboard.snapshot) {
       this.panel.snapshotData = data;
     }

--- a/public/app/plugins/datasource/testdata/StreamHandler.ts
+++ b/public/app/plugins/datasource/testdata/StreamHandler.ts
@@ -113,7 +113,7 @@ export class StreamWorker {
     const maxRows = query.buffer ? query.buffer : stream.request.maxDataPoints;
 
     // Edit the first series
-    const series = stream.series[0];
+    const series = stream.data[0];
     let rows = series.rows.concat(append);
     const extra = maxRows - rows.length;
     if (extra < 0) {
@@ -143,7 +143,7 @@ export class SignalWorker extends StreamWorker {
   constructor(key: string, query: TestDataQuery, request: DataQueryRequest, observer: DataStreamObserver) {
     super(key, query, request, observer);
     setTimeout(() => {
-      this.stream.series = [this.initBuffer(query.refId)];
+      this.stream.data = [this.initBuffer(query.refId)];
       this.looper();
     }, 10);
 
@@ -253,7 +253,7 @@ export class FetchWorker extends StreamWorker {
 
   onHeader = (series: DataFrame) => {
     series.refId = this.refId;
-    this.stream.series = [series];
+    this.stream.data = [series];
   };
 
   onRow = (row: any[]) => {
@@ -269,7 +269,7 @@ export class LogsWorker extends StreamWorker {
     super(key, query, request, observer);
 
     window.setTimeout(() => {
-      this.stream.series = [this.initBuffer(query.refId)];
+      this.stream.data = [this.initBuffer(query.refId)];
       this.looper();
     }, 10);
   }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -13,7 +13,7 @@ import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 import { DataFrame, DataLink } from '@grafana/data';
 import { getColorFromHexRgbOrName, LegacyResponseData, VariableSuggestion } from '@grafana/ui';
-import { getProcessedDataFrame } from 'app/features/dashboard/state/PanelQueryState';
+import { getProcessedDataFrames } from 'app/features/dashboard/state/PanelQueryState';
 import { PanelQueryRunnerFormat } from 'app/features/dashboard/state/PanelQueryRunner';
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
@@ -143,7 +143,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel.xaxis, this.panelDefaults.xaxis);
     _.defaults(this.panel.options, this.panelDefaults.options);
 
-    this.dataFormat = PanelQueryRunnerFormat.series;
+    this.dataFormat = PanelQueryRunnerFormat.frames;
     this.processor = new DataProcessor(this.panel);
     this.contextMenuCtrl = new GraphContextMenuCtrl($scope);
 
@@ -210,12 +210,12 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   // This should only be called from the snapshot callback
   onDataReceived(dataList: LegacyResponseData[]) {
-    this.handleDataFrame(getProcessedDataFrame(dataList));
+    this.handleDataFrames(getProcessedDataFrames(dataList));
   }
 
   // Directly support DataFrame skipping event callbacks
-  handleDataFrame(data: DataFrame[]) {
-    super.handleDataFrame(data);
+  handleDataFrames(data: DataFrame[]) {
+    super.handleDataFrames(data);
 
     this.dataList = data;
     this.seriesList = this.processor.getSeriesList({

--- a/public/app/plugins/panel/graph/specs/data_processor.test.ts
+++ b/public/app/plugins/panel/graph/specs/data_processor.test.ts
@@ -1,5 +1,5 @@
 import { DataProcessor } from '../data_processor';
-import { getProcessedDataFrame } from 'app/features/dashboard/state/PanelQueryState';
+import { getProcessedDataFrames } from 'app/features/dashboard/state/PanelQueryState';
 
 describe('Graph DataProcessor', () => {
   const panel: any = {
@@ -11,7 +11,7 @@ describe('Graph DataProcessor', () => {
 
   describe('getTimeSeries from LegacyResponseData', () => {
     // Try each type of data
-    const dataList = getProcessedDataFrame([
+    const dataList = getProcessedDataFrames([
       {
         alias: 'First (time_series)',
         datapoints: [[1, 1001], [2, 1002], [3, 1003]],


### PR DESCRIPTION
This PR does a few naming refactors:
```
-  series?: DataFrame[];
+  data?: DataFrame[];
```

It may be worth considering this for 6.3 cherry pick since it will be nicer to have this in the API sooner than later.  In particular this option is introduced in 6.3: https://github.com/grafana/grafana/compare/series-to-DataFrame-flag?expand=1#diff-54fb55ab8d49df25dcf1f0057946b4b1