### PR TITLE
MSSQL: Fix memory leak when debug enabled

### DIFF
--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -68,7 +68,7 @@ func (t *mssqlRowTransformer) Transform(columnTypes []*sql.ColumnType, rows *cor
 	values := make([]interface{}, len(columnTypes))
 	valuePtrs := make([]interface{}, len(columnTypes))
 
-	for i, stype := range columnTypes {
+	for i := range columnTypes {
 		// debug output on large tables causes high memory utilization/leak
 		// t.log.Debug("type", "type", stype)
 		valuePtrs[i] = &values[i]

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -69,7 +69,8 @@ func (t *mssqlRowTransformer) Transform(columnTypes []*sql.ColumnType, rows *cor
 	valuePtrs := make([]interface{}, len(columnTypes))
 
 	for i, stype := range columnTypes {
-		t.log.Debug("type", "type", stype)
+		// debug output on large tables causes high memory utilization/leak
+		// t.log.Debug("type", "type", stype)
 		valuePtrs[i] = &values[i]
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes debug logging from MSSQL backend datasource
 
**Which issue(s) this PR fixes**:

Fixes #19046 

**Special notes for your reviewer**:

Verified by setting up MSSQL datasource and toggling debug output. No longer uses large amount of RAM.
