### PR TITLE
Prometheus: constant-value timeseries for instant queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -140,7 +140,14 @@ export class ResultTransformer {
     const dps = [];
     let metricLabel = null;
     metricLabel = this.createMetricLabel(md.metric, options);
-    dps.push([parseFloat(md.value[1]), md.value[0] * 1000]);
+    // Produce constant series from single value, ending on ts from instant result
+    const value = parseFloat(md.value[1]);
+    const start = options.start;
+    const end = md.value[0];
+    const step = options.step;
+    for (let ts = start; ts <= end; ts += step) {
+      dps.push([value, ts * 1000]);
+    }
     return { target: metricLabel, datapoints: dps, labels: md.metric };
   }
 

--- a/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/result_transformer.test.ts
@@ -291,5 +291,36 @@ describe('Prometheus Result Transformer', () => {
         },
       ]);
     });
+
+    it('should transform a vector into a time series with a constant value', () => {
+      const response = {
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [
+            {
+              metric: { __name__: 'test', job: 'testjob' },
+              value: [2, '3846'],
+            },
+          ],
+        },
+      };
+
+      const options = {
+        format: 'timeseries',
+        step: 1,
+        start: 0,
+        end: 2,
+      };
+
+      const result = ctx.resultTransformer.transform({ data: response }, options);
+      expect(result).toEqual([
+        {
+          target: 'test{job="testjob"}',
+          datapoints: [[3846, 0], [3846, 1000], [3846, 2000]],
+          labels: { job: 'testjob' },
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Timeseries are usually graphed from a range query. Table data is usually
graphed from an instant query. Now there is a use case where you would
like to draw a single line (timeseries) from the result of an instant
query. This commit changes the instant/timeseries combination in the
query options to produce a constant-value timeseries.

![Screenshot 2019-08-29 at 12 36 25](https://user-images.githubusercontent.com/859729/63933538-bc34fc80-ca59-11e9-9d6b-ee26716beb17.png)


While this seems to help with the stated use case, I could use some feedback if the combination "Instant query, formatted as timeseries", which prints a single datapoint (last value), is already being used for a different purpose.

Fixes: #9084