### PR TITLE
Docker: Allow installing specific plugin versions

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -85,6 +85,17 @@ docker run \
   grafana/grafana
 ```
 
+To install a plugin with a specific version, append `:<version>` to the plugin name.
+
+```bash
+docker run \
+  -d \
+  -p 3000:3000 \
+  --name=grafana \
+  -e "GF_INSTALL_PLUGINS=grafana-clock-panel:1.0.2" \
+  grafana/grafana
+```
+
 ## Building a custom Grafana image with pre-installed plugins
 
 In the [grafana-docker](https://github.com/grafana/grafana/tree/master/packaging/docker)  there is a folder called `custom/` which includes a `Dockerfile` that can be used to build a custom Grafana image.  It accepts `GRAFANA_VERSION` and `GF_INSTALL_PLUGINS` as build arguments.
@@ -107,7 +118,7 @@ docker run \
 
 > Only available in Grafana v5.3.1+
 
-It's possible to install plugins from custom url:s by specifying the url like this: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin name>`
+It's possible to install plugins from custom urls by specifying the url like this: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin name>`
 
 ```bash
 docker run \

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -68,9 +68,15 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   for plugin in ${GF_INSTALL_PLUGINS}; do
     IFS=$OLDIFS
     if [[ $plugin =~ .*\;.* ]]; then
+        # Plugin with URL
         pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
         pluginWithoutUrl=$(echo "$plugin" | cut -d';' -f 2)
         grafana-cli --pluginUrl "${pluginUrl}" --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${pluginWithoutUrl}
+    elif [[ $plugin =~ .+\:.+ ]]; then
+        # Plugin with version
+        pluginWithoutVersion=$(echo "$plugin" | cut -d':' -f 1)
+        version=$(echo "$plugin" | cut -d':' -f 2)
+        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${pluginWithoutVersion} ${version}
     else
         grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
     fi


### PR DESCRIPTION
When installing Grafana plugins on Docker, it is possible to use the environment variable `GF_INSTALL_PLUGINS`. However, the version cannot be specified. This commit adds an optional version to the plugins to install.