### PR TITLE
LDAP: Show non-matched groups returned from LDAP

### DIFF
--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -90,6 +90,10 @@ func (user *LDAPUserDTO) FetchOrgs() error {
 	}
 
 	for i, orgDTO := range user.OrgRoles {
+		if orgDTO.OrgId < 1 {
+			continue
+		}
+
 		orgName := orgNamesById[orgDTO.OrgId]
 
 		if orgName != "" {

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -260,6 +260,7 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 	user, serverConfig, err := ldap.User(username)
 
 	if user == nil {
+		logger.Error(err.Error())
 		return Error(http.StatusNotFound, "No user was found in the LDAP server(s) with that username", nil)
 	}
 
@@ -325,12 +326,6 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 	u.Teams = cmd.Result
 
 	return JSON(200, u)
-}
-
-// isMatchToLDAPGroup determines if we were able to match an LDAP group to an organization+role.
-// Since we allow one role per organization. If it's set, we were able to match it.
-func isMatchToLDAPGroup(user *models.ExternalUserInfo, groupConfig *ldap.GroupToOrgRole) bool {
-	return user.OrgRoles[groupConfig.OrgId] == groupConfig.OrgRole
 }
 
 // splitName receives the full name of a user and splits it into two parts: A name and a surname.

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -260,8 +260,7 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 	user, serverConfig, err := ldap.User(username)
 
 	if user == nil {
-		logger.Error(err.Error())
-		return Error(http.StatusNotFound, "No user was found in the LDAP server(s) with that username", nil)
+		return Error(http.StatusNotFound, "No user was found in the LDAP server(s) with that username", err)
 	}
 
 	logger.Debug("user found", "user", user)

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -94,7 +94,7 @@ func TestGetUserFromLDAPApiEndpoint_UserNotFound(t *testing.T) {
 	sc := getUserFromLDAPContext(t, "/api/admin/ldap/user-that-does-not-exist")
 
 	require.Equal(t, sc.resp.Code, http.StatusNotFound)
-	assert.JSONEq(t, "{\"message\":\"No user was found on the LDAP server(s)\"}", sc.resp.Body.String())
+	assert.JSONEq(t, "{\"message\":\"No user was found in the LDAP server(s) with that username\"}", sc.resp.Body.String())
 }
 
 func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
@@ -103,6 +103,7 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 		Name:           "John Doe",
 		Email:          "john.doe@example.com",
 		Login:          "johndoe",
+		Groups:         []string{"cn=admins,ou=groups,dc=grafana,dc=org"},
 		OrgRoles:       map[int64]models.RoleType{1: models.ROLE_ADMIN, 2: models.ROLE_VIEWER},
 		IsGrafanaAdmin: &isAdmin,
 	}
@@ -117,12 +118,12 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 		Groups: []*ldap.GroupToOrgRole{
 			{
 				GroupDN: "cn=admins,ou=groups,dc=grafana,dc=org",
-				OrgID:   1,
+				OrgId:   1,
 				OrgRole: models.ROLE_ADMIN,
 			},
 			{
 				GroupDN: "cn=admins,ou=groups,dc=grafana2,dc=org",
-				OrgID:   2,
+				OrgId:   2,
 				OrgRole: models.ROLE_VIEWER,
 			},
 		},
@@ -178,7 +179,7 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 		Groups: []*ldap.GroupToOrgRole{
 			{
 				GroupDN: "cn=admins,ou=groups,dc=grafana,dc=org",
-				OrgID:   1,
+				OrgId:   1,
 				OrgRole: models.ROLE_ADMIN,
 			},
 		},
@@ -251,7 +252,7 @@ func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
 		Groups: []*ldap.GroupToOrgRole{
 			{
 				GroupDN: "cn=admins,ou=groups,dc=grafana,dc=org",
-				OrgID:   1,
+				OrgId:   1,
 				OrgRole: models.ROLE_ADMIN,
 			},
 		},

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -165,6 +165,7 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 		Name:           "John Doe",
 		Email:          "john.doe@example.com",
 		Login:          "johndoe",
