### PR TITLE
BarGauge: Fix so that default thresholds not keeps resetting

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -24,6 +24,7 @@ describe('PanelModel', () => {
           },
         ],
       },
+      arrayWith2Values: [{ value: 'name' }, { value: 'name2' }],
       showThresholds: true,
     };
 
@@ -43,6 +44,7 @@ describe('PanelModel', () => {
             },
           ],
         },
+        arrayWith2Values: [{ name: 'changed to only one value' }],
       };
 
       modelJson = {
@@ -70,6 +72,10 @@ describe('PanelModel', () => {
 
     it('should apply option defaults', () => {
       expect(model.getOptions().showThresholds).toBeTruthy();
+    });
+
+    it('should apply option defaults but not override if array is changed', () => {
+      expect(model.getOptions().arrayWith2Values.length).toBe(1);
     });
 
     it('should set model props on instance', () => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -255,7 +255,16 @@ export class PanelModel {
     if (plugin.angularConfigCtrl) {
       return;
     }
-    this.options = _.defaultsDeep({}, this.options || {}, plugin.defaults);
+    this.options = _.mergeWith(
+      {},
+      plugin.defaults,
+      this.options || {},
+      (objValue: any, srcValue: any): any => {
+        if (_.isArray(srcValue)) {
+          return srcValue;
+        }
+      }
+    );
   }
 
   pluginLoaded(plugin: PanelPlugin) {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -255,7 +255,17 @@ export class PanelModel {
     if (plugin.angularConfigCtrl) {
       return;
     }
-    this.options = _.defaultsDeep({}, this.options || {}, plugin.defaults);
+
+    this.options = _.mergeWith(
+      {},
+      plugin.defaults,
+      this.options || {},
+      (objValue: any, srcValue: any): any => {
+        if (_.isArray(srcValue)) {
+          return srcValue;
+        }
+      }
+    );
   }
 
   pluginLoaded(plugin: PanelPlugin) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
  If remove one of the default threshold options,  and then save the dashboard, the default  threshold options still exist after refresh page.
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20007 

**Special notes for your reviewer**:

