### PR TITLE
Explore: Open new window when exploring panel metrics

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -253,7 +253,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     if (this.contextSrv.hasAccessToExplore() && this.datasource) {
       items.push({
         text: 'Explore',
-        click: 'ctrl.explore();',
+        click: 'ctrl.explore($event);',
         icon: 'gicon gicon-explore',
         shortcut: 'x',
       });
@@ -261,10 +261,15 @@ class MetricsPanelCtrl extends PanelCtrl {
     return items;
   }
 
-  async explore() {
+  async explore(e: any) {
     const url = await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
     if (url) {
-      this.$timeout(() => this.$location.url(url));
+      if (e.shiftKey || e.ctrlKey || e.metaKey) {
+        window.open(url);
+      } else {
+        e.preventDefault();
+        this.$timeout(() => this.$location.url(url));
+      }
     }
   }
 }

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -248,7 +248,7 @@ class MetricsPanelCtrl extends PanelCtrl {
     }
   }
 
-  getAdditionalMenuItems() {
+  async getAdditionalMenuItems() {
     const items = [];
     if (this.contextSrv.hasAccessToExplore() && this.datasource) {
       items.push({
@@ -256,6 +256,7 @@ class MetricsPanelCtrl extends PanelCtrl {
         click: 'ctrl.explore($event);',
         icon: 'gicon gicon-explore',
         shortcut: 'x',
+        href: await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv),
       });
     }
     return items;
@@ -264,9 +265,7 @@ class MetricsPanelCtrl extends PanelCtrl {
   async explore(e: any) {
     const url = await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
     if (url) {
-      if (e.shiftKey || e.ctrlKey || e.metaKey) {
-        window.open(url);
-      } else {
+      if (!(e.shiftKey || e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         this.$timeout(() => this.$location.url(url));
       }

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -253,23 +253,12 @@ class MetricsPanelCtrl extends PanelCtrl {
     if (this.contextSrv.hasAccessToExplore() && this.datasource) {
       items.push({
         text: 'Explore',
-        click: 'ctrl.explore($event);',
         icon: 'gicon gicon-explore',
         shortcut: 'x',
         href: await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv),
       });
     }
     return items;
-  }
-
-  async explore(e: any) {
-    const url = await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
-    if (url) {
-      if (!(e.shiftKey || e.ctrlKey || e.metaKey)) {
-        e.preventDefault();
-        this.$timeout(() => this.$location.url(url));
-      }
-    }
   }
 }
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -120,7 +120,7 @@ export class PanelCtrl {
     }
   }
 
-  getMenu() {
+  async getMenu() {
     const menu = [];
     menu.push({
       text: 'View',
@@ -147,7 +147,7 @@ export class PanelCtrl {
     });
 
     // Additional items from sub-class
-    menu.push(...this.getAdditionalMenuItems());
+    menu.push(...(await this.getAdditionalMenuItems()));
 
     const extendedMenu = this.getExtendedMenu();
     menu.push({
@@ -198,7 +198,7 @@ export class PanelCtrl {
   }
 
   // Override in sub-class to add items before extended menu
-  getAdditionalMenuItems(): any[] {
+  async getAdditionalMenuItems(): Promise<any[]> {
     return [];
   }
 

--- a/public/app/features/panel/panel_header.ts
+++ b/public/app/features/panel/panel_header.ts
@@ -55,10 +55,10 @@ function renderMenuItem(item: AngularPanelMenuItem, ctrl: any) {
   return html;
 }
 
-function createMenuTemplate(ctrl: any) {
+async function createMenuTemplate(ctrl: any) {
   let html = '';
 
-  for (const item of ctrl.getMenu()) {
+  for (const item of await ctrl.getMenu()) {
     html += renderMenuItem(item, ctrl);
   }
 
@@ -75,7 +75,7 @@ function panelHeader($compile: any) {
       let menuScope: any;
       let isDragged: boolean;
 
-      elem.click((evt: any) => {
+      elem.click(async (evt: any) => {
         const targetClass = evt.target.className;
 
         // remove existing scope
@@ -84,7 +84,7 @@ function panelHeader($compile: any) {
         }
 
         menuScope = scope.$new();
-        const menuHtml = createMenuTemplate(scope.ctrl);
+        const menuHtml = await createMenuTemplate(scope.ctrl);
         menuElem.html(menuHtml);
         $compile(menuElem)(menuScope);
 

--- a/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
@@ -21,30 +21,30 @@ import { MetricsPanelCtrl } from '../metrics_panel_ctrl';
 describe('MetricsPanelCtrl', () => {
   describe('when getting additional menu items', () => {
     describe('and has no datasource set but user has access to explore', () => {
-      it('should not return any items', () => {
+      it('should not return any items', async () => {
         const ctrl = setupController({ hasAccessToExplore: true });
 
-        expect(ctrl.getAdditionalMenuItems().length).toBe(0);
+        expect((await ctrl.getAdditionalMenuItems()).length).toBe(0);
       });
     });
 
     describe('and has datasource set that supports explore and user does not have access to explore', () => {
-      it('should not return any items', () => {
+      it('should not return any items', async () => {
         const ctrl = setupController({ hasAccessToExplore: false });
         ctrl.datasource = { meta: { explore: true } } as any;
 
-        expect(ctrl.getAdditionalMenuItems().length).toBe(0);
+        expect((await ctrl.getAdditionalMenuItems()).length).toBe(0);
       });
     });
 
-    describe('and has datasource set that supports explore and user has access to explore', () => {
-      it('should return one item', () => {
-        const ctrl = setupController({ hasAccessToExplore: true });
-        ctrl.datasource = { meta: { explore: true } } as any;
+    // describe('and has datasource set that supports explore and user has access to explore', () => {
+    //   it('should return one item', async () => {
+    //     const ctrl = setupController({ hasAccessToExplore: true });
+    //     ctrl.datasource = { meta: { explore: true } } as any;
 
-        expect(ctrl.getAdditionalMenuItems().length).toBe(1);
-      });
-    });
+    //     expect((await ctrl.getAdditionalMenuItems()).length).toBe(1);
+    //   });
+    // });
   });
 });
 

--- a/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
@@ -58,6 +58,9 @@ function setupController({ hasAccessToExplore } = { hasAccessToExplore: false })
         case 'contextSrv': {
           return { hasAccessToExplore: () => hasAccessToExplore };
         }
+        case 'timeSrv': {
+          return { timeRangeForUrl: () => {} };
+        }
         default: {
           return jest.fn();
         }

--- a/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
@@ -37,14 +37,14 @@ describe('MetricsPanelCtrl', () => {
       });
     });
 
-    // describe('and has datasource set that supports explore and user has access to explore', () => {
-    //   it('should return one item', async () => {
-    //     const ctrl = setupController({ hasAccessToExplore: true });
-    //     ctrl.datasource = { meta: { explore: true } } as any;
+    describe('and has datasource set that supports explore and user has access to explore', () => {
+      it('should return one item', async () => {
+        const ctrl = setupController({ hasAccessToExplore: true });
+        ctrl.datasource = { meta: { explore: true } } as any;
 
-    //     expect((await ctrl.getAdditionalMenuItems()).length).toBe(1);
-    //   });
-    // });
+        expect((await ctrl.getAdditionalMenuItems()).length).toBe(1);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds option to optionally open the explore view in a new window (cmd + click), as switching to the explore view was available only in the same window. This was done by adding href to additional menu items. As async function `getExploreUrl()` was used, we had to then propagate async in this PR. 

**Which issue(s) this PR fixes**:
Fixes #18308 

**Special notes for your reviewer**:
I would like to ask/discuss couple of options that I discovered during working on this.
The code in the current PR fixes the issue, however, I have one question regarding using just href and in that case, we wouldn't need explore function and just use:
```
async getAdditionalMenuItems() {
    const items = [];
    if (this.contextSrv.hasAccessToExplore() && this.datasource) {
      items.push({
        text: 'Explore',
        icon: 'gicon gicon-explore',
        shortcut: 'x',
        href: await getExploreUrl(this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv),
      });
    }
    return items;
  }
```

According to docs/experience of other developers href should always reload the page. But when I tested it in the network tab, href didn't reloaded the page. So I am not sure why is that and if we can rely on that (and therefore we wouldn't need explore function).

Network tab using href: 
![image](https://user-images.githubusercontent.com/30407135/64012312-b86aae00-cb1d-11e9-8318-cc353ef151d2.png)

Network tab using ng-onclick:
![image](https://user-images.githubusercontent.com/30407135/64012352-cb7d7e00-cb1d-11e9-8ea4-691b1336cf9f.png)

Can you please give me more insight on this? Thank you! 🙂

