### PR TITLE
Frontend: Fixes flakey text edit mode toggle

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -83,7 +83,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     this.setState({
       datasource,
       loadedDataSourceValue: this.props.dataSourceValue,
-      hasTextEditMode: false,
+      hasTextEditMode: _.has(datasource, 'components.QueryCtrl.prototype.toggleEditorMode'),
     });
   }
 
@@ -122,14 +122,8 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     const loader = getAngularLoader();
     const template = '<plugin-component type="query-ctrl" />';
     const scopeProps = { ctrl: this.getAngularQueryComponentScope() };
-
     this.angularQueryEditor = loader.load(this.element, scopeProps, template);
     this.angularScope = scopeProps.ctrl;
-
-    // give angular time to compile
-    setTimeout(() => {
-      this.setState({ hasTextEditMode: !!this.angularScope.toggleEditorMode });
-    }, 100);
   }
 
   onToggleCollapse = () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the text edit mode toggle was sometimes not appearing.

**Which issue(s) this PR fixes**:
Closes #18037

