### PR TITLE
Profile: Fix issue with user profile not showing more than sessions sessions in some cases

### DIFF
--- a/public/app/features/profile/ReactProfileWrapper.tsx
+++ b/public/app/features/profile/ReactProfileWrapper.tsx
@@ -23,13 +23,15 @@ export const ReactProfileWrapper = () => (
           )}
           <SharedPreferences resourceUri="user" />
           <UserTeams isLoading={states.loadTeams} loadTeams={api.loadTeams} teams={teams} />
-          <UserOrganizations
-            isLoading={states.loadOrgs}
-            setUserOrg={api.setUserOrg}
-            loadOrgs={api.loadOrgs}
-            orgs={orgs}
-            user={user}
-          />
+          {states.loadUser && (
+            <UserOrganizations
+              isLoading={states.loadOrgs}
+              setUserOrg={api.setUserOrg}
+              loadOrgs={api.loadOrgs}
+              orgs={orgs}
+              user={user}
+            />
+          )}
         </>
       );
     }}

--- a/public/app/features/profile/ReactProfileWrapper.tsx
+++ b/public/app/features/profile/ReactProfileWrapper.tsx
@@ -23,7 +23,7 @@ export const ReactProfileWrapper = () => (
           )}
           <SharedPreferences resourceUri="user" />
           <UserTeams isLoading={states.loadTeams} loadTeams={api.loadTeams} teams={teams} />
-          {states.loadUser && (
+          {!states.loadUser && (
             <UserOrganizations
               isLoading={states.loadOrgs}
               setUserOrg={api.setUserOrg}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
_Bug reproducing_: In profile page (tab `Preference` in menu bar), when we navigate from dashboard to Preference, sometime we get only `Sessions` section, other sections such as `Edit Profile`, `Teams` and `Org.` not found (crashing by `<UserOrganizations/>`). 



**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

Nothing

**Special notes for your reviewer**:

I see profile page use `<react-profile-wrapper>`, which is a component converted from React to Angular. In `<react-profile-wrapper>`, component `<UserOrganizations/>` will be crashed if prop `user` is `null` (because inside `<UserOrganizations/>`, we accesses `user.orgId`).

I've fixed this bug by checking whether `user` was loaded.
