### PR TITLE
CloudWatch: Add ap-east-1 to hard-coded region lists

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -285,7 +285,7 @@ func (e *CloudWatchExecutor) handleGetRegions(ctx context.Context, parameters *s
 	}
 
 	regions := []string{
-		"ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1",
+		"ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1",
 		"eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2",
 		"cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-isob-east-1", "us-iso-east-1",
 	}

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -120,8 +120,9 @@ func TestCloudWatchMetrics(t *testing.T) {
 		result, _ := executor.handleGetRegions(context.Background(), simplejson.New(), &tsdb.TsdbQuery{})
 
 		Convey("Should return regions", func() {
-			So(result[0].Text, ShouldEqual, "ap-northeast-1")
-			So(result[1].Text, ShouldEqual, "ap-northeast-2")
+			So(result[0].Text, ShouldEqual, "ap-east-1")
+			So(result[1].Text, ShouldEqual, "ap-northeast-1")
+			So(result[2].Text, ShouldEqual, "ap-northeast-2")
 		})
 	})
 

--- a/public/app/plugins/datasource/cloudwatch/config_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/config_ctrl.ts
@@ -44,6 +44,7 @@ export class CloudWatchConfigCtrl {
   ];
 
   regions = [
+    'ap-east-1',
     'ap-northeast-1',
     'ap-northeast-2',
     'ap-northeast-3',


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a missing region to the CloudWatch plugin.

**Which issue(s) this PR fixes**:

Fixes #17448

