### PR TITLE
API: Readonly datasources should not be created via the API

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -231,7 +231,6 @@ func GetDataSourceByName(c *m.ReqContext) Response {
 	}
 
 	dtos := convertModelToDtos(query.Result)
-	dtos.ReadOnly = true
 	return JSON(200, &dtos)
 }
 

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -144,9 +144,9 @@ type AddDataSourceCommand struct {
 	IsDefault         bool              `json:"isDefault"`
 	JsonData          *simplejson.Json  `json:"jsonData"`
 	SecureJsonData    map[string]string `json:"secureJsonData"`
-	ReadOnly          bool              `json:"readOnly"`
 
-	OrgId int64 `json:"-"`
+	OrgId    int64 `json:"-"`
+	ReadOnly bool  `json:"-"`
 
 	Result *DataSource
 }
@@ -168,10 +168,10 @@ type UpdateDataSourceCommand struct {
 	JsonData          *simplejson.Json  `json:"jsonData"`
 	SecureJsonData    map[string]string `json:"secureJsonData"`
 	Version           int               `json:"version"`
-	ReadOnly          bool              `json:"readOnly"`
 
-	OrgId int64 `json:"-"`
-	Id    int64 `json:"-"`
+	OrgId    int64 `json:"-"`
+	Id       int64 `json:"-"`
+	ReadOnly bool  `json:"-"`
 
 	Result *DataSource
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
One should not be able to create a readonly data source via the API (as it can only be removed via provisioning).
With this fix:
- the `readOnly` field is ignored when setting up or updating the datasource via JSON
- fixes `GetDataSourceByName` call which used to return always `true` for the `ReadOnly` field.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #17347

**Special notes for your reviewer**:
Maybe this modification should also be documented [here](https://grafana.com/docs/http_api/data_source/). However now there is no reference to the `ReadOnly` field. 