### PR TITLE
Repo docs: Update pkg\README.md

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,45 +1,46 @@
 # Grafana backend codebase
 
-The code [styleguide](/contribute/style-guides/backend.md) and brief description of the [architecture](ARCHITECTURE.md)
+The code should follow the [Backend style guide](/contribute/style-guides/backend.md). 
 
-# Ongoing refactorings
+Refer to [architecture](ARCHITECTURE.md) for a description of the backend codebase architecture.
 
-These issues are not something we want to address all at once but something we will improve over time. Since Grafana is released at a regular schedule the preferred approach is to do this in batches. Not only is it easier to review, but it also reduces the risk of conflicts when cherry-picking fixes from master to release branches. Please try to submit changes that span multiple locations at the end of the release cycle. We prefer waiting until the end because we make fewer patch releases at the end of the release cycle, so there are fewer opportunities for complications.
+## Ongoing refactoring
+
+These issues are not something we want to address all at once but something we will improve incrementally. Since Grafana is released at a regular schedule the preferred approach is to do this in batches. Not only is it easier to review, but it also reduces the risk of conflicts when cherry-picking fixes from master to release branches. Please try to submit changes that span multiple locations at the end of the release cycle. We prefer to wait until the end because we make fewer patch releases at the end of the release cycle, so there are fewer opportunities for complications.
 
 ## Global state
 
-Global state makes testing and debugging software harder and its something we want to avoid when possible.
-Unfortunately, there is quite a lot of global state in Grafana. The way we want to migrate away from this
-is to use the `inject` package to wire up all dependencies either in `pkg/cmd/grafana-server/main.go` or
-self registering using `registry.RegisterService` ex https://github.com/grafana/grafana/blob/master/pkg/services/cleanup/cleanup.go#L25
+Global state makes testing and debugging software harder and it's something we want to avoid when possible. Unfortunately, there is quite a lot of global state in Grafana. 
 
-## Reduce the use of the init() function
+We want to migrate away from this by using the `inject` package to wire up all dependencies either in `pkg/cmd/grafana-server/main.go` or self-registering using `registry.RegisterService` ex https://github.com/grafana/grafana/blob/master/pkg/services/cleanup/cleanup.go#L25.
 
-Should only be used to register services/implementations.
+## Limit the use of the init() function
+
+Only use the init() function to register services/implementations.
 
 ## Settings refactoring
 
-The plan is to move all settings to from package level vars in settings package to the [setting.Cfg](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/setting/setting.go#L210) struct. To access the settings services/components can inject this setting.Cfg struct.
+The plan is to move all settings to from package level vars in settings package to the [setting.Cfg](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/setting/setting.go#L210) struct. To access the settings, services and components can inject this setting.Cfg struct:
 
 [Cfg struct](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/setting/setting.go#L210)
 [Injection example](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/services/cleanup/cleanup.go#L20)
 
-## Reduce the use of Goconvey
+## Reduce the use of GoConvey
 
-We want to migrated away from using Goconvey and use stdlib testing as its the most common approuch in the GO community and we think it will make it easier for new contributors. Read more about how we want to write tests in the [ARCHITECTURE.MD](ARCHITECTURE.md#Testing) docs.
+We want to migrate away from using GoConvey. Instead, we want to use stdlib testing, because it's the most common approach in the Go community and we think it will be easier for new contributors. Read more about how we want to write tests in [ARCHITECTURE.MD](ARCHITECTURE.md#Testing).
 
-## Sqlstore refactoring
+## SQLStore refactoring
 
-The sqlstore handlers all use a global xorm engine variable. This should be refactored to use the Sqlstore instance.
+The SQLStore handlers all use a global xorm engine variable. Refactor them to use the SQLStore instance.
 
-## Avoid global HTTP Handler functions
+## Avoid global HTTP handler functions
 
-HTTP handlers should be refactored to so the handler methods are on the HttpServer instance or a more detailed handler struct. E.g (AuthHandler). This way they get access to HttpServer service dependencies (& Cfg object) and can avoid global state
+Refactor HTTP handlers so that the handler methods are on the HttpServer instance or a more detailed handler struct. E.g (AuthHandler). This ensures they get access to HttpServer service dependencies (and Cfg object) and can avoid global state.
 
 ## Date comparison
 
-Newly introduced date columns in the database should be stored as epochs if date comparison is required. This permits to have a unifed approach for comparing dates against all the supported databases instead of handling seperately each one of them. In addition to this, by comparing epochs error pruning transformations from/to other time zones are no more needed.
+Store newly introduced date columns in the database as epochs if they require date comparison. This permits a unified approach for comparing dates against all the supported databases instead of handling each one separately. Also, by comparing epochs, we no longer need error pruning transformations to and from other time zones.
 
-# Dependency management
+## Dependency management
 
-Documented in [UPDRAGING_DEPENDENCIES.md](https://github.com/grafana/grafana/blob/master/UPGRADING_DEPENDENCIES.md).
+Refer to [UPGRADING_DEPENDENCIES.md](https://github.com/grafana/grafana/blob/master/UPGRADING_DEPENDENCIES.md).

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -29,9 +29,11 @@ The plan is to move all settings to from package level vars in settings package 
 
 We want to migrate away from using GoConvey. Instead, we want to use stdlib testing, because it's the most common approach in the Go community and we think it will be easier for new contributors. Read more about how we want to write tests in [ARCHITECTURE.MD](ARCHITECTURE.md#Testing).
 
-## SQLStore refactoring
+## Refactor SqlStore
 
-The SQLStore handlers all use a global xorm engine variable. Refactor them to use the SQLStore instance.
+The `sqlstore` handlers all use a global xorm engine variable. Refactor them to use the `SqlStore` instance.
+
+In the long term, all instances should change to SQLStore. Refer to Issue ##### for more information.
 
 ## Avoid global HTTP handler functions
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,6 +1,6 @@
 # Grafana backend codebase
 
-The code should follow the [Backend style guide](/contribute/style-guides/backend.md). 
+The code should follow the [Backend style guide](/contribute/style-guides/backend.md).
 
 Refer to [architecture](ARCHITECTURE.md) for a description of the backend codebase architecture.
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -33,15 +33,13 @@ We want to migrate away from using GoConvey. Instead, we want to use stdlib test
 
 The `sqlstore` handlers all use a global xorm engine variable. Refactor them to use the `SqlStore` instance.
 
-In the long term, all instances should change to SQLStore. Refer to Issue ##### for more information.
-
 ## Avoid global HTTP handler functions
 
 Refactor HTTP handlers so that the handler methods are on the HttpServer instance or a more detailed handler struct. E.g (AuthHandler). This ensures they get access to HttpServer service dependencies (and Cfg object) and can avoid global state.
 
 ## Date comparison
 
-Store newly introduced date columns in the database as epochs if they require date comparison. This permits a unified approach for comparing dates against all the supported databases instead of handling each one separately. Also, by comparing epochs, we no longer need error pruning transformations to and from other time zones.
+Store newly introduced date columns in the database as epochs if they require date comparison. This permits a unified approach for comparing dates against all the supported databases instead of handling dates differently for each database. Also, by comparing epochs, we no longer need error pruning transformations to and from other time zones.
 
 ## Dependency management
 


### PR DESCRIPTION
Grammar and spelling edits

**What this PR does / why we need it**: Improves readability and makes the document look more professional.

**Special notes for your reviewer**: There is an unclear antecedent in line 42:
> This permits a unified approach for comparing dates against all the supported databases instead of handling each one separately.

What is "one"? Is it supported databases, dates, or date comparisons? 

