### PR TITLE
Segment multi select

### DIFF
--- a/packages/grafana-ui/src/components/Segment/Segment.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.story.tsx
@@ -112,8 +112,40 @@ SegmentStories.add('With custom options allowed', () => {
   );
 });
 
-const CustomLabelComponent = ({ value }: any) => <div className="gf-form-label">custom({value})</div>;
+SegmentStories.add('With multiple values allowed', () => {
+  const options = ['Option1', 'Option2', 'OptionWithLooongLabel', 'Option4'].map(toOption);
+  return (
+    <UseState initialState={['Option2', 'OptionWithLooongLabel']}>
+      {(value, updateValue) => (
+        <>
+          <div className="gf-form-inline">
+            <div className="gf-form">
+              <span className="gf-form-label width-8 query-keyword">Segment Name</span>
+            </div>
+            <Segment
+              allowCustomValue
+              isMulti={true}
+              value={value}
+              options={options}
+              onChange={(values: any) => {
+                updateValue(values);
+                action('Segment value changed')(values);
+              }}
+            />
+            <Segment
+              allowCustomValue
+              Component={AddButton}
+              onChange={(value: SelectableValue<string>) => action('New value added')(value)}
+              options={options}
+            />
+          </div>
+        </>
+      )}
+    </UseState>
+  );
+});
 
