### PR TITLE
Prometheus: Custom query parameters string for Thanos downsampling

### DIFF
--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -25,16 +25,17 @@ Grafana includes built-in support for Prometheus.
 
 ## Data source options
 
-| Name              | Description                                                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| _Name_            | The data source name. This is how you refer to the data source in panels & queries.                                                   |
-| _Default_         | Default data source means that it will be pre-selected for new panels.                                                                |
-| _Url_             | The http protocol, ip and port of you Prometheus server (default port is usually 9090)                                                |
-| _Access_          | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. |
-| _Basic Auth_      | Enable basic authentication to the Prometheus data source.                                                                            |
-| _User_            | Name of your Prometheus user                                                                                                          |
-| _Password_        | Database user's password                                                                                                              |
-| _Scrape interval_ | This will be used as a lower limit for the Prometheus step query parameter. Default value is 15s.                                     |
+| Name                    | Description                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| _Name_                  | The data source name. This is how you refer to the data source in panels & queries.                                                   |
+| _Default_               | Default data source means that it will be pre-selected for new panels.                                                                |
+| _Url_                   | The http protocol, ip and port of you Prometheus server (default port is usually 9090)                                                |
+| _Access_                | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. |
+| _Basic Auth_            | Enable basic authentication to the Prometheus data source.                                                                            |
+| _User_                  | Name of your Prometheus user                                                                                                          |
+| _Password_              | Database user's password                                                                                                              |
+| _Scrape interval_       | This will be used as a lower limit for the Prometheus step query parameter. Default value is 15s.                                     |
+| _CustomQueryParameters_ | Add Custom parameters to Prometheus query url. For example `timeout`, `partial_response`, `dedup` or `max_source_resolution`.         |
 
 ## Query editor
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -55,6 +55,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
   resultTransformer: ResultTransformer;
+  customQueryParameters: any;
 
   /** @ngInject */
   constructor(
@@ -78,6 +79,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
     this.languageProvider = new PrometheusLanguageProvider(this);
+    this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
   }
 
   init = () => {
@@ -348,6 +350,12 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       data['timeout'] = this.queryTimeout;
     }
 
+    for (const [key, value] of this.customQueryParameters) {
+      if (data[key] == null) {
+        data[key] = value;
+      }
+    }
+
     return this._request(url, data, { requestId: query.requestId, headers: query.headers }).catch((err: any) => {
       if (err.cancelled) {
         return err;
@@ -366,6 +374,12 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
     if (this.queryTimeout) {
       data['timeout'] = this.queryTimeout;
+    }
+
+    for (const [key, value] of this.customQueryParameters) {
+      if (data[key] == null) {
+        data[key] = value;
+      }
     }
 
     return this._request(url, data, { requestId: query.requestId, headers: query.headers }).catch((err: any) => {

--- a/public/app/plugins/datasource/prometheus/partials/config.html
+++ b/public/app/plugins/datasource/prometheus/partials/config.html
@@ -48,3 +48,23 @@
   </div>
 </div>
 
+<h3 class="page-heading">Misc</h3>
+<div class="gf-form-group">
+  <div class="gf-form-inline">
+    <div class="gf-form max-width-30">
+      <span class="gf-form-label width-13">Custom query parameters</span>
+      <input
+        type="text"
+        class="gf-form-input gf-form-input--has-help-icon"
+        ng-model="ctrl.current.jsonData.customQueryParameters"
+        spellcheck="false"
+        placeholder="Example: max_source_resolution=5m&timeout=10"
+      ></input>
+      <info-popover mode="right-absolute">
+        Add Custom parameters to Prometheus or Thanos queries.
+      </info-popover>
+    </div>
+  </div>
+</div>
+
+

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -25,6 +25,7 @@ export interface PromOptions extends DataSourceJsonData {
   queryTimeout: string;
   httpMethod: string;
   directUrl: string;
+  customQueryParameters?: string;
 }
 
 export interface PromQueryRequest extends PromQuery {


### PR DESCRIPTION
Add Prometheus custom parameters to datasource config.
All parameters will be parsed and added to the prometheus query api request.
For example you can set prometheus custom parameters to `max_source_resolution=1h&partial_response=true` if you have a Thanos backend with downsampling enabled.

Related Issue : https://github.com/grafana/grafana/issues/16665

