### PR TITLE
Graph: Fixes legend issue clicking on series line icon and issue with horizontal scrollbar being visible on windows

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -77,7 +77,7 @@ export class CustomScrollbar extends Component<Props> {
         {...passedProps}
         className={cx(
           css`
-            visibility: ${hideTrack ? 'none' : 'visible'};
+            visibility: ${hideTrack ? 'hidden' : 'visible'};
           `,
           track
         )}


### PR DESCRIPTION
Fixes issue with it being hard to hit the line icon in the legend to make the color selection appear, similar issue hitting the series name to toggle series visibility. 

Might fix the issue with the visible horizontal scrollbar on windows. 

Maybe #18534