### PR TITLE
Plugins: fix previous commit, output "build" property in json

### DIFF
--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -124,7 +124,7 @@ type PluginInfo struct {
 	Description string              `json:"description"`
 	Links       []PluginInfoLink    `json:"links"`
 	Logos       PluginLogos         `json:"logos"`
-	Build       PluginBuildInfo     `json:"source"`
+	Build       PluginBuildInfo     `json:"build"`
 	Screenshots []PluginScreenshots `json:"screenshots"`
 	Version     string              `json:"version"`
 	Updated     string              `json:"updated"`


### PR DESCRIPTION
Fixing a mistake in #18164.  The golang json and typescript should match!