### PR TITLE
OAuth: Store generated state in server side

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	oauthLogger          = log.New("oauth")
-	OauthStateCookieName = "oauth_state"
+	oauthLogger       = log.New("oauth")
+	OauthStateKeyName = "oauth_state"
 )
 
 func GenStateString() (string, error) {
@@ -71,7 +71,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 		}
 
 		hashedState := hashStatecode(state, setting.OAuthService.OAuthInfos[name].ClientSecret)
-		hs.RemoteCacheService.Set(fmt.Sprintf("%v_%v", OauthStateCookieName, state[:8]), hashedState, 60*time.Second)
+		hs.RemoteCacheService.Set(fmt.Sprintf("%v_%v", OauthStateKeyName, state[:8]), hashedState, 60*time.Second)
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
 			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
 		} else {
@@ -81,7 +81,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 	}
 
 	state := ctx.Query("state")
-	cacheKey := fmt.Sprintf("%v_%v", OauthStateCookieName, state[:8])
+	cacheKey := fmt.Sprintf("%v_%v", OauthStateKeyName, state[:8])
 	cacheValue, err := hs.RemoteCacheService.Get(cacheKey)
 	if err != nil {
 		ctx.Handle(500, "login.OAuthLogin(unable to get saved state)", nil)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Before the generated code used during OAuth authentication was stored in a cookie in the client's browser. With this fix the code is stored in the remote cache in the server side (defaulting to the database) to bypass `SameSite` issues that required some Grafana instances not using the SameSite cookie attribute and by that becoming less secure.
More specifically, this fix introduces the following modifications:
* Increases the generated code size by 8 bytes
* The 8 first bytes are used as a key for storing the code in the remote cache
* Whenever a login request with a OAuth code arrives the server looks in the remote cache for a key containing the 8 first bytes of the state provided in the request and if finds one it validates it against the one provided in the request. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18456

**Special notes for your reviewer**: