### PR TITLE
Prometheus: allow step to be smaller than $__interval

### DIFF
--- a/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
@@ -418,7 +418,7 @@ const instanceSettings = ({
   directUrl: 'direct',
   user: 'test',
   password: 'mupp',
-  jsonData: { httpMethod: 'GET' },
+  jsonData: { httpMethod: 'GET', minInterval: '60s' },
 } as unknown) as DataSourceInstanceSettings<PromOptions>;
 const backendSrv = {
   datasourceRequest: jest.fn(),
@@ -1199,7 +1199,7 @@ describe('PrometheusDatasource', () => {
         },
       });
     });
-    it('should be min interval when greater than interval * intervalFactor', async () => {
+    it('should be independent from step', async () => {
       const query = {
         // 6 minute range
         range: { from: time({ minutes: 1 }), to: time({ minutes: 7 }) },
@@ -1210,16 +1210,16 @@ describe('PrometheusDatasource', () => {
             intervalFactor: 2,
           },
         ],
-        interval: '5s',
+        interval: '50s',
         scopedVars: {
-          __interval: { text: '5s', value: '5s' },
-          __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
+          __interval: { text: '50s', value: '50s' },
+          __interval_ms: { text: 50 * 1000, value: 50 * 1000 },
         },
       };
       const urlExpected =
         'proxied/api/v1/query_range?query=' +
         encodeURIComponent('rate(test[$__interval])') +
-        '&start=60&end=420&step=15';
+        '&start=60&end=420&step=30';
 
       backendSrv.datasourceRequest = jest.fn(() => Promise.resolve(response));
       ctx.ds = new PrometheusDatasource(instanceSettings, q, backendSrv as any, templateSrv as any, timeSrv as any);
@@ -1231,12 +1231,12 @@ describe('PrometheusDatasource', () => {
       // @ts-ignore
       expect(templateSrv.replace.mock.calls[0][1]).toEqual({
         __interval: {
-          text: '5s',
-          value: '5s',
+          text: '50s',
+          value: '50s',
         },
         __interval_ms: {
-          text: 5000,
-          value: 5000,
+          text: 50000,
+          value: 50000,
         },
       });
     });


### PR DESCRIPTION
**What this PR does / why we need it**:

In #14209 there is a request for uncoupling step and interval. This PR treats them separately.

Current behavior:

<img width="920" alt="Screenshot 2019-10-17 at 17 51 20" src="https://user-images.githubusercontent.com/859729/67025717-ca70d200-f106-11e9-8a75-bf2b328d428d.png">


After this change, you can have a higher resolution, independent of the dynamically calculated interval:

<img width="918" alt="Screenshot 2019-10-17 at 17 50 47" src="https://user-images.githubusercontent.com/859729/67025760-de1c3880-f106-11e9-8833-e52b3a306bbe.png">



Open questions:

- should the interval factor be applied to both still? I'd say yes, In effect that determines how many datapoints are being returned

Todos:

- [ ] Fix tests once behavior is decided