### PR TITLE
Graph: Added series override option to have hidden series be persisted on save

### DIFF
--- a/docs/sources/features/panels/graph.md
+++ b/docs/sources/features/panels/graph.md
@@ -137,6 +137,7 @@ Display styles control visual properties of the graph.
 - **Line Width** - The width of the line for a series (default 1).
 - **Staircase** - Draws adjacent points as staircase
 - **Points Radius** - Adjust the size of points when *Points* are selected as *Draw Mode*.
+- **Hidden Series** - Hide series by default in graph.
 
 #### Hover tooltip
 

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -94,6 +94,7 @@ export default class TimeSeries {
   isOutsideRange: boolean;
 
   lines: any;
+  hiddenSeries: boolean;
   dashes: any;
   bars: any;
   points: any;
@@ -199,6 +200,9 @@ export default class TimeSeries {
 
       if (override.yaxis !== void 0) {
         this.yaxis = override.yaxis;
+      }
+      if (override.hiddenSeries !== void 0) {
+        this.hiddenSeries = override.hiddenSeries;
       }
     }
   }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -27,6 +27,7 @@ class GraphCtrl extends MetricsPanelCtrl {
 
   renderError: boolean;
   hiddenSeries: any = {};
+  hiddenSeriesTainted = false;
   seriesList: TimeSeries[] = [];
   dataList: DataFrame[] = [];
   annotations: any = [];
@@ -84,6 +85,8 @@ class GraphCtrl extends MetricsPanelCtrl {
     linewidth: 1,
     // show/hide dashed line
     dashes: false,
+    // show/hide line
+    hiddenSeries: false,
     // length of a dash
     dashLength: 10,
     // length of space between two dashes
@@ -165,6 +168,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.addEditorTab('Thresholds & Time Regions', 'public/app/plugins/panel/graph/tab_thresholds_time_regions.html');
     this.addEditorTab('Data links', 'public/app/plugins/panel/graph/tab_drilldown_links.html');
     this.subTabIndex = 0;
+    this.hiddenSeriesTainted = false;
   }
 
   onInitPanelActions(actions: any[]) {
@@ -267,6 +271,9 @@ class GraphCtrl extends MetricsPanelCtrl {
       if (series.unit) {
         this.panel.yaxes[series.yaxis - 1].format = series.unit;
       }
+      if (this.hiddenSeriesTainted === false && series.hiddenSeries === true) {
+        this.hiddenSeries[series.alias] = true;
+      }
     }
   }
 
@@ -277,6 +284,7 @@ class GraphCtrl extends MetricsPanelCtrl {
   };
 
   onToggleSeries = (hiddenSeries: any) => {
+    this.hiddenSeriesTainted = true;
     this.hiddenSeries = hiddenSeries;
     this.render();
   };

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.ts
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.ts
@@ -106,6 +106,7 @@ export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: a
   $scope.addOverrideOption('Fill below to', 'fillBelowTo', $scope.getSeriesNames());
   $scope.addOverrideOption('Staircase line', 'steppedLine', [true, false]);
   $scope.addOverrideOption('Dashes', 'dashes', [true, false]);
+  $scope.addOverrideOption('Hidden Series', 'hiddenSeries', [true, false]);
   $scope.addOverrideOption('Dash Length', 'dashLength', [
     1,
     2,


### PR DESCRIPTION
**What this PR does / why we need it**:
This helps you set default hidden visibility for series on a graph

**Which issue(s) this PR fixes**:
Fixes #4645

**Special notes for your reviewer**:
`hiddenSeriesTainted` is useful to let people customize it via panel instead of forcing to use what is set on overrides 

<img width="1021" alt="Screen Shot 2019-10-31 at 5 08 38 AM" src="https://user-images.githubusercontent.com/620559/67946805-58d16300-fb9f-11e9-92bd-1cf32b4d42fa.png">
<img width="792" alt="Screen Shot 2019-10-31 at 5 08 14 AM" src="https://user-images.githubusercontent.com/620559/67946816-5e2ead80-fb9f-11e9-974f-06da15d55802.png">

Continuation of PR https://github.com/grafana/grafana/pull/17388