### PR TITLE
Build: Fix correct sort order of merged pr's in cherrypick task

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/cherrypick.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/cherrypick.ts
@@ -10,7 +10,10 @@ const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
   const res = await client.get('/issues', {
     params: {
       state: 'closed',
+      per_page: 100,
       labels: 'cherry-pick needed',
+      sort: 'closed',
+      direction: 'asc',
     },
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherrypick task didn't include all of the PR's that was labeled `cherry-pick needed` plus that the cherry-pick commands list didn't sort in correct order.

