### PR TITLE
@grafana/toolkit: Don't fail plugin creation when git user.name config is not set

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
@@ -29,7 +29,10 @@ const RepositoriesPaths = {
   'datasource-plugin': 'git@github.com:grafana/simple-datasource.git',
 };
 
-export const getGitUsername = async () => await simpleGit.raw(['config', '--global', 'user.name']);
+export const getGitUsername = async () => {
+  const name = await simpleGit.raw(['config', '--global', 'user.name']);
+  return name || '';
+};
 export const getPluginIdFromName = (name: string) => kebabCase(name);
 export const getPluginId = (pluginDetails: PluginDetails) =>
   `${kebabCase(pluginDetails.org)}-${getPluginIdFromName(pluginDetails.name)}`;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/19617#issuecomment-538319686