### PR TITLE
API: Add `createdAt` and `updatedAt` to api/users/lookup

### DIFF
--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -116,12 +116,18 @@ HTTP/1.1 200
 Content-Type: application/json
 
 {
-  "email": "user@mygraf.com"
+  "id": "1",
+  "email": "user@mygraf.com",
   "name": "admin",
   "login": "admin",
   "theme": "light",
   "orgId": 1,
-  "isGrafanaAdmin": true
+  "isGrafanaAdmin": true,
+  "isDisabled": true,
+  "isExternal": false,
+  "authLabels": [],
+  "updatedAt": "2019-09-09T11:31:26+01:00",
+  "createdAt": "2019-09-09T11:31:26+01:00"
 }
 ```
 
@@ -162,7 +168,12 @@ Content-Type: application/json
   "login": "admin",
   "theme": "light",
   "orgId": 1,
-  "isGrafanaAdmin": true
+  "isGrafanaAdmin": true,
+  "isDisabled": false,
+  "isExternal": false,
+  "authLabels": null,
+  "updatedAt": "2019-09-25T14:44:37+01:00",
+  "createdAt": "2019-09-25T14:44:37+01:00"
 }
 ```
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -57,6 +57,8 @@ func GetUserByLoginOrEmail(c *m.ReqContext) Response {
 		Theme:          user.Theme,
 		IsGrafanaAdmin: user.IsAdmin,
 		OrgId:          user.OrgId,
+		UpdatedAt:      user.Updated,
+		CreatedAt:      user.Created,
 	}
 	return JSON(200, &result)
 }

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -73,6 +73,51 @@ func TestUserApiEndpoint(t *testing.T) {
 			require.JSONEq(t, expected, sc.resp.Body.String())
 		})
 
+		loggedInUserScenario("When calling GET on", "/api/users/lookup", func(sc *scenarioContext) {
+			fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
+			bus.AddHandler("test", func(query *models.GetUserByLoginQuery) error {
+				require.Equal(t, "danlee", query.LoginOrEmail)
+
+				query.Result = &models.User{
+					Id:         int64(1),
+					Email:      "daniel@grafana.com",
+					Name:       "Daniel",
+					Login:      "danlee",
+					Theme:      "light",
+					IsAdmin:    true,
+					OrgId:      int64(2),
+					IsDisabled: false,
+					Updated:    fakeNow,
+					Created:    fakeNow,
+				}
+
+				return nil
+			})
+
+			sc.handlerFunc = GetUserByLoginOrEmail
+			sc.fakeReqWithParams("GET", sc.url, map[string]string{"loginOrEmail": "danlee"}).exec()
+
+			expected := `
+			{
+				"id": 1,
+				"email": "daniel@grafana.com",
+				"name": "Daniel",
+				"login": "danlee",
+				"theme": "light",
+				"orgId": 2,
+				"isGrafanaAdmin": true,
+				"isDisabled": false,
+				"authLabels": null,
+				"isExternal": false,
+				"updatedAt": "2019-02-11T17:30:40Z",
+				"createdAt": "2019-02-11T17:30:40Z"
+			}
+			`
+
+			require.Equal(t, http.StatusOK, sc.resp.Code)
+			require.JSONEq(t, expected, sc.resp.Body.String())
+		})
+
 		loggedInUserScenario("When calling GET on", "/api/users", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int


### PR DESCRIPTION
In the past, we have added both `updatedAt` (#19004) and `createdAt` (#19475) to /api/users/:id

Turns out, /api/users/lookup uses the same DTO. This fixes the serialization of both `createdAt` and `updatedAt` for this endpoint.

Also, adds a test to ensure no further regressions.