### PR TITLE
DataLinks: Fix access to labels when using Prometheus instant queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -141,7 +141,7 @@ export class ResultTransformer {
     let metricLabel = null;
     metricLabel = this.createMetricLabel(md.metric, options);
     dps.push([parseFloat(md.value[1]), md.value[0] * 1000]);
-    return { target: metricLabel, datapoints: dps, labels: md.metric };
+    return { target: metricLabel, datapoints: dps, tags: md.metric };
   }
 
   createMetricLabel(labelData: { [key: string]: string }, options: any) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/20090

As suggested by @torkelo, changing `transformInstantMetricData` to return the tag property instead of the label property completely fixed this issue.