### PR TITLE
Tests: Adds throwUnhandledRejections to jest setup

### DIFF
--- a/public/app/features/alerting/TestRuleResult.test.tsx
+++ b/public/app/features/alerting/TestRuleResult.test.tsx
@@ -3,7 +3,7 @@ import { TestRuleResult, Props } from './TestRuleResult';
 import { DashboardModel } from '../dashboard/state';
 import { shallow } from 'enzyme';
 
-jest.mock('../../core/services/backend_srv', () => ({
+jest.mock('@grafana/runtime/src/services/backendSrv', () => ({
   getBackendSrv: () => ({
     post: jest.fn(),
   }),

--- a/public/app/features/alerting/TestRuleResult.test.tsx
+++ b/public/app/features/alerting/TestRuleResult.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { TestRuleResult, Props } from './TestRuleResult';
+import { DashboardModel } from '../dashboard/state';
 import { shallow } from 'enzyme';
-import { DashboardModel } from '../dashboard/state/DashboardModel';
-import { Props, TestRuleResult } from './TestRuleResult';
 
-jest.mock('app/core/services/backend_srv', () => ({
+jest.mock('../../core/services/backend_srv', () => ({
   getBackendSrv: () => ({
     post: jest.fn(),
   }),

--- a/public/app/features/alerting/TestRuleResult.tsx
+++ b/public/app/features/alerting/TestRuleResult.tsx
@@ -4,7 +4,7 @@ import { LoadingPlaceholder, JSONFormatter } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { CopyToClipboard } from 'app/core/components/CopyToClipboard/CopyToClipboard';
 import { DashboardModel } from '../dashboard/state/DashboardModel';
-import { getBackendSrv, BackendSrv } from '../../core/services/backend_srv';
+import { getBackendSrv, BackendSrv } from '@grafana/runtime';
 
 export interface Props {
   panelId: number;

--- a/public/app/features/alerting/TestRuleResult.tsx
+++ b/public/app/features/alerting/TestRuleResult.tsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
+import { LoadingPlaceholder, JSONFormatter } from '@grafana/ui';
+
 import appEvents from 'app/core/app_events';
 import { CopyToClipboard } from 'app/core/components/CopyToClipboard/CopyToClipboard';
-import { getBackendSrv } from '@grafana/runtime';
 import { DashboardModel } from '../dashboard/state/DashboardModel';
-import { LoadingPlaceholder, JSONFormatter } from '@grafana/ui';
+import { getBackendSrv, BackendSrv } from '../../core/services/backend_srv';
 
 export interface Props {
   panelId: number;
@@ -25,6 +26,12 @@ export class TestRuleResult extends PureComponent<Props, State> {
 
   formattedJson: any;
   clipboard: any;
+  backendSrv: BackendSrv = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.backendSrv = getBackendSrv();
+  }
 
   componentDidMount() {
     this.testRule();
@@ -35,7 +42,7 @@ export class TestRuleResult extends PureComponent<Props, State> {
     const payload = { dashboard: dashboard.getSaveModelClone(), panelId };
 
     this.setState({ isLoading: true });
-    const testRuleResponse = await getBackendSrv().post(`/api/alerts/test`, payload);
+    const testRuleResponse = await this.backendSrv.post(`/api/alerts/test`, payload);
     this.setState({ isLoading: false, testRuleResponse });
   }
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
@@ -224,7 +224,7 @@ describe('AzureMonitorQueryCtrl', () => {
         };
       });
 
-      it('should set the options and default selected value for the Aggregations dropdown', () => {
+      it.skip('should set the options and default selected value for the Aggregations dropdown', () => {
         queryCtrl.onMetricNameChange().then(() => {
           expect(queryCtrl.target.azureMonitor.aggregation).toBe('Average');
           expect(queryCtrl.target.azureMonitor.aggOptions).toBe(['Average', 'Total']);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
@@ -194,8 +194,8 @@ describe('AzureMonitorQueryCtrl', () => {
     describe('when onMetricNameChange is triggered for the Metric Names dropdown', () => {
       const response: any = {
         primaryAggType: 'Average',
-        supportAggOptions: ['Average', 'Total'],
-        supportedTimeGrains: ['PT1M', 'P1D'],
+        supportedAggTypes: ['Average', 'Total'],
+        supportedTimeGrains: [{ text: 'PT1M', value: 'PT1M' }, { text: 'P1D', value: 'P1D' }],
         dimensions: [],
       };
 
@@ -224,11 +224,15 @@ describe('AzureMonitorQueryCtrl', () => {
         };
       });
 
-      it.skip('should set the options and default selected value for the Aggregations dropdown', () => {
+      it('should set the options and default selected value for the Aggregations dropdown', () => {
         queryCtrl.onMetricNameChange().then(() => {
           expect(queryCtrl.target.azureMonitor.aggregation).toBe('Average');
-          expect(queryCtrl.target.azureMonitor.aggOptions).toBe(['Average', 'Total']);
-          expect(queryCtrl.target.azureMonitor.timeGrains).toBe(['PT1M', 'P1D']);
+          expect(queryCtrl.target.azureMonitor.aggOptions).toEqual(['Average', 'Total']);
+          expect(queryCtrl.target.azureMonitor.timeGrains).toEqual([
+            { text: 'auto', value: 'auto' },
+            { text: 'PT1M', value: 'PT1M' },
+            { text: 'P1D', value: 'P1D' },
+          ]);
         });
       });
     });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -6,7 +6,7 @@ import './editor/editor_component';
 import kbn from 'app/core/utils/kbn';
 
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { auto } from 'angular';
+import { auto, IPromise } from 'angular';
 import { DataFrame } from '@grafana/data';
 
 export interface ResultFormat {
@@ -396,9 +396,9 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
     this.target.azureMonitor.dimension = '';
   }
 
-  onMetricNameChange() {
+  onMetricNameChange(): IPromise<void> {
     if (!this.target.azureMonitor.metricName || this.target.azureMonitor.metricName === this.defaultDropdownValue) {
-      return;
+      return Promise.resolve();
     }
 
     return this.datasource

--- a/public/test/jest-setup.ts
+++ b/public/test/jest-setup.ts
@@ -41,3 +41,11 @@ const localStorageMock = (() => {
 
 global.localStorage = localStorageMock;
 // Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+const throwUnhandledRejections = () => {
+  process.on('unhandledRejection', err => {
+    throw err;
+  });
+};
+
+throwUnhandledRejections();


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `throwUnhandledRejections` function to jest setup so that any unhandled rejections will be thrown and failing test.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

