### PR TITLE
grafana/toolkit: Find module files correctly

### DIFF
--- a/packages/grafana-toolkit/src/cli/utils/execTask.ts
+++ b/packages/grafana-toolkit/src/cli/utils/execTask.ts
@@ -9,7 +9,7 @@ export const execTask = <TOptions>(task: Task<TOptions>) => async (options: TOpt
     await task.exec();
     console.groupEnd();
   } catch (e) {
-    console.log(e);
+    console.trace(e);
     process.exit(1);
   }
 };

--- a/packages/grafana-toolkit/src/cli/utils/useSpinner.ts
+++ b/packages/grafana-toolkit/src/cli/utils/useSpinner.ts
@@ -10,6 +10,7 @@ export const useSpinner = <T>(spinnerLabel: string, fn: FnToSpin<T>, killProcess
       await fn(options);
       spinner.succeed();
     } catch (e) {
+      console.trace(e);
       spinner.fail(e.message || e);
       if (killProcess) {
         process.exit(1);

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.test.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.test.ts
@@ -1,0 +1,29 @@
+import { findModuleFiles } from './webpack.plugin.config';
+const fs = require('fs');
+
+jest.mock('fs');
+
+const modulePathsMock = [
+  'some/path/module.ts',
+  'some/path/module.ts.whatever',
+  'some/path/module.tsx',
+  'some/path/module.tsx.whatever',
+  'some/path/anotherFile.ts',
+  'some/path/anotherFile.tsx',
+];
+
+describe('Plugin webpack config', () => {
+  describe('findModuleTs', () => {
+    beforeAll(() => {
+      fs.statSync.mockReturnValue({
+        isDirectory: () => false,
+      });
+    });
+
+    it('finds module.ts and module.tsx files', () => {
+      const moduleFiles = findModuleFiles('/', modulePathsMock);
+      expect(moduleFiles.length).toBe(2);
+      expect(moduleFiles).toEqual(['/some/path/module.ts', '/some/path/module.tsx']);
+    });
+  });
+});

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -16,7 +16,7 @@ interface WebpackConfigurationOptions {
 }
 type WebpackConfigurationGetter = (options: WebpackConfigurationOptions) => webpack.Configuration;
 
-const findModuleTs = (base: string, files?: string[], result?: string[]) => {
+export const findModuleFiles = (base: string, files?: string[], result?: string[]) => {
   files = files || fs.readdirSync(base);
   result = result || [];
 
@@ -24,9 +24,10 @@ const findModuleTs = (base: string, files?: string[], result?: string[]) => {
     files.forEach(file => {
       const newbase = path.join(base, file);
       if (fs.statSync(newbase).isDirectory()) {
-        result = findModuleTs(newbase, fs.readdirSync(newbase), result);
+        result = findModuleFiles(newbase, fs.readdirSync(newbase), result);
       } else {
-        if (file.indexOf('module.ts') > -1) {
+        const filename = path.basename(file);
+        if (/^module.tsx?$/.exec(filename)) {
           // @ts-ignore
           result.push(newbase);
         }
@@ -37,7 +38,7 @@ const findModuleTs = (base: string, files?: string[], result?: string[]) => {
 };
 
 const getModuleFiles = () => {
-  return findModuleTs(path.resolve(process.cwd(), 'src'));
+  return findModuleFiles(path.resolve(process.cwd(), 'src'));
 };
 
 const getManualChunk = (id: string) => {
@@ -206,11 +207,5 @@ export const getWebpackConfig: WebpackConfigurationGetter = options => {
       ],
     },
     optimization,
-    // optimization: {
-    //   splitChunks: {
-    //     chunks: 'all',
-    //     name: 'shared'
-    //   }
-    // }
   };
 };

--- a/packages/grafana-toolkit/tslint.json
+++ b/packages/grafana-toolkit/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tslint.json",
   "rules": {
-    "import-blacklist": [true, ["^@grafana/runtime.*"]]
+    "import-blacklist": [true, ["^@grafana/runtime.*"]],
+    "no-console": [true, "debug", "info", "time", "timeEnd"]
   }
 }


### PR DESCRIPTION
Fixes #19034

Also, prints error stack trace in the console when toolkit fails executing task.