### PR TITLE
Add glossary

### DIFF
--- a/docs/sources/guides/glossary.md
+++ b/docs/sources/guides/glossary.md
@@ -14,89 +14,30 @@ weight = 4
 
 This topic lists words and abbreviations that commonly used in the Grafana documentation and community.
 
-<dl>
-<dt>Admin</dt>
-<dd>Special user with global rights.</dd>
+**Dashboard**
 
-<dt>alias</dt>
-<dd> </dd>
+A set of one or more panels organized and arranged into one or more rows.
 
-<dt>app</dt>
-<dd> </dd>
+**Data source**
 
-<dt>data source</dt> 
-<dd> </dd>
+A file, database, or service providing data.
 
-<dt>Elasticsearch</dt> 
-<dd>Marcus - if we define one other partner/vendor/whatever, we need to define all or most</dd>
+**Graph**
 
-<dt>embedded</dt> 
-<dd> </dd>
+Most commonly-used visualization.
 
-<dt>folder</dt> 
-<dd> </dd>
+**Panel**
 
-<dt>Go</dt> 
-<dd>A programming language. See (http://golang.org/).</dd>
+Basic building block in Grafana, composed of a query and a visualization.
 
-<dt>Grafana</dt> 
-<dd> </dd>
+**Query**
 
-<dt>Grafana CLI</dt> 
-<dd> </dd>
+Used to request data from a data source.
 
-<dt>grafana-server</dt> 
-<dd> </dd>
+**Time series**
 
-<dt>Grafana server</dt> 
-<dd> </dd>
+A series of measurements, ordered by time.
 
-<dt>graph</dt> 
-<dd> </dd>
+**Visualization**
 
-<dt>Loki</dt> 
-<dd> </dd>
-
-<dt>Loki context queries</dt> 
-<dd> </dd>
-
-<dt>Loki live streaming</dt> 
-<dd> </dd>
-
-<dt>org</dt> 
-<dd> </dd>
-
-<dt>panel</dt> 
-<dd>A panel consists of a set of queries along with a visualization.</dd>
-
-<dt>plugin</dt> 
-<dd> </dd>
-
-<dt>Prometheus</dt> 
-<dd> </dd>
-
-Pretty much everything on the menu
-- Marcus, can you narrow this down?
-
-<dt>query</dt> 
-<dd> </dd>
-
-<dt>session</dt> 
-<dd> </dd>
-
-<dt>target</dt> 
-<dd> </dd>
-
-<dt>time series</dt> 
-<dd>(including general concept vs. what’s in the JSON returned in a query, which has multiple series)</dd>
-
-<dt>user</dt> 
-<dd> </dd>
-
-<dt>variable</dt> 
-<dd> </dd>
-
-<dt>visualization</dt> 
-<dd> </dd>
-
-</dl>
+A graphical representation of the result from a query.

--- a/docs/sources/guides/glossary.md
+++ b/docs/sources/guides/glossary.md
@@ -1,0 +1,102 @@
++++
+title = "Glossary"
+description = "Grafana glossary"
+keywords = ["grafana", "intro", "glossary", "dictionary"]
+type = "docs"
+[menu.docs]
+name = "Glossary"
+identifier = "glossary"
+parent = "guides"
+weight = 4
++++
+
+# Glossary
+
+This topic lists words and abbreviations that commonly used in the Grafana documentation and community.
+
+<dl>
+<dt>Admin</dt>
+<dd>Special user with global rights.</dd>
+
+<dt>alias</dt>
+<dd> </dd>
+
+<dt>app</dt>
+<dd> </dd>
+
+<dt>data source</dt> 
+<dd> </dd>
+
+<dt>Elasticsearch</dt> 
+<dd>Marcus - if we define one other partner/vendor/whatever, we need to define all or most</dd>
+
+<dt>embedded</dt> 
+<dd> </dd>
+
+<dt>folder</dt> 
+<dd> </dd>
+
+<dt>Go</dt> 
+<dd>A programming language. See (http://golang.org/).</dd>
+
+<dt>Grafana</dt> 
+<dd> </dd>
+
+<dt>Grafana CLI</dt> 
+<dd> </dd>
+
+<dt>grafana-server</dt> 
+<dd> </dd>
+
+<dt>Grafana server</dt> 
+<dd> </dd>
+
+<dt>graph</dt> 
+<dd> </dd>
+
+<dt>Loki</dt> 
+<dd> </dd>
+
+<dt>Loki context queries</dt> 
+<dd> </dd>
+
+<dt>Loki live streaming</dt> 
+<dd> </dd>
+
+<dt>org</dt> 
+<dd> </dd>
+
+<dt>panel</dt> 
+<dd> </dd>
+
+<dt>plugin</dt> 
+<dd> </dd>
+
+<dt>Prometheus</dt> 
+<dd> </dd>
+
+Pretty much everything on the menu
+- Marcus, can you narrow this down?
+
+<dt>query</dt> 
+<dd> </dd>
+
+<dt>session</dt> 
+<dd> </dd>
+
+<dt>target</dt> 
+<dd> </dd>
+
+<dt>time series</dt> 
+<dd>(including general concept vs. what’s in the JSON returned in a query, which has multiple series)</dd>
+
+<dt>user</dt> 
+<dd> </dd>
+
+<dt>variable</dt> 
+<dd> </dd>
+
+<dt>visualization</dt> 
+<dd> </dd>
+
+</dl>

--- a/docs/sources/guides/glossary.md
+++ b/docs/sources/guides/glossary.md
@@ -67,7 +67,7 @@ This topic lists words and abbreviations that commonly used in the Grafana docum
 <dd> </dd>
 
 <dt>panel</dt> 
-<dd> </dd>
+<dd>A panel consists of a set of queries along with a visualization.</dd>
 
 <dt>plugin</dt> 
 <dd> </dd>

--- a/docs/sources/guides/glossary.md
+++ b/docs/sources/guides/glossary.md
@@ -53,4 +53,4 @@ This topic lists words and abbreviations that commonly used in the Grafana docum
     <td style = "vertical-align: top;">Visualization</td>
     <td>A graphical representation of query results.</td>
   </tr>
-</table
+</table>

--- a/docs/sources/guides/glossary.md
+++ b/docs/sources/guides/glossary.md
@@ -14,30 +14,43 @@ weight = 4
 
 This topic lists words and abbreviations that commonly used in the Grafana documentation and community.
 
-**Dashboard**
-
-A set of one or more panels organized and arranged into one or more rows.
-
-**Data source**
-
-A file, database, or service providing data.
-
-**Graph**
-
-Most commonly-used visualization.
-
-**Panel**
-
-Basic building block in Grafana, composed of a query and a visualization.
-
-**Query**
-
-Used to request data from a data source.
-
-**Time series**
-
-A series of measurements, ordered by time.
-
-**Visualization**
-
-A graphical representation of the result from a query.
+<table>
+  <tr>
+    <td style = "vertical-align: top;">Dashboard</td>
+    <td>A set of one or more panels, organized and arranged into one or more rows, that provide an at-a-glance view of related information.</td>
+  </tr>
+  <tr>
+    <td style = "vertical-align: top;">Data source</td>
+    <td>A file, database, or service providing the data. Grafana supports a several data sources by default, and can be extended to support additional ones through plugins.</td>
+  </tr>
+    <tr>
+    <td style = "vertical-align: top;">Graph</td>
+    <td>A commonly-used visualization that displays data as points, lines, or bars.</td>
+  </tr>
+    <tr>
+    <td style = "vertical-align: top;">Panel</td>
+    <td>Basic building block in Grafana, composed by a query and a visualization. Can be moved and resized within a dashboard.</td>
+  </tr>
+  <tr>
+    <td style = "vertical-align: top;">Plugin</td>
+    <td>An extension of Grafana that allows users to provide additional functionality to enhance their experience. The types of plugins currently supported are:
+    <ul>
+      <li><b>App plugin:</b> Extends Grafana with a customized experience. It includes a set of panel and data source plugins, as well as custom pages.</li>
+      <li><b>Data source plugin:</b> Extends Grafana with supports additional data sources in Grafana.</li>
+      <li><b>Panel plugin:</b> Extends Grafana with additional visualization options.</li>
+    </ul>
+    </td>
+  </tr>
+    <tr>
+    <td style = "vertical-align: top;">Query</td>
+    <td>Used to request data from a data source. The structure and format of the query depend on the specific data source.</td>
+  </tr>
+    <tr>
+    <td style = "vertical-align: top;">Time series</td>
+    <td>A series of measurements, ordered by time. Time series are stored in data sources and returned as the result of a query.</td>
+  </tr>
+  <tr>
+    <td style = "vertical-align: top;">Visualization</td>
+    <td>A graphical representation of query results.</td>
+  </tr>
+</table


### PR DESCRIPTION
Working with @marcusolsson  to add a Glossary to the Grafana documentation.

Fixes #19133 

**Special notes for your reviewer**: I think some of the suggested terms are pretty basic and could be removed, but I left them in case Grafana uses the terms in ways I am not familiar with. Folder, user, app, and org all seem pretty basic.

