### PR TITLE
Feature: Encapsulated dynamic imports with error boundary and suspense

### DIFF
--- a/public/app/core/components/PageLoader/PageLoader.tsx
+++ b/public/app/core/components/PageLoader/PageLoader.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { LoadingPlaceholder } from '@grafana/ui';
 
 interface Props {
   pageName?: string;
@@ -8,8 +9,7 @@ const PageLoader: FC<Props> = ({ pageName = '' }) => {
   const loadingText = `Loading ${pageName}...`;
   return (
     <div className="page-loader-wrapper">
-      <i className="page-loader-wrapper__spinner fa fa-spinner fa-spin" />
-      <div className="page-loader-wrapper__text">{loadingText}</div>
+      <LoadingPlaceholder text={loadingText} />
     </div>
   );
 };

--- a/public/app/core/components/SafeDynamicImport.tsx
+++ b/public/app/core/components/SafeDynamicImport.tsx
@@ -1,0 +1,20 @@
+import React, { lazy, Suspense, FunctionComponent } from 'react';
+import { cx } from 'emotion';
+import { ErrorBoundaryAlert, LoadingPlaceholder } from '@grafana/ui';
+
+export const LoadingChunkPlaceHolder: FunctionComponent = () => (
+  <div className={cx('preloader')}>
+    <LoadingPlaceholder text={'Loading chunk...'} />
+  </div>
+);
+
+export const SafeDynamicImport = (importStatement: Promise<any>) => ({ ...props }) => {
+  const LazyComponent = lazy(() => importStatement);
+  return (
+    <ErrorBoundaryAlert style={'page'} title={"We did't manage to load a chunk, try refreshing the page."}>
+      <Suspense fallback={<LoadingChunkPlaceHolder />}>
+        <LazyComponent {...props} />
+      </Suspense>
+    </ErrorBoundaryAlert>
+  );
+};

--- a/public/app/core/components/SafeDynamicImport.tsx
+++ b/public/app/core/components/SafeDynamicImport.tsx
@@ -30,7 +30,7 @@ export const SafeDynamicImport = (importStatement: Promise<any>) => ({ ...props 
 
         return (
           <div className={getAlertPageStyle()}>
-            <h2>Failed to find application file</h2>
+            <h2>Unable to find application file</h2>
             <br />
             <h2 className="page-heading">Grafana has likely been updated. Please try reloading the page.</h2>
             <br />

--- a/public/app/core/components/SafeDynamicImport.tsx
+++ b/public/app/core/components/SafeDynamicImport.tsx
@@ -1,20 +1,48 @@
 import React, { lazy, Suspense, FunctionComponent } from 'react';
-import { cx } from 'emotion';
-import { ErrorBoundaryAlert, LoadingPlaceholder } from '@grafana/ui';
+import { cx, css } from 'emotion';
+import { LoadingPlaceholder, ErrorBoundary, Button } from '@grafana/ui';
 
 export const LoadingChunkPlaceHolder: FunctionComponent = () => (
   <div className={cx('preloader')}>
-    <LoadingPlaceholder text={'Loading chunk...'} />
+    <LoadingPlaceholder text={'Loading...'} />
   </div>
 );
+
+function getAlertPageStyle() {
+  return css`
+    width: 500px;
+    margin: 64px auto;
+  `;
+}
 
 export const SafeDynamicImport = (importStatement: Promise<any>) => ({ ...props }) => {
   const LazyComponent = lazy(() => importStatement);
   return (
-    <ErrorBoundaryAlert style={'page'} title={"We did't manage to load a chunk, try refreshing the page."}>
-      <Suspense fallback={<LoadingChunkPlaceHolder />}>
-        <LazyComponent {...props} />
-      </Suspense>
-    </ErrorBoundaryAlert>
+    <ErrorBoundary>
+      {({ error, errorInfo }) => {
+        if (!errorInfo) {
+          return (
+            <Suspense fallback={<LoadingChunkPlaceHolder />}>
+              <LazyComponent {...props} />
+            </Suspense>
+          );
+        }
+
+        return (
+          <div className={getAlertPageStyle()}>
+            <h2>Grafana has been updated. Please refresh your browser.</h2>
+            <br />
+            <Button size={'lg'} variant={'secondary'} icon="fa fa-repeat" onClick={() => window.location.reload()}>
+              Refresh
+            </Button>
+            <details style={{ whiteSpace: 'pre-wrap' }}>
+              {error && error.toString()}
+              <br />
+              {errorInfo.componentStack}
+            </details>
+          </div>
+        );
+      }}
+    </ErrorBoundary>
   );
 };

--- a/public/app/core/components/SafeDynamicImport.tsx
+++ b/public/app/core/components/SafeDynamicImport.tsx
@@ -10,8 +10,8 @@ export const LoadingChunkPlaceHolder: FunctionComponent = () => (
 
 function getAlertPageStyle() {
   return css`
-    width: 500px;
-    margin: 64px auto;
+    width: 508px;
+    margin: 128px auto;
   `;
 }
 
@@ -30,11 +30,15 @@ export const SafeDynamicImport = (importStatement: Promise<any>) => ({ ...props 
 
         return (
           <div className={getAlertPageStyle()}>
-            <h2>Grafana has been updated. Please refresh your browser.</h2>
+            <h2>Failed to find application file</h2>
             <br />
-            <Button size={'lg'} variant={'secondary'} icon="fa fa-repeat" onClick={() => window.location.reload()}>
-              Refresh
-            </Button>
+            <h2 className="page-heading">Grafana has likely been updated. Please try reloading the page.</h2>
+            <br />
+            <div className="gf-form-group">
+              <Button size={'md'} variant={'secondary'} icon="fa fa-repeat" onClick={() => window.location.reload()}>
+                Reload
+              </Button>
+            </div>
             <details style={{ whiteSpace: 'pre-wrap' }}>
               {error && error.toString()}
               <br />

--- a/public/app/routes/routes.ts
+++ b/public/app/routes/routes.ts
@@ -1,17 +1,16 @@
 import './dashboard_loaders';
 import './ReactContainer';
 import { applyRouteRegistrationHandlers } from './registry';
-
 // Pages
 import CreateFolderCtrl from 'app/features/folders/CreateFolderCtrl';
 import FolderDashboardsCtrl from 'app/features/folders/FolderDashboardsCtrl';
 import DashboardImportCtrl from 'app/features/manage-dashboards/DashboardImportCtrl';
 import config from 'app/core/config';
 import { route, ILocationProvider } from 'angular';
-
 // Types
 import { DashboardRouteInfo } from 'app/types';
 import { LoginPage } from 'app/core/components/Login/LoginPage';
+import { SafeDynamicImport } from '../core/components/SafeDynamicImport';
 
 /** @ngInject */
 export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locationProvider: ILocationProvider) {
@@ -21,7 +20,7 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
   // ones. That means angular ones could be navigated to in case there is a client side link some where.
 
   const importDashboardPage = () =>
-    import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage');
+    SafeDynamicImport(import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage'));
 
   $routeProvider
     .when('/', {
@@ -77,7 +76,9 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       reloadOnSearch: false,
       resolve: {
         component: () =>
-          import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage'),
+          SafeDynamicImport(
+            import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage')
+          ),
       },
     })
     .when('/dashboard-solo/:type/:slug', {
@@ -87,7 +88,9 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       reloadOnSearch: false,
       resolve: {
         component: () =>
-          import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage'),
+          SafeDynamicImport(
+            import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage')
+          ),
       },
     })
     .when('/dashboard/import', {
@@ -99,7 +102,9 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       template: '<react-container />',
       resolve: {
         component: () =>
-          import(/* webpackChunkName: "DataSourcesListPage"*/ 'app/features/datasources/DataSourcesListPage'),
+          SafeDynamicImport(
+            import(/* webpackChunkName: "DataSourcesListPage"*/ 'app/features/datasources/DataSourcesListPage')
+          ),
       },
     })
     .when('/datasources/edit/:id/', {
@@ -107,20 +112,27 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       reloadOnSearch: false, // for tabs
       resolve: {
         component: () =>
-          import(/* webpackChunkName: "DataSourceSettingsPage"*/ '../features/datasources/settings/DataSourceSettingsPage'),
+          SafeDynamicImport(
+            import(/* webpackChunkName: "DataSourceSettingsPage"*/ '../features/datasources/settings/DataSourceSettingsPage')
+          ),
       },
     })
     .when('/datasources/edit/:id/dashboards', {
       template: '<react-container />',
       resolve: {
         component: () =>
-          import(/* webpackChunkName: "DataSourceDashboards"*/ 'app/features/datasources/DataSourceDashboards'),
+          SafeDynamicImport(
+            import(/* webpackChunkName: "DataSourceDashboards"*/ 'app/features/datasources/DataSourceDashboards')
+          ),
       },
     })
     .when('/datasources/new', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "NewDataSourcePage"*/ '../features/datasources/NewDataSourcePage'),
+        component: () =>
+          SafeDynamicImport(
+            import(/* webpackChunkName: "NewDataSourcePage"*/ '../features/datasources/NewDataSourcePage')
+          ),
       },
     })
     .when('/dashboards', {
@@ -136,13 +148,19 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
     .when('/dashboards/f/:uid/:slug/permissions', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "FolderPermissions"*/ 'app/features/folders/FolderPermissions'),
+        component: () =>
+          SafeDynamicImport(
+            import(/* webpackChunkName: "FolderPermissions"*/ 'app/features/folders/FolderPermissions')
+          ),
       },
     })
     .when('/dashboards/f/:uid/:slug/settings', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "FolderSettingsPage"*/ 'app/features/folders/FolderSettingsPage'),
+        component: () =>
+          SafeDynamicImport(
+            import(/* webpackChunkName: "FolderSettingsPage"*/ 'app/features/folders/FolderSettingsPage')
+          ),
       },
     })
     .when('/dashboards/f/:uid/:slug', {
@@ -160,7 +178,7 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       reloadOnSearch: false,
       resolve: {
         roles: () => (config.viewersCanEdit ? [] : ['Editor', 'Admin']),
-        component: () => import(/* webpackChunkName: "explore" */ 'app/features/explore/Wrapper'),
+        component: () => SafeDynamicImport(import(/* webpackChunkName: "explore" */ 'app/features/explore/Wrapper')),
       },
     })
     .when('/a/:pluginId/', {
@@ -168,13 +186,15 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       template: '<react-container />',
       reloadOnSearch: false,
       resolve: {
-        component: () => import(/* webpackChunkName: "AppRootPage" */ 'app/features/plugins/AppRootPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "AppRootPage" */ 'app/features/plugins/AppRootPage')),
       },
     })
     .when('/org', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "OrgDetailsPage" */ '../features/org/OrgDetailsPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "OrgDetailsPage" */ '../features/org/OrgDetailsPage')),
       },
     })
     .when('/org/new', {
@@ -184,7 +204,8 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
     .when('/org/users', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "UsersListPage" */ 'app/features/users/UsersListPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "UsersListPage" */ 'app/features/users/UsersListPage')),
       },
     })
     .when('/org/users/invite', {
@@ -196,14 +217,15 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       template: '<react-container />',
       resolve: {
         roles: () => ['Editor', 'Admin'],
-        component: () => import(/* webpackChunkName: "ApiKeysPage" */ 'app/features/api-keys/ApiKeysPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "ApiKeysPage" */ 'app/features/api-keys/ApiKeysPage')),
       },
     })
     .when('/org/teams', {
       template: '<react-container />',
       resolve: {
         roles: () => (config.editorsCanAdmin ? [] : ['Editor', 'Admin']),
-        component: () => import(/* webpackChunkName: "TeamList" */ 'app/features/teams/TeamList'),
+        component: () => SafeDynamicImport(import(/* webpackChunkName: "TeamList" */ 'app/features/teams/TeamList')),
       },
     })
     .when('/org/teams/new', {
@@ -215,7 +237,7 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       template: '<react-container />',
       resolve: {
         roles: () => (config.editorsCanAdmin ? [] : ['Admin']),
-        component: () => import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages'),
+        component: () => SafeDynamicImport(import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages')),
       },
     })
     .when('/profile', {
@@ -226,7 +248,10 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
     .when('/profile/password', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webPackChunkName: "ChangePasswordPage" */ 'app/features/profile/ChangePasswordPage'),
+        component: () =>
+          SafeDynamicImport(
+            import(/* webPackChunkName: "ChangePasswordPage" */ 'app/features/profile/ChangePasswordPage')
+          ),
       },
     })
     .when('/profile/select-org', {
@@ -270,7 +295,8 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
     .when('/admin/stats', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "ServerStats" */ 'app/features/admin/ServerStats'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "ServerStats" */ 'app/features/admin/ServerStats')),
       },
     })
     // LOGIN / SIGNUP
@@ -309,14 +335,16 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
     .when('/plugins', {
       template: '<react-container />',
       resolve: {
-        component: () => import(/* webpackChunkName: "PluginListPage" */ 'app/features/plugins/PluginListPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "PluginListPage" */ 'app/features/plugins/PluginListPage')),
       },
     })
     .when('/plugins/:pluginId/', {
       template: '<react-container />',
       reloadOnSearch: false, // tabs from query parameters
       resolve: {
-        component: () => import(/* webpackChunkName: "PluginPage" */ '../features/plugins/PluginPage'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "PluginPage" */ '../features/plugins/PluginPage')),
       },
     })
     .when('/plugins/:pluginId/page/:slug', {
@@ -336,7 +364,8 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       template: '<react-container />',
       reloadOnSearch: false,
       resolve: {
-        component: () => import(/* webpackChunkName: "AlertRuleList" */ 'app/features/alerting/AlertRuleList'),
+        component: () =>
+          SafeDynamicImport(import(/* webpackChunkName: "AlertRuleList" */ 'app/features/alerting/AlertRuleList')),
       },
     })
     .when('/alerting/notifications', {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an initial proposal to encapsulate dynamic imports with a common framework to make it more user friendly when Grafana fails to load chunks.

**Which issue(s) this PR fixes**:
Closes: #18912

**Special notes for your reviewer**:
Known limitation: This doesn't handle the plugin loader as that already throws an error that is displayed for user. Could be more user-friendly though.

To test ERROR case:
1. Login
2. Goto Datasources for instance `http://localhost:3000/datasources`
3. Add a comment in `ApiKeysPage`for instance and wait for compile to finish
4. Navigate to `http://localhost:3000/org/apikeys`
5. The following message should appear
![image](https://user-images.githubusercontent.com/562238/64958882-4bcb0f80-d890-11e9-8a56-0c389e6e532e.png)
6. Refresh page
7. `ApiKeysPage` should appear

To test the OK case you need slow down the network
![image](https://user-images.githubusercontent.com/562238/64956491-01935f80-d88b-11e9-9806-915571c09b3a.png)

You should be able to see the Suspense component while navigating around the application
![image](https://user-images.githubusercontent.com/562238/64956534-1c65d400-d88b-11e9-9dc1-c4c275a8e79b.png)


