### PR TITLE
Send alert notification after recovering from no_data (WIP)

### DIFF
--- a/pkg/models/alert.go
+++ b/pkg/models/alert.go
@@ -78,6 +78,7 @@ type Alert struct {
 	ExecutionError string
 	Frequency      int64
 	For            time.Duration
+	NoDataFlag     bool
 
 	EvalData     *simplejson.Json
 	NewStateDate time.Time
@@ -171,11 +172,12 @@ type PauseAllAlertCommand struct {
 }
 
 type SetAlertStateCommand struct {
-	AlertId  int64
-	OrgId    int64
-	State    AlertStateType
-	Error    string
-	EvalData *simplejson.Json
+	AlertId    int64
+	OrgId      int64
+	State      AlertStateType
+	Error      string
+	EvalData   *simplejson.Json
+	NoDataFlag bool
 
 	Result Alert
 }

--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -146,6 +146,20 @@ func (c *EvalContext) GetNewState() models.AlertStateType {
 	return models.AlertStatePending
 }
 
+func (c *EvalContext) ToggleNoDataFlag() bool {
+	if c.Rule.NoDataFlag {
+		okOrAlerting := c.Rule.State == models.AlertStateOK || c.Rule.State == models.AlertStateAlerting
+		if okOrAlerting {
+			return false
+		}
+	} else {
+		if c.Rule.State == models.AlertStateNoData {
+			return true
+		}
+	}
+	return c.Rule.NoDataFlag
+}
+
 func getNewStateInternal(c *EvalContext) models.AlertStateType {
 	if c.Error != nil {
 		c.log.Error("Alert Rule Result Error",

--- a/pkg/services/alerting/eval_context_test.go
+++ b/pkg/services/alerting/eval_context_test.go
@@ -204,3 +204,80 @@ func TestGetStateFromEvalContext(t *testing.T) {
 		assert.Equal(t, tc.expected, newState, "failed: %s \n expected '%s' have '%s'\n", tc.name, tc.expected, string(newState))
 	}
 }
+
+func TestToggleNoDataFlag(t *testing.T) {
+	tcs := []struct {
+		name           string
+		ruleNoDataFlag bool
+		ruleState      models.AlertStateType
+		expected       bool
+	}{
+		{
+			name:           "NoDataFlag=false and state=unknown -> false",
+			ruleNoDataFlag: false,
+			ruleState:      models.AlertStateUnknown,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=false and state=pending -> false",
+			ruleNoDataFlag: false,
+			ruleState:      models.AlertStatePending,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=false and state=ok -> false",
+			ruleNoDataFlag: false,
+			ruleState:      models.AlertStateOK,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=false and state=alerting -> false",
+			ruleNoDataFlag: false,
+			ruleState:      models.AlertStateAlerting,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=false and state=no_date -> true",
+			ruleNoDataFlag: false,
+			ruleState:      models.AlertStateNoData,
+			expected:       true,
+		},
+		{
+			name:           "NoDataFlag=true and state=unknown -> true",
+			ruleNoDataFlag: true,
+			ruleState:      models.AlertStateUnknown,
+			expected:       true,
+		},
+		{
+			name:           "NoDataFlag=true and state=pending -> true",
+			ruleNoDataFlag: true,
+			ruleState:      models.AlertStatePending,
+			expected:       true,
+		},
+		{
+			name:           "NoDataFlag=true and state=ok -> false",
+			ruleNoDataFlag: true,
+			ruleState:      models.AlertStateOK,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=true and state=alerting -> false",
+			ruleNoDataFlag: true,
+			ruleState:      models.AlertStateAlerting,
+			expected:       false,
+		},
+		{
+			name:           "NoDataFlag=true and state=no_data -> true",
+			ruleNoDataFlag: true,
+			ruleState:      models.AlertStateNoData,
+			expected:       true,
+		},
+	}
+	for _, tc := range tcs {
+
+		evalContext := NewEvalContext(context.Background(), &Rule{State: tc.ruleState, NoDataFlag: tc.ruleNoDataFlag})
+
+		newNoDataFlag := evalContext.ToggleNoDataFlag()
+		assert.Equal(t, tc.expected, newNoDataFlag, "failed: %s \n expected '%s' have '%s'\n", tc.name, tc.expected, newNoDataFlag)
+	}
+}

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -134,6 +134,7 @@ func (e *DashAlertExtractor) getAlertFromPanels(jsonWithPanels *simplejson.Json,
 			Message:     jsonAlert.Get("message").MustString(),
 			Frequency:   frequency,
 			For:         forValue,
+			NoDataFlag:  jsonAlert.Get("no_data_flag").MustBool(),
 		}
 
 		for _, condition := range jsonAlert.Get("conditions").MustArray() {

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -134,7 +134,6 @@ func (e *DashAlertExtractor) getAlertFromPanels(jsonWithPanels *simplejson.Json,
 			Message:     jsonAlert.Get("message").MustString(),
 			Frequency:   frequency,
 			For:         forValue,
-			NoDataFlag:  jsonAlert.Get("no_data_flag").MustBool(),
 		}
 
 		for _, condition := range jsonAlert.Get("conditions").MustArray() {

--- a/pkg/services/alerting/notifiers/base_test.go
+++ b/pkg/services/alerting/notifiers/base_test.go
@@ -23,6 +23,7 @@ func TestShouldSendAlertNotification(t *testing.T) {
 		sendReminder bool
 		frequency    time.Duration
 		state        *models.AlertNotificationState
+		noDataFlag   bool
 
 		expect bool
 	}{
@@ -157,6 +158,28 @@ func TestShouldSendAlertNotification(t *testing.T) {
 
 			expect: false,
 		},
+		{
+			name:      "no_data -> ok",
+			prevState: models.AlertStateNoData,
+			newState:  models.AlertStateOK,
+
+			expect: true,
+		},
+		{
+			name:      "pending -> ok",
+			prevState: models.AlertStatePending,
+			newState:  models.AlertStateOK,
+
+			expect: false,
+		},
+		{
+			name:       "no_data -> pending -> ok",
+			prevState:  models.AlertStatePending,
+			newState:   models.AlertStateOK,
+			noDataFlag: true,
+
+			expect: true,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -169,6 +192,7 @@ func TestShouldSendAlertNotification(t *testing.T) {
 		}
 
 		evalContext.Rule.State = tc.newState
+		evalContext.Rule.NoDataFlag = tc.noDataFlag
 		nb := &NotifierBase{SendReminder: tc.sendReminder, Frequency: tc.frequency}
 
 		r := nb.ShouldNotify(evalContext.Ctx, evalContext, tc.state)

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -78,6 +78,9 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 
 			// Update the last state change of the alert rule in memory
 			evalContext.Rule.LastStateChange = time.Now()
+
+			// Update the flag of the alert rule in memory
+			evalContext.Rule.NoDataFlag = cmd.NoDataFlag
 		}
 
 		// save annotation

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -78,9 +78,6 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 
 			// Update the last state change of the alert rule in memory
 			evalContext.Rule.LastStateChange = time.Now()
-
-			// Update the flag of the alert rule in memory
-			evalContext.Rule.NoDataFlag = cmd.NoDataFlag
 		}
 
 		// save annotation

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -49,11 +49,12 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 		handler.log.Info("New state change", "ruleId", evalContext.Rule.ID, "newState", evalContext.Rule.State, "prev state", evalContext.PrevAlertState)
 
 		cmd := &models.SetAlertStateCommand{
-			AlertId:  evalContext.Rule.ID,
-			OrgId:    evalContext.Rule.OrgID,
-			State:    evalContext.Rule.State,
-			Error:    executionError,
-			EvalData: annotationData,
+			AlertId:    evalContext.Rule.ID,
+			OrgId:      evalContext.Rule.OrgID,
+			State:      evalContext.Rule.State,
+			Error:      executionError,
+			EvalData:   annotationData,
+			NoDataFlag: evalContext.ToggleNoDataFlag(),
 		}
 
 		if err := bus.Dispatch(cmd); err != nil {

--- a/pkg/services/alerting/rule.go
+++ b/pkg/services/alerting/rule.go
@@ -36,6 +36,7 @@ type Rule struct {
 	Conditions          []Condition
 	Notifications       []string
 	AlertRuleTags       []*models.Tag
+	NoDataFlag          bool
 
 	StateChanges int64
 }
@@ -126,6 +127,7 @@ func NewRuleFromDBAlert(ruleDef *models.Alert) (*Rule, error) {
 	model.NoDataState = models.NoDataOption(ruleDef.Settings.Get("noDataState").MustString("no_data"))
 	model.ExecutionErrorState = models.ExecutionErrorOption(ruleDef.Settings.Get("executionErrorState").MustString("alerting"))
 	model.StateChanges = ruleDef.StateChanges
+	model.NoDataFlag = ruleDef.NoDataFlag
 
 	model.Frequency = ruleDef.Frequency
 	// frequency cannot be zero since that would not execute the alert rule.

--- a/pkg/services/alerting/rule_test.go
+++ b/pkg/services/alerting/rule_test.go
@@ -97,6 +97,7 @@ func TestAlertRuleModel(t *testing.T) {
 					OrgId:       1,
 					DashboardId: 1,
 					PanelId:     1,
+					NoDataFlag:  true,
 
 					Settings: alertJSON,
 				}
@@ -105,6 +106,7 @@ func TestAlertRuleModel(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				So(len(alertRule.Conditions), ShouldEqual, 1)
+				So(alertRule.NoDataFlag, ShouldBeTrue)
 
 				Convey("Can read notifications", func() {
 					So(len(alertRule.Notifications), ShouldEqual, 2)

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -197,7 +197,7 @@ func updateAlerts(existingAlerts []*m.Alert, cmd *m.SaveAlertsCommand, sess *DBS
 			if alertToUpdate.ContainsUpdates(alert) {
 				alert.Updated = timeNow()
 				alert.State = alertToUpdate.State
-				sess.MustCols("message", "for")
+				sess.MustCols("message", "for", "no_data_flag")
 
 				_, err := sess.ID(alert.Id).Update(alert)
 				if err != nil {

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -197,6 +197,7 @@ func updateAlerts(existingAlerts []*m.Alert, cmd *m.SaveAlertsCommand, sess *DBS
 			if alertToUpdate.ContainsUpdates(alert) {
 				alert.Updated = timeNow()
 				alert.State = alertToUpdate.State
+				alert.NoDataFlag = alertToUpdate.NoDataFlag
 				sess.MustCols("message", "for", "no_data_flag")
 
 				_, err := sess.ID(alert.Id).Update(alert)
@@ -299,7 +300,9 @@ func SetAlertState(cmd *m.SetAlertStateCommand) error {
 			alert.ExecutionError = cmd.Error
 		}
 
-		_, err := sess.ID(alert.Id).Update(&alert)
+		// UseBool is required because boolean columns are not updated by default
+		// See also: https://github.com/go-xorm/xorm/issues/706
+		_, err := sess.ID(alert.Id).UseBool().Update(&alert)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -291,6 +291,7 @@ func SetAlertState(cmd *m.SetAlertStateCommand) error {
 		alert.StateChanges++
 		alert.NewStateDate = timeNow()
 		alert.EvalData = cmd.EvalData
+		alert.NoDataFlag = cmd.NoDataFlag
 
 		if cmd.Error == "" {
 			alert.ExecutionError = " " //without this space, xorm skips updating this field

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -60,12 +60,14 @@ func TestAlertingDataAccess(t *testing.T) {
 		Convey("Can set new states", func() {
 			Convey("new state ok", func() {
 				cmd := &m.SetAlertStateCommand{
-					AlertId: 1,
-					State:   m.AlertStateOK,
+					AlertId:    1,
+					State:      m.AlertStateOK,
+					NoDataFlag: true,
 				}
 
 				err = SetAlertState(cmd)
 				So(err, ShouldBeNil)
+				So(cmd.Result.NoDataFlag, ShouldBeTrue)
 			})
 
 			alert, _ := getAlertById(1)

--- a/pkg/services/sqlstore/migrations/alert_mig.go
+++ b/pkg/services/sqlstore/migrations/alert_mig.go
@@ -168,4 +168,8 @@ func addAlertMigrations(mg *Migrator) {
 	mg.AddMigration("Remove unique index org_id_name", NewDropIndexMigration(alert_notification, &Index{
 		Cols: []string{"org_id", "name"}, Type: UniqueIndex,
 	}))
+
+	mg.AddMigration("Add column no_data_flag in alert", NewAddColumnMigration(alertV1, &Column{
+		Name: "no_data_flag", Type: DB_Bool, Nullable: false, Default: "0",
+	}))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With this fix alert notifications are sent when state changes from `no_data` to `ok` or `alerting`.
In addition to this, an alert notification should also be sent if the state changes from `pending` to `ok` or `alerting` and it was `no_data` in the past as illustrated [here](https://github.com/grafana/grafana/issues/17780#issuecomment-509554611).
This fix tries to implement the first option suggested in the above comment.
Therefore it introduces a new Alert field `NoDataFlag` which is set when `no_data` occurs for first time and it is cleared when the alert rule state becomes `ok` or `alerting`.
The notifier checks this flag in order to decide whether a notification should be sent.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #17780

**Special notes for your reviewer**:


