### PR TITLE
Multi-LDAP: Do not fail-fast on invalid credentials

### DIFF
--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -152,7 +152,7 @@ func TestMultiLDAP(t *testing.T) {
 				teardown()
 			})
 
-			Convey("Should still call a second error for invalid credentials error", func() {
+			Convey("Should still try to auth with the second server after receiving an invalid credentials error from the first", func() {
 				mock := setup()
 
 				mock.loginErrReturn = ErrInvalidCredentials

--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -152,6 +152,25 @@ func TestMultiLDAP(t *testing.T) {
 				teardown()
 			})
 
+			Convey("Should still call a second error for invalid credentials error", func() {
+				mock := setup()
+
+				mock.loginErrReturn = ErrInvalidCredentials
+
+				multi := New([]*ldap.ServerConfig{
+					{}, {},
+				})
+				_, err := multi.Login(&models.LoginUserQuery{})
+
+				So(mock.dialCalledTimes, ShouldEqual, 2)
+				So(mock.loginCalledTimes, ShouldEqual, 2)
+				So(mock.closeCalledTimes, ShouldEqual, 2)
+
+				So(err, ShouldEqual, ErrInvalidCredentials)
+
+				teardown()
+			})
+
 			Convey("Should return unknown error", func() {
 				mock := setup()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When configuring LDAP authentication, it is very common to have multiple
servers configured. When using user bind (authenticating with LDAP using
the same credentials as the user authenticating to Grafana) we don't
expect all the users to be on all LDAP servers.

Because of this use-case, we should not fail-fast when authenticating on
a multiple LDAP server configuration. Instead, we should continue to try
the credentials with the next LDAP server configured.

Fixes #19066


