### PR TITLE
Grafana frontend: absolute url replaced with relative

### DIFF
--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -403,7 +403,7 @@ function getPluginTabsNav(
     text: meta.name,
     img: meta.info.logos.large,
     subTitle: meta.info.author.name,
-    breadcrumbs: [{ title: 'Plugins', url: '/plugins' }],
+    breadcrumbs: [{ title: 'Plugins', url: 'plugins' }],
     url: `${appSubUrl}${path}`,
     children: setActivePage(query.page as string, pages, defaultPage),
   };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/19968
Hello, just a quick fix of breadcrumbs URL on the plugin page, which were leading to wrong navigation