### PR TITLE
ColorPicker: Adds communication between Angular and SeriesColorPickerPopover

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/SeriesColorPickerPopover.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/SeriesColorPickerPopover.tsx
@@ -1,9 +1,10 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 
 import { ColorPickerPopover, ColorPickerProps } from './ColorPickerPopover';
 import { PopoverContentProps } from '../Tooltip/Tooltip';
 import { Switch } from '../Switch/Switch';
 import { withTheme } from '../../themes/ThemeContext';
+import appEvents from '../../../../../public/app/core/app_events';
 
 export interface SeriesColorPickerPopoverProps extends ColorPickerProps, PopoverContentProps {
   yaxis?: number;
@@ -11,7 +12,22 @@ export interface SeriesColorPickerPopoverProps extends ColorPickerProps, Popover
 }
 
 export const SeriesColorPickerPopover: FunctionComponent<SeriesColorPickerPopoverProps> = props => {
-  const { yaxis, onToggleAxis, color, ...colorPickerProps } = props;
+  const [color, setColor] = useState(props.color);
+  useEffect(() => setColor(props.color), [props.color]);
+  useEffect(() => {
+    if (props.onColorChange) {
+      // used by Angular components only
+      appEvents.on('series-override-colors-changed', changeColor);
+    }
+    return function unsubscribeEvents() {
+      if (props.onColorChange) {
+        // used by Angular components only
+        appEvents.off('series-override-colors-changed', changeColor);
+      }
+    };
+  }, []);
+  const changeColor = (color: any) => setColor(color);
+  const { yaxis, onToggleAxis, ...colorPickerProps } = props;
   return (
     <ColorPickerPopover
       {...colorPickerProps}

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.ts
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import coreModule from 'app/core/core_module';
+import appEvents from '../../../core/app_events';
 
 /** @ngInject */
 export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: any) {
@@ -45,6 +46,7 @@ export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: a
     $scope.override['color'] = color;
     $scope.updateCurrentOverrides();
     $scope.ctrl.render();
+    appEvents.emit('series-override-colors-changed', color);
   };
 
   $scope.openColorSelector = (color: any) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously there was no communication between Angular and the opened ColorPicker so the color would not be updated in an opened ColorPicker. This PR attempts to solve this.

**Which issue(s) this PR fixes**:
Fixes #19493

**Special notes for your reviewer**:

