### PR TITLE
Auth: Do not set SameSite cookie attribute if cookie_samesite is none

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -199,15 +199,18 @@ func (hs *HTTPServer) trySetEncryptedCookie(ctx *models.ReqContext, cookieName s
 		return err
 	}
 
-	http.SetCookie(ctx.Resp, &http.Cookie{
+	cookie := http.Cookie{
 		Name:     cookieName,
 		MaxAge:   60,
 		Value:    hex.EncodeToString(encryptedError),
 		HttpOnly: true,
 		Path:     setting.AppSubUrl + "/",
 		Secure:   hs.Cfg.CookieSecure,
-		SameSite: hs.Cfg.CookieSameSite,
-	})
+	}
+	if hs.Cfg.CookieSameSite != http.SameSiteDefaultMode {
+		cookie.SameSite = hs.Cfg.CookieSameSite
+	}
+	http.SetCookie(ctx.Resp, &cookie)
 
 	return nil
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -256,7 +256,9 @@ func WriteSessionCookie(ctx *models.ReqContext, value string, maxLifetimeDays in
 		Path:     setting.AppSubUrl + "/",
 		Secure:   setting.CookieSecure,
 		MaxAge:   maxAge,
-		SameSite: setting.CookieSameSite,
+	}
+	if setting.CookieSameSite != http.SameSiteDefaultMode {
+		cookie.SameSite = setting.CookieSameSite
 	}
 
 	http.SetCookie(ctx.Resp, &cookie)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Some safari versions seems to have a [bug](https://bugs.webkit.org/show_bug.cgi?id=198181) where it recognises `SameSite=None` as `SameSite=Strict`. 

- Also `cookie_samesite=none` actually sets the cookie SameSite to `http.SameSiteDefaultMode` which in Go [1.12](https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/cookie.go#L215) results to a cookie like this:
`oauth_state=ae6032f47f6181118d489072fa15bc0c8142c96b1aa01215684924c426e749c0; Path=/grafana/; Max-Age=60; HttpOnly; SameSite`
instead of:
`oauth_state=ae6032f47f6181118d489072fa15bc0c8142c96b1aa01215684924c426e749c0; Path=/grafana/; Max-Age=60; HttpOnly; SameSite=None`
as someone might expect and it is not clearly documented how each browser handles this.

Therefore SameSite should not be set for any cookie if cookie_samesite=none. This fix affects `grafana_session` and `login_error` cookies. There was a separate [fix](https://github.com/grafana/grafana/pull/18392) for `oauth_state` cookie.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18450

**Special notes for your reviewer**:

