### PR TITLE
grafana/toolkit: Use http rather than ssh for git checkout when creating plugin

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
@@ -24,9 +24,9 @@ interface PluginDetails {
 type PluginType = 'angular-panel' | 'react-panel' | 'datasource-plugin';
 
 const RepositoriesPaths = {
-  'angular-panel': 'git@github.com:grafana/simple-angular-panel.git',
-  'react-panel': 'git@github.com:grafana/simple-react-panel.git',
-  'datasource-plugin': 'git@github.com:grafana/simple-datasource.git',
+  'angular-panel': 'https://github.com/grafana/simple-angular-panel.git',
+  'react-panel': 'https://github.com/grafana/simple-react-panel.git',
+  'datasource-plugin': 'https://github.com/grafana/simple-datasource.git',
 };
 
 export const getGitUsername = async () => await simpleGit.raw(['config', '--global', 'user.name']);


### PR DESCRIPTION
Fixes #19617

