### PR TITLE
E2E: saving a dashboard should wait for success

### DIFF
--- a/public/e2e-test/pages/dashboards/saveDashboardModal.ts
+++ b/public/e2e-test/pages/dashboards/saveDashboardModal.ts
@@ -4,17 +4,20 @@ import {
   Selector,
   InputPageObjectType,
   InputPageObject,
+  PageObject,
 } from 'e2e-test/core/pageObjects';
 import { TestPage } from 'e2e-test/core/pages';
 
 export interface SaveDashboardModal {
   name: InputPageObjectType;
   save: ClickablePageObjectType;
+  success: PageObject;
 }
 
 export const saveDashboardModal = new TestPage<SaveDashboardModal>({
   pageObjects: {
     name: new InputPageObject(Selector.fromAriaLabel('Save dashboard title field')),
     save: new ClickablePageObject(Selector.fromAriaLabel('Save dashboard button')),
+    success: new PageObject(Selector.fromSelector('.alert-success')),
   },
 });

--- a/public/e2e-test/scenarios/smoke.test.ts
+++ b/public/e2e-test/scenarios/smoke.test.ts
@@ -57,6 +57,7 @@ e2eScenario(
     const dashboardTitle = new Date().toISOString();
     await saveDashboardModal.pageObjects.name.enter(dashboardTitle);
     await saveDashboardModal.pageObjects.save.click();
+    await saveDashboardModal.pageObjects.success.exists();
 
     // Share the dashboard
     const dashboardsPage = dashboardsPageFactory(dashboardTitle);


### PR DESCRIPTION
- navigating right away triggered the unsaved warning on slower machines
- this change makes sure we see a success message first

Fixes issues like these:
```
      Trying to click on: [aria-label="Save dashboard button"]
    console.log public/e2e-test/core/pages.ts:61
      Trying to navigate to: http://localhost:3000/dashboards

  ● Login scenario, create test data source, dashboard, panel, and export scenario › should pass

    TimeoutError: Navigation Timeout Exceeded: 30000ms exceeded

      60 | 
      61 |     console.log('Trying to navigate to:', this.pageUrl);
    > 62 |     await this.page.goto(this.pageUrl);
         |                     ^
      63 |   };
      64 | 
      65 |   expectSelector = async (config: ExpectSelectorConfig): Promise<void> => {
```