### PR TITLE
LDAP: Allow an user to be synchronized against LDAP

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -395,6 +395,7 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/provisioning/datasources/reload", Wrap(hs.AdminProvisioningReloadDatasources))
 		adminRoute.Post("/provisioning/notifications/reload", Wrap(hs.AdminProvisioningReloadNotifications))
 		adminRoute.Post("/ldap/reload", Wrap(hs.ReloadLDAPCfg))
+		adminRoute.Post("/ldap/sync/:id", Wrap(hs.PostSyncUserWithLDAP))
 		adminRoute.Get("/ldap/:username", Wrap(hs.GetUserFromLDAP))
 		adminRoute.Get("/ldap/status", Wrap(hs.GetLDAPStatus))
 	}, reqGrafanaAdmin)

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -100,7 +100,7 @@ func (server *HTTPServer) ReloadLDAPCfg() Response {
 
 	err := ldap.ReloadConfig()
 	if err != nil {
-		return Error(http.StatusInternalServerError, "Failed to reload ldap config.", err)
+		return Error(http.StatusInternalServerError, "Failed to reload ldap config", err)
 	}
 	return Success("LDAP config reloaded")
 }
@@ -114,7 +114,7 @@ func (server *HTTPServer) GetLDAPStatus(c *models.ReqContext) Response {
 	ldapConfig, err := getLDAPConfig()
 
 	if err != nil {
-		return Error(http.StatusBadRequest, "Failed to obtain the LDAP configuration. Please verify the configuration and try again.", err)
+		return Error(http.StatusBadRequest, "Failed to obtain the LDAP configuration. Please verify the configuration and try again", err)
 	}
 
 	ldap := newLDAP(ldapConfig.Servers)
@@ -151,14 +151,14 @@ func (server *HTTPServer) PostSyncUserWithLDAP(c *models.ReqContext) Response {
 	ldapConfig, err := getLDAPConfig()
 
 	if err != nil {
-		return Error(http.StatusBadRequest, "Failed to obtain the LDAP configuration. Please verify the configuration and try again.", err)
+		return Error(http.StatusBadRequest, "Failed to obtain the LDAP configuration. Please verify the configuration and try again", err)
 	}
 
 	userId := c.ParamsInt64(":id")
 
 	query := models.GetUserByIdQuery{Id: userId}
 
-	err = bus.Dispatch(query)
+	err = bus.Dispatch(&query)
 
 	if err := bus.Dispatch(&query); err != nil {
 		if err == models.ErrUserNotFound {
@@ -199,7 +199,7 @@ func (server *HTTPServer) PostSyncUserWithLDAP(c *models.ReqContext) Response {
 		return Error(http.StatusInternalServerError, "Failed to udpate the user", err)
 	}
 
-	return JSON(http.StatusOK, "user synced")
+	return Success("User synced successfully")
 }
 
 // GetUserFromLDAP finds an user based on a username in LDAP. This helps illustrate how would the particular user be mapped in Grafana when synced.

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -100,7 +100,7 @@ func (server *HTTPServer) ReloadLDAPCfg() Response {
 
 	err := ldap.ReloadConfig()
 	if err != nil {
-		return Error(http.StatusInternalServerError, "Failed to reload ldap config", err)
+		return Error(http.StatusInternalServerError, "Failed to reload LDAP config", err)
 	}
 	return Success("LDAP config reloaded")
 }
@@ -143,6 +143,7 @@ func (server *HTTPServer) GetLDAPStatus(c *models.ReqContext) Response {
 	return JSON(http.StatusOK, serverDTOs)
 }
 
+// PostSyncUserWithLDAP enables a single Grafana user to be synchronized against LDAP
 func (server *HTTPServer) PostSyncUserWithLDAP(c *models.ReqContext) Response {
 	if !ldap.IsEnabled() {
 		return Error(http.StatusBadRequest, "LDAP is not enabled", nil)

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -87,10 +86,7 @@ func TestGetUserFromLDAPApiEndpoint_UserNotFound(t *testing.T) {
 	sc := getUserFromLDAPContext(t, "/api/admin/ldap/user-that-does-not-exist")
 
 	require.Equal(t, sc.resp.Code, http.StatusNotFound)
-	responseString, err := getBody(sc.resp)
-
-	assert.Nil(t, err)
-	assert.Equal(t, "{\"message\":\"No user was found on the LDAP server(s)\"}", responseString)
+	assert.JSONEq(t, "{\"message\":\"No user was found on the LDAP server(s)\"}", sc.resp.Body.String())
 }
 
 func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
@@ -145,19 +141,13 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 
 	require.Equal(t, sc.resp.Code, http.StatusBadRequest)
 
-	jsonResponse, err := getJSONbody(sc.resp)
-	assert.Nil(t, err)
-
 	expected := `
 	{
 		"error": "Unable to find organization with ID '2'",
 		"message": "An oganization was not found - Please verify your LDAP configuration"
 	}
 	`
-	var expectedJSON interface{}
-	_ = json.Unmarshal([]byte(expected), &expectedJSON)
-
-	assert.Equal(t, expectedJSON, jsonResponse)
+	assert.JSONEq(t, expected, sc.resp.Body.String())
 }
 
 func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
@@ -207,9 +197,6 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 
 	require.Equal(t, sc.resp.Code, http.StatusOK)
 
-	jsonResponse, err := getJSONbody(sc.resp)
-	assert.Nil(t, err)
-
 	expected := `
 		{
 		  "name": {
@@ -232,10 +219,8 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 			"teams": null
 		}
 	`
-	var expectedJSON interface{}
-	_ = json.Unmarshal([]byte(expected), &expectedJSON)
 
-	assert.Equal(t, expectedJSON, jsonResponse)
+	assert.JSONEq(t, expected, sc.resp.Body.String())
 }
 
 func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
@@ -290,9 +275,6 @@ func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
 
 	require.Equal(t, sc.resp.Code, http.StatusOK)
 
-	jsonResponse, err := getJSONbody(sc.resp)
-	assert.Nil(t, err)
-
 	expected := `
 		{
 		  "name": {
@@ -315,10 +297,8 @@ func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
 			"teams": []
 		}
 	`
-	var expectedJSON interface{}
-	_ = json.Unmarshal([]byte(expected), &expectedJSON)
 
-	assert.Equal(t, expectedJSON, jsonResponse)
+	assert.JSONEq(t, expected, sc.resp.Body.String())
 }
 
 //***
@@ -370,8 +350,6 @@ func TestGetLDAPStatusApiEndpoint(t *testing.T) {
 	sc := getLDAPStatusContext(t)
 
 	require.Equal(t, http.StatusOK, sc.resp.Code)
-	jsonResponse, err := getJSONbody(sc.resp)
-	assert.Nil(t, err)
 
 	expected := `
 	[
@@ -380,10 +358,7 @@ func TestGetLDAPStatusApiEndpoint(t *testing.T) {
 		{ "host": "10.0.0.5", "port": 361, "available": false, "error": "something is awfully wrong" }
 	]
 	`
-	var expectedJSON interface{}
-	_ = json.Unmarshal([]byte(expected), &expectedJSON)
-
-	assert.Equal(t, expectedJSON, jsonResponse)
+	assert.JSONEq(t, expected, sc.resp.Body.String())
 }
 
 //***

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -437,7 +437,14 @@ func TestPostSyncUserWithLDAPAPIEndpoint_Success(t *testing.T) {
 	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
-		q.Result = &models.User{Login: "ldap-daniel"}
+		q.Result = &models.User{Login: "ldap-daniel", Id: 34}
+		return nil
+	})
+
+	bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+		require.Equal(t, q.UserId, int64(34))
+		require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
+
 		return nil
 	})
 
