### PR TITLE
DataSource: don't filter hidden queries automatically

### DIFF
--- a/packages/grafana-ui/src/types/datasource.ts
+++ b/packages/grafana-ui/src/types/datasource.ts
@@ -109,13 +109,6 @@ export interface DataSourcePluginMeta extends PluginMeta {
   queryOptions?: PluginMetaQueryOptions;
   sort?: number;
   streaming?: boolean;
-
-  /**
-   * By default, hidden queries are not passed to the datasource
-   * Set this to true in plugin.json to have hidden queries passed to the
-   * DataSource query method
-   */
-  hiddenQueries?: boolean;
 }
 
 interface PluginMetaQueryOptions {

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -31,7 +31,6 @@ type DataSourcePlugin struct {
 	Alerting      bool              `json:"alerting"`
 	Explore       bool              `json:"explore"`
 	Table         bool              `json:"tables"`
-	HiddenQueries bool              `json:"hiddenQueries"`
 	Logs          bool              `json:"logs"`
 	QueryOptions  map[string]bool   `json:"queryOptions,omitempty"`
 	BuiltIn       bool              `json:"builtIn,omitempty"`

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -26,17 +26,17 @@ import (
 // DataSourcePlugin contains all metadata about a datasource plugin
 type DataSourcePlugin struct {
 	FrontendPluginBase
-	Annotations   bool              `json:"annotations"`
-	Metrics       bool              `json:"metrics"`
-	Alerting      bool              `json:"alerting"`
-	Explore       bool              `json:"explore"`
-	Table         bool              `json:"tables"`
-	Logs          bool              `json:"logs"`
-	QueryOptions  map[string]bool   `json:"queryOptions,omitempty"`
-	BuiltIn       bool              `json:"builtIn,omitempty"`
-	Mixed         bool              `json:"mixed,omitempty"`
-	Routes        []*AppPluginRoute `json:"routes"`
-	Streaming     bool              `json:"streaming"`
+	Annotations  bool              `json:"annotations"`
+	Metrics      bool              `json:"metrics"`
+	Alerting     bool              `json:"alerting"`
+	Explore      bool              `json:"explore"`
+	Table        bool              `json:"tables"`
+	Logs         bool              `json:"logs"`
+	QueryOptions map[string]bool   `json:"queryOptions,omitempty"`
+	BuiltIn      bool              `json:"builtIn,omitempty"`
+	Mixed        bool              `json:"mixed,omitempty"`
+	Routes       []*AppPluginRoute `json:"routes"`
+	Streaming    bool              `json:"streaming"`
 
 	Backend    bool   `json:"backend,omitempty"`
 	Executable string `json:"executable,omitempty"`

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -118,10 +118,6 @@ export class PanelQueryRunner {
     try {
       const ds = await getDataSource(datasource, request.scopedVars);
 
-      if (ds.meta && !ds.meta.hiddenQueries) {
-        request.targets = request.targets.filter(q => !q.hide);
-      }
-
       // Attach the datasource name to each query
       request.targets = request.targets.map(query => {
         if (!query.datasource) {

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -4,7 +4,6 @@
   "id": "cloudwatch",
   "category": "cloud",
 
-  "hiddenQueries": true,
   "metrics": true,
   "alerting": true,
   "annotations": true,

--- a/public/app/plugins/datasource/graphite/plugin.json
+++ b/public/app/plugins/datasource/graphite/plugin.json
@@ -6,7 +6,6 @@
 
   "includes": [{ "type": "dashboard", "name": "Graphite Carbon Metrics", "path": "dashboards/carbon_metrics.json" }],
 
-  "hiddenQueries": true,
   "metrics": true,
   "alerting": true,
   "annotations": true,

--- a/public/app/plugins/datasource/input/InputDatasource.ts
+++ b/public/app/plugins/datasource/input/InputDatasource.ts
@@ -49,6 +49,9 @@ export class InputDatasource extends DataSourceApi<InputQuery, InputOptions> {
   query(options: DataQueryRequest<InputQuery>): Promise<DataQueryResponse> {
     const results: DataFrame[] = [];
     for (const query of options.targets) {
+      if (query.hide) {
+        continue;
+      }
       let data = this.data;
       if (query.data) {
         data = query.data.map(v => toDataFrame(v));

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -37,13 +37,6 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
         mergeMap((dataSourceApi: DataSourceApi) => {
           const datasourceRequest = cloneDeep(request);
 
-          // Remove any unused hidden queries
-          let newTargets = targets.slice();
-          if (!dataSourceApi.meta.hiddenQueries) {
-            newTargets = newTargets.filter((t: DataQuery) => !t.hide);
-          }
-
-          datasourceRequest.targets = newTargets;
           datasourceRequest.requestId = `${dsName}${datasourceRequest.requestId || ''}`;
 
           // all queries hidden return empty result for for this requestId

--- a/public/app/plugins/datasource/mixed/plugin.json
+++ b/public/app/plugins/datasource/mixed/plugin.json
@@ -6,7 +6,6 @@
   "builtIn": true,
   "mixed": true,
   "metrics": true,
-  "hiddenQueries": true,
 
   "queryOptions": {
     "minInterval": true

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -27,6 +27,9 @@ export class TestDataDataSource extends DataSourceApi<TestDataQuery> {
 
     // Start streams and prepare queries
     for (const target of options.targets) {
+      if (target.hide) {
+        continue;
+      }
       if (target.scenarioId === 'streaming_client') {
         streams.push(runStream(target, options));
       } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5821,6 +5821,11 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-db@1.0.30000772:
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
+  integrity sha1-UarokXaChureSj2DGep21qAbUSs=
+
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000947, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30000999:
   version "1.0.30000999"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz#427253a69ad7bea4aa8d8345687b8eec51ca0e43"


### PR DESCRIPTION
In 6.2 we added a property for datasources to say if they want to handle hidden queries.  See #17124

This change has caused more problems than it has solved.  In particular, most external plugins need to set this flag and have not.  Also, with the addition of GEL/expressions we need a standard way to send hidden queries to the backend.