### PR TITLE
fix: export Bus on search service

### DIFF
--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -45,11 +45,11 @@ type FindPersistedDashboardsQuery struct {
 }
 
 type SearchService struct {
-	bus bus.Bus `inject:""`
+	Bus bus.Bus `inject:""`
 }
 
 func (s *SearchService) Init() error {
-	s.bus.AddHandler(s.searchHandler)
+	s.Bus.AddHandler(s.searchHandler)
 	return nil
 }
 


### PR DESCRIPTION
fix `pkg/services/search/service.go:52:3: s.bus undefined (type *SearchService has no field or method bus, but does have Bus)`

fixes issue introduced by https://github.com/grafana/grafana/pull/19765