### PR TITLE
GaugePlugin: add optional sign support

### DIFF
--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -17,6 +17,10 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
     const { options } = this.props;
     const { field, display } = value;
 
+    if (options.showSign && display.numeric > 0 && display.text[0] !== '+') {
+      display.text = '+' + display.text;
+    }
+
     return (
       <DataLinksContextMenu links={getFieldLinksSupplier(value)}>
         {({ openMenu, targetClassName }) => {

--- a/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanelEditor.tsx
@@ -32,6 +32,12 @@ export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOption
       showThresholdMarkers: !this.props.options.showThresholdMarkers,
     });
 
+  onToggleSign = () =>
+    this.props.onOptionsChange({
+      ...this.props.options,
+      showSign: !this.props.options.showSign,
+    });
+
   onThresholdsChanged = (thresholds: Threshold[]) => {
     const current = this.props.options.fieldOptions.defaults;
     this.onDefaultsChange({
@@ -70,7 +76,7 @@ export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOption
 
   render() {
     const { options } = this.props;
-    const { fieldOptions, showThresholdLabels, showThresholdMarkers } = options;
+    const { fieldOptions, showThresholdLabels, showThresholdMarkers, showSign } = options;
     const { defaults } = fieldOptions;
 
     const suggestions = fieldOptions.values
@@ -97,6 +103,12 @@ export class GaugePanelEditor extends PureComponent<PanelEditorProps<GaugeOption
               labelClass={`width-${this.labelWidth}`}
               checked={showThresholdMarkers}
               onChange={this.onToggleThresholdMarkers}
+            />
+            <Switch
+              label="Sign"
+              labelClass={`width-${this.labelWidth}`}
+              checked={showSign}
+              onChange={this.onToggleSign}
             />
           </PanelOptionsGroup>
 

--- a/public/app/plugins/panel/gauge/types.ts
+++ b/public/app/plugins/panel/gauge/types.ts
@@ -5,6 +5,7 @@ import { standardFieldDisplayOptions } from '../singlestat2/types';
 export interface GaugeOptions extends SingleStatBaseOptions {
   showThresholdLabels: boolean;
   showThresholdMarkers: boolean;
+  showSign: boolean;
 }
 
 export const standardGaugeFieldOptions: FieldDisplayOptions = {
@@ -14,6 +15,7 @@ export const standardGaugeFieldOptions: FieldDisplayOptions = {
 export const defaults: GaugeOptions = {
   showThresholdMarkers: true,
   showThresholdLabels: false,
+  showSign: true,
   fieldOptions: standardGaugeFieldOptions,
   orientation: VizOrientation.Auto,
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Displays positive numbers with "+" sign if setting "Sign" is set
This little feature makes trends graphs more visual and illustrative

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

