### PR TITLE
FieldDisplay: Fixes issue with Gauge & Bar Gauge when query returns no data 

### DIFF
--- a/packages/grafana-ui/src/utils/fieldDisplay.test.ts
+++ b/packages/grafana-ui/src/utils/fieldDisplay.test.ts
@@ -135,4 +135,30 @@ describe('FieldDisplay', () => {
     expect(field.thresholds!.length).toEqual(2);
     expect(field.thresholds![0].value).toBe(-Infinity);
   });
+
+  it('Should return field thresholds when there is no data', () => {
+    const options: GetFieldDisplayValuesOptions = {
+      data: [
+        {
+          name: 'No data',
+          fields: [],
+          rows: [],
+        },
+      ],
+      replaceVariables: (value: string) => {
+        return value;
+      },
+      fieldOptions: {
+        calcs: [],
+        override: {},
+        defaults: {
+          thresholds: [{ color: '#F2495C', value: 50 }],
+        },
+      },
+      theme: getTheme(GrafanaThemeType.Dark),
+    };
+
+    const display = getFieldDisplayValues(options);
+    expect(display[0].field.thresholds!.length).toEqual(1);
+  });
 });

--- a/packages/grafana-ui/src/utils/fieldDisplay.ts
+++ b/packages/grafana-ui/src/utils/fieldDisplay.ts
@@ -182,7 +182,10 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
 
   if (values.length === 0) {
     values.push({
-      field: { name: 'No Data' },
+      field: {
+        ...defaults,
+        name: 'No Data',
+      },
       display: {
         numeric: 0,
         text: 'No data',
@@ -244,6 +247,7 @@ type PartialField = Partial<Field>;
 
 export function getFieldProperties(...props: PartialField[]): Field {
   let field = props[0] as Field;
+
   for (let i = 1; i < props.length; i++) {
     field = applyFieldProperties(field, props[i]);
   }


### PR DESCRIPTION
When there was no data the field defaults were not returned. 

Currently, the Gauge & BarGauge expects there to be thresholds. Not sure what we should do long term here. 

Similar issue with https://github.com/grafana/grafana/pull/18353 where the mappings array was undefined but that was not supported in ValueMappingsEditor. Technically the Field type allows both mappings & thresholds to be undefined but there is no code in the panel to handle that nor in the field display processing (to add defaults if they are missing). 

Fixes #18351