### PR TITLE
Login: Fix undefined redirect

### DIFF
--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -102,22 +102,10 @@ export class LoginCtrl extends PureComponent<Props, State> {
     // Use window.location.href to force page reload
     if (params.redirect && params.redirect[0] === '/') {
       window.location.href = config.appSubUrl + params.redirect;
-
-      // this.props.updateLocation({
-      //   path: config.appSubUrl + params.redirect,
-      // });
     } else if (this.result.redirectUrl) {
-      window.location.href = config.appSubUrl + params.redirect;
-
-      // this.props.updateLocation({
-      //   path: this.result.redirectUrl,
-      // });
+      window.location.href = config.appSubUrl + this.result.redirectUrl;
     } else {
       window.location.href = config.appSubUrl + '/';
-
-      // this.props.updateLocation({
-      //   path: '/',
-      // });
     }
   };
 


### PR DESCRIPTION
There was an issue if the login response had an redirectUrl, it would redirect to `/undefined`, which is understandable, since that value actually wasn't read.
