### PR TITLE
Auth: Allow inviting existing users when login form is disabled

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -27,10 +27,6 @@ func GetPendingOrgInvites(c *m.ReqContext) Response {
 }
 
 func AddOrgInvite(c *m.ReqContext, inviteDto dtos.AddInviteForm) Response {
-	if setting.DisableLoginForm {
-		return Error(400, "Cannot invite when login is disabled.", nil)
-	}
-
 	if !inviteDto.Role.IsValid() {
 		return Error(400, "Invalid role specified", nil)
 	}
@@ -44,7 +40,11 @@ func AddOrgInvite(c *m.ReqContext, inviteDto dtos.AddInviteForm) Response {
 	} else {
 		return inviteExistingUserToOrg(c, userQuery.Result, &inviteDto)
 	}
-
+	
+	if setting.DisableLoginForm {
+		return Error(400, "Cannot invite when login is disabled.", nil)
+	}
+	
 	cmd := m.CreateTempUserCommand{}
 	cmd.OrgId = c.OrgId
 	cmd.Email = inviteDto.LoginOrEmail

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -40,11 +40,11 @@ func AddOrgInvite(c *m.ReqContext, inviteDto dtos.AddInviteForm) Response {
 	} else {
 		return inviteExistingUserToOrg(c, userQuery.Result, &inviteDto)
 	}
-	
+
 	if setting.DisableLoginForm {
 		return Error(400, "Cannot invite when login is disabled.", nil)
 	}
-	
+
 	cmd := m.CreateTempUserCommand{}
 	cmd.OrgId = c.OrgId
 	cmd.Email = inviteDto.LoginOrEmail

--- a/public/app/features/users/state/reducers.ts
+++ b/public/app/features/users/state/reducers.ts
@@ -6,7 +6,7 @@ export const initialState: UsersState = {
   invitees: [] as Invitee[],
   users: [] as OrgUser[],
   searchQuery: '',
-  canInvite: !config.disableLoginForm && !config.externalUserMngLinkName,
+  canInvite: !config.externalUserMngLinkName,
   externalUserMngInfo: config.externalUserMngInfo,
   externalUserMngLinkName: config.externalUserMngLinkName,
   externalUserMngLinkUrl: config.externalUserMngLinkUrl,


### PR DESCRIPTION
**What this PR does / why we need it**: It allows an Org admin to invite existing users into an Org.

**Which issue(s) this PR fixes**: #17824

Fixes (https://github.com/grafana/grafana/issues/17824)

**Special notes for your reviewer**:
API already has comprehensive error messages for different flows (user already in org, user not found, etc…) so just delaying the check for setting.DisableLoginForm is enough to fix issue (unless I'm missing something).
