### PR TITLE
grafana/ui: Add disabled prop to LinkButton

### DIFF
--- a/packages/grafana-ui/src/components/Button/AbstractButton.tsx
+++ b/packages/grafana-ui/src/components/Button/AbstractButton.tsx
@@ -19,7 +19,9 @@ export interface CommonButtonProps {
   className?: string;
 }
 
-export interface LinkButtonProps extends CommonButtonProps, AnchorHTMLAttributes<HTMLAnchorElement> {}
+export interface LinkButtonProps extends CommonButtonProps, AnchorHTMLAttributes<HTMLAnchorElement> {
+  disabled?: boolean;
+}
 export interface ButtonProps extends CommonButtonProps, ButtonHTMLAttributes<HTMLButtonElement> {}
 
 interface AbstractButtonProps extends CommonButtonProps, Themeable {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a disabled prop to LinkButtonProps, so you can implement LinkButton with disabled={true} without getting a ts error.

**Which issue(s) this PR fixes**:
 #19179

Fixes #19179
