### PR TITLE
Packages: Temporarily skip canary releases if packages build fail

### DIFF
--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -46,6 +46,12 @@ else
   echo $'\nBuilding packages'
   yarn packages:build
 
+  exit_status=$?
+  if [ $exit_status -eq 1 ]; then
+    echo "Packages build failed, skipping canary release"
+    # TODO: notify on slack/email?
+    exit
+  fi
   prapare_version_commit
 
   unpublish_previous_canary


### PR DESCRIPTION
@ryan regarding grafana-ui build failing on master. Did some debugging and apparently merge of https://github.com/grafana/grafana/pull/18549 introduced this regression (as proven checked here https://github.com/grafana/grafana/pull/18574). Could find a solution nor reproduce yet.

@kaydelaney is investigating that, we don't have a solution yet. For now, to unblock master builds, I suggest merging this and simply skip canary releases if packages build fails.

**This should be reverted as soon as we find the underlying problem!** 