### PR TITLE
Datasource: Add custom headers on alerting queries

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -119,28 +119,6 @@ func (proxy *DataSourceProxy) addTraceFromHeaderValue(span opentracing.Span, hea
 	}
 }
 
-func (proxy *DataSourceProxy) useCustomHeaders(req *http.Request) {
-	decryptSdj := proxy.ds.SecureJsonData.Decrypt()
-	index := 1
-	for {
-		headerNameSuffix := fmt.Sprintf("httpHeaderName%d", index)
-		headerValueSuffix := fmt.Sprintf("httpHeaderValue%d", index)
-		if key := proxy.ds.JsonData.Get(headerNameSuffix).MustString(); key != "" {
-			if val, ok := decryptSdj[headerValueSuffix]; ok {
-				// remove if exists
-				if req.Header.Get(key) != "" {
-					req.Header.Del(key)
-				}
-				req.Header.Add(key, val)
-				logger.Debug("Using custom header ", "CustomHeaders", key)
-			}
-		} else {
-			break
-		}
-		index += 1
-	}
-}
-
 func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 	return func(req *http.Request) {
 		req.URL.Scheme = proxy.targetUrl.Scheme
@@ -167,11 +145,6 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 		if proxy.ds.BasicAuth {
 			req.Header.Del("Authorization")
 			req.Header.Add("Authorization", util.GetBasicAuthHeader(proxy.ds.BasicAuthUser, proxy.ds.DecryptedBasicAuthPassword()))
-		}
-
-		// Lookup and use custom headers
-		if proxy.ds.SecureJsonData != nil {
-			proxy.useCustomHeaders(req)
 		}
 
 		dsAuth := req.Header.Get("X-DS-Authorization")

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -328,37 +327,6 @@ func TestDSRouteRule(t *testing.T) {
 
 			Convey("Should keep named cookies", func() {
 				So(req.Header.Get("Cookie"), ShouldEqual, "JSESSION_ID=test")
-			})
-		})
-
-		Convey("When proxying a data source with custom headers specified", func() {
-			plugin := &plugins.DataSourcePlugin{}
-
-			encryptedData, err := util.Encrypt([]byte(`Bearer xf5yhfkpsnmgo`), setting.SecretKey)
-			ds := &m.DataSource{
-				Type: m.DS_PROMETHEUS,
-				Url:  "http://prometheus:9090",
-				JsonData: simplejson.NewFromAny(map[string]interface{}{
-					"httpHeaderName1": "Authorization",
-				}),
-				SecureJsonData: map[string][]byte{
-					"httpHeaderValue1": encryptedData,
-				},
-			}
-
-			ctx := &m.ReqContext{}
-			proxy := NewDataSourceProxy(ds, plugin, ctx, "", &setting.Cfg{})
-
-			requestURL, _ := url.Parse("http://grafana.com/sub")
-			req := http.Request{URL: requestURL, Header: make(http.Header)}
-			proxy.getDirector()(&req)
-
-			if err != nil {
-				log.Fatal(4, err.Error())
-			}
-
-			Convey("Match header value after decryption", func() {
-				So(req.Header.Get("Authorization"), ShouldEqual, "Bearer xf5yhfkpsnmgo")
 			})
 		})
 

--- a/pkg/models/datasource_cache_test.go
+++ b/pkg/models/datasource_cache_test.go
@@ -191,7 +191,7 @@ func TestDataSourceCache(t *testing.T) {
 		headers := ds.getCustomHeaders()
 
 		Convey("Should match header value after decryption", func() {
-			So(headers["httpHeaderName1"], ShouldEqual, "Bearer xf5yhfkpsnmgo")
+			So(headers["Authorization"], ShouldEqual, "Bearer xf5yhfkpsnmgo")
 		})
 	})
 }

