### PR TITLE
Graph: New series override transform constant that renders a single point as a line across the whole graph

### DIFF
--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -51,9 +51,21 @@ Open a graph in edit mode by click the title > Edit (or by pressing `e` key whil
 | _Resolution_       | Controls the step option. Small steps create high-resolution graphs but can be slow over larger time ranges, lowering the resolution can speed things up. `1/2` will try to set step option to generate 1 data point for every other pixel. A value of `1/10` will try to set step option so there is a data point every 10 pixels. |
 | _Metric lookup_    | Search for metric names in this input field.                                                                                                                                                                                                                                                                                        |
 | _Format as_        | Switch between Table, Time series or Heatmap. Table format will only work in the Table panel. Heatmap format is suitable for displaying metrics having histogram type on Heatmap panel. Under the hood, it converts cumulative histogram to regular and sorts series by the bucket bound.                                           |
+| _Instant_          | Perform an "instant" query, to return only the latest value that Prometheus has scraped for the requested time series. Instant queries return results much faster than normal range queries. Use them to look up label sets.                                                                                                        |
 
 > NOTE: Grafana slightly modifies the request dates for queries to align them with the dynamically calculated step.
 > This ensures consistent display of metrics data but can result in a small gap of data at the right edge of a graph.
+
+### Instant queries
+
+The Prometheus datasource allows you to run "instant" queries, which queries only the latest value.
+You can visualize the results in a table panel to see all available labels of a timeseries.
+
+Instant query results are made up only of one datapoint per series but can be shown in the graph panel with the help of [series overrides](/features/panels/graph/#series-overrides).
+To show them in the graph as a latest value point, add a series override and select `Points > true`.
+To show a horizontal line across the whole graph, add a series override and select `Transform > constant`.
+
+> Support for constant series overrides is available from Grafana v6.4
 
 ## Templating
 

--- a/packages/grafana-ui/src/utils/flotPairs.test.ts
+++ b/packages/grafana-ui/src/utils/flotPairs.test.ts
@@ -1,5 +1,5 @@
-import { getFlotPairs } from './flotPairs';
-import { MutableDataFrame } from '@grafana/data';
+import { getFlotPairs, getFlotPairsConstant } from './flotPairs';
+import { MutableDataFrame, TimeRange, dateTime } from '@grafana/data';
 
 describe('getFlotPairs', () => {
   const series = new MutableDataFrame({
@@ -31,5 +31,30 @@ describe('getFlotPairs', () => {
     expect(pairs[0].length).toEqual(2);
     expect(pairs[0][0]).toEqual(1);
     expect(pairs[0][1]).toEqual('a');
+  });
+});
+
+describe('getFlotPairsConstant', () => {
+  const makeRange = (from: number, to: number): TimeRange => ({
+    from: dateTime(from),
+    to: dateTime(to),
+    raw: { from: `${from}`, to: `${to}` },
+  });
+
+  it('should return an empty series on empty data', () => {
+    const range: TimeRange = makeRange(0, 1);
+    const pairs = getFlotPairsConstant([], range);
+    expect(pairs).toMatchObject([]);
+  });
+
+  it('should return an empty series on missing range', () => {
+    const pairs = getFlotPairsConstant([], {} as TimeRange);
+    expect(pairs).toMatchObject([]);
+  });
+
+  it('should return an constant series for range', () => {
+    const range: TimeRange = makeRange(0, 1);
+    const pairs = getFlotPairsConstant([[2, 123], [4, 456]], range);
+    expect(pairs).toMatchObject([[0, 123], [1, 123]]);
   });
 });

--- a/packages/grafana-ui/src/utils/flotPairs.ts
+++ b/packages/grafana-ui/src/utils/flotPairs.ts
@@ -1,5 +1,5 @@
 // Types
-import { NullValueMode, GraphSeriesValue, Field } from '@grafana/data';
+import { NullValueMode, GraphSeriesValue, Field, TimeRange } from '@grafana/data';
 
 export interface FlotPairsOptions {
   xField: Field;
@@ -41,4 +41,20 @@ export function getFlotPairs({ xField, yField, nullValueMode }: FlotPairsOptions
     pairs.push([x, y]);
   }
   return pairs;
+}
+
+/**
+ * Returns a constant series based on the first value from the provide series.
+ * @param seriesData Series
+ * @param range Start and end time for the constant series
+ */
+export function getFlotPairsConstant(seriesData: GraphSeriesValue[][], range: TimeRange): GraphSeriesValue[][] {
+  if (!range.from || !range.to || !seriesData || seriesData.length === 0) {
+    return [];
+  }
+
+  const from = range.from.valueOf();
+  const to = range.to.valueOf();
+  const value = seriesData[0][1];
+  return [[from, value], [to, value]];
 }

--- a/packages/grafana-ui/src/utils/index.ts
+++ b/packages/grafana-ui/src/utils/index.ts
@@ -4,7 +4,7 @@ export * from './namedColorsPalette';
 export * from './displayProcessor';
 export * from './fieldDisplay';
 export * from './validate';
-export { getFlotPairs } from './flotPairs';
+export { getFlotPairs, getFlotPairsConstant } from './flotPairs';
 export * from './slate';
 export * from './dataLinks';
 export { default as ansicolor } from './ansicolor';

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -24,7 +24,14 @@ import ReactDOM from 'react-dom';
 import { GraphLegendProps, Legend } from './Legend/Legend';
 
 import { GraphCtrl } from './module';
-import { getValueFormat, ContextMenuGroup, FieldDisplay, ContextMenuItem, getDisplayProcessor } from '@grafana/ui';
+import {
+  getValueFormat,
+  ContextMenuGroup,
+  FieldDisplay,
+  ContextMenuItem,
+  getDisplayProcessor,
+  getFlotPairsConstant,
+} from '@grafana/ui';
 import { provideTheme, getCurrentTheme } from 'app/core/utils/ConfigProvider';
 import { toUtc, LinkModelSupplier, DataFrameView } from '@grafana/data';
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
@@ -396,10 +403,7 @@ class GraphElement {
       series.data = series.getFlotPairs(series.nullPointMode || this.panel.nullPointMode);
 
       if (series.transform === 'constant') {
-        const start = _.isUndefined(this.ctrl.range.from) ? null : this.ctrl.range.from.valueOf();
-        const end = _.isUndefined(this.ctrl.range.to) ? null : this.ctrl.range.to.valueOf();
-        const value = series.data[0][1];
-        series.data = [[start, value], [end, value]];
+        series.data = getFlotPairsConstant(series.data, this.ctrl.range);
       }
 
       // if hidden remove points and disable stack

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -395,6 +395,13 @@ class GraphElement {
       const series = data[i];
       series.data = series.getFlotPairs(series.nullPointMode || this.panel.nullPointMode);
 
+      if (series.transform === 'constant') {
+        const start = _.isUndefined(this.ctrl.range.from) ? null : this.ctrl.range.from.valueOf();
+        const end = _.isUndefined(this.ctrl.range.to) ? null : this.ctrl.range.to.valueOf();
+        const value = series.data[0][1];
+        series.data = [[start, value], [end, value]];
+      }
+
       // if hidden remove points and disable stack
       if (this.ctrl.hiddenSeries[series.alias]) {
         series.data = [];

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.ts
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.ts
@@ -152,7 +152,7 @@ export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: a
   $scope.addOverrideOption('Color', 'color', ['change']);
   $scope.addOverrideOption('Y-axis', 'yaxis', [1, 2]);
   $scope.addOverrideOption('Z-index', 'zindex', [-3, -2, -1, 0, 1, 2, 3]);
-  $scope.addOverrideOption('Transform', 'transform', ['negative-Y']);
+  $scope.addOverrideOption('Transform', 'transform', ['constant', 'negative-Y']);
   $scope.addOverrideOption('Legend', 'legend', [true, false]);
   $scope.addOverrideOption('Hide in tooltip', 'hideTooltip', [true, false]);
   $scope.updateCurrentOverrides();


### PR DESCRIPTION
- [x] ability to define a series override that takes the first value of a
timeseries and produces constant series from it.
- [x] error handling and tests 

<img width="987" alt="Screenshot 2019-09-13 at 18 43 36" src="https://user-images.githubusercontent.com/859729/64879515-6f0a7a80-d656-11e9-81a3-992d94725010.png">

Fixes #9084
Alternative to #18770