### PR TITLE
TimePicker: Fixes hiding time picker dropdown in FireFox

### DIFF
--- a/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Select/ButtonSelect.tsx
@@ -13,11 +13,12 @@ const ButtonComponent = (buttonProps: ButtonComponentProps) => (props: any) => {
   const { label, className, iconClass } = buttonProps;
 
   return (
-    <button
+    <div // changed to div because of FireFox on MacOs issue below
       ref={props.innerRef}
       className={`btn navbar-button navbar-button--tight ${className}`}
       onClick={props.selectProps.menuIsOpen ? props.selectProps.onMenuClose : props.selectProps.onMenuOpen}
       onBlur={props.selectProps.onMenuClose}
+      tabIndex={0} // necessary to get onBlur to work https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
     >
       <div className="select-button">
         {iconClass && <i className={`select-button-icon ${iconClass}`} />}
@@ -25,7 +26,7 @@ const ButtonComponent = (buttonProps: ButtonComponentProps) => (props: any) => {
         {!props.menuIsOpen && <i className="fa fa-caret-down fa-fw" />}
         {props.menuIsOpen && <i className="fa fa-caret-up fa-fw" />}
       </div>
-    </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes: #18531

**Special notes for your reviewer**:
You need to try this PR out in FireFox on MacOS 
