### PR TITLE
DisplayFormat: use toLocaleString for infinity

### DIFF
--- a/packages/grafana-ui/src/utils/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/valueFormats.test.ts
@@ -1,11 +1,21 @@
-import { toFixed, getValueFormat } from './valueFormats';
+import { toFixed, getValueFormat, scaledUnits } from './valueFormats';
 
 describe('valueFormats', () => {
-  describe('toFixed with edge cases', () => {
-    it('should handle non number input gracefully', () => {
+  describe('format edge cases', () => {
+    const negInf = Number.NEGATIVE_INFINITY.toLocaleString();
+    const posInf = Number.POSITIVE_INFINITY.toLocaleString();
+
+    it('toFixed should handle non number input gracefully', () => {
       expect(toFixed(NaN)).toBe('NaN');
-      expect(toFixed(Number.NEGATIVE_INFINITY)).toBe('-Inf');
-      expect(toFixed(Number.POSITIVE_INFINITY)).toBe('Inf');
+      expect(toFixed(Number.NEGATIVE_INFINITY)).toBe(negInf);
+      expect(toFixed(Number.POSITIVE_INFINITY)).toBe(posInf);
+    });
+
+    it('scaledUnits should handle non number input gracefully', () => {
+      const disp = scaledUnits(5, ['a', 'b', 'c']);
+      expect(disp(NaN)).toBe('NaN');
+      expect(disp(Number.NEGATIVE_INFINITY)).toBe(negInf);
+      expect(disp(Number.POSITIVE_INFINITY)).toBe(posInf);
     });
   });
 

--- a/packages/grafana-ui/src/utils/valueFormats/valueFormats.ts
+++ b/packages/grafana-ui/src/utils/valueFormats/valueFormats.ts
@@ -33,11 +33,8 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   if (value === null) {
     return '';
   }
-  if (value === Number.NEGATIVE_INFINITY) {
-    return '-Inf';
-  }
-  if (value === Number.POSITIVE_INFINITY) {
-    return 'Inf';
+  if (value === Number.NEGATIVE_INFINITY || value === Number.POSITIVE_INFINITY) {
+    return value.toLocaleString();
   }
 
   const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
@@ -93,6 +90,9 @@ export function scaledUnits(factor: number, extArray: string[]) {
   return (size: number, decimals?: DecimalCount, scaledDecimals?: DecimalCount) => {
     if (size === null) {
       return '';
+    }
+    if (size === Number.NEGATIVE_INFINITY || size === Number.POSITIVE_INFINITY || isNaN(size)) {
+      return size.toLocaleString();
     }
 
     let steps = 0;


### PR DESCRIPTION
Fixes #19375

This updates infinity handling so it is the same for `toFixed` vs `scaledUnits`
