### PR TITLE
Metrics: use consistent naming for exported variables

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -34,7 +34,7 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) {
 		return
 	}
 
-	metrics.M_Api_Admin_User_Create.Inc()
+	metrics.MApiAdminUserCreate.Inc()
 
 	user := cmd.Result
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -133,7 +133,7 @@ func (hs *HTTPServer) GetDashboard(c *m.ReqContext) Response {
 		Meta:      meta,
 	}
 
-	c.TimeRequest(metrics.M_Api_Dashboard_Get)
+	c.TimeRequest(metrics.MApiDashboardGet)
 	return JSON(200, dto)
 }
 
@@ -282,7 +282,7 @@ func (hs *HTTPServer) PostDashboard(c *m.ReqContext, cmd m.SaveDashboardCommand)
 		}
 	}
 
-	c.TimeRequest(metrics.M_Api_Dashboard_Save)
+	c.TimeRequest(metrics.MApiDashboardSave)
 	return JSON(200, util.DynMap{
 		"status":  "success",
 		"slug":    dashboard.Slug,

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -97,7 +97,7 @@ func CreateDashboardSnapshot(c *m.ReqContext, cmd m.CreateDashboardSnapshotComma
 		cmd.ExternalDeleteUrl = response.DeleteUrl
 		cmd.Dashboard = simplejson.New()
 
-		metrics.M_Api_Dashboard_Snapshot_External.Inc()
+		metrics.MApiDashboardSnapshotExternal.Inc()
 	} else {
 		if cmd.Key == "" {
 			cmd.Key = util.GetRandomString(32)
@@ -109,7 +109,7 @@ func CreateDashboardSnapshot(c *m.ReqContext, cmd m.CreateDashboardSnapshotComma
 
 		url = setting.ToAbsUrl("dashboard/snapshot/" + cmd.Key)
 
-		metrics.M_Api_Dashboard_Snapshot_Create.Inc()
+		metrics.MApiDashboardSnapshotCreate.Inc()
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -154,7 +154,7 @@ func GetDashboardSnapshot(c *m.ReqContext) {
 		},
 	}
 
-	metrics.M_Api_Dashboard_Snapshot_Get.Inc()
+	metrics.MApiDashboardSnapshotGet.Inc()
 
 	c.Resp.Header().Set("Cache-Control", "public, max-age=3600")
 	c.JSON(200, dto)

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (hs *HTTPServer) ProxyDataSourceRequest(c *m.ReqContext) {
-	c.TimeRequest(metrics.M_DataSource_ProxyReq_Timer)
+	c.TimeRequest(metrics.MDataSourceProxyReqTimer)
 
 	dsId := c.ParamsInt64(":id")
 	ds, err := hs.DatasourceCache.GetDatasource(dsId, c.SignedInUser, c.SkipCache)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -138,7 +138,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
 	}
 
-	metrics.M_Api_Login_Post.Inc()
+	metrics.MApiLoginPost.Inc()
 	return JSON(200, result)
 }
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -199,7 +199,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 	// login
 	hs.loginUserWithUser(cmd.Result, ctx)
 
-	metrics.M_Api_Login_OAuth.Inc()
+	metrics.MApiLoginOAuth.Inc()
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		ctx.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -88,7 +88,7 @@ func CreateOrg(c *m.ReqContext, cmd m.CreateOrgCommand) Response {
 		return Error(500, "Failed to create organization", err)
 	}
 
-	metrics.M_Api_Org_Create.Inc()
+	metrics.MApiOrgCreate.Inc()
 
 	return JSON(200, &util.DynMap{
 		"orgId":   cmd.Result.Id,

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -188,8 +188,8 @@ func (hs *HTTPServer) CompleteInvite(c *m.ReqContext, completeInvite dtos.Comple
 
 	hs.loginUserWithUser(user, c)
 
-	metrics.M_Api_User_SignUpCompleted.Inc()
-	metrics.M_Api_User_SignUpInvite.Inc()
+	metrics.MApiUserSignUpCompleted.Inc()
+	metrics.MApiUserSignUpInvite.Inc()
 
 	return Success("User created and logged in")
 }

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -61,6 +61,6 @@ func Search(c *m.ReqContext) Response {
 		return Error(500, "Search failed", err)
 	}
 
-	c.TimeRequest(metrics.M_Api_Dashboard_Search)
+	c.TimeRequest(metrics.MApiDashboardSearch)
 	return JSON(200, searchQuery.Result)
 }

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -46,7 +46,7 @@ func SignUp(c *m.ReqContext, form dtos.SignUpForm) Response {
 		Code:  cmd.Code,
 	})
 
-	metrics.M_Api_User_SignUpStarted.Inc()
+	metrics.MApiUserSignUpStarted.Inc()
 
 	return JSON(200, util.DynMap{"status": "SignUpCreated"})
 }
@@ -110,7 +110,7 @@ func (hs *HTTPServer) SignUpStep2(c *m.ReqContext, form dtos.SignUpStep2Form) Re
 	}
 
 	hs.loginUserWithUser(user, c)
-	metrics.M_Api_User_SignUpCompleted.Inc()
+	metrics.MApiUserSignUpCompleted.Inc()
 
 	return JSON(200, apiResponse)
 }

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -3,80 +3,155 @@ package metrics
 import (
 	"runtime"
 
-	"github.com/grafana/grafana/pkg/setting"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 const exporterName = "grafana"
 
 var (
-	MInstanceStart       prometheus.Counter
-	MPageStatus          *prometheus.CounterVec
-	MApiStatus           *prometheus.CounterVec
-	MProxyStatus         *prometheus.CounterVec
-	MHttpRequestTotal   *prometheus.CounterVec
+	// MInstanceStart is a metric counter for started instances
+	MInstanceStart prometheus.Counter
+
+	// MPageStatus is a metric page http response status
+	MPageStatus *prometheus.CounterVec
+
+	// MApiStatus is a metric api http response status
+	MApiStatus *prometheus.CounterVec
+
+	// MProxyStatus is a metric proxy http response status
+	MProxyStatus *prometheus.CounterVec
+
+	// MHttpRequestTotal is a metric http request counter
+	MHttpRequestTotal *prometheus.CounterVec
+
+	// MHttpRequestSummary is a metric http request summary
 	MHttpRequestSummary *prometheus.SummaryVec
 
-	MApiUserSignUpStarted   prometheus.Counter
+	// MApiUserSignUpStarted is a metric amount of users who started the signup flow
+	MApiUserSignUpStarted prometheus.Counter
+
+	// MApiUserSignUpCompleted is a metric amount of users who completed the signup flow
 	MApiUserSignUpCompleted prometheus.Counter
-	MApiUserSignUpInvite    prometheus.Counter
-	MApiDashboardSave       prometheus.Summary
-	MApiDashboardGet        prometheus.Summary
-	MApiDashboardSearch     prometheus.Summary
-	MApiAdminUserCreate    prometheus.Counter
-	MApiLoginPost           prometheus.Counter
-	MApiLoginOAuth          prometheus.Counter
-	MApiOrgCreate           prometheus.Counter
 
-	MApiDashboardSnapshotCreate      prometheus.Counter
-	MApiDashboardSnapshotExternal    prometheus.Counter
-	MApiDashboardSnapshotGet         prometheus.Counter
-	MApiDashboardInsert               prometheus.Counter
-	MAlertingResultState              *prometheus.CounterVec
-	MAlertingNotificationSent         *prometheus.CounterVec
+	// MApiUserSignUpInvite is a metric amount of users who have been invited
+	MApiUserSignUpInvite prometheus.Counter
+
+	// MApiDashboardSave is a metric summary for dashboard save duration
+	MApiDashboardSave prometheus.Summary
+
+	// MApiDashboardGet is a metric summary for dashboard get duration
+	MApiDashboardGet prometheus.Summary
+
+	// MApiDashboardSearch is a metric summary for dashboard search duration
+	MApiDashboardSearch prometheus.Summary
+
+	// MApiAdminUserCreate is a metric api admin user created counter
+	MApiAdminUserCreate prometheus.Counter
+
+	// MApiLoginPost is a metric api login post counter
+	MApiLoginPost prometheus.Counter
+
+	// MApiLoginOAuth is a metric api login oauth counter
+	MApiLoginOAuth prometheus.Counter
+
+	// MApiOrgCreate is a metric api org created counter
+	MApiOrgCreate prometheus.Counter
+
+	// MApiDashboardSnapshotCreate is a metric dashboard snapshots created
+	MApiDashboardSnapshotCreate prometheus.Counter
+
+	// MApiDashboardSnapshotExternal is a metric external dashboard snapshots created
+	MApiDashboardSnapshotExternal prometheus.Counter
+
+	// MApiDashboardSnapshotGet is a metric loaded dashboards
+	MApiDashboardSnapshotGet prometheus.Counter
+
+	// MApiDashboardInsert is a metric dashboards inserted
+	MApiDashboardInsert prometheus.Counter
+
+	// MAlertingResultState is a metric alert execution result counter
+	MAlertingResultState *prometheus.CounterVec
+
+	// MAlertingNotificationSent is a metric counter for how many alert notifications been sent
+	MAlertingNotificationSent *prometheus.CounterVec
+
+	// MAwsCloudWatchGetMetricStatistics is a metric counter for getting metric statistics from aws
 	MAwsCloudWatchGetMetricStatistics prometheus.Counter
-	MAwsCloudWatchListMetrics         prometheus.Counter
-	MAwsCloudWatchGetMetricData       prometheus.Counter
-	MDBDataSourceQueryById            prometheus.Counter
 
-	// LDAPUsersSyncExecutionTime is a metric for
-	// how much time it took to sync the LDAP users
+	// MAwsCloudWatchListMetrics is a metric counter for getting list of metrics from aws
+	MAwsCloudWatchListMetrics prometheus.Counter
+
+	// MAwsCloudWatchGetMetricData is a metric counter for getting metric data time series from aws
+	MAwsCloudWatchGetMetricData prometheus.Counter
+
+	// MDBDataSourceQueryById is a metric counter for getting datasource by id
+	MDBDataSourceQueryById prometheus.Counter
+
+	// LDAPUsersSyncExecutionTime is a metric summary for LDAP users sync execution duration
 	LDAPUsersSyncExecutionTime prometheus.Summary
+)
 
-	// Timers
+// Timers
+var (
+	// MDataSourceProxyReqTimer is a metric summary for dataproxy request duration
 	MDataSourceProxyReqTimer prometheus.Summary
-	MAlertingExecutionTime   prometheus.Summary
+
+	// MAlertingExecutionTime is a metric summary of alert exeuction duration
+	MAlertingExecutionTime prometheus.Summary
 )
 
 // StatTotals
 var (
+	// MAlertingActiveAlerts is a metric amount of active alerts
 	MAlertingActiveAlerts prometheus.Gauge
-	MStatTotalDashboards   prometheus.Gauge
-	MStatTotalUsers        prometheus.Gauge
-	MStatActiveUsers       prometheus.Gauge
-	MStatTotalOrgs         prometheus.Gauge
-	MStatTotalPlaylists    prometheus.Gauge
 
-	StatsTotalViewers       prometheus.Gauge
-	StatsTotalEditors       prometheus.Gauge
-	StatsTotalAdmins        prometheus.Gauge
+	// MStatTotalDashboards is a metric total amount of dashboards
+	MStatTotalDashboards prometheus.Gauge
+
+	// MStatTotalUsers is a metric total amount of users
+	MStatTotalUsers prometheus.Gauge
+
+	// MStatActiveUsers is a metric number of active users
+	MStatActiveUsers prometheus.Gauge
+
+	// MStatTotalOrgs is a metric total amount of orgs
+	MStatTotalOrgs prometheus.Gauge
+
+	// MStatTotalPlaylists is a metric total amount of playlists
+	MStatTotalPlaylists prometheus.Gauge
+
+	// StatsTotalViewers is a metric total amount of viewers
+	StatsTotalViewers prometheus.Gauge
+
+	// StatsTotalEditors is a metric total amount of editors
+	StatsTotalEditors prometheus.Gauge
+
+	// StatsTotalAdmins is a metric total amount of admins
+	StatsTotalAdmins prometheus.Gauge
+
+	// StatsTotalActiveViewers is a metric total amount of viewers
 	StatsTotalActiveViewers prometheus.Gauge
-	StatsTotalActiveEditors prometheus.Gauge
-	StatsTotalActiveAdmins  prometheus.Gauge
 
-	// grafanaBuildVersion is a gauge that contains build info about this binary
+	// StatsTotalActiveEditors is a metric total amount of active editors
+	StatsTotalActiveEditors prometheus.Gauge
+
+	// StatsTotalActiveAdmins is a metric total amount of active admins
+	StatsTotalActiveAdmins prometheus.Gauge
+
+	// grafanaBuildVersion is a metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built
 	grafanaBuildVersion *prometheus.GaugeVec
 )
 
 func init() {
+	httpStatusCodes := []string{"200", "404", "500", "unknown"}
 	MInstanceStart = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "instance_start_total",
 		Help:      "counter for started instances",
 		Namespace: exporterName,
 	})
 
-	httpStatusCodes := []string{"200", "404", "500", "unknown"}
 	MPageStatus = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "page_response_status_total",
@@ -326,7 +401,7 @@ func init() {
 
 	grafanaBuildVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "build_info",
-		Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built.",
+		Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built",
 		Namespace: exporterName,
 	}, []string{"version", "revision", "branch", "goversion", "edition"})
 }

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -65,11 +65,6 @@ var (
 	StatsTotalActiveEditors prometheus.Gauge
 	StatsTotalActiveAdmins  prometheus.Gauge
 
-	// M_Grafana_Version is a gauge that contains build info about this binary
-	//
-	// Deprecated: use M_Grafana_Build_Version instead.
-	M_Grafana_Version *prometheus.GaugeVec
-
 	// grafanaBuildVersion is a gauge that contains build info about this binary
 	grafanaBuildVersion *prometheus.GaugeVec
 )
@@ -329,12 +324,6 @@ func init() {
 		Namespace: exporterName,
 	})
 
-	M_Grafana_Version = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:      "info",
-		Help:      "Information about the Grafana. This metric is deprecated. please use `grafana_build_info`",
-		Namespace: exporterName,
-	}, []string{"version"})
-
 	grafanaBuildVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built.",
@@ -344,16 +333,11 @@ func init() {
 
 // SetBuildInformation sets the build information for this binary
 func SetBuildInformation(version, revision, branch string) {
-	// We export this info twice for backwards compatibility.
-	// Once this have been released for some time we should be able to remote `M_Grafana_Version`
-	// The reason we added a new one is that its common practice in the prometheus community
-	// to name this metric `*_build_info` so its easy to do aggregation on all programs.
 	edition := "oss"
 	if setting.IsEnterprise {
 		edition = "enterprise"
 	}
 
-	M_Grafana_Version.WithLabelValues(version).Set(1)
 	grafanaBuildVersion.WithLabelValues(version, revision, branch, runtime.Version(), edition).Set(1)
 }
 
@@ -394,7 +378,6 @@ func initMetricVars() {
 		M_StatActive_Users,
 		M_StatTotal_Orgs,
 		M_StatTotal_Playlists,
-		M_Grafana_Version,
 		StatsTotalViewers,
 		StatsTotalEditors,
 		StatsTotalAdmins,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -11,52 +11,52 @@ import (
 const exporterName = "grafana"
 
 var (
-	M_Instance_Start       prometheus.Counter
-	M_Page_Status          *prometheus.CounterVec
-	M_Api_Status           *prometheus.CounterVec
-	M_Proxy_Status         *prometheus.CounterVec
-	M_Http_Request_Total   *prometheus.CounterVec
-	M_Http_Request_Summary *prometheus.SummaryVec
+	MInstanceStart       prometheus.Counter
+	MPageStatus          *prometheus.CounterVec
+	MApiStatus           *prometheus.CounterVec
+	MProxyStatus         *prometheus.CounterVec
+	MHttpRequestTotal   *prometheus.CounterVec
+	MHttpRequestSummary *prometheus.SummaryVec
 
-	M_Api_User_SignUpStarted   prometheus.Counter
-	M_Api_User_SignUpCompleted prometheus.Counter
-	M_Api_User_SignUpInvite    prometheus.Counter
-	M_Api_Dashboard_Save       prometheus.Summary
-	M_Api_Dashboard_Get        prometheus.Summary
-	M_Api_Dashboard_Search     prometheus.Summary
-	M_Api_Admin_User_Create    prometheus.Counter
-	M_Api_Login_Post           prometheus.Counter
-	M_Api_Login_OAuth          prometheus.Counter
-	M_Api_Org_Create           prometheus.Counter
+	MApiUserSignUpStarted   prometheus.Counter
+	MApiUserSignUpCompleted prometheus.Counter
+	MApiUserSignUpInvite    prometheus.Counter
+	MApiDashboardSave       prometheus.Summary
+	MApiDashboardGet        prometheus.Summary
+	MApiDashboardSearch     prometheus.Summary
+	MApiAdminUserCreate    prometheus.Counter
+	MApiLoginPost           prometheus.Counter
+	MApiLoginOAuth          prometheus.Counter
+	MApiOrgCreate           prometheus.Counter
 
-	M_Api_Dashboard_Snapshot_Create      prometheus.Counter
-	M_Api_Dashboard_Snapshot_External    prometheus.Counter
-	M_Api_Dashboard_Snapshot_Get         prometheus.Counter
-	M_Api_Dashboard_Insert               prometheus.Counter
-	M_Alerting_Result_State              *prometheus.CounterVec
-	M_Alerting_Notification_Sent         *prometheus.CounterVec
-	M_Aws_CloudWatch_GetMetricStatistics prometheus.Counter
-	M_Aws_CloudWatch_ListMetrics         prometheus.Counter
-	M_Aws_CloudWatch_GetMetricData       prometheus.Counter
-	M_DB_DataSource_QueryById            prometheus.Counter
+	MApiDashboardSnapshotCreate      prometheus.Counter
+	MApiDashboardSnapshotExternal    prometheus.Counter
+	MApiDashboardSnapshotGet         prometheus.Counter
+	MApiDashboardInsert               prometheus.Counter
+	MAlertingResultState              *prometheus.CounterVec
+	MAlertingNotificationSent         *prometheus.CounterVec
+	MAwsCloudWatchGetMetricStatistics prometheus.Counter
+	MAwsCloudWatchListMetrics         prometheus.Counter
+	MAwsCloudWatchGetMetricData       prometheus.Counter
+	MDBDataSourceQueryById            prometheus.Counter
 
 	// LDAPUsersSyncExecutionTime is a metric for
 	// how much time it took to sync the LDAP users
 	LDAPUsersSyncExecutionTime prometheus.Summary
 
 	// Timers
-	M_DataSource_ProxyReq_Timer prometheus.Summary
-	M_Alerting_Execution_Time   prometheus.Summary
+	MDataSourceProxyReqTimer prometheus.Summary
+	MAlertingExecutionTime   prometheus.Summary
 )
 
 // StatTotals
 var (
-	M_Alerting_Active_Alerts prometheus.Gauge
-	M_StatTotal_Dashboards   prometheus.Gauge
-	M_StatTotal_Users        prometheus.Gauge
-	M_StatActive_Users       prometheus.Gauge
-	M_StatTotal_Orgs         prometheus.Gauge
-	M_StatTotal_Playlists    prometheus.Gauge
+	MAlertingActiveAlerts prometheus.Gauge
+	MStatTotalDashboards   prometheus.Gauge
+	MStatTotalUsers        prometheus.Gauge
+	MStatActiveUsers       prometheus.Gauge
+	MStatTotalOrgs         prometheus.Gauge
+	MStatTotalPlaylists    prometheus.Gauge
 
 	StatsTotalViewers       prometheus.Gauge
 	StatsTotalEditors       prometheus.Gauge
@@ -70,35 +70,35 @@ var (
 )
 
 func init() {
-	M_Instance_Start = prometheus.NewCounter(prometheus.CounterOpts{
+	MInstanceStart = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "instance_start_total",
 		Help:      "counter for started instances",
 		Namespace: exporterName,
 	})
 
 	httpStatusCodes := []string{"200", "404", "500", "unknown"}
-	M_Page_Status = newCounterVecStartingAtZero(
+	MPageStatus = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "page_response_status_total",
 			Help:      "page http response status",
 			Namespace: exporterName,
 		}, []string{"code"}, httpStatusCodes...)
 
-	M_Api_Status = newCounterVecStartingAtZero(
+	MApiStatus = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "api_response_status_total",
 			Help:      "api http response status",
 			Namespace: exporterName,
 		}, []string{"code"}, httpStatusCodes...)
 
-	M_Proxy_Status = newCounterVecStartingAtZero(
+	MProxyStatus = newCounterVecStartingAtZero(
 		prometheus.CounterOpts{
 			Name:      "proxy_response_status_total",
 			Help:      "proxy http response status",
 			Namespace: exporterName,
 		}, []string{"code"}, httpStatusCodes...)
 
-	M_Http_Request_Total = prometheus.NewCounterVec(
+	MHttpRequestTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "http_request_total",
 			Help: "http request counter",
@@ -106,7 +106,7 @@ func init() {
 		[]string{"handler", "statuscode", "method"},
 	)
 
-	M_Http_Request_Summary = prometheus.NewSummaryVec(
+	MHttpRequestSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name: "http_request_duration_milliseconds",
 			Help: "http request summary",
@@ -114,121 +114,121 @@ func init() {
 		[]string{"handler", "statuscode", "method"},
 	)
 
-	M_Api_User_SignUpStarted = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiUserSignUpStarted = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_started_total",
 		Help:      "amount of users who started the signup flow",
 		Namespace: exporterName,
 	})
 
-	M_Api_User_SignUpCompleted = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiUserSignUpCompleted = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_completed_total",
 		Help:      "amount of users who completed the signup flow",
 		Namespace: exporterName,
 	})
 
-	M_Api_User_SignUpInvite = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiUserSignUpInvite = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_invite_total",
 		Help:      "amount of users who have been invited",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Save = prometheus.NewSummary(prometheus.SummaryOpts{
+	MApiDashboardSave = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "api_dashboard_save_milliseconds",
 		Help:      "summary for dashboard save duration",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Get = prometheus.NewSummary(prometheus.SummaryOpts{
+	MApiDashboardGet = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "api_dashboard_get_milliseconds",
 		Help:      "summary for dashboard get duration",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Search = prometheus.NewSummary(prometheus.SummaryOpts{
+	MApiDashboardSearch = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "api_dashboard_search_milliseconds",
 		Help:      "summary for dashboard search duration",
 		Namespace: exporterName,
 	})
 
-	M_Api_Admin_User_Create = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiAdminUserCreate = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_admin_user_created_total",
 		Help:      "api admin user created counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Login_Post = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiLoginPost = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_login_post_total",
 		Help:      "api login post counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Login_OAuth = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiLoginOAuth = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_login_oauth_total",
 		Help:      "api login oauth counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Org_Create = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiOrgCreate = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_org_create_total",
 		Help:      "api org created counter",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_Create = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiDashboardSnapshotCreate = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_create_total",
 		Help:      "dashboard snapshots created",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_External = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiDashboardSnapshotExternal = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_external_total",
 		Help:      "external dashboard snapshots created",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Snapshot_Get = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiDashboardSnapshotGet = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_dashboard_snapshot_get_total",
 		Help:      "loaded dashboards",
 		Namespace: exporterName,
 	})
 
-	M_Api_Dashboard_Insert = newCounterStartingAtZero(prometheus.CounterOpts{
+	MApiDashboardInsert = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_models_dashboard_insert_total",
 		Help:      "dashboards inserted ",
 		Namespace: exporterName,
 	})
 
-	M_Alerting_Result_State = prometheus.NewCounterVec(prometheus.CounterOpts{
+	MAlertingResultState = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      "alerting_result_total",
 		Help:      "alert execution result counter",
 		Namespace: exporterName,
 	}, []string{"state"})
 
-	M_Alerting_Notification_Sent = prometheus.NewCounterVec(prometheus.CounterOpts{
+	MAlertingNotificationSent = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      "alerting_notification_sent_total",
 		Help:      "counter for how many alert notifications been sent",
 		Namespace: exporterName,
 	}, []string{"type"})
 
-	M_Aws_CloudWatch_GetMetricStatistics = newCounterStartingAtZero(prometheus.CounterOpts{
+	MAwsCloudWatchGetMetricStatistics = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_get_metric_statistics_total",
 		Help:      "counter for getting metric statistics from aws",
 		Namespace: exporterName,
 	})
 
-	M_Aws_CloudWatch_ListMetrics = newCounterStartingAtZero(prometheus.CounterOpts{
+	MAwsCloudWatchListMetrics = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_list_metrics_total",
 		Help:      "counter for getting list of metrics from aws",
 		Namespace: exporterName,
 	})
 
-	M_Aws_CloudWatch_GetMetricData = newCounterStartingAtZero(prometheus.CounterOpts{
+	MAwsCloudWatchGetMetricData = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "aws_cloudwatch_get_metric_data_total",
 		Help:      "counter for getting metric data time series from aws",
 		Namespace: exporterName,
 	})
 
-	M_DB_DataSource_QueryById = newCounterStartingAtZero(prometheus.CounterOpts{
+	MDBDataSourceQueryById = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "db_datasource_query_by_id_total",
 		Help:      "counter for getting datasource by id",
 		Namespace: exporterName,
@@ -240,49 +240,49 @@ func init() {
 		Namespace: exporterName,
 	})
 
-	M_DataSource_ProxyReq_Timer = prometheus.NewSummary(prometheus.SummaryOpts{
+	MDataSourceProxyReqTimer = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "api_dataproxy_request_all_milliseconds",
 		Help:      "summary for dataproxy request duration",
 		Namespace: exporterName,
 	})
 
-	M_Alerting_Execution_Time = prometheus.NewSummary(prometheus.SummaryOpts{
+	MAlertingExecutionTime = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:      "alerting_execution_time_milliseconds",
 		Help:      "summary of alert exeuction duration",
 		Namespace: exporterName,
 	})
 
-	M_Alerting_Active_Alerts = prometheus.NewGauge(prometheus.GaugeOpts{
+	MAlertingActiveAlerts = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "alerting_active_alerts",
 		Help:      "amount of active alerts",
 		Namespace: exporterName,
 	})
 
-	M_StatTotal_Dashboards = prometheus.NewGauge(prometheus.GaugeOpts{
+	MStatTotalDashboards = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_dashboard",
 		Help:      "total amount of dashboards",
 		Namespace: exporterName,
 	})
 
-	M_StatTotal_Users = prometheus.NewGauge(prometheus.GaugeOpts{
+	MStatTotalUsers = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_total_users",
 		Help:      "total amount of users",
 		Namespace: exporterName,
 	})
 
-	M_StatActive_Users = prometheus.NewGauge(prometheus.GaugeOpts{
+	MStatActiveUsers = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_active_users",
 		Help:      "number of active users",
 		Namespace: exporterName,
 	})
 
-	M_StatTotal_Orgs = prometheus.NewGauge(prometheus.GaugeOpts{
+	MStatTotalOrgs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_total_orgs",
 		Help:      "total amount of orgs",
 		Namespace: exporterName,
 	})
 
-	M_StatTotal_Playlists = prometheus.NewGauge(prometheus.GaugeOpts{
+	MStatTotalPlaylists = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_total_playlists",
 		Help:      "total amount of playlists",
 		Namespace: exporterName,
@@ -343,41 +343,41 @@ func SetBuildInformation(version, revision, branch string) {
 
 func initMetricVars() {
 	prometheus.MustRegister(
-		M_Instance_Start,
-		M_Page_Status,
-		M_Api_Status,
-		M_Proxy_Status,
-		M_Http_Request_Total,
-		M_Http_Request_Summary,
-		M_Api_User_SignUpStarted,
-		M_Api_User_SignUpCompleted,
-		M_Api_User_SignUpInvite,
-		M_Api_Dashboard_Save,
-		M_Api_Dashboard_Get,
-		M_Api_Dashboard_Search,
-		M_DataSource_ProxyReq_Timer,
-		M_Alerting_Execution_Time,
-		M_Api_Admin_User_Create,
-		M_Api_Login_Post,
-		M_Api_Login_OAuth,
-		M_Api_Org_Create,
-		M_Api_Dashboard_Snapshot_Create,
-		M_Api_Dashboard_Snapshot_External,
-		M_Api_Dashboard_Snapshot_Get,
-		M_Api_Dashboard_Insert,
-		M_Alerting_Result_State,
-		M_Alerting_Notification_Sent,
-		M_Aws_CloudWatch_GetMetricStatistics,
-		M_Aws_CloudWatch_ListMetrics,
-		M_Aws_CloudWatch_GetMetricData,
-		M_DB_DataSource_QueryById,
+		MInstanceStart,
+		MPageStatus,
+		MApiStatus,
+		MProxyStatus,
+		MHttpRequestTotal,
+		MHttpRequestSummary,
+		MApiUserSignUpStarted,
+		MApiUserSignUpCompleted,
+		MApiUserSignUpInvite,
+		MApiDashboardSave,
+		MApiDashboardGet,
+		MApiDashboardSearch,
+		MDataSourceProxyReqTimer,
+		MAlertingExecutionTime,
+		MApiAdminUserCreate,
+		MApiLoginPost,
+		MApiLoginOAuth,
+		MApiOrgCreate,
+		MApiDashboardSnapshotCreate,
+		MApiDashboardSnapshotExternal,
+		MApiDashboardSnapshotGet,
+		MApiDashboardInsert,
+		MAlertingResultState,
+		MAlertingNotificationSent,
+		MAwsCloudWatchGetMetricStatistics,
+		MAwsCloudWatchListMetrics,
+		MAwsCloudWatchGetMetricData,
+		MDBDataSourceQueryById,
 		LDAPUsersSyncExecutionTime,
-		M_Alerting_Active_Alerts,
-		M_StatTotal_Dashboards,
-		M_StatTotal_Users,
-		M_StatActive_Users,
-		M_StatTotal_Orgs,
-		M_StatTotal_Playlists,
+		MAlertingActiveAlerts,
+		MStatTotalDashboards,
+		MStatTotalUsers,
+		MStatActiveUsers,
+		MStatTotalOrgs,
+		MStatTotalPlaylists,
 		StatsTotalViewers,
 		StatsTotalEditors,
 		StatsTotalAdmins,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -86,8 +86,8 @@ var (
 	// MAwsCloudWatchGetMetricData is a metric counter for getting metric data time series from aws
 	MAwsCloudWatchGetMetricData prometheus.Counter
 
-	// MDBDataSourceQueryById is a metric counter for getting datasource by id
-	MDBDataSourceQueryById prometheus.Counter
+	// MDBDataSourceQueryByID is a metric counter for getting datasource by id
+	MDBDataSourceQueryByID prometheus.Counter
 
 	// LDAPUsersSyncExecutionTime is a metric summary for LDAP users sync execution duration
 	LDAPUsersSyncExecutionTime prometheus.Summary
@@ -303,7 +303,7 @@ func init() {
 		Namespace: exporterName,
 	})
 
-	MDBDataSourceQueryById = newCounterStartingAtZero(prometheus.CounterOpts{
+	MDBDataSourceQueryByID = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "db_datasource_query_by_id_total",
 		Help:      "counter for getting datasource by id",
 		Namespace: exporterName,
@@ -445,7 +445,7 @@ func initMetricVars() {
 		MAwsCloudWatchGetMetricStatistics,
 		MAwsCloudWatchListMetrics,
 		MAwsCloudWatchGetMetricData,
-		MDBDataSourceQueryById,
+		MDBDataSourceQueryByID,
 		LDAPUsersSyncExecutionTime,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,

--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -46,7 +46,7 @@ func (im *InternalMetricsService) Run(ctx context.Context) error {
 		}
 	}
 
-	M_Instance_Start.Inc()
+	MInstanceStart.Inc()
 
 	<-ctx.Done()
 	return ctx.Err()

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -161,11 +161,11 @@ func (uss *UsageStatsService) updateTotalStats() {
 		return
 	}
 
-	metrics.M_StatTotal_Dashboards.Set(float64(statsQuery.Result.Dashboards))
-	metrics.M_StatTotal_Users.Set(float64(statsQuery.Result.Users))
-	metrics.M_StatActive_Users.Set(float64(statsQuery.Result.ActiveUsers))
-	metrics.M_StatTotal_Playlists.Set(float64(statsQuery.Result.Playlists))
-	metrics.M_StatTotal_Orgs.Set(float64(statsQuery.Result.Orgs))
+	metrics.MStatTotalDashboards.Set(float64(statsQuery.Result.Dashboards))
+	metrics.MStatTotalUsers.Set(float64(statsQuery.Result.Users))
+	metrics.MStatActiveUsers.Set(float64(statsQuery.Result.ActiveUsers))
+	metrics.MStatTotalPlaylists.Set(float64(statsQuery.Result.Playlists))
+	metrics.MStatTotalOrgs.Set(float64(statsQuery.Result.Orgs))
 	metrics.StatsTotalViewers.Set(float64(statsQuery.Result.Viewers))
 	metrics.StatsTotalActiveViewers.Set(float64(statsQuery.Result.ActiveViewers))
 	metrics.StatsTotalEditors.Set(float64(statsQuery.Result.Editors))

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -20,9 +20,9 @@ func RequestMetrics(handler string) macaron.Handler {
 
 		code := sanitizeCode(status)
 		method := sanitizeMethod(req.Method)
-		metrics.M_Http_Request_Total.WithLabelValues(handler, code, method).Inc()
+		metrics.MHttpRequestTotal.WithLabelValues(handler, code, method).Inc()
 		duration := time.Since(now).Nanoseconds() / int64(time.Millisecond)
-		metrics.M_Http_Request_Summary.WithLabelValues(handler, code, method).Observe(float64(duration))
+		metrics.MHttpRequestSummary.WithLabelValues(handler, code, method).Observe(float64(duration))
 
 		if strings.HasPrefix(req.RequestURI, "/api/datasources/proxy") {
 			countProxyRequests(status)
@@ -37,39 +37,39 @@ func RequestMetrics(handler string) macaron.Handler {
 func countApiRequests(status int) {
 	switch status {
 	case 200:
-		metrics.M_Api_Status.WithLabelValues("200").Inc()
+		metrics.MApiStatus.WithLabelValues("200").Inc()
 	case 404:
-		metrics.M_Api_Status.WithLabelValues("404").Inc()
+		metrics.MApiStatus.WithLabelValues("404").Inc()
 	case 500:
-		metrics.M_Api_Status.WithLabelValues("500").Inc()
+		metrics.MApiStatus.WithLabelValues("500").Inc()
 	default:
-		metrics.M_Api_Status.WithLabelValues("unknown").Inc()
+		metrics.MApiStatus.WithLabelValues("unknown").Inc()
 	}
 }
 
 func countPageRequests(status int) {
 	switch status {
 	case 200:
-		metrics.M_Page_Status.WithLabelValues("200").Inc()
+		metrics.MPageStatus.WithLabelValues("200").Inc()
 	case 404:
-		metrics.M_Page_Status.WithLabelValues("404").Inc()
+		metrics.MPageStatus.WithLabelValues("404").Inc()
 	case 500:
-		metrics.M_Page_Status.WithLabelValues("500").Inc()
+		metrics.MPageStatus.WithLabelValues("500").Inc()
 	default:
-		metrics.M_Page_Status.WithLabelValues("unknown").Inc()
+		metrics.MPageStatus.WithLabelValues("unknown").Inc()
 	}
 }
 
 func countProxyRequests(status int) {
 	switch status {
 	case 200:
-		metrics.M_Proxy_Status.WithLabelValues("200").Inc()
+		metrics.MProxyStatus.WithLabelValues("200").Inc()
 	case 404:
-		metrics.M_Proxy_Status.WithLabelValues("400").Inc()
+		metrics.MProxyStatus.WithLabelValues("400").Inc()
 	case 500:
-		metrics.M_Proxy_Status.WithLabelValues("500").Inc()
+		metrics.MProxyStatus.WithLabelValues("500").Inc()
 	default:
-		metrics.M_Proxy_Status.WithLabelValues("unknown").Inc()
+		metrics.MProxyStatus.WithLabelValues("unknown").Inc()
 	}
 }
 

--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -70,5 +70,5 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 	context.EndTime = time.Now()
 
 	elapsedTime := context.EndTime.Sub(context.StartTime).Nanoseconds() / int64(time.Millisecond)
-	metrics.M_Alerting_Execution_Time.Observe(float64(elapsedTime))
+	metrics.MAlertingExecutionTime.Observe(float64(elapsedTime))
 }

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -57,7 +57,7 @@ func (n *notificationService) sendAndMarkAsComplete(evalContext *EvalContext, no
 	notifier := notifierState.notifier
 
 	n.log.Debug("Sending notification", "type", notifier.GetType(), "uid", notifier.GetNotifierUID(), "isDefault", notifier.GetIsDefault())
-	metrics.M_Alerting_Notification_Sent.WithLabelValues(notifier.GetType()).Inc()
+	metrics.MAlertingNotificationSent.WithLabelValues(notifier.GetType()).Inc()
 
 	err := notifier.Notify(evalContext)
 

--- a/pkg/services/alerting/reader.go
+++ b/pkg/services/alerting/reader.go
@@ -43,6 +43,6 @@ func (arr *defaultRuleReader) fetch() []*Rule {
 		}
 	}
 
-	metrics.M_Alerting_Active_Alerts.Set(float64(len(res)))
+	metrics.MAlertingActiveAlerts.Set(float64(len(res)))
 	return res
 }

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -44,7 +44,7 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 		annotationData.Set("noData", true)
 	}
 
-	metrics.M_Alerting_Result_State.WithLabelValues(string(evalContext.Rule.State)).Inc()
+	metrics.MAlertingResultState.WithLabelValues(string(evalContext.Rule.State)).Inc()
 	if evalContext.shouldUpdateAlertState() {
 		handler.log.Info("New state change", "alertId", evalContext.Rule.ID, "newState", evalContext.Rule.State, "prev state", evalContext.PrevAlertState)
 

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -87,7 +87,7 @@ func saveDashboard(sess *DBSession, cmd *m.SaveDashboardCommand) error {
 		dash.CreatedBy = userId
 		dash.Updated = time.Now()
 		dash.UpdatedBy = userId
-		metrics.M_Api_Dashboard_Insert.Inc()
+		metrics.MApiDashboardInsert.Inc()
 		affectedRows, err = sess.Insert(dash)
 	} else {
 		dash.SetVersion(dash.Version + 1)

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func GetDataSourceById(query *m.GetDataSourceByIdQuery) error {
-	metrics.MDBDataSourceQueryById.Inc()
+	metrics.MDBDataSourceQueryByID.Inc()
 
 	datasource := m.DataSource{OrgId: query.OrgId, Id: query.Id}
 	has, err := x.Get(&datasource)

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func GetDataSourceById(query *m.GetDataSourceByIdQuery) error {
-	metrics.M_DB_DataSource_QueryById.Inc()
+	metrics.MDBDataSourceQueryById.Inc()
 
 	datasource := m.DataSource{OrgId: query.OrgId, Id: query.Id}
 	has, err := x.Get(&datasource)

--- a/pkg/tsdb/cloudwatch/get_metric_data.go
+++ b/pkg/tsdb/cloudwatch/get_metric_data.go
@@ -37,7 +37,7 @@ func (e *CloudWatchExecutor) executeGetMetricDataQuery(ctx context.Context, regi
 		if err != nil {
 			return queryResponses, err
 		}
-		metrics.M_Aws_CloudWatch_GetMetricData.Add(float64(len(params.MetricDataQueries)))
+		metrics.MAwsCloudWatchGetMetricData.Add(float64(len(params.MetricDataQueries)))
 
 		for _, r := range resp.MetricDataResults {
 			if _, ok := mdr[*r.Id]; !ok {

--- a/pkg/tsdb/cloudwatch/get_metric_statistics.go
+++ b/pkg/tsdb/cloudwatch/get_metric_statistics.go
@@ -81,7 +81,7 @@ func (e *CloudWatchExecutor) executeQuery(ctx context.Context, query *CloudWatch
 			resp = partResp
 
 		}
-		metrics.M_Aws_CloudWatch_GetMetricStatistics.Inc()
+		metrics.MAwsCloudWatchGetMetricStatistics.Inc()
 	}
 
 	queryRes, err := parseResponse(resp, query)

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -642,7 +642,7 @@ func (e *CloudWatchExecutor) cloudwatchListMetrics(region string, namespace stri
 	var resp cloudwatch.ListMetricsOutput
 	err = svc.ListMetricsPages(params,
 		func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
-			metrics.M_Aws_CloudWatch_ListMetrics.Inc()
+			metrics.MAwsCloudWatchListMetrics.Inc()
 			metrics, _ := awsutil.ValuesAtPath(page, "Metrics")
 			for _, metric := range metrics {
 				resp.Metrics = append(resp.Metrics, metric.(*cloudwatch.Metric))
@@ -722,7 +722,7 @@ func getAllMetrics(cwData *DatasourceInfo) (cloudwatch.ListMetricsOutput, error)
 	var resp cloudwatch.ListMetricsOutput
 	err = svc.ListMetricsPages(params,
 		func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
-			metrics.M_Aws_CloudWatch_ListMetrics.Inc()
+			metrics.MAwsCloudWatchListMetrics.Inc()
 			metrics, _ := awsutil.ValuesAtPath(page, "Metrics")
 			for _, metric := range metrics {
 				resp.Metrics = append(resp.Metrics, metric.(*cloudwatch.Metric))


### PR DESCRIPTION
* Add comments for exported methods

* Change all occurrences of the exported metrics

* Correct the naming

* Remove unused metric