--- a/pkg/models/datasource_cache_test.go
+++ b/pkg/models/datasource_cache_test.go
@@ -31,13 +31,13 @@ func TestDataSourceCache(t *testing.T) {
 			So(t2, ShouldEqual, t1)
 		})
 		Convey("Should verify TLS by default", func() {
-			So(t1.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
+			So(t1.transport.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
 		})
 		Convey("Should have no TLS client certificate configured", func() {
-			So(len(t1.TLSClientConfig.Certificates), ShouldEqual, 0)
+			So(len(t1.transport.TLSClientConfig.Certificates), ShouldEqual, 0)
 		})
 		Convey("Should have no user-supplied TLS CA onfigured", func() {
-			So(t1.TLSClientConfig.RootCAs, ShouldBeNil)
+			So(t1.transport.TLSClientConfig.RootCAs, ShouldBeNil)
 		})
 	})
 
@@ -62,13 +62,13 @@ func TestDataSourceCache(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Should verify TLS by default", func() {
-			So(t1.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
+			So(t1.transport.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
 		})
 		Convey("Should have no TLS client certificate configured", func() {
-			So(len(t1.TLSClientConfig.Certificates), ShouldEqual, 0)
+			So(len(t1.transport.TLSClientConfig.Certificates), ShouldEqual, 0)
 		})
 		Convey("Should have no user-supplied TLS CA configured", func() {
-			So(t1.TLSClientConfig.RootCAs, ShouldBeNil)
+			So(t1.transport.TLSClientConfig.RootCAs, ShouldBeNil)
 		})
 
 		ds.JsonData = nil
@@ -79,7 +79,7 @@ func TestDataSourceCache(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Should have no user-supplied TLS CA configured after the update", func() {
-			So(t2.TLSClientConfig.RootCAs, ShouldBeNil)
+			So(t2.transport.TLSClientConfig.RootCAs, ShouldBeNil)
 		})
 	})
 
@@ -110,10 +110,10 @@ func TestDataSourceCache(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Should verify TLS by default", func() {
-			So(tr.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
+			So(tr.transport.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
 		})
 		Convey("Should have a TLS client certificate configured", func() {
-			So(len(tr.TLSClientConfig.Certificates), ShouldEqual, 1)
+			So(len(tr.transport.TLSClientConfig.Certificates), ShouldEqual, 1)
 		})
 	})
 
@@ -139,10 +139,10 @@ func TestDataSourceCache(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Should verify TLS by default", func() {
-			So(tr.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
+			So(tr.transport.TLSClientConfig.InsecureSkipVerify, ShouldEqual, false)
 		})
 		Convey("Should have a TLS CA configured", func() {
-			So(len(tr.TLSClientConfig.RootCAs.Subjects()), ShouldEqual, 1)
+			So(len(tr.transport.TLSClientConfig.RootCAs.Subjects()), ShouldEqual, 1)
 		})
 	})
 
@@ -163,7 +163,7 @@ func TestDataSourceCache(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Should skip TLS verification", func() {
-			So(tr.TLSClientConfig.InsecureSkipVerify, ShouldEqual, true)
+			So(tr.transport.TLSClientConfig.InsecureSkipVerify, ShouldEqual, true)
 		})
 	})
 }

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -21,11 +21,11 @@ import (
 )
 
 type PrometheusExecutor struct {
-	Transport *http.Transport
+	Transport http.RoundTripper
 }
 
 type basicAuthTransport struct {
-	*http.Transport
+	Transport http.RoundTripper
 
 	username string
 	password string


### PR DESCRIPTION
Reference issue #15381

**Which issue(s) this PR fixes**:

Fixes #15381 

I am not sure whether this pull request fixes the problem for all datasources, but it does fix the Problem for the Prometheus datasource. Thus I have omitted the keyword which automatically closes the referenced issue.

**Special notes for your reviewer**:

This PR does not add any further tests, as I wasn't sure how I can implement the tests for the custom headers. Additionally this breaks the existing `datasource_cache.test` as it is testing the TLS configuration.

What's the best way to handle this? Maintainers' changes obviously welcome.