### PR TITLE
GitHub Templates: Pull Request Template update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Thank you for sending a pull request!  Here are some tips:
+Thank you for sending a pull request! Here are some tips:
 
 1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md
 
@@ -12,7 +12,7 @@ Thank you for sending a pull request!  Here are some tips:
 
 5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.
 
-6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
+6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,17 @@
-<!--  Thank you for sending a pull request!  Here are some tips:
+<!--
+
+Thank you for sending a pull request!  Here are some tips:
 
 1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md
+
 2. Ensure you include and run the appropriate tests as part of your Pull Request.
+
 3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
+
 4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
+
 5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.
+
 6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
 
 -->
@@ -12,10 +19,15 @@
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:
+
 <!--
-*Automatically closes linked issue when PR is merged.
-Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+
+* Automatically closes linked issue when the Pull Request is merged.
+
+Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
+
 -->
+
 Fixes #
 
 **Special notes for your reviewer**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 <!--  Thank you for sending a pull request!  Here are some tips:
 
-1. If this is your first time, please read our contribution guide at: https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md
-2. Ensure you have added or ran the appropriate tests for your PR.
-3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
-4. If the PR is unfinished, mark it as a draft PR.
-5. Rebase your PR if it gets out of sync with master
-6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
+1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md
+2. Ensure you include and run the appropriate tests as part of your Pull Request.
+3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
+4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
+5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.
+6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,12 @@
 <!--  Thank you for sending a pull request!  Here are some tips:
 
-1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
+1. If this is your first time, please read our contribution guide at: https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md
 2. Ensure you have added or ran the appropriate tests for your PR.
 3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
 4. If the PR is unfinished, mark it as a draft PR.
 5. Rebase your PR if it gets out of sync with master
-6. Name your PR as `<FeatureArea>: Describe your change`. If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
+6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for changelog describe the user  impact in the title. The PR title is used in changelog for issues marked with `add to changelog` label. 
+
 -->
 
 **What this PR does / why we need it**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
+<!--  Thank you for sending a pull request!  Here are some tips for you:
 
 1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
 2. Ensure you have added or ran the appropriate tests for your PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--  Thank you for sending a pull request!  Here are some tips for you:
+<!--  Thank you for sending a pull request!  Here are some tips:
 
 1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
 2. Ensure you have added or ran the appropriate tests for your PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Thank you for sending a pull request! Here are some tips:
 
 5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.
 
-6. Name your PR as "<FeatureArea>: Describe your change". If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
+6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
 
 -->
 


### PR DESCRIPTION
For a while now, it's been a bit hard to read the very useful comments included as part of the Pull Request template.

Initially, I set out to fix two typos but ended up quickly making some minor changes here and there. 

The main gist is that the English language suggests that when giving out instructions or considerations is best to use imperative mood as the writing style. I have done:

- some worth smithing to match this style
- changed the format to match the fact that this is commonly read as part of a text box when opening up your PRs
- and extended a few descriptions to make it more friendly for newcomers 

What do others think? 