### PR TITLE
Fix: Align back arrow in back button in edit mode

### DIFF
--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -218,7 +218,8 @@ i.navbar-page-btn__search {
   i {
     font-size: $font-size-lg;
     position: relative;
-    top: 2px;
+    top: 1px;
+    right: 1px;
   }
 
   &:hover {


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed the arrow in the back button in edit panel was a bit off. This is a suggestion to correct that. 

Before: 
![Screenshot from 2019-09-13 10-07-02](https://user-images.githubusercontent.com/946275/64847490-6c386700-d60f-11e9-9a8f-18b82840012d.png)

After: 
![Screenshot from 2019-09-13 10-06-41](https://user-images.githubusercontent.com/946275/64847504-7195b180-d60f-11e9-934d-91daf417a408.png)

