### PR TITLE
docs: Update Azure AD instructions in generic-oauth.md

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -156,11 +156,11 @@ allowed_organizations =
 
 5.  Note down the "Application ID", this will be the OAuth client id.
 
-6.  Click "Settings", then click "Keys" and add a new entry under Passwords
-    - Key Description: Grafana OAuth
-    - Duration: Never Expires
+6.  Click "Certificates & secrets" and add a new entry under Client secrets
+    - Description: Grafana OAuth
+    - Expires: Never
 
-7.  Click Save then copy the key value, this will be the OAuth client secret.
+7.  Click Add then copy the key value, this will be the OAuth client secret.
 
 8.  Configure Grafana as follows:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Azure AD instructions in Grafana docs to follow changes in Azure Portal.

> In the legacy experience, an app had **Keys** page. In the new experience, it has been renamed to **Certificates & secrets**. In addition, **Public keys** are referred to as **Certificates** and **Passwords** are referred to as **Client secrets**.

Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-registrations-training-guide#keyscertificates--secrets

This was reported by a customer in a technical support ticket. I verified visually by logging in Azure AD and walking through the steps.