### PR TITLE
Testdata: Rename package to circumvent convention in go

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb"
-	"github.com/grafana/grafana/pkg/tsdb/testdata"
+	"github.com/grafana/grafana/pkg/tsdb/testdatasource"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -68,13 +68,13 @@ func GetTestDataScenarios(c *m.ReqContext) Response {
 	result := make([]interface{}, 0)
 
 	scenarioIds := make([]string, 0)
-	for id := range testdata.ScenarioRegistry {
+	for id := range testdatasource.ScenarioRegistry {
 		scenarioIds = append(scenarioIds, id)
 	}
 	sort.Strings(scenarioIds)
 
 	for _, scenarioId := range scenarioIds {
-		scenario := testdata.ScenarioRegistry[scenarioId]
+		scenario := testdatasource.ScenarioRegistry[scenarioId]
 		result = append(result, map[string]interface{}{
 			"id":          scenario.Id,
 			"name":        scenario.Name,

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/tsdb/postgres"
 	_ "github.com/grafana/grafana/pkg/tsdb/prometheus"
 	_ "github.com/grafana/grafana/pkg/tsdb/stackdriver"
-	_ "github.com/grafana/grafana/pkg/tsdb/testdata"
+	_ "github.com/grafana/grafana/pkg/tsdb/testdatasource"
 )
 
 var version = "5.0.0"

--- a/pkg/tsdb/testdatasource/scenarios_test.go
+++ b/pkg/tsdb/testdatasource/scenarios_test.go
@@ -1,4 +1,4 @@
-package testdata
+package testdatasource
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 
 func TestTestdataScenarios(t *testing.T) {
 	Convey("random walk ", t, func() {
-		scenario, _ := ScenarioRegistry["random_walk"]
+		scenario := ScenarioRegistry["random_walk"]
 
 		Convey("Should start at the requested value", func() {
 			req := &tsdb.TsdbQuery{
@@ -32,7 +32,7 @@ func TestTestdataScenarios(t *testing.T) {
 	})
 
 	Convey("random walk table", t, func() {
-		scenario, _ := ScenarioRegistry["random_walk_table"]
+		scenario := ScenarioRegistry["random_walk_table"]
 
 		Convey("Should return a table that looks like value/min/max", func() {
 			req := &tsdb.TsdbQuery{
@@ -99,9 +99,9 @@ func TestToLabels(t *testing.T) {
 		tags["job"] = "foo"
 		tags["instance"] = "bar"
 
-		So(parseLabels(`{job="foo", instance="bar"}`), ShouldEqual, tags)
-		So(parseLabels(`job="foo", instance="bar"`), ShouldEqual, tags)
-		So(parseLabels(`job=foo, instance=bar`), ShouldEqual, tags)
-		So(parseLabels(`job = foo,instance = bar`), ShouldEqual, tags)
+		So(parseLabels(`{job="foo", instance="bar"}`), ShouldResemble, tags)
+		So(parseLabels(`job="foo", instance="bar"`), ShouldResemble, tags)
+		So(parseLabels(`job=foo, instance=bar`), ShouldResemble, tags)
+		So(parseLabels(`job = foo,instance = bar`), ShouldResemble, tags)
 	})
 }

--- a/pkg/tsdb/testdatasource/testdata.go
+++ b/pkg/tsdb/testdatasource/testdata.go
@@ -1,4 +1,4 @@
-package testdata
+package testdatasource
 
 import (
 	"context"

--- a/pkg/tsdb/testdatasource/utils.go
+++ b/pkg/tsdb/testdatasource/utils.go
@@ -1,4 +1,4 @@
-package testdata
+package testdatasource
 
 import (
 	"math/rand"

--- a/public/app/plugins/datasource/testdata/partials/query.editor.html
+++ b/public/app/plugins/datasource/testdata/partials/query.editor.html
@@ -35,7 +35,7 @@
 			<label class="gf-form-label query-keyword width-7">New value</label>
       <input type="number" class="gf-form-input width-15" placeholder="value" ng-model="ctrl.newPointValue">
 			<label class="gf-form-label query-keyword">Time</label>
-      <input type="string" class="gf-form-input width-12" placeholder="time" ng-model="ctrl.newPointTime" input-datetime>
+      <input type="string" class="gf-form-input width-12" placeholder="time" ng-model="ctrl.newPointTime">
 			<button class="btn btn-secondary gf-form-btn" ng-click="ctrl.addPoint()">Add</button>
 			<label class="gf-form-label query-keyword">All values</label>
 			<gf-form-dropdown css-class="width-12" model="ctrl.selectedPoint" get-options="ctrl.getPoints()" on-change="ctrl.pointSelected($option)">

--- a/public/app/plugins/datasource/testdata/query_ctrl.ts
+++ b/public/app/plugins/datasource/testdata/query_ctrl.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { QueryCtrl } from 'app/plugins/sdk';
 import { defaultQuery } from './runStreams';
 import { getBackendSrv } from 'app/core/services/backend_srv';
-import { dateTime } from '@grafana/data';
+import { dateTime, dateMath } from '@grafana/data';
 
 export const defaultPulse: any = {
   timeStep: 60,
@@ -63,6 +63,7 @@ export class TestDataQueryCtrl extends QueryCtrl {
 
   addPoint() {
     this.target.points = this.target.points || [];
+    this.newPointTime = dateMath.parse(this.newPointTime);
     this.target.points.push([this.newPointValue, this.newPointTime.valueOf()]);
     this.target.points = _.sortBy(this.target.points, p => p[1]);
     this.refresh();


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change the tests was not run.
Seems like angular directive inputDatetime is no longer there so
had to make a fix to be able to get the manual input scenario to
work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

