### PR TITLE
Update routing to require sign in on every route

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,7 +24,6 @@ func (hs *HTTPServer) registerRoutes() {
 	r := hs.RouteRegister
 
 	// not logged in views
-	r.Get("/", reqSignedIn, hs.Index)
 	r.Get("/logout", hs.Logout)
 	r.Post("/login", quota("session"), bind(dtos.LoginCommand{}), Wrap(hs.LoginPost))
 	r.Get("/login/:name", quota("session"), hs.OAuthLogin)
@@ -32,6 +31,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/invite/:code", hs.Index)
 
 	// authed views
+	r.Get("/*", reqSignedIn, hs.Index)
 	r.Get("/profile/", reqSignedIn, hs.Index)
 	r.Get("/profile/password", reqSignedIn, hs.Index)
 	r.Get("/profile/switch-org/:id", reqSignedIn, hs.ChangeActiveOrgAndRedirectToHome)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,7 +31,6 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/invite/:code", hs.Index)
 
 	// authed views
-	r.Get("/*", reqSignedIn, hs.Index)
 	r.Get("/profile/", reqSignedIn, hs.Index)
 	r.Get("/profile/password", reqSignedIn, hs.Index)
 	r.Get("/profile/switch-org/:id", reqSignedIn, hs.ChangeActiveOrgAndRedirectToHome)
@@ -422,4 +421,6 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/snapshots/:key", GetDashboardSnapshot)
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrSignedIn, Wrap(DeleteDashboardSnapshotByDeleteKey))
 	r.Delete("/api/snapshots/:key", reqEditorRole, Wrap(DeleteDashboardSnapshot))
+
+	r.Get("/*", reqSignedIn, hs.Index)
 }


### PR DESCRIPTION
Fixes #19003 

This make all routes require sign in by default. The issue mentioned in #19003 was caused by the fact that backend router was returning 404 on route `/%2f` which path was considered to be `/`. Instead, it should redirect to login.

When investigating this I have also noticed that for instance it is possible to navigate to `/dashboard/new` when not being singed in. That's because this route is not specified as the one that requires sign in. 

Not 100% sure, maybe there is a reason for allowing some routes to be accessible without login when anonymous access is disabled?

