### PR TITLE
toolkit: run make for backend plugins

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -156,9 +156,13 @@ export const run = (includeInternalScripts = false) => {
 
   program
     .command('plugin:ci-build')
-    .option('--backend <backend>', 'For backend task, which backend to run')
-    .description('Build the plugin, leaving artifacts in /dist')
+    .option('--backend', 'For backend task, will run Makefile', false)
+    .description('Build the plugin, leaving results in /dist and /coverage')
     .action(async cmd => {
+      if (typeof cmd === 'string') {
+        console.error(`Invalid argument: ${cmd}\nSee --help for a list of available commands.`);
+        process.exit(1);
+      }
       await execTask(ciBuildPluginTask)({
         backend: cmd.backend,
       });

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -156,7 +156,7 @@ export const run = (includeInternalScripts = false) => {
 
   program
     .command('plugin:ci-build')
-    .option('--backend', 'For backend task, will run Makefile', false)
+    .option('--backend', 'Run Makefile for backend task', false)
     .description('Build the plugin, leaving results in /dist and /coverage')
     .action(async cmd => {
       if (typeof cmd === 'string') {

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -63,12 +63,12 @@ const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ backend }) => {
       throw new Error('Backend plugins are build with makefiles.  Missing: ' + makefile);
     }
 
-    // Run make
-    let exe = await execa('make');
+    // Run tests
+    let exe = await execa('make', ['test']);
     console.log(exe.stdout);
 
-    // Run tests
-    exe = await execa('make', ['test']);
+    // Run build.  Make should figure out the right platform internally
+    exe = await execa('make');
     console.log(exe.stdout);
   } else {
     // Do regular build process with coverage

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -35,7 +35,7 @@ import { runEndToEndTests } from '../../plugins/e2e/launcher';
 import { getEndToEndSettings } from '../../plugins/index';
 
 export interface PluginCIOptions {
-  backend?: string;
+  backend?: boolean;
   full?: boolean;
   upload?: boolean;
 }
@@ -58,14 +58,18 @@ const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ backend }) => {
   fs.mkdirSync(workDir);
 
   if (backend) {
-    console.log('TODO, backend support?');
-    fs.mkdirSync(path.resolve(process.cwd(), 'dist'));
-    const file = path.resolve(process.cwd(), 'dist', `README_${backend}.txt`);
-    fs.writeFile(file, `TODO... build bakend plugin: ${backend}!`, err => {
-      if (err) {
-        throw new Error('Unable to write: ' + file);
-      }
-    });
+    const makefile = path.resolve(process.cwd(), 'Makefile');
+    if (!fs.existsSync(makefile)) {
+      throw new Error('Backend plugins are build with makefiles.  Missing: ' + makefile);
+    }
+
+    // Run make
+    let exe = await execa('make');
+    console.log(exe.stdout);
+
+    // Run tests
+    exe = await execa('make', ['test']);
+    console.log(exe.stdout);
   } else {
     // Do regular build process with coverage
     await pluginBuildRunner({ coverage: true });

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -63,12 +63,8 @@ const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ backend }) => {
       throw new Error('Backend plugins are build with makefiles.  Missing: ' + makefile);
     }
 
-    // Run tests
-    let exe = await execa('make', ['test']);
-    console.log(exe.stdout);
-
-    // Run build.  Make should figure out the right platform internally
-    exe = await execa('make');
+    // Run plugin-ci task
+    const exe = await execa('make', ['backend-plugin-ci']);
     console.log(exe.stdout);
   } else {
     // Do regular build process with coverage

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -60,7 +60,7 @@ const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ backend }) => {
   if (backend) {
     const makefile = path.resolve(process.cwd(), 'Makefile');
     if (!fs.existsSync(makefile)) {
-      throw new Error('Backend plugins are build with makefiles.  Missing: ' + makefile);
+      throw new Error(`Missing: ${makefile}. A Makefile is required for backend plugins.`);
     }
 
     // Run plugin-ci task


### PR DESCRIPTION
The plugin-ci task should check for a Makefile with backend tasks.

This runs `make backend-plugin-ci` for backend tasks.  The makefile is expected to do whatever it wants including writing the correct files to `dist` and `coverage`