### PR TITLE
Explore: Fixes error when switching from prometheus to loki data sources

### DIFF
--- a/public/app/features/explore/QueryField.tsx
+++ b/public/app/features/explore/QueryField.tsx
@@ -115,7 +115,7 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
     if (initialQuery !== prevProps.initialQuery) {
       // and we have a version that differs
       if (initialQuery !== Plain.serialize(value)) {
-        this.setState({ value: makeValue(initialQuery, syntax) });
+        this.setState({ value: makeValue(initialQuery || '', syntax) });
       }
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an error that occurred when switching from prometheus to loki in Explore.

**Which issue(s) this PR fixes**:
Closes #18594
Closes #18596
