### PR TITLE
Enforce usage of context when using the bus

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -42,7 +42,7 @@ func AdminGetStats(c *m.ReqContext) {
 
 	statsQuery := m.GetAdminStatsQuery{}
 
-	if err := bus.Dispatch(&statsQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &statsQuery); err != nil {
 		c.JsonApiErr(500, "Failed to get admin stats from database", err)
 		return
 	}

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -29,7 +29,7 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) {
 		return
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		c.JsonApiErr(500, "failed to create user", err)
 		return
 	}
@@ -56,7 +56,7 @@ func AdminUpdateUserPassword(c *models.ReqContext, form dtos.AdminUpdateUserPass
 
 	userQuery := models.GetUserByIdQuery{Id: userID}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &userQuery); err != nil {
 		c.JsonApiErr(500, "Could not read user from database", err)
 		return
 	}
@@ -68,7 +68,7 @@ func AdminUpdateUserPassword(c *models.ReqContext, form dtos.AdminUpdateUserPass
 		NewPassword: passwordHashed,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		c.JsonApiErr(500, "Failed to update user password", err)
 		return
 	}
@@ -85,7 +85,7 @@ func AdminUpdateUserPermissions(c *models.ReqContext, form dtos.AdminUpdateUserP
 		IsGrafanaAdmin: form.IsGrafanaAdmin,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == models.ErrLastGrafanaAdmin {
 			c.JsonApiErr(400, models.ErrLastGrafanaAdmin.Error(), nil)
 			return
@@ -103,7 +103,7 @@ func AdminDeleteUser(c *models.ReqContext) {
 
 	cmd := models.DeleteUserCommand{UserId: userID}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		c.JsonApiErr(500, "Failed to delete user", err)
 		return
 	}
@@ -117,12 +117,12 @@ func (server *HTTPServer) AdminDisableUser(c *models.ReqContext) Response {
 
 	// External users shouldn't be disabled from API
 	authInfoQuery := &models.GetAuthInfoQuery{UserId: userID}
-	if err := bus.Dispatch(authInfoQuery); err != models.ErrUserNotFound {
+	if err := bus.DispatchCtx(c.Ctx(), authInfoQuery); err != models.ErrUserNotFound {
 		return Error(500, "Could not disable external user", nil)
 	}
 
 	disableCmd := models.DisableUserCommand{UserId: userID, IsDisabled: true}
-	if err := bus.Dispatch(&disableCmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &disableCmd); err != nil {
 		return Error(500, "Failed to disable user", err)
 	}
 
@@ -140,12 +140,12 @@ func AdminEnableUser(c *models.ReqContext) Response {
 
 	// External users shouldn't be disabled from API
 	authInfoQuery := &models.GetAuthInfoQuery{UserId: userID}
-	if err := bus.Dispatch(authInfoQuery); err != models.ErrUserNotFound {
+	if err := bus.DispatchCtx(c.Ctx(), authInfoQuery); err != models.ErrUserNotFound {
 		return Error(500, "Could not enable external user", nil)
 	}
 
 	disableCmd := models.DisableUserCommand{UserId: userID, IsDisabled: false}
-	if err := bus.Dispatch(&disableCmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &disableCmd); err != nil {
 		return Error(500, "Failed to enable user", err)
 	}
 

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -20,7 +21,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 			IsGrafanaAdmin: false,
 		}
 
-		bus.AddHandler("test", func(cmd *m.UpdateUserPermissionsCommand) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.UpdateUserPermissionsCommand) error {
 			return m.ErrLastGrafanaAdmin
 		})
 
@@ -31,7 +32,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When a server admin attempts to logout himself from all devices", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			cmd.Result = &m.User{Id: TestUserID}
 			return nil
 		})
@@ -44,7 +45,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 
 	Convey("When a server admin attempts to logout a non-existing user from all devices", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			userId = cmd.Id
 			return m.ErrUserNotFound
 		})
@@ -58,7 +59,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 
 	Convey("When a server admin attempts to revoke an auth token for a non-existing user", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			userId = cmd.Id
 			return m.ErrUserNotFound
 		})
@@ -74,7 +75,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 
 	Convey("When a server admin gets auth tokens for a non-existing user", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			userId = cmd.Id
 			return m.ErrUserNotFound
 		})
@@ -88,7 +89,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 
 	Convey("When a server admin attempts to disable/enable external user", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetAuthInfoQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetAuthInfoQuery) error {
 			userId = cmd.UserId
 			return nil
 		})

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -16,7 +16,7 @@ func ValidateOrgAlert(c *models.ReqContext) {
 	id := c.ParamsInt64(":alertId")
 	query := models.GetAlertByIdQuery{Id: id}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		c.JsonApiErr(404, "Alert not found", nil)
 		return
 	}
@@ -39,7 +39,7 @@ func GetAlertStatesForDashboard(c *models.ReqContext) Response {
 		DashboardId: c.QueryInt64("dashboardId"),
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to fetch alert states", err)
 	}
 
@@ -82,7 +82,7 @@ func GetAlerts(c *models.ReqContext) Response {
 			Permission:   models.PERMISSION_VIEW,
 		}
 
-		err := bus.Dispatch(&searchQuery)
+		err := bus.DispatchCtx(c.Ctx(), &searchQuery)
 		if err != nil {
 			return Error(500, "List alerts failed", err)
 		}
@@ -113,7 +113,7 @@ func GetAlerts(c *models.ReqContext) Response {
 		query.State = states
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "List alerts failed", err)
 	}
 
@@ -137,7 +137,7 @@ func AlertTest(c *models.ReqContext, dto dtos.AlertTestCommand) Response {
 		User:      c.SignedInUser,
 	}
 
-	if err := bus.Dispatch(&backendCmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &backendCmd); err != nil {
 		if validationErr, ok := err.(alerting.ValidationError); ok {
 			return Error(422, validationErr.Error(), nil)
 		}
@@ -175,7 +175,7 @@ func GetAlert(c *models.ReqContext) Response {
 	id := c.ParamsInt64(":alertId")
 	query := models.GetAlertByIdQuery{Id: id}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "List alerts failed", err)
 	}
 
@@ -219,7 +219,7 @@ func GetAlertNotifications(c *models.ReqContext) Response {
 func getAlertNotificationsInternal(c *models.ReqContext) ([]*models.AlertNotification, error) {
 	query := &models.GetAllAlertNotificationsQuery{OrgId: c.OrgId}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), query); err != nil {
 		return nil, err
 	}
 
@@ -236,7 +236,7 @@ func GetAlertNotificationByID(c *models.ReqContext) Response {
 		return Error(404, "Alert notification not found", nil)
 	}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), query); err != nil {
 		return Error(500, "Failed to get alert notifications", err)
 	}
 
@@ -257,7 +257,7 @@ func GetAlertNotificationByUID(c *models.ReqContext) Response {
 		return Error(404, "Alert notification not found", nil)
 	}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), query); err != nil {
 		return Error(500, "Failed to get alert notifications", err)
 	}
 
@@ -271,7 +271,7 @@ func GetAlertNotificationByUID(c *models.ReqContext) Response {
 func CreateAlertNotification(c *models.ReqContext, cmd models.CreateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to create alert notification", err)
 	}
 
@@ -281,7 +281,7 @@ func CreateAlertNotification(c *models.ReqContext, cmd models.CreateAlertNotific
 func UpdateAlertNotification(c *models.ReqContext, cmd models.UpdateAlertNotificationCommand) Response {
 	cmd.OrgId = c.OrgId
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to update alert notification", err)
 	}
 
@@ -296,7 +296,7 @@ func UpdateAlertNotificationByUID(c *models.ReqContext, cmd models.UpdateAlertNo
 	cmd.OrgId = c.OrgId
 	cmd.Uid = c.Params("uid")
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to update alert notification", err)
 	}
 
@@ -313,7 +313,7 @@ func DeleteAlertNotification(c *models.ReqContext) Response {
 		Id:    c.ParamsInt64("notificationId"),
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to delete alert notification", err)
 	}
 
@@ -326,7 +326,7 @@ func DeleteAlertNotificationByUID(c *models.ReqContext) Response {
 		Uid:   c.Params("uid"),
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to delete alert notification", err)
 	}
 
@@ -341,7 +341,7 @@ func NotificationTest(c *models.ReqContext, dto dtos.NotificationTestCommand) Re
 		Settings: dto.Settings,
 	}
 
-	if err := bus.Dispatch(cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), cmd); err != nil {
 		if err == models.ErrSmtpNotEnabled {
 			return Error(412, err.Error(), err)
 		}
@@ -357,7 +357,7 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 
 	query := models.GetAlertByIdQuery{Id: alertID}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Get Alert failed", err)
 	}
 
@@ -376,7 +376,7 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 		Paused:   dto.Paused,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "", err)
 	}
 
@@ -402,7 +402,7 @@ func PauseAllAlerts(c *models.ReqContext, dto dtos.PauseAllAlertsCommand) Respon
 		Paused: dto.Paused,
 	}
 
-	if err := bus.Dispatch(&updateCmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &updateCmd); err != nil {
 		return Error(500, "Failed to pause alerts", err)
 	}
 

--- a/pkg/api/alerting_test.go
+++ b/pkg/api/alerting_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -16,7 +17,7 @@ func TestAlertingApiEndpoint(t *testing.T) {
 
 		singleAlert := &models.Alert{Id: 1, DashboardId: 1, Name: "singlealert"}
 
-		bus.AddHandler("test", func(query *models.GetAlertByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetAlertByIdQuery) error {
 			query.Result = singleAlert
 			return nil
 		})
@@ -25,12 +26,12 @@ func TestAlertingApiEndpoint(t *testing.T) {
 		editorRole := models.ROLE_EDITOR
 
 		aclMockResp := []*models.DashboardAclInfoDTO{}
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
 			query.Result = []*models.TeamDTO{}
 			return nil
 		})
@@ -68,13 +69,13 @@ func TestAlertingApiEndpoint(t *testing.T) {
 
 		loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/alerts?dashboardId=1", "/api/alerts", models.ROLE_EDITOR, func(sc *scenarioContext) {
 			var searchQuery *search.Query
-			bus.AddHandler("test", func(query *search.Query) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *search.Query) error {
 				searchQuery = query
 				return nil
 			})
 
 			var getAlertsQuery *models.GetAlertsQuery
-			bus.AddHandler("test", func(query *models.GetAlertsQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetAlertsQuery) error {
 				getAlertsQuery = query
 				return nil
 			})
@@ -88,7 +89,7 @@ func TestAlertingApiEndpoint(t *testing.T) {
 
 		loggedInUserScenarioWithRole("When calling GET on", "GET", "/api/alerts?dashboardId=1&dashboardId=2&folderId=3&dashboardTag=abc&dashboardQuery=dbQuery&limit=5&query=alertQuery", "/api/alerts", models.ROLE_EDITOR, func(sc *scenarioContext) {
 			var searchQuery *search.Query
-			bus.AddHandler("test", func(query *search.Query) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *search.Query) error {
 				searchQuery = query
 				query.Result = search.HitList{
 					&search.Hit{Id: 1},
@@ -98,7 +99,7 @@ func TestAlertingApiEndpoint(t *testing.T) {
 			})
 
 			var getAlertsQuery *models.GetAlertsQuery
-			bus.AddHandler("test", func(query *models.GetAlertsQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetAlertsQuery) error {
 				getAlertsQuery = query
 				return nil
 			})
@@ -129,7 +130,7 @@ func TestAlertingApiEndpoint(t *testing.T) {
 }
 
 func CallPauseAlert(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *models.PauseAlertCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.PauseAlertCommand) error {
 		return nil
 	})
 

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -120,12 +121,12 @@ func TestAnnotationsApiEndpoint(t *testing.T) {
 			{Role: &editorRole, Permission: m.PERMISSION_EDIT},
 		}
 
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetTeamsByUserQuery) error {
 			query.Result = []*m.TeamDTO{}
 			return nil
 		})

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -84,7 +84,7 @@ func UpdateDashboardPermissions(c *m.ReqContext, apiCmd dtos.UpdateDashboardAclC
 		return Error(403, "Cannot remove own admin permission for a folder", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrDashboardAclInfoMissing || err == m.ErrDashboardPermissionDashboardEmpty {
 			return Error(409, err.Error(), err)
 		}

--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -15,7 +16,7 @@ import (
 func TestDashboardPermissionApiEndpoint(t *testing.T) {
 	Convey("Dashboard permissions test", t, func() {
 		Convey("Given dashboard not exists", func() {
-			bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 				return m.ErrDashboardNotFound
 			})
 
@@ -41,7 +42,7 @@ func TestDashboardPermissionApiEndpoint(t *testing.T) {
 			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanAdminValue: false})
 
 			getDashboardQueryResult := m.NewDashboard("Dash")
-			bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 				query.Result = getDashboardQueryResult
 				return nil
 			})
@@ -82,7 +83,7 @@ func TestDashboardPermissionApiEndpoint(t *testing.T) {
 			})
 
 			getDashboardQueryResult := m.NewDashboard("Dash")
-			bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 				query.Result = getDashboardQueryResult
 				return nil
 			})
@@ -122,7 +123,7 @@ func TestDashboardPermissionApiEndpoint(t *testing.T) {
 			})
 
 			getDashboardQueryResult := m.NewDashboard("Dash")
-			bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 				query.Result = getDashboardQueryResult
 				return nil
 			})
@@ -152,7 +153,7 @@ func TestDashboardPermissionApiEndpoint(t *testing.T) {
 			)
 
 			getDashboardQueryResult := m.NewDashboard("Dash")
-			bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 				query.Result = getDashboardQueryResult
 				return nil
 			})
@@ -181,7 +182,7 @@ func callGetDashboardPermissions(sc *scenarioContext) {
 }
 
 func callUpdateDashboardPermissions(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *m.UpdateDashboardAclCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.UpdateDashboardAclCommand) error {
 		return nil
 	})
 

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -112,7 +112,7 @@ func CreateDashboardSnapshot(c *m.ReqContext, cmd m.CreateDashboardSnapshotComma
 		metrics.MApiDashboardSnapshotCreate.Inc()
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		c.JsonApiErr(500, "Failed to create snaphost", err)
 		return
 	}
@@ -130,7 +130,7 @@ func GetDashboardSnapshot(c *m.ReqContext) {
 	key := c.Params(":key")
 	query := &m.GetDashboardSnapshotQuery{Key: key}
 
-	err := bus.Dispatch(query)
+	err := bus.DispatchCtx(c.Ctx(), query)
 	if err != nil {
 		c.JsonApiErr(500, "Failed to get dashboard snapshot", err)
 		return
@@ -193,7 +193,7 @@ func DeleteDashboardSnapshotByDeleteKey(c *m.ReqContext) Response {
 
 	query := &m.GetDashboardSnapshotQuery{DeleteKey: key}
 
-	err := bus.Dispatch(query)
+	err := bus.DispatchCtx(c.Ctx(), query)
 	if err != nil {
 		return Error(500, "Failed to get dashboard snapshot", err)
 	}
@@ -207,7 +207,7 @@ func DeleteDashboardSnapshotByDeleteKey(c *m.ReqContext) Response {
 
 	cmd := &m.DeleteDashboardSnapshotCommand{DeleteKey: query.Result.DeleteKey}
 
-	if err := bus.Dispatch(cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), cmd); err != nil {
 		return Error(500, "Failed to delete dashboard snapshot", err)
 	}
 
@@ -220,7 +220,7 @@ func DeleteDashboardSnapshot(c *m.ReqContext) Response {
 
 	query := &m.GetDashboardSnapshotQuery{Key: key}
 
-	err := bus.Dispatch(query)
+	err := bus.DispatchCtx(c.Ctx(), query)
 	if err != nil {
 		return Error(500, "Failed to get dashboard snapshot", err)
 	}
@@ -250,7 +250,7 @@ func DeleteDashboardSnapshot(c *m.ReqContext) Response {
 
 	cmd := &m.DeleteDashboardSnapshotCommand{DeleteKey: query.Result.DeleteKey}
 
-	if err := bus.Dispatch(cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), cmd); err != nil {
 		return Error(500, "Failed to delete dashboard snapshot", err)
 	}
 
@@ -273,7 +273,7 @@ func SearchDashboardSnapshots(c *m.ReqContext) Response {
 		SignedInUser: c.SignedInUser,
 	}
 
-	err := bus.Dispatch(&searchQuery)
+	err := bus.DispatchCtx(c.Ctx(), &searchQuery)
 	if err != nil {
 		return Error(500, "Search failed", err)
 	}

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -29,25 +30,25 @@ func TestDashboardSnapshotApiEndpoint(t *testing.T) {
 			External:  true,
 		}
 
-		bus.AddHandler("test", func(query *m.GetDashboardSnapshotQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardSnapshotQuery) error {
 			query.Result = mockSnapshotResult
 			return nil
 		})
 
-		bus.AddHandler("test", func(cmd *m.DeleteDashboardSnapshotCommand) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.DeleteDashboardSnapshotCommand) error {
 			return nil
 		})
 
 		viewerRole := m.ROLE_VIEWER
 		editorRole := m.ROLE_EDITOR
 		aclMockResp := []*m.DashboardAclInfoDTO{}
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
 		teamResp := []*m.TeamDTO{}
-		bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetTeamsByUserQuery) error {
 			query.Result = teamResp
 			return nil
 		})

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -30,7 +31,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		fakeDash.FolderId = 1
 		fakeDash.HasAcl = false
 
-		bus.AddHandler("test", func(query *m.GetDashboardsBySlugQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardsBySlugQuery) error {
 			dashboards := []*m.Dashboard{fakeDash}
 			query.Result = dashboards
 			return nil
@@ -38,13 +39,13 @@ func TestDashboardApiEndpoint(t *testing.T) {
 
 		var getDashboardQueries []*m.GetDashboardQuery
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = fakeDash
 			getDashboardQueries = append(getDashboardQueries, query)
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetProvisionedDashboardDataByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetProvisionedDashboardDataByIdQuery) error {
 			query.Result = nil
 			return nil
 		})
@@ -57,12 +58,12 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			{Role: &editorRole, Permission: m.PERMISSION_EDIT},
 		}
 
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetTeamsByUserQuery) error {
 			query.Result = []*m.TeamDTO{}
 			return nil
 		})
@@ -199,12 +200,12 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		fakeDash.HasAcl = true
 		setting.ViewersCanEdit = false
 
-		bus.AddHandler("test", func(query *m.GetProvisionedDashboardDataByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetProvisionedDashboardDataByIdQuery) error {
 			query.Result = nil
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardsBySlugQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardsBySlugQuery) error {
 			dashboards := []*m.Dashboard{fakeDash}
 			query.Result = dashboards
 			return nil
@@ -218,20 +219,20 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			},
 		}
 
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
 		var getDashboardQueries []*m.GetDashboardQuery
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = fakeDash
 			getDashboardQueries = append(getDashboardQueries, query)
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetTeamsByUserQuery) error {
 			query.Result = []*m.TeamDTO{}
 			return nil
 		})
@@ -371,7 +372,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				{OrgId: 1, DashboardId: 2, UserId: 1, Permission: m.PERMISSION_EDIT},
 			}
 
-			bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
@@ -441,7 +442,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				{OrgId: 1, DashboardId: 2, UserId: 1, Permission: m.PERMISSION_VIEW},
 			}
 
-			bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
@@ -500,7 +501,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				{OrgId: 1, DashboardId: 2, UserId: 1, Permission: m.PERMISSION_ADMIN},
 			}
 
-			bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
@@ -569,7 +570,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 				{OrgId: 1, DashboardId: 2, UserId: 1, Permission: m.PERMISSION_VIEW},
 			}
 
-			bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
@@ -641,12 +642,12 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		dashTwo.FolderId = 3
 		dashTwo.HasAcl = false
 
