### PR TITLE
LDAP: Fetch teams in debug view

### DIFF
--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -100,6 +100,17 @@ type GetAuthInfoQuery struct {
 	Result *UserAuth
 }
 
+type TeamOrgGroupDTO struct {
+	TeamName string `json:"teamName"`
+	OrgName  string `json:"orgName"`
+	GroupDN  string `json:"groupDN"`
+}
+
+type GetTeamsForLDAPGroupCommand struct {
+	Groups []string
+	Result []TeamOrgGroupDTO
+}
+
 type SyncTeamsCommand struct {
 	ExternalUser *ExternalUserInfo
 	User         *User


### PR DESCRIPTION
Adds the definition of `GetTeamsForLDAPGroupCommand` which handles the lookup of team information based on LDAP groupDNs.

This is an Enterprise only feature. To differentiate, a response will contain the `team` key as `null` on OSS while on Enterprise the key will contain an empty array `[]` when no teams are found

