### PR TITLE
LDAP: Support env variable expressions in ldap.toml file

### DIFF
--- a/pkg/services/ldap/settings_test.go
+++ b/pkg/services/ldap/settings_test.go
@@ -1,0 +1,22 @@
+package ldap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadingLDAPSettings(t *testing.T) {
+	config, err := readConfig("testdata/ldap.toml")
+	assert.Nil(t, err, "No error when reading ldap config")
+	assert.EqualValues(t, "127.0.0.1", config.Servers[0].Host)
+}
+
+func TestReadingLDAPSettingsWithEnvVariable(t *testing.T) {
+	os.Setenv("ENV_PASSWORD", "MySecret")
+
+	config, err := readConfig("testdata/ldap.toml")
+	assert.Nil(t, err, "No error when reading ldap config")
+	assert.EqualValues(t, "MySecret", config.Servers[0].BindPassword)
+}

--- a/pkg/services/ldap/testdata/ldap.toml
+++ b/pkg/services/ldap/testdata/ldap.toml
@@ -1,0 +1,27 @@
+[[servers]]
+host = "127.0.0.1"
+port = 389
+use_ssl = false
+start_tls = false
+ssl_skip_verify = false
+bind_dn = "cn=admin,dc=grafana,dc=org"
+bind_password = '${ENV_PASSWORD}'
+search_filter = "(cn=%s)"
+search_base_dns = ["dc=grafana,dc=org"]
+
+[servers.attributes]
+name = "givenName"
+surname = "sn"
+username = "cn"
+member_of = "memberOf"
+email =  "email"
+
+[[servers.group_mappings]]
+group_dn = "cn=admins,ou=groups,dc=grafana,dc=org"
+org_role = "Admin"
+grafana_admin = true
+
+[[servers.group_mappings]]
+group_dn = "cn=users,ou=groups,dc=grafana,dc=org"
+org_role = "Editor"
+

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -412,12 +412,13 @@ func makeAbsolute(path string, root string) string {
 	return filepath.Join(root, path)
 }
 
-func evalEnvVarExpression(value string) string {
+func EvalEnvVarExpression(value string) string {
 	regex := regexp.MustCompile(`\${(\w+)}`)
 	return regex.ReplaceAllStringFunc(value, func(envVar string) string {
 		envVar = strings.TrimPrefix(envVar, "${")
 		envVar = strings.TrimSuffix(envVar, "}")
 		envValue := os.Getenv(envVar)
+		fmt.Println(fmt.Sprintf("envVar %s value %s", envVar, envValue))
 
 		// if env variable is hostname and it is empty use os.Hostname as default
 		if envVar == "HOSTNAME" && envValue == "" {
@@ -431,7 +432,7 @@ func evalEnvVarExpression(value string) string {
 func evalConfigValues(file *ini.File) {
 	for _, section := range file.Sections() {
 		for _, key := range section.Keys() {
-			key.SetValue(evalEnvVarExpression(key.Value()))
+			key.SetValue(EvalEnvVarExpression(key.Value()))
 		}
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -418,7 +418,6 @@ func EvalEnvVarExpression(value string) string {
 		envVar = strings.TrimPrefix(envVar, "${")
 		envVar = strings.TrimSuffix(envVar, "}")
 		envValue := os.Getenv(envVar)
-		fmt.Println(fmt.Sprintf("envVar %s value %s", envVar, envValue))
 
 		// if env variable is hostname and it is empty use os.Hostname as default
 		if envVar == "HOSTNAME" && envValue == "" {


### PR DESCRIPTION
Fixes #8832 

Alternative fix to #17526 

The only scary thing with this is that it interpolates the whole file for ${var_name} expressions so for existing configs that could have ${a} in the password or anywhere would be broken. But think it should be very rare?



