### PR TITLE
WIP/Idea: Streaming: add common request options

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -378,6 +378,13 @@ export interface DataStreamState {
   delta?: DataFrame[];
 
   /**
+   * Is the data the entire buffer, or just the changes
+   *
+   * NOTE: optional now, but should be required
+   */
+  shape?: StreamingResponseShape;
+
+  /**
    * Stop listening to this stream
    */
   unsubscribe: () => void;
@@ -437,6 +444,29 @@ export interface ScopedVars {
   [key: string]: ScopedVar;
 }
 
+enum StreamingResponseShape {
+  /**
+   * Full DataFrames
+   */
+  full = 'full',
+
+  /**
+   * Send only the changes since the last notifiction
+   */
+  delta = 'delta',
+}
+
+interface ObserverConfig {
+  pause?: boolean;
+  throttle?: number;
+}
+
+export interface StramingQueryOptions {
+  frames?: StreamingResponseShape;
+  listener?: ObserverConfig;
+  notification?: ObserverConfig;
+}
+
 export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   requestId: string; // Used to identify results and optionally cancel the request in backendSrv
   timezone: string;
@@ -451,6 +481,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   intervalMs: number;
   maxDataPoints: number;
   scopedVars: ScopedVars;
+  stream?: StramingQueryOptions;
 
   // Request Timing
   startTime: number;

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -363,6 +363,12 @@ export interface DataStreamState {
   data?: DataFrame[];
 
   /**
+   * True when the data represents changes since the last event rather
+   * than an entire DataFrame result
+   */
+  isDelta?: boolean;
+
+  /**
    * Error in stream (but may still be running)
    */
   error?: DataQueryError;
@@ -376,13 +382,6 @@ export interface DataStreamState {
    * additions.
    */
   delta?: DataFrame[];
-
-  /**
-   * Is the data the entire buffer, or just the changes
-   *
-   * NOTE: optional now, but should be required
-   */
-  shape?: StreamingResponseShape;
 
   /**
    * Stop listening to this stream
@@ -444,28 +443,9 @@ export interface ScopedVars {
   [key: string]: ScopedVar;
 }
 
-enum StreamingResponseShape {
-  /**
-   * Full DataFrames
-   */
-  full = 'full',
-
-  /**
-   * Send only the changes since the last notifiction
-   */
-  delta = 'delta',
-}
-
-interface ObserverConfig {
-  pause?: boolean;
-  throttle?: number;
-}
-
-export interface StramingQueryOptions {
+export interface StreamingQueryOptions {
   buffer?: number; // defaults to `maxDataPoints`
-  frames?: StreamingResponseShape; // defaults to `full`
-  listener?: ObserverConfig;
-  notification?: ObserverConfig;
+  asDelta?: boolean; // defaults to false
 }
 
 export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
@@ -482,7 +462,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   intervalMs: number;
   maxDataPoints: number;
   scopedVars: ScopedVars;
-  stream?: StramingQueryOptions;
+  stream?: StreamingQueryOptions;
 
   // Request Timing
   startTime: number;

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -444,8 +444,17 @@ export interface ScopedVars {
 }
 
 export interface StreamingQueryOptions {
-  buffer?: number; // defaults to `maxDataPoints`
-  asDelta?: boolean; // defaults to false
+  /**
+   * Request an explicit buffer size.  When not specified, this will
+   * default to `request.maxDataPoints`
+   */
+  buffer?: number;
+
+  /**
+   * Ask the DataSource to send only changes since the last notification
+   * rather than full buffered DataFrames
+   */
+  isDelta?: boolean;
 }
 
 export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -462,7 +462,8 @@ interface ObserverConfig {
 }
 
 export interface StramingQueryOptions {
-  frames?: StreamingResponseShape;
+  buffer?: number; // defaults to `maxDataPoints`
+  frames?: StreamingResponseShape; // defaults to `full`
   listener?: ObserverConfig;
   notification?: ObserverConfig;
 }


### PR DESCRIPTION
Looking at how to remove `delta` and settle on common streaming semantics... I think we should add some well-typed options to the `DataQueryRequest` that support streaming.

The immediate need to ask for `delta` vs `full` results.  However while looking at the work in #18696, it seems we should also have clear semantics on pause and throttle.  In particular are we pausing all events (the listener) or do we want them back when we unpause (the notification)?

Posting here to get quick feedback ideas etc.  all names are looking for better alternatives :)  If people like this, I will add it to #18709 and get it working there.




