### PR TITLE
Docker: Upgrade packages to resolve reported vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash
+RUN apk add --no-cache ca-certificates bash \
+  && apk add --upgrade --no-cache openssl  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY conf ./conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash \
-  && apk add --upgrade --no-cache openssl  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache ca-certificates bash && \
+    apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
 
 COPY conf ./conf
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -23,8 +23,8 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash \
-  && apk add --upgrade --no-cache openssl  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache ca-certificates bash && \
+    apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
 
 # PhantomJS
 RUN if [ `arch` = "x86_64" ]; then \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -23,7 +23,8 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash
+RUN apk add --no-cache ca-certificates bash \
+  && apk add --upgrade --no-cache openssl  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 # PhantomJS
 RUN if [ `arch` = "x86_64" ]; then \


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates openssl to version 1.1.1d-r1. This scans cleanly using trivy. 

**Which issue(s) this PR fixes**:
Fixes #19186

**Special notes for your reviewer**:
Can't get PhantomJS to work when building container locally using `build-docker-full` so need someone to try this out as well. Think my computer needs a reboot.