### PR TITLE
grafana/ui: Set placeholder color on AsyncSelect

### DIFF
--- a/packages/grafana-ui/src/components/Select/_Select.scss
+++ b/packages/grafana-ui/src/components/Select/_Select.scss
@@ -111,6 +111,10 @@ $select-input-bg-disabled: $input-bg-disabled;
   }
 }
 
+.gf-form-select-box__placeholder {
+  color: $input-color-placeholder;
+}
+
 .gf-form-select-box__control--is-focused .gf-form-select-box__placeholder {
   display: none;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The color of the placeholder in AsyncSelect does not match the color in other form elements. This fixes that.