### PR TITLE
Explore: UX/UI improvements for pausing and resuming of live tailing

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Render should render with base threshold 1`] = `
                           Object {
                             "background": Object {
                               "dropdown": "#1f1f20",
-                              "logsFresh": "#303032",
+                              "logsFresh": "#5794F240",
                               "scrollbar": "#343436",
                               "scrollbar2": "#343436",
                             },
@@ -236,7 +236,7 @@ exports[`Render should render with base threshold 1`] = `
                                 Object {
                                   "background": Object {
                                     "dropdown": "#1f1f20",
-                                    "logsFresh": "#303032",
+                                    "logsFresh": "#5794F240",
                                     "scrollbar": "#343436",
                                     "scrollbar2": "#343436",
                                   },

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`Render should render with base threshold 1`] = `
                           Object {
                             "background": Object {
                               "dropdown": "#1f1f20",
+                              "liveLogs": "#1250B0",
                               "scrollbar": "#343436",
                               "scrollbar2": "#343436",
                             },
@@ -235,6 +236,7 @@ exports[`Render should render with base threshold 1`] = `
                                 Object {
                                   "background": Object {
                                     "dropdown": "#1f1f20",
+                                    "liveLogs": "#1250B0",
                                     "scrollbar": "#343436",
                                     "scrollbar2": "#343436",
                                   },

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Render should render with base threshold 1`] = `
                           Object {
                             "background": Object {
                               "dropdown": "#1f1f20",
-                              "liveLogs": "#1250B0",
+                              "logsFresh": "#1250B0",
                               "scrollbar": "#343436",
                               "scrollbar2": "#343436",
                             },
@@ -236,7 +236,7 @@ exports[`Render should render with base threshold 1`] = `
                                 Object {
                                   "background": Object {
                                     "dropdown": "#1f1f20",
-                                    "liveLogs": "#1250B0",
+                                    "logsFresh": "#1250B0",
                                     "scrollbar": "#343436",
                                     "scrollbar2": "#343436",
                                   },

--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Render should render with base threshold 1`] = `
                           Object {
                             "background": Object {
                               "dropdown": "#1f1f20",
-                              "logsFresh": "#1250B0",
+                              "logsFresh": "#303032",
                               "scrollbar": "#343436",
                               "scrollbar2": "#343436",
                             },
@@ -236,7 +236,7 @@ exports[`Render should render with base threshold 1`] = `
                                 Object {
                                   "background": Object {
                                     "dropdown": "#1f1f20",
-                                    "logsFresh": "#1250B0",
+                                    "logsFresh": "#303032",
                                     "scrollbar": "#343436",
                                     "scrollbar2": "#343436",
                                   },

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -75,6 +75,7 @@ const darkTheme: GrafanaTheme = {
     dropdown: basicColors.dark3,
     scrollbar: basicColors.dark9,
     scrollbar2: basicColors.dark9,
+    liveLogs: '#1250B0',
   },
 };
 

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -75,7 +75,7 @@ const darkTheme: GrafanaTheme = {
     dropdown: basicColors.dark3,
     scrollbar: basicColors.dark9,
     scrollbar2: basicColors.dark9,
-    logsFresh: '#1250B0',
+    logsFresh: '#303032',
   },
 };
 

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -75,7 +75,7 @@ const darkTheme: GrafanaTheme = {
     dropdown: basicColors.dark3,
     scrollbar: basicColors.dark9,
     scrollbar2: basicColors.dark9,
-    logsFresh: '#303032',
+    logsFresh: '#5794F240',
   },
 };
 

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -75,7 +75,7 @@ const darkTheme: GrafanaTheme = {
     dropdown: basicColors.dark3,
     scrollbar: basicColors.dark9,
     scrollbar2: basicColors.dark9,
-    liveLogs: '#1250B0',
+    logsFresh: '#1250B0',
   },
 };
 

--- a/packages/grafana-ui/src/themes/light.ts
+++ b/packages/grafana-ui/src/themes/light.ts
@@ -76,6 +76,7 @@ const lightTheme: GrafanaTheme = {
     dropdown: basicColors.white,
     scrollbar: basicColors.gray5,
     scrollbar2: basicColors.gray5,
+    liveLogs: '#d8e7ff',
   },
 };
 

--- a/packages/grafana-ui/src/themes/light.ts
+++ b/packages/grafana-ui/src/themes/light.ts
@@ -76,7 +76,7 @@ const lightTheme: GrafanaTheme = {
     dropdown: basicColors.white,
     scrollbar: basicColors.gray5,
     scrollbar2: basicColors.gray5,
-    liveLogs: '#d8e7ff',
+    logsFresh: '#d8e7ff',
   },
 };
 

--- a/packages/grafana-ui/src/types/theme.ts
+++ b/packages/grafana-ui/src/types/theme.ts
@@ -96,6 +96,7 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
     dropdown: string;
     scrollbar: string;
     scrollbar2: string;
+    liveLogs: string;
   };
   colors: {
     black: string;

--- a/packages/grafana-ui/src/types/theme.ts
+++ b/packages/grafana-ui/src/types/theme.ts
@@ -96,7 +96,7 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
     dropdown: string;
     scrollbar: string;
     scrollbar2: string;
-    liveLogs: string;
+    logsFresh: string;
   };
   colors: {
     black: string;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -9,6 +9,8 @@ import ElapsedTime from './ElapsedTime';
 const getStyles = (theme: GrafanaTheme) => ({
   logsRowsLive: css`
     label: logs-rows-live;
+    font-family: ${theme.typography.fontFamily.monospace};
+    font-size: ${theme.typography.size.sm};
     display: flex;
     flex-flow: column nowrap;
     height: 65vh;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -22,7 +22,11 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    animation: fade 2s linear 0s 1 normal forwards;
+    background-color: ${selectThemeVariant(
+      { light: theme.background.logsFresh, dark: theme.background.logsFresh },
+      theme.type
+    )};
+    animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {
       from {
         background-color: ${selectThemeVariant(

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -22,7 +22,10 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    background-color: ${selectThemeVariant({ light: theme.colors.gray6, dark: theme.colors.gray1 }, theme.type)};
+    background-color: ${selectThemeVariant(
+      { light: theme.background.liveLogs, dark: theme.background.liveLogs },
+      theme.type
+    )};
   `,
   logsRowOld: css`
     label: logs-row-old;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -22,7 +22,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    animation: fade 1.5s linear 0s 1 normal forwards;
+    animation: fade 2s linear 0s 1 normal forwards;
     @keyframes fade {
       from {
         background-color: ${selectThemeVariant(

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -23,7 +23,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     label: logs-row-fresh;
     color: ${theme.colors.text};
     background-color: ${selectThemeVariant(
-      { light: theme.background.liveLogs, dark: theme.background.liveLogs },
+      { light: theme.background.logsFresh, dark: theme.background.logsFresh },
       theme.type
     )};
   `,

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -186,7 +186,7 @@ class LiveLogs extends PureComponent<Props, State> {
             {isPaused ? 'Resume' : 'Pause'}
           </button>
           <button onClick={this.props.stopLive} className={cx('btn btn-inverse', styles.button)}>
-            <i className={'fa fa-stop'} />
+            <i className={'fa fa-times'} />
             &nbsp; Exit live mode
           </button>
           {isPaused || (

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -22,18 +22,25 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    background-color: ${selectThemeVariant(
-      { light: theme.background.logsFresh, dark: theme.background.logsFresh },
-      theme.type
-    )};
+    animation: fade 1.5s linear 0s 1 normal forwards;
+    @keyframes fade {
+      from {
+        background-color: ${selectThemeVariant(
+          { light: theme.background.logsFresh, dark: theme.background.logsFresh },
+          theme.type
+        )};
+      }
+      to {
+        background-color: transparent;
+      }
+    }
   `,
   logsRowOld: css`
     label: logs-row-old;
-    opacity: 0.8;
   `,
   logsRowsIndicator: css`
     font-size: ${theme.typography.size.md};
-    padding: ${theme.spacing.sm} 0;
+    padding-top: ${theme.spacing.sm};
     display: flex;
     align-items: center;
   `,

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -173,7 +173,7 @@ class LiveLogs extends PureComponent<Props, State> {
           </button>
           <button onClick={this.props.stopLive} className={cx('btn btn-inverse', styles.button)}>
             <i className={'fa fa-stop'} />
-            &nbsp; Stop
+            &nbsp; Exit live mode
           </button>
           {isPaused || (
             <span>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR includes several UX/UI improvements for pausing and resuming of live tailing:
- [x] Adds margins/paddings to buttons, logs list and logs headline within the logs box for more consistent look
- [x] Fixes live logging font and line spacing as it was different than the non-live
- [x] Adds nicer design when new rows are showed than - **introduces new background colour for dark and light theme** and fading animation (WIP)
- [x] Changes stop button text to "Exit live mode"

**Which issue(s) this PR fixes**:

Fixes #18850

