### PR TITLE
Keyboard Shortcuts: check for user being signedin for keyboardshortcuts

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -39,13 +39,15 @@ export class KeybindingSrv {
   }
 
   setupGlobal() {
-    this.bind(['?', 'h'], this.showHelpModal);
-    this.bind('g h', this.goToHome);
-    this.bind('g a', this.openAlerting);
-    this.bind('g p', this.goToProfile);
-    this.bind('s o', this.openSearch);
-    this.bind('f', this.openSearch);
-    this.bindGlobal('esc', this.exit);
+    if (this.contextSrv.user.isSignedIn) {
+      this.bind(['?', 'h'], this.showHelpModal);
+      this.bind('g h', this.goToHome);
+      this.bind('g a', this.openAlerting);
+      this.bind('g p', this.goToProfile);
+      this.bind('s o', this.openSearch);
+      this.bind('f', this.openSearch);
+      this.bindGlobal('esc', this.exit);
+    }
   }
 
   openSearch() {


### PR DESCRIPTION
**What this PR does / why we need it**:
User now needs to be signed in to be able to use keyboard shortcuts.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/18243