### PR TITLE
Docs: Adds a requirements page

### DIFF
--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -12,6 +12,7 @@ weight = 1
 
 ## Installing Grafana
 
+- [Requirements](requirements)
 - [Installing on Debian / Ubuntu](debian)
 - [Installing on RPM-based Linux (CentOS, Fedora, OpenSuse, RedHat)](rpm)
 - [Installing on Mac OS X](mac)

--- a/docs/sources/installation/requirements.md
+++ b/docs/sources/installation/requirements.md
@@ -29,7 +29,7 @@ Installation of Grafana on other operating systems is possible, but not supporte
 
 ## Hardware requirements
 
-Grafana does not use a lot of resources and is very lightweight in use of memory and CPU. Minimum recommendation of 255mb memory and 1 CPU.
+Grafana does not use a lot of resources and is very lightweight in use of memory and CPU. Minimum recommendation is 255mb of memory and 1 CPU.
 
 Depending on what features are being used and to what extent the requirements varies. Features that consume and requires more resources:
 

--- a/docs/sources/installation/requirements.md
+++ b/docs/sources/installation/requirements.md
@@ -1,0 +1,75 @@
++++
+title = "Requirements"
+description = "Requirements for Grafana"
+keywords = ["grafana", "installation", "documentation"]
+type = "docs"
+[menu.docs]
+name = "Requirements"
+identifier = "requirements"
+parent = "installation"
+weight = -1
++++
+
+# Requirements
+
+This page includes useful information on the supported Operating Systems as well as the hardware requirements that are needed to install and use Grafana.
+
+## Operating Systems
+
+### Supported
+
+- [Debian / Ubuntu](/installation/debian)
+- [RPM-based Linux (CentOS, Fedora, OpenSuse, RedHat)](/installation/rpm)
+- [Mac OS X](/installation/mac)
+- [Windows](/installation/windows)
+
+### Unsupported
+
+Installation of Grafana on other operating systems is possible, but not supported. Please see the [building from source](/project/building_from_source/#building-grafana-from-source) guide for more information.
+
+## Hardware requirements
+
+Grafana does not use a lot of resources and is very lightweight in use of memory and CPU. Minimum recommendation of 255mb memory and 1 CPU.
+
+Depending on what features are being used and to what extent the requirements varies. Features that consume and requires more resources:
+
+- Server side rendering of images
+- [Alerting](/alerting/rules/)
+- Data source proxy
+
+## Database
+
+Grafana requires a database to store its configuration data, e.g. users, data sources and dashboards. The exact requirements depend on the size of the Grafana installation (e.g. the number of users, data sources, dashboards, features in use etc).
+
+Grafana supports the following databases:
+
+- SQLite
+- MySQL
+- PostgreSQL
+
+Per default Grafana ships with and uses SQLite which is an embedded database stored on disk in Grafana's installation location.
+
+## Supported web browsers
+
+Grafana is supported in the following browsers:
+
+- Chrome/Chromium
+- Firefox
+- Safari
+- Microsoft Edge
+
+> Note 1: Older versions of above browsers may not be supported
+
+> Note 2: Internet Explorer 11 is only fully supported in Grafana versions prior v6.0.
+
+> Note 3: Running Grafana without JavaScript enabled in the browser is not supported
+
+### Known issues
+
+#### Problem with logging in using Safari 12
+
+There is a known [iOS Safari 12 issue](https://bugs.webkit.org/show_bug.cgi?id=188165) that prevents the Grafana session cookie from being written after a successful login.
+A quick workaround for this problem would be to configure [cookie_samesite](/installation/configuration/#cookie-samesite) to `none`. However, there is another known [Safari 12 issue](https://bugs.webkit.org/show_bug.cgi?id=198181) that threats `SameSite=none` as `strict` which also
+prevents the Grafana session cookie from being written after a successful login.
+
+To resolve using `none` as `SameSite` cookie attribute in combination with Safari 12, please upgrade to at least Grafana v6.3.3 which includes a fix.

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -135,11 +135,6 @@ If you have text panels with script tags they will no longer work due to a new s
 Read more [here](/installation/configuration/#disable-sanitize-html) about this new setting.
 
 
-## Upgrading to v6.4
-
-One of the database migrations included in this release will merge multiple rows used to represent an annotation range into a single row.  If you have a large number of region annotations the database migration may take a long time to complete.  See [Upgrading to v5.2](#upgrading-to-v5-2) for tips on how to manage this process.
-
-
 ### Authentication and security
 
 If your using Grafana's builtin, LDAP (without Auth Proxy) or OAuth authentication all users will be required to login upon the next visit after the upgrade.
@@ -165,7 +160,6 @@ login_maximum_lifetime_days = 1
 ```
 
 The default cookie name for storing the auth token is `grafana_session`. you can configure this with `login_cookie_name` in `[auth]` settings.
-
 
 ## Upgrading to v6.2
 
@@ -199,3 +193,7 @@ The semantics of `max concurrent shard requests` changed in Elasticsearch v7.0, 
 
 If you upgrade Elasticsearch to v7.0+ you should make sure to update the datasource configuration in Grafana so that version
 is `7.0+` and `max concurrent shard requests` properly configured. 256 was the default in pre v7.0 versions. In v7.0 and above 5 is the default.
+
+## Upgrading to v6.4
+
+One of the database migrations included in this release will merge multiple rows used to represent an annotation range into a single row.  If you have a large number of region annotations the database migration may take a long time to complete.  See [Upgrading to v5.2](#upgrading-to-v5-2) for tips on how to manage this process.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new requirements page to the installation docs. 
Wanted/needed some place to document known browser issues and thought that adding this missing page together with OS, hardware, database and browser requirements would be a good thing.

**Which issue(s) this PR fixes**:
Fixes #16487
Ref #18690

**Special notes for your reviewer**:
Hope that we could extend the requirements page eventually so please see this as a first step towards a great requirements page.