### PR TITLE
Templating: Introduces $__searchFilter to Query Variables

### DIFF
--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -114,6 +114,19 @@ variable with all possible values that exist in the wildcard position.
 You can also create nested variables that use other variables in their definition. For example
 `apps.$app.servers.*` uses the variable `$app` in its query definition.
 
+#### Using `$__searchFilter` to filter results in Query Variable
+> Available from Grafana 6.5 and above
+
+Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `$__searchFilter` is `*`.
+
+The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `server` while the user types in the dropdown select box.
+
+Query
+```bash
+apps.$app.servers.$__searchFilter
+```
+
 ### Variable Usage
 
 You can use a variable in a metric node path or as a parameter to a function.

--- a/docs/sources/features/datasources/mysql.md
+++ b/docs/sources/features/datasources/mysql.md
@@ -276,6 +276,19 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM my_host  WHERE region IN($region)
 ```
 
+#### Using `$__searchFilter` to filter results in Query Variable
+> Available from Grafana 6.5 and above
+
+Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `$__searchFilter` is `%`.
+
+The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
+
+Query
+```sql
+SELECT hostname FROM my_host  WHERE hostname LIKE $__searchFilter
+```
+
 ### Using Variables in Queries
 
 From Grafana 4.3.0 to 4.6.0, template variables are always quoted automatically so if it is a string value do not wrap them in quotes in where clauses.

--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -282,6 +282,19 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM host  WHERE region IN($region)
 ```
 
+#### Using `$__searchFilter` to filter results in Query Variable
+> Available from Grafana 6.5 and above
+
+Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `$__searchFilter` is `%`.
+
+The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
+
+Query
+```sql
+SELECT hostname FROM my_host  WHERE hostname LIKE $__searchFilter
+```
+
 ### Using Variables in Queries
 
 From Grafana 4.3.0 to 4.6.0, template variables are always quoted automatically. If your template variables are strings, do not wrap them in quotes in where clauses.

--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -165,6 +165,23 @@ Option | Description
 *Regex* | Regex to filter or capture specific parts of the names return by your data source query. Optional.
 *Sort* | Define sort order for options in dropdown. **Disabled** means that the order of options returned by your data source query will be used.
 
+#### Using `$__searchFilter` to filter query results
+> Only supported for Graphite, MySQL and Postgres data sources
+
+Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box
+
+Examples of how to use `$__searchFilter` as part of the query
+
+Graphite:
+```bash
+server.$__searchFilter
+```
+
+MySQL:
+```bash
+SELECT server FROM servers WHERE server LIKE $__searchFilter
+```
+
 #### Using regex to filter/modify values in the Variable dropdown
 
 Using the Regex Query Option, you filter the list of options returned by the Variable query or modify the options returned.

--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -165,23 +165,6 @@ Option | Description
 *Regex* | Regex to filter or capture specific parts of the names return by your data source query. Optional.
 *Sort* | Define sort order for options in dropdown. **Disabled** means that the order of options returned by your data source query will be used.
 
-#### Using `$__searchFilter` to filter query results
-> Only supported for Graphite, MySQL and Postgres data sources
-
-Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box
-
-Examples of how to use `$__searchFilter` as part of the query
-
-Graphite:
-```bash
-server.$__searchFilter
-```
-
-MySQL:
-```bash
-SELECT server FROM servers WHERE server LIKE $__searchFilter
-```
-
 #### Using regex to filter/modify values in the Variable dropdown
 
 Using the Regex Query Option, you filter the list of options returned by the Variable query or modify the options returned.

--- a/public/app/core/directives/value_select_dropdown.ts
+++ b/public/app/core/directives/value_select_dropdown.ts
@@ -256,12 +256,11 @@ export class ValueSelectDropdownCtrl {
       return;
     }
 
-    this.highlightIndex = -1;
-    this.search.options = filter(this.options, option => {
+    const options = filter(this.options, option => {
       return option.text.toLowerCase().indexOf(this.search.query.toLowerCase()) !== -1;
     });
 
-    this.search.options = this.search.options.slice(0, Math.min(this.search.options.length, 1000));
+    this.updateUIBoundOptions(this.$scope, options);
   }
 
   init() {
@@ -270,8 +269,8 @@ export class ValueSelectDropdownCtrl {
   }
 
   async updateLazyLoadedOptions() {
-    const options = await this.lazyLoadOptions(this.search.query);
-    this.refreshLazyOptions(this.$scope, options);
+    this.options = await this.lazyLoadOptions(this.search.query);
+    this.updateUIBoundOptions(this.$scope, this.options);
   }
 
   async lazyLoadOptions(query: string): Promise<any[]> {
@@ -279,9 +278,8 @@ export class ValueSelectDropdownCtrl {
     return this.variable.options;
   }
 
-  refreshLazyOptions($scope: IScope, options: any[]) {
+  updateUIBoundOptions($scope: IScope, options: any[]) {
     this.highlightIndex = -1;
-    this.options = options;
     this.search.options = options.slice(0, Math.min(options.length, 1000));
     $scope.$apply();
   }

--- a/public/app/core/specs/value_select_dropdown.test.ts
+++ b/public/app/core/specs/value_select_dropdown.test.ts
@@ -172,7 +172,7 @@ describe('queryChanged', () => {
         { text: 'server-3', value: 'server-3' },
       ];
       ctrl.lazyLoadOptions = jest.fn().mockResolvedValue(options);
-      ctrl.refreshLazyOptions = jest.fn();
+      ctrl.updateUIBoundOptions = jest.fn();
       ctrl.search = {
         query: 'alpha',
       };
@@ -182,8 +182,8 @@ describe('queryChanged', () => {
 
       expect(ctrl.lazyLoadOptions).toBeCalledTimes(1);
       expect(ctrl.lazyLoadOptions).toBeCalledWith('alpha');
-      expect(ctrl.refreshLazyOptions).toBeCalledTimes(1);
-      expect(ctrl.refreshLazyOptions).toBeCalledWith($scope, options);
+      expect(ctrl.updateUIBoundOptions).toBeCalledTimes(1);
+      expect(ctrl.updateUIBoundOptions).toBeCalledWith($scope, options);
     });
   });
 
@@ -192,7 +192,7 @@ describe('queryChanged', () => {
       const $scope = {} as IScope;
       const ctrl = new ValueSelectDropdownCtrl(q, $scope);
       ctrl.lazyLoadOptions = jest.fn().mockResolvedValue([]);
-      ctrl.refreshLazyOptions = jest.fn();
+      ctrl.updateUIBoundOptions = jest.fn();
       ctrl.search = {
         query: 'alpha',
       };
@@ -201,7 +201,7 @@ describe('queryChanged', () => {
       await ctrl.queryChanged();
 
       expect(ctrl.lazyLoadOptions).toBeCalledTimes(0);
-      expect(ctrl.refreshLazyOptions).toBeCalledTimes(0);
+      expect(ctrl.updateUIBoundOptions).toBeCalledTimes(1);
     });
   });
 });
@@ -230,7 +230,7 @@ describe('lazyLoadOptions', () => {
   });
 });
 
