### PR TITLE
CircleCi: Run End-to-End tests for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,34 @@ jobs:
                 path: public/e2e-test/screenShots/theOutput
                 destination: output-screenshots
 
+  end-to-end-test-release:
+      docker:
+        - image: circleci/node:10-browsers
+        - image: grafana/grafana:$CIRCLE_TAG
+      steps:
+          - run: dockerize -wait tcp://127.0.0.1:3000 -timeout 120s
+          - checkout
+          - restore_cache:
+              key: dependency-cache-{{ checksum "yarn.lock" }}
+          - run:
+              name: yarn install
+              command: 'yarn install --pure-lockfile --no-progress'
+              no_output_timeout: 5m
+          - save_cache:
+              key: dependency-cache-{{ checksum "yarn.lock" }}
+              paths:
+                - node_modules
+          - run:
+              name: run end-to-end tests
+              command: 'env BASE_URL=http://127.0.0.1:3000 yarn e2e-tests'
+              no_output_timeout: 5m
+          - store_artifacts:
+                path: public/e2e-test/screenShots/theTruth
+                destination: expected-screenshots
+          - store_artifacts:
+                path: public/e2e-test/screenShots/theOutput
+                destination: output-screenshots
+
   codespell:
     docker:
       - image: circleci/python
@@ -774,6 +802,10 @@ workflows:
             - lint-go
             - mysql-integration-test
             - postgres-integration-test
+          filters: *filter-only-release
+      - end-to-end-test-release:
+          requires:
+            - grafana-docker-release
           filters: *filter-only-release
 
   build-branches-and-prs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:
Introduces and new CicleCi job `end-to-end-test-release` in the `release` workflow for enabling end to end test execution in for release builds.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #17897

**Special notes for your reviewer**:
The `end-to-end-test-release` job only differs from the existing `end-to-end-test` in the docker image therefore ideally this one should have been reused instead. However, [executors](https://circleci.com/docs/2.0/reusing-config/#executor) are only supported in CircleCi since 2.1.
Another alternative would be to create two [contexts](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-context) (one for master and another for releases) and define an environmental variable for which grafana image to be used in each case. Then it would be enough to [set the appropriate job context](https://circleci.com/docs/2.0/configuration-reference/#context) to each workflow (master and release). However, this also was not possible in this specific case since CircleCI does not support interpolation when setting environment variables.
Finally, since the modifications are in the release workflow I haven't test them properly in action!