### PR TITLE
Singlestat: Various fixes to singlestat and DataFrame

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
+++ b/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
@@ -26,7 +26,7 @@ $popper-margin-from-ref: 5px;
   background: $tooltipBackground;
   border-radius: $border-radius-sm;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
-  padding: 6px 10px;
+  padding: $space-sm;
   color: $tooltipColor;
   font-weight: $font-weight-semi-bold;
 

--- a/packages/grafana-ui/src/types/panel.ts
+++ b/packages/grafana-ui/src/types/panel.ts
@@ -24,8 +24,6 @@ export interface PanelData {
 export interface PanelProps<T = any> {
   id: number; // ID within the current dashboard
   data: PanelData;
-  // TODO: annotation?: PanelData;
-
   timeRange: TimeRange;
   timeZone: TimeZone;
   options: T;

--- a/public/app/features/dashboard/panel_editor/QueriesTab.tsx
+++ b/public/app/features/dashboard/panel_editor/QueriesTab.tsx
@@ -76,11 +76,15 @@ export class QueriesTab extends PureComponent<Props, State> {
   // Updates the response with information from the stream
   panelDataObserver = {
     next: (data: PanelData) => {
-      const { panel } = this.props;
-      if (data.state === LoadingState.Error) {
-        panel.events.emit('data-error', data.error);
-      } else if (data.state === LoadingState.Done) {
-        panel.events.emit('data-received', data.legacy);
+      try {
+        const { panel } = this.props;
+        if (data.state === LoadingState.Error) {
+          panel.events.emit('data-error', data.error);
+        } else if (data.state === LoadingState.Done) {
+          panel.events.emit('data-received', data.legacy);
+        }
+      } catch (err) {
+        console.log('Panel.events handler error', err);
       }
       this.setState({ data });
     },

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -249,23 +249,25 @@ export class PanelCtrl {
   }
 
   getInfoContent(options: { mode: string }) {
-    let markdown = this.panel.description || '';
+    const { panel } = this;
+    let markdown = panel.description || '';
 
     if (options.mode === 'tooltip') {
-      markdown = this.error || this.panel.description || '';
+      markdown = this.error || panel.description || '';
     }
 
     const templateSrv: TemplateSrv = this.$injector.get('templateSrv');
-    const interpolatedMarkdown = templateSrv.replace(markdown, this.panel.scopedVars);
+    const interpolatedMarkdown = templateSrv.replace(markdown, panel.scopedVars);
     let html = '<div class="markdown-html panel-info-content">';
 
     const md = renderMarkdown(interpolatedMarkdown);
     html += config.disableSanitizeHtml ? md : sanitize(md);
-    const links = this.panel.links && getPanelLinksSupplier(this.panel).getLinks();
 
-    if (links && links.length > 0) {
+    if (panel.links && panel.links.length > 0) {
+      const interpolatedLinks = getPanelLinksSupplier(panel).getLinks();
+
       html += '<ul class="panel-info-corner-links">';
-      for (const link of links) {
+      for (const link of interpolatedLinks) {
         html +=
           '<li><a class="panel-menu-link" href="' +
           escapeHtml(link.href) +

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -149,6 +149,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     this.events.on('render', this.onRender.bind(this));
     this.events.on('data-received', this.onDataReceived.bind(this));
+    this.events.on('data-frames-received', this.onDataReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
     this.events.on('data-snapshot-load', this.onDataSnapshotLoad.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
@@ -210,13 +211,11 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   // This should only be called from the snapshot callback
   onDataReceived(dataList: LegacyResponseData[]) {
-    this.handleDataFrames(getProcessedDataFrames(dataList));
+    this.onDataFramesReceived(getProcessedDataFrames(dataList));
   }
 
   // Directly support DataFrame skipping event callbacks
-  handleDataFrames(data: DataFrame[]) {
-    super.handleDataFrames(data);
-
+  onDataFramesReceived(data: DataFrame[]) {
     this.dataList = data;
     this.seriesList = this.processor.getSeriesList({
       dataList: this.dataList,

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -119,7 +119,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     super($scope, $injector);
     _.defaults(this.panel, this.panelDefaults);
 
-    this.events.on('data-received', this.onDataReceived.bind(this));
+    this.events.on('data-frames-received', this.onFramesReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
     this.events.on('data-snapshot-load', this.onDataReceived.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
@@ -157,14 +157,24 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
   // This should only be called from the snapshot callback
   onDataReceived(dataList: LegacyResponseData[]) {
-    this.handleDataFrames(getProcessedDataFrames(dataList));
+    this.onFramesReceived(getProcessedDataFrames(dataList));
   }
 
   // Directly support DataFrame skipping event callbacks
-  handleDataFrames(frames: DataFrame[]) {
+  onFramesReceived(frames: DataFrame[]) {
     const { panel } = this;
-    super.handleDataFrames(frames);
-    this.loading = false;
+
+    if (frames && frames.length > 1) {
+      this.data = {
+        value: 0,
+        display: {
+          text: 'Only queries that return single series/table is supported',
+          numeric: NaN,
+        },
+      };
+      this.render();
+      return;
+    }
 
     const distinct = getDistinctNames(frames);
     let fieldInfo = distinct.byName[panel.tableColumn]; //

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -160,7 +160,6 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     this.onFramesReceived(getProcessedDataFrames(dataList));
   }
 
-  // Directly support DataFrame skipping event callbacks
   onFramesReceived(frames: DataFrame[]) {
     const { panel } = this;
 

--- a/public/sass/components/_drop.scss
+++ b/public/sass/components/_drop.scss
@@ -5,7 +5,7 @@ $useDropShadow: false;
 $attachmentOffset: 0%;
 $easing: cubic-bezier(0, 0, 0.265, 1);
 
-@include drop-theme('error', $popover-error-bg, $popover-color);
+@include drop-theme('error', $popover-error-bg, $white);
 @include drop-theme('popover', $popover-bg, $popover-color, $popover-border-color);
 @include drop-theme('help', $popover-help-bg, $popover-help-color);
 

--- a/public/sass/mixins/_drop_element.scss
+++ b/public/sass/mixins/_drop_element.scss
@@ -6,7 +6,7 @@
     .drop-content {
       border-radius: $border-radius-lg;
       position: relative;
-      font-family: inherit;
+      font-weight: $font-weight-semi-bold;
       background: $theme-bg;
       color: $theme-color;
       padding: $space-sm;


### PR DESCRIPTION
* Fixes issue with panel events emitted from QueriesTab taking down react container, Fixes #18766
* Adds back multi-series error to singlestat
* Fixes issue with DataFrameHelper being saved in the snapshotData, this had issues when loading data from snapshot as the logic that transforms to DataFrame skip wrapping it in DataFrameHelper if there is a length property (which it had as it was a jsonified DataFrameHelper). 
https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/utils/processDataFrame.ts#L233
* The above issue is also there for react panels (snapshots store the DataFrameHelper, not the DTO). Not fixed in this PR 
* Aligns some tooltip styles that were different in react and angular panels.
* Improves how data frames are supported in angular panels so they use the same pattern of subscribing to an event instead of overriding a base function. (data-frames-received). 

 