### PR TITLE
ContextMenu: make ContextMenu positioning aware of the viewport width

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -162,15 +162,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
 
   return (
     <Portal>
-      <div
-        ref={menuRef}
-        style={{
-          position: 'fixed',
-          left: x - 5,
-          top: y + 5,
-        }}
-        className={styles.wrapper}
-      >
+      <div ref={menuRef} style={getStyle(menuRef.current)} className={styles.wrapper}>
         {renderHeader && <div className={styles.header}>{renderHeader()}</div>}
         <List
           items={items || []}
@@ -185,6 +177,25 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
       </div>
     </Portal>
   );
+
+  function getStyle(menuNode: HTMLDivElement | null) {
+    const haventMeasuredMenuYet = !menuNode;
+    if (haventMeasuredMenuYet) {
+      return { visibility: 'hidden' as const };
+    }
+    const rect = menuNode!.getBoundingClientRect();
+    const OFFSET = 5;
+    const collisions = {
+      right: window.innerWidth < x + rect.width,
+      bottom: window.innerHeight < rect.bottom + rect.height + OFFSET,
+    };
+
+    return {
+      position: 'fixed' as const,
+      left: collisions.right ? x - rect.width - OFFSET : x - OFFSET,
+      top: collisions.bottom ? y - rect.height - OFFSET : y + OFFSET,
+    };
+  }
 });
 
 interface ContextMenuItemProps {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the positioning of the ContextMenu component when there is a collision with the browser width
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19631

**Special notes for your reviewer**:
I noticed that the position of the ContextMenu does not change when the viewport is resized. That is something that I could fix as well but not sure if it is the desired behaviour.
Secondly, I also fixed the case when it collides with the bottom edge of the window, which was not mentioned in the issue.

Here is a link to a video of how it works after the fix
https://cl.ly/b761e63438ea
