### PR TITLE
Alerting: Add meta data, including tags to alert rules for pagerduty

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -187,7 +187,7 @@ func (pm *PluginManager) scan(pluginDir string) error {
 	}
 
 	if len(scanner.errors) > 0 {
-		pm.log.Warn("Some plugins failed to load", "errors", scanner.errors)
+		return errutil.Wrapf(scanner.errors[0], "Some plugins failed to load")
 	}
 
 	return nil


### PR DESCRIPTION


**What this PR does / why we need it**:  This PR add panel tags to the Pagerduty panel, which are important for deterministic routing in the global rules api.  This feature was added for the Promethous Alert Manager panel already in https://github.com/grafana/grafana/pull/10989/files#.  It also adds the eval context cleanly to the payload body so we can route on those as well

**Which issue(s) this PR fixes**: n/a

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

