### PR TITLE
 Docs: Archive 6.3 and make 6.4 the current version

### DIFF
--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,5 +1,6 @@
 [
-  { "version": "v6.2", "path": "/", "archived": false, "current": true },
+  { "version": "v6.3", "path": "/", "archived": false, "current": true },
+  { "version": "v6.2", "path": "/v6.2", "archived": true },
   { "version": "v6.1", "path": "/v6.1", "archived": true },
   { "version": "v6.0", "path": "/v6.0", "archived": true },
   { "version": "v5.4", "path": "/v5.4", "archived": true },

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,5 +1,6 @@
 [
-  { "version": "v6.3", "path": "/", "archived": false, "current": true },
+  { "version": "v6.4", "path": "/", "archived": false, "current": true },
+  { "version": "v6.3", "path": "/v6.3", "archived": true },
   { "version": "v6.2", "path": "/v6.2", "archived": true },
   { "version": "v6.1", "path": "/v6.1", "archived": true },
   { "version": "v6.0", "path": "/v6.0", "archived": true },


### PR DESCRIPTION
It's split across two commits due to the cherry-pick from: https://github.com/grafana/grafana/pull/18257