### PR TITLE
TimeSeries: Assume values are all numbers

### DIFF
--- a/packages/grafana-data/src/utils/processDataFrame.test.ts
+++ b/packages/grafana-data/src/utils/processDataFrame.test.ts
@@ -29,6 +29,15 @@ describe('toDataFrame', () => {
     expect(series.fields[0].name).toEqual('Value');
   });
 
+  it('assumes TimeSeries values are numbers', () => {
+    const input1 = {
+      target: 'time',
+      datapoints: [[100, 1], [200, 2]],
+    };
+    let series = toDataFrame(input1);
+    expect(series.fields[0].type).toBe(FieldType.number);
+  });
+
   it('keeps dataFrame unchanged', () => {
     const input = {
       fields: [{ text: 'A' }, { text: 'B' }, { text: 'C' }],

--- a/packages/grafana-data/src/utils/processDataFrame.test.ts
+++ b/packages/grafana-data/src/utils/processDataFrame.test.ts
@@ -34,8 +34,8 @@ describe('toDataFrame', () => {
       target: 'time',
       datapoints: [[100, 1], [200, 2]],
     };
-    let series = toDataFrame(input1);
-    expect(series.fields[0].type).toBe(FieldType.number);
+    const data = toDataFrame(input1);
+    expect(data.fields[0].type).toBe(FieldType.number);
   });
 
   it('keeps dataFrame unchanged', () => {

--- a/packages/grafana-data/src/utils/processDataFrame.ts
+++ b/packages/grafana-data/src/utils/processDataFrame.ts
@@ -29,6 +29,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
     fields: [
       {
         name: timeSeries.target || 'Value',
+        type: FieldType.number,
         unit: timeSeries.unit,
       },
       {


### PR DESCRIPTION
Fixes #18479

If the field type is not set explicitly, DataFrame willl guess it from the name or first value.  When the name is "time", it assumes a time type.

BUT with existing TimeSeries data, the value type should always be set to number