### PR TITLE
Units: Adding T,P,E,Z,and Y bytes

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/categories.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/categories.ts
@@ -75,6 +75,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'TFLOP/s', id: 'tflops', fn: decimalSIPrefix('FLOP/s', 4) },
       { name: 'PFLOP/s', id: 'pflops', fn: decimalSIPrefix('FLOP/s', 5) },
       { name: 'EFLOP/s', id: 'eflops', fn: decimalSIPrefix('FLOP/s', 6) },
+      { name: 'ZFLOP/s', id: 'zflops', fn: decimalSIPrefix('FLOP/s', 6) },
     ],
   },
   {
@@ -124,6 +125,9 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'gibibytes', id: 'gbytes', fn: binarySIPrefix('B', 3) },
       { name: 'tebibytes', id: 'tbytes', fn: binarySIPrefix('B', 4) },
       { name: 'pebibytes', id: 'pbytes', fn: binarySIPrefix('B', 5) },
+      { name: 'exbibytes', id: 'ebytes', fn: binarySIPrefix('B', 6) },
+      { name: 'zobibytes', id: 'zbytes', fn: binarySIPrefix('B', 7) },
+      { name: 'yobibytes', id: 'ybytes', fn: binarySIPrefix('B', 8) },
     ],
   },
   {
@@ -136,6 +140,9 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'gigabytes', id: 'decgbytes', fn: decimalSIPrefix('B', 3) },
       { name: 'terabytes', id: 'dectbytes', fn: decimalSIPrefix('B', 4) },
       { name: 'petabytes', id: 'decpbytes', fn: decimalSIPrefix('B', 5) },
+      { name: 'exabytes', id: 'decebytes', fn: decimalSIPrefix('B', 6) },
+      { name: 'zettabytes', id: 'deczbytes', fn: decimalSIPrefix('B', 7) },
+      { name: 'yottabytes', id: 'decybytes', fn: decimalSIPrefix('B', 8) },
     ],
   },
   {
@@ -153,7 +160,13 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'terabytes/sec', id: 'TBs', fn: decimalSIPrefix('Bs', 4) },
       { name: 'terabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 4) },
       { name: 'petabytes/sec', id: 'PBs', fn: decimalSIPrefix('Bs', 5) },
-      { name: 'petabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 5) },
+      { name: 'petabits/sec', id: 'Pbits', fn: decimalSIPrefix('bps', 5) },
+      { name: 'exabytes/sec', id: 'EBs', fn: decimalSIPrefix('Bs', 6) },
+      { name: 'exabits/sec', id: 'Ebits', fn: decimalSIPrefix('bps', 6) },
+      { name: 'zettabytes/sec', id: 'ZBs', fn: decimalSIPrefix('Bs', 7) },
+      { name: 'zettabits/sec', id: 'Zbits', fn: decimalSIPrefix('bps', 7) },
+      { name: 'yottabytes/sec', id: 'YBs', fn: decimalSIPrefix('Bs', 8) },
+      { name: 'yottabits/sec', id: 'Ybits', fn: decimalSIPrefix('bps', 8) },
     ],
   },
   {

--- a/packages/grafana-ui/src/utils/valueFormats/categories.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/categories.ts
@@ -126,9 +126,6 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'gibibytes', id: 'gbytes', fn: binarySIPrefix('B', 3) },
       { name: 'tebibytes', id: 'tbytes', fn: binarySIPrefix('B', 4) },
       { name: 'pebibytes', id: 'pbytes', fn: binarySIPrefix('B', 5) },
-      { name: 'exbibytes', id: 'ebytes', fn: binarySIPrefix('B', 6) },
-      { name: 'zobibytes', id: 'zbytes', fn: binarySIPrefix('B', 7) },
-      { name: 'yobibytes', id: 'ybytes', fn: binarySIPrefix('B', 8) },
     ],
   },
   {
@@ -141,9 +138,6 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'gigabytes', id: 'decgbytes', fn: decimalSIPrefix('B', 3) },
       { name: 'terabytes', id: 'dectbytes', fn: decimalSIPrefix('B', 4) },
       { name: 'petabytes', id: 'decpbytes', fn: decimalSIPrefix('B', 5) },
