### PR TITLE
Datasource/Elasticsearch: Fix logs which were displayed with incorrec…

### DIFF
--- a/packages/grafana-data/src/dataframe/MutableDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.test.ts
@@ -57,6 +57,16 @@ describe('Apending DataFrame', () => {
       { time: null, name: null, value: null, value2: 'XXX' }, // 4
     ]);
 
+    // Add a time value that has an array type
+    frame.add({ time: [300] });
+    expect(frame.toArray()).toEqual([
+      { time: 100, name: 'a', value: 1, value2: null }, // 1
+      { time: 200, name: 'BB', value: 20, value2: null }, // 2
+      { time: null, name: null, value: 3, value2: null }, // 3
+      { time: null, name: null, value: null, value2: 'XXX' }, // 4
+      { time: 300, name: null, value: null, value2: null }, // 5
+    ]);
+
     // Make sure length survives a spread operator
     const keys = Object.keys(frame);
     const copy = { ...frame } as any;

--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -234,6 +234,11 @@ export class MutableDataFrame<T = any> implements DataFrame, MutableVector<T> {
           field.parse = makeFieldParser(val, field);
         }
         val = field.parse(val);
+      } else if (field.type === FieldType.time && isArray(val)) {
+        if (!field.parse) {
+          field.parse = (val: any[]) => val[0] || undefined;
+        }
+        val = field.parse(val);
       }
 
       if (val === undefined) {


### PR DESCRIPTION
…rrect timestamp in the Explore tab

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
 Logs were displayed with incorrect timestamp in  Explore logs tab  if use  Elasticsearch  datasource.
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19909 

**Special notes for your reviewer**:

