### PR TITLE
Dashboard: Fixes overlapping back button in kiosk mode

### DIFF
--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -193,6 +193,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 
 // sidemenu
 $side-menu-width: 60px;
+$navbar-padding: 20px;
 
 // dashboard
 $dashboard-padding: $space-md;

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -196,6 +196,7 @@ $btn-semi-transparent: rgba(0, 0, 0, 0.2) !default;
 
 // sidemenu
 $side-menu-width: 60px;
+$navbar-padding: 20px;
 
 // dashboard
 $dashboard-padding: $space-md;

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -46,7 +46,7 @@
 
 .panel-in-fullscreen {
   .navbar {
-    padding-left: 20px;
+    padding-left: $navbar-padding;
   }
 
   .navbar-button--add-panel,

--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -14,6 +14,10 @@
     i {
       opacity: 0;
     }
+
+    i.navbar-page-btn__folder-icon {
+      opacity: inherit;
+    }
   }
 
   .navbar-button--zoom {
@@ -23,6 +27,17 @@
 
 .view-mode--playlist {
   @extend .view-mode--inactive;
+}
+
+// https://github.com/grafana/grafana/issues/18114
+.view-mode--tv.panel-in-fullscreen {
+  .navbar {
+    padding-left: $navbar-padding;
+  }
+
+  .navbar-page-btn {
+    transform: none;
+  }
 }
 
 .view-mode--tv {


### PR DESCRIPTION
**What this PR does / why we need it**:
**Before**

Dashboard view
![image](https://user-images.githubusercontent.com/562238/65036079-e425ca80-d94a-11e9-8deb-b6ee7c59eddc.png)

Fullview Panel
![image](https://user-images.githubusercontent.com/562238/65036215-3666eb80-d94b-11e9-9939-2f0c51ba7a35.png)

**After**

Dashboard view
![image](https://user-images.githubusercontent.com/562238/65036088-f0118c80-d94a-11e9-8f51-4e59cd7017e4.png)

Fullview Panel
![image](https://user-images.githubusercontent.com/562238/65036230-41218080-d94b-11e9-861a-b7845e3e63be.png)

**Which issue(s) this PR fixes**:
Fixes: #18114

**Special notes for your reviewer**:
Made the `caret` visible to make views more consistent UX-wise but we'll probably redesign parts of this moving forward so didn't do to much refactoring

