### PR TITLE
Dashboard/timerange: fix highlight day on calendar when dashboard timezone is UTC

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePickerCalendar.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePickerCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import Calendar from 'react-calendar/dist/entry.nostyle';
-import { TimeFragment, TimeZone, TIME_FORMAT } from '@grafana/data';
+import { TimeFragment, TimeZone, TIME_FORMAT, isDateTime } from '@grafana/data';
 import { DateTime, dateTime, toUtc } from '@grafana/data';
 import { stringToDateTimeType } from './time';
 
@@ -37,8 +37,13 @@ export class TimePickerCalendar extends PureComponent<Props> {
   };
 
   render() {
-    const { value, roundup, timeZone } = this.props;
-    let date = stringToDateTimeType(value, roundup, timeZone);
+    const { value, roundup } = this.props;
+    let formatValue = value;
+    if (isDateTime(value)) {
+      formatValue = value.format(TIME_FORMAT);
+    }
+
+    let date = stringToDateTimeType(formatValue, roundup);
 
     if (!date.isValid()) {
       date = dateTime();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Remove  timezone offset on calendar when custom time range if  dashboard timezone is UTC.
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19091 

**Special notes for your reviewer**:

