### PR TITLE
Graph: Switching to series mode should re-render graph

### DIFF
--- a/public/app/plugins/panel/graph/axes_editor.ts
+++ b/public/app/plugins/panel/graph/axes_editor.ts
@@ -1,8 +1,9 @@
 import { getValueFormats } from '@grafana/ui';
+import { GraphCtrl } from './module';
 
 export class AxesEditorCtrl {
   panel: any;
-  panelCtrl: any;
+  panelCtrl: GraphCtrl;
   unitFormats: any;
   logScales: any;
   xAxisModes: any;
@@ -11,7 +12,7 @@ export class AxesEditorCtrl {
 
   /** @ngInject */
   constructor(private $scope: any) {
-    this.panelCtrl = $scope.ctrl;
+    this.panelCtrl = $scope.ctrl as GraphCtrl;
     this.panel = this.panelCtrl.panel;
     this.$scope.ctrl = this;
 
@@ -59,11 +60,11 @@ export class AxesEditorCtrl {
 
   xAxisModeChanged() {
     this.panelCtrl.processor.setPanelDefaultsForNewXAxisMode();
-    this.panelCtrl.onDataReceived(this.panelCtrl.dataList);
+    this.panelCtrl.onDataFramesReceived(this.panelCtrl.dataList);
   }
 
   xAxisValueChanged() {
-    this.panelCtrl.onDataReceived(this.panelCtrl.dataList);
+    this.panelCtrl.onDataFramesReceived(this.panelCtrl.dataList);
   }
 }
 


### PR DESCRIPTION
Fixes #19279 

When you changed Graph axis mode it tried to call old onDataReceived function, so the graph did not update. 