### PR TITLE
Explore/UI: Removes unnecessary grafana-info-box wrapper around InfluxCheatSheet

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/InfluxStartPage.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxStartPage.tsx
@@ -4,10 +4,6 @@ import InfluxCheatSheet from './InfluxCheatSheet';
 
 export default class InfluxStartPage extends PureComponent<ExploreStartPageProps> {
   render() {
-    return (
-      <div className="grafana-info-box grafana-info-box--max-lg">
-        <InfluxCheatSheet onClickExample={this.props.onClickExample} />
-      </div>
-    );
+    return <InfluxCheatSheet onClickExample={this.props.onClickExample} />;
   }
 }

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -61,7 +61,7 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
     const { userExamples } = this.state;
 
     return (
-      <div>
+      <>
         <h2>Loki Cheat Sheet</h2>
         <div className="cheat-sheet-item">
           <div className="cheat-sheet-item__title">See your logs</div>
@@ -95,7 +95,7 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
             supports exact and regular expression filters.
           </div>
         </div>
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a small styling issue where the InfluxCheatSheet was wrapped in a `grafana-info-box` div, nesting it inside another `grafana-info-box` div. Also removes an unnecessary div wrapping LokiCheatSheet.
