### PR TITLE
enforce GO111MODULE=on when running make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ shellcheck: $(SH_FILES)
 	$(SH_FILES) -e SC1071 -e SC2162
 
 run: scripts/go/bin/bra
-	@scripts/go/bin/bra run
+	@GO111MODULE=on scripts/go/bin/bra run
 
 # create docker-compose file with provided sources and start them
 # example: make devenv sources=postgres,openldap


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes so `make run` works on older Go versions than 1.13.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

