### PR TITLE
CircleCi: Fix failing end to end tests job for release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
   end-to-end-test-release:
       docker:
         - image: circleci/node:10-browsers
-        - image: grafana/grafana:$CIRCLE_TAG
+        - image: grafana/grafana-dev:$CIRCLE_TAG
       steps:
           - run: dockerize -wait tcp://127.0.0.1:3000 -timeout 120s
           - checkout

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -67,6 +67,8 @@ fi
 # Tag as 'latest' for official release; otherwise tag as grafana/grafana:master
 if echo "$_grafana_tag" | grep -q "^v"; then
 	docker_tag_all "${_docker_repo}" "latest"
+	# Create the expected tag for running the end to end tests successfully
+	docker tag "${_docker_repo}:${_grafana_version}" "grafana/grafana-dev:${_grafana_tag}"
 else
 	docker_tag_all "${_docker_repo}" "master"
 	docker tag "${_docker_repo}:${_grafana_version}" "grafana/grafana-dev:${_grafana_version}"

--- a/packaging/docker/push_to_docker_hub.sh
+++ b/packaging/docker/push_to_docker_hub.sh
@@ -38,8 +38,14 @@ if echo "$_grafana_tag" | grep -q "^v" && echo "$_grafana_tag" | grep -vq "beta"
 	echo "pushing ${_docker_repo}:latest"
 	docker_push_all "${_docker_repo}" "latest"
 	docker_push_all "${_docker_repo}" "${_grafana_version}"
+	# Push to the grafana-dev repository with the expected tag
+	# for running the end to end tests successfully
+	docker push "grafana/grafana-dev:${_grafana_tag}"
 elif echo "$_grafana_tag" | grep -q "^v" && echo "$_grafana_tag" | grep -q "beta"; then
 	docker_push_all "${_docker_repo}" "${_grafana_version}"
+	# Push to the grafana-dev repository with the expected tag
+	# for running the end to end tests successfully
+	docker push "grafana/grafana-dev:${_grafana_tag}"
 elif echo "$_grafana_tag" | grep -q "master"; then
 	docker_push_all "${_docker_repo}" "master"
 	docker push "grafana/grafana-dev:${_grafana_version}"


### PR DESCRIPTION
Create and push the expected tag to `grafana-dev` repository and use this instead for running the end to end tests for the release.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The end to end tests used to fail to run in the release flow. The reason is that the image tag does not contain the v (in v6.3.0-beta2).

**Which issue(s) this PR fixes**:
As a workaround a new docker tag prefixed with `v` is created and pushed to `grafana-dev` repository and it is used instead for running the job.

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18280

**Special notes for your reviewer**:
Warning: since the modifications are in the release workflow I haven't test them properly in action!

