### PR TITLE
Docker blocks: Add loki blocks for loki releases

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -227,6 +227,20 @@ datasources:
       authType: credentials
       defaultRegion: eu-west-2
 
+  # Keep to test old /api/prom API
+  - name: gdev-loki-0.3
+    type: loki
+    access: proxy
+    url: http://localhost:3103
+    editable: false
+
+  # First version with new v1 API (remove once v1 is out)
+  - name: gdev-loki-0.4
+    type: loki
+    access: proxy
+    url: http://localhost:3104
+    editable: false
+
   - name: gdev-loki
     type: loki
     access: proxy

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -1,3 +1,4 @@
+  # datasource URL: http://localhost:3100/
   loki:
     image: grafana/loki:master
     ports:

--- a/devenv/docker/blocks/loki0.3/config.yaml
+++ b/devenv/docker/blocks/loki0.3/config.yaml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: http://loki0.3:3100/api/prom/push
+
+scrape_configs:
+  - job_name: system
+    entry_parser: raw
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+  - job_name: grafana
+    entry_parser: raw
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: grafana
+          __path__: /var/log/grafana/*log

--- a/devenv/docker/blocks/loki0.3/docker-compose.yaml
+++ b/devenv/docker/blocks/loki0.3/docker-compose.yaml
@@ -1,0 +1,15 @@
+  # datasource URL: http://localhost:3103/
+  loki0.3:
+    image: grafana/loki:v0.3.0
+    ports:
+      - "3103:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail0.3:
+    image: grafana/promtail:v0.3.0
+    volumes:
+      - ./docker/blocks/loki0.3/config.yaml:/etc/promtail/docker-config.yaml
+      - /var/log:/var/log
+      - ../data/log:/var/log/grafana
+    command:
+      -config.file=/etc/promtail/docker-config.yaml

--- a/devenv/docker/blocks/loki0.4/config.yaml
+++ b/devenv/docker/blocks/loki0.4/config.yaml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: http://loki0.4:3100/api/prom/push
+
+scrape_configs:
+  - job_name: system
+    entry_parser: raw
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+  - job_name: grafana
+    entry_parser: raw
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: grafana
+          __path__: /var/log/grafana/*log

--- a/devenv/docker/blocks/loki0.4/docker-compose.yaml
+++ b/devenv/docker/blocks/loki0.4/docker-compose.yaml
@@ -1,0 +1,15 @@
+  # datasource URL: http://localhost:3104/
+  loki0.4:
+    image: grafana/loki:v0.4.0
+    ports:
+      - "3104:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail0.4:
+    image: grafana/promtail:v0.4.0
+    volumes:
+      - ./docker/blocks/loki0.4/config.yaml:/etc/promtail/docker-config.yaml
+      - /var/log:/var/log
+      - ../data/log:/var/log/grafana
+    command:
+      -config.file=/etc/promtail/docker-config.yaml


### PR DESCRIPTION
- Loki did major API changes between 0.3 and 0.4
- Adding blocks to simplify Grafana datasource testing for different
versions
- keeing `loki` block pointing at loki master
- Run all versions in parallel:
```
./create_docker_compose.sh loki0.3 loki0.4 loki
```
- all versions have different hostnames and ports internally
- datasource url depends on version so you can set them up as separate
datasources:
  - master: http://localhost:3100/
  - 0.3.0: http://localhost:3103/
  - 0.4.0: http://localhost:3104/
- will remove pre-1.0 version blocks again when adding post-1.x blocks to not have too many loki blocks