### PR TITLE
Gauge/BarGauge: Fix issue with [object Object] in titles  

### DIFF
--- a/packages/grafana-ui/src/utils/fieldDisplay.ts
+++ b/packages/grafana-ui/src/utils/fieldDisplay.ts
@@ -50,13 +50,13 @@ function getTitleTemplate(title: string | undefined, stats: string[], data?: Dat
 
   const parts: string[] = [];
   if (stats.length > 1) {
-    parts.push('$' + VAR_CALC);
+    parts.push('${' + VAR_CALC + '}');
   }
   if (data.length > 1) {
     parts.push('${' + VAR_SERIES_NAME + '}');
   }
   if (fieldCount > 1 || !parts.length) {
-    parts.push('$' + VAR_FIELD_NAME);
+    parts.push('${' + VAR_FIELD_NAME + '}');
   }
   return parts.join(' ');
 }


### PR DESCRIPTION
The default title variable does not include `${ }` -- so now now it expands wrong:
![image](https://user-images.githubusercontent.com/705951/65215055-09a4f800-da61-11e9-9e7c-afd5cca8565e.png)

This fixes the title so it is:
![image](https://user-images.githubusercontent.com/705951/65215171-699b9e80-da61-11e9-9b69-ce35d0f819e3.png)
