### PR TITLE
GraphPanel: don't listen to legacy onDataReceived events

### DIFF
--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -188,7 +188,7 @@ export function getProcessedDataFrames(results?: DataQueryResponseData[]): DataF
 }
 
 export function preProcessPanelData(data: PanelData, lastResult: PanelData) {
-  let { series } = data;
+  const { series } = data;
 
   //  for loading states with no data, use last result
   if (data.state === LoadingState.Loading && series.length === 0) {

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -187,7 +187,7 @@ export function getProcessedDataFrames(results?: DataQueryResponseData[]): DataF
   return dataFrames;
 }
 
-export function preProcessPanelData(data: PanelData, lastResult: PanelData) {
+export function preProcessPanelData(data: PanelData, lastResult: PanelData): PanelData {
   const { series } = data;
 
   //  for loading states with no data, use last result
@@ -199,6 +199,9 @@ export function preProcessPanelData(data: PanelData, lastResult: PanelData) {
     return { ...lastResult, state: LoadingState.Loading };
   }
 
-  // Makes sure the data is properly formatted
-  return getProcessedDataFrames(series);
+  // Make sure the data frames are properly formatted
+  return {
+    ...data,
+    series: getProcessedDataFrames(series),
+  };
 }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -12,7 +12,7 @@ import { axesEditorComponent } from './axes_editor';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 import { DataFrame, DataLink, DateTimeInput } from '@grafana/data';
-import { getColorFromHexRgbOrName, LegacyResponseData, VariableSuggestion } from '@grafana/ui';
+import { getColorFromHexRgbOrName, VariableSuggestion } from '@grafana/ui';
 import { getProcessedDataFrames } from 'app/features/dashboard/state/runRequest';
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
@@ -147,7 +147,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.contextMenuCtrl = new GraphContextMenuCtrl($scope);
 
     this.events.on('render', this.onRender.bind(this));
-    this.events.on('data-received', this.onDataReceived.bind(this));
     this.events.on('data-frames-received', this.onDataFramesReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
     this.events.on('data-snapshot-load', this.onDataSnapshotLoad.bind(this));
@@ -199,7 +198,9 @@ class GraphCtrl extends MetricsPanelCtrl {
       panel: this.panel,
       range: this.range,
     });
-    this.onDataReceived(snapshotData);
+
+    const frames = getProcessedDataFrames(snapshotData);
+    this.onDataFramesReceived(frames);
   }
 
   onDataError(err: any) {
@@ -208,12 +209,6 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.render([]);
   }
 
-  // This should only be called from the snapshot callback
-  onDataReceived(dataList: LegacyResponseData[]) {
-    this.onDataFramesReceived(getProcessedDataFrames(dataList));
-  }
-
-  // Directly support DataFrame skipping event callbacks
   onDataFramesReceived(data: DataFrame[]) {
     this.dataList = data;
     this.seriesList = this.processor.getSeriesList({

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -88,6 +88,9 @@ describe('grafanaGraph', () => {
         from: dateTime([2015, 1, 1, 10]),
         to: dateTime([2015, 1, 1, 22]),
       },
+      annotationsSrv: {
+        getAnnotations: () => Promise.resolve({}),
+      },
     } as any;
 
     ctx.data = [];

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -37,6 +37,9 @@ describe('GraphCtrl', () => {
     ctx.ctrl.events = {
       emit: () => {},
     };
+    ctx.ctrl.annotationsSrv = {
+      getAnnotations: () => Promise.resolve({}),
+    };
     ctx.ctrl.annotationsPromise = Promise.resolve({});
     ctx.ctrl.updateTimeRange();
   });

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -76,7 +76,7 @@ describe('GraphCtrl', () => {
       ];
 
       ctx.ctrl.range = range;
-      ctx.ctrl.onDataReceived(data);
+      ctx.ctrl.onDataSnapshotLoad(data);
     });
 
     it('should set datapointsOutside', () => {
@@ -87,7 +87,7 @@ describe('GraphCtrl', () => {
   describe('datapointsCount given 2 series', () => {
     beforeEach(() => {
       const data: any = [{ target: 'test.cpu1', datapoints: [] }, { target: 'test.cpu2', datapoints: [] }];
-      ctx.ctrl.onDataReceived(data);
+      ctx.ctrl.onDataSnapshotLoad(data);
     });
 
     it('should set datapointsCount warning', () => {

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -51,7 +51,7 @@ describe('GraphCtrl', () => {
       ];
 
       ctx.ctrl.range = { from: dateTime().valueOf(), to: dateTime().valueOf() };
-      ctx.ctrl.onDataReceived(data);
+      ctx.ctrl.onDataSnapshotLoad(data);
     });
 
     it('should set datapointsOutside', () => {

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -120,7 +120,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
 
     this.events.on('data-frames-received', this.onFramesReceived.bind(this));
     this.events.on('data-error', this.onDataError.bind(this));
-    this.events.on('data-snapshot-load', this.onDataReceived.bind(this));
+    this.events.on('data-snapshot-load', this.onSnapshotLoad.bind(this));
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
 
     this.useDataFrames = true;
@@ -154,8 +154,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     this.handleDataFrames([]);
   }
 
-  // This should only be called from the snapshot callback
-  onDataReceived(dataList: LegacyResponseData[]) {
+  onSnapshotLoad(dataList: LegacyResponseData[]) {
     this.onFramesReceived(getProcessedDataFrames(dataList));
   }
 

--- a/public/app/plugins/panel/singlestat/specs/singlestat.test.ts
+++ b/public/app/plugins/panel/singlestat/specs/singlestat.test.ts
@@ -45,7 +45,7 @@ describe('SingleStatCtrl', () => {
           // @ts-ignore
           ctx.ctrl = new SingleStatCtrl($scope, $injector, {} as LinkSrv, $sanitize);
           setupFunc();
-          ctx.ctrl.onDataReceived(ctx.input);
+          ctx.ctrl.onSnapshotLoad(ctx.input);
           ctx.data = ctx.ctrl.data;
         });
       };


### PR DESCRIPTION
The graph panel now uses 'data-frames-received' events.  It should not listen to 'data-received' events.  This will avoid unnecessary updates when the query editors are open.