### PR TITLE
Improve scripts/build/ci-build/build-deploy.sh script

### DIFF
--- a/scripts/build/ci-build/README.md
+++ b/scripts/build/ci-build/README.md
@@ -18,3 +18,6 @@ This is a container for cross-platform builds of Grafana. You can run it locally
 * `make attach`
   - Opens bash within the running container
 
+## Build/Publish Docker Image
+In order to build and publish the Grafana build Docker image, execute the following:
+`./build-deploy.sh`.

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+set -eo pipefail
 
 _version="1.2.9"
 _tag="grafana/build-container:${_version}"
+
+_dpath=$(dirname "${BASH_SOURCE[0]}")
+cd "$_dpath"
 
 docker build -t $_tag .
 docker push $_tag


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve scripts/build/ci-build/build-deploy.sh to change its location to the containing directory, so it can be executed from anywhere. Also configure the shell so that it exits on failure (`-eo pipefail`), to stop it from continuing for example after hitting Ctrl+C while it builds.

**Which issue(s) this PR fixes**:
