### PR TITLE
Provisioning: provisioning playlists

### DIFF
--- a/conf/provisioning/playlists/sample.yaml
+++ b/conf/provisioning/playlists/sample.yaml
@@ -1,0 +1,17 @@
+# # config file version
+apiVersion: 1
+
+# playlists:
+#   - org_name: Main Org.
+#     uid: playlist1
+#     name: First playlist
+#     interval: 5m
+#     items:
+#       - type: dashboard_by_tag
+#         value: myTag
+#         order: 1
+#         title: Tagged dashboards
+#
+# delete_playlists:
+#   - org_name: Main Org.
+#     uid: playlist2

--- a/devenv/playlists.yaml
+++ b/devenv/playlists.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+playlists:
+- uid: demo-playlist
+  name: Demo Playlist
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: demo
+    order: 1
+    title: Demo dashboards

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -47,6 +47,12 @@ devDatasources() {
 		ln -s -f ../../../devenv/datasources.yaml ../conf/provisioning/datasources/dev.yaml
 }
 
+devPlaylists() {
+		echo -e "\xE2\x9C\x94 Setting up all dev playlists using provisioning"
+
+		ln -s -f ../../../devenv/playlists.yaml ../conf/provisioning/playlists/dev.yaml
+}
+
 usage() {
 	echo -e "\n"
 	echo "Usage:"
@@ -70,6 +76,7 @@ main() {
 	else
 		devDashboards
 		devDatasources
+    devPlaylists
 	fi
 
   if [[ -z "$cmd" ]]; then

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -18,7 +18,7 @@ func ValidateOrgPlaylist(c *m.ReqContext) {
 		return
 	}
 
-	if query.Result.OrgId == 0 {
+	if query.Result == nil {
 		c.JsonApiErr(404, "Playlist not found", err)
 		return
 	}
@@ -67,14 +67,21 @@ func GetPlaylist(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 	cmd := m.GetPlaylistByIdQuery{Id: id}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	err := bus.Dispatch(&cmd)
+
+	if err != nil {
 		return Error(500, "Playlist not found", err)
+	}
+
+	if cmd.Result == nil {
+		return Error(404, "Playlist not found", err)
 	}
 
 	playlistDTOs, _ := LoadPlaylistItemDTOs(id)
 
 	dto := &m.PlaylistDTO{
 		Id:       cmd.Result.Id,
+		Uid:      cmd.Result.Uid,
 		Name:     cmd.Result.Name,
 		Interval: cmd.Result.Interval,
 		OrgId:    cmd.Result.OrgId,

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -6,13 +6,15 @@ import (
 
 // Typed errors
 var (
-	ErrPlaylistNotFound           = errors.New("Playlist not found")
-	ErrPlaylistWithSameNameExists = errors.New("A playlist with the same name already exists")
+	ErrPlaylistNotFound                = errors.New("Playlist not found")
+	ErrPlaylistWithSameNameExists      = errors.New("A playlist with the same name already exists")
+	ErrPlaylistFailedGenerateUniqueUid = errors.New("Failed to generate unique playlist uid")
 )
 
 // Playlist model
 type Playlist struct {
 	Id       int64  `json:"id"`
+	Uid      string `json:"uid"`
 	Name     string `json:"name"`
 	Interval string `json:"interval"`
 	OrgId    int64  `json:"-"`
@@ -20,6 +22,7 @@ type Playlist struct {
 
 type PlaylistDTO struct {
 	Id       int64             `json:"id"`
+	Uid      string            `json:"uid"`
 	Name     string            `json:"name"`
 	Interval string            `json:"interval"`
 	OrgId    int64             `json:"-"`
@@ -71,7 +74,18 @@ type UpdatePlaylistCommand struct {
 	Result *PlaylistDTO
 }
 
+type UpdatePlaylistWithUidCommand struct {
+	OrgId    int64             `json:"-"`
+	Uid      string            `json:"id"`
+	Name     string            `json:"name" binding:"Required"`
+	Interval string            `json:"interval"`
+	Items    []PlaylistItemDTO `json:"items"`
+
+	Result *PlaylistDTO
+}
+
 type CreatePlaylistCommand struct {
+	Uid      string            `json:"uid"`
 	Name     string            `json:"name" binding:"Required"`
 	Interval string            `json:"interval"`
 	Items    []PlaylistItemDTO `json:"items"`
@@ -82,6 +96,11 @@ type CreatePlaylistCommand struct {
 
 type DeletePlaylistCommand struct {
 	Id    int64
+	OrgId int64
+}
+
+type DeletePlaylistWithUidCommand struct {
+	Uid   string
 	OrgId int64
 }
 
@@ -99,6 +118,13 @@ type GetPlaylistsQuery struct {
 
 type GetPlaylistByIdQuery struct {
 	Id     int64
+	Result *Playlist
+}
+
+type GetPlaylistByUidQuery struct {
+	OrgId int64
+	Uid   string
+
 	Result *Playlist
 }
 

--- a/pkg/services/provisioning/playlists/config_reader.go
+++ b/pkg/services/provisioning/playlists/config_reader.go
@@ -1,0 +1,141 @@
+package playlists
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type configReader struct {
+	log log.Logger
+}
+
+func (cr *configReader) readConfig(path string) ([]*playlistsAsConfig, error) {
+	var playlists []*playlistsAsConfig
+	cr.log.Debug("Looking for playlists provisioning files", "path", path)
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		cr.log.Error("Can't read playlists provisioning files from directory", "path", path, "error", err)
+		return playlists, nil
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
+			cr.log.Debug("Parsing playlists provisioning file", "path", path, "file.Name", file.Name())
+			p, err := cr.parsePlaylistsConfig(path, file)
+			if err != nil {
+				return nil, err
+			}
+
+			if p != nil {
+				playlists = append(playlists, p)
+			}
+		}
+	}
+
+	cr.log.Debug("Validating playlists")
+	if err = validateRequiredField(playlists); err != nil {
+		return nil, err
+	}
+
+	checkOrgIdAndOrgName(playlists)
+
+	return playlists, nil
+}
+
+func (cr *configReader) parsePlaylistsConfig(path string, file os.FileInfo) (*playlistsAsConfig, error) {
+	filename, _ := filepath.Abs(filepath.Join(path, file.Name()))
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg *playlistsAsConfigV0
+	err = yaml.Unmarshal(yamlFile, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.mapToPlaylistsAsConfig(), nil
+}
+
+func checkOrgIdAndOrgName(cfgs []*playlistsAsConfig) {
+	for _, cfg := range cfgs {
+		for _, playlist := range cfg.Playlists {
+			if playlist.OrgId < 1 {
+				if playlist.OrgName == "" {
+					playlist.OrgId = 1
+				} else {
+					playlist.OrgId = 0
+				}
+			}
+		}
+
+		for _, playlist := range cfg.DeletePlaylists {
+			if playlist.OrgId < 1 {
+				if playlist.OrgName == "" {
+					playlist.OrgId = 1
+				} else {
+					playlist.OrgId = 0
+				}
+			}
+		}
+	}
+}
+
+func validateRequiredField(cfgs []*playlistsAsConfig) error {
+	for _, cfg := range cfgs {
+		var errStrings []string
+		for index, playlist := range cfg.Playlists {
+			if playlist.Uid == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("Added playlist item %d in configuration doesn't contain required field uid", index+1),
+				)
+			}
+
+			if playlist.Name == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("Added playlist item %d in configuration doesn't contain required field name", index+1),
+				)
+			}
+
+			if playlist.Interval == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("Added playlist item %d in configuration doesn't contain required field interval", index+1),
+				)
+			}
+
+			if len(playlist.Items) == 0 {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("Added playlist item %d in configuration has no items", index+1),
+				)
+			}
+		}
+
+		for index, playlist := range cfg.DeletePlaylists {
+			if playlist.Uid == "" {
+				errStrings = append(
+					errStrings,
+					fmt.Sprintf("Deleted playlist item %d in configuration doesn't contain required field uid", index+1),
+				)
+			}
+		}
+
+		if len(errStrings) != 0 {
+			return fmt.Errorf(strings.Join(errStrings, "\n"))
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/playlists/config_reader_test.go
+++ b/pkg/services/provisioning/playlists/config_reader_test.go
@@ -1,0 +1,103 @@
+package playlists
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	nonExistingDir   = "testdata/nonExistingDir"
+	emptyDir         = "testdata/emptyDir"
+	invalidYamlDir   = "testdata/invalidYaml"
+	interpolationDir = "testdata/interpolation"
+	orgIdDir         = "testdata/orgId"
+	noUidDir         = "testdata/noUid"
+	noItemDir        = "testdata/noItem"
+)
+
+func TestNonExistingDir(t *testing.T) {
+	// Should skip directory if it does not exist
+	cfgReader := configReader{logger}
+	cfgs, err := cfgReader.readConfig(nonExistingDir)
+	assert.Nil(t, err)
+	assert.Len(t, cfgs, 0)
+}
+
+func TestEmptyDir(t *testing.T) {
+	// Should skip empty directory
+	cfgReader := configReader{logger}
+	cfgs, err := cfgReader.readConfig(emptyDir)
+	assert.Nil(t, err)
+	assert.Len(t, cfgs, 0)
+}
+
+func TestInvalidYaml(t *testing.T) {
+	// Should throw error if YAML file is malformed
+	cfgReader := configReader{logger}
+	_, err := cfgReader.readConfig(invalidYamlDir)
+	assert.NotNil(t, err)
+}
+
+func TestInterpolation(t *testing.T) {
+	os.Setenv("PLAYLIST_NAME", "theName")
+	defer os.Unsetenv("PLAYLIST_NAME")
+
+	cfgReader := configReader{logger}
+	cfgs, err := cfgReader.readConfig(interpolationDir)
+	assert.Nil(t, err)
+	assert.Len(t, cfgs, 1)
+	cfg := cfgs[0]
+
+	assert.Len(t, cfg.Playlists, 1)
+	assert.Equal(t, "theName", cfg.Playlists[0].Name)
+}
+
+func TestOrgId(t *testing.T) {
+	cfgReader := configReader{logger}
+	cfgs, err := cfgReader.readConfig(orgIdDir)
+	assert.Nil(t, err)
+	assert.Len(t, cfgs, 1)
+	assert.Len(t, cfgs[0].Playlists, 4)
+
+	// No org defined: defaults to organization ID 1
+	noOrgDefined := cfgs[0].Playlists[0]
+	assert.Equal(t, int64(1), noOrgDefined.OrgId)
+
+	// org_id defined
+	orgIdDefined := cfgs[0].Playlists[1]
+	assert.Equal(t, int64(2), orgIdDefined.OrgId)
+
+	// org_name defined
+	orgNameDefined := cfgs[0].Playlists[2]
+	assert.Equal(t, int64(0), orgNameDefined.OrgId)
+
+	// both org_id and org_name defined: keep org_id
+	orgDefinedTwice := cfgs[0].Playlists[3]
+	assert.Equal(t, int64(2), orgDefinedTwice.OrgId)
+
+	// Works also for deletion
+	assert.Len(t, cfgs[0].DeletePlaylists, 3)
+	delNoOrgId := cfgs[0].DeletePlaylists[0]
+	assert.Equal(t, int64(1), delNoOrgId.OrgId)
+	delOrgId := cfgs[0].DeletePlaylists[1]
+	assert.Equal(t, int64(2), delOrgId.OrgId)
+	delOrgName := cfgs[0].DeletePlaylists[2]
+	assert.Equal(t, int64(0), delOrgName.OrgId)
+}
+
+func TestNoUid(t *testing.T) {
+	cfgReader := configReader{logger}
+	_, err := cfgReader.readConfig(noUidDir)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "uid"))
+}
+
+func TestNoItem(t *testing.T) {
+	cfgReader := configReader{logger}
+	_, err := cfgReader.readConfig(noItemDir)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "item"))
+}

--- a/pkg/services/provisioning/playlists/playlists.go
+++ b/pkg/services/provisioning/playlists/playlists.go
@@ -1,0 +1,147 @@
+package playlists
+
+import (
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+func Provision(configDirectory string) error {
+	dc := newPlaylistProvisioner(log.New("provisioning.playlists"))
+	return dc.applyChanges(configDirectory)
+}
+
+type PlaylistProvisioner struct {
+	log       log.Logger
+	cfgReader *configReader
+}
+
+func newPlaylistProvisioner(log log.Logger) PlaylistProvisioner {
+	return PlaylistProvisioner{
+		log:       log,
+		cfgReader: &configReader{log: log},
+	}
+}
+
+func (dc *PlaylistProvisioner) applyChanges(configPath string) error {
+	configs, err := dc.cfgReader.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range configs {
+		if err := dc.apply(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (dc *PlaylistProvisioner) apply(cfg *playlistsAsConfig) error {
+	if err := dc.deletePlaylists(cfg.DeletePlaylists); err != nil {
+		return err
+	}
+
+	if err := dc.mergePlaylists(cfg.Playlists); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (dc *PlaylistProvisioner) deletePlaylists(playlistsToDelete []*deletePlaylistConfig) error {
+	for _, playlist := range playlistsToDelete {
+		if playlist.OrgId == 0 && playlist.OrgName != "" {
+			getOrg := &models.GetOrgByNameQuery{Name: playlist.OrgName}
+			if err := bus.Dispatch(getOrg); err != nil {
+				return err
+			}
+			playlist.OrgId = getOrg.Result.Id
+		} else if playlist.OrgId < 0 {
+			playlist.OrgId = 1
+		}
+
+		getPlaylist := &models.GetPlaylistByUidQuery{Uid: playlist.Uid, OrgId: playlist.OrgId}
+
+		if err := bus.Dispatch(getPlaylist); err != nil {
+			return err
+		}
+
+		if getPlaylist.Result != nil {
+			dc.log.Debug("deleting playlist from configuration", "orgId", getPlaylist.Result.OrgId, "uid", getPlaylist.Result.Uid)
+
+			cmd := &models.DeletePlaylistWithUidCommand{Uid: getPlaylist.Result.Uid, OrgId: getPlaylist.Result.OrgId}
+			if err := bus.Dispatch(cmd); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (dc *PlaylistProvisioner) mergePlaylists(playlistsToMerge []*playlistFromConfig) error {
+	for _, playlist := range playlistsToMerge {
+		if playlist.OrgId == 0 && playlist.OrgName != "" {
+			getOrg := &models.GetOrgByNameQuery{Name: playlist.OrgName}
+			if err := bus.Dispatch(getOrg); err != nil {
+				return err
+			}
+			playlist.OrgId = getOrg.Result.Id
+		} else if playlist.OrgId < 0 {
+			playlist.OrgId = 1
+		}
+
+		cmd := &models.GetPlaylistByUidQuery{OrgId: playlist.OrgId, Uid: playlist.Uid}
+		err := bus.Dispatch(cmd)
+		if err != nil {
+			return err
+		}
+
+		if cmd.Result == nil {
+			dc.log.Debug("inserting playlist from configuration", "name", playlist.Name, "orgId", playlist.OrgId, "uid", playlist.Uid)
+			insertCmd := &models.CreatePlaylistCommand{
+				OrgId:    playlist.OrgId,
+				Uid:      playlist.Uid,
+				Name:     playlist.Name,
+				Interval: playlist.Interval,
+				Items:    []models.PlaylistItemDTO{},
+			}
+			for _, item := range playlist.Items {
+				insertCmd.Items = append(insertCmd.Items, models.PlaylistItemDTO{
+					Type:  item.Type,
+					Title: item.Title,
+					Value: item.Value,
+					Order: item.Order,
+				})
+			}
+
+			if err := bus.Dispatch(insertCmd); err != nil {
+				return err
+			}
+		} else {
+			dc.log.Debug("updating playlist from configuration", "name", playlist.Name, "orgId", playlist.OrgId, "uid", playlist.Uid)
+			updateCmd := &models.UpdatePlaylistWithUidCommand{
+				OrgId:    playlist.OrgId,
+				Uid:      playlist.Uid,
+				Name:     playlist.Name,
+				Interval: playlist.Interval,
+				Items:    []models.PlaylistItemDTO{},
+			}
+			for _, item := range playlist.Items {
+				updateCmd.Items = append(updateCmd.Items, models.PlaylistItemDTO{
+					Type:  item.Type,
+					Title: item.Title,
+					Value: item.Value,
+					Order: item.Order,
+				})
+			}
+
+			if err := bus.Dispatch(updateCmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/playlists/playlists_test.go
+++ b/pkg/services/provisioning/playlists/playlists_test.go
@@ -1,0 +1,114 @@
+package playlists
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	m "github.com/grafana/grafana/pkg/models"
+)
+
+const (
+	testNewPlaylistsMultipleFiles = "testdata/testNewPlaylistsMultipleFiles"
+	testWithExistingPlaylists     = "testdata/testWithExistingPlaylists"
+)
+
+var (
+	logger log.Logger = log.New("fake.log")
+
+	fakeRepo *fakeRepository
+)
+
+func initTests() {
+	fakeRepo = &fakeRepository{}
+	bus.ClearBusHandlers()
+	bus.AddHandler("test", mockCreate)
+	bus.AddHandler("test", mockDelete)
+	bus.AddHandler("test", mockUpdate)
+	bus.AddHandler("test", mockGet)
+}
+
+func TestNewPlaylistsMultipleFiles(t *testing.T) {
+	initTests()
+
+	dc := newPlaylistProvisioner(logger)
+	err := dc.applyChanges(testNewPlaylistsMultipleFiles)
+	assert.Nil(t, err)
+	assert.Len(t, fakeRepo.created, 3)
+	assert.Len(t, fakeRepo.deleted, 0)
+	assert.Len(t, fakeRepo.updated, 0)
+
+	assert.Contains(t, fakeRepo.created, &m.CreatePlaylistCommand{
+		Uid:      "px",
+		Name:     "Other playlist",
+		Interval: "15s",
+		OrgId:    1,
+		Items: []m.PlaylistItemDTO{
+			{
+				Type:  "dashboard_by_tag",
+				Title: "Tag 1",
+				Value: "tag1",
+				Order: 1,
+			},
+			{
+				Type:  "dashboard_by_tag",
+				Title: "Tag 2",
+				Value: "tag2",
+				Order: 2,
+			},
+		},
+	})
+}
+
+func TestWithExistingPlaylists(t *testing.T) {
+	initTests()
+	fakeRepo.loadAll = []*m.Playlist{
+		{Uid: "p1", OrgId: 1},
+		{Uid: "p2", OrgId: 2},
+		{Uid: "p3", OrgId: 1},
+		{Uid: "p4", OrgId: 1},
+	}
+
+	dc := newPlaylistProvisioner(logger)
+	err := dc.applyChanges(testWithExistingPlaylists)
+	assert.Nil(t, err)
+	assert.Len(t, fakeRepo.created, 1)
+	assert.Len(t, fakeRepo.deleted, 2)
+	assert.Len(t, fakeRepo.updated, 1)
+}
+
+type fakeRepository struct {
+	created []*m.CreatePlaylistCommand
+	deleted []*m.DeletePlaylistWithUidCommand
+	updated []*m.UpdatePlaylistWithUidCommand
+
+	loadAll []*m.Playlist
+}
+
+func mockCreate(cmd *m.CreatePlaylistCommand) error {
+	fakeRepo.created = append(fakeRepo.created, cmd)
+	return nil
+}
+
+func mockDelete(cmd *m.DeletePlaylistWithUidCommand) error {
+	fakeRepo.deleted = append(fakeRepo.deleted, cmd)
+	return nil
+}
+
+func mockUpdate(cmd *m.UpdatePlaylistWithUidCommand) error {
+	fakeRepo.updated = append(fakeRepo.updated, cmd)
+	return nil
+}
+
+func mockGet(cmd *m.GetPlaylistByUidQuery) error {
+	for _, v := range fakeRepo.loadAll {
+		if cmd.Uid == v.Uid && cmd.OrgId == v.OrgId {
+			cmd.Result = v
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/playlists/testdata/interpolation/interpolation.yaml
+++ b/pkg/services/provisioning/playlists/testdata/interpolation/interpolation.yaml
@@ -1,0 +1,9 @@
+playlists:
+- uid: p1
+  name: $PLAYLIST_NAME
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: myTag
+    order: 1
+    title: First Dashboard

--- a/pkg/services/provisioning/playlists/testdata/invalidYaml/invalid.yaml
+++ b/pkg/services/provisioning/playlists/testdata/invalidYaml/invalid.yaml
@@ -1,0 +1,1 @@
+playlists:invalid

--- a/pkg/services/provisioning/playlists/testdata/noItem/noItem.yaml
+++ b/pkg/services/provisioning/playlists/testdata/noItem/noItem.yaml
@@ -1,0 +1,5 @@
+playlists:
+- uid: p1
+  name: Playlist with no item
+  interval: 1m
+  items: []

--- a/pkg/services/provisioning/playlists/testdata/noUid/noUid.yml
+++ b/pkg/services/provisioning/playlists/testdata/noUid/noUid.yml
@@ -1,0 +1,8 @@
+playlists:
+- name: Playlist without uid
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: myTag
+    order: 1
+    title: First Dashboard

--- a/pkg/services/provisioning/playlists/testdata/orgId/orgId.yml
+++ b/pkg/services/provisioning/playlists/testdata/orgId/orgId.yml
@@ -1,0 +1,44 @@
+playlists:
+- uid: noOrgDefined
+  name: No org defined
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+- uid: orgIdDefined
+  name: Org defined by id
+  org_id: 2
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+- uid: orgNameDefined
+  name: Org defined by name
+  org_name: MyOrg
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+- uid: orgDefinedTwice
+  name: Org defined by ID and name
+  org_id: 2
+  org_name: MyOrg
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+
+delete_playlists:
+- uid: toDelete
+- uid: toDeleteInOrg
+  org_id: 2
+- uid: toDeleteInOrgName
+  org_name: MyOrg

--- a/pkg/services/provisioning/playlists/testdata/testNewPlaylistsMultipleFiles/file1.yaml
+++ b/pkg/services/provisioning/playlists/testdata/testNewPlaylistsMultipleFiles/file1.yaml
@@ -1,0 +1,25 @@
+playlists:
+- uid: p1
+  name: First playlist
+  interval: 1m
+  items:
+  - type: dashboard_by_id
+    value: "1"
+    order: 1
+    title: First dashboard
+  - type: dashboard_by_tag
+    value: myTag
+    order: 2
+    title: Tagged dashboard
+- uid: p2
+  name: Second playlist
+  interval: 10m
+  items:
+  - type: dashboard_by_id
+    value: "1"
+    order: 1
+    title: First dashboard
+  - type: dashboard_by_id
+    value: "2"
+    order: 2
+    title: Second dashboard

--- a/pkg/services/provisioning/playlists/testdata/testNewPlaylistsMultipleFiles/file2.yaml
+++ b/pkg/services/provisioning/playlists/testdata/testNewPlaylistsMultipleFiles/file2.yaml
@@ -1,0 +1,13 @@
+playlists:
+- uid: px
+  name: Other playlist
+  interval: 15s
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: Tag 1
+  - type: dashboard_by_tag
+    value: tag2
+    order: 2
+    title: Tag 2

--- a/pkg/services/provisioning/playlists/testdata/testWithExistingPlaylists/test.yaml
+++ b/pkg/services/provisioning/playlists/testdata/testWithExistingPlaylists/test.yaml
@@ -1,0 +1,26 @@
+delete_playlists:
+- uid: p1
+- uid: p2
+  org_id: 2
+
+playlists:
+- uid: p4
+  name: Playlist updated
+  interval: 1m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+- uid: p5
+  name: New playlist
+  interval: 10m
+  items:
+  - type: dashboard_by_tag
+    value: tag1
+    order: 1
+    title: First Dashboard
+  - type: dashboard_by_id
+    value: "2"
+    order: 2
+    title: Second dashboard

--- a/pkg/services/provisioning/playlists/types.go
+++ b/pkg/services/provisioning/playlists/types.go
@@ -1,0 +1,102 @@
+package playlists
+
+import (
+	"github.com/grafana/grafana/pkg/services/provisioning/values"
+)
+
+// playlistsAsConfig is normalized data object for playlists config data.
+// Any config version should be mappable to this type.
+type playlistsAsConfig struct {
+	Playlists       []*playlistFromConfig
+	DeletePlaylists []*deletePlaylistConfig
+}
+
+type playlistFromConfig struct {
+	OrgId    int64
+	OrgName  string
+	Uid      string
+	Name     string
+	Interval string
+	Items    []*playlistItemFromConfig
+}
+
+type playlistItemFromConfig struct {
+	Type  string
+	Value string
+	Order int
+	Title string
+}
+
+type deletePlaylistConfig struct {
+	OrgId   int64
+	OrgName string
+	Uid     string
+}
+
+// Version 0
+
+// playlistsAsConfigV0 is mapping for version 0. This is mapped to its normalised version.
+type playlistsAsConfigV0 struct {
+	Playlists       []*playlistFromConfigV0   `json:"playlists" yaml:"playlists"`
+	DeletePlaylists []*deletePlaylistConfigV0 `json:"delete_playlists" yaml:"delete_playlists"`
+}
+
+type playlistFromConfigV0 struct {
+	OrgId    values.Int64Value           `json:"org_id" yaml:"org_id"`
+	OrgName  values.StringValue          `json:"org_name" yaml:"org_name"`
+	Uid      values.StringValue          `json:"uid" yaml:"uid"`
+	Name     values.StringValue          `json:"name" yaml:"name"`
+	Interval values.StringValue          `json:"interval" yaml:"interval"`
+	Items    []*playlistItemFromConfigV0 `json:"items" yaml:"items"`
+}
+
+type playlistItemFromConfigV0 struct {
+	Type  values.StringValue `json:"type" yaml:"type"`
+	Value values.StringValue `json:"value" yaml:"value"`
+	Order values.IntValue    `json:"order" yaml:"order"`
+	Title values.StringValue `json:"title" yaml:"title"`
+}
+
+type deletePlaylistConfigV0 struct {
+	OrgId   values.Int64Value  `json:"org_id" yaml:"org_id"`
+	OrgName values.StringValue `json:"org_name" yaml:"org_name"`
+	Uid     values.StringValue `json:"uid" yaml:"uid"`
+}
+
+func (cfg *playlistsAsConfigV0) mapToPlaylistsAsConfig() *playlistsAsConfig {
+	r := &playlistsAsConfig{}
+	if cfg == nil {
+		return r
+	}
+
+	for _, playlist := range cfg.Playlists {
+		items := []*playlistItemFromConfig{}
+		for _, item := range playlist.Items {
+			items = append(items, &playlistItemFromConfig{
+				Type:  item.Type.Value(),
+				Value: item.Value.Value(),
+				Order: item.Order.Value(),
+				Title: item.Title.Value(),
+			})
+		}
+
+		r.Playlists = append(r.Playlists, &playlistFromConfig{
+			OrgId:    playlist.OrgId.Value(),
+			OrgName:  playlist.OrgName.Value(),
+			Uid:      playlist.Uid.Value(),
+			Name:     playlist.Name.Value(),
+			Interval: playlist.Interval.Value(),
+			Items:    items,
+		})
+	}
+
+	for _, playlist := range cfg.DeletePlaylists {
+		r.DeletePlaylists = append(r.DeletePlaylists, &deletePlaylistConfig{
+			OrgId:   playlist.OrgId.Value(),
+			OrgName: playlist.OrgName.Value(),
+			Uid:     playlist.Uid.Value(),
+		})
+	}
+
+	return r
+}

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -3,6 +3,7 @@ package provisioning
 type Calls struct {
 	ProvisionDatasources                []interface{}
 	ProvisionNotifications              []interface{}
+	ProvisionPlaylists                  []interface{}
 	ProvisionDashboards                 []interface{}
 	GetDashboardProvisionerResolvedPath []interface{}
 }
@@ -11,6 +12,7 @@ type ProvisioningServiceMock struct {
 	Calls                                   *Calls
 	ProvisionDatasourcesFunc                func() error
 	ProvisionNotificationsFunc              func() error
+	ProvisionPlaylistsFunc                  func() error
 	ProvisionDashboardsFunc                 func() error
 	GetDashboardProvisionerResolvedPathFunc func(name string) string
 }
@@ -33,6 +35,14 @@ func (mock *ProvisioningServiceMock) ProvisionNotifications() error {
 	mock.Calls.ProvisionNotifications = append(mock.Calls.ProvisionNotifications, nil)
 	if mock.ProvisionNotificationsFunc != nil {
 		return mock.ProvisionNotificationsFunc()
+	}
+	return nil
+}
+
+func (mock *ProvisioningServiceMock) ProvisionPlaylists() error {
+	mock.Calls.ProvisionPlaylists = append(mock.Calls.ProvisionPlaylists, nil)
+	if mock.ProvisionPlaylistsFunc != nil {
+		return mock.ProvisionPlaylistsFunc()
 	}
 	return nil
 }

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -97,6 +97,7 @@ func setup() *serviceTestStruct {
 		},
 		nil,
 		nil,
+		nil,
 	)
 	serviceTest.service.Cfg = setting.NewCfg()
 

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -43,4 +43,17 @@ func addPlaylistMigrations(mg *Migrator) {
 		{Name: "value", Type: DB_Text, Nullable: false},
 		{Name: "title", Type: DB_Text, Nullable: false},
 	}))
+
+	mg.AddMigration("Add column uid in playlist", NewAddColumnMigration(playlistV2, &Column{
+		Name: "uid", Type: DB_NVarchar, Length: 40, Nullable: true,
+	}))
+
+	mg.AddMigration("Update uid column values in playlist", new(RawSqlMigration).
+		Sqlite("UPDATE playlist SET uid=printf('%09d',id) WHERE uid IS NULL;").
+		Postgres("UPDATE playlist SET uid=lpad('' || id::text,9,'0') WHERE uid IS NULL;").
+		Mysql("UPDATE playlist SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
+
+	mg.AddMigration("Add unique index playlist_org_id_uid", NewAddIndexMigration(playlistV2, &Index{
+		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
+	}))
 }

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -126,8 +126,7 @@ func UpdatePlaylistByUid(cmd *m.UpdatePlaylistWithUidCommand) error {
 }
 
 func updatePlaylistInternal(id int64, orgId int64, name string, interval string, items []m.PlaylistItemDTO, sess *DBSession) error {
-	updateRawSql := "UPDATE playlist SET name = ?, interval = ? WHERE id = ? AND org_id = ?"
-	_, err := sess.Exec(updateRawSql, name, interval, id, orgId)
+	_, err := sess.Cols("name", "interval").Update(&m.Playlist{Name: name, Interval: interval}, &m.Playlist{Id: id, OrgId: orgId})
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -33,8 +33,40 @@ func TestPlaylistDataAccess(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("can remove playlist", func() {
-					query := m.DeletePlaylistCommand{Id: 1}
+					query := m.DeletePlaylistCommand{Id: 1, OrgId: 1}
 					err = DeletePlaylist(&query)
+
+					So(err, ShouldBeNil)
+				})
+			})
+		})
+	})
+
+	Convey("Testing Playlist data access with Uid", t, func() {
+		InitTestDB(t)
+
+		Convey("Can create playlist", func() {
+			items := []m.PlaylistItemDTO{
+				{Title: "graphite", Value: "graphite", Type: "dashboard_by_tag"},
+				{Title: "Backend response times", Value: "3", Type: "dashboard_by_id"},
+			}
+			cmd := m.CreatePlaylistCommand{Uid: "p1", Name: "NYC office", Interval: "10m", OrgId: 1, Items: items}
+			err := CreatePlaylist(&cmd)
+			So(err, ShouldBeNil)
+
+			Convey("can update playlist", func() {
+				items := []m.PlaylistItemDTO{
+					{Title: "influxdb", Value: "influxdb", Type: "dashboard_by_tag"},
+					{Title: "Backend response times", Value: "2", Type: "dashboard_by_id"},
+				}
+				query := m.UpdatePlaylistWithUidCommand{Name: "NYC office ", OrgId: 1, Uid: "p1", Interval: "10s", Items: items}
+				err = UpdatePlaylistByUid(&query)
+
+				So(err, ShouldBeNil)
+
+				Convey("can remove playlist", func() {
+					query := m.DeletePlaylistWithUidCommand{Uid: "p1", OrgId: 1}
+					err = DeletePlaylistByUid(&query)
 
 					So(err, ShouldBeNil)
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables provisioning of playlists, in a similar way to provisioning of dashboards, datasources and notifiers.

When Grafana is deployed using GitOps, this is required to add playlists easily along with dashboards.

**Which issue(s) this PR fixes**:

Fixes #11842

**Special notes for your reviewer**:
In order to have a unique user-facing ID for playlists, I added a new field `uid` to playlists.

Perhaps I should also add new APIs using `uid`? I'd like to have the opinion of a reviewer/maintainer before adding APIs commands and documentation...
I also thought about a new URL to get playlist display, such as http://grafana:3000/playlists/play/uid/myuid?kiosk. Could that be useful?