### PR TITLE
Units: add counts/sec (cps) and counts/min (cpm) in Throughput

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/categories.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/categories.ts
@@ -292,11 +292,13 @@ export const getCategories = (): ValueFormatCategory[] => [
   {
     name: 'Throughput',
     formats: [
+      { name: 'counts/sec (cps)', id: 'cps', fn: simpleCountUnit('cps') },
       { name: 'ops/sec (ops)', id: 'ops', fn: simpleCountUnit('ops') },
       { name: 'requests/sec (rps)', id: 'reqps', fn: simpleCountUnit('reqps') },
       { name: 'reads/sec (rps)', id: 'rps', fn: simpleCountUnit('rps') },
       { name: 'writes/sec (wps)', id: 'wps', fn: simpleCountUnit('wps') },
       { name: 'I/O ops/sec (iops)', id: 'iops', fn: simpleCountUnit('iops') },
+      { name: 'counts/min (cpm)', id: 'cpm', fn: simpleCountUnit('cpm') },
       { name: 'ops/min (opm)', id: 'opm', fn: simpleCountUnit('opm') },
       { name: 'reads/min (rpm)', id: 'rpm', fn: simpleCountUnit('rpm') },
       { name: 'writes/min (wpm)', id: 'wpm', fn: simpleCountUnit('wpm') },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Add another set of throughput units: counts/sec (cps) and counts/min (cpm)

Although cps/cpm are used in radiology they can be seen as a more general set of units for rates of values without units. Image you have a metric for a total cumulative number of database connections and want to graph a rate of it. The resulting unit of the rate would be 1/s or 1/min. This doesn't read well especially when used with short units: "10k 1/s". Hertz is used for period events and it reads strange when used in the context of rates.

**Which issue(s) this PR fixes**:

None

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

None