### PR TITLE
Singlestat: fix format messes up on negative values if select duratio…

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.test.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.test.ts
@@ -7,6 +7,7 @@ import {
   toDuration,
   toDurationInMilliseconds,
   toDurationInSeconds,
+  toDurationInHoursMinutesSeconds,
 } from './dateTimeFormatters';
 import { toUtc, dateTime } from '@grafana/data';
 
@@ -160,6 +161,14 @@ describe('duration', () => {
   it('floating point error', () => {
     const str = toDuration(36993906007, 8, Interval.Millisecond);
     expect(str).toBe('1 year, 2 months, 0 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds');
+  });
+  it('1 dthms', () => {
+    const str = toDurationInHoursMinutesSeconds(1);
+    expect(str).toBe('00:00:01');
+  });
+  it('-1 dthms', () => {
+    const str = toDurationInHoursMinutesSeconds(-1);
+    expect(str).toBe('00:00:01 ago');
   });
 });
 

--- a/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.test.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.test.ts
@@ -170,6 +170,10 @@ describe('duration', () => {
     const str = toDurationInHoursMinutesSeconds(-1);
     expect(str).toBe('00:00:01 ago');
   });
+  it('0 dthms', () => {
+    const str = toDurationInHoursMinutesSeconds(0);
+    expect(str).toBe('00:00:00');
+  });
 });
 
 describe('clock', () => {

--- a/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/dateTimeFormatters.ts
@@ -283,7 +283,10 @@ export function toDurationInSeconds(size: number, decimals: DecimalCount) {
   return toDuration(size, decimals, Interval.Second);
 }
 
-export function toDurationInHoursMinutesSeconds(size: number) {
+export function toDurationInHoursMinutesSeconds(size: number): string {
+  if (size < 0) {
+    return toDurationInHoursMinutesSeconds(-size) + ' ago';
+  }
   const strings = [];
   const numHours = Math.floor(size / 3600);
   const numMinutes = Math.floor((size % 3600) / 60);


### PR DESCRIPTION
…n (hh:mm:ss) unit

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
    Format messes up on negative values if the  duration (hh:mm:ss) unit is selected.
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19012 

**Special notes for your reviewer**:

