### PR TITLE
Gauge/BarGauge: Rewrite of how migrations are applied

### DIFF
--- a/devenv/dev-dashboards/panel-gauge/gauge_tests.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests.json
@@ -44,7 +44,7 @@
       "nullPointMode": "null",
       "options-gauge": {
         "baseColor": "#299c46",
-        "decimals": "2",
+        "decimals": 2,
         "maxValue": 100,
         "minValue": 0,
         "options": {
@@ -111,7 +111,7 @@
       "nullPointMode": "null",
       "options-gauge": {
         "baseColor": "#299c46",
-        "decimals": "",
+        "decimals": null,
         "maxValue": 100,
         "minValue": 0,
         "options": {
@@ -178,7 +178,7 @@
       "nullPointMode": "null",
       "options-gauge": {
         "baseColor": "#299c46",
-        "decimals": "",
+        "decimals": null,
         "maxValue": 100,
         "minValue": 0,
         "options": {

--- a/packages/grafana-data/src/utils/fieldReducer.ts
+++ b/packages/grafana-data/src/utils/fieldReducer.ts
@@ -104,7 +104,7 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
     name: 'Last (not null)',
     description: 'Last non-null value',
     standard: true,
-    alias: 'current',
+    aliasIds: ['current'],
     reduce: calculateLastNotNull,
   },
   {
@@ -124,14 +124,14 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
   },
   { id: ReducerID.min, name: 'Min', description: 'Minimum Value', standard: true },
   { id: ReducerID.max, name: 'Max', description: 'Maximum Value', standard: true },
-  { id: ReducerID.mean, name: 'Mean', description: 'Average Value', standard: true, alias: 'avg' },
+  { id: ReducerID.mean, name: 'Mean', description: 'Average Value', standard: true, aliasIds: ['avg'] },
   {
     id: ReducerID.sum,
     name: 'Total',
     description: 'The sum of all values',
     emptyInputResult: 0,
     standard: true,
-    alias: 'total',
+    aliasIds: ['total'],
   },
   {
     id: ReducerID.count,

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -1,0 +1,39 @@
+import { sharedSingleStatMigrationCheck } from './SingleStatBaseOptions';
+
+describe('sharedSingleStatMigrationCheck', () => {
+  it('from old valueOptions model without pluginVersion', () => {
+    const panel = {
+      options: {
+        valueOptions: {
+          unit: 'watt',
+          stat: 'last',
+          decimals: 5,
+        },
+        minValue: 10,
+        maxValue: 100,
+        valueMappings: [{ type: 1, value: '1', text: 'OK' }],
+        thresholds: [
+          {
+            color: 'green',
+            index: 0,
+            value: null,
+          },
+          {
+            color: 'orange',
+            index: 1,
+            value: 40,
+          },
+          {
+            color: 'red',
+            index: 2,
+            value: 80,
+          },
+        ],
+      },
+      title: 'Usage',
+      type: 'bargauge',
+    };
+
+    expect(sharedSingleStatMigrationCheck(panel as any)).toMatchSnapshot();
+  });
+});

--- a/packages/grafana-ui/src/components/SingleStatShared/__snapshots__/SingleStatBaseOptions.test.ts.snap
+++ b/packages/grafana-ui/src/components/SingleStatShared/__snapshots__/SingleStatBaseOptions.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sharedSingleStatMigrationCheck from old valueOptions model without pluginVersion 1`] = `
+Object {
+  "fieldOptions": Object {
+    "calcs": Array [
+      "last",
+    ],
+    "defaults": Object {
+      "decimals": 5,
+      "mappings": Array [
+        Object {
+          "text": "OK",
+          "type": 1,
+          "value": "1",
+        },
+      ],
+      "max": 100,
+      "min": 10,
+      "thresholds": Array [
+        Object {
+          "color": "green",
+          "value": -Infinity,
+        },
+        Object {
+          "color": "orange",
+          "value": 40,
+        },
+        Object {
+          "color": "red",
+          "value": 80,
+        },
+      ],
+      "unit": "watt",
+    },
+  },
+}
+`;

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -152,8 +152,6 @@ export class PanelChrome extends PureComponent<Props, State> {
   onRefresh = () => {
     const { panel, isInView, width } = this.props;
 
-    console.log('onRefresh', panel.id);
-
     if (!isInView) {
       console.log('Refresh when panel is visible', panel.id);
       this.setState({ refreshWhenInView: true });

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -247,8 +247,6 @@ export class PanelModel {
   pluginLoaded(plugin: PanelPlugin) {
     this.plugin = plugin;
 
-    this.applyPluginOptionDefaults(plugin);
-
     if (plugin.panel && plugin.onPanelMigration) {
       const version = getPluginVersion(plugin);
       if (version !== this.pluginVersion) {
@@ -256,6 +254,8 @@ export class PanelModel {
         this.pluginVersion = version;
       }
     }
+
+    this.applyPluginOptionDefaults(plugin);
   }
 
   changePlugin(newPlugin: PanelPlugin) {

--- a/public/app/plugins/panel/bargauge/BarGaugeMigrations.test.ts
+++ b/public/app/plugins/panel/bargauge/BarGaugeMigrations.test.ts
@@ -40,18 +40,7 @@ describe('BarGauge Panel Migrations', () => {
         orientation: 'vertical',
       },
       pluginVersion: '6.2.0',
-      targets: [
-        {
-          refId: 'A',
-          scenarioId: 'random_walk',
-        },
-        {
-          refId: 'B',
-          scenarioId: 'random_walk',
-        },
-      ],
-      timeFrom: null,
-      timeShift: null,
+      targets: [],
       title: 'Usage',
       type: 'bargauge',
     } as PanelModel;

--- a/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
+++ b/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
@@ -1,36 +1,7 @@
 import { PanelModel } from '@grafana/ui';
-import {
-  sharedSingleStatMigrationCheck,
-  migrateOldThresholds,
-} from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
+import { sharedSingleStatMigrationCheck } from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
 import { BarGaugeOptions } from './types';
 
 export const barGaugePanelMigrationCheck = (panel: PanelModel<BarGaugeOptions>): Partial<BarGaugeOptions> => {
-  if (!panel.options) {
-    // This happens on the first load or when migrating from angular
-    return {};
-  }
-
-  // Move thresholds to field
-  const previousVersion = panel.pluginVersion || '';
-  if (previousVersion.startsWith('6.2') || previousVersion.startsWith('6.3')) {
-    console.log('TRANSFORM', panel.options);
-    const old = panel.options as any;
-    const { fieldOptions } = old;
-    if (fieldOptions) {
-      const { mappings, thresholds, ...rest } = fieldOptions;
-      rest.defaults = {
-        mappings,
-        thresholds: migrateOldThresholds(thresholds),
-        ...rest.defaults,
-      };
-      return {
-        ...old,
-        fieldOptions: rest,
-      };
-    }
-  }
-
-  // Default to the standard migration path
   return sharedSingleStatMigrationCheck(panel);
 };

--- a/public/app/plugins/panel/gauge/GaugeMigrations.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.ts
@@ -1,60 +1,7 @@
-import { Field, fieldReducers } from '@grafana/data';
-import { PanelModel, FieldDisplayOptions } from '@grafana/ui';
+import { PanelModel } from '@grafana/ui';
 import { GaugeOptions } from './types';
-import {
-  sharedSingleStatMigrationCheck,
-  migrateOldThresholds,
-} from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
+import { sharedSingleStatMigrationCheck } from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
 
 export const gaugePanelMigrationCheck = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
-  if (!panel.options) {
-    // This happens on the first load or when migrating from angular
-    return {};
-  }
-
-  const previousVersion = panel.pluginVersion || '';
-  if (!previousVersion || previousVersion.startsWith('6.1')) {
-    const old = panel.options as any;
-    const { valueOptions } = old;
-
-    const options = {} as GaugeOptions;
-    options.showThresholdLabels = old.showThresholdLabels;
-    options.showThresholdMarkers = old.showThresholdMarkers;
-    options.orientation = old.orientation;
-
-    const fieldOptions = (options.fieldOptions = {} as FieldDisplayOptions);
-
-    const field = (fieldOptions.defaults = {} as Field);
-    field.mappings = old.valueMappings;
-    field.thresholds = migrateOldThresholds(old.thresholds);
-    field.unit = valueOptions.unit;
-    field.decimals = valueOptions.decimals;
-
-    // Make sure the stats have a valid name
-    if (valueOptions.stat) {
-      fieldOptions.calcs = [fieldReducers.get(valueOptions.stat).id];
-    }
-    field.min = old.minValue;
-    field.max = old.maxValue;
-
-    return options;
-  } else if (previousVersion.startsWith('6.2') || previousVersion.startsWith('6.3')) {
-    const old = panel.options as any;
-    const { fieldOptions } = old;
-    if (fieldOptions) {
-      const { mappings, thresholds, ...rest } = fieldOptions;
-      rest.default = {
-        mappings,
-        thresholds: migrateOldThresholds(thresholds),
-        ...rest.defaults,
-      };
-      return {
-        ...old.options,
-        fieldOptions: rest,
-      };
-    }
-  }
-
-  // Default to the standard migration path
   return sharedSingleStatMigrationCheck(panel);
 };


### PR DESCRIPTION
Discovered a couple of issues with the panel migration logic that made the logic more complex than needed. 

1) Main problem I identified was that the migration code tried to jump (do) multiple migrations in one step and then directly returning. Instead of just doing a single migration, then letting subsequent migrations take place. The later process allowed for simpler logic and more reuse. 

For example the change from valueOptions -> fieldOptions should not also move thresholds to field defaults. That is a separate migration action.

2 ) Also moved so that panel defaults are applied after the migrations take place as I think this is better and makes the migration less error prone as "new defaults" could make the panel option state inconsistent. 

For example:

{
 ..old model from 6.1
}

Apply new defaults from 6.2 

Migration to 6.2 

The new defaults applied before migration will leave options in an inconsistent & mixed state with parts from 6.1 and defaults from 6.2. So moved the so that panel defaults are applied after migration.  

3) Also parsed pluginVersion to a float this greatly simplifies the logic of what migrations to apply. "6.2.1" is parsed as **6.2** so could be a problem in the future if we need to a do a migration only for a patch version but that feels like something we can avoid. 

4) the actual bug of lost thresholds was caused by defaults being copied over the migrated thresholds. https://github.com/grafana/grafana/blob/master/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts#L25  And because panel defaults are applied before migration the field { defaults } contained the default thresholds and was hence overwriting the newly migrated thresholds. 

Fixes #18371  (lost thresholds)
Fixes #18372  (avg reducer not found due to field reducer alias not working)  