### PR TITLE
Loki: Remove prefetching of default label values

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -246,13 +246,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
         [EMPTY_SELECTOR]: labelKeys,
       };
       this.logLabelOptions = labelKeys.map((key: string) => ({ label: key, value: key, isLeaf: false }));
-
-      // Pre-load values for default labels
-      return Promise.all(
-        labelKeys
-          .filter((key: string) => DEFAULT_KEYS.indexOf(key) > -1)
-          .map((key: string) => this.fetchLabelValues(key, absoluteRange))
-      );
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
With the introduction of time-scoped label values, the prefetching makes less sense, and it slowed down datasource switching.
Both Loki's label selector and the typeahead support lazy loading quite well now.