### PR TITLE
PluginLoader: fix imports for react-redux 

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -15,8 +15,8 @@ import slateReact from '@grafana/slate-react';
 import slatePlain from 'slate-plain-serializer';
 import react from 'react';
 import reactDom from 'react-dom';
-import reactRedux from 'react-redux';
-import redux from 'redux';
+import * as reactRedux from 'react-redux';
+import * as redux from 'redux';
 
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Bug fix

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/grafana/issues/18443, it was closed, but when I try to use the react-redux, I get an error saying cannot import connect from undefined. Then the issue narrow down to the loader.

sample plugin code to test the bug:
```js
import React, {PureComponent} from 'react';
import {PanelProps, PanelPlugin} from '@grafana/ui';
import {Provider} from 'react-redux';
import {createStore} from 'redux';

const reducer = (state: any, action: any) => state;
const store = createStore(reducer);

export class MyPanel extends PureComponent<PanelProps> {
    render() {
        return (<Provider store={store}>
                <div>Hello!!!</div>
        </Provider>);
    }
}

export const plugin = new PanelPlugin(MyPanel);

```

