### PR TITLE
Alerting: Add configurable severity support for PagerDuty notifier

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -100,6 +100,7 @@ To set up PagerDuty, all you have to do is to provide an API key.
 Setting | Description
 ---------- | -----------
 Integration Key | Integration key for PagerDuty.
+Severity | Level for dynamic notifications, default is `critical`
 Auto resolve incidents | Resolve incidents in PagerDuty once the alert goes back to ok
 
 ### Webhook

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -27,13 +27,16 @@ func init() {
         <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.integrationKey" placeholder="Pagerduty Integration Key"></input>
       </div>
       <div class="gf-form">
-	    <span class="gf-form-label width-10">Severity</span>
+        <span class="gf-form-label width-10">Severity</span>
         <div class="gf-form-select-wrapper width-14">
-          <select class="gf-form-input"
-		     ng-model="ctrl.model.settings.severity"
-			 ng-options="t for t in ['critical', 'error', 'warning', 'info']">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.model.settings.severity"
+            ng-options="s for s in ['critical', 'error', 'warning', 'info']">
           </select>
         </div>
+      </div>
+      <div class="gf-form">
         <gf-form-switch
            class="gf-form"
            label="Auto resolve incidents"

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -25,6 +25,27 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 
+			Convey("severity should default to critical", func() {
+				json := `{ "integrationKey": "abcdefgh0123456789" }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "pagerduty_testing",
+					Type:     "pagerduty",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewPagerdutyNotifier(model)
+				pagerdutyNotifier := not.(*PagerdutyNotifier)
+
+				So(err, ShouldBeNil)
+				So(pagerdutyNotifier.Name, ShouldEqual, "pagerduty_testing")
+				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
+				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
+				So(pagerdutyNotifier.Severity, ShouldEqual, "critical")
+				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
+			})
+
 			Convey("auto resolve should default to false", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789" }`
 

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -25,7 +25,28 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 
-			Convey("severity should default to critical", func() {
+			Convey("severity should override default", func() {
+				json := `{ "integrationKey": "abcdefgh0123456789", "severity": "info" }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "pagerduty_testing",
+					Type:     "pagerduty",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewPagerdutyNotifier(model)
+				pagerdutyNotifier := not.(*PagerdutyNotifier)
+
+				So(err, ShouldBeNil)
+				So(pagerdutyNotifier.Name, ShouldEqual, "pagerduty_testing")
+				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
+				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
+				So(pagerdutyNotifier.Severity, ShouldEqual, "info")
+				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
+			})
+
+			Convey("auto resolve and severity should have expected defaults", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789" }`
 
 				settingsJSON, _ := simplejson.NewJson([]byte(json))
@@ -43,26 +64,6 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
 				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
 				So(pagerdutyNotifier.Severity, ShouldEqual, "critical")
-				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
-			})
-
-			Convey("auto resolve should default to false", func() {
-				json := `{ "integrationKey": "abcdefgh0123456789" }`
-
-				settingsJSON, _ := simplejson.NewJson([]byte(json))
-				model := &models.AlertNotification{
-					Name:     "pagerduty_testing",
-					Type:     "pagerduty",
-					Settings: settingsJSON,
-				}
-
-				not, err := NewPagerdutyNotifier(model)
-				pagerdutyNotifier := not.(*PagerdutyNotifier)
-
-				So(err, ShouldBeNil)
-				So(pagerdutyNotifier.Name, ShouldEqual, "pagerduty_testing")
-				So(pagerdutyNotifier.Type, ShouldEqual, "pagerduty")
-				So(pagerdutyNotifier.Key, ShouldEqual, "abcdefgh0123456789")
 				So(pagerdutyNotifier.AutoResolve, ShouldBeFalse)
 			})
 

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -14,7 +14,9 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("empty settings should return error", func() {
 				json := `{ }`
 
-				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				settingsJSON, err := simplejson.NewJson([]byte(json))
+				So(err, ShouldBeNil)
+
 				model := &models.AlertNotification{
 					Name:     "pageduty_testing",
 					Type:     "pagerduty",
@@ -28,7 +30,9 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("severity should override default", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789", "severity": "info" }`
 
-				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				settingsJSON, err := simplejson.NewJson([]byte(json))
+				So(err, ShouldBeNil)
+
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",
 					Type:     "pagerduty",
@@ -49,7 +53,9 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("auto resolve and severity should have expected defaults", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789" }`
 
-				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				settingsJSON, err := simplejson.NewJson([]byte(json))
+				So(err, ShouldBeNil)
+
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",
 					Type:     "pagerduty",
@@ -74,7 +80,9 @@ func TestPagerdutyNotifier(t *testing.T) {
 					"autoResolve": false
 				}`
 
-				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				settingsJSON, err := simplejson.NewJson([]byte(json))
+				So(err, ShouldBeNil)
+
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",
 					Type:     "pagerduty",

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -14,8 +14,8 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("empty settings should return error", func() {
 				json := `{ }`
 
-				settingsJSON, err := simplejson.NewJson([]byte(json))
-				So(err, ShouldBeNil)
+				settingsJSON, jerr := simplejson.NewJson([]byte(json))
+				So(jerr, ShouldBeNil)
 
 				model := &models.AlertNotification{
 					Name:     "pageduty_testing",
@@ -30,8 +30,8 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("severity should override default", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789", "severity": "info" }`
 
-				settingsJSON, err := simplejson.NewJson([]byte(json))
-				So(err, ShouldBeNil)
+				settingsJSON, jerr := simplejson.NewJson([]byte(json))
+				So(jerr, ShouldBeNil)
 
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",
@@ -53,8 +53,8 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Convey("auto resolve and severity should have expected defaults", func() {
 				json := `{ "integrationKey": "abcdefgh0123456789" }`
 
-				settingsJSON, err := simplejson.NewJson([]byte(json))
-				So(err, ShouldBeNil)
+				settingsJSON, jerr := simplejson.NewJson([]byte(json))
+				So(jerr, ShouldBeNil)
 
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",
@@ -80,8 +80,8 @@ func TestPagerdutyNotifier(t *testing.T) {
 					"autoResolve": false
 				}`
 
-				settingsJSON, err := simplejson.NewJson([]byte(json))
-				So(err, ShouldBeNil)
+				settingsJSON, jerr := simplejson.NewJson([]byte(json))
+				So(jerr, ShouldBeNil)
 
 				model := &models.AlertNotification{
 					Name:     "pagerduty_testing",

--- a/public/app/features/alerting/NotificationsEditCtrl.ts
+++ b/public/app/features/alerting/NotificationsEditCtrl.ts
@@ -18,6 +18,7 @@ export class AlertNotificationEditCtrl {
     settings: {
       httpMethod: 'POST',
       autoResolve: true,
+      severity: 'critical',
       uploadImage: true,
     },
     isDefault: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

Existing behavior forces every alert to be severity `critical`, preventing proper use of the [dynamic notifications feature](https://support.pagerduty.com/docs/dynamic-notifications) in PagerDuty.

This change makes the severity configurable per notification channel. Default value is `critical`, same as the current constant so should not break existing configurations (unit tested).

### Notes

* Can't seem to build with `go 1.13`; may need an update to `golang.org/x/xerrors` unrelated to this PR.