### PR TITLE
MSSQL: Revert usage of new connectionstring format introduced by #18384

### DIFF
--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -3,7 +3,6 @@ package mssql
 import (
 	"database/sql"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -24,7 +23,10 @@ func init() {
 func newMssqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.mssql")
 
-	cnnstr := generateConnectionString(datasource)
+	cnnstr, err := generateConnectionString(datasource)
+	if err != nil {
+		return nil, err
+	}
 	if setting.Env == setting.DEV {
 		logger.Debug("getEngine", "connection", cnnstr)
 	}
@@ -43,21 +45,21 @@ func newMssqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 	return sqleng.NewSqlQueryEndpoint(&config, &rowTransformer, newMssqlMacroEngine(), logger)
 }
 
-func generateConnectionString(datasource *models.DataSource) string {
+func generateConnectionString(datasource *models.DataSource) (string, error) {
 	server, port := util.SplitHostPortDefault(datasource.Url, "localhost", "1433")
+
 	encrypt := datasource.JsonData.Get("encrypt").MustString("false")
-
-	query := url.Values{}
-	query.Add("database", datasource.Database)
-	query.Add("encrypt", encrypt)
-
-	u := &url.URL{
-		Scheme:   "sqlserver",
-		User:     url.UserPassword(datasource.User, datasource.DecryptedPassword()),
-		Host:     fmt.Sprintf("%s:%s", server, port),
-		RawQuery: query.Encode(),
+	connStr := fmt.Sprintf("server=%s;port=%s;database=%s;user id=%s;password=%s;",
+		server,
+		port,
+		datasource.Database,
+		datasource.User,
+		datasource.DecryptedPassword(),
+	)
+	if encrypt != "false" {
+		connStr += fmt.Sprintf("encrypt=%s;", encrypt)
 	}
-	return u.String()
+	return connStr, nil
 }
 
 type mssqlRowTransformer struct {

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -28,33 +28,6 @@ import (
 // If needed, change the variable below to the IP address of the database.
 var serverIP = "localhost"
 
-func TestGenerateConnectionString(t *testing.T) {
-	encrypted, _ := simplejson.NewJson([]byte(`{"encrypt":"false"}`))
-	testSet := []struct {
-		ds       *models.DataSource
-		expected string
-	}{
-		{
-			&models.DataSource{
-				User:     "user",
-				Database: "db",
-				Url:      "localhost:1433",
-				SecureJsonData: securejsondata.GetEncryptedJsonData(map[string]string{
-					"password": "pass;word",
-				}),
-				JsonData: encrypted,
-			},
-			"sqlserver://user:pass;word@localhost:1433?database=db&encrypt=false",
-		},
-	}
-	for i := range testSet {
-		got := generateConnectionString(testSet[i].ds)
-		if got != testSet[i].expected {
-			t.Errorf("mssql connString error for testCase %d got: %s expected: %s", i, got, testSet[i].expected)
-		}
-	}
-}
-
 func TestMSSQL(t *testing.T) {
 	SkipConvey("MSSQL", t, func() {
 		x := InitMSSQLTestDB(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 25142090838265494c2868708326bed932cd03ed from #18384. Reason is that it doesn't work due to xorm 0.7.1 doesn't support this new connectionstring format. 

Tried to upgrade xorm to 0.7.2 but it was [a lot of changes](https://github.com/go-xorm/xorm/compare/v0.7.1...v0.7.2?expand=1) and to risky to include in v6.4 stable so we'll have to wait with this for v6.5. Plus, I still couldn't get MSSQL to connect in Grafana due to TLS handshake error.

**Which issue(s) this PR fixes**:
Fixes #19189
Ref #18384
Ref #17665

**Special notes for your reviewer**:

