### PR TITLE
MySQL, Postgres: Update raw sql when query builder updates

### DIFF
--- a/public/app/plugins/datasource/mysql/query_ctrl.ts
+++ b/public/app/plugins/datasource/mysql/query_ctrl.ts
@@ -82,7 +82,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
             this.target.timeColumnType = 'timestamp';
             this.target.select = [[{ type: 'column', params: [result[2].text] }]];
             this.updateProjection();
-            this.panelCtrl.refresh();
+            this.updateRawSqlAndRefresh();
           }
         });
       }
@@ -103,6 +103,14 @@ export class MysqlQueryCtrl extends QueryCtrl {
 
     this.panelCtrl.events.on('data-received', this.onDataReceived.bind(this), $scope);
     this.panelCtrl.events.on('data-error', this.onDataError.bind(this), $scope);
+  }
+
+  updateRawSqlAndRefresh() {
+    if (!this.target.rawQuery) {
+      this.target.rawSql = this.queryModel.buildQuery();
+    }
+
+    this.panelCtrl.refresh();
   }
 
   updateProjection() {
@@ -205,7 +213,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
     });
 
     this.$q.all([task1, task2]).then(() => {
-      this.panelCtrl.refresh();
+      this.updateRawSqlAndRefresh();
     });
   }
 
@@ -242,7 +250,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
 
         this.updatePersistedParts();
         if (refresh !== false) {
-          this.panelCtrl.refresh();
+          this.updateRawSqlAndRefresh();
         }
       });
   }
@@ -256,7 +264,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
 
   metricColumnChanged() {
     this.target.metricColumn = this.metricColumnSegment.value;
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   onDataReceived(dataList: any) {
@@ -391,7 +399,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
     }
 
     this.updatePersistedParts();
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   removeSelectPart(selectParts: any, part: { def: { type: string } }) {
@@ -427,12 +435,12 @@ export class MysqlQueryCtrl extends QueryCtrl {
       }
       case 'part-param-changed': {
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         this.removeSelectPart(selectParts, part);
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -451,12 +459,12 @@ export class MysqlQueryCtrl extends QueryCtrl {
       }
       case 'part-param-changed': {
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         this.removeGroup(part, index);
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -550,14 +558,14 @@ export class MysqlQueryCtrl extends QueryCtrl {
             part.datatype = d[0].text;
           }
         });
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         // remove element
         whereParts.splice(index, 1);
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -596,7 +604,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
 
     this.updatePersistedParts();
     this.resetPlusButton(this.whereAdd);
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   getGroupOptions() {
@@ -623,7 +631,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
     }
 
     this.resetPlusButton(this.groupAdd);
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   handleQueryError(err: any): any[] {

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -80,7 +80,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
             this.target.timeColumnType = 'timestamp';
             this.target.select = [[{ type: 'column', params: [result[2].text] }]];
             this.updateProjection();
-            this.panelCtrl.refresh();
+            this.updateRawSqlAndRefresh();
           }
         });
       }
@@ -101,6 +101,14 @@ export class PostgresQueryCtrl extends QueryCtrl {
 
     this.panelCtrl.events.on('data-received', this.onDataReceived.bind(this), $scope);
     this.panelCtrl.events.on('data-error', this.onDataError.bind(this), $scope);
+  }
+
+  updateRawSqlAndRefresh() {
+    if (!this.target.rawQuery) {
+      this.target.rawSql = this.queryModel.buildQuery();
+    }
+
+    this.panelCtrl.refresh();
   }
 
   updateProjection() {
@@ -236,7 +244,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     });
 
     this.$q.all([task1, task2]).then(() => {
-      this.panelCtrl.refresh();
+      this.updateRawSqlAndRefresh();
     });
   }
 
@@ -273,7 +281,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
 
         this.updatePersistedParts();
         if (refresh !== false) {
-          this.panelCtrl.refresh();
+          this.updateRawSqlAndRefresh();
         }
       });
   }
@@ -287,7 +295,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
 
   metricColumnChanged() {
     this.target.metricColumn = this.metricColumnSegment.value;
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   onDataReceived(dataList: any) {
@@ -423,7 +431,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     }
 
     this.updatePersistedParts();
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   removeSelectPart(selectParts: any, part: { def: { type: string } }) {
@@ -459,12 +467,12 @@ export class PostgresQueryCtrl extends QueryCtrl {
       }
       case 'part-param-changed': {
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         this.removeSelectPart(selectParts, part);
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -483,12 +491,12 @@ export class PostgresQueryCtrl extends QueryCtrl {
       }
       case 'part-param-changed': {
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         this.removeGroup(part, index);
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -582,14 +590,14 @@ export class PostgresQueryCtrl extends QueryCtrl {
             part.datatype = d[0].text;
           }
         });
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'action': {
         // remove element
         whereParts.splice(index, 1);
         this.updatePersistedParts();
-        this.panelCtrl.refresh();
+        this.updateRawSqlAndRefresh();
         break;
       }
       case 'get-part-actions': {
@@ -628,7 +636,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
 
     this.updatePersistedParts();
     this.resetPlusButton(this.whereAdd);
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   getGroupOptions() {
@@ -655,7 +663,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     }
 
     this.resetPlusButton(this.groupAdd);
-    this.panelCtrl.refresh();
+    this.updateRawSqlAndRefresh();
   }
 
   handleQueryError(err: any): any[] {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes so that when an update of the query is made using the query builder the `rawSql` property is updated. This used to work for Postgres at least in v5.3.

The `rawSql` property is what is sent to the backend to execute MySQL and Postgres queries and also what needs to be stored in the panel json for an alert to be able to properly execute.

**Which issue(s) this PR fixes**:
Fixes #19063 

**Special notes for your reviewer**:
Feels like a hack, but maybe this is enough?
This doesn't do anything to automatically "fixing" panels with a non-updated `rawSql`.Is it enough without since you can resolve it by editing the query?