### PR TITLE
@grafana/toolkit: TSLint line number off by 1

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -152,9 +152,11 @@ export const lintPlugin = useSpinner<Fixable>('Linting', async ({ fix }) => {
     failures.forEach(f => {
       // tslint:disable-next-line
       console.log(
-        `${f.getRuleSeverity() === 'warning' ? 'WARNING' : 'ERROR'}: ${f.getFileName().split('src')[1]}[${
-          f.getStartPosition().getLineAndCharacter().line
-        }:${f.getStartPosition().getLineAndCharacter().character}]: ${f.getFailure()}`
+        `${f.getRuleSeverity() === 'warning' ? 'WARNING' : 'ERROR'}: ${
+          f.getFileName().split('src')[1]
+        }[${f.getStartPosition().getLineAndCharacter().line + 1}:${
+          f.getStartPosition().getLineAndCharacter().character
+        }]: ${f.getFailure()}`
       );
     });
     console.log('\n');


### PR DESCRIPTION
**What this PR does / why we need it**:
When running `yarn dev` , the lint info returned back has line number off by 1.
