### PR TITLE
CLI: Reduce memory usage for plugin installation

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commandstest/fake_api_client.go
+++ b/pkg/cmd/grafana-cli/commands/commandstest/fake_api_client.go
@@ -1,12 +1,14 @@
 package commandstest
 
 import (
+	"os"
+
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
 type FakeGrafanaComClient struct {
 	GetPluginFunc      func(pluginId, repoUrl string) (models.Plugin, error)
-	DownloadFileFunc   func(pluginName, filePath, url string, checksum string) (content []byte, err error)
+	DownloadFileFunc   func(pluginName string, tmpFile *os.File, url string, checksum string) (err error)
 	ListAllPluginsFunc func(repoUrl string) (models.PluginRepo, error)
 }
 
@@ -18,12 +20,12 @@ func (client *FakeGrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.
 	return models.Plugin{}, nil
 }
 
-func (client *FakeGrafanaComClient) DownloadFile(pluginName, filePath, url string, checksum string) (content []byte, err error) {
+func (client *FakeGrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error) {
 	if client.DownloadFileFunc != nil {
-		return client.DownloadFileFunc(pluginName, filePath, url, checksum)
+		return client.DownloadFileFunc(pluginName, tmpFile, url, checksum)
 	}
 
-	return make([]byte, 0), nil
+	return nil
 }
 
 func (client *FakeGrafanaComClient) ListAllPlugins(repoUrl string) (models.PluginRepo, error) {

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -107,12 +108,19 @@ func InstallPlugin(pluginName, version string, c utils.CommandLine) error {
 	logger.Infof("into: %v\n", pluginFolder)
 	logger.Info("\n")
 
-	content, err := c.ApiClient().DownloadFile(pluginName, pluginFolder, downloadURL, checksum)
+	// Create temp file for downloading zip file
+	tmpFile, err := ioutil.TempFile("", "*.zip")
+	if err != nil {
+		errutil.Wrap("Failed to create temporary file", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	err = c.ApiClient().DownloadFile(pluginName, tmpFile, downloadURL, checksum)
 	if err != nil {
 		return errutil.Wrap("Failed to download plugin archive", err)
 	}
 
-	err = extractFiles(content, pluginName, pluginFolder, isInternal)
+	err = extractFiles(tmpFile.Name(), pluginName, pluginFolder, isInternal)
 	if err != nil {
 		return errutil.Wrap("Failed to extract plugin archive", err)
 	}
@@ -194,8 +202,10 @@ func RemoveGitBuildFromName(pluginName, filename string) string {
 
 var permissionsDeniedMessage = "Could not create %s. Permission denied. Make sure you have write access to plugindir"
 
-func extractFiles(body []byte, pluginName string, filePath string, allowSymlinks bool) error {
-	r, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+func extractFiles(archiveFile string, pluginName string, filePath string, allowSymlinks bool) error {
+	logger.Debugf("Extracting archive %v to %v...\n", archiveFile, filePath)
+
+	r, err := zip.OpenReader(archiveFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -111,13 +111,18 @@ func InstallPlugin(pluginName, version string, c utils.CommandLine) error {
 	// Create temp file for downloading zip file
 	tmpFile, err := ioutil.TempFile("", "*.zip")
 	if err != nil {
-		errutil.Wrap("Failed to create temporary file", err)
+		return errutil.Wrap("Failed to create temporary file", err)
 	}
 	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
 
 	err = c.ApiClient().DownloadFile(pluginName, tmpFile, downloadURL, checksum)
 	if err != nil {
 		return errutil.Wrap("Failed to download plugin archive", err)
+	}
+	err = tmpFile.Close()
+	if err != nil {
+		return errutil.Wrap("Failed to close tmp file", err)
 	}
 
 	err = extractFiles(tmpFile.Name(), pluginName, pluginFolder, isInternal)

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -114,10 +114,10 @@ func InstallPlugin(pluginName, version string, c utils.CommandLine) error {
 		return errutil.Wrap("Failed to create temporary file", err)
 	}
 	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
 
 	err = c.ApiClient().DownloadFile(pluginName, tmpFile, downloadURL, checksum)
 	if err != nil {
+		tmpFile.Close()
 		return errutil.Wrap("Failed to download plugin archive", err)
 	}
 	err = tmpFile.Close()

--- a/pkg/cmd/grafana-cli/commands/install_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/install_command_test.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -52,10 +52,8 @@ func TestExtractFiles(t *testing.T) {
 		pluginDir, del := setupFakePluginsDir(t)
 		defer del()
 
-		body, err := ioutil.ReadFile("testdata/grafana-simple-json-datasource-ec18fa4da8096a952608a7e4c7782b4260b41bcf.zip")
-		assert.Nil(t, err)
-
-		err = extractFiles(body, "grafana-simple-json-datasource", pluginDir, false)
+		archive := "testdata/grafana-simple-json-datasource-ec18fa4da8096a952608a7e4c7782b4260b41bcf.zip"
+		err := extractFiles(archive, "grafana-simple-json-datasource", pluginDir, false)
 		assert.Nil(t, err)
 
 		//File in zip has permissions 755
@@ -83,10 +81,7 @@ func TestExtractFiles(t *testing.T) {
 		pluginDir, del := setupFakePluginsDir(t)
 		defer del()
 
-		body, err := ioutil.ReadFile("testdata/plugin-with-symlink.zip")
-		assert.Nil(t, err)
-
-		err = extractFiles(body, "plugin-with-symlink", pluginDir, false)
+		err := extractFiles("testdata/plugin-with-symlink.zip", "plugin-with-symlink", pluginDir, false)
 		assert.Nil(t, err)
 
 		_, err = os.Stat(pluginDir + "/plugin-with-symlink/text.txt")
@@ -100,10 +95,7 @@ func TestExtractFiles(t *testing.T) {
 		pluginDir, del := setupFakePluginsDir(t)
 		defer del()
 
-		body, err := ioutil.ReadFile("testdata/plugin-with-symlink.zip")
-		assert.Nil(t, err)
-
-		err = extractFiles(body, "plugin-with-symlink", pluginDir, true)
+		err := extractFiles("testdata/plugin-with-symlink.zip", "plugin-with-symlink", pluginDir, true)
 		assert.Nil(t, err)
 
 		_, err = os.Stat(pluginDir + "/plugin-with-symlink/symlink_to_txt")
@@ -228,13 +220,17 @@ func setupPluginInstallCmd(t *testing.T, pluginDir string) utils.CommandLine {
 		return plugin, nil
 	}
 
-	client.DownloadFileFunc = func(pluginName, filePath, url string, checksum string) (content []byte, err error) {
+	client.DownloadFileFunc = func(pluginName string, tmpFile *os.File, url string, checksum string) (err error) {
 		assert.Equal(t, "test-plugin-panel", pluginName)
 		assert.Equal(t, "/test-plugin-panel/versions/1.0.0/download", url)
 		assert.Equal(t, "test", checksum)
-		body, err := ioutil.ReadFile("testdata/grafana-simple-json-datasource-ec18fa4da8096a952608a7e4c7782b4260b41bcf.zip")
+		f, err := os.Open("testdata/grafana-simple-json-datasource-ec18fa4da8096a952608a7e4c7782b4260b41bcf.zip")
 		assert.Nil(t, err)
-		return body, nil
+		_, err = io.Copy(tmpFile, f)
+		assert.Nil(t, err)
+		err = tmpFile.Close()
+		assert.Nil(t, err)
+		return nil
 	}
 
 	cmd.Client = client

--- a/pkg/cmd/grafana-cli/commands/install_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/install_command_test.go
@@ -228,8 +228,6 @@ func setupPluginInstallCmd(t *testing.T, pluginDir string) utils.CommandLine {
 		assert.Nil(t, err)
 		_, err = io.Copy(tmpFile, f)
 		assert.Nil(t, err)
-		err = tmpFile.Close()
-		assert.Nil(t, err)
 		return nil
 	}
 

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -67,11 +67,11 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 				logger.Info("Failed downloading. Will retry once.")
 				err = tmpFile.Truncate(0)
 				if err != nil {
-					panic(err)
+					return
 				}
 				_, err = tmpFile.Seek(0, 0)
 				if err != nil {
-					panic(err)
+					return
 				}
 				err = client.DownloadFile(pluginName, tmpFile, url, checksum)
 			} else {

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -65,8 +65,14 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 			client.retryCount++
 			if client.retryCount < 3 {
 				logger.Info("Failed downloading. Will retry once.")
-				tmpFile.Truncate(0)
-				tmpFile.Seek(0, 0)
+				err = tmpFile.Truncate(0)
+				if err != nil {
+					panic(err)
+				}
+				_, err = tmpFile.Seek(0, 0)
+				if err != nil {
+					panic(err)
+				}
 				err = client.DownloadFile(pluginName, tmpFile, url, checksum)
 			} else {
 				client.retryCount = 0
@@ -147,6 +153,9 @@ func createRequest(repoUrl string, subPaths ...string) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	req.Header.Set("grafana-version", grafanaVersion)
 	req.Header.Set("grafana-os", runtime.GOOS)

--- a/pkg/cmd/grafana-cli/services/api_client_test.go
+++ b/pkg/cmd/grafana-cli/services/api_client_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestHandleResponse(t *testing.T) {
 	t.Run("Returns body if status == 200", func(t *testing.T) {
-		body, err := handleResponse(makeResponse(200, "test"))
+		bodyReader, err := handleResponse(makeResponse(200, "test"))
 		assert.Nil(t, err)
+		body, _ := ioutil.ReadAll(bodyReader)
 		assert.Equal(t, "test", string(body))
 	})
 

--- a/pkg/cmd/grafana-cli/services/api_client_test.go
+++ b/pkg/cmd/grafana-cli/services/api_client_test.go
@@ -13,8 +13,9 @@ import (
 func TestHandleResponse(t *testing.T) {
 	t.Run("Returns body if status == 200", func(t *testing.T) {
 		bodyReader, err := handleResponse(makeResponse(200, "test"))
-		assert.Nil(t, err)
-		body, _ := ioutil.ReadAll(bodyReader)
+		assert.NoError(t, err)
+		body, err := ioutil.ReadAll(bodyReader)
+		assert.NoError(t, err)
 		assert.Equal(t, "test", string(body))
 	})
 
@@ -25,25 +26,25 @@ func TestHandleResponse(t *testing.T) {
 
 	t.Run("Returns message from body if status == 400", func(t *testing.T) {
 		_, err := handleResponse(makeResponse(400, "{ \"message\": \"error_message\" }"))
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, "error_message", asBadRequestError(t, err).Message)
 	})
 
 	t.Run("Returns body if status == 400 and no message key", func(t *testing.T) {
 		_, err := handleResponse(makeResponse(400, "{ \"test\": \"test_message\"}"))
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Equal(t, "{ \"test\": \"test_message\"}", asBadRequestError(t, err).Message)
 	})
 
 	t.Run("Returns Bad request error if status == 400 and no body", func(t *testing.T) {
 		_, err := handleResponse(makeResponse(400, ""))
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		_ = asBadRequestError(t, err)
 	})
 
 	t.Run("Returns error with invalid status if status == 500", func(t *testing.T) {
 		_, err := handleResponse(makeResponse(500, ""))
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
 }

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+
 	"github.com/codegangsta/cli"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
@@ -27,7 +29,7 @@ type CommandLine interface {
 
 type ApiClient interface {
 	GetPlugin(pluginId, repoUrl string) (models.Plugin, error)
-	DownloadFile(pluginName, filePath, url string, checksum string) (content []byte, err error)
+	DownloadFile(pluginName string, tmpFile *os.File, url string, checksum string) (err error)
 	ListAllPlugins(repoUrl string) (models.PluginRepo, error)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When `grafana-cli` installs a plugin, it downloads the zip file from Grafana plugin repository, verifies the checksum and extract files, all in memory.

For a plugin with a large file, such as `grafana-image-renderer` (114 MB on Linux), it causes an out-of-memory error in environments with memory constraints.

Example on a Docker container with 100 MB memory limit:
```
➜ ~ docker run --rm --name grafana -e "GF_INSTALL_PLUGINS=grafana-image-renderer" --memory 100m grafana/grafana
installing grafana-image-renderer @ 1.0.5
from: https://grafana.com/api/plugins/grafana-image-renderer/versions/1.0.5/download
into: /var/lib/grafana/plugins

/run.sh: line 68:    10 Killed              grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
```

Docker container is then killed.

With this pull request, the archive file content is never kept in memory as `[]byte`:
- md5 checksum is done in streaming
- zip file is written to a temporary file before uncompressing (unlike tar.gz, zip files cannot be opened in streaming).

Example with the same plugin and the same memory constraint:

```
➜ ~ docker run --rm --name grafana -e "GF_INSTALL_PLUGINS=grafana-image-renderer" --memory 100m grafana/grafana:dev
installing grafana-image-renderer @ 1.0.5
from: https://grafana.com/api/plugins/grafana-image-renderer/versions/1.0.5/download
into: /var/lib/grafana/plugins

✔ Installed grafana-image-renderer successfully 

Restart grafana after installing plugins . <service grafana-server restart>

t=2019-10-05T18:07:16+0000 lvl=info msg="Starting Grafana" logger=server version=6.5.0-pre commit=unknown-dev branch=master compiled=2019-10-05T17:23:25+0000
...
```

Please note that it also works with local zip files:
```
➜ ~ docker run --rm -d --name grafana --memory 100m grafana/grafana:dev
9f854043b0ab6c19fb42f56929fb18ba46ca7ee7e82a7fa33b79648c4ddeea97
➜ ~ docker exec -ti grafana bash
bash-5.0$ cd /tmp
bash-5.0$ wget https://github.com/grafana/grafana-image-renderer/releases/download/v1.0.5/plugin-linux-x64-glibc.zip
Connecting to github.com (140.82.118.3:443)
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (52.217.32.180:443)
plugin-linux-x64-gli 100% |*******************************************************************************************************************************************************************|  113M  0:00:00 ETA
bash-5.0$ grafana-cli --pluginUrl /tmp/plugin-linux-x64-glibc.zip plugins install grafana-image-renderer
installing grafana-image-renderer @ 
from: /tmp/plugin-linux-x64-glibc.zip
into: /var/lib/grafana/plugins

✔ Installed grafana-image-renderer successfully 

Restart grafana after installing plugins . <service grafana-server restart>

bash-5.0$ grafana-cli plugins ls
installed plugins:
grafana-image-renderer @ 1.0.5 
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Please also note there was a "TODO" comment in the code to change the way the archive file was downloaded: https://github.com/grafana/grafana/blob/3e603cd8/pkg/cmd/grafana-cli/services/api_client.go#L75

