### PR TITLE
Streaming: remove delta message from streaming callback

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -319,11 +319,6 @@ export interface DataStreamState {
   error?: DataQueryError;
 
   /**
-   * Optionally return only the rows that changed in this event
-   */
-  delta?: DataFrame[];
-
-  /**
    * Stop listening to this stream
    */
   unsubscribe: () => void;

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -242,7 +242,6 @@ export interface ProcessQueryResultsPayload {
   datasourceId: string;
   loadingState: LoadingState;
   series?: DataQueryResponseData[];
-  delta?: DataFrame[];
 }
 
 export interface RunQueriesBatchPayload {

--- a/public/app/features/explore/state/epics/limitMessageRateEpic.ts
+++ b/public/app/features/explore/state/epics/limitMessageRateEpic.ts
@@ -17,8 +17,7 @@ export const limitMessageRateEpic: Epic<ActionOf<any>, ActionOf<any>, StoreState
         latency: 0,
         datasourceId,
         loadingState: LoadingState.Streaming,
-        series: null,
-        delta: series,
+        series,
       });
     })
   );

--- a/public/app/features/explore/state/epics/processQueryResultsEpic.ts
+++ b/public/app/features/explore/state/epics/processQueryResultsEpic.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { Epic } from 'redux-observable';
 import { mergeMap } from 'rxjs/operators';
 import { NEVER } from 'rxjs';
-import { LoadingState } from '@grafana/data';
 
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
 import { StoreState } from 'app/types/store';
@@ -25,7 +24,7 @@ export const processQueryResultsEpic: Epic<ActionOf<any>, ActionOf<any>, StoreSt
 ) => {
   return action$.ofType(processQueryResultsAction.type).pipe(
     mergeMap((action: ActionOf<ProcessQueryResultsPayload>) => {
-      const { exploreId, datasourceId, latency, loadingState, series, delta } = action.payload;
+      const { exploreId, datasourceId, latency, loadingState, series } = action.payload;
       const { datasourceInstance, scanning, eventBridge } = state$.value.explore[exploreId];
 
       // If datasource already changed, results do not matter
@@ -33,8 +32,8 @@ export const processQueryResultsEpic: Epic<ActionOf<any>, ActionOf<any>, StoreSt
         return NEVER;
       }
 
-      const result = series || delta || [];
-      const replacePreviousResults = loadingState === LoadingState.Done && series && !delta ? true : false;
+      const result = series || [];
+      const replacePreviousResults = true; // ??? loadingState === LoadingState.Done && series && !delta ? true : false;
       const resultProcessor = new ResultProcessor(state$.value.explore[exploreId], replacePreviousResults, result);
       const graphResult = resultProcessor.getGraphResult();
       const tableResult = resultProcessor.getTableResult();

--- a/public/app/features/explore/state/epics/runQueriesBatchEpic.test.ts
+++ b/public/app/features/explore/state/epics/runQueriesBatchEpic.test.ts
@@ -70,7 +70,6 @@ describe('runQueriesBatchEpic', () => {
               historyUpdatedAction({ exploreId, history }),
               processQueryResultsAction({
                 exploreId,
-                delta: null,
                 series,
                 latency: 0,
                 datasourceId,
@@ -123,14 +122,14 @@ describe('runQueriesBatchEpic', () => {
             )
             .whenQueryObserverReceivesEvent({
               state: LoadingState.Streaming,
-              delta: [serieA],
+              data: [serieA],
               key: 'some key',
               request: {} as DataQueryRequest,
               unsubscribe,
             })
             .whenQueryObserverReceivesEvent({
               state: LoadingState.Streaming,
-              delta: [serieB],
+              data: [serieB],
               key: 'some key',
               request: {} as DataQueryRequest,
               unsubscribe,
@@ -181,7 +180,7 @@ describe('runQueriesBatchEpic', () => {
             rows: [],
             refId: 'B',
           };
-          const delta = [serieA, serieB];
+          const data = [serieA, serieB];
 
           epicTester(runQueriesBatchEpic, state)
             .whenActionIsDispatched(
@@ -189,8 +188,7 @@ describe('runQueriesBatchEpic', () => {
             )
             .whenQueryObserverReceivesEvent({
               state: LoadingState.Done,
-              data: null,
-              delta,
+              data,
               key: 'some key',
               request: {} as DataQueryRequest,
               unsubscribe,
@@ -200,8 +198,7 @@ describe('runQueriesBatchEpic', () => {
               historyUpdatedAction({ exploreId, history }),
               processQueryResultsAction({
                 exploreId,
-                delta,
-                series: null,
+                series: data,
                 latency: 0,
                 datasourceId,
                 loadingState: LoadingState.Done,
@@ -245,7 +242,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }), // output from first observable
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,
@@ -257,7 +253,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }), // output from second observable
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,
@@ -295,7 +290,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }),
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,
@@ -332,7 +326,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }),
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,
@@ -369,7 +362,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }),
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,
@@ -406,7 +398,6 @@ describe('runQueriesBatchEpic', () => {
             historyUpdatedAction({ exploreId, history }),
             processQueryResultsAction({
               exploreId,
-              delta: null,
               series,
               latency: 0,
               datasourceId,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -179,12 +179,12 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const subscription = webSocket(liveTarget.url)
         .pipe(
           map((results: any[]) => {
-            const delta = this.processResult(results, liveTarget);
+            const data = this.processResult(results, liveTarget);
             const state: DataStreamState = {
               key: `loki-${liveTarget.refId}`,
               request: options,
               state: LoadingState.Streaming,
-              delta,
+              data,
               unsubscribe: () => this.unsubscribe(liveTarget.refId),
             };
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -199,12 +199,12 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
           single(), // unsubscribes automatically after first result
           filter((response: any) => (response.cancelled ? false : true)),
           map((response: any) => {
-            const delta = this.processResult(response, query, target, queries.length);
+            const data = this.processResult(response, query, target, queries.length);
             const state: DataStreamState = {
               key: `prometheus-${target.refId}`,
               state: query.instant ? LoadingState.Loading : LoadingState.Done,
               request: options,
-              delta,
+              data,
               unsubscribe: () => undefined,
             };
 

--- a/public/app/plugins/datasource/testdata/StreamHandler.ts
+++ b/public/app/plugins/datasource/testdata/StreamHandler.ts
@@ -121,9 +121,6 @@ export class StreamWorker {
     }
     series.rows = rows;
 
-    // Tell the event about only the rows that changed (it may want to process them)
-    stream.delta = [{ ...series, rows: append }];
-
     // Broadcast the changes
     if (this.observer) {
       this.observer(stream);


### PR DESCRIPTION
In working on #18391, I found that explore is using `delta` as the full result from a streaming query.

In the streaming result, `data` returns the full DataFrame, while `delta` should just contain the changes in that event.

This is obviously confusing, and we don't need the delta event for anythign right now, so I suggest we remove it until we have a real need.  Also I added it before since the row model made it essentially free to add.  With columnar layout, the delta object would require creating a new object and should only be done if necessary.

This PR touches a bunch of explore that I do not understand, and will need help to make sure it makes sense
