### PR TITLE
Fix exit live mode icon: change back to Stop.

### DIFF
--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -201,7 +201,7 @@ class LiveLogs extends PureComponent<Props, State> {
             {isPaused ? 'Resume' : 'Pause'}
           </button>
           <button onClick={this.props.stopLive} className={cx('btn btn-inverse', styles.button)}>
-            <i className={'fa fa-times'} />
+            <i className={'fa fa-stop'} />
             &nbsp; Exit live mode
           </button>
           {isPaused || (


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to future changes to the entry to and exit from live tailing, the "X" icon to exit live mode will not work in split view. See the figma mockup to prove that here:
https://www.figma.com/file/fjlhfGs8JYYSYxR0g2occv/Explore-Live-Tailing?node-id=45%3A183

**Which issue(s) this PR fixes**:
Prevents future double X button in Explore split view.

**Special notes for your reviewer**: <3 Thank you for the help!

