### PR TITLE
Azure Monitor : Query more than 10 dimensions ( Fixes #17230 )

### DIFF
--- a/docs/sources/guides/whats-new-in-v4-5.md
+++ b/docs/sources/guides/whats-new-in-v4-5.md
@@ -56,7 +56,7 @@ More information [here](https://community.grafana.com/t/using-grafanas-query-ins
 This option is now renamed (and moved to Options sub section above your queries):
 ![image|519x120](upload://ySjHOVpavV6yk9LHQxL9nq2HIsT.png)
 
-Datas source selection & options & help are now above your metric queries.
+Data source selection & options & help are now above your metric queries.
 ![image|690x179](upload://5kNDxKgMz1BycOKgG3iWYLsEVXv.png)
 
 ### Minor Changes

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -125,6 +125,7 @@ func (e *AzureMonitorDatasource) buildQueries(queries []*tsdb.Query, timeRange *
 		dimensionFilter := strings.TrimSpace(fmt.Sprintf("%v", azureMonitorTarget["dimensionFilter"]))
 		if azureMonitorTarget["dimension"] != nil && azureMonitorTarget["dimensionFilter"] != nil && len(dimension) > 0 && len(dimensionFilter) > 0 && dimension != "None" {
 			params.Add("$filter", fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter))
+			params.Add("top", fmt.Sprintf("%v", azureMonitorTarget["top"]))
 		}
 
 		target = params.Encode()

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -43,6 +43,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 								"metricDefinition": "Microsoft.Compute/virtualMachines",
 								"metricNamespace":  "Microsoft.Compute-virtualMachines",
 								"metricName":       "Percentage CPU",
+								"top":              "10",
 								"alias":            "testalias",
 								"queryType":        "Azure Monitor",
 							},
@@ -127,13 +128,14 @@ func TestAzureMonitorDatasource(t *testing.T) {
 						"queryType":        "Azure Monitor",
 						"dimension":        "blob",
 						"dimensionFilter":  "*",
+						"top":              "30",
 					},
 				})
 
 				queries, err := datasource.buildQueries(tsdbQuery.Queries, tsdbQuery.TimeRange)
 				So(err, ShouldBeNil)
 
-				So(queries[0].Target, ShouldEqual, "%24filter=blob+eq+%27%2A%27&aggregation=Average&api-version=2018-01-01&interval=PT1M&metricnames=Percentage+CPU&metricnamespace=Microsoft.Compute-virtualMachines&timespan=2018-03-15T13%3A00%3A00Z%2F2018-03-15T13%3A34%3A00Z")
+				So(queries[0].Target, ShouldEqual, "%24filter=blob+eq+%27%2A%27&aggregation=Average&api-version=2018-01-01&interval=PT1M&metricnames=Percentage+CPU&metricnamespace=Microsoft.Compute-virtualMachines&timespan=2018-03-15T13%3A00%3A00Z%2F2018-03-15T13%3A34%3A00Z&top=30")
 
 			})
 
@@ -151,6 +153,7 @@ func TestAzureMonitorDatasource(t *testing.T) {
 						"queryType":        "Azure Monitor",
 						"dimension":        "None",
 						"dimensionFilter":  "*",
+						"top":              "10",
 					},
 				})
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -75,7 +75,7 @@ export default class AzureMonitorDatasource {
       const metricDefinition = this.templateSrv.replace(item.metricDefinition, options.scopedVars);
       const timeGrain = this.templateSrv.replace((item.timeGrain || '').toString(), options.scopedVars);
       const aggregation = this.templateSrv.replace(item.aggregation, options.scopedVars);
-      const top = this.templateSrv.replace(item.top || `10`, options.scopedVars);
+      const top = this.templateSrv.replace(item.top || '', options.scopedVars);
 
       return {
         refId: target.refId,
@@ -96,7 +96,7 @@ export default class AzureMonitorDatasource {
             metricNamespace && metricNamespace !== this.defaultDropdownValue ? metricNamespace : metricDefinition,
           aggregation: aggregation,
           dimension: this.templateSrv.replace(item.dimension, options.scopedVars),
-          top: top || `10`,
+          top: top || '10',
           dimensionFilter: this.templateSrv.replace(item.dimensionFilter, options.scopedVars),
           alias: item.alias,
           format: target.format,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -75,6 +75,7 @@ export default class AzureMonitorDatasource {
       const metricDefinition = this.templateSrv.replace(item.metricDefinition, options.scopedVars);
       const timeGrain = this.templateSrv.replace((item.timeGrain || '').toString(), options.scopedVars);
       const aggregation = this.templateSrv.replace(item.aggregation, options.scopedVars);
+      const top = this.templateSrv.replace(item.top || `10`, options.scopedVars);
 
       return {
         refId: target.refId,
@@ -95,6 +96,7 @@ export default class AzureMonitorDatasource {
             metricNamespace && metricNamespace !== this.defaultDropdownValue ? metricNamespace : metricDefinition,
           aggregation: aggregation,
           dimension: this.templateSrv.replace(item.dimension, options.scopedVars),
+          top: top || `10`,
           dimensionFilter: this.templateSrv.replace(item.dimensionFilter, options.scopedVars),
           alias: item.alias,
           format: target.format,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -91,6 +91,11 @@
         <input type="text" class="gf-form-input width-17" ng-model="ctrl.target.azureMonitor.dimensionFilter"
           spellcheck="false" placeholder="auto" ng-blur="ctrl.refresh()">
       </div>
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-9">Top</label>
+        <input type="text" class="gf-form-input width-3" ng-model="ctrl.target.azureMonitor.top"
+          spellcheck="false" placeholder="10" ng-blur="ctrl.refresh()">
+      </div>
       <div class="gf-form gf-form--grow">
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -72,7 +72,7 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
       metricName: this.defaultDropdownValue,
       dimensionFilter: '*',
       timeGrain: 'auto',
-      top: `10`,
+      top: '10',
     },
     azureLogAnalytics: {
       query: [

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -36,6 +36,7 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
       allowedTimeGrainsMs: number[];
       dimensions: any[];
       dimension: any;
+      top: string;
       aggregation: string;
       aggOptions: string[];
     };
@@ -71,6 +72,7 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
       metricName: this.defaultDropdownValue,
       dimensionFilter: '*',
       timeGrain: 'auto',
+      top: `10`,
     },
     azureLogAnalytics: {
       query: [

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
@@ -41,6 +41,7 @@ export interface AzureMetricQuery {
   dimension: string;
   dimensionFilter: string;
   alias: string;
+  top: string;
 }
 
 export interface AzureLogsQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:

Query more than 10 dimensions in Azure Monitor API. Azure monitor pulls only 10 dimensions by default.  This PR gives ability to pull more than 10 dimension instances.

![image](https://user-images.githubusercontent.com/153843/63582621-52b47a00-c591-11e9-924d-9594fd7cb082.png)

Fixes #17230


