### PR TITLE
build: use vendored packages for backend tests

### DIFF
--- a/scripts/circle-test-backend.sh
+++ b/scripts/circle-test-backend.sh
@@ -3,6 +3,9 @@
 # shellcheck source=./scripts/helpers/exit-if-fail.sh
 source "$(dirname "$0")/helpers/exit-if-fail.sh"
 
+# use vendor folder for packages
+export GOFLAGS=-mod=vendor
+
 echo "building backend with install to cache pkgs"
 exit_if_fail time go install ./pkg/cmd/grafana-server
 


### PR DESCRIPTION
stops the test from having to download the packages, and also the tests use same code as for building.