### PR TITLE
LDAP: Show all ldap groups

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -398,12 +398,12 @@ func (server *Server) buildGrafanaUser(user *ldap.Entry) (*models.ExternalUserIn
 
 	for _, group := range server.Config.Groups {
 		// only use the first match for each org
-		if extUser.OrgRoles[group.OrgID] != "" {
+		if extUser.OrgRoles[group.OrgId] != "" {
 			continue
 		}
 
 		if isMemberOf(memberOf, group.GroupDN) {
-			extUser.OrgRoles[group.OrgID] = group.OrgRole
+			extUser.OrgRoles[group.OrgId] = group.OrgRole
 			if extUser.IsGrafanaAdmin == nil || !*extUser.IsGrafanaAdmin {
 				extUser.IsGrafanaAdmin = group.IsGrafanaAdmin
 			}

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -55,7 +55,7 @@ type AttributeMap struct {
 // config "group_mappings" setting
 type GroupToOrgRole struct {
 	GroupDN string `toml:"group_dn"`
-	OrgID   int64  `toml:"org_id"`
+	OrgId   int64  `toml:"org_id"`
 
 	// This pointer specifies if setting was set (for backwards compatibility)
 	IsGrafanaAdmin *bool `toml:"grafana_admin"`
@@ -139,8 +139,8 @@ func readConfig(configFile string) (*Config, error) {
 		}
 
 		for _, groupMap := range server.Groups {
-			if groupMap.OrgID == 0 {
-				groupMap.OrgID = 1
+			if groupMap.OrgId == 0 {
+				groupMap.OrgId = 1
 			}
 		}
 	}


### PR DESCRIPTION
Think the ldap debug page was missing important information. The ldap groups <-> org role table did not show all ldap groups returned. To me, this is the primary thing this table needs to show. 

This is a quick PR to test how easy this change was. 

TODO: Sort missed matches to the bottom of the table (think this makes sense?) Or sort by OrgName & Role (will also cause no match entries to the bottom) 