-      { name: 'exabytes', id: 'decebytes', fn: decimalSIPrefix('B', 6) },
-      { name: 'zettabytes', id: 'deczbytes', fn: decimalSIPrefix('B', 7) },
-      { name: 'yottabytes', id: 'decybytes', fn: decimalSIPrefix('B', 8) },
     ],
   },
   {
@@ -162,12 +156,6 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'terabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 4) },
       { name: 'petabytes/sec', id: 'PBs', fn: decimalSIPrefix('Bs', 5) },
       { name: 'petabits/sec', id: 'Pbits', fn: decimalSIPrefix('bps', 5) },
-      { name: 'exabytes/sec', id: 'EBs', fn: decimalSIPrefix('Bs', 6) },
-      { name: 'exabits/sec', id: 'Ebits', fn: decimalSIPrefix('bps', 6) },
-      { name: 'zettabytes/sec', id: 'ZBs', fn: decimalSIPrefix('Bs', 7) },
-      { name: 'zettabits/sec', id: 'Zbits', fn: decimalSIPrefix('bps', 7) },
-      { name: 'yottabytes/sec', id: 'YBs', fn: decimalSIPrefix('Bs', 8) },
-      { name: 'yottabits/sec', id: 'Ybits', fn: decimalSIPrefix('bps', 8) },
     ],
   },
   {

--- a/packages/grafana-ui/src/utils/valueFormats/categories.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/categories.ts
@@ -122,6 +122,8 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'kibibytes', id: 'kbytes', fn: binarySIPrefix('B', 1) },
       { name: 'mebibytes', id: 'mbytes', fn: binarySIPrefix('B', 2) },
       { name: 'gibibytes', id: 'gbytes', fn: binarySIPrefix('B', 3) },
+      { name: 'tebibytes', id: 'tbytes', fn: binarySIPrefix('B', 4) },
+      { name: 'pebibytes', id: 'pbytes', fn: binarySIPrefix('B', 5) },
     ],
   },
   {
@@ -132,6 +134,8 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'kilobytes', id: 'deckbytes', fn: decimalSIPrefix('B', 1) },
       { name: 'megabytes', id: 'decmbytes', fn: decimalSIPrefix('B', 2) },
       { name: 'gigabytes', id: 'decgbytes', fn: decimalSIPrefix('B', 3) },
+      { name: 'terabytes', id: 'dectbytes', fn: decimalSIPrefix('B', 4) },
+      { name: 'petabytes', id: 'decpbytes', fn: decimalSIPrefix('B', 5) },
     ],
   },
   {
@@ -146,6 +150,10 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'megabits/sec', id: 'Mbits', fn: decimalSIPrefix('bps', 2) },
       { name: 'gigabytes/sec', id: 'GBs', fn: decimalSIPrefix('Bs', 3) },
       { name: 'gigabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 3) },
+      { name: 'terabytes/sec', id: 'TBs', fn: decimalSIPrefix('Bs', 4) },
+      { name: 'terabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 4) },
+      { name: 'petabytes/sec', id: 'PBs', fn: decimalSIPrefix('Bs', 5) },
+      { name: 'petabits/sec', id: 'Gbits', fn: decimalSIPrefix('bps', 5) },
     ],
   },
   {

--- a/packages/grafana-ui/src/utils/valueFormats/categories.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/categories.ts
@@ -75,7 +75,8 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'TFLOP/s', id: 'tflops', fn: decimalSIPrefix('FLOP/s', 4) },
       { name: 'PFLOP/s', id: 'pflops', fn: decimalSIPrefix('FLOP/s', 5) },
       { name: 'EFLOP/s', id: 'eflops', fn: decimalSIPrefix('FLOP/s', 6) },
-      { name: 'ZFLOP/s', id: 'zflops', fn: decimalSIPrefix('FLOP/s', 6) },
+      { name: 'ZFLOP/s', id: 'zflops', fn: decimalSIPrefix('FLOP/s', 7) },
+      { name: 'YFLOP/s', id: 'yflops', fn: decimalSIPrefix('FLOP/s', 8) },
     ],
   },
   {


### PR DESCRIPTION
<details>
<summary>Details</summary>



</details>

Luckily, all the hard work was done before; just added in these prefixes for our production environment.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Adds higher Bytes measurements (we care about Tera and Peta) to all the places where it might be used. In a datacenter, TBs are a totally viable number to work with, and should be easier to read than GBs, as you can see here:
![screenshot of current storage stats](https://i.ibb.co/7S08R39/Screen-Shot-2019-08-28-at-5-11-12-PM.png)
Currently we are using `bytes`, since that almost works, but in the total at the end, and in places where there's less than 1TB, we get GBs instead. Not ideal for visualization.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #12793

**Special notes for your reviewer**:

<details>
<summary>Details</summary>



</details>