### PR TITLE
Emails: update templates (copyright year)

### DIFF
--- a/emails/package.json
+++ b/emails/package.json
@@ -13,16 +13,14 @@
     "start": "grunt watch"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-premailer": "^1.1.10",
+    "grunt": "1.0.1",
+    "grunt-premailer": "1.1.0",
     "grunt-processhtml": "^0.4.2",
-    "grunt-uncss": "^0.3.7",
-    "load-grunt-config": "^0.14.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-text-replace": "^0.3.12"
-  },
-  "dependencies": {
-    "grunt-assemble": "^0.4.0",
-    "grunt-contrib-clean": "^0.6.0"
+    "grunt-uncss": "0.9.0",
+    "load-grunt-config": "3.0.1",
+    "grunt-contrib-watch": "1.1.0",
+    "grunt-text-replace": "0.4.0",
+    "grunt-assemble": "0.6.3",
+    "grunt-contrib-clean": "2.0.0"
   }
 }

--- a/emails/templates/layouts/default.html
+++ b/emails/templates/layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width"/>
@@ -143,7 +143,7 @@ td[class="stack-column-center"] {
 											<center>
 												<p style="text-align: center; font-size: 12px; color: #999999;">
 													Sent by <a href="[[.AppUrl]]">Grafana v[[.BuildVersion]]</a>
-													<br />&copy; 2018 Grafana Labs
+													<br />&copy; 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/alert_notification.html
+++ b/public/emails/alert_notification.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width" />
-
+	
 <style>body {
 width: 100% !important; min-width: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; margin: 0; padding: 0;
 }
@@ -339,11 +339,11 @@ text-decoration: underline;
 
 
 
-
+								
 							</td>
 						</tr>
 					</table>
-
+					
 					<table class="footer center" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: center; color: #999999; margin-top: 20px; padding: 0;" bgcolor="#2e2e2e">
 						<tr style="vertical-align: top; padding: 0;" align="left">
 							<td class="wrapper last" style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; position: relative; color: #222222; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0; padding: 10px 20px 0px 0px;" align="left" valign="top">
@@ -353,7 +353,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/invited_to_org.html
+++ b/public/emails/invited_to_org.html
@@ -266,7 +266,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/new_user_invite.html
+++ b/public/emails/new_user_invite.html
@@ -267,7 +267,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/reset_password.html
+++ b/public/emails/reset_password.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width" />
@@ -261,7 +261,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/signup_started.html
+++ b/public/emails/signup_started.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width" />
@@ -265,7 +265,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>

--- a/public/emails/welcome_on_signup.html
+++ b/public/emails/welcome_on_signup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width" />
@@ -268,7 +268,7 @@ text-decoration: underline;
 											<center style="width: 100%; min-width: 580px;">
 												<p style="font-size: 12px; color: #999999; font-family: 'Open Sans', 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-weight: normal; line-height: 19px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; margin: 0 0 10px; padding: 0;" align="center">
 													Sent by <a href="{{.AppUrl}}" style="color: #E67612; text-decoration: none;">Grafana v{{.BuildVersion}}</a>
-													<br />© 2016 Grafana and raintank
+													<br />© 2019 Grafana Labs
 												</p>
 											</center>
 										</td>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update copyright year in email templates and regenerate `public/emails`. Last time it was done, in commit 7a4475fbf3d7af, templates were not re-generated; current emails still have `© 2016 Grafana and raintank`.
- Update Grunt dependencies in `package.json` because generation did not work without it.
- Remove `xmlns` attribute from template layout, because Premailer adds it and it was duplicated in final `public/emails` templates.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:
1. Do we really need printing a copyright in all emails from Grafana? Grafana web UI does not display a copyright.

1. **Is it even ok to print `© 2019 Grafana Labs`?** IANAL, but I read in [Grafana CLA, § 2.1](https://grafana.com/docs/contribute/cla/#2-1-copyright-license): _You retain ownership of the Copyright in Your Contribution_.
  I understand that for parts of Grafana which are contributed by the Community, Grafana Labs has a _perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license_, but does not own the copyright...

1. I've created a separate issue for email templates generation improvements: #19661