### PR TITLE
Release: Create cherrypick task work for enterprise repo

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -68,9 +68,10 @@ export const run = (includeInternalScripts = false) => {
 
     program
       .command('cherrypick')
+      .option('-e, --enterprise', 'Run task for grafana-enterprise')
       .description('Helps find commits to cherry pick')
       .action(async cmd => {
-        await execTask(cherryPickTask)({});
+        await execTask(cherryPickTask)({ enterprise: !!cmd.enterprise });
       });
 
     program

--- a/packages/grafana-toolkit/src/cli/tasks/cherrypick.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/cherrypick.ts
@@ -1,10 +1,12 @@
 import { Task, TaskRunner } from './task';
 import GithubClient from '../utils/githubClient';
 
-interface CherryPickOptions {}
+interface CherryPickOptions {
+  enterprise: boolean;
+}
 
-const cherryPickRunner: TaskRunner<CherryPickOptions> = async () => {
-  const githubClient = new GithubClient();
+const cherryPickRunner: TaskRunner<CherryPickOptions> = async ({ enterprise }) => {
+  const githubClient = new GithubClient({ enterprise });
   const client = githubClient.client;
 
   const res = await client.get('/issues', {

--- a/packages/grafana-toolkit/src/cli/tasks/closeMilestone.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/closeMilestone.ts
@@ -6,7 +6,7 @@ interface CloseMilestoneOptions {
 }
 
 const closeMilestoneTaskRunner: TaskRunner<CloseMilestoneOptions> = async ({ milestone }) => {
-  const githubClient = new GithubClient(true);
+  const githubClient = new GithubClient({ required: true });
 
   const cherryPickLabel = 'cherry-pick needed';
   const client = githubClient.client;

--- a/packages/grafana-toolkit/src/cli/utils/githubClient.test.ts
+++ b/packages/grafana-toolkit/src/cli/utils/githubClient.test.ts
@@ -15,11 +15,13 @@ afterEach(() => {
 describe('GithubClient', () => {
   it('should initialise a GithubClient', () => {
     const github = new GithubClient();
+    const githubEnterprise = new GithubClient({ enterprise: true });
     expect(github).toBeInstanceOf(GithubClient);
+    expect(githubEnterprise).toBeInstanceOf(GithubClient);
   });
 
   describe('#client', () => {
-    it('it should contain a client', () => {
+    it('it should contain a grafana client', () => {
       // @ts-ignore
       const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
 
@@ -28,6 +30,20 @@ describe('GithubClient', () => {
 
       expect(spy).toHaveBeenCalledWith({
         baseURL: 'https://api.github.com/repos/grafana/grafana',
+        timeout: 10000,
+      });
+      expect(client).toEqual(fakeClient);
+    });
+
+    it('it should contain a grafana enterprise client', () => {
+      // @ts-ignore
+      const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
+
+      const github = new GithubClient({ enterprise: true });
+      const client = github.client;
+
+      expect(spy).toHaveBeenCalledWith({
+        baseURL: 'https://api.github.com/repos/grafana/grafana-enterprise',
         timeout: 10000,
       });
       expect(client).toEqual(fakeClient);
@@ -44,7 +60,7 @@ describe('GithubClient', () => {
         // @ts-ignore
         const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
 
-        const github = new GithubClient(true);
+        const github = new GithubClient({ required: true });
         const client = github.client;
 
         expect(spy).toHaveBeenCalledWith({
@@ -56,11 +72,33 @@ describe('GithubClient', () => {
         expect(client).toEqual(fakeClient);
       });
 
+      it('should create the enterprise client when the credentials are defined', () => {
+        const username = 'grafana';
+        const token = 'averysecureaccesstoken';
+
+        process.env.GITHUB_USERNAME = username;
+        process.env.GITHUB_ACCESS_TOKEN = token;
+
+        // @ts-ignore
+        const spy = jest.spyOn(GithubClient.prototype, 'createClient').mockImplementation(() => fakeClient);
+
+        const github = new GithubClient({ required: true, enterprise: true });
+        const client = github.client;
+
+        expect(spy).toHaveBeenCalledWith({
+          baseURL: 'https://api.github.com/repos/grafana/grafana-enterprise',
+          timeout: 10000,
+          auth: { username, password: token },
+        });
+
+        expect(client).toEqual(fakeClient);
+      });
+
       describe('when the credentials are not defined', () => {
         it('should throw an error', () => {
           expect(() => {
             // tslint:disable-next-line
-            new GithubClient(true);
+            new GithubClient({ required: true });
           }).toThrow(/operation needs a GITHUB_USERNAME and GITHUB_ACCESS_TOKEN environment variables/);
         });
       });

--- a/packages/grafana-toolkit/src/cli/utils/githubClient.ts
+++ b/packages/grafana-toolkit/src/cli/utils/githubClient.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-const baseURL = 'https://api.github.com/repos/grafana/grafana';
+const grafanaURL = 'https://api.github.com/repos/grafana/grafana';
+const enterpriseURL = 'https://api.github.com/repos/grafana/grafana-enterprise';
 
 // Encapsulates the creation of a client for the Github API
 //
@@ -10,15 +11,20 @@ const baseURL = 'https://api.github.com/repos/grafana/grafana';
 // they're not required - the library will use them. This allows us to overcome
 // any API rate limiting imposed without authentication.
 
+interface GithubClientProps {
+  required?: boolean;
+  enterprise?: boolean;
+}
+
 class GithubClient {
   client: AxiosInstance;
 
-  constructor(required = false) {
+  constructor({ required = false, enterprise = false }: GithubClientProps = {}) {
     const username = process.env.GITHUB_USERNAME;
     const token = process.env.GITHUB_ACCESS_TOKEN;
 
     const clientConfig: AxiosRequestConfig = {
-      baseURL: baseURL,
+      baseURL: enterprise ? enterpriseURL : grafanaURL,
       timeout: 10000,
     };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Creates cherrypick task work for enterprise repo by adding command option `'-e, --enterprise', 'Run task for grafana-enterprise'`.  Note about this task has been added to the Grafana Release Guide. 

**Which issue(s) this PR fixes**:
Fixes #19390