### PR TITLE
@grafana/toolkit: make ts-loader ignore files that are not bundled

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -185,8 +185,10 @@ export const getWebpackConfig: WebpackConfigurationGetter = options => {
                 plugins: ['angularjs-annotate'],
               },
             },
-
-            'ts-loader',
+            {
+              loader: 'ts-loader',
+              options: { onlyCompileBundledFiles: true },
+            },
           ],
           exclude: /(node_modules)/,
         },


### PR DESCRIPTION
By default ts-loader compiles all typescript files, including mocks and tests. This makes it focus on bundled files only.
