### PR TITLE
Packages: Fix path import from grafana/data

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -14,7 +14,7 @@ import { rawToTimeRange } from './time';
 
 // Types
 import { TimeRange, TimeOption, TimeZone, TIME_FORMAT, SelectableValue } from '@grafana/data';
-import { isMathString } from '@grafana/data/src/utils/datemath';
+import { dateMath } from '@grafana/data';
 
 export interface Props {
   value: TimeRange;
@@ -129,8 +129,8 @@ export class TimePicker extends PureComponent<Props, State> {
 
     const adjustedTime = (time: DateTime) => (isUTC ? time.utc() : time.local()) || null;
     const adjustedTimeRange = {
-      to: isMathString(value.raw.to) ? value.raw.to : adjustedTime(value.to),
-      from: isMathString(value.raw.from) ? value.raw.from : adjustedTime(value.from),
+      to: dateMath.isMathString(value.raw.to) ? value.raw.to : adjustedTime(value.to),
+      from: dateMath.isMathString(value.raw.from) ? value.raw.from : adjustedTime(value.from),
     };
     const rangeString = rangeUtil.describeTimeRange(adjustedTimeRange);
 


### PR DESCRIPTION
Fixes issue mentioned in: https://github.com/grafana/simple-json-datasource/pull/129#issuecomment-521054894

When importing from grafana/ui (in datasource.test.ts file in ^^ PR) node tries to load grafana/data package as well because grafana/ui has dependency on it. But the path fails, as the bundled version of grafana/data does not have src dir. To avoid that we could bundle packages with src in path _or_ ban path imports from grafana/* packages. Anyways would be good to research the way how not to bundle packages to a single entry point.