### PR TITLE
Grafana/Loki: Adds support for new Loki endpoints and metrics

### DIFF
--- a/packages/grafana-data/src/dataframe/DataFrameView.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameView.ts
@@ -26,22 +26,24 @@ export class DataFrameView<T = any> implements Vector<T> {
 
   constructor(private data: DataFrame) {
     const obj = ({} as unknown) as T;
+
     for (let i = 0; i < data.fields.length; i++) {
       const field = data.fields[i];
-      const getter = () => {
-        return field.values.get(this.index);
-      };
+      const getter = () => field.values.get(this.index);
+
       if (!(obj as any).hasOwnProperty(field.name)) {
         Object.defineProperty(obj, field.name, {
           enumerable: true, // Shows up as enumerable property
           get: getter,
         });
       }
+
       Object.defineProperty(obj, i, {
         enumerable: false, // Don't enumerate array index
         get: getter,
       });
     }
+
     this.obj = obj;
   }
 
@@ -59,11 +61,7 @@ export class DataFrameView<T = any> implements Vector<T> {
   }
 
   toArray(): T[] {
-    const arr: T[] = [];
-    for (let i = 0; i < this.data.length; i++) {
-      arr.push({ ...this.get(i) });
-    }
-    return arr;
+    return new Array(this.data.length).fill(0).map((_, i) => ({ ...this.get(i) }));
   }
 
   toJSON(): T[] {

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -436,10 +436,11 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
 
   dashboardId: number;
   interval: string;
-  intervalMs: number;
-  maxDataPoints: number;
+  intervalMs?: number;
+  maxDataPoints?: number;
   panelId: number;
-  range: TimeRange;
+  range?: TimeRange;
+  reverse?: boolean;
   scopedVars: ScopedVars;
   targets: TQuery[];
   timezone: string;

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -100,8 +100,7 @@ export interface DataSourcePluginMeta extends PluginMeta {
   category?: string;
   queryOptions?: PluginMetaQueryOptions;
   sort?: number;
-  streaming?: Record<string, boolean>;
-  versions?: Record<string, Partial<Omit<DataSourcePluginMeta, (keyof PluginMeta) | 'versions'>>>;
+  streaming?: boolean;
 }
 
 interface PluginMetaQueryOptions {

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -100,7 +100,8 @@ export interface DataSourcePluginMeta extends PluginMeta {
   category?: string;
   queryOptions?: PluginMetaQueryOptions;
   sort?: number;
-  streaming?: boolean;
+  streaming?: Record<string, boolean>;
+  versions?: Record<string, Partial<Omit<DataSourcePluginMeta, (keyof PluginMeta) | 'versions'>>>;
 }
 
 interface PluginMetaQueryOptions {
@@ -248,6 +249,8 @@ export abstract class DataSourceApi<
    */
   languageProvider?: any;
 
+  getVersion?(): Promise<string>;
+
   /**
    * Can be optionally implemented to allow datasource to be a source of annotations for dashboard. To be visible
    * in the annotation editor `annotations` capability also needs to be enabled in plugin.json.
@@ -288,6 +291,7 @@ export interface ExploreQueryFieldProps<
 
 export interface ExploreStartPageProps {
   datasource?: DataSourceApi;
+  exploreMode: 'Logs' | 'Metrics';
   onClickExample: (query: DataQuery) => void;
 }
 
@@ -429,18 +433,21 @@ export interface DataQueryError {
 
 export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   requestId: string; // Used to identify results and optionally cancel the request in backendSrv
-  timezone: string;
-  range: TimeRange;
-  rangeRaw?: RawTimeRange;
-  timeInfo?: string; // The query time description (blue text in the upper right)
-  targets: TQuery[];
-  panelId: number;
+
   dashboardId: number;
-  cacheTimeout?: string;
   interval: string;
   intervalMs: number;
   maxDataPoints: number;
+  panelId: number;
+  range: TimeRange;
   scopedVars: ScopedVars;
+  targets: TQuery[];
+  timezone: string;
+
+  cacheTimeout?: string;
+  exploreMode?: 'Logs' | 'Metrics';
+  rangeRaw?: RawTimeRange;
+  timeInfo?: string; // The query time description (blue text in the upper right)
 
   // Request Timing
   startTime: number;

--- a/packages/grafana-data/src/types/graph.ts
+++ b/packages/grafana-data/src/types/graph.ts
@@ -10,11 +10,10 @@ export type GraphSeriesValue = number | null;
 
 /** View model projection of a series */
 export interface GraphSeriesXY {
-  label: string;
   color: string;
   data: GraphSeriesValue[][]; // [x,y][]
-  info?: DisplayValue[]; // Legend info
   isVisible: boolean;
+  label: string;
   yAxis: YAxis;
   // Field with series' time values
   timeField: Field;
@@ -22,6 +21,8 @@ export interface GraphSeriesXY {
   valueField: Field;
   seriesIndex: number;
   timeStep: number;
+
+  info?: DisplayValue[]; // Legend info
 }
 
 export interface CreatePlotOverlay {

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -23,20 +23,33 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// Subset of metadata allowed as a value in the Versions map of datasource plugin metadata
+type SubMetaData struct {
+	Annotations  bool            `json:"annotations,omitempty"`
+	Metrics      bool            `json:"metrics"`
+	Alerting     bool            `json:"alerting,omitempty"`
+	Logs         bool            `json:"logs,omitempty"`
+	QueryOptions map[string]bool `json:"queryOptions,omitempty"`
+	BuiltIn      bool            `json:"builtIn,omitempty"`
+	Mixed        bool            `json:"mixed,omitempty"`
+	Streaming    map[string]bool `json:"streaming,omitempty"`
+}
+
 // DataSourcePlugin contains all metadata about a datasource plugin
 type DataSourcePlugin struct {
 	FrontendPluginBase
-	Annotations  bool              `json:"annotations"`
-	Metrics      bool              `json:"metrics"`
-	Alerting     bool              `json:"alerting"`
-	Explore      bool              `json:"explore"`
-	Table        bool              `json:"tables"`
-	Logs         bool              `json:"logs"`
-	QueryOptions map[string]bool   `json:"queryOptions,omitempty"`
-	BuiltIn      bool              `json:"builtIn,omitempty"`
-	Mixed        bool              `json:"mixed,omitempty"`
-	Routes       []*AppPluginRoute `json:"routes"`
-	Streaming    bool              `json:"streaming"`
+	Annotations  bool                   `json:"annotations"`
+	Metrics      bool                   `json:"metrics"`
+	Alerting     bool                   `json:"alerting"`
+	Explore      bool                   `json:"explore"`
+	Table        bool                   `json:"tables"`
+	Logs         bool                   `json:"logs"`
+	QueryOptions map[string]bool        `json:"queryOptions,omitempty"`
+	BuiltIn      bool                   `json:"builtIn,omitempty"`
+	Mixed        bool                   `json:"mixed,omitempty"`
+	Routes       []*AppPluginRoute      `json:"routes"`
+	Streaming    map[string]bool        `json:"streaming"`
+	Versions     map[string]SubMetaData `json:"versions,omitempty"`
 
 	Backend    bool   `json:"backend,omitempty"`
 	Executable string `json:"executable,omitempty"`

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -23,33 +23,20 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Subset of metadata allowed as a value in the Versions map of datasource plugin metadata
-type SubMetaData struct {
-	Annotations  bool            `json:"annotations,omitempty"`
-	Metrics      bool            `json:"metrics"`
-	Alerting     bool            `json:"alerting,omitempty"`
-	Logs         bool            `json:"logs,omitempty"`
-	QueryOptions map[string]bool `json:"queryOptions,omitempty"`
-	BuiltIn      bool            `json:"builtIn,omitempty"`
-	Mixed        bool            `json:"mixed,omitempty"`
-	Streaming    map[string]bool `json:"streaming,omitempty"`
-}
-
 // DataSourcePlugin contains all metadata about a datasource plugin
 type DataSourcePlugin struct {
 	FrontendPluginBase
-	Annotations  bool                   `json:"annotations"`
-	Metrics      bool                   `json:"metrics"`
-	Alerting     bool                   `json:"alerting"`
-	Explore      bool                   `json:"explore"`
-	Table        bool                   `json:"tables"`
-	Logs         bool                   `json:"logs"`
-	QueryOptions map[string]bool        `json:"queryOptions,omitempty"`
-	BuiltIn      bool                   `json:"builtIn,omitempty"`
-	Mixed        bool                   `json:"mixed,omitempty"`
-	Routes       []*AppPluginRoute      `json:"routes"`
-	Streaming    map[string]bool        `json:"streaming"`
-	Versions     map[string]SubMetaData `json:"versions,omitempty"`
+	Annotations  bool              `json:"annotations"`
+	Metrics      bool              `json:"metrics"`
+	Alerting     bool              `json:"alerting"`
+	Explore      bool              `json:"explore"`
+	Table        bool              `json:"tables"`
+	Logs         bool              `json:"logs"`
+	QueryOptions map[string]bool   `json:"queryOptions,omitempty"`
+	BuiltIn      bool              `json:"builtIn,omitempty"`
+	Mixed        bool              `json:"mixed,omitempty"`
+	Routes       []*AppPluginRoute `json:"routes"`
+	Streaming    bool              `json:"streaming"`
 
 	Backend    bool   `json:"backend,omitempty"`
 	Executable string `json:"executable,omitempty"`

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -10,6 +10,17 @@ import { FolderInfo, DashboardDTO, CoreEvents } from 'app/types';
 import { BackendSrv as BackendService, getBackendSrv as getBackendService, BackendSrvRequest } from '@grafana/runtime';
 import { AppEvents } from '@grafana/data';
 
+export interface DatasourceRequestOptions {
+  retry?: number;
+  method?: string;
+  requestId?: string;
+  timeout?: angular.IPromise<any>;
+  url?: string;
+  headers?: { [key: string]: any };
+  silent?: boolean;
+  data?: { [key: string]: any };
+}
+
 export class BackendSrv implements BackendService {
   private inFlightRequests: { [key: string]: Array<angular.IDeferred<any>> } = {};
   private HTTP_REQUEST_CANCELED = -1;

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -518,7 +518,7 @@ export const convertToWebSocketUrl = (url: string) => {
   const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
   let backend = `${protocol}${window.location.host}${config.appSubUrl}`;
   if (backend.endsWith('/')) {
-    backend = backend.slice(0, backend.length - 1);
+    backend = backend.slice(0, -1);
   }
   return `${backend}${url}`;
 };

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -148,6 +148,7 @@ export function buildQueryTransaction(
       __interval_ms: { text: intervalMs, value: intervalMs },
     },
     maxDataPoints: queryOptions.maxDataPoints,
+    exploreMode: queryOptions.mode,
   };
 
   return {

--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -14,7 +14,7 @@ import { DashboardModel } from '../dashboard/state/DashboardModel';
 import DatasourceSrv from '../plugins/datasource_srv';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TimeSrv } from '../dashboard/services/TimeSrv';
-import { DataSourceApi, PanelEvents, AnnotationEvent, AppEvents } from '@grafana/data';
+import { DataSourceApi, PanelEvents, AnnotationEvent, AppEvents, PanelModel, TimeRange } from '@grafana/data';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 
 export class AnnotationsSrv {
@@ -44,7 +44,7 @@ export class AnnotationsSrv {
     this.datasourcePromises = null;
   }
 
-  getAnnotations(options: any) {
+  getAnnotations(options: { dashboard: DashboardModel; panel: PanelModel; range: TimeRange }) {
     return this.$q
       .all([this.getGlobalAnnotations(options), this.getAlertStates(options)])
       .then(results => {
@@ -104,7 +104,7 @@ export class AnnotationsSrv {
     return this.alertStatesPromise;
   }
 
-  getGlobalAnnotations(options: any) {
+  getGlobalAnnotations(options: { dashboard: DashboardModel; panel: PanelModel; range: TimeRange }) {
     const dashboard = options.dashboard;
 
     if (this.globalAnnotationsPromise) {
@@ -130,7 +130,7 @@ export class AnnotationsSrv {
           .then((datasource: DataSourceApi) => {
             // issue query against data source
             return datasource.annotationQuery({
-              range: range,
+              range,
               rangeRaw: range.raw,
               annotation: annotation,
               dashboard: dashboard,

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -78,7 +78,7 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
  * It will
  *  * Merge multiple responses into a single DataFrame array based on the packet key
  *  * Will emit a loading state if no response after 50ms
- *  * Cancel any still runnning network requests on unsubscribe (using request.requestId)
+ *  * Cancel any still running network requests on unsubscribe (using request.requestId)
  */
 export function runRequest(datasource: DataSourceApi, request: DataQueryRequest): Observable<PanelData> {
   let state: RunningQueryState = {

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -83,7 +83,7 @@ export const getPanelMenu = (dashboard: DashboardModel, panel: PanelModel) => {
   const onNavigateToExplore = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     const openInNewWindow = event.ctrlKey || event.metaKey ? (url: string) => window.open(url) : undefined;
-    store.dispatch(navigateToExplore(panel, { getDataSourceSrv, getTimeSrv, getExploreUrl, openInNewWindow }));
+    store.dispatch(navigateToExplore(panel, { getDataSourceSrv, getTimeSrv, getExploreUrl, openInNewWindow }) as any);
   };
 
   const menu: PanelMenuItem[] = [];

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -34,7 +34,9 @@ import {
   GraphSeriesXY,
   TimeZone,
   AbsoluteTimeRange,
+  LogsModel,
 } from '@grafana/data';
+
 import {
   ExploreItemState,
   ExploreUrlState,
@@ -97,6 +99,7 @@ interface ExploreProps {
   syncedTimes: boolean;
   updateTimeRange: typeof updateTimeRange;
   graphResult?: GraphSeriesXY[];
+  logsResult?: LogsModel;
   loading?: boolean;
   absoluteRange: AbsoluteTimeRange;
   showingGraph?: boolean;
@@ -288,7 +291,11 @@ export class Explore extends React.PureComponent<ExploreProps> {
                     <ErrorBoundaryAlert>
                       {showingStartPage && (
                         <div className="grafana-info-box grafana-info-box--max-lg">
-                          <StartPage onClickExample={this.onClickExample} datasource={datasourceInstance} />
+                          <StartPage
+                            onClickExample={this.onClickExample}
+                            datasource={datasourceInstance}
+                            exploreMode={mode}
+                          />
                         </div>
                       )}
                       {!showingStartPage && (
@@ -359,6 +366,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     supportedModes,
     mode,
     graphResult,
+    logsResult,
     loading,
     showingGraph,
     showingTable,
@@ -373,6 +381,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
   const initialRange = urlRange ? getTimeRangeFromUrlMemoized(urlRange, timeZone).raw : DEFAULT_RANGE;
 
   let newMode: ExploreMode;
+
   if (supportedModes.length) {
     const urlModeIsValid = supportedModes.includes(urlMode);
     const modeStateIsValid = supportedModes.includes(mode);
@@ -385,7 +394,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
       newMode = supportedModes[0];
     }
   } else {
-    newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(mode) ? mode : ExploreMode.Metrics;
+    newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(urlMode) ? urlMode : ExploreMode.Metrics;
   }
 
   const initialUI = ui || DEFAULT_UI_STATE;
@@ -406,6 +415,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     initialUI,
     isLive,
     graphResult,
+    logsResult,
     loading,
     showingGraph,
     showingTable,

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -34,7 +34,6 @@ import {
   GraphSeriesXY,
   TimeZone,
   AbsoluteTimeRange,
-  LogsModel,
 } from '@grafana/data';
 
 import {
@@ -99,7 +98,6 @@ interface ExploreProps {
   syncedTimes: boolean;
   updateTimeRange: typeof updateTimeRange;
   graphResult?: GraphSeriesXY[];
-  logsResult?: LogsModel;
   loading?: boolean;
   absoluteRange: AbsoluteTimeRange;
   showingGraph?: boolean;
@@ -366,7 +364,6 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     supportedModes,
     mode,
     graphResult,
-    logsResult,
     loading,
     showingGraph,
     showingTable,
@@ -394,7 +391,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
       newMode = supportedModes[0];
     }
   } else {
-    newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(urlMode) ? urlMode : ExploreMode.Metrics;
+    newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(urlMode) ? urlMode : null;
   }
 
   const initialUI = ui || DEFAULT_UI_STATE;
@@ -415,7 +412,6 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     initialUI,
     isLive,
     graphResult,
-    logsResult,
     loading,
     showingGraph,
     showingTable,

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -347,10 +347,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     ? exploreDatasources.find(datasource => datasource.name === datasourceInstance.name)
     : undefined;
   const hasLiveOption =
-    datasourceInstance &&
-    datasourceInstance.meta &&
-    datasourceInstance.meta.streaming &&
-    datasourceInstance.meta.streaming[mode.toLowerCase()]
+    datasourceInstance && datasourceInstance.meta && datasourceInstance.meta.streaming && mode === ExploreMode.Logs
       ? true
       : false;
 

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -347,7 +347,12 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     ? exploreDatasources.find(datasource => datasource.name === datasourceInstance.name)
     : undefined;
   const hasLiveOption =
-    datasourceInstance && datasourceInstance.meta && datasourceInstance.meta.streaming ? true : false;
+    datasourceInstance &&
+    datasourceInstance.meta &&
+    datasourceInstance.meta.streaming &&
+    datasourceInstance.meta.streaming[mode.toLowerCase()]
+      ? true
+      : false;
 
   return {
     datasourceMissing,

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -186,6 +186,7 @@ export interface UpdateUIStatePayload extends Partial<ExploreUIState> {
 export interface UpdateDatasourceInstancePayload {
   exploreId: ExploreId;
   datasourceInstance: DataSourceApi;
+  version?: string;
 }
 
 export interface ToggleLogLevelPayload {

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -123,8 +123,15 @@ export function changeDatasource(exploreId: ExploreId, datasource: string): Thun
     const currentDataSourceInstance = getState().explore[exploreId].datasourceInstance;
     const queries = getState().explore[exploreId].queries;
     const orgId = getState().user.orgId;
+    const datasourceVersion = newDataSourceInstance.getVersion && (await newDataSourceInstance.getVersion());
 
-    dispatch(updateDatasourceInstanceAction({ exploreId, datasourceInstance: newDataSourceInstance }));
+    dispatch(
+      updateDatasourceInstanceAction({
+        exploreId,
+        datasourceInstance: newDataSourceInstance,
+        version: datasourceVersion,
+      })
+    );
 
     await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, newDataSourceInstance));
 
@@ -436,6 +443,7 @@ export function runQueries(exploreId: ExploreId): ThunkResult<void> {
       liveStreaming: live,
       showingGraph,
       showingTable,
+      mode,
     };
 
     const datasourceId = datasourceInstance.meta.id;

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -686,6 +686,12 @@ const getModesForDatasource = (dataSource: DataSourceApi, currentMode: ExploreMo
     mode = supportedModes[0];
   }
 
+  // HACK: Used to set Loki's default explore mode to Logs mode.
+  // A better solution would be to introduce a "default" or "preferred" mode to the datasource config
+  if (dataSource.meta.name === 'Loki' && !currentMode) {
+    mode = ExploreMode.Logs;
+  }
+
   return [supportedModes, mode];
 };
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -283,13 +283,18 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
 
       let newMetadata = datasourceInstance.meta;
 
-      if (
-        version &&
-        version.length &&
-        datasourceInstance.meta.versions &&
-        datasourceInstance.meta.versions.hasOwnProperty(version)
-      ) {
-        newMetadata = { ...newMetadata, ...datasourceInstance.meta.versions[version] };
+      // HACK: Temporary hack for Loki datasource. Can remove when plugin.json structure is changed.
+      if (version && version.length && datasourceInstance.meta.name === 'Loki') {
+        const lokiVersionMetadata: Record<string, { metrics: boolean }> = {
+          v0: {
+            metrics: false,
+          },
+
+          v1: {
+            metrics: true,
+          },
+        };
+        newMetadata = { ...newMetadata, ...lokiVersionMetadata[version] };
       }
 
       const updatedDatasourceInstance = Object.assign(datasourceInstance, { meta: newMetadata });

--- a/public/app/features/playlist/specs/playlist_srv.test.ts
+++ b/public/app/features/playlist/specs/playlist_srv.test.ts
@@ -3,13 +3,11 @@ import configureMockStore from 'redux-mock-store';
 import { PlaylistSrv } from '../playlist_srv';
 import { setStore } from 'app/store/store';
 
-const mockStore = configureMockStore();
+const mockStore = configureMockStore<any, any>();
 
-setStore(
-  mockStore({
-    location: {},
-  })
-);
+setStore(mockStore({
+  location: {},
+}) as any);
 
 const dashboards = [{ url: 'dash1' }, { url: 'dash2' }];
 
@@ -122,13 +120,11 @@ describe('PlaylistSrv', () => {
 
     srv.next();
 
-    setStore(
-      mockStore({
-        location: {
-          path: 'dash2',
-        },
-      })
-    );
+    setStore(mockStore({
+      location: {
+        path: 'dash2',
+      },
+    }) as any);
 
     expect((srv as any).validPlaylistUrl).toBe('dash2');
 

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -66,7 +66,7 @@ export class DatasourceSrv implements DataSourceService {
 
     const dsConfig = config.datasources[name];
     if (!dsConfig) {
-      return this.$q.reject({ message: 'Datasource named ' + name + ' was not found' });
+      return this.$q.reject({ message: `Datasource named ${name} was not found` });
     }
 
     const deferred = this.$q.defer();

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -285,7 +285,7 @@ describe('CloudWatchDatasource', () => {
       beforeEach(() => {
         redux.setStore({
           dispatch: jest.fn(),
-        });
+        } as any);
 
         ctx.backendSrv.datasourceRequest = jest.fn(() => {
           return Promise.reject(backendErrorResponse);

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -2,10 +2,30 @@ import React, { PureComponent } from 'react';
 import { shuffle } from 'lodash';
 import { ExploreStartPageProps, DataQuery } from '@grafana/data';
 import LokiLanguageProvider from '../language_provider';
+import { ExploreMode } from 'app/types';
 
 const DEFAULT_EXAMPLES = ['{job="default/prometheus"}'];
 const PREFERRED_LABELS = ['job', 'app', 'k8s_app'];
 const EXAMPLES_LIMIT = 5;
+
+const LOGQL_EXAMPLES = [
+  {
+    title: 'Count over time',
+    expression: 'count_over_time({job="mysql"}[5m])',
+    label: 'This query counts all the log lines within the last five minutes for the MySQL job.',
+  },
+  {
+    title: 'Rate',
+    expression: 'rate(({job="mysql"} |= "error" != "timeout)[10s]))',
+    label:
+      'This query gets the per-second rate of all non-timeout errors within the last ten seconds for the MySQL job.',
+  },
+  {
+    title: 'Aggregate, count, and group',
+    expression: 'sum(count_over_time({job="mysql"}[5m])) by (level)',
+    label: 'Get the count of logs during the last five minutes, grouping by level.',
+  },
+];
 
 export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps, { userExamples: string[] }> {
   userLabelTimer: NodeJS.Timeout;
@@ -57,7 +77,7 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
     );
   }
 
-  render() {
+  renderLogsCheatSheet() {
     const { userExamples } = this.state;
 
     return (
@@ -97,5 +117,26 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
         </div>
       </>
     );
+  }
+
+  renderMetricsCheatSheet() {
+    return (
+      <div>
+        <h2>LogQL Cheat Sheet</h2>
+        {LOGQL_EXAMPLES.map(item => (
+          <div className="cheat-sheet-item" key={item.expression}>
+            <div className="cheat-sheet-item__title">{item.title}</div>
+            {this.renderExpression(item.expression)}
+            <div className="cheat-sheet-item__label">{item.label}</div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    const { exploreMode } = this.props;
+
+    return exploreMode === ExploreMode.Logs ? this.renderLogsCheatSheet() : this.renderMetricsCheatSheet();
   }
 }

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -16,7 +16,7 @@ const LOGQL_EXAMPLES = [
   },
   {
     title: 'Rate',
-    expression: 'rate(({job="mysql"} |= "error" != "timeout)[10s]))',
+    expression: 'rate(({job="mysql"} |= "error" != "timeout")[10s])',
     label:
       'This query gets the per-second rate of all non-timeout errors within the last ten seconds for the MySQL job.',
   },

--- a/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
@@ -17,9 +17,9 @@ import {
 import { Plugin, Node } from 'slate';
 
 // Types
-import { LokiQuery } from '../types';
 import { DOMUtil } from '@grafana/ui';
 import { ExploreQueryFieldProps, AbsoluteTimeRange } from '@grafana/data';
+import { LokiQuery, LokiOptions } from '../types';
 import { Grammar } from 'prismjs';
 import LokiLanguageProvider, { LokiHistoryItem } from '../language_provider';
 import LokiDatasource from '../datasource';
@@ -61,7 +61,7 @@ function willApplySuggestion(suggestion: string, { typeaheadContext, typeaheadTe
   return suggestion;
 }
 
-export interface LokiQueryFieldFormProps extends ExploreQueryFieldProps<LokiDatasource, LokiQuery> {
+export interface LokiQueryFieldFormProps extends ExploreQueryFieldProps<LokiDatasource, LokiQuery, LokiOptions> {
   history: LokiHistoryItem[];
   syntax: Grammar;
   logLabelOptions: CascaderOption[];

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1,17 +1,20 @@
 import LokiDatasource from './datasource';
-import { LokiQuery } from './types';
+import { LokiQuery, LokiResultType, LokiResponse, LokiLegacyStreamResponse } from './types';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { AnnotationQueryRequest, DataSourceApi, DataFrame, dateTime } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { CustomVariable } from 'app/features/templating/custom_variable';
+import { ExploreMode } from 'app/types';
+import { of } from 'rxjs';
+import omit from 'lodash/omit';
 
 describe('LokiDatasource', () => {
   const instanceSettings: any = {
     url: 'myloggingurl',
   };
 
-  const testResp = {
+  const legacyTestResp: { data: LokiLegacyStreamResponse; status: number } = {
     data: {
       streams: [
         {
@@ -23,6 +26,21 @@ describe('LokiDatasource', () => {
     status: 404, // for simulating legacy endpoint
   };
 
+  const testResp: { data: LokiResponse } = {
+    data: {
+      data: {
+        resultType: LokiResultType.Stream,
+        result: [
+          {
+            stream: {},
+            values: [['1573646419522934000', 'hello']],
+          },
+        ],
+      },
+      status: 'success',
+    },
+  };
+
   const backendSrvMock = { datasourceRequest: jest.fn() };
   const backendSrv = (backendSrvMock as unknown) as BackendSrv;
 
@@ -31,8 +49,65 @@ describe('LokiDatasource', () => {
     replace: (a: string) => a,
   } as unknown) as TemplateSrv;
 
+  describe('when running range query with fallback', () => {
+    let ds: LokiDatasource;
+    beforeEach(() => {
+      const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+      const customSettings = { ...instanceSettings, jsonData: customData };
+      ds = new LokiDatasource(customSettings, backendSrv, templateSrvMock);
+      backendSrvMock.datasourceRequest = jest.fn(() => Promise.resolve(legacyTestResp));
+    });
+
+    test('should try latest endpoint but fall back to legacy endpoint if it cannot be reached', async () => {
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: 'rate({job="grafana"}[5m])', refId: 'B' }],
+        exploreMode: ExploreMode.Metrics,
+      });
+
+      ds.runLegacyQuery = jest.fn();
+      await ds.runRangeQueryWithFallback(options.targets[0], options).toPromise();
+      expect(ds.runLegacyQuery).toBeCalled();
+    });
+  });
+
   describe('when querying', () => {
-    const testLimit = makeLimitTest(instanceSettings, backendSrvMock, backendSrv, templateSrvMock, testResp);
+    const testLimit = makeLimitTest(instanceSettings, backendSrvMock, backendSrv, templateSrvMock, legacyTestResp);
+    let ds: LokiDatasource;
+
+    beforeEach(() => {
+      const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+      const customSettings = { ...instanceSettings, jsonData: customData };
+      ds = new LokiDatasource(customSettings, backendSrv, templateSrvMock);
+      backendSrvMock.datasourceRequest = jest.fn(() => Promise.resolve(testResp));
+    });
+
+    test('should run instant query and range query when in metrics mode', async () => {
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: 'rate({job="grafana"}[5m])', refId: 'A' }],
+        exploreMode: ExploreMode.Metrics,
+      });
+
+      ds.runInstantQuery = jest.fn(() => of({ data: [] }));
+      ds.runRangeQueryWithFallback = jest.fn(() => of({ data: [] }));
+      await ds.query(options).toPromise();
+
+      expect(ds.runInstantQuery).toBeCalled();
+      expect(ds.runRangeQueryWithFallback).toBeCalled();
+    });
+
+    test('should just run range query when in logs mode', async () => {
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{job="grafana"}', refId: 'B' }],
+        exploreMode: ExploreMode.Logs,
+      });
+
+      ds.runInstantQuery = jest.fn(() => of({ data: [] }));
+      ds.runRangeQueryWithFallback = jest.fn(() => of({ data: [] }));
+      await ds.query(options).toPromise();
+
+      expect(ds.runInstantQuery).not.toBeCalled();
+      expect(ds.runRangeQueryWithFallback).toBeCalled();
+    });
 
     test('should use default max lines when no limit given', () => {
       testLimit({
@@ -62,14 +137,17 @@ describe('LokiDatasource', () => {
       });
     });
 
-    test('should return series data', async done => {
+    test('should return series data', async () => {
       const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
       const customSettings = { ...instanceSettings, jsonData: customData };
       const ds = new LokiDatasource(customSettings, backendSrv, templateSrvMock);
-      backendSrvMock.datasourceRequest = jest.fn(() => Promise.resolve(testResp));
+      backendSrvMock.datasourceRequest = jest
+        .fn()
+        .mockReturnValueOnce(Promise.resolve(legacyTestResp))
+        .mockReturnValueOnce(Promise.resolve(omit(legacyTestResp, 'status')));
 
       const options = getQueryOptions<LokiQuery>({
-        targets: [{ expr: '{} foo', refId: 'B' }],
+        targets: [{ expr: '{job="grafana"} |= "foo"', refId: 'B' }],
       });
 
       const res = await ds.query(options).toPromise();
@@ -77,14 +155,13 @@ describe('LokiDatasource', () => {
       const dataFrame = res.data[0] as DataFrame;
       expect(dataFrame.fields[1].values.get(0)).toBe('hello');
       expect(dataFrame.meta.limit).toBe(20);
-      expect(dataFrame.meta.searchWords).toEqual(['(?i)foo']);
-      done();
+      expect(dataFrame.meta.searchWords).toEqual(['foo']);
     });
   });
 
   describe('When interpolating variables', () => {
-    let ds: any = {};
-    let variable: any = {};
+    let ds: LokiDatasource;
+    let variable: CustomVariable;
 
     beforeEach(() => {
       const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
@@ -156,23 +233,25 @@ describe('LokiDatasource', () => {
     });
 
     describe('and call fails with 401 error', () => {
-      beforeEach(async () => {
-        const backendSrv = ({
-          async datasourceRequest() {
-            return Promise.reject({
-              statusText: 'Unauthorized',
-              status: 401,
-              data: {
-                message: 'Unauthorized',
-              },
-            });
-          },
-        } as unknown) as BackendSrv;
-        ds = new LokiDatasource(instanceSettings, backendSrv, {} as TemplateSrv);
-        result = await ds.testDatasource();
+      let ds: LokiDatasource;
+      beforeEach(() => {
+        backendSrvMock.datasourceRequest = jest.fn(() =>
+          Promise.reject({
+            statusText: 'Unauthorized',
+            status: 401,
+            data: {
+              message: 'Unauthorized',
+            },
+          })
+        );
+
+        const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+        const customSettings = { ...instanceSettings, jsonData: customData };
+        ds = new LokiDatasource(customSettings, backendSrv, templateSrvMock);
       });
 
-      it('should return error status and a detailed error message', () => {
+      it('should return error status and a detailed error message', async () => {
+        const result = await ds.testDatasource();
         expect(result.status).toEqual('error');
         expect(result.message).toBe('Loki: Unauthorized. 401. Unauthorized');
       });
@@ -222,24 +301,32 @@ describe('LokiDatasource', () => {
   });
 
   describe('annotationQuery', () => {
-    it('should transform the loki data to annototion response', async () => {
+    it('should transform the loki data to annotation response', async () => {
       const ds = new LokiDatasource(instanceSettings, backendSrv, templateSrvMock);
-      backendSrvMock.datasourceRequest = jest.fn(() =>
-        Promise.resolve({
-          data: {
-            streams: [
-              {
-                entries: [{ ts: '2019-02-01T10:27:37.498180581Z', line: 'hello' }],
-                labels: '{label="value"}',
-              },
-              {
-                entries: [{ ts: '2019-02-01T12:27:37.498180581Z', line: 'hello 2' }],
-                labels: '{label2="value2"}',
-              },
-            ],
-          },
-        })
-      );
+      backendSrvMock.datasourceRequest = jest
+        .fn()
+        .mockReturnValueOnce(
+          Promise.resolve({
+            data: [],
+            status: 404,
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            data: {
+              streams: [
+                {
+                  entries: [{ ts: '2019-02-01T10:27:37.498180581Z', line: 'hello' }],
+                  labels: '{label="value"}',
+                },
+                {
+                  entries: [{ ts: '2019-02-01T12:27:37.498180581Z', line: 'hello 2' }],
+                  labels: '{label2="value2"}',
+                },
+              ],
+            },
+          })
+        );
       const query = makeAnnotationQueryRequest();
 
       const res = await ds.annotationQuery(query);

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -60,8 +60,8 @@ describe('LokiDatasource', () => {
 
     test('should try latest endpoint but fall back to legacy endpoint if it cannot be reached', async () => {
       const options = getQueryOptions<LokiQuery>({
-        targets: [{ expr: 'rate({job="grafana"}[5m])', refId: 'B' }],
-        exploreMode: ExploreMode.Metrics,
+        targets: [{ expr: '{job="grafana"}', refId: 'B' }],
+        exploreMode: ExploreMode.Logs,
       });
 
       ds.runLegacyQuery = jest.fn();
@@ -88,10 +88,12 @@ describe('LokiDatasource', () => {
       });
 
       ds.runInstantQuery = jest.fn(() => of({ data: [] }));
+      ds.runLegacyQuery = jest.fn();
       ds.runRangeQueryWithFallback = jest.fn(() => of({ data: [] }));
       await ds.query(options).toPromise();
 
       expect(ds.runInstantQuery).toBeCalled();
+      expect(ds.runLegacyQuery).not.toBeCalled();
       expect(ds.runRangeQueryWithFallback).toBeCalled();
     });
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -20,6 +20,7 @@ describe('LokiDatasource', () => {
         },
       ],
     },
+    status: 404, // for simulating legacy endpoint
   };
 
   const backendSrvMock = { datasourceRequest: jest.fn() };

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -10,6 +10,18 @@ import { beforeEach } from 'test/lib/common';
 import { makeMockLokiDatasource } from './mocks';
 import LokiDatasource from './datasource';
 
+jest.mock('app/store/store', () => ({
+  store: {
+    getState: jest.fn().mockReturnValue({
+      explore: {
+        left: {
+          mode: 'Logs',
+        },
+      },
+    }),
+  },
+}));
+
 describe('Language completion provider', () => {
   const datasource = makeMockLokiDatasource({});
 

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -3,15 +3,18 @@ import _ from 'lodash';
 
 // Services & Utils
 import { parseSelector, labelRegexp, selectorRegexp } from 'app/plugins/datasource/prometheus/language_utils';
-import syntax from './syntax';
+import { store } from 'app/store/store';
+import syntax, { FUNCTIONS } from './syntax';
 
 // Types
 import { LokiQuery } from './types';
 import { dateTime, AbsoluteTimeRange, LanguageProvider, HistoryItem } from '@grafana/data';
 import { PromQuery } from '../prometheus/types';
+import { RATE_RANGES } from '../prometheus/promql';
 
 import LokiDatasource from './datasource';
 import { CompletionItem, TypeaheadInput, TypeaheadOutput } from '@grafana/ui';
+import { ExploreMode } from 'app/types/explore';
 
 const DEFAULT_KEYS = ['job', 'namespace'];
 const EMPTY_SELECTOR = '{}';
@@ -32,14 +35,15 @@ type TypeaheadContext = {
 
 export function addHistoryMetadata(item: CompletionItem, history: LokiHistoryItem[]): CompletionItem {
   const cutoffTs = Date.now() - HISTORY_COUNT_CUTOFF;
-  const historyForItem = history.filter(h => h.ts > cutoffTs && (h.query.expr as string) === item.label);
-  const count = historyForItem.length;
+  const historyForItem = history.filter(h => h.ts > cutoffTs && h.query.expr === item.label);
+  let hint = `Queried ${historyForItem.length} times in the last 24h.`;
   const recent = historyForItem[0];
-  let hint = `Queried ${count} times in the last 24h.`;
+
   if (recent) {
     const lastQueried = dateTime(recent.ts).fromNow();
     hint = `${hint} Last queried ${lastQueried}.`;
   }
+
   return {
     ...item,
     documentation: hint,
@@ -72,7 +76,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     return syntax;
   }
 
-  request = (url: string, params?: any) => {
+  request = (url: string, params?: any): Promise<{ data: { data: string[] } }> => {
     return this.datasource.metadataRequest(url, params);
   };
 
@@ -87,6 +91,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         return [];
       });
     }
+
     return this.startTask;
   };
 
@@ -108,15 +113,53 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * @param context.history Optional used only in getEmptyCompletionItems
    */
   async provideCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
-    const { wrapperClasses, value } = input;
+    const exploreMode = store.getState().explore.left.mode;
+
+    if (exploreMode === ExploreMode.Logs) {
+      return this.provideLogCompletionItems(input, context);
+    }
+
+    return this.provideMetricsCompletionItems(input, context);
+  }
+
+  async provideMetricsCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
+    const { wrapperClasses, value, prefix, text } = input;
+
     // Local text properties
     const empty = value.document.text.length === 0;
+    const selectedLines = value.document.getTextsAtRange(value.selection);
+    const currentLine = selectedLines.size === 1 ? selectedLines.first().getText() : null;
+
+    const nextCharacter = currentLine ? currentLine[value.selection.anchor.offset] : null;
+
+    // Syntax spans have 3 classes by default. More indicate a recognized token
+    const tokenRecognized = wrapperClasses.length > 3;
+
+    // Non-empty prefix, but not inside known token
+    const prefixUnrecognized = prefix && !tokenRecognized;
+
+    // Prevent suggestions in `function(|suffix)`
+    const noSuffix = !nextCharacter || nextCharacter === ')';
+
+    // Empty prefix is safe if it does not immediately follow a complete expression and has no text after it
+    const safeEmptyPrefix = prefix === '' && !text.match(/^[\]})\s]+$/) && noSuffix;
+
+    // About to type next operand if preceded by binary operator
+    const operatorsPattern = /[+\-*/^%]/;
+    const isNextOperand = text.match(operatorsPattern);
+
     // Determine candidates by CSS context
-    if (_.includes(wrapperClasses, 'context-labels')) {
+    if (wrapperClasses.includes('context-range')) {
+      // Suggestions for metric[|]
+      return this.getRangeCompletionItems();
+    } else if (wrapperClasses.includes('context-labels')) {
       // Suggestions for {|} and {foo=|}
       return await this.getLabelCompletionItems(input, context);
     } else if (empty) {
-      return this.getEmptyCompletionItems(context || {});
+      return this.getEmptyCompletionItems(context || {}, ExploreMode.Metrics);
+    } else if ((prefixUnrecognized && noSuffix) || safeEmptyPrefix || isNextOperand) {
+      // Show term suggestions in a couple of scenarios
+      return this.getTermCompletionItems();
     }
 
     return {
@@ -124,13 +167,30 @@ export default class LokiLanguageProvider extends LanguageProvider {
     };
   }
 
-  getEmptyCompletionItems(context: any): TypeaheadOutput {
+  async provideLogCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
+    const { wrapperClasses, value } = input;
+    // Local text properties
+    const empty = value.document.text.length === 0;
+    // Determine candidates by CSS context
+    if (wrapperClasses.includes('context-labels')) {
+      // Suggestions for {|} and {foo=|}
+      return await this.getLabelCompletionItems(input, context);
+    } else if (empty) {
+      return this.getEmptyCompletionItems(context || {}, ExploreMode.Logs);
+    }
+
+    return {
+      suggestions: [],
+    };
+  }
+
+  getEmptyCompletionItems(context: TypeaheadContext, mode?: ExploreMode): TypeaheadOutput {
     const { history } = context;
     const suggestions = [];
 
-    if (history && history.length > 0) {
+    if (history && history.length) {
       const historyItems = _.chain(history)
-        .map((h: any) => h.query.expr)
+        .map(h => h.query.expr)
         .filter()
         .uniq()
         .take(HISTORY_ITEM_COUNT)
@@ -146,7 +206,36 @@ export default class LokiLanguageProvider extends LanguageProvider {
       });
     }
 
+    if (mode === ExploreMode.Metrics) {
+      const termCompletionItems = this.getTermCompletionItems();
+      suggestions.push(...termCompletionItems.suggestions);
+    }
+
     return { suggestions };
+  }
+
+  getTermCompletionItems = (): TypeaheadOutput => {
+    const suggestions = [];
+
+    suggestions.push({
+      prefixMatch: true,
+      label: 'Functions',
+      items: FUNCTIONS.map(suggestion => ({ ...suggestion, kind: 'function' })),
+    });
+
+    return { suggestions };
+  };
+
+  getRangeCompletionItems(): TypeaheadOutput {
+    return {
+      context: 'context-range',
+      suggestions: [
+        {
+          label: 'Range vector',
+          items: [...RATE_RANGES],
+        },
+      ],
+    };
   }
 
   async getLabelCompletionItems(
@@ -186,7 +275,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       const labelKeys = this.labelKeys[selector] || DEFAULT_KEYS;
       if (labelKeys) {
         const possibleKeys = _.difference(labelKeys, existingKeys);
-        if (possibleKeys.length > 0) {
+        if (possibleKeys.length) {
           context = 'context-labels';
           suggestions.push({ label: `Labels`, items: possibleKeys.map(wrapLabel) });
         }
@@ -223,40 +312,40 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     // Consider only first selector in query
     const selectorMatch = query.match(selectorRegexp);
-    if (selectorMatch) {
-      const selector = selectorMatch[0];
-      const labels: { [key: string]: { value: any; operator: any } } = {};
-      selector.replace(labelRegexp, (_, key, operator, value) => {
-        labels[key] = { value, operator };
-        return '';
-      });
-
-      // Keep only labels that exist on origin and target datasource
-      await this.start(); // fetches all existing label keys
-      const existingKeys = this.labelKeys[EMPTY_SELECTOR];
-      let labelsToKeep: { [key: string]: { value: any; operator: any } } = {};
-      if (existingKeys && existingKeys.length > 0) {
-        // Check for common labels
-        for (const key in labels) {
-          if (existingKeys && existingKeys.includes(key)) {
-            // Should we check for label value equality here?
-            labelsToKeep[key] = labels[key];
-          }
-        }
-      } else {
-        // Keep all labels by default
-        labelsToKeep = labels;
-      }
-
-      const labelKeys = Object.keys(labelsToKeep).sort();
-      const cleanSelector = labelKeys
-        .map(key => `${key}${labelsToKeep[key].operator}${labelsToKeep[key].value}`)
-        .join(',');
-
-      return ['{', cleanSelector, '}'].join('');
+    if (!selectorMatch) {
+      return '';
     }
 
-    return '';
+    const selector = selectorMatch[0];
+    const labels: { [key: string]: { value: any; operator: any } } = {};
+    selector.replace(labelRegexp, (_, key, operator, value) => {
+      labels[key] = { value, operator };
+      return '';
+    });
+
+    // Keep only labels that exist on origin and target datasource
+    await this.start(); // fetches all existing label keys
+    const existingKeys = this.labelKeys[EMPTY_SELECTOR];
+    let labelsToKeep: { [key: string]: { value: any; operator: any } } = {};
+    if (existingKeys && existingKeys.length) {
+      // Check for common labels
+      for (const key in labels) {
+        if (existingKeys && existingKeys.includes(key)) {
+          // Should we check for label value equality here?
+          labelsToKeep[key] = labels[key];
+        }
+      }
+    } else {
+      // Keep all labels by default
+      labelsToKeep = labels;
+    }
+
+    const labelKeys = Object.keys(labelsToKeep).sort();
+    const cleanSelector = labelKeys
+      .map(key => `${key}${labelsToKeep[key].operator}${labelsToKeep[key].value}`)
+      .join(',');
+
+    return ['{', cleanSelector, '}'].join('');
   }
 
   async fetchLogLabels(absoluteRange: AbsoluteTimeRange): Promise<any> {
@@ -265,8 +354,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
       this.logLabelFetchTs = Date.now();
 
       const res = await this.request(url, rangeToParams(absoluteRange));
-      const body = await (res.data || res.json());
-      const labelKeys = body.data.slice().sort();
+      const labelKeys = res.data.data.slice().sort();
+
       this.labelKeys = {
         ...this.labelKeys,
         [EMPTY_SELECTOR]: labelKeys,
@@ -291,15 +380,14 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const url = `/api/prom/label/${key}/values`;
     try {
       const res = await this.request(url, rangeToParams(absoluteRange));
-      const body = await (res.data || res.json());
-      const values = body.data.slice().sort();
+      const values = res.data.data.slice().sort();
 
       // Add to label options
       this.logLabelOptions = this.logLabelOptions.map(keyOption => {
         if (keyOption.value === key) {
           return {
             ...keyOption,
-            children: values.map((value: string) => ({ label: value, value })),
+            children: values.map(value => ({ label: value, value })),
           };
         }
         return keyOption;

--- a/public/app/plugins/datasource/loki/live_streams.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams.test.ts
@@ -36,7 +36,7 @@ describe('Live Stream Tests', () => {
     fakeSocket = new Subject<any>();
     const labels: Labels = { job: 'varlogs' };
     const target = makeTarget('fake', labels);
-    const stream = new LiveStreams().getStream(target);
+    const stream = new LiveStreams().getLegacyStream(target);
     expect.assertions(4);
 
     const tests = [
@@ -74,21 +74,21 @@ describe('Live Stream Tests', () => {
   it('returns the same subscription if the url matches existing one', () => {
     fakeSocket = new Subject<any>();
     const liveStreams = new LiveStreams();
-    const stream1 = liveStreams.getStream(makeTarget('url_to_match'));
-    const stream2 = liveStreams.getStream(makeTarget('url_to_match'));
+    const stream1 = liveStreams.getLegacyStream(makeTarget('url_to_match'));
+    const stream2 = liveStreams.getLegacyStream(makeTarget('url_to_match'));
     expect(stream1).toBe(stream2);
   });
 
   it('returns new subscription when the previous unsubscribed', () => {
     fakeSocket = new Subject<any>();
     const liveStreams = new LiveStreams();
-    const stream1 = liveStreams.getStream(makeTarget('url_to_match'));
+    const stream1 = liveStreams.getLegacyStream(makeTarget('url_to_match'));
     const subscription = stream1.subscribe({
       next: noop,
     });
     subscription.unsubscribe();
 
-    const stream2 = liveStreams.getStream(makeTarget('url_to_match'));
+    const stream2 = liveStreams.getLegacyStream(makeTarget('url_to_match'));
     expect(stream1).not.toBe(stream2);
   });
 
@@ -101,7 +101,7 @@ describe('Live Stream Tests', () => {
     spy.and.returnValue(fakeSocket);
 
     const liveStreams = new LiveStreams();
-    const stream1 = liveStreams.getStream(makeTarget('url_to_match'));
+    const stream1 = liveStreams.getLegacyStream(makeTarget('url_to_match'));
     const subscription = stream1.subscribe({
       next: noop,
     });

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -1,19 +1,26 @@
 import { DataFrame, FieldType, parseLabels, KeyValue, CircularDataFrame } from '@grafana/data';
 import { Observable } from 'rxjs';
 import { webSocket } from 'rxjs/webSocket';
-import { LokiLegacyStreamResponse } from './types';
+import { LokiLegacyStreamResponse, LokiTailResponse } from './types';
 import { finalize, map } from 'rxjs/operators';
-import { appendResponseToBufferedData } from './result_transformer';
+import { appendLegacyResponseToBufferedData, appendResponseToBufferedData } from './result_transformer';
 
 /**
  * Maps directly to a query in the UI (refId is key)
  */
-export interface LiveTarget {
+export interface LegacyTarget {
   query: string;
   regexp: string;
   url: string;
   refId: string;
   size: number;
+}
+
+export interface LiveTarget {
+  query: string;
+  delay_for?: string;
+  limit?: string;
+  start?: string;
 }
 
 /**
@@ -23,7 +30,7 @@ export interface LiveTarget {
 export class LiveStreams {
   private streams: KeyValue<Observable<DataFrame[]>> = {};
 
-  getStream(target: LiveTarget): Observable<DataFrame[]> {
+  getLegacyStream(target: LegacyTarget): Observable<DataFrame[]> {
     let stream = this.streams[target.url];
 
     if (stream) {
@@ -40,7 +47,36 @@ export class LiveStreams {
       finalize(() => {
         delete this.streams[target.url];
       }),
+
       map((response: LokiLegacyStreamResponse) => {
+        appendLegacyResponseToBufferedData(response, data);
+        return [data];
+      })
+    );
+    this.streams[target.url] = stream;
+
+    return stream;
+  }
+
+  getStream(target: LegacyTarget): Observable<DataFrame[]> {
+    let stream = this.streams[target.url];
+
+    if (stream) {
+      return stream;
+    }
+
+    const data = new CircularDataFrame({ capacity: target.size });
+    data.addField({ name: 'ts', type: FieldType.time, config: { title: 'Time' } });
+    data.addField({ name: 'line', type: FieldType.string }).labels = parseLabels(target.query);
+    data.addField({ name: 'labels', type: FieldType.other }); // The labels for each line
+    data.addField({ name: 'id', type: FieldType.string });
+
+    stream = webSocket(target.url).pipe(
+      finalize(() => {
+        delete this.streams[target.url];
+      }),
+
+      map((response: LokiTailResponse) => {
         appendResponseToBufferedData(response, data);
         return [data];
       })

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -1,7 +1,7 @@
 import { DataFrame, FieldType, parseLabels, KeyValue, CircularDataFrame } from '@grafana/data';
 import { Observable } from 'rxjs';
 import { webSocket } from 'rxjs/webSocket';
-import { LokiLegacyResponse } from './types';
+import { LokiLegacyStreamResponse } from './types';
 import { finalize, map } from 'rxjs/operators';
 import { appendResponseToBufferedData } from './result_transformer';
 
@@ -40,7 +40,7 @@ export class LiveStreams {
       finalize(() => {
         delete this.streams[target.url];
       }),
-      map((response: LokiLegacyResponse) => {
+      map((response: LokiLegacyStreamResponse) => {
         appendResponseToBufferedData(response, data);
         return [data];
       })

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -4,11 +4,24 @@
   "id": "loki",
   "category": "logging",
 
+  "logs": true,
   "metrics": true,
   "alerting": false,
   "annotations": true,
-  "logs": true,
-  "streaming": true,
+
+  "streaming": {
+    "logs": true,
+    "metrics": false
+  },
+
+  "versions": {
+    "v0": {
+      "metrics": false
+    },
+    "v1": {
+      "metrics": true
+    }
+  },
 
   "queryOptions": {
     "maxDataPoints": true
@@ -24,8 +37,7 @@
       "small": "img/loki_icon.svg",
       "large": "img/loki_icon.svg"
     },
-    "links": [
-      {
+    "links": [{
         "name": "Learn more",
         "url": "https://grafana.com/loki"
       },

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -8,20 +8,7 @@
   "metrics": true,
   "alerting": false,
   "annotations": true,
-
-  "streaming": {
-    "logs": true,
-    "metrics": false
-  },
-
-  "versions": {
-    "v0": {
-      "metrics": false
-    },
-    "v1": {
-      "metrics": true
-    }
-  },
+  "streaming": true,
 
   "queryOptions": {
     "maxDataPoints": true
@@ -37,7 +24,8 @@
       "small": "img/loki_icon.svg",
       "large": "img/loki_icon.svg"
     },
-    "links": [{
+    "links": [
+      {
         "name": "Learn more",
         "url": "https://grafana.com/loki"
       },

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -1,8 +1,8 @@
 import { logStreamToDataFrame, appendResponseToBufferedData } from './result_transformer';
 import { FieldType, MutableDataFrame } from '@grafana/data';
-import { LokiLogsStream } from './types';
+import { LokiStreamResult } from './types';
 
-const streams: LokiLogsStream[] = [
+const streams: LokiStreamResult[] = [
   {
     labels: '{foo="bar"}',
     entries: [

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -1,4 +1,4 @@
-import { legacyLogStreamToDataFrame, appendResponseToBufferedData } from './result_transformer';
+import { legacyLogStreamToDataFrame, appendLegacyResponseToBufferedData } from './result_transformer';
 import { FieldType, MutableDataFrame } from '@grafana/data';
 import { LokiLegacyStreamResult } from './types';
 
@@ -46,7 +46,7 @@ describe('appendResponseToBufferedData', () => {
     data.addField({ name: 'labels', type: FieldType.other });
     data.addField({ name: 'id', type: FieldType.string });
 
-    appendResponseToBufferedData({ streams }, data);
+    appendLegacyResponseToBufferedData({ streams }, data);
     expect(data.get(0)).toEqual({
       ts: '1970-01-01T00:00:00Z',
       line: "foo: [32m'bar'[39m",

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -1,8 +1,8 @@
-import { logStreamToDataFrame, appendResponseToBufferedData } from './result_transformer';
+import { legacyLogStreamToDataFrame, appendResponseToBufferedData } from './result_transformer';
 import { FieldType, MutableDataFrame } from '@grafana/data';
-import { LokiStreamResult } from './types';
+import { LokiLegacyStreamResult } from './types';
 
-const streams: LokiStreamResult[] = [
+const streams: LokiLegacyStreamResult[] = [
   {
     labels: '{foo="bar"}',
     entries: [
@@ -25,7 +25,7 @@ const streams: LokiStreamResult[] = [
 
 describe('logStreamToDataFrame', () => {
   it('converts streams to series', () => {
-    const data = streams.map(stream => logStreamToDataFrame(stream));
+    const data = streams.map(stream => legacyLogStreamToDataFrame(stream));
 
     expect(data.length).toBe(2);
     expect(data[0].fields[1].labels['foo']).toEqual('bar');

--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -1,14 +1,90 @@
 import { Grammar } from 'prismjs';
+import { CompletionItem } from '@grafana/ui';
 
-/* tslint:disable max-line-length */
+const AGGREGATION_OPERATORS: CompletionItem[] = [
+  {
+    label: 'sum',
+    insertText: 'sum',
+    documentation: 'Calculate sum over dimensions',
+  },
+  {
+    label: 'min',
+    insertText: 'min',
+    documentation: 'Select minimum over dimensions',
+  },
+  {
+    label: 'max',
+    insertText: 'max',
+    documentation: 'Select maximum over dimensions',
+  },
+  {
+    label: 'avg',
+    insertText: 'avg',
+    documentation: 'Calculate the average over dimensions',
+  },
+  {
+    label: 'stddev',
+    insertText: 'stddev',
+    documentation: 'Calculate population standard deviation over dimensions',
+  },
+  {
+    label: 'stdvar',
+    insertText: 'stdvar',
+    documentation: 'Calculate population standard variance over dimensions',
+  },
+  {
+    label: 'count',
+    insertText: 'count',
+    documentation: 'Count number of elements in the vector',
+  },
+  {
+    label: 'bottomk',
+    insertText: 'bottomk',
+    documentation: 'Smallest k elements by sample value',
+  },
+  {
+    label: 'topk',
+    insertText: 'topk',
+    documentation: 'Largest k elements by sample value',
+  },
+];
+
+export const RANGE_VEC_FUNCTIONS = [
+  {
+    insertText: 'count_over_time',
+    label: 'count_over_time',
+    detail: 'count_over_time(range-vector)',
+    documentation: 'The count of all values in the specified interval.',
+  },
+  {
+    insertText: 'rate',
+    label: 'rate',
+    detail: 'rate(v range-vector)',
+    documentation:
+      "Calculates the per-second average rate of increase of the time series in the range vector. Breaks in monotonicity (such as counter resets due to target restarts) are automatically adjusted for. Also, the calculation extrapolates to the ends of the time range, allowing for missed scrapes or imperfect alignment of scrape cycles with the range's time period.",
+  },
+];
+
+export const FUNCTIONS = [...AGGREGATION_OPERATORS, ...RANGE_VEC_FUNCTIONS];
 
 const tokenizer: Grammar = {
   comment: {
     pattern: /(^|[^\n])#.*/,
     lookbehind: true,
   },
+  'context-aggregation': {
+    pattern: /((without|by)\s*)\([^)]*\)/, // by ()
+    lookbehind: true,
+    inside: {
+      'label-key': {
+        pattern: /[^(),\s][^,)]*[^),\s]*/,
+        alias: 'attr-name',
+      },
+      punctuation: /[()]/,
+    },
+  },
   'context-labels': {
-    pattern: /(^|\s)\{[^}]*(?=})/,
+    pattern: /\{[^}]*(?=})/,
     lookbehind: true,
     inside: {
       'label-key': {
@@ -23,9 +99,31 @@ const tokenizer: Grammar = {
       punctuation: /[{]/,
     },
   },
-  // number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
+  function: new RegExp(`\\b(?:${FUNCTIONS.map(f => f.label).join('|')})(?=\\s*\\()`, 'i'),
+  'context-range': [
+    {
+      pattern: /\[[^\]]*(?=\])/, // [1m]
+      inside: {
+        'range-duration': {
+          pattern: /\b\d+[smhdwy]\b/i,
+          alias: 'number',
+        },
+      },
+    },
+    {
+      pattern: /(offset\s+)\w+/, // offset 1m
+      lookbehind: true,
+      inside: {
+        'range-duration': {
+          pattern: /\b\d+[smhdwy]\b/i,
+          alias: 'number',
+        },
+      },
+    },
+  ],
+  number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
   operator: new RegExp(`/&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?`, 'i'),
-  punctuation: /[{}`,.]/,
+  punctuation: /[{}()`,.]/,
 };
 
 export default tokenizer;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -3,8 +3,8 @@ import { Labels, DataQuery, DataSourceJsonData } from '@grafana/data';
 export interface LokiLegacyQueryRequest {
   query: string;
   limit?: number;
-  start?: number | string;
-  end?: number | string;
+  start?: number;
+  end?: number;
   direction?: 'BACKWARD' | 'FORWARD';
   regexp?: string;
 
@@ -18,7 +18,7 @@ export interface LokiInstantQueryRequest {
   direction?: 'BACKWARD' | 'FORWARD';
 }
 
-export interface LokiQueryRangeRequest {
+export interface LokiRangeQueryRequest {
   query: string;
   limit?: number;
   start?: number;
@@ -39,6 +39,7 @@ export interface LokiQuery extends DataQuery {
   query?: string;
   regexp?: string;
   format?: string;
+  reverse?: boolean;
   legendFormat?: string;
   valueWithRefId?: boolean;
 }
@@ -97,6 +98,14 @@ export interface LokiLegacyStreamResult {
 
 export interface LokiLegacyStreamResponse {
   streams: LokiLegacyStreamResult[];
+}
+
+export interface LokiTailResponse {
+  streams: LokiStreamResult[];
+  dropped_entries?: Array<{
+    labels: Record<string, string>;
+    timestamp: string;
+  }>;
 }
 
 export type LokiResult = LokiVectorResult | LokiMatrixResult | LokiStreamResult | LokiLegacyStreamResult;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -48,13 +48,17 @@ export interface LokiOptions extends DataSourceJsonData {
   derivedFields?: DerivedFieldConfig[];
 }
 
-export interface LokiLegacyResponse {
-  streams: LokiStreamResult[];
-}
-
 export interface LokiVectorResult {
   metric: { [label: string]: string };
   value: [number, string];
+}
+
+export interface LokiVectorResponse {
+  status: string;
+  data: {
+    resultType: LokiResultType.Vector;
+    result: LokiVectorResult[];
+  };
 }
 
 export interface LokiMatrixResult {
@@ -62,32 +66,41 @@ export interface LokiMatrixResult {
   values: Array<[number, string]>;
 }
 
-export type LokiResult = LokiMatrixResult | LokiVectorResult | LokiStreamResult;
-
-export interface LokiVectorResponse {
-  resultType: LokiResultType.Vector;
-  result: LokiVectorResult[];
+export interface LokiMatrixResponse {
+  status: string;
+  data: {
+    resultType: LokiResultType.Matrix;
+    result: LokiMatrixResult[];
+  };
 }
 
-export interface LokiMatrixResponse {
-  resultType: LokiResultType.Matrix;
-  result: LokiMatrixResult[];
+export interface LokiStreamResult {
+  stream: Record<string, string>;
+  values: Array<[string, string]>;
 }
 
 export interface LokiStreamResponse {
-  resultType: LokiResultType.Stream;
-  result: LokiStreamResult[];
+  status: string;
+  data: {
+    resultType: LokiResultType.Stream;
+    result: LokiStreamResult[];
+  };
 }
 
-export type LokiResponse = LokiVectorResponse | LokiMatrixResponse | LokiStreamResponse;
-
-export interface LokiStreamResult {
+export interface LokiLegacyStreamResult {
   labels: string;
   entries: LokiLogsStreamEntry[];
   search?: string;
   parsedLabels?: Labels;
   uniqueLabels?: Labels;
 }
+
+export interface LokiLegacyStreamResponse {
+  streams: LokiLegacyStreamResult[];
+}
+
+export type LokiResult = LokiVectorResult | LokiMatrixResult | LokiStreamResult | LokiLegacyStreamResult;
+export type LokiResponse = LokiVectorResponse | LokiMatrixResponse | LokiStreamResponse;
 
 export interface LokiLogsStreamEntry {
   line: string;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -1,10 +1,46 @@
 import { Labels, DataQuery, DataSourceJsonData } from '@grafana/data';
 
+export interface LokiLegacyQueryRequest {
+  query: string;
+  limit?: number;
+  start?: number | string;
+  end?: number | string;
+  direction?: 'BACKWARD' | 'FORWARD';
+  regexp?: string;
+
+  refId: string;
+}
+
+export interface LokiInstantQueryRequest {
+  query: string;
+  limit?: number;
+  time?: string;
+  direction?: 'BACKWARD' | 'FORWARD';
+}
+
+export interface LokiQueryRangeRequest {
+  query: string;
+  limit?: number;
+  start?: number;
+  end?: number;
+  step?: number;
+  direction?: 'BACKWARD' | 'FORWARD';
+}
+
+export enum LokiResultType {
+  Stream = 'streams',
+  Vector = 'vector',
+  Matrix = 'matrix',
+}
+
 export interface LokiQuery extends DataQuery {
   expr: string;
   liveStreaming?: boolean;
   query?: string;
   regexp?: string;
+  format?: string;
+  legendFormat?: string;
+  valueWithRefId?: boolean;
 }
 
 export interface LokiOptions extends DataSourceJsonData {
@@ -12,11 +48,40 @@ export interface LokiOptions extends DataSourceJsonData {
   derivedFields?: DerivedFieldConfig[];
 }
 
-export interface LokiResponse {
-  streams: LokiLogsStream[];
+export interface LokiLegacyResponse {
+  streams: LokiStreamResult[];
 }
 
-export interface LokiLogsStream {
+export interface LokiVectorResult {
+  metric: { [label: string]: string };
+  value: [number, string];
+}
+
+export interface LokiMatrixResult {
+  metric: { [label: string]: string };
+  values: Array<[number, string]>;
+}
+
+export type LokiResult = LokiMatrixResult | LokiVectorResult | LokiStreamResult;
+
+export interface LokiVectorResponse {
+  resultType: LokiResultType.Vector;
+  result: LokiVectorResult[];
+}
+
+export interface LokiMatrixResponse {
+  resultType: LokiResultType.Matrix;
+  result: LokiMatrixResult[];
+}
+
+export interface LokiStreamResponse {
+  resultType: LokiResultType.Stream;
+  result: LokiStreamResult[];
+}
+
+export type LokiResponse = LokiVectorResponse | LokiMatrixResponse | LokiStreamResponse;
+
+export interface LokiStreamResult {
   labels: string;
   entries: LokiLogsStreamEntry[];
   search?: string;
@@ -41,3 +106,15 @@ export type DerivedFieldConfig = {
   name: string;
   url?: string;
 };
+
+export interface TransformerOptions {
+  format: string;
+  legendFormat: string;
+  step: number;
+  start: number;
+  end: number;
+  query: string;
+  responseListLength: number;
+  refId: string;
+  valueWithRefId?: boolean;
+}

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -6,6 +6,7 @@ import { setStore } from './store';
 import { StoreState } from 'app/types/store';
 import { toggleLogActionsMiddleware } from 'app/core/middlewares/application';
 import { addReducer, createRootReducer } from '../core/reducers/root';
+import { ActionOf } from 'app/core/redux';
 
 export function addRootReducer(reducers: any) {
   // this is ok now because we add reducers before configureStore is called
@@ -27,7 +28,11 @@ export function configureStore() {
       ? applyMiddleware(toggleLogActionsMiddleware, thunk, logger)
       : applyMiddleware(thunk);
 
-  const store: any = createStore(createRootReducer(), {}, composeEnhancers(storeEnhancers));
+  const store = createStore<StoreState, ActionOf<any>, any, any>(
+    createRootReducer(),
+    {},
+    composeEnhancers(storeEnhancers)
+  );
   setStore(store);
   return store;
 }

--- a/public/app/store/store.ts
+++ b/public/app/store/store.ts
@@ -1,5 +1,9 @@
-export let store: any;
+import { ActionOf } from 'app/core/redux';
+import { StoreState } from 'app/types';
+import { Store } from 'redux';
 
-export function setStore(newStore: any) {
+export let store: Store<StoreState, ActionOf<any>>;
+
+export function setStore(newStore: Store<StoreState, ActionOf<any>>) {
   store = newStore;
 }

--- a/public/app/store/store.ts
+++ b/public/app/store/store.ts
@@ -1,9 +1,8 @@
-import { ActionOf } from 'app/core/redux';
 import { StoreState } from 'app/types';
 import { Store } from 'redux';
 
-export let store: Store<StoreState, ActionOf<any>>;
+export let store: Store<StoreState>;
 
-export function setStore(newStore: Store<StoreState, ActionOf<any>>) {
+export function setStore(newStore: Store<StoreState>) {
   store = newStore;
 }

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -228,6 +228,7 @@ export interface QueryOptions {
   liveStreaming?: boolean;
   showingGraph?: boolean;
   showingTable?: boolean;
+  mode?: ExploreMode;
 }
 
 export interface QueryTransaction {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds support to Grafana for Loki's vector and range vector aggregation features, and the associated endpoints.
- Adds a Metrics mode to the Loki data source in Explore.
- Uses new `/api/v1/query_range` endpoint but falls back to legacy `/api/prom/query` endpoint if necessary. (e.g. user is using an old version of Loki)
- ~~Adds new parameter to datasource plugin.json, `versions`, where a user can specify metadata that should override top-level definitions if a specific datasource version is being used.~~ Might introduce in a later PR.
- ~~Changes `streaming` parameter in datasource plugin.json to accept an object with explore modes as keys and booleans as values.~~ Might introduce in a later PR.
- Adds an optional `getVersion` method to the DatasourceApi interface to facilitate the above.

Haven't done any super in-depth exploratory testing, but it seems to work well based on what I've tried.

Work to be done:
- Add tests for methods transforming results from new endpoints
- Add tests for new suggestion logic
- Improved suggestions (e.g. not suggesting aggregation operators inside `rate(|)`)
- Change all queries to legacy endpoints to new endpoints with fallback.