### PR TITLE
prometheus rerun query on input update

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -40,7 +40,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
     super(props);
     const { query } = props;
     this.query = query;
-    // Query target properties that are fullu controlled inputs
+    // Query target properties that are fully controlled inputs
     this.state = {
       // Fully controlled text inputs
       interval: query.interval,

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -72,7 +72,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   onIntervalChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const interval = e.currentTarget.value;
     this.query.interval = interval;
-    this.setState({ interval });
+    this.setState({ interval }, this.onRunQuery);
   };
 
   onIntervalFactorChange = (option: SelectOptionItem<number>) => {
@@ -83,7 +83,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   onLegendChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const legendFormat = e.currentTarget.value;
     this.query.legendFormat = legendFormat;
-    this.setState({ legendFormat });
+    this.setState({ legendFormat }, this.onRunQuery);
   };
 
   onRunQuery = () => {

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -72,7 +72,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   onIntervalChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const interval = e.currentTarget.value;
     this.query.interval = interval;
-    this.setState({ interval }, this.onRunQuery);
+    this.setState({ interval });
   };
 
   onIntervalFactorChange = (option: SelectOptionItem<number>) => {
@@ -83,7 +83,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   onLegendChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const legendFormat = e.currentTarget.value;
     this.query.legendFormat = legendFormat;
-    this.setState({ legendFormat }, this.onRunQuery);
+    this.setState({ legendFormat });
   };
 
   onRunQuery = () => {
@@ -124,6 +124,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
               placeholder="legend format"
               value={legendFormat}
               onChange={this.onLegendChange}
+              onBlur={this.onRunQuery}
             />
           </div>
 
@@ -141,6 +142,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
               className="gf-form-input width-8"
               placeholder={interval}
               onChange={this.onIntervalChange}
+              onBlur={this.onRunQuery}
               value={interval}
             />
           </div>

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
       </Component>
       <input
         className="gf-form-input"
+        onBlur={[Function]}
         onChange={[Function]}
         placeholder="legend format"
         type="text"
@@ -53,6 +54,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
       </Component>
       <input
         className="gf-form-input width-8"
+        onBlur={[Function]}
         onChange={[Function]}
         type="text"
       />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**: When a user updates the fields for "Legend" and "Min step" the query is not re-run.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**: I think this functionality at some point moved from '/public/app/plugins/datasource/prometheus/partials/query.editor.html' where this used to work by calling "ctrl.refreshMetricData()". Maybe there is a good reason not to do it anymore but I can't figure out why.

Also I fixed a small typo in a comment in the file. Maybe I should have done that in a separate PR?

Thanks

