### PR TITLE
Prometheus: Prevents panel editor crash when switching to Prometheus datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -1,0 +1,44 @@
+import { getQueryHints } from './query_hints';
+
+describe('getQueryHints', () => {
+  describe('when called without datapoints in series', () => {
+    it('then it should use rows instead and return correct hint', () => {
+      const series = [
+        {
+          fields: [
+            {
+              name: 'Some Name',
+            },
+          ],
+          rows: [[1], [2]],
+        },
+      ];
+
+      const result = getQueryHints('up', series);
+      expect(result).toEqual([
+        {
+          fix: { action: { query: 'up', type: 'ADD_RATE' }, label: 'Fix by adding rate().' },
+          label: 'Time series is monotonically increasing.',
+          type: 'APPLY_RATE',
+        },
+      ]);
+    });
+  });
+
+  describe('when called without datapoints and rows in series', () => {
+    it('then it should use an empty array and return null', () => {
+      const series = [
+        {
+          fields: [
+            {
+              name: 'Some Name',
+            },
+          ],
+        },
+      ];
+
+      const result = getQueryHints('up', series);
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -29,7 +29,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: any): 
   // Check for monotonicity on series (table results are being ignored here)
   if (series && series.length > 0) {
     series.forEach(s => {
-      const datapoints: number[][] = s.datapoints;
+      const datapoints: number[][] = s.datapoints || s.rows || [];
       if (query.indexOf('rate(') === -1 && datapoints.length > 1) {
         let increasing = false;
         const nonNullData = datapoints.filter(dp => dp[0] !== null);


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus QueryDield tries to lookup any queryhints [here](https://github.com/grafana/grafana/blob/21948e80e0c5ab0db4223caa555310abb1eba27c/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx#L184) but in some cases when the Fields array only has 1 entry then the conversion [toLegacyData](https://github.com/grafana/grafana/blob/21948e80e0c5ab0db4223caa555310abb1eba27c/packages/grafana-data/src/utils/processDataFrame.ts#L252) fails and the query hints fails.

**Which issue(s) this PR fixes**:
Fixes: #18600

**Special notes for your reviewer**:

