### PR TITLE
Markdown: Handle undefined/null strings

### DIFF
--- a/packages/grafana-data/src/utils/markdown.test.ts
+++ b/packages/grafana-data/src/utils/markdown.test.ts
@@ -1,0 +1,8 @@
+import { renderMarkdown } from './markdown';
+
+describe('Markdown wrapper', () => {
+  it('should be able to handle undefined value', () => {
+    const str = renderMarkdown(undefined);
+    expect(str).toBe('');
+  });
+});

--- a/packages/grafana-data/src/utils/markdown.ts
+++ b/packages/grafana-data/src/utils/markdown.ts
@@ -15,6 +15,6 @@ export function setMarkdownOptions(optionsOverride?: MarkedOptions) {
   marked.setOptions({ ...defaultMarkedOptions, ...optionsOverride });
 }
 
-export function renderMarkdown(str: string): string {
-  return marked(str);
+export function renderMarkdown(str?: string): string {
+  return marked(str || '');
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If `marked()` was called with an undefined or null string, it threw an exception. Now it just returns an empty string.

This fix is a more sustainable solution for #18430