### PR TITLE
Explore: Add unit test to TimeSyncButton

### DIFF
--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TimeSyncButton } from './TimeSyncButton';
+import { mount } from 'enzyme';
+
+const setup = (isSynced: boolean) => {
+  const onClick = () => {};
+  return mount(<TimeSyncButton onClick={onClick} isSynced={isSynced} />);
+};
+
+describe('TimeSyncButton', () => {
+  it('should change style when synced', () => {
+    expect(
+      setup(true)
+        .find('button')
+        .hasClass('css-14r9fpj-timePickerSynced')
+    ).toEqual(true);
+  });
+  it('should not change style when not synced', () => {
+    expect(
+      setup(false)
+        .find('button')
+        .hasClass('css-14r9fpj-timePickerSynced')
+    ).toEqual(false);
+  });
+});

--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -14,10 +14,10 @@ describe('TimeSyncButton', () => {
   });
   it('should change style when synced', () => {
     const wrapper = setup(true);
-    expect(wrapper.find('button').props()['aria-label']).toEqual('synced-times');
+    expect(wrapper.find('button').props()['aria-label']).toEqual('Synced times');
   });
   it('should not change style when not synced', () => {
     const wrapper = setup(false);
-    expect(wrapper.find('button').props()['aria-label']).toEqual('unsynced-times');
+    expect(wrapper.find('button').props()['aria-label']).toEqual('Unsynced times');
   });
 });

--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -2,24 +2,22 @@ import React from 'react';
 import { TimeSyncButton } from './TimeSyncButton';
 import { mount } from 'enzyme';
 
-const setup = (isSynced: boolean) => {
+const setup = (isSynced: boolean = true) => {
   const onClick = () => {};
   return mount(<TimeSyncButton onClick={onClick} isSynced={isSynced} />);
 };
 
 describe('TimeSyncButton', () => {
+  it('should render component', () => {
+    const wrapper = setup(true);
+    expect(wrapper).toMatchSnapshot();
+  });
   it('should change style when synced', () => {
-    expect(
-      setup(true)
-        .find('button')
-        .hasClass('css-14r9fpj-timePickerSynced')
-    ).toEqual(true);
+    const wrapper = setup(true);
+    expect(wrapper.find('button').hasClass('css-14r9fpj-timePickerSynced')).toEqual(true);
   });
   it('should not change style when not synced', () => {
-    expect(
-      setup(false)
-        .find('button')
-        .hasClass('css-14r9fpj-timePickerSynced')
-    ).toEqual(false);
+    const wrapper = setup(false);
+    expect(wrapper.find('button').hasClass('css-14r9fpj-timePickerSynced')).toEqual(false);
   });
 });

--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TimeSyncButton } from './TimeSyncButton';
 import { mount } from 'enzyme';
 
-const setup = (isSynced: boolean = true) => {
+const setup = (isSynced: boolean) => {
   const onClick = () => {};
   return mount(<TimeSyncButton onClick={onClick} isSynced={isSynced} />);
 };

--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -14,10 +14,10 @@ describe('TimeSyncButton', () => {
   });
   it('should change style when synced', () => {
     const wrapper = setup(true);
-    expect(wrapper.find('button').hasClass('css-14r9fpj-timePickerSynced')).toEqual(true);
+    expect(wrapper.find('button').props()['aria-label']).toEqual('synced-times');
   });
   it('should not change style when not synced', () => {
     const wrapper = setup(false);
-    expect(wrapper.find('button').hasClass('css-14r9fpj-timePickerSynced')).toEqual(false);
+    expect(wrapper.find('button').props()['aria-label']).toEqual('unsynced-times');
   });
 });

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -51,7 +51,7 @@ export function TimeSyncButton(props: TimeSyncButtonProps) {
         className={classNames('btn navbar-button navbar-button--attached', {
           [styles.timePickerSynced]: isSynced,
         })}
-        aria-label={isSynced ? 'synced-times' : 'unsynced-times'}
+        aria-label={isSynced ? 'Synced times' : 'Unsynced times'}
         onClick={() => onClick()}
       >
         <i className="fa fa-link" />

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -51,6 +51,7 @@ export function TimeSyncButton(props: TimeSyncButtonProps) {
         className={classNames('btn navbar-button navbar-button--attached', {
           [styles.timePickerSynced]: isSynced,
         })}
+        aria-label={isSynced ? 'synced-times' : 'unsynced-times'}
         onClick={() => onClick()}
       >
         <i className="fa fa-link" />

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeSyncButton should render component 1`] = `
+<TimeSyncButton
+  isSynced={true}
+  onClick={[Function]}
+>
+  <Component
+    content={[Function]}
+    placement="bottom"
+  >
+    <PopoverController
+      content={[Function]}
+      placement="bottom"
+    >
+      <button
+        className="btn navbar-button navbar-button--attached css-14r9fpj-timePickerSynced"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <i
+          className="fa fa-link"
+        />
+      </button>
+    </PopoverController>
+  </Component>
+</TimeSyncButton>
+`;

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`TimeSyncButton should render component 1`] = `
       placement="bottom"
     >
       <button
-        aria-label="synced-times"
+        aria-label="Synced times"
         className="btn navbar-button navbar-button--attached css-14r9fpj-timePickerSynced"
         onClick={[Function]}
         onMouseEnter={[Function]}

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`TimeSyncButton should render component 1`] = `
       placement="bottom"
     >
       <button
+        aria-label="synced-times"
         className="btn navbar-button navbar-button--attached css-14r9fpj-timePickerSynced"
         onClick={[Function]}
         onMouseEnter={[Function]}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add unit tests to TimeSyncButton introduced in https://github.com/grafana/grafana/pull/19274:

- snapshot test
- testing of classname/color change based on synced/unsynced state
