### PR TITLE
Explore: makes toolbar's "Live tailing" button responsive

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -288,6 +288,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props, {}> {
                 <LiveTailControls exploreId={exploreId}>
                   {controls => (
                     <LiveTailButton
+                      splitted={splitted}
                       isLive={isLive}
                       isPaused={isPaused}
                       start={controls.start}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -43,6 +43,9 @@ const getStyles = memoizeOne(() => {
   return {
     liveTailButtons: css`
       margin-left: 10px;
+      @media (max-width: 1110px) {
+        margin-left: 4px;
+      }
     `,
   };
 });

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -91,8 +91,8 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
   };
 });
 
-const defaultZoomOutTooltip = () => {
-  return <>Live tailing</>;
+const defaultLiveTooltip = () => {
+  return <>Live</>;
 };
 
 type LiveTailButtonProps = {
@@ -112,7 +112,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
 
   return (
     <>
-      <Tooltip content={defaultZoomOutTooltip} placement="bottom">
+      <Tooltip content={defaultLiveTooltip} placement="bottom">
         <button
           className={classNames('btn navbar-button', styles.liveButton, {
             [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: isLive,
@@ -122,7 +122,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
           onClick={onClickMain}
         >
           <i className={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')} />
-          <span>&nbsp; Live tailing</span>
+          <span>&nbsp; Live</span>
         </button>
       </Tooltip>
       <CSSTransition

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -5,7 +5,7 @@ import memoizeOne from 'memoize-one';
 import tinycolor from 'tinycolor2';
 import { CSSTransition } from 'react-transition-group';
 
-import { GrafanaTheme, useTheme } from '@grafana/ui';
+import { GrafanaTheme, useTheme, Tooltip } from '@grafana/ui';
 
 const getStyles = memoizeOne((theme: GrafanaTheme) => {
   const orangeLighter = tinycolor(theme.colors.orangeDark)
@@ -91,6 +91,10 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
   };
 });
 
+const defaultZoomOutTooltip = () => {
+  return <>Live tailing</>;
+};
+
 type LiveTailButtonProps = {
   start: () => void;
   stop: () => void;
@@ -108,17 +112,19 @@ export function LiveTailButton(props: LiveTailButtonProps) {
 
   return (
     <>
-      <button
-        className={classNames('btn navbar-button', styles.liveButton, {
-          [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: isLive,
-          [styles.isLive]: isLive && !isPaused,
-          [styles.isPaused]: isLive && isPaused,
-        })}
-        onClick={onClickMain}
-      >
-        <i className={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')} />
-        &nbsp; Live tailing
-      </button>
+      <Tooltip content={defaultZoomOutTooltip} placement="bottom">
+        <button
+          className={classNames('btn navbar-button', styles.liveButton, {
+            [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: isLive,
+            [styles.isLive]: isLive && !isPaused,
+            [styles.isPaused]: isLive && isPaused,
+          })}
+          onClick={onClickMain}
+        >
+          <i className={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')} />
+          <span>&nbsp; Live tailing</span>
+        </button>
+      </Tooltip>
       <CSSTransition
         mountOnEnter={true}
         unmountOnExit={true}

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -4,6 +4,7 @@ import { css } from 'emotion';
 import memoizeOne from 'memoize-one';
 import tinycolor from 'tinycolor2';
 import { CSSTransition } from 'react-transition-group';
+import { ResponsiveButton } from './ResponsiveButton';
 
 import { GrafanaTheme, useTheme, Tooltip } from '@grafana/ui';
 
@@ -96,6 +97,7 @@ const defaultLiveTooltip = () => {
 };
 
 type LiveTailButtonProps = {
+  splitted: boolean;
   start: () => void;
   stop: () => void;
   pause: () => void;
@@ -104,7 +106,7 @@ type LiveTailButtonProps = {
   isPaused: boolean;
 };
 export function LiveTailButton(props: LiveTailButtonProps) {
-  const { start, pause, resume, isLive, isPaused, stop } = props;
+  const { start, pause, resume, isLive, isPaused, stop, splitted } = props;
   const theme = useTheme();
   const styles = getStyles(theme);
 
@@ -113,17 +115,17 @@ export function LiveTailButton(props: LiveTailButtonProps) {
   return (
     <>
       <Tooltip content={defaultLiveTooltip} placement="bottom">
-        <button
-          className={classNames('btn navbar-button', styles.liveButton, {
+        <ResponsiveButton
+          splitted={splitted}
+          buttonClassName={classNames('btn navbar-button', styles.liveButton, {
             [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: isLive,
             [styles.isLive]: isLive && !isPaused,
             [styles.isPaused]: isLive && isPaused,
           })}
+          iconClassName={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')}
           onClick={onClickMain}
-        >
-          <i className={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')} />
-          <span>&nbsp; Live</span>
-        </button>
+          title={'\xa0Live'}
+        />
       </Tooltip>
       <CSSTransition
         mountOnEnter={true}

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -131,6 +131,16 @@
   }
 }
 
+@media only screen and (max-width: 788px) {
+  .explore-toolbar {
+    .explore-toolbar-content-item {
+      .navbar-button span {
+        display: none;
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: 702px) {
   .explore-toolbar-content-item:first-child {
     padding-left: 2px;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -100,6 +100,18 @@
   }
 }
 
+@media only screen and (max-width: 1400px) {
+  .explore-toolbar.splitted {
+    .explore-toolbar-content-item {
+      .navbar-button {
+        span {
+          display: none;
+        }
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: 1070px) {
   .timepicker {
     .timepicker-rangestring {
@@ -221,6 +233,7 @@
   from {
     color: $text-color-faint;
   }
+
   to {
     color: $blue;
   }
@@ -266,51 +279,63 @@
   border-bottom: 2px solid $body-bg;
   height: 2em;
 }
+
 .ReactTable .rt-thead.-header .rt-th {
   text-align: left;
   color: $blue;
   font-weight: $font-weight-semi-bold;
 }
+
 .ReactTable .rt-thead .rt-td,
 .ReactTable .rt-thead .rt-th {
   padding: 0.45em 0 0.45em 1.1em;
   border-right: none;
   box-shadow: none;
 }
+
 .ReactTable .rt-tbody .rt-td {
   padding: 0.45em 0 0.45em 1.1em;
   border-bottom: 2px solid $body-bg;
   border-right: 2px solid $body-bg;
 }
+
 .ReactTable .rt-tbody .rt-td:last-child {
   border-right: none;
 }
+
 .ReactTable .-pagination {
   border-top: none;
   box-shadow: none;
   margin-top: $space-sm;
 }
+
 .ReactTable .-pagination .-btn {
   color: $blue;
   background: $list-item-bg;
 }
+
 .ReactTable .-pagination input,
 .ReactTable .-pagination select {
   color: $input-color;
   background-color: $input-bg;
 }
+
 .ReactTable .-loading {
   background: $input-bg;
 }
+
 .ReactTable .-loading.-active {
   opacity: 0.8;
 }
+
 .ReactTable .-loading > div {
   color: $input-color;
 }
+
 .ReactTable .rt-tr .rt-td:last-child {
   text-align: right;
 }
+
 .ReactTable .rt-noData {
   top: 60px;
   z-index: inherit;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -126,7 +126,6 @@
   .explore-toolbar.splitted {
     .explore-toolbar-content-item {
       padding: 2px 0;
-      margin: 0;
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a fold of "Live tailing" button while in either normal and split view. Adds a tooltip for the live button and updates its text.

**Which issue(s) this PR fixes**:

Fixes #19350 