### PR TITLE
Singlestat: render lines on the panel when sparklines are enabled

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -250,11 +250,13 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       isUtc: dashboard.isTimezoneUtc && dashboard.isTimezoneUtc(),
     });
 
+    const sparkline: any[] = [];
     const data = {
       field: fieldInfo.field,
       value: val,
       display: processor(val),
       scopedVars: _.extend({}, panel.scopedVars),
+      sparkline,
     };
 
     data.scopedVars['__name'] = name;
@@ -262,7 +264,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
     // Get the fields for a sparkline
     if (panel.sparkline && panel.sparkline.show && fieldInfo.frame.firstTimeField) {
-      this.data.sparkline = getFlotPairs({
+      data.sparkline = getFlotPairs({
         xField: fieldInfo.frame.firstTimeField,
         yField: fieldInfo.field,
         nullValueMode: panel.nullPointMode,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
    If sparklines  are enabled , the sparklines do not get rendered on the panel.
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18956 
**Special notes for your reviewer**:

