### PR TITLE
Backend: null.Float NaN -> null for json marshal

### DIFF
--- a/pkg/components/null/float.go
+++ b/pkg/components/null/float.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 )
@@ -99,7 +100,7 @@ func (f *Float) UnmarshalText(text []byte) error {
 // MarshalJSON implements json.Marshaler.
 // It will encode null if this Float is null.
 func (f Float) MarshalJSON() ([]byte, error) {
-	if !f.Valid {
+	if !f.Valid || math.IsNaN(f.Float64) {
 		return []byte(nullString), nil
 	}
 	return []byte(strconv.FormatFloat(f.Float64, 'f', -1, 64)), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it so when a float is NaN it will be marshalled to Null for JSON. 

I'm not entirely sure this is the correct "fix" to be honest. I got here by:

1. Working on a backend plugin
2. Wanting to be able to set a `Point` with a `TimeSeries` to be null. 

The type for a `Value` of a `Point` in the plugin model datasource is a `float64`, where as in the `tsdb` package it is a `null.Float`. The `null.Float` gets created in datasource plugin wrapper's `Query` via `null.FloatFrom`.

So perhaps the plugin model should change to match the same types as the `tsdb.Response` in the server.

Even if this is the are to change it in, perhaps this should be marked as not `Valid` in the null package when making a new float, instead of this marshal condition?

Without this change, a float64 with a NaN value passed via a backend plugin returns a marshal error to the frontend, so this does fix that immediate situation. 

