### PR TITLE
Explore: Allow pausing and resuming of live tailing

### DIFF
--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { css, cx } from 'emotion';
-import { Themeable, withTheme, GrafanaTheme, selectThemeVariant, LinkButton, getLogRowStyles } from '@grafana/ui';
+import { Themeable, withTheme, GrafanaTheme, selectThemeVariant, getLogRowStyles } from '@grafana/ui';
 
 import { LogsModel, LogRowModel, TimeZone } from '@grafana/data';
 
@@ -44,13 +44,20 @@ export interface Props extends Themeable {
 }
 
 interface State {
-  logsResultToRender: LogsModel;
+  logsResultToRender?: LogsModel;
 }
 
 class LiveLogs extends PureComponent<Props, State> {
   private liveEndDiv: HTMLDivElement = null;
   private scrollContainerRef = React.createRef<HTMLDivElement>();
   private lastScrollPos: number | null = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      logsResultToRender: props.logsResult,
+    };
+  }
 
   componentDidUpdate(prevProps: Props) {
     if (!prevProps.isPaused && this.props.isPaused) {
@@ -154,25 +161,24 @@ class LiveLogs extends PureComponent<Props, State> {
           />
         </div>
         <div className={cx([styles.logsRowsIndicator])}>
-          <span>
-            Last line received: <ElapsedTime resetKey={this.props.logsResult} humanize={true} /> ago
-          </span>
-          <LinkButton
+          <button
             onClick={isPaused ? onResume : onPause}
-            size="md"
-            variant="transparent"
-            style={{ color: theme.colors.orange }}
+            style={{ marginRight: theme.spacing.sm }}
+            className={'btn btn-secondary'}
           >
+            <i className={cx('fa', isPaused ? 'fa-play' : 'fa-pause')} />
+            &nbsp;
             {isPaused ? 'Resume' : 'Pause'}
-          </LinkButton>
-          <LinkButton
-            onClick={this.props.stopLive}
-            size="md"
-            variant="transparent"
-            style={{ color: theme.colors.orange }}
-          >
-            Stop Live
-          </LinkButton>
+          </button>
+          <button onClick={this.props.stopLive} style={{ marginRight: theme.spacing.sm }} className={'btn btn-inverse'}>
+            <i className={'fa fa-stop'} />
+            &nbsp; Stop
+          </button>
+          {isPaused || (
+            <span>
+              Last line received: <ElapsedTime resetKey={this.props.logsResult} humanize={true} /> ago
+            </span>
+          )}
         </div>
       </>
     );

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -32,6 +32,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     display: flex;
     align-items: center;
   `,
+  button: css`
+    margin-right: ${theme.spacing.sm};
+  `,
 });
 
 export interface Props extends Themeable {
@@ -161,16 +164,12 @@ class LiveLogs extends PureComponent<Props, State> {
           />
         </div>
         <div className={cx([styles.logsRowsIndicator])}>
-          <button
-            onClick={isPaused ? onResume : onPause}
-            style={{ marginRight: theme.spacing.sm }}
-            className={'btn btn-secondary'}
-          >
+          <button onClick={isPaused ? onResume : onPause} className={cx('btn btn-secondary', styles.button)}>
             <i className={cx('fa', isPaused ? 'fa-play' : 'fa-pause')} />
             &nbsp;
             {isPaused ? 'Resume' : 'Pause'}
           </button>
-          <button onClick={this.props.stopLive} style={{ marginRight: theme.spacing.sm }} className={'btn btn-inverse'}>
+          <button onClick={this.props.stopLive} className={cx('btn btn-inverse', styles.button)}>
             <i className={'fa fa-stop'} />
             &nbsp; Stop
           </button>

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -38,28 +38,91 @@ export interface Props extends Themeable {
   logsResult?: LogsModel;
   timeZone: TimeZone;
   stopLive: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  isPaused: boolean;
 }
 
-class LiveLogs extends PureComponent<Props> {
+interface State {
+  logsResultToRender: LogsModel;
+}
+
+class LiveLogs extends PureComponent<Props, State> {
   private liveEndDiv: HTMLDivElement = null;
+  private scrollContainerRef = React.createRef<HTMLDivElement>();
+  private lastScrollPos: number | null = null;
 
   componentDidUpdate(prevProps: Props) {
-    if (this.liveEndDiv) {
-      this.liveEndDiv.scrollIntoView(false);
+    if (!prevProps.isPaused && this.props.isPaused) {
+      // So we paused the view and we changed the content size, but we want to keep the relative offset from the bottom.
+      if (this.lastScrollPos) {
+        // There is last scroll pos from when user scrolled up a bit so go to that position.
+        const { clientHeight, scrollHeight } = this.scrollContainerRef.current;
+        const scrollTop = scrollHeight - (this.lastScrollPos + clientHeight);
+        this.scrollContainerRef.current.scrollTo(0, scrollTop);
+        this.lastScrollPos = null;
+      } else {
+        // We do not have any position to jump to su the assumption is user just clicked pause. We can just scroll
+        // to the bottom.
+        if (this.liveEndDiv) {
+          this.liveEndDiv.scrollIntoView(false);
+        }
+      }
     }
   }
 
+  static getDerivedStateFromProps(nextProps: Props) {
+    if (!nextProps.isPaused) {
+      return {
+        // We update what we show only if not paused. We keep any background subscriptions running and keep updating
+        // our state, but we do not show the updates, this allows us start again showing correct result after resuming
+        // without creating a gap in the log results.
+        logsResultToRender: nextProps.logsResult,
+      };
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Handle pausing when user scrolls up so that we stop resetting his position to the bottom when new row arrives.
+   * We do not need to throttle it here much, adding new rows should be throttled/buffered itself in the query epics
+   * and after you pause we remove the handler and add it after you manually resume, so this should not be fired often.
+   */
+  onScroll = (event: React.SyntheticEvent) => {
+    const { isPaused, onPause } = this.props;
+    const { scrollTop, clientHeight, scrollHeight } = event.currentTarget;
+    const distanceFromBottom = scrollHeight - (scrollTop + clientHeight);
+    if (distanceFromBottom >= 5 && !isPaused) {
+      onPause();
+      this.lastScrollPos = distanceFromBottom;
+    }
+  };
+
+  rowsToRender = () => {
+    const { isPaused } = this.props;
+    let rowsToRender: LogRowModel[] = this.state.logsResultToRender ? this.state.logsResultToRender.rows : [];
+    if (!isPaused) {
+      // A perf optimisation here. Show just 100 rows when streaming and full length when the streaming is paused.
+      rowsToRender = rowsToRender.slice(-100);
+    }
+    return rowsToRender;
+  };
+
   render() {
-    const { theme, timeZone } = this.props;
+    const { theme, timeZone, onPause, onResume, isPaused } = this.props;
     const styles = getStyles(theme);
-    const rowsToRender: LogRowModel[] = this.props.logsResult ? this.props.logsResult.rows : [];
     const showUtc = timeZone === 'utc';
     const { logsRow, logsRowLocalTime, logsRowMessage } = getLogRowStyles(theme);
 
     return (
       <>
-        <div className={cx(['logs-rows', styles.logsRowsLive])}>
-          {rowsToRender.map((row: any, index) => {
+        <div
+          onScroll={isPaused ? undefined : this.onScroll}
+          className={cx(['logs-rows', styles.logsRowsLive])}
+          ref={this.scrollContainerRef}
+        >
+          {this.rowsToRender().map((row: any, index) => {
             return (
               <div
                 className={row.fresh ? cx([logsRow, styles.logsRowFresh]) : cx([logsRow, styles.logsRowOld])}
@@ -82,7 +145,9 @@ class LiveLogs extends PureComponent<Props> {
           <div
             ref={element => {
               this.liveEndDiv = element;
-              if (this.liveEndDiv) {
+              // This is triggered on every update so on every new row. It keeps the view scrolled at the bottom by
+              // default.
+              if (this.liveEndDiv && !isPaused) {
                 this.liveEndDiv.scrollIntoView(false);
               }
             }}
@@ -92,6 +157,14 @@ class LiveLogs extends PureComponent<Props> {
           <span>
             Last line received: <ElapsedTime resetKey={this.props.logsResult} humanize={true} /> ago
           </span>
+          <LinkButton
+            onClick={isPaused ? onResume : onPause}
+            size="md"
+            variant="transparent"
+            style={{ color: theme.colors.orange }}
+          >
+            {isPaused ? 'Resume' : 'Pause'}
+          </LinkButton>
           <LinkButton
             onClick={this.props.stopLive}
             size="md"

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -19,7 +19,11 @@ import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { StoreState } from 'app/types';
 
 import { changeDedupStrategy, updateTimeRange } from './state/actions';
-import { toggleLogLevelAction, changeRefreshIntervalAction } from 'app/features/explore/state/actionTypes';
+import {
+  toggleLogLevelAction,
+  changeRefreshIntervalAction,
+  setPausedStateAction,
+} from 'app/features/explore/state/actionTypes';
 import { deduplicatedLogsSelector, exploreItemUIStateSelector } from 'app/features/explore/state/selectors';
 import { getTimeZone } from '../profile/state/selectors';
 import { LiveLogsWithTheme } from './LiveLogs';
@@ -49,6 +53,8 @@ interface LogsContainerProps {
   updateTimeRange: typeof updateTimeRange;
   range: TimeRange;
   absoluteRange: AbsoluteTimeRange;
+  setPausedStateAction: typeof setPausedStateAction;
+  isPaused: boolean;
 }
 
 export class LogsContainer extends PureComponent<LogsContainerProps> {
@@ -61,6 +67,16 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
   onStopLive = () => {
     const { exploreId } = this.props;
     this.props.stopLive({ exploreId, refreshInterval: offOption.value });
+  };
+
+  onPause = () => {
+    const { exploreId } = this.props;
+    this.props.setPausedStateAction({ exploreId, isPaused: true });
+  };
+
+  onResume = () => {
+    const { exploreId } = this.props;
+    this.props.setPausedStateAction({ exploreId, isPaused: false });
   };
 
   handleDedupStrategyChange = (dedupStrategy: LogsDedupStrategy) => {
@@ -105,7 +121,14 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     if (isLive) {
       return (
         <Collapse label="Logs" loading={false} isOpen>
-          <LiveLogsWithTheme logsResult={logsResult} timeZone={timeZone} stopLive={this.onStopLive} />
+          <LiveLogsWithTheme
+            logsResult={logsResult}
+            timeZone={timeZone}
+            stopLive={this.onStopLive}
+            isPaused={this.props.isPaused}
+            onPause={this.onPause}
+            onResume={this.onResume}
+          />
         </Collapse>
       );
     }
@@ -147,6 +170,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     scanning,
     datasourceInstance,
     isLive,
+    isPaused,
     range,
     absoluteRange,
   } = item;
@@ -165,6 +189,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     dedupedResult,
     datasourceInstance,
     isLive,
+    isPaused,
     range,
     absoluteRange,
   };
@@ -175,6 +200,7 @@ const mapDispatchToProps = {
   toggleLogLevelAction,
   stopLive: changeRefreshIntervalAction,
   updateTimeRange,
+  setPausedStateAction,
 };
 
 export default hot(module)(

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -225,6 +225,11 @@ export interface ChangeLoadingStatePayload {
   loadingState: LoadingState;
 }
 
+export interface SetPausedStatePayload {
+  exploreId: ExploreId;
+  isPaused: boolean;
+}
+
 /**
  * Adds a query row after the row with the given index.
  */
@@ -420,6 +425,8 @@ export const changeRangeAction = actionCreatorFactory<ChangeRangePayload>('explo
 export const changeLoadingStateAction = actionCreatorFactory<ChangeLoadingStatePayload>(
   'changeLoadingStateAction'
 ).create();
+
+export const setPausedStateAction = actionCreatorFactory<SetPausedStatePayload>('explore/SET_PAUSED_STATE').create();
 
 export type HigherOrderAction =
   | ActionOf<SplitCloseActionPayload>

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -53,6 +53,7 @@ import {
   toggleLogLevelAction,
   changeLoadingStateAction,
   resetExploreAction,
+  setPausedStateAction,
 } from './actionTypes';
 import { reducerFactory } from 'app/core/redux';
 import { updateLocation } from 'app/core/actions/location';
@@ -115,6 +116,7 @@ export const makeExploreItemState = (): ExploreItemState => ({
   supportedModes: [],
   mode: null,
   isLive: false,
+  isPaused: false,
   urlReplaced: false,
   queryState: new PanelQueryState(),
 });
@@ -198,6 +200,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         refreshInterval,
         loadingState: live ? LoadingState.Streaming : LoadingState.NotStarted,
         isLive: live,
+        isPaused: false,
         logsResult,
       };
     },
@@ -598,6 +601,16 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       return {
         ...state,
         loadingState,
+      };
+    },
+  })
+  .addMapper({
+    filter: setPausedStateAction,
+    mapper: (state, action): ExploreItemState => {
+      const { isPaused } = action.payload;
+      return {
+        ...state,
+        isPaused: isPaused,
       };
     },
   })

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -254,7 +254,15 @@ export interface ExploreItemState {
   supportedModes: ExploreMode[];
   mode: ExploreMode;
 
+  /**
+   * If true, the view is in live tailing mode.
+   */
   isLive: boolean;
+
+  /**
+   * If true, the live tailing view is paused.
+   */
+  isPaused: boolean;
   urlReplaced: boolean;
 
   queryState: PanelQueryState;


### PR DESCRIPTION
Code split from https://github.com/grafana/grafana/pull/18696.

This adds new button in the bottom of the live tail window that pauses and resumes streaming. Also it pauses when user scrolls the the logs.

This is to prevent window scrolling to the bottom when new rows arrive and user is scrolling and searching for some previous log.