### PR TITLE
Chore: Use ruleId instead of alertId as log keyword

### DIFF
--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -46,7 +46,7 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 
 	metrics.MAlertingResultState.WithLabelValues(string(evalContext.Rule.State)).Inc()
 	if evalContext.shouldUpdateAlertState() {
-		handler.log.Info("New state change", "alertId", evalContext.Rule.ID, "newState", evalContext.Rule.State, "prev state", evalContext.PrevAlertState)
+		handler.log.Info("New state change", "ruleId", evalContext.Rule.ID, "newState", evalContext.Rule.State, "prev state", evalContext.PrevAlertState)
 
 		cmd := &models.SetAlertStateCommand{
 			AlertId:  evalContext.Rule.ID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the in-memory representation of alert identifier, `ruleId`, instead of the database one, `alertId`, as keyword when logging.

**Which issue(s) this PR fixes**:
Fixes #18688 

**Special notes for your reviewer**:

