### PR TITLE
Explore: Fix deferred rendering of logs

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRows.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { LogRows } from './LogRows';
+import { mount } from 'enzyme';
+import { LogLevel, LogRowModel, LogsDedupStrategy } from '@grafana/data';
+import { LogRow } from './LogRow';
+
+describe('LogRows', () => {
+  it('renders rows', () => {
+    const rows: LogRowModel[] = [makeLog({ uid: '1' }), makeLog({ uid: '2' }), makeLog({ uid: '3' })];
+    const wrapper = mount(
+      <LogRows
+        data={{
+          rows,
+          hasUniqueLabels: false,
+        }}
+        dedupStrategy={LogsDedupStrategy.none}
+        highlighterExpressions={[]}
+        showTime={false}
+        showLabels={false}
+        timeZone={'utc'}
+      />
+    );
+
+    expect(wrapper.find(LogRow).length).toBe(3);
+    expect(wrapper.contains('log message 1')).toBeTruthy();
+    expect(wrapper.contains('log message 2')).toBeTruthy();
+    expect(wrapper.contains('log message 3')).toBeTruthy();
+  });
+
+  it('renders rows only limited number of rows first', () => {
+    const rows: LogRowModel[] = [makeLog({ uid: '1' }), makeLog({ uid: '2' }), makeLog({ uid: '3' })];
+    jest.useFakeTimers();
+    const wrapper = mount(
+      <LogRows
+        data={{
+          rows,
+          hasUniqueLabels: false,
+        }}
+        dedupStrategy={LogsDedupStrategy.none}
+        highlighterExpressions={[]}
+        showTime={false}
+        showLabels={false}
+        timeZone={'utc'}
+        previewLimit={1}
+      />
+    );
+
+    expect(wrapper.find(LogRow).length).toBe(1);
+    expect(wrapper.contains('log message 1')).toBeTruthy();
+    jest.runAllTimers();
+    wrapper.update();
+
+    expect(wrapper.find(LogRow).length).toBe(3);
+    expect(wrapper.contains('log message 1')).toBeTruthy();
+    expect(wrapper.contains('log message 2')).toBeTruthy();
+    expect(wrapper.contains('log message 3')).toBeTruthy();
+
+    jest.useRealTimers();
+  });
+
+  it('renders deduped rows if supplied', () => {
+    const rows: LogRowModel[] = [makeLog({ uid: '1' }), makeLog({ uid: '2' }), makeLog({ uid: '3' })];
+    const dedupedRows: LogRowModel[] = [makeLog({ uid: '4' }), makeLog({ uid: '5' })];
+    const wrapper = mount(
+      <LogRows
+        data={{
+          rows,
+          hasUniqueLabels: false,
+        }}
+        deduplicatedData={{
+          rows: dedupedRows,
+          hasUniqueLabels: false,
+        }}
+        dedupStrategy={LogsDedupStrategy.none}
+        highlighterExpressions={[]}
+        showTime={false}
+        showLabels={false}
+        timeZone={'utc'}
+      />
+    );
+
+    expect(wrapper.find(LogRow).length).toBe(2);
+    expect(wrapper.contains('log message 4')).toBeTruthy();
+    expect(wrapper.contains('log message 5')).toBeTruthy();
+  });
+});
+
+const makeLog = (overides: Partial<LogRowModel>): LogRowModel => {
+  const uid = overides.uid || '1';
+  const entry = `log message ${uid}`;
+  return {
+    uid,
+    logLevel: LogLevel.debug,
+    entry,
+    hasAnsi: false,
+    labels: {},
+    raw: entry,
+    timestamp: '',
+    timeFromNow: '',
+    timeEpochMs: 1,
+    timeLocal: '',
+    timeUtc: '',
+    ...overides,
+  };
+};

--- a/packages/grafana-ui/src/components/Logs/LogRows.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { LogRows } from './LogRows';
+import { range } from 'lodash';
+import { LogRows, PREVIEW_LIMIT } from './LogRows';
 import { mount } from 'enzyme';
 import { LogLevel, LogRowModel, LogsDedupStrategy } from '@grafana/data';
 import { LogRow } from './LogRow';
