### PR TITLE
Theme: Generate colors for SASS

### DIFF
--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -23,6 +23,7 @@ $red-base: #e02f44;
 $red-shade: #c4162a;
 $green-base: #299c46;
 $green-shade: #23843b;
+$orange-dark: #ff780a;
 
 // Grays
 // -------------------------

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -23,6 +23,7 @@ $red-base: #e02f44;
 $red-shade: #c4162a;
 $green-base: #3eb15b;
 $green-shade: #369b4f;
+$orange-dark: #ed5700;
 
 // Grays
 // -------------------------


### PR DESCRIPTION
After https://github.com/grafana/grafana/pull/19407, where new theme colors have been introduced, `yarn start` hasn't been run. This is required, as running `yarn start`, after adding theme colors, automatically generates colors in ` public/sass/_variables.light.generated.scss` and ` public/sass/_variables.dark.generated.scss`. This PR fixes it.  

