### PR TITLE
Cherry picks for v6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "private": true,
   "name": "grafana",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "repository": {
     "type": "git",
     "url": "http://github.com/grafana/grafana.git"

--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -155,7 +155,13 @@ func (val *StringMapValue) Value() map[string]string {
 // slices and the actual interpolation is done on all simple string values in the structure. It returns a copy of any
 // map or slice value instead of modifying them in place.
 func tranformInterface(i interface{}) interface{} {
-	switch reflect.TypeOf(i).Kind() {
+	typeOf := reflect.TypeOf(i)
+
+	if typeOf == nil {
+		return nil
+	}
+
+	switch typeOf.Kind() {
 	case reflect.Slice:
 		return transformSlice(i.([]interface{}))
 	case reflect.Map:

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -131,6 +131,8 @@ func TestValues(t *testing.T) {
                      - two
                      - three:
                          inside: $STRING
+                     - six:
+                         empty:
                    four:
                      nested:
                        onemore: $INT
@@ -146,9 +148,16 @@ func TestValues(t *testing.T) {
 					"one": 1,
 					"two": "test",
 					"three": []interface{}{
-						1, "two", anyMap{
+						1,
+						"two",
+						anyMap{
 							"three": anyMap{
 								"inside": "test",
+							},
+						},
+						anyMap{
+							"six": anyMap{
+								"empty": interface{}(nil),
 							},
 						},
 					},
@@ -166,9 +175,16 @@ func TestValues(t *testing.T) {
 					"one": 1,
 					"two": "$STRING",
 					"three": []interface{}{
-						1, "two", anyMap{
+						1,
+						"two",
+						anyMap{
 							"three": anyMap{
 								"inside": "$STRING",
+							},
+						},
+						anyMap{
+							"six": anyMap{
+								"empty": interface{}(nil),
 							},
 						},
 					},


### PR DESCRIPTION
* Provisioning: Handle empty nested keys on YAML provisioning datasources, (#19547), merge-sha: 8e508e5ce48e38d96a5da8cba49f1482c5134601

Also bumps version to 6.4.1