+const CustomLabelComponent = ({ value }: any) => <div className="gf-form-label">custom({value})</div>;
 SegmentStories.add('Custom Label Field', () => {
   return (
     <UseState initialState={groupedOptions[0].options[0].value}>

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { cx } from 'emotion';
 import { SelectableValue } from '@grafana/data';
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
 
@@ -14,22 +13,27 @@ export function Segment<T>({
   Component,
   className,
   allowCustomValue,
+  isMulti,
 }: React.PropsWithChildren<SegmentSyncProps<T>>) {
-  const [Label, width, expanded, setExpanded] = useExpandableLabel(false);
+  const [Label, width, expanded, setExpanded] = useExpandableLabel(false, value, className, Component);
 
   if (!expanded) {
-    return <Label Component={Component || <a className={cx('gf-form-label', 'query-part', className)}>{value}</a>} />;
+    return <Label />;
   }
 
   return (
     <SegmentSelect
       width={width}
+      value={value}
       options={options}
       onClickOutside={() => setExpanded(false)}
       allowCustomValue={allowCustomValue}
-      onChange={value => {
-        setExpanded(false);
-        onChange(value);
+      isMulti={isMulti}
+      onChange={v => {
+        if (!isMulti) {
+          setExpanded(false);
+        }
+        onChange(v);
       }}
     />
   );

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.story.tsx
@@ -113,6 +113,37 @@ SegmentStories.add('With custom options allowed', () => {
   );
 });
 
+SegmentStories.add('With multiple values allowed', () => {
+  const options = ['Option1', 'Option2', 'OptionWithLooongLabel', 'Option4'].map(toOption);
+  return (
+    <UseState initialState={options[0].value}>
+      {(value, updateValue) => (
+        <>
+          <div className="gf-form-inline">
+            <div className="gf-form">
+              <span className="gf-form-label width-8 query-keyword">Segment Name</span>
+            </div>
+            <SegmentAsync
+              isMulti
+              value={value}
+              loadOptions={() => loadOptions(options)}
+              onChange={value => {
+                updateValue(value);
+                action('Segment value changed')(value);
+              }}
+            />
+            <SegmentAsync
+              Component={AddButton}
+              onChange={value => action('New value added')(value)}
+              loadOptions={() => loadOptions(options)}
+            />
+          </div>
+        </>
+      )}
+    </UseState>
+  );
+});
+
 const CustomLabelComponent = ({ value }: any) => <div className="gf-form-label">custom({value})</div>;
 SegmentStories.add('Custom Label Field', () => {
   return (

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { cx } from 'emotion';
 import { SegmentSelect } from './SegmentSelect';
 import { SelectableValue } from '@grafana/data';
 import { useExpandableLabel, SegmentProps } from '.';
@@ -15,10 +14,11 @@ export function SegmentAsync<T>({
   Component,
   className,
   allowCustomValue,
+  isMulti,
 }: React.PropsWithChildren<SegmentAsyncProps<T>>) {
   const [selectPlaceholder, setSelectPlaceholder] = useState<string>('');
   const [loadedOptions, setLoadedOptions] = useState<Array<SelectableValue<T>>>([]);
-  const [Label, width, expanded, setExpanded] = useExpandableLabel(false);
+  const [Label, width, expanded, setExpanded] = useExpandableLabel(false, value, className, Component);
 
   if (!expanded) {
     return (
@@ -29,7 +29,6 @@ export function SegmentAsync<T>({
           setLoadedOptions(opts);
           setSelectPlaceholder(opts.length ? '' : 'No options found');
         }}
-        Component={Component || <a className={cx('gf-form-label', 'query-part', className)}>{value}</a>}
       />
     );
   }
@@ -38,17 +37,21 @@ export function SegmentAsync<T>({
     <SegmentSelect
       width={width}
       options={loadedOptions}
+      value={value}
       noOptionsMessage={selectPlaceholder}
       allowCustomValue={allowCustomValue}
+      isMulti={isMulti}
       onClickOutside={() => {
         setSelectPlaceholder('');
         setLoadedOptions([]);
         setExpanded(false);
       }}
       onChange={value => {
-        setSelectPlaceholder('');
-        setLoadedOptions([]);
-        setExpanded(false);
+        if (!isMulti) {
+          setSelectPlaceholder('');
+          setLoadedOptions([]);
+          setExpanded(false);
+        }
         onChange(value);
       }}
     />

--- a/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
@@ -6,20 +6,24 @@ import { Select } from '../Select/Select';
 
 export interface Props<T> {
   options: Array<SelectableValue<T>>;
-  onChange: (value: T) => void;
+  value?: T | T[];
+  onChange: (value: T | T[]) => void;
   onClickOutside: () => void;
   width: number;
   noOptionsMessage?: string;
   allowCustomValue?: boolean;
+  isMulti?: boolean;
 }
 
 export function SegmentSelect<T>({
   options = [],
+  noOptionsMessage = '',
+  allowCustomValue = false,
+  isMulti = false,
+  value,
   onChange,
   onClickOutside,
   width,
-  noOptionsMessage = '',
-  allowCustomValue = false,
 }: React.PropsWithChildren<Props<T>>) {
   const ref = useRef(null);
 
@@ -27,19 +31,39 @@ export function SegmentSelect<T>({
     onClickOutside();
   });
 
+  function toSelectableValue(v: any): SelectableValue<T> {
+    return { label: v, value: v };
+  }
+
   return (
     <div ref={ref}>
       <Select
         className={cx(
           css`
-            width: ${width > 120 ? width : 120}px;
+            min-width: ${width > 120 ? width : 120}px;
           `
         )}
+        isMulti={isMulti}
         noOptionsMessage={() => noOptionsMessage}
         placeholder=""
         autoFocus={true}
         isOpen={true}
-        onChange={({ value }) => onChange(value!)}
+        onChange={v => {
+          let res: T | T[];
+          if (isMulti) {
+            if (v.length) {
+              res = v.map(({ value }: SelectableValue<T>) => value);
+            } else if (options.length) {
+              res = options[0].value!; //Select first option if all were deselected
+            } else {
+              res = [];
+            }
+          } else {
+            res = (v as SelectableValue<T>).value!;
+          }
+          onChange(res);
+        }}
+        value={value ? (Array.isArray(value) ? value.map(toSelectableValue) : toSelectableValue(value)) : undefined}
         options={options}
         allowCustomValue={allowCustomValue}
       />

--- a/packages/grafana-ui/src/components/Segment/types.ts
+++ b/packages/grafana-ui/src/components/Segment/types.ts
@@ -1,9 +1,10 @@
 import { ReactElement } from 'react';
 
 export interface SegmentProps<T> {
-  onChange: (item: T) => void;
-  value?: T;
+  onChange: (v: T | T[]) => void;
+  value?: T | T[];
   Component?: ReactElement;
   className?: string;
   allowCustomValue?: boolean;
+  isMulti?: boolean;
 }

--- a/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
+++ b/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
@@ -1,10 +1,24 @@
 import React, { useState, useRef, ReactElement } from 'react';
+import { cx } from 'emotion';
 
-export const useExpandableLabel = (initialExpanded: boolean) => {
+type Hook = (
+  initialExpanded: boolean,
+  value: any | any[],
+  className?: string,
+  CustomComponent?: ReactElement
+) => [
+  ({ onClick }: { onClick?: () => void }) => JSX.Element,
+  number,
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>
+];
+
+export const useExpandableLabel: Hook = (initialExpanded, value, className, CustomComponent) => {
   const ref = useRef<HTMLDivElement>(null);
-  const [expanded, setExpanded] = useState(initialExpanded);
-  const [width, setWidth] = useState();
-  const Label = ({ Component, onClick }: { Component: ReactElement; onClick: () => void }) => (
+  const [expanded, setExpanded] = useState<boolean>(initialExpanded);
+  const [width, setWidth] = useState<number>(0);
+
+  const Label = ({ onClick }: { onClick?: () => void }) => (
     <div
       className="gf-form"
       ref={ref}
@@ -18,7 +32,11 @@ export const useExpandableLabel = (initialExpanded: boolean) => {
         }
       }}
     >
-      {Component}
+      {CustomComponent || (
+        <a className={cx('gf-form-label', 'query-part', className)}>
+          {Array.isArray(value) && value.length > 1 ? `(${value.length}) selected` : value}
+        </a>
+      )}
     </div>
   );
 

--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -28,10 +28,10 @@ export interface CommonProps<T> {
   defaultValue?: any;
   getOptionLabel?: (item: SelectableValue<T>) => string;
   getOptionValue?: (item: SelectableValue<T>) => string;
-  onChange: (item: SelectableValue<T>) => {} | void;
+  onChange: (item: SelectableValue<T> | SelectableValue<T>[]) => {} | void;
   placeholder?: string;
   width?: number;
-  value?: SelectableValue<T>;
+  value?: SelectableValue<T> | SelectableValue<T>[];
   className?: string;
   isDisabled?: boolean;
   isSearchable?: boolean;

--- a/packages/grafana-ui/src/components/TransformersUI/TransformationsEditor.tsx
+++ b/packages/grafana-ui/src/components/TransformersUI/TransformationsEditor.tsx
@@ -1,4 +1,10 @@
-import { DataTransformerID, DataTransformerConfig, DataFrame, transformDataFrame } from '@grafana/data';
+import {
+  DataTransformerID,
+  DataTransformerConfig,
+  DataFrame,
+  transformDataFrame,
+  SelectableValue,
+} from '@grafana/data';
 import { Select } from '../Select/Select';
 import { transformersUIRegistry } from './transformers';
 import React from 'react';
@@ -74,7 +80,7 @@ export class TransformationsEditor extends React.PureComponent<TransformationsEd
                 key={`${t.id}-${i}`}
                 options={availableTransformers}
                 placeholder="Select transformation"
-                onChange={v => {
+                onChange={(v: SelectableValue<string>) => {
                   this.onTransformationChange(i, {
                     id: v.value as string,
                     options: {},


### PR DESCRIPTION
Support for multi select in segments will be necessary in Cloudwatch. 

It does get pretty messy, especially in SegmentSelect, when it supports both isMulti and single select. One thing that would address that is to expose two segment components - Segment and SegmentMulti. What do you think is better?  