### PR TITLE
Alerting: fix duplicate alert states when the alert fails to save to the database

### DIFF
--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -298,7 +298,11 @@ func SetAlertState(cmd *m.SetAlertStateCommand) error {
 			alert.ExecutionError = cmd.Error
 		}
 
-		sess.ID(alert.Id).Update(&alert)
+		_, err := sess.ID(alert.Id).Update(&alert)
+		if err != nil {
+			sqlog.Debug("Failed to update AlertState in sql", "alertId", alert.Id, "stateDate", alert.NewStateDate, "state", alert.State, "stateChanges", alert.StateChanges)
+			return err
+		}
 
 		cmd.Result = alert
 		return nil

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -300,7 +300,6 @@ func SetAlertState(cmd *m.SetAlertStateCommand) error {
 
 		_, err := sess.ID(alert.Id).Update(&alert)
 		if err != nil {
-			sqlog.Debug("Failed to update AlertState in sql", "alertId", alert.Id, "stateDate", alert.NewStateDate, "state", alert.State, "stateChanges", alert.StateChanges)
 			return err
 		}
 


### PR DESCRIPTION
Return error when SetAlertState fails to save. Previously the error was not returned to caller.
fixes #18176 (duplicate states in alert).

