### PR TITLE
Precommit changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "test": "grunt test",
     "tslint": "tslint -c tslint.json --project tsconfig.json",
     "typecheck": "tsc --noEmit",
+    "typecheckPackages": "yarn workspaces run typecheck",
     "jest": "jest --notify --watch",
     "e2e-tests": "jest --runInBand --config=jest.config.e2e.js",
     "api-tests": "jest --notify --watch --config=devenv/e2e-api-tests/jest.js",

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -7,7 +7,8 @@ var path = require('path') ;
 var tsProjectPath = path.resolve(__dirname, '../tsconfig.json');
 
 require('ts-node').register({
-  project: tsProjectPath
+  project: tsProjectPath,
+  transpileOnly: true
 });
 
 require('../src/cli/index.ts').run(true);

--- a/packages/grafana-toolkit/src/cli/tasks/precommit.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/precommit.ts
@@ -12,15 +12,6 @@ const simpleGit = require('simple-git/promise')(process.cwd());
 interface PrecommitOptions {}
 
 const tasks = {
-  lint: {
-    sass: ['newer:sasslint'],
-    core: ['newer:exec:tslintRoot'],
-    gui: ['newer:exec:tslintPackages'],
-  },
-  typecheck: {
-    core: ['newer:exec:typecheckRoot'],
-    gui: ['newer:exec:typecheckPackages'],
-  },
   test: {
     lint: {
       ts: ['no-only-tests'],
@@ -43,16 +34,11 @@ const precommitRunner: TaskRunner<PrecommitOptions> = async () => {
     file => file.path.match(/^[a-zA-Z0-9\_\-\/]+(\.scss)$/g) || file.path.indexOf('.sass-lint.yml') > -1
   );
 
-  const tsFiles = status.files.filter(file => file.path.match(/^[a-zA-Z0-9\_\-\/]+(\.(ts|tsx))$/g));
   const testFiles = status.files.filter(file => file.path.match(/^[a-zA-Z0-9\_\-\/]+(\.test.(ts|tsx))$/g));
   const goTestFiles = status.files.filter(file => file.path.match(/^[a-zA-Z0-9\_\-\/]+(\_test.go)$/g));
-  const grafanaUiFiles = tsFiles.filter(file => file.path.indexOf('grafana-ui') > -1);
   const affectedNodeVersionFiles = status.files
     .filter(file => nodeVersionFiles.indexOf(file.path) !== -1)
     .map(f => f.path);
-
-  const grafanaUIFilesChangedOnly = tsFiles.length > 0 && tsFiles.length - grafanaUiFiles.length === 0;
-  const coreFilesChangedOnly = tsFiles.length > 0 && grafanaUiFiles.length === 0;
 
   const taskPaths = [];
 
@@ -72,16 +58,6 @@ const precommitRunner: TaskRunner<PrecommitOptions> = async () => {
     taskPaths.push('test.lint.go');
   }
 
-  if (tsFiles.length > 0) {
-    if (grafanaUIFilesChangedOnly) {
-      taskPaths.push('lint.gui', 'typecheck.core', 'typecheck.gui');
-    } else if (coreFilesChangedOnly) {
-      taskPaths.push('lint.core', 'typecheck.core');
-    } else {
-      taskPaths.push('lint.core', 'lint.gui', 'typecheck.core', 'typecheck.gui');
-    }
-  }
-
   const gruntTasks = flatten(taskPaths.map(path => get(tasks, path)));
   if (gruntTasks.length > 0) {
     console.log(chalk.yellow(`Precommit checks: ${taskPaths.join(', ')}`));
@@ -93,6 +69,7 @@ const precommitRunner: TaskRunner<PrecommitOptions> = async () => {
     }
     return task;
   }
+
   console.log(chalk.yellow('Skipping precommit checks, not front-end changes detected'));
   return;
 };


### PR DESCRIPTION
Running pre-commit task can take a long time (30s or more) 

* Removed the tslint step (very uncommon that his catches anything as the editor usually does this)
* Even when doing almost nothing precommit took 8s on my 2018 macbook. So disabled typechecking when compiling the precommit task (and the cli lib). Got it down to ~3s for doing the remaining checks (do not checking it.only tests). 
* The remaining checks might be better refactored to a makefile script (in the future)-
* added new yarn run task "typecheckPackages"  run tsc --noEmit on all packages. Useful if you have done a lot of work in the npm packages and want to make sure you have no strictNullChecks issues as that typescript option is enabled for those packages but not in the main app yet (and so webpack wont catch them). 