### PR TITLE
Alerting: Validate and show validation error when creating alert

### DIFF
--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -382,6 +382,7 @@ export class AlertTabCtrl {
     this.panel.alert = {};
     this.initModel();
     this.panel.alert.for = '5m'; //default value for new alerts. for existing alerts we use 0m to avoid breaking changes
+    this.validateModel();
   };
 
   evaluatorParamsChanged() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes so that validation of alert rule happens when clicking on Create Alert. 

The experience could probably be improved like validating before showing Create Alert CTA and not allowing alert to be created, but that's much bigger work involved in solving that. This change should make the user experience a lot better than before.  

**Which issue(s) this PR fixes**:
Fixes #19087 

**Special notes for your reviewer**:

