### PR TITLE
Loki: Apply start parameter to speed up test query

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -357,7 +357,10 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   };
 
   testDatasource() {
-    return this._request('/api/prom/label')
+    // Consider only last 10 minutes otherwise request takes too long
+    const startMs = Date.now() - 10 * 60 * 1000;
+    const start = `${startMs}000000`; // API expects nanoseconds
+    return this._request('/api/prom/label', { start })
       .then((res: DataQueryResponse) => {
         if (res && res.data && res.data.values && res.data.values.length > 0) {
           return { status: 'success', message: 'Data source connected and labels found.' };


### PR DESCRIPTION
- Explore calls `testDatasource` after every datasource switch
- for Loki this means querying available labels. the existing query was unbounded, leading up to 20 sec long requests just to test the datasource
- this change adds a time parameter to only test labels for the last 10 minutes
- Speedup on one of our clusters is from 10s down to 5s (still a long time)