### PR TITLE
OAuth: return GitLab groups as a part of user info (enable team sync)

### DIFF
--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -116,3 +116,14 @@ api_url = https://gitlab.com/api/v4
 allowed_groups = example, foo/bar
 ```
 
+### Team Sync (Enterprise only)
+
+> Only available in Grafana Enterprise v6.4+
+
+With Team Sync you can map your GitLab groups to teams in Grafana so that your users will automatically be added to
+the correct teams. 
+
+Your GitLab groups can be referenced in the same way as `allowed_groups`, like `example` or `foo/bar`.
+
+[Learn more about Team Sync]({{< relref "auth/enhanced_ldap.md" >}})
+

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -35,12 +35,11 @@ func (s *SocialGitlab) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
-func (s *SocialGitlab) IsGroupMember(client *http.Client) bool {
+func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 	if len(s.allowedGroups) == 0 {
 		return true
 	}
 
-	groups := s.GetGroups(client)
 	for _, allowedGroup := range s.allowedGroups {
 		for _, group := range groups {
 			if group == allowedGroup {
@@ -128,14 +127,17 @@ func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 		return nil, fmt.Errorf("User %s is inactive", data.Username)
 	}
 
+	groups := s.GetGroups(client)
+
 	userInfo := &BasicUserInfo{
-		Id:    fmt.Sprintf("%d", data.Id),
-		Name:  data.Name,
-		Login: data.Username,
-		Email: data.Email,
+		Id:     fmt.Sprintf("%d", data.Id),
+		Name:   data.Name,
+		Login:  data.Username,
+		Email:  data.Email,
+		Groups: groups,
 	}
 
-	if !s.IsGroupMember(client) {
+	if !s.IsGroupMember(groups) {
 		return nil, ErrMissingGroupMembership
 	}
 

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -54,8 +54,8 @@ func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 func (s *SocialGitlab) GetGroups(client *http.Client) []string {
 	groups := make([]string, 0)
 
-	for groupsPage, url := s.GetGroupsPage(client, s.apiUrl+"/groups"); groupsPage != nil; groupsPage, url = s.GetGroupsPage(client, url) {
-		groups = append(groups, groupsPage...)
+	for page, url := s.GetGroupsPage(client, s.apiUrl+"/groups"); page != nil; page, url = s.GetGroupsPage(client, url) {
+		groups = append(groups, page...)
 	}
 
 	return groups


### PR DESCRIPTION
This PR enables team sync (Enterprise feature) for the GitLab OAuth. Group should be specified in the same way it's set in [allowed_groups](https://grafana.com/docs/auth/gitlab/#allowed-groups) OAuth option in config.
This is a part of https://github.com/grafana/grafana-enterprise/issues/59