### PR TITLE
DataLinks: support dots in label names

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -56,6 +56,10 @@ const valueVars = [
   },
 ];
 
+const buildLabelPath = (label: string) => {
+  return label.indexOf('.') > -1 ? `["${label}"]` : `.${label}`;
+};
+
 export const getDataLinksVariableSuggestions = (dataFrames: DataFrame[]): VariableSuggestion[] => {
   const labels = _.flatten(dataFrames.map(df => Object.keys(df.labels || {})));
 
@@ -67,7 +71,7 @@ export const getDataLinksVariableSuggestions = (dataFrames: DataFrame[]): Variab
       origin: VariableOrigin.Series,
     },
     ...labels.map(label => ({
-      value: `__series.labels.${label}`,
+      value: `__series.labels${buildLabelPath(label)}`,
       label: `labels.${label}`,
       documentation: `${label} label value`,
       origin: VariableOrigin.Series,

--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -31,6 +31,13 @@ describe('templateSrv', () => {
       expect(target).toBe('Server1 nested');
     });
 
+    it('scoped vars should support objects with propert names with dot', () => {
+      const target = _templateSrv.replace('${series.name} ${series.nested["field.with.dot"]}', {
+        series: { value: { name: 'Server1', nested: { 'field.with.dot': 'nested' } } },
+      });
+      expect(target).toBe('Server1 nested');
+    });
+
     it('scoped vars should support arrays of objects', () => {
       const target = _templateSrv.replace('${series.rows[0].name} ${series.rows[1].name}', {
         series: { value: { rows: [{ name: 'first' }, { name: 'second' }] } },


### PR DESCRIPTION
While working on #18918 I have noticed the proposed syntax `${__series.labels.<LABEL>}` does not support labels that have dots in the name. To address that problem I propose following changes to variable syntax:
1. For labels without dots we use syntax `${__series.labels.<LABEL>}`
2. For labels with dots we modify the syntax to be `${__series.labels.["<LABEL>"]}`

This new syntax should be applied to all future variables that's path could contain dots