### PR TITLE
Add heightPixels and widthPixels to datasource call signature

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -449,6 +449,8 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   interval: string;
   intervalMs: number;
   maxDataPoints: number;
+  widthPixels: number;
+  heightPixels: number;
   scopedVars: ScopedVars;
 
   // Request Timing

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -139,6 +139,8 @@ export function buildQueryTransaction(
       __interval_ms: { text: intervalMs, value: intervalMs },
     },
     maxDataPoints: queryOptions.maxDataPoints,
+    widthPixels: queryOptions.widthPixels,
+    heightPixels: queryOptions.heightPixels,
   };
 
   return {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -150,7 +150,7 @@ export class PanelChrome extends PureComponent<Props, State> {
   };
 
   onRefresh = () => {
-    const { panel, isInView, width } = this.props;
+    const { panel, isInView, width, height } = this.props;
 
     if (!isInView) {
       console.log('Refresh when panel is visible', panel.id);
@@ -182,6 +182,7 @@ export class PanelChrome extends PureComponent<Props, State> {
         timeRange: timeData.timeRange,
         timeInfo: timeData.timeInfo,
         widthPixels: width,
+        heightPixels: height,
         maxDataPoints: panel.maxDataPoints,
         minInterval: panel.interval,
         scopedVars: panel.scopedVars,

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -27,6 +27,7 @@ export interface QueryRunnerOptions<
   timeRange: TimeRange;
   timeInfo?: string; // String description of time range for display
   widthPixels: number;
+  heightPixels: number;
   maxDataPoints: number | undefined | null;
   minInterval: string | undefined | null;
   scopedVars?: ScopedVars;
@@ -85,6 +86,7 @@ export class PanelQueryRunner {
       timeInfo,
       cacheTimeout,
       widthPixels,
+      heightPixels,
       maxDataPoints,
       scopedVars,
       minInterval,
@@ -107,6 +109,8 @@ export class PanelQueryRunner {
       intervalMs: 0,
       targets: cloneDeep(queries),
       maxDataPoints: maxDataPoints || widthPixels,
+      widthPixels,
+      heightPixels,
       scopedVars: scopedVars || {},
       cacheTimeout,
       startTime: Date.now(),

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -164,11 +164,15 @@ export function applyPanelTimeOverrides(panel: PanelModel, timeRange: TimeRange)
   return newTimeData;
 }
 
-export function getResolution(panel: PanelModel): number {
+export function getResolution(panel: PanelModel): { width: number; height: number } {
   const htmlEl = document.getElementsByTagName('html')[0];
   const width = htmlEl.getBoundingClientRect().width; // https://stackoverflow.com/a/21454625
+  const height = htmlEl.getBoundingClientRect().height;
 
-  return panel.maxDataPoints ? panel.maxDataPoints : Math.ceil(width * (panel.gridPos.w / 24));
+  return {
+    width: panel.maxDataPoints ? panel.maxDataPoints : Math.ceil(width * (panel.gridPos.w / 24)),
+    height,
+  };
 }
 
 export function calculateInnerPanelHeight(panel: PanelModel, containerHeight: number): number {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -148,6 +148,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
       originPanelId,
     } = this.props;
     const width = this.el ? this.el.offsetWidth : 0;
+    const height = this.el ? this.el.offsetHeight : 0;
 
     // initialize the whole explore first time we mount and if browser history contains a change in datasource
     if (!initialized) {
@@ -158,6 +159,7 @@ export class Explore extends React.PureComponent<ExploreProps> {
         initialRange,
         mode,
         width,
+        height,
         this.exploreEvents,
         initialUI,
         originPanelId

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -83,6 +83,7 @@ export interface HighlightLogsExpressionPayload {
 export interface InitializeExplorePayload {
   exploreId: ExploreId;
   containerWidth: number;
+  containerHeight: number;
   eventBridge: Emitter;
   queries: DataQuery[];
   range: TimeRange;

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -264,6 +264,7 @@ export function initializeExplore(
   rawRange: RawTimeRange,
   mode: ExploreMode,
   containerWidth: number,
+  containerHeight: number,
   eventBridge: Emitter,
   ui: ExploreUIState,
   originPanelId: number
@@ -276,6 +277,7 @@ export function initializeExplore(
       initializeExploreAction({
         exploreId,
         containerWidth,
+        containerHeight,
         eventBridge,
         queries,
         range,
@@ -443,6 +445,7 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
       queries,
       datasourceError,
       containerWidth,
+      containerHeight,
       isLive: live,
       range,
       scanning,
@@ -476,6 +479,8 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
       // This is used for logs streaming for buffer size, with undefined it falls back to datasource config if it
       // supports that.
       maxDataPoints: mode === ExploreMode.Logs ? undefined : containerWidth,
+      widthPixels: containerWidth,
+      heightPixels: containerHeight,
       liveStreaming: live,
       showingGraph,
       showingTable,
@@ -756,7 +761,7 @@ export function refreshExplore(exploreId: ExploreId): ThunkResult<void> {
       return;
     }
 
-    const { urlState, update, containerWidth, eventBridge } = itemState;
+    const { urlState, update, containerWidth, containerHeight, eventBridge } = itemState;
     const { datasource, queries, range: urlRange, mode, ui, originPanelId } = urlState;
     const refreshQueries: DataQuery[] = [];
     for (let index = 0; index < queries.length; index++) {
@@ -777,6 +782,7 @@ export function refreshExplore(exploreId: ExploreId): ThunkResult<void> {
           range,
           mode,
           containerWidth,
+          containerHeight,
           eventBridge,
           ui,
           originPanelId

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -80,6 +80,7 @@ export const makeInitialUpdateState = (): ExploreUpdateState => ({
 export const makeExploreItemState = (): ExploreItemState => ({
   StartPage: undefined,
   containerWidth: 0,
+  containerHeight: 0,
   datasourceInstance: null,
   requestedDatasourceName: null,
   datasourceError: null,
@@ -177,7 +178,8 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
     filter: changeSizeAction,
     mapper: (state, action): ExploreItemState => {
       const containerWidth = action.payload.width;
-      return { ...state, containerWidth };
+      const containerHeight = action.payload.height;
+      return { ...state, containerWidth, containerHeight };
     },
   })
   .addMapper({
@@ -250,10 +252,11 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
   .addMapper({
     filter: initializeExploreAction,
     mapper: (state, action): ExploreItemState => {
-      const { containerWidth, eventBridge, queries, range, mode, ui, originPanelId } = action.payload;
+      const { containerWidth, containerHeight, eventBridge, queries, range, mode, ui, originPanelId } = action.payload;
       return {
         ...state,
         containerWidth,
+        containerHeight,
         eventBridge,
         range,
         mode,

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -24,7 +24,7 @@ class MetricsPanelCtrl extends PanelCtrl {
   range: TimeRange;
   interval: any;
   intervalMs: any;
-  resolution: any;
+  resolution: { width: number; height: number };
   timeInfo?: string;
   skipDataOnInit: boolean;
   dataList: LegacyResponseData[];
@@ -175,7 +175,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       intervalOverride = this.datasource.interval;
     }
 
-    const res = kbn.calculateInterval(this.range, this.resolution, intervalOverride);
+    const res = kbn.calculateInterval(this.range, this.resolution.width, intervalOverride);
     this.interval = res.interval;
     this.intervalMs = res.intervalMs;
   }
@@ -197,7 +197,8 @@ class MetricsPanelCtrl extends PanelCtrl {
       dashboardId: this.dashboard.id,
       timezone: this.dashboard.timezone,
       timeRange: this.range,
-      widthPixels: this.resolution, // The pixel width
+      widthPixels: this.resolution.width, // The pixel width
+      heightPixels: this.resolution.height, // The pixel height
       maxDataPoints: panel.maxDataPoints,
       minInterval: panel.interval,
       scopedVars: panel.scopedVars,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -417,6 +417,9 @@ function queryRequestFromAnnotationOptions(options: AnnotationQueryRequest<LokiQ
     // This should mean the default defined on datasource is used.
     maxDataPoints: 0,
 
+    widthPixels: 0,
+    heightPixels: 0,
+
     // Dummy values, are required in type but not used here.
     timezone: 'utc',
     panelId: 0,

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -154,6 +154,10 @@ export interface ExploreItemState {
    */
   containerWidth: number;
   /**
+   * Height in pixels
+   */
+  containerHeight: number;
+  /**
    * Datasource instance that has been selected. Datasource-specific logic can be run on this object.
    */
   datasourceInstance: DataSourceApi | null;
@@ -349,6 +353,8 @@ export interface QueryIntervals {
 
 export interface QueryOptions {
   minInterval: string;
+  widthPixels?: number;
+  heightPixels?: number;
   maxDataPoints?: number;
   liveStreaming?: boolean;
   showingGraph?: boolean;

--- a/public/test/helpers/getQueryOptions.ts
+++ b/public/test/helpers/getQueryOptions.ts
@@ -17,6 +17,8 @@ export function getQueryOptions<TQuery extends DataQuery>(
     dashboardId: 1,
     interval: '60s',
     intervalMs: 60000,
+    widthPixels: 500,
+    heightPixels: 500,
     maxDataPoints: 500,
     startTime: 0,
   };


### PR DESCRIPTION
Fixes #19746 

My main concern with this is that it feels a little odd to add pixel width/heights into the `DataQueryRequest` because it's pretty well-abstracted from anything view related. But on the other hand the data reduction I can do in my datasource when given a width/height is tremendous (We often see 10x reduction with https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) 

I wanted to hear feedback from the team about this implementation before I continue with adding more tests, so I've marked this pr as a draft.