### PR TITLE
Keybindings: Disable on login url

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -39,7 +39,7 @@ export class KeybindingSrv {
   }
 
   setupGlobal() {
-    if (this.contextSrv.user.isSignedIn) {
+    if (!(this.$location.path() === '/login')) {
       this.bind(['?', 'h'], this.showHelpModal);
       this.bind('g h', this.goToHome);
       this.bind('g a', this.openAlerting);


### PR DESCRIPTION
**What this PR does / why we need it**:
#18243

Disables keybindings based on URL rather than if user is logged in. That way they are enabled for anonymous users. See #18271