### PR TITLE
Datasource: enforce elasticsearch index configuration

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	logger = log.New("data-proxy-log")
-	client = newHTTPClient()
+	logger      = log.New("data-proxy-log")
+	client      = newHTTPClient()
+	POST_METHOD = "POST"
 )
 
 type DataSourceProxy struct {
@@ -224,7 +225,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("Puts not allowed on proxied Prometheus datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range") {
+		if proxy.ctx.Req.Request.Method == POST_METHOD && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range") {
 			return errors.New("Posts not allowed on proxied Prometheus datasource except on /query and /query_range")
 		}
 	}
@@ -236,10 +237,10 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("Puts not allowed on proxied Elasticsearch datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath != "_msearch" {
+		if proxy.ctx.Req.Request.Method == POST_METHOD && proxy.proxyPath != "_msearch" {
 			return errors.New("Posts not allowed on proxied Elasticsearch datasource except on /_msearch")
 		}
-		if proxy.ctx.Req.Request.Body != nil && proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath == "_msearch" {
+		if proxy.ctx.Req.Request.Body != nil && proxy.ctx.Req.Request.Method == POST_METHOD && proxy.proxyPath == "_msearch" {
 			err := enforceRequestedEsIndex(proxy)
 			if err != nil {
 				return err

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -241,8 +241,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			return errors.New("Posts not allowed on proxied Elasticsearch datasource except on /_msearch")
 		}
 		if proxy.ctx.Req.Request.Body != nil && proxy.ctx.Req.Request.Method == POST_METHOD && proxy.proxyPath == "_msearch" {
-			err := enforceRequestedEsIndex(proxy)
-			if err != nil {
+			if err := enforceRequestedEsIndex(proxy); err != nil {
 				return err
 			}
 		}

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -239,6 +239,12 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath != "_msearch" {
 			return errors.New("Posts not allowed on proxied Elasticsearch datasource except on /_msearch")
 		}
+		if proxy.ctx.Req.Request.Body != nil && proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath == "_msearch" {
+			err := enforceRequestedEsIndex(proxy)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// found route if there are any

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -148,7 +148,6 @@ func TestDSRouteRule(t *testing.T) {
 				}
 
 				Convey("requested elasticsearch index is not the right one", func() {
-					ctx.SignedInUser.OrgRole = m.ROLE_ADMIN
 					proxy := NewDataSourceProxy(ds, plugin, ctx, "_msearch", &setting.Cfg{})
 					err := proxy.validateRequest()
 					So(err, ShouldNotBeNil)

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -45,7 +45,7 @@ func InterpolateURL(anURL *url.URL, route *plugins.AppPluginRoute, orgID int64, 
 			if err == nil {
 				result, err = url.Parse(interpolatedResult)
 				if err != nil {
-					return nil, fmt.Errorf("Error parsing plugin route url %v", err)
+					return nil, fmt.Errorf("error parsing plugin route url %v", err)
 				}
 			}
 		}
@@ -87,7 +87,7 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 	}
 	err = json.Unmarshal([]byte(jsonPart), &requestIndex)
 	if err != nil {
-		return fmt.Errorf("Unable to unmarshall JSON request body : %s", err.Error())
+		return fmt.Errorf("unable to unmarshall JSON request body : %s", err.Error())
 	}
 	var found = false
 	switch requestIndex.Names.(type) {
@@ -108,10 +108,10 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 			}
 		}
 	default:
-		return fmt.Errorf("Unable to get type of the index: %+v", requestIndex.Names)
+		return fmt.Errorf("unable to get type of the index: %+v", requestIndex.Names)
 	}
 	if !found {
-		return fmt.Errorf("The index requested '%v' is not present in the datasources.\n", requestIndex.Names)
+		return fmt.Errorf("the index requested '%v' is not present in the datasources", requestIndex.Names)
 	}
 	return nil
 }

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -3,7 +3,6 @@ package pluginproxy
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -88,7 +87,7 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 	}
 	err = json.Unmarshal([]byte(jsonPart), &requestIndex)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Unable to unmarshall JSON request body : %s", err.Error()))
+		return fmt.Errorf("Unable to unmarshall JSON request body : %s", err.Error())
 	}
 	var found = false
 	switch requestIndex.Names.(type) {
@@ -109,10 +108,10 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 			}
 		}
 	default:
