### PR TITLE
update triggers to use new deployment_tools location

### DIFF
--- a/packaging/docker/deploy_to_k8s.sh
+++ b/packaging/docker/deploy_to_k8s.sh
@@ -3,4 +3,4 @@
 curl -s --header "Content-Type: application/json" \
      --data "{\"build_parameters\": {\"CIRCLE_JOB\": \"deploy\", \"IMAGE_NAMES\": \"$1\"}}" \
      --request POST \
-     https://circleci.com/api/v1.1/project/github/raintank/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN
+     https://circleci.com/api/v1.1/project/github/grafana/deployment_tools/tree/master?circle-token=$CIRCLE_TOKEN


### PR DESCRIPTION
raintank/deployment_tools repo is being moved to grafana/deployment_tools

