### PR TITLE
Frontend: Fixes progress tracker close button to use `$link-hover-color`

### DIFF
--- a/public/sass/components/_panel_gettingstarted.scss
+++ b/public/sass/components/_panel_gettingstarted.scss
@@ -30,7 +30,7 @@ $path-position: $marker-size-half - ($path-height / 2);
   border: none;
 
   &:hover {
-    color: $white;
+    color: $link-hover-color;
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes progress tracker close button to use `$link-hover-color` rather than `$white` on hover, which rendered the close icon invisible using the light theme.