### PR TITLE
Typo: fix threshodsWithoutKey

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { mount } from 'enzyme';
-import { ThresholdsEditor, Props, threshodsWithoutKey } from './ThresholdsEditor';
+import { ThresholdsEditor, Props, thresholdsWithoutKey } from './ThresholdsEditor';
 import { colors } from '../../utils';
 
 const setup = (propOverrides?: Partial<Props>) => {
@@ -21,7 +21,7 @@ const setup = (propOverrides?: Partial<Props>) => {
 };
 
 function getCurrentThresholds(editor: ThresholdsEditor) {
-  return threshodsWithoutKey(editor.state.thresholds);
+  return thresholdsWithoutKey(editor.state.thresholds);
 }
 
 describe('Render', () => {

--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.tsx
@@ -155,7 +155,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
 
   onChange = () => {
     const { thresholds } = this.state;
-    this.props.onChange(threshodsWithoutKey(thresholds));
+    this.props.onChange(thresholdsWithoutKey(thresholds));
   };
 
   renderInput = (threshold: ThresholdWithKey) => {
@@ -231,7 +231,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
   }
 }
 
-export function threshodsWithoutKey(thresholds: ThresholdWithKey[]): Threshold[] {
+export function thresholdsWithoutKey(thresholds: ThresholdWithKey[]): Threshold[] {
   return thresholds.map(t => {
     const { key, ...rest } = t;
     return rest; // everything except key


### PR DESCRIPTION
Fix a typo introduced in #17043 

` threshods` => ` thresholds`

Thanks @jordanhoworth