### PR TITLE
Stalebot: Automatically label PRs with no activity after 14 days as stale, then after 30 days close

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,49 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# General configuration
+# Label to use when marking as stale
+staleLabel: stale
+
+# Pull request specific configuration
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 14
+  # Number of days of inactivity before a stale Issue or Pull Request is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 30
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in the last 2 weeks. It will be closed in 30 days if no further activity occurs. Please
+    feel free to give a status update now, ping for review, or re-open when it's ready.
+    Thank you for your contributions!
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+     This pull request has been automatically closed because it has not had
+     activity in the last 30 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+     Thank you for your contributions!
+  # Limit the number of actions per hour, from 1-30. Default is 30
+  limitPerRun: 1
+
+exemptLabels:
+  - help wanted
+  - type/bug
+  - type/feature-request
+  - Epic
+  - no stalebot
+
+# Issue specific configuration
+issues:
+  # TODO: Consider increasing the limitPerRun once we are satisfied with the bot's performance
+  limitPerRun: 1
+  daysUntilStale: 90
+  daysUntilClose: 30
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity in the
+    last 90 days. It will be closed in the next 30 days if no activity occurs.
+    Thank you for your contributions.
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the
+    last month and a half. If this issue is still valid, please ping a maintainer and ask them to check this again.
+    Thank you for your contributions.
+

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -33,17 +33,16 @@ exemptLabels:
   - no stalebot
 
 # Issue specific configuration
-issues:
-  # TODO: Consider increasing the limitPerRun once we are satisfied with the bot's performance
-  limitPerRun: 1
-  daysUntilStale: 90
-  daysUntilClose: 30
-  markComment: >
-    This issue has been automatically marked as stale because it has not had activity in the
-    last 90 days. It will be closed in the next 30 days if no activity occurs.
-    Thank you for your contributions.
-  closeComment: >
-    This issue has been automatically closed because it has not had activity in the
-    last month and a half. If this issue is still valid, please ping a maintainer and ask them to check this again.
-    Thank you for your contributions.
-
+# issues:
+#   # TODO: Consider increasing the limitPerRun once we are satisfied with the bot's performance
+#   limitPerRun: 1
+#   daysUntilStale: 100
+#   daysUntilClose: 100
+#   markComment: >
+#     This issue has been automatically marked as stale because it has not had activity in the
+#     last 100 days. It will be closed in the next 100 days if no activity occurs.
+#     Thank you for your contributions.
+#   closeComment: >
+#     This issue has been automatically closed because it has not had activity in the
+#     last month and a half. If this issue is still valid, please ping a maintainer and ask them to check this again.
+#     Thank you for your contributions.


### PR DESCRIPTION
need some help with good message texts when label is added and when the issue closed. 

Currently, these are exempt 
  - help wanted
  - type/bug
  - type/feature-request
  - Epic
  - no stalebot

possibly we want to close stale feature-requests?

inspired by: https://github.com/istio/istio/blob/master/.github/stale.yml 

another example: https://github.com/rails/rails/blob/master/.github/stale.yml