### PR TITLE
UI: Centers the filter tags in input field

### DIFF
--- a/packages/grafana-ui/src/components/Select/_Select.scss
+++ b/packages/grafana-ui/src/components/Select/_Select.scss
@@ -129,6 +129,11 @@ $select-input-bg-disabled: $input-bg-disabled;
   }
 }
 
+.tag-filter .gf-form-select-box__value-container {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
 .gf-form-select-box__indicators {
   position: absolute;
   height: 100%;

--- a/packages/grafana-ui/src/components/Select/_Select.scss
+++ b/packages/grafana-ui/src/components/Select/_Select.scss
@@ -85,7 +85,6 @@ $select-input-bg-disabled: $input-bg-disabled;
   display: inline-block;
   margin-left: 2px;
   position: relative;
-  top: 3px;
 }
 
 .gf-form-select-box__multi-value__label {
@@ -127,11 +126,6 @@ $select-input-bg-disabled: $input-bg-disabled;
     display: inline-block;
     vertical-align: middle;
   }
-}
-
-.tag-filter .gf-form-select-box__value-container {
-  padding-top: 3px;
-  padding-bottom: 3px;
 }
 
 .gf-form-select-box__indicators {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds correct padding to the tags in filter dropdown multi select.

![image](https://user-images.githubusercontent.com/30407135/65999244-4e875080-e49d-11e9-80ce-7badda31c6cd.png)

**Which issue(s) this PR fixes**:
Fixes #19371


