### PR TITLE
grafana/toolkit: Unpublish previous "next" version when releasing a new one

### DIFF
--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -24,7 +24,7 @@ function unpublish_previous_canary () {
 
 # Get current version from lerna.json
 PACKAGE_VERSION=$(grep '"version"' lerna.json | cut -d '"' -f 4)
-# Get short current commit's has
+# Get  current commit's short hash
 GIT_SHA=$(parse_git_hash)
 
 echo "Commit: ${GIT_SHA}"

--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+  #!/bin/bash
 
 function parse_git_hash() {
   git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/"
@@ -11,7 +11,18 @@ function prapare_version_commit () {
   git commit -am "Version commit"
 }
 
-#Get current version from lerna.json
+function unpublish_previous_canary () {
+  echo $'\nUnpublishing previous canary packages'
+  for PACKAGE in ui toolkit data runtime
+  do
+    # dist-tag next to be changed to canary when https://github.com/grafana/grafana/pull/18195 is merged
+    CURRENT_CANARY=$(npm view @grafana/${PACKAGE} dist-tags.next)
+    echo "Unpublish @grafana/${PACKAGE}@${CURRENT_CANARY}"
+    npm unpublish @grafana/${PACKAGE}@${CURRENT_CANARY}
+  done
+}
+
+# Get current version from lerna.json
 PACKAGE_VERSION=$(grep '"version"' lerna.json | cut -d '"' -f 4)
 # Get short current commit's has
 GIT_SHA=$(parse_git_hash)
@@ -31,10 +42,13 @@ else
   echo $'\nGit status:'
   git status -s
 
+
   echo $'\nBuilding packages'
   yarn packages:build
 
   prapare_version_commit
+
+  unpublish_previous_canary
 
   echo $'\nPublishing packages'
   yarn packages:publishNext

--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -1,4 +1,4 @@
-  #!/bin/bash
+#!/usr/bin/env bash
 
 function parse_git_hash() {
   git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/"
@@ -18,7 +18,7 @@ function unpublish_previous_canary () {
     # dist-tag next to be changed to canary when https://github.com/grafana/grafana/pull/18195 is merged
     CURRENT_CANARY=$(npm view @grafana/${PACKAGE} dist-tags.next)
     echo "Unpublish @grafana/${PACKAGE}@${CURRENT_CANARY}"
-    npm unpublish @grafana/${PACKAGE}@${CURRENT_CANARY}
+    npm unpublish "@grafana/${PACKAGE}@${CURRENT_CANARY}"
   done
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/18550

Hopefully this will limit the amount of versions visible on npm. Next step is to request npm to remove all of those SHA-hashed version that are on npm now and are older than 72h.

