### PR TITLE
Annotations: Fix failing annotation query when time series query is cancelled

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -41,6 +41,7 @@ export interface PromDataQueryResponse {
       result?: DataQueryResponseData[];
     };
   };
+  cancelled?: boolean;
 }
 
 export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> {
@@ -528,6 +529,9 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       const eventList: AnnotationEvent[] = [];
       tagKeys = tagKeys.split(',');
 
+      if (results.cancelled) {
+        return [];
+      }
       _.each(results.data.data.result, series => {
         const tags = _.chain(series.metric)
           .filter((v, k) => {

--- a/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
@@ -667,6 +667,19 @@ describe('PrometheusDatasource', () => {
       },
     };
 
+    describe('when time series query is cancelled', () => {
+      it('should return empty results', async () => {
+        backendSrv.datasourceRequest = jest.fn(() => Promise.resolve({ cancelled: true }));
+        ctx.ds = new PrometheusDatasource(instanceSettings, q, backendSrv as any, templateSrv as any, timeSrv as any);
+
+        await ctx.ds.annotationQuery(options).then((data: any) => {
+          results = data;
+        });
+
+        expect(results).toEqual([]);
+      });
+    });
+
     describe('not use useValueForTime', () => {
       beforeEach(async () => {
         options.annotation.useValueForTime = false;


### PR DESCRIPTION
Fixes #18441 

In https://github.com/grafana/grafana/commit/fb39831df243386377d9188eedeb951c3e1c3698 we have introduced a change to how Prometheus query is created. In particular, the `requestId` was added to the request object https://github.com/grafana/grafana/commit/fb39831df243386377d9188eedeb951c3e1c3698#diff-a59431ca1f1f94cdb3ae176c50a585b2R304. Because of that the backend_srv started cancelling ongoing queries with the same `requestId` (as in https://github.com/grafana/grafana/blob/master/public/app/core/services/backend_srv.ts#L155)

This PR fixes the Prometheus datasource to take the cancelled query into consideration when performing annotation query.

