### PR TITLE
Explore: Unify background color for fresh logs

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/__snapshots__/ThresholdsEditor.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`Render should render with base threshold 1`] = `
                           Object {
                             "background": Object {
                               "dropdown": "#1f1f20",
-                              "logsFresh": "#5794F240",
                               "scrollbar": "#343436",
                               "scrollbar2": "#343436",
                             },
@@ -236,7 +235,6 @@ exports[`Render should render with base threshold 1`] = `
                                 Object {
                                   "background": Object {
                                     "dropdown": "#1f1f20",
-                                    "logsFresh": "#5794F240",
                                     "scrollbar": "#343436",
                                     "scrollbar2": "#343436",
                                   },

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -75,7 +75,6 @@ const darkTheme: GrafanaTheme = {
     dropdown: basicColors.dark3,
     scrollbar: basicColors.dark9,
     scrollbar2: basicColors.dark9,
-    logsFresh: '#5794F240',
   },
 };
 

--- a/packages/grafana-ui/src/themes/light.ts
+++ b/packages/grafana-ui/src/themes/light.ts
@@ -76,7 +76,6 @@ const lightTheme: GrafanaTheme = {
     dropdown: basicColors.white,
     scrollbar: basicColors.gray5,
     scrollbar2: basicColors.gray5,
-    logsFresh: '#d8e7ff',
   },
 };
 

--- a/packages/grafana-ui/src/types/theme.ts
+++ b/packages/grafana-ui/src/types/theme.ts
@@ -96,7 +96,6 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
     dropdown: string;
     scrollbar: string;
     scrollbar2: string;
-    logsFresh: string;
   };
   colors: {
     black: string;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -8,9 +8,8 @@ import { LogsModel, LogRowModel, TimeZone } from '@grafana/data';
 import ElapsedTime from './ElapsedTime';
 
 /*
-setting alpha using Hexadecimal notation: #RRGGBB[AA]
-R,G, B and A (alpha) are hexadecimal characters. A is optional.
-https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+  Setting alpha using Hexadecimal notation: #RRGGBB[AA], where A is optional.
+  https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
 */
 const setAlpha = (hex: string, alpha: number) => {
   const hexAlpha = ((alpha * 255) | (1 << 8)).toString(16).slice(1);

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -23,6 +23,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
+    /*Background color with 25% opacity using Hexadecimal color code for transparency*/
     background-color: ${theme.colors.blueLight}40;
     animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { css, cx } from 'emotion';
 import { last } from 'lodash';
 
-import { Themeable, withTheme, GrafanaTheme, selectThemeVariant, getLogRowStyles } from '@grafana/ui';
+import { Themeable, withTheme, GrafanaTheme, getLogRowStyles } from '@grafana/ui';
 import { LogsModel, LogRowModel, TimeZone } from '@grafana/data';
 
 import ElapsedTime from './ElapsedTime';
@@ -23,17 +23,11 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    background-color: ${selectThemeVariant(
-      { light: theme.background.logsFresh, dark: theme.background.logsFresh },
-      theme.type
-    )};
+    background-color: ${theme.colors.blueLight}40;
     animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {
       from {
-        background-color: ${selectThemeVariant(
-          { light: theme.background.logsFresh, dark: theme.background.logsFresh },
-          theme.type
-        )};
+        background-color: ${theme.colors.blueLight}40;
       }
       to {
         background-color: transparent;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -23,7 +23,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    /*Background color with 25% opacity using Hexadecimal color code for transparency*/
+    /* applying 25% opacity to background color using HEX color code for transparency */
     background-color: ${theme.colors.blueLight}40;
     animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -7,6 +7,16 @@ import { LogsModel, LogRowModel, TimeZone } from '@grafana/data';
 
 import ElapsedTime from './ElapsedTime';
 
+/*
+setting alpha using Hexadecimal notation: #RRGGBB[AA]
+R,G, B and A (alpha) are hexadecimal characters. A is optional.
+https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+*/
+const setAlpha = (hex: string, alpha: number) => {
+  const hexAlpha = ((alpha * 255) | (1 << 8)).toString(16).slice(1);
+  return hex + hexAlpha;
+};
+
 const getStyles = (theme: GrafanaTheme) => ({
   logsRowsLive: css`
     label: logs-rows-live;
@@ -23,12 +33,11 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    /* applying 25% opacity to background color using HEX color code for transparency */
-    background-color: ${theme.colors.blueLight}40;
+    background-color: ${setAlpha(theme.colors.blueLight, 0.25)};
     animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {
       from {
-        background-color: ${theme.colors.blueLight}40;
+        background-color: ${setAlpha(theme.colors.blueLight, 0.25)};
       }
       to {
         background-color: transparent;

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -1,20 +1,12 @@
 import React, { PureComponent } from 'react';
 import { css, cx } from 'emotion';
+import tinycolor from 'tinycolor2';
 import { last } from 'lodash';
 
 import { Themeable, withTheme, GrafanaTheme, getLogRowStyles } from '@grafana/ui';
 import { LogsModel, LogRowModel, TimeZone } from '@grafana/data';
 
 import ElapsedTime from './ElapsedTime';
-
-/*
-  Setting alpha using Hexadecimal notation: #RRGGBB[AA], where A is optional.
-  https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
-*/
-const setAlpha = (hex: string, alpha: number) => {
-  const hexAlpha = ((alpha * 255) | (1 << 8)).toString(16).slice(1);
-  return hex + hexAlpha;
-};
 
 const getStyles = (theme: GrafanaTheme) => ({
   logsRowsLive: css`
@@ -32,11 +24,15 @@ const getStyles = (theme: GrafanaTheme) => ({
   logsRowFresh: css`
     label: logs-row-fresh;
     color: ${theme.colors.text};
-    background-color: ${setAlpha(theme.colors.blueLight, 0.25)};
+    background-color: ${tinycolor(theme.colors.blueLight)
+      .setAlpha(0.25)
+      .toString()};
     animation: fade 1s ease-out 1s 1 normal forwards;
     @keyframes fade {
       from {
-        background-color: ${setAlpha(theme.colors.blueLight, 0.25)};
+        background-color: ${tinycolor(theme.colors.blueLight)
+          .setAlpha(0.25)
+          .toString()};
       }
       to {
         background-color: transparent;


### PR DESCRIPTION
**What this PR does / why we need it**:
In the [18931](https://github.com/grafana/grafana/pull/18931) we have introduced 2 new colors for fresh logs background. This is unnecessary as almost identical visuals could be achieved by using blueLight color with 25% alpha transparency for both themes. This PR removes the newly introduced colors and uses colors already used in theme.  
![image](https://user-images.githubusercontent.com/30407135/64557433-d4522900-d341-11e9-8be2-618dbb1365b6.png)
![image](https://user-images.githubusercontent.com/30407135/64557496-f3e95180-d341-11e9-891a-a70290d0d64d.png)

