### PR TITLE
Rename live option in queries

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -33,7 +33,7 @@ import {
   isDateTime,
   dateTimeForTimeZone,
 } from '@grafana/data';
-import { ExploreId, ExploreUIState, ExploreMode } from 'app/types/explore';
+import { ExploreId, ExploreUIState, ExploreMode, QueryOptions } from 'app/types/explore';
 import {
   updateDatasourceInstanceAction,
   changeQueryAction,
@@ -463,12 +463,12 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
 
     stopQueryState(querySubscription);
 
-    const queryOptions = {
+    const queryOptions: QueryOptions = {
       minInterval,
       // This is used for logs streaming for buffer size, with undefined it falls back to datasource config if it
       // supports that.
       maxDataPoints: mode === ExploreMode.Logs ? undefined : containerWidth,
-      live,
+      liveStreaming: live,
       showingGraph,
       showingTable,
     };

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -797,7 +797,7 @@ describe('ElasticResponse', () => {
           interval: '10s',
           isLogsQuery: true,
           key: 'Q-1561369883389-0.7611823271062786-0',
-          live: false,
+          liveStreaming: false,
           maxDataPoints: 1620,
           query: '',
           timeField: '@timestamp',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -216,7 +216,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     const subQueries = options.targets
       .filter(target => target.expr && !target.hide)
       .map(target => {
-        if (target.live) {
+        if (target.liveStreaming) {
           return this.runLiveQuery(options, target);
         }
         return this.runQuery(options, target);

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -3,7 +3,7 @@ import { Labels } from '@grafana/data';
 
 export interface LokiQuery extends DataQuery {
   expr: string;
-  live?: boolean;
+  liveStreaming?: boolean;
   query?: string;
   regexp?: string;
 }

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -345,7 +345,9 @@ export interface QueryIntervals {
 export interface QueryOptions {
   minInterval: string;
   maxDataPoints?: number;
-  live?: boolean;
+  liveStreaming?: boolean;
+  showingGraph?: boolean;
+  showingTable?: boolean;
 }
 
 export interface QueryTransaction {


### PR DESCRIPTION
- Live tailing in loki panels had some issues in 6.4, so we removed the live option in 6.4.1
- users who had enabled live and saved the panels in 6.4 and then upgraded to 6.4.1 could no longer switch off live
- this PR renames `live` in query options so that Loki panels that enabled Live in 6.4 are simply being ignored.

Related to #19533

To test: create panel with live option (needs 6.4.0), and then load that dashboard with Grafana from this PR.