### PR TITLE
grafana/toolkit: Update changelog task to generate toolkit changelog too

### DIFF
--- a/packages/grafana-toolkit/CHANGELOG.md
+++ b/packages/grafana-toolkit/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 6.4.0 (unreleased)
+
+# 6.4.0-beta1 (2019-09-17)
+First release, see [Readme](https://github.com/grafana/grafana/blob/v6.4.0-beta1/packages/grafana-toolkit/README.md) for details.

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -62,6 +62,7 @@ export const run = (includeInternalScripts = false) => {
 
         await execTask(changelogTask)({
           milestone: cmd.milestone,
+          silent: true,
         });
       });
 


### PR DESCRIPTION
This introduces changes to toolkit's changelog task so that it generates changelog for grafana-toolkit too