### PR TITLE
pkg/util: Replace custom pbkdf2 implementation by maintained version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	go.uber.org/atomic v1.3.2 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/pkg/util/encryption.go
+++ b/pkg/util/encryption.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
+	"golang.org/x/crypto/pbkdf2"
 	"io"
 )
 
@@ -73,5 +74,5 @@ func Encrypt(payload []byte, secret string) ([]byte, error) {
 
 // Key needs to be 32bytes
 func encryptionKeyToBytes(secret, salt string) ([]byte, error) {
-	return PBKDF2([]byte(secret), []byte(salt), 10000, 32, sha256.New)
+	return pbkdf2.Key([]byte(secret), []byte(salt), 10000, 32, sha256.New), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the custom pbkdf2 implementation by "upstream" maintained version.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
It's bad practice to implement crypto our own. Better rely on (maintained) libs or upstream implementations.
