### PR TITLE
Change target branch in CI task trigger-docs-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,7 +626,7 @@ jobs:
               echo "Build URL:"
               curl -s -u "$DOCS_CIRCLE_TOKEN:" \
                 -d build_parameters[CIRCLE_JOB]=pull-submodule-changes \
-                https://circleci.com/api/v1.1/project/github/grafana/docs.grafana.com/tree/staging \
+                https://circleci.com/api/v1.1/project/github/grafana/docs.grafana.com/tree/master \
               | jq .build_url
             else
               echo "-- no changes to docs files --"


### PR DESCRIPTION
This changes trigger-docs-update job so that the docs build goes to production.

There is no additional risk to push a broken site in production. The docs build process is to publish to staging, then wait for a manual approval before publishing to prod.