### PR TITLE
Heatmap: Add Cividis and Turbo color schemes

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "classnames": "2.2.6",
     "clipboard": "2.0.4",
     "d3": "4.13.0",
-    "d3-scale-chromatic": "1.3.3",
+    "d3-scale-chromatic": "1.5.0",
     "eventemitter3": "2.0.3",
     "fast-text-encoding": "^1.0.0",
     "file-saver": "1.3.8",

--- a/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
@@ -80,6 +80,8 @@ const colorSchemes = [
   { name: 'Reds', value: 'interpolateReds', invert: 'dark' },
 
   // Sequential (Multi-Hue)
+  { name: 'Turbo', value: 'interpolateTurbo', invert: 'light' },
+  { name: 'Cividis', value: 'interpolateCividis', invert: 'light' },
   { name: 'Viridis', value: 'interpolateViridis', invert: 'light' },
   { name: 'Magma', value: 'interpolateMagma', invert: 'light' },
   { name: 'Inferno', value: 'interpolateInferno', invert: 'light' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,9 +6621,17 @@ d3-request@1.0.6:
     d3-dsv "1"
     xmlhttprequest "1"
 
-d3-scale-chromatic@1, d3-scale-chromatic@1.3.3:
+d3-scale-chromatic@1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz#dad4366f0edcb288f490128979c3c793583ed3c0"
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale-chromatic@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
   dependencies:
     d3-color "1"
     d3-interpolate "1"


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds two new heatmap color schemes: [Cividis](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0199239) and [Turbo](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

The dependency diff is straightforward: https://github.com/d3/d3-scale-chromatic/compare/v1.3.3...v1.5.0

