### PR TITLE
Explore: Take root_url setting into account when redirecting from dashboard to explore

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import coreModule from 'app/core/core_module';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
+import locationUtil from 'app/core/utils/location_util';
+import { config } from '@grafana/runtime';
 import { store } from 'app/store/store';
 
 import Mousetrap from 'mousetrap';
@@ -220,8 +222,11 @@ export class KeybindingSrv {
           const panel = dashboard.getPanelById(dashboard.meta.focusPanelId);
           const datasource = await this.datasourceSrv.get(panel.datasource);
           const url = await getExploreUrl(panel, panel.targets, datasource, this.datasourceSrv, this.timeSrv);
-          if (url) {
-            this.$timeout(() => this.$location.url(url));
+          const urlWithoutBase = locationUtil.stripBaseFromUrl(url);
+          const finalUrl = config.appSubUrl + urlWithoutBase;
+
+          if (finalUrl) {
+            this.$timeout(() => this.$location.url(finalUrl));
           }
         }
       });

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -4,7 +4,6 @@ import coreModule from 'app/core/core_module';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import locationUtil from 'app/core/utils/location_util';
-import { config } from '@grafana/runtime';
 import { store } from 'app/store/store';
 
 import Mousetrap from 'mousetrap';
@@ -223,10 +222,9 @@ export class KeybindingSrv {
           const datasource = await this.datasourceSrv.get(panel.datasource);
           const url = await getExploreUrl(panel, panel.targets, datasource, this.datasourceSrv, this.timeSrv);
           const urlWithoutBase = locationUtil.stripBaseFromUrl(url);
-          const finalUrl = config.appSubUrl + urlWithoutBase;
 
-          if (finalUrl) {
-            this.$timeout(() => this.$location.url(finalUrl));
+          if (urlWithoutBase) {
+            this.$timeout(() => this.$location.url(urlWithoutBase));
           }
         }
       });

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -91,7 +91,8 @@ export async function getExploreUrl(
     const exploreState = JSON.stringify({ ...state, originPanelId: panel.id });
     url = renderUrl('/explore', { left: exploreState });
   }
-  return url;
+  const finalUrl = config.appSubUrl + url;
+  return finalUrl;
 }
 
 export function buildQueryTransaction(

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -11,7 +11,6 @@ import { toLegacyResponseData, TimeRange, LoadingState, DataFrame, toDataFrameDT
 import { LegacyResponseData, DataSourceApi, PanelData, DataQueryResponse } from '@grafana/ui';
 import { Unsubscribable } from 'rxjs';
 import { PanelModel } from 'app/features/dashboard/state';
-import { config } from '@grafana/runtime';
 
 class MetricsPanelCtrl extends PanelCtrl {
   scope: any;
@@ -247,9 +246,7 @@ class MetricsPanelCtrl extends PanelCtrl {
         text: 'Explore',
         icon: 'gicon gicon-explore',
         shortcut: 'x',
-        href:
-          config.appSubUrl +
-          (await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv)),
+        href: await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv),
       });
     }
     return items;

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -11,6 +11,7 @@ import { toLegacyResponseData, TimeRange, LoadingState, DataFrame, toDataFrameDT
 import { LegacyResponseData, DataSourceApi, PanelData, DataQueryResponse } from '@grafana/ui';
 import { Unsubscribable } from 'rxjs';
 import { PanelModel } from 'app/features/dashboard/state';
+import { config } from '@grafana/runtime';
 
 class MetricsPanelCtrl extends PanelCtrl {
   scope: any;
@@ -246,17 +247,12 @@ class MetricsPanelCtrl extends PanelCtrl {
         text: 'Explore',
         icon: 'gicon gicon-explore',
         shortcut: 'x',
-        href: await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv),
+        href:
+          config.appSubUrl +
+          (await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv)),
       });
     }
     return items;
-  }
-
-  async explore() {
-    const url = await getExploreUrl(this.panel, this.panel.targets, this.datasource, this.datasourceSrv, this.timeSrv);
-    if (url) {
-      this.$timeout(() => this.$location.url(url));
-    }
   }
 }
 

--- a/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
+++ b/public/app/features/panel/specs/metrics_panel_ctrl.test.ts
@@ -10,6 +10,9 @@ jest.mock('app/core/config', () => {
         name: 'test',
       },
     },
+    config: {
+      appSubUrl: 'test',
+    },
   };
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Take root_url setting into account when redirecting from dashboard to explore. 
2. Remove function that is not used anywhere due to previous refactor.
