### PR TITLE
remote_cache: Fix redis connstr parsing

### DIFF
--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -26,7 +26,7 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 		if len(keyValueTuple) != 2 {
 			if strings.HasPrefix(rawKeyValue, "password") {
 				// don't log the password
-				rawKeyValue = "password=******"
+				rawKeyValue = "password******"
 			}
 			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
 		}

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -24,7 +24,12 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 	for _, rawKeyValue := range keyValueCSV {
 		keyValueTuple := strings.SplitN(rawKeyValue, "=", 2)
 		if len(keyValueTuple) != 2 {
-			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
+			if strings.HasPrefix(rawKeyValue, "password") {
+				// don't log the password
+				return nil, fmt.Errorf("incorrect redis connection string format detected for 'password', format is key=value,key=value")
+			} else {
+				return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
+			}
 		}
 		connKey := keyValueTuple[0]
 		connVal := keyValueTuple[1]

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -26,10 +26,9 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 		if len(keyValueTuple) != 2 {
 			if strings.HasPrefix(rawKeyValue, "password") {
 				// don't log the password
-				return nil, fmt.Errorf("incorrect redis connection string format detected for 'password', format is key=value,key=value")
-			} else {
-				return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
+				rawKeyValue="password=******"
 			}
+			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
 		}
 		connKey := keyValueTuple[0]
 		connVal := keyValueTuple[1]

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -22,7 +22,7 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 	keyValueCSV := strings.Split(connStr, ",")
 	options := &redis.Options{Network: "tcp"}
 	for _, rawKeyValue := range keyValueCSV {
-		keyValueTuple := strings.Split(rawKeyValue, "=")
+		keyValueTuple := strings.SplitN(rawKeyValue, "=", 2)
 		if len(keyValueTuple) != 2 {
 			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
 		}

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -26,7 +26,7 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 		if len(keyValueTuple) != 2 {
 			if strings.HasPrefix(rawKeyValue, "password") {
 				// don't log the password
-				rawKeyValue="password=******"
+				rawKeyValue = "password=******"
 			}
 			return nil, fmt.Errorf("incorrect redis connection string format detected for '%v', format is key=value,key=value", rawKeyValue)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes wrong splitting string after the first `=`, allows usage of base64 passwords like Azure Redis is using.
Instead of split the string into multiple pieces only split it into max of 2 pieces.

**Which issue(s) this PR fixes**:
Fixes #18199

**Special notes for your reviewer**:

