### PR TITLE
17278 prometheus custom step alignment

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -28,6 +28,7 @@ interface State {
   legendFormat: string;
   formatOption: SelectOptionItem<string>;
   interval: string;
+  stepAlignment: string;
   intervalFactorOption: SelectOptionItem<number>;
   instant: boolean;
 }
@@ -40,10 +41,11 @@ export class PromQueryEditor extends PureComponent<Props, State> {
     super(props);
     const { query } = props;
     this.query = query;
-    // Query target properties that are fullu controlled inputs
+    // Query target properties that are fully controlled inputs
     this.state = {
       // Fully controlled text inputs
       interval: query.interval,
+      stepAlignment: query.stepAlignment,
       legendFormat: query.legendFormat,
       // Select options
       formatOption: FORMAT_OPTIONS.find(option => option.value === query.format) || FORMAT_OPTIONS[0],
@@ -73,6 +75,12 @@ export class PromQueryEditor extends PureComponent<Props, State> {
     const interval = e.currentTarget.value;
     this.query.interval = interval;
     this.setState({ interval });
+  };
+
+  onStepAlignmentChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const stepAlignment = e.currentTarget.value;
+    this.query.stepAlignment = stepAlignment;
+    this.setState({ stepAlignment });
   };
 
   onIntervalFactorChange = (option: SelectOptionItem<number>) => {
@@ -142,6 +150,22 @@ export class PromQueryEditor extends PureComponent<Props, State> {
               placeholder={interval}
               onChange={this.onIntervalChange}
               value={interval}
+            />
+          </div>
+          
+          
+       <div className="gf-form">
+            <FormLabel
+              width={7}
+              tooltip="Amount of time to offset the query step alignment. Leave blank for no additional offset">
+              Step align
+            </FormLabel>
+            <input
+              type="text"
+              className="gf-form-input width-8"
+              placeholder={stepAlignment}
+              onChange={this.onStepAlignmentChange}
+              value={stepAlignment}
             />
           </div>
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -152,9 +152,8 @@ export class PromQueryEditor extends PureComponent<Props, State> {
               value={interval}
             />
           </div>
-          
-          
-       <div className="gf-form">
+
+          <div className="gf-form">
             <FormLabel
               width={7}
               tooltip="Amount of time to offset the query step alignment. Leave blank for no additional offset">

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -155,7 +155,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
           <div className="gf-form">
             <FormLabel
-              width={7}
+              width={8}
               tooltip="Amount of time to offset the query step alignment. Leave blank for no additional offset">
               Step align
             </FormLabel>

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -102,7 +102,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
   render() {
     const { datasource, query, panelData, queryResponse } = this.props;
-    const { formatOption, instant, interval, intervalFactorOption, legendFormat } = this.state;
+    const { formatOption, instant, interval, stepAlignment, intervalFactorOption, legendFormat } = this.state;
 
     return (
       <div>

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -80,7 +80,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   onStepAlignmentChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const stepAlignment = e.currentTarget.value;
     this.query.stepAlignment = stepAlignment;
-    this.setState({ stepAlignment });
+    this.setState({ stepAlignment }, this.onRunQuery);
   };
 
   onIntervalFactorChange = (option: SelectOptionItem<number>) => {

--- a/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
@@ -219,36 +219,42 @@ describe('PrometheusDatasource', () => {
 
   describe('alignRange', () => {
     it('does not modify already aligned intervals with perfect step', () => {
-      const range = alignRange(0, 3, 3, 0);
+      const range = alignRange(0, 3, 3, 0, '0m');
       expect(range.start).toEqual(0);
       expect(range.end).toEqual(3);
     });
     it('does modify end-aligned intervals to reflect number of steps possible', () => {
-      const range = alignRange(1, 6, 3, 0);
+      const range = alignRange(1, 6, 3, 0, '0m');
       expect(range.start).toEqual(0);
       expect(range.end).toEqual(6);
     });
     it('does align intervals that are a multiple of steps', () => {
-      const range = alignRange(1, 4, 3, 0);
+      const range = alignRange(1, 4, 3, 0, '0m');
       expect(range.start).toEqual(0);
       expect(range.end).toEqual(3);
     });
     it('does align intervals that are not a multiple of steps', () => {
-      const range = alignRange(1, 5, 3, 0);
+      const range = alignRange(1, 5, 3, 0, '0m');
       expect(range.start).toEqual(0);
       expect(range.end).toEqual(3);
     });
     it('does align intervals with local midnight -UTC offset', () => {
       //week range, location 4+ hours UTC offset, 24h step time
-      const range = alignRange(4 * 60 * 60, (7 * 24 + 4) * 60 * 60, 24 * 60 * 60, -4 * 60 * 60); //04:00 UTC, 7 day range
+      const range = alignRange(4 * 60 * 60, (7 * 24 + 4) * 60 * 60, 24 * 60 * 60, -4 * 60 * 60, '0m'); //04:00 UTC, 7 day range
       expect(range.start).toEqual(4 * 60 * 60);
       expect(range.end).toEqual((7 * 24 + 4) * 60 * 60);
     });
     it('does align intervals with local midnight +UTC offset', () => {
       //week range, location 4- hours UTC offset, 24h step time
-      const range = alignRange(20 * 60 * 60, (8 * 24 - 4) * 60 * 60, 24 * 60 * 60, 4 * 60 * 60); //20:00 UTC on day1, 7 days later is 20:00 on day8
+      const range = alignRange(20 * 60 * 60, (8 * 24 - 4) * 60 * 60, 24 * 60 * 60, 4 * 60 * 60, '0m'); //20:00 UTC on day1, 7 days later is 20:00 on day8
       expect(range.start).toEqual(20 * 60 * 60);
       expect(range.end).toEqual((8 * 24 - 4) * 60 * 60);
+    });
+    it('does align intervals with user entered step alignment offset', () => {
+      //week range, 12h step time, offset by 5 hours
+      const range = alignRange(24*60*60, 8*24*60*60, 12*60*60, 0, '5h');  //start day1, end day8 = 7 days range, user step alignment to 05:00
+      expect(range.start).toEqual((24-5)*60*60);   //19:00 on day0
+      expect(range.end).toEqual((8*24 - 5)*60*60);  //19:00 on day 7 = 8d-5h
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -12,6 +12,7 @@ export interface PromQuery extends DataQuery {
   instant?: boolean;
   hinting?: boolean;
   interval?: string;
+  stepAlignment?: string;
   intervalFactor?: number;
   legendFormat?: string;
   valueWithRefId?: boolean;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:  This is a new feature that gives the ability to have a custom step alignment on prometheus panels. Specifically where I want to use this feature is cases where I display prometheus counter changes over intervals of time.

The classic case is where a facility runs work shifts (day shift and night shift) and the shift change time may not align with midnight. So for example:

Facility A operates with two shifts with shift change at 05:00 and 17:00. To display a nice bar chart of their production my query looks like "increase(ProductionCounts[12h])" with 'Min step'=12h and 'Step align'=5h

![customStepAlignment](https://user-images.githubusercontent.com/51002364/61327798-ba83e200-a7e7-11e9-8ba6-a0e73b59dd41.PNG)

Facility B operates with three shifts with shift change at 7:00, 15:00, 23:00. A bar chart of their production my query looks like "increase(ProductionCounts[8h])" with 'Min step'=8h and 'Step align'=7h


**Which issue(s) this PR fixes**: [17278](https://github.com/grafana/grafana/issues/17278)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 17278

**Special notes for your reviewer**: I would understand if this feature is in low demand (maybe it's just me) that its not worth integrating into grafana base code. Any suggestions for another way I could get this for myself without forking the entire repository? Forking the prometheus datasource as a new plugin or something? 

As it often is, Daylight savings time can be an issue. Independent of this change it messes with graphs that the time change is within the range and has query where 'Min step' > 1h.  So a user of this feature may need to work around daylight savings.

Thanks for your help.