### PR TITLE
Utils: avoid calling console.warn() too often for deprecation warnings

### DIFF
--- a/packages/grafana-ui/src/utils/deprecationWarning.test.ts
+++ b/packages/grafana-ui/src/utils/deprecationWarning.test.ts
@@ -23,6 +23,11 @@ test('It should not output deprecation warnings too often', () => {
   deprecationWarning('file', 'oldName', 'newName');
   expect(console.warn).toHaveBeenCalledTimes(2);
 
+  deprecationWarning('file2', 'oldName', 'newName');
+  deprecationWarning('file2', 'oldName', 'newName');
+  deprecationWarning('file2', 'oldName', 'newName');
+  expect(console.warn).toHaveBeenCalledTimes(3);
+
   // or restoreMocks automatically?
   spyConsoleWarn.mockRestore();
   spyDateNow.mockRestore();

--- a/packages/grafana-ui/src/utils/deprecationWarning.test.ts
+++ b/packages/grafana-ui/src/utils/deprecationWarning.test.ts
@@ -1,0 +1,29 @@
+import { deprecationWarning } from './deprecationWarning';
+
+let dateNowValue = 10000000;
+
+test('It should not output deprecation warnings too often', () => {
+  const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+  const spyDateNow = jest.spyOn(global.Date, 'now').mockImplementation(() => dateNowValue);
+  // Make sure the mock works
+  expect(Date.now()).toEqual(dateNowValue);
+  expect(console.warn).toHaveBeenCalledTimes(0);
+
+  // Call the deprecation many times
+  deprecationWarning('file', 'oldName', 'newName');
+  deprecationWarning('file', 'oldName', 'newName');
+  deprecationWarning('file', 'oldName', 'newName');
+  deprecationWarning('file', 'oldName', 'newName');
+  deprecationWarning('file', 'oldName', 'newName');
+  expect(console.warn).toHaveBeenCalledTimes(1);
+
+  // Increment the time by 1min
+  dateNowValue += 60000;
+  deprecationWarning('file', 'oldName', 'newName');
+  deprecationWarning('file', 'oldName', 'newName');
+  expect(console.warn).toHaveBeenCalledTimes(2);
+
+  // or restoreMocks automatically?
+  spyConsoleWarn.mockRestore();
+  spyDateNow.mockRestore();
+});

--- a/packages/grafana-ui/src/utils/deprecationWarning.test.ts
+++ b/packages/grafana-ui/src/utils/deprecationWarning.test.ts
@@ -1,8 +1,8 @@
 import { deprecationWarning } from './deprecationWarning';
 
-let dateNowValue = 10000000;
-
 test('It should not output deprecation warnings too often', () => {
+  let dateNowValue = 10000000;
+
   const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
   const spyDateNow = jest.spyOn(global.Date, 'now').mockImplementation(() => dateNowValue);
   // Make sure the mock works

--- a/packages/grafana-ui/src/utils/deprecationWarning.ts
+++ b/packages/grafana-ui/src/utils/deprecationWarning.ts
@@ -1,7 +1,17 @@
+import { KeyValue } from '../types/index';
+
+// Avoid writing the warning message more than once every 10s
+const history: KeyValue<number> = {};
+
 export const deprecationWarning = (file: string, oldName: string, newName?: string) => {
   let message = `[Deprecation warning] ${file}: ${oldName} is deprecated`;
   if (newName) {
     message += `.  Use ${newName} instead`;
   }
-  console.warn(message);
+  const now = Date.now();
+  const last = history[message];
+  if (!last || now - last > 10000) {
+    console.warn(message);
+    history[message] = now;
+  }
 };

--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -229,7 +229,7 @@ kbn.slugifyForUrl = str => {
     .replace(/ +/g, '-');
 };
 
-/** deprecated since 6.1, use grafana/ui */
+/** deprecated since 6.1, use grafana/data */
 kbn.stringToJsRegex = str => {
   deprecationWarning('kbn.ts', 'kbn.stringToJsRegex()', '@grafana/data');
   return stringToJsRegex(str);


### PR DESCRIPTION
We added a deprecation warning utility function that prints a nice warning message and suggestion when using an old signature.  For example:

```
kbn.stringToJsRegex = str => {
  deprecationWarning('kbn.ts', 'kbn.stringToJsRegex()', '@grafana/data');
  return stringToJsRegex(str);
};
```

But, this function can be called very often -- and calling `console.warn()` so often makes it unusable.

This PR makes sure we do not output the same message more than once every 10s


cc @briangann 