### PR TITLE
Docs: Archive 6.2 and make 6.3 current version

### DIFF
--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,5 +1,6 @@
 [
-  { "version": "v6.2", "path": "/", "archived": false, "current": true },
+  { "version": "v6.3", "path": "/", "archived": false, "current": true },
+  { "version": "v6.2", "path": "/v6.2", "archived": true },
   { "version": "v6.1", "path": "/v6.1", "archived": true },
   { "version": "v6.0", "path": "/v6.0", "archived": true },
   { "version": "v5.4", "path": "/v5.4", "archived": true },


### PR DESCRIPTION
Docs were not updated as part of of the first few releases to 6.3.

After updating the documentation today. This reflects the current state of affairs, where documentation pertinent to 6.3 is what's currently part of docs.grafana.org.

Master needs to be bumped to 6.4, which I'll do shortly.