### PR TITLE
@grafana/toolkit: enable plugin themes to work with common stylesheet

### DIFF
--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -90,6 +90,7 @@ Adidtionaly, you can also provide additional Jest config via package.json file. 
 We support pure css, SASS and CSS in JS approach (via Emotion).
 
 1. Single css/sass file
+
 Create your css/sass file and import it in your plugin entry point (typically module.ts):
 
 ```ts
@@ -100,6 +101,7 @@ The styles will be injected via `style` tag during runtime.
 Note, that imported static assets will be inlined as base64 URIs. *This can be a subject of change in the future!*
 
 2. Theme specific css/sass files
+
 If you want to provide different stylesheets for dark/light theme, create `dark.[css|scss]` and `light.[css|scss]` files in `src/styles` directory of your plugin. Based on that we will generate stylesheets that will end up in `dist/styles` directory.
 
 TODO: add note about loadPluginCss
@@ -107,6 +109,7 @@ TODO: add note about loadPluginCss
 Note that static files (png, svg, json, html) are all copied to dist directory when the plugin is bundled. Relative paths to those files does not change.
 
 3. Emotion
+
 Starting from Grafana 6.2 our suggested way of styling plugins is by using [Emotion](https://emotion.sh). It's a css-in-js library that we use internaly at Grafana. The biggest advantage of using Emotion is that you will get access to Grafana Theme variables.
 
 To use start using Emotion you first need to add it to your plugin dependencies:

--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -63,16 +63,12 @@ export const hasThemeStylesheets = (root: string = process.cwd()) => {
 };
 
 export const getStyleLoaders = () => {
-  const shouldExtractCss = hasThemeStylesheets();
-
-  const executiveLoader = shouldExtractCss
-    ? {
-        loader: MiniCssExtractPlugin.loader,
-        options: {
-          publicPath: '../',
-        },
-      }
-    : 'style-loader';
+  const extractionLoader = {
+    loader: MiniCssExtractPlugin.loader,
+    options: {
+      publicPath: '../',
+    },
+  };
 
   const cssLoaders = [
     {
@@ -95,21 +91,32 @@ export const getStyleLoaders = () => {
     },
   ];
 
-  return [
+  const rules = [
+    {
+      test: /(dark|light)\.css$/,
+      use: [extractionLoader, ...cssLoaders],
+    },
+    {
+      test: /(dark|light)\.scss$/,
+      use: [extractionLoader, ...cssLoaders, 'sass-loader'],
+    },
     {
       test: /\.css$/,
-      use: [executiveLoader, ...cssLoaders],
+      use: ['style-loader', ...cssLoaders, 'sass-loader'],
+      exclude: [`${process.cwd()}/src/styles/light.css`, `${process.cwd()}/src/styles/dark.css`],
     },
     {
       test: /\.scss$/,
-      use: [executiveLoader, ...cssLoaders, 'sass-loader'],
+      use: ['style-loader', ...cssLoaders, 'sass-loader'],
+      exclude: [`${process.cwd()}/src/styles/light.scss`, `${process.cwd()}/src/styles/dark.scss`],
     },
   ];
+
+  return rules;
 };
 
 export const getFileLoaders = () => {
   const shouldExtractCss = hasThemeStylesheets();
-  // const pluginJson = getPluginJson();
 
   return [
     {


### PR DESCRIPTION
This makes it possible to use themes styleshheet files and stylesheet imports at the same time. The problem occurred when trying to migrate polystat panel to toolkit: https://github.com/grafana/grafana-polystat-panel/pull/62 