### PR TITLE
SAML: add auth provider label

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -335,6 +335,8 @@ func GetAuthProviderLabel(authModule string) string {
 		return "GitLab"
 	case "oauth_grafana_com", "oauth_grafananet":
 		return "grafana.com"
+	case "auth.saml":
+		return "SAML"
 	case "ldap", "":
 		return "LDAP"
 	default:


### PR DESCRIPTION
Small update for `admin/users` page - add `SAML` badge for users which is signed in with SAML:

![Screenshot from 2019-07-19 16-55-44](https://user-images.githubusercontent.com/4932851/61540460-5743bb00-aa46-11e9-82df-e231128ba339.png)
