### PR TITLE
Explore: No logs should show an empty graph

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -79,22 +79,26 @@ export class Graph extends PureComponent<GraphProps> {
     const ticks = width / 100;
     const min = timeRange.from.valueOf();
     const max = timeRange.to.valueOf();
-    const yaxes = uniqBy(
-      series.map(s => {
-        const index = s.yAxis ? s.yAxis.index : 1;
-        const min = s.yAxis && !isNaN(s.yAxis.min as number) ? s.yAxis.min : null;
-        const tickDecimals = s.yAxis && !isNaN(s.yAxis.tickDecimals as number) ? s.yAxis.tickDecimals : null;
 
-        return {
-          show: true,
-          index,
-          position: index === 1 ? 'left' : 'right',
-          min,
-          tickDecimals,
-        };
-      }),
-      yAxisConfig => yAxisConfig.index
-    );
+    const noDataToBeDisplayed = series.length === 0;
+    const yaxes = noDataToBeDisplayed
+      ? [{ show: true, min: -1, max: 1 }]
+      : uniqBy(
+          series.map(s => {
+            const index = s.yAxis ? s.yAxis.index : 1;
+            const min = s.yAxis && !isNaN(s.yAxis.min as number) ? s.yAxis.min : null;
+            const tickDecimals = s.yAxis && !isNaN(s.yAxis.tickDecimals as number) ? s.yAxis.tickDecimals : null;
+
+            return {
+              show: true,
+              index,
+              position: index === 1 ? 'left' : 'right',
+              min,
+              tickDecimals,
+            };
+          }),
+          yAxisConfig => yAxisConfig.index
+        );
     const flotOptions: any = {
       legend: {
         show: false,
@@ -122,6 +126,7 @@ export class Graph extends PureComponent<GraphProps> {
         shadowSize: 0,
       },
       xaxis: {
+        show: true,
         mode: 'time',
         min: min,
         max: max,
@@ -151,16 +156,17 @@ export class Graph extends PureComponent<GraphProps> {
     try {
       $.plot(this.element, series, flotOptions);
     } catch (err) {
-      console.log('Graph rendering error', err, flotOptions, series);
       throw new Error('Error rendering panel');
     }
   }
 
   render() {
-    const { height } = this.props;
+    const { height, series } = this.props;
+    const noDataToBeDisplayed = series.length === 0;
     return (
       <div className="graph-panel">
         <div className="graph-panel__chart" ref={e => (this.element = e)} style={{ height }} />
+        {noDataToBeDisplayed && <div className="datapoints-warning flot-temp-elem">No data points</div>}
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -54,6 +54,27 @@ export class Graph extends PureComponent<GraphProps> {
     }
   };
 
+  getYAxes(series: GraphSeriesXY[]) {
+    if (series.length === 0) {
+      return [{ show: true, min: -1, max: 1 }];
+    }
+    uniqBy(
+      series.map(s => {
+        const index = s.yAxis ? s.yAxis.index : 1;
+        const min = s.yAxis && !isNaN(s.yAxis.min as number) ? s.yAxis.min : null;
+        const tickDecimals = s.yAxis && !isNaN(s.yAxis.tickDecimals as number) ? s.yAxis.tickDecimals : null;
+        return {
+          show: true,
+          index,
+          position: index === 1 ? 'left' : 'right',
+          min,
+          tickDecimals,
+        };
+      }),
+      yAxisConfig => yAxisConfig.index
+    );
+  }
+
   draw() {
     if (this.element === null) {
       return;
@@ -79,26 +100,8 @@ export class Graph extends PureComponent<GraphProps> {
     const ticks = width / 100;
     const min = timeRange.from.valueOf();
     const max = timeRange.to.valueOf();
+    const yaxes = this.getYAxes(series);
 
-    const noDataToBeDisplayed = series.length === 0;
-    const yaxes = noDataToBeDisplayed
-      ? [{ show: true, min: -1, max: 1 }]
-      : uniqBy(
-          series.map(s => {
-            const index = s.yAxis ? s.yAxis.index : 1;
-            const min = s.yAxis && !isNaN(s.yAxis.min as number) ? s.yAxis.min : null;
-            const tickDecimals = s.yAxis && !isNaN(s.yAxis.tickDecimals as number) ? s.yAxis.tickDecimals : null;
-
-            return {
-              show: true,
-              index,
-              position: index === 1 ? 'left' : 'right',
-              min,
-              tickDecimals,
-            };
-          }),
-          yAxisConfig => yAxisConfig.index
-        );
     const flotOptions: any = {
       legend: {
         show: false,
@@ -167,7 +170,7 @@ export class Graph extends PureComponent<GraphProps> {
     return (
       <div className="graph-panel">
         <div className="graph-panel__chart" ref={e => (this.element = e)} style={{ height }} />
-        {noDataToBeDisplayed && <div className="datapoints-warning flot-temp-elem">No data points</div>}
+        {noDataToBeDisplayed && <div className="datapoints-warning">No data points</div>}
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -156,6 +156,7 @@ export class Graph extends PureComponent<GraphProps> {
     try {
       $.plot(this.element, series, flotOptions);
     } catch (err) {
+      console.log('Graph rendering error', err, flotOptions, series);
       throw new Error('Error rendering panel');
     }
   }

--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -58,7 +58,7 @@ export class Graph extends PureComponent<GraphProps> {
     if (series.length === 0) {
       return [{ show: true, min: -1, max: 1 }];
     }
-    uniqBy(
+    return uniqBy(
       series.map(s => {
         const index = s.yAxis ? s.yAxis.index : 1;
         const min = s.yAxis && !isNaN(s.yAxis.min as number) ? s.yAxis.min : null;

--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -170,7 +170,7 @@ export class Graph extends PureComponent<GraphProps> {
     return (
       <div className="graph-panel">
         <div className="graph-panel__chart" ref={e => (this.element = e)} style={{ height }} />
-        {noDataToBeDisplayed && <div className="datapoints-warning">No data points</div>}
+        {noDataToBeDisplayed && <div className="datapoints-warning">No data</div>}
       </div>
     );
   }

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -286,6 +286,7 @@ class GraphElement {
   }
 
   drawHook(plot: any) {
+    console.log('this ctrl', this.ctrl);
     // add left axis labels
     if (this.panel.yaxes[0].label && this.panel.yaxes[0].show) {
       $("<div class='axisLabel left-yaxis-label flot-temp-elem'></div>")

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -286,7 +286,6 @@ class GraphElement {
   }
 
   drawHook(plot: any) {
-    console.log('this ctrl', this.ctrl);
     // add left axis labels
     if (this.panel.yaxes[0].label && this.panel.yaxes[0].show) {
       $("<div class='axisLabel left-yaxis-label flot-temp-elem'></div>")

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -225,14 +225,14 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     if (datapointsCount === 0) {
       this.dataWarning = {
-        title: 'No data points',
-        tip: 'No datapoints returned from data query',
+        title: 'No data',
+        tip: 'No data returned from query',
       };
     } else {
       for (const series of this.seriesList) {
         if (series.isOutsideRange) {
           this.dataWarning = {
-            title: 'Data points outside time range',
+            title: 'Data outside time range',
             tip: 'Can be caused by timezone mismatch or missing time filter in query',
           };
           break;

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -58,7 +58,7 @@ describe('GraphCtrl', () => {
     });
 
     it('should set datapointsOutside', () => {
-      expect(ctx.ctrl.dataWarning.title).toBe('Data points outside time range');
+      expect(ctx.ctrl.dataWarning.title).toBe('Data outside time range');
     });
   });
 
@@ -94,7 +94,7 @@ describe('GraphCtrl', () => {
     });
 
     it('should set datapointsCount warning', () => {
-      expect(ctx.ctrl.dataWarning.title).toBe('No data points');
+      expect(ctx.ctrl.dataWarning.title).toBe('No data');
     });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
In Explore, if there are no logs for selected time interval, the section where should be graph layout is empty. Graph layout is not displayed. This PR fixes this issue. So if there are no logs, you see an empty graph with *No data point* message.  
![image](https://user-images.githubusercontent.com/30407135/64959874-6ef6be80-d892-11e9-9814-10370ed37730.png)

**Which issue(s) this PR fixes**:
Fixes #19125
