### PR TITLE
Core: Clean up state after navigating away

### DIFF
--- a/public/app/core/actions/location.ts
+++ b/public/app/core/actions/location.ts
@@ -2,3 +2,10 @@ import { LocationUpdate } from '@grafana/runtime';
 import { actionCreatorFactory } from 'app/core/redux';
 
 export const updateLocation = actionCreatorFactory<LocationUpdate>('UPDATE_LOCATION').create();
+
+export interface LocationChanged {
+  fromPath: string;
+  toPath: string;
+}
+
+export const locationChanged = actionCreatorFactory<LocationChanged>('LOCATION_CHANGED').create();

--- a/public/app/core/middlewares/updateLocationMiddleware.ts
+++ b/public/app/core/middlewares/updateLocationMiddleware.ts
@@ -1,0 +1,24 @@
+import { Store, Dispatch } from 'redux';
+import { StoreState } from '../../types';
+import { ActionOf } from '../redux';
+import { updateLocation } from '../actions';
+import { LocationUpdate } from '@grafana/runtime';
+import { locationChanged } from '../actions/location';
+
+export const updateLocationMiddleware = (store: Store<StoreState>) => (next: Dispatch) => (action: ActionOf<any>) => {
+  const isUpdateLocationAction = action.type === updateLocation.type;
+  if (!isUpdateLocationAction) {
+    next(action);
+    return;
+  }
+
+  // Fetch these values before we call the first next, after that state will be updated
+  const state = store.getState().location;
+  const { path } = action.payload as LocationUpdate;
+
+  next(action);
+
+  if (path !== state.path) {
+    next(locationChanged({ fromPath: state.path, toPath: path }));
+  }
+};

--- a/public/app/core/reducers/application.ts
+++ b/public/app/core/reducers/application.ts
@@ -15,3 +15,7 @@ export const applicationReducer = reducerFactory<ApplicationState>(initialState)
     }),
   })
   .create();
+
+export default {
+  application: applicationReducer,
+};

--- a/public/app/core/redux/resetStateForPath.ts
+++ b/public/app/core/redux/resetStateForPath.ts
@@ -1,0 +1,17 @@
+import { Reducer } from 'redux';
+import { ActionOf } from './actionCreatorFactory';
+import { locationChanged, LocationChanged } from '../actions/location';
+
+export const resetStateForPath = <State>(reducer: Reducer<State, ActionOf<any>>, resetStateForPath: string) => (
+  state: State,
+  action: ActionOf<any>
+): State => {
+  if (action.type === locationChanged.type) {
+    const { fromPath, toPath } = action.payload as LocationChanged;
+    if (resetStateForPath && resetStateForPath === fromPath && toPath.indexOf(fromPath) === -1) {
+      state = undefined;
+    }
+  }
+
+  return reducer(state, action);
+};

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -1,5 +1,6 @@
 import { Team, TeamGroup, TeamMember, TeamsState, TeamState } from 'app/types';
 import { Action, ActionTypes } from './actions';
+import { resetStateForPath } from '../../../core/redux/resetStateForPath';
 
 export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', hasFetched: false };
 export const initialTeamState: TeamState = {
@@ -39,6 +40,6 @@ export const teamReducer = (state = initialTeamState, action: Action): TeamState
 };
 
 export default {
-  teams: teamsReducer,
-  team: teamReducer,
+  teams: resetStateForPath(teamsReducer, '/org/teams'),
+  team: resetStateForPath(teamReducer, '/org/teams'),
 };

--- a/public/app/features/users/UsersActionBar.test.tsx
+++ b/public/app/features/users/UsersActionBar.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { UsersActionBar, Props } from './UsersActionBar';
+import { setUsersSearchQuery } from './state/actions';
+import { mockActionCreator } from '../../core/redux';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
     searchQuery: '',
-    setUsersSearchQuery: jest.fn(),
+    setUsersSearchQuery: mockActionCreator(setUsersSearchQuery),
     onShowInvites: jest.fn(),
     pendingInvitesCount: 0,
     canInvite: false,

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -48,7 +48,7 @@ export class UsersActionBar extends PureComponent<Props> {
             labelClassName="gf-form--has-input-icon"
             inputClassName="gf-form-input width-20"
             value={searchQuery}
-            onChange={setUsersSearchQuery}
+            onChange={query => setUsersSearchQuery({ query })}
             placeholder="Filter by name or type"
           />
           {pendingInvitesCount > 0 && (

--- a/public/app/features/users/UsersListPage.test.tsx
+++ b/public/app/features/users/UsersListPage.test.tsx
@@ -5,6 +5,8 @@ import { Invitee, OrgUser } from 'app/types';
 import { getMockUser } from './__mocks__/userMocks';
 import appEvents from '../../core/app_events';
 import { NavModel } from '@grafana/data';
+import { mockActionCreator } from '../../core/redux';
+import { setUsersSearchQuery } from './state/actions';
 
 jest.mock('../../core/app_events', () => ({
   emit: jest.fn(),
@@ -28,7 +30,7 @@ const setup = (propOverrides?: object) => {
     loadUsers: jest.fn(),
     updateUser: jest.fn(),
     removeUser: jest.fn(),
-    setUsersSearchQuery: jest.fn(),
+    setUsersSearchQuery: mockActionCreator(setUsersSearchQuery),
     hasFetched: false,
   };
 

--- a/public/app/features/users/__snapshots__/UsersActionBar.test.tsx.snap
+++ b/public/app/features/users/__snapshots__/UsersActionBar.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Render should render component 1`] = `
     <ForwardRef
       inputClassName="gf-form-input width-20"
       labelClassName="gf-form--has-input-icon"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       placeholder="Filter by name or type"
       value=""
     />
@@ -31,7 +31,7 @@ exports[`Render should render pending invites button 1`] = `
     <ForwardRef
       inputClassName="gf-form-input width-20"
       labelClassName="gf-form--has-input-icon"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       placeholder="Filter by name or type"
       value=""
     />
@@ -76,7 +76,7 @@ exports[`Render should show external user management button 1`] = `
     <ForwardRef
       inputClassName="gf-form-input width-20"
       labelClassName="gf-form--has-input-icon"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       placeholder="Filter by name or type"
       value=""
     />
@@ -108,7 +108,7 @@ exports[`Render should show invite button 1`] = `
     <ForwardRef
       inputClassName="gf-form-input width-20"
       labelClassName="gf-form--has-input-icon"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       placeholder="Filter by name or type"
       value=""
     />

--- a/public/app/features/users/state/actions.ts
+++ b/public/app/features/users/state/actions.ts
@@ -2,58 +2,39 @@ import { ThunkAction } from 'redux-thunk';
 import { StoreState } from '../../../types';
 import { getBackendSrv } from '@grafana/runtime';
 import { Invitee, OrgUser } from 'app/types';
-
-export enum ActionTypes {
-  LoadUsers = 'LOAD_USERS',
-  LoadInvitees = 'LOAD_INVITEES',
-  SetUsersSearchQuery = 'SET_USERS_SEARCH_QUERY',
-}
+import { actionCreatorFactory, ActionOf } from '../../../core/redux';
 
 export interface LoadUsersAction {
-  type: ActionTypes.LoadUsers;
-  payload: OrgUser[];
+  users: OrgUser[];
 }
 
 export interface LoadInviteesAction {
-  type: ActionTypes.LoadInvitees;
-  payload: Invitee[];
+  invitees: Invitee[];
 }
 
 export interface SetUsersSearchQueryAction {
-  type: ActionTypes.SetUsersSearchQuery;
-  payload: string;
+  query: string;
 }
 
-const usersLoaded = (users: OrgUser[]): LoadUsersAction => ({
-  type: ActionTypes.LoadUsers,
-  payload: users,
-});
-
-const inviteesLoaded = (invitees: Invitee[]): LoadInviteesAction => ({
-  type: ActionTypes.LoadInvitees,
-  payload: invitees,
-});
-
-export const setUsersSearchQuery = (query: string): SetUsersSearchQueryAction => ({
-  type: ActionTypes.SetUsersSearchQuery,
-  payload: query,
-});
+export const usersLoaded = actionCreatorFactory<LoadUsersAction>('LOAD_USERS').create();
+export const inviteesLoaded = actionCreatorFactory<LoadInviteesAction>('LOAD_INVITEES').create();
+export const setUsersSearchQuery = actionCreatorFactory<SetUsersSearchQueryAction>('SET_USERS_SEARCH_QUERY').create();
 
 export type Action = LoadUsersAction | SetUsersSearchQueryAction | LoadInviteesAction;
 
-type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action>;
+type ThunkResult<R> = ThunkAction<R, StoreState, undefined, ActionOf<any>>;
 
 export function loadUsers(): ThunkResult<void> {
   return async dispatch => {
-    const users = await getBackendSrv().get('/api/org/users');
-    dispatch(usersLoaded(users));
+    const users: OrgUser[] = await getBackendSrv().get('/api/org/users');
+    dispatch(usersLoaded({ users }));
   };
 }
 
 export function loadInvitees(): ThunkResult<void> {
   return async dispatch => {
-    const invitees = await getBackendSrv().get('/api/org/invites');
-    dispatch(inviteesLoaded(invitees));
+    const invitees: Invitee[] = await getBackendSrv().get('/api/org/invites');
+    dispatch(inviteesLoaded({ invitees }));
   };
 }
 

--- a/public/app/features/users/state/reducers.ts
+++ b/public/app/features/users/state/reducers.ts
@@ -1,6 +1,7 @@
 import { Invitee, OrgUser, UsersState } from 'app/types';
-import { Action, ActionTypes } from './actions';
 import config from 'app/core/config';
+import { reducerFactory } from '../../../core/redux';
+import { usersLoaded, inviteesLoaded, setUsersSearchQuery } from './actions';
 
 export const initialState: UsersState = {
   invitees: [] as Invitee[],
@@ -13,20 +14,20 @@ export const initialState: UsersState = {
   hasFetched: false,
 };
 
-export const usersReducer = (state = initialState, action: Action): UsersState => {
-  switch (action.type) {
-    case ActionTypes.LoadUsers:
-      return { ...state, hasFetched: true, users: action.payload };
-
-    case ActionTypes.LoadInvitees:
-      return { ...state, hasFetched: true, invitees: action.payload };
-
-    case ActionTypes.SetUsersSearchQuery:
-      return { ...state, searchQuery: action.payload };
-  }
-
-  return state;
-};
+export const usersReducer = reducerFactory<UsersState>(initialState)
+  .addMapper({
+    filter: usersLoaded,
+    mapper: (state, action): UsersState => ({ ...state, hasFetched: true, users: action.payload.users }),
+  })
+  .addMapper({
+    filter: inviteesLoaded,
+    mapper: (state, action): UsersState => ({ ...state, hasFetched: true, invitees: action.payload.invitees }),
+  })
+  .addMapper({
+    filter: setUsersSearchQuery,
+    mapper: (state, action): UsersState => ({ ...state, hasFetched: true, searchQuery: action.payload.query }),
+  })
+  .create({ resetStateForPath: '/org/users' });
 
 export default {
   users: usersReducer,

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -16,6 +16,7 @@ import organizationReducers from 'app/features/org/state/reducers';
 import { setStore } from './store';
 import { StoreState } from 'app/types/store';
 import { toggleLogActionsMiddleware } from 'app/core/middlewares/application';
+import { updateLocationMiddleware } from '../core/middlewares/updateLocationMiddleware';
 
 const rootReducers = {
   ...sharedReducers,
@@ -39,6 +40,18 @@ export function addRootReducer(reducers: any) {
 export function configureStore() {
   const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const rootReducer = combineReducers(rootReducers);
+  // const rootReducer = (state: StoreState, action: ActionOf<any>) => {
+  //   if (action.type === updateLocation.type) {
+  //     const { path } = action.payload as LocationUpdate;
+  //     if (path !== state.location.path) {
+  //       const { explore, dashboard, application } = state;
+  //       state = { explore, dashboard, application } as StoreState;
+  //     }
+  //   }
+  //
+  //   return appReducer(state, action);
+  // };
+
   const logger = createLogger({
     predicate: (getState: () => StoreState) => {
       return getState().application.logActions;
@@ -46,8 +59,8 @@ export function configureStore() {
   });
   const storeEnhancers =
     process.env.NODE_ENV !== 'production'
-      ? applyMiddleware(toggleLogActionsMiddleware, thunk, logger)
-      : applyMiddleware(thunk);
+      ? applyMiddleware(toggleLogActionsMiddleware, updateLocationMiddleware, thunk, logger)
+      : applyMiddleware(updateLocationMiddleware, thunk);
 
   const store = createStore(rootReducer, {}, composeEnhancers(storeEnhancers));
   setStore(store);

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -40,18 +40,6 @@ export function addRootReducer(reducers: any) {
 export function configureStore() {
   const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const rootReducer = combineReducers(rootReducers);
-  // const rootReducer = (state: StoreState, action: ActionOf<any>) => {
-  //   if (action.type === updateLocation.type) {
-  //     const { path } = action.payload as LocationUpdate;
-  //     if (path !== state.location.path) {
-  //       const { explore, dashboard, application } = state;
-  //       state = { explore, dashboard, application } as StoreState;
-  //     }
-  //   }
-  //
-  //   return appReducer(state, action);
-  // };
-
   const logger = createLogger({
     predicate: (getState: () => StoreState) => {
       return getState().application.logActions;

--- a/public/app/types/store.ts
+++ b/public/app/types/store.ts
@@ -14,11 +14,13 @@ import { AppNotificationsState } from './appNotifications';
 import { PluginsState } from './plugins';
 import { NavIndex } from '@grafana/data';
 import { ApplicationState } from './application';
+import { ApiKeysState } from './apiKeys';
 
 export interface StoreState {
   navIndex: NavIndex;
   location: LocationState;
   alertRules: AlertRulesState;
+  apiKeys: ApiKeysState;
   teams: TeamsState;
   team: TeamState;
   folder: FolderState;


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now most state slices except `dashboard` and `explore` actually clean up their state after navigating away, this can potentially create weird bugs. This PR makes a first attempt to remedy this by being explicit when reducers should clear their state.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

