### PR TITLE
Explore: Change loading state to done after live-tailing stops

### DIFF
--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -179,7 +179,7 @@ describe('Explore item reducer', () => {
     it("should result in 'streaming' state, when live-tailing is active", () => {
       const initalState = makeExploreItemState();
       const expectedState = {
-        ...initalState,
+        ...makeExploreItemState(),
         refreshInterval: 'LIVE',
         isLive: true,
         loading: true,
@@ -201,7 +201,7 @@ describe('Explore item reducer', () => {
     it("should result in 'done' state, when live-tailing is stopped", () => {
       const initalState = makeExploreItemState();
       const expectedState = {
-        ...initalState,
+        ...makeExploreItemState(),
         refreshInterval: '',
         logsResult: {
           hasUniqueLabels: false,

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -21,6 +21,7 @@ import {
   toggleGraphAction,
   toggleTableAction,
   changeRangeAction,
+  changeRefreshIntervalAction,
 } from './actionTypes';
 import { Reducer } from 'redux';
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
@@ -28,7 +29,7 @@ import { updateLocation } from 'app/core/actions/location';
 import { serializeStateToUrlParam } from 'app/core/utils/explore';
 import TableModel from 'app/core/table_model';
 import { DataSourceApi, DataQuery } from '@grafana/ui';
-import { LogsModel, LogsDedupStrategy, dateTime } from '@grafana/data';
+import { LogsModel, LogsDedupStrategy, dateTime, LoadingState } from '@grafana/data';
 
 describe('Explore item reducer', () => {
   describe('scanning', () => {
@@ -171,6 +172,56 @@ describe('Explore item reducer', () => {
             .thenStateShouldEqual(expectedState);
         });
       });
+    });
+  });
+
+  describe('changing refresh intervals', () => {
+    it("should result in 'streaming' state, when live-tailing is active", () => {
+      const initalState = {
+        ...makeExploreItemState(),
+      };
+
+      const expectedState = {
+        ...initalState,
+        refreshInterval: 'LIVE',
+        isLive: true,
+        loading: true,
+        logsResult: {
+          hasUniqueLabels: false,
+          rows: [] as any[],
+        },
+        queryResponse: {
+          ...initalState.queryResponse,
+          state: LoadingState.Streaming,
+        },
+      };
+      reducerTester()
+        .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
+        .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.left, refreshInterval: 'LIVE' }))
+        .thenStateShouldEqual(expectedState);
+    });
+
+    it("should result in 'done' state, when live-tailing is stopped", () => {
+      const initalState = {
+        ...makeExploreItemState(),
+      };
+
+      const expectedState = {
+        ...initalState,
+        refreshInterval: '',
+        logsResult: {
+          hasUniqueLabels: false,
+          rows: [] as any[],
+        },
+        queryResponse: {
+          ...initalState.queryResponse,
+          state: LoadingState.Done,
+        },
+      };
+      reducerTester()
+        .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
+        .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.left, refreshInterval: '' }))
+        .thenStateShouldEqual(expectedState);
     });
   });
 

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -43,7 +43,7 @@ describe('Explore item reducer', () => {
         .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
         .whenActionIsDispatched(scanStartAction({ exploreId: ExploreId.left }))
         .thenStateShouldEqual({
-          ...initalState,
+          ...makeExploreItemState(),
           scanning: true,
         });
     });
@@ -58,7 +58,7 @@ describe('Explore item reducer', () => {
         .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
         .whenActionIsDispatched(scanStopAction({ exploreId: ExploreId.left }))
         .thenStateShouldEqual({
-          ...initalState,
+          ...makeExploreItemState(),
           scanning: false,
           scanRange: undefined,
         });
@@ -188,7 +188,7 @@ describe('Explore item reducer', () => {
           rows: [] as any[],
         },
         queryResponse: {
-          ...initalState.queryResponse,
+          ...makeExploreItemState().queryResponse,
           state: LoadingState.Streaming,
         },
       };
@@ -208,7 +208,7 @@ describe('Explore item reducer', () => {
           rows: [] as any[],
         },
         queryResponse: {
-          ...initalState.queryResponse,
+          ...makeExploreItemState().queryResponse,
           state: LoadingState.Done,
         },
       };

--- a/public/app/features/explore/state/reducers.test.ts
+++ b/public/app/features/explore/state/reducers.test.ts
@@ -177,10 +177,7 @@ describe('Explore item reducer', () => {
 
   describe('changing refresh intervals', () => {
     it("should result in 'streaming' state, when live-tailing is active", () => {
-      const initalState = {
-        ...makeExploreItemState(),
-      };
-
+      const initalState = makeExploreItemState();
       const expectedState = {
         ...initalState,
         refreshInterval: 'LIVE',
@@ -196,16 +193,13 @@ describe('Explore item reducer', () => {
         },
       };
       reducerTester()
-        .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
+        .givenReducer(itemReducer, initalState)
         .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.left, refreshInterval: 'LIVE' }))
         .thenStateShouldEqual(expectedState);
     });
 
     it("should result in 'done' state, when live-tailing is stopped", () => {
-      const initalState = {
-        ...makeExploreItemState(),
-      };
-
+      const initalState = makeExploreItemState();
       const expectedState = {
         ...initalState,
         refreshInterval: '',
@@ -219,7 +213,7 @@ describe('Explore item reducer', () => {
         },
       };
       reducerTester()
-        .givenReducer(itemReducer as Reducer<ExploreItemState, ActionOf<any>>, initalState)
+        .givenReducer(itemReducer, initalState)
         .whenActionIsDispatched(changeRefreshIntervalAction({ exploreId: ExploreId.left, refreshInterval: '' }))
         .thenStateShouldEqual(expectedState);
     });

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -204,7 +204,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         refreshInterval,
         queryResponse: {
           ...state.queryResponse,
-          state: live ? LoadingState.Streaming : LoadingState.NotStarted,
+          state: live ? LoadingState.Streaming : LoadingState.Done,
         },
         isLive: live,
         isPaused: live ? false : state.isPaused,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes loadingState to Done, instead of NotStarted, after live-tailing is stoped. 
This is also connected to: 
- https://github.com/grafana/grafana/issues/19954 -> live-tailing is initialised with runQueries function. When user stops live-tailing, we display last values from the live-tailing. We don't run new runQueries function. Therefore loadingState should be Done and not NotStarted. 
- https://github.com/grafana/grafana/pull/19794 -> as hide/show query results button is disabled for `loadingState === NotStarted`, after the live-tailing is stopped, this button is disabled due to NotStarted loadingState (which is a bug). This PR fixes this.
