### PR TITLE
Docs: Display panels alphabetically

### DIFF
--- a/docs/sources/features/panels/graph.md
+++ b/docs/sources/features/panels/graph.md
@@ -6,7 +6,7 @@ aliases = ["/reference/graph/"]
 [menu.docs]
 name = "Graph"
 parent = "panels"
-weight = 1
+weight = 4
 +++
 
 # Graph Panel

--- a/docs/sources/features/panels/heatmap.md
+++ b/docs/sources/features/panels/heatmap.md
@@ -6,7 +6,7 @@ type = "docs"
 [menu.docs]
 name = "Heatmap"
 parent = "panels"
-weight = 3
+weight = 4
 +++
 
 # Heatmap Panel

--- a/docs/sources/features/panels/logs.md
+++ b/docs/sources/features/panels/logs.md
@@ -6,7 +6,7 @@ aliases = ["/reference/logs/"]
 [menu.docs]
 name = "Logs"
 parent = "panels"
-weight = 2
+weight = 4
 +++
 
 # Logs Panel

--- a/docs/sources/features/panels/singlestat.md
+++ b/docs/sources/features/panels/singlestat.md
@@ -6,7 +6,7 @@ aliases = ["/reference/singlestat/"]
 [menu.docs]
 name = "Singlestat"
 parent = "panels"
-weight = 2
+weight = 4
 +++
 
 

--- a/docs/sources/features/panels/table_panel.md
+++ b/docs/sources/features/panels/table_panel.md
@@ -6,7 +6,7 @@ aliases = ["/reference/table/"]
 [menu.docs]
 name = "Table"
 parent = "panels"
-weight = 2
+weight = 4
 +++
 
 


### PR DESCRIPTION
Using the same weight for all panels, so that the panels are displayed
in an alphabetical order.
