### PR TITLE
Docs: update links to sample plugins

### DIFF
--- a/docs/sources/plugins/developing/development.md
+++ b/docs/sources/plugins/developing/development.md
@@ -20,7 +20,8 @@ You can extend Grafana by writing your own plugins and then share them with othe
 
 Example plugins
 
-- [Typescript data source example](https://github.com/grafana/typescript-template-datasource)
+- ["Hello World" Panel using Angular](https://github.com/grafana/simple-angular-panel)
+- ["Hello World" Panel using React](https://github.com/grafana/simple-react-panel)
 - [Simple json data source](https://github.com/grafana/simple-json-datasource)
 - [Clock panel](https://github.com/grafana/clock-panel)
 - [Pie chart panel](https://github.com/grafana/piechart-panel)

--- a/docs/sources/plugins/developing/development.md
+++ b/docs/sources/plugins/developing/development.md
@@ -20,8 +20,8 @@ You can extend Grafana by writing your own plugins and then share them with othe
 
 Example plugins
 
-- ["Hello World" Panel using Angular](https://github.com/grafana/simple-angular-panel)
-- ["Hello World" Panel using React](https://github.com/grafana/simple-react-panel)
+- ["Hello World" panel using Angular](https://github.com/grafana/simple-angular-panel)
+- ["Hello World" panel using React](https://github.com/grafana/simple-react-panel)
 - [Simple json data source](https://github.com/grafana/simple-json-datasource)
 - [Clock panel](https://github.com/grafana/clock-panel)
 - [Pie chart panel](https://github.com/grafana/piechart-panel)


### PR DESCRIPTION
We removed some old plugin repositories and this broke links in the documentation.

This updates the links to something we can maintain

