### PR TITLE
grafana/ui: fix value time zone names to be capitalized

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeZonePicker.tsx
@@ -16,7 +16,7 @@ export const TimeZonePicker: FC<Props> = ({ onChange, value, width }) => {
     const options = group.options.map(timeZone => {
       return {
         label: timeZone,
-        value: timeZone.toLowerCase(),
+        value: timeZone,
       };
     });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
time zones should not be lowercased according to [iana](https://www.iana.org/time-zones)
