### PR TITLE
Graphite: Avoid glob of single-value array variables 

### DIFF
--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -112,6 +112,23 @@ describe('templateSrv', () => {
       expect(target).toBe('this.{value1,value2}.filters');
     });
 
+    describe('when the globbed variable only has one value', () => {
+      beforeEach(() => {
+        initTemplateSrv([
+          {
+            type: 'query',
+            name: 'test',
+            current: { value: ['value1'] },
+          },
+        ]);
+      });
+
+      it('should not glob the value', () => {
+        const target = _templateSrv.replace('this.$test.filters', {}, 'glob');
+        expect(target).toBe('this.value1.filters');
+      });
+    });
+
     it('should replace ${test} with globbed value', () => {
       const target = _templateSrv.replace('this.${test}.filters', {}, 'glob');
       expect(target).toBe('this.{value1,value2}.filters');

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -172,7 +172,7 @@ export class TemplateSrv {
         return this.encodeURIComponentStrict(value);
       }
       default: {
-        if (_.isArray(value)) {
+        if (_.isArray(value) && value.length > 1) {
           return '{' + value.join(',') + '}';
         }
         return value;

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -453,6 +453,16 @@ export class GraphiteDatasource {
     return this.getFuncDefs();
   }
 
+  variableFormat(formatValue: Function) {
+    return (value: any, format: any, variable: any) => {
+      if (_.isArray(value) && value.length === 1) {
+        return value.join(',');
+      }
+
+      return formatValue(value, format, variable);
+    };
+  }
+
   getFuncDefs() {
     if (this.funcDefsPromise !== null) {
       return this.funcDefsPromise;
@@ -546,7 +556,8 @@ export class GraphiteDatasource {
         target.refId = this._seriesRefLetters[i];
       }
 
-      targetValue = this.templateSrv.replace(target.target, scopedVars);
+      const formatFn = this.variableFormat(this.templateSrv.formatValue);
+      targetValue = this.templateSrv.replace(target.target, scopedVars, formatFn);
       targetValue = targetValue.replace(intervalFormatFixRegex, fixIntervalFormat);
       targets[target.refId] = targetValue;
     }

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -453,16 +453,6 @@ export class GraphiteDatasource {
     return this.getFuncDefs();
   }
 
-  variableFormat(formatValue: Function) {
-    return (value: any, format: any, variable: any) => {
-      if (_.isArray(value) && value.length === 1) {
-        return value.join(',');
-      }
-
-      return formatValue(value, format, variable);
-    };
-  }
-
   getFuncDefs() {
     if (this.funcDefsPromise !== null) {
       return this.funcDefsPromise;
@@ -556,8 +546,7 @@ export class GraphiteDatasource {
         target.refId = this._seriesRefLetters[i];
       }
 
-      const formatFn = this.variableFormat(this.templateSrv.formatValue);
-      targetValue = this.templateSrv.replace(target.target, scopedVars, formatFn);
+      targetValue = this.templateSrv.replace(target.target, scopedVars);
       targetValue = targetValue.replace(intervalFormatFixRegex, fixIntervalFormat);
       targets[target.refId] = targetValue;
     }

--- a/public/app/plugins/datasource/graphite/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/datasource.test.ts
@@ -353,7 +353,7 @@ describe('graphiteDatasource', () => {
       expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/find');
       expect(requestOptions.method).toEqual('POST');
       expect(requestOptions.headers).toHaveProperty('Content-Type', 'application/x-www-form-urlencoded');
-      expect(requestOptions.data).toMatch(`query={bar}`);
+      expect(requestOptions.data).toMatch(`query=bar`);
       expect(requestOptions).toHaveProperty('params');
     });
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Based on our current implementation of templates, when multi-select
variables are part of a dashboard query the default/fallback formatting option is `glob`.

Some datasources do not support glob (e.g. metrics.{a}.* instead of
metrics.a.*) for single variable queries. This behaviour breaks dashboards.

This commit introduces an alternative formatting option where globing is avoided if it's there is only one value as part of the query variable.

This means, queries previously formatted as `query=metrics.{a}.*.*`, are
now formatted as `query=metrics.a.*.*`. However, queries formatted as
`query=metrics.{a,b}.*.*` continue to be as is.

![Screenshot 2019-08-06 at 18 47 53](https://user-images.githubusercontent.com/231583/62563325-bd1fa780-b87a-11e9-94ce-d059d235775c.png)

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #TBD

**Special notes for your reviewer**:

I'm not certain on whenever this is something simple to understand. I'm leaving a trail of my investigation/solution as part of the PR in case it proves useful for the future.

### Context and motivation

Assuming:
We have a variable `$metric` with a list of: `a,b,c`
A Graphite query of `test.$metric.*.*`
Metrics stored with a format of `test.a.a.a`, `test.b.a.a`, `test.c.a.a`, etc.

When selecting values from the Grafana variable within the dashboard, the query interpolated results in `test.{a}.*.*`, `test.{a,b}.*.*` or `test.{a,b,c}.*.*` depending on the selection. This behaviour is part of Grafana's [default glob format](https://grafana.com/docs/reference/templating/#glob
) as dictated by [Graphite's documention](https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards) on the section named "value list".

The main reason for this change is that single-value value lists are not supported as part of Graphite 0.9. Multi-value value lists are supported in 0.9 and above. 

### before

```
# example request request with one variable
INFO[08-06|16:57:12] Proxying incoming request                logger=data-proxy-log userid=1 orgid=1 username=admin datasource=graphite uri=/api/datasources/proxy/4/render method=POST body="target=test.%7Ba%7D.*.*&from=-30min&until=now&format=json&maxDataPoints=860"

# example request with multiple variables
INFO[08-06|17:01:25] Proxying incoming request                logger=data-proxy-log userid=1 orgid=1 username=admin datasource=graphite uri=/api/datasources/proxy/4/render method=POST body="target=test.%7Ba%2Cb%2Cc%7D.*.*&from=-30min&until=now&format=json&maxDataPoints=860"

```

### after
```
INFO[08-06|16:58:41] Proxying incoming request                logger=data-proxy-log userid=1 orgid=1 username=admin datasource=graphite uri=/api/datasources/proxy/4/render method=POST body="target=test.a.*.*&from=-30min&until=now&format=json&maxDataPoints=860"

INFO[08-06|16:59:35] Proxying incoming request                logger=data-proxy-log userid=1 orgid=1 username=admin datasource=graphite uri=/api/datasources/proxy/4/render method=POST body="target=test.%7Ba%2Cb%2Cc%7D.*.*&from=-30min&until=now&format=json&maxDataPoints=860"
```

TODO
- [x] explain the reasoning for using the real `TemplateSrv`