### PR TITLE
Frontend: Changes in Redux location should not strip subpath from location url

### DIFF
--- a/public/app/core/services/bridge_srv.ts
+++ b/public/app/core/services/bridge_srv.ts
@@ -51,7 +51,7 @@ export class BridgeSrv {
     store.subscribe(() => {
       const state = store.getState();
       const angularUrl = this.$location.url();
-      const url = locationUtil.stripBaseFromUrl(state.location.url);
+      const url = state.location.url;
       if (angularUrl !== url) {
         this.$timeout(() => {
           this.$location.url(url);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When I try to serve Grafana under the `/dashboards` subpath it's falling into infinite loop while accessing folder settings, as it strips the `dashboards` string from the folder URL. 

This PR fixes this issue by removing the `locationUtil.stripBaseFromUrl()` call on `state.location.url` (which already does not contain the subpath). 

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-
