### PR TITLE
Explore: elastic small fixes

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -455,6 +455,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   // Request Timing
   startTime: number;
   endTime?: number;
+  cancelled?: boolean;
 }
 
 export interface QueryFix {

--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -425,6 +425,7 @@ export interface DataQueryError {
   status?: string;
   statusText?: string;
   refId?: string;
+  cancelled?: boolean;
 }
 
 export interface ScopedVar {
@@ -455,7 +456,6 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   // Request Timing
   startTime: number;
   endTime?: number;
-  cancelled?: boolean;
 }
 
 export interface QueryFix {

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -260,7 +260,9 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel {
       const timeLocal = time.format('YYYY-MM-DD HH:mm:ss');
       const timeUtc = toUtc(ts).format('YYYY-MM-DD HH:mm:ss');
 
-      const message = stringField.values.get(j);
+      let message = stringField.values.get(j);
+      // This should be string but sometimes isn't (eg elastic) because the dataFrame is not strongly typed.
+      message = typeof message === 'string' ? message : JSON.stringify(message);
 
       let logLevel = LogLevel.unknown;
       if (logLevelField) {

--- a/public/app/features/explore/Table.tsx
+++ b/public/app/features/explore/Table.tsx
@@ -46,7 +46,7 @@ export default class Table extends PureComponent<TableProps> {
       show: text !== 'Time',
       Cell: (row: any) => (
         <span className={filterable ? 'link' : ''} title={text + ': ' + row.value}>
-          {row.value}
+          {typeof row.value === 'string' ? row.value : JSON.stringify(row.value)}
         </span>
       ),
     }));

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -589,6 +589,10 @@ export const processQueryResponse = (
   const replacePreviousResults = action.type === queryEndedAction.type;
 
   if (error) {
+    if (error.cancelled) {
+      return state;
+    }
+
     // For Angular editors
     state.eventBridge.emit('data-error', error);
 


### PR DESCRIPTION
Some issues that I did not notice from https://github.com/grafana/grafana/pull/18859 or were there before not sure now.

- We start query 2 times when initialising the Explore (not sure why need to take a look at that more) and with slow queries this could result in cancellation of the first request which was handled as regular error.
- With elastic some row values are objects or arrays, which would trip the react rendering.