### PR TITLE
Templating: add a 'dashboardurl' variable formatting mode

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -114,6 +114,17 @@ String to interpolate: '${servers:percentencode}'
 Interpolation result: 'foo%28%29bar%20BAZ%2Ctest2'
 ```
 
+### Dashboardurl
+Formats single and multi-value variables for use in URLs of Grafana dashboards,
+to propagate variables from the current dashboard to another one being linked
+to.
+
+```bash
+servers = ['foo()bar BAZ', 'test2']
+String to interpolate: '/d/XAsdys2Wk/variables-test?${servers:dashboardurl}'
+Interpolation result: '/d/XAsdys2Wk/variables-test?var-servers=foo%28%29bar%20BAZ&var-servers=test2'
+```
+
 Test the formatting options on the [Grafana Play site](http://play.grafana.org/d/cJtIfcWiz/template-variable-formatting-options?orgId=1).
 
 If any invalid formatting option is specified, then `glob` is the default/fallback option.

--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -322,6 +322,11 @@ describe('templateSrv', () => {
       const result = _templateSrv.formatValue('Gi3/14', 'regex');
       expect(result).toBe('Gi3\\/14');
     });
+
+    it('multi value and dashboardurl format should name the variable each time', () => {
+      const result = _templateSrv.formatValue(['foo', 'bar'], 'dashboardurl', { name: 'test' });
+      expect(result).toBe('var-test=foo&var-test=bar');
+    });
   });
 
   describe('can check if variable exists', () => {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -175,6 +175,10 @@ export class TemplateSrv {
         }
         return this.encodeURIComponentStrict(value);
       }
+      case 'dashboardurl': {
+        const escaped = _.map(value, this.encodeURIComponentStrict);
+        return _.map(escaped, val => 'var-' + variable.name + '=' + val).join('&');
+      }
       default: {
         if (_.isArray(value) && value.length > 1) {
           return '{' + value.join(',') + '}';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Makes it possible to propagate some of the current dashboard's variables to another one through a link, such as in a text panel. In particular, makes it possible to do so with multi-value variables. See the feature request issue for more details.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19614

**Special notes for your reviewer**:

* This kind of also needs #19690 fixed in order to be most useful, but it will at least work in plain text and HTML mode right now.

* Please note that I'm not very experienced in TypeScript or JS, so please let me know if I'm doing something in a less than optimal way!