### PR TITLE
devenv: Fix failing provision alerts generation script if there too many existing alerts

### DIFF
--- a/devenv/docker/ha_test/alerts.sh
+++ b/devenv/docker/ha_test/alerts.sh
@@ -101,7 +101,7 @@ provision() {
 
 	requiresJsonnet
 
-	rm -rf grafana/provisioning/dashboards/alerts/alert-*.json
+	find grafana/provisioning/dashboards/alerts -maxdepth 1 -name 'alert*.json' -delete
 	jsonnet -m grafana/provisioning/dashboards/alerts grafana/provisioning/alerts.jsonnet --ext-code alerts=$alerts --ext-code condition=$condition
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
The script tries to delete previously existing alerts and it used to fail if there were too many of them with the following error:
`./alerts.sh: line 104: /bin/rm: Argument list too long`
This fix handles this situation by using the `find` command instead.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
I had generated ~5000 alerts (using this script) and tried to reset them using:
`./alerts.sh provision 0`