-describe('refreshLazyOptions', () => {
+describe('updateUIBoundOptions', () => {
   describe('when called with options', () => {
     let options: any[];
     let ctrl: ValueSelectDropdownCtrl;
@@ -250,21 +250,18 @@ describe('refreshLazyOptions', () => {
       ctrl.search = {
         options: [],
       };
-      ctrl.refreshLazyOptions($scope, options);
+      ctrl.updateUIBoundOptions($scope, options);
     });
 
     it('then highlightIndex should be reset', () => {
       expect(ctrl.highlightIndex).toEqual(-1);
     });
 
-    it('then options should be set', () => {
-      expect(ctrl.options).toEqual(options);
-    });
-
     it('then search.options should be same as options but capped to 1000', () => {
       expect(ctrl.search.options.length).toEqual(1000);
+
       for (let index = 0; index < 1000; index++) {
-        expect(ctrl.search.options[index]).toEqual(ctrl.options[index]);
+        expect(ctrl.search.options[index]).toEqual(options[index]);
       }
     });
 

--- a/public/app/core/specs/value_select_dropdown.test.ts
+++ b/public/app/core/specs/value_select_dropdown.test.ts
@@ -3,7 +3,6 @@ import { ValueSelectDropdownCtrl } from '../directives/value_select_dropdown';
 // @ts-ignore
 import q from 'q';
 import { IScope } from 'angular';
-import { SEARCH_FILTER_VARIABLE } from '../../features/templating/variable';
 
 describe('SelectDropdownCtrl', () => {
   const tagValuesMap: any = {};
@@ -174,12 +173,10 @@ describe('queryChanged', () => {
       ];
       ctrl.lazyLoadOptions = jest.fn().mockResolvedValue(options);
       ctrl.refreshLazyOptions = jest.fn();
-      ctrl.variable = {
-        query: `$server.${SEARCH_FILTER_VARIABLE}`,
-      };
       ctrl.search = {
         query: 'alpha',
       };
+      ctrl.queryHasSearchFilter = true;
 
       await ctrl.queryChanged();
 
@@ -196,12 +193,10 @@ describe('queryChanged', () => {
       const ctrl = new ValueSelectDropdownCtrl(q, $scope);
       ctrl.lazyLoadOptions = jest.fn().mockResolvedValue([]);
       ctrl.refreshLazyOptions = jest.fn();
-      ctrl.variable = {
-        query: `$server.alpha`,
-      };
       ctrl.search = {
         query: 'alpha',
       };
+      ctrl.queryHasSearchFilter = false;
 
       await ctrl.queryChanged();
 

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { Variable, containsVariable, assignModelProperties, variableTypes } from './variable';
+import { assignModelProperties, containsVariable, SEARCH_FILTER_VARIABLE, Variable, variableTypes } from './variable';
 import { stringToJsRegex } from '@grafana/data';
 import DatasourceSrv from '../plugins/datasource_srv';
 import { TemplateSrv } from './template_srv';
@@ -62,6 +62,7 @@ export class QueryVariable implements Variable {
   ) {
     // copy model properties to this instance
     assignModelProperties(this, model, this.defaults);
+    this.updateOptionsFromMetricFindQuery.bind(this);
   }
 
   getSaveModel() {
@@ -91,10 +92,10 @@ export class QueryVariable implements Variable {
     return this.current.value;
   }
 
-  updateOptions() {
+  updateOptions(searchFilter?: string) {
     return this.datasourceSrv
       .get(this.datasource)
-      .then(this.updateOptionsFromMetricFindQuery.bind(this))
+      .then(ds => this.updateOptionsFromMetricFindQuery(ds, searchFilter))
       .then(this.updateTags.bind(this))
       .then(this.variableSrv.validateVariableSelectionState.bind(this.variableSrv, this));
   }
@@ -126,8 +127,10 @@ export class QueryVariable implements Variable {
     });
   }
 
-  updateOptionsFromMetricFindQuery(datasource: any) {
-    return this.metricFindQuery(datasource, this.query).then((results: any) => {
+  updateOptionsFromMetricFindQuery(datasource: any, searchFilter?: string) {
+    const filter = searchFilter ? `${searchFilter}*` : '*';
+    const query = this.query.replace(SEARCH_FILTER_VARIABLE, filter);
+    return this.metricFindQuery(datasource, query).then((results: any) => {
       this.options = this.metricNamesToVariableValues(results);
       if (this.includeAll) {
         this.addAllOption();

--- a/public/app/features/templating/query_variable.ts
+++ b/public/app/features/templating/query_variable.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { assignModelProperties, containsVariable, SEARCH_FILTER_VARIABLE, Variable, variableTypes } from './variable';
+import { assignModelProperties, containsVariable, Variable, variableTypes } from './variable';
 import { stringToJsRegex } from '@grafana/data';
 import DatasourceSrv from '../plugins/datasource_srv';
 import { TemplateSrv } from './template_srv';
@@ -128,9 +128,7 @@ export class QueryVariable implements Variable {
   }
 
   updateOptionsFromMetricFindQuery(datasource: any, searchFilter?: string) {
-    const filter = searchFilter ? `${searchFilter}*` : '*';
-    const query = this.query.replace(SEARCH_FILTER_VARIABLE, filter);
-    return this.metricFindQuery(datasource, query).then((results: any) => {
+    return this.metricFindQuery(datasource, this.query, searchFilter).then((results: any) => {
       this.options = this.metricNamesToVariableValues(results);
       if (this.includeAll) {
         this.addAllOption();
@@ -142,8 +140,8 @@ export class QueryVariable implements Variable {
     });
   }
 
-  metricFindQuery(datasource: any, query: string) {
-    const options: any = { range: undefined, variable: this };
+  metricFindQuery(datasource: any, query: string, searchFilter?: string) {
+    const options: any = { range: undefined, variable: this, searchFilter };
 
     if (this.refresh === 2) {
       options.range = this.timeSrv.timeRange();

--- a/public/app/features/templating/specs/variable.test.ts
+++ b/public/app/features/templating/specs/variable.test.ts
@@ -1,4 +1,10 @@
-import { containsVariable, assignModelProperties } from '../variable';
+import {
+  assignModelProperties,
+  containsSearchFilter,
+  containsVariable,
+  interpolateSearchFilter,
+  SEARCH_FILTER_VARIABLE,
+} from '../variable';
 
 describe('containsVariable', () => {
   describe('when checking if a string contains a variable', () => {
@@ -66,5 +72,106 @@ describe('assignModelProperties', () => {
     const target: any = { test: 'asd' };
     assignModelProperties(target, { propA: 1, propB: 2 }, { propC: 10 });
     expect(target.propC).toBe(10);
+  });
+});
+
+describe('containsSearchFilter', () => {
+  describe('when called without query', () => {
+    it('then it should return false', () => {
+      const result = containsSearchFilter(null);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe(`when called with a query without ${SEARCH_FILTER_VARIABLE}`, () => {
+    it('then it should return false', () => {
+      const result = containsSearchFilter('$app.*');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe(`when called with a query with ${SEARCH_FILTER_VARIABLE}`, () => {
+    it('then it should return false', () => {
+      const result = containsSearchFilter(`$app.${SEARCH_FILTER_VARIABLE}`);
+
+      expect(result).toBe(true);
+    });
+  });
+});
+
+describe('interpolateSearchFilter', () => {
+  describe('when called with a query without ${SEARCH_FILTER_VARIABLE}', () => {
+    it('then it should return query', () => {
+      const query = '$app.*';
+      const options = { searchFilter: 'filter' };
+      const wildcharChar = '*';
+      const quoteLiteral = false;
+
+      const result = interpolateSearchFilter({
+        query,
+        options,
+        wildcharChar,
+        quoteLiteral,
+      });
+
+      expect(result).toEqual(query);
+    });
+  });
+
+  describe(`when called with a query with ${SEARCH_FILTER_VARIABLE}`, () => {
+    const query = `$app.${SEARCH_FILTER_VARIABLE}`;
+
+    describe('and no searchFilter is given', () => {
+      it(`then ${SEARCH_FILTER_VARIABLE} should be replaced by wildchar character`, () => {
+        const options = {};
+        const wildcharChar = '*';
+        const quoteLiteral = false;
+
+        const result = interpolateSearchFilter({
+          query,
+          options,
+          wildcharChar,
+          quoteLiteral,
+        });
+
+        expect(result).toEqual(`$app.*`);
+      });
+    });
+
+    describe('and searchFilter is given', () => {
+      const options = { searchFilter: 'filter' };
+
+      it(`then ${SEARCH_FILTER_VARIABLE} should be replaced with searchfilter and wildchar character`, () => {
+        const wildcharChar = '*';
+        const quoteLiteral = false;
+
+        const result = interpolateSearchFilter({
+          query,
+          options,
+          wildcharChar,
+          quoteLiteral,
+        });
+
+        expect(result).toEqual(`$app.filter*`);
+      });
+
+      describe(`and quoteLiteral is used`, () => {
+        it(`then the literal should be quoted`, () => {
+          const wildcharChar = '*';
+          const quoteLiteral = true;
+
+          const result = interpolateSearchFilter({
+            query,
+            options,
+            wildcharChar,
+            quoteLiteral,
+          });
+
+          expect(result).toEqual(`$app.'filter*'`);
+        });
+      });
+    });
   });
 });

--- a/public/app/features/templating/specs/variable.test.ts
+++ b/public/app/features/templating/specs/variable.test.ts
@@ -106,13 +106,13 @@ describe('interpolateSearchFilter', () => {
     it('then it should return query', () => {
       const query = '$app.*';
       const options = { searchFilter: 'filter' };
-      const wildcharChar = '*';
+      const wildcardChar = '*';
       const quoteLiteral = false;
 
       const result = interpolateSearchFilter({
         query,
         options,
-        wildcharChar,
+        wildcardChar,
         quoteLiteral,
       });
 
@@ -126,13 +126,13 @@ describe('interpolateSearchFilter', () => {
     describe('and no searchFilter is given', () => {
       it(`then ${SEARCH_FILTER_VARIABLE} should be replaced by wildchar character`, () => {
         const options = {};
-        const wildcharChar = '*';
+        const wildcardChar = '*';
         const quoteLiteral = false;
 
         const result = interpolateSearchFilter({
           query,
           options,
-          wildcharChar,
+          wildcardChar,
           quoteLiteral,
         });
 
@@ -144,13 +144,13 @@ describe('interpolateSearchFilter', () => {
       const options = { searchFilter: 'filter' };
 
       it(`then ${SEARCH_FILTER_VARIABLE} should be replaced with searchfilter and wildchar character`, () => {
-        const wildcharChar = '*';
+        const wildcardChar = '*';
         const quoteLiteral = false;
 
         const result = interpolateSearchFilter({
           query,
           options,
-          wildcharChar,
+          wildcardChar,
           quoteLiteral,
         });
 
@@ -159,13 +159,13 @@ describe('interpolateSearchFilter', () => {
 
       describe(`and quoteLiteral is used`, () => {
         it(`then the literal should be quoted`, () => {
-          const wildcharChar = '*';
+          const wildcardChar = '*';
           const quoteLiteral = true;
 
           const result = interpolateSearchFilter({
             query,
             options,
-            wildcharChar,
+            wildcardChar,
             quoteLiteral,
           });
 

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -16,8 +16,8 @@ export const variableRegexExec = (variableString: string) => {
 };
 
 export const SEARCH_FILTER_VARIABLE = '$__searchFilter';
-export const containsSearchFilter = (variable: any): boolean =>
-  variable && variable.query ? variable.query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
+export const containsSearchFilter = (query: string): boolean =>
+  query ? query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
 
 export interface Variable {
   setValue(option: any): any;

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -15,9 +15,13 @@ export const variableRegexExec = (variableString: string) => {
   return variableRegex.exec(variableString);
 };
 
+export const SEARCH_FILTER_VARIABLE = '$__searchFilter';
+export const containsSearchFilter = (variable: any): boolean =>
+  variable && variable.query ? variable.query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
+
 export interface Variable {
   setValue(option: any): any;
-  updateOptions(): any;
+  updateOptions(searchFilter?: string): any;
   dependsOn(variable: any): any;
   setValueFromUrl(urlValue: any): any;
   getValueForUrl(): any;

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -22,12 +22,12 @@ export const containsSearchFilter = (query: string): boolean =>
 export interface InterpolateSearchFilterOptions {
   query: string;
   options: any;
-  wildcharChar: string;
+  wildcardChar: string;
   quoteLiteral: boolean;
 }
 
 export const interpolateSearchFilter = (args: InterpolateSearchFilterOptions): string => {
-  const { query, wildcharChar, quoteLiteral } = args;
+  const { query, wildcardChar, quoteLiteral } = args;
   let { options } = args;
 
   if (!containsSearchFilter(query)) {
@@ -36,7 +36,7 @@ export const interpolateSearchFilter = (args: InterpolateSearchFilterOptions): s
 
   options = options || {};
 
-  const filter = options.searchFilter ? `${options.searchFilter}${wildcharChar}` : `${wildcharChar}`;
+  const filter = options.searchFilter ? `${options.searchFilter}${wildcardChar}` : `${wildcardChar}`;
   const replaceValue = quoteLiteral ? `'${filter}'` : filter;
 
   return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -19,6 +19,29 @@ export const SEARCH_FILTER_VARIABLE = '$__searchFilter';
 export const containsSearchFilter = (query: string): boolean =>
   query ? query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
 
+export interface InterpolateSearchFilterOptions {
+  query: string;
+  options: any;
+  wildcharChar: string;
+  quoteLiteral: boolean;
+}
+
+export const interpolateSearchFilter = (args: InterpolateSearchFilterOptions): string => {
+  const { query, wildcharChar, quoteLiteral } = args;
+  let { options } = args;
+
+  if (!containsSearchFilter(query)) {
+    return query;
+  }
+
+  options = options || {};
+
+  const filter = options.searchFilter ? `${options.searchFilter}${wildcharChar}` : `${wildcharChar}`;
+  const replaceValue = quoteLiteral ? `'${filter}'` : filter;
+
+  return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
+};
+
 export interface Variable {
   setValue(option: any): any;
   updateOptions(searchFilter?: string): any;

--- a/public/app/partials/valueSelectDropdown.html
+++ b/public/app/partials/valueSelectDropdown.html
@@ -10,7 +10,7 @@
 		<i class="fa fa-caret-down" style="font-size:12px"></i>
 	</a>
 
-	<input type="text" class="gf-form-input" style="display: none" ng-keydown="vm.keyDown($event)" ng-model="vm.search.query" ng-change="vm.queryChanged()" ></input>
+	<input type="text" class="gf-form-input" style="display: none" ng-keydown="vm.keyDown($event)" ng-model="vm.search.query" ng-change="vm.debouncedQueryChanged()" ></input>
 
 	<div class="variable-value-dropdown" ng-if="vm.dropdownVisible" ng-class="{'multi': vm.variable.multi, 'single': !vm.variable.multi}">
 		<div class="variable-options-wrapper">

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -254,7 +254,7 @@ export class GraphiteDatasource {
     const interpolatedQuery = interpolateSearchFilter({
       query: this.templateSrv.replace(query),
       options: optionalOptions,
-      wildcharChar: '*',
+      wildcardChar: '*',
       quoteLiteral: false,
     });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -5,9 +5,9 @@ import gfunc from './gfunc';
 import { IQService } from 'angular';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-
 //Types
 import { GraphiteQuery } from './types';
+import { containsSearchFilter, SEARCH_FILTER_VARIABLE } from '../../../features/templating/variable';
 
 export class GraphiteDatasource {
   basicAuth: string;
@@ -249,9 +249,21 @@ export class GraphiteDatasource {
     return date.unix();
   }
 
+  interpolateSearchFilter(query: string, options: any) {
+    if (!containsSearchFilter(query)) {
+      return query;
+    }
+
+    options = options || {};
+
+    const replaceValue = options.searchFilter ? `${options.searchFilter}*` : '*';
+
+    return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
+  }
+
   metricFindQuery(query: string, optionalOptions: any) {
     const options: any = optionalOptions || {};
-    const interpolatedQuery = this.templateSrv.replace(query);
+    const interpolatedQuery = this.interpolateSearchFilter(this.templateSrv.replace(query), optionalOptions);
 
     // special handling for tag_values(<tag>[,<expression>]*), this is used for template variables
     let matches = interpolatedQuery.match(/^tag_values\(([^,]+)((, *[^,]+)*)\)$/);

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -7,7 +7,7 @@ import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 //Types
 import { GraphiteQuery } from './types';
-import { containsSearchFilter, SEARCH_FILTER_VARIABLE } from '../../../features/templating/variable';
+import { interpolateSearchFilter } from '../../../features/templating/variable';
 
 export class GraphiteDatasource {
   basicAuth: string;
@@ -249,21 +249,14 @@ export class GraphiteDatasource {
     return date.unix();
   }
 
-  interpolateSearchFilter(query: string, options: any) {
-    if (!containsSearchFilter(query)) {
-      return query;
-    }
-
-    options = options || {};
-
-    const replaceValue = options.searchFilter ? `${options.searchFilter}*` : '*';
-
-    return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
-  }
-
   metricFindQuery(query: string, optionalOptions: any) {
     const options: any = optionalOptions || {};
-    const interpolatedQuery = this.interpolateSearchFilter(this.templateSrv.replace(query), optionalOptions);
+    const interpolatedQuery = interpolateSearchFilter({
+      query: this.templateSrv.replace(query),
+      options: optionalOptions,
+      wildcharChar: '*',
+      quoteLiteral: false,
+    });
 
     // special handling for tag_values(<tag>[,<expression>]*), this is used for template variables
     let matches = interpolatedQuery.match(/^tag_values\(([^,]+)((, *[^,]+)*)\)$/);

--- a/public/app/plugins/datasource/graphite/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/datasource.test.ts
@@ -356,6 +356,28 @@ describe('graphiteDatasource', () => {
       expect(requestOptions.data).toMatch(`query=bar`);
       expect(requestOptions).toHaveProperty('params');
     });
+
+    it('should interpolate $__searchFilter with searchFilter', () => {
+      ctx.ds.metricFindQuery('app.$__searchFilter', { searchFilter: 'backend' }).then((data: any) => {
+        results = data;
+      });
+
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/find');
+      expect(requestOptions.params).toEqual({});
+      expect(requestOptions.data).toEqual('query=app.backend*');
+      expect(results).not.toBe(null);
+    });
+
+    it('should interpolate $__searchFilter with default when searchFilter is missing', () => {
+      ctx.ds.metricFindQuery('app.$__searchFilter', {}).then((data: any) => {
+        results = data;
+      });
+
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/find');
+      expect(requestOptions.params).toEqual({});
+      expect(requestOptions.data).toEqual('query=app.*');
+      expect(results).not.toBe(null);
+    });
   });
 });
 

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -7,11 +7,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { MysqlQueryForInterpolation } from './types';
-import {
-  containsSearchFilter,
-  interpolateSearchFilter,
-  SEARCH_FILTER_VARIABLE,
-} from '../../../features/templating/variable';
+import { interpolateSearchFilter } from '../../../features/templating/variable';
 
 export class MysqlDatasource {
   id: any;
@@ -129,18 +125,6 @@ export class MysqlDatasource {
       .then((data: any) => this.responseParser.transformAnnotationResponse(options, data));
   }
 
-  interpolateSearchFilter(query: string, options: any) {
-    if (!containsSearchFilter(query)) {
-      return query;
-    }
-
-    options = options || {};
-
-    const replaceValue = options.searchFilter ? `'${options.searchFilter}%'` : "'%'";
-
-    return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
-  }
-
   metricFindQuery(query: string, optionalOptions: any) {
     let refId = 'tempvar';
     if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
@@ -150,7 +134,7 @@ export class MysqlDatasource {
     const rawSql = interpolateSearchFilter({
       query: this.templateSrv.replace(query, {}, this.interpolateVariable),
       options: optionalOptions,
-      wildcharChar: '%',
+      wildcardChar: '%',
       quoteLiteral: true,
     });
 

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -7,6 +7,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { MysqlQueryForInterpolation } from './types';
+import { containsSearchFilter, SEARCH_FILTER_VARIABLE } from '../../../features/templating/variable';
 
 export class MysqlDatasource {
   id: any;
@@ -124,6 +125,18 @@ export class MysqlDatasource {
       .then((data: any) => this.responseParser.transformAnnotationResponse(options, data));
   }
 
+  interpolateSearchFilter(query: string, options: any) {
+    if (!containsSearchFilter(query)) {
+      return query;
+    }
+
+    options = options || {};
+
+    const replaceValue = options.searchFilter ? `'${options.searchFilter}%'` : "'%'";
+
+    return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
+  }
+
   metricFindQuery(query: string, optionalOptions: any) {
     let refId = 'tempvar';
     if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
@@ -133,7 +146,10 @@ export class MysqlDatasource {
     const interpolatedQuery = {
       refId: refId,
       datasourceId: this.id,
-      rawSql: this.templateSrv.replace(query, {}, this.interpolateVariable),
+      rawSql: this.interpolateSearchFilter(
+        this.templateSrv.replace(query, {}, this.interpolateVariable),
+        optionalOptions
+      ),
       format: 'table',
     };
 

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -7,7 +7,11 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { MysqlQueryForInterpolation } from './types';
-import { containsSearchFilter, SEARCH_FILTER_VARIABLE } from '../../../features/templating/variable';
+import {
+  containsSearchFilter,
+  interpolateSearchFilter,
+  SEARCH_FILTER_VARIABLE,
+} from '../../../features/templating/variable';
 
 export class MysqlDatasource {
   id: any;
@@ -143,13 +147,17 @@ export class MysqlDatasource {
       refId = optionalOptions.variable.name;
     }
 
+    const rawSql = interpolateSearchFilter({
+      query: this.templateSrv.replace(query, {}, this.interpolateVariable),
+      options: optionalOptions,
+      wildcharChar: '%',
+      quoteLiteral: true,
+    });
+
     const interpolatedQuery = {
       refId: refId,
       datasourceId: this.id,
-      rawSql: this.interpolateSearchFilter(
-        this.templateSrv.replace(query, {}, this.interpolateVariable),
-        optionalOptions
-      ),
+      rawSql,
       format: 'table',
     };
 

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -121,7 +121,7 @@ describe('MySQLDatasource', () => {
     });
   });
 
-  describe('When performing metricFindQuery with $__searchFilter', () => {
+  describe('When performing metricFindQuery with $__searchFilter and a searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
     const query = 'select title from atable where title LIKE $__searchFilter';
@@ -159,7 +159,7 @@ describe('MySQLDatasource', () => {
     });
   });
 
-  describe('When performing metricFindQuery with $__searchFilter but no searchfilter is given', () => {
+  describe('When performing metricFindQuery with $__searchFilter but no searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
     const query = 'select title from atable where title LIKE $__searchFilter';

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -1,6 +1,6 @@
 import { MysqlDatasource } from '../datasource';
 import { CustomVariable } from 'app/features/templating/custom_variable';
-import { toUtc, dateTime } from '@grafana/data';
+import { dateTime, toUtc } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
@@ -118,6 +118,82 @@ describe('MySQLDatasource', () => {
       expect(results.length).toBe(6);
       expect(results[0].text).toBe('aTitle');
       expect(results[5].text).toBe('some text3');
+    });
+  });
+
+  describe('When performing metricFindQuery with $__searchFilter', () => {
+    let results: any;
+    let calledWith: any = {};
+    const query = 'select title from atable where title LIKE $__searchFilter';
+    const response = {
+      results: {
+        tempvar: {
+          meta: {
+            rowCount: 3,
+          },
+          refId: 'tempvar',
+          tables: [
+            {
+              columns: [{ text: 'title' }, { text: 'text' }],
+              rows: [['aTitle', 'some text'], ['aTitle2', 'some text2'], ['aTitle3', 'some text3']],
+            },
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      ctx.backendSrv.datasourceRequest = jest.fn(options => {
+        calledWith = options;
+        return Promise.resolve({ data: response, status: 200 });
+      });
+      ctx.ds.metricFindQuery(query, { searchFilter: 'aTit' }).then((data: any) => {
+        results = data;
+      });
+    });
+
+    it('should return list of all column values', () => {
+      expect(ctx.backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE 'aTit%'");
+      expect(results.length).toBe(6);
+    });
+  });
+
+  describe('When performing metricFindQuery with $__searchFilter but no searchfilter is given', () => {
+    let results: any;
+    let calledWith: any = {};
+    const query = 'select title from atable where title LIKE $__searchFilter';
+    const response = {
+      results: {
+        tempvar: {
+          meta: {
+            rowCount: 3,
+          },
+          refId: 'tempvar',
+          tables: [
+            {
+              columns: [{ text: 'title' }, { text: 'text' }],
+              rows: [['aTitle', 'some text'], ['aTitle2', 'some text2'], ['aTitle3', 'some text3']],
+            },
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      ctx.backendSrv.datasourceRequest = jest.fn(options => {
+        calledWith = options;
+        return Promise.resolve({ data: response, status: 200 });
+      });
+      ctx.ds.metricFindQuery(query, {}).then((data: any) => {
+        results = data;
+      });
+    });
+
+    it('should return list of all column values', () => {
+      expect(ctx.backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
+      expect(results.length).toBe(6);
     });
   });
 

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -7,11 +7,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { PostgresQueryForInterpolation } from './types';
-import {
-  containsSearchFilter,
-  interpolateSearchFilter,
-  SEARCH_FILTER_VARIABLE,
-} from '../../../features/templating/variable';
+import { interpolateSearchFilter } from '../../../features/templating/variable';
 
 export class PostgresDatasource {
   id: any;
@@ -131,18 +127,6 @@ export class PostgresDatasource {
       .then((data: any) => this.responseParser.transformAnnotationResponse(options, data));
   }
 
-  interpolateSearchFilter(query: string, options: any) {
-    if (!containsSearchFilter(query)) {
-      return query;
-    }
-
-    options = options || {};
-
-    const replaceValue = options.searchFilter ? `'${options.searchFilter}%'` : "'%'";
-
-    return query.replace(SEARCH_FILTER_VARIABLE, replaceValue);
-  }
-
   metricFindQuery(query: string, optionalOptions: { variable?: any }) {
     let refId = 'tempvar';
     if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
@@ -152,7 +136,7 @@ export class PostgresDatasource {
     const rawSql = interpolateSearchFilter({
       query: this.templateSrv.replace(query, {}, this.interpolateVariable),
       options: optionalOptions,
-      wildcharChar: '%',
+      wildcardChar: '%',
       quoteLiteral: true,
     });
 

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -1,6 +1,6 @@
 import { PostgresDatasource } from '../datasource';
 import { CustomVariable } from 'app/features/templating/custom_variable';
-import { toUtc, dateTime } from '@grafana/data';
+import { dateTime, toUtc } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { IQService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
@@ -125,6 +125,82 @@ describe('PostgreSQLDatasource', () => {
       expect(results.length).toBe(6);
       expect(results[0].text).toBe('aTitle');
       expect(results[5].text).toBe('some text3');
+    });
+  });
+
+  describe('When performing metricFindQuery with $__searchFilter and a searchFilter is given', () => {
+    let results: any;
+    let calledWith: any = {};
+    const query = 'select title from atable where title LIKE $__searchFilter';
+    const response = {
+      results: {
+        tempvar: {
+          meta: {
+            rowCount: 3,
+          },
+          refId: 'tempvar',
+          tables: [
+            {
+              columns: [{ text: 'title' }, { text: 'text' }],
+              rows: [['aTitle', 'some text'], ['aTitle2', 'some text2'], ['aTitle3', 'some text3']],
+            },
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      ctx.backendSrv.datasourceRequest = jest.fn(options => {
+        calledWith = options;
+        return Promise.resolve({ data: response, status: 200 });
+      });
+      ctx.ds.metricFindQuery(query, { searchFilter: 'aTit' }).then((data: any) => {
+        results = data;
+      });
+    });
+
+    it('should return list of all column values', () => {
+      expect(ctx.backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE 'aTit%'");
+      expect(results.length).toBe(6);
+    });
+  });
+
+  describe('When performing metricFindQuery with $__searchFilter but no searchFilter is given', () => {
+    let results: any;
+    let calledWith: any = {};
+    const query = 'select title from atable where title LIKE $__searchFilter';
+    const response = {
+      results: {
+        tempvar: {
+          meta: {
+            rowCount: 3,
+          },
+          refId: 'tempvar',
+          tables: [
+            {
+              columns: [{ text: 'title' }, { text: 'text' }],
+              rows: [['aTitle', 'some text'], ['aTitle2', 'some text2'], ['aTitle3', 'some text3']],
+            },
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      ctx.backendSrv.datasourceRequest = jest.fn(options => {
+        calledWith = options;
+        return Promise.resolve({ data: response, status: 200 });
+      });
+      ctx.ds.metricFindQuery(query, {}).then((data: any) => {
+        results = data;
+      });
+    });
+
+    it('should return list of all column values', () => {
+      expect(ctx.backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
+      expect(results.length).toBe(6);
     });
   });
 

--- a/public/app/plugins/datasource/testdata/metricTree.test.ts
+++ b/public/app/plugins/datasource/testdata/metricTree.test.ts
@@ -16,4 +16,9 @@ describe('MetricTree', () => {
     const nodes = queryMetricTree('A.{AB,AC}.*').map(i => i.name);
     expect(nodes).toEqual(['ABA', 'ABB', 'ABC', 'ACA', 'ACB', 'ACC']);
   });
+
+  it('queryMetric tree supports wildcard matching', () => {
+    const nodes = queryMetricTree('A.AB.AB*').map(i => i.name);
+    expect(nodes).toEqual(['ABA', 'ABB', 'ABC']);
+  });
 });

--- a/public/app/plugins/datasource/testdata/metricTree.ts
+++ b/public/app/plugins/datasource/testdata/metricTree.ts
@@ -35,6 +35,10 @@ function buildMetricTree(parent: string, depth: number): TreeNode[] {
 }
 
 function queryTree(children: TreeNode[], query: string[], queryIndex: number): TreeNode[] {
+  if (queryIndex >= query.length) {
+    return children;
+  }
+
   if (query[queryIndex] === '*') {
     return children;
   }
@@ -50,7 +54,13 @@ function queryTree(children: TreeNode[], query: string[], queryIndex: number): T
 
   for (const node of children) {
     for (const nameToMatch of namesToMatch) {
-      if (node.name === nameToMatch) {
+      if (nameToMatch.indexOf('*') !== -1) {
+        const pattern = nameToMatch.replace('*', '');
+        const regex = new RegExp(`^${pattern}.*`, 'gi');
+        if (regex.test(node.name)) {
+          result = result.concat(queryTree([node], query, queryIndex + 1));
+        }
+      } else if (node.name === nameToMatch) {
         result = result.concat(queryTree(node.children, query, queryIndex + 1));
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before I start on a bigger endeavour a would like some feedback on the job done so far.

Things to discuss:
1. Is this a viable approach?
2. Right now the default for $__searchFilter is `All` or * for Graphite and % for MySQL, I imagine that's not what we want moving forward because we can potentially walk into a big initial hit against the backend. What should we use instead? Some randomized name? How do we show this to the user so they don't get confused when there is no data in the dropdown?

**Limitations**
Right now it's only implemented for `Graphite` and `MySQL`.

<details>
  <summary>Graphite dashboard:</summary>
  <p>

```json
{
  "__inputs": [
    {
      "name": "DS_GDEV-GRAPHITE",
      "label": "gdev-graphite",
      "description": "",
      "type": "datasource",
      "pluginId": "graphite",
      "pluginName": "Graphite"
    }
  ],
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "6.5.0-pre"
    },
    {
      "type": "panel",
      "id": "graph",
      "name": "Graph",
      "version": ""
    },
    {
      "type": "datasource",
      "id": "graphite",
      "name": "Graphite",
      "version": "1.0.0"
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": null,
  "iteration": 1571227765593,
  "links": [],
  "panels": [
    {
      "aliasColors": {},
      "bars": false,
      "cacheTimeout": "",
      "dashLength": 10,
      "dashes": false,
      "datasource": "${DS_GDEV-GRAPHITE}",
      "fill": 1,
      "fillGradient": 0,
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 1,
      "maxDataPoints": "",
      "nullPointMode": "null",
      "options": {
        "dataLinks": []
      },
      "percentage": false,
      "pointradius": 2,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "refId": "A",
          "target": "sumSeries($root.$sub, A)"
        }
      ],
      "thresholds": [],
      "timeFrom": null,
      "timeRegions": [],
      "timeShift": null,
      "title": "Panel Title",
      "tooltip": {
        "shared": true,
        "sort": 0,
        "value_type": "individual"
      },
      "type": "graph",
      "xaxis": {
        "buckets": null,
        "mode": "time",
        "name": null,
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        },
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        }
      ],
      "yaxis": {
        "align": false,
        "alignLevel": null
      }
    }
  ],
  "schemaVersion": 20,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": [
      {
        "allValue": null,
        "current": {},
        "datasource": "${DS_GDEV-GRAPHITE}",
        "definition": ".$__searchFilter",
        "hide": 0,
        "includeAll": true,
        "label": null,
        "multi": true,
        "name": "root",
        "options": [],
        "query": ".$__searchFilter",
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "tagValuesQuery": "",
        "tags": [],
        "tagsQuery": "",
        "type": "query",
        "useTags": false
      },
      {
        "allValue": null,
        "current": {},
        "datasource": "${DS_GDEV-GRAPHITE}",
        "definition": "$root.$__searchFilter",
        "hide": 0,
        "includeAll": true,
        "label": null,
        "multi": true,
        "name": "sub",
        "options": [],
        "query": "$root.$__searchFilter",
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "tagValuesQuery": "",
        "tags": [],
        "tagsQuery": "",
        "type": "query",
        "useTags": false
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {
    "refresh_intervals": [
      "5s",
      "10s",
      "30s",
      "1m",
      "5m",
      "15m",
      "30m",
      "1h",
      "2h",
      "1d"
    ]
  },
  "timezone": "",
  "title": "Graphite SearchFilter template variable query",
  "uid": "VEgKNOoWk",
  "version": 9
}
```
</p>
</details>

<details>
  <summary>MySQL dashboard</summary>
  <p>

```json
{
  "__inputs": [
    {
      "name": "DS_GDEV-MYSQL",
      "label": "gdev-mysql",
      "description": "",
      "type": "datasource",
      "pluginId": "mysql",
      "pluginName": "MySQL"
    }
  ],
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "6.5.0-pre"
    },
    {
      "type": "panel",
      "id": "graph",
      "name": "Graph",
      "version": ""
    },
    {
      "type": "datasource",
      "id": "mysql",
      "name": "MySQL",
      "version": "1.0.0"
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": null,
  "iteration": 1571226934740,
  "links": [],
  "panels": [
    {
      "aliasColors": {},
      "bars": false,
      "cacheTimeout": "",
      "dashLength": 10,
      "dashes": false,
      "datasource": "${DS_GDEV-MYSQL}",
      "fill": 1,
      "fillGradient": 0,
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "interval": "",
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 1,
      "maxDataPoints": "",
      "nullPointMode": "null",
      "options": {
        "dataLinks": []
      },
      "percentage": false,
      "pointradius": 2,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "format": "time_series",
          "group": [],
          "metricColumn": "datacenter",
          "rawQuery": true,
          "rawSql": "SELECT\n  createdAt AS \"time\",\n  datacenter AS metric,\n  id\nFROM grafana_metric\nWHERE\n  $__timeFilter(createdAt)\n  AND datacenter IN ($datacenter)\nORDER BY createdAt",
          "refId": "A",
          "select": [
            [
              {
                "params": [
                  "id"
                ],
                "type": "column"
              }
            ]
          ],
          "table": "grafana_metric",
          "timeColumn": "createdAt",
          "timeColumnType": "timestamp",
          "where": [
            {
              "name": "$__timeFilter",
              "params": [],
              "type": "macro"
            }
          ]
        }
      ],
      "thresholds": [],
      "timeFrom": null,
      "timeRegions": [],
      "timeShift": null,
      "title": "Panel Title",
      "tooltip": {
        "shared": true,
        "sort": 0,
        "value_type": "individual"
      },
      "type": "graph",
      "xaxis": {
        "buckets": null,
        "mode": "time",
        "name": null,
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        },
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        }
      ],
      "yaxis": {
        "align": false,
        "alignLevel": null
      }
    }
  ],
  "schemaVersion": 20,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": [
      {
        "allValue": null,
        "current": {},
        "datasource": "${DS_GDEV-MYSQL}",
        "definition": "SELECT  datacenter FROM grafana_metric WHERE datacenter LIKE $__searchFilter",
        "hide": 0,
        "includeAll": true,
        "label": null,
        "multi": true,
        "name": "datacenter",
        "options": [],
        "query": "SELECT  datacenter FROM grafana_metric WHERE datacenter LIKE $__searchFilter",
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "tagValuesQuery": "",
        "tags": [],
        "tagsQuery": "",
        "type": "query",
        "useTags": false
      }
    ]
  },
  "time": {
    "from": "now-5m",
    "to": "now"
  },
  "timepicker": {
    "refresh_intervals": [
      "5s",
      "10s",
      "30s",
      "1m",
      "5m",
      "15m",
      "30m",
      "1h",
      "2h",
      "1d"
    ]
  },
  "timezone": "",
  "title": "MySql SearchFilter template variable query",
  "uid": "FmygjcoZk",
  "version": 7
}
```
  </p>
</details>

**Which issue(s) this PR fixes**:
Fixes #7644

**Special notes for your reviewer**:

