### PR TITLE
Show SAML login button if SAML is enabled

### DIFF
--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -41,24 +41,7 @@ export const LoginPage: FC = () => {
                   />
                 ) : null}
 
-                {isOauthEnabled ? (
-                  <>
-                    <div className="text-center login-divider">
-                      <div>
-                        <div className="login-divider-line" />
-                      </div>
-                      <div>
-                        <span className="login-divider-text">{disableLoginForm ? null : <span>or</span>}</span>
-                      </div>
-                      <div>
-                        <div className="login-divider-line" />
-                      </div>
-                    </div>
-                    <div className="clearfix" />
-
-                    <LoginServiceButtons />
-                  </>
-                ) : null}
+                <LoginServiceButtons />
                 {!disableUserSignUp ? <UserSignup /> : null}
               </div>
               <CSSTransition

--- a/public/app/core/components/Login/LoginServiceButtons.tsx
+++ b/public/app/core/components/Login/LoginServiceButtons.tsx
@@ -46,12 +46,8 @@ export interface LoginServices {
   [key: string]: LoginService;
 }
 
-const LoginDivider = (keyNames: string[]) => {
-  const serviceElementsEnabled = keyNames.filter(key => {
-    const service: LoginService = loginServices()[key];
-    return service.enabled;
-  });
-  return serviceElementsEnabled.length > 0 ? (
+const LoginDivider = () => {
+  return (
     <>
       <div className="text-center login-divider">
         <div>
@@ -66,14 +62,23 @@ const LoginDivider = (keyNames: string[]) => {
       </div>
       <div className="clearfix" />
     </>
-  ) : null;
+  );
 };
 
 export const LoginServiceButtons = () => {
   const keyNames = Object.keys(loginServices());
-  const serviceElements = keyNames.map(key => {
+  const serviceElementsEnabled = keyNames.filter(key => {
     const service: LoginService = loginServices()[key];
-    return service.enabled ? (
+    return service.enabled;
+  });
+
+  if (serviceElementsEnabled.length === 0) {
+    return null;
+  }
+
+  const serviceElements = serviceElementsEnabled.map(key => {
+    const service: LoginService = loginServices()[key];
+    return (
       <a
         key={key}
         className={`btn btn-medium btn-service btn-service--${service.className || key} login-btn`}
@@ -83,10 +88,10 @@ export const LoginServiceButtons = () => {
         <i className={`btn-service-icon fa fa-${service.icon ? service.icon : key}`} />
         Sign in with {service.name}
       </a>
-    ) : null;
+    );
   });
 
-  const divider = LoginDivider(keyNames);
+  const divider = LoginDivider();
   return (
     <>
       {divider}

--- a/public/app/core/components/Login/LoginServiceButtons.tsx
+++ b/public/app/core/components/Login/LoginServiceButtons.tsx
@@ -46,6 +46,29 @@ export interface LoginServices {
   [key: string]: LoginService;
 }
 
+const LoginDivider = (keyNames: string[]) => {
+  const serviceElementsEnabled = keyNames.filter(key => {
+    const service: LoginService = loginServices()[key];
+    return service.enabled;
+  });
+  return serviceElementsEnabled.length > 0 ? (
+    <>
+      <div className="text-center login-divider">
+        <div>
+          <div className="login-divider-line" />
+        </div>
+        <div>
+          <span className="login-divider-text">{config.disableLoginForm ? null : <span>or</span>}</span>
+        </div>
+        <div>
+          <div className="login-divider-line" />
+        </div>
+      </div>
+      <div className="clearfix" />
+    </>
+  ) : null;
+};
+
 export const LoginServiceButtons = () => {
   const keyNames = Object.keys(loginServices());
   const serviceElements = keyNames.map(key => {
@@ -63,5 +86,11 @@ export const LoginServiceButtons = () => {
     ) : null;
   });
 
-  return <div className="login-oauth text-center">{serviceElements}</div>;
+  const divider = LoginDivider(keyNames);
+  return (
+    <>
+      {divider}
+      <div className="login-oauth text-center">{serviceElements}</div>
+    </>
+  );
 };


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
SAML login was not shown despite having SAML enabled and being on Enterprise version.
Move wrapping elements inside LoginServiceButtons as suggested [here](https://github.com/grafana/grafana/pull/19580#discussion_r330675700).

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19572

**Special notes for your reviewer**:

- This is alternative fix for #19580

- If the login form is disabled and at least a login service is enabled the divider line is still shown. I guess that is not something we do not want. So, I tried to removed it but then the button text was not wrapped correctly and I didn't know how to fix it.