@@ -82,6 +83,26 @@ describe('LogRows', () => {
     expect(wrapper.find(LogRow).length).toBe(2);
     expect(wrapper.contains('log message 4')).toBeTruthy();
     expect(wrapper.contains('log message 5')).toBeTruthy();
+  });
+
+  it('renders with default preview limit', () => {
+    // PREVIEW_LIMIT * 2 is there because otherwise we just render all rows
+    const rows: LogRowModel[] = range(PREVIEW_LIMIT * 2 + 1).map(num => makeLog({ uid: num.toString() }));
+    const wrapper = mount(
+      <LogRows
+        data={{
+          rows,
+          hasUniqueLabels: false,
+        }}
+        dedupStrategy={LogsDedupStrategy.none}
+        highlighterExpressions={[]}
+        showTime={false}
+        showLabels={false}
+        timeZone={'utc'}
+      />
+    );
+
+    expect(wrapper.find(LogRow).length).toBe(100);
   });
 });
 

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -22,45 +22,34 @@ export interface Props extends Themeable {
   rowLimit?: number;
   onClickLabel?: (label: string, value: string) => void;
   getRowContext?: (row: LogRowModel, options?: any) => Promise<any>;
+  previewLimit?: number;
 }
 
 interface State {
-  deferLogs: boolean;
   renderAll: boolean;
 }
 
 class UnThemedLogRows extends PureComponent<Props, State> {
-  deferLogsTimer: number | null = null;
   renderAllTimer: number | null = null;
 
   state: State = {
-    deferLogs: true,
     renderAll: false,
   };
 
   componentDidMount() {
     // Staged rendering
-    if (this.state.deferLogs) {
-      const { data } = this.props;
-      const rowCount = data && data.rows ? data.rows.length : 0;
-      // Render all right away if not too far over the limit
-      const renderAll = rowCount <= PREVIEW_LIMIT * 2;
-      this.deferLogsTimer = window.setTimeout(() => this.setState({ deferLogs: false, renderAll }), rowCount);
-    }
-  }
-
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    // Staged rendering
-    if (prevState.deferLogs && !this.state.deferLogs && !this.state.renderAll) {
+    const { data, previewLimit } = this.props;
+    const rowCount = data ? data.rows.length : 0;
+    // Render all right away if not too far over the limit
+    const renderAll = rowCount <= (previewLimit || PREVIEW_LIMIT) * 2;
+    if (renderAll) {
+      this.setState({ renderAll });
+    } else {
       this.renderAllTimer = window.setTimeout(() => this.setState({ renderAll: true }), 2000);
     }
   }
 
   componentWillUnmount() {
-    if (this.deferLogsTimer) {
-      clearTimeout(this.deferLogsTimer);
-    }
-
     if (this.renderAllTimer) {
       clearTimeout(this.renderAllTimer);
     }
@@ -82,8 +71,9 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       onClickLabel,
       rowLimit,
       theme,
+      previewLimit,
     } = this.props;
-    const { deferLogs, renderAll } = this.state;
+    const { renderAll } = this.state;
     const dedupedData = deduplicatedData ? deduplicatedData : data;
     const hasData = data && data.rows && data.rows.length > 0;
     const hasLabel = hasData && dedupedData && dedupedData.hasUniqueLabels ? true : false;
@@ -94,10 +84,10 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
     // Staged rendering
     const processedRows = dedupedData ? dedupedData.rows : [];
-    const firstRows = processedRows.slice(0, PREVIEW_LIMIT);
+    const firstRows = processedRows.slice(0, previewLimit || PREVIEW_LIMIT);
     const renderLimit = rowLimit || RENDER_LIMIT;
     const rowCount = Math.min(processedRows.length, renderLimit);
-    const lastRows = processedRows.slice(PREVIEW_LIMIT, rowCount);
+    const lastRows = processedRows.slice(previewLimit || PREVIEW_LIMIT, rowCount);
 
     // React profiler becomes unusable if we pass all rows to all rows and their labels, using getter instead
     const getRows = this.makeGetRows(processedRows);
@@ -107,7 +97,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     return (
       <div className={cx([logsRows])}>
         {hasData &&
-        !deferLogs && // Only inject highlighterExpression in the first set for performance reasons
           firstRows.map((row, index) => (
             <LogRow
               key={row.uid}
@@ -123,7 +112,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
             />
           ))}
         {hasData &&
-          !deferLogs &&
           renderAll &&
           lastRows.map((row, index) => (
             <LogRow
@@ -138,7 +126,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               onClickLabel={onClickLabel}
             />
           ))}
-        {hasData && deferLogs && <span>Rendering {rowCount} rows...</span>}
+        {hasData && !renderAll && <span>Rendering {rowCount - PREVIEW_LIMIT} rows...</span>}
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -8,8 +8,8 @@ import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
 import memoizeOne from 'memoize-one';
 
-const PREVIEW_LIMIT = 100;
-const RENDER_LIMIT = 500;
+export const PREVIEW_LIMIT = 100;
+export const RENDER_LIMIT = 500;
 
 export interface Props extends Themeable {
   data: LogsModel;
@@ -32,6 +32,11 @@ interface State {
 class UnThemedLogRows extends PureComponent<Props, State> {
   renderAllTimer: number | null = null;
 
+  static defaultProps = {
+    previewLimit: PREVIEW_LIMIT,
+    rowLimit: RENDER_LIMIT,
+  };
+
   state: State = {
     renderAll: false,
   };
@@ -41,7 +46,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     const { data, previewLimit } = this.props;
     const rowCount = data ? data.rows.length : 0;
     // Render all right away if not too far over the limit
-    const renderAll = rowCount <= (previewLimit || PREVIEW_LIMIT) * 2;
+    const renderAll = rowCount <= previewLimit * 2;
     if (renderAll) {
       this.setState({ renderAll });
     } else {
@@ -84,10 +89,9 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
     // Staged rendering
     const processedRows = dedupedData ? dedupedData.rows : [];
-    const firstRows = processedRows.slice(0, previewLimit || PREVIEW_LIMIT);
-    const renderLimit = rowLimit || RENDER_LIMIT;
-    const rowCount = Math.min(processedRows.length, renderLimit);
-    const lastRows = processedRows.slice(previewLimit || PREVIEW_LIMIT, rowCount);
+    const firstRows = processedRows.slice(0, previewLimit);
+    const rowCount = Math.min(processedRows.length, rowLimit);
+    const lastRows = processedRows.slice(previewLimit, rowCount);
 
     // React profiler becomes unusable if we pass all rows to all rows and their labels, using getter instead
     const getRows = this.makeGetRows(processedRows);
@@ -126,7 +130,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               onClickLabel={onClickLabel}
             />
           ))}
-        {hasData && !renderAll && <span>Rendering {rowCount - PREVIEW_LIMIT} rows...</span>}
+        {hasData && !renderAll && <span>Rendering {rowCount - previewLimit} rows...</span>}
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -19,9 +19,9 @@ export interface Props extends Themeable {
   showLabels: boolean;
   timeZone: TimeZone;
   deduplicatedData?: LogsModel;
-  rowLimit?: number;
   onClickLabel?: (label: string, value: string) => void;
   getRowContext?: (row: LogRowModel, options?: any) => Promise<any>;
+  rowLimit?: number;
   previewLimit?: number;
 }
 
@@ -46,7 +46,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     const { data, previewLimit } = this.props;
     const rowCount = data ? data.rows.length : 0;
     // Render all right away if not too far over the limit
-    const renderAll = rowCount <= previewLimit * 2;
+    const renderAll = rowCount <= previewLimit! * 2;
     if (renderAll) {
       this.setState({ renderAll });
     } else {
@@ -89,9 +89,9 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
     // Staged rendering
     const processedRows = dedupedData ? dedupedData.rows : [];
-    const firstRows = processedRows.slice(0, previewLimit);
-    const rowCount = Math.min(processedRows.length, rowLimit);
-    const lastRows = processedRows.slice(previewLimit, rowCount);
+    const firstRows = processedRows.slice(0, previewLimit!);
+    const rowCount = Math.min(processedRows.length, rowLimit!);
+    const lastRows = processedRows.slice(previewLimit!, rowCount);
 
     // React profiler becomes unusable if we pass all rows to all rows and their labels, using getter instead
     const getRows = this.makeGetRows(processedRows);
@@ -130,7 +130,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               onClickLabel={onClickLabel}
             />
           ))}
-        {hasData && !renderAll && <span>Rendering {rowCount - previewLimit} rows...</span>}
+        {hasData && !renderAll && <span>Rendering {rowCount - previewLimit!} rows...</span>}
       </div>
     );
   }


### PR DESCRIPTION
Not exactly sure if by design or by error but the logs rendering was deferred for both first 100 lines and then another timeout for the rest. This first timeout was also a bit weird because the time was based on number of all rows. So if you had 1000 rows you wait 1s until we render the first 100 and then 2s to render the 900 rest.