### PR TITLE
LDAP: All LDAP servers should be tried even if one of them returns a connection error

### DIFF
--- a/pkg/services/multildap/multildap.go
+++ b/pkg/services/multildap/multildap.go
@@ -113,13 +113,7 @@ func (multiples *MultiLDAP) Login(query *models.LoginUserQuery) (
 		server := newLDAP(config)
 
 		if err := server.Dial(); err != nil {
-
-			logger.Debug(
-				"unable to dial LDAP server",
-				"host", config.Host,
-				"port", config.Port,
-				"error", err,
-			)
+			logDialFailure(err, config)
 
 			// Only return an error if it is the last server so we can try next server
 			if index == len(multiples.configs)-1 {
@@ -167,11 +161,17 @@ func (multiples *MultiLDAP) User(login string) (
 	}
 
 	search := []string{login}
-	for _, config := range multiples.configs {
+	for index, config := range multiples.configs {
 		server := newLDAP(config)
 
 		if err := server.Dial(); err != nil {
-			return nil, *config, err
+			logDialFailure(err, config)
+
+			// Only return an error if it is the last server so we can try next server
+			if index == len(multiples.configs)-1 {
+				return nil, *config, err
+			}
+			continue
 		}
 
 		defer server.Close()
@@ -204,11 +204,17 @@ func (multiples *MultiLDAP) Users(logins []string) (
 		return nil, ErrNoLDAPServers
 	}
 
-	for _, config := range multiples.configs {
+	for index, config := range multiples.configs {
 		server := newLDAP(config)
 
 		if err := server.Dial(); err != nil {
-			return nil, err
+			logDialFailure(err, config)
+
+			// Only return an error if it is the last server so we can try next server
+			if index == len(multiples.configs)-1 {
+				return nil, err
+			}
+			continue
 		}
 
 		defer server.Close()
@@ -239,4 +245,13 @@ func isSilentError(err error) bool {
 	}
 
 	return false
+}
+
+func logDialFailure(err error, config *ldap.ServerConfig) {
+	logger.Debug(
+		"unable to dial LDAP server",
+		"host", config.Host,
+		"port", config.Port,
+		"error", err,
+	)
 }

--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -305,9 +305,42 @@ func TestMultiLDAP(t *testing.T) {
 
 				teardown()
 			})
+
+			Convey("Should still try to auth with the second server after receiving a dial error from the first", func() {
+				mock := setup()
+
+				expectedError := errors.New("Dial error")
+				mock.dialErrReturn = expectedError
+
+				multi := New([]*ldap.ServerConfig{
+					{}, {},
+				})
+				_, _, err := multi.User("test")
+
+				So(mock.dialCalledTimes, ShouldEqual, 2)
+				So(err, ShouldEqual, expectedError)
+
+				teardown()
+			})
 		})
 
 		Convey("Users()", func() {
+			Convey("Should still try to auth with the second server after receiving a dial error from the first", func() {
+				mock := setup()
+
+				expectedError := errors.New("Dial error")
+				mock.dialErrReturn = expectedError
+
+				multi := New([]*ldap.ServerConfig{
+					{}, {},
+				})
+				_, err := multi.Users([]string{"test"})
+
+				So(mock.dialCalledTimes, ShouldEqual, 2)
+				So(err, ShouldEqual, expectedError)
+
+				teardown()
+			})
 			Convey("Should return error for absent config list", func() {
 				setup()
 

--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -171,6 +171,24 @@ func TestMultiLDAP(t *testing.T) {
 				teardown()
 			})
 
+			Convey("Should still try to auth with the second server after receiving a dial error from the first", func() {
+				mock := setup()
+
+				expectedError := errors.New("Dial error")
+				mock.dialErrReturn = expectedError
+
+				multi := New([]*ldap.ServerConfig{
+					{}, {},
+				})
+				_, err := multi.Login(&models.LoginUserQuery{})
+
+				So(mock.dialCalledTimes, ShouldEqual, 2)
+
+				So(err, ShouldEqual, expectedError)
+
+				teardown()
+			})
+
 			Convey("Should return unknown error", func() {
 				mock := setup()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It goes on and tries next ldap server in the configuration if dial fails

**Which issue(s) this PR fixes**:
Fixes #19306
