### PR TITLE
Explore: Fixes incorrect handling of utc in timeEpic

### DIFF
--- a/packages/grafana-data/src/utils/datemath.ts
+++ b/packages/grafana-data/src/utils/datemath.ts
@@ -1,6 +1,6 @@
 import includes from 'lodash/includes';
 import isDate from 'lodash/isDate';
-import { DateTime, dateTime, dateTimeFromTimeZone, ISO_8601, isDateTime, DurationUnit } from './moment_wrapper';
+import { DateTime, dateTime, dateTimeForTimeZone, ISO_8601, isDateTime, DurationUnit } from './moment_wrapper';
 import { TimeZone } from '../types';
 
 const units: DurationUnit[] = ['y', 'M', 'w', 'd', 'h', 'm', 's'];
@@ -45,7 +45,7 @@ export function parse(text: string | DateTime | Date, roundUp?: boolean, timezon
     let parseString;
 
     if (text.substring(0, 3) === 'now') {
-      time = dateTimeFromTimeZone(timezone);
+      time = dateTimeForTimeZone(timezone);
       mathString = text.substring('now'.length);
     } else {
       index = text.indexOf('||');

--- a/packages/grafana-data/src/utils/datemath.ts
+++ b/packages/grafana-data/src/utils/datemath.ts
@@ -1,6 +1,6 @@
 import includes from 'lodash/includes';
 import isDate from 'lodash/isDate';
-import { DateTime, dateTime, toUtc, ISO_8601, isDateTime, DurationUnit } from './moment_wrapper';
+import { DateTime, dateTime, dateTimeFromTimeZone, ISO_8601, isDateTime, DurationUnit } from './moment_wrapper';
 import { TimeZone } from '../types';
 
 const units: DurationUnit[] = ['y', 'M', 'w', 'd', 'h', 'm', 's'];
@@ -45,11 +45,7 @@ export function parse(text: string | DateTime | Date, roundUp?: boolean, timezon
     let parseString;
 
     if (text.substring(0, 3) === 'now') {
-      if (timezone === 'utc') {
-        time = toUtc();
-      } else {
-        time = dateTime();
-      }
+      time = dateTimeFromTimeZone(timezone);
       mathString = text.substring('now'.length);
     } else {
       index = text.indexOf('||');

--- a/packages/grafana-data/src/utils/moment_wrapper.ts
+++ b/packages/grafana-data/src/utils/moment_wrapper.ts
@@ -98,7 +98,7 @@ export const dateTime = (input?: DateTimeInput, formatInput?: FormatInput): Date
   return moment(input as MomentInput, formatInput) as DateTime;
 };
 
-export const dateTimeFromTimeZone = (
+export const dateTimeForTimeZone = (
   timezone?: TimeZone,
   input?: DateTimeInput,
   formatInput?: FormatInput

--- a/packages/grafana-data/src/utils/moment_wrapper.ts
+++ b/packages/grafana-data/src/utils/moment_wrapper.ts
@@ -1,3 +1,4 @@
+import { TimeZone } from '../types/time';
 /* tslint:disable:import-blacklist ban ban-types */
 import moment, { MomentInput, DurationInputArg1 } from 'moment';
 
@@ -95,4 +96,16 @@ export const toDuration = (input?: DurationInput, unit?: DurationUnit): DateTime
 
 export const dateTime = (input?: DateTimeInput, formatInput?: FormatInput): DateTime => {
   return moment(input as MomentInput, formatInput) as DateTime;
+};
+
+export const dateTimeFromTimeZone = (
+  timezone?: TimeZone,
+  input?: DateTimeInput,
+  formatInput?: FormatInput
+): DateTime => {
+  if (timezone === 'utc') {
+    return toUtc(input, formatInput);
+  }
+
+  return dateTime(input, formatInput);
 };

--- a/packages/grafana-ui/src/components/TimePicker/time.ts
+++ b/packages/grafana-ui/src/components/TimePicker/time.ts
@@ -8,7 +8,7 @@ import {
   isDateTime,
   dateTime,
   DateTime,
-  dateTimeFromTimeZone,
+  dateTimeForTimeZone,
 } from '@grafana/data';
 
 export const rawToTimeRange = (raw: RawTimeRange, timeZone?: TimeZone): TimeRange => {
@@ -32,7 +32,7 @@ export const stringToDateTimeType = (value: string | DateTime, roundUp?: boolean
     return parsed || dateTime();
   }
 
-  return dateTimeFromTimeZone(timeZone, value, TIME_FORMAT);
+  return dateTimeForTimeZone(timeZone, value, TIME_FORMAT);
 };
 
 export const mapTimeRangeToRangeString = (timeRange: RawTimeRange): string => {

--- a/packages/grafana-ui/src/components/TimePicker/time.ts
+++ b/packages/grafana-ui/src/components/TimePicker/time.ts
@@ -8,7 +8,7 @@ import {
   isDateTime,
   dateTime,
   DateTime,
-  toUtc,
+  dateTimeFromTimeZone,
 } from '@grafana/data';
 
 export const rawToTimeRange = (raw: RawTimeRange, timeZone?: TimeZone): TimeRange => {
@@ -32,11 +32,7 @@ export const stringToDateTimeType = (value: string | DateTime, roundUp?: boolean
     return parsed || dateTime();
   }
 
-  if (timeZone === 'utc') {
-    return toUtc(value, TIME_FORMAT);
-  }
-
-  return dateTime(value, TIME_FORMAT);
+  return dateTimeFromTimeZone(timeZone, value, TIME_FORMAT);
 };
 
 export const mapTimeRangeToRangeString = (timeRange: RawTimeRange): string => {

--- a/public/app/features/explore/ExploreTimeControls.tsx
+++ b/public/app/features/explore/ExploreTimeControls.tsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 
 // Types
 import { ExploreId } from 'app/types';
-import { TimeRange, TimeOption, TimeZone, toUtc, dateTime, RawTimeRange } from '@grafana/data';
+import { TimeRange, TimeOption, TimeZone, RawTimeRange, dateTimeFromTimeZone } from '@grafana/data';
 
 // State
 
@@ -32,8 +32,8 @@ export class ExploreTimeControls extends Component<Props> {
     const { range, onChangeTime, timeZone } = this.props;
     const { from, to } = getShiftedTimeRange(direction, range);
     const nextTimeRange = {
-      from: timeZone === 'utc' ? toUtc(from) : dateTime(from),
-      to: timeZone === 'utc' ? toUtc(to) : dateTime(to),
+      from: dateTimeFromTimeZone(timeZone, from),
+      to: dateTimeFromTimeZone(timeZone, to),
     };
 
     onChangeTime(nextTimeRange);
@@ -50,8 +50,8 @@ export class ExploreTimeControls extends Component<Props> {
     const { range, onChangeTime, timeZone } = this.props;
     const { from, to } = getZoomedTimeRange(range, 2);
     const nextTimeRange = {
-      from: timeZone === 'utc' ? toUtc(from) : dateTime(from),
-      to: timeZone === 'utc' ? toUtc(to) : dateTime(to),
+      from: dateTimeFromTimeZone(timeZone, from),
+      to: dateTimeFromTimeZone(timeZone, to),
     };
 
     onChangeTime(nextTimeRange);

--- a/public/app/features/explore/ExploreTimeControls.tsx
+++ b/public/app/features/explore/ExploreTimeControls.tsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 
 // Types
 import { ExploreId } from 'app/types';
-import { TimeRange, TimeOption, TimeZone, RawTimeRange, dateTimeFromTimeZone } from '@grafana/data';
+import { TimeRange, TimeOption, TimeZone, RawTimeRange, dateTimeForTimeZone } from '@grafana/data';
 
 // State
 
@@ -32,8 +32,8 @@ export class ExploreTimeControls extends Component<Props> {
     const { range, onChangeTime, timeZone } = this.props;
     const { from, to } = getShiftedTimeRange(direction, range);
     const nextTimeRange = {
-      from: dateTimeFromTimeZone(timeZone, from),
-      to: dateTimeFromTimeZone(timeZone, to),
+      from: dateTimeForTimeZone(timeZone, from),
+      to: dateTimeForTimeZone(timeZone, to),
     };
 
     onChangeTime(nextTimeRange);
@@ -50,8 +50,8 @@ export class ExploreTimeControls extends Component<Props> {
     const { range, onChangeTime, timeZone } = this.props;
     const { from, to } = getZoomedTimeRange(range, 2);
     const nextTimeRange = {
-      from: dateTimeFromTimeZone(timeZone, from),
-      to: dateTimeFromTimeZone(timeZone, to),
+      from: dateTimeForTimeZone(timeZone, from),
+      to: dateTimeForTimeZone(timeZone, to),
     };
 
     onChangeTime(nextTimeRange);

--- a/public/app/features/explore/state/epics/timeEpic.test.ts
+++ b/public/app/features/explore/state/epics/timeEpic.test.ts
@@ -62,7 +62,7 @@ describe('timeEpic', () => {
             .thenDependencyWasCalledTimes(1, 'getTimeSrv', 'init')
             .thenDependencyWasCalledTimes(1, 'getTimeRange')
             .thenDependencyWasCalledWith([DefaultTimeZone, { from: null, to: null }], 'getTimeRange')
-            .thenDependencyWasCalledTimes(2, 'dateTime')
+            .thenDependencyWasCalledTimes(2, 'dateTimeFromTimeZone')
             .thenResultingActionsEqual(
               changeRangeAction({
                 exploreId,

--- a/public/app/features/explore/state/epics/timeEpic.test.ts
+++ b/public/app/features/explore/state/epics/timeEpic.test.ts
@@ -62,7 +62,7 @@ describe('timeEpic', () => {
             .thenDependencyWasCalledTimes(1, 'getTimeSrv', 'init')
             .thenDependencyWasCalledTimes(1, 'getTimeRange')
             .thenDependencyWasCalledWith([DefaultTimeZone, { from: null, to: null }], 'getTimeRange')
-            .thenDependencyWasCalledTimes(2, 'dateTimeFromTimeZone')
+            .thenDependencyWasCalledTimes(2, 'dateTimeForTimeZone')
             .thenResultingActionsEqual(
               changeRangeAction({
                 exploreId,

--- a/public/app/features/explore/state/epics/timeEpic.ts
+++ b/public/app/features/explore/state/epics/timeEpic.ts
@@ -10,7 +10,7 @@ import { EpicDependencies } from 'app/store/configureStore';
 export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDependencies> = (
   action$,
   state$,
-  { getTimeSrv, getTimeRange, getTimeZone, dateTimeFromTimeZone }
+  { getTimeSrv, getTimeRange, getTimeZone, dateTimeForTimeZone }
 ) => {
   return action$.ofType(updateTimeRangeAction.type).pipe(
     map((action: ActionOf<UpdateTimeRangePayload>) => {
@@ -22,8 +22,8 @@ export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDepend
 
       if (absRange) {
         rawRange = {
-          from: dateTimeFromTimeZone(timeZone, absRange.from),
-          to: dateTimeFromTimeZone(timeZone, absRange.to),
+          from: dateTimeForTimeZone(timeZone, absRange.from),
+          to: dateTimeForTimeZone(timeZone, absRange.to),
         };
       }
 

--- a/public/app/features/explore/state/epics/timeEpic.ts
+++ b/public/app/features/explore/state/epics/timeEpic.ts
@@ -5,11 +5,12 @@ import { AbsoluteTimeRange, RawTimeRange } from '@grafana/data';
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
 import { StoreState } from 'app/types/store';
 import { updateTimeRangeAction, UpdateTimeRangePayload, changeRangeAction } from '../actionTypes';
+import { EpicDependencies } from 'app/store/configureStore';
 
-export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = (
+export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState, EpicDependencies> = (
   action$,
   state$,
-  { getTimeSrv, getTimeRange, getTimeZone, toUtc, dateTime }
+  { getTimeSrv, getTimeRange, getTimeZone, dateTimeFromTimeZone }
 ) => {
   return action$.ofType(updateTimeRangeAction.type).pipe(
     map((action: ActionOf<UpdateTimeRangePayload>) => {
@@ -21,8 +22,8 @@ export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = (
 
       if (absRange) {
         rawRange = {
-          from: timeZone.isUtc ? toUtc(absRange.from) : dateTime(absRange.from),
-          to: timeZone.isUtc ? toUtc(absRange.to) : dateTime(absRange.to),
+          from: dateTimeFromTimeZone(timeZone, absRange.from),
+          to: dateTimeFromTimeZone(timeZone, absRange.to),
         };
       }
 
@@ -36,7 +37,7 @@ export const timeEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState> = (
       getTimeSrv().init({
         time: range.raw,
         refresh: false,
-        getTimezone: () => timeZone.raw,
+        getTimezone: () => timeZone,
         timeRangeUpdated: (): any => undefined,
       });
 

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -37,9 +37,8 @@ import {
   DateTimeInput,
   FormatInput,
   DateTime,
-  toUtc,
-  dateTime,
   AbsoluteTimeRange,
+  dateTimeFromTimeZone,
 } from '@grafana/data';
 import { Observable } from 'rxjs';
 import { getQueryResponse } from 'app/core/utils/explore';
@@ -90,9 +89,8 @@ export interface EpicDependencies {
   getTimeSrv: () => TimeSrv;
   getTimeRange: (timeZone: TimeZone, rawRange: RawTimeRange) => TimeRange;
   getTimeZone: (state: UserState) => TimeZone;
-  toUtc: (input?: DateTimeInput, formatInput?: FormatInput) => DateTime;
-  dateTime: (input?: DateTimeInput, formatInput?: FormatInput) => DateTime;
   getShiftedTimeRange: (direction: number, origRange: TimeRange, timeZone: TimeZone) => AbsoluteTimeRange;
+  dateTimeFromTimeZone: (timezone?: TimeZone, input?: DateTimeInput, formatInput?: FormatInput) => DateTime;
 }
 
 const dependencies: EpicDependencies = {
@@ -100,9 +98,8 @@ const dependencies: EpicDependencies = {
   getTimeSrv,
   getTimeRange,
   getTimeZone,
-  toUtc,
-  dateTime,
   getShiftedTimeRange,
+  dateTimeFromTimeZone,
 };
 
 const epicMiddleware = createEpicMiddleware({ dependencies });

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -38,7 +38,7 @@ import {
   FormatInput,
   DateTime,
   AbsoluteTimeRange,
-  dateTimeFromTimeZone,
+  dateTimeForTimeZone,
 } from '@grafana/data';
 import { Observable } from 'rxjs';
 import { getQueryResponse } from 'app/core/utils/explore';
@@ -90,7 +90,7 @@ export interface EpicDependencies {
   getTimeRange: (timeZone: TimeZone, rawRange: RawTimeRange) => TimeRange;
   getTimeZone: (state: UserState) => TimeZone;
   getShiftedTimeRange: (direction: number, origRange: TimeRange, timeZone: TimeZone) => AbsoluteTimeRange;
-  dateTimeFromTimeZone: (timezone?: TimeZone, input?: DateTimeInput, formatInput?: FormatInput) => DateTime;
+  dateTimeForTimeZone: (timezone?: TimeZone, input?: DateTimeInput, formatInput?: FormatInput) => DateTime;
 }
 
 const dependencies: EpicDependencies = {
@@ -99,7 +99,7 @@ const dependencies: EpicDependencies = {
   getTimeRange,
   getTimeZone,
   getShiftedTimeRange,
-  dateTimeFromTimeZone,
+  dateTimeForTimeZone,
 };
 
 const epicMiddleware = createEpicMiddleware({ dependencies });

--- a/public/test/core/redux/epicTester.ts
+++ b/public/test/core/redux/epicTester.ts
@@ -54,7 +54,7 @@ export const epicTester = (
 
   const getTimeZone = jest.fn().mockReturnValue(DefaultTimeZone);
 
-  const dateTimeFromTimeZone = jest.fn().mockReturnValue(null);
+  const dateTimeForTimeZone = jest.fn().mockReturnValue(null);
 
   const defaultDependencies: EpicDependencies = {
     getQueryResponse,
@@ -62,7 +62,7 @@ export const epicTester = (
     getTimeRange,
     getTimeZone,
     getShiftedTimeRange,
-    dateTimeFromTimeZone,
+    dateTimeForTimeZone,
   };
 
   const theDependencies: EpicDependencies = { ...defaultDependencies, ...dependencies };

--- a/public/test/core/redux/epicTester.ts
+++ b/public/test/core/redux/epicTester.ts
@@ -54,18 +54,15 @@ export const epicTester = (
 
   const getTimeZone = jest.fn().mockReturnValue(DefaultTimeZone);
 
-  const toUtc = jest.fn().mockReturnValue(null);
-
-  const dateTime = jest.fn().mockReturnValue(null);
+  const dateTimeFromTimeZone = jest.fn().mockReturnValue(null);
 
   const defaultDependencies: EpicDependencies = {
     getQueryResponse,
     getTimeSrv,
     getTimeRange,
     getTimeZone,
-    toUtc,
-    dateTime,
     getShiftedTimeRange,
+    dateTimeFromTimeZone,
   };
 
   const theDependencies: EpicDependencies = { ...defaultDependencies, ...dependencies };


### PR DESCRIPTION
**What this PR does / why we need it**:
During a refactoring a while ago the timeZone prop was converted from object to string and because of missing typings this was not caught in timeEpic. This PR should fix both typings and the bug.

**Which issue(s) this PR fixes**:
Fixes #18385

**Special notes for your reviewer**:

