### PR TITLE
DataLinks: Respect timezone when displaying datapoint's timestamp in graph context menu

### DIFF
--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -77,6 +77,7 @@ export function registerAngularDirectives() {
     'items',
     ['onClose', { watchDepth: 'reference', wrapApply: true }],
     ['getContextMenuSource', { watchDepth: 'reference', wrapApply: true }],
+    ['formatSourceDate', { watchDepth: 'reference', wrapApply: true }],
   ]);
 
   // We keep the drilldown terminology here because of as using data-* directive

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -699,13 +699,13 @@ export class DashboardModel {
     return newPanel;
   }
 
-  formatDate(date: DateTimeInput, format?: string) {
+  formatDate = (date: DateTimeInput, format?: string) => {
     date = isDateTime(date) ? date : dateTime(date);
     format = format || 'YYYY-MM-DD HH:mm:ss';
     const timezone = this.getTimezone();
 
     return timezone === 'browser' ? dateTime(date).format(format) : toUtc(date).format(format);
-  }
+  };
 
   destroy() {
     this.events.removeAllListeners();

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -699,13 +699,13 @@ export class DashboardModel {
     return newPanel;
   }
 
-  formatDate = (date: DateTimeInput, format?: string) => {
+  formatDate(date: DateTimeInput, format?: string) {
     date = isDateTime(date) ? date : dateTime(date);
     format = format || 'YYYY-MM-DD HH:mm:ss';
     const timezone = this.getTimezone();
 
     return timezone === 'browser' ? dateTime(date).format(format) : toUtc(date).format(format);
-  };
+  }
 
   destroy() {
     this.events.removeAllListeners();

--- a/public/app/plugins/panel/graph/GraphContextMenu.tsx
+++ b/public/app/plugins/panel/graph/GraphContextMenu.tsx
@@ -1,14 +1,20 @@
 import React, { useContext } from 'react';
 import { FlotDataPoint } from './GraphContextMenuCtrl';
 import { ContextMenu, ContextMenuProps, SeriesIcon, ThemeContext } from '@grafana/ui';
-import { dateTime } from '@grafana/data';
+import { DateTimeInput } from '@grafana/data';
 import { css } from 'emotion';
 
 type GraphContextMenuProps = ContextMenuProps & {
   getContextMenuSource: () => FlotDataPoint | null;
+  formatSourceDate: (date: DateTimeInput, format?: string) => string;
 };
 
-export const GraphContextMenu: React.FC<GraphContextMenuProps> = ({ getContextMenuSource, items, ...otherProps }) => {
+export const GraphContextMenu: React.FC<GraphContextMenuProps> = ({
+  getContextMenuSource,
+  formatSourceDate,
+  items,
+  ...otherProps
+}) => {
   const theme = useContext(ThemeContext);
   const source = getContextMenuSource();
 
@@ -35,7 +41,7 @@ export const GraphContextMenu: React.FC<GraphContextMenuProps> = ({ getContextMe
               font-size: ${theme.typography.size.sm};
             `}
           >
-            <strong>{dateTime(source.datapoint[0]).format(timeFormat)}</strong>
+            <strong>{formatSourceDate(source.datapoint[0], timeFormat)}</strong>
             <div>
               <SeriesIcon color={source.series.color} />
               <span

--- a/public/app/plugins/panel/graph/GraphContextMenuCtrl.ts
+++ b/public/app/plugins/panel/graph/GraphContextMenuCtrl.ts
@@ -65,6 +65,7 @@ export class GraphContextMenuCtrl {
   setSource = (source: FlotDataPoint | null) => {
     this.source = source;
   };
+
   getSource = () => {
     return this.source;
   };

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -11,7 +11,7 @@ import { DataProcessor } from './data_processor';
 import { axesEditorComponent } from './axes_editor';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
-import { DataFrame, DataLink } from '@grafana/data';
+import { DataFrame, DataLink, DateTimeInput } from '@grafana/data';
 import { getColorFromHexRgbOrName, LegacyResponseData, VariableSuggestion } from '@grafana/ui';
 import { getProcessedDataFrames } from 'app/features/dashboard/state/PanelQueryState';
 import { PanelQueryRunnerFormat } from 'app/features/dashboard/state/PanelQueryRunner';
@@ -339,6 +339,10 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   onContextMenuClose = () => {
     this.contextMenuCtrl.toggleMenu();
+  };
+
+  formatDate = (date: DateTimeInput, format?: string) => {
+    return this.dashboard.formatDate.apply(this.dashboard, [date, format]);
   };
 }
 

--- a/public/app/plugins/panel/graph/template.ts
+++ b/public/app/plugins/panel/graph/template.ts
@@ -11,7 +11,7 @@ const template = `
       items="ctrl.contextMenuCtrl.menuItems"
       onClose="ctrl.onContextMenuClose"
       getContextMenuSource="ctrl.contextMenuCtrl.getSource"
-      formatSourceDate="ctrl.dashboard.formatDate"
+      formatSourceDate="ctrl.formatDate"
       x="ctrl.contextMenuCtrl.position.x"
       y="ctrl.contextMenuCtrl.position.y"
     ></graph-context-menu>

--- a/public/app/plugins/panel/graph/template.ts
+++ b/public/app/plugins/panel/graph/template.ts
@@ -11,6 +11,7 @@ const template = `
       items="ctrl.contextMenuCtrl.menuItems"
       onClose="ctrl.onContextMenuClose"
       getContextMenuSource="ctrl.contextMenuCtrl.getSource"
+      formatSourceDate="ctrl.dashboard.formatDate"
       x="ctrl.contextMenuCtrl.position.x"
       y="ctrl.contextMenuCtrl.position.y"
     ></graph-context-menu>


### PR DESCRIPTION
Graph's context menu displays datapoint's timestamp. It didn't respect the timezone settings though.