### PR TITLE
Explore: Fix limit in case of Loki logs.

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -466,8 +466,9 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
 
     const queryOptions = {
       minInterval,
-      // This is used for logs streaming for buffer size.
-      maxDataPoints: mode === ExploreMode.Logs ? 1000 : containerWidth,
+      // This is used for logs streaming for buffer size, with undefined it falls back to datasource config if it
+      // supports that.
+      maxDataPoints: mode === ExploreMode.Logs ? undefined : containerWidth,
       live,
       showingGraph,
       showingTable,


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/19199

Do not send explicit limit for logs and just fallback to config of the datasource (for Loki 1000 is the default there.)