### PR TITLE
check if optional func toggleEditorMode is provided

### DIFF
--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -73,7 +73,7 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
     const hasNewError = prevProps.error !== this.props.error;
 
     if (this.component) {
-      if (hasToggledEditorMode) {
+      if (hasToggledEditorMode && this.angularScope && this.angularScope.toggleEditorMode) {
         this.angularScope.toggleEditorMode();
       }
 


### PR DESCRIPTION
This func was being called when it had not been supplied to the component. Added check to see if it was defined.