### PR TITLE
Panels: skip query for getting started panel

### DIFF
--- a/public/app/plugins/panel/gettingstarted/plugin.json
+++ b/public/app/plugins/panel/gettingstarted/plugin.json
@@ -3,6 +3,7 @@
   "name": "Getting Started",
   "id": "gettingstarted",
 
+  "skipDataQuery": true,
   "hideFromList": true,
 
   "info": {


### PR DESCRIPTION
The "Getting Started" panel includes a query editor... it should not.