### PR TITLE
Docs: Fixed a broken link to LogQL in the docs

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -102,7 +102,7 @@ The following filter types are currently supported:
 * `|~` line matches regular expression.
 * `!~` line does not match regular expression.
 
-> Note: For more details about LogQL, Loki's query language, refer to the [documentation](https://github.com/grafana/loki/blob/master/docs/querying.md)
+> Note: For more details about LogQL, Loki's query language, refer to the [documentation](https://github.com/grafana/loki/blob/master/docs/logql.md)
 
 ## Live tailing
 


### PR DESCRIPTION
This PR fixes a broken link to LogQL here:

https://grafana.com/docs/features/datasources/loki/