+		Groups:         []string{"cn=admins,ou=groups,dc=grafana,dc=org", "another-group-not-matched"},
 		OrgRoles:       map[int64]models.RoleType{1: models.ROLE_ADMIN},
 		IsGrafanaAdmin: &isAdmin,
 	}
@@ -204,7 +205,7 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 
 	sc := getUserFromLDAPContext(t, "/api/admin/ldap/johndoe")
 
-	require.Equal(t, sc.resp.Code, http.StatusOK)
+	assert.Equal(t, sc.resp.Code, http.StatusOK)
 
 	expected := `
 		{
@@ -223,7 +224,8 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 			"isGrafanaAdmin": true,
 			"isDisabled": false,
 			"roles": [
-				{ "orgId": 1, "orgRole": "Admin", "orgName": "Main Org.", "groupDN": "cn=admins,ou=groups,dc=grafana,dc=org" }
+				{ "orgId": 1, "orgRole": "Admin", "orgName": "Main Org.", "groupDN": "cn=admins,ou=groups,dc=grafana,dc=org" },
+				{ "orgId": 0, "orgRole": "", "orgName": "", "groupDN": "another-group-not-matched" }
 			],
 			"teams": null
 		}

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -408,12 +408,12 @@ func (server *Server) buildGrafanaUser(user *ldap.Entry) (*models.ExternalUserIn
 
 	for _, group := range server.Config.Groups {
 		// only use the first match for each org
-		if extUser.OrgRoles[group.OrgID] != "" {
+		if extUser.OrgRoles[group.OrgId] != "" {
 			continue
 		}
 
 		if isMemberOf(memberOf, group.GroupDN) {
-			extUser.OrgRoles[group.OrgID] = group.OrgRole
+			extUser.OrgRoles[group.OrgId] = group.OrgRole
 			if extUser.IsGrafanaAdmin == nil || !*extUser.IsGrafanaAdmin {
 				extUser.IsGrafanaAdmin = group.IsGrafanaAdmin
 			}

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -3,11 +3,10 @@ package ldap
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ldap.v3"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/ldap.v3"
 )
 
 func TestLDAPPrivateMethods(t *testing.T) {
@@ -124,7 +123,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 				Config: &ServerConfig{
 					Groups: []*GroupToOrgRole{
 						{
-							OrgID: 1,
+							OrgId: 1,
 						},
 					},
 				},
@@ -162,7 +161,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 				Config: &ServerConfig{
 					Groups: []*GroupToOrgRole{
 						{
-							OrgID: 1,
+							OrgId: 1,
 						},
 					},
 				},

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -55,7 +55,7 @@ type AttributeMap struct {
 // config "group_mappings" setting
 type GroupToOrgRole struct {
 	GroupDN string `toml:"group_dn"`
-	OrgID   int64  `toml:"org_id"`
+	OrgId   int64  `toml:"org_id"`
 
 	// This pointer specifies if setting was set (for backwards compatibility)
 	IsGrafanaAdmin *bool `toml:"grafana_admin"`
@@ -139,8 +139,8 @@ func readConfig(configFile string) (*Config, error) {
 		}
 
 		for _, groupMap := range server.Groups {
-			if groupMap.OrgID == 0 {
-				groupMap.OrgID = 1
+			if groupMap.OrgId == 0 {
+				groupMap.OrgId = 1
 			}
 		}
 	}

--- a/public/app/features/admin/ldap/LdapPage.tsx
+++ b/public/app/features/admin/ldap/LdapPage.tsx
@@ -89,12 +89,12 @@ export class LdapPage extends PureComponent<Props, State> {
 
             {config.buildInfo.isEnterprise && ldapSyncInfo && <LdapSyncInfo ldapSyncInfo={ldapSyncInfo} />}
 
-            <h3 className="page-heading">User mapping</h3>
+            <h3 className="page-heading">Test user mapping</h3>
             <div className="gf-form-group">
               <form onSubmit={this.search} className="gf-form-inline">
                 <FormField label="Username" labelWidth={8} inputWidth={30} type="text" id="username" name="username" />
                 <button type="submit" className="btn btn-primary">
-                  Test LDAP mapping
+                  Run
                 </button>
               </form>
             </div>

--- a/public/app/features/admin/ldap/LdapPage.tsx
+++ b/public/app/features/admin/ldap/LdapPage.tsx
@@ -92,7 +92,7 @@ export class LdapPage extends PureComponent<Props, State> {
             <h3 className="page-heading">User mapping</h3>
             <div className="gf-form-group">
               <form onSubmit={this.search} className="gf-form-inline">
-                <FormField label="User name" labelWidth={8} inputWidth={30} type="text" id="username" name="username" />
+                <FormField label="Username" labelWidth={8} inputWidth={30} type="text" id="username" name="username" />
                 <button type="submit" className="btn btn-primary">
                   Test LDAP mapping
                 </button>

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -9,7 +9,6 @@ interface Props {
 
 export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
   const items = showAttributeMapping ? groups : groups.filter(item => item.orgRole);
-  const roleColumnClass = showAttributeMapping && 'width-14';
 
   return (
     <div className="gf-form-group">
@@ -17,32 +16,39 @@ export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
         <table className="filter-table form-inline">
           <thead>
             <tr>
+              {showAttributeMapping && <th>LDAP Group</th>}
               <th>Organisation</th>
               <th>Role</th>
-              {showAttributeMapping && <th colSpan={2}>LDAP Group</th>}
             </tr>
           </thead>
           <tbody>
             {items.map((group, index) => {
               return (
                 <tr key={`${group.orgId}-${index}`}>
-                  <td className="width-16">{group.orgName}</td>
-                  <td className={roleColumnClass}>{group.orgRole}</td>
                   {showAttributeMapping && (
                     <>
                       <td>{group.groupDN}</td>
-                      <td>
-                        {!group.orgRole && (
-                          <span className="text-warning pull-right">
-                            No match
-                            <Tooltip placement="top" content="No matching groups found" theme={'info'}>
-                              <div className="gf-form-help-icon gf-form-help-icon--right-normal">
-                                <i className="fa fa-info-circle" />
-                              </div>
-                            </Tooltip>
-                          </span>
-                        )}
-                      </td>
+                      {!group.orgRole && (
+                        <>
+                          <td />
+                          <td>
+                            <span className="text-warning">
+                              No match
+                              <Tooltip placement="top" content="No matching groups found" theme={'info'}>
+                                <span className="gf-form-help-icon">
+                                  <i className="fa fa-info-circle" />
+                                </span>
+                              </Tooltip>
+                            </span>
+                          </td>
+                        </>
+                      )}
+                    </>
+                  )}
+                  {group.orgName && (
+                    <>
+                      <td>{group.orgName}</td>
+                      <td>{group.orgRole}</td>
                     </>
                   )}
                 </tr>

--- a/public/app/features/admin/ldap/LdapUserInfo.tsx
+++ b/public/app/features/admin/ldap/LdapUserInfo.tsx
@@ -18,8 +18,21 @@ export const LdapUserInfo: FC<Props> = ({ ldapUser, showAttributeMapping }) => {
       {ldapUser.roles && ldapUser.roles.length > 0 && (
         <LdapUserGroups groups={ldapUser.roles} showAttributeMapping={showAttributeMapping} />
       )}
-      {ldapUser.teams && ldapUser.teams.length > 0 && (
+
+      {ldapUser.teams && ldapUser.teams.length > 0 ? (
         <LdapUserTeams teams={ldapUser.teams} showAttributeMapping={showAttributeMapping} />
+      ) : (
+        <div className="gf-form-group">
+          <div className="gf-form">
+            <table className="filter-table form-inline">
+              <tbody>
+                <tr>
+                  <td>No teams found via LDAP</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       )}
     </>
   );

--- a/public/app/features/admin/ldap/LdapUserMappingInfo.tsx
+++ b/public/app/features/admin/ldap/LdapUserMappingInfo.tsx
@@ -9,6 +9,7 @@ interface Props {
 export const LdapUserMappingInfo: FC<Props> = ({ info, showAttributeMapping }) => {
   return (
     <div className="gf-form-group">
+      <h2>Mapping Result</h2>
       <div className="gf-form">
         <table className="filter-table form-inline">
           <thead>

--- a/public/app/features/admin/ldap/LdapUserMappingInfo.tsx
+++ b/public/app/features/admin/ldap/LdapUserMappingInfo.tsx
@@ -9,7 +9,6 @@ interface Props {
 export const LdapUserMappingInfo: FC<Props> = ({ info, showAttributeMapping }) => {
   return (
     <div className="gf-form-group">
-      <h2>Mapping Result</h2>
       <div className="gf-form">
         <table className="filter-table form-inline">
           <thead>

--- a/public/app/features/admin/ldap/LdapUserTeams.tsx
+++ b/public/app/features/admin/ldap/LdapUserTeams.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-import { css } from 'emotion';
 import { Tooltip } from '@grafana/ui';
 import { LdapTeam } from 'app/types';
 
@@ -10,10 +9,6 @@ interface Props {
 
 export const LdapUserTeams: FC<Props> = ({ teams, showAttributeMapping }) => {
   const items = showAttributeMapping ? teams : teams.filter(item => item.teamName);
-  const teamColumnClass = showAttributeMapping && 'width-14';
-  const noMatchPlaceholderStyle = css`
-    display: flex;
-  `;
 
   return (
     <div className="gf-form-group">
@@ -21,29 +16,41 @@ export const LdapUserTeams: FC<Props> = ({ teams, showAttributeMapping }) => {
         <table className="filter-table form-inline">
           <thead>
             <tr>
+              {showAttributeMapping && <th>LDAP Group</th>}
               <th>Organisation</th>
               <th>Team</th>
-              {showAttributeMapping && <th>LDAP</th>}
             </tr>
           </thead>
           <tbody>
             {items.map((team, index) => {
               return (
                 <tr key={`${team.teamName}-${index}`}>
-                  <td className="width-16">
-                    {team.orgName || (
-                      <div className={`text-warning ${noMatchPlaceholderStyle}`}>
-                        No match
-                        <Tooltip placement="top" content="No matching teams found" theme={'info'}>
-                          <div className="gf-form-help-icon gf-form-help-icon--right-normal">
-                            <i className="fa fa-info-circle" />
-                          </div>
-                        </Tooltip>
-                      </div>
-                    )}
-                  </td>
-                  <td className={teamColumnClass}>{team.teamName}</td>
-                  {showAttributeMapping && <td>{team.groupDN}</td>}
+                  {showAttributeMapping && (
+                    <>
+                      <td>{team.groupDN}</td>
+                      {!team.orgName && (
+                        <>
+                          <td />
+                          <td>
+                            <div className="text-warning">
+                              No match
+                              <Tooltip placement="top" content="No matching teams found" theme={'info'}>
+                                <span className="gf-form-help-icon">
+                                  <i className="fa fa-info-circle" />
+                                </span>
+                              </Tooltip>
+                            </div>
+                          </td>
+                        </>
+                      )}
+                    </>
+                  )}
+                  {team.orgName && (
+                    <>
+                      <td>{team.orgName}</td>
+                      <td>{team.teamName}</td>
+                    </>
+                  )}
                 </tr>
               );
             })}

--- a/public/sass/layout/_page.scss
+++ b/public/sass/layout/_page.scss
@@ -99,7 +99,7 @@
 .page-heading {
   font-size: $font-size-h4;
   margin-top: 0;
-  margin-bottom: $spacer * 0.7;
+  margin-bottom: $spacer;
 }
 
 .page-action-bar {


### PR DESCRIPTION
This fixes the returned matched or unmatched LDAP group(s) to use what we returned from LDAP as the single source of truth.

This allows us to prioritise showing what we got from LDAP to the user at all times.