### PR TITLE
Release: Fix issue with tag script on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ lint-go: go-vet golangci-lint revive revive-alerting gosec
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
 shellcheck: $(SH_FILES)
 	@docker run --rm -v "$$PWD:/mnt" koalaman/shellcheck:stable \
-	$(SH_FILES) -e SC1071
+	$(SH_FILES) -e SC1071 -e SC2162
 
 run: scripts/go/bin/bra
 	@scripts/go/bin/bra run

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -31,7 +31,7 @@ git tag -v "${_tag}"
 echo "Make sure the tag is signed as expected"
 echo "press [y] to push the tags"
 
-read -n -r 1 confirm
+read -n 1 confirm
 
 if [ "${confirm}" == "y" ]; then
     git push origin "${_branch}" --tags


### PR DESCRIPTION
Fixes the release script so that it works on osx as well. 