### PR TITLE
Build: watch and dev mode webpack improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "zone.js": "0.7.8"
   },
   "scripts": {
-    "dev": "webpack --progress --colors --mode development --config scripts/webpack/webpack.dev.js",
+    "dev": "webpack --progress --colors --config scripts/webpack/webpack.dev.js",
     "start": "grafana-toolkit core:start --watchTheme",
     "start:hot": "grafana-toolkit core:start --hot --watchTheme",
     "start:ignoreTheme": "grafana-toolkit core:start --hot",

--- a/packages/grafana-toolkit/src/cli/tasks/core.start.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/core.start.ts
@@ -15,11 +15,11 @@ const startTaskRunner: TaskRunner<StartTaskOptions> = async ({ watchThemes, hot 
     },
     hot
       ? {
-          command: 'webpack-dev-server --progress --colors --mode development --config scripts/webpack/webpack.hot.js',
+          command: 'webpack-dev-server --progress --colors --config scripts/webpack/webpack.hot.js',
           name: 'Dev server',
         }
       : {
-          command: 'webpack --progress --colors --watch --mode development --config scripts/webpack/webpack.dev.js',
+          command: 'webpack --progress --colors --watch --config scripts/webpack/webpack.dev.js',
           name: 'Webpack',
         },
   ];

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -19,6 +19,11 @@ module.exports = merge(common, {
     light: './public/sass/grafana.light.scss',
   },
 
+  // If we enabled watch option via CLI
+  watchOptions: {
+    ignored: /node_modules/
+  },
+
   module: {
     rules: [
       {

--- a/scripts/webpack/webpack.hot.js
+++ b/scripts/webpack/webpack.hot.js
@@ -10,6 +10,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const IgnoreNotFoundExportPlugin = require("./IgnoreNotFoundExportPlugin.js");
 
 module.exports = merge(common, {
+  mode: 'development',
   entry: {
     app: ['webpack-dev-server/client?http://localhost:3333', './public/app/dev.ts'],
   },
@@ -34,6 +35,9 @@ module.exports = merge(common, {
     proxy: {
       '!/public/build': 'http://localhost:3000',
     },
+    watchOptions: {
+      ignored: /node_modules/
+    }
   },
 
   optimization: {


### PR DESCRIPTION
* Ignore `node_modules` in watch mode

* Simplify development setup
