### PR TITLE
Panel: Show error in edit mode

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -110,8 +110,10 @@ class MetricsPanelCtrl extends PanelCtrl {
       }
     }
 
-    this.events.emit('data-error', err);
     console.log('Panel data error:', err);
+    return this.$timeout(() => {
+      this.events.emit('data-error', err);
+    });
   }
 
   // Updates the response with information from the stream


### PR DESCRIPTION
- the error was set, but has not been shown
- this change will force a digest before the query promises return with
their error handling

Fixes: #18169