### PR TITLE
Explore: Reduce default time range to last hour

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -41,7 +41,7 @@ import {
 import { config } from '../config';
 
 export const DEFAULT_RANGE = {
-  from: 'now-6h',
+  from: 'now-1h',
   to: 'now',
 };
 


### PR DESCRIPTION
Explore's default time range used to be Last 6 hours. After getting more feedback, we've decide to reduce this to Last 1 hour.

This also aligns the default range with the Prometheus UI. 

I've looked through the docs, the default range is not mentioned there, so no docs update needed.

This should be mentioned in the release notes though.
