### PR TITLE
Image rendering: Add deprecation warning when PhantomJS is used for rendering images

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -68,7 +68,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 
 	if plugins.Renderer == nil {
 		rs.log.Info("Backend rendering via phantomJS")
-		rs.log.Warn("phantomJS is deprecated and will be removed from the next version. " +
+		rs.log.Warn("phantomJS is deprecated and will be removed in a future release. " +
 			"You should consider migrating from phantomJS to grafana-image-renderer plugin.")
 		rs.renderAction = rs.renderViaPhantomJS
 		<-ctx.Done()

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -68,6 +68,8 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 
 	if plugins.Renderer == nil {
 		rs.log.Info("Backend rendering via phantomJS")
+		rs.log.Warn("phantomJS is deprecated and will be removed from the next version. " +
+			"You should consider migrating from phantomJS to grafana-image-renderer plugin.")
 		rs.renderAction = rs.renderViaPhantomJS
 		<-ctx.Done()
 		return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This fix introduces a deprecation warning when no other image rendering plugin is found and  PhantomJS is used for rendering images

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18913

**Special notes for your reviewer**:

