### PR TITLE
Macros: Support parentheses within macro functions

### DIFF
--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -14,12 +14,13 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
 /*
-	The below regex is for matching content within parantheses, with the
+	The below regex is for matching content within parentheses, with the
 	possibility of nested parathesis. For example given $__timeFilter(CAST(time_column) AS datetime),
 	this expression would match the part CAST(time_column) AS datetime
 
-	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
-	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+	Currently, since golang's regex uses the RE2 library, it lacks the support for recursive expressions.
+	Therefore capturing such cases with unlimited levels of nesting is not trivial.
+	Below regex only supports 2 levels of nesting, which might be good enough for simple use cases.
 
 	For more details, refer: https://stackoverflow.com/a/35271017
 	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -12,7 +12,13 @@ import (
 )
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
+
+// The below regex is for matching content within parantheses, with the
+// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
+// this expression would match the part to_timestamp(time_column)
+// For more details, refer: https://stackoverflow.com/a/35271017
+// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 type msSqlMacroEngine struct {
 	*sqleng.SqlMacroEngineBase

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -13,11 +13,17 @@ import (
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
-// The below regex is for matching content within parantheses, with the
-// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
-// this expression would match the part to_timestamp(time_column)
-// For more details, refer: https://stackoverflow.com/a/35271017
-// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+/*
+	The below regex is for matching content within parantheses, with the
+	possibility of nested parathesis. For example given $__timeFilter(CAST(time_column) AS datetime),
+	this expression would match the part CAST(time_column) AS datetime
+
+	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
+	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+
+	For more details, refer: https://stackoverflow.com/a/35271017
+	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+*/
 const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 type msSqlMacroEngine struct {

--- a/pkg/tsdb/mssql/macros_test.go
+++ b/pkg/tsdb/mssql/macros_test.go
@@ -52,6 +52,13 @@ func TestMacroEngine(t *testing.T) {
 				So(sql, ShouldEqual, fmt.Sprintf("WHERE time_column BETWEEN '%s' AND '%s'", from.Format(time.RFC3339), to.Format(time.RFC3339)))
 			})
 
+			Convey("interpolate __timeFilter function with a nested mssql function call", func() {
+				sql, err := engine.Interpolate(query, timeRange, "WHERE $__timeFilter(CAST(time_column) AS datetime)")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, fmt.Sprintf("WHERE CAST(time_column) AS datetime BETWEEN '%s' AND '%s'", from.Format(time.RFC3339), to.Format(time.RFC3339)))
+			})
+
 			Convey("interpolate __timeFrom function", func() {
 				sql, err := engine.Interpolate(query, timeRange, "select $__timeFrom()")
 				So(err, ShouldBeNil)

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -15,12 +15,13 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
 /*
-	The below regex is for matching content within parantheses, with the
+	The below regex is for matching content within parentheses, with the
 	possibility of nested parathesis. For example given $__timeFilter(TIME(time_column)),
 	this expression would match the part TIME(time_column)
 
-	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
-	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+	Currently, since golang's regex uses the RE2 library, it lacks the support for recursive expressions.
+	Therefore capturing such cases with unlimited levels of nesting is not trivial.
+	Below regex only supports 2 levels of nesting, which might be good enough for simple use cases.
 
 	For more details, refer: https://stackoverflow.com/a/35271017
 	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -13,7 +13,13 @@ import (
 )
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
+
+// The below regex is for matching content within parantheses, with the
+// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
+// this expression would match the part to_timestamp(time_column)
+// For more details, refer: https://stackoverflow.com/a/35271017
+// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)
 

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -14,11 +14,17 @@ import (
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
-// The below regex is for matching content within parantheses, with the
-// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
-// this expression would match the part to_timestamp(time_column)
-// For more details, refer: https://stackoverflow.com/a/35271017
-// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+/*
+	The below regex is for matching content within parantheses, with the
+	possibility of nested parathesis. For example given $__timeFilter(TIME(time_column)),
+	this expression would match the part TIME(time_column)
+
+	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
+	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+
+	For more details, refer: https://stackoverflow.com/a/35271017
+	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+*/
 const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 var restrictedRegExp = regexp.MustCompile(`(?im)([\s]*show[\s]+grants|[\s,]session_user\([^\)]*\)|[\s,]current_user(\([^\)]*\))?|[\s,]system_user\([^\)]*\)|[\s,]user\([^\)]*\))([\s,;]|$)`)

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -66,6 +66,13 @@ func TestMacroEngine(t *testing.T) {
 				So(sql, ShouldEqual, fmt.Sprintf("WHERE time_column BETWEEN FROM_UNIXTIME(%d) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()))
 			})
 
+			Convey("interpolate __timeFilter function with a nested mysql function call", func() {
+				sql, err := engine.Interpolate(query, timeRange, "WHERE $__timeFilter(TIME(time_column))")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, fmt.Sprintf("WHERE TIME(time_column) BETWEEN FROM_UNIXTIME(%d) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()))
+			})
+
 			Convey("interpolate __timeFrom function", func() {
 				sql, err := engine.Interpolate(query, timeRange, "select $__timeFrom()")
 				So(err, ShouldBeNil)

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -13,11 +13,17 @@ import (
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
-// The below regex is for matching content within parantheses, with the
-// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
-// this expression would match the part to_timestamp(time_column)
-// For more details, refer: https://stackoverflow.com/a/35271017
-// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+/*
+	The below regex is for matching content within parantheses, with the
+	possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
+	this expression would match the part to_timestamp(time_column)
+
+	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
+	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+
+	For more details, refer: https://stackoverflow.com/a/35271017
+	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+*/
 const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 type postgresMacroEngine struct {

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -14,12 +14,13 @@ import (
 const rsIdentifier = `([_a-zA-Z0-9]+)`
 
 /*
-	The below regex is for matching content within parantheses, with the
+	The below regex is for matching content within parentheses, with the
 	possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
 	this expression would match the part to_timestamp(time_column)
 
-	Currently, because of the lack of recursive capture groups, capturing such cases with unlimited
-	levels of nesting is not trivial using regular expressions. Below regex only supports 2 levels of nesting.
+	Currently, since golang's regex uses the RE2 library, it lacks the support for recursive expressions.
+	Therefore capturing such cases with unlimited levels of nesting is not trivial.
+	Below regex only supports 2 levels of nesting, which might be good enough for simple use cases.
 
 	For more details, refer: https://stackoverflow.com/a/35271017
 	For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -12,7 +12,13 @@ import (
 )
 
 const rsIdentifier = `([_a-zA-Z0-9]+)`
-const sExpr = `\$` + rsIdentifier + `\(([^\)]*)\)`
+
+// The below regex is for matching content within parantheses, with the
+// possibility of nested parathesis. For example given $__timeFilter(to_timestamp(time_column)),
+// this expression would match the part to_timestamp(time_column)
+// For more details, refer: https://stackoverflow.com/a/35271017
+// For playing around more with this regex, refer: https://regex101.com/r/eBtSTM/26
+const sExpr = `\$` + rsIdentifier + `\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)`
 
 type postgresMacroEngine struct {
 	*sqleng.SqlMacroEngineBase

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -44,6 +44,13 @@ func TestMacroEngine(t *testing.T) {
 				So(sql, ShouldEqual, fmt.Sprintf("WHERE time_column BETWEEN '%s' AND '%s'", from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano)))
 			})
 
+			Convey("interpolate __timeFilter function with a nested postgres function call", func() {
+				sql, err := engine.Interpolate(query, timeRange, "WHERE $__timeFilter(to_timestamp(time_column))")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, fmt.Sprintf("WHERE to_timestamp(time_column) BETWEEN '%s' AND '%s'", from.Format(time.RFC3339Nano), to.Format(time.RFC3339Nano)))
+			})
+
 			Convey("interpolate __timeFrom function", func() {
 				sql, err := engine.Interpolate(query, timeRange, "select $__timeFrom()")
 				So(err, ShouldBeNil)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request aim is to fix the long-standing, closely related issues https://github.com/grafana/grafana/issues/10380 and https://github.com/grafana/grafana/issues/8411

For a brief context, when using SQL based data sources in grafana like postgres or MySQL, we have the feature of macros, which allow for dynamic queries to be built. While we can have custom SQL code within these macro calls, because of the current regex-based parsing of the macros, parentheses are not processed as expected.

So to be honest, the current fix does complicate the regex a bit. But in my opinion, this is still a decent solution as any other option seems to need us to rewrite the parsing logic without doing any regex. A similar argument was rightly pointed out by @ikirker earlier in his issue (https://github.com/grafana/grafana/issues/8411) as well.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/10380
Fixes https://github.com/grafana/grafana/issues/8411

**Special notes for your reviewer**:

I've ran the tests using: `go test -v ./pkg/...` and all PASS as expected