### PR TITLE
Docs: Link to architecture docs from Developer guide

### DIFF
--- a/contribute/architecture/README.md
+++ b/contribute/architecture/README.md
@@ -1,0 +1,9 @@
+# Architecture
+
+Are you looking to take on contributions with bigger impact? These guides help you get a better understanding of the structure and design of the Grafana codebase.
+
+Learn more about the backend architecture:
+
+- Part 1: [Services](services.md) 
+- Part 2: [Communication](communication.md)
+

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -197,5 +197,5 @@ Another alternative is to limit the files being watched. The directories that ar
 
 - [Create a pull request](/contribute/pull-request.md)
 - [Style guides](/contribute/style-guides)
-- [Architecture](architecture/README.md)
+- [Architecture](architecture)
 - [How to contribute to Grafana as a junior dev](https://medium.com/@ivanahuckova/how-to-contribute-to-grafana-as-junior-dev-c01fe3064502)

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -193,8 +193,9 @@ find ./conf ./pkg ./public/views | wc -l
 
 Another alternative is to limit the files being watched. The directories that are watched for changes are listed in the `.bra.toml` file in the root directory. 
 
-## Learn more
+## Next steps
 
-- Read our [style guides](/contribute/style-guides).
-- Learn how to [Create a pull request](/contribute/pull-request.md).
-- Read [How to contribute to Grafana as a junior dev](https://medium.com/@ivanahuckova/how-to-contribute-to-grafana-as-junior-dev-c01fe3064502) by [Ivana Huckova](https://medium.com/@ivanahuckova).
+- [Create a pull request](/contribute/pull-request.md)
+- [Style guides](/contribute/style-guides)
+- [Architecture](architecture/README.md)
+- [How to contribute to Grafana as a junior dev](https://medium.com/@ivanahuckova/how-to-contribute-to-grafana-as-junior-dev-c01fe3064502)


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds links to the architecture docs, from the Developer guide.
