### PR TITLE
Dashboard: Fixes dashboard overwriting behavior

### DIFF
--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -91,6 +91,8 @@ export class DashboardSrv {
     options: DashboardSaveOptions,
     err: { data: { status: string; message: any }; isHandled: boolean }
   ) {
+    options.overwrite = true;
+
     if (err.data && err.data.status === 'version-mismatch') {
       err.isHandled = true;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed to fix a regression caused by https://github.com/grafana/grafana/pull/17982 which broke overwriting existing dashboards.

**Which issue(s) this PR fixes**:
Fixes #18941

