### PR TITLE
SAML: Only show SAML login button on Enterprise version

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -44,7 +44,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	viewData.Settings["loginHint"] = setting.LoginHint
 	viewData.Settings["passwordHint"] = setting.PasswordHint
 	viewData.Settings["disableLoginForm"] = setting.DisableLoginForm
-	viewData.Settings["samlEnabled"] = hs.Cfg.SAMLEnabled
+	viewData.Settings["samlEnabled"] = setting.IsEnterprise && hs.Cfg.SAMLEnabled
 
 	if loginError, ok := tryGetEncryptedCookie(c, LoginErrorCookieName); ok {
 		//this cookie is only set whenever an OAuth login fails


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:

SAML Authentication is an Enterprise only feature. This change enables
the SAML login button to only be shown on enterprise.

