### PR TITLE
Build: Fix building when $LDFLAGS is set

### DIFF
--- a/build.go
+++ b/build.go
@@ -529,7 +529,7 @@ func ldflags() string {
 	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp()))
 	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", getGitBranch()))
 	if v := os.Getenv("LDFLAGS"); v != "" {
-		b.WriteString(fmt.Sprintf(" -extldflags=%s", v))
+		b.WriteString(fmt.Sprintf(" -extldflags \"%s\"", v))
 	}
 	return b.String()
 }


### PR DESCRIPTION
Signed-off-by: Arve Knudsen <arve.knudsen@gmail.com>

**What this PR does / why we need it**:

This PR fixes the use of the `-extldflags` switch when `$LDFLAGS` is set in the environment, i.e. it replaces the `=` sign with a space and puts double quotes around the argument to `-extldflags` to protect whitespace.

**Which issue(s) this PR fixes**:

Building when `$LDFLAGS` is set, for example to " -L/usr/local/opt/ruby/lib" as it was in my case, which triggered a build failure due to malformed build command.
