### PR TITLE
Docs: Data Sources subsection naming

### DIFF
--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -23,7 +23,7 @@ The Azure Monitor Datasource supports multiple services in the Azure cloud:
 - **[Azure Log Analytics]({{< relref "#querying-the-azure-log-analytics-service" >}})** (or Azure Logs) gives you access to log data collected by Azure Monitor.
 - **[Application Insights Analytics]({{< relref "#writing-analytics-queries-for-the-application-insights-service" >}})** allows you to query [Application Insights data](https://docs.microsoft.com/en-us/azure/azure-monitor/app/analytics) using the same query language used for Azure Log Analytics.
 
-## Adding the data source to Grafana
+## Adding the data source
 
 The datasource can access metrics from four different services. You can configure access to the services that you use. It is also possible to use the same credentials for multiple services if that is how you have set it up in Azure AD.
 

--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -15,7 +15,7 @@ weight = 5
 
 Grafana ships with built in support for CloudWatch. You just have to add it as a data source and you will be ready to build dashboards for your CloudWatch metrics.
 
-## Adding the data source to Grafana
+## Adding the data source
 
 1. Open the side menu by clicking the Grafana icon in the top header.
 2. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.

--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -20,7 +20,7 @@ weight = 6
 Grafana ships with built-in support for Loki, Grafana's log aggregation system.
 Just add it as a datasource and you are ready to query your log data in [Explore](/features/explore).
 
-## Adding the data source to Grafana
+## Adding the data source
 
 1. Open Grafana and make sure you are logged in.
 2. In the side menu under the `Configuration` link you should find a link named `Data Sources`.

--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -14,7 +14,7 @@ weight = 1
 
 Grafana includes built-in support for Prometheus.
 
-## Adding the data source to Grafana
+## Adding the data source
 
 1. Open the side menu by clicking the Grafana icon in the top header.
 2. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.

--- a/docs/sources/features/datasources/stackdriver.md
+++ b/docs/sources/features/datasources/stackdriver.md
@@ -17,7 +17,7 @@ weight = 4
 
 Grafana ships with built-in support for Google Stackdriver. Just add it as a datasource and you are ready to build dashboards for your Stackdriver metrics.
 
-## Adding the data source to Grafana
+## Adding the data source
 
 1. Open the side menu by clicking the Grafana icon in the top header.
 2. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.

--- a/docs/sources/guides/whats-new-in-v4-5.md
+++ b/docs/sources/guides/whats-new-in-v4-5.md
@@ -56,7 +56,7 @@ More information [here](https://community.grafana.com/t/using-grafanas-query-ins
 This option is now renamed (and moved to Options sub section above your queries):
 ![image|519x120](upload://ySjHOVpavV6yk9LHQxL9nq2HIsT.png)
 
-Datas source selection & options & help are now above your metric queries.
+Data source selection & options & help are now above your metric queries.
 ![image|690x179](upload://5kNDxKgMz1BycOKgG3iWYLsEVXv.png)
 
 ### Minor Changes


### PR DESCRIPTION
In the data sources docs two similar subsection names were used.
This PR renames `Adding the data source to Grafana` subsection to
`Adding data source` so that all data sources have the same
subsection name.
