### PR TITLE
Alerting: Fix dates stored in local time when pausing alerts

### DIFF
--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -320,10 +320,10 @@ func PauseAlert(cmd *m.PauseAlertCommand) error {
 		buffer.WriteString(`UPDATE alert SET state = ?, new_state_date = ?`)
 		if cmd.Paused {
 			params = append(params, string(m.AlertStatePaused))
-			params = append(params, timeNow())
+			params = append(params, timeNow().UTC())
 		} else {
 			params = append(params, string(m.AlertStateUnknown))
-			params = append(params, timeNow())
+			params = append(params, timeNow().UTC())
 		}
 
 		buffer.WriteString(` WHERE id IN (?` + strings.Repeat(",?", len(cmd.AlertIds)-1) + `)`)
@@ -351,7 +351,7 @@ func PauseAllAlerts(cmd *m.PauseAllAlertCommand) error {
 			newState = string(m.AlertStateUnknown)
 		}
 
-		res, err := sess.Exec(`UPDATE alert SET state = ?, new_state_date = ?`, newState, timeNow())
+		res, err := sess.Exec(`UPDATE alert SET state = ?, new_state_date = ?`, newState, timeNow().UTC())
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -85,6 +85,12 @@ func TestAlertingDataAccess(t *testing.T) {
 					So(err, ShouldNotBeNil)
 				})
 
+				Convey("alert is paused", func() {
+					alert, _ = getAlertById(1)
+					currentState := alert.State
+					So(currentState, ShouldEqual, "paused")
+				})
+
 				Convey("pausing alerts should update their NewStateDate", func() {
 					alert, _ = getAlertById(1)
 					stateDateAfterPause := alert.NewStateDate

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -14,7 +14,7 @@ func mockTimeNow() {
 	timeNow = func() time.Time {
 		fakeNow := time.Unix(timeSeed, 0)
 		timeSeed++
-		return fakeNow.UTC()
+		return fakeNow
 	}
 }
 
@@ -82,12 +82,6 @@ func TestAlertingDataAccess(t *testing.T) {
 
 					err = SetAlertState(cmd)
 					So(err, ShouldNotBeNil)
-				})
-
-				Convey("alert is paused", func() {
-					alert, _ = getAlertById(1)
-					currentState := alert.State
-					So(currentState, ShouldEqual, "paused")
 				})
 
 				Convey("pausing alerts should update their NewStateDate", func() {

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -12,7 +12,8 @@ import (
 func mockTimeNow() {
 	var timeSeed int64
 	timeNow = func() time.Time {
-		fakeNow := time.Unix(timeSeed, 0)
+		loc := time.FixedZone("MockZoneUTC-5", -5*60*60)
+		fakeNow := time.Unix(timeSeed, 0).In(loc)
 		timeSeed++
 		return fakeNow
 	}

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -14,7 +14,7 @@ func mockTimeNow() {
 	timeNow = func() time.Time {
 		fakeNow := time.Unix(timeSeed, 0)
 		timeSeed++
-		return fakeNow
+		return fakeNow.UTC()
 	}
 }
 
@@ -82,6 +82,12 @@ func TestAlertingDataAccess(t *testing.T) {
 
 					err = SetAlertState(cmd)
 					So(err, ShouldNotBeNil)
+				})
+
+				Convey("alert is paused", func() {
+					alert, _ = getAlertById(1)
+					currentState := alert.State
+					So(currentState, ShouldEqual, "paused")
 				})
 
 				Convey("pausing alerts should update their NewStateDate", func() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->



<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**What this PR does / why we need it**:

When running tests under this service locally, I found the time comparison tests would fail because the comparisons would assume the timestamp generated by the mock was in UTC, with no adjustment for the local timezone when starting the clock at `1970-01-01`, but the system under test would set a new time, using the local time zone and _adjusting_ it for UTC for comparison purposes.

Solve this problem by ensuring the mock starts with the UTC adjustment from the localtime zone, making it more of an apples-to-apples comparison. To wit, this hardens the test such that it can be run locally by a given developer.

Example error snippet below:
```
* /Users/benpatterson/go/src/github.com/grafana/grafana/pkg/services/sqlstore/alert_test.go 
  Line 90:
  Expected '1970-01-01 00:00:13 +0000 UTC' to happen before '1969-12-31 19:00:14 +0000 UTC' (it happened '4h59m59s' after)!

```
Also ensuring alert state is `paused` as an additional test.

**Which issue(s) this PR fixes**:
* There is no logged issue for this problem that I could see.
* Since this is a small adjustment, I felt I could just submit the PR, as per the `CONTRIBUTING` doc.

Thanks!
