### PR TITLE
grafana/toolkit: Remove hack to expose plugin/e2e exports & types

### DIFF
--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -100,6 +100,5 @@
   },
   "_moduleAliases": {
     "puppeteer": "node_modules/puppeteer-core"
-  },
-  "types": "src/index.ts"
+  }
 }

--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import chalk from 'chalk';
 import { useSpinner } from '../utils/useSpinner';
 import { Task, TaskRunner } from './task';
-import escapeRegExp from 'lodash/escapeRegExp';
 
 const path = require('path');
 
@@ -120,21 +119,6 @@ const toolkitBuildTaskRunner: TaskRunner<ToolkitBuildOptions> = async () => {
   fs.mkdirSync('./dist/sass');
   await copyFiles();
   await copySassFiles();
-
-  // RYAN HACK HACK HACK
-  // when Dominik is back from vacation, we can find a better way
-  // This moves the index to the root so plugin e2e tests can import them
-  console.warn('hacking an index.js file for toolkit.  Help!');
-  const index = `${distDir}/src/index.js`;
-  fs.readFile(index, 'utf8', (err, data) => {
-    const pattern = 'require("./';
-    const js = data.replace(new RegExp(escapeRegExp(pattern), 'g'), 'require("./src/');
-    fs.writeFile(`${distDir}/index.js`, js, err => {
-      if (err) {
-        throw new Error('Error writing index: ' + err);
-      }
-    });
-  });
 };
 
 export const toolkitBuildTask = new Task<ToolkitBuildOptions>('@grafana/toolkit build', toolkitBuildTaskRunner);

--- a/packages/grafana-toolkit/src/index.ts
+++ b/packages/grafana-toolkit/src/index.ts
@@ -1,6 +1,0 @@
-export * from './e2e';
-
-// Namespace for Plugins
-import * as plugins from './plugins';
-
-export { plugins };

--- a/packages/grafana-toolkit/src/plugins/e2e/commonPluginTests.ts
+++ b/packages/grafana-toolkit/src/plugins/e2e/commonPluginTests.ts
@@ -1,6 +1,7 @@
 import { Browser, Page } from 'puppeteer-core';
 
-import { e2eScenario, takeScreenShot, plugins, pages } from '@grafana/toolkit';
+import { e2eScenario, takeScreenShot, pages } from '@grafana/toolkit/src/e2e';
+import { getEndToEndSettings } from '@grafana/toolkit/src/plugins';
 
 // ****************************************************************
 // NOTE, This file is copied to plugins at runtime, it is not run locally
@@ -11,7 +12,7 @@ const sleep = (milliseconds: number) => {
 };
 
 e2eScenario('Common Plugin Test', 'should pass', async (browser: Browser, page: Page) => {
-  const settings = plugins.getEndToEndSettings();
+  const settings = getEndToEndSettings();
   const pluginPage = pages.getPluginPage(settings.plugin.id);
   await pluginPage.init(page);
   await pluginPage.navigateTo();

--- a/packages/grafana-toolkit/tsconfig.json
+++ b/packages/grafana-toolkit/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDirs": ["."],
     "outDir": "dist/src",
     "declaration": true,
-    "declarationDir": "dist",
+    "declarationDir": "dist/src",
     "typeRoots": ["./node_modules/@types"],
     "esModuleInterop": true,
     "lib": ["es2015", "es2017.string", "dom"]

--- a/public/e2e-test/pages/dashboards/createDashboardPage.ts
+++ b/public/e2e-test/pages/dashboards/createDashboardPage.ts
@@ -1,4 +1,4 @@
-import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit';
+import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit/src/e2e';
 
 export interface CreateDashboardPage {
   addQuery: ClickablePageObjectType;

--- a/public/e2e-test/pages/dashboards/dashboardsPage.ts
+++ b/public/e2e-test/pages/dashboards/dashboardsPage.ts
@@ -1,4 +1,4 @@
-import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit';
+import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit/src/e2e';
 
 export interface DashboardsPage {
   dashboard: ClickablePageObjectType;

--- a/public/e2e-test/pages/dashboards/saveDashboardModal.ts
+++ b/public/e2e-test/pages/dashboards/saveDashboardModal.ts
@@ -6,7 +6,7 @@ import {
   InputPageObjectType,
   InputPageObject,
   PageObject,
-} from '@grafana/toolkit';
+} from '@grafana/toolkit/src/e2e';
 
 export interface SaveDashboardModal {
   name: InputPageObjectType;

--- a/public/e2e-test/pages/datasources/addDataSourcePage.ts
+++ b/public/e2e-test/pages/datasources/addDataSourcePage.ts
@@ -1,4 +1,4 @@
-import { TestPage, ClickablePageObject, Selector, ClickablePageObjectType } from '@grafana/toolkit';
+import { TestPage, ClickablePageObject, Selector, ClickablePageObjectType } from '@grafana/toolkit/src/e2e';
 
 export interface AddDataSourcePage {
   testDataDB: ClickablePageObjectType;

--- a/public/e2e-test/pages/datasources/dataSources.ts
+++ b/public/e2e-test/pages/datasources/dataSources.ts
@@ -1,4 +1,4 @@
-import { TestPage } from '@grafana/toolkit';
+import { TestPage } from '@grafana/toolkit/src/e2e';
 
 export interface DataSourcesPage {}
 

--- a/public/e2e-test/pages/datasources/editDataSourcePage.ts
+++ b/public/e2e-test/pages/datasources/editDataSourcePage.ts
@@ -5,7 +5,7 @@ import {
   ClickablePageObject,
   PageObject,
   Selector,
-} from '@grafana/toolkit';
+} from '@grafana/toolkit/src/e2e';
 
 export interface EditDataSourcePage {
   saveAndTest: ClickablePageObjectType;

--- a/public/e2e-test/pages/panels/editPanel.ts
+++ b/public/e2e-test/pages/panels/editPanel.ts
@@ -5,7 +5,7 @@ import {
   Selector,
   ClickablePageObjectType,
   ClickablePageObject,
-} from '@grafana/toolkit';
+} from '@grafana/toolkit/src/e2e';
 
 export interface EditPanelPage {
   queriesTab: ClickablePageObjectType;

--- a/public/e2e-test/pages/panels/panel.ts
+++ b/public/e2e-test/pages/panels/panel.ts
@@ -1,4 +1,4 @@
-import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit';
+import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit/src/e2e';
 
 export interface Panel {
   panelTitle: ClickablePageObjectType;

--- a/public/e2e-test/pages/panels/sharePanelModal.ts
+++ b/public/e2e-test/pages/panels/sharePanelModal.ts
@@ -1,4 +1,4 @@
-import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit';
+import { TestPage, ClickablePageObjectType, ClickablePageObject, Selector } from '@grafana/toolkit/src/e2e';
 
 export interface SharePanelModal {
   directLinkRenderedImage: ClickablePageObjectType;

--- a/public/e2e-test/scenarios/smoke.test.ts
+++ b/public/e2e-test/scenarios/smoke.test.ts
@@ -1,6 +1,6 @@
 import { Browser, Page, Target } from 'puppeteer-core';
 
-import { e2eScenario, constants, takeScreenShot, compareScreenShots } from '@grafana/toolkit';
+import { e2eScenario, constants, takeScreenShot, compareScreenShots } from '@grafana/toolkit/src/e2e';
 import { addDataSourcePage } from 'e2e-test/pages/datasources/addDataSourcePage';
 import { editDataSourcePage } from 'e2e-test/pages/datasources/editDataSourcePage';
 import { dataSourcesPage } from 'e2e-test/pages/datasources/dataSources';


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/18513

This PR does the following: 

1. Toolkit dist types now are located next to source files - this makes it possible to import from i.e. `@grafana/toolkit/src/plugins` as in `plugins-ci-app`
2. Removed @ryantxu hack (btw it was really long come back from vacation;)
3. Updated paths in core's e2e tests to be use full toolkit's paths