-		bus.AddHandler("test", func(query *m.GetProvisionedDashboardDataByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetProvisionedDashboardDataByIdQuery) error {
 			query.Result = nil
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardsBySlugQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardsBySlugQuery) error {
 			dashboards := []*m.Dashboard{dashOne, dashTwo}
 			query.Result = dashboards
 			return nil
@@ -766,17 +767,17 @@ func TestDashboardApiEndpoint(t *testing.T) {
 
 	Convey("Given two dashboards being compared", t, func() {
 		mockResult := []*m.DashboardAclInfoDTO{}
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = mockResult
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetProvisionedDashboardDataByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetProvisionedDashboardDataByIdQuery) error {
 			query.Result = nil
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardVersionQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardVersionQuery) error {
 			query.Result = &m.DashboardVersion{
 				Data: simplejson.NewFromAny(map[string]interface{}{
 					"title": "Dash" + string(query.DashboardId),
@@ -822,12 +823,12 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		fakeDash.FolderId = 1
 		fakeDash.HasAcl = false
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = fakeDash
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardVersionQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardVersionQuery) error {
 			query.Result = &m.DashboardVersion{
 				DashboardId: 2,
 				Version:     1,
@@ -865,12 +866,12 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		fakeDash.Id = 2
 		fakeDash.HasAcl = false
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = fakeDash
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardVersionQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardVersionQuery) error {
 			query.Result = &m.DashboardVersion{
 				DashboardId: 2,
 				Version:     1,
@@ -905,21 +906,21 @@ func TestDashboardApiEndpoint(t *testing.T) {
 
 	Convey("Given provisioned dashboard", t, func() {
 
-		bus.AddHandler("test", func(query *m.GetDashboardsBySlugQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardsBySlugQuery) error {
 			query.Result = []*m.Dashboard{{}}
 			return nil
 		})
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = &m.Dashboard{Id: 1, Data: &simplejson.Json{}}
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetProvisionedDashboardDataByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetProvisionedDashboardDataByIdQuery) error {
 			query.Result = &m.DashboardProvisioning{ExternalId: "/tmp/grafana/dashboards/test/dashboard1.json"}
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 			query.Result = []*m.DashboardAclInfoDTO{
 				{OrgId: TestOrgID, DashboardId: 1, UserId: TestUserID, Permission: m.PERMISSION_EDIT},
 			}
@@ -992,7 +993,7 @@ func CallGetDashboard(sc *scenarioContext, hs *HTTPServer) {
 }
 
 func CallGetDashboardVersion(sc *scenarioContext) {
-	bus.AddHandler("test", func(query *m.GetDashboardVersionQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardVersionQuery) error {
 		query.Result = &m.DashboardVersion{}
 		return nil
 	})
@@ -1002,7 +1003,7 @@ func CallGetDashboardVersion(sc *scenarioContext) {
 }
 
 func CallGetDashboardVersions(sc *scenarioContext) {
-	bus.AddHandler("test", func(query *m.GetDashboardVersionsQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardVersionsQuery) error {
 		query.Result = []*m.DashboardVersionDTO{}
 		return nil
 	})
@@ -1012,7 +1013,7 @@ func CallGetDashboardVersions(sc *scenarioContext) {
 }
 
 func CallDeleteDashboardBySlug(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *m.DeleteDashboardCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.DeleteDashboardCommand) error {
 		return nil
 	})
 
@@ -1021,7 +1022,7 @@ func CallDeleteDashboardBySlug(sc *scenarioContext) {
 }
 
 func CallDeleteDashboardByUID(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *m.DeleteDashboardCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.DeleteDashboardCommand) error {
 		return nil
 	})
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -13,7 +14,7 @@ import (
 func GetDataSources(c *m.ReqContext) Response {
 	query := m.GetDataSourcesQuery{OrgId: c.OrgId}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to query datasources", err)
 	}
 
@@ -55,7 +56,7 @@ func GetDataSourceById(c *m.ReqContext) Response {
 		OrgId: c.OrgId,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}
@@ -86,7 +87,7 @@ func DeleteDataSourceById(c *m.ReqContext) Response {
 
 	cmd := &m.DeleteDataSourceByIdCommand{Id: id, OrgId: c.OrgId}
 
-	err = bus.Dispatch(cmd)
+	err = bus.DispatchCtx(c.Ctx(), cmd)
 	if err != nil {
 		return Error(500, "Failed to delete datasource", err)
 	}
@@ -102,7 +103,7 @@ func DeleteDataSourceByName(c *m.ReqContext) Response {
 	}
 
 	getCmd := &m.GetDataSourceByNameQuery{Name: name, OrgId: c.OrgId}
-	if err := bus.Dispatch(getCmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), getCmd); err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}
@@ -114,7 +115,7 @@ func DeleteDataSourceByName(c *m.ReqContext) Response {
 	}
 
 	cmd := &m.DeleteDataSourceByNameCommand{Name: name, OrgId: c.OrgId}
-	err := bus.Dispatch(cmd)
+	err := bus.DispatchCtx(c.Ctx(), cmd)
 	if err != nil {
 		return Error(500, "Failed to delete datasource", err)
 	}
@@ -125,7 +126,7 @@ func DeleteDataSourceByName(c *m.ReqContext) Response {
 func AddDataSource(c *m.ReqContext, cmd m.AddDataSourceCommand) Response {
 	cmd.OrgId = c.OrgId
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrDataSourceNameExists {
 			return Error(409, err.Error(), err)
 		}
@@ -151,7 +152,7 @@ func UpdateDataSource(c *m.ReqContext, cmd m.UpdateDataSourceCommand) Response {
 		return Error(500, "Failed to update datasource", err)
 	}
 
-	err = bus.Dispatch(&cmd)
+	err = bus.DispatchCtx(c.Ctx(), &cmd)
 	if err != nil {
 		if err == m.ErrDataSourceUpdatingOldVersion {
 			return Error(500, "Failed to update datasource. Reload new version and try again", err)
@@ -164,7 +165,7 @@ func UpdateDataSource(c *m.ReqContext, cmd m.UpdateDataSourceCommand) Response {
 		OrgId: c.OrgId,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}
@@ -212,7 +213,7 @@ func getRawDataSourceById(id int64, orgID int64) (*m.DataSource, error) {
 		OrgId: orgID,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 
@@ -223,7 +224,7 @@ func getRawDataSourceById(id int64, orgID int64) (*m.DataSource, error) {
 func GetDataSourceByName(c *m.ReqContext) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}
@@ -238,7 +239,7 @@ func GetDataSourceByName(c *m.ReqContext) Response {
 func GetDataSourceIdByName(c *m.ReqContext) Response {
 	query := m.GetDataSourceByNameQuery{Name: c.Params(":name"), OrgId: c.OrgId}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrDataSourceNotFound {
 			return Error(404, "Data source not found", nil)
 		}

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestDataSourcesProxy(t *testing.T) {
 		loggedInUserScenario("When calling GET on", "/api/datasources/", func(sc *scenarioContext) {
 
 			// Stubs the database query
-			bus.AddHandler("test", func(query *models.GetDataSourcesQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDataSourcesQuery) error {
 				So(query.OrgId, ShouldEqual, TestOrgID)
 				query.Result = []*models.DataSource{
 					{Name: "mmm"},

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -94,7 +94,7 @@ func UpdateFolderPermissions(c *m.ReqContext, apiCmd dtos.UpdateDashboardAclComm
 		return Error(403, "Cannot remove own admin permission for a folder", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrDashboardAclInfoMissing {
 			err = m.ErrFolderAclInfoMissing
 		}

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -213,7 +214,7 @@ func callGetFolderPermissions(sc *scenarioContext) {
 }
 
 func callUpdateFolderPermissions(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *m.UpdateDashboardAclCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.UpdateDashboardAclCommand) error {
 		return nil
 	})
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -19,7 +19,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 
 	if c.OrgId != 0 {
 		query := m.GetDataSourcesQuery{OrgId: c.OrgId}
-		err := bus.Dispatch(&query)
+		err := bus.DispatchCtx(c.Ctx(), &query)
 
 		if err != nil {
 			return nil, err
@@ -30,7 +30,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			Datasources: query.Result,
 		}
 
-		if err := bus.Dispatch(&dsFilterQuery); err != nil {
+		if err := bus.DispatchCtx(c.Ctx(), &dsFilterQuery); err != nil {
 			if err != bus.ErrHandlerNotFound {
 				return nil, err
 			}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -330,7 +330,7 @@ func (hs *HTTPServer) healthHandler(ctx *macaron.Context) {
 	data.Set("version", setting.BuildVersion)
 	data.Set("commit", setting.BuildCommit)
 
-	if err := bus.Dispatch(&models.GetDBHealthQuery{}); err != nil {
+	if err := bus.DispatchCtx(ctx.Req.Context(), &models.GetDBHealthQuery{}); err != nil {
 		data.Set("database", "failing")
 		ctx.Resp.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		ctx.Resp.WriteHeader(503)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -24,7 +24,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	}
 
 	prefsQuery := m.GetPreferencesWithDefaultsQuery{User: c.SignedInUser}
-	if err := bus.Dispatch(&prefsQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &prefsQuery); err != nil {
 		return nil, err
 	}
 	prefs := prefsQuery.Result
@@ -49,7 +49,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	}
 
 	hasEditPermissionInFoldersQuery := m.HasEditPermissionInFoldersQuery{SignedInUser: c.SignedInUser}
-	if err := bus.Dispatch(&hasEditPermissionInFoldersQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &hasEditPermissionInFoldersQuery); err != nil {
 		return nil, err
 	}
 

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -133,7 +133,7 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
@@ -190,7 +190,7 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
@@ -264,12 +264,12 @@ func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
 
-	bus.AddHandler("test", func(cmd *models.GetTeamsForLDAPGroupCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetTeamsForLDAPGroupCommand) error {
 		cmd.Result = []models.TeamOrgGroupDTO{}
 		return nil
 	})
@@ -415,19 +415,19 @@ func TestPostSyncUserWithLDAPAPIEndpoint_Success(t *testing.T) {
 		Login: "ldap-daniel",
 	}
 
-	bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
 		require.Equal(t, "ldap-daniel", cmd.ExternalUser.Login)
 		return nil
 	})
 
-	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
 		q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 		return nil
 	})
 
-	bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetAuthInfoQuery) error {
 		require.Equal(t, q.UserId, int64(34))
 		require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
 
@@ -456,7 +456,7 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotFound(t *testing.T) {
 		return &LDAPMock{}
 	}
 
-	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
 		return models.ErrUserNotFound
@@ -490,14 +490,14 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenGrafanaAdmin(t *testing.T) {
 	setting.AdminUser = "ldap-daniel"
 	defer func() { setting.AdminUser = admin }()
 
-	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
 		q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 		return nil
 	})
 
-	bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetAuthInfoQuery) error {
 		require.Equal(t, q.UserId, int64(34))
 		require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
 
@@ -531,26 +531,26 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotInLDAP(t *testing.T) {
 
 	userSearchResult = nil
 
-	bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
 		require.Equal(t, "ldap-daniel", cmd.ExternalUser.Login)
 		return nil
 	})
 
-	bus.AddHandler("test", func(q *models.GetUserByIdQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
 		require.Equal(t, q.Id, int64(34))
 
 		q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 		return nil
 	})
 
-	bus.AddHandler("test", func(q *models.GetExternalUserInfoByLoginQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetExternalUserInfoByLoginQuery) error {
 		assert.Equal(t, "ldap-daniel", q.LoginOrEmail)
 		q.Result = &models.ExternalUserInfo{IsDisabled: true, UserId: 34}
 
 		return nil
 	})
 
-	bus.AddHandler("test", func(cmd *models.DisableUserCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.DisableUserCommand) error {
 		assert.Equal(t, 34, cmd.UserId)
 		return nil
 	})

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -109,7 +109,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 		IpAddress:  c.Req.RemoteAddr,
 	}
 
-	if err := bus.Dispatch(authQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), authQuery); err != nil {
 		e401 := Error(401, "Invalid username or password", err)
 		if err == login.ErrInvalidCredentials || err == login.ErrTooManyLoginAttempts {
 			return e401

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -185,7 +185,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 		SignupAllowed: connect.IsSignupAllowed(),
 	}
 
-	err = bus.Dispatch(cmd)
+	err = bus.DispatchCtx(ctx.Ctx(), cmd)
 	if err != nil {
 		hs.redirectWithError(ctx, err)
 		return

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -95,7 +95,7 @@ func GenerateError(c *m.ReqContext) Response {
 
 // GET /api/tsdb/testdata/gensql
 func GenerateSQLTestData(c *m.ReqContext) Response {
-	if err := bus.Dispatch(&m.InsertSqlTestDataCommand{}); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &m.InsertSqlTestDataCommand{}); err != nil {
 		return Error(500, "Failed to insert test data", err)
 	}
 

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -22,7 +24,7 @@ func GetOrgByID(c *m.ReqContext) Response {
 // Get /api/orgs/name/:name
 func GetOrgByName(c *m.ReqContext) Response {
 	query := m.GetOrgByNameQuery{Name: c.Params(":name")}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrOrgNotFound {
 			return Error(404, "Organization not found", err)
 		}
@@ -49,7 +51,7 @@ func GetOrgByName(c *m.ReqContext) Response {
 func getOrgHelper(orgID int64) Response {
 	query := m.GetOrgByIdQuery{Id: orgID}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		if err == m.ErrOrgNotFound {
 			return Error(404, "Organization not found", err)
 		}
@@ -81,7 +83,7 @@ func CreateOrg(c *m.ReqContext, cmd m.CreateOrgCommand) Response {
 	}
 
 	cmd.UserId = c.UserId
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrOrgNameTaken {
 			return Error(409, "Organization name taken", err)
 		}
@@ -108,7 +110,7 @@ func UpdateOrg(c *m.ReqContext, form dtos.UpdateOrgForm) Response {
 
 func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) Response {
 	cmd := m.UpdateOrgCommand{Name: form.Name, OrgId: orgID}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		if err == m.ErrOrgNameTaken {
 			return Error(400, "Organization name taken", err)
 		}
@@ -141,7 +143,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) Respons
 		},
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		return Error(500, "Failed to update org address", err)
 	}
 
@@ -150,7 +152,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) Respons
 
 // GET /api/orgs/:orgId
 func DeleteOrgByID(c *m.ReqContext) Response {
-	if err := bus.Dispatch(&m.DeleteOrgCommand{Id: c.ParamsInt64(":orgId")}); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &m.DeleteOrgCommand{Id: c.ParamsInt64(":orgId")}); err != nil {
 		if err == m.ErrOrgNotFound {
 			return Error(404, "Failed to delete organization. ID not found", nil)
 		}
@@ -167,7 +169,7 @@ func SearchOrgs(c *m.ReqContext) Response {
 		Limit: 1000,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to search orgs", err)
 	}
 

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -177,7 +177,7 @@ func (hs *HTTPServer) CompleteInvite(c *m.ReqContext, completeInvite dtos.Comple
 
 	user := &cmd.Result
 
-	bus.Publish(&events.SignUpCompleted{
+	bus.Publish(c.Context, &events.SignUpCompleted{
 		Name:  user.NameOrFallback(),
 		Email: user.Email,
 	})

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -11,7 +12,7 @@ import (
 func ValidateOrgPlaylist(c *m.ReqContext) {
 	id := c.ParamsInt64(":id")
 	query := m.GetPlaylistByIdQuery{Id: id}
-	err := bus.Dispatch(&query)
+	err := bus.DispatchCtx(c.Ctx(), &query)
 
 	if err != nil {
 		c.JsonApiErr(404, "Playlist not found", err)
@@ -55,7 +56,7 @@ func SearchPlaylists(c *m.ReqContext) Response {
 		OrgId: c.OrgId,
 	}
 
-	err := bus.Dispatch(&searchQuery)
+	err := bus.DispatchCtx(c.Ctx(), &searchQuery)
 	if err != nil {
 		return Error(500, "Search failed", err)
 	}
@@ -67,7 +68,7 @@ func GetPlaylist(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 	cmd := m.GetPlaylistByIdQuery{Id: id}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Playlist not found", err)
 	}
 
@@ -109,7 +110,7 @@ func LoadPlaylistItemDTOs(id int64) ([]m.PlaylistItemDTO, error) {
 
 func LoadPlaylistItems(id int64) ([]m.PlaylistItem, error) {
 	itemQuery := m.GetPlaylistItemsByIdQuery{PlaylistId: id}
-	if err := bus.Dispatch(&itemQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &itemQuery); err != nil {
 		return nil, err
 	}
 
@@ -143,7 +144,7 @@ func DeletePlaylist(c *m.ReqContext) Response {
 	id := c.ParamsInt64(":id")
 
 	cmd := m.DeletePlaylistCommand{Id: id, OrgId: c.OrgId}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to delete playlist", err)
 	}
 
@@ -153,7 +154,7 @@ func DeletePlaylist(c *m.ReqContext) Response {
 func CreatePlaylist(c *m.ReqContext, cmd m.CreatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to create playlist", err)
 	}
 
@@ -164,7 +165,7 @@ func UpdatePlaylist(c *m.ReqContext, cmd m.UpdatePlaylistCommand) Response {
 	cmd.OrgId = c.OrgId
 	cmd.Id = c.ParamsInt64(":id")
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to save playlist", err)
 	}
 

--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"sort"
 	"strconv"
 
@@ -16,7 +17,7 @@ func populateDashboardsByID(dashboardByIDs []int64, dashboardIDOrder map[int64]i
 
 	if len(dashboardByIDs) > 0 {
 		dashboardQuery := m.GetDashboardsQuery{DashboardIds: dashboardByIDs}
-		if err := bus.Dispatch(&dashboardQuery); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), &dashboardQuery); err != nil {
 			return result, err
 		}
 
@@ -48,7 +49,7 @@ func populateDashboardsByTag(orgID int64, signedInUser *m.SignedInUser, dashboar
 			OrgId:        orgID,
 		}
 
-		if err := bus.Dispatch(&searchQuery); err == nil {
+		if err := bus.DispatchCtx(context.TODO(), &searchQuery); err == nil {
 			for _, item := range searchQuery.Result {
 				result = append(result, dtos.PlaylistDashboard{
 					Id:    item.Id,

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -327,7 +327,7 @@ func checkWhiteList(c *m.ReqContext, host string) bool {
 
 func addOAuthPassThruAuth(c *m.ReqContext, req *http.Request) {
 	authInfoQuery := &m.GetAuthInfoQuery{UserId: c.UserId}
-	if err := bus.Dispatch(authInfoQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), authInfoQuery); err != nil {
 		logger.Error("Error feching oauth information for user", "error", err)
 		return
 	}
@@ -359,7 +359,7 @@ func addOAuthPassThruAuth(c *m.ReqContext, req *http.Request) {
 			AuthId:     authInfoQuery.Result.AuthId,
 			OAuthToken: token,
 		}
-		if err := bus.Dispatch(updateAuthCommand); err != nil {
+		if err := bus.DispatchCtx(c.Ctx(), updateAuthCommand); err != nil {
 			logger.Error("Failed to update access token during token refresh", "error", err)
 			return
 		}

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -2,6 +2,7 @@ package pluginproxy
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -396,7 +397,7 @@ func TestDSRouteRule(t *testing.T) {
 				},
 			}
 
-			bus.AddHandler("test", func(query *m.GetAuthInfoQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetAuthInfoQuery) error {
 				query.Result = &m.UserAuth{
 					Id:                1,
 					UserId:            1,

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -1,6 +1,7 @@
 package pluginproxy
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -26,7 +27,7 @@ func getHeaders(route *plugins.AppPluginRoute, orgId int64, appID string) (http.
 
 	query := m.GetPluginSettingByIdQuery{OrgId: orgId, PluginId: appID}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 
@@ -41,7 +42,7 @@ func getHeaders(route *plugins.AppPluginRoute, orgId int64, appID string) (http.
 
 func updateURL(route *plugins.AppPluginRoute, orgId int64, appID string) (string, error) {
 	query := m.GetPluginSettingByIdQuery{OrgId: orgId, PluginId: appID}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return "", err
 	}
 

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -1,6 +1,7 @@
 package pluginproxy
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestPluginProxy(t *testing.T) {
 
 		setting.SecretKey = "password"
 
-		bus.AddHandler("test", func(query *m.GetPluginSettingByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetPluginSettingByIdQuery) error {
 			key, err := util.Encrypt([]byte("123"), "password")
 			if err != nil {
 				return err
@@ -99,7 +100,7 @@ func TestPluginProxy(t *testing.T) {
 			Method: "GET",
 		}
 
-		bus.AddHandler("test", func(query *m.GetPluginSettingByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetPluginSettingByIdQuery) error {
 			query.Result = &m.PluginSetting{
 				JsonData: map[string]interface{}{
 					"dynamicUrl": "https://dynamic.grafana.com",

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -107,7 +107,7 @@ func GetPluginSettingByID(c *m.ReqContext) Response {
 	}
 
 	query := m.GetPluginSettingByIdQuery{PluginId: pluginID, OrgId: c.OrgId}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err != m.ErrPluginSettingNotFound {
 			return Error(500, "Failed to get login settings", nil)
 		}
@@ -130,7 +130,7 @@ func UpdatePluginSetting(c *m.ReqContext, cmd m.UpdatePluginSettingCmd) Response
 		return Error(404, "Plugin not installed.", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to update plugin setting", err)
 	}
 
@@ -191,7 +191,7 @@ func ImportDashboard(c *m.ReqContext, apiCmd dtos.ImportDashboardCommand) Respon
 		Dashboard: apiCmd.Dashboard,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to import dashboard", err)
 	}
 

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
@@ -12,7 +14,7 @@ func SetHomeDashboard(c *m.ReqContext, cmd m.SavePreferencesCommand) Response {
 	cmd.UserId = c.UserId
 	cmd.OrgId = c.OrgId
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to set home dashboard", err)
 	}
 
@@ -27,7 +29,7 @@ func GetUserPreferences(c *m.ReqContext) Response {
 func getPreferencesFor(orgID, userID, teamID int64) Response {
 	prefsQuery := m.GetPreferencesQuery{UserId: userID, OrgId: orgID, TeamId: teamID}
 
-	if err := bus.Dispatch(&prefsQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &prefsQuery); err != nil {
 		return Error(500, "Failed to get preferences", err)
 	}
 
@@ -55,7 +57,7 @@ func updatePreferencesFor(orgID, userID, teamId int64, dtoCmd *dtos.UpdatePrefsC
 		HomeDashboardId: dtoCmd.HomeDashboardID,
 	}
 
-	if err := bus.Dispatch(&saveCmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &saveCmd); err != nil {
 		return Error(500, "Failed to save preferences", err)
 	}
 

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -12,7 +12,7 @@ func GetOrgQuotas(c *m.ReqContext) Response {
 	}
 	query := m.GetOrgQuotasQuery{OrgId: c.ParamsInt64(":orgId")}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to get org quotas", err)
 	}
 
@@ -30,7 +30,7 @@ func UpdateOrgQuota(c *m.ReqContext, cmd m.UpdateOrgQuotaCmd) Response {
 		return Error(404, "Invalid quota target", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to update org quotas", err)
 	}
 	return Success("Organization quota updated")
@@ -42,7 +42,7 @@ func GetUserQuotas(c *m.ReqContext) Response {
 	}
 	query := m.GetUserQuotasQuery{UserId: c.ParamsInt64(":id")}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to get org quotas", err)
 	}
 
@@ -60,7 +60,7 @@ func UpdateUserQuota(c *m.ReqContext, cmd m.UpdateUserQuotaCmd) Response {
 		return Error(404, "Invalid quota target", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to update org quotas", err)
 	}
 	return Success("Organization quota updated")

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -56,7 +56,7 @@ func Search(c *m.ReqContext) Response {
 		Permission:   permission,
 	}
 
-	err := bus.Dispatch(&searchQuery)
+	err := bus.DispatchCtx(c.Ctx(), &searchQuery)
 	if err != nil {
 		return Error(500, "Search failed", err)
 	}

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -41,7 +41,7 @@ func SignUp(c *m.ReqContext, form dtos.SignUpForm) Response {
 		return Error(500, "Failed to create signup", err)
 	}
 
-	bus.Publish(&events.SignUpStarted{
+	bus.Publish(c.Context, &events.SignUpStarted{
 		Email: form.Email,
 		Code:  cmd.Code,
 	})
@@ -85,7 +85,7 @@ func (hs *HTTPServer) SignUpStep2(c *m.ReqContext, form dtos.SignUpStep2Form) Re
 
 	// publish signup event
 	user := &createUserCmd.Result
-	bus.Publish(&events.SignUpCompleted{
+	bus.Publish(c.Context, &events.SignUpCompleted{
 		Email: user.Email,
 		Name:  user.NameOrFallback(),
 	})

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -16,7 +16,7 @@ func StarDashboard(c *m.ReqContext) Response {
 		return Error(400, "Missing dashboard id", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to star dashboard", err)
 	}
 
@@ -31,7 +31,7 @@ func UnstarDashboard(c *m.ReqContext) Response {
 		return Error(400, "Missing dashboard id", nil)
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		return Error(500, "Failed to unstar dashboard", err)
 	}
 

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -16,7 +16,7 @@ func (hs *HTTPServer) CreateTeam(c *m.ReqContext, cmd m.CreateTeamCommand) Respo
 		return Error(403, "Not allowed to create team.", nil)
 	}
 
-	if err := hs.Bus.Dispatch(&cmd); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrTeamNameTaken {
 			return Error(409, "Team name taken", err)
 		}
@@ -35,7 +35,7 @@ func (hs *HTTPServer) CreateTeam(c *m.ReqContext, cmd m.CreateTeamCommand) Respo
 				Permission: m.PERMISSION_ADMIN,
 			}
 
-			if err := hs.Bus.Dispatch(&addMemberCmd); err != nil {
+			if err := hs.Bus.DispatchCtx(c.Ctx(), &addMemberCmd); err != nil {
 				c.Logger.Error("Could not add creator to team.", "error", err)
 			}
 		} else {
@@ -58,7 +58,7 @@ func (hs *HTTPServer) UpdateTeam(c *m.ReqContext, cmd m.UpdateTeamCommand) Respo
 		return Error(403, "Not allowed to update team", err)
 	}
 
-	if err := hs.Bus.Dispatch(&cmd); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrTeamNameTaken {
 			return Error(400, "Team name taken", err)
 		}
@@ -78,7 +78,7 @@ func (hs *HTTPServer) DeleteTeamByID(c *m.ReqContext) Response {
 		return Error(403, "Not allowed to delete team", err)
 	}
 
-	if err := hs.Bus.Dispatch(&m.DeleteTeamCommand{OrgId: orgId, Id: teamId}); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &m.DeleteTeamCommand{OrgId: orgId, Id: teamId}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return Error(404, "Failed to delete Team. ID not found", nil)
 		}
@@ -112,7 +112,7 @@ func (hs *HTTPServer) SearchTeams(c *m.ReqContext) Response {
 		Limit:        perPage,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to search Teams", err)
 	}
 
@@ -130,7 +130,7 @@ func (hs *HTTPServer) SearchTeams(c *m.ReqContext) Response {
 func GetTeamByID(c *m.ReqContext) Response {
 	query := m.GetTeamByIdQuery{OrgId: c.OrgId, Id: c.ParamsInt64(":teamId")}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		if err == m.ErrTeamNotFound {
 			return Error(404, "Team not found", err)
 		}

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -13,7 +13,7 @@ import (
 func GetTeamMembers(c *m.ReqContext) Response {
 	query := m.GetTeamMembersQuery{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId")}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 		return Error(500, "Failed to get Team Members", err)
 	}
 
@@ -39,7 +39,7 @@ func (hs *HTTPServer) AddTeamMember(c *m.ReqContext, cmd m.AddTeamMemberCommand)
 		return Error(403, "Not allowed to add team member", err)
 	}
 
-	if err := hs.Bus.Dispatch(&cmd); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrTeamNotFound {
 			return Error(404, "Team not found", nil)
 		}
@@ -73,7 +73,7 @@ func (hs *HTTPServer) UpdateTeamMember(c *m.ReqContext, cmd m.UpdateTeamMemberCo
 	cmd.UserId = c.ParamsInt64(":userId")
 	cmd.OrgId = orgId
 
-	if err := hs.Bus.Dispatch(&cmd); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &cmd); err != nil {
 		if err == m.ErrTeamMemberNotFound {
 			return Error(404, "Team member not found.", nil)
 		}
@@ -97,7 +97,7 @@ func (hs *HTTPServer) RemoveTeamMember(c *m.ReqContext) Response {
 		protectLastAdmin = true
 	}
 
-	if err := hs.Bus.Dispatch(&m.RemoveTeamMemberCommand{OrgId: orgId, TeamId: teamId, UserId: userId, ProtectLastAdmin: protectLastAdmin}); err != nil {
+	if err := hs.Bus.DispatchCtx(c.Ctx(), &m.RemoveTeamMemberCommand{OrgId: orgId, TeamId: teamId, UserId: userId, ProtectLastAdmin: protectLastAdmin}); err != nil {
 		if err == m.ErrTeamNotFound {
 			return Error(404, "Team not found", nil)
 		}

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -9,11 +10,12 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	macaron "gopkg.in/macaron.v1"
-	"net/http"
 )
 
 type testLogger struct {
@@ -45,7 +47,7 @@ func TestTeamApiEndpoint(t *testing.T) {
 			loggedInUserScenario("When calling GET on", "/api/teams/search", func(sc *scenarioContext) {
 				var sentLimit int
 				var sendPage int
-				bus.AddHandler("test", func(query *models.SearchTeamsQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchTeamsQuery) error {
 					query.Result = mockResult
 
 					sentLimit = query.Limit
@@ -72,7 +74,7 @@ func TestTeamApiEndpoint(t *testing.T) {
 			loggedInUserScenario("When calling GET on", "/api/teams/search", func(sc *scenarioContext) {
 				var sentLimit int
 				var sendPage int
-				bus.AddHandler("test", func(query *models.SearchTeamsQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchTeamsQuery) error {
 					query.Result = mockResult
 
 					sentLimit = query.Limit
@@ -102,14 +104,14 @@ func TestTeamApiEndpoint(t *testing.T) {
 		teamName := "team foo"
 
 		createTeamCalled := 0
-		bus.AddHandler("test", func(cmd *models.CreateTeamCommand) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.CreateTeamCommand) error {
 			createTeamCalled += 1
 			cmd.Result = models.Team{Name: teamName, Id: 42}
 			return nil
 		})
 
 		addTeamMemberCalled := 0
-		bus.AddHandler("test", func(cmd *models.AddTeamMemberCommand) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.AddTeamMemberCommand) error {
 			addTeamMemberCalled += 1
 			return nil
 		})

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ func TestUserApiEndpoint(t *testing.T) {
 
 		loggedInUserScenario("When calling GET on", "api/users/:id", func(sc *scenarioContext) {
 			fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
-			bus.AddHandler("test", func(query *models.GetUserProfileQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetUserProfileQuery) error {
 				query.Result = models.UserProfileDTO{
 					Id:             int64(1),
 					Email:          "daniel@grafana.com",
@@ -39,7 +40,7 @@ func TestUserApiEndpoint(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetAuthInfoQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetAuthInfoQuery) error {
 				query.Result = &models.UserAuth{
 					AuthModule: models.AuthModuleLDAP,
 				}
@@ -74,7 +75,7 @@ func TestUserApiEndpoint(t *testing.T) {
 		loggedInUserScenario("When calling GET on", "/api/users", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchUsersQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit
@@ -97,7 +98,7 @@ func TestUserApiEndpoint(t *testing.T) {
 		loggedInUserScenario("When calling GET with page and limit querystring parameters on", "/api/users", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchUsersQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit
@@ -116,7 +117,7 @@ func TestUserApiEndpoint(t *testing.T) {
 		loggedInUserScenario("When calling GET on", "/api/users/search", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchUsersQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit
@@ -141,7 +142,7 @@ func TestUserApiEndpoint(t *testing.T) {
 		loggedInUserScenario("When calling GET with page and perpage querystring parameters on", "/api/users/search", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.SearchUsersQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit

--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -24,7 +24,7 @@ func (server *HTTPServer) RevokeUserAuthToken(c *models.ReqContext, cmd models.R
 func (server *HTTPServer) logoutUserFromAllDevicesInternal(ctx context.Context, userID int64) Response {
 	userQuery := models.GetUserByIdQuery{Id: userID}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(ctx, &userQuery); err != nil {
 		if err == models.ErrUserNotFound {
 			return Error(404, "User not found", err)
 		}
@@ -44,7 +44,7 @@ func (server *HTTPServer) logoutUserFromAllDevicesInternal(ctx context.Context, 
 func (server *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID int64) Response {
 	userQuery := models.GetUserByIdQuery{Id: userID}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &userQuery); err != nil {
 		if err == models.ErrUserNotFound {
 			return Error(404, "User not found", err)
 		}
@@ -111,7 +111,7 @@ func (server *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID
 func (server *HTTPServer) revokeUserAuthTokenInternal(c *models.ReqContext, userID int64, cmd models.RevokeAuthTokenCmd) Response {
 	userQuery := models.GetUserByIdQuery{Id: userID}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(c.Ctx(), &userQuery); err != nil {
 		if err == models.ErrUserNotFound {
 			return Error(404, "User not found", err)
 		}

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -15,7 +15,7 @@ import (
 func TestUserTokenApiEndpoint(t *testing.T) {
 	Convey("When current user attempts to revoke an auth token for a non-existing user", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			userId = cmd.Id
 			return m.ErrUserNotFound
 		})
@@ -31,7 +31,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 
 	Convey("When current user gets auth tokens for a non-existing user", t, func() {
 		userId := int64(0)
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			userId = cmd.Id
 			return m.ErrUserNotFound
 		})
@@ -44,7 +44,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When logout an existing user from all devices", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			cmd.Result = &m.User{Id: 200}
 			return nil
 		})
@@ -56,7 +56,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When logout a non-existing user from all devices", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			return m.ErrUserNotFound
 		})
 
@@ -67,7 +67,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When revoke an auth token for a user", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			cmd.Result = &m.User{Id: 200}
 			return nil
 		})
@@ -85,7 +85,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When revoke the active auth token used by himself", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			cmd.Result = &m.User{Id: TestUserID}
 			return nil
 		})
@@ -103,7 +103,7 @@ func TestUserTokenApiEndpoint(t *testing.T) {
 	})
 
 	Convey("When gets auth tokens for a user", t, func() {
-		bus.AddHandler("test", func(cmd *m.GetUserByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetUserByIdQuery) error {
 			cmd.Result = &m.User{Id: TestUserID}
 			return nil
 		})

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -25,9 +25,8 @@ type TransactionManager interface {
 
 // Bus type defines the bus interface structure
 type Bus interface {
-	Dispatch(msg Msg) error
 	DispatchCtx(ctx context.Context, msg Msg) error
-	Publish(msg Msg) error
+	Publish(ctx context.Context, msg Msg) error
 
 	// InTransaction starts a transaction and store it in the context.
 	// The caller can then pass a function with multiple DispatchCtx calls that
@@ -35,7 +34,6 @@ type Bus interface {
 	// callback returns an error.
 	InTransaction(ctx context.Context, fn func(ctx context.Context) error) error
 
-	AddHandler(handler HandlerFunc)
 	AddHandlerCtx(handler HandlerFunc)
 	AddEventListener(handler HandlerFunc)
 	AddWildcardListener(handler HandlerFunc)
@@ -53,7 +51,6 @@ func (b *InProcBus) InTransaction(ctx context.Context, fn func(ctx context.Conte
 
 // InProcBus defines the bus structure
 type InProcBus struct {
-	handlers          map[string]HandlerFunc
 	handlersWithCtx   map[string]HandlerFunc
 	listeners         map[string][]HandlerFunc
 	wildcardListeners []HandlerFunc
@@ -66,7 +63,6 @@ var globalBus = New()
 // New initialize the bus
 func New() Bus {
 	bus := &InProcBus{}
-	bus.handlers = make(map[string]HandlerFunc)
 	bus.handlersWithCtx = make(map[string]HandlerFunc)
 	bus.listeners = make(map[string][]HandlerFunc)
 	bus.wildcardListeners = make([]HandlerFunc, 0)
@@ -106,43 +102,14 @@ func (b *InProcBus) DispatchCtx(ctx context.Context, msg Msg) error {
 	return err.(error)
 }
 
-// Dispatch function dispatch a message to the bus.
-func (b *InProcBus) Dispatch(msg Msg) error {
-	var msgName = reflect.TypeOf(msg).Elem().Name()
-
-	var handler = b.handlersWithCtx[msgName]
-	withCtx := true
-
-	if handler == nil {
-		withCtx = false
-		handler = b.handlers[msgName]
-	}
-
-	if handler == nil {
-		return ErrHandlerNotFound
-	}
-
-	var params = []reflect.Value{}
-	if withCtx {
-		params = append(params, reflect.ValueOf(context.Background()))
-	}
-	params = append(params, reflect.ValueOf(msg))
-
-	ret := reflect.ValueOf(handler).Call(params)
-	err := ret[0].Interface()
-	if err == nil {
-		return nil
-	}
-	return err.(error)
-}
-
 // Publish function publish a message to the bus listener.
-func (b *InProcBus) Publish(msg Msg) error {
+func (b *InProcBus) Publish(ctx context.Context, msg Msg) error {
 	var msgName = reflect.TypeOf(msg).Elem().Name()
 	var listeners = b.listeners[msgName]
 
-	var params = make([]reflect.Value, 1)
-	params[0] = reflect.ValueOf(msg)
+	var params = []reflect.Value{}
+	params = append(params, reflect.ValueOf(ctx))
+	params = append(params, reflect.ValueOf(msg))
 
 	for _, listenerHandler := range listeners {
 		ret := reflect.ValueOf(listenerHandler).Call(params)
@@ -167,12 +134,6 @@ func (b *InProcBus) AddWildcardListener(handler HandlerFunc) {
 	b.wildcardListeners = append(b.wildcardListeners, handler)
 }
 
-func (b *InProcBus) AddHandler(handler HandlerFunc) {
-	handlerType := reflect.TypeOf(handler)
-	queryTypeName := handlerType.In(0).Elem().Name()
-	b.handlers[queryTypeName] = handler
-}
-
 func (b *InProcBus) AddHandlerCtx(handler HandlerFunc) {
 	handlerType := reflect.TypeOf(handler)
 	queryTypeName := handlerType.In(1).Elem().Name()
@@ -181,18 +142,12 @@ func (b *InProcBus) AddHandlerCtx(handler HandlerFunc) {
 
 func (b *InProcBus) AddEventListener(handler HandlerFunc) {
 	handlerType := reflect.TypeOf(handler)
-	eventName := handlerType.In(0).Elem().Name()
+	eventName := handlerType.In(1).Elem().Name()
 	_, exists := b.listeners[eventName]
 	if !exists {
 		b.listeners[eventName] = make([]HandlerFunc, 0)
 	}
 	b.listeners[eventName] = append(b.listeners[eventName], handler)
-}
-
-// AddHandler attach a handler function to the global bus
-// Package level function
-func AddHandler(implName string, handler HandlerFunc) {
-	globalBus.AddHandler(handler)
 }
 
 // AddHandlerCtx attach a handler function to the global bus context
@@ -212,16 +167,12 @@ func AddWildcardListener(handler HandlerFunc) {
 	globalBus.AddWildcardListener(handler)
 }
 
-func Dispatch(msg Msg) error {
-	return globalBus.Dispatch(msg)
-}
-
 func DispatchCtx(ctx context.Context, msg Msg) error {
 	return globalBus.DispatchCtx(ctx, msg)
 }
 
-func Publish(msg Msg) error {
-	return globalBus.Publish(msg)
+func Publish(ctx context.Context, msg Msg) error {
+	return globalBus.Publish(ctx, msg)
 }
 
 // InTransaction starts a transaction and store it in the context.

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -12,56 +12,23 @@ type testQuery struct {
 	Resp string
 }
 
-func TestDispatchCtxCanUseNormalHandlers(t *testing.T) {
+func TestDispatchCtx(t *testing.T) {
 	bus := New()
-
-	handlerWithCtxCallCount := 0
-	handlerCallCount := 0
-
-	handlerWithCtx := func(ctx context.Context, query *testQuery) error {
-		handlerWithCtxCallCount++
-		return nil
-	}
-
-	handler := func(query *testQuery) error {
-		handlerCallCount++
-		return nil
-	}
 
 	err := bus.DispatchCtx(context.Background(), &testQuery{})
 	if err != ErrHandlerNotFound {
 		t.Errorf("expected bus to return HandlerNotFound is no handler is registered")
 	}
-
-	bus.AddHandler(handler)
-
-	t.Run("when a normal handler is registered", func(t *testing.T) {
-		bus.Dispatch(&testQuery{})
-
-		if handlerCallCount != 1 {
-			t.Errorf("Expected normal handler to be called 1 time. was called %d", handlerCallCount)
-		}
-
-		t.Run("when a ctx handler is registered", func(t *testing.T) {
-			bus.AddHandlerCtx(handlerWithCtx)
-			bus.Dispatch(&testQuery{})
-
-			if handlerWithCtxCallCount != 1 {
-				t.Errorf("Expected ctx handler to be called 1 time. was called %d", handlerWithCtxCallCount)
-			}
-		})
-	})
-
 }
 
 func TestQueryHandlerReturnsError(t *testing.T) {
 	bus := New()
 
-	bus.AddHandler(func(query *testQuery) error {
+	bus.AddHandlerCtx(func(ctx context.Context, query *testQuery) error {
 		return errors.New("handler error")
 	})
 
-	err := bus.Dispatch(&testQuery{})
+	err := bus.DispatchCtx(context.Background(), &testQuery{})
 
 	if err == nil {
 		t.Fatal("Send query failed")
@@ -73,13 +40,13 @@ func TestQueryHandlerReturnsError(t *testing.T) {
 func TestQueryHandlerReturn(t *testing.T) {
 	bus := New()
 
-	bus.AddHandler(func(q *testQuery) error {
+	bus.AddHandlerCtx(func(ctx context.Context, q *testQuery) error {
 		q.Resp = "hello from handler"
 		return nil
 	})
 
 	query := &testQuery{}
-	err := bus.Dispatch(query)
+	err := bus.DispatchCtx(context.Background(), query)
 
 	if err != nil {
 		t.Fatal("Send query failed " + err.Error())
@@ -92,17 +59,17 @@ func TestEventListeners(t *testing.T) {
 	bus := New()
 	count := 0
 
-	bus.AddEventListener(func(query *testQuery) error {
+	bus.AddEventListener(func(ctx context.Context, query *testQuery) error {
 		count++
 		return nil
 	})
 
-	bus.AddEventListener(func(query *testQuery) error {
+	bus.AddEventListener(func(ctx context.Context, query *testQuery) error {
 		count += 10
 		return nil
 	})
 
-	err := bus.Publish(&testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 
 	if err != nil {
 		t.Fatal("Publish event failed " + err.Error())

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -24,7 +25,7 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 
 	userQuery := models.GetUserByIdQuery{Id: AdminUserId}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &userQuery); err != nil {
 		return fmt.Errorf("Could not read user from database. Error: %v", err)
 	}
 
@@ -35,7 +36,7 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 		NewPassword: passwordHashed,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		return fmt.Errorf("Failed to update user password")
 	}
 

--- a/pkg/components/dashdiffs/compare.go
+++ b/pkg/components/dashdiffs/compare.go
@@ -1,6 +1,7 @@
 package dashdiffs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -64,7 +65,7 @@ func CalculateDiff(options *Options) (*Result, error) {
 		OrgId:       options.OrgId,
 	}
 
-	if err := bus.Dispatch(&baseVersionQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &baseVersionQuery); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +75,7 @@ func CalculateDiff(options *Options) (*Result, error) {
 		OrgId:       options.OrgId,
 	}
 
-	if err := bus.Dispatch(&newVersionQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &newVersionQuery); err != nil {
 		return nil, err
 	}
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,7 +38,7 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 	}
 
 	statsQuery := models.GetSystemStatsQuery{}
-	if err := uss.Bus.Dispatch(&statsQuery); err != nil {
+	if err := uss.Bus.DispatchCtx(context.TODO(), &statsQuery); err != nil {
 		metricsLogger.Error("Failed to get system stats", "error", err)
 		return
 	}
@@ -70,7 +71,7 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 	metrics["stats.avg_auth_token_per_user.count"] = avgAuthTokensPerUser
 
 	dsStats := models.GetDataSourceStatsQuery{}
-	if err := uss.Bus.Dispatch(&dsStats); err != nil {
+	if err := uss.Bus.DispatchCtx(context.TODO(), &dsStats); err != nil {
 		metricsLogger.Error("Failed to get datasource stats", "error", err)
 		return
 	}
@@ -91,7 +92,7 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 	metrics["stats.packaging."+setting.Packaging+".count"] = 1
 
 	dsAccessStats := models.GetDataSourceAccessStatsQuery{}
-	if err := uss.Bus.Dispatch(&dsAccessStats); err != nil {
+	if err := uss.Bus.DispatchCtx(context.TODO(), &dsAccessStats); err != nil {
 		metricsLogger.Error("Failed to get datasource access stats", "error", err)
 		return
 	}
@@ -120,7 +121,7 @@ func (uss *UsageStatsService) sendUsageStats(oauthProviders map[string]bool) {
 	}
 
 	anStats := models.GetAlertNotifierUsageStatsQuery{}
-	if err := uss.Bus.Dispatch(&anStats); err != nil {
+	if err := uss.Bus.DispatchCtx(context.TODO(), &anStats); err != nil {
 		metricsLogger.Error("Failed to get alert notification stats", "error", err)
 		return
 	}
@@ -160,7 +161,7 @@ func (uss *UsageStatsService) updateTotalStats() {
 	}
 
 	statsQuery := models.GetSystemStatsQuery{}
-	if err := uss.Bus.Dispatch(&statsQuery); err != nil {
+	if err := uss.Bus.DispatchCtx(context.TODO(), &statsQuery); err != nil {
 		metricsLogger.Error("Failed to get system stats", "error", err)
 		return
 	}

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"runtime"
 	"sync"
@@ -28,7 +29,7 @@ func TestMetrics(t *testing.T) {
 		}
 
 		var getSystemStatsQuery *models.GetSystemStatsQuery
-		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
+		uss.Bus.AddHandlerCtx(func(ctx context.Context, query *models.GetSystemStatsQuery) error {
 
 			query.Result = &models.SystemStats{
 				Dashboards:            1,
@@ -52,7 +53,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		var getDataSourceStatsQuery *models.GetDataSourceStatsQuery
-		uss.Bus.AddHandler(func(query *models.GetDataSourceStatsQuery) error {
+		uss.Bus.AddHandlerCtx(func(ctx context.Context, query *models.GetDataSourceStatsQuery) error {
 			query.Result = []*models.DataSourceStats{
 				{
 					Type:  models.DS_ES,
@@ -76,7 +77,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		var getDataSourceAccessStatsQuery *models.GetDataSourceAccessStatsQuery
-		uss.Bus.AddHandler(func(query *models.GetDataSourceAccessStatsQuery) error {
+		uss.Bus.AddHandlerCtx(func(ctx context.Context, query *models.GetDataSourceAccessStatsQuery) error {
 			query.Result = []*models.DataSourceAccessStats{
 				{
 					Type:   models.DS_ES,
@@ -124,7 +125,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		var getAlertNotifierUsageStatsQuery *models.GetAlertNotifierUsageStatsQuery
-		uss.Bus.AddHandler(func(query *models.GetAlertNotifierUsageStatsQuery) error {
+		uss.Bus.AddHandlerCtx(func(ctx context.Context, query *models.GetAlertNotifierUsageStatsQuery) error {
 			query.Result = []*models.NotifierUsageStats{
 				{
 					Type:  "slack",
@@ -273,7 +274,7 @@ func TestMetrics(t *testing.T) {
 		uss.Cfg.MetricsEndpointEnabled = true
 		uss.Cfg.MetricsEndpointDisableTotalStats = false
 		getSystemStatsWasCalled := false
-		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
+		uss.Bus.AddHandlerCtx(func(ctx context.Context, query *models.GetSystemStatsQuery) error {
 			query.Result = &models.SystemStats{}
 			getSystemStatsWasCalled = true
 			return nil

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"errors"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -20,11 +21,11 @@ var (
 )
 
 func Init() {
-	bus.AddHandler("auth", AuthenticateUser)
+	bus.AddHandlerCtx("auth", AuthenticateUser)
 }
 
 // AuthenticateUser authenticates the user via username & password
-func AuthenticateUser(query *models.LoginUserQuery) error {
+func AuthenticateUser(ctx context.Context, query *models.LoginUserQuery) error {
 	if err := validateLoginAttempts(query.Username); err != nil {
 		return err
 	}

--- a/pkg/login/auth_test.go
+++ b/pkg/login/auth_test.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestAuthenticateUser(t *testing.T) {
 				Username: "user",
 				Password: "",
 			}
-			err := AuthenticateUser(&loginQuery)
+			err := AuthenticateUser(context.TODO(), &loginQuery)
 
 			Convey("login should fail", func() {
 				So(sc.grafanaLoginWasCalled, ShouldBeFalse)
@@ -36,7 +37,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrTooManyLoginAttempts)
@@ -53,7 +54,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, nil)
@@ -71,7 +72,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -88,7 +89,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(false, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -105,7 +106,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, ldap.ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)
@@ -122,7 +123,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, nil, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldBeNil)
@@ -140,7 +141,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, customErr, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, customErr)
@@ -157,7 +158,7 @@ func TestAuthenticateUser(t *testing.T) {
 			mockLoginUsingLDAP(true, ldap.ErrInvalidCredentials, sc)
 			mockSaveInvalidLoginAttempt(sc)
 
-			err := AuthenticateUser(sc.loginUserQuery)
+			err := AuthenticateUser(context.TODO(), sc.loginUserQuery)
 
 			Convey("it should result in", func() {
 				So(err, ShouldEqual, ErrInvalidCredentials)

--- a/pkg/login/brute_force_login_protection.go
+++ b/pkg/login/brute_force_login_protection.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -23,7 +24,7 @@ var validateLoginAttempts = func(username string) error {
 		Since:    time.Now().Add(-loginAttemptsWindow),
 	}
 
-	if err := bus.Dispatch(&loginAttemptCountQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &loginAttemptCountQuery); err != nil {
 		return err
 	}
 
@@ -44,5 +45,5 @@ var saveInvalidLoginAttempt = func(query *m.LoginUserQuery) {
 		IpAddress: query.IpAddress,
 	}
 
-	bus.Dispatch(&loginAttemptCommand)
+	bus.DispatchCtx(context.TODO(), &loginAttemptCommand)
 }

--- a/pkg/login/brute_force_login_protection_test.go
+++ b/pkg/login/brute_force_login_protection_test.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -45,7 +46,7 @@ func TestLoginAttemptsValidation(t *testing.T) {
 				defer bus.ClearBusHandlers()
 				createLoginAttemptCmd := &m.CreateLoginAttemptCommand{}
 
-				bus.AddHandler("test", func(cmd *m.CreateLoginAttemptCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.CreateLoginAttemptCommand) error {
 					createLoginAttemptCmd = cmd
 					return nil
 				})
@@ -98,7 +99,7 @@ func TestLoginAttemptsValidation(t *testing.T) {
 				defer bus.ClearBusHandlers()
 				createLoginAttemptCmd := (*m.CreateLoginAttemptCommand)(nil)
 
-				bus.AddHandler("test", func(cmd *m.CreateLoginAttemptCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.CreateLoginAttemptCommand) error {
 					createLoginAttemptCmd = cmd
 					return nil
 				})
@@ -118,7 +119,7 @@ func TestLoginAttemptsValidation(t *testing.T) {
 }
 
 func withLoginAttempts(loginAttempts int64) {
-	bus.AddHandler("test", func(query *m.GetUserLoginAttemptCountQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetUserLoginAttemptCountQuery) error {
 		query.Result = loginAttempts
 		return nil
 	})

--- a/pkg/login/grafana_login.go
+++ b/pkg/login/grafana_login.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"crypto/subtle"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -20,7 +21,7 @@ var validatePassword = func(providedPassword string, userPassword string, userSa
 var loginUsingGrafanaDB = func(query *m.LoginUserQuery) error {
 	userQuery := m.GetUserByLoginQuery{LoginOrEmail: query.Username}
 
-	if err := bus.Dispatch(&userQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &userQuery); err != nil {
 		return err
 	}
 

--- a/pkg/login/grafana_login_test.go
+++ b/pkg/login/grafana_login_test.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -124,7 +125,7 @@ func mockPasswordValidation(valid bool, sc *grafanaLoginScenarioContext) {
 }
 
 func (sc *grafanaLoginScenarioContext) getUserByLoginQueryReturns(user *m.User) {
-	bus.AddHandler("test", func(query *m.GetUserByLoginQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetUserByLoginQuery) error {
 		if user == nil {
 			return m.ErrUserNotFound
 		}

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -1,6 +1,8 @@
 package login
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -52,7 +54,7 @@ var loginUsingLDAP = func(query *models.LoginUserQuery) (bool, error) {
 		ExternalUser:  externalUser,
 		SignupAllowed: setting.LDAPAllowSignup,
 	}
-	err = bus.Dispatch(upsert)
+	err = bus.DispatchCtx(context.TODO(), upsert)
 	if err != nil {
 		return true, err
 	}
@@ -68,7 +70,7 @@ func DisableExternalUser(username string) error {
 		LoginOrEmail: username,
 	}
 
-	if err := bus.Dispatch(userQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), userQuery); err != nil {
 		return err
 	}
 
@@ -87,7 +89,7 @@ func DisableExternalUser(username string) error {
 			IsDisabled: true,
 		}
 
-		if err := bus.Dispatch(disableUserCmd); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), disableUserCmd); err != nil {
 			logger.Debug(
 				"Error disabling external user",
 				"user",

--- a/pkg/middleware/auth_proxy/auth_proxy.go
+++ b/pkg/middleware/auth_proxy/auth_proxy.go
@@ -1,6 +1,7 @@
 package authproxy
 
 import (
+	"context"
 	"encoding/base32"
 	"fmt"
 	"net"
@@ -229,7 +230,7 @@ func (auth *AuthProxy) LoginViaLDAP() (int64, *Error) {
 		SignupAllowed: auth.LDAPAllowSignup,
 		ExternalUser:  extUser,
 	}
-	err = bus.Dispatch(upsert)
+	err = bus.DispatchCtx(context.TODO(), upsert)
 	if err != nil {
 		return 0, newError(err.Error(), nil)
 	}
@@ -274,7 +275,7 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 		ExternalUser:  extUser,
 	}
 
-	err := bus.Dispatch(upsert)
+	err := bus.DispatchCtx(context.TODO(), upsert)
 	if err != nil {
 		return 0, err
 	}
@@ -304,7 +305,7 @@ func (auth *AuthProxy) GetSignedUser(userID int64) (*models.SignedInUser, *Error
 		UserId: userID,
 	}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), query); err != nil {
 		return nil, newError(err.Error(), nil)
 	}
 

--- a/pkg/middleware/auth_proxy/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy/auth_proxy_test.go
@@ -1,6 +1,7 @@
 package authproxy
 
 import (
+	"context"
 	"encoding/base32"
 	"errors"
 	"fmt"
@@ -114,7 +115,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 		Convey("LDAP", func() {
 			Convey("logs in via LDAP", func() {
-				bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
 					cmd.Result = &models.User{
 						Id: 42,
 					}

--- a/pkg/middleware/dashboard_redirect.go
+++ b/pkg/middleware/dashboard_redirect.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 func getDashboardURLBySlug(orgID int64, slug string) (string, error) {
 	query := m.GetDashboardQuery{Slug: slug, OrgId: orgID}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return "", m.ErrDashboardNotFound
 	}
 

--- a/pkg/middleware/dashboard_redirect_test.go
+++ b/pkg/middleware/dashboard_redirect_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestMiddlewareDashboardRedirect(t *testing.T) {
 		fakeDash.HasAcl = false
 		fakeDash.Uid = util.GenerateShortUID()
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			query.Result = fakeDash
 			return nil
 		})

--- a/pkg/middleware/middleware_basic_auth_test.go
+++ b/pkg/middleware/middleware_basic_auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			var orgID int64 = 2
 			keyhash := util.EncodePassword("v5nAwpMafFP6znaS4urhdWDLS5511M42", "asd")
 
-			bus.AddHandler("test", func(query *models.GetApiKeyByNameQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetApiKeyByNameQuery) error {
 				query.Result = &models.ApiKey{OrgId: orgID, Role: models.ROLE_EDITOR, Key: keyhash}
 				return nil
 			})
@@ -53,7 +54,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			var salt = "Salt"
 			var orgID int64 = 2
 
-			bus.AddHandler("grafana-auth", func(query *models.LoginUserQuery) error {
+			bus.AddHandlerCtx("grafana-auth", func(ctx context.Context, query *models.LoginUserQuery) error {
 				query.User = &models.User{
 					Password: util.EncodePassword(password, salt),
 					Salt:     salt,
@@ -61,7 +62,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("get-sign-user", func(query *models.GetSignedInUserQuery) error {
+			bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				query.Result = &models.SignedInUser{OrgId: orgID, UserId: id}
 				return nil
 			})
@@ -84,7 +85,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 
 			authLogin.Init()
 
-			bus.AddHandler("user-query", func(query *models.GetUserByLoginQuery) error {
+			bus.AddHandlerCtx("user-query", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
 				query.Result = &models.User{
 					Password: util.EncodePassword(password, salt),
 					Id:       id,
@@ -93,7 +94,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("get-sign-user", func(query *models.GetSignedInUserQuery) error {
+			bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				query.Result = &models.SignedInUser{UserId: query.UserId}
 				return nil
 			})
@@ -120,7 +121,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 		})
 
 		middlewareScenario(t, "Should return error if user & password do not match", func(sc *scenarioContext) {
-			bus.AddHandler("user-query", func(loginUserQuery *models.GetUserByLoginQuery) error {
+			bus.AddHandlerCtx("user-query", func(ctx context.Context, loginUserQuery *models.GetUserByLoginQuery) error {
 				return nil
 			})
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -498,7 +498,7 @@ func TestMiddlewareContext(t *testing.T) {
 			})
 
 			middlewareScenario(t, "Should return 407 status code if there is cache mishap", func(sc *scenarioContext) {
-				bus.AddHandlerCtx("Do not have ctx context.Context, the user", func(query *models.GetSignedInUserQuery) error {
+				bus.AddHandlerCtx("Do not have ctx context.Context, the user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 					return errors.New("Do not add user")
 				})
 

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -31,7 +31,7 @@ func OrgRedirect() macaron.Handler {
 		}
 
 		cmd := m.SetUsingOrgCommand{UserId: ctx.UserId, OrgId: orgId}
-		if err := bus.Dispatch(&cmd); err != nil {
+		if err := bus.DispatchCtx(req.Context(), &cmd); err != nil {
 			if ctx.IsApiRequest() {
 				ctx.JsonApiErr(404, "Not found", nil)
 			} else {

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -15,11 +15,11 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 	Convey("Can redirect to correct org", t, func() {
 		middlewareScenario(t, "when setting a correct org for the user", func(sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
-			bus.AddHandler("test", func(query *m.SetUsingOrgCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.SetUsingOrgCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 1, UserId: 12}
 				return nil
 			})
@@ -41,11 +41,11 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 		middlewareScenario(t, "when setting an invalid org for user", func(sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
-			bus.AddHandler("test", func(query *m.SetUsingOrgCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.SetUsingOrgCommand) error {
 				return fmt.Errorf("")
 			})
 
-			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 1, UserId: 12}
 				return nil
 			})

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -44,7 +44,7 @@ func TestMiddlewareQuota(t *testing.T) {
 		QuotaFn := Quota(qs)
 
 		middlewareScenario(t, "with user not logged in", func(sc *scenarioContext) {
-			bus.AddHandler("globalQuota", func(query *m.GetGlobalQuotaByTargetQuery) error {
+			bus.AddHandlerCtx("globalQuota", func(ctx context.Context, query *m.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &m.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -83,7 +83,7 @@ func TestMiddlewareQuota(t *testing.T) {
 
 		middlewareScenario(t, "with user logged in", func(sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
-			bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetSignedInUserQuery) error {
 				query.Result = &m.SignedInUser{OrgId: 2, UserId: 12}
 				return nil
 			})
@@ -95,7 +95,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				}, nil
 			}
 
-			bus.AddHandler("globalQuota", func(query *m.GetGlobalQuotaByTargetQuery) error {
+			bus.AddHandlerCtx("globalQuota", func(ctx context.Context, query *m.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &m.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -104,7 +104,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("userQuota", func(query *m.GetUserQuotaByTargetQuery) error {
+			bus.AddHandlerCtx("userQuota", func(ctx context.Context, query *m.GetUserQuotaByTargetQuery) error {
 				query.Result = &m.UserQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -113,7 +113,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("orgQuota", func(query *m.GetOrgQuotaByTargetQuery) error {
+			bus.AddHandlerCtx("orgQuota", func(ctx context.Context, query *m.GetOrgQuotaByTargetQuery) error {
 				query.Result = &m.OrgQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -35,6 +36,10 @@ func (ctx *ReqContext) Handle(status int, title string, err error) {
 	ctx.Data["Theme"] = "dark"
 
 	ctx.HTML(status, setting.ERR_TEMPLATE_NAME)
+}
+
+func (ctx *ReqContext) Ctx() context.Context {
+	return ctx.Req.Context()
 }
 
 func (ctx *ReqContext) JsonOK(message string) {

--- a/pkg/plugins/dashboard_importer.go
+++ b/pkg/plugins/dashboard_importer.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -40,10 +41,10 @@ func (e DashboardInputMissingError) Error() string {
 }
 
 func init() {
-	bus.AddHandler("plugins", ImportDashboard)
+	bus.AddHandlerCtx("plugins", ImportDashboard)
 }
 
-func ImportDashboard(cmd *ImportDashboardCommand) error {
+func ImportDashboard(ctx context.Context, cmd *ImportDashboardCommand) error {
 	var dashboard *m.Dashboard
 	var err error
 

--- a/pkg/plugins/dashboard_importer_test.go
+++ b/pkg/plugins/dashboard_importer_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestDashboardImport(t *testing.T) {
 			},
 		}
 
-		err := ImportDashboard(&cmd)
+		err := ImportDashboard(context.Background(), &cmd)
 		So(err, ShouldBeNil)
 
 		Convey("should install dashboard", func() {

--- a/pkg/plugins/dashboards.go
+++ b/pkg/plugins/dashboards.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -36,7 +37,7 @@ func GetPluginDashboards(orgId int64, pluginId string) ([]*PluginDashboardInfoDT
 
 	// load current dashboards
 	query := m.GetDashboardsByPluginIdQuery{OrgId: orgId, PluginId: pluginId}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 

--- a/pkg/plugins/dashboards_test.go
+++ b/pkg/plugins/dashboards_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -23,7 +24,7 @@ func TestPluginDashboards(t *testing.T) {
 
 		So(err, ShouldBeNil)
 
-		bus.AddHandler("test", func(query *m.GetDashboardQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardQuery) error {
 			if query.Slug == "nginx-connections" {
 				dash := m.NewDashboard("Nginx Connections")
 				dash.Data.Set("revision", "1.1")
@@ -34,7 +35,7 @@ func TestPluginDashboards(t *testing.T) {
 			return m.ErrDashboardNotFound
 		})
 
-		bus.AddHandler("test", func(query *m.GetDashboardsByPluginIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardsByPluginIdQuery) error {
 			var data = simplejson.New()
 			data.Set("title", "Nginx Connections")
 			data.Set("revision", 22)

--- a/pkg/plugins/dashboards_updater.go
+++ b/pkg/plugins/dashboards_updater.go
@@ -16,7 +16,7 @@ func (pm *PluginManager) updateAppDashboards() {
 
 	query := m.GetPluginSettingsQuery{OrgId: 0}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		plog.Error("Failed to get all plugin settings", "error", err)
 		return
 	}
@@ -50,7 +50,7 @@ func autoUpdateAppDashboard(pluginDashInfo *PluginDashboardInfoDTO, orgId int64)
 		Path:      pluginDashInfo.Path,
 	}
 
-	return bus.Dispatch(&updateCmd)
+	return bus.DispatchCtx(context.TODO(), &updateCmd)
 }
 
 func syncPluginDashboards(pluginDef *PluginBase, orgId int64) {
@@ -71,7 +71,7 @@ func syncPluginDashboards(pluginDef *PluginBase, orgId int64) {
 			plog.Info("Deleting plugin dashboard", "pluginId", pluginDef.Id, "dashboard", dash.Slug)
 
 			deleteCmd := m.DeleteDashboardCommand{OrgId: orgId, Id: dash.DashboardId}
-			if err := bus.Dispatch(&deleteCmd); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), &deleteCmd); err != nil {
 				plog.Error("Failed to auto update app dashboard", "pluginId", pluginDef.Id, "error", err)
 				return
 			}
@@ -90,7 +90,7 @@ func syncPluginDashboards(pluginDef *PluginBase, orgId int64) {
 
 	// update version in plugin_setting table to mark that we have processed the update
 	query := m.GetPluginSettingByIdQuery{PluginId: pluginDef.Id, OrgId: orgId}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		plog.Error("Failed to read plugin setting by id", "error", err)
 		return
 	}
@@ -102,7 +102,7 @@ func syncPluginDashboards(pluginDef *PluginBase, orgId int64) {
 		PluginVersion: pluginDef.Info.Version,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		plog.Error("Failed to update plugin setting version", "error", err)
 	}
 }
@@ -115,7 +115,7 @@ func handlePluginStateChanged(ctx context.Context, event *m.PluginStateChangedEv
 	} else {
 		query := m.GetDashboardsByPluginIdQuery{PluginId: event.PluginId, OrgId: event.OrgId}
 
-		if err := bus.Dispatch(&query); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 			return err
 		}
 		for _, dash := range query.Result {
@@ -123,7 +123,7 @@ func handlePluginStateChanged(ctx context.Context, event *m.PluginStateChangedEv
 
 			plog.Info("Deleting plugin dashboard", "pluginId", event.PluginId, "dashboard", dash.Slug)
 
-			if err := bus.Dispatch(&deleteCmd); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), &deleteCmd); err != nil {
 				return err
 			}
 		}

--- a/pkg/plugins/dashboards_updater.go
+++ b/pkg/plugins/dashboards_updater.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -105,7 +107,7 @@ func syncPluginDashboards(pluginDef *PluginBase, orgId int64) {
 	}
 }
 
-func handlePluginStateChanged(event *m.PluginStateChangedEvent) error {
+func handlePluginStateChanged(ctx context.Context, event *m.PluginStateChangedEvent) error {
 	plog.Info("Plugin state changed", "pluginId", event.PluginId, "enabled", event.Enabled)
 
 	if event.Enabled {

--- a/pkg/plugins/queries.go
+++ b/pkg/plugins/queries.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -8,7 +10,7 @@ import (
 func GetPluginSettings(orgId int64) (map[string]*m.PluginSettingInfoDTO, error) {
 	query := m.GetPluginSettingsQuery{OrgId: orgId}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/alerting/commands.go
+++ b/pkg/services/alerting/commands.go
@@ -1,22 +1,24 @@
 package alerting
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 )
 
 func init() {
-	bus.AddHandler("alerting", updateDashboardAlerts)
-	bus.AddHandler("alerting", validateDashboardAlerts)
+	bus.AddHandlerCtx("alerting", updateDashboardAlerts)
+	bus.AddHandlerCtx("alerting", validateDashboardAlerts)
 }
 
-func validateDashboardAlerts(cmd *models.ValidateDashboardAlertsCommand) error {
+func validateDashboardAlerts(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId, cmd.User)
 
 	return extractor.ValidateAlerts()
 }
 
-func updateDashboardAlerts(cmd *models.UpdateDashboardAlertsCommand) error {
+func updateDashboardAlerts(ctx context.Context, cmd *models.UpdateDashboardAlertsCommand) error {
 	saveAlerts := models.SaveAlertsCommand{
 		OrgId:       cmd.OrgId,
 		UserId:      cmd.User.UserId,

--- a/pkg/services/alerting/commands.go
+++ b/pkg/services/alerting/commands.go
@@ -34,5 +34,5 @@ func updateDashboardAlerts(ctx context.Context, cmd *models.UpdateDashboardAlert
 
 	saveAlerts.Alerts = alerts
 
-	return bus.Dispatch(&saveAlerts)
+	return bus.DispatchCtx(ctx, &saveAlerts)
 }

--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -110,7 +110,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 		OrgId: context.Rule.OrgID,
 	}
 
-	if err := bus.Dispatch(getDsInfo); err != nil {
+	if err := bus.DispatchCtx(context.Ctx, getDsInfo); err != nil {
 		return nil, fmt.Errorf("Could not find datasource %v", err)
 	}
 

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -189,6 +189,7 @@ func queryConditionScenario(desc string, fn queryConditionScenarioFunc) {
 		ctx := &queryConditionTestContext{}
 		ctx.result = &alerting.EvalContext{
 			Rule: &alerting.Rule{},
+			Ctx:  context.Background(),
 		}
 
 		fn(ctx)

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -181,7 +181,7 @@ func (ctx *queryConditionTestContext) exec() (*alerting.ConditionResult, error) 
 func queryConditionScenario(desc string, fn queryConditionScenarioFunc) {
 	Convey(desc, func() {
 
-		bus.AddHandler("test", func(query *models.GetDataSourceByIdQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDataSourceByIdQuery) error {
 			query.Result = &models.DataSource{Id: 1, Type: "graphite"}
 			return nil
 		})

--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -104,7 +104,7 @@ func (c *EvalContext) GetDashboardUID() (*models.DashboardRef, error) {
 	}
 
 	uidQuery := &models.GetDashboardRefByIdQuery{Id: c.Rule.DashboardID}
-	if err := bus.Dispatch(uidQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), uidQuery); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -32,7 +33,7 @@ func NewDashAlertExtractor(dash *models.Dashboard, orgID int64, user *models.Sig
 func (e *DashAlertExtractor) lookupDatasourceID(dsName string) (*models.DataSource, error) {
 	if dsName == "" {
 		query := &models.GetDataSourcesQuery{OrgId: e.OrgID}
-		if err := bus.Dispatch(query); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), query); err != nil {
 			return nil, err
 		}
 
@@ -43,7 +44,7 @@ func (e *DashAlertExtractor) lookupDatasourceID(dsName string) (*models.DataSour
 		}
 	} else {
 		query := &models.GetDataSourceByNameQuery{Name: dsName, OrgId: e.OrgID}
-		if err := bus.Dispatch(query); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), query); err != nil {
 			return nil, err
 		}
 
@@ -166,7 +167,7 @@ func (e *DashAlertExtractor) getAlertFromPanels(jsonWithPanels *simplejson.Json,
 				Datasources: []*models.DataSource{datasource},
 			}
 
-			if err := bus.Dispatch(&dsFilterQuery); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), &dsFilterQuery); err != nil {
 				if err != bus.ErrHandlerNotFound {
 					return nil, err
 				}

--- a/pkg/services/alerting/extractor_test.go
+++ b/pkg/services/alerting/extractor_test.go
@@ -202,10 +202,10 @@ func TestAlertRuleExtraction(t *testing.T) {
 		Convey("Alert notifications are in DB", func() {
 			sqlstore.InitTestDB(t)
 			firstNotification := models.CreateAlertNotificationCommand{Uid: "notifier1", OrgId: 1, Name: "1"}
-			err = sqlstore.CreateAlertNotificationCommand(&firstNotification)
+			err = sqlstore.CreateAlertNotificationCommand(context.Background(), &firstNotification)
 			So(err, ShouldBeNil)
 			secondNotification := models.CreateAlertNotificationCommand{Uid: "notifier2", OrgId: 1, Name: "2"}
-			err = sqlstore.CreateAlertNotificationCommand(&secondNotification)
+			err = sqlstore.CreateAlertNotificationCommand(context.Background(), &secondNotification)
 			So(err, ShouldBeNil)
 
 			Convey("Parse and validate dashboard containing influxdb alert", func() {

--- a/pkg/services/alerting/extractor_test.go
+++ b/pkg/services/alerting/extractor_test.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -26,12 +27,12 @@ func TestAlertRuleExtraction(t *testing.T) {
 		influxDBDs := &models.DataSource{Id: 16, OrgId: 1, Name: "InfluxDB"}
 		prom := &models.DataSource{Id: 17, OrgId: 1, Name: "Prometheus"}
 
-		bus.AddHandler("test", func(query *models.GetDataSourcesQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDataSourcesQuery) error {
 			query.Result = []*models.DataSource{defaultDs, graphite2Ds}
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetDataSourceByNameQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDataSourceByNameQuery) error {
 			if query.Name == defaultDs.Name {
 				query.Result = defaultDs
 			}

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -159,7 +160,7 @@ func (n *notificationService) uploadImage(context *EvalContext) (err error) {
 func (n *notificationService) getNeededNotifiers(orgID int64, notificationUids []string, evalContext *EvalContext) (notifierStateSlice, error) {
 	query := &models.GetAlertNotificationsWithUidToSendQuery{OrgId: orgID, Uids: notificationUids}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), query); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/alerting/reader.go
+++ b/pkg/services/alerting/reader.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -29,7 +30,7 @@ func newRuleReader() *defaultRuleReader {
 func (arr *defaultRuleReader) fetch() []*Rule {
 	cmd := &models.GetAllAlertsQuery{}
 
-	if err := bus.Dispatch(cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), cmd); err != nil {
 		arr.log.Error("Could not load alerts", "error", err)
 		return []*Rule{}
 	}

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -56,7 +56,7 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 			EvalData: annotationData,
 		}
 
-		if err := bus.Dispatch(cmd); err != nil {
+		if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 			if err == models.ErrCannotChangeStateOnPausedAlert {
 				handler.log.Error("Cannot change state on alert that's paused", "error", err)
 				return err

--- a/pkg/services/alerting/rule_test.go
+++ b/pkg/services/alerting/rule_test.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -61,10 +62,10 @@ func TestAlertRuleModel(t *testing.T) {
 
 		Convey("can construct alert rule model", func() {
 			firstNotification := models.CreateAlertNotificationCommand{OrgId: 1, Name: "1"}
-			err := sqlstore.CreateAlertNotificationCommand(&firstNotification)
+			err := sqlstore.CreateAlertNotificationCommand(context.Background(), &firstNotification)
 			So(err, ShouldBeNil)
 			secondNotification := models.CreateAlertNotificationCommand{Uid: "notifier2", OrgId: 1, Name: "2"}
-			err = sqlstore.CreateAlertNotificationCommand(&secondNotification)
+			err = sqlstore.CreateAlertNotificationCommand(context.Background(), &secondNotification)
 			So(err, ShouldBeNil)
 
 			Convey("with notification id and uid", func() {

--- a/pkg/services/alerting/test_notification.go
+++ b/pkg/services/alerting/test_notification.go
@@ -25,10 +25,10 @@ var (
 )
 
 func init() {
-	bus.AddHandler("alerting", handleNotificationTestCommand)
+	bus.AddHandlerCtx("alerting", handleNotificationTestCommand)
 }
 
-func handleNotificationTestCommand(cmd *NotificationTestCommand) error {
+func handleNotificationTestCommand(ctx context.Context, cmd *NotificationTestCommand) error {
 	notifier := newNotificationService(nil)
 
 	model := &models.AlertNotification{

--- a/pkg/services/alerting/test_rule.go
+++ b/pkg/services/alerting/test_rule.go
@@ -21,10 +21,10 @@ type AlertTestCommand struct {
 }
 
 func init() {
-	bus.AddHandler("alerting", handleAlertTestCommand)
+	bus.AddHandlerCtx("alerting", handleAlertTestCommand)
 }
 
-func handleAlertTestCommand(cmd *AlertTestCommand) error {
+func handleAlertTestCommand(ctx context.Context, cmd *AlertTestCommand) error {
 
 	dash := models.NewDashboardFromJson(cmd.Dashboard)
 

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -91,7 +91,7 @@ func (srv *CleanUpService) shouldCleanupTempFile(filemtime time.Time, now time.T
 
 func (srv *CleanUpService) deleteExpiredSnapshots() {
 	cmd := m.DeleteExpiredSnapshotsCommand{}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		srv.log.Error("Failed to delete expired snapshots", "error", err.Error())
 	} else {
 		srv.log.Debug("Deleted expired snapshots", "rows affected", cmd.DeletedRows)
@@ -100,7 +100,7 @@ func (srv *CleanUpService) deleteExpiredSnapshots() {
 
 func (srv *CleanUpService) deleteExpiredDashboardVersions() {
 	cmd := m.DeleteExpiredVersionsCommand{}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		srv.log.Error("Failed to delete expired dashboard versions", "error", err.Error())
 	} else {
 		srv.log.Debug("Deleted old/expired dashboard versions", "rows affected", cmd.DeletedRows)
@@ -115,7 +115,7 @@ func (srv *CleanUpService) deleteOldLoginAttempts() {
 	cmd := m.DeleteOldLoginAttemptsCommand{
 		OlderThan: time.Now().Add(time.Minute * -10),
 	}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		srv.log.Error("Problem deleting expired login attempts", "error", err.Error())
 	} else {
 		srv.log.Debug("Deleted expired login attempts", "rows affected", cmd.DeletedRows)

--- a/pkg/services/dashboards/acl_service.go
+++ b/pkg/services/dashboards/acl_service.go
@@ -1,9 +1,11 @@
 package dashboards
 
 import (
+	"context"
+	"time"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
-	"time"
 )
 
 func MakeUserAdmin(bus bus.Bus, orgId int64, userId int64, dashboardId int64, setViewAndEditPermissions bool) error {
@@ -47,7 +49,7 @@ func MakeUserAdmin(bus bus.Bus, orgId int64, userId int64, dashboardId int64, se
 		Items:       items,
 	}
 
-	if err := bus.Dispatch(aclCmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), aclCmd); err != nil {
 		return err
 	}
 

--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -1,6 +1,7 @@
 package dashboards
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -60,7 +61,7 @@ type dashboardServiceImpl struct {
 
 func (dr *dashboardServiceImpl) GetProvisionedDashboardData(name string) ([]*models.DashboardProvisioning, error) {
 	cmd := &models.GetProvisionedDashboardDataQuery{Name: name}
-	err := bus.Dispatch(cmd)
+	err := bus.DispatchCtx(context.TODO(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func (dr *dashboardServiceImpl) GetProvisionedDashboardData(name string) ([]*mod
 
 func (dr *dashboardServiceImpl) GetProvisionedDashboardDataByDashboardId(dashboardId int64) (*models.DashboardProvisioning, error) {
 	cmd := &models.GetProvisionedDashboardDataByIdQuery{DashboardId: dashboardId}
-	err := bus.Dispatch(cmd)
+	err := bus.DispatchCtx(context.TODO(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (dr *dashboardServiceImpl) buildSaveDashboardCommand(dto *SaveDashboardDTO,
 			User:      dto.User,
 		}
 
-		if err := bus.Dispatch(&validateAlertsCmd); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), &validateAlertsCmd); err != nil {
 			return nil, err
 		}
 	}
@@ -121,7 +122,7 @@ func (dr *dashboardServiceImpl) buildSaveDashboardCommand(dto *SaveDashboardDTO,
 		Overwrite: dto.Overwrite,
 	}
 
-	if err := bus.Dispatch(&validateBeforeSaveCmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &validateBeforeSaveCmd); err != nil {
 		return nil, err
 	}
 
@@ -179,7 +180,7 @@ func (dr *dashboardServiceImpl) updateAlerting(cmd *models.SaveDashboardCommand,
 		User:      dto.User,
 	}
 
-	return bus.Dispatch(&alertCmd)
+	return bus.DispatchCtx(context.TODO(), &alertCmd)
 }
 
 func (dr *dashboardServiceImpl) SaveProvisionedDashboard(dto *SaveDashboardDTO, provisioning *models.DashboardProvisioning) (*models.Dashboard, error) {
@@ -200,7 +201,7 @@ func (dr *dashboardServiceImpl) SaveProvisionedDashboard(dto *SaveDashboardDTO, 
 	}
 
 	// dashboard
-	err = bus.Dispatch(saveCmd)
+	err = bus.DispatchCtx(context.TODO(), saveCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +225,7 @@ func (dr *dashboardServiceImpl) SaveFolderForProvisionedDashboards(dto *SaveDash
 		return nil, err
 	}
 
-	err = bus.Dispatch(cmd)
+	err = bus.DispatchCtx(context.TODO(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +244,7 @@ func (dr *dashboardServiceImpl) SaveDashboard(dto *SaveDashboardDTO) (*models.Da
 		return nil, err
 	}
 
-	err = bus.Dispatch(cmd)
+	err = bus.DispatchCtx(context.TODO(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +280,7 @@ func (dr *dashboardServiceImpl) deleteDashboard(dashboardId int64, orgId int64, 
 		}
 	}
 	cmd := &models.DeleteDashboardCommand{OrgId: orgId, Id: dashboardId}
-	return bus.Dispatch(cmd)
+	return bus.DispatchCtx(context.TODO(), cmd)
 }
 
 func (dr *dashboardServiceImpl) ImportDashboard(dto *SaveDashboardDTO) (*models.Dashboard, error) {
@@ -288,7 +289,7 @@ func (dr *dashboardServiceImpl) ImportDashboard(dto *SaveDashboardDTO) (*models.
 		return nil, err
 	}
 
-	err = bus.Dispatch(cmd)
+	err = bus.DispatchCtx(context.TODO(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (dr *dashboardServiceImpl) ImportDashboard(dto *SaveDashboardDTO) (*models.
 // and provisioned dashboards are left behind but not deleted.
 func (dr *dashboardServiceImpl) UnprovisionDashboard(dashboardId int64) error {
 	cmd := &models.UnprovisionDashboardCommand{Id: dashboardId}
-	return bus.Dispatch(cmd)
+	return bus.DispatchCtx(context.TODO(), cmd)
 }
 
 type FakeDashboardService struct {

--- a/pkg/services/dashboards/dashboard_service_test.go
+++ b/pkg/services/dashboards/dashboard_service_test.go
@@ -1,6 +1,7 @@
 package dashboards
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -46,16 +47,16 @@ func TestDashboardService(t *testing.T) {
 			})
 
 			Convey("When saving a dashboard should validate uid", func() {
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 					cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 					cmd.Result = nil
 					return nil
 				})
@@ -85,17 +86,17 @@ func TestDashboardService(t *testing.T) {
 
 			Convey("Should return validation error if dashboard is provisioned", func() {
 				provisioningValidated := false
-				bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 					provisioningValidated = true
 					cmd.Result = &models.DashboardProvisioning{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 					cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 					return nil
 				})
@@ -109,12 +110,12 @@ func TestDashboardService(t *testing.T) {
 			})
 
 			Convey("Should return validation error if alert data is invalid", func() {
-				bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 					cmd.Result = nil
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 					return xerrors.New("Alert validation error")
 				})
 
@@ -129,26 +130,26 @@ func TestDashboardService(t *testing.T) {
 
 			Convey("Should not return validation error if dashboard is provisioned", func() {
 				provisioningValidated := false
-				bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 					provisioningValidated = true
 					cmd.Result = &models.DashboardProvisioning{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 					cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.SaveProvisionedDashboardCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SaveProvisionedDashboardCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.UpdateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpdateDashboardAlertsCommand) error {
 					return nil
 				})
 
@@ -166,26 +167,26 @@ func TestDashboardService(t *testing.T) {
 
 			Convey("Should return validation error if dashboard is provisioned", func() {
 				provisioningValidated := false
-				bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 					provisioningValidated = true
 					cmd.Result = &models.DashboardProvisioning{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 					cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.SaveProvisionedDashboardCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SaveProvisionedDashboardCommand) error {
 					return nil
 				})
 
-				bus.AddHandler("test", func(cmd *models.UpdateDashboardAlertsCommand) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpdateDashboardAlertsCommand) error {
 					return nil
 				})
 
@@ -241,7 +242,7 @@ type Result struct {
 }
 
 func setupDeleteHandlers(provisioned bool) *Result {
-	bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 		if provisioned {
 			cmd.Result = &models.DashboardProvisioning{}
 		} else {
@@ -251,7 +252,7 @@ func setupDeleteHandlers(provisioned bool) *Result {
 	})
 
 	result := &Result{}
-	bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
 		So(cmd.Id, ShouldEqual, 1)
 		So(cmd.OrgId, ShouldEqual, 1)
 		result.deleteWasCalled = true

--- a/pkg/services/dashboards/folder_service.go
+++ b/pkg/services/dashboards/folder_service.go
@@ -1,6 +1,8 @@
 package dashboards
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
@@ -36,7 +38,7 @@ func (dr *dashboardServiceImpl) GetFolders(limit int64) ([]*models.Folder, error
 		Permission:   models.PERMISSION_VIEW,
 	}
 
-	if err := bus.Dispatch(&searchQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &searchQuery); err != nil {
 		return nil, err
 	}
 
@@ -105,7 +107,7 @@ func (dr *dashboardServiceImpl) CreateFolder(cmd *models.CreateFolderCommand) er
 		return toFolderError(err)
 	}
 
-	err = bus.Dispatch(saveDashboardCmd)
+	err = bus.DispatchCtx(context.TODO(), saveDashboardCmd)
 	if err != nil {
 		return toFolderError(err)
 	}
@@ -142,7 +144,7 @@ func (dr *dashboardServiceImpl) UpdateFolder(existingUid string, cmd *models.Upd
 		return toFolderError(err)
 	}
 
-	err = bus.Dispatch(saveDashboardCmd)
+	err = bus.DispatchCtx(context.TODO(), saveDashboardCmd)
 	if err != nil {
 		return toFolderError(err)
 	}
@@ -174,7 +176,7 @@ func (dr *dashboardServiceImpl) DeleteFolder(uid string) (*models.Folder, error)
 	}
 
 	deleteCmd := models.DeleteDashboardCommand{OrgId: dr.orgId, Id: dashFolder.Id}
-	if err := bus.Dispatch(&deleteCmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &deleteCmd); err != nil {
 		return nil, toFolderError(err)
 	}
 
@@ -182,7 +184,7 @@ func (dr *dashboardServiceImpl) DeleteFolder(uid string) (*models.Folder, error)
 }
 
 func getFolder(query models.GetDashboardQuery) (*models.Dashboard, error) {
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, toFolderError(err)
 	}
 

--- a/pkg/services/dashboards/folder_service_test.go
+++ b/pkg/services/dashboards/folder_service_test.go
@@ -1,6 +1,7 @@
 package dashboards
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -22,16 +23,16 @@ func TestFolderService(t *testing.T) {
 			origNewGuardian := guardian.New
 			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{})
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = models.NewDashboardFolder("Folder")
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 				cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 				return models.ErrDashboardUpdateAccessDenied
 			})
@@ -83,36 +84,36 @@ func TestFolderService(t *testing.T) {
 			dash := models.NewDashboardFolder("Folder")
 			dash.Id = 1
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = dash
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.ValidateDashboardBeforeSaveCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardBeforeSaveCommand) error {
 				cmd.Result = &models.ValidateDashboardBeforeSaveResult{}
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.UpdateDashboardAlertsCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpdateDashboardAlertsCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.SaveDashboardCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SaveDashboardCommand) error {
 				cmd.Result = dash
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
 				return nil
 			})
 
 			provisioningValidated := false
 
-			bus.AddHandler("test", func(query *models.GetProvisionedDashboardDataByIdQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetProvisionedDashboardDataByIdQuery) error {
 				provisioningValidated = true
 				query.Result = nil
 				return nil
@@ -153,7 +154,7 @@ func TestFolderService(t *testing.T) {
 			dashFolder.Id = 1
 			dashFolder.Uid = "uid-abc"
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = dashFolder
 				return nil
 			})

--- a/pkg/services/datasources/cache.go
+++ b/pkg/services/datasources/cache.go
@@ -1,6 +1,7 @@
 package datasources
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -44,7 +45,7 @@ func (dc *CacheServiceImpl) GetDatasource(datasourceID int64, user *m.SignedInUs
 	}
 
 	query := m.GetDataSourceByIdQuery{Id: datasourceID, OrgId: user.OrgId}
-	if err := dc.Bus.Dispatch(&query); err != nil {
+	if err := dc.Bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -1,6 +1,7 @@
 package guardian
 
 import (
+	"context"
 	"errors"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -193,7 +194,7 @@ func (g *dashboardGuardianImpl) GetAcl() ([]*m.DashboardAclInfoDTO, error) {
 	}
 
 	query := m.GetDashboardAclInfoListQuery{DashboardId: g.dashId, OrgId: g.orgId}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return nil, err
 	}
 
@@ -207,7 +208,7 @@ func (g *dashboardGuardianImpl) getTeams() ([]*m.TeamDTO, error) {
 	}
 
 	query := m.GetTeamsByUserQuery{OrgId: g.orgId, UserId: g.user.UserId}
-	err := bus.Dispatch(&query)
+	err := bus.DispatchCtx(context.TODO(), &query)
 
 	g.teams = query.Result
 	return query.Result, err

--- a/pkg/services/guardian/guardian_util_test.go
+++ b/pkg/services/guardian/guardian_util_test.go
@@ -2,6 +2,7 @@ package guardian
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -72,7 +73,7 @@ func apiKeyScenario(desc string, t *testing.T, role m.RoleType, fn scenarioFunc)
 func permissionScenario(desc string, dashboardID int64, sc *scenarioContext, permissions []*m.DashboardAclInfoDTO, fn scenarioFunc) {
 	bus.ClearBusHandlers()
 
-	bus.AddHandler("test", func(query *m.GetDashboardAclInfoListQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 		if query.OrgId != sc.givenUser.OrgId {
 			sc.reportFailure("Invalid organization id for GetDashboardAclInfoListQuery", sc.givenUser.OrgId, query.OrgId)
 		}
@@ -92,7 +93,7 @@ func permissionScenario(desc string, dashboardID int64, sc *scenarioContext, per
 		}
 	}
 
-	bus.AddHandler("test", func(query *m.GetTeamsByUserQuery) error {
+	bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetTeamsByUserQuery) error {
 		if query.OrgId != sc.givenUser.OrgId {
 			sc.reportFailure("Invalid organization id for GetTeamsByUserQuery", sc.givenUser.OrgId, query.OrgId)
 		}

--- a/pkg/services/login/login.go
+++ b/pkg/services/login/login.go
@@ -1,6 +1,8 @@
 package login
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -22,12 +24,12 @@ type LoginService struct {
 }
 
 func (ls *LoginService) Init() error {
-	ls.Bus.AddHandler(ls.UpsertUser)
+	ls.Bus.AddHandlerCtx(ls.UpsertUser)
 
 	return nil
 }
 
-func (ls *LoginService) UpsertUser(cmd *models.UpsertUserCommand) error {
+func (ls *LoginService) UpsertUser(ctx context.Context, cmd *models.UpsertUserCommand) error {
 	extUser := cmd.ExternalUser
 
 	userQuery := &models.GetUserByAuthInfoQuery{

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -187,7 +187,7 @@ func (ns *NotificationService) signUpStartedHandler(ctx context.Context, evt *ev
 		return nil
 	}
 
-	err := ns.sendEmailCommandHandler(&m.SendEmailCommand{
+	err := ns.sendEmailCommandHandler(ctx, &m.SendEmailCommand{
 		To:       []string{evt.Email},
 		Template: tmplSignUpStarted,
 		Data: map[string]interface{}{
@@ -202,7 +202,7 @@ func (ns *NotificationService) signUpStartedHandler(ctx context.Context, evt *ev
 	}
 
 	emailSentCmd := m.UpdateTempUserWithEmailSentCommand{Code: evt.Code}
-	return bus.Dispatch(&emailSentCmd)
+	return bus.DispatchCtx(ctx, &emailSentCmd)
 }
 
 func (ns *NotificationService) signUpCompletedHandler(ctx context.Context, evt *events.SignUpCompleted) error {
@@ -210,7 +210,7 @@ func (ns *NotificationService) signUpCompletedHandler(ctx context.Context, evt *
 		return nil
 	}
 
-	return ns.sendEmailCommandHandler(&m.SendEmailCommand{
+	return ns.sendEmailCommandHandler(ctx, &m.SendEmailCommand{
 		To:       []string{evt.Email},
 		Template: tmplWelcomeOnSignUp,
 		Data: map[string]interface{}{

--- a/pkg/services/notifications/notifications_test.go
+++ b/pkg/services/notifications/notifications_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -26,7 +27,7 @@ func TestNotifications(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When sending reset email password", func() {
-			err := ns.sendResetPasswordEmail(&m.SendResetPasswordEmailCommand{User: &m.User{Email: "asd@asd.com"}})
+			err := ns.sendResetPasswordEmail(context.Background(), &m.SendResetPasswordEmailCommand{User: &m.User{Email: "asd@asd.com"}})
 			So(err, ShouldBeNil)
 
 			sentMsg := <-ns.mailQueue

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestEmailIntegrationTest(t *testing.T) {
 				Template: "alert_notification.html",
 			}
 
-			err := ns.sendEmailCommandHandler(cmd)
+			err := ns.sendEmailCommandHandler(context.Background(), cmd)
 			So(err, ShouldBeNil)
 
 			sentMsg := <-ns.mailQueue

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -214,7 +214,7 @@ func getOrCreateFolderId(cfg *DashboardsAsConfig, service dashboards.DashboardPr
 	}
 
 	cmd := &models.GetDashboardQuery{Slug: models.SlugifyTitle(cfg.Folder), OrgId: cfg.OrgId}
-	err := bus.Dispatch(cmd)
+	err := bus.DispatchCtx(context.TODO(), cmd)
 
 	if err != nil && err != models.ErrDashboardNotFound {
 		return 0, err

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -1,13 +1,15 @@
 package dashboards
 
 import (
-	"github.com/grafana/grafana/pkg/util"
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -82,7 +84,7 @@ func TestDashboardFileReader(t *testing.T) {
 		origNewDashboardProvisioningService := dashboards.NewProvisioningService
 		fakeService = mockDashboardProvisioningService()
 
-		bus.AddHandler("test", mockGetDashboardQuery)
+		bus.AddHandlerCtx("test", mockGetDashboardQuery)
 		logger := log.New("test.logger")
 
 		Convey("Reading dashboards from disk", func() {
@@ -439,7 +441,7 @@ func (s *fakeDashboardProvisioningService) GetProvisionedDashboardDataByDashboar
 	return nil, nil
 }
 
-func mockGetDashboardQuery(cmd *models.GetDashboardQuery) error {
+func mockGetDashboardQuery(ctx context.Context, cmd *models.GetDashboardQuery) error {
 	for _, d := range fakeService.getDashboard {
 		if d.Slug == cmd.Slug {
 			cmd.Result = d

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -1,6 +1,7 @@
 package datasources
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -29,11 +30,11 @@ func TestDatasourceAsConfig(t *testing.T) {
 	Convey("Testing datasource as configuration", t, func() {
 		fakeRepo = &fakeRepository{}
 		bus.ClearBusHandlers()
-		bus.AddHandler("test", mockDelete)
-		bus.AddHandler("test", mockInsert)
-		bus.AddHandler("test", mockUpdate)
-		bus.AddHandler("test", mockGet)
-		bus.AddHandler("test", mockGetAll)
+		bus.AddHandlerCtx("test", mockDelete)
+		bus.AddHandlerCtx("test", mockInsert)
+		bus.AddHandlerCtx("test", mockUpdate)
+		bus.AddHandlerCtx("test", mockGet)
+		bus.AddHandlerCtx("test", mockGetAll)
 
 		Convey("One configured datasource", func() {
 			Convey("no datasource in database", func() {
@@ -237,27 +238,27 @@ type fakeRepository struct {
 	loadAll []*models.DataSource
 }
 
-func mockDelete(cmd *models.DeleteDataSourceByNameCommand) error {
+func mockDelete(ctx context.Context, cmd *models.DeleteDataSourceByNameCommand) error {
 	fakeRepo.deleted = append(fakeRepo.deleted, cmd)
 	return nil
 }
 
-func mockUpdate(cmd *models.UpdateDataSourceCommand) error {
+func mockUpdate(ctx context.Context, cmd *models.UpdateDataSourceCommand) error {
 	fakeRepo.updated = append(fakeRepo.updated, cmd)
 	return nil
 }
 
-func mockInsert(cmd *models.AddDataSourceCommand) error {
+func mockInsert(ctx context.Context, cmd *models.AddDataSourceCommand) error {
 	fakeRepo.inserted = append(fakeRepo.inserted, cmd)
 	return nil
 }
 
-func mockGetAll(cmd *models.GetAllDataSourcesQuery) error {
+func mockGetAll(ctx context.Context, cmd *models.GetAllDataSourcesQuery) error {
 	cmd.Result = fakeRepo.loadAll
 	return nil
 }
 
-func mockGet(cmd *models.GetDataSourceByNameQuery) error {
+func mockGet(ctx context.Context, cmd *models.GetDataSourceByNameQuery) error {
 	for _, v := range fakeRepo.loadAll {
 		if cmd.Name == v.Name && cmd.OrgId == v.OrgId {
 			cmd.Result = v

--- a/pkg/services/provisioning/notifiers/alert_notifications.go
+++ b/pkg/services/provisioning/notifiers/alert_notifications.go
@@ -1,6 +1,7 @@
 package notifiers
 
 import (
+	"context"
 	"errors"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -47,7 +48,7 @@ func (dc *NotificationProvisioner) deleteNotifications(notificationToDelete []*d
 
 		if notification.OrgId == 0 && notification.OrgName != "" {
 			getOrg := &models.GetOrgByNameQuery{Name: notification.OrgName}
-			if err := bus.Dispatch(getOrg); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), getOrg); err != nil {
 				return err
 			}
 			notification.OrgId = getOrg.Result.Id
@@ -57,13 +58,13 @@ func (dc *NotificationProvisioner) deleteNotifications(notificationToDelete []*d
 
 		getNotification := &models.GetAlertNotificationsWithUidQuery{Uid: notification.Uid, OrgId: notification.OrgId}
 
-		if err := bus.Dispatch(getNotification); err != nil {
+		if err := bus.DispatchCtx(context.TODO(), getNotification); err != nil {
 			return err
 		}
 
 		if getNotification.Result != nil {
 			cmd := &models.DeleteAlertNotificationWithUidCommand{Uid: getNotification.Result.Uid, OrgId: getNotification.OrgId}
-			if err := bus.Dispatch(cmd); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), cmd); err != nil {
 				return err
 			}
 		}
@@ -77,7 +78,7 @@ func (dc *NotificationProvisioner) mergeNotifications(notificationToMerge []*not
 
 		if notification.OrgId == 0 && notification.OrgName != "" {
 			getOrg := &models.GetOrgByNameQuery{Name: notification.OrgName}
-			if err := bus.Dispatch(getOrg); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), getOrg); err != nil {
 				return err
 			}
 			notification.OrgId = getOrg.Result.Id
@@ -86,7 +87,7 @@ func (dc *NotificationProvisioner) mergeNotifications(notificationToMerge []*not
 		}
 
 		cmd := &models.GetAlertNotificationsWithUidQuery{OrgId: notification.OrgId, Uid: notification.Uid}
-		err := bus.Dispatch(cmd)
+		err := bus.DispatchCtx(context.TODO(), cmd)
 		if err != nil {
 			return err
 		}
@@ -105,7 +106,7 @@ func (dc *NotificationProvisioner) mergeNotifications(notificationToMerge []*not
 				SendReminder:          notification.SendReminder,
 			}
 
-			if err := bus.Dispatch(insertCmd); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), insertCmd); err != nil {
 				return err
 			}
 		} else {
@@ -122,7 +123,7 @@ func (dc *NotificationProvisioner) mergeNotifications(notificationToMerge []*not
 				SendReminder:          notification.SendReminder,
 			}
 
-			if err := bus.Dispatch(updateCmd); err != nil {
+			if err := bus.DispatchCtx(context.TODO(), updateCmd); err != nil {
 				return err
 			}
 		}

--- a/pkg/services/provisioning/notifiers/config_reader_test.go
+++ b/pkg/services/provisioning/notifiers/config_reader_test.go
@@ -1,6 +1,7 @@
 package notifiers
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -121,7 +122,7 @@ func TestNotificationAsConfig(t *testing.T) {
 					t.Fatalf("applyChanges return an error %v", err)
 				}
 				notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: 1}
-				err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+				err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 				So(err, ShouldBeNil)
 				So(notificationsQuery.Result, ShouldNotBeNil)
 				So(len(notificationsQuery.Result), ShouldEqual, 2)
@@ -134,11 +135,11 @@ func TestNotificationAsConfig(t *testing.T) {
 					Uid:   "notifier1",
 					Type:  "slack",
 				}
-				err := sqlstore.CreateAlertNotificationCommand(&existingNotificationCmd)
+				err := sqlstore.CreateAlertNotificationCommand(context.Background(), &existingNotificationCmd)
 				So(err, ShouldBeNil)
 				So(existingNotificationCmd.Result, ShouldNotBeNil)
 				notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: 1}
-				err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+				err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 				So(err, ShouldBeNil)
 				So(notificationsQuery.Result, ShouldNotBeNil)
 				So(len(notificationsQuery.Result), ShouldEqual, 1)
@@ -149,7 +150,7 @@ func TestNotificationAsConfig(t *testing.T) {
 					if err != nil {
 						t.Fatalf("applyChanges return an error %v", err)
 					}
-					err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+					err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 					So(err, ShouldBeNil)
 					So(notificationsQuery.Result, ShouldNotBeNil)
 					So(len(notificationsQuery.Result), ShouldEqual, 2)
@@ -172,7 +173,7 @@ func TestNotificationAsConfig(t *testing.T) {
 				Convey("should both be inserted", func() {
 					So(err, ShouldBeNil)
 					notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: 1}
-					err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+					err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 					So(err, ShouldBeNil)
 					So(notificationsQuery.Result, ShouldNotBeNil)
 					So(len(notificationsQuery.Result), ShouldEqual, 2)
@@ -191,7 +192,7 @@ func TestNotificationAsConfig(t *testing.T) {
 					Uid:   "notifier0",
 					Type:  "slack",
 				}
-				err := sqlstore.CreateAlertNotificationCommand(&existingNotificationCmd)
+				err := sqlstore.CreateAlertNotificationCommand(context.Background(), &existingNotificationCmd)
 				So(err, ShouldBeNil)
 				existingNotificationCmd = m.CreateAlertNotificationCommand{
 					Name:  "channel3",
@@ -199,11 +200,11 @@ func TestNotificationAsConfig(t *testing.T) {
 					Uid:   "notifier3",
 					Type:  "slack",
 				}
-				err = sqlstore.CreateAlertNotificationCommand(&existingNotificationCmd)
+				err = sqlstore.CreateAlertNotificationCommand(context.Background(), &existingNotificationCmd)
 				So(err, ShouldBeNil)
 
 				notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: 1}
-				err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+				err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 				So(err, ShouldBeNil)
 				So(notificationsQuery.Result, ShouldNotBeNil)
 				So(len(notificationsQuery.Result), ShouldEqual, 2)
@@ -215,7 +216,7 @@ func TestNotificationAsConfig(t *testing.T) {
 						t.Fatalf("applyChanges return an error %v", err)
 					}
 					notificationsQuery = m.GetAllAlertNotificationsQuery{OrgId: 1}
-					err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+					err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 					So(err, ShouldBeNil)
 					So(notificationsQuery.Result, ShouldNotBeNil)
 					So(len(notificationsQuery.Result), ShouldEqual, 4)
@@ -225,11 +226,11 @@ func TestNotificationAsConfig(t *testing.T) {
 
 		Convey("Can read correct properties with orgName instead of orgId", func() {
 			existingOrg1 := m.CreateOrgCommand{Name: "Main Org. 1"}
-			err := sqlstore.CreateOrg(&existingOrg1)
+			err := sqlstore.CreateOrg(context.Background(), &existingOrg1)
 			So(err, ShouldBeNil)
 			So(existingOrg1.Result, ShouldNotBeNil)
 			existingOrg2 := m.CreateOrgCommand{Name: "Main Org. 2"}
-			err = sqlstore.CreateOrg(&existingOrg2)
+			err = sqlstore.CreateOrg(context.Background(), &existingOrg2)
 			So(err, ShouldBeNil)
 			So(existingOrg2.Result, ShouldNotBeNil)
 
@@ -239,7 +240,7 @@ func TestNotificationAsConfig(t *testing.T) {
 				Uid:   "notifier2",
 				Type:  "slack",
 			}
-			err = sqlstore.CreateAlertNotificationCommand(&existingNotificationCmd)
+			err = sqlstore.CreateAlertNotificationCommand(context.Background(), &existingNotificationCmd)
 			So(err, ShouldBeNil)
 
 			dc := newNotificationProvisioner(logger)
@@ -249,7 +250,7 @@ func TestNotificationAsConfig(t *testing.T) {
 			}
 
 			notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: existingOrg2.Result.Id}
-			err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+			err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 			So(err, ShouldBeNil)
 			So(notificationsQuery.Result, ShouldNotBeNil)
 			So(len(notificationsQuery.Result), ShouldEqual, 1)
@@ -280,7 +281,7 @@ func TestNotificationAsConfig(t *testing.T) {
 					t.Fatalf("applyChanges return an error %v", err)
 				}
 				notificationsQuery := m.GetAllAlertNotificationsQuery{OrgId: 1}
-				err = sqlstore.GetAllAlertNotifications(&notificationsQuery)
+				err = sqlstore.GetAllAlertNotifications(context.Background(), &notificationsQuery)
 				So(err, ShouldBeNil)
 				So(notificationsQuery.Result, ShouldBeEmpty)
 			})

--- a/pkg/services/quota/quota.go
+++ b/pkg/services/quota/quota.go
@@ -55,7 +55,7 @@ func (qs *QuotaService) QuotaReached(c *m.ReqContext, target string) (bool, erro
 				continue
 			}
 			query := m.GetGlobalQuotaByTargetQuery{Target: scope.Target}
-			if err := bus.Dispatch(&query); err != nil {
+			if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 				return true, err
 			}
 			if query.Result.Used >= scope.DefaultLimit {
@@ -66,7 +66,7 @@ func (qs *QuotaService) QuotaReached(c *m.ReqContext, target string) (bool, erro
 				continue
 			}
 			query := m.GetOrgQuotaByTargetQuery{OrgId: c.OrgId, Target: scope.Target, Default: scope.DefaultLimit}
-			if err := bus.Dispatch(&query); err != nil {
+			if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 				return true, err
 			}
 			if query.Result.Limit < 0 {
@@ -84,7 +84,7 @@ func (qs *QuotaService) QuotaReached(c *m.ReqContext, target string) (bool, erro
 				continue
 			}
 			query := m.GetUserQuotaByTargetQuery{UserId: c.UserId, Target: scope.Target, Default: scope.DefaultLimit}
-			if err := bus.Dispatch(&query); err != nil {
+			if err := bus.DispatchCtx(c.Ctx(), &query); err != nil {
 				return true, err
 			}
 			if query.Result.Limit < 0 {

--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -36,7 +36,7 @@ func (s *SearchService) searchHandler(ctx context.Context, query *Query) error {
 		Permission:   query.Permission,
 	}
 
-	if err := bus.Dispatch(&dashQuery); err != nil {
+	if err := bus.DispatchCtx(ctx, &dashQuery); err != nil {
 		return err
 	}
 
@@ -62,7 +62,7 @@ func (s *SearchService) searchHandler(ctx context.Context, query *Query) error {
 
 func setIsStarredFlagOnSearchResults(userId int64, hits []*Hit) error {
 	query := m.GetUserStarsQuery{UserId: userId}
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return err
 	}
 

--- a/pkg/services/search/handlers.go
+++ b/pkg/services/search/handlers.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -17,11 +18,11 @@ type SearchService struct {
 }
 
 func (s *SearchService) Init() error {
-	s.Bus.AddHandler(s.searchHandler)
+	s.Bus.AddHandlerCtx(s.searchHandler)
 	return nil
 }
 
-func (s *SearchService) searchHandler(query *Query) error {
+func (s *SearchService) searchHandler(ctx context.Context, query *Query) error {
 	dashQuery := FindPersistedDashboardsQuery{
 		Title:        query.Title,
 		SignedInUser: query.SignedInUser,

--- a/pkg/services/search/handlers_test.go
+++ b/pkg/services/search/handlers_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -14,7 +15,7 @@ func TestSearch(t *testing.T) {
 		query := Query{Limit: 2000, SignedInUser: &m.SignedInUser{IsGrafanaAdmin: true}}
 		ss := &SearchService{}
 
-		bus.AddHandler("test", func(query *FindPersistedDashboardsQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *FindPersistedDashboardsQuery) error {
 			query.Result = HitList{
 				&Hit{Id: 16, Title: "CCAA", Type: "dash-db", Tags: []string{"BB", "AA"}},
 				&Hit{Id: 10, Title: "AABB", Type: "dash-db", Tags: []string{"CC", "AA"}},
@@ -25,12 +26,12 @@ func TestSearch(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetUserStarsQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetUserStarsQuery) error {
 			query.Result = map[int64]bool{10: true, 12: true}
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *m.GetSignedInUserQuery) error {
+		bus.AddHandlerCtx("test", func(ctx context.Context, query *m.GetSignedInUserQuery) error {
 			query.Result = &m.SignedInUser{IsGrafanaAdmin: true}
 			return nil
 		})

--- a/pkg/services/search/handlers_test.go
+++ b/pkg/services/search/handlers_test.go
@@ -37,7 +37,7 @@ func TestSearch(t *testing.T) {
 		})
 
 		Convey("That is empty", func() {
-			err := ss.searchHandler(&query)
+			err := ss.searchHandler(context.Background(), &query)
 			So(err, ShouldBeNil)
 
 			Convey("should return sorted results", func() {

--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -55,7 +55,7 @@ func DeleteAlertNotificationWithUid(ctx context.Context, cmd *m.DeleteAlertNotif
 			Id:    existingNotification.Result.Id,
 			OrgId: existingNotification.Result.OrgId,
 		}
-		if err := bus.Dispatch(deleteCommand); err != nil {
+		if err := bus.DispatchCtx(ctx, deleteCommand); err != nil {
 			return err
 		}
 	}
@@ -379,7 +379,7 @@ func UpdateAlertNotificationWithUid(ctx context.Context, cmd *m.UpdateAlertNotif
 		OrgId: cmd.OrgId,
 	}
 
-	if err := bus.Dispatch(updateNotification); err != nil {
+	if err := bus.DispatchCtx(ctx, updateNotification); err != nil {
 		return err
 	}
 

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -145,7 +145,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				Name:  "email",
 			}
 
-			err := GetAlertNotifications(cmd)
+			err := GetAlertNotifications(context.Background(), cmd)
 			So(err, ShouldBeNil)
 			So(cmd.Result, ShouldBeNil)
 		})
@@ -160,14 +160,14 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 			}
 
 			Convey("and missing frequency", func() {
-				err := CreateAlertNotificationCommand(cmd)
+				err := CreateAlertNotificationCommand(context.Background(), cmd)
 				So(err, ShouldEqual, models.ErrNotificationFrequencyNotFound)
 			})
 
 			Convey("invalid frequency", func() {
 				cmd.Frequency = "invalid duration"
 
-				err := CreateAlertNotificationCommand(cmd)
+				err := CreateAlertNotificationCommand(context.Background(), cmd)
 				So(err.Error(), ShouldEqual, "time: invalid duration invalid duration")
 			})
 		})
@@ -181,7 +181,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				Settings:     simplejson.New(),
 			}
 
-			err := CreateAlertNotificationCommand(cmd)
+			err := CreateAlertNotificationCommand(context.Background(), cmd)
 			So(err, ShouldBeNil)
 
 			updateCmd := &models.UpdateAlertNotificationCommand{
@@ -190,14 +190,14 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 			}
 
 			Convey("and missing frequency", func() {
-				err := UpdateAlertNotification(updateCmd)
+				err := UpdateAlertNotification(context.Background(), updateCmd)
 				So(err, ShouldEqual, models.ErrNotificationFrequencyNotFound)
 			})
 
 			Convey("invalid frequency", func() {
 				updateCmd.Frequency = "invalid duration"
 
-				err := UpdateAlertNotification(updateCmd)
+				err := UpdateAlertNotification(context.Background(), updateCmd)
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldEqual, "time: invalid duration invalid duration")
 			})
@@ -213,7 +213,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				Settings:     simplejson.New(),
 			}
 
-			err := CreateAlertNotificationCommand(cmd)
+			err := CreateAlertNotificationCommand(context.Background(), cmd)
 			So(err, ShouldBeNil)
 			So(cmd.Result.Id, ShouldNotEqual, 0)
 			So(cmd.Result.OrgId, ShouldNotEqual, 0)
@@ -223,7 +223,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 			So(cmd.Result.Uid, ShouldNotBeEmpty)
 
 			Convey("Cannot save Alert Notification with the same name", func() {
-				err = CreateAlertNotificationCommand(cmd)
+				err = CreateAlertNotificationCommand(context.Background(), cmd)
 				So(err, ShouldNotBeNil)
 			})
 			Convey("Cannot save Alert Notification with the same name and another uid", func() {
@@ -236,7 +236,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					Settings:     cmd.Settings,
 					Uid:          "notifier1",
 				}
-				err = CreateAlertNotificationCommand(anotherUidCmd)
+				err = CreateAlertNotificationCommand(context.Background(), anotherUidCmd)
 				So(err, ShouldNotBeNil)
 			})
 			Convey("Can save Alert Notification with another name and another uid", func() {
@@ -249,7 +249,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					Settings:     cmd.Settings,
 					Uid:          "notifier2",
 				}
-				err = CreateAlertNotificationCommand(anotherUidCmd)
+				err = CreateAlertNotificationCommand(context.Background(), anotherUidCmd)
 				So(err, ShouldBeNil)
 			})
 
@@ -264,7 +264,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					Settings:              simplejson.New(),
 					Id:                    cmd.Result.Id,
 				}
-				err := UpdateAlertNotification(newCmd)
+				err := UpdateAlertNotification(context.Background(), newCmd)
 				So(err, ShouldBeNil)
 				So(newCmd.Result.Name, ShouldEqual, "NewName")
 				So(newCmd.Result.Frequency, ShouldEqual, 60*time.Second)
@@ -280,7 +280,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					Settings:     simplejson.New(),
 					Id:           cmd.Result.Id,
 				}
-				err := UpdateAlertNotification(newCmd)
+				err := UpdateAlertNotification(context.Background(), newCmd)
 				So(err, ShouldBeNil)
 				So(newCmd.Result.SendReminder, ShouldBeFalse)
 			})
@@ -294,11 +294,11 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 
 			otherOrg := models.CreateAlertNotificationCommand{Name: "default", Type: "email", OrgId: 2, SendReminder: true, Frequency: "10s", Settings: simplejson.New()}
 
-			So(CreateAlertNotificationCommand(&cmd1), ShouldBeNil)
-			So(CreateAlertNotificationCommand(&cmd2), ShouldBeNil)
-			So(CreateAlertNotificationCommand(&cmd3), ShouldBeNil)
-			So(CreateAlertNotificationCommand(&cmd4), ShouldBeNil)
-			So(CreateAlertNotificationCommand(&otherOrg), ShouldBeNil)
+			So(CreateAlertNotificationCommand(context.Background(), &cmd1), ShouldBeNil)
+			So(CreateAlertNotificationCommand(context.Background(), &cmd2), ShouldBeNil)
+			So(CreateAlertNotificationCommand(context.Background(), &cmd3), ShouldBeNil)
+			So(CreateAlertNotificationCommand(context.Background(), &cmd4), ShouldBeNil)
+			So(CreateAlertNotificationCommand(context.Background(), &otherOrg), ShouldBeNil)
 
 			Convey("search", func() {
 				query := &models.GetAlertNotificationsWithUidToSendQuery{
@@ -306,7 +306,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err := GetAlertNotificationsWithUidToSend(query)
+				err := GetAlertNotificationsWithUidToSend(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 3)
 			})
@@ -316,7 +316,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err := GetAllAlertNotifications(query)
+				err := GetAllAlertNotifications(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 4)
 			})

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -9,14 +9,14 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", GetApiKeys)
-	bus.AddHandler("sql", GetApiKeyById)
-	bus.AddHandler("sql", GetApiKeyByName)
+	bus.AddHandlerCtx("sql", GetApiKeys)
+	bus.AddHandlerCtx("sql", GetApiKeyById)
+	bus.AddHandlerCtx("sql", GetApiKeyByName)
 	bus.AddHandlerCtx("sql", DeleteApiKeyCtx)
-	bus.AddHandler("sql", AddApiKey)
+	bus.AddHandlerCtx("sql", AddApiKey)
 }
 
-func GetApiKeys(query *models.GetApiKeysQuery) error {
+func GetApiKeys(ctx context.Context, query *models.GetApiKeysQuery) error {
 	sess := x.Limit(100, 0).Where("org_id=? and ( expires IS NULL or expires >= ?)",
 		query.OrgId, timeNow().Unix()).Asc("name")
 	if query.IncludeInvalid {
@@ -35,7 +35,7 @@ func DeleteApiKeyCtx(ctx context.Context, cmd *models.DeleteApiKeyCommand) error
 	})
 }
 
-func AddApiKey(cmd *models.AddApiKeyCommand) error {
+func AddApiKey(ctx context.Context, cmd *models.AddApiKeyCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		key := models.ApiKey{OrgId: cmd.OrgId, Name: cmd.Name}
 		exists, _ := sess.Get(&key)
@@ -69,7 +69,7 @@ func AddApiKey(cmd *models.AddApiKeyCommand) error {
 	})
 }
 
-func GetApiKeyById(query *models.GetApiKeyByIdQuery) error {
+func GetApiKeyById(ctx context.Context, query *models.GetApiKeyByIdQuery) error {
 	var apikey models.ApiKey
 	has, err := x.Id(query.ApiKeyId).Get(&apikey)
 
@@ -83,7 +83,7 @@ func GetApiKeyById(query *models.GetApiKeyByIdQuery) error {
 	return nil
 }
 
-func GetApiKeyByName(query *models.GetApiKeyByNameQuery) error {
+func GetApiKeyByName(ctx context.Context, query *models.GetApiKeyByNameQuery) error {
 	var apikey models.ApiKey
 	has, err := x.Where("org_id=? AND name=?", query.OrgId, query.KeyName).Get(&apikey)
 

--- a/pkg/services/sqlstore/dashboard_acl.go
+++ b/pkg/services/sqlstore/dashboard_acl.go
@@ -1,16 +1,18 @@
 package sqlstore
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 func init() {
-	bus.AddHandler("sql", UpdateDashboardAcl)
-	bus.AddHandler("sql", GetDashboardAclInfoList)
+	bus.AddHandlerCtx("sql", UpdateDashboardAcl)
+	bus.AddHandlerCtx("sql", GetDashboardAclInfoList)
 }
 
-func UpdateDashboardAcl(cmd *m.UpdateDashboardAclCommand) error {
+func UpdateDashboardAcl(ctx context.Context, cmd *m.UpdateDashboardAclCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		// delete existing items
 		_, err := sess.Exec("DELETE FROM dashboard_acl WHERE dashboard_id=?", cmd.DashboardId)
@@ -45,7 +47,7 @@ func UpdateDashboardAcl(cmd *m.UpdateDashboardAclCommand) error {
 // 1) Permissions for the dashboard
 // 2) permissions for its parent folder
 // 3) if no specific permissions have been set for the dashboard or its parent folder then get the default permissions
-func GetDashboardAclInfoList(query *m.GetDashboardAclInfoListQuery) error {
+func GetDashboardAclInfoList(ctx context.Context, query *m.GetDashboardAclInfoListQuery) error {
 	var err error
 
 	falseStr := dialect.BooleanStr(false)

--- a/pkg/services/sqlstore/dashboard_acl_test.go
+++ b/pkg/services/sqlstore/dashboard_acl_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -29,7 +30,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				Convey("When reading folder acl should include default acl", func() {
 					query := m.GetDashboardAclInfoListQuery{DashboardId: savedFolder.Id, OrgId: 1}
 
-					err := GetDashboardAclInfoList(&query)
+					err := GetDashboardAclInfoList(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -45,7 +46,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				Convey("When reading dashboard acl should include acl for parent folder", func() {
 					query := m.GetDashboardAclInfoListQuery{DashboardId: childDash.Id, OrgId: 1}
 
-					err := GetDashboardAclInfoList(&query)
+					err := GetDashboardAclInfoList(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -60,7 +61,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 			})
 
 			Convey("Given dashboard folder with removed default permissions", func() {
-				err := UpdateDashboardAcl(&m.UpdateDashboardAclCommand{
+				err := UpdateDashboardAcl(context.Background(), &m.UpdateDashboardAclCommand{
 					DashboardId: savedFolder.Id,
 					Items:       []*m.DashboardAcl{},
 				})
@@ -69,7 +70,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				Convey("When reading dashboard acl should return no acl items", func() {
 					query := m.GetDashboardAclInfoListQuery{DashboardId: childDash.Id, OrgId: 1}
 
-					err := GetDashboardAclInfoList(&query)
+					err := GetDashboardAclInfoList(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 0)
@@ -88,7 +89,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				Convey("When reading dashboard acl should include acl for parent folder", func() {
 					query := m.GetDashboardAclInfoListQuery{DashboardId: childDash.Id, OrgId: 1}
 
-					err := GetDashboardAclInfoList(&query)
+					err := GetDashboardAclInfoList(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 1)
@@ -107,7 +108,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 					Convey("When reading dashboard acl should include acl for parent folder and child", func() {
 						query := m.GetDashboardAclInfoListQuery{OrgId: 1, DashboardId: childDash.Id}
 
-						err := GetDashboardAclInfoList(&query)
+						err := GetDashboardAclInfoList(context.Background(), &query)
 						So(err, ShouldBeNil)
 
 						So(len(query.Result), ShouldEqual, 2)
@@ -131,7 +132,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				Convey("When reading dashboard acl should include default acl for parent folder and the child acl", func() {
 					query := m.GetDashboardAclInfoListQuery{OrgId: 1, DashboardId: childDash.Id}
 
-					err := GetDashboardAclInfoList(&query)
+					err := GetDashboardAclInfoList(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					defaultPermissionsId := -1
@@ -157,7 +158,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				q1 := &m.GetDashboardAclInfoListQuery{DashboardId: savedFolder.Id, OrgId: 1}
-				err = GetDashboardAclInfoList(q1)
+				err = GetDashboardAclInfoList(context.Background(), q1)
 				So(err, ShouldBeNil)
 
 				So(q1.Result[0].DashboardId, ShouldEqual, savedFolder.Id)
@@ -172,7 +173,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					q3 := &m.GetDashboardAclInfoListQuery{DashboardId: savedFolder.Id, OrgId: 1}
-					err = GetDashboardAclInfoList(q3)
+					err = GetDashboardAclInfoList(context.Background(), q3)
 					So(err, ShouldBeNil)
 					So(len(q3.Result), ShouldEqual, 0)
 				})
@@ -180,7 +181,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 
 			Convey("Given a team", func() {
 				group1 := m.CreateTeamCommand{Name: "group1 name", OrgId: 1}
-				err := CreateTeam(&group1)
+				err := CreateTeam(context.Background(), &group1)
 				So(err, ShouldBeNil)
 
 				Convey("Should be able to add a user permission for a team", func() {
@@ -193,7 +194,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					q1 := &m.GetDashboardAclInfoListQuery{DashboardId: savedFolder.Id, OrgId: 1}
-					err = GetDashboardAclInfoList(q1)
+					err = GetDashboardAclInfoList(context.Background(), q1)
 					So(err, ShouldBeNil)
 					So(q1.Result[0].DashboardId, ShouldEqual, savedFolder.Id)
 					So(q1.Result[0].Permission, ShouldEqual, m.PERMISSION_EDIT)
@@ -210,7 +211,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					q3 := &m.GetDashboardAclInfoListQuery{DashboardId: savedFolder.Id, OrgId: 1}
-					err = GetDashboardAclInfoList(q3)
+					err = GetDashboardAclInfoList(context.Background(), q3)
 					So(err, ShouldBeNil)
 					So(len(q3.Result), ShouldEqual, 1)
 					So(q3.Result[0].DashboardId, ShouldEqual, savedFolder.Id)
@@ -226,7 +227,7 @@ func TestDashboardAclDataAccess(t *testing.T) {
 			Convey("When reading dashboard acl should return default permissions", func() {
 				query := m.GetDashboardAclInfoListQuery{DashboardId: rootFolderId, OrgId: 1}
 
-				err := GetDashboardAclInfoList(&query)
+				err := GetDashboardAclInfoList(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 2)

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -28,7 +29,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						OrgId:        1,
 						DashboardIds: []int64{folder.Id, dashInRoot.Id},
 					}
-					err := SearchDashboards(query)
+					err := SearchDashboards(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 2)
 					So(query.Result[0].Id, ShouldEqual, folder.Id)
@@ -45,7 +46,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 						OrgId:        1, DashboardIds: []int64{folder.Id, dashInRoot.Id},
 					}
-					err := SearchDashboards(query)
+					err := SearchDashboards(context.Background(), query)
 
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 1)
@@ -61,7 +62,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 2)
 						So(query.Result[0].Id, ShouldEqual, folder.Id)
@@ -80,7 +81,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 2)
 						So(query.Result[0].Id, ShouldEqual, folder.Id)
@@ -96,7 +97,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 
 				Convey("should not return folder or child", func() {
 					query := &search.FindPersistedDashboardsQuery{SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
-					err := SearchDashboards(query)
+					err := SearchDashboards(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 1)
 					So(query.Result[0].Id, ShouldEqual, dashInRoot.Id)
@@ -107,7 +108,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 
 					Convey("should be able to search for child dashboard but not folder", func() {
 						query := &search.FindPersistedDashboardsQuery{SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 2)
 						So(query.Result[0].Id, ShouldEqual, childDash.Id)
@@ -126,7 +127,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id, childDash.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 3)
 						So(query.Result[0].Id, ShouldEqual, folder.Id)
@@ -150,7 +151,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 			Convey("and one folder is expanded, the other collapsed", func() {
 				Convey("should return dashboards in root and expanded folder", func() {
 					query := &search.FindPersistedDashboardsQuery{FolderIds: []int64{rootFolderId, folder1.Id}, SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1}
-					err := SearchDashboards(query)
+					err := SearchDashboards(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 4)
 					So(query.Result[0].Id, ShouldEqual, folder1.Id)
@@ -173,7 +174,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder1.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 1)
 						So(query.Result[0].Id, ShouldEqual, dashInRoot.Id)
@@ -188,7 +189,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder2.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 4)
 						So(query.Result[0].Id, ShouldEqual, folder2.Id)
@@ -208,7 +209,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder2.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(query)
+						err := SearchDashboards(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(len(query.Result), ShouldEqual, 4)
 						So(query.Result[0].Id, ShouldEqual, folder2.Id)
@@ -238,7 +239,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						Type:         "dash-folder",
 					}
 
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -254,7 +255,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						OrgRole:      models.ROLE_ADMIN,
 					}
 
-					err := GetDashboardPermissionsForUser(&query)
+					err := GetDashboardPermissionsForUser(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -268,7 +269,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasEditPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: adminUser.Id, OrgId: 1, OrgRole: models.ROLE_ADMIN},
 					}
-					err := HasEditPermissionInFolders(query)
+					err := HasEditPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeTrue)
 				})
@@ -277,7 +278,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasAdminPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: adminUser.Id, OrgId: 1, OrgRole: models.ROLE_ADMIN},
 					}
-					err := HasAdminPermissionInFolders(query)
+					err := HasAdminPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeTrue)
 				})
@@ -291,7 +292,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				}
 
 				Convey("Should have write access to all dashboard folders with default ACL", func() {
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -307,7 +308,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						OrgRole:      models.ROLE_EDITOR,
 					}
 
-					err := GetDashboardPermissionsForUser(&query)
+					err := GetDashboardPermissionsForUser(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -320,7 +321,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				Convey("Should have write access to one dashboard folder if default role changed to view for one folder", func() {
 					testHelperUpdateDashboardAcl(folder1.Id, models.DashboardAcl{DashboardId: folder1.Id, OrgId: 1, UserId: editorUser.Id, Permission: models.PERMISSION_VIEW})
 
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 1)
@@ -331,7 +332,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasEditPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: editorUser.Id, OrgId: 1, OrgRole: models.ROLE_EDITOR},
 					}
-					err := HasEditPermissionInFolders(query)
+					err := HasEditPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeTrue)
 				})
@@ -340,7 +341,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasAdminPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: adminUser.Id, OrgId: 1, OrgRole: models.ROLE_EDITOR},
 					}
-					err := HasAdminPermissionInFolders(query)
+					err := HasAdminPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeFalse)
 				})
@@ -354,7 +355,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				}
 
 				Convey("Should have no write access to any dashboard folders with default ACL", func() {
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 0)
@@ -368,7 +369,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						OrgRole:      models.ROLE_VIEWER,
 					}
 
-					err := GetDashboardPermissionsForUser(&query)
+					err := GetDashboardPermissionsForUser(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -381,7 +382,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				Convey("Should be able to get one dashboard folder if default role changed to edit for one folder", func() {
 					testHelperUpdateDashboardAcl(folder1.Id, models.DashboardAcl{DashboardId: folder1.Id, OrgId: 1, UserId: viewerUser.Id, Permission: models.PERMISSION_EDIT})
 
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 1)
@@ -392,7 +393,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasEditPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 					}
-					err := HasEditPermissionInFolders(query)
+					err := HasEditPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeFalse)
 				})
@@ -401,7 +402,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &models.HasAdminPermissionInFoldersQuery{
 						SignedInUser: &models.SignedInUser{UserId: adminUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 					}
-					err := HasAdminPermissionInFolders(query)
+					err := HasAdminPermissionInFolders(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldBeFalse)
 				})
@@ -413,7 +414,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						query := &models.HasEditPermissionInFoldersQuery{
 							SignedInUser: &models.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 						}
-						err := HasEditPermissionInFolders(query)
+						err := HasEditPermissionInFolders(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(query.Result, ShouldBeTrue)
 					})
@@ -426,7 +427,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						query := &models.HasEditPermissionInFoldersQuery{
 							SignedInUser: &models.SignedInUser{UserId: viewerUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 						}
-						err := HasEditPermissionInFolders(query)
+						err := HasEditPermissionInFolders(context.Background(), query)
 						So(err, ShouldBeNil)
 						So(query.Result, ShouldBeTrue)
 					})

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			}),
 		}
 
-		err := SaveDashboard(folderCmd)
+		err := SaveDashboard(context.Background(), folderCmd)
 		So(err, ShouldBeNil)
 
 		saveDashboardCmd := &models.SaveDashboardCommand{
@@ -48,7 +49,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 				},
 			}
 
-			err := SaveProvisionedDashboard(cmd)
+			err := SaveProvisionedDashboard(context.Background(), cmd)
 			So(err, ShouldBeNil)
 			So(cmd.Result, ShouldNotBeNil)
 			So(cmd.Result.Id, ShouldNotEqual, 0)
@@ -56,7 +57,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 
 			Convey("Can query for provisioned dashboards", func() {
 				query := &models.GetProvisionedDashboardDataQuery{Name: "default"}
-				err := GetProvisionedDashboardDataQuery(query)
+				err := GetProvisionedDashboardDataQuery(context.Background(), query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 1)
@@ -67,7 +68,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			Convey("Can query for one provisioned dashboard", func() {
 				query := &models.GetProvisionedDashboardDataByIdQuery{DashboardId: cmd.Result.Id}
 
-				err := GetProvisionedDataByDashboardId(query)
+				err := GetProvisionedDataByDashboardId(context.Background(), query)
 				So(err, ShouldBeNil)
 
 				So(query.Result, ShouldNotBeNil)
@@ -76,7 +77,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			Convey("Can query for none provisioned dashboard", func() {
 				query := &models.GetProvisionedDashboardDataByIdQuery{DashboardId: 3000}
 
-				err := GetProvisionedDataByDashboardId(query)
+				err := GetProvisionedDataByDashboardId(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Result, ShouldBeNil)
 			})
@@ -87,11 +88,11 @@ func TestDashboardProvisioningTest(t *testing.T) {
 					OrgId: 1,
 				}
 
-				So(DeleteDashboard(deleteCmd), ShouldBeNil)
+				So(DeleteDashboard(context.Background(), deleteCmd), ShouldBeNil)
 
 				query := &models.GetProvisionedDashboardDataByIdQuery{DashboardId: cmd.Result.Id}
 
-				err = GetProvisionedDataByDashboardId(query)
+				err = GetProvisionedDataByDashboardId(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Result, ShouldBeNil)
 			})
@@ -101,11 +102,11 @@ func TestDashboardProvisioningTest(t *testing.T) {
 					Id: dashId,
 				}
 
-				So(UnprovisionDashboard(unprovisionCmd), ShouldBeNil)
+				So(UnprovisionDashboard(context.Background(), unprovisionCmd), ShouldBeNil)
 
 				query := &models.GetProvisionedDashboardDataByIdQuery{DashboardId: dashId}
 
-				err = GetProvisionedDataByDashboardId(query)
+				err = GetProvisionedDataByDashboardId(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Result, ShouldBeNil)
 			})

--- a/pkg/services/sqlstore/dashboard_service_integration_test.go
+++ b/pkg/services/sqlstore/dashboard_service_integration_test.go
@@ -116,7 +116,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: otherOrgId, Uid: savedDashInFolder.Uid}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldNotEqual, savedDashInFolder.Id)
 							So(query.Result.Id, ShouldEqual, res.Id)
@@ -392,7 +392,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should create a new dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldEqual, res.Id)
 							So(query.Result.FolderId, ShouldEqual, 0)
@@ -418,7 +418,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.FolderId, ShouldEqual, savedFolder.Id)
 						})
@@ -444,7 +444,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.FolderId, ShouldEqual, 0)
 							So(query.Result.IsFolder, ShouldBeTrue)
@@ -468,7 +468,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							So(len(res.Uid), ShouldBeGreaterThan, 0)
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldEqual, res.Id)
 							So(query.Result.Uid, ShouldEqual, res.Uid)
@@ -491,7 +491,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should create a new dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldEqual, res.Id)
 						})
@@ -552,7 +552,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should update dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: savedDashInGeneralFolder.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Title, ShouldEqual, "Updated title")
 							So(query.Result.FolderId, ShouldEqual, savedFolder.Id)
@@ -597,7 +597,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should update dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: savedDashInFolder.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Title, ShouldEqual, "Updated title")
 							So(query.Result.FolderId, ShouldEqual, 0)
@@ -683,7 +683,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should update dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: savedDashInGeneralFolder.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Title, ShouldEqual, "Updated title")
 							So(query.Result.FolderId, ShouldEqual, savedFolder.Id)
@@ -708,7 +708,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Convey("It should update dashboard", func() {
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: savedDashInFolder.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Title, ShouldEqual, "Updated title")
 							So(query.Result.FolderId, ShouldEqual, 0)
@@ -736,7 +736,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: savedDashInFolder.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Uid, ShouldEqual, "new-uid")
 							So(query.Result.Version, ShouldBeGreaterThan, savedDashInFolder.Version)
@@ -782,7 +782,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldEqual, res.Id)
 							So(query.Result.Uid, ShouldEqual, res.Uid)
@@ -809,7 +809,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 
 							query := models.GetDashboardQuery{OrgId: cmd.OrgId, Id: res.Id}
 
-							err := bus.Dispatch(&query)
+							err := bus.DispatchCtx(context.Background(), &query)
 							So(err, ShouldBeNil)
 							So(query.Result.Id, ShouldEqual, res.Id)
 							So(query.Result.Uid, ShouldEqual, res.Uid)

--- a/pkg/services/sqlstore/dashboard_service_integration_test.go
+++ b/pkg/services/sqlstore/dashboard_service_integration_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -19,15 +20,15 @@ func TestIntegratedDashboardService(t *testing.T) {
 		var testOrgId int64 = 1
 
 		Convey("Given saved folders and dashboards in organization A", func() {
-			bus.AddHandler("test", func(cmd *models.ValidateDashboardAlertsCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.ValidateDashboardAlertsCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.UpdateDashboardAlertsCommand) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.UpdateDashboardAlertsCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.GetProvisionedDashboardDataByIdQuery) error {
+			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetProvisionedDashboardDataByIdQuery) error {
 				cmd.Result = nil
 				return nil
 			})

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -25,12 +26,12 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 				UserId: 1000,
 				OrgId:  1,
 			}
-			err := CreateDashboardSnapshot(&cmd)
+			err := CreateDashboardSnapshot(context.Background(), &cmd)
 			So(err, ShouldBeNil)
 
 			Convey("Should be able to get snapshot by key", func() {
 				query := m.GetDashboardSnapshotQuery{Key: "hej"}
-				err = GetDashboardSnapshot(&query)
+				err = GetDashboardSnapshot(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result, ShouldNotBeNil)
@@ -43,7 +44,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 						OrgId:        1,
 						SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_ADMIN},
 					}
-					err := SearchDashboardSnapshots(&query)
+					err := SearchDashboardSnapshots(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(query.Result, ShouldNotBeNil)
@@ -57,7 +58,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 						OrgId:        1,
 						SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_EDITOR, UserId: 1000},
 					}
-					err := SearchDashboardSnapshots(&query)
+					err := SearchDashboardSnapshots(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(query.Result, ShouldNotBeNil)
@@ -71,7 +72,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 						OrgId:        1,
 						SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_EDITOR, UserId: 2},
 					}
-					err := SearchDashboardSnapshots(&query)
+					err := SearchDashboardSnapshots(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(query.Result, ShouldNotBeNil)
@@ -89,7 +90,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 					UserId: 0,
 					OrgId:  1,
 				}
-				err := CreateDashboardSnapshot(&cmd)
+				err := CreateDashboardSnapshot(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 
 				Convey("Should not return any snapshots", func() {
@@ -97,7 +98,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 						OrgId:        1,
 						SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_EDITOR, IsAnonymous: true, UserId: 0},
 					}
-					err := SearchDashboardSnapshots(&query)
+					err := SearchDashboardSnapshots(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(query.Result, ShouldNotBeNil)
@@ -118,27 +119,27 @@ func TestDeleteExpiredSnapshots(t *testing.T) {
 		createTestSnapshot(sqlstore, "key2", -1200)
 		createTestSnapshot(sqlstore, "key3", -1200)
 
-		err := DeleteExpiredSnapshots(&m.DeleteExpiredSnapshotsCommand{})
+		err := DeleteExpiredSnapshots(context.Background(), &m.DeleteExpiredSnapshotsCommand{})
 		So(err, ShouldBeNil)
 
 		query := m.GetDashboardSnapshotsQuery{
 			OrgId:        1,
 			SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_ADMIN},
 		}
-		err = SearchDashboardSnapshots(&query)
+		err = SearchDashboardSnapshots(context.Background(), &query)
 		So(err, ShouldBeNil)
 
 		So(len(query.Result), ShouldEqual, 1)
 		So(query.Result[0].Key, ShouldEqual, notExpiredsnapshot.Key)
 
-		err = DeleteExpiredSnapshots(&m.DeleteExpiredSnapshotsCommand{})
+		err = DeleteExpiredSnapshots(context.Background(), &m.DeleteExpiredSnapshotsCommand{})
 		So(err, ShouldBeNil)
 
 		query = m.GetDashboardSnapshotsQuery{
 			OrgId:        1,
 			SignedInUser: &m.SignedInUser{OrgRole: m.ROLE_ADMIN},
 		}
-		SearchDashboardSnapshots(&query)
+		SearchDashboardSnapshots(context.Background(), &query)
 
 		So(len(query.Result), ShouldEqual, 1)
 		So(query.Result[0].Key, ShouldEqual, notExpiredsnapshot.Key)
@@ -156,7 +157,7 @@ func createTestSnapshot(sqlstore *SqlStore, key string, expires int64) *m.Dashbo
 		OrgId:   1,
 		Expires: expires,
 	}
-	err := CreateDashboardSnapshot(&cmd)
+	err := CreateDashboardSnapshot(context.Background(), &cmd)
 	So(err, ShouldBeNil)
 
 	// Set expiry date manually - to be able to create expired snapshots

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -46,7 +46,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err := GetDashboard(&query)
+				err := GetDashboard(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Title, ShouldEqual, "test dash 23")
@@ -62,7 +62,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err := GetDashboard(&query)
+				err := GetDashboard(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Title, ShouldEqual, "test dash 23")
@@ -78,7 +78,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err := GetDashboard(&query)
+				err := GetDashboard(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Title, ShouldEqual, "test dash 23")
@@ -91,7 +91,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			Convey("Should be able to delete dashboard", func() {
 				dash := insertTestDashboard("delete me", 1, 0, false, "delete this")
 
-				err := DeleteDashboard(&m.DeleteDashboardCommand{
+				err := DeleteDashboard(context.Background(), &m.DeleteDashboardCommand{
 					Id:    dash.Id,
 					OrgId: 1,
 				})
@@ -116,7 +116,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					}),
 				}
 
-				err := SaveDashboard(&cmd)
+				err := SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 
 				generateNewUid = util.GenerateShortUID
@@ -132,7 +132,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					UserId: 100,
 				}
 
-				err := SaveDashboard(&cmd)
+				err := SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 				So(cmd.Result.CreatedBy, ShouldEqual, 100)
 				So(cmd.Result.Created.IsZero(), ShouldBeFalse)
@@ -153,7 +153,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					UserId:    100,
 				}
 
-				err := SaveDashboard(&cmd)
+				err := SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 				So(cmd.Result.FolderId, ShouldEqual, 2)
 
@@ -169,7 +169,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					UserId:    100,
 				}
 
-				err = SaveDashboard(&cmd)
+				err = SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 
 				query := m.GetDashboardQuery{
@@ -177,7 +177,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					OrgId: 1,
 				}
 
-				err = GetDashboard(&query)
+				err = GetDashboard(context.Background(), &query)
 				So(err, ShouldBeNil)
 				So(query.Result.FolderId, ShouldEqual, 0)
 				So(query.Result.CreatedBy, ShouldEqual, savedDash.CreatedBy)
@@ -188,7 +188,7 @@ func TestDashboardDataAccess(t *testing.T) {
 
 			Convey("Should be able to delete a dashboard folder and its children", func() {
 				deleteCmd := &m.DeleteDashboardCommand{Id: savedFolder.Id}
-				err := DeleteDashboard(deleteCmd)
+				err := DeleteDashboard(context.Background(), deleteCmd)
 				So(err, ShouldBeNil)
 
 				query := search.FindPersistedDashboardsQuery{
@@ -197,7 +197,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{},
 				}
 
-				err = SearchDashboards(&query)
+				err = SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 0)
@@ -214,7 +214,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					}),
 				}
 
-				err := SaveDashboard(&cmd)
+				err := SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldEqual, m.ErrDashboardNotFound)
 			})
 
@@ -229,14 +229,14 @@ func TestDashboardDataAccess(t *testing.T) {
 					}),
 				}
 
-				err := SaveDashboard(&cmd)
+				err := SaveDashboard(context.Background(), &cmd)
 				So(err, ShouldBeNil)
 			})
 
 			Convey("Should be able to get dashboard tags", func() {
 				query := m.GetDashboardTagsQuery{OrgId: 1}
 
-				err := GetDashboardTags(&query)
+				err := GetDashboardTags(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 2)
@@ -249,7 +249,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 				}
 
-				err := SearchDashboards(&query)
+				err := SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 1)
@@ -266,7 +266,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 				}
 
-				err := SearchDashboards(&query)
+				err := SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 1)
@@ -281,7 +281,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 				}
 
-				err := SearchDashboards(&query)
+				err := SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 1)
@@ -296,7 +296,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 				}
 
-				err := SearchDashboards(&query)
+				err := SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 3)
@@ -310,7 +310,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 				}
 
-				err := SearchDashboards(&query)
+				err := SearchDashboards(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(len(query.Result), ShouldEqual, 2)
@@ -330,7 +330,7 @@ func TestDashboardDataAccess(t *testing.T) {
 						SignedInUser: &m.SignedInUser{OrgId: 1, OrgRole: m.ROLE_EDITOR},
 					}
 
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					So(len(query.Result), ShouldEqual, 2)
@@ -345,12 +345,12 @@ func TestDashboardDataAccess(t *testing.T) {
 
 			Convey("Given two dashboards, one is starred dashboard by user 10, other starred by user 1", func() {
 				starredDash := insertTestDashboard("starred dash", 1, 0, false)
-				StarDashboard(&m.StarDashboardCommand{
+				StarDashboard(context.Background(), &m.StarDashboardCommand{
 					DashboardId: starredDash.Id,
 					UserId:      10,
 				})
 
-				StarDashboard(&m.StarDashboardCommand{
+				StarDashboard(context.Background(), &m.StarDashboardCommand{
 					DashboardId: savedDash.Id,
 					UserId:      1,
 				})
@@ -360,7 +360,7 @@ func TestDashboardDataAccess(t *testing.T) {
 						SignedInUser: &m.SignedInUser{UserId: 10, OrgId: 1, OrgRole: m.ROLE_EDITOR},
 						IsStarred:    true,
 					}
-					err := SearchDashboards(&query)
+					err := SearchDashboards(context.Background(), &query)
 
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 1)
@@ -382,7 +382,7 @@ func TestDashboardDataAccess(t *testing.T) {
 					OrgId:    1,
 				}
 
-				err := GetDashboardsByPluginId(&query)
+				err := GetDashboardsByPluginId(context.Background(), &query)
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 2)
 			})
@@ -402,7 +402,7 @@ func insertTestDashboard(title string, orgId int64, folderId int64, isFolder boo
 		}),
 	}
 
-	err := SaveDashboard(&cmd)
+	err := SaveDashboard(context.Background(), &cmd)
 	So(err, ShouldBeNil)
 
 	cmd.Result.Data.Set("id", cmd.Result.Id)
@@ -423,7 +423,7 @@ func insertTestDashboardForPlugin(title string, orgId int64, folderId int64, isF
 		PluginId: pluginId,
 	}
 
-	err := SaveDashboard(&cmd)
+	err := SaveDashboard(context.Background(), &cmd)
 	So(err, ShouldBeNil)
 
 	return cmd.Result
@@ -439,7 +439,7 @@ func createUser(name string, role string, isAdmin bool) m.User {
 	So(err, ShouldBeNil)
 
 	q1 := m.GetUserOrgListQuery{UserId: currentUserCmd.Result.Id}
-	GetUserOrgList(&q1)
+	GetUserOrgList(context.Background(), &q1)
 	So(q1.Result[0].Role, ShouldEqual, role)
 
 	return currentUserCmd.Result
@@ -453,7 +453,7 @@ func moveDashboard(orgId int64, dashboard *simplejson.Json, newFolderId int64) *
 		Overwrite: true,
 	}
 
-	err := SaveDashboard(&cmd)
+	err := SaveDashboard(context.Background(), &cmd)
 	So(err, ShouldBeNil)
 
 	return cmd.Result

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -17,7 +18,7 @@ func TestDataAccess(t *testing.T) {
 	Convey("Testing DB", t, func() {
 		InitTestDB(t)
 		Convey("Can add datasource", func() {
-			err := AddDataSource(&models.AddDataSourceCommand{
+			err := AddDataSource(context.Background(), &models.AddDataSourceCommand{
 				OrgId:    10,
 				Name:     "laban",
 				Type:     models.DS_INFLUXDB,
@@ -30,7 +31,7 @@ func TestDataAccess(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			query := models.GetDataSourcesQuery{OrgId: 10}
-			err = GetDataSources(&query)
+			err = GetDataSources(context.Background(), &query)
 			So(err, ShouldBeNil)
 
 			So(len(query.Result), ShouldEqual, 1)
@@ -43,7 +44,7 @@ func TestDataAccess(t *testing.T) {
 		})
 
 		Convey("Given a datasource", func() {
-			err := AddDataSource(&models.AddDataSourceCommand{
+			err := AddDataSource(context.Background(), &models.AddDataSourceCommand{
 				OrgId:  10,
 				Name:   "nisse",
 				Type:   models.DS_GRAPHITE,
@@ -53,7 +54,7 @@ func TestDataAccess(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			query := models.GetDataSourcesQuery{OrgId: 10}
-			err = GetDataSources(&query)
+			err = GetDataSources(context.Background(), &query)
 			So(err, ShouldBeNil)
 
 			ds := query.Result[0]
@@ -70,13 +71,13 @@ func TestDataAccess(t *testing.T) {
 				}
 
 				Convey("with same version as source", func() {
-					err := UpdateDataSource(cmd)
+					err := UpdateDataSource(context.Background(), cmd)
 					So(err, ShouldBeNil)
 				})
 
 				Convey("when someone else updated between read and update", func() {
 					query := models.GetDataSourcesQuery{OrgId: 10}
-					err = GetDataSources(&query)
+					err = GetDataSources(context.Background(), &query)
 					So(err, ShouldBeNil)
 
 					ds := query.Result[0]
@@ -100,10 +101,10 @@ func TestDataAccess(t *testing.T) {
 						Version: ds.Version,
 					}
 
-					err := UpdateDataSource(updateFromOtherUser)
+					err := UpdateDataSource(context.Background(), updateFromOtherUser)
 					So(err, ShouldBeNil)
 
-					err = UpdateDataSource(intendedUpdate)
+					err = UpdateDataSource(context.Background(), intendedUpdate)
 					So(err, ShouldNotBeNil)
 				})
 
@@ -118,7 +119,7 @@ func TestDataAccess(t *testing.T) {
 					}
 
 					Convey("should not raise errors", func() {
-						err := UpdateDataSource(cmd)
+						err := UpdateDataSource(context.Background(), cmd)
 						So(err, ShouldBeNil)
 					})
 				})
@@ -135,33 +136,33 @@ func TestDataAccess(t *testing.T) {
 					}
 
 					Convey("should not raise errors", func() {
-						err := UpdateDataSource(cmd)
+						err := UpdateDataSource(context.Background(), cmd)
 						So(err, ShouldBeNil)
 					})
 				})
 			})
 
 			Convey("Can delete datasource by id", func() {
-				err := DeleteDataSourceById(&models.DeleteDataSourceByIdCommand{Id: ds.Id, OrgId: ds.OrgId})
+				err := DeleteDataSourceById(context.Background(), &models.DeleteDataSourceByIdCommand{Id: ds.Id, OrgId: ds.OrgId})
 				So(err, ShouldBeNil)
 
-				GetDataSources(&query)
+				GetDataSources(context.Background(), &query)
 				So(len(query.Result), ShouldEqual, 0)
 			})
 
 			Convey("Can delete datasource by name", func() {
-				err := DeleteDataSourceByName(&models.DeleteDataSourceByNameCommand{Name: ds.Name, OrgId: ds.OrgId})
+				err := DeleteDataSourceByName(context.Background(), &models.DeleteDataSourceByNameCommand{Name: ds.Name, OrgId: ds.OrgId})
 				So(err, ShouldBeNil)
 
-				GetDataSources(&query)
+				GetDataSources(context.Background(), &query)
 				So(len(query.Result), ShouldEqual, 0)
 			})
 
 			Convey("Can not delete datasource with wrong orgId", func() {
-				err := DeleteDataSourceById(&models.DeleteDataSourceByIdCommand{Id: ds.Id, OrgId: 123123})
+				err := DeleteDataSourceById(context.Background(), &models.DeleteDataSourceByIdCommand{Id: ds.Id, OrgId: 123123})
 				So(err, ShouldBeNil)
 
-				GetDataSources(&query)
+				GetDataSources(context.Background(), &query)
 				So(len(query.Result), ShouldEqual, 1)
 			})
 		})

--- a/pkg/services/sqlstore/health.go
+++ b/pkg/services/sqlstore/health.go
@@ -1,14 +1,16 @@
 package sqlstore
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 func init() {
-	bus.AddHandler("sql", GetDBHealthQuery)
+	bus.AddHandlerCtx("sql", GetDBHealthQuery)
 }
 
-func GetDBHealthQuery(query *m.GetDBHealthQuery) error {
+func GetDBHealthQuery(ctx context.Context, query *m.GetDBHealthQuery) error {
 	return x.Ping()
 }

--- a/pkg/services/sqlstore/login_attempt.go
+++ b/pkg/services/sqlstore/login_attempt.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -11,12 +12,12 @@ import (
 var getTimeNow = time.Now
 
 func init() {
-	bus.AddHandler("sql", CreateLoginAttempt)
-	bus.AddHandler("sql", DeleteOldLoginAttempts)
-	bus.AddHandler("sql", GetUserLoginAttemptCount)
+	bus.AddHandlerCtx("sql", CreateLoginAttempt)
+	bus.AddHandlerCtx("sql", DeleteOldLoginAttempts)
+	bus.AddHandlerCtx("sql", GetUserLoginAttemptCount)
 }
 
-func CreateLoginAttempt(cmd *m.CreateLoginAttemptCommand) error {
+func CreateLoginAttempt(ctx context.Context, cmd *m.CreateLoginAttemptCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		loginAttempt := m.LoginAttempt{
 			Username:  cmd.Username,
@@ -34,7 +35,7 @@ func CreateLoginAttempt(cmd *m.CreateLoginAttemptCommand) error {
 	})
 }
 
-func DeleteOldLoginAttempts(cmd *m.DeleteOldLoginAttemptsCommand) error {
+func DeleteOldLoginAttempts(ctx context.Context, cmd *m.DeleteOldLoginAttemptsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		var maxId int64
 		sql := "SELECT max(id) as id FROM login_attempt WHERE created < ?"
@@ -66,7 +67,7 @@ func DeleteOldLoginAttempts(cmd *m.DeleteOldLoginAttemptsCommand) error {
 	})
 }
 
-func GetUserLoginAttemptCount(query *m.GetUserLoginAttemptCountQuery) error {
+func GetUserLoginAttemptCount(ctx context.Context, query *m.GetUserLoginAttemptCountQuery) error {
 	loginAttempt := new(m.LoginAttempt)
 	total, err := x.
 		Where("username = ?", query.Username).

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ func TestLoginAttempts(t *testing.T) {
 		user := "user"
 		beginningOfTime := mockTime(time.Date(2017, 10, 22, 8, 0, 0, 0, time.Local))
 
-		err := CreateLoginAttempt(&m.CreateLoginAttemptCommand{
+		err := CreateLoginAttempt(context.Background(), &m.CreateLoginAttemptCommand{
 			Username:  user,
 			IpAddress: "192.168.0.1",
 		})
@@ -28,7 +29,7 @@ func TestLoginAttempts(t *testing.T) {
 
 		timePlusOneMinute := mockTime(beginningOfTime.Add(time.Minute * 1))
 
-		err = CreateLoginAttempt(&m.CreateLoginAttemptCommand{
+		err = CreateLoginAttempt(context.Background(), &m.CreateLoginAttemptCommand{
 			Username:  user,
 			IpAddress: "192.168.0.1",
 		})
@@ -36,7 +37,7 @@ func TestLoginAttempts(t *testing.T) {
 
 		timePlusTwoMinutes := mockTime(beginningOfTime.Add(time.Minute * 2))
 
-		err = CreateLoginAttempt(&m.CreateLoginAttemptCommand{
+		err = CreateLoginAttempt(context.Background(), &m.CreateLoginAttemptCommand{
 			Username:  user,
 			IpAddress: "192.168.0.1",
 		})
@@ -47,7 +48,7 @@ func TestLoginAttempts(t *testing.T) {
 				Username: user,
 				Since:    timePlusTwoMinutes.Add(time.Second * 1),
 			}
-			err := GetUserLoginAttemptCount(&query)
+			err := GetUserLoginAttemptCount(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result, ShouldEqual, 0)
 		})
@@ -57,7 +58,7 @@ func TestLoginAttempts(t *testing.T) {
 				Username: user,
 				Since:    beginningOfTime,
 			}
-			err := GetUserLoginAttemptCount(&query)
+			err := GetUserLoginAttemptCount(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result, ShouldEqual, 3)
 		})
@@ -67,7 +68,7 @@ func TestLoginAttempts(t *testing.T) {
 				Username: user,
 				Since:    timePlusOneMinute,
 			}
-			err := GetUserLoginAttemptCount(&query)
+			err := GetUserLoginAttemptCount(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result, ShouldEqual, 2)
 		})
@@ -77,7 +78,7 @@ func TestLoginAttempts(t *testing.T) {
 				Username: user,
 				Since:    timePlusTwoMinutes,
 			}
-			err := GetUserLoginAttemptCount(&query)
+			err := GetUserLoginAttemptCount(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result, ShouldEqual, 1)
 		})
@@ -86,7 +87,7 @@ func TestLoginAttempts(t *testing.T) {
 			cmd := m.DeleteOldLoginAttemptsCommand{
 				OlderThan: beginningOfTime,
 			}
-			err := DeleteOldLoginAttempts(&cmd)
+			err := DeleteOldLoginAttempts(context.Background(), &cmd)
 
 			So(err, ShouldBeNil)
 			So(cmd.DeletedRows, ShouldEqual, 0)
@@ -96,7 +97,7 @@ func TestLoginAttempts(t *testing.T) {
 			cmd := m.DeleteOldLoginAttemptsCommand{
 				OlderThan: timePlusOneMinute,
 			}
-			err := DeleteOldLoginAttempts(&cmd)
+			err := DeleteOldLoginAttempts(context.Background(), &cmd)
 
 			So(err, ShouldBeNil)
 			So(cmd.DeletedRows, ShouldEqual, 1)
@@ -106,7 +107,7 @@ func TestLoginAttempts(t *testing.T) {
 			cmd := m.DeleteOldLoginAttemptsCommand{
 				OlderThan: timePlusTwoMinutes,
 			}
-			err := DeleteOldLoginAttempts(&cmd)
+			err := DeleteOldLoginAttempts(context.Background(), &cmd)
 
 			So(err, ShouldBeNil)
 			So(cmd.DeletedRows, ShouldEqual, 2)
@@ -116,7 +117,7 @@ func TestLoginAttempts(t *testing.T) {
 			cmd := m.DeleteOldLoginAttemptsCommand{
 				OlderThan: timePlusTwoMinutes.Add(time.Second * 1),
 			}
-			err := DeleteOldLoginAttempts(&cmd)
+			err := DeleteOldLoginAttempts(context.Background(), &cmd)
 
 			So(err, ShouldBeNil)
 			So(cmd.DeletedRows, ShouldEqual, 3)

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -11,13 +12,13 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", AddOrgUser)
-	bus.AddHandler("sql", RemoveOrgUser)
-	bus.AddHandler("sql", GetOrgUsers)
-	bus.AddHandler("sql", UpdateOrgUser)
+	bus.AddHandlerCtx("sql", AddOrgUser)
+	bus.AddHandlerCtx("sql", RemoveOrgUser)
+	bus.AddHandlerCtx("sql", GetOrgUsers)
+	bus.AddHandlerCtx("sql", UpdateOrgUser)
 }
 
-func AddOrgUser(cmd *m.AddOrgUserCommand) error {
+func AddOrgUser(ctx context.Context, cmd *m.AddOrgUserCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		// check if user exists
 		var user m.User
@@ -71,7 +72,7 @@ func AddOrgUser(cmd *m.AddOrgUserCommand) error {
 	})
 }
 
-func UpdateOrgUser(cmd *m.UpdateOrgUserCommand) error {
+func UpdateOrgUser(ctx context.Context, cmd *m.UpdateOrgUserCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		var orgUser m.OrgUser
 		exists, err := sess.Where("org_id=? AND user_id=?", cmd.OrgId, cmd.UserId).Get(&orgUser)
@@ -94,7 +95,7 @@ func UpdateOrgUser(cmd *m.UpdateOrgUserCommand) error {
 	})
 }
 
-func GetOrgUsers(query *m.GetOrgUsersQuery) error {
+func GetOrgUsers(ctx context.Context, query *m.GetOrgUsersQuery) error {
 	query.Result = make([]*m.OrgUserDTO, 0)
 
 	sess := x.Table("org_user")
@@ -134,7 +135,7 @@ func GetOrgUsers(query *m.GetOrgUsersQuery) error {
 	return nil
 }
 
-func RemoveOrgUser(cmd *m.RemoveOrgUserCommand) error {
+func RemoveOrgUser(ctx context.Context, cmd *m.RemoveOrgUserCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		// check if user exists
 		var user m.User

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -1,20 +1,22 @@
 package sqlstore
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 func init() {
-	bus.AddHandler("sql", CreatePlaylist)
-	bus.AddHandler("sql", UpdatePlaylist)
-	bus.AddHandler("sql", DeletePlaylist)
-	bus.AddHandler("sql", SearchPlaylists)
-	bus.AddHandler("sql", GetPlaylist)
-	bus.AddHandler("sql", GetPlaylistItem)
+	bus.AddHandlerCtx("sql", CreatePlaylist)
+	bus.AddHandlerCtx("sql", UpdatePlaylist)
+	bus.AddHandlerCtx("sql", DeletePlaylist)
+	bus.AddHandlerCtx("sql", SearchPlaylists)
+	bus.AddHandlerCtx("sql", GetPlaylist)
+	bus.AddHandlerCtx("sql", GetPlaylistItem)
 }
 
-func CreatePlaylist(cmd *m.CreatePlaylistCommand) error {
+func CreatePlaylist(ctx context.Context, cmd *m.CreatePlaylistCommand) error {
 	playlist := m.Playlist{
 		Name:     cmd.Name,
 		Interval: cmd.Interval,
@@ -43,7 +45,7 @@ func CreatePlaylist(cmd *m.CreatePlaylistCommand) error {
 	return err
 }
 
-func UpdatePlaylist(cmd *m.UpdatePlaylistCommand) error {
+func UpdatePlaylist(ctx context.Context, cmd *m.UpdatePlaylistCommand) error {
 	playlist := m.Playlist{
 		Id:       cmd.Id,
 		OrgId:    cmd.OrgId,
@@ -94,7 +96,7 @@ func UpdatePlaylist(cmd *m.UpdatePlaylistCommand) error {
 	return err
 }
 
-func GetPlaylist(query *m.GetPlaylistByIdQuery) error {
+func GetPlaylist(ctx context.Context, query *m.GetPlaylistByIdQuery) error {
 	if query.Id == 0 {
 		return m.ErrCommandValidationFailed
 	}
@@ -107,7 +109,7 @@ func GetPlaylist(query *m.GetPlaylistByIdQuery) error {
 	return err
 }
 
-func DeletePlaylist(cmd *m.DeletePlaylistCommand) error {
+func DeletePlaylist(ctx context.Context, cmd *m.DeletePlaylistCommand) error {
 	if cmd.Id == 0 {
 		return m.ErrCommandValidationFailed
 	}
@@ -127,7 +129,7 @@ func DeletePlaylist(cmd *m.DeletePlaylistCommand) error {
 	})
 }
 
-func SearchPlaylists(query *m.GetPlaylistsQuery) error {
+func SearchPlaylists(ctx context.Context, query *m.GetPlaylistsQuery) error {
 	var playlists = make(m.Playlists, 0)
 
 	sess := x.Limit(query.Limit)
@@ -143,7 +145,7 @@ func SearchPlaylists(query *m.GetPlaylistsQuery) error {
 	return err
 }
 
-func GetPlaylistItem(query *m.GetPlaylistItemsByIdQuery) error {
+func GetPlaylistItem(ctx context.Context, query *m.GetPlaylistItemsByIdQuery) error {
 	if query.PlaylistId == 0 {
 		return m.ErrCommandValidationFailed
 	}

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -19,7 +20,7 @@ func TestPlaylistDataAccess(t *testing.T) {
 				{Title: "Backend response times", Value: "3", Type: "dashboard_by_id"},
 			}
 			cmd := m.CreatePlaylistCommand{Name: "NYC office", Interval: "10m", OrgId: 1, Items: items}
-			err := CreatePlaylist(&cmd)
+			err := CreatePlaylist(context.Background(), &cmd)
 			So(err, ShouldBeNil)
 
 			Convey("can update playlist", func() {
@@ -28,13 +29,13 @@ func TestPlaylistDataAccess(t *testing.T) {
 					{Title: "Backend response times", Value: "2", Type: "dashboard_by_id"},
 				}
 				query := m.UpdatePlaylistCommand{Name: "NYC office ", OrgId: 1, Id: 1, Interval: "10s", Items: items}
-				err = UpdatePlaylist(&query)
+				err = UpdatePlaylist(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 
 				Convey("can remove playlist", func() {
 					query := m.DeletePlaylistCommand{Id: 1}
-					err = DeletePlaylist(&query)
+					err = DeletePlaylist(context.Background(), &query)
 
 					So(err, ShouldBeNil)
 				})

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -11,12 +12,12 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", GetPreferences)
-	bus.AddHandler("sql", GetPreferencesWithDefaults)
-	bus.AddHandler("sql", SavePreferences)
+	bus.AddHandlerCtx("sql", GetPreferences)
+	bus.AddHandlerCtx("sql", GetPreferencesWithDefaults)
+	bus.AddHandlerCtx("sql", SavePreferences)
 }
 
-func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error {
+func GetPreferencesWithDefaults(ctx context.Context, query *m.GetPreferencesWithDefaultsQuery) error {
 	params := make([]interface{}, 0)
 	filter := ""
 	if len(query.User.Teams) > 0 {
@@ -61,7 +62,7 @@ func GetPreferencesWithDefaults(query *m.GetPreferencesWithDefaultsQuery) error 
 	return nil
 }
 
-func GetPreferences(query *m.GetPreferencesQuery) error {
+func GetPreferences(ctx context.Context, query *m.GetPreferencesQuery) error {
 	var prefs m.Preferences
 	exists, err := x.Where("org_id=? AND user_id=? AND team_id=?", query.OrgId, query.UserId, query.TeamId).Get(&prefs)
 
@@ -78,7 +79,7 @@ func GetPreferences(query *m.GetPreferencesQuery) error {
 	return nil
 }
 
-func SavePreferences(cmd *m.SavePreferencesCommand) error {
+func SavePreferences(ctx context.Context, cmd *m.SavePreferencesCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 
 		var prefs m.Preferences

--- a/pkg/services/sqlstore/preferences_test.go
+++ b/pkg/services/sqlstore/preferences_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -15,7 +16,7 @@ func TestPreferencesDataAccess(t *testing.T) {
 
 		Convey("GetPreferencesWithDefaults with no saved preferences should return defaults", func() {
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.Theme, ShouldEqual, setting.DefaultTheme)
 			So(query.Result.Timezone, ShouldEqual, "browser")
@@ -23,67 +24,67 @@ func TestPreferencesDataAccess(t *testing.T) {
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org and user home dashboard should return user home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1, UserId: 1}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 4)
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org and other user home dashboard should return org home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1, UserId: 2}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 1)
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org and teams home dashboard should return last team home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1, Teams: []int64{2, 3}}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 3)
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org and other teams home dashboard should return org home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 1)
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org, teams and user home dashboard should return user home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1, UserId: 1, Teams: []int64{2, 3}}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 4)
 		})
 
 		Convey("GetPreferencesWithDefaults with saved org, other teams and user home dashboard should return org home dashboard", func() {
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
-			SavePreferences(&models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, HomeDashboardId: 1})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 2, HomeDashboardId: 2})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, TeamId: 3, HomeDashboardId: 3})
+			SavePreferences(context.Background(), &models.SavePreferencesCommand{OrgId: 1, UserId: 1, HomeDashboardId: 4})
 
 			query := &models.GetPreferencesWithDefaultsQuery{User: &models.SignedInUser{OrgId: 1, UserId: 2}}
-			err := GetPreferencesWithDefaults(query)
+			err := GetPreferencesWithDefaults(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.HomeDashboardId, ShouldEqual, 1)
 		})

--- a/pkg/services/sqlstore/quota.go
+++ b/pkg/services/sqlstore/quota.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -10,20 +11,20 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", GetOrgQuotaByTarget)
-	bus.AddHandler("sql", GetOrgQuotas)
-	bus.AddHandler("sql", UpdateOrgQuota)
-	bus.AddHandler("sql", GetUserQuotaByTarget)
-	bus.AddHandler("sql", GetUserQuotas)
-	bus.AddHandler("sql", UpdateUserQuota)
-	bus.AddHandler("sql", GetGlobalQuotaByTarget)
+	bus.AddHandlerCtx("sql", GetOrgQuotaByTarget)
+	bus.AddHandlerCtx("sql", GetOrgQuotas)
+	bus.AddHandlerCtx("sql", UpdateOrgQuota)
+	bus.AddHandlerCtx("sql", GetUserQuotaByTarget)
+	bus.AddHandlerCtx("sql", GetUserQuotas)
+	bus.AddHandlerCtx("sql", UpdateUserQuota)
+	bus.AddHandlerCtx("sql", GetGlobalQuotaByTarget)
 }
 
 type targetCount struct {
 	Count int64
 }
 
-func GetOrgQuotaByTarget(query *m.GetOrgQuotaByTargetQuery) error {
+func GetOrgQuotaByTarget(ctx context.Context, query *m.GetOrgQuotaByTargetQuery) error {
 	quota := m.Quota{
 		Target: query.Target,
 		OrgId:  query.OrgId,
@@ -52,7 +53,7 @@ func GetOrgQuotaByTarget(query *m.GetOrgQuotaByTargetQuery) error {
 	return nil
 }
 
-func GetOrgQuotas(query *m.GetOrgQuotasQuery) error {
+func GetOrgQuotas(ctx context.Context, query *m.GetOrgQuotasQuery) error {
 	quotas := make([]*m.Quota, 0)
 	sess := x.Table("quota")
 	if err := sess.Where("org_id=? AND user_id=0", query.OrgId).Find(&quotas); err != nil {
@@ -95,7 +96,7 @@ func GetOrgQuotas(query *m.GetOrgQuotasQuery) error {
 	return nil
 }
 
-func UpdateOrgQuota(cmd *m.UpdateOrgQuotaCmd) error {
+func UpdateOrgQuota(ctx context.Context, cmd *m.UpdateOrgQuotaCmd) error {
 	return inTransaction(func(sess *DBSession) error {
 		//Check if quota is already defined in the DB
 		quota := m.Quota{
@@ -125,7 +126,7 @@ func UpdateOrgQuota(cmd *m.UpdateOrgQuotaCmd) error {
 	})
 }
 
-func GetUserQuotaByTarget(query *m.GetUserQuotaByTargetQuery) error {
+func GetUserQuotaByTarget(ctx context.Context, query *m.GetUserQuotaByTargetQuery) error {
 	quota := m.Quota{
 		Target: query.Target,
 		UserId: query.UserId,
@@ -154,7 +155,7 @@ func GetUserQuotaByTarget(query *m.GetUserQuotaByTargetQuery) error {
 	return nil
 }
 
-func GetUserQuotas(query *m.GetUserQuotasQuery) error {
+func GetUserQuotas(ctx context.Context, query *m.GetUserQuotasQuery) error {
 	quotas := make([]*m.Quota, 0)
 	sess := x.Table("quota")
 	if err := sess.Where("user_id=? AND org_id=0", query.UserId).Find(&quotas); err != nil {
@@ -197,7 +198,7 @@ func GetUserQuotas(query *m.GetUserQuotasQuery) error {
 	return nil
 }
 
-func UpdateUserQuota(cmd *m.UpdateUserQuotaCmd) error {
+func UpdateUserQuota(ctx context.Context, cmd *m.UpdateUserQuotaCmd) error {
 	return inTransaction(func(sess *DBSession) error {
 		//Check if quota is already defined in the DB
 		quota := m.Quota{
@@ -227,7 +228,7 @@ func UpdateUserQuota(cmd *m.UpdateUserQuotaCmd) error {
 	})
 }
 
-func GetGlobalQuotaByTarget(query *m.GetGlobalQuotaByTargetQuery) error {
+func GetGlobalQuotaByTarget(ctx context.Context, query *m.GetGlobalQuotaByTargetQuery) error {
 	//get quota used.
 	rawSql := fmt.Sprintf("SELECT COUNT(*) as count from %s", dialect.Quote(query.Target))
 	resp := make([]*targetCount, 0)

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -45,7 +46,7 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 			UserId: 1,
 		}
 
-		err := CreateOrg(&userCmd)
+		err := CreateOrg(context.Background(), &userCmd)
 		So(err, ShouldBeNil)
 		orgId = userCmd.Result.Id
 
@@ -55,40 +56,40 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  10,
 			}
-			err := UpdateOrgQuota(&orgCmd)
+			err := UpdateOrgQuota(context.Background(), &orgCmd)
 			So(err, ShouldBeNil)
 
 			Convey("Should be able to get saved quota by org id and target", func() {
 				query := m.GetOrgQuotaByTargetQuery{OrgId: orgId, Target: "org_user", Default: 1}
-				err = GetOrgQuotaByTarget(&query)
+				err = GetOrgQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Limit, ShouldEqual, 10)
 			})
 			Convey("Should be able to get default quota by org id and target", func() {
 				query := m.GetOrgQuotaByTargetQuery{OrgId: 123, Target: "org_user", Default: 11}
-				err = GetOrgQuotaByTarget(&query)
+				err = GetOrgQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Limit, ShouldEqual, 11)
 			})
 			Convey("Should be able to get used org quota when rows exist", func() {
 				query := m.GetOrgQuotaByTargetQuery{OrgId: orgId, Target: "org_user", Default: 11}
-				err = GetOrgQuotaByTarget(&query)
+				err = GetOrgQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Used, ShouldEqual, 1)
 			})
 			Convey("Should be able to get used org quota when no rows exist", func() {
 				query := m.GetOrgQuotaByTargetQuery{OrgId: 2, Target: "org_user", Default: 11}
-				err = GetOrgQuotaByTarget(&query)
+				err = GetOrgQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Used, ShouldEqual, 0)
 			})
 			Convey("Should be able to quota list for org", func() {
 				query := m.GetOrgQuotasQuery{OrgId: orgId}
-				err = GetOrgQuotas(&query)
+				err = GetOrgQuotas(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 4)
@@ -111,40 +112,40 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  10,
 			}
-			err := UpdateUserQuota(&userQuotaCmd)
+			err := UpdateUserQuota(context.Background(), &userQuotaCmd)
 			So(err, ShouldBeNil)
 
 			Convey("Should be able to get saved quota by user id and target", func() {
 				query := m.GetUserQuotaByTargetQuery{UserId: userId, Target: "org_user", Default: 1}
-				err = GetUserQuotaByTarget(&query)
+				err = GetUserQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Limit, ShouldEqual, 10)
 			})
 			Convey("Should be able to get default quota by user id and target", func() {
 				query := m.GetUserQuotaByTargetQuery{UserId: 9, Target: "org_user", Default: 11}
-				err = GetUserQuotaByTarget(&query)
+				err = GetUserQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Limit, ShouldEqual, 11)
 			})
 			Convey("Should be able to get used user quota when rows exist", func() {
 				query := m.GetUserQuotaByTargetQuery{UserId: userId, Target: "org_user", Default: 11}
-				err = GetUserQuotaByTarget(&query)
+				err = GetUserQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Used, ShouldEqual, 1)
 			})
 			Convey("Should be able to get used user quota when no rows exist", func() {
 				query := m.GetUserQuotaByTargetQuery{UserId: 2, Target: "org_user", Default: 11}
-				err = GetUserQuotaByTarget(&query)
+				err = GetUserQuotaByTarget(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Used, ShouldEqual, 0)
 			})
 			Convey("Should be able to quota list for user", func() {
 				query := m.GetUserQuotasQuery{UserId: userId}
-				err = GetUserQuotas(&query)
+				err = GetUserQuotas(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 1)
@@ -155,7 +156,7 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 
 		Convey("Should be able to global user quota", func() {
 			query := m.GetGlobalQuotaByTargetQuery{Target: "user", Default: 5}
-			err = GetGlobalQuotaByTarget(&query)
+			err = GetGlobalQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 
 			So(query.Result.Limit, ShouldEqual, 5)
@@ -163,7 +164,7 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 		})
 		Convey("Should be able to global org quota", func() {
 			query := m.GetGlobalQuotaByTargetQuery{Target: "org", Default: 5}
-			err = GetGlobalQuotaByTarget(&query)
+			err = GetGlobalQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 
 			So(query.Result.Limit, ShouldEqual, 5)
@@ -177,11 +178,11 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  5,
 			}
-			err := UpdateOrgQuota(&orgCmd)
+			err := UpdateOrgQuota(context.Background(), &orgCmd)
 			So(err, ShouldBeNil)
 
 			query := m.GetOrgQuotaByTargetQuery{OrgId: orgId, Target: "org_user", Default: 1}
-			err = GetOrgQuotaByTarget(&query)
+			err = GetOrgQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result.Limit, ShouldEqual, 5)
 
@@ -193,11 +194,11 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  10,
 			}
-			err = UpdateOrgQuota(&orgCmd)
+			err = UpdateOrgQuota(context.Background(), &orgCmd)
 			So(err, ShouldBeNil)
 
 			query = m.GetOrgQuotaByTargetQuery{OrgId: orgId, Target: "org_user", Default: 1}
-			err = GetOrgQuotaByTarget(&query)
+			err = GetOrgQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result.Limit, ShouldEqual, 10)
 		})
@@ -209,11 +210,11 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  5,
 			}
-			err := UpdateUserQuota(&userQuotaCmd)
+			err := UpdateUserQuota(context.Background(), &userQuotaCmd)
 			So(err, ShouldBeNil)
 
 			query := m.GetUserQuotaByTargetQuery{UserId: userId, Target: "org_user", Default: 1}
-			err = GetUserQuotaByTarget(&query)
+			err = GetUserQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result.Limit, ShouldEqual, 5)
 
@@ -225,11 +226,11 @@ func TestQuotaCommandsAndQueries(t *testing.T) {
 				Target: "org_user",
 				Limit:  10,
 			}
-			err = UpdateUserQuota(&userQuotaCmd)
+			err = UpdateUserQuota(context.Background(), &userQuotaCmd)
 			So(err, ShouldBeNil)
 
 			query = m.GetUserQuotaByTargetQuery{UserId: userId, Target: "org_user", Default: 1}
-			err = GetUserQuotaByTarget(&query)
+			err = GetUserQuotaByTarget(context.Background(), &query)
 			So(err, ShouldBeNil)
 			So(query.Result.Limit, ShouldEqual, 10)
 		})

--- a/pkg/services/sqlstore/sql_test_data.go
+++ b/pkg/services/sqlstore/sql_test_data.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", InsertSqlTestData)
+	bus.AddHandlerCtx("sql", InsertSqlTestData)
 }
 
 func sqlRandomWalk(m1 string, m2 string, intWalker int64, floatWalker float64, sess *DBSession) error {
@@ -44,7 +45,7 @@ func sqlRandomWalk(m1 string, m2 string, intWalker int64, floatWalker float64, s
 	return nil
 }
 
-func InsertSqlTestData(cmd *m.InsertSqlTestDataCommand) error {
+func InsertSqlTestData(ctx context.Context, cmd *m.InsertSqlTestDataCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		var err error
 

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -219,7 +219,7 @@ func createDummyTeam() (*models.Team, error) {
 		Name:  "test",
 		Email: "test@example.com",
 	}
-	err := CreateTeam(cmd)
+	err := CreateTeam(context.Background(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func createDummyDashboard(dashboardProps DashboardProps) (*models.Dashboard, err
 		saveDashboardCmd.OrgId = 1
 	}
 
-	err := SaveDashboard(saveDashboardCmd)
+	err := SaveDashboard(context.Background(), saveDashboardCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func createDummyAcl(dashboardPermission *DashboardPermission, search Search, das
 				OrgId:  1,
 				TeamId: team.Id,
 			}
-			err = AddTeamMember(addTeamMemberCmd)
+			err = AddTeamMember(context.Background(), addTeamMemberCmd)
 			if err != nil {
 				return 0, err
 			}
@@ -307,7 +307,7 @@ func createDummyAcl(dashboardPermission *DashboardPermission, search Search, das
 		DashboardId: dashboardId,
 		Items:       []*models.DashboardAcl{acl},
 	}
-	err = UpdateDashboardAcl(updateAclCmd)
+	err = UpdateDashboardAcl(context.Background(), updateAclCmd)
 	if user != nil {
 		return user.Id, err
 	}

--- a/pkg/services/sqlstore/star.go
+++ b/pkg/services/sqlstore/star.go
@@ -1,18 +1,20 @@
 package sqlstore
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
 
 func init() {
-	bus.AddHandler("sql", StarDashboard)
-	bus.AddHandler("sql", UnstarDashboard)
-	bus.AddHandler("sql", GetUserStars)
-	bus.AddHandler("sql", IsStarredByUser)
+	bus.AddHandlerCtx("sql", StarDashboard)
+	bus.AddHandlerCtx("sql", UnstarDashboard)
+	bus.AddHandlerCtx("sql", GetUserStars)
+	bus.AddHandlerCtx("sql", IsStarredByUser)
 }
 
-func IsStarredByUser(query *m.IsStarredByUserQuery) error {
+func IsStarredByUser(ctx context.Context, query *m.IsStarredByUserQuery) error {
 	rawSql := "SELECT 1 from star where user_id=? and dashboard_id=?"
 	results, err := x.Query(rawSql, query.UserId, query.DashboardId)
 
@@ -29,7 +31,7 @@ func IsStarredByUser(query *m.IsStarredByUserQuery) error {
 	return nil
 }
 
-func StarDashboard(cmd *m.StarDashboardCommand) error {
+func StarDashboard(ctx context.Context, cmd *m.StarDashboardCommand) error {
 	if cmd.DashboardId == 0 || cmd.UserId == 0 {
 		return m.ErrCommandValidationFailed
 	}
@@ -46,7 +48,7 @@ func StarDashboard(cmd *m.StarDashboardCommand) error {
 	})
 }
 
-func UnstarDashboard(cmd *m.UnstarDashboardCommand) error {
+func UnstarDashboard(ctx context.Context, cmd *m.UnstarDashboardCommand) error {
 	if cmd.DashboardId == 0 || cmd.UserId == 0 {
 		return m.ErrCommandValidationFailed
 	}
@@ -58,7 +60,7 @@ func UnstarDashboard(cmd *m.UnstarDashboardCommand) error {
 	})
 }
 
-func GetUserStars(query *m.GetUserStarsQuery) error {
+func GetUserStars(ctx context.Context, query *m.GetUserStarsQuery) error {
 	var stars = make([]m.Star, 0)
 	err := x.Where("user_id=?", query.UserId).Find(&stars)
 

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	m "github.com/grafana/grafana/pkg/models"
@@ -18,12 +19,12 @@ func TestUserStarsDataAccess(t *testing.T) {
 				UserId:      12,
 			}
 
-			err := StarDashboard(&cmd)
+			err := StarDashboard(context.Background(), &cmd)
 			So(err, ShouldBeNil)
 
 			Convey("IsStarredByUser should return true when starred", func() {
 				query := m.IsStarredByUserQuery{UserId: 12, DashboardId: 10}
-				err := IsStarredByUser(&query)
+				err := IsStarredByUser(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result, ShouldBeTrue)
@@ -31,7 +32,7 @@ func TestUserStarsDataAccess(t *testing.T) {
 
 			Convey("IsStarredByUser should return false when not starred", func() {
 				query := m.IsStarredByUserQuery{UserId: 12, DashboardId: 12}
-				err := IsStarredByUser(&query)
+				err := IsStarredByUser(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result, ShouldBeFalse)

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -9,10 +9,10 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", GetSystemStats)
-	bus.AddHandler("sql", GetDataSourceStats)
-	bus.AddHandler("sql", GetDataSourceAccessStats)
-	bus.AddHandler("sql", GetAdminStats)
+	bus.AddHandlerCtx("sql", GetSystemStats)
+	bus.AddHandlerCtx("sql", GetDataSourceStats)
+	bus.AddHandlerCtx("sql", GetDataSourceAccessStats)
+	bus.AddHandlerCtx("sql", GetAdminStats)
 	bus.AddHandlerCtx("sql", GetAlertNotifiersUsageStats)
 	bus.AddHandlerCtx("sql", GetSystemUserCountStats)
 }
@@ -26,21 +26,21 @@ func GetAlertNotifiersUsageStats(ctx context.Context, query *m.GetAlertNotifierU
 	return err
 }
 
-func GetDataSourceStats(query *m.GetDataSourceStatsQuery) error {
+func GetDataSourceStats(ctx context.Context, query *m.GetDataSourceStatsQuery) error {
 	var rawSql = `SELECT COUNT(*) as count, type FROM data_source GROUP BY type`
 	query.Result = make([]*m.DataSourceStats, 0)
 	err := x.SQL(rawSql).Find(&query.Result)
 	return err
 }
 
-func GetDataSourceAccessStats(query *m.GetDataSourceAccessStatsQuery) error {
+func GetDataSourceAccessStats(ctx context.Context, query *m.GetDataSourceAccessStatsQuery) error {
 	var rawSql = `SELECT COUNT(*) as count, type, access FROM data_source GROUP BY type, access`
 	query.Result = make([]*m.DataSourceAccessStats, 0)
 	err := x.SQL(rawSql).Find(&query.Result)
 	return err
 }
 
-func GetSystemStats(query *m.GetSystemStatsQuery) error {
+func GetSystemStats(ctx context.Context, query *m.GetSystemStatsQuery) error {
 	sb := &SqlBuilder{}
 	sb.Write("SELECT ")
 	sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("user") + `) AS users,`)
@@ -106,7 +106,7 @@ func roleCounterSQL(role, alias string) string {
 		) as active_` + alias
 }
 
-func GetAdminStats(query *m.GetAdminStatsQuery) error {
+func GetAdminStats(ctx context.Context, query *m.GetAdminStatsQuery) error {
 	activeEndDate := time.Now().Add(-activeUserTimeLimit)
 
 	var rawSql = `SELECT

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -14,7 +14,7 @@ func TestStatsDataAccess(t *testing.T) {
 
 		Convey("Get system stats should not results in error", func() {
 			query := models.GetSystemStatsQuery{}
-			err := GetSystemStats(&query)
+			err := GetSystemStats(context.Background(), &query)
 			So(err, ShouldBeNil)
 		})
 
@@ -26,13 +26,13 @@ func TestStatsDataAccess(t *testing.T) {
 
 		Convey("Get datasource stats should not results in error", func() {
 			query := models.GetDataSourceStatsQuery{}
-			err := GetDataSourceStats(&query)
+			err := GetDataSourceStats(context.Background(), &query)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("Get datasource access stats should not results in error", func() {
 			query := models.GetDataSourceAccessStatsQuery{}
-			err := GetDataSourceAccessStats(&query)
+			err := GetDataSourceAccessStats(context.Background(), &query)
 			So(err, ShouldBeNil)
 		})
 
@@ -44,7 +44,7 @@ func TestStatsDataAccess(t *testing.T) {
 
 		Convey("Get admin stats should not result in error", func() {
 			query := models.GetAdminStatsQuery{}
-			err := GetAdminStats(&query)
+			err := GetAdminStats(context.Background(), &query)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -32,14 +32,14 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 			group1 := models.CreateTeamCommand{OrgId: testOrgId, Name: "group1 name", Email: "test1@test.com"}
 			group2 := models.CreateTeamCommand{OrgId: testOrgId, Name: "group2 name", Email: "test2@test.com"}
 
-			err := CreateTeam(&group1)
+			err := CreateTeam(context.Background(), &group1)
 			So(err, ShouldBeNil)
-			err = CreateTeam(&group2)
+			err = CreateTeam(context.Background(), &group2)
 			So(err, ShouldBeNil)
 
 			Convey("Should be able to create teams and add users", func() {
 				query := &models.SearchTeamsQuery{OrgId: testOrgId, Name: "group1 name", Page: 1, Limit: 10}
-				err = SearchTeams(query)
+				err = SearchTeams(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Page, ShouldEqual, 1)
 
@@ -48,13 +48,13 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				So(team1.Email, ShouldEqual, "test1@test.com")
 				So(team1.OrgId, ShouldEqual, testOrgId)
 
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userIds[0]})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userIds[0]})
 				So(err, ShouldBeNil)
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userIds[1], External: true})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userIds[1], External: true})
 				So(err, ShouldBeNil)
 
 				q1 := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team1.Id}
-				err = GetTeamMembers(q1)
+				err = GetTeamMembers(context.Background(), q1)
 				So(err, ShouldBeNil)
 				So(q1.Result, ShouldHaveLength, 2)
 				So(q1.Result[0].TeamId, ShouldEqual, team1.Id)
@@ -66,7 +66,7 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				So(q1.Result[1].External, ShouldEqual, true)
 
 				q2 := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team1.Id, External: true}
-				err = GetTeamMembers(q2)
+				err = GetTeamMembers(context.Background(), q2)
 				So(err, ShouldBeNil)
 				So(q2.Result, ShouldHaveLength, 1)
 				So(q2.Result[0].TeamId, ShouldEqual, team1.Id)
@@ -77,21 +77,21 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 
 			Convey("Should return latest auth module for users when getting team members", func() {
 				userId := userIds[1]
-				err := SetAuthInfo(&models.SetAuthInfoCommand{UserId: userId, AuthModule: "oauth_github", AuthId: "1234567"})
+				err := SetAuthInfo(context.Background(), &models.SetAuthInfoCommand{UserId: userId, AuthModule: "oauth_github", AuthId: "1234567"})
 				So(err, ShouldBeNil)
 
 				teamQuery := &models.SearchTeamsQuery{OrgId: testOrgId, Name: "group1 name", Page: 1, Limit: 10}
-				err = SearchTeams(teamQuery)
+				err = SearchTeams(context.Background(), teamQuery)
 				So(err, ShouldBeNil)
 				So(teamQuery.Page, ShouldEqual, 1)
 
 				team1 := teamQuery.Result.Teams[0]
 
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userId, External: true})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team1.Id, UserId: userId, External: true})
 				So(err, ShouldBeNil)
 
 				memberQuery := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team1.Id, External: true}
-				err = GetTeamMembers(memberQuery)
+				err = GetTeamMembers(context.Background(), memberQuery)
 				So(err, ShouldBeNil)
 				So(memberQuery.Result, ShouldHaveLength, 1)
 				So(memberQuery.Result[0].TeamId, ShouldEqual, team1.Id)
@@ -105,15 +105,15 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				userId := userIds[0]
 				team := group1.Result
 				addMemberCmd := models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team.Id, UserId: userId}
-				err = AddTeamMember(&addMemberCmd)
+				err = AddTeamMember(context.Background(), &addMemberCmd)
 				So(err, ShouldBeNil)
 
 				qBeforeUpdate := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team.Id}
-				err = GetTeamMembers(qBeforeUpdate)
+				err = GetTeamMembers(context.Background(), qBeforeUpdate)
 				So(err, ShouldBeNil)
 				So(qBeforeUpdate.Result[0].Permission, ShouldEqual, 0)
 
-				err = UpdateTeamMember(&models.UpdateTeamMemberCommand{
+				err = UpdateTeamMember(context.Background(), &models.UpdateTeamMemberCommand{
 					UserId:     userId,
 					OrgId:      testOrgId,
 					TeamId:     team.Id,
@@ -123,7 +123,7 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				qAfterUpdate := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team.Id}
-				err = GetTeamMembers(qAfterUpdate)
+				err = GetTeamMembers(context.Background(), qAfterUpdate)
 				So(err, ShouldBeNil)
 				So(qAfterUpdate.Result[0].Permission, ShouldEqual, models.PERMISSION_ADMIN)
 			})
@@ -132,16 +132,16 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				userID := userIds[0]
 				team := group1.Result
 				addMemberCmd := models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: team.Id, UserId: userID}
-				err = AddTeamMember(&addMemberCmd)
+				err = AddTeamMember(context.Background(), &addMemberCmd)
 				So(err, ShouldBeNil)
 
 				qBeforeUpdate := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team.Id}
-				err = GetTeamMembers(qBeforeUpdate)
+				err = GetTeamMembers(context.Background(), qBeforeUpdate)
 				So(err, ShouldBeNil)
 				So(qBeforeUpdate.Result[0].Permission, ShouldEqual, 0)
 
 				invalidPermissionLevel := models.PERMISSION_EDIT
-				err = UpdateTeamMember(&models.UpdateTeamMemberCommand{
+				err = UpdateTeamMember(context.Background(), &models.UpdateTeamMemberCommand{
 					UserId:     userID,
 					OrgId:      testOrgId,
 					TeamId:     team.Id,
@@ -151,13 +151,13 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				qAfterUpdate := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: team.Id}
-				err = GetTeamMembers(qAfterUpdate)
+				err = GetTeamMembers(context.Background(), qAfterUpdate)
 				So(err, ShouldBeNil)
 				So(qAfterUpdate.Result[0].Permission, ShouldEqual, 0)
 			})
 
 			Convey("Shouldn't be able to update a user not in the team.", func() {
-				err = UpdateTeamMember(&models.UpdateTeamMemberCommand{
+				err = UpdateTeamMember(context.Background(), &models.UpdateTeamMemberCommand{
 					UserId:     1,
 					OrgId:      testOrgId,
 					TeamId:     group1.Result.Id,
@@ -169,24 +169,24 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 
 			Convey("Should be able to search for teams", func() {
 				query := &models.SearchTeamsQuery{OrgId: testOrgId, Query: "group", Page: 1}
-				err = SearchTeams(query)
+				err = SearchTeams(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(len(query.Result.Teams), ShouldEqual, 2)
 				So(query.Result.TotalCount, ShouldEqual, 2)
 
 				query2 := &models.SearchTeamsQuery{OrgId: testOrgId, Query: ""}
-				err = SearchTeams(query2)
+				err = SearchTeams(context.Background(), query2)
 				So(err, ShouldBeNil)
 				So(len(query2.Result.Teams), ShouldEqual, 2)
 			})
 
 			Convey("Should be able to return all teams a user is member of", func() {
 				groupId := group2.Result.Id
-				err := AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[0]})
+				err := AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[0]})
 				So(err, ShouldBeNil)
 
 				query := &models.GetTeamsByUserQuery{OrgId: testOrgId, UserId: userIds[0]}
-				err = GetTeamsByUser(query)
+				err = GetTeamsByUser(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 1)
 				So(query.Result[0].Name, ShouldEqual, "group2 name")
@@ -194,62 +194,62 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 			})
 
 			Convey("Should be able to remove users from a group", func() {
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0]})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0]})
 				So(err, ShouldBeNil)
 
-				err = RemoveTeamMember(&models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0]})
+				err = RemoveTeamMember(context.Background(), &models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0]})
 				So(err, ShouldBeNil)
 
 				q2 := &models.GetTeamMembersQuery{OrgId: testOrgId, TeamId: group1.Result.Id}
-				err = GetTeamMembers(q2)
+				err = GetTeamMembers(context.Background(), q2)
 				So(err, ShouldBeNil)
 				So(len(q2.Result), ShouldEqual, 0)
 			})
 
 			Convey("When ProtectLastAdmin is set to true", func() {
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: models.PERMISSION_ADMIN})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: models.PERMISSION_ADMIN})
 				So(err, ShouldBeNil)
 
 				Convey("A user should not be able to remove the last admin", func() {
-					err = RemoveTeamMember(&models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], ProtectLastAdmin: true})
+					err = RemoveTeamMember(context.Background(), &models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], ProtectLastAdmin: true})
 					So(err, ShouldEqual, models.ErrLastTeamAdmin)
 				})
 
 				Convey("A user should be able to remove an admin if there are other admins", func() {
-					AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
-					err = RemoveTeamMember(&models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], ProtectLastAdmin: true})
+					AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
+					err = RemoveTeamMember(context.Background(), &models.RemoveTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], ProtectLastAdmin: true})
 					So(err, ShouldEqual, nil)
 				})
 
 				Convey("A user should not be able to remove the admin permission for the last admin", func() {
-					err = UpdateTeamMember(&models.UpdateTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: 0, ProtectLastAdmin: true})
+					err = UpdateTeamMember(context.Background(), &models.UpdateTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: 0, ProtectLastAdmin: true})
 					So(err, ShouldEqual, models.ErrLastTeamAdmin)
 				})
 
 				Convey("A user should be able to remove the admin permission if there are other admins", func() {
-					AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
-					err = UpdateTeamMember(&models.UpdateTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: 0, ProtectLastAdmin: true})
+					AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
+					err = UpdateTeamMember(context.Background(), &models.UpdateTeamMemberCommand{OrgId: testOrgId, TeamId: group1.Result.Id, UserId: userIds[0], Permission: 0, ProtectLastAdmin: true})
 					So(err, ShouldEqual, nil)
 				})
 			})
 
 			Convey("Should be able to remove a group with users and permissions", func() {
 				groupId := group2.Result.Id
-				err := AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[1]})
+				err := AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[1]})
 				So(err, ShouldBeNil)
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[2]})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[2]})
 				So(err, ShouldBeNil)
 				err = testHelperUpdateDashboardAcl(1, models.DashboardAcl{DashboardId: 1, OrgId: testOrgId, Permission: models.PERMISSION_EDIT, TeamId: groupId})
 				So(err, ShouldBeNil)
-				err = DeleteTeam(&models.DeleteTeamCommand{OrgId: testOrgId, Id: groupId})
+				err = DeleteTeam(context.Background(), &models.DeleteTeamCommand{OrgId: testOrgId, Id: groupId})
 				So(err, ShouldBeNil)
 
 				query := &models.GetTeamByIdQuery{OrgId: testOrgId, Id: groupId}
-				err = GetTeamById(query)
+				err = GetTeamById(context.Background(), query)
 				So(err, ShouldEqual, models.ErrTeamNotFound)
 
 				permQuery := &models.GetDashboardAclInfoListQuery{DashboardId: 1, OrgId: testOrgId}
-				err = GetDashboardAclInfoList(permQuery)
+				err = GetDashboardAclInfoList(context.Background(), permQuery)
 				So(err, ShouldBeNil)
 
 				So(len(permQuery.Result), ShouldEqual, 0)
@@ -257,18 +257,18 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 
 			Convey("Should be able to return if user is admin of teams or not", func() {
 				groupId := group2.Result.Id
-				err := AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[0]})
+				err := AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[0]})
 				So(err, ShouldBeNil)
-				err = AddTeamMember(&models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
+				err = AddTeamMember(context.Background(), &models.AddTeamMemberCommand{OrgId: testOrgId, TeamId: groupId, UserId: userIds[1], Permission: models.PERMISSION_ADMIN})
 				So(err, ShouldBeNil)
 
 				query := &models.IsAdminOfTeamsQuery{SignedInUser: &models.SignedInUser{OrgId: testOrgId, UserId: userIds[0]}}
-				err = IsAdminOfTeams(query)
+				err = IsAdminOfTeams(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Result, ShouldBeFalse)
 
 				query = &models.IsAdminOfTeamsQuery{SignedInUser: &models.SignedInUser{OrgId: testOrgId, UserId: userIds[1]}}
-				err = IsAdminOfTeams(query)
+				err = IsAdminOfTeams(context.Background(), query)
 				So(err, ShouldBeNil)
 				So(query.Result, ShouldBeTrue)
 			})

--- a/pkg/services/sqlstore/temp_user.go
+++ b/pkg/services/sqlstore/temp_user.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -8,14 +9,14 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", CreateTempUser)
-	bus.AddHandler("sql", GetTempUsersQuery)
-	bus.AddHandler("sql", UpdateTempUserStatus)
-	bus.AddHandler("sql", GetTempUserByCode)
-	bus.AddHandler("sql", UpdateTempUserWithEmailSent)
+	bus.AddHandlerCtx("sql", CreateTempUser)
+	bus.AddHandlerCtx("sql", GetTempUsersQuery)
+	bus.AddHandlerCtx("sql", UpdateTempUserStatus)
+	bus.AddHandlerCtx("sql", GetTempUserByCode)
+	bus.AddHandlerCtx("sql", UpdateTempUserWithEmailSent)
 }
 
-func UpdateTempUserStatus(cmd *m.UpdateTempUserStatusCommand) error {
+func UpdateTempUserStatus(ctx context.Context, cmd *m.UpdateTempUserStatusCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		var rawSql = "UPDATE temp_user SET status=? WHERE code=?"
 		_, err := sess.Exec(rawSql, string(cmd.Status), cmd.Code)
@@ -23,7 +24,7 @@ func UpdateTempUserStatus(cmd *m.UpdateTempUserStatusCommand) error {
 	})
 }
 
-func CreateTempUser(cmd *m.CreateTempUserCommand) error {
+func CreateTempUser(ctx context.Context, cmd *m.CreateTempUserCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 
 		// create user
@@ -50,7 +51,7 @@ func CreateTempUser(cmd *m.CreateTempUserCommand) error {
 	})
 }
 
-func UpdateTempUserWithEmailSent(cmd *m.UpdateTempUserWithEmailSentCommand) error {
+func UpdateTempUserWithEmailSent(ctx context.Context, cmd *m.UpdateTempUserWithEmailSentCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		user := &m.TempUser{
 			EmailSent:   true,
@@ -63,7 +64,7 @@ func UpdateTempUserWithEmailSent(cmd *m.UpdateTempUserWithEmailSentCommand) erro
 	})
 }
 
-func GetTempUsersQuery(query *m.GetTempUsersQuery) error {
+func GetTempUsersQuery(ctx context.Context, query *m.GetTempUsersQuery) error {
 	rawSql := `SELECT
 	                tu.id             as id,
 	                tu.org_id         as org_id,
@@ -101,7 +102,7 @@ func GetTempUsersQuery(query *m.GetTempUsersQuery) error {
 	return err
 }
 
-func GetTempUserByCode(query *m.GetTempUserByCodeQuery) error {
+func GetTempUserByCode(ctx context.Context, query *m.GetTempUserByCodeQuery) error {
 	var rawSql = `SELECT
 	                tu.id             as id,
 	                tu.org_id         as org_id,

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -21,12 +22,12 @@ func TestTempUserCommandsAndQueries(t *testing.T) {
 				Email:  "e@as.co",
 				Status: m.TmpUserInvitePending,
 			}
-			err := CreateTempUser(&cmd)
+			err := CreateTempUser(context.Background(), &cmd)
 			So(err, ShouldBeNil)
 
 			Convey("Should be able to get temp users by org id", func() {
 				query := m.GetTempUsersQuery{OrgId: 2256, Status: m.TmpUserInvitePending}
-				err = GetTempUsersQuery(&query)
+				err = GetTempUsersQuery(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 1)
@@ -34,7 +35,7 @@ func TestTempUserCommandsAndQueries(t *testing.T) {
 
 			Convey("Should be able to get temp users by email", func() {
 				query := m.GetTempUsersQuery{Email: "e@as.co", Status: m.TmpUserInvitePending}
-				err = GetTempUsersQuery(&query)
+				err = GetTempUsersQuery(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 1)
@@ -42,7 +43,7 @@ func TestTempUserCommandsAndQueries(t *testing.T) {
 
 			Convey("Should be able to get temp users by code", func() {
 				query := m.GetTempUserByCodeQuery{Code: "asd"}
-				err = GetTempUserByCode(&query)
+				err = GetTempUserByCode(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result.Name, ShouldEqual, "hello")
@@ -50,17 +51,17 @@ func TestTempUserCommandsAndQueries(t *testing.T) {
 
 			Convey("Should be able update status", func() {
 				cmd2 := m.UpdateTempUserStatusCommand{Code: "asd", Status: m.TmpUserRevoked}
-				err := UpdateTempUserStatus(&cmd2)
+				err := UpdateTempUserStatus(context.Background(), &cmd2)
 				So(err, ShouldBeNil)
 			})
 
 			Convey("Should be able update email sent and email sent on", func() {
 				cmd3 := m.UpdateTempUserWithEmailSentCommand{Code: cmd.Result.Code}
-				err := UpdateTempUserWithEmailSent(&cmd3)
+				err := UpdateTempUserWithEmailSent(context.Background(), &cmd3)
 				So(err, ShouldBeNil)
 
 				query := m.GetTempUsersQuery{OrgId: 2256, Status: m.TmpUserInvitePending}
-				err = GetTempUsersQuery(&query)
+				err = GetTempUsersQuery(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(query.Result[0].EmailSent, ShouldBeTrue)

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -59,7 +59,7 @@ func inTransactionWithRetryCtx(ctx context.Context, engine *xorm.Engine, callbac
 
 	if len(sess.events) > 0 {
 		for _, e := range sess.events {
-			if err = bus.Publish(e); err != nil {
+			if err = bus.Publish(ctx, e); err != nil {
 				log.Error(3, "Failed to publish event after commit. error: %v", err)
 			}
 		}

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -18,7 +18,7 @@ func TestTransaction(t *testing.T) {
 	Convey("InTransaction asdf asdf", t, func() {
 		cmd := &models.AddApiKeyCommand{Key: "secret-key", Name: "key", OrgId: 1}
 
-		err := AddApiKey(cmd)
+		err := AddApiKey(context.Background(), cmd)
 		So(err, ShouldBeNil)
 
 		deleteApiKeyCmd := &models.DeleteApiKeyCommand{Id: cmd.Result.Id, OrgId: 1}
@@ -31,7 +31,7 @@ func TestTransaction(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			query := &models.GetApiKeyByIdQuery{ApiKeyId: cmd.Result.Id}
-			err = GetApiKeyById(query)
+			err = GetApiKeyById(context.Background(), query)
 			So(err, ShouldEqual, models.ErrInvalidApiKey)
 		})
 
@@ -48,7 +48,7 @@ func TestTransaction(t *testing.T) {
 			So(err, ShouldEqual, ErrProvokedError)
 
 			query := &models.GetApiKeyByIdQuery{ApiKeyId: cmd.Result.Id}
-			err = GetApiKeyById(query)
+			err = GetApiKeyById(context.Background(), query)
 			So(err, ShouldBeNil)
 			So(query.Result.Id, ShouldEqual, cmd.Result.Id)
 		})

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -284,7 +284,7 @@ func UpdateUserLastSeenAt(ctx context.Context, cmd *models.UpdateUserLastSeenAtC
 
 func SetUsingOrg(ctx context.Context, cmd *models.SetUsingOrgCommand) error {
 	getOrgsForUserCmd := &models.GetUserOrgListQuery{UserId: cmd.UserId}
-	GetUserOrgList(getOrgsForUserCmd)
+	GetUserOrgList(ctx, getOrgsForUserCmd)
 
 	valid := false
 	for _, other := range getOrgsForUserCmd.Result {
@@ -414,7 +414,7 @@ func GetSignedInUser(query *models.GetSignedInUserQuery) error {
 	}
 
 	getTeamsByUserQuery := &models.GetTeamsByUserQuery{OrgId: user.OrgId, UserId: user.UserId}
-	err = GetTeamsByUser(getTeamsByUserQuery)
+	err = GetTeamsByUser(context.TODO(), getTeamsByUserQuery)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -1,6 +1,7 @@
 package sqlstore
 
 import (
+	"context"
 	"encoding/base64"
 	"time"
 
@@ -13,15 +14,15 @@ import (
 var getTime = time.Now
 
 func init() {
-	bus.AddHandler("sql", GetUserByAuthInfo)
-	bus.AddHandler("sql", GetExternalUserInfoByLogin)
-	bus.AddHandler("sql", GetAuthInfo)
-	bus.AddHandler("sql", SetAuthInfo)
-	bus.AddHandler("sql", UpdateAuthInfo)
-	bus.AddHandler("sql", DeleteAuthInfo)
+	bus.AddHandlerCtx("sql", GetUserByAuthInfo)
+	bus.AddHandlerCtx("sql", GetExternalUserInfoByLogin)
+	bus.AddHandlerCtx("sql", GetAuthInfo)
+	bus.AddHandlerCtx("sql", SetAuthInfo)
+	bus.AddHandlerCtx("sql", UpdateAuthInfo)
+	bus.AddHandlerCtx("sql", DeleteAuthInfo)
 }
 
-func GetUserByAuthInfo(query *models.GetUserByAuthInfoQuery) error {
+func GetUserByAuthInfo(ctx context.Context, query *models.GetUserByAuthInfoQuery) error {
 	user := &models.User{}
 	has := false
 	var err error
@@ -116,7 +117,7 @@ func GetUserByAuthInfo(query *models.GetUserByAuthInfoQuery) error {
 	return nil
 }
 
-func GetExternalUserInfoByLogin(query *models.GetExternalUserInfoByLoginQuery) error {
+func GetExternalUserInfoByLogin(ctx context.Context, query *models.GetExternalUserInfoByLoginQuery) error {
 	userQuery := models.GetUserByLoginQuery{LoginOrEmail: query.LoginOrEmail}
 	err := bus.Dispatch(&userQuery)
 	if err != nil {
@@ -140,7 +141,7 @@ func GetExternalUserInfoByLogin(query *models.GetExternalUserInfoByLoginQuery) e
 	return nil
 }
 
-func GetAuthInfo(query *models.GetAuthInfoQuery) error {
+func GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error {
 	userAuth := &models.UserAuth{
 		UserId:     query.UserId,
 		AuthModule: query.AuthModule,
@@ -174,7 +175,7 @@ func GetAuthInfo(query *models.GetAuthInfoQuery) error {
 	return nil
 }
 
-func SetAuthInfo(cmd *models.SetAuthInfoCommand) error {
+func SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		authUser := &models.UserAuth{
 			UserId:     cmd.UserId,
@@ -208,7 +209,7 @@ func SetAuthInfo(cmd *models.SetAuthInfoCommand) error {
 	})
 }
 
-func UpdateAuthInfo(cmd *models.UpdateAuthInfoCommand) error {
+func UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		authUser := &models.UserAuth{
 			UserId:     cmd.UserId,
@@ -247,7 +248,7 @@ func UpdateAuthInfo(cmd *models.UpdateAuthInfoCommand) error {
 	})
 }
 
-func DeleteAuthInfo(cmd *models.DeleteAuthInfoCommand) error {
+func DeleteAuthInfo(ctx context.Context, cmd *models.DeleteAuthInfoCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		_, err := sess.Delete(cmd.UserAuth)
 		return err

--- a/pkg/services/sqlstore/user_auth_test.go
+++ b/pkg/services/sqlstore/user_auth_test.go
@@ -45,7 +45,7 @@ func TestUserAuth(t *testing.T) {
 			login := "loginuser0"
 
 			query := &m.GetUserByAuthInfoQuery{Login: login}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, login)
@@ -54,7 +54,7 @@ func TestUserAuth(t *testing.T) {
 			id := query.Result.Id
 
 			query = &m.GetUserByAuthInfoQuery{UserId: id}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Id, ShouldEqual, id)
@@ -63,7 +63,7 @@ func TestUserAuth(t *testing.T) {
 			email := "user1@test.com"
 
 			query = &m.GetUserByAuthInfoQuery{Email: email}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Email, ShouldEqual, email)
@@ -72,7 +72,7 @@ func TestUserAuth(t *testing.T) {
 			email = "nonexistent@test.com"
 
 			query = &m.GetUserByAuthInfoQuery{Email: email}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldEqual, m.ErrUserNotFound)
 			So(query.Result, ShouldBeNil)
@@ -81,7 +81,7 @@ func TestUserAuth(t *testing.T) {
 		Convey("Can set & locate by AuthModule and AuthId", func() {
 			// get nonexistent user_auth entry
 			query := &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldEqual, m.ErrUserNotFound)
 			So(query.Result, ShouldBeNil)
@@ -90,14 +90,14 @@ func TestUserAuth(t *testing.T) {
 			login := "loginuser0"
 
 			query.Login = login
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, login)
 
 			// get via user_auth
 			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, login)
@@ -106,14 +106,14 @@ func TestUserAuth(t *testing.T) {
 			id := query.Result.Id
 
 			query.UserId = id + 1
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, "loginuser1")
 
 			// get via user_auth
 			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, "loginuser1")
@@ -124,7 +124,7 @@ func TestUserAuth(t *testing.T) {
 
 			// get via user_auth for deleted user
 			query = &m.GetUserByAuthInfoQuery{AuthModule: "test", AuthId: "test"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldEqual, m.ErrUserNotFound)
 			So(query.Result, ShouldBeNil)
@@ -143,7 +143,7 @@ func TestUserAuth(t *testing.T) {
 
 			// Calling GetUserByAuthInfoQuery on an existing user will populate an entry in the user_auth table
 			query := &m.GetUserByAuthInfoQuery{Login: login, AuthModule: "test", AuthId: "test"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 
 			So(err, ShouldBeNil)
 			So(query.Result.Login, ShouldEqual, login)
@@ -154,7 +154,7 @@ func TestUserAuth(t *testing.T) {
 				AuthModule: query.AuthModule,
 				OAuthToken: token,
 			}
-			err = UpdateAuthInfo(cmd)
+			err = UpdateAuthInfo(context.Background(), cmd)
 
 			So(err, ShouldBeNil)
 
@@ -162,7 +162,7 @@ func TestUserAuth(t *testing.T) {
 				UserId: query.Result.Id,
 			}
 
-			err = GetAuthInfo(getAuthQuery)
+			err = GetAuthInfo(context.Background(), getAuthQuery)
 
 			So(err, ShouldBeNil)
 			So(getAuthQuery.Result.OAuthAccessToken, ShouldEqual, token.AccessToken)
@@ -179,7 +179,7 @@ func TestUserAuth(t *testing.T) {
 			// Make the first log-in during the past
 			getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
 			query := &m.GetUserByAuthInfoQuery{Login: login, AuthModule: "test1", AuthId: "test1"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 			getTime = time.Now
 
 			So(err, ShouldBeNil)
@@ -189,7 +189,7 @@ func TestUserAuth(t *testing.T) {
 			// Have this module's last log-in be more recent
 			getTime = func() time.Time { return time.Now().AddDate(0, 0, -1) }
 			query = &m.GetUserByAuthInfoQuery{Login: login, AuthModule: "test2", AuthId: "test2"}
-			err = GetUserByAuthInfo(query)
+			err = GetUserByAuthInfo(context.Background(), query)
 			getTime = time.Now
 
 			So(err, ShouldBeNil)
@@ -200,14 +200,14 @@ func TestUserAuth(t *testing.T) {
 				UserId: query.Result.Id,
 			}
 
-			err = GetAuthInfo(getAuthQuery)
+			err = GetAuthInfo(context.Background(), getAuthQuery)
 
 			So(err, ShouldBeNil)
 			So(getAuthQuery.Result.AuthModule, ShouldEqual, "test2")
 
 			// "log in" again with the first auth module
 			updateAuthCmd := &m.UpdateAuthInfoCommand{UserId: query.Result.Id, AuthModule: "test1", AuthId: "test1"}
-			err = UpdateAuthInfo(updateAuthCmd)
+			err = UpdateAuthInfo(context.Background(), updateAuthCmd)
 
 			So(err, ShouldBeNil)
 
@@ -216,7 +216,7 @@ func TestUserAuth(t *testing.T) {
 				UserId: query.Result.Id,
 			}
 
-			err = GetAuthInfo(getAuthQuery)
+			err = GetAuthInfo(context.Background(), getAuthQuery)
 
 			So(err, ShouldBeNil)
 			So(getAuthQuery.Result.AuthModule, ShouldEqual, "test1")

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -28,7 +28,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Loading a user", func() {
 				query := models.GetUserByIdQuery{Id: cmd.Result.Id}
-				err := GetUserById(&query)
+				err := GetUserById(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Email, ShouldEqual, "usertest@test.com")
@@ -52,7 +52,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Loading a user", func() {
 				query := models.GetUserByIdQuery{Id: cmd.Result.Id}
-				err := GetUserById(&query)
+				err := GetUserById(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Email, ShouldEqual, "usertest@test.com")
@@ -75,7 +75,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Can return the first page of users and a total count", func() {
 				query := models.SearchUsersQuery{Query: "", Page: 1, Limit: 3}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 3)
@@ -84,7 +84,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Can return the second page of users and a total count", func() {
 				query := models.SearchUsersQuery{Query: "", Page: 2, Limit: 3}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 2)
@@ -93,28 +93,28 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Can return list of users matching query on user name", func() {
 				query := models.SearchUsersQuery{Query: "use", Page: 1, Limit: 3}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 3)
 				So(query.Result.TotalCount, ShouldEqual, 5)
 
 				query = models.SearchUsersQuery{Query: "ser1", Page: 1, Limit: 3}
-				err = SearchUsers(&query)
+				err = SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 1)
 				So(query.Result.TotalCount, ShouldEqual, 1)
 
 				query = models.SearchUsersQuery{Query: "USER1", Page: 1, Limit: 3}
-				err = SearchUsers(&query)
+				err = SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 1)
 				So(query.Result.TotalCount, ShouldEqual, 1)
 
 				query = models.SearchUsersQuery{Query: "idontexist", Page: 1, Limit: 3}
-				err = SearchUsers(&query)
+				err = SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 0)
@@ -123,7 +123,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Can return list of users matching query on email", func() {
 				query := models.SearchUsersQuery{Query: "ser1@test.com", Page: 1, Limit: 3}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 1)
@@ -132,7 +132,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Can return list of users matching query on login name", func() {
 				query := models.SearchUsersQuery{Query: "loginuser1", Page: 1, Limit: 3}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result.Users), ShouldEqual, 1)
@@ -154,11 +154,11 @@ func TestUserDataAccess(t *testing.T) {
 						AuthModule: authModule,
 						AuthId:     "gorilla",
 					}
-					err := SetAuthInfo(cmd2)
+					err := SetAuthInfo(context.Background(), cmd2)
 					So(err, ShouldBeNil)
 				}
 				query := models.SearchUsersQuery{AuthModule: "ldap"}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Users, ShouldHaveLength, 3)
@@ -196,7 +196,7 @@ func TestUserDataAccess(t *testing.T) {
 
 				isDisabled := false
 				query := models.SearchUsersQuery{IsDisabled: &isDisabled}
-				err := SearchUsers(&query)
+				err := SearchUsers(context.Background(), &query)
 				So(err, ShouldBeNil)
 
 				So(query.Result.Users, ShouldHaveLength, 2)
@@ -227,17 +227,17 @@ func TestUserDataAccess(t *testing.T) {
 			})
 
 			Convey("when a user is an org member and has been assigned permissions", func() {
-				err := AddOrgUser(&models.AddOrgUserCommand{LoginOrEmail: users[1].Login, Role: models.ROLE_VIEWER, OrgId: users[0].OrgId, UserId: users[1].Id})
+				err := AddOrgUser(context.Background(), &models.AddOrgUserCommand{LoginOrEmail: users[1].Login, Role: models.ROLE_VIEWER, OrgId: users[0].OrgId, UserId: users[1].Id})
 				So(err, ShouldBeNil)
 
 				testHelperUpdateDashboardAcl(1, models.DashboardAcl{DashboardId: 1, OrgId: users[0].OrgId, UserId: users[1].Id, Permission: models.PERMISSION_EDIT})
 				So(err, ShouldBeNil)
 
-				err = SavePreferences(&models.SavePreferencesCommand{UserId: users[1].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, Theme: "dark"})
+				err = SavePreferences(context.Background(), &models.SavePreferencesCommand{UserId: users[1].Id, OrgId: users[0].OrgId, HomeDashboardId: 1, Theme: "dark"})
 				So(err, ShouldBeNil)
 
 				Convey("when the user is deleted", func() {
-					err = DeleteUser(&models.DeleteUserCommand{UserId: users[1].Id})
+					err = DeleteUser(context.Background(), &models.DeleteUserCommand{UserId: users[1].Id})
 					So(err, ShouldBeNil)
 
 					Convey("Should delete connected org users and permissions", func() {
@@ -248,13 +248,13 @@ func TestUserDataAccess(t *testing.T) {
 						So(len(query.Result), ShouldEqual, 1)
 
 						permQuery := &models.GetDashboardAclInfoListQuery{DashboardId: 1, OrgId: users[0].OrgId}
-						err = GetDashboardAclInfoList(permQuery)
+						err = GetDashboardAclInfoList(context.Background(), permQuery)
 						So(err, ShouldBeNil)
 
 						So(len(permQuery.Result), ShouldEqual, 0)
 
 						prefsQuery := &models.GetPreferencesQuery{OrgId: users[0].OrgId, UserId: users[1].Id}
-						err = GetPreferences(prefsQuery)
+						err = GetPreferences(context.Background(), prefsQuery)
 						So(err, ShouldBeNil)
 
 						So(prefsQuery.Result.OrgId, ShouldEqual, 0)
@@ -266,14 +266,14 @@ func TestUserDataAccess(t *testing.T) {
 					ss.CacheService.Flush()
 
 					query := &models.GetSignedInUserQuery{OrgId: users[1].OrgId, UserId: users[1].Id}
-					err := ss.GetSignedInUserWithCache(query)
+					err := ss.GetSignedInUserWithCache(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldNotBeNil)
 					So(query.OrgId, ShouldEqual, users[1].OrgId)
-					err = SetUsingOrg(&models.SetUsingOrgCommand{UserId: users[1].Id, OrgId: users[0].OrgId})
+					err = SetUsingOrg(context.Background(), &models.SetUsingOrgCommand{UserId: users[1].Id, OrgId: users[0].OrgId})
 					So(err, ShouldBeNil)
 					query = &models.GetSignedInUserQuery{OrgId: 0, UserId: users[1].Id}
-					err = ss.GetSignedInUserWithCache(query)
+					err = ss.GetSignedInUserWithCache(context.Background(), query)
 					So(err, ShouldBeNil)
 					So(query.Result, ShouldNotBeNil)
 					So(query.Result.OrgId, ShouldEqual, users[0].OrgId)
@@ -291,12 +291,12 @@ func TestUserDataAccess(t *testing.T) {
 						IsDisabled: true,
 					}
 
-					err := BatchDisableUsers(&disableCmd)
+					err := BatchDisableUsers(context.Background(), &disableCmd)
 					So(err, ShouldBeNil)
 
 					isDisabled := true
 					query := &models.SearchUsersQuery{IsDisabled: &isDisabled}
-					err = SearchUsers(query)
+					err = SearchUsers(context.Background(), query)
 
 					So(err, ShouldBeNil)
 					So(query.Result.TotalCount, ShouldEqual, 5)
@@ -318,12 +318,12 @@ func TestUserDataAccess(t *testing.T) {
 						IsDisabled: false,
 					}
 
-					err := BatchDisableUsers(&disableCmd)
+					err := BatchDisableUsers(context.Background(), &disableCmd)
 					So(err, ShouldBeNil)
 
 					isDisabled := false
 					query := &models.SearchUsersQuery{IsDisabled: &isDisabled}
-					err = SearchUsers(query)
+					err = SearchUsers(context.Background(), query)
 
 					So(err, ShouldBeNil)
 					So(query.Result.TotalCount, ShouldEqual, 5)
@@ -349,11 +349,11 @@ func TestUserDataAccess(t *testing.T) {
 						IsDisabled: true,
 					}
 
-					err := BatchDisableUsers(&disableCmd)
+					err := BatchDisableUsers(context.Background(), &disableCmd)
 					So(err, ShouldBeNil)
 
 					query := models.SearchUsersQuery{}
-					err = SearchUsers(&query)
+					err = SearchUsers(context.Background(), &query)
 
 					So(err, ShouldBeNil)
 					So(query.Result.TotalCount, ShouldEqual, 5)
@@ -395,7 +395,7 @@ func TestUserDataAccess(t *testing.T) {
 				// Make the first log-in during the past
 				getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
 				query := &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "test1", AuthId: "test1"}
-				err := GetUserByAuthInfo(query)
+				err := GetUserByAuthInfo(context.Background(), query)
 				getTime = time.Now
 
 				So(err, ShouldBeNil)
@@ -405,7 +405,7 @@ func TestUserDataAccess(t *testing.T) {
 				// Have this module's last log-in be more recent
 				getTime = func() time.Time { return time.Now().AddDate(0, 0, -1) }
 				query = &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "test2", AuthId: "test2"}
-				err = GetUserByAuthInfo(query)
+				err = GetUserByAuthInfo(context.Background(), query)
 				getTime = time.Now
 
 				So(err, ShouldBeNil)
@@ -413,7 +413,7 @@ func TestUserDataAccess(t *testing.T) {
 
 				Convey("Should return the only most recently used auth_module", func() {
 					searchUserQuery := &models.SearchUsersQuery{}
-					err = SearchUsers(searchUserQuery)
+					err = SearchUsers(context.Background(), searchUserQuery)
 
 					So(err, ShouldBeNil)
 					So(searchUserQuery.Result.Users, ShouldHaveLength, 5)
@@ -426,11 +426,11 @@ func TestUserDataAccess(t *testing.T) {
 
 					// "log in" again with the first auth module
 					updateAuthCmd := &models.UpdateAuthInfoCommand{UserId: query.Result.Id, AuthModule: "test1", AuthId: "test1"}
-					err = UpdateAuthInfo(updateAuthCmd)
+					err = UpdateAuthInfo(context.Background(), updateAuthCmd)
 					So(err, ShouldBeNil)
 
 					searchUserQuery = &models.SearchUsersQuery{}
-					err = SearchUsers(searchUserQuery)
+					err = SearchUsers(context.Background(), searchUserQuery)
 
 					So(err, ShouldBeNil)
 					for _, user := range searchUserQuery.Result.Users {
@@ -456,12 +456,12 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("Cannot make themselves a non-admin", func() {
 				updateUserPermsCmd := models.UpdateUserPermissionsCommand{IsGrafanaAdmin: false, UserId: 1}
-				updatePermsError := UpdateUserPermissions(&updateUserPermsCmd)
+				updatePermsError := UpdateUserPermissions(context.Background(), &updateUserPermsCmd)
 
 				So(updatePermsError, ShouldEqual, models.ErrLastGrafanaAdmin)
 
 				query := models.GetUserByIdQuery{Id: createUserCmd.Result.Id}
-				getUserError := GetUserById(&query)
+				getUserError := GetUserById(context.Background(), &query)
 
 				So(getUserError, ShouldBeNil)
 

--- a/pkg/services/teamguardian/team.go
+++ b/pkg/services/teamguardian/team.go
@@ -1,6 +1,8 @@
 package teamguardian
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 )
@@ -20,7 +22,7 @@ func CanAdmin(bus bus.Bus, orgId int64, teamId int64, user *m.SignedInUser) erro
 		UserId: user.UserId,
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		return err
 	}
 

--- a/pkg/services/teamguardian/teams_test.go
+++ b/pkg/services/teamguardian/teams_test.go
@@ -1,10 +1,12 @@
 package teamguardian
 
 import (
+	"context"
+	"testing"
+
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestUpdateTeam(t *testing.T) {
@@ -28,7 +30,7 @@ func TestUpdateTeam(t *testing.T) {
 
 		Convey("Given an editor and a team he isn't a member of", func() {
 			Convey("Should not be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *m.GetTeamMembersQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetTeamMembersQuery) error {
 					cmd.Result = []*m.TeamMemberDTO{}
 					return nil
 				})
@@ -40,7 +42,7 @@ func TestUpdateTeam(t *testing.T) {
 
 		Convey("Given an editor and a team he is an admin in", func() {
 			Convey("Should be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *m.GetTeamMembersQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetTeamMembersQuery) error {
 					cmd.Result = []*m.TeamMemberDTO{{
 						OrgId:      testTeam.OrgId,
 						TeamId:     testTeam.Id,
@@ -62,7 +64,7 @@ func TestUpdateTeam(t *testing.T) {
 			}
 
 			Convey("Shouldn't be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *m.GetTeamMembersQuery) error {
+				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *m.GetTeamMembersQuery) error {
 					cmd.Result = []*m.TeamMemberDTO{{
 						OrgId:      testTeamOtherOrg.OrgId,
 						TeamId:     testTeamOtherOrg.Id,


### PR DESCRIPTION
**What this PR does / why we need it**:
POC of encorcing use of context when using the bus. 

To be able to move towards having context available everywhere I think this is a first good step even if we want to migrate away from using the bus eventually.

Let me know if this would be easier if split up in smaller commits. I suggest locking at the first commit to start with to see changes in the bus package.

