### PR TITLE
Validate there's enough colors for thresholds in Table panel

### DIFF
--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -58,6 +58,18 @@ export class TableRenderer {
     if (!style.thresholds || !style.colors) {
       return null;
     }
+
+    if (style.thresholds.length >= style.colors.length) {
+      console.error(
+        // tslint:disable-next-line:max-line-length
+        `There must be max ${style.colors.length - 1} thresholds for ${style.colors.length} colors. You have ${
+          style.thresholds.length
+        } set.`
+      );
+
+      return null;
+    }
+
     for (let i = style.thresholds.length; i > 0; i--) {
       if (value >= style.thresholds[i - 1]) {
         return getColorFromHexRgbOrName(style.colors[i], this.theme);

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -60,14 +60,12 @@ export class TableRenderer {
     }
 
     if (style.thresholds.length >= style.colors.length) {
-      console.error(
+      throw new Error(
         // tslint:disable-next-line:max-line-length
         `There must be max ${style.colors.length - 1} thresholds for ${style.colors.length} colors. You have ${
           style.thresholds.length
         } set.`
       );
-
-      return null;
     }
 
     for (let i = style.thresholds.length; i > 0; i--) {


### PR DESCRIPTION
Currently having 3 thresholds and 3 colors results in "calling indexOf on undefined" when passing `style.colors[i]` (out of bounds) to `getColorFromHexRgbOrName()`