### PR TITLE
Going to Explore from a panel with mixed data sources now works

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -199,7 +199,7 @@ export class KeybindingSrv {
         if (dashboard.meta.focusPanelId) {
           const panel = dashboard.getPanelById(dashboard.meta.focusPanelId);
           const datasource = await this.datasourceSrv.get(panel.datasource);
-          const url = await getExploreUrl(panel, panel.targets, datasource, this.datasourceSrv, this.timeSrv);
+          const url = await getExploreUrl(panel.targets, datasource, this.datasourceSrv, this.timeSrv);
           if (url) {
             this.$timeout(() => this.$location.url(url));
           }

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -253,7 +253,7 @@ class MetricsPanelCtrl extends PanelCtrl {
   }
 
   async explore() {
-    const url = await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
+    const url = await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
     if (url) {
       this.$timeout(() => this.$location.url(url));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously going to Explore from a panel with mixed data sources didn't correctly transfer the queries from the panel to Explore, resulting in "empty" queries.
This PR fixes this behavior.

**Which issue(s) this PR fixes**:
Closes #18597