### PR TITLE
BarGauge: Color transparency now reflected in basic mode bar background

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -409,10 +409,11 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
 
     if (isBasic) {
       // Basic styles
-      barStyles.background = `${tinycolor(valueColor)
-        .setAlpha(0.25)
+      barStyles.background = valueColor;
+      barStyles.borderTop = `2px solid ${tinycolor(valueColor)
+        .setAlpha(1)
         .toRgbString()}`;
-      barStyles.borderTop = `2px solid ${valueColor}`;
+
     } else {
       // Gradient styles
       barStyles.background = getBarGradient(props, maxBarHeight);
@@ -433,10 +434,10 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
 
     if (isBasic) {
       // Basic styles
-      barStyles.background = `${tinycolor(valueColor)
-        .setAlpha(0.25)
+      barStyles.background = valueColor;
+      barStyles.borderRight = `2px solid ${tinycolor(valueColor)
+        .setAlpha(1)
         .toRgbString()}`;
-      barStyles.borderRight = `2px solid ${valueColor}`;
     } else {
       // Gradient styles
       barStyles.background = getBarGradient(props, maxBarWidth);
@@ -504,7 +505,7 @@ function getValueStyles(value: string, color: string, width: number, height: num
   const fontSize = Math.min(Math.max(guess, 14), heightFont);
 
   return {
-    color: color,
+    color: `${tinycolor(color).setAlpha(1).toRgbString()}`,
     height: `${height}px`,
     width: `${width}px`,
     display: 'flex',


### PR DESCRIPTION
Small tweak to let the transparency selection reflect on the bar background instead of border and text in the bargauge component basic mode.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Instead of forcing the bars background to always have an alpha of 0.25 it is now fetched from the color selected in the color picker. The user can now choose himself how he wants the bar to look, if that is almost transparent or fully colored. Do we need it, probably not, but it is helpful especially when you have a dashboard full of small bars monitoring certain things.

**Which issue(s) this PR fixes**:
None
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
I wasn't sure about setting barStyles.background as a rgbstring or not.
