### PR TITLE
Update behind_proxy.md with linkback to nginx.com

### DIFF
--- a/docs/sources/installation/behind_proxy.md
+++ b/docs/sources/installation/behind_proxy.md
@@ -35,6 +35,8 @@ domain = foo.bar
 
 ### Nginx configuration
 
+Nginx is a high performance load balancer, web server and reverse proxy: https://www.nginx.com/
+
 ```bash
 server {
   listen 80;


### PR DESCRIPTION
We were contacted by a company managing the NGINX digital marketing. This page mentions NGNIX. They ask if it was possible to include a backlink to https://www.nginx.com/

Reference ticket #3907.

I will ask the person to look at this PR to let me know if this is satisfactory.

This also needs to be approved by the Grafana team to make sure this ties in with the style and tone of the documentation site.