### PR TITLE
Docs: remove codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Grafana](https://grafana.com) [![Circle CI](https://circleci.com/gh/grafana/grafana.svg?style=svg)](https://circleci.com/gh/grafana/grafana) [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana)](https://goreportcard.com/report/github.com/grafana/grafana) [![codecov](https://codecov.io/gh/grafana/grafana/branch/master/graph/badge.svg)](https://codecov.io/gh/grafana/grafana)
+# [Grafana](https://grafana.com) [![Circle CI](https://circleci.com/gh/grafana/grafana.svg?style=svg)](https://circleci.com/gh/grafana/grafana) [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana)](https://goreportcard.com/report/github.com/grafana/grafana) 
 
 [Website](https://grafana.com) |
 [Twitter](https://twitter.com/grafana) |


### PR DESCRIPTION
For a long time we haven't been using codecov, remove it so it wouldn't confuse
    the readers