### PR TITLE
API: Add createdAt field to /api/users/:id

### DIFF
--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -35,6 +35,7 @@ func TestUserApiEndpoint(t *testing.T) {
 					IsDisabled:     false,
 					IsExternal:     false,
 					UpdatedAt:      fakeNow,
+					CreatedAt:      fakeNow,
 				}
 				return nil
 			})
@@ -63,7 +64,8 @@ func TestUserApiEndpoint(t *testing.T) {
 				"authLabels": [
 					"LDAP"
 				],
-				"updatedAt": "2019-02-11T17:30:40Z"
+				"updatedAt": "2019-02-11T17:30:40Z",
+				"createdAt": "2019-02-11T17:30:40Z"
 			}
 			`
 

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -226,6 +226,7 @@ type UserProfileDTO struct {
 	IsExternal     bool      `json:"isExternal"`
 	AuthLabels     []string  `json:"authLabels"`
 	UpdatedAt      time.Time `json:"updatedAt"`
+	CreatedAt      time.Time `json:"createdAt"`
 }
 
 type UserSearchHitDTO struct {

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -332,6 +332,7 @@ func GetUserProfile(query *models.GetUserProfileQuery) error {
 		IsDisabled:     user.IsDisabled,
 		OrgId:          user.OrgId,
 		UpdatedAt:      user.Updated,
+		CreatedAt:      user.Created,
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:

per @dconrique01
`
It would help for auditing purposes to have the user's created date exposed via the API along with the other fields already exposed via the API.
`

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/19329

**Special notes for your reviewer**: