### PR TITLE
Fix: Correct Loading/Rendering logic in PageContent

### DIFF
--- a/public/app/core/components/Page/PageContents.tsx
+++ b/public/app/core/components/Page/PageContents.tsx
@@ -13,12 +13,7 @@ class PageContents extends Component<Props> {
   render() {
     const { isLoading } = this.props;
 
-    return (
-      <div className="page-container page-body">
-        {isLoading && <PageLoader />}
-        {this.props.children}
-      </div>
-    );
+    return <div className="page-container page-body">{isLoading ? <PageLoader /> : this.props.children}</div>;
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Correcting logic in `<PageContent />` component. Before we render the children even if the page was not done loading. This fixes that issue.
