### PR TITLE
Templating -  add support for simple expressions in template variables

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -117,7 +117,7 @@ export class LinkSrv implements LinkService {
 
     const variablesQuery = toUrlParams(params);
 
-    info.href = this.templateSrv.replace(link.url, {
+    let varsToApply = {
       ...scopedVars,
       [DataLinkBuiltInVars.keepTime]: {
         text: timeRangeUrl,
@@ -127,15 +127,16 @@ export class LinkSrv implements LinkService {
         text: variablesQuery,
         value: variablesQuery,
       },
-    });
+    };
 
     if (dataPoint) {
-      info.href = this.templateSrv.replace(
-        info.href,
-        this.getDataPointVars(dataPoint.seriesName, dateTime(dataPoint.datapoint[0]))
-      );
+      varsToApply = {
+        ...varsToApply,
+        ...this.getDataPointVars(dataPoint.seriesName, dateTime(dataPoint.datapoint[0])),
+      };
     }
 
+    info.href = this.templateSrv.replace(link.url, varsToApply);
     return info;
   };
 

--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -530,4 +530,89 @@ describe('templateSrv', () => {
       expect(target).toBe('10 * 100');
     });
   });
+
+  describe('expressions evaluation', () => {
+    beforeEach(() => {
+      initTemplateSrv([]);
+    });
+
+    describe('built-in string expressions ', () => {
+      test('replace', () => {
+        const expr = '${replace($instancePath, region, $region)}';
+        const result = _templateSrv.evaluateExpressionVariable(expr, {
+          instancePath: {
+            text: 'grafana.region.instance',
+            value: 'grafana.region.instance',
+          },
+          region: {
+            text: 'eu-west-1',
+            value: 'eu-west-1',
+          },
+        });
+        expect(result).toBe('grafana.eu-west-1.instance');
+      });
+    });
+
+    describe('built-in math expressions ', () => {
+      describe('integer arguments', () => {
+        test('add', () => {
+          const expr = '${add(10, 10)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(20);
+        });
+
+        test('subtract', () => {
+          const expr = '${subtract(20, 10)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(10);
+        });
+
+        test('multiply', () => {
+          const expr = '${multiply(5, 6)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(30);
+        });
+      });
+
+      describe('float argument', () => {
+        test('add', () => {
+          const expr = '${add(1.5, 0.5)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(2);
+        });
+
+        test('subtract', () => {
+          const expr = '${subtract(2.5, 1.3)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(1.2);
+        });
+
+        test('multiply', () => {
+          const expr = '${multiply(1.5, 1.5)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(2.25);
+        });
+      });
+
+      describe('mixed arguments', () => {
+        test('add', () => {
+          const expr = '${add(1, 0.5)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(1.5);
+        });
+
+        test('subtract', () => {
+          const expr = '${subtract(2, 1.3)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(0.7);
+        });
+
+        test('multiply', () => {
+          const expr = '${multiply(2, 1.5)}';
+          const result = _templateSrv.evaluateExpressionVariable(expr);
+          expect(result).toBe(3);
+        });
+      });
+    });
+  });
 });

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -7,7 +7,9 @@ import { assignModelProperties } from 'app/core/utils/model_utils';
  * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
  * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
  */
-export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?::(\w+))?}/g;
+export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?::(\w+))?}|\${\w+\((.*?)\)}/g;
+
+export const expressionVariableRegex = /(\${\w+\((.*?)\)})$/;
 
 // Helper function since lastIndex is not reset
 export const variableRegexExec = (variableString: string) => {


### PR DESCRIPTION
This PR adds simple support for expressions within template strings. I.e. you can do `${add($__value_time, 10)}` or `${replace($var1, regex, $var2)}`. See https://github.com/grafana/grafana/compare/data-links/fn?expand=1#diff-6819db476648351f2780cfdefec09421 for test cases

It adds new capture group to variables regex to pickup variables with expressions being used. 

Basic expressions supported are:

Math:
  - add
  - subtract
  - multiply

String:
  - replace

One big limitation for this solution is lack of expressions nesting. 

Some initial thoughts @torkelo, @ryantxu?

TODO:

- [ ] Add syntax highlighting for data links editor to support expression
- [ ] Add UI to enable functions selection
- [ ] Implement some benchmarks for the code as it's adding new capture group to our variable regexp
