### PR TITLE
Allow extending of LDFLAGS in build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -528,6 +528,9 @@ func ldflags() string {
 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", getGitSha()))
 	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp()))
 	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", getGitBranch()))
+	if v := os.Getenv("LDFLAGS"); v != "" {
+		b.WriteString(fmt.Sprintf(" -extldflags=%s", v))
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
Allow extending LDFALGS by setting LDFLAGS to be able to pass
-zrelro,-znow for Arch Linux packaging
to get full relro.
