### PR TITLE
Templating: Add time expression variable

### DIFF
--- a/public/app/features/templating/TimeExpressionVariable.ts
+++ b/public/app/features/templating/TimeExpressionVariable.ts
@@ -1,4 +1,5 @@
 import { Variable, assignModelProperties, variableTypes } from './variable';
+import { VariableSrv } from './variable_srv';
 import * as dateMath from '@grafana/data/src/utils/datemath';
 
 export class TimeExpressionVariable implements Variable {
@@ -25,7 +26,7 @@ export class TimeExpressionVariable implements Variable {
   };
 
   /** @ngInject */
-  constructor(private model, private variableSrv) {
+  constructor(private model: any, private variableSrv: VariableSrv) {
     assignModelProperties(this, model, this.defaults);
     this.refresh = 2;
   }
@@ -35,7 +36,7 @@ export class TimeExpressionVariable implements Variable {
     return this.model;
   }
 
-  setValue(option) {
+  setValue(option: any) {
     this.variableSrv.setOptionAsCurrent(this, option);
   }
 
@@ -46,11 +47,11 @@ export class TimeExpressionVariable implements Variable {
     return Promise.resolve();
   }
 
-  dependsOn(variable) {
+  dependsOn(variable: any) {
     return false;
   }
 
-  setValueFromUrl(urlValue) {
+  setValueFromUrl(urlValue: string) {
     const time = this.getFormattedDatetime(urlValue, this.format);
     this.current = { text: urlValue, value: time };
     return this.variableSrv.setOptionFromUrl(this, urlValue);
@@ -73,5 +74,5 @@ variableTypes['timeexpression'] = {
   name: 'Time expression',
   ctor: TimeExpressionVariable,
   description: 'Enabled you to dynamically calculate a datetime according to the current time',
-  supportsMulti: false
+  supportsMulti: false,
 };

--- a/public/app/features/templating/TimeExpressionVariable.ts
+++ b/public/app/features/templating/TimeExpressionVariable.ts
@@ -1,0 +1,77 @@
+import { Variable, assignModelProperties, variableTypes } from './variable';
+import * as dateMath from '@grafana/data/src/utils/datemath';
+
+export class TimeExpressionVariable implements Variable {
+  query: string;
+  current: any;
+  options: any[];
+  skipUrlSync: boolean;
+  roundMethod: number;
+  format: string;
+  refresh: number;
+
+  defaults = {
+    type: 'timeexpression',
+    name: '',
+    hide: 0,
+    label: '',
+    refresh: 2,
+    query: 'now/d',
+    current: {},
+    options: [],
+    skipUrlSync: false,
+    roundMethod: 0,
+    format: '',
+  };
+
+  /** @ngInject */
+  constructor(private model, private variableSrv) {
+    assignModelProperties(this, model, this.defaults);
+    this.refresh = 2;
+  }
+
+  getSaveModel() {
+    assignModelProperties(this.model, this, this.defaults);
+    return this.model;
+  }
+
+  setValue(option) {
+    this.variableSrv.setOptionAsCurrent(this, option);
+  }
+
+  updateOptions() {
+    const time = this.getFormattedDatetime(this.query.trim(), this.format);
+    this.options = [{ text: this.query.trim(), value: time }];
+    this.current = this.options[0];
+    return Promise.resolve();
+  }
+
+  dependsOn(variable) {
+    return false;
+  }
+
+  setValueFromUrl(urlValue) {
+    const time = this.getFormattedDatetime(urlValue, this.format);
+    this.current = { text: urlValue, value: time };
+    return this.variableSrv.setOptionFromUrl(this, urlValue);
+  }
+
+  getValueForUrl() {
+    const time = this.getFormattedDatetime(this.current.text, this.format);
+    this.current = { text: this.current.text, value: time };
+    return this.current.text;
+  }
+
+  getFormattedDatetime(date: string, format: string) {
+    const timezone = this.variableSrv.dashboard && this.variableSrv.dashboard.getTimezone();
+    const dateTime = dateMath.parse(date, this.roundMethod !== 0, timezone);
+    return dateTime.format(format);
+  }
+}
+
+variableTypes['timeexpression'] = {
+  name: 'Time expression',
+  ctor: TimeExpressionVariable,
+  description: 'Enabled you to dynamically calculate a datetime according to the current time',
+  supportsMulti: false
+};

--- a/public/app/features/templating/all.ts
+++ b/public/app/features/templating/all.ts
@@ -10,6 +10,7 @@ import { CustomVariable } from './custom_variable';
 import { ConstantVariable } from './constant_variable';
 import { AdhocVariable } from './adhoc_variable';
 import { TextBoxVariable } from './TextBoxVariable';
+import { TimeExpressionVariable } from './TimeExpressionVariable';
 
 coreModule.factory('templateSrv', () => {
   return templateSrv;
@@ -24,4 +25,5 @@ export {
   ConstantVariable,
   AdhocVariable,
   TextBoxVariable,
+  TimeExpressionVariable,
 };

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -33,6 +33,8 @@ export class VariableEditorCtrl {
 
     $scope.hideOptions = [{ value: 0, text: '' }, { value: 1, text: 'Label' }, { value: 2, text: 'Variable' }];
 
+    $scope.roundMethodOptions = [{ value: 0, text: 'Start of time unit' }, { value: 1, text: 'End of time unit' }];
+
     $scope.init = () => {
       $scope.mode = 'list';
 

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -251,7 +251,8 @@
             rows="6"
             ng-model="current.query"
             ng-blur="runQuery()"
-            placeholder="时间表达式"
+            placeholder="time expression"
+            required
           />
         </div>
         <div class="gf-form">
@@ -280,7 +281,7 @@
           class="gf-form-input width-30"
           ng-model="current.format"
           ng-blur="runQuery()"
-          placeholder="Default format: 'YYYY-MM-DDTHH:mm:ssZ'"
+          placeholder="format as 'YYYY-MM-DDTHH:mm:ssZ' if empty"
         />
       </div>
     </div>

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -236,6 +236,55 @@
       </div>
     </div>
 
+    <div ng-if="current.type === 'timeexpression'" class="gf-form-group">
+      <h5 class="section-heading">Time expression options</h5>
+      <div class="gf-form-inline">
+        <div class="gf-form">
+          <span class="gf-form-label width-8">
+            Expression
+            <info-popover mode="right-normal">
+              Syntax：now [[+-]\d[yMwdhms]] /[yMwdhms]
+            </info-popover>
+          </span>
+          <input
+            class="gf-form-input width-12"
+            rows="6"
+            ng-model="current.query"
+            ng-blur="runQuery()"
+            placeholder="时间表达式"
+          />
+        </div>
+        <div class="gf-form">
+          <span class="gf-form-label width-9">
+            Round method
+          </span>
+          <div class="gf-form-select-wrapper width-12">
+            <select
+              class="gf-form-input"
+              ng-model="current.roundMethod"
+              ng-change="runQuery()"
+              ng-options="f.value as f.text for f in roundMethodOptions"
+            ></select>
+          </div>
+        </div>
+      </div>
+      <div class="gf-form">
+        <span class="gf-form-label width-8">
+          Format
+          <info-popover mode="right-normal">
+              See: <a href="https://momentjs.com/docs/#/displaying/format/" target="_blank">Moment.js format tokens</a>"
+            </info-popover>
+        </span>
+        <input
+          type="text"
+          class="gf-form-input width-30"
+          ng-model="current.format"
+          ng-blur="runQuery()"
+          placeholder="Default format: 'YYYY-MM-DDTHH:mm:ssZ'"
+        />
+      </div>
+    </div>
+
     <div ng-if="current.type === 'query'" class="gf-form-group">
       <h5 class="section-heading">Query Options</h5>
 


### PR DESCRIPTION
Templating: Add time expression variable
Add time expression variable, which gives dynamically calculate datetime according to the current time, and format with [Moment.js](https://momentjs.com/docs/#/displaying/format/).  

For example:  To query yesterday's datas in influxdb, we should define two variables.  
1. variable=`$startOfYesterday`,  expression=`now-1d/d`, roundMethod=`Start of time unit`, format=`x\m\s`
    value=`1563984000000ms`
2. variable=`$endOfYesterday`,  expression=`now-1d/d`, roundMethod=`End of time unit`, format=`'YYYY-MM-DDTHH:mm:ss.SSSZ'`
    value=`'2019-07-25T23:59:59.999+08:00'`
