### PR TITLE
Alerting: Include alert_state in Kafka notifier payload

### DIFF
--- a/pkg/services/alerting/notifiers/kafka.go
+++ b/pkg/services/alerting/notifiers/kafka.go
@@ -75,6 +75,8 @@ func (kn *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
 	records := make([]interface{}, 1)
 
 	bodyJSON := simplejson.New()
+	//get alert state in the kafka output issue #11401
+	bodyJSON.Set("alert_state", state)
 	bodyJSON.Set("description", evalContext.Rule.Name+" - "+evalContext.Rule.Message)
 	bodyJSON.Set("client", "Grafana")
 	bodyJSON.Set("details", customData)

--- a/pkg/services/alerting/notifiers/kafka.go
+++ b/pkg/services/alerting/notifiers/kafka.go
@@ -75,8 +75,6 @@ func (kn *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
 	records := make([]interface{}, 1)
 
 	bodyJSON := simplejson.New()
-	//get alert state in the kafka output issue #11401
-	bodyJSON.Set("alert_state", state)
 	bodyJSON.Set("description", evalContext.Rule.Name+" - "+evalContext.Rule.Message)
 	bodyJSON.Set("client", "Grafana")
 	bodyJSON.Set("details", customData)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It adds the alert state to the kafka message output within the kafka rest notification.
We need it because, the alarm state is mandatory later in the alarm processing to know if it is a new alert or a reconciliation.

**Which issue(s) this PR fixes**:
the original message received in the kafka bus (sent from Grafana notification then to Kafka Rest proxy) is
{"client":"Grafana","client_url":"http://grafana-blabla.com/","contexts":[{"src":"https://grafana.com/assets/img/blog/mixed_styles.png","type":"image"}],"description":"Test notification - Someone is testing the alert notification within grafana.","details":"Triggered metrics:\n\nHigh value: 100.000\nHigher Value: 200.000\n","incident_key":"alertId-0"} 

it is simply adding the alert_state
{**"alert_state":"alerting"**,"client":"Grafana","client_url":"http://grafana-blabla.com/","contexts":[{"src":"https://grafana.com/assets/img/blog/mixed_styles.png","type":"image"}],"description":"Test notification - Someone is testing the alert notification within grafana.","details":"Triggered metrics:\n\nHigh value: 100.000\nHigher Value: 200.000\n","incident_key":"alertId-0"}

this feature is requested in #11401, https://community.grafana.com/t/no-status-field-through-kafka-rest-proxy/15080 and also in my use case :)
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #11401

**Special notes for your reviewer**:
I did not found where I could have unit-tested this change, instead I tested it via re-compiling the code and deploying my grafana image in my OCP cluster using a kafka rest proxy
so the result below is an End to End test read from the kafka bus according to the grafana kafka topic.
{**"alert_state":"alerting"**,"client":"Grafana","client_url":"http://grafana-blabla.com/","contexts":[{"src":"https://grafana.com/assets/img/blog/mixed_styles.png","type":"image"}],"description":"Test notification - Someone is testing the alert notification within grafana.","details":"Triggered metrics:\n\nHigh value: 100.000\nHigher Value: 200.000\n","incident_key":"alertId-0"}

