### PR TITLE
Docs: Ordering and formatting of datasources in docs - #19285

### DIFF
--- a/docs/sources/guides/basic_concepts.md
+++ b/docs/sources/guides/basic_concepts.md
@@ -18,7 +18,14 @@ This document is a “bottom up” introduction to basic concepts in Grafana, an
 
 Grafana supports many different storage backends for your time series data (Data Source). Each Data Source has a specific Query Editor that is customized for the features and capabilities that the particular Data Source exposes.
 
-The following data sources are officially supported: [Graphite]({{< relref "features/datasources/graphite.md" >}}), [InfluxDB]({{< relref "features/datasources/influxdb.md" >}}), [OpenTSDB]({{< relref "features/datasources/opentsdb.md" >}}), [Prometheus]({{< relref "features/datasources/prometheus.md" >}}), [Elasticsearch]({{< relref "features/datasources/elasticsearch.md" >}}), [CloudWatch]({{< relref "features/datasources/cloudwatch.md" >}}).
+The following data sources are officially supported:
+
+* [CloudWatch]({{< relref "features/datasources/cloudwatch.md" >}})
+* [Elasticsearch]({{< relref "features/datasources/elasticsearch.md" >}})
+* [Graphite]({{< relref "features/datasources/graphite.md" >}})
+* [InfluxDB]({{< relref "features/datasources/influxdb.md" >}})
+* [OpenTSDB]({{< relref "features/datasources/opentsdb.md" >}})
+* [Prometheus]({{< relref "features/datasources/prometheus.md" >}})
 
 The query language and capabilities of each Data Source are obviously very different. You can combine data from multiple Data Sources onto a single Dashboard, but each Panel is tied to a specific Data Source that belongs to a particular Organization.
 


### PR DESCRIPTION
Fixed ordering in both the initially suggested `guides/basic_concepts.md` and the `datasources/index.md`

Closes: #19285