### PR TITLE
LDAP: multildap + ldap integration

### DIFF
--- a/pkg/services/multildap/multildap.go
+++ b/pkg/services/multildap/multildap.go
@@ -19,6 +19,9 @@ var newLDAP = ldap.New
 // ErrInvalidCredentials is returned if username and password do not match
 var ErrInvalidCredentials = ldap.ErrInvalidCredentials
 
+// ErrCouldNotFindUser is returned when username hasn't been found (not username+password)
+var ErrCouldNotFindUser = ldap.ErrCouldNotFindUser
+
 // ErrNoLDAPServers is returned when there is no LDAP servers specified
 var ErrNoLDAPServers = errors.New("No LDAP servers are configured")
 
@@ -76,7 +79,7 @@ func (multiples *MultiLDAP) Login(query *models.LoginUserQuery) (
 		}
 
 		// Continue if we couldn't find the user
-		if err == ErrInvalidCredentials {
+		if err == ErrCouldNotFindUser {
 			continue
 		}
 

--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -82,10 +82,10 @@ func TestMultiLDAP(t *testing.T) {
 				teardown()
 			})
 
-			Convey("Should still call a second error for invalid cred error", func() {
+			Convey("Should still call a second error for invalid not found error", func() {
 				mock := setup()
 
-				mock.loginErrReturn = ErrInvalidCredentials
+				mock.loginErrReturn = ErrCouldNotFindUser
 
 				multi := New([]*ldap.ServerConfig{
 					{}, {},


### PR DESCRIPTION
It seems `ldap` module introduced new error type of which
multildap module didn't know about.

This broke the multildap login logic

Fixes #18491
Ref #18587
