### PR TITLE
Metrics field nested Dropdown

### DIFF
--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -136,26 +136,29 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
       };
 
       $scope.doNested = function(items) {
-        // Making array to an object and set the end to the full path. It also cancells duplications!
-        // i.e ['system.cpu'] becomes { system: { cpu: 'system.cpu' } }
-        let tmpObject = items.reduce(function(o, property) { return _.setWith(o, property, property, Object); }, {});
+      // Making array to an object and set the end to the full path. It also cancells duplications!
+      // i.e ['system.cpu'] becomes { system: { cpu: 'system.cpu' } }
+      const tmpObject = items.reduce(function(o, property) {
+        return _.setWith(o, property, property, Object);
+      }, {});
 
-        // Recursive function to build the nested ul from the object
-        let toHtml = function(object) {
-          return _.map(object, function(i, item) {
-            if (typeof (i) === "string") {
-              return '<li data-value="' + i + '"> <a href="#">' + item + ' </a> </li>';
-            }
+      // Recursive function to build the nested ul from the object
+      const toHtml = function(object) {
+        return _.map(object, function(i, item) {
+          if (typeof i === 'string') {
+            return `<li data-value="${i}"> <a href="#">${item} </a> </li>`;
+          }
 
-            let li = '<li class="dropdown-submenu"> <a href="#">' + item +
-              '</a> <ul class="dropdown-menu"> ' + toHtml(i).join(' ') + ' </ul> </li>';
+          const li = `<li class="dropdown-submenu"> <a href="#">${item}</a> <ul class="dropdown-menu"> ${toHtml(i).join(
+            ' ',
+          )} </ul> </li>`;
 
-            return li;
-          });
-        };
-
-        return toHtml(tmpObject).join(' ');
+          return li;
+        });
       };
+
+      return toHtml(tmpObject).join(' ');
+    };
 
       $input.attr('data-provide', 'typeahead');
       $input.typeahead({

--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -135,6 +135,28 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
         }
       };
 
+      $scope.doNested = function(items) {
+        // Making array to an object and set the end to the full path. It also cancells duplications!
+        // i.e ['system.cpu'] becomes { system: { cpu: 'system.cpu' } }
+        let tmpObject = items.reduce(function(o, property) { return _.setWith(o, property, property, Object); }, {});
+
+        // Recursive function to build the nested ul from the object
+        let toHtml = function(object) {
+          return _.map(object, function(i, item) {
+            if (typeof (i) === "string") {
+              return '<li data-value="' + i + '"> <a href="#">' + item + ' </a> </li>';
+            }
+
+            let li = '<li class="dropdown-submenu"> <a href="#">' + item +
+              '</a> <ul class="dropdown-menu"> ' + toHtml(i).join(' ') + ' </ul> </li>';
+
+            return li;
+          });
+        };
+
+        return toHtml(tmpObject).join(' ');
+      };
+
       $input.attr('data-provide', 'typeahead');
       $input.typeahead({
         source: $scope.source,
@@ -142,6 +164,7 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
         items: 10000,
         updater: $scope.updater,
         matcher: $scope.matcher,
+        doNested: $scope.doNested,
       });
 
       const typeahead = $input.data('typeahead');

--- a/public/vendor/bootstrap/bootstrap.js
+++ b/public/vendor/bootstrap/bootstrap.js
@@ -1068,6 +1068,7 @@
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
     this.source = this.options.source
+    this.doNested = this.options.doNested || this.doNested
     this.$menu = $(this.options.menu)
     this.shown = false
     this.listen()
@@ -1175,15 +1176,24 @@
   , render: function (items) {
       var that = this
 
-      items = $(items).map(function (i, item) {
-        i = $(that.options.item).attr('data-value', item)
-        i.find('a').html(that.highlighter(item))
-        return i[0]
-      })
+      if ($.isFunction(this.doNested) && !this.query) {
+        items = this.doNested(items)
+      } else {
+        items = $(items).map(function (i, item) {
+          i = $(that.options.item).attr('data-value', item)
+          i.find('a').html(that.highlighter(item))
+          return i[0]
+        })
+      }
 
       // CHANGE (rashidpc) Do not select first element by default
       // items.first().addClass('active')
       this.$menu.html(items)
+      if (this.$menu.has('.dropdown-submenu').length) {
+         this.$menu.css("overflow-y", "unset")
+      } else {
+        this.$menu.css("overflow-y", "auto")
+      }
       return this
     }
 
@@ -1360,6 +1370,7 @@
 
   $.fn.typeahead.defaults = {
     source: []
+  , doNested: []
   , items: 8
   , menu: '<ul class="typeahead dropdown-menu"></ul>'
   , item: '<li><a href="#"></a></li>'


### PR DESCRIPTION
Metric field can sometimes be very long and nested.
The goal of this PR, is to supply a more user-friendly display by changing the regular field dropdown into a nested one.
The feature will only show if there are dots in the field name.
Also, if the input is not empty and there is search term on the metric field or if there are no nested metric fields names (=includes dots), the old show will be displayed.
This PR is not providing new css classes and only uses exists ones.

**Which issue(s) this PR fixes:**
#18496 

**For example:**
Current view:
<img width="961" alt="before" src="https://user-images.githubusercontent.com/15690241/62835320-d00def80-bc5f-11e9-92e6-033295c08ed7.png">

With this PR:
<img width="1050" alt="after" src="https://user-images.githubusercontent.com/15690241/62835326-d56b3a00-bc5f-11e9-8a8c-428d64af77a6.png">
