### PR TITLE
Chore: remove logging from panelQueryRunner

### DIFF
--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -142,7 +142,6 @@ export class PanelQueryRunner {
 
       request.interval = norm.interval;
       request.intervalMs = norm.intervalMs;
-      console.log('to', request.range.to.valueOf());
 
       this.pipeToSubject(runRequest(ds, request));
     } catch (err) {


### PR DESCRIPTION
panel QueryRunner is currently writing the `to` value for every query...

```
>> PASS public/app/features/dashboard/state/PanelQueryRunner.test.ts
>> ● Console
>>
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319296994
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297026
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297034
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297045
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297049
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297051
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297053
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297056
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297059
>>     console.log public/app/features/dashboard/state/PanelQueryRunner.ts:145
>>       to 1572319297062
``

I don't think we actually want that