### PR TITLE
Toolkit: write PR report to a folder with the circle build number

### DIFF
--- a/packages/grafana-toolkit/src/plugins/aws.ts
+++ b/packages/grafana-toolkit/src/plugins/aws.ts
@@ -94,7 +94,7 @@ export class S3Client {
     });
   }
 
-  async exits(key: string): Promise<boolean> {
+  async exists(key: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       this.s3.getObject(
         {


### PR DESCRIPTION
Currently multiple builds to the same PR fail because the report files collide.

This includes the circle build number in the path so it is unique.

This also fixes a typo: exits => exists