### PR TITLE
Editor: Use font awesome icons on the dashboard settings header

### DIFF
--- a/public/app/features/annotations/partials/editor.html
+++ b/public/app/features/annotations/partials/editor.html
@@ -2,8 +2,8 @@
   <div class="page-action-bar">
     <h3 class="dashboard-settings__header">
       <a ng-click="ctrl.backToList()">Annotations</a>
-      <span ng-show="ctrl.mode === 'new'">&gt; New</span>
-      <span ng-show="ctrl.mode === 'edit'">&gt; Edit</span>
+      <span ng-show="ctrl.mode === 'new'"><i class="fa fa-fw fa-chevron-right"></i> New</span>
+      <span ng-show="ctrl.mode === 'edit'"><i class="fa fa-fw fa-chevron-right"></i> Edit</span>
     </h3>
 
     <div class="page-action-bar__spacer"></div>

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -1,8 +1,8 @@
 <div class="page-action-bar">
   <h3 class="dashboard-settings__header">
     <a ng-click="ctrl.backToList()">Dashboard Links</a>
-    <span ng-show="ctrl.mode === 'new'">&gt; New</span>
-    <span ng-show="ctrl.mode === 'edit'">&gt; Edit</span>
+    <span ng-show="ctrl.mode === 'new'"><i class="fa fa-fw fa-chevron-right"></i> New</span>
+    <span ng-show="ctrl.mode === 'edit'"><i class="fa fa-fw fa-chevron-right"></i> Edit</span>
   </h3>
 
   <div class="page-action-bar__spacer"></div>

--- a/public/app/features/dashboard/components/VersionHistory/template.html
+++ b/public/app/features/dashboard/components/VersionHistory/template.html
@@ -1,7 +1,7 @@
 <h3 class="dashboard-settings__header">
   <a ng-click="ctrl.switchMode('list')">Versions</a>
   <span ng-show="ctrl.mode === 'compare'">
-    &gt; Comparing {{ctrl.baseInfo.version}}
+    <i class="fa fa-fw fa-chevron-right"></i> Comparing {{ctrl.baseInfo.version}}
     <i class="fa fa-arrows-h"></i>
     {{ctrl.newInfo.version}}
     <cite class="muted" ng-if="ctrl.isNewLatest">(Latest)</cite>

--- a/public/app/features/templating/partials/editor.html
+++ b/public/app/features/templating/partials/editor.html
@@ -2,8 +2,8 @@
   <div class="page-action-bar">
     <h3 class="dashboard-settings__header">
       <a ng-click="setMode('list')">Variables</a>
-      <span ng-show="mode === 'new'">&gt; New</span>
-      <span ng-show="mode === 'edit'">&gt; Edit</span>
+      <span ng-show="mode === 'new'"><i class="fa fa-fw fa-chevron-right"></i> New</span>
+      <span ng-show="mode === 'edit'"><i class="fa fa-fw fa-chevron-right"></i> Edit</span>
     </h3>
 
     <div class="page-action-bar__spacer"></div>


### PR DESCRIPTION
I've never really liked the usage of the `&gt;` character in the header of the dashboard settings. It has always looked a bit off to me. I know that this is not a huge problem for anyone but, even though the font awesome chevrons are not great, I think it looks better than the character from the Roboto font.

This PR replaces the `&gt;` on the headers of the dashboard settings and uses the font awesome chevron right icon instead.

Before:
![image](https://user-images.githubusercontent.com/1291846/66087256-1ce2b800-e577-11e9-89a2-8a86d2ea1911.png)

After:
![image](https://user-images.githubusercontent.com/1291846/66087585-4b14c780-e578-11e9-956e-b643f91a6b89.png)

Ideally, I would prefer to use a thinner icon, but since font awesome is already used through the Grafana UI I think this is better for the scope of this PR.