### PR TITLE
Docs: Update issue triage doc with external PRs section

### DIFF
--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -353,6 +353,15 @@ For some other combinations there may not be possible at all for a maintainer to
 
 Even if you don't have the time or knowledge to investigate an issue we highly recommend that you [upvote](https://help.github.com/en/articles/about-conversations-on-github#reacting-to-ideas-in-comments) the issue if you happen to have the same problem. If you have further details that may help investigating the issue please provide as much information as possible.
 
+## External PRs
+
+Part of issue triage should also be triaging of external PRs. Main goal should to make sure PRs from external contributors have an owner and are not forgotten.
+
+1. Check new external PRs which do not have a reviewer.
+1. Check if there is a link to existing issue.
+1. If not and you know which issue it is solving add the link yourself, otherwise ask the author to link the issue or create one.
+1. Assign a reviewer based on who was handling the linked issue or what code or feature does the PR touches (look at who was the last to make changes there if all else fails).
+
 ## Appendix
 
 ### Setting up Gmail filters

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -355,7 +355,7 @@ Even if you don't have the time or knowledge to investigate an issue we highly r
 
 ## External PRs
 
-Part of issue triage should also be triaging of external PRs. Main goal should to make sure PRs from external contributors have an owner and are not forgotten.
+Part of issue triage should also be triaging of external PRs. Main goal should to make sure PRs from external contributors have an owner/reviewer and are not forgotten.
 
 1. Check new external PRs which do not have a reviewer.
 1. Check if there is a link to existing issue.

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -355,10 +355,10 @@ Even if you don't have the time or knowledge to investigate an issue we highly r
 
 ## External PRs
 
-Part of issue triage should also be triaging of external PRs. Main goal should to make sure PRs from external contributors have an owner/reviewer and are not forgotten.
+Part of issue triage should also be triaging of external PRs. Main goal should be to make sure PRs from external contributors have an owner/reviewer and are not forgotten.
 
 1. Check new external PRs which do not have a reviewer.
-1. Check if there is a link to existing issue.
+1. Check if there is a link to an existing issue.
 1. If not and you know which issue it is solving add the link yourself, otherwise ask the author to link the issue or create one.
 1. Assign a reviewer based on who was handling the linked issue or what code or feature does the PR touches (look at who was the last to make changes there if all else fails).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a section about external PRs. Discussed on issue triage weekly that there is not a set process how we handle external PRs and they can be sometimes forgotten.

