### PR TITLE
DataLinks: Use datapoint timestamp correctly when interpolating variables

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -132,7 +132,7 @@ export class LinkSrv implements LinkService {
     if (dataPoint) {
       info.href = this.templateSrv.replace(
         info.href,
-        this.getDataPointVars(dataPoint.seriesName, dateTime(dataPoint[0]))
+        this.getDataPointVars(dataPoint.seriesName, dateTime(dataPoint.datapoint[0]))
       );
     }
 

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -11,7 +11,7 @@ jest.mock('angular', () => {
 
 const dataPointMock = {
   seriesName: 'A-series',
-  datapoint: [1000000000, 1],
+  datapoint: [1000000001, 1],
 };
 
 describe('linkSrv', () => {
@@ -119,7 +119,7 @@ describe('linkSrv', () => {
           {},
           dataPointMock
         ).href
-      ).toEqual('/d/1?time=1000000000');
+      ).toEqual('/d/1?time=1000000001');
     });
   });
 });


### PR DESCRIPTION
Fixes #18457 