### PR TITLE
Graphite: Time range expansion reduced from 1 minute to 1 second

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -220,11 +220,11 @@ export class GraphiteDatasource {
     // exists for the specified range
     if (roundUp) {
       if (date.get('s')) {
-        date.add(1, 'm');
+        date.add(1, 's');
       }
     } else if (roundUp === false) {
       if (date.get('s')) {
-        date.subtract(1, 'm');
+        date.subtract(1, 's');
       }
     }
 


### PR DESCRIPTION
Fixes #11472

Changed so that only 1s is added to the from/to range for absolute ranges. 
