### PR TITLE
Fix security issues: bump ubuntu to 19.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:19.04
 FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
@@ -12,7 +12,7 @@ COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 # Change to tar xfzv to make tar print every file it extracts
 RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:19.04
 FROM ${BASE_IMAGE}
 
 ARG GF_UID="472"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,10 +59,10 @@ docker_tag_all () {
 	fi
 }
 
-docker_build "ubuntu:18.04" "grafana-latest.linux-x64.tar.gz" "${_docker_repo}:${_grafana_version}"
+docker_build "ubuntu:19.04" "grafana-latest.linux-x64.tar.gz" "${_docker_repo}:${_grafana_version}"
 if [ $BUILD_FAST = "0" ]; then
-	docker_build "arm32v7/ubuntu:18.04" "grafana-latest.linux-armv7.tar.gz" "${_docker_repo}-arm32v7-linux:${_grafana_version}"
-	docker_build "arm64v8/ubuntu:18.04" "grafana-latest.linux-arm64.tar.gz" "${_docker_repo}-arm64v8-linux:${_grafana_version}"
+	docker_build "arm32v7/ubuntu:19.04" "grafana-latest.linux-armv7.tar.gz" "${_docker_repo}-arm32v7-linux:${_grafana_version}"
+	docker_build "arm64v8/ubuntu:19.04" "grafana-latest.linux-arm64.tar.gz" "${_docker_repo}-arm64v8-linux:${_grafana_version}"
 fi
 # Tag as 'latest' for official release; otherwise tag as grafana/grafana:master
 if echo "$_grafana_tag" | grep -q "^v"; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix security issues, after scanning `grafana/grafana:master` image.

i'm using coreos/clair scanner with most recent database:

```
clair-scanner --ip=192.168.1.199 grafana/grafana:master
2019/07/29 22:22:14 [INFO] ▶ Start clair-scanner
2019/07/29 22:22:17 [INFO] ▶ Server listening on port 9279
2019/07/29 22:22:17 [INFO] ▶ Analyzing 3e5c6c9f67d04737ec933b3473bb2dfac1f6e7c1c3f995ff6369690196e5b081
2019/07/29 22:22:19 [INFO] ▶ Analyzing c479ec8e43a02717da6123a82e8d45f06b92d2c05294cbd58fcfd707fc46b118
2019/07/29 22:22:19 [INFO] ▶ Analyzing f4da9e41fc23e69c88f6819d1665f7f6e7326126afe2b624357d6afac7139913
2019/07/29 22:22:19 [INFO] ▶ Analyzing b7679969db0e541cc10973bf58b2f78d69b71f1cba02adf461e4aeb4c15f73ba
2019/07/29 22:22:19 [INFO] ▶ Analyzing e6487e50c0700356ed099db7addee139106307537f0e8b2aeded1436b16083b6
2019/07/29 22:22:19 [INFO] ▶ Analyzing 85561cdc7e87a155bf932a044e9560f8bdfe084b6927aba924096ab4868051a7
2019/07/29 22:22:19 [INFO] ▶ Analyzing dfe57aba1d71bd05c705708a7bd4152e509fbdc7275efb371a09dfcded1af66c
2019/07/29 22:22:23 [INFO] ▶ Analyzing 08d6d6e805e4ddc465db3021550a202e48e3d78223dd2b4a941acfce342a67da
2019/07/29 22:22:23 [INFO] ▶ Analyzing ad8a6eaee5a671fd8a2d5962dcde32d137c342c64a832ea0c811dc89b4ac0d8c
2019/07/29 22:22:23 [WARN] ▶ Image [grafana/grafana:master] contains 37 total vulnerabilities
2019/07/29 22:22:23 [ERRO] ▶ Image [grafana/grafana:master] contains 37 unapproved vulnerabilities
```

<details>

