### PR TITLE
Plugins: expose whole rxjs to plugins

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -37,7 +37,8 @@ import * as grafanaUI from '@grafana/ui';
 import * as grafanaRuntime from '@grafana/runtime';
 
 // rxjs
-import { Observable, Subject } from 'rxjs';
+import * as rxjs from 'rxjs';
+import * as rxjsOperators from 'rxjs/operators';
 
 // add cache busting
 const bust = `?_cache=${Date.now()}`;
@@ -81,12 +82,8 @@ exposeToPlugin('moment', moment);
 exposeToPlugin('jquery', jquery);
 exposeToPlugin('angular', angular);
 exposeToPlugin('d3', d3);
-exposeToPlugin('rxjs/Subject', Subject);
-exposeToPlugin('rxjs/Observable', Observable);
-exposeToPlugin('rxjs', {
-  Subject: Subject,
-  Observable: Observable,
-});
+exposeToPlugin('rxjs', rxjs);
+exposeToPlugin('rxjs/operators', rxjsOperators);
 
 // Experimental modules
 exposeToPlugin('prismjs', prismjs);


### PR DESCRIPTION
This PR partially closes #19176. The problem was that plugin uses its own rxjs build included in webpack (this required for using functions and operators from rxjs). With this fix we can just use whole rxjs library exposed from grafana. So the only things required to fix plugin is adding rxjs to list of externally loaded modules in webpack:
```js
module.exports = {
  target: 'node',
  context: resolve('src'),
  entry: './module.ts',
  externals: [
    // remove the line below if you don't want to use buildin versions
    'jquery', 'lodash', 'angular', 'rxjs/operators', 'rxjs',
...
```