### PR TITLE
Webpack: Fix accidental double typechecking

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
   target: 'web',
@@ -93,9 +92,4 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    new ForkTsCheckerWebpackPlugin({
-      checkSyntacticErrors: true,
-    })
-  ],
 };

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -69,7 +69,7 @@ module.exports = (env = {}) =>
         checkSyntacticErrors: true,
       }),
       new MiniCssExtractPlugin({
-        filename: "grafana.[name].[hash].css"
+        filename: 'grafana.[name].[hash].css'
       }),
       new HtmlWebpackPlugin({
         filename: path.resolve(__dirname, '../../public/views/error.html'),
@@ -89,7 +89,7 @@ module.exports = (env = {}) =>
       new webpack.HotModuleReplacementPlugin(),
       new webpack.DefinePlugin({
         'process.env': {
-          'NODE_ENV': JSON.stringify('development')
+          NODE_ENV: JSON.stringify('development')
         }
       }),
       // new BundleAnalyzerPlugin({


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue where 2 typescript typecheckers would run in parallel.

