### PR TITLE
SignIn: Update redirect on reroute

### DIFF
--- a/public/app/core/components/sidemenu/SignIn.test.tsx
+++ b/public/app/core/components/sidemenu/SignIn.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import SignIn from './SignIn';
+import { SignIn } from './SignIn';
 
 describe('Render', () => {
   it('should render component', () => {
-    const wrapper = shallow(<SignIn />);
+    const wrapper = shallow(<SignIn url="/" />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/public/app/core/components/sidemenu/SignIn.tsx
+++ b/public/app/core/components/sidemenu/SignIn.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react';
+import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
+import { StoreState } from 'app/types';
 
-const SignIn: FC<any> = () => {
-  const loginUrl = `login?redirect=${encodeURIComponent(window.location.pathname)}`;
+const SignIn: FC<any> = ({ url }) => {
+  const loginUrl = `login?redirect=${encodeURIComponent(url)}`;
   return (
     <div className="sidemenu-item">
       <a href={loginUrl} className="sidemenu-link" target="_self">
@@ -20,4 +22,8 @@ const SignIn: FC<any> = () => {
   );
 };
 
-export default SignIn;
+const mapStateToProps = (state: StoreState) => ({
+  url: state.location.url,
+});
+
+export default connectWithStore(SignIn, mapStateToProps);

--- a/public/app/core/components/sidemenu/SignIn.tsx
+++ b/public/app/core/components/sidemenu/SignIn.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
 import { StoreState } from 'app/types';
 
-const SignIn: FC<any> = ({ url }) => {
+export const SignIn: FC<any> = ({ url }) => {
   const loginUrl = `login?redirect=${encodeURIComponent(url)}`;
   return (
     <div className="sidemenu-item">

--- a/public/app/core/components/sidemenu/__snapshots__/BottomSection.test.tsx.snap
+++ b/public/app/core/components/sidemenu/__snapshots__/BottomSection.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Render should render component 1`] = `
 <div
   className="sidemenu__bottom"
 >
-  <SignIn />
+  <Component />
   <BottomNavLinks
     key="undefined-0"
     link={


### PR DESCRIPTION
Fixes #16552

Previously the link was only generated on page reload. I connected the component to Redux to solve this. Tested with Apache proxy.
