### PR TITLE
Keybindings: Improve esc / exit / blur logic

### DIFF
--- a/packages/grafana-ui/src/components/Select/_Select.scss
+++ b/packages/grafana-ui/src/components/Select/_Select.scss
@@ -83,9 +83,9 @@ $select-input-bg-disabled: $input-bg-disabled;
 .gf-form-select-box__multi-value__remove {
   text-align: center;
   display: inline-block;
-  height: 14px;
-  vertical-align: middle;
   margin-left: 2px;
+  position: relative;
+  top: 3px;
 }
 
 .gf-form-select-box__multi-value__label {

--- a/packages/grafana-ui/src/components/TransformersUI/ReduceTransformerEditor.tsx
+++ b/packages/grafana-ui/src/components/TransformersUI/ReduceTransformerEditor.tsx
@@ -11,7 +11,7 @@ export const ReduceTransformerEditor: React.FC<TransformerUIProps<ReduceTransfor
 }) => {
   return (
     <StatsPicker
-      width={12}
+      width={25}
       placeholder="Choose Stat"
       allowMultiple
       stats={options.reducers || []}

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -47,7 +47,26 @@ export class KeybindingSrv {
       this.bind('s o', this.openSearch);
       this.bind('f', this.openSearch);
       this.bind('esc', this.exit);
+      this.bindGlobal('esc', this.globalEsc);
     }
+  }
+
+  globalEsc() {
+    const anyDoc = document as any;
+    const activeElement = anyDoc.activeElement;
+
+    if (activeElement && activeElement.blur) {
+      if (
+        activeElement.nodeName === 'INPUT' ||
+        activeElement.nodeName === 'TEXTAREA' ||
+        activeElement.hasAttribute('data-slate-editor')
+      ) {
+        anyDoc.activeElement.blur();
+        return;
+      }
+    }
+
+    this.exit();
   }
 
   openSearch() {

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import _ from 'lodash';
 
 import coreModule from 'app/core/core_module';
@@ -56,7 +55,7 @@ export class KeybindingSrv {
     const activeElement = anyDoc.activeElement;
 
     // typehead needs to handle it
-    const typeaheads = $('.slate-typeahead--open');
+    const typeaheads = document.querySelectorAll('.slate-typeahead--open');
     if (typeaheads.length > 0) {
       return;
     }

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -55,6 +55,13 @@ export class KeybindingSrv {
     const anyDoc = document as any;
     const activeElement = anyDoc.activeElement;
 
+    // typehead needs to handle it
+    const typeaheads = $('.slate-typeahead--open');
+    if (typeaheads.length > 0) {
+      return;
+    }
+
+    // second check if we are in an input we can blur
     if (activeElement && activeElement.blur) {
       if (
         activeElement.nodeName === 'INPUT' ||
@@ -66,6 +73,7 @@ export class KeybindingSrv {
       }
     }
 
+    // ok no focused input or editor that should block this, let exist!
     this.exit();
   }
 
@@ -90,11 +98,6 @@ export class KeybindingSrv {
   }
 
   exit() {
-    const popups = $('.popover.in, .slate-typeahead');
-    if (popups.length > 0) {
-      return;
-    }
-
     appEvents.emit('hide-modal');
 
     if (this.modalOpen) {

--- a/public/app/features/explore/Typeahead.tsx
+++ b/public/app/features/explore/Typeahead.tsx
@@ -215,7 +215,10 @@ class Portal extends React.PureComponent<PortalProps, {}> {
   render() {
     if (this.props.isOpen) {
       this.node.setAttribute('style', this.props.style);
+      this.node.classList.add(`slate-typeahead--open`);
       return ReactDOM.createPortal(this.props.children, this.node);
+    } else {
+      this.node.classList.remove(`slate-typeahead--open`);
     }
 
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15123,12 +15123,6 @@ react-popper@^1.3.3:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-portal@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.2.0.tgz#4224e19b2b05d5cbe730a7ba0e34ec7585de0043"
-  dependencies:
-    prop-types "^15.5.8"
-
 react-redux@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"


### PR DESCRIPTION
When working on DataLink editor we removed the global esc binding. This made esc not work in any input field any longer and found this frustrating as I very frequently use esc to close modals & edit modes and if I happen to have an input focus this does not work. 

This adds back the global esc bind but makes it check the current focused element, if the current focused element is an input, textarea or a slate editor it will blur (defocus it). so next time you hit esc the normal close logic will work. 

It even works with DataLinks / slate editor typeaheads, first esc closes typeahead (handled by editors themselves), second esc will blur, and third will close edit view 