### PR TITLE
Explore: Add throttling when doing live queries

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -1,5 +1,6 @@
 // Libraries
-import { map } from 'rxjs/operators';
+import { map, throttleTime } from 'rxjs/operators';
+import { identity } from 'rxjs';
 // Services & Utils
 import store from 'app/core/store';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -479,7 +480,13 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
     let firstResponse = true;
 
     const newQuerySub = runRequest(datasourceInstance, transaction.request)
-      .pipe(map(preProcessPanelData()))
+      .pipe(
+        map(preProcessPanelData()),
+        // Simple throttle for live tailing, in case of > 1000 rows per interval we spend about 200ms on processing and
+        // rendering. In case this is optimized this can be tweaked, but also it should be only as fast as user
+        // actually can see what is happening.
+        live ? throttleTime(500) : identity
+      )
       .subscribe((data: PanelData) => {
         if (!data.error && firstResponse) {
           // Side-effect: Saving history in localstorage


### PR DESCRIPTION
When doing live queries we cannot keep up with the websocket if there is too much data even though we show only 100 rows at the time. This adds simple throttling when doing the live query which makes live tailing mode less likely to have perf issues.
