### PR TITLE
grafana/toolkit: support windows paths

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -42,7 +42,7 @@ const getModuleFiles = () => {
 
 const getManualChunk = (id: string) => {
   if (id.endsWith('module.ts') || id.endsWith('module.tsx')) {
-    const idx = id.indexOf('/src/');
+    const idx = id.indexOf(path.delimiter + 'src' + path.delimiter);
     if (idx > 0) {
       const name = id.substring(idx + 5, id.lastIndexOf('.'));
 

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -42,7 +42,7 @@ const getModuleFiles = () => {
 
 const getManualChunk = (id: string) => {
   if (id.endsWith('module.ts') || id.endsWith('module.tsx')) {
-    const idx = id.indexOf(path.delimiter + 'src' + path.delimiter);
+    const idx = id.indexOf(path.sep + 'src' + path.sep);
     if (idx > 0) {
       const name = id.substring(idx + 5, id.lastIndexOf('.'));
 


### PR DESCRIPTION
Fixes #18294 and https://github.com/grafana/simple-react-panel/issues/2

This uses `path.sep` rather than `/` to identify the path

