### PR TITLE
Release: Make sure packages are released from clean git state

### DIFF
--- a/scripts/build/release-packages.sh
+++ b/scripts/build/release-packages.sh
@@ -16,6 +16,9 @@ fi
 
 echo "$_grafana_version"
 
+# lerna bootstrap might have created yarn.lock
+git checkout .
+
 # Get current version from lerna.json
 # Since this happens on tagged branch, the lerna.json version and package.json file SHOULD be updated already
 # as specified in release guideline


### PR DESCRIPTION
As of latest release (6.4.0b2) - `lerna bootstrap` created `yarn.lock` file that made the release-package job fail. This change makes sure the script is run in a clean repo state