-		return errors.New(fmt.Sprintf("Unable to get type of the index: %+v", requestIndex.Names))
+		return fmt.Errorf("Unable to get type of the index: %+v", requestIndex.Names)
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("The index requested '%v' is not present in the datasources.\n", requestIndex.Names))
+		return fmt.Errorf("The index requested '%v' is not present in the datasources.\n", requestIndex.Names)
 	}
 	return nil
 }

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -106,6 +106,9 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 					break
 				}
 			}
+			if found {
+				break
+			}
 		}
 	default:
 		return fmt.Errorf("unable to get type of the index: %+v", requestIndex.Names)

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -59,7 +59,7 @@ func enforceRequestedEsIndex(proxy *DataSourceProxy) error {
 	nowFrom := time.Now()
 	from := time.Date(nowFrom.Year(), nowFrom.Month(), nowFrom.Day(), nowFrom.Hour(), nowFrom.Minute(), 0, 0, time.UTC)
 
-	nowTo := nowFrom.Add(time.Duration(5) * time.Minute) // Add the 5minutes
+	nowTo := nowFrom.Add(time.Duration(5) * time.Minute)
 	to := time.Date(nowTo.Year(), nowTo.Month(), nowTo.Day(), nowTo.Hour(), nowTo.Minute(), 0, 0, time.UTC)
 
 	fromStr := fmt.Sprintf("%d", from.UnixNano()/int64(time.Millisecond))

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -54,7 +54,7 @@ var NewClient = func(ctx context.Context, ds *models.DataSource, timeRange *tsdb
 	}
 
 	indexInterval := ds.JsonData.Get("interval").MustString()
-	ip, err := newIndexPattern(indexInterval, ds.Database)
+	ip, err := NewIndexPattern(indexInterval, ds.Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -22,11 +22,10 @@ type indexPattern interface {
 	GetIndices(timeRange *tsdb.TimeRange) ([]string, error)
 }
 
-var newIndexPattern = func(interval string, pattern string) (indexPattern, error) {
+var NewIndexPattern = func(interval string, pattern string) (indexPattern, error) {
 	if interval == noInterval {
 		return &staticIndexPattern{indexName: pattern}, nil
 	}
-
 	return newDynamicIndexPattern(interval, pattern)
 }
 

--- a/pkg/tsdb/elasticsearch/client/index_pattern_test.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern_test.go
@@ -268,7 +268,7 @@ func TestIndexPattern(t *testing.T) {
 
 func indexPatternScenario(interval string, pattern string, timeRange *tsdb.TimeRange, fn func(indices []string)) {
 	Convey(fmt.Sprintf("Index pattern (interval=%s, index=%s", interval, pattern), func() {
-		ip, err := newIndexPattern(interval, pattern)
+		ip, err := NewIndexPattern(interval, pattern)
 		So(err, ShouldBeNil)
 		So(ip, ShouldNotBeNil)
 		indices, err := ip.GetIndices(timeRange)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The purpose of this PR is to enforce the elasticsearch index configuration in case the elasticsearch datasource has been configured with the `Server access mode`.

When loading a dashboard, a `POST` request is made from the client browser to the server which include the elasticsearch `index`, in this form : 
```json
{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"<ELASTICSEARCH_INDEX>"}
```

By intercepting the request and modifying the `index` parameter in the request, it is possible to request data from a different index.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/5880

**Special notes for your reviewer**:

It is my first contribution to grafana, so I might have put the code in the wrong file, sorry about that

Thanks in advance
