### PR TITLE
Templating:  Add millisecond formatting option

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -114,6 +114,15 @@ String to interpolate: '${servers:percentencode}'
 Interpolation result: 'foo%28%29bar%20BAZ%2Ctest2'
 ```
 
+### Milliseconds
+Format single valued variables in milliseconds.
+
+```bash
+interval = '10s'
+String to interpolate: '${interval:ms}'
+Interpolation result: '10000'
+```
+
 Test the formatting options on the [Grafana Play site](http://play.grafana.org/d/cJtIfcWiz/template-variable-formatting-options?orgId=1).
 
 If any invalid formatting option is specified, then `glob` is the default/fallback option.

--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -324,6 +324,13 @@ describe('templateSrv', () => {
     });
   });
 
+  describe('format interval variable to number', () => {
+    it('single interval value and ms format should render millisecond', () => {
+      const result = _templateSrv.formatValue('10s', 'ms');
+      expect(result).toBe(10000);
+    });
+  });
+
   describe('can check if variable exists', () => {
     beforeEach(() => {
       initTemplateSrv([{ type: 'query', name: 'test', current: { value: 'oogle' } }]);

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -175,6 +175,9 @@ export class TemplateSrv {
         }
         return this.encodeURIComponentStrict(value);
       }
+      case 'ms': {
+        return kbn.interval_to_ms(value);
+      }
       default: {
         if (_.isArray(value) && value.length > 1) {
           return '{' + value.join(',') + '}';


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch adds a new formatting option to convert an _Interval_ variable to a millisecond number. 

Providing an integer value, eg. milliseconds or seconds, rather than a human readable string, eg. "10s",  is required by many data sources to compute rate or throughput.

**Which issue(s) this PR fixes**:

Fixes #17682

**Special notes for your reviewer**:

While `{my_interval:seconds}` is likely the primary use case, I decided to convert to milliseconds to match `$__interval(_ms)?`.
