### PR TITLE
Dev: Sets `preserveSymlinks` to `false` in top-level tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,8 +34,7 @@
       "sass": ["sass"],
       "@grafana/slate-react": ["../node_modules/@types/slate-react"]
     },
-    "skipLibCheck": true,
-    "preserveSymlinks": false
+    "skipLibCheck": true
   },
   "include": [
     "public/app/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
       "@grafana/slate-react": ["../node_modules/@types/slate-react"]
     },
     "skipLibCheck": true,
-    "preserveSymlinks": true
+    "preserveSymlinks": false
   },
   "include": [
     "public/app/**/*.ts",


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets `preserveSymlinks` to `false` in top-level tsconfig, which allows for easier navigation to `packages/grafana-*` in vscode (and possibly other editors?), and triggers `tsc` on changes to source files.