### PR TITLE
Metrics: Adds setting for turning off total stats metrics

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -593,8 +593,10 @@ enabled = true
 #################################### Internal Grafana Metrics ############
 # Metrics available at HTTP API Url /metrics
 [metrics]
-enabled           = true
-interval_seconds  = 10
+enabled              = true
+interval_seconds     = 10
+# Disable total stats (stat_totals_*) metrics to be generated
+disable_total_stats = false
 
 #If both are set, basic auth will be required for the metrics endpoint.
 basic_auth_username =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -526,6 +526,8 @@
 [metrics]
 # Disable / Enable internal metrics
 ;enabled           = true
+# Disable total stats (stat_totals_*) metrics to be generated
+;disable_total_stats = false
 
 # Publish interval
 ;interval_seconds  = 10

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -548,6 +548,9 @@ If set configures the username to use for basic authentication on the metrics en
 ### basic_auth_password
 If set configures the password to use for basic authentication on the metrics endpoint.
 
+### disable_total_stats
+If set to `true`, then total stats generation (`stat_totals_*` metrics) is disabled. The default is `false`.
+
 ### interval_seconds
 
 Flush/Write interval when sending metrics to external TSDB. Defaults to 10s.

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -155,7 +155,7 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 }
 
 func (uss *UsageStatsService) updateTotalStats() {
-	if !uss.Cfg.MetricsEndpointEnabled {
+	if !uss.Cfg.MetricsEndpointEnabled || uss.Cfg.MetricsEndpointDisableTotalStats {
 		return
 	}
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -155,6 +155,10 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 }
 
 func (uss *UsageStatsService) updateTotalStats() {
+	if !uss.Cfg.MetricsEndpointEnabled {
+		return
+	}
+
 	statsQuery := models.GetSystemStatsQuery{}
 	if err := uss.Bus.Dispatch(&statsQuery); err != nil {
 		metricsLogger.Error("Failed to get system stats", "error", err)

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -271,6 +271,7 @@ func TestMetrics(t *testing.T) {
 			Cfg: setting.NewCfg(),
 		}
 		uss.Cfg.MetricsEndpointEnabled = true
+		uss.Cfg.MetricsEndpointDisableTotalStats = false
 		getSystemStatsWasCalled := false
 		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
 			query.Result = &models.SystemStats{}
@@ -278,14 +279,30 @@ func TestMetrics(t *testing.T) {
 			return nil
 		})
 
-		Convey("should not update stats when reporting is disabled", func() {
+		Convey("should not update stats when metrics is disabled and total stats is disabled", func() {
 			uss.Cfg.MetricsEndpointEnabled = false
+			uss.Cfg.MetricsEndpointDisableTotalStats = true
 			uss.updateTotalStats()
 			So(getSystemStatsWasCalled, ShouldBeFalse)
 		})
 
-		Convey("should update stats when reporting is enabled", func() {
+		Convey("should not update stats when metrics is disabled and total stats enabled", func() {
+			uss.Cfg.MetricsEndpointEnabled = false
+			uss.Cfg.MetricsEndpointDisableTotalStats = false
+			uss.updateTotalStats()
+			So(getSystemStatsWasCalled, ShouldBeFalse)
+		})
+
+		Convey("should not update stats when metrics is enabled and total stats disabled", func() {
 			uss.Cfg.MetricsEndpointEnabled = true
+			uss.Cfg.MetricsEndpointDisableTotalStats = true
+			uss.updateTotalStats()
+			So(getSystemStatsWasCalled, ShouldBeFalse)
+		})
+
+		Convey("should update stats when metrics is enabled and total stats enabled", func() {
+			uss.Cfg.MetricsEndpointEnabled = true
+			uss.Cfg.MetricsEndpointDisableTotalStats = false
 			uss.updateTotalStats()
 			So(getSystemStatsWasCalled, ShouldBeTrue)
 		})

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -264,6 +264,32 @@ func TestMetrics(t *testing.T) {
 			ts.Close()
 		})
 	})
+
+	Convey("Test update total stats", t, func() {
+		uss := &UsageStatsService{
+			Bus: bus.New(),
+			Cfg: setting.NewCfg(),
+		}
+		uss.Cfg.MetricsEndpointEnabled = true
+		getSystemStatsWasCalled := false
+		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
+			query.Result = &models.SystemStats{}
+			getSystemStatsWasCalled = true
+			return nil
+		})
+
+		Convey("should not update stats when reporting is disabled", func() {
+			uss.Cfg.MetricsEndpointEnabled = false
+			uss.updateTotalStats()
+			So(getSystemStatsWasCalled, ShouldBeFalse)
+		})
+
+		Convey("should update stats when reporting is enabled", func() {
+			uss.Cfg.MetricsEndpointEnabled = true
+			uss.updateTotalStats()
+			So(getSystemStatsWasCalled, ShouldBeTrue)
+		})
+	})
 }
 
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -243,6 +243,7 @@ type Cfg struct {
 	MetricsEndpointEnabled           bool
 	MetricsEndpointBasicAuthUsername string
 	MetricsEndpointBasicAuthPassword string
+	MetricsEndpointDisableTotalStats bool
 	PluginsEnableAlpha               bool
 	PluginsAppsSkipVerifyTLS         bool
 	DisableSanitizeHtml              bool
@@ -907,6 +908,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	if err != nil {
 		return err
 	}
+	cfg.MetricsEndpointDisableTotalStats = iniFile.Section("metrics").Key("disable_total_stats").MustBool(false)
 
 	analytics := iniFile.Section("analytics")
 	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)


### PR DESCRIPTION
**What this PR does / why we need it**:
Update of total stats (stat_totals_*) metrics shouldn't be made when metrics endpoint is disabled.
Generation of total stats metrics is made each minute and can add quite high load on a database so for those that still want metrics endpoint enabled, but without total stats metrics, we introduce a new setting `disable_total_stats` to configure that. 

**Which issue(s) this PR fixes**:
Ref #19137

**Special notes for your reviewer**:

