### PR TITLE
Docker: Makes it possible to parse timezones in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash && \
+RUN apk add --no-cache ca-certificates bash tzdata && \
     apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
 
 COPY conf ./conf

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash && \
+RUN apk add --no-cache ca-certificates bash tzdata && \
     apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
 
 # PhantomJS


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `tzdata` package to the alpine docker image. This allows us to parse timezones like `Europe/Stockholm`

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20080 

**Special notes for your reviewer**:

