### PR TITLE
Plugins: show a clear error on the plugin page when it failed to load

### DIFF
--- a/packages/grafana-ui/src/types/plugin.ts
+++ b/packages/grafana-ui/src/types/plugin.ts
@@ -124,6 +124,9 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
   // Meta is filled in by the plugin loading system
   meta?: T;
 
+  // This is set if the plugin system had errors loading the plugin
+  loadError?: boolean;
+
   // Config control (app/datasource)
   angularConfigCtrl?: any;
 

--- a/public/app/features/dashboard/dashgrid/PanelPluginError.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelPluginError.tsx
@@ -36,7 +36,7 @@ class PanelPluginError extends PureComponent<Props> {
 }
 
 export function getPanelPluginLoadError(meta: PanelPluginMeta, err: any): PanelPlugin {
-  const NotFound = class NotFound extends PureComponent<PanelProps> {
+  const LoadError = class LoadError extends PureComponent<PanelProps> {
     render() {
       const text = (
         <>
@@ -47,8 +47,9 @@ export function getPanelPluginLoadError(meta: PanelPluginMeta, err: any): PanelP
       return <PanelPluginError title={`Error loading: ${meta.id}`} text={text} />;
     }
   };
-  const plugin = new PanelPlugin(NotFound);
+  const plugin = new PanelPlugin(LoadError);
   plugin.meta = meta;
+  plugin.loadError = true;
   return plugin;
 }
 

--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -44,7 +44,6 @@ export function getLoadingNav(): NavModel {
 }
 
 function loadPlugin(pluginId: string): Promise<GrafanaPlugin> {
-  console.log('GET', pluginId);
   return getPluginSettings(pluginId).then(info => {
     if (info.type === PluginType.app) {
       return importAppPlugin(info);

--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -6,7 +6,7 @@ import find from 'lodash/find';
 
 // Types
 import { UrlQueryMap } from '@grafana/runtime';
-import { StoreState } from 'app/types';
+import { StoreState, AppNotificationSeverity } from 'app/types';
 import {
   PluginType,
   GrafanaPlugin,
@@ -30,6 +30,7 @@ import { PluginDashboards } from './PluginDashboards';
 import { appEvents } from 'app/core/core';
 import { config } from 'app/core/config';
 import { ContextSrv } from '../../core/services/context_srv';
+import { AlertBox } from 'app/core/components/AlertBox/AlertBox';
 
 export function getLoadingNav(): NavModel {
   const node = {
@@ -43,6 +44,7 @@ export function getLoadingNav(): NavModel {
 }
 
 function loadPlugin(pluginId: string): Promise<GrafanaPlugin> {
+  console.log('GET', pluginId);
   return getPluginSettings(pluginId).then(info => {
     if (info.type === PluginType.app) {
       return importAppPlugin(info);
@@ -140,7 +142,7 @@ class PluginPage extends PureComponent<Props, State> {
     const { plugin, nav } = this.state;
 
     if (!plugin) {
-      return <div>Plugin not found.</div>;
+      return <AlertBox severity={AppNotificationSeverity.Error} title="Plugin Not Found" />;
     }
 
     const active = nav.main.children.find(tab => tab.active);
@@ -297,7 +299,21 @@ class PluginPage extends PureComponent<Props, State> {
         <Page.Contents isLoading={loading}>
           {!loading && (
             <div className="sidebar-container">
-              <div className="sidebar-content">{this.renderBody()}</div>
+              <div className="sidebar-content">
+                {plugin.loadError && (
+                  <AlertBox
+                    severity={AppNotificationSeverity.Error}
+                    title="Error Loading Plugin"
+                    body={
+                      <>
+                        Check the server startup logs for more information. <br />
+                        If this plugin was loaded from git, make sure it was compiled.
+                      </>
+                    }
+                  />
+                )}
+                {this.renderBody()}
+              </div>
               <aside className="page-sidebar">
                 {plugin && (
                   <section className="page-sidebar-section">


### PR DESCRIPTION
Similar to #18671, but on the plugins page.

This will now show a more clear error on the plugin page rather than business as usual:

![image](https://user-images.githubusercontent.com/705951/63716683-70851780-c7fb-11e9-8217-c01893ef7e65.png)

This will be super helpful in the plugin ci process that sanity checks everything.