### PR TITLE
Explore: Style panel containers

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -12,7 +12,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   collapseBody: css`
     label: collapse__body;
-    padding: ${theme.panelPadding};
+    padding: ${theme.panelPadding}px;
   `,
   loader: css`
     label: collapse__loader;

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -59,7 +59,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   headerCollapsed: css`
     label: collapse__header--collapsed;
     cursor: pointer;
-    padding: ${theme.panelPadding}px;
+    padding: ${theme.spacing.sm} ${theme.spacing.md} 0 ${theme.spacing.md};
   `,
   headerButtons: css`
     label: collapse__header-buttons;

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -59,6 +59,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   headerCollapsed: css`
     label: collapse__header--collapsed;
     cursor: pointer;
+    padding: ${theme.panelPadding}px;
   `,
   headerButtons: css`
     label: collapse__header-buttons;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixed styling of panel containers in Explore. It is specifically adding padding to Explore panel containers. Graph panel has already had panelPadding, but panelPadding is type of _number_ and therefore it was missing _px_. Logs panel was missing header padding. Therefore it has been added as well.

**Which issue(s) this PR fixes**:
Fixes #18782 

**Special notes for your reviewer**:
Graph panel with added padding:
![image](https://user-images.githubusercontent.com/30407135/64114382-16e99380-cd8d-11e9-9f50-97a58df409b6.png)
![image](https://user-images.githubusercontent.com/30407135/64114415-2c5ebd80-cd8d-11e9-8526-943703915f35.png)

Logs panel with added padding:
![image](https://user-images.githubusercontent.com/30407135/64114338-fcafb580-cd8c-11e9-911d-28f1943ace21.png)
![image](https://user-images.githubusercontent.com/30407135/64114681-e48c6600-cd8d-11e9-866a-a43cac48650e.png)

@davkal could you please check the ui and let me know, if you can see anything else that needs to be styled/fixed. 
