### PR TITLE
Build: Fix Dockerfile glibc version error in v6.3.x branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Golang build container
-FROM golang:1.12.9
+FROM golang:1.12.9-stretch
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently, the Dockerfile in root directory on v6.3.x branch can build, but the container doesn't run due to a glibc version error:

```
/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found (required by grafana-server)
```

This PR changes the base image for the golang build stage from golang:1.12.9 (Debian 'Buster' 10) to golang:1.12.9-stretch (Debian 'Stretch' 9), so that the glibc version in golang build stage matches the glibc version in the final container based on ubuntu:18.04. Otherwise, the built binaries cannot execute in the final container.

This issue does not affect v6.4.x branch or master, probably as Dockerfile there uses alpine golang build container and alpine final container.

**Which issue(s) this PR fixes**: 
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Issue brought up on certain comments on #18865 (like https://github.com/grafana/grafana/issues/18865#issuecomment-529421585)

I'm not 100% sure it fixes the specific issue in the opening comment on #18865, but it matches the https://github.com/grafana/grafana/issues/18865#issuecomment-533667518 from issue author later in issue discussion.

**Special notes for your reviewer**:

