### PR TITLE
Plugins: add build info to plugin metadata

### DIFF
--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -77,6 +77,12 @@ interface PluginMetaInfoLink {
   url: string;
 }
 
+export interface PluginSourceInfo {
+  repo?: string;
+  branch?: string;
+  hash?: string;
+}
+
 export interface PluginMetaInfo {
   author: {
     name: string;
@@ -88,6 +94,7 @@ export interface PluginMetaInfo {
     large: string;
     small: string;
   };
+  source?: PluginSourceInfo;
   screenshots: any[];
   updated: string;
   version: string;

--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -78,6 +78,7 @@ interface PluginMetaInfoLink {
 }
 
 export interface PluginSourceInfo {
+  time?: number;
   repo?: string;
   branch?: string;
   hash?: string;

--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -77,7 +77,7 @@ interface PluginMetaInfoLink {
   url: string;
 }
 
-export interface PluginSourceInfo {
+export interface PluginBuildInfo {
   time?: number;
   repo?: string;
   branch?: string;
@@ -95,7 +95,7 @@ export interface PluginMetaInfo {
     large: string;
     small: string;
   };
-  source?: PluginSourceInfo;
+  build?: PluginBuildInfo;
   screenshots: any[];
   updated: string;
   version: string;

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -112,7 +112,7 @@ type PluginDependencyItem struct {
 	Version string `json:"version"`
 }
 
-type PluginSourceInfo struct {
+type PluginBuildInfo struct {
 	Time   int64  `json:"time,omitempty"`
 	Repo   string `json:"repo,omitempty"`
 	Branch string `json:"branch,omitempty"`
@@ -124,7 +124,7 @@ type PluginInfo struct {
 	Description string              `json:"description"`
 	Links       []PluginInfoLink    `json:"links"`
 	Logos       PluginLogos         `json:"logos"`
-	Source      PluginSourceInfo    `json:"source"`
+	Build       PluginBuildInfo     `json:"source"`
 	Screenshots []PluginScreenshots `json:"screenshots"`
 	Version     string              `json:"version"`
 	Updated     string              `json:"updated"`

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -113,6 +113,7 @@ type PluginDependencyItem struct {
 }
 
 type PluginSourceInfo struct {
+	Time   int64  `json:"time,omitempty"`
 	Repo   string `json:"repo,omitempty"`
 	Branch string `json:"branch,omitempty"`
 	Hash   string `json:"hash,omitempty"`
@@ -123,7 +124,7 @@ type PluginInfo struct {
 	Description string              `json:"description"`
 	Links       []PluginInfoLink    `json:"links"`
 	Logos       PluginLogos         `json:"logos"`
-	Source      PluginSourceInfo    `json:"source,omitempty"`
+	Source      PluginSourceInfo    `json:"source"`
 	Screenshots []PluginScreenshots `json:"screenshots"`
 	Version     string              `json:"version"`
 	Updated     string              `json:"updated"`

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -112,11 +112,18 @@ type PluginDependencyItem struct {
 	Version string `json:"version"`
 }
 
+type PluginSourceInfo struct {
+	Repo   string `json:"repo,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	Hash   string `json:"hash,omitempty"`
+}
+
 type PluginInfo struct {
 	Author      PluginInfoLink      `json:"author"`
 	Description string              `json:"description"`
 	Links       []PluginInfoLink    `json:"links"`
 	Logos       PluginLogos         `json:"logos"`
+	Source      PluginSourceInfo    `json:"source,omitempty"`
 	Screenshots []PluginScreenshots `json:"screenshots"`
 	Version     string              `json:"version"`
 	Updated     string              `json:"updated"`


### PR DESCRIPTION
While working on a plugin build system, it would be nice to have a standard way to know exactly what version your plugin is.

This adds:
```
export interface PluginSourceInfo {
  time?: number;
  repo?: string;
  branch?: string;
  hash?: string;
}
```

to the info section.  This is all optional, so private repos don't need to expose it if they don't want to.  Or could expose the hash without the repo and branch info