### PR TITLE
grafana/toolkit: Add font file loader

### DIFF
--- a/packages/grafana-toolkit/src/config/utils/getPluginId.ts
+++ b/packages/grafana-toolkit/src/config/utils/getPluginId.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+
+let PLUGIN_ID: string;
+
+export const getPluginId = () => {
+  if (!PLUGIN_ID) {
+    const pluginJson = require(path.resolve(process.cwd(), 'src/plugin.json'));
+    PLUGIN_ID = pluginJson.id;
+  }
+  return PLUGIN_ID;
+};

--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -145,7 +145,6 @@ export const getFileLoaders = () => {
       loader: 'file-loader',
       options: {
         publicPath: `/public/plugins/${getPluginId()}`,
-        outputPath: 'fonts/',
         name: '[path][name].[ext]',
       },
     },

--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -139,5 +139,13 @@ export const getFileLoaders = () => {
             },
       ],
     },
+    {
+      test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file-loader',
+      options: {
+        outputPath: 'fonts/',
+        name: '[path][name].[ext]',
+      },
+    },
   ];
 };

--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { getPluginId } from '../utils/getPluginId';
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
@@ -143,6 +144,7 @@ export const getFileLoaders = () => {
       test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
       loader: 'file-loader',
       options: {
+        publicPath: `/public/plugins/${getPluginId()}`,
         outputPath: 'fonts/',
         name: '[path][name].[ext]',
       },

--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -144,8 +144,9 @@ export const getFileLoaders = () => {
       test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
       loader: 'file-loader',
       options: {
-        publicPath: `/public/plugins/${getPluginId()}`,
-        name: '[path][name].[ext]',
+        publicPath: `/public/plugins/${getPluginId()}/fonts`,
+        outputPath: 'fonts',
+        name: '[name].[ext]',
       },
     },
   ];


### PR DESCRIPTION
**What this PR does / why we need it**:

Some third party libraries has fonts within their style sheet, it breaks the grafana toolkit when building the plugin:
```
  ../node_modules/pivotal-ui/css/typography/fonts/SourceSansPro-normal-200-latin.woff 1:4
  Module parse failed: Unexpected character '' (1:4)
  You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
  (Source code omitted for this binary file)
```


