### PR TITLE
prometheus_datasource_plugin: Add possibility show prometheus warnings as error

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -53,6 +53,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   metricsNameCache: any;
   interval: string;
   queryTimeout: string;
+  errorIfWarning: boolean;
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
   resultTransformer: ResultTransformer;
@@ -75,6 +76,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
+    this.errorIfWarning = instanceSettings.jsonData.errorIfWarning || false;
     this.directUrl = instanceSettings.jsonData.directUrl;
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
@@ -169,6 +171,11 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       refId: target.refId,
       valueWithRefId: target.valueWithRefId,
     };
+    console.log(this);
+    console.log(this.errorIfWarning);
+    if (this.errorIfWarning === true && response.data.warnings && response.data.warnings.length > 0) {
+      throw { message: '* ' + response.data.warnings.join('\n\n* ') };
+    }
     const series = this.resultTransformer.transform(response, transformerOptions);
 
     return series;

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -37,6 +37,12 @@
     </div>
   </div>
 
+  <div class="gf-form-inline">
+    <gf-form-checkbox class="gf-form" label="Show error if warnings"
+      tooltip="Return error is response from prometheus service contains warnings" checked="ctrl.current.jsonData.errorIfWarning"
+      label-class="width-12" switch-class="width-4"></gf-form-checkbox>
+  </div>
+
   <div class="gf-form">
     <label class="gf-form-label width-8">HTTP Method</label>
     <div class="gf-form-select-wrapper width-8 gf-form-select-wrapper--has-help-icon">

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -24,6 +24,7 @@ export interface PromOptions extends DataSourceJsonData {
   timeInterval: string;
   queryTimeout: string;
   httpMethod: string;
+  errorIfWarning: boolean;
   directUrl: string;
 }
 


### PR DESCRIPTION
When prometheus returns warnings clients show pick those warnings up and show for users. Related discassions can be found here:
https://github.com/prometheus/prometheus/pull/5964
https://github.com/prometheus/prometheus/pull/5963

Currently if any query errors that occur while we try to read from remote are returned as a list of warnings and the query continues. Sometimes it can return partition result (data from all other not failed remote readers) or even no results. Now only query inspector can show what's going on. Very often user see only 'no data' on his panels. In ideal world we should show it as warning, but it require panels refactoring (see https://github.com/grafana/grafana/pull/14899, https://github.com/grafana/grafana/issues/14487).

As current solution this patch will add setting that allow to set warnings as error in panel. By default behaviour wasn't changed. If user's data require to show all data or nothing with error (ex. We have remote reader that reads data from prometheus instances per server role. If one of prometheus instances doesn't response we want to show it for user as error of query execution for prevent receive partial data of no data).
