### PR TITLE
LDAP: No longer shows incorrectly matching groups based on role in debug page

### DIFF
--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -278,13 +278,15 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 
 	orgRoles := []LDAPRoleDTO{}
 
-	// First, let's find the groupDN that we did match by inspecting the assigned user OrgRoles.
-	for _, group := range serverConfig.Groups {
-		orgRole, ok := user.OrgRoles[group.OrgId]
+	// First, let's find the groupDN that match the users groups
+	for _, configGroup := range serverConfig.Groups {
+		for _, userGroup := range user.Groups {
+			if configGroup.GroupDN == userGroup {
+				r := &LDAPRoleDTO{GroupDN: configGroup.GroupDN, OrgId: configGroup.OrgId, OrgRole: configGroup.OrgRole}
+				orgRoles = append(orgRoles, *r)
 
-		if ok && orgRole == group.OrgRole {
-			r := &LDAPRoleDTO{GroupDN: group.GroupDN, OrgId: group.OrgId, OrgRole: group.OrgRole}
-			orgRoles = append(orgRoles, *r)
+				break
+			}
 		}
 	}
 

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -287,6 +287,7 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 					r := &LDAPRoleDTO{GroupDN: configGroup.GroupDN, OrgId: configGroup.OrgId, OrgRole: configGroup.OrgRole}
 					orgRoles = append(orgRoles, *r)
 					matchedOrgIds[configGroup.OrgId] = true
+					break
 				}
 			}
 		}

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -277,20 +277,19 @@ func (server *HTTPServer) GetUserFromLDAP(c *models.ReqContext) Response {
 	}
 
 	orgRoles := []LDAPRoleDTO{}
-	matchedOrgIds := map[int64]bool{}
 
 	// Need to iterate based on the config groups as only the first match for an org is used
+	// We are showing all matches as that should help in understanding why one match wins out
+	// over another.
 	for _, configGroup := range serverConfig.Groups {
-		if _, matched := matchedOrgIds[configGroup.OrgId]; !matched {
-			for _, userGroup := range user.Groups {
-				if configGroup.GroupDN == userGroup {
-					r := &LDAPRoleDTO{GroupDN: configGroup.GroupDN, OrgId: configGroup.OrgId, OrgRole: configGroup.OrgRole}
-					orgRoles = append(orgRoles, *r)
-					matchedOrgIds[configGroup.OrgId] = true
-					break
-				}
+		for _, userGroup := range user.Groups {
+			if configGroup.GroupDN == userGroup {
+				r := &LDAPRoleDTO{GroupDN: configGroup.GroupDN, OrgId: configGroup.OrgId, OrgRole: configGroup.OrgRole}
+				orgRoles = append(orgRoles, *r)
+				break
 			}
 		}
+		//}
 	}
 
 	// Then, we find what we did not match by inspecting the list of groups returned from

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -183,6 +183,11 @@ func TestGetUserFromLDAPApiEndpoint(t *testing.T) {
 				OrgId:   1,
 				OrgRole: models.ROLE_ADMIN,
 			},
+			{
+				GroupDN: "cn=admins2,ou=groups,dc=grafana,dc=org",
+				OrgId:   1,
+				OrgRole: models.ROLE_ADMIN,
+			},
 		},
 	}
 

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -122,7 +122,7 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 				OrgRole: models.ROLE_ADMIN,
 			},
 			{
-				GroupDN: "cn=admins,ou=groups,dc=grafana2,dc=org",
+				GroupDN: "cn=admins,ou=groups,dc=grafana,dc=org",
 				OrgId:   2,
 				OrgRole: models.ROLE_VIEWER,
 			},
@@ -148,7 +148,7 @@ func TestGetUserFromLDAPApiEndpoint_OrgNotfound(t *testing.T) {
 
 	sc := getUserFromLDAPContext(t, "/api/admin/ldap/johndoe")
 
-	require.Equal(t, sc.resp.Code, http.StatusBadRequest)
+	require.Equal(t, http.StatusBadRequest, sc.resp.Code)
 
 	expected := `
 	{
@@ -245,6 +245,7 @@ func TestGetUserFromLDAPApiEndpoint_WithTeamHandler(t *testing.T) {
 		Name:           "John Doe",
 		Email:          "john.doe@example.com",
 		Login:          "johndoe",
+		Groups:         []string{"cn=admins,ou=groups,dc=grafana,dc=org"},
 		OrgRoles:       map[int64]models.RoleType{1: models.ROLE_ADMIN},
 		IsGrafanaAdmin: &isAdmin,
 	}

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -19,7 +19,7 @@ export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
               {showAttributeMapping && <th>LDAP Group</th>}
               <th>
                 Organization
-                <Tooltip placement="top" content="Only the first match for an Organisation will be used" theme={'info'}>
+                <Tooltip placement="top" content="Only the first match for an Organization will be used" theme={'info'}>
                   <span className="gf-form-help-icon">
                     <i className="fa fa-info-circle" />
                   </span>

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -18,7 +18,7 @@ export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
             <tr>
               {showAttributeMapping && <th>LDAP Group</th>}
               <th>
-                Organisation
+                Organization
                 <Tooltip placement="top" content="Only the first match for an Organisation will be used" theme={'info'}>
                   <span className="gf-form-help-icon">
                     <i className="fa fa-info-circle" />

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -17,7 +17,14 @@ export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
           <thead>
             <tr>
               {showAttributeMapping && <th>LDAP Group</th>}
-              <th>Organisation</th>
+              <th>
+                Organisation
+                <Tooltip placement="top" content="Only the first match for an Organisation will be used" theme={'info'}>
+                  <span className="gf-form-help-icon">
+                    <i className="fa fa-info-circle" />
+                  </span>
+                </Tooltip>
+              </th>
               <th>Role</th>
             </tr>
           </thead>


### PR DESCRIPTION
**What this PR does / why we need it**:

No longer show all groups that gives a specific Org Role for a user that gets that role from one of them. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20016

**Special notes for your reviewer**:

