### PR TITLE
Docker: switch docker image to alpine base with phantomjs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,17 @@ COPY package.json package.json
 RUN go run build.go build
 
 # Node build container
-FROM node:10.14.2
+FROM node:10.14.2-alpine
+
+# PhantomJS
+RUN apk add --no-cache curl &&\
+    cd /tmp && curl -Ls https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz | tar xz &&\
+    cp -R lib lib64 / &&\
+    cp -R usr/lib/x86_64-linux-gnu /usr/lib &&\
+    cp -R usr/share /usr/share &&\
+    cp -R etc/fonts /etc &&\
+    curl -k -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf - &&\
+    cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 
 WORKDIR /usr/src/app/
 
@@ -33,7 +43,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM ubuntu:18.04
+FROM alpine:3.10
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 
@@ -50,16 +60,13 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -qq -y libfontconfig1 ca-certificates && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates bash
 
 COPY conf ./conf
 
 RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
-    groupadd -r -g $GF_GID grafana && \
-    useradd -r -u $GF_UID -g grafana grafana && \
+    addgroup -S -g $GF_GID grafana && \
+    adduser -S -u $GF_UID -G grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \
@@ -70,6 +77,14 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod 777 -R "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+
+# PhantomJS
+COPY --from=1 /tmp/lib /lib
+COPY --from=1 /tmp/lib64 /lib64
+COPY --from=1 /tmp/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=1 /tmp/usr/share /usr/share
+COPY --from=1 /tmp/etc/fonts /etc/fonts
+COPY --from=1 /usr/local/bin/phantomjs /usr/local/bin
 
 COPY --from=0 /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-cli ./bin/
 COPY --from=1 /usr/src/app/public ./public

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-    chmod 777 -R "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
+    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
 # PhantomJS
 COPY --from=1 /tmp/lib /lib

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,21 +1,16 @@
 ARG BASE_IMAGE=alpine:3.10
-FROM ubuntu:18.04
+FROM alpine:3.10
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
-
-RUN apt-get update && apt-get install -qq -y tar && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
 
 COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
 # Change to tar xfzv to make tar print every file it extracts
 RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
-# Node build container
-FROM node:10.14.2-alpine
-
 # PhantomJS
+FROM alpine:3.10
+
 RUN apk add --no-cache curl &&\
     cd /tmp && curl -Ls https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz | tar xz &&\
     cp -R lib lib64 / &&\

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -34,8 +34,6 @@ RUN if [ `arch` = "x86_64" ]; then \
       cp -R usr/lib/x86_64-linux-gnu /usr/lib && \
       cp -R usr/share/fonts /usr/share && \
       cp -R etc/fonts /etc && \
-      curl -k -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf - && \
-      cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
       rm -rf /tmp/* && \
       apk del --no-cache phantomjs-utils; \
     fi

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE=ubuntu:18.04
-FROM ${BASE_IMAGE}
+ARG BASE_IMAGE=alpine:3.10
+FROM ubuntu:18.04
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
 
@@ -12,12 +12,23 @@ COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 # Change to tar xfzv to make tar print every file it extracts
 RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
-ARG BASE_IMAGE=ubuntu:18.04
+# Node build container
+FROM node:10.14.2-alpine
+
+# PhantomJS
+RUN apk add --no-cache curl &&\
+    cd /tmp && curl -Ls https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz | tar xz &&\
+    cp -R lib lib64 / &&\
+    cp -R usr/lib/x86_64-linux-gnu /usr/lib &&\
+    cp -R usr/share /usr/share &&\
+    cp -R etc/fonts /etc &&\
+    curl -k -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf - &&\
+    cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+
 FROM ${BASE_IMAGE}
 
 ARG GF_UID="472"
 ARG GF_GID="472"
-ARG DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
@@ -29,16 +40,21 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -qq -y libfontconfig1 ca-certificates curl && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates bash
+
+# PhantomJS
+COPY --from=1 /tmp/lib /lib
+COPY --from=1 /tmp/lib64 /lib64
+COPY --from=1 /tmp/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=1 /tmp/usr/share /usr/share
+COPY --from=1 /tmp/etc/fonts /etc/fonts
+COPY --from=1 /usr/local/bin/phantomjs /usr/local/bin
 
 COPY --from=0 /tmp/grafana "$GF_PATHS_HOME"
 
 RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
-    groupadd -r -g $GF_GID grafana && \
-    useradd -r -u $GF_UID -g grafana grafana && \
+    addgroup -S -g $GF_GID grafana && \
+    adduser -S -u $GF_UID -G grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=alpine:3.10
-FROM alpine:3.10
+FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
 
@@ -7,18 +7,6 @@ COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
 # Change to tar xfzv to make tar print every file it extracts
 RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
-
-# PhantomJS
-FROM alpine:3.10
-
-RUN apk add --no-cache curl &&\
-    cd /tmp && curl -Ls https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz | tar xz &&\
-    cp -R lib lib64 / &&\
-    cp -R usr/lib/x86_64-linux-gnu /usr/lib &&\
-    cp -R usr/share /usr/share &&\
-    cp -R etc/fonts /etc &&\
-    curl -k -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf - &&\
-    cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 
 FROM ${BASE_IMAGE}
 
@@ -38,12 +26,19 @@ WORKDIR $GF_PATHS_HOME
 RUN apk add --no-cache ca-certificates bash
 
 # PhantomJS
-COPY --from=1 /tmp/lib /lib
-COPY --from=1 /tmp/lib64 /lib64
-COPY --from=1 /tmp/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
-COPY --from=1 /tmp/usr/share /usr/share
-COPY --from=1 /tmp/etc/fonts /etc/fonts
-COPY --from=1 /usr/local/bin/phantomjs /usr/local/bin
+RUN if [ `arch` = "x86_64" ]; then \
+      apk add --no-cache --virtual phantomjs-utils curl && \
+      cd /tmp && \
+      curl -Ls https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz | tar xz && \
+      cp -R lib lib64 / && \
+      cp -R usr/lib/x86_64-linux-gnu /usr/lib && \
+      cp -R usr/share/fonts /usr/share && \
+      cp -R etc/fonts /etc && \
+      curl -k -Ls https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -jxf - && \
+      cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+      rm -rf /tmp/* && \
+      apk del --no-cache phantomjs-utils; \
+    fi
 
 COPY --from=0 /tmp/grafana "$GF_PATHS_HOME"
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -16,6 +16,10 @@ Further documentation can be found at http://docs.grafana.org/installation/docke
 
 ## Changelog
 
+### v6.4.0-pre1
+
+* Switch base image from ubuntu:18.04 to alpine:3.10
+
 ### v6.3.0-beta2
 * Switch base image from ubuntu:latest to ubuntu:18.04
 

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -59,10 +59,10 @@ docker_tag_all () {
 	fi
 }
 
-docker_build "ubuntu:18.04" "grafana-latest.linux-x64.tar.gz" "${_docker_repo}:${_grafana_version}"
+docker_build "alpine:3.10" "grafana-latest.linux-x64.tar.gz" "${_docker_repo}:${_grafana_version}"
 if [ $BUILD_FAST = "0" ]; then
-	docker_build "arm32v7/ubuntu:18.04" "grafana-latest.linux-armv7.tar.gz" "${_docker_repo}-arm32v7-linux:${_grafana_version}"
-	docker_build "arm64v8/ubuntu:18.04" "grafana-latest.linux-arm64.tar.gz" "${_docker_repo}-arm64v8-linux:${_grafana_version}"
+	docker_build "arm32v7/alpine:3.10" "grafana-latest.linux-armv7.tar.gz" "${_docker_repo}-arm32v7-linux:${_grafana_version}"
+	docker_build "arm64v8/alpine:3.10" "grafana-latest.linux-arm64.tar.gz" "${_docker_repo}-arm64v8-linux:${_grafana_version}"
 fi
 # Tag as 'latest' for official release; otherwise tag as grafana/grafana:master
 if echo "$_grafana_tag" | grep -q "^v"; then


### PR DESCRIPTION
This PR explores one method of getting phantomjs to work on a docker base image, which may be a workable approach until we can remove phantomjs altogether.

I have tested this locally without encountering any errors, and was able to render panels via phantomjs.  There is some error output from yarn during the build because the optional `iltorb` dependency can't be installed on alpine, but that can be safely ignored (afaik there is no way to tell yarn not to attempt installing a specific optional dependency).

Once we don't require phantomjs any more we would just need to remove the 2 commented blocks from the Dockerfile.

The image produced by this Dockerfile scans clean with trivvy.

Closes #18084 