### PR TITLE
Settings: Add setting for global default timezone

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -250,6 +250,9 @@ password_hint = password
 # Default UI theme ("dark" or "light")
 default_theme = dark
 
+# Default timezone ("utc" or "browser")
+default_timezone = browser
+
 # External user management
 external_manage_link_url =
 external_manage_link_name =

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -41,7 +41,7 @@ func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error 
 
 	res := &m.Preferences{
 		Theme:           setting.DefaultTheme,
-		Timezone:        "browser",
+		Timezone:        setting.DefaultTimezone,
 		HomeDashboardId: 0,
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -121,6 +121,7 @@ var (
 	LoginHint               string
 	PasswordHint            string
 	DefaultTheme            string
+	DefaultTimezone         string
 	DisableLoginForm        bool
 	DisableSignoutMenu      bool
 	SignoutRedirectUrl      string
@@ -770,6 +771,10 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 		return err
 	}
 	DefaultTheme, err = valueAsString(users, "default_theme", "")
+	if err != nil {
+		return err
+	}
+	DefaultTimezone, err = valueAsString(users, "default_timezone", "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the setting "default_timezone" under "[users]" for setting the
default timezone globally.

Most of our monitoring tooling uses UTC, and this will let us set the
global default timezone to UTC instead of having to set the timezone
for every user or dashboard individually.

Tested that the default timezone is still "browser" without any
custom.ini, and that the default timezone changes to "utc" after
adding the following to custom.ini:

```
[users]
default_timezone = utc
```

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->


**Special notes for your reviewer**:

Not sure what docs I should update.