### PR TITLE
tsconfig: Add @grafana packages to tsconfig paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
     "typeRoots": ["node_modules/@types", "public/app/types"],
     "paths": {
       "app": ["app"],
-      "sass": ["sass"]
+      "sass": ["sass"],
+      "@grafana/*": ["../packages/grafana-*"]
     },
     "skipLibCheck": true,
     "preserveSymlinks": true


### PR DESCRIPTION
This resolves issue with VSCode navigating to `node_modules/@grafana-*` when using `Go to definition`