### PR TITLE
PanelLinks: Fix render issue when there is no panel description

### DIFF
--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -254,6 +254,10 @@ export class PanelCtrl {
       markdown = this.error || this.panel.description;
     }
 
+    if (!markdown) {
+      markdown = '';
+    }
+
     const linkSrv: LinkSrv = this.$injector.get('linkSrv');
     const templateSrv: TemplateSrv = this.$injector.get('templateSrv');
     const interpolatedMarkdown = templateSrv.replace(markdown, this.panel.scopedVars);

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -248,14 +248,10 @@ export class PanelCtrl {
   }
 
   getInfoContent(options: { mode: string }) {
-    let markdown = this.panel.description;
+    let markdown = this.panel.description || '';
 
     if (options.mode === 'tooltip') {
-      markdown = this.error || this.panel.description;
-    }
-
-    if (!markdown) {
-      markdown = '';
+      markdown = this.error || this.panel.description || '';
     }
 
     const linkSrv: LinkSrv = this.$injector.get('linkSrv');


### PR DESCRIPTION
Panel links would render improperly if there was no panel description. Set `markdown` to an empty string if this is the case, so it can be parsed.