### PR TITLE
Build: copy .browserslistrc to node build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY packages packages
 
 RUN yarn install --pure-lockfile --no-progress
 
-COPY Gruntfile.js tsconfig.json tslint.json ./
+COPY Gruntfile.js tsconfig.json tslint.json .browserslistrc ./
 COPY public public
 COPY scripts scripts
 COPY emails emails


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
Fixes the following bug:

When building a container using the Dockerfile from project root, rendering graphs for alert emails or when sharing "direct link rendered image" did not work. This was caused by a missing .browserlistrc in the node build container, which caused autoprefixer to omit prefixes that were needed by phantomjs/headless chromium to render graphs correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**: