### PR TITLE
Docs: Add "the" to license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ If you're interested in contributing to the Grafana project:
 
 ## License
 
-Grafana is distributed under [Apache 2.0 License](https://github.com/grafana/grafana/blob/master/LICENSE).
+Grafana is distributed under the [Apache 2.0 License](https://github.com/grafana/grafana/blob/master/LICENSE).


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a "the" between `under` and `Apache` to license reference in `README.md`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/20162

**Special notes for your reviewer**:

None.
