### PR TITLE
Docs: Add Troubleshooting section to Developer guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -69,7 +69,6 @@ Log in using the default credentials:
 
 When you log in for the first time, Grafana will ask you to change your password.
 
-
 ## Test Grafana
 
 The test suite consists of three types of tests: _Frontend tests_, _backend tests_, and _end-to-end tests_.

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -57,6 +57,8 @@ Next, we'll build the web server that will serve the frontend assets we just bui
 
 Build and run the backend, by running `make run` in the root directory of the repository. This command will compile the Go source code, and start a web server.
 
+> Are you having problems with [too many open files](#troubleshooting)?
+
 By default, you can access the web server at `http://localhost:3000/`.
 
 Log in using the default credentials:
@@ -66,6 +68,7 @@ Log in using the default credentials:
 | `admin`  | `admin`  |
 
 When you log in for the first time, Grafana will ask you to change your password.
+
 
 ## Test Grafana
 
@@ -162,6 +165,34 @@ The resulting image will be tagged as grafana/grafana:dev.
 1. Build the Docker image: `make build-docker-dev`.
 
 **Note:** If you are using Docker for macOS, be sure to set the memory limit to be larger than 2 GiB. Otherwise `grunt build` may fail. The memory limit settings are available under **Docker Desktop** -> **Preferences** -> **Advanced**.
+
+## Troubleshooting
+
+Are you having issues with setting up your environment? Here are some tips that might help.
+
+### Too many open files when running `make run`
+
+Depending on your environment, you may have to increase the maximum number of open files allowed.
+
+To see how many open files are allowed, run:
+
+```
+ulimit -a
+```
+
+To change the number of open files allowed, run:
+
+```
+ulimit -S -n 2048
+```
+
+The number of files needed may be different on your environment. To determine the number of open files needed by `make run`, run:
+
+```
+find ./conf ./pkg ./public/views | wc -l
+```
+
+Another alternative is to limit the files being watched. The directories that are watched for changes are listed in the `.bra.toml` file in the root directory. 
 
 ## Learn more
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`make run` may throw an error if too many files are being watched by `bra`. This pull request adds a Troubleshooting section to the Developer guide, with instructions on how to increase the limit.