### PR TITLE
Alerting: Add lock on Job to prevent a race condition

### DIFF
--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -117,7 +117,7 @@ func (e *AlertEngine) processJobWithRetry(grafanaCtx context.Context, job *Job) 
 
 	// Initialize with first attemptID=1
 	attemptChan <- 1
-	job.Running = true
+	job.SetRunning(true)
 
 	for {
 		select {
@@ -141,7 +141,7 @@ func (e *AlertEngine) processJobWithRetry(grafanaCtx context.Context, job *Job) 
 }
 
 func (e *AlertEngine) endJob(err error, cancelChan chan context.CancelFunc, job *Job) error {
-	job.Running = false
+	job.SetRunning(false)
 	close(cancelChan)
 	for cancelFn := range cancelChan {
 		cancelFn()

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -22,7 +22,7 @@ func TestEngineTimeouts(t *testing.T) {
 		setting.AlertingNotificationTimeout = 30 * time.Second
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
-		job := &Job{Running: true, Rule: &Rule{}}
+		job := &Job{running: true, Rule: &Rule{}}
 
 		Convey("Should trigger as many retries as needed", func() {
 			Convey("pended alert for datasource -> result handler should be worked", func() {

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -45,7 +45,7 @@ func TestEngineProcessJob(t *testing.T) {
 		setting.AlertingNotificationTimeout = 30 * time.Second
 		setting.AlertingMaxAttempts = 3
 		engine.resultHandler = &FakeResultHandler{}
-		job := &Job{Running: true, Rule: &Rule{}}
+		job := &Job{running: true, Rule: &Rule{}}
 
 		Convey("Should trigger retry if needed", func() {
 

--- a/pkg/services/alerting/models.go
+++ b/pkg/services/alerting/models.go
@@ -1,14 +1,34 @@
 package alerting
 
-import "github.com/grafana/grafana/pkg/components/null"
+import (
+	"sync"
+
+	"github.com/grafana/grafana/pkg/components/null"
+)
 
 // Job holds state about when the alert rule should be evaluated.
 type Job struct {
-	Offset     int64
-	OffsetWait bool
-	Delay      bool
-	Running    bool
-	Rule       *Rule
+	Offset      int64
+	OffsetWait  bool
+	Delay       bool
+	running     bool
+	Rule        *Rule
+	runningLock sync.Mutex // Lock for running property which is used in the Scheduler and AlertEngine execution
+}
+
+// GetRunning returns true if the job is running. A lock is taken and released on the Job to ensure atomicity.
+func (j *Job) GetRunning() bool {
+	defer j.runningLock.Unlock()
+	j.runningLock.Lock()
+	return j.running
+}
+
+// SetRunning sets the running property on the Job. A lock is taken and released on the Job to ensure atomicity.
+func (j *Job) SetRunning(b bool) {
+	j.runningLock.Lock()
+	j.running = b
+	j.runningLock.Unlock()
+	return
 }
 
 // ResultLogEntry represents log data for the alert evaluation.

--- a/pkg/services/alerting/models.go
+++ b/pkg/services/alerting/models.go
@@ -28,7 +28,6 @@ func (j *Job) SetRunning(b bool) {
 	j.runningLock.Lock()
 	j.running = b
 	j.runningLock.Unlock()
-	return
 }
 
 // ResultLogEntry represents log data for the alert evaluation.

--- a/pkg/services/alerting/scheduler.go
+++ b/pkg/services/alerting/scheduler.go
@@ -30,9 +30,8 @@ func (s *schedulerImpl) Update(rules []*Rule) {
 		if s.jobs[rule.ID] != nil {
 			job = s.jobs[rule.ID]
 		} else {
-			job = &Job{
-				Running: false,
-			}
+			job = &Job{}
+			job.SetRunning(false)
 		}
 
 		job.Rule = rule
@@ -52,7 +51,7 @@ func (s *schedulerImpl) Tick(tickTime time.Time, execQueue chan *Job) {
 	now := tickTime.Unix()
 
 	for _, job := range s.jobs {
-		if job.Running || job.Rule.State == models.AlertStatePaused {
+		if job.GetRunning() || job.Rule.State == models.AlertStatePaused {
 			continue
 		}
 


### PR DESCRIPTION
without this lock there were a couple race condition between the scheduler and job processing on the Running property.

As per the race detector:

```
==================
WARNING: DATA RACE
Read at 0x00c0005afaaa by goroutine 101:
  github.com/grafana/grafana/pkg/services/alerting.(*schedulerImpl).Tick()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/scheduler.go:55 +0x17d
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).alertingTicker()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:85 +0xfd
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).Run.func1()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:59 +0x53
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x64

Previous write at 0x00c0005afaaa by goroutine 64:
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).endJob()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:144 +0x42
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).processJobWithRetry()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:136 +0x282
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).runJobDispatcher.func1()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:99 +0x60
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x64

Goroutine 101 (running) created at:
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x73
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).Run()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:59 +0x186
  main.(*GrafanaServerImpl).Run.func1()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/cmd/grafana-server/server.go:150 +0xd6
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x64

Goroutine 64 (finished) created at:
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x73
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).runJobDispatcher()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:99 +0x100
  github.com/grafana/grafana/pkg/services/alerting.(*AlertEngine).Run.func2()
      /home/kbrandt/src/github.com/grafana/grafana/pkg/services/alerting/engine.go:60 +0x53
  github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/kbrandt/src/github.com/grafana/grafana/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x64
==================
```

