### PR TITLE
Auth Proxy: Include additional headers as part of the cache key

### DIFF
--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -1,6 +1,7 @@
 package authproxy
 
 import (
+	"encoding/base32"
 	"fmt"
 	"net"
 	"net/mail"
@@ -31,6 +32,9 @@ var isLDAPEnabled = ldap.IsEnabled
 
 // newLDAP creates multiple LDAP instance
 var newLDAP = multildap.New
+
+// supportedHeaders states the supported headers configuration fields
+var supportedHeaderFields = []string{"Name", "Email", "Login", "Groups"}
 
 // AuthProxy struct
 type AuthProxy struct {
@@ -142,9 +146,18 @@ func (auth *AuthProxy) IsAllowedIP() (bool, *Error) {
 	return false, newError("Proxy authentication required", err)
 }
 
-// getKey forms a key for the cache
+// getKey forms a key for the cache based on the headers received as part of the authentication flow.
+// Our configuration supports multiple headers. The main header contains the email or username.
+// And the additional ones that allow us to specify extra attributes: Name, Email or Groups.
 func (auth *AuthProxy) getKey() string {
-	return fmt.Sprintf(CachePrefix, auth.header)
+	key := strings.TrimSpace(auth.header) // start the key with the main header
+
+	auth.headersIterator(func(_, header string) {
+		key = strings.Join([]string{key, header}, "-") // compose the key with any additional headers
+	})
+
+	hashedKey := base32.StdEncoding.EncodeToString([]byte(key))
+	return fmt.Sprintf(CachePrefix, hashedKey)
 }
 
 // Login logs in user id with whatever means possible
@@ -247,31 +260,41 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 		return 0, newError("Auth proxy header property invalid", nil)
 	}
 
-	for _, field := range []string{"Name", "Email", "Login", "Groups"} {
-		if auth.headers[field] == "" {
-			continue
+	auth.headersIterator(func(field string, header string) {
+		if field == "Groups" {
+			extUser.Groups = util.SplitString(header)
+		} else {
+			reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(header)
 		}
-
-		if val := auth.ctx.Req.Header.Get(auth.headers[field]); val != "" {
-			if field == "Groups" {
-				extUser.Groups = util.SplitString(val)
-			} else {
-				reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(val)
-			}
-		}
-	}
+	})
 
 	upsert := &models.UpsertUserCommand{
 		ReqContext:    auth.ctx,
 		SignupAllowed: setting.AuthProxyAutoSignUp,
 		ExternalUser:  extUser,
 	}
+
 	err := bus.Dispatch(upsert)
 	if err != nil {
 		return 0, err
 	}
 
 	return upsert.Result.Id, nil
+}
+
+// headersIterator iterates over all non-empty supported additional headers
+func (auth *AuthProxy) headersIterator(fn func(field string, header string)) {
+	for _, field := range supportedHeaderFields {
+		h := auth.headers[field]
+
+		if h == "" {
+			continue
+		}
+
+		if value := auth.ctx.Req.Header.Get(h); value != "" {
+			fn(field, strings.TrimSpace(value))
+		}
+	}
 }
 
 // GetSignedUser get full signed user info

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -245,19 +245,20 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 		AuthId:     auth.header,
 	}
 
-	if auth.headerType == "username" {
+	switch auth.headerType {
+	case "username":
 		extUser.Login = auth.header
 
-		// only set Email if it can be parsed as an email address
-		emailAddr, emailErr := mail.ParseAddress(auth.header)
+		emailAddr, emailErr := mail.ParseAddress(auth.header) // only set Email if it can be parsed as an email address
 		if emailErr == nil {
 			extUser.Email = emailAddr.Address
 		}
-	} else if auth.headerType == "email" {
+	case "email":
 		extUser.Email = auth.header
 		extUser.Login = auth.header
-	} else {
+	default:
 		return 0, newError("Auth proxy header property invalid", nil)
+
 	}
 
 	auth.headersIterator(func(field string, header string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
-->

**What this PR does / why we need it**:

Auth proxy has support to send additional user attributes as part of the
authentication flow. These attributes (e.g. Groups) need to be monitored
as part of the process in case of change.

This commit changes the way we compute the cache key to include all of the
attributes sent as part of the authentication request. That way, if we
change any user attributes we'll upsert the user information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #18276 

**Special notes for your reviewer**:
- There's a tiny refactor of an if/iflese statement to a switch as I feel this reads a bit better - I'm happy to take the commit if others feel is not relevant
- I chose to encode the cache key for two main reasons: a) we can't be certain that what we receive is safe to use as a key and b) we're not certain that it is not sensitive data that could be stored as part of a cache log
- Choice of base32 is because I wanted something to be [filename and URL safe](https://tools.ietf.org/html/rfc4648#section-6).
