### PR TITLE
SingleStat: add a gauge migration call to action button in the editor

### DIFF
--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -1,6 +1,6 @@
-import { sharedSingleStatMigrationCheck } from './SingleStatBaseOptions';
+import { sharedSingleStatMigrationHandler } from './SingleStatBaseOptions';
 
-describe('sharedSingleStatMigrationCheck', () => {
+describe('sharedSingleStatMigrationHandler', () => {
   it('from old valueOptions model without pluginVersion', () => {
     const panel = {
       options: {
@@ -34,6 +34,6 @@ describe('sharedSingleStatMigrationCheck', () => {
       type: 'bargauge',
     };
 
-    expect(sharedSingleStatMigrationCheck(panel as any)).toMatchSnapshot();
+    expect(sharedSingleStatMigrationHandler(panel as any)).toMatchSnapshot();
   });
 });

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -190,7 +190,7 @@ export function migrateOldThresholds(thresholds?: any[]): Threshold[] | undefine
 }
 
 /**
- * Convert the existing format to new format
+ * Convert the angular single stat mapping to new react style
  */
 function convertOldAngulrValueMapping(panel: any): ValueMapping[] {
   const mappings: ValueMapping[] = [];

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -20,11 +20,11 @@ export interface SingleStatBaseOptions {
 
 const optionsToKeep = ['fieldOptions', 'orientation'];
 
-export const sharedSingleStatOptionsCheck = (
+export function sharedSingleStatPanelChangedHandler(
   options: Partial<SingleStatBaseOptions> | any,
   prevPluginId: string,
   prevOptions: any
-) => {
+) {
   // Migrating from angular singlestat
   if (prevPluginId === 'singlestat' && prevOptions.angular) {
     const panel = prevOptions.angular;
@@ -90,9 +90,9 @@ export const sharedSingleStatOptionsCheck = (
     }
   }
   return options;
-};
+}
 
-export function sharedSingleStatMigrationCheck(panel: PanelModel<SingleStatBaseOptions>): SingleStatBaseOptions {
+export function sharedSingleStatMigrationHandler(panel: PanelModel<SingleStatBaseOptions>): SingleStatBaseOptions {
   if (!panel.options) {
     // This happens on the first load or when migrating from angular
     return {} as any;

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -25,10 +25,10 @@ export const sharedSingleStatOptionsCheck = (
   return options;
 };
 
-export function sharedSingleStatMigrationCheck(panel: PanelModel<SingleStatBaseOptions>) {
+export function sharedSingleStatMigrationCheck(panel: PanelModel<SingleStatBaseOptions>): SingleStatBaseOptions {
   if (!panel.options) {
     // This happens on the first load or when migrating from angular
-    return {};
+    return {} as any;
   }
 
   const previousVersion = parseFloat(panel.pluginVersion || '6.1');

--- a/packages/grafana-ui/src/components/SingleStatShared/__snapshots__/SingleStatBaseOptions.test.ts.snap
+++ b/packages/grafana-ui/src/components/SingleStatShared/__snapshots__/SingleStatBaseOptions.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sharedSingleStatMigrationCheck from old valueOptions model without pluginVersion 1`] = `
+exports[`sharedSingleStatMigrationHandler from old valueOptions model without pluginVersion 1`] = `
 Object {
   "fieldOptions": Object {
     "calcs": Array [

--- a/packages/grafana-ui/src/components/SingleStatShared/index.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/index.ts
@@ -3,6 +3,6 @@ export { FieldPropertiesEditor } from './FieldPropertiesEditor';
 
 export {
   SingleStatBaseOptions,
-  sharedSingleStatOptionsCheck,
-  sharedSingleStatMigrationCheck,
+  sharedSingleStatPanelChangedHandler,
+  sharedSingleStatMigrationHandler,
 } from './SingleStatBaseOptions';

--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -98,6 +98,8 @@ export class DashboardPanel extends PureComponent<Props, State> {
       this.setState({ isLazy: false });
     }
 
+    console.log('XXXX', this.props);
+
     if (!this.element || this.state.angularPanel) {
       return;
     }

--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -61,7 +61,7 @@ export class DashboardPanel extends PureComponent<Props, State> {
     return <AddPanelWidget panel={this.props.panel} dashboard={this.props.dashboard} />;
   }
 
-  onPluginTypeChanged = (plugin: PanelPluginMeta) => {
+  onPluginTypeChange = (plugin: PanelPluginMeta) => {
     this.loadPlugin(plugin.id);
   };
 
@@ -97,8 +97,6 @@ export class DashboardPanel extends PureComponent<Props, State> {
     if (this.state.isLazy && this.props.isInView) {
       this.setState({ isLazy: false });
     }
-
-    console.log('XXXX', this.props);
 
     if (!this.element || this.state.angularPanel) {
       return;
@@ -213,7 +211,7 @@ export class DashboardPanel extends PureComponent<Props, State> {
             plugin={plugin}
             dashboard={dashboard}
             angularPanel={angularPanel}
-            onTypeChanged={this.onPluginTypeChanged}
+            onPluginTypeChange={this.onPluginTypeChange}
           />
         )}
       </div>

--- a/public/app/features/dashboard/panel_editor/PanelEditor.tsx
+++ b/public/app/features/dashboard/panel_editor/PanelEditor.tsx
@@ -20,7 +20,7 @@ interface PanelEditorProps {
   dashboard: DashboardModel;
   plugin: PanelPlugin;
   angularPanel?: AngularComponent;
-  onTypeChanged: (newType: PanelPluginMeta) => void;
+  onPluginTypeChange: (newType: PanelPluginMeta) => void;
 }
 
 interface PanelEditorTab {
@@ -59,10 +59,6 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
     super(props);
   }
 
-  componentDidUpdate(prevProps: PanelEditorProps) {
-    console.log('CHECK Panel Update', this.props);
-  }
-
   onChangeTab = (tab: PanelEditorTab) => {
     store.dispatch(
       updateLocation({
@@ -74,7 +70,7 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
   };
 
   renderCurrentTab(activeTab: string) {
-    const { panel, dashboard, onTypeChanged, plugin, angularPanel } = this.props;
+    const { panel, dashboard, onPluginTypeChange, plugin, angularPanel } = this.props;
 
     switch (activeTab) {
       case 'advanced':
@@ -89,7 +85,7 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
             panel={panel}
             dashboard={dashboard}
             plugin={plugin}
-            onTypeChanged={onTypeChanged}
+            onPluginTypeChange={onPluginTypeChange}
             angularPanel={angularPanel}
           />
         );

--- a/public/app/features/dashboard/panel_editor/PanelEditor.tsx
+++ b/public/app/features/dashboard/panel_editor/PanelEditor.tsx
@@ -59,6 +59,10 @@ export class PanelEditor extends PureComponent<PanelEditorProps> {
     super(props);
   }
 
+  componentDidUpdate(prevProps: PanelEditorProps) {
+    console.log('CHECK Panel Update', this.props);
+  }
+
   onChangeTab = (tab: PanelEditorTab) => {
     store.dispatch(
       updateLocation({

--- a/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/panel_editor/VisualizationTab.tsx
@@ -19,13 +19,14 @@ import { DashboardModel } from '../state';
 import { VizPickerSearch } from './VizPickerSearch';
 import PluginStateinfo from 'app/features/plugins/PluginStateInfo';
 import { PanelPlugin, PanelPluginMeta } from '@grafana/ui';
+import { PanelCtrl } from 'app/plugins/sdk';
 
 interface Props {
   panel: PanelModel;
   dashboard: DashboardModel;
   plugin: PanelPlugin;
   angularPanel?: AngularComponent;
-  onTypeChanged: (newType: PanelPluginMeta) => void;
+  onPluginTypeChange: (newType: PanelPluginMeta) => void;
   updateLocation: typeof updateLocation;
   urlOpenVizPicker: boolean;
 }
@@ -104,8 +105,9 @@ export class VisualizationTab extends PureComponent<Props, State> {
       return;
     }
 
-    const panelCtrl = scope.$$childHead.ctrl;
+    const panelCtrl: PanelCtrl = scope.$$childHead.ctrl;
     panelCtrl.initEditMode();
+    panelCtrl.onPluginTypeChange = this.onPluginTypeChange;
 
     let template = '';
     for (let i = 0; i < panelCtrl.editorTabs.length; i++) {
@@ -197,11 +199,11 @@ export class VisualizationTab extends PureComponent<Props, State> {
     }
   };
 
-  onTypeChanged = (plugin: PanelPluginMeta) => {
+  onPluginTypeChange = (plugin: PanelPluginMeta) => {
     if (plugin.id === this.props.plugin.meta.id) {
       this.setState({ isVizPickerOpen: false });
     } else {
-      this.props.onTypeChanged(plugin);
+      this.props.onPluginTypeChange(plugin);
     }
   };
 
@@ -235,7 +237,7 @@ export class VisualizationTab extends PureComponent<Props, State> {
           <FadeIn in={isVizPickerOpen} duration={200} unmountOnExit={true} onExited={this.clearQuery}>
             <VizTypePicker
               current={meta}
-              onTypeChanged={this.onTypeChanged}
+              onTypeChange={this.onPluginTypeChange}
               searchQuery={searchQuery}
               onClose={this.onCloseVizPicker}
             />

--- a/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
+++ b/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
@@ -6,7 +6,7 @@ import { PanelPluginMeta, EmptySearchResult } from '@grafana/ui';
 
 export interface Props {
   current: PanelPluginMeta;
-  onTypeChanged: (newType: PanelPluginMeta) => void;
+  onTypeChange: (newType: PanelPluginMeta) => void;
   searchQuery: string;
   onClose: () => void;
 }
@@ -34,16 +34,11 @@ export class VizTypePicker extends PureComponent<Props> {
   }
 
   renderVizPlugin = (plugin: PanelPluginMeta, index: number) => {
-    const { onTypeChanged } = this.props;
+    const { onTypeChange } = this.props;
     const isCurrent = plugin.id === this.props.current.id;
 
     return (
-      <VizTypePickerPlugin
-        key={plugin.id}
-        isCurrent={isCurrent}
-        plugin={plugin}
-        onClick={() => onTypeChanged(plugin)}
-      />
+      <VizTypePickerPlugin key={plugin.id} isCurrent={isCurrent} plugin={plugin} onClick={() => onTypeChange(plugin)} />
     );
   };
 

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -165,7 +165,7 @@ describe('PanelModel', () => {
       it('should call react onPanelTypeChanged', () => {
         expect(onPanelTypeChanged.mock.calls.length).toBe(1);
         expect(onPanelTypeChanged.mock.calls[0][1]).toBe('table');
-        expect(onPanelTypeChanged.mock.calls[0][2].fieldOptions).toBeDefined();
+        expect(onPanelTypeChanged.mock.calls[0][2].angular).toBeDefined();
       });
 
       it('getQueryRunner() should return same instance after changing to another react panel', () => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -262,12 +262,11 @@ export class PanelModel {
     const pluginId = newPlugin.meta.id;
     const oldOptions: any = this.getOptionsToRemember();
     const oldPluginId = this.type;
-    let wasAngular = false;
+    const wasAngular = !!this.plugin.angularPanelCtrl;
 
     // for angular panels we must remove all events and let angular panels do some cleanup
-    if (this.plugin.angularPanelCtrl) {
+    if (wasAngular) {
       this.destroy();
-      wasAngular = true;
     }
 
     // remove panel type specific  options
@@ -282,9 +281,6 @@ export class PanelModel {
     this.cachedPluginOptions[oldPluginId] = oldOptions;
     this.restorePanelOptions(pluginId);
 
-    // switch
-    this.type = pluginId;
-    this.plugin = newPlugin;
     // Let panel plugins inspect options from previous panel and keep any that it can use
     if (newPlugin.onPanelTypeChanged) {
       let old: any = {};
@@ -296,6 +292,9 @@ export class PanelModel {
       this.options = this.options || {};
       Object.assign(this.options, newPlugin.onPanelTypeChanged(this.options, oldPluginId, old));
     }
+    // switch
+    this.type = pluginId;
+    this.plugin = newPlugin;
     this.applyPluginOptionDefaults(newPlugin);
 
     if (newPlugin.onPanelMigration) {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -284,14 +284,17 @@ export class PanelModel {
     // Let panel plugins inspect options from previous panel and keep any that it can use
     if (newPlugin.onPanelTypeChanged) {
       let old: any = {};
+
       if (wasAngular) {
         old = { angular: oldOptions };
       } else if (oldOptions && oldOptions.options) {
         old = oldOptions.options;
       }
+
       this.options = this.options || {};
       Object.assign(this.options, newPlugin.onPanelTypeChanged(this.options, oldPluginId, old));
     }
+
     // switch
     this.type = pluginId;
     this.plugin = newPlugin;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -262,10 +262,12 @@ export class PanelModel {
     const pluginId = newPlugin.meta.id;
     const oldOptions: any = this.getOptionsToRemember();
     const oldPluginId = this.type;
+    let wasAngular = false;
 
     // for angular panels we must remove all events and let angular panels do some cleanup
     if (this.plugin.angularPanelCtrl) {
       this.destroy();
+      wasAngular = true;
     }
 
     // remove panel type specific  options
@@ -283,13 +285,18 @@ export class PanelModel {
     // switch
     this.type = pluginId;
     this.plugin = newPlugin;
-    this.applyPluginOptionDefaults(newPlugin);
     // Let panel plugins inspect options from previous panel and keep any that it can use
     if (newPlugin.onPanelTypeChanged) {
+      let old: any = {};
+      if (wasAngular) {
+        old = { angular: oldOptions };
+      } else if (oldOptions && oldOptions.options) {
+        old = oldOptions.options;
+      }
       this.options = this.options || {};
-      const old = oldOptions && oldOptions.options ? oldOptions.options : {};
       Object.assign(this.options, newPlugin.onPanelTypeChanged(this.options, oldPluginId, old));
     }
+    this.applyPluginOptionDefaults(newPlugin);
 
     if (newPlugin.onPanelMigration) {
       this.pluginVersion = getPluginVersion(newPlugin);

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -19,6 +19,7 @@ import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import { auto } from 'angular';
 import { TemplateSrv } from '../templating/template_srv';
 import { LinkSrv } from './panellinks/link_srv';
+import { PanelPluginMeta } from '@grafana/ui/src/types/panel';
 
 export class PanelCtrl {
   panel: any;
@@ -281,4 +282,7 @@ export class PanelCtrl {
     html += '</div>';
     return html;
   }
+
+  // overriden from react
+  onPluginTypeChange = (plugin: PanelPluginMeta) => {};
 }

--- a/public/app/plugins/panel/bargauge/BarGaugeMigrations.test.ts
+++ b/public/app/plugins/panel/bargauge/BarGaugeMigrations.test.ts
@@ -1,5 +1,5 @@
 import { PanelModel } from '@grafana/ui';
-import { barGaugePanelMigrationCheck } from './BarGaugeMigrations';
+import { barGaugePanelMigrationHandler } from './BarGaugeMigrations';
 
 describe('BarGauge Panel Migrations', () => {
   it('from 6.2', () => {
@@ -45,6 +45,6 @@ describe('BarGauge Panel Migrations', () => {
       type: 'bargauge',
     } as PanelModel;
 
-    expect(barGaugePanelMigrationCheck(panel)).toMatchSnapshot();
+    expect(barGaugePanelMigrationHandler(panel)).toMatchSnapshot();
   });
 });

--- a/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
+++ b/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
@@ -1,5 +1,4 @@
-import { PanelModel } from '@grafana/ui';
-import { sharedSingleStatMigrationCheck } from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
+import { PanelModel, sharedSingleStatMigrationCheck } from '@grafana/ui';
 import { BarGaugeOptions } from './types';
 
 export const barGaugePanelMigrationCheck = (panel: PanelModel<BarGaugeOptions>): Partial<BarGaugeOptions> => {

--- a/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
+++ b/public/app/plugins/panel/bargauge/BarGaugeMigrations.ts
@@ -1,6 +1,6 @@
-import { PanelModel, sharedSingleStatMigrationCheck } from '@grafana/ui';
+import { PanelModel, sharedSingleStatMigrationHandler } from '@grafana/ui';
 import { BarGaugeOptions } from './types';
 
-export const barGaugePanelMigrationCheck = (panel: PanelModel<BarGaugeOptions>): Partial<BarGaugeOptions> => {
-  return sharedSingleStatMigrationCheck(panel);
+export const barGaugePanelMigrationHandler = (panel: PanelModel<BarGaugeOptions>): Partial<BarGaugeOptions> => {
+  return sharedSingleStatMigrationHandler(panel);
 };

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -1,11 +1,11 @@
-import { PanelPlugin, sharedSingleStatOptionsCheck } from '@grafana/ui';
+import { PanelPlugin, sharedSingleStatPanelChangedHandler } from '@grafana/ui';
 import { BarGaugePanel } from './BarGaugePanel';
 import { BarGaugePanelEditor } from './BarGaugePanelEditor';
 import { BarGaugeOptions, defaults } from './types';
-import { barGaugePanelMigrationCheck } from './BarGaugeMigrations';
+import { barGaugePanelMigrationHandler } from './BarGaugeMigrations';
 
 export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
   .setDefaults(defaults)
   .setEditor(BarGaugePanelEditor)
-  .setPanelChangeHandler(sharedSingleStatOptionsCheck)
-  .setMigrationHandler(barGaugePanelMigrationCheck);
+  .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
+  .setMigrationHandler(barGaugePanelMigrationHandler);

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -79,4 +79,23 @@ describe('Gauge Panel Migrations', () => {
 
     expect(gaugePanelMigrationCheck(panel)).toMatchSnapshot();
   });
+
+  it('from old gauge', () => {
+    const panel = {
+      format: 'ms',
+      gauge: {
+        maxValue: 150,
+        minValue: -10,
+        show: true,
+        thresholdLabels: false,
+        thresholdMarkers: true,
+      },
+    };
+
+    const newOptions = gaugePanelMigrationCheck(panel as any);
+    expect(newOptions.fieldOptions.defaults.min).toBe(-10);
+    expect(newOptions.fieldOptions.defaults.max).toBe(150);
+    expect(newOptions.showThresholdMarkers).toBe(true);
+    expect(newOptions.showThresholdLabels).toBe(true);
+  });
 });

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -1,5 +1,5 @@
 import { PanelModel } from '@grafana/ui';
-import { gaugePanelMigrationCheck } from './GaugeMigrations';
+import { gaugePanelMigrationCheck, gaugePanelChangedCheck } from './GaugeMigrations';
 
 describe('Gauge Panel Migrations', () => {
   it('from 6.1.1', () => {
@@ -80,21 +80,26 @@ describe('Gauge Panel Migrations', () => {
     expect(gaugePanelMigrationCheck(panel)).toMatchSnapshot();
   });
 
-  it('from old gauge', () => {
-    const panel = {
-      format: 'ms',
-      gauge: {
-        maxValue: 150,
-        minValue: -10,
-        show: true,
-        thresholdLabels: false,
-        thresholdMarkers: true,
+  it('change from angular singlestat to gauge', () => {
+    const old: any = {
+      angular: {
+        format: 'ms',
+        decimals: 7,
+        gauge: {
+          maxValue: 150,
+          minValue: -10,
+          show: true,
+          thresholdLabels: false,
+          thresholdMarkers: true,
+        },
       },
     };
 
-    const newOptions = gaugePanelMigrationCheck(panel as any);
+    const newOptions = gaugePanelChangedCheck({} as any, 'singlestat', old);
+    expect(newOptions.fieldOptions.defaults.unit).toBe('ms');
     expect(newOptions.fieldOptions.defaults.min).toBe(-10);
     expect(newOptions.fieldOptions.defaults.max).toBe(150);
+    expect(newOptions.fieldOptions.defaults.decimals).toBe(7);
     expect(newOptions.showThresholdMarkers).toBe(true);
     expect(newOptions.showThresholdLabels).toBe(true);
   });

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -89,7 +89,7 @@ describe('Gauge Panel Migrations', () => {
           maxValue: 150,
           minValue: -10,
           show: true,
-          thresholdLabels: false,
+          thresholdLabels: true,
           thresholdMarkers: true,
         },
       },

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -1,5 +1,5 @@
 import { PanelModel } from '@grafana/ui';
-import { gaugePanelMigrationCheck, gaugePanelChangedCheck } from './GaugeMigrations';
+import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMigrations';
 
 describe('Gauge Panel Migrations', () => {
   it('from 6.1.1', () => {
@@ -77,7 +77,7 @@ describe('Gauge Panel Migrations', () => {
       type: 'gauge',
     } as PanelModel;
 
-    expect(gaugePanelMigrationCheck(panel)).toMatchSnapshot();
+    expect(gaugePanelMigrationHandler(panel)).toMatchSnapshot();
   });
 
   it('change from angular singlestat to gauge', () => {
@@ -95,7 +95,7 @@ describe('Gauge Panel Migrations', () => {
       },
     };
 
-    const newOptions = gaugePanelChangedCheck({} as any, 'singlestat', old);
+    const newOptions = gaugePanelChangedHandler({} as any, 'singlestat', old);
     expect(newOptions.fieldOptions.defaults.unit).toBe('ms');
     expect(newOptions.fieldOptions.defaults.min).toBe(-10);
     expect(newOptions.fieldOptions.defaults.max).toBe(150);

--- a/public/app/plugins/panel/gauge/GaugeMigrations.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.ts
@@ -1,7 +1,30 @@
-import { PanelModel } from '@grafana/ui';
+import { PanelModel, VizOrientation } from '@grafana/ui';
+import { FieldConfig } from '@grafana/data';
 import { GaugeOptions } from './types';
 import { sharedSingleStatMigrationCheck } from '@grafana/ui/src/components/SingleStatShared/SingleStatBaseOptions';
 
 export const gaugePanelMigrationCheck = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
+  if (!panel.options && (panel as any).format) {
+    return migrateFromAngularSingleStat(panel);
+  }
+
   return sharedSingleStatMigrationCheck(panel);
 };
+
+function migrateFromAngularSingleStat(panel: any): Partial<GaugeOptions> {
+  const options = {
+    fieldOptions: {
+      defaults: {} as FieldConfig,
+      override: {} as FieldConfig,
+      calcs: [panel.format],
+    },
+    orientation: VizOrientation.Horizontal,
+  };
+
+  if (panel.gauge) {
+    options.fieldOptions.defaults.min = panel.gauge.minValue;
+    options.fieldOptions.defaults.max = panel.gauge.maxValue;
+  }
+
+  return options;
+}

--- a/public/app/plugins/panel/gauge/GaugeMigrations.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.ts
@@ -1,19 +1,19 @@
-import { PanelModel, sharedSingleStatOptionsCheck, sharedSingleStatMigrationCheck } from '@grafana/ui';
+import { PanelModel, sharedSingleStatPanelChangedHandler, sharedSingleStatMigrationHandler } from '@grafana/ui';
 import { GaugeOptions } from './types';
 
 // This is called when the panel first loads
-export const gaugePanelMigrationCheck = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
-  return sharedSingleStatMigrationCheck(panel);
+export const gaugePanelMigrationHandler = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
+  return sharedSingleStatMigrationHandler(panel);
 };
 
 // This is called when the panel changes from another panel
-export const gaugePanelChangedCheck = (
+export const gaugePanelChangedHandler = (
   options: Partial<GaugeOptions> | any,
   prevPluginId: string,
   prevOptions: any
 ) => {
   // This handles most config changes
-  const opts = sharedSingleStatOptionsCheck(options, prevPluginId, prevOptions) as GaugeOptions;
+  const opts = sharedSingleStatPanelChangedHandler(options, prevPluginId, prevOptions) as GaugeOptions;
 
   // Changing from angular singlestat
   if (prevPluginId === 'singlestat' && prevOptions.angular) {

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,11 +1,11 @@
-import { PanelPlugin, sharedSingleStatOptionsCheck } from '@grafana/ui';
+import { PanelPlugin } from '@grafana/ui';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
-import { gaugePanelMigrationCheck } from './GaugeMigrations';
+import { gaugePanelMigrationCheck, gaugePanelChangedCheck } from './GaugeMigrations';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setDefaults(defaults)
   .setEditor(GaugePanelEditor)
-  .setPanelChangeHandler(sharedSingleStatOptionsCheck)
+  .setPanelChangeHandler(gaugePanelChangedCheck)
   .setMigrationHandler(gaugePanelMigrationCheck);

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,10 +1,11 @@
-import { PanelPlugin, sharedSingleStatMigrationCheck, sharedSingleStatOptionsCheck } from '@grafana/ui';
+import { PanelPlugin, sharedSingleStatOptionsCheck } from '@grafana/ui';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
+import { gaugePanelMigrationCheck } from './GaugeMigrations';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setDefaults(defaults)
   .setEditor(GaugePanelEditor)
   .setPanelChangeHandler(sharedSingleStatOptionsCheck)
-  .setMigrationHandler(sharedSingleStatMigrationCheck);
+  .setMigrationHandler(gaugePanelMigrationCheck);

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -2,10 +2,10 @@ import { PanelPlugin } from '@grafana/ui';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
-import { gaugePanelMigrationCheck, gaugePanelChangedCheck } from './GaugeMigrations';
+import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMigrations';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setDefaults(defaults)
   .setEditor(GaugePanelEditor)
-  .setPanelChangeHandler(gaugePanelChangedCheck)
-  .setMigrationHandler(gaugePanelMigrationCheck);
+  .setPanelChangeHandler(gaugePanelChangedHandler)
+  .setMigrationHandler(gaugePanelMigrationHandler);

--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -1,4 +1,27 @@
 <div class="editor-row">
+
+  <div class="grafana-info-box" ng-if="ctrl.panel.gauge.show">
+    <h5>Gauge Migration</h5>
+    <p>
+      Gauge visualizations within the Singlestat panel are now deprecated.  Please
+      migrate this panel to use the Gauge panel
+    
+      <div class="gf-form-button-row">
+        <button class="btn btn-primary" ng-click="ctrl.migrateToGaugePanel(true)">
+          Migrate to Gauge Panel
+        </button>
+        <button class="btn btn-inverse" ng-click="ctrl.migrateToGaugePanel(false)">
+          Show as single stat
+        </button>
+      </div>
+    
+      <div ng-if="ctrl.panel.sparkline.show">
+        TODO... note about sparkline... and possible soltuion with shared querys?
+      </div>
+    </p>
+  </div>
+    
+
   <div class="section gf-form-group">
     <h5 class="section-heading">Value</h5>
 

--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -3,7 +3,7 @@
   <div class="grafana-info-box" ng-if="ctrl.panel.gauge.show">
     <h5>Gauge Migration</h5>
     <p>
-      Gauge visualizations within the Singlestat panel are now deprecated.  Please
+      Gauge visualizations within the Singlestat panel are deprecated.  Please
       migrate this panel to use the Gauge panel
     
       <div class="gf-form-button-row">
@@ -15,8 +15,22 @@
         </button>
       </div>
     
+      <br/>
+      
       <div ng-if="ctrl.panel.sparkline.show">
-        TODO... note about sparkline... and possible soltuion with shared querys?
+        <b>NOTE:</b> Sparklines are not supported in the gauge panel
+      </div>
+
+      <div ng-if="ctrl.panel.prefix">
+        <b>NOTE:</b> Prefix will not be show in the gauge panel
+      </div>
+
+      <div ng-if="ctrl.panel.postfix">
+        <b>NOTE:</b> Postfix will not be show in the gauge panel
+      </div>
+
+      <div ng-if="ctrl.panel.links && ctrl.panel.links.length">
+        <b>NOTE:</b> Links will be in the upper left corner, rather than anywhere on the gauge
       </div>
     </p>
   </div>

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -14,7 +14,6 @@ import { GrafanaThemeType, getValueFormat, getColorFromHexRgbOrName } from '@gra
 import { auto } from 'angular';
 import { LinkSrv, LinkModel } from 'app/features/panel/panellinks/link_srv';
 import TableModel from 'app/core/table_model';
-import { getLocationSrv } from '@grafana/runtime';
 
 const BASE_FONT_SIZE = 38;
 
@@ -116,24 +115,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
   migrateToGaugePanel(migrate: boolean) {
     if (migrate) {
-      console.log('Change the panel type... the wrapper should pick this up after render');
-      this.panel.type = 'gauge';
-
-      // maybe change some parameter?
-      getLocationSrv().update({ query: { chage: 'xxxxx' }, partial: true });
-
-      // or refresh?
-      this.refresh();
-
-      // debugger;
-      // const panel = this.panel as PanelModel;
-      // importPanelPlugin('gauge').then( gauge => {
-      //   console.warn('MIGRATE', panel, 'to', gauge );
-      //   panel.type = gauge.id;
-      //   panel.changePlugin(gauge);
-      // }).catch( err => {
-      //   console.warn('error loading gauge', err);
-      // });
+      this.onPluginTypeChange(config.panels['gauge']);
     } else {
       this.panel.gauge.show = false;
       this.render();

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -14,6 +14,7 @@ import { GrafanaThemeType, getValueFormat, getColorFromHexRgbOrName } from '@gra
 import { auto } from 'angular';
 import { LinkSrv, LinkModel } from 'app/features/panel/panellinks/link_srv';
 import TableModel from 'app/core/table_model';
+import { getLocationSrv } from '@grafana/runtime';
 
 const BASE_FONT_SIZE = 38;
 
@@ -111,6 +112,32 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     this.addEditorTab('Options', 'public/app/plugins/panel/singlestat/editor.html', 2);
     this.addEditorTab('Value Mappings', 'public/app/plugins/panel/singlestat/mappings.html', 3);
     this.unitFormats = kbn.getUnitFormats();
+  }
+
+  migrateToGaugePanel(migrate: boolean) {
+    if (migrate) {
+      console.log('Change the panel type... the wrapper should pick this up after render');
+      this.panel.type = 'gauge';
+
+      // maybe change some parameter?
+      getLocationSrv().update({ query: { chage: 'xxxxx' }, partial: true });
+
+      // or refresh?
+      this.refresh();
+
+      // debugger;
+      // const panel = this.panel as PanelModel;
+      // importPanelPlugin('gauge').then( gauge => {
+      //   console.warn('MIGRATE', panel, 'to', gauge );
+      //   panel.type = gauge.id;
+      //   panel.changePlugin(gauge);
+      // }).catch( err => {
+      //   console.warn('error loading gauge', err);
+      // });
+    } else {
+      this.panel.gauge.show = false;
+      this.render();
+    }
   }
 
   setUnitFormat(subItem: { value: any }) {

--- a/public/app/plugins/panel/singlestat2/module.tsx
+++ b/public/app/plugins/panel/singlestat2/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin, sharedSingleStatMigrationCheck, sharedSingleStatOptionsCheck } from '@grafana/ui';
+import { PanelPlugin, sharedSingleStatMigrationHandler, sharedSingleStatPanelChangedHandler } from '@grafana/ui';
 import { SingleStatOptions, defaults } from './types';
 import { SingleStatPanel } from './SingleStatPanel';
 import { SingleStatEditor } from './SingleStatEditor';
@@ -6,5 +6,5 @@ import { SingleStatEditor } from './SingleStatEditor';
 export const plugin = new PanelPlugin<SingleStatOptions>(SingleStatPanel)
   .setDefaults(defaults)
   .setEditor(SingleStatEditor)
-  .setPanelChangeHandler(sharedSingleStatOptionsCheck)
-  .setMigrationHandler(sharedSingleStatMigrationCheck);
+  .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
+  .setMigrationHandler(sharedSingleStatMigrationHandler);


### PR DESCRIPTION
First step towards #14554

This adds a notice to the singlestat panel asking to be migrated to gauge:
![image](https://user-images.githubusercontent.com/705951/63196631-91df4a00-c02a-11e9-9158-a5ce231896f4.png)

TODO: Help wanted!
- [x] actually migrate!  how do we get an event from angular to react context?
- [ ] refine language / wording
- Add warnings that some settings will be lost: (when configured)
   - [x] singlestat
   - [ ] prefix / suffix
   - [ ] datalink