### PR TITLE
devenv: have bra watch attempt graceful shutdown

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -17,3 +17,5 @@ cmds = [
   ["go", "run", "-mod=vendor", "build.go", "-dev", "build-server"],
 	["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]
+interrupt_timout = 5
+graceful_kill = true


### PR DESCRIPTION
This is useful when working with backend plugins and grafana at the same time. This makes it so grafana-server has a chance to shutdown the external process

Adds the following to `.bra.toml` (so you don't need to click the diff tab :P):

```
interrupt_timout = 5
graceful_kill = true
```

This will send os.Interrupt signal first and wait for 5 seconds before force kill.