### PR TITLE
Add pointer events none to  .disabled class

### DIFF
--- a/public/sass/components/_buttons.scss
+++ b/public/sass/components/_buttons.scss
@@ -49,6 +49,7 @@
     cursor: $cursor-disabled;
     opacity: 0.65;
     @include box-shadow(none);
+    pointer-events: none;
   }
 
   &--radius-left-0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases we may want to have an `<a>` styled as a button, for these cases we want to disable mouse events so that clicking it does not trigger a navigation.
