### PR TITLE
TimePicker: Increase max height of quick range dropdown

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -147,6 +147,7 @@ export class TimePicker extends PureComponent<Props, State> {
             value={currentOption}
             label={label}
             options={options}
+            maxMenuHeight={600}
             onChange={this.onSelectChanged}
             iconClass={'fa fa-clock-o fa-fw'}
             tooltipContent={<TimePickerTooltipContent timeRange={value} />}


### PR DESCRIPTION
The feedback on the new time picker makes it clear it will probably need a design update soon. 

But in the meantime, this increases the max height of the quick ranges dropdown to make more visible at once. 

<img width="535" alt="Screen Shot 2019-07-24 at 12 46 58" src="https://user-images.githubusercontent.com/10999/61787938-34802080-ae11-11e9-98a1-e5bc0c25ed0b.png">
 