### PR TITLE
Select full field name on right click

### DIFF
--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -162,10 +162,6 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
         }
       });
 
-      $button.contextmenu(evt => {
-        window.getSelection().selectAllChildren(evt.target);
-      });
-
       $button.click(() => {
         options = null;
         $input.css('width', Math.max($button.width(), 80) + 16 + 'px');

--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -163,7 +163,6 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
       });
 
       $button.contextmenu(evt => {
-        // Select the full field name
         window.getSelection().selectAllChildren(evt.target);
       });
 

--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -162,6 +162,10 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
         }
       });
 
+      $button.contextmenu(evt => {
+        window.getSelection().selectAllChildren(evt.target);
+      });
+
       $button.click(() => {
         options = null;
         $input.css('width', Math.max($button.width(), 80) + 16 + 'px');

--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -163,6 +163,7 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
       });
 
       $button.contextmenu(evt => {
+        // Select the full field name
         window.getSelection().selectAllChildren(evt.target);
       });
 


### PR DESCRIPTION
The goal of this PR, is to perform selection of the full field name and by this allowing the user to perform a copy of the name, something that isn't possible in many scenarios.

**Which issue(s) this PR fixes:**
#19010 

**For example:**
Current situation:
<img width="755" alt="Screen Shot 2019-09-11 at 14 25 39 copy" src="https://user-images.githubusercontent.com/15690241/64695298-725e0480-d4a4-11e9-8935-0b3819f597cc.png">

With this PR:
<img width="761" alt="Screen Shot 2019-09-11 at 14 22 23" src="https://user-images.githubusercontent.com/15690241/64695309-768a2200-d4a4-11e9-8613-2095104f1a23.png">
