### PR TITLE
Loki: remove live option for logs panel

### DIFF
--- a/docs/sources/features/panels/logs.md
+++ b/docs/sources/features/panels/logs.md
@@ -26,12 +26,7 @@ Note that you can scroll inside the panel in case the datasource returns more li
 
 ### Query Options
 
-Some datasources (e.g., Loki) allow the use of **Live** tailing to show a steady stream of log messages.
-When the panel is in **Live** mode, results are directly streamed from the datasource and the dashboard's time range is ignored.
-Note that the streaming can put extra effort on the datasource and your browser.
-Usually, the dashboard-wide refresh should be enough to get a recent set of log lines.
-
-To limit the number of lines rendered, you can use the query-wide **Max data points** setting. If it is not set, the datasource will usually enforce a limit.
+To limit the number of lines rendered, you can use the queries-wide **Max data points** setting. If it is not set, the datasource will usually enforce a limit.
 
 ## Visualization Options
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -3,7 +3,7 @@ import React, { memo } from 'react';
 
 // Types
 import { AbsoluteTimeRange } from '@grafana/data';
-import { QueryEditorProps, Switch, DataSourceStatus } from '@grafana/ui';
+import { QueryEditorProps, DataSourceStatus } from '@grafana/ui';
 import { LokiDatasource } from '../datasource';
 import { LokiQuery } from '../types';
 import { LokiQueryField } from './LokiQueryField';
@@ -51,14 +51,6 @@ export const LokiQueryEditor = memo(function LokiQueryEditor(props: Props) {
         absoluteRange={absolute}
         {...syntaxProps}
       />
-      <div className="gf-form-inline">
-        <div className="gf-form">
-          <Switch label="Live" checked={!!query.live} onChange={() => onChange({ ...query, live: !query.live })} />
-        </div>
-        <div className="gf-form gf-form--grow">
-          <div className="gf-form-label gf-form-label--grow" />
-        </div>
-      </div>
     </div>
   );
 });


### PR DESCRIPTION
The live option for Loki in the logs panels caused a couple of issues:

- Log Panel: Live tailing recreates websocket on refresh #19532
- Log Panel: Selecting Live doesn't trigger a preview. #19530

This PR is a quick-fix to prevent live panel related issues from impacting too many people.

Speaking to the Loki team, they don't see a use for a live option in the dashboards to begin with, since it will be out of sync with the rest of the dashboard.