### PR TITLE
Plugins: include build number and PR# in metadata

### DIFF
--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -82,6 +82,8 @@ export interface PluginBuildInfo {
   repo?: string;
   branch?: string;
   hash?: string;
+  number?: number;
+  pr?: string;
 }
 
 export interface PluginMetaInfo {


### PR DESCRIPTION
More properties for #18164

These are included in the typescript interface, and used externally -- they are not needed in go, but adding them would be harmless.