### PR TITLE
DataFrame: remove dateFormat from field

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -48,7 +48,6 @@ export interface Field {
   type?: FieldType;
   filterable?: boolean;
   unit?: string;
-  dateFormat?: string; // Source data format
   decimals?: number | null; // Significant digits (for display)
   min?: number | null;
   max?: number | null;

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -98,7 +98,6 @@ export class CSVReader {
               name: '#',
               type: FieldType.number,
               unit: '#',
-              dateFormat: '#',
             };
 
             // Check if it is a known/supported column

--- a/packages/grafana-ui/src/utils/displayValue.ts
+++ b/packages/grafana-ui/src/utils/displayValue.ts
@@ -1,15 +1,6 @@
 // Libraries
 import _ from 'lodash';
-import {
-  DateTime,
-  dateTime,
-  Threshold,
-  getMappedValue,
-  Field,
-  DecimalInfo,
-  DisplayValue,
-  DecimalCount,
-} from '@grafana/data';
+import { Threshold, getMappedValue, Field, DecimalInfo, DisplayValue, DecimalCount } from '@grafana/data';
 
 // Utils
 import { getValueFormat } from './valueFormats/valueFormats';
@@ -60,14 +51,6 @@ export function getDisplayProcessor(options?: DisplayValueOptions): DisplayProce
         }
       }
 
-      if (field.dateFormat) {
-        const date = toMoment(value, numeric, field.dateFormat);
-        if (date.isValid()) {
-          text = date.format(field.dateFormat);
-          shouldFormat = false;
-        }
-      }
-
       if (!isNaN(numeric)) {
         if (shouldFormat && !_.isBoolean(value)) {
           const { decimals, scaledDecimals } = getDecimalsForValue(value, field.decimals);
@@ -86,20 +69,6 @@ export function getDisplayProcessor(options?: DisplayValueOptions): DisplayProce
   }
 
   return toStringProcessor;
-}
-
-function toMoment(value: any, numeric: number, format: string): DateTime {
-  if (!isNaN(numeric)) {
-    const v = dateTime(numeric);
-    if (v.isValid()) {
-      return v;
-    }
-  }
-  const v = dateTime(value, format);
-  if (v.isValid) {
-    return v;
-  }
-  return dateTime(value); // moment will try to parse the format
 }
 
 /** Will return any value as a number or NaN */

--- a/packages/grafana-ui/src/utils/fieldDisplay.test.ts
+++ b/packages/grafana-ui/src/utils/fieldDisplay.test.ts
@@ -8,7 +8,6 @@ describe('FieldDisplay', () => {
     const f0 = {
       min: 0,
       max: 100,
-      dateFormat: 'YYYY',
     };
     const f1 = {
       unit: 'ms',
@@ -20,7 +19,6 @@ describe('FieldDisplay', () => {
     expect(field.min).toEqual(0);
     expect(field.max).toEqual(100);
     expect(field.unit).toEqual('ms');
-    expect(field.dateFormat).toEqual('YYYY');
 
     // last one overrieds
     const f2 = {


### PR DESCRIPTION
Field has a property `dateFormat` that was added when it was copied form properties in the [Table colum style](https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/Table/TableCellBuilder.tsx#L55)

This property is not used, and I think will cause confusion.  

We either want:

**A**. Something to format the date value for display.  I suggest something like #16038

or

**B**. Something to *parse* the string value into a Date.  For this, I think we need the setting to be more explicit, and maybe on something like a `schema` tag

Regardless, we should remove it since it is not used and add it when we know what is should be/do
