### PR TITLE
Graph: fix time label description for data link suggestion

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -39,7 +39,7 @@ export const getDataLinksVariableSuggestions = (): VariableSuggestion[] => [
   },
   {
     value: `${DataLinkBuiltInVars.valueTime}`,
-    documentation: "Adds narrowed down time range relative to data point's timestamp",
+    documentation: 'Time value of the clicked datapoint (in ms epoch)',
     origin: VariableOrigin.BuiltIn,
   },
 ];


### PR DESCRIPTION
Fixed typeahead label. Slightly tweaked suggestion from issue.

![Screenshot 2019-07-22 at 11 37 39](https://user-images.githubusercontent.com/859729/61623035-3feb1480-ac76-11e9-978e-2653add5645c.png)


Fixes #18185 