### PR TITLE
DataFormats: When transforming TableModel -> DataFrame -> Table preserve the type attribute

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -124,11 +124,13 @@ describe('SerisData backwards compatibility', () => {
     const table = {
       columns: [],
       rows: [],
+      type: 'table',
     };
 
     const series = toDataFrame(table);
     const roundtrip = toLegacyResponseData(series) as TableData;
     expect(roundtrip.columns.length).toBe(0);
+    expect(roundtrip.type).toBe('table');
   });
 
   it('converts TableData to series and back again', () => {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -299,6 +299,7 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
       }
       return { text: name };
     }),
+    type: 'table',
     refId: frame.refId,
     meta: frame.meta,
     rows,

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -47,6 +47,7 @@ export interface TableData extends QueryResultBase {
   name?: string;
   columns: Column[];
   rows: any[][];
+  type?: string;
 }
 
 export type TimeSeriesValue = number | null;


### PR DESCRIPTION
Not sure where I saw an issue that encountered this, could not find it now. 