### PR TITLE
Add typings to package.json in packages

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -40,5 +40,6 @@
     "rollup-plugin-visualizer": "0.9.2",
     "sinon": "1.17.6",
     "typescript": "3.5.3"
-  }
+  },
+  "typings": "src/index.ts"
 }

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -41,5 +41,5 @@
     "sinon": "1.17.6",
     "typescript": "3.5.3"
   },
-  "typings": "src/index.ts"
+  "types": "src/index.ts"
 }

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -40,5 +40,5 @@
     "rollup-plugin-visualizer": "0.9.2",
     "typescript": "3.5.3"
   },
-  "typings": "src/index.ts"
+  "types": "src/index.ts"
 }

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -39,5 +39,6 @@
     "rollup-plugin-typescript2": "0.19.3",
     "rollup-plugin-visualizer": "0.9.2",
     "typescript": "3.5.3"
-  }
+  },
+  "typings": "src/index.ts"
 }

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -99,5 +99,5 @@
   "_moduleAliases": {
     "puppeteer": "node_modules/puppeteer-core"
   },
-  "typings": "src/index.ts"
+  "types": "src/index.ts"
 }

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -98,5 +98,6 @@
   },
   "_moduleAliases": {
     "puppeteer": "node_modules/puppeteer-core"
-  }
+  },
+  "typings": "src/index.ts"
 }

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -83,5 +83,6 @@
     "rollup-plugin-typescript2": "0.19.3",
     "rollup-plugin-visualizer": "0.9.2",
     "typescript": "3.5.3"
-  }
+  },
+  "typings": "src/index.ts"
 }

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -84,5 +84,5 @@
     "rollup-plugin-visualizer": "0.9.2",
     "typescript": "3.5.3"
   },
-  "typings": "src/index.ts"
+  "types": "src/index.ts"
 }


### PR DESCRIPTION
This should fix issues with code navigation (jump to def, autocomplete) in webstorm at least (https://intellij-support.jetbrains.com/hc/en-us/community/posts/360001029920--main-field-in-package-json-is-ignored-when-importing-from-node-module).

One thing to note is that it points to `src/index.ts` file. Issue is I am not sure if that is also distributed? @dprokop @ryantxu ? I could put there `dist/index.d.ts` which probably would make sense but would need to build (and rebuild on change) during dev.