### PR TITLE
Explore: Fixes so Show context shows results again

### DIFF
--- a/packages/grafana-data/src/utils/dataFrameHelper.test.ts
+++ b/packages/grafana-data/src/utils/dataFrameHelper.test.ts
@@ -1,4 +1,4 @@
-import { FieldType, DataFrameDTO, FieldDTO, Field } from '../types/index';
+import { DataFrameDTO, FieldDTO, FieldType } from '../types';
 import { DataFrameHelper } from './dataFrameHelper';
 
 describe('dataFrameHelper', () => {

--- a/packages/grafana-data/src/utils/dataFrameHelper.test.ts
+++ b/packages/grafana-data/src/utils/dataFrameHelper.test.ts
@@ -1,4 +1,4 @@
-import { FieldType, DataFrameDTO, FieldDTO } from '../types/index';
+import { FieldType, DataFrameDTO, FieldDTO, Field } from '../types/index';
 import { DataFrameHelper } from './dataFrameHelper';
 
 describe('dataFrameHelper', () => {
@@ -85,5 +85,31 @@ describe('FieldCache', () => {
     expect(fieldCache.getFieldByName('other')!.name).toEqual(expectedFieldNames[4]);
     expect(fieldCache.getFieldByName('undefined')!.name).toEqual(expectedFieldNames[5]);
     expect(fieldCache.getFieldByName('null')).toBeUndefined();
+  });
+});
+
+describe('reverse', () => {
+  describe('when called with a DataFrame', () => {
+    it('then it should reverse the order of values in all fields', () => {
+      const frame: DataFrameDTO = {
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'name', type: FieldType.string, values: ['a', 'b', 'c'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+      };
+
+      const helper = new DataFrameHelper(frame);
+
+      expect(helper.getFieldByName('time')!.values.toArray()).toEqual([100, 200, 300]);
+      expect(helper.getFieldByName('name')!.values.toArray()).toEqual(['a', 'b', 'c']);
+      expect(helper.getFieldByName('value')!.values.toArray()).toEqual([1, 2, 3]);
+
+      helper.reverse();
+
+      expect(helper.getFieldByName('time')!.values.toArray()).toEqual([300, 200, 100]);
+      expect(helper.getFieldByName('name')!.values.toArray()).toEqual(['c', 'b', 'a']);
+      expect(helper.getFieldByName('value')!.values.toArray()).toEqual([3, 2, 1]);
+    });
   });
 });

--- a/packages/grafana-data/src/utils/dataFrameHelper.ts
+++ b/packages/grafana-data/src/utils/dataFrameHelper.ts
@@ -44,10 +44,7 @@ export class DataFrameHelper implements DataFrame {
    */
   reverse() {
     for (const f of this.fields) {
-      if (isArray(f.values)) {
-        const arr = f.values as any[];
-        arr.reverse();
-      }
+      f.values.toArray().reverse();
     }
   }
 

--- a/public/app/features/explore/LogRowContextProvider.test.ts
+++ b/public/app/features/explore/LogRowContextProvider.test.ts
@@ -1,0 +1,74 @@
+import { DataFrameHelper, FieldType, LogRowModel } from '@grafana/data';
+import { getRowContexts } from './LogRowContextProvider';
+
+describe('getRowContexts', () => {
+  describe('when called with a DataFrame and results are returned', () => {
+    it('then the result should be in correct format', async () => {
+      const firstResult = new DataFrameHelper({
+        refId: 'B',
+        labels: {},
+        fields: [
+          { name: 'ts', type: FieldType.time, values: [3, 2, 1] },
+          { name: 'line', type: FieldType.string, values: ['3', '2', '1'] },
+        ],
+      });
+      const secondResult = new DataFrameHelper({
+        refId: 'B',
+        labels: {},
+        fields: [
+          { name: 'ts', type: FieldType.time, values: [6, 5, 4] },
+          { name: 'line', type: FieldType.string, values: ['6', '5', '4'] },
+        ],
+      });
+      const row: LogRowModel = {
+        entry: '4',
+        labels: null,
+        hasAnsi: false,
+        raw: '4',
+        logLevel: null,
+        timeEpochMs: 4,
+        timeFromNow: '',
+        timeLocal: '',
+        timeUtc: '',
+        timestamp: '4',
+      };
+
+      const getRowContext = jest
+        .fn()
+        .mockResolvedValueOnce({ data: [firstResult] })
+        .mockResolvedValueOnce({ data: [secondResult] });
+
+      const result = await getRowContexts(getRowContext, row, 10);
+
+      expect(result).toEqual({ data: [[['3', '2', '1']], [['6', '5', '4']]], errors: [null, null] });
+    });
+  });
+
+  describe('when called with a DataFrame and errors occur', () => {
+    it('then the result should be in correct format', async () => {
+      const firstError = new Error('Error 1');
+      const secondError = new Error('Error 2');
+      const row: LogRowModel = {
+        entry: '4',
+        labels: null,
+        hasAnsi: false,
+        raw: '4',
+        logLevel: null,
+        timeEpochMs: 4,
+        timeFromNow: '',
+        timeLocal: '',
+        timeUtc: '',
+        timestamp: '4',
+      };
+
+      const getRowContext = jest
+        .fn()
+        .mockRejectedValueOnce(firstError)
+        .mockRejectedValueOnce(secondError);
+
+      const result = await getRowContexts(getRowContext, row, 10);
+
+      expect(result).toEqual({ data: [[], []], errors: ['Error 1', 'Error 2'] });
+    });
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
During the change to columnar data model we missed how the LogRowContextProvider builds it's result. This PR fixes this and adds tests.

**Which issue(s) this PR fixes**:
Fixes: #18656

**Special notes for your reviewer**:

