### PR TITLE
TablePanel, GraphPanel: Exclude hidden columns from CSV

### DIFF
--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -334,7 +334,9 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   exportCsv() {
     const scope = this.$scope.$new(true);
-    scope.seriesList = this.seriesList;
+    scope.seriesList = this.seriesList
+      .filter(series => !this.panel.legend.hideEmpty || !series.allIsNull)
+      .filter(series => !this.panel.legend.hideZero || !series.allIsZero);
     this.publishAppEvent(CoreEvents.showModal, {
       templateHtml: '<export-data-modal data="seriesList"></export-data-modal>',
       scope,

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -1,5 +1,6 @@
 import { GraphCtrl } from '../module';
 import { dateTime } from '@grafana/data';
+import TimeSeries from 'app/core/time_series2';
 
 jest.mock('../graph', () => ({}));
 
@@ -17,7 +18,7 @@ describe('GraphCtrl', () => {
     },
   };
 
-  const scope = {
+  const scope: any = {
     $on: () => {},
   };
 
@@ -95,6 +96,77 @@ describe('GraphCtrl', () => {
 
     it('should set datapointsCount warning', () => {
       expect(ctx.ctrl.dataWarning.title).toBe('No data');
+    });
+  });
+
+  describe('when data is exported to CSV', () => {
+    const appEventMock = jest.fn();
+
+    beforeEach(() => {
+      appEventMock.mockReset();
+      scope.$root = { appEvent: appEventMock };
+      scope.$new = () => ({});
+      const data = [
+        {
+          target: 'test.normal',
+          datapoints: [[10, 1], [10, 2]],
+        },
+        {
+          target: 'test.nulls',
+          datapoints: [[null, 1], [null, 2]],
+        },
+        {
+          target: 'test.zeros',
+          datapoints: [[0, 1], [0, 2]],
+        },
+      ];
+      ctx.ctrl.onDataSnapshotLoad(data);
+      // allIsNull / allIsZero are set by getFlotPairs
+      ctx.ctrl.seriesList.forEach((series: TimeSeries) => series.getFlotPairs(''));
+    });
+
+    const thenExportYieldedNSeries = (n: number) => {
+      expect(appEventMock.mock.calls.length).toBe(1);
+      const eventPayload = appEventMock.mock.calls[0][1];
+      expect(eventPayload.scope.seriesList).toHaveLength(n);
+    };
+
+    const thenExportDidNotYieldSeriesName = (unexpectedName: string) => {
+      expect(appEventMock.mock.calls.length).toBe(1);
+      const eventPayload = appEventMock.mock.calls[0][1];
+      expect(
+        eventPayload.scope.seriesList.filter((series: TimeSeries) => series.label === unexpectedName)
+      ).toHaveLength(0);
+    };
+
+    it('should not ignore anything if not asked to', () => {
+      ctx.ctrl.exportCsv();
+      thenExportYieldedNSeries(3);
+    });
+
+    it('should ignore all-null series when asked to', () => {
+      ctx.ctrl.panel.legend.hideEmpty = true;
+      ctx.ctrl.exportCsv();
+      thenExportYieldedNSeries(2);
+      thenExportDidNotYieldSeriesName('test.nulls');
+    });
+
+    it('should ignore all-zero series when asked to', () => {
+      ctx.ctrl.panel.legend.hideZero = true;
+      ctx.ctrl.exportCsv();
+      // impl treats all-null series as all-zero as well
+      thenExportYieldedNSeries(1);
+      thenExportDidNotYieldSeriesName('test.zeros');
+      thenExportDidNotYieldSeriesName('test.empty');
+    });
+
+    it('should ignore both when asked to', () => {
+      ctx.ctrl.panel.legend.hideZero = true;
+      ctx.ctrl.panel.legend.hideEmpty = true;
+      ctx.ctrl.exportCsv();
+      thenExportYieldedNSeries(1);
+      thenExportDidNotYieldSeriesName('test.zeros');
+      thenExportDidNotYieldSeriesName('test.empty');
     });
   });
 });

--- a/public/app/plugins/panel/table/renderer.ts
+++ b/public/app/plugins/panel/table/renderer.ts
@@ -344,17 +344,20 @@ export class TableRenderer {
 
   render_values() {
     const rows = [];
+    const visibleColumns = this.table.columns.filter(column => !column.hidden);
 
     for (let y = 0; y < this.table.rows.length; y++) {
       const row = this.table.rows[y];
       const newRow = [];
       for (let i = 0; i < this.table.columns.length; i++) {
-        newRow.push(this.formatColumnValue(i, row[i]));
+        if (!this.table.columns[i].hidden) {
+          newRow.push(this.formatColumnValue(i, row[i]));
+        }
       }
       rows.push(newRow);
     }
     return {
-      columns: this.table.columns,
+      columns: visibleColumns,
       rows: rows,
     };
   }

--- a/public/app/plugins/panel/table/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table/specs/renderer.test.ts
@@ -3,6 +3,7 @@ import TableModel from 'app/core/table_model';
 import { TableRenderer } from '../renderer';
 import { getColorDefinitionByName } from '@grafana/data';
 import { ScopedVars } from '@grafana/data';
+import { ColumnRender } from '../types';
 
 describe('when rendering table', () => {
   const SemiDarkOrange = getColorDefinitionByName('semi-dark-orange');
@@ -23,9 +24,10 @@ describe('when rendering table', () => {
       { text: 'RangeMapping' },
       { text: 'MappingColored' },
       { text: 'RangeMappingColored' },
+      { text: 'HiddenType' },
     ];
     table.rows = [
-      [1388556366666, 1230, 40, undefined, '', '', 'my.host.com', 'host1', ['value1', 'value2'], 1, 2, 1, 2],
+      [1388556366666, 1230, 40, undefined, '', '', 'my.host.com', 'host1', ['value1', 'value2'], 1, 2, 1, 2, 'ignored'],
     ];
 
     const panel = {
@@ -163,6 +165,10 @@ describe('when rendering table', () => {
           colorMode: 'value',
           thresholds: [2, 5],
           colors: ['#00ff00', SemiDarkOrange.name, 'rgb(1,0,0)'],
+        },
+        {
+          pattern: 'HiddenType',
+          type: 'hidden',
         },
       ],
     };
@@ -384,6 +390,19 @@ describe('when rendering table', () => {
     it('value should be mapped to text (range) and colored cell should have style', () => {
       const html = renderer.renderCell(12, 0, '7.1');
       expect(html).toBe('<td style="color:rgb(1,0,0)">7.1</td>');
+    });
+
+    it('hidden columns should not be rendered', () => {
+      const html = renderer.renderCell(13, 0, 'ignored');
+      expect(html).toBe('');
+    });
+
+    it('render_values should ignore hidden columns', () => {
+      renderer.render(0); // this computes the hidden markers on the columns
+      const { columns, rows } = renderer.render_values();
+      expect(rows).toHaveLength(1);
+      expect(columns).toHaveLength(table.columns.length - 1);
+      expect(columns.filter((col: ColumnRender) => col.hidden)).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

2. Ensure you include and run the appropriate tests as part of your Pull Request.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As a user, when I export a table with hidden columns to a CSV, I expect the CSV not to contain hidden columns. Likewise, when I export a graph to a CSV, and "Hide series:" is configured to "With only nulls/empty", I expect the relevant columns to be hidden from the CSV as well. That makes the CSV output consistent with what is displayed on-screen.

I was able to reproduce both issues locally with latest `master`, and they are no longer reproducible with the changes.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/12076

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/12076

**Special notes for your reviewer**:
* [ ] The original post of the issue only references the issue with the table and explicitly hidden columns. The graph issue was noted in a comment. Those issues are closely related, but I can split this PR if necessary. (The commits are separate already)
* [x] This PR does not add any tests for I was unable to locate where the affected code is currently being tested. If tests exist for that code already, a pointer would be great so that we can prevent regressions in the future.
* [ ] I'm not quite happy with the double-filter with rather complex conditions in ` graph/module.ts`. Suggestions appreciated!
* [ ] intransparent call-order dependencies, see https://github.com/grafana/grafana/pull/19925#issuecomment-549187694
* ~~For the Jest tests, `ElasticDatasource › When testing datasource with index pattern › should translate index pattern to current day` fails on my machine (one-off error with a date), but this also happens on `master`. Likewise, `e2e-tests` fails as well, but also fails with the same message on `master`.~~ Tests pass locally as well now.
* Here's an export of the dashboard I used to test this: https://gist.github.com/xxyy/ece7a1e54579f480f7ef26fb40815fce

Thank you! :)
