### PR TITLE
Folders visibility: add listing private folders that contain public dashboards

### DIFF
--- a/docs/sources/permissions/dashboard_folder_permissions.md
+++ b/docs/sources/permissions/dashboard_folder_permissions.md
@@ -27,7 +27,8 @@ Permission levels:
 
 ## Restricting Access
 
-The highest permission always wins so if you for example want to hide a folder or dashboard from others you need to remove the **Organization Role** based permission from the Access Control List (ACL).
+The highest permission always wins for dashboards so if you for example want to hide a dashboard from others you need to remove the **Organization Role** based permission from the Access Control List (ACL).
+However in case of folder - restricting its permission will not be enough when dashboards inside are visible to user.
 
 - You cannot override permissions for users with the **Org Admin Role**. Admins always have access to everything.
 - A more specific permission with a lower permission level will not have any effect if a more general rule exists with higher permission level. You need to remove or lower the permission level of the more general rule.

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -209,6 +209,14 @@ func GetDashboardFolderUrl(isFolder bool, uid string, slug string) string {
 	return GetDashboardUrl(uid, slug)
 }
 
+// GetDashboardFolderUrl return the html url for a folder if it's folder, otherwise for a dashboard
+func GetDashboardFolderUrlForPermission(isFolder bool, uid string, slug string, viewable bool, admin bool) string {
+	if !viewable && !admin {
+		return ""
+	}
+	return GetDashboardFolderUrl(isFolder, uid, slug)
+}
+
 // GetDashboardUrl return the html url for a dashboard
 func GetDashboardUrl(uid string, slug string) string {
 	return fmt.Sprintf("%s/d/%s/%s", setting.AppSubUrl, uid, slug)

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -93,7 +93,11 @@ func (g *dashboardGuardianImpl) logHasPermissionResult(permission m.PermissionTy
 }
 
 func (g *dashboardGuardianImpl) checkAcl(permission m.PermissionType, acl []*m.DashboardAclInfoDTO) (bool, error) {
-	orgRole := g.user.OrgRole
+	orgOkRoles := []m.RoleType{g.user.OrgRole}
+	if g.user.OrgRole == m.ROLE_EDITOR {
+		orgOkRoles = append(orgOkRoles, m.ROLE_VIEWER)
+	}
+
 	teamAclItems := []*m.DashboardAclInfoDTO{}
 
 	for _, p := range acl {
@@ -105,9 +109,11 @@ func (g *dashboardGuardianImpl) checkAcl(permission m.PermissionType, acl []*m.D
 		}
 
 		// role match
-		if p.Role != nil {
-			if *p.Role == orgRole && p.Permission >= permission {
-				return true, nil
+		for _, orgRole := range orgOkRoles {
+			if p.Role != nil {
+				if *p.Role == orgRole && p.Permission >= permission {
+					return true, nil
+				}
 			}
 		}
 

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -95,9 +95,9 @@ func TestGuardianEditor(t *testing.T) {
 			sc.dashboardPermissionScenario(EDITOR, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// dashboard has viewer role with permission
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_ADMIN, NO_ACCESS)
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_EDIT, NO_ACCESS)
-			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_VIEW, NO_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_ADMIN, FULL_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_EDIT, EDITOR_ACCESS)
+			sc.dashboardPermissionScenario(VIEWER, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// parent folder has user with permission
 			sc.parentFolderPermissionScenario(USER, m.PERMISSION_ADMIN, FULL_ACCESS)
@@ -115,9 +115,9 @@ func TestGuardianEditor(t *testing.T) {
 			sc.parentFolderPermissionScenario(EDITOR, m.PERMISSION_VIEW, VIEWER_ACCESS)
 
 			// parent folder has viweer role with permission
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_ADMIN, NO_ACCESS)
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_EDIT, NO_ACCESS)
-			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_VIEW, NO_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_ADMIN, FULL_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_EDIT, EDITOR_ACCESS)
+			sc.parentFolderPermissionScenario(VIEWER, m.PERMISSION_VIEW, VIEWER_ACCESS)
 		})
 	})
 }

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -16,7 +16,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		Convey("Given one dashboard folder with two dashboards and one dashboard in the root folder", func() {
 			folder := insertTestDashboard("1 test dash folder", 1, 0, true, "prod", "webapp")
 			dashInRoot := insertTestDashboard("test dash 67", 1, 0, false, "prod", "webapp")
-			childDash := insertTestDashboard("test dash 23", 1, folder.Id, false, "prod", "webapp")
+			childDash := insertTestDashboard("test dash 23", 1, folder.Id, false, "prod", "webapp", "detailed")
 			insertTestDashboard("test dash 45", 1, folder.Id, false, "prod")
 
 			currentUser := createUser("viewer", "Viewer", false)
@@ -105,13 +105,27 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				Convey("when the user is given permission to child", func() {
 					testHelperUpdateDashboardAcl(childDash.Id, models.DashboardAcl{DashboardId: childDash.Id, OrgId: 1, UserId: currentUser.Id, Permission: models.PERMISSION_EDIT})
 
-					Convey("should be able to search for child dashboard but not folder", func() {
-						query := &search.FindPersistedDashboardsQuery{SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
+					Convey("should be able to search for child dashboard and the folder", func() {
+						query := &search.FindPersistedDashboardsQuery{SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}, Permission: models.PERMISSION_VIEW}
 						err := SearchDashboards(query)
 						So(err, ShouldBeNil)
-						So(len(query.Result), ShouldEqual, 2)
+						So(len(query.Result), ShouldEqual, 3)
+						So(query.Result[0].Id, ShouldEqual, folder.Id)
+						So(query.Result[0].Url, ShouldBeEmpty)
+						So(query.Result[1].Id, ShouldEqual, childDash.Id)
+						So(query.Result[1].Url, ShouldContainSubstring, childDash.Uid)
+						So(query.Result[2].Id, ShouldEqual, dashInRoot.Id)
+						So(query.Result[2].Url, ShouldContainSubstring, dashInRoot.Uid)
+					})
+
+					Convey("should be able to search (by tags) for child dashboard and the folder", func() {
+						query := &search.FindPersistedDashboardsQuery{Tags: []string{"detailed"}, SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}, Permission: models.PERMISSION_VIEW}
+						err := SearchDashboards(query)
+						So(err, ShouldBeNil)
+						So(len(query.Result), ShouldEqual, 1)
 						So(query.Result[0].Id, ShouldEqual, childDash.Id)
-						So(query.Result[1].Id, ShouldEqual, dashInRoot.Id)
+						So(query.Result[0].Url, ShouldContainSubstring, childDash.Uid)
+						So(query.Result[0].FolderUrl, ShouldBeEmpty)
 					})
 				})
 

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -30,6 +30,7 @@ func (sb *SqlBuilder) AddParams(params ...interface{}) {
 
 func (sb *SqlBuilder) buildPermissionsTable(user *m.SignedInUser, permission m.PermissionType) {
 	falseStr := dialect.BooleanStr(false)
+	trueStr := dialect.BooleanStr(true)
 	okRoles := []interface{}{user.OrgRole}
 
 	if user.OrgRole == m.ROLE_EDITOR {
@@ -66,7 +67,7 @@ func (sb *SqlBuilder) buildPermissionsTable(user *m.SignedInUser, permission m.P
 						da.dashboard_id = d.id
 					LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
 					WHERE
-						folder.is_folder =1 AND
+						folder.is_folder = ` + trueStr + ` AND
 						d.org_id = ? AND
 						da.permission >= ? AND
 						(

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -336,8 +336,10 @@ func getDashboards(sqlStore *SqlStore, search Search, aclUserId int64) ([]*dashb
 	}
 
 	var res []*dashboardResponse
-	builder.Write("SELECT * FROM dashboard WHERE true")
-	builder.writeDashboardPermissionFilter(signedInUser, search.RequiredPermission)
+	builder.Write("SELECT * FROM dashboard LEFT OUTER JOIN")
+	builder.buildPermissionsTable(signedInUser, search.RequiredPermission)
+	builder.Write(` as permissions ON dashboard.id = permissions.d_id
+		WHERE permissions.viewable = 1`)
 	err := sqlStore.engine.SQL(builder.GetSqlString(), builder.params...).Find(&res)
 	return res, err
 }


### PR DESCRIPTION
Fixes #12948 issue

This is recreation and rebase of the PR that I've created some time ago (#16741)

Description:
I've change the backend code to fetch also permissions of child dashboards to determine which folders should be present in the search.

Before this change users with access to the dashboards but not the folder were allowed to reach it through direct url. After the change they will be also able to see this folders in search and on the list.

I've also noticed inconsistency between dashboards search and guardian (for example when editor was also viewer in search but no in guardian). 