@@ -500,7 +507,14 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenGrafanaAdmin(t *testing.T) {
 	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
-		q.Result = &models.User{Login: "ldap-daniel"}
+		q.Result = &models.User{Login: "ldap-daniel", Id: 34}
+		return nil
+	})
+
+	bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+		require.Equal(t, q.UserId, int64(34))
+		require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
+
 		return nil
 	})
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -50,18 +49,6 @@ func getBody(resp *httptest.ResponseRecorder) (string, error) {
 		return "", err
 	}
 	return string(responseData), nil
-}
-
-func getJSONbody(resp *httptest.ResponseRecorder) (interface{}, error) {
-	var j interface{}
-
-	err := json.Unmarshal(resp.Body.Bytes(), &j)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return j, nil
 }
 
 func TestLoginErrorCookieApiEndpoint(t *testing.T) {

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -40,7 +40,7 @@ var loginUsingLDAP = func(query *models.LoginUserQuery) (bool, error) {
 	if err != nil {
 		if err == ldap.ErrCouldNotFindUser {
 			// Ignore the error since user might not be present anyway
-			disableExternalUser(query.Username)
+			DisableExternalUser(query.Username)
 
 			return true, ldap.ErrInvalidCredentials
 		}
@@ -61,8 +61,8 @@ var loginUsingLDAP = func(query *models.LoginUserQuery) (bool, error) {
 	return true, nil
 }
 
-// disableExternalUser marks external user as disabled in Grafana db
-func disableExternalUser(username string) error {
+// DisableExternalUser marks external user as disabled in Grafana db
+func DisableExternalUser(username string) error {
 	// Check if external user exist in Grafana
 	userQuery := &models.GetExternalUserInfoByLoginQuery{
 		LoginOrEmail: username,


### PR DESCRIPTION
This PR introduces the `/ldap/sync/:id` endpoint. It allows a user to be synchronized against LDAP on demand.

A few things to note are:

- LDAP needs to be enabled for the sync to work
- It only works against users that originally authenticated against LDAP
- If the user is **the** Grafana admin and it needs to be disabled - it will _not_ sync the information

Includes a tiny refactor that favours the `JSONEq ` assertion helper instead of manually parsing JSON strings.