### PR TITLE
e2e tests: Make pageObjects mandatory (strictNullChecks: true)

### DIFF
--- a/packages/grafana-toolkit/src/e2e/login.ts
+++ b/packages/grafana-toolkit/src/e2e/login.ts
@@ -7,9 +7,9 @@ export const login = async (page: Page) => {
   await loginPage.init(page);
   await loginPage.navigateTo();
 
-  await loginPage.pageObjects!.username.enter('admin');
-  await loginPage.pageObjects!.password.enter('admin');
-  await loginPage.pageObjects!.submit.click();
+  await loginPage.pageObjects.username.enter('admin');
+  await loginPage.pageObjects.password.enter('admin');
+  await loginPage.pageObjects.submit.click();
   await loginPage.waitForResponse();
 };
 

--- a/packages/grafana-toolkit/src/e2e/pageInfo.ts
+++ b/packages/grafana-toolkit/src/e2e/pageInfo.ts
@@ -25,11 +25,11 @@ type PageObjects<T> = { [P in keyof T]: T[P] };
 
 export interface TestPageConfig<T> {
   url?: string;
-  pageObjects?: PageObjects<T>;
+  pageObjects: PageObjects<T>;
 }
 
 export class TestPage<T> implements TestPageType<T> {
-  pageObjects?: PageObjects<T>;
+  pageObjects: PageObjects<T>;
   private page?: Page;
   private pageUrl?: string;
 

--- a/public/e2e-test/pages/datasources/dataSources.ts
+++ b/public/e2e-test/pages/datasources/dataSources.ts
@@ -4,4 +4,5 @@ export interface DataSourcesPage {}
 
 export const dataSourcesPage = new TestPage<DataSourcesPage>({
   url: '/datasources',
+  pageObjects: {},
 });


### PR DESCRIPTION
#18389 

**What this PR does / why we need it**:
Makes pageObjects mandatory. Pages that do not have any objects should be initiated with an empty object.