### PR TITLE
Explore: calculate intervals when building data source request

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -442,7 +442,7 @@ describe('sortLogsResult', () => {
     it('it should calculate interval taking minInterval into account', () => {
       const queries = [{ refId: 'A' }];
       const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
-      const range = { from: dateTime().subtract(1, '1m'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+      const range = { from: dateTime().subtract(1, 'm'), to: dateTime(), raw: { from: '1h', to: '1h' } };
       const transaction = buildQueryTransaction(queries, queryOptions, range, false);
 
       expect(transaction.request.intervalMs).toEqual(15000);

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -11,10 +11,11 @@ import {
   refreshIntervalToSortOrder,
   SortOrder,
   sortLogsResult,
+  buildQueryTransaction,
 } from './explore';
 import { ExploreUrlState, ExploreMode } from 'app/types/explore';
 import store from 'app/core/store';
-import { LogsDedupStrategy, LogsModel, LogLevel } from '@grafana/data';
+import { LogsDedupStrategy, LogsModel, LogLevel, dateTime } from '@grafana/data';
 import { DataQueryError } from '@grafana/ui';
 import { liveOption, offOption } from '@grafana/ui/src/components/RefreshPicker/RefreshPicker';
 
@@ -425,6 +426,35 @@ describe('sortLogsResult', () => {
         rows: [firstRow, sameAsFirstRow, secondRow],
         hasUniqueLabels: false,
       });
+    });
+  });
+
+  describe('when buildQueryTransaction', () => {
+    it('it should calculate interval based on time range', () => {
+      const queries = [{ refId: 'A' }];
+      const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
+      const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+      const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+
+      expect(transaction.request.intervalMs).toEqual(60000);
+    });
+
+    it('it should calculate interval taking minInterval into account', () => {
+      const queries = [{ refId: 'A' }];
+      const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
+      const range = { from: dateTime().subtract(1, '1m'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+      const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+
+      expect(transaction.request.intervalMs).toEqual(15000);
+    });
+
+    it('it should calculate interval taking maxDataPoints into account', () => {
+      const queries = [{ refId: 'A' }];
+      const queryOptions = { maxDataPoints: 10, minInterval: '15s' };
+      const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
+      const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+
+      expect(transaction.request.interval).toEqual('2h');
     });
   });
 });

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -437,7 +437,6 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
       datasourceError,
       containerWidth,
       isLive: live,
-      queryIntervals,
       range,
       scanning,
       queryResponse,
@@ -461,14 +460,13 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
 
     // Some datasource's query builders allow per-query interval limits,
     // but we're using the datasource interval limit for now
-    const interval = datasourceInstance.interval;
+    const minInterval = datasourceInstance.interval;
 
     stopQueryState(querySubscription);
 
     const queryOptions = {
-      interval,
+      minInterval,
       // This is used for logs streaming for buffer size.
-      // TODO: not sure if this makes sense for normal query when using both graph and table
       maxDataPoints: mode === ExploreMode.Logs ? 1000 : containerWidth,
       live,
       showingGraph,
@@ -476,7 +474,7 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
     };
 
     const datasourceId = datasourceInstance.meta.id;
-    const transaction = buildQueryTransaction(queries, queryOptions, range, queryIntervals, scanning);
+    const transaction = buildQueryTransaction(queries, queryOptions, range, scanning);
 
     let firstResponse = true;
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -67,9 +67,6 @@ export const DEFAULT_RANGE = {
   to: 'now',
 };
 
-// Millies step for helper bar charts
-const DEFAULT_GRAPH_INTERVAL = 15 * 1000;
-
 export const makeInitialUpdateState = (): ExploreUpdateState => ({
   datasource: false,
   queries: false,
@@ -93,7 +90,6 @@ export const makeExploreItemState = (): ExploreItemState => ({
   history: [],
   queries: [],
   initialized: false,
-  queryIntervals: { interval: '15s', intervalMs: DEFAULT_GRAPH_INTERVAL },
   range: {
     from: null,
     to: null,
@@ -617,7 +613,7 @@ export const processQueryResponse = (
   }
 
   const latency = request.endTime ? request.endTime - request.startTime : 0;
-  const processor = new ResultProcessor(state, series);
+  const processor = new ResultProcessor(state, series, request.intervalMs);
   const graphResult = processor.getGraphResult();
   const tableResult = processor.getTableResult();
   const logsResult = processor.getLogsResult();

--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -56,7 +56,7 @@ const testContext = (options: any = {}) => {
     queryIntervals: { intervalMs: 10 },
   } as any) as ExploreItemState;
 
-  const resultProcessor = new ResultProcessor(state, combinedOptions.dataFrames);
+  const resultProcessor = new ResultProcessor(state, combinedOptions.dataFrames, 60000);
 
   return {
     dataFrames: combinedOptions.dataFrames,

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -7,7 +7,7 @@ import { dataFrameToLogsModel } from 'app/core/logs_model';
 import { getGraphSeriesModel } from 'app/plugins/panel/graph2/getGraphSeriesModel';
 
 export class ResultProcessor {
-  constructor(private state: ExploreItemState, private dataFrames: DataFrame[]) {}
+  constructor(private state: ExploreItemState, private dataFrames: DataFrame[], private intervalMs: number) {}
 
   getGraphResult(): GraphSeriesXY[] {
     if (this.state.mode !== ExploreMode.Metrics) {
@@ -77,9 +77,7 @@ export class ResultProcessor {
       return null;
     }
 
-    const graphInterval = this.state.queryIntervals.intervalMs;
-
-    const newResults = dataFrameToLogsModel(this.dataFrames, graphInterval);
+    const newResults = dataFrameToLogsModel(this.dataFrames, this.intervalMs);
     const sortOrder = refreshIntervalToSortOrder(this.state.refreshInterval);
     const sortedNewResults = sortLogsResult(newResults, sortOrder);
 

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -187,11 +187,6 @@ export interface ExploreItemState {
   logsResult?: LogsModel;
 
   /**
-   * Query intervals for graph queries to determine how many datapoints to return.
-   * Needs to be updated when `datasourceInstance` or `containerWidth` is changed.
-   */
-  queryIntervals: QueryIntervals;
-  /**
    * Time range for this Explore. Managed by the time picker and used by all query runs.
    */
   range: TimeRange;
@@ -330,7 +325,7 @@ export interface QueryIntervals {
 }
 
 export interface QueryOptions {
-  interval: string;
+  minInterval: string;
   maxDataPoints?: number;
   live?: boolean;
 }


### PR DESCRIPTION
Somewhere during 6.4 development, the re-calc of intervals was lost :) 

Since the introduction of PanelData in explore state we can remove queryIntervals from redux state as this interval is already stored on the PanelData.request. 

added back getIntervals (found in git history) and made this part of buildTransaction. 
 
Fixes #19086

Sorry for hijacking a fix you where working on @ivanahuckova but think this was pretty tricky to fix as this code had gotten lost and there were relics of old solutions that were actually no longer need (storing/updating queryIntervals in redux state for example). So wanted to help out here so you did not spend too much time trying to figure out how this ever worked as the current state was very messy due to recent changes & missing pieces. 

 