### PR TITLE
grafana/toolkit: Disable name mangling in Webpack minification

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -117,7 +117,12 @@ export const getWebpackConfig: WebpackConfigurationGetter = options => {
   const optimization: { [key: string]: any } = {};
 
   if (options.production) {
-    optimization.minimizer = [new TerserPlugin(), new OptimizeCssAssetsPlugin()];
+    const terserPlugin = new TerserPlugin({
+      terserOptions: {
+        mangle: false
+      }
+    });
+    optimization.minimizer = [terserPlugin, new OptimizeCssAssetsPlugin()];
   } else if (options.watch) {
     plugins.push(new HtmlWebpackPlugin());
   }


### PR DESCRIPTION
Disables name mangling for Terser minimizer in Webpack config, as this breaks Angular component injection:

```
Error: [$injector:unpr] Unknown provider: tProvider <- t
http://errors.angularjs.org/1.6.6/$injector/unpr?p0=tProvider%20%3C-%20t
    at angular.js:116
    at angular.js:4826
    at Object.s [as get] (angular.js:4981)
    at angular.js:4831
    at s (angular.js:4981)
    at u (angular.js:5006)
    at Object.invoke (angular.js:5032)
    at M.instance (angular.js:11000)
    at ie (angular.js:9852)
    at angular.js:10273```