### PR TITLE
DataFrame: problem with query editor events

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueriesTab.tsx
+++ b/public/app/features/dashboard/panel_editor/QueriesTab.tsx
@@ -73,22 +73,28 @@ export class QueriesTab extends PureComponent<Props, State> {
     }
   }
 
-  // Updates the response with information from the stream
   panelDataObserver = {
     next: (data: PanelData) => {
-      try {
-        const { panel } = this.props;
-        if (data.state === LoadingState.Error) {
-          panel.events.emit('data-error', data.error);
-        } else if (data.state === LoadingState.Done) {
-          panel.events.emit('data-received', data.legacy);
-        }
-      } catch (err) {
-        console.log('Panel.events handler error', err);
+      if (this.props.panel.isReactPlugin()) {
+        this.notifyAngularQueryEditorsOfData(data);
       }
       this.setState({ data });
     },
   };
+
+  notifyAngularQueryEditorsOfData(data: PanelData) {
+    const { panel } = this.props;
+
+    try {
+      if (data.state === LoadingState.Error) {
+        panel.events.emit('data-error', data.error);
+      } else if (data.state === LoadingState.Done) {
+        panel.events.emit('data-received', data.legacy);
+      }
+    } catch (err) {
+      console.log('Panel.events handler error', err);
+    }
+  }
 
   findCurrentDataSource(): DataSourceSelectItem {
     const { panel } = this.props;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -335,6 +335,10 @@ export class PanelModel {
     return this.title && this.title.length > 0;
   }
 
+  isReactPlugin(): boolean {
+    return this.plugin && !!this.plugin.panel;
+  }
+
   destroy() {
     this.events.emit('panel-teardown');
     this.events.removeAllListeners();


### PR DESCRIPTION
We have a bit of a problem with legacy & data frame bits. Especially the panel events. 

* QueriesTab was always emitting 'data-received' events, so for angular panels these where duplicated (also sent from MetricsPanelCtrl).
* Easy fix only send these events for react panel plugins

Unsolved problem: 
* But the graph & singlestat now only handle DataFrames and only sends 'data-frames-received' event. So the events "bridge" in QueriesTab is actually needed for angular panels that only use DataFrame
