### PR TITLE
Docs: Fix broken link for the Grafana on RHEL or Ubuntu tutorial

### DIFF
--- a/docs/sources/tutorials/_index.md
+++ b/docs/sources/tutorials/_index.md
@@ -20,7 +20,7 @@ This section of the docs contains a series for tutorials and stack setup guides.
 
 ## External links
 
-- [Installing Graphite and Grafana on RHEL 6, 7, or Ubuntu in under 30 minutes](http://blog.pkiwi.com/installing-graphite-and-grafana-on-rhel-6-7-or-ubuntu-in-under-30-minutes/)
+- [Installing Graphite and Grafana on RHEL 6, 7, or Ubuntu in under 30 minutes](https://www.beginswithdata.com/2015/09/14/installing-graphite-and-grafana-on-rhel-6-7-or-ubuntu-in-under-30-minutes/)
 - [Monitoring Urbancode deployments with Docker, Graphite, Grafana, collectd and chef!](http://cloud.boriskuschel.com/2015/08/monitoring-urbancode-deploments-with.html)
 - [Scripting Grafana dashboards](http://anatolijd.blogspot.se/2014/07/scripting-grafana-dashboards.html)
 


### PR DESCRIPTION
The author updated their site and now the link for the tutorial changed.

**What this PR does**: This PR updates the link in the tutorial page so it's reachable again.

