### PR TITLE
grafana-ui: Fix `toTimeTicks` error

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.ts
@@ -295,7 +295,7 @@ export function toDurationInHoursMinutesSeconds(size: number) {
 }
 
 export function toTimeTicks(size: number, decimals: DecimalCount, scaledDecimals: DecimalCount) {
-  return toSeconds(size, decimals, scaledDecimals);
+  return toSeconds(size / 100, decimals, scaledDecimals);
 }
 
 export function toClockMilliseconds(size: number, decimals: DecimalCount) {


### PR DESCRIPTION
Unit `Timeticks` means 1/100 seconds. But in function `toTimeTicks`:
```typescript
// current code
export function toTimeTicks(size: number, decimals: DecimalCount, scaledDecimals: DecimalCount) {
  return toSeconds(size, decimals, scaledDecimals);
}
```
It forwards all parameters directly as it is to `toSeconds`, so in the current code, `toTimeTicks` equals to `toSeconds`

I think it must be a little mistake, and should be fixed:
```typescript
// fixed code
export function toTimeTicks(size: number, decimals: DecimalCount, scaledDecimals: DecimalCount) {
  return toSeconds(size / 100, decimals, scaledDecimals);
}
```
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fix a little error of `toTimeTicks`
**Which issue(s) this PR fixes**:
No issue.
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

