### PR TITLE
Templating: Makes so $__searchFilter can be used as part of regular expression

### DIFF
--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -114,13 +114,13 @@ variable with all possible values that exist in the wildcard position.
 You can also create nested variables that use other variables in their definition. For example
 `apps.$app.servers.*` uses the variable `$app` in its query definition.
 
-#### Using `$__searchFilter` to filter results in Query Variable
+#### Using `__searchFilter` to filter results in Query Variable
 > Available from Grafana 6.5 and above
 
-Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
-When nothing has been entered by the user the default value for `$__searchFilter` is `*` or `(.*)` when used as part of a regular expression.
+Using `__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `__searchFilter` is `*` and `` when used as part of a regular expression.
 
-The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `server` while the user types in the dropdown select box.
+The example below shows how to use `__searchFilter` as part of the query field to enable searching for `server` while the user types in the dropdown select box.
 
 Query
 ```bash
@@ -129,7 +129,7 @@ apps.$app.servers.$__searchFilter
 
 TagValues
 ```bash
-tag_values(server, server=~$__searchFilter)
+tag_values(server, server=~${__searchFilter:regex})
 ```
 
 

--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -118,7 +118,7 @@ You can also create nested variables that use other variables in their definitio
 > Available from Grafana 6.5 and above
 
 Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
-When nothing has been entered by the user the default value for `$__searchFilter` is `*`.
+When nothing has been entered by the user the default value for `$__searchFilter` is `*` or `(.*)` when used as part of a regular expression.
 
 The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `server` while the user types in the dropdown select box.
 
@@ -126,6 +126,12 @@ Query
 ```bash
 apps.$app.servers.$__searchFilter
 ```
+
+TagValues
+```bash
+tag_values(server, server=~$__searchFilter)
+```
+
 
 ### Variable Usage
 

--- a/docs/sources/features/datasources/mysql.md
+++ b/docs/sources/features/datasources/mysql.md
@@ -276,17 +276,19 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM my_host  WHERE region IN($region)
 ```
 
-#### Using `$__searchFilter` to filter results in Query Variable
+#### Using `__searchFilter` to filter results in Query Variable
 > Available from Grafana 6.5 and above
 
-Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
-When nothing has been entered by the user the default value for `$__searchFilter` is `%`.
+Using `__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `__searchFilter` is `%`.
 
-The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
+> Important that you surround the `__searchFilter` expression with quotes as Grafana does not do this for you.
+
+The example below shows how to use `__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
 
 Query
 ```sql
-SELECT hostname FROM my_host  WHERE hostname LIKE $__searchFilter
+SELECT hostname FROM my_host  WHERE hostname LIKE '$__searchFilter'
 ```
 
 ### Using Variables in Queries

--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -282,17 +282,19 @@ the hosts variable only show hosts from the current selected region with a query
 SELECT hostname FROM host  WHERE region IN($region)
 ```
 
-#### Using `$__searchFilter` to filter results in Query Variable
+#### Using `__searchFilter` to filter results in Query Variable
 > Available from Grafana 6.5 and above
 
-Using `$__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
-When nothing has been entered by the user the default value for `$__searchFilter` is `%`.
+Using `__searchFilter` in the query field will filter the query result based on what the user types in the dropdown select box.
+When nothing has been entered by the user the default value for `__searchFilter` is `%`.
 
-The example below shows how to use `$__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
+> Important that you surround the `__searchFilter` expression with quotes as Grafana does not do this for you.
+
+The example below shows how to use `__searchFilter` as part of the query field to enable searching for `hostname` while the user types in the dropdown select box.
 
 Query
 ```sql
-SELECT hostname FROM my_host  WHERE hostname LIKE $__searchFilter
+SELECT hostname FROM my_host  WHERE hostname LIKE '$__searchFilter'
 ```
 
 ### Using Variables in Queries

--- a/public/app/features/templating/specs/variable.test.ts
+++ b/public/app/features/templating/specs/variable.test.ts
@@ -94,7 +94,7 @@ describe('containsSearchFilter', () => {
   });
 
   describe(`when called with a query with $${SEARCH_FILTER_VARIABLE}`, () => {
-    it('then it should return false', () => {
+    it('then it should return true', () => {
       const result = containsSearchFilter(`$app.$${SEARCH_FILTER_VARIABLE}`);
 
       expect(result).toBe(true);
@@ -102,7 +102,7 @@ describe('containsSearchFilter', () => {
   });
 
   describe(`when called with a query with [[${SEARCH_FILTER_VARIABLE}]]`, () => {
-    it('then it should return false', () => {
+    it('then it should return true', () => {
       const result = containsSearchFilter(`$app.[[${SEARCH_FILTER_VARIABLE}]]`);
 
       expect(result).toBe(true);
@@ -110,7 +110,7 @@ describe('containsSearchFilter', () => {
   });
 
   describe(`when called with a query with \$\{${SEARCH_FILTER_VARIABLE}:regex\}`, () => {
-    it('then it should return false', () => {
+    it('then it should return true', () => {
       const result = containsSearchFilter(`$app.\$\{${SEARCH_FILTER_VARIABLE}:regex\}`);
 
       expect(result).toBe(true);

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -1,7 +1,7 @@
 import kbn from 'app/core/utils/kbn';
 import _ from 'lodash';
 import { variableRegex } from 'app/features/templating/variable';
-import { TimeRange, ScopedVars } from '@grafana/data';
+import { ScopedVars, TimeRange } from '@grafana/data';
 
 function luceneEscape(value: string) {
   return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -7,7 +7,7 @@ import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 //Types
 import { GraphiteQuery } from './types';
-import { interpolateSearchFilter } from '../../../features/templating/variable';
+import { getSearchFilterScopedVar } from '../../../features/templating/variable';
 
 export class GraphiteDatasource {
   basicAuth: string;
@@ -251,12 +251,10 @@ export class GraphiteDatasource {
 
   metricFindQuery(query: string, optionalOptions: any) {
     const options: any = optionalOptions || {};
-    const interpolatedQuery = interpolateSearchFilter({
-      query: this.templateSrv.replace(query),
-      options: optionalOptions,
-      wildcardChar: '*',
-      quoteLiteral: false,
-    });
+    let interpolatedQuery = this.templateSrv.replace(
+      query,
+      getSearchFilterScopedVar({ query, wildcardChar: '', options: optionalOptions })
+    );
 
     // special handling for tag_values(<tag>[,<expression>]*), this is used for template variables
     let matches = interpolatedQuery.match(/^tag_values\(([^,]+)((, *[^,]+)*)\)$/);
@@ -288,6 +286,11 @@ export class GraphiteDatasource {
       options.limit = 10000;
       return this.getTagsAutoComplete(expressions, undefined, options);
     }
+
+    interpolatedQuery = this.templateSrv.replace(
+      query,
+      getSearchFilterScopedVar({ query, wildcardChar: '*', options: optionalOptions })
+    );
 
     const httpOptions: any = {
       method: 'POST',

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -7,7 +7,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { MysqlQueryForInterpolation } from './types';
-import { interpolateSearchFilter } from '../../../features/templating/variable';
+import { getSearchFilterScopedVar } from '../../../features/templating/variable';
 
 export class MysqlDatasource {
   id: any;
@@ -131,12 +131,11 @@ export class MysqlDatasource {
       refId = optionalOptions.variable.name;
     }
 
-    const rawSql = interpolateSearchFilter({
-      query: this.templateSrv.replace(query, {}, this.interpolateVariable),
-      options: optionalOptions,
-      wildcardChar: '%',
-      quoteLiteral: true,
-    });
+    const rawSql = this.templateSrv.replace(
+      query,
+      getSearchFilterScopedVar({ query, wildcardChar: '%', options: optionalOptions }),
+      this.interpolateVariable
+    );
 
     const interpolatedQuery = {
       refId: refId,

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -124,7 +124,7 @@ describe('MySQLDatasource', () => {
   describe('When performing metricFindQuery with $__searchFilter and a searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
-    const query = 'select title from atable where title LIKE $__searchFilter';
+    const query = "select title from atable where title LIKE '$__searchFilter'";
     const response = {
       results: {
         tempvar: {
@@ -162,7 +162,7 @@ describe('MySQLDatasource', () => {
   describe('When performing metricFindQuery with $__searchFilter but no searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
-    const query = 'select title from atable where title LIKE $__searchFilter';
+    const query = "select title from atable where title LIKE '$__searchFilter'";
     const response = {
       results: {
         tempvar: {

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -127,7 +127,7 @@ export class PostgresDatasource {
       .then((data: any) => this.responseParser.transformAnnotationResponse(options, data));
   }
 
-  metricFindQuery(query: string, optionalOptions: { variable?: any }) {
+  metricFindQuery(query: string, optionalOptions: { variable?: any; searchFilter?: string }) {
     let refId = 'tempvar';
     if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
       refId = optionalOptions.variable.name;

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -7,7 +7,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
 import { PostgresQueryForInterpolation } from './types';
-import { interpolateSearchFilter } from '../../../features/templating/variable';
+import { getSearchFilterScopedVar } from '../../../features/templating/variable';
 
 export class PostgresDatasource {
   id: any;
@@ -133,12 +133,11 @@ export class PostgresDatasource {
       refId = optionalOptions.variable.name;
     }
 
-    const rawSql = interpolateSearchFilter({
-      query: this.templateSrv.replace(query, {}, this.interpolateVariable),
-      options: optionalOptions,
-      wildcardChar: '%',
-      quoteLiteral: true,
-    });
+    const rawSql = this.templateSrv.replace(
+      query,
+      getSearchFilterScopedVar({ query, wildcardChar: '%', options: optionalOptions }),
+      this.interpolateVariable
+    );
 
     const interpolatedQuery = {
       refId: refId,

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -131,7 +131,7 @@ describe('PostgreSQLDatasource', () => {
   describe('When performing metricFindQuery with $__searchFilter and a searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
-    const query = 'select title from atable where title LIKE $__searchFilter';
+    const query = "select title from atable where title LIKE '$__searchFilter'";
     const response = {
       results: {
         tempvar: {
@@ -169,7 +169,7 @@ describe('PostgreSQLDatasource', () => {
   describe('When performing metricFindQuery with $__searchFilter but no searchFilter is given', () => {
     let results: any;
     let calledWith: any = {};
-    const query = 'select title from atable where title LIKE $__searchFilter';
+    const query = "select title from atable where title LIKE '$__searchFilter'";
     const response = {
       results: {
         tempvar: {

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -12,7 +12,7 @@ import { queryMetricTree } from './metricTree';
 import { from, merge, Observable } from 'rxjs';
 import { runStream } from './runStreams';
 import templateSrv from 'app/features/templating/template_srv';
-import { interpolateSearchFilter } from '../../../features/templating/variable';
+import { getSearchFilterScopedVar } from '../../../features/templating/variable';
 
 type TestData = TimeSeries | TableData;
 
@@ -122,12 +122,10 @@ export class TestDataDataSource extends DataSourceApi<TestDataQuery> {
   metricFindQuery(query: string, options: any) {
     return new Promise<MetricFindValue[]>((resolve, reject) => {
       setTimeout(() => {
-        const interpolatedQuery = interpolateSearchFilter({
-          query: templateSrv.replace(query),
-          options,
-          wildcardChar: '*',
-          quoteLiteral: false,
-        });
+        const interpolatedQuery = templateSrv.replace(
+          query,
+          getSearchFilterScopedVar({ query, wildcardChar: '*', options })
+        );
         const children = queryMetricTree(interpolatedQuery);
         const items = children.map(item => ({ value: item.name, text: item.name }));
         resolve(items);


### PR DESCRIPTION
**What this PR does / why we need it**:
Next iteration of $__searchFilter adds the possibility to use it in regular expressions like the `tag_values` query in Graphite.

**Which issue(s) this PR fixes**:
Fixes #20006

**Special notes for your reviewer**:

