### PR TITLE
SingleStat: The gauge option in now disabled/hidden (unless it's an old panel with it already enabled) 

### DIFF
--- a/public/app/plugins/panel/singlestat/editor.html
+++ b/public/app/plugins/panel/singlestat/editor.html
@@ -148,7 +148,7 @@
     </div>
   </div>
 
-  <div class="section gf-form-group">
+  <div class="section gf-form-group" ng-if="ctrl.panel.gauge.show">
     <h5 class="section-heading">Gauge</h5>
     <gf-form-switch class="gf-form" label-class="width-10" switch-class="max-width-6" label="Show" checked="ctrl.panel.gauge.show" on-change="ctrl.render()"></gf-form-switch>
     <div ng-if="ctrl.panel.gauge.show">


### PR DESCRIPTION
Gauges should be implemented in the Gauge panel, not the singlestat panel.

This PR just removes the option to create a new gauge in singlestat, but any existing gauges will keep working the same.

TODO:
- [x] Update this with the text we want in the changelog