```
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| STATUS     | CVE SEVERITY                | PACKAGE NAME | PACKAGE VERSION          | CVE DESCRIPTION                                                |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20839       | systemd      | 237-3ubuntu10.24         | systemd 242 changes the VT1 mode upon a logout, which          |
|            |                             |              |                          | allows attackers to read cleartext passwords in certain        |
|            |                             |              |                          | circumstances, such as watching a shutdown, or using           |
|            |                             |              |                          | Ctrl-Alt-F1 and Ctrl-Alt-F2. This occurs because the           |
|            |                             |              |                          | KDGKBMODE (aka current keyboard mode) check is mishandled.     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13050       | gnupg2       | 2.2.4-1ubuntu1.2         | Interaction between the sks-keyserver code through 1.2.0       |
|            |                             |              |                          | of the SKS keyserver network, and GnuPG through 2.2.16,        |
|            |                             |              |                          | makes it risky to have a GnuPG keyserver configuration line    |
|            |                             |              |                          | referring to a host on the SKS keyserver network. Retrieving   |
|            |                             |              |                          | data from this network may cause a persistent denial           |
|            |                             |              |                          | of service, because of a Certificate Spamming Attack.          |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13050   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2019-11922       | libzstd      | 1.3.3+dfsg-2ubuntu1      | A race condition in the one-pass compression functions         |
|            |                             |              |                          | of Zstandard prior to version 1.3.8 could allow an             |
|            |                             |              |                          | attacker to write bytes out of bounds if an output             |
|            |                             |              |                          | buffer smaller than the recommended size was used.             |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-11922   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2018-11237       | glibc        | 2.27-3ubuntu1            | An AVX-512-optimized implementation of the mempcpy             |
|            |                             |              |                          | function in the GNU C Library (aka glibc or libc6) 2.27 and    |
|            |                             |              |                          | earlier may write data beyond the target buffer, leading       |
|            |                             |              |                          | to a buffer overflow in __mempcpy_avx512_no_vzeroupper.        |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2018-19591       | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through 2.28,        |
|            |                             |              |                          | attempting to resolve a crafted hostname via getaddrinfo()     |
|            |                             |              |                          | leads to the allocation of a socket descriptor that is not     |
|            |                             |              |                          | closed. This is related to the if_nametoindex() function.      |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13565       | openldap     | 2.4.45+dfsg-1ubuntu1.2   | An issue was discovered in OpenLDAP 2.x before 2.4.48.         |
|            |                             |              |                          | When using SASL authentication and session encryption,         |
|            |                             |              |                          | and relying on the SASL security layers in slapd access        |
|            |                             |              |                          | controls, it is possible to obtain access that would           |
|            |                             |              |                          | otherwise be denied via a simple bind for any identity         |
|            |                             |              |                          | covered in those ACLs. After the first SASL bind is            |
|            |                             |              |                          | completed, the sasl_ssf value is retained for all new          |
|            |                             |              |                          | non-SASL connections. Depending on the ACL configuration,      |
|            |                             |              |                          | this can affect different types of operations (searches,       |
|            |                             |              |                          | modifications, etc.). In other words, a successful             |
|            |                             |              |                          | authorization step completed by one user affects               |
|            |                             |              |                          | the authorization requirement for a different user.            |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13565   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2018-11236       | glibc        | 2.27-3ubuntu1            | stdlib/canonicalize.c in the GNU C Library (aka glibc          |
|            |                             |              |                          | or libc6) 2.27 and earlier, when processing very               |
|            |                             |              |                          | long pathname arguments to the realpath function,              |
|            |                             |              |                          | could encounter an integer overflow on 32-bit                  |
|            |                             |              |                          | architectures, leading to a stack-based buffer                 |
|            |                             |              |                          | overflow and, potentially, arbitrary code execution.           |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2019-12904       | libgcrypt20  | 1.8.1-4ubuntu1.1         | In Libgcrypt 1.8.4, the C implementation of AES is             |
|            |                             |              |                          | vulnerable to a flush-and-reload side-channel attack           |
|            |                             |              |                          | because physical addresses are available to other              |
|            |                             |              |                          | processes. (The C implementation is used on platforms          |
|            |                             |              |                          | where an assembly-language implementation is unavailable.)     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12904   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20217       | krb5         | 1.16-2ubuntu0.1          | A Reachable Assertion issue was discovered in the KDC          |
|            |                             |              |                          | in MIT Kerberos 5 (aka krb5) before 1.17. If an attacker       |
|            |                             |              |                          | can obtain a krbtgt ticket using an older encryption           |
|            |                             |              |                          | type (single-DES, triple-DES, or RC4), the attacker            |
|            |                             |              |                          | can crash the KDC by making an S4U2Self request.               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20217   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-1543           | openssl      | 1.1.1-1ubuntu2.1~18.04.4 | ChaCha20-Poly1305 is an AEAD cipher, and requires a            |
|            |                             |              |                          | unique nonce input for every encryption operation. RFC         |
|            |                             |              |                          | 7539 specifies that the nonce value (IV) should be 96          |
|            |                             |              |                          | bits (12 bytes). OpenSSL allows a variable nonce length        |
|            |                             |              |                          | and front pads the nonce with 0 bytes if it is less than       |
|            |                             |              |                          | 12 bytes. However it also incorrectly allows a nonce to        |
|            |                             |              |                          | be set of up to 16 bytes. In this case only the last 12        |
|            |                             |              |                          | bytes are significant and any additional leading bytes         |
|            |                             |              |                          | are ignored. It is a requirement of using this cipher that     |
|            |                             |              |                          | nonce values are unique. Messages encrypted using a reused     |
|            |                             |              |                          | nonce value are susceptible to serious confidentiality and     |
|            |                             |              |                          | integrity attacks. If an application changes the default       |
|            |                             |              |                          | nonce length to be longer than 12 bytes and then makes a       |
|            |                             |              |                          | change to the leading bytes of the nonce expecting the new     |
|            |                             |              |                          | value to be a new unique nonce then such an application        |
|            |                             |              |                          | could inadvertently encrypt messages with a reused nonce.      |
|            |                             |              |                          | Additionally the ignored bytes in a long nonce are not         |
|            |                             |              |                          | covered by the integrity guarantee of this cipher. Any         |
|            |                             |              |                          | application that relies on the integrity of these ignored      |
|            |                             |              |                          | leading bytes of a long nonce may be further affected. Any     |
|            |                             |              |                          | OpenSSL internal use of this cipher, including in SSL/TLS,     |
|            |                             |              |                          | is safe because no such use sets such a long nonce value.      |
|            |                             |              |                          | However user applications that use this cipher directly        |
|            |                             |              |                          | and set a non-default nonce length to be longer than 12        |
|            |                             |              |                          | bytes may be vulnerable. OpenSSL versions 1.1.1 and 1.1.0      |
|            |                             |              |                          | are affected by this issue. Due to the limited scope of        |
|            |                             |              |                          | affected deployments this has been assessed as low severity    |
|            |                             |              |                          | and therefore we are not creating new releases at this         |
|            |                             |              |                          | time. Fixed in OpenSSL 1.1.1c (Affected 1.1.1-1.1.1b).         |
|            |                             |              |                          | Fixed in OpenSSL 1.1.0k (Affected 1.1.0-1.1.0j).               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-1543    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-3844           | systemd      | 237-3ubuntu10.24         | It was discovered that a systemd service that uses             |
|            |                             |              |                          | DynamicUser property can get new privileges through the        |
|            |                             |              |                          | execution of SUID binaries, which would allow to create        |
|            |                             |              |                          | binaries owned by the service transient group with the         |
|            |                             |              |                          | setgid bit set. A local attacker may use this flaw to access   |
|            |                             |              |                          | resources that will be owned by a potentially different        |
|            |                             |              |                          | service in the future, when the GID will be recycled.          |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2015-8985           | glibc        | 2.27-3ubuntu1            | The pop_fail_stack function in the GNU C Library               |
|            |                             |              |                          | (aka glibc or libc6) allows context-dependent                  |
|            |                             |              |                          | attackers to cause a denial of service (assertion              |
|            |                             |              |                          | failure and application crash) via vectors related             |
|            |                             |              |                          | to extended regular expression processing.                     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2018-14048          | libpng1.6    | 1.6.34-1ubuntu0.18.04.2  | An issue has been found in libpng 1.6.34. It is a SEGV         |
|            |                             |              |                          | in the function png_free_data in png.c, related to             |
|            |                             |              |                          | the recommended error handling for png_read_image.             |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-14048   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2016-2781           | coreutils    | 8.28-1ubuntu1            | chroot in GNU coreutils, when used with --userspec,            |
|            |                             |              |                          | allows local users to escape to the parent session             |
|            |                             |              |                          | via a crafted TIOCSTI ioctl call, which pushes                 |
|            |                             |              |                          | characters to the terminal's input buffer.                     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-2781    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2016-10739          | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through              |
|            |                             |              |                          | 2.28, the getaddrinfo function would successfully parse        |
|            |                             |              |                          | a string that contained an IPv4 address followed by            |
|            |                             |              |                          | whitespace and arbitrary characters, which could lead          |
|            |                             |              |                          | applications to incorrectly assume that it had parsed a        |
|            |                             |              |                          | valid string, without the possibility of embedded HTTP         |
|            |                             |              |                          | headers or other potentially dangerous substrings.             |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2013-4235           | shadow       | 1:4.5-1ubuntu2           | TOCTOU race conditions by copying                              |
|            |                             |              |                          | and removing directory trees                                   |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2018-7169           | shadow       | 1:4.5-1ubuntu2           | An issue was discovered in shadow 4.5. newgidmap (in           |
|            |                             |              |                          | shadow-utils) is setuid and allows an unprivileged user        |
|            |                             |              |                          | to be placed in a user namespace where setgroups(2) is         |
|            |                             |              |                          | permitted. This allows an attacker to remove themselves        |
|            |                             |              |                          | from a supplementary group, which may allow access to          |
|            |                             |              |                          | certain filesystem paths if the administrator has used         |
|            |                             |              |                          | "group blacklisting" (e.g., chmod g-rwx) to restrict access    |
|            |                             |              |                          | to paths. This flaw effectively reverts a security feature     |
|            |                             |              |                          | in the kernel (in particular, the /proc/self/setgroups         |
|            |                             |              |                          | knob) to prevent this sort of privilege escalation.            |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-12098          | heimdal      | 7.5.0+dfsg-1             | In the client side of Heimdal before 7.6.0, failure            |
|            |                             |              |                          | to verify anonymous PKINIT PA-PKINIT-KX key exchange           |
|            |                             |              |                          | permits a man-in-the-middle attack. This issue is in           |
|            |                             |              |                          | krb5_init_creds_step in lib/krb5/init_creds_pw.c.              |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12098   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2017-14159          | openldap     | 2.4.45+dfsg-1ubuntu1.2   | slapd in OpenLDAP 2.4.45 and earlier creates a PID file        |
|            |                             |              |                          | after dropping privileges to a non-root account, which might   |
|            |                             |              |                          | allow local users to kill arbitrary processes by leveraging    |
|            |                             |              |                          | access to this non-root account for PID file modification      |
|            |                             |              |                          | before a root script executes a "kill `cat /pathname`"         |
|            |                             |              |                          | command, as demonstrated by openldap-initscript.               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-14159   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-13057          | openldap     | 2.4.45+dfsg-1ubuntu1.2   | An issue was discovered in the server in OpenLDAP before       |
|            |                             |              |                          | 2.4.48. When the server administrator delegates rootDN         |
|            |                             |              |                          | (database admin) privileges for certain databases but          |
|            |                             |              |                          | wants to maintain isolation (e.g., for multi-tenant            |
|            |                             |              |                          | deployments), slapd does not properly stop a rootDN from       |
|            |                             |              |                          | requesting authorization as an identity from another           |
|            |                             |              |                          | database during a SASL bind or with a proxyAuthz (RFC          |
|            |                             |              |                          | 4370) control. (It is not a common configuration to            |
|            |                             |              |                          | deploy a system where the server administrator and a           |
|            |                             |              |                          | DB administrator enjoy different levels of trust.)             |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13057   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2009-5155           | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) before 2.28,         |
|            |                             |              |                          | parse_reg_exp in posix/regcomp.c misparses alternatives,       |
|            |                             |              |                          | which allows attackers to cause a denial of service            |
|            |                             |              |                          | (assertion failure and application exit) or trigger an         |
|            |                             |              |                          | incorrect result by attempting a regular-expression match.     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-9169           | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through              |
|            |                             |              |                          | 2.29, proceed_next_node in posix/regexec.c has                 |
|            |                             |              |                          | a heap-based buffer over-read via an attempted                 |
|            |                             |              |                          | case-insensitive regular-expression match.                     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-5827           | sqlite3      | 3.22.0-1ubuntu0.1        | Integer overflow in SQLite via WebSQL in Google Chrome         |
|            |                             |              |                          | prior to 74.0.3729.131 allowed a remote attacker to            |
|            |                             |              |                          | potentially exploit heap corruption via a crafted HTML page.   |
|            |                             |              |                          |  http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5827   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2019-3843           | systemd      | 237-3ubuntu10.24         | It was discovered that a systemd service that uses             |
|            |                             |              |                          | DynamicUser property can create a SUID/SGID binary             |
|            |                             |              |                          | that would be allowed to run as the transient service          |
|            |                             |              |                          | UID/GID even after the service is terminated. A local          |
|            |                             |              |                          | attacker may use this flaw to access resources that            |
|            |                             |              |                          | will be owned by a potentially different service               |
|            |                             |              |                          | in the future, when the UID/GID will be recycled.              |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2017-11164          | pcre3        | 2:8.39-9                 | In PCRE 8.41, the OP_KETRMAX feature in the match function     |
|            |                             |              |                          | in pcre_exec.c allows stack exhaustion (uncontrolled           |
|            |                             |              |                          | recursion) when processing a crafted regular expression.       |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-11164   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2018-20482          | tar          | 1.29b-2ubuntu0.1         | GNU Tar through 1.30, when --sparse is used, mishandles        |
|            |                             |              |                          | file shrinkage during read access, which allows local          |
|            |                             |              |                          | users to cause a denial of service (infinite read loop         |
|            |                             |              |                          | in sparse_dump_region in sparse.c) by modifying a file         |
|            |                             |              |                          | that is supposed to be archived by a different user's          |
|            |                             |              |                          | process (e.g., a system backup running as root).               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20482   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2018-16868          | gnutls28     | 3.5.18-1ubuntu1.1        | A Bleichenbacher type side-channel based padding oracle        |
|            |                             |              |                          | attack was found in the way gnutls handles verification        |
|            |                             |              |                          | of RSA decrypted PKCS#1 v1.5 data. An attacker who is able     |
|            |                             |              |                          | to run process on the same physical core as the victim         |
|            |                             |              |                          | process, could use this to extract plaintext or in some        |
|            |                             |              |                          | cases downgrade any TLS connections to a vulnerable server.    |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16868   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Low CVE-2018-16869          | nettle       | 3.4-1                    | A Bleichenbacher type side-channel based padding oracle        |
|            |                             |              |                          | attack was found in the way nettle handles endian conversion   |
|            |                             |              |                          | of RSA decrypted PKCS#1 v1.5 data. An attacker who is able     |
|            |                             |              |                          | to run a process on the same physical core as the victim       |
|            |                             |              |                          | process, could use this flaw extract plaintext or in some      |
|            |                             |              |                          | cases downgrade any TLS connections to a vulnerable server.    |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-7246    | pcre3        | 2:8.39-9                 | Stack-based buffer overflow in the pcre32_copy_substring       |
|            |                             |              |                          | function in pcre_get.c in libpcre1 in PCRE 8.40                |
|            |                             |              |                          | allows remote attackers to cause a denial of                   |
|            |                             |              |                          | service (WRITE of size 268) or possibly have                   |
|            |                             |              |                          | unspecified other impact via a crafted file.                   |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7246    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-1000654 | libtasn1-6   | 4.13-2                   | GNU Libtasn1-4.13 libtasn1-4.13 version libtasn1-4.13,         |
|            |                             |              |                          | libtasn1-4.12 contains a DoS, specifically CPU usage           |
|            |                             |              |                          | will reach 100% when running asn1Paser against the POC         |
|            |                             |              |                          | due to an issue in _asn1_expand_object_id(p_tree), after       |
|            |                             |              |                          | a long time, the program will be killed. This attack           |
|            |                             |              |                          | appears to be exploitable via parsing a crafted file.          |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1000654 |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-7245    | pcre3        | 2:8.39-9                 | Stack-based buffer overflow in the pcre32_copy_substring       |
|            |                             |              |                          | function in pcre_get.c in libpcre1 in PCRE 8.40 allows remote  |
|            |                             |              |                          | attackers to cause a denial of service (WRITE of size 4) or    |
|            |                             |              |                          | possibly have unspecified other impact via a crafted file.     |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7245    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-20796   | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through              |
|            |                             |              |                          | 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c           |
|            |                             |              |                          | has Uncontrolled Recursion, as demonstrated                    |
|            |                             |              |                          | by '(\227|)(\\1\\1|t1|\\\2537)+' in grep.                      |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2016-10228   | glibc        | 2.27-3ubuntu1            | The iconv program in the GNU C Library (aka glibc or           |
|            |                             |              |                          | libc6) 2.25 and earlier, when invoked with the -c option,      |
|            |                             |              |                          | enters an infinite loop when processing invalid multi-byte     |
|            |                             |              |                          | input sequences, leading to a denial of service.               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228   |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-9192    | glibc        | 2.27-3ubuntu1            | ** DISPUTED ** In the GNU C Library (aka glibc or libc6)       |
|            |                             |              |                          | through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c   |
|            |                             |              |                          | has Uncontrolled Recursion, as demonstrated by '(|)(\\1\\1)*'  |
|            |                             |              |                          | in grep, a different issue than CVE-2018-20796. NOTE: the      |
|            |                             |              |                          | software maintainer disputes that this is a vulnerability      |
|            |                             |              |                          | because the behavior occurs only with a crafted pattern.       |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2019-7309    | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through 2.29, the    |
|            |                             |              |                          | memcmp function for the x32 architecture can incorrectly       |
|            |                             |              |                          | return zero (indicating that the inputs are equal)             |
|            |                             |              |                          | because the RDX most significant bit is mishandled.            |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-8283    | dpkg         | 1.19.0.5ubuntu2.1        | dpkg-source in dpkg 1.3.0 through 1.18.23 is able              |
|            |                             |              |                          | to use a non-GNU patch program and does not offer a            |
|            |                             |              |                          | protection mechanism for blank-indented diff hunks,            |
|            |                             |              |                          | which allows remote attackers to conduct directory             |
|            |                             |              |                          | traversal attacks via a crafted Debian source package,         |
|            |                             |              |                          | as demonstrated by use of dpkg-source on NetBSD.               |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-8283    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
| Unapproved | Negligible CVE-2018-7738    | util-linux   | 2.31.1-0.4ubuntu3.3      | In util-linux before 2.32-rc1, bash-completion/umount          |
|            |                             |              |                          | allows local users to gain privileges by embedding             |
|            |                             |              |                          | shell commands in a mountpoint name, which is mishandled       |
|            |                             |              |                          | during a umount command (within Bash) by a different           |
|            |                             |              |                          | user, as demonstrated by logging in as root and entering       |
|            |                             |              |                          | umount followed by a tab character for autocompletion.         |
|            |                             |              |                          | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738    |
+------------+-----------------------------+--------------+--------------------------+----------------------------------------------------------------+
```

</details>

