### PR TITLE
SingleStat2: save options to defaults not override

### DIFF
--- a/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
+++ b/public/app/plugins/panel/singlestat2/SingleStatEditor.tsx
@@ -49,7 +49,7 @@ export class SingleStatEditor extends PureComponent<PanelEditorProps<SingleStatO
   onDefaultsChange = (field: FieldConfig) => {
     this.onDisplayOptionsChanged({
       ...this.props.options.fieldOptions,
-      override: field,
+      defaults: field,
     });
   };
 


### PR DESCRIPTION
The alpha panel SingleStat2 currently saves its options to the override section.  This is different from all the other react gauge panels that save it to defaults.

Lets make it the same.

I don't think we need to worry about migrations since this is an alpha panel that only kinda-sorta works
