### PR TITLE
@grafana/toolkit: add package versions to the ci report

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -9,7 +9,7 @@ import { PluginMeta } from '@grafana/ui';
 import execa = require('execa');
 import path = require('path');
 import fs from 'fs';
-import { getPackageDetails, findImagesInFolder, appendPluginHistory } from '../../plugins/utils';
+import { getPackageDetails, findImagesInFolder, appendPluginHistory, getGrafanaVersions } from '../../plugins/utils';
 import {
   job,
   getJobFolder,
@@ -318,6 +318,7 @@ const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
 
   const pluginJsonFile = path.resolve(ciDir, 'dist', 'plugin.json');
   console.log('Load info from: ' + pluginJsonFile);
+
   const pluginMeta = getPluginJson(pluginJsonFile);
   const report: PluginBuildReport = {
     plugin: pluginMeta,
@@ -326,6 +327,7 @@ const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
     coverage: agregateCoverageInfo(),
     tests: agregateTestInfo(),
     artifactsBaseURL: await getCircleDownloadBaseURL(),
+    grafanaVersion: getGrafanaVersions(),
   };
   const pr = getPullRequestNumber();
   if (pr) {

--- a/packages/grafana-toolkit/src/plugins/env.ts
+++ b/packages/grafana-toolkit/src/plugins/env.ts
@@ -23,12 +23,21 @@ export const job = process.env.CIRCLE_JOB || getJobFromProcessArgv();
 
 export const getPluginBuildInfo = async (): Promise<PluginBuildInfo> => {
   if (process.env.CIRCLE_SHA1) {
-    return Promise.resolve({
+    const info: PluginBuildInfo = {
       time: Date.now(),
       repo: process.env.CIRCLE_REPOSITORY_URL,
       branch: process.env.CIRCLE_BRANCH,
       hash: process.env.CIRCLE_SHA1,
-    });
+    };
+    const pr = getPullRequestNumber();
+    const build = getBuildNumber();
+    if (pr) {
+      info.pr = pr;
+    }
+    if (build) {
+      info.number = build;
+    }
+    return Promise.resolve(info);
   }
   const branch = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
   const hash = await execa('git', ['rev-parse', 'HEAD']);

--- a/packages/grafana-toolkit/src/plugins/types.ts
+++ b/packages/grafana-toolkit/src/plugins/types.ts
@@ -1,5 +1,5 @@
 import { PluginMeta, PluginBuildInfo } from '@grafana/ui';
-import { DataFrame } from '@grafana/data';
+import { DataFrame, KeyValue } from '@grafana/data';
 
 export interface PluginPackageDetails {
   plugin: ZipFileInfo;
@@ -14,6 +14,7 @@ export interface PluginBuildReport {
   tests: TestResultsInfo[];
   pullRequest?: number;
   artifactsBaseURL?: string;
+  grafanaVersion?: KeyValue<string>;
 }
 
 export interface JobInfo {

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -1,9 +1,24 @@
 import execa from 'execa';
 import path from 'path';
 import fs from 'fs';
+import { KeyValue } from '@grafana/data';
 import { PluginDevInfo, ExtensionSize, ZipFileInfo, PluginBuildReport, PluginHistory } from './types';
 
 const md5File = require('md5-file');
+
+export function getGrafanaVersions(): KeyValue<string> {
+  const dir = path.resolve(process.cwd(), 'node_modules', '@grafana');
+  const versions: KeyValue = {};
+  try {
+    fs.readdirSync(dir).forEach(file => {
+      const json = require(path.resolve(dir, file, 'package.json'));
+      versions[file] = json.version;
+    });
+  } catch (err) {
+    console.warn('Error reading toolkit versions', err);
+  }
+  return versions;
+}
 
 export function getFileSizeReportInFolder(dir: string, info?: ExtensionSize): ExtensionSize {
   const acc: ExtensionSize = info ? info : {};


### PR DESCRIPTION
This adds a node to the uploaded report with the versions of toolkit/ui/data used.  For example:

```
  "grafanaVersion": {
    "data": "6.4.0-alpha.44-ead2d6e88",
    "toolkit": "6.4.0-alpha.44",
    "ui": "6.4.0-alpha.44-ead2d6e88"
  }
```
(with yarn link)