### PR TITLE
API: Add `updatedAt` to api/users/:id

### DIFF
--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -22,7 +22,7 @@ func TestUserApiEndpoint(t *testing.T) {
 			TotalCount: 2,
 		}
 
-		loggedInUserScenario("hen calling GET on", "api/users/:id", func(sc *scenarioContext) {
+		loggedInUserScenario("When calling GET on", "api/users/:id", func(sc *scenarioContext) {
 			fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
 			bus.AddHandler("test", func(query *models.GetUserProfileQuery) error {
 				query.Result = models.UserProfileDTO{

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -1,13 +1,15 @@
 package api
 
 import (
+	"net/http"
 	"testing"
-
-	"github.com/grafana/grafana/pkg/models"
+	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserApiEndpoint(t *testing.T) {
@@ -19,6 +21,55 @@ func TestUserApiEndpoint(t *testing.T) {
 			},
 			TotalCount: 2,
 		}
+
+		loggedInUserScenario("hen calling GET on", "api/users/:id", func(sc *scenarioContext) {
+			fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
+			bus.AddHandler("test", func(query *models.GetUserProfileQuery) error {
+				query.Result = models.UserProfileDTO{
+					Id:             int64(1),
+					Email:          "daniel@grafana.com",
+					Name:           "Daniel",
+					Login:          "danlee",
+					OrgId:          int64(2),
+					IsGrafanaAdmin: true,
+					IsDisabled:     false,
+					IsExternal:     false,
+					UpdatedAt:      fakeNow,
+				}
+				return nil
+			})
+
+			bus.AddHandler("test", func(query *models.GetAuthInfoQuery) error {
+				query.Result = &models.UserAuth{
+					AuthModule: models.AuthModuleLDAP,
+				}
+				return nil
+			})
+
+			sc.handlerFunc = GetUserByID
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+			expected := `
+			{
+				"id": 1,
+				"email": "daniel@grafana.com",
+				"name": "Daniel",
+				"login": "danlee",
+				"theme": "",
+				"orgId": 2,
+				"isGrafanaAdmin": true,
+				"isDisabled": false,
+				"isExternal": true,
+				"authLabels": [
+					"LDAP"
+				],
+				"updatedAt": "2019-02-11T17:30:40Z"
+			}
+			`
+
+			require.Equal(t, http.StatusOK, sc.resp.Code)
+			require.JSONEq(t, expected, sc.resp.Body.String())
+		})
 
 		loggedInUserScenario("When calling GET on", "/api/users", func(sc *scenarioContext) {
 			var sentLimit int

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -215,16 +215,17 @@ func (user *SignedInUser) IsRealUser() bool {
 }
 
 type UserProfileDTO struct {
-	Id             int64    `json:"id"`
-	Email          string   `json:"email"`
-	Name           string   `json:"name"`
-	Login          string   `json:"login"`
-	Theme          string   `json:"theme"`
-	OrgId          int64    `json:"orgId"`
-	IsGrafanaAdmin bool     `json:"isGrafanaAdmin"`
-	IsDisabled     bool     `json:"isDisabled"`
-	IsExternal     bool     `json:"isExternal"`
-	AuthLabels     []string `json:"authLabels"`
+	Id             int64     `json:"id"`
+	Email          string    `json:"email"`
+	Name           string    `json:"name"`
+	Login          string    `json:"login"`
+	Theme          string    `json:"theme"`
+	OrgId          int64     `json:"orgId"`
+	IsGrafanaAdmin bool      `json:"isGrafanaAdmin"`
+	IsDisabled     bool      `json:"isDisabled"`
+	IsExternal     bool      `json:"isExternal"`
+	AuthLabels     []string  `json:"authLabels"`
+	UpdatedAt      time.Time `json:"updatedAt"`
 }
 
 type UserSearchHitDTO struct {

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -331,6 +331,7 @@ func GetUserProfile(query *models.GetUserProfileQuery) error {
 		IsGrafanaAdmin: user.IsAdmin,
 		IsDisabled:     user.IsDisabled,
 		OrgId:          user.OrgId,
+		UpdatedAt:      user.Updated,
 	}
 
 	return err


### PR DESCRIPTION
This adds the timestamp of when a particular user was last updated to
the `api/users/:id` endpoint.

This helps our administrators understand when was the user information last updated. Particularly when it comes from external systems, e.g. LDAP

Helps with the work at #18759 