### PR TITLE
Prometheus: Field to specify step in Explore

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromCheatSheet.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromCheatSheet.tsx
@@ -18,20 +18,26 @@ const CHEAT_SHEET_ITEMS = [
     expression: 'sort_desc(sum(sum_over_time(ALERTS{alertstate="firing"}[24h])) by (alertname))',
     label: 'Sums up the alerts that have been firing over the last 24 hours.',
   },
+  {
+    title: 'Step',
+    label: 'Sets up query resolution step width in duration format (e.g. 5s, 10m, 2h, 1d). Default: auto.',
+  },
 ];
 
 export default (props: ExploreStartPageProps) => (
   <div>
     <h2>PromQL Cheat Sheet</h2>
-    {CHEAT_SHEET_ITEMS.map(item => (
-      <div className="cheat-sheet-item" key={item.expression}>
+    {CHEAT_SHEET_ITEMS.map((item, index) => (
+      <div className="cheat-sheet-item" key={index}>
         <div className="cheat-sheet-item__title">{item.title}</div>
-        <div
-          className="cheat-sheet-item__example"
-          onClick={e => props.onClickExample({ refId: 'A', expr: item.expression } as DataQuery)}
-        >
-          <code>{item.expression}</code>
-        </div>
+        {item.expression ? (
+          <div
+            className="cheat-sheet-item__example"
+            onClick={e => props.onClickExample({ refId: 'A', expr: item.expression } as DataQuery)}
+          >
+            <code>{item.expression}</code>
+          </div>
+        ) : null}
         <div className="cheat-sheet-item__label">{item.label}</div>
       </div>
     ))}

--- a/public/app/plugins/datasource/prometheus/components/PromCheatSheet.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromCheatSheet.tsx
@@ -20,7 +20,8 @@ const CHEAT_SHEET_ITEMS = [
   },
   {
     title: 'Step',
-    label: 'Sets up query resolution step width in duration format (e.g. 5s, 10m, 2h, 1d). Default: auto.',
+    label:
+      'Defines the graph resolution using a duration format (15s, 1m, 3h, ...). Small steps create high-resolution graphs but can be slow over larger time ranges. Using a longer step lowers the resolution and smooths the graph by producing fewer datapoints. If no step is given the resolution is calculated automatically.',
   },
 ];
 

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, { PureComponent } from 'react';
 
 // Types

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -66,7 +66,7 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
             <FormLabel width={4}>Step</FormLabel>
             <input
               type="text"
-              className="gf-form-input width-8"
+              className="gf-form-input width-6"
               placeholder={'Enter step'}
               onChange={this.onIntervalChange}
               onBlur={this.onRunQuery}

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -60,7 +60,7 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
           data={data}
         />
 
-        <div className="gf-form-inline">
+        <div className="gf-form-inline explore-input--ml">
           <div className="gf-form">
             <FormLabel width={4}>Step</FormLabel>
             <input

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 
 // Types
-import { FormLabel } from '@grafana/ui';
 import { ExploreQueryFieldProps } from '@grafana/data';
 
 import { PrometheusDatasource } from '../datasource';
@@ -58,21 +57,10 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
           onChange={this.onFieldChange}
           history={history}
           data={data}
+          explore={true}
+          interval={interval}
+          onIntervalChange={this.onIntervalChange}
         />
-
-        <div className="gf-form-inline explore-input--ml">
-          <div className="gf-form">
-            <FormLabel width={4}>Step</FormLabel>
-            <input
-              type="text"
-              className="gf-form-input width-6"
-              placeholder={'auto'}
-              onChange={this.onIntervalChange}
-              onBlur={this.onRunQuery}
-              value={interval}
-            />
-          </div>
-        </div>
       </div>
     );
   }

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -3,13 +3,13 @@ import React, { PureComponent } from 'react';
 
 // Types
 import { FormLabel } from '@grafana/ui';
-import { QueryEditorProps } from '@grafana/data';
+import { ExploreQueryFieldProps } from '@grafana/data';
 
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery, PromOptions } from '../types';
 
 import PromQueryField from './PromQueryField';
-export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOptions>;
+export type Props = ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions>;
 
 interface State {
   interval: string;
@@ -47,7 +47,7 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const { datasource, query, data } = this.props;
+    const { datasource, query, data, history } = this.props;
     const { interval } = this.state;
 
     return (
@@ -57,7 +57,7 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
           query={query}
           onRunQuery={this.onRunQuery}
           onChange={this.onFieldChange}
-          history={[]}
+          history={history}
           data={data}
         />
 

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 
 // Types
 import { ExploreQueryFieldProps } from '@grafana/data';
+import { FormLabel } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery, PromOptions } from '../types';
@@ -44,6 +45,12 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
     this.props.onRunQuery();
   };
 
+  onReturnKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      this.onRunQuery();
+    }
+  };
+
   render() {
     const { datasource, query, data, history } = this.props;
     const { interval } = this.state;
@@ -57,10 +64,21 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
           onChange={this.onFieldChange}
           history={history}
           data={data}
-          explore={true}
-          interval={interval}
-          onIntervalChange={this.onIntervalChange}
-        />
+        >
+          <div className="gf-form-inline explore-input--ml">
+            <div className="gf-form">
+              <FormLabel width={4}>Step</FormLabel>
+              <input
+                type="text"
+                className="gf-form-input width-6"
+                placeholder={'auto'}
+                onChange={this.onIntervalChange}
+                onKeyDown={this.onReturnKeyDown}
+                value={interval}
+              />
+            </div>
+          </div>
+        </PromQueryField>
       </div>
     );
   }

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,0 +1,80 @@
+import _ from 'lodash';
+import React, { PureComponent } from 'react';
+
+// Types
+import { FormLabel } from '@grafana/ui';
+import { QueryEditorProps } from '@grafana/data';
+
+import { PrometheusDatasource } from '../datasource';
+import { PromQuery, PromOptions } from '../types';
+
+import PromQueryField from './PromQueryField';
+export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOptions>;
+
+interface State {
+  interval: string;
+}
+
+export class PromExploreQueryEditor extends PureComponent<Props, State> {
+  // Query target to be modified and used for queries
+  query: PromQuery;
+
+  constructor(props: Props) {
+    super(props);
+    const { query } = props;
+    this.query = query;
+    // Query target properties that are fully controlled inputs
+    this.state = {
+      // Fully controlled text inputs
+      interval: query.interval,
+    };
+  }
+
+  onFieldChange = (query: PromQuery, override?: any) => {
+    this.query.expr = query.expr;
+  };
+
+  onIntervalChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const interval = e.currentTarget.value;
+    this.query.interval = interval;
+    this.setState({ interval });
+  };
+
+  onRunQuery = () => {
+    const { query } = this;
+    this.props.onChange(query);
+    this.props.onRunQuery();
+  };
+
+  render() {
+    const { datasource, query, data } = this.props;
+    const { interval } = this.state;
+
+    return (
+      <div className="gf-form-inline">
+        <PromQueryField
+          datasource={datasource}
+          query={query}
+          onRunQuery={this.onRunQuery}
+          onChange={this.onFieldChange}
+          history={[]}
+          data={data}
+        />
+
+        <div className="gf-form-inline">
+          <div className="gf-form">
+            <FormLabel width={4}>Step</FormLabel>
+            <input
+              type="text"
+              className="gf-form-input width-8"
+              placeholder={'Enter step'}
+              onChange={this.onIntervalChange}
+              onBlur={this.onRunQuery}
+              value={interval}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -67,7 +67,7 @@ export class PromExploreQueryEditor extends PureComponent<Props, State> {
             <input
               type="text"
               className="gf-form-input width-6"
-              placeholder={'Enter step'}
+              placeholder={'auto'}
               onChange={this.onIntervalChange}
               onBlur={this.onRunQuery}
               value={interval}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -5,7 +5,6 @@ import { Plugin } from 'slate';
 import {
   Cascader,
   CascaderOption,
-  FormLabel,
   SlatePrism,
   TypeaheadInput,
   TypeaheadOutput,
@@ -101,9 +100,6 @@ export function willApplySuggestion(suggestion: string, { typeaheadContext, type
 
 interface PromQueryFieldProps extends ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions> {
   history: Array<HistoryItem<PromQuery>>;
-  explore?: boolean;
-  interval?: string;
-  onIntervalChange?: (e: React.SyntheticEvent<HTMLInputElement>) => void;
 }
 
 interface PromQueryFieldState {
@@ -279,7 +275,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   };
 
   render() {
-    const { data, query, explore, interval } = this.props;
+    const { data, query, children } = this.props;
     const { metricsOptions, syntaxLoaded, hint } = this.state;
     const cleanText = this.languageProvider ? this.languageProvider.cleanText : undefined;
     const chooserText = getChooserText(syntaxLoaded, metricsOptions);
@@ -313,31 +309,23 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
               syntaxLoaded={syntaxLoaded}
             />
           </div>
-          {explore ? (
-            <div className="gf-form-inline explore-input--ml">
-              <div className="gf-form">
-                <FormLabel width={4}>Step</FormLabel>
-                <input
-                  type="text"
-                  className="gf-form-input width-6"
-                  placeholder={'auto'}
-                  onChange={this.props.onIntervalChange}
-                  onBlur={this.props.onRunQuery}
-                  value={interval}
-                />
-              </div>
-            </div>
-          ) : null}
+          {children}
         </div>
-        {showError ? <div className="prom-query-field-info text-error">{data.error.message}</div> : null}
+        {showError ? (
+          <div className="query-row-break">
+            <div className="prom-query-field-info text-error">{data.error.message}</div>
+          </div>
+        ) : null}
         {hint ? (
-          <div className="prom-query-field-info text-warning">
-            {hint.label}{' '}
-            {hint.fix ? (
-              <a className="text-link muted" onClick={this.onClickHintFix}>
-                {hint.fix.label}
-              </a>
-            ) : null}
+          <div className="query-row-break">
+            <div className="prom-query-field-info text-warning">
+              {hint.label}{' '}
+              {hint.fix ? (
+                <a className="text-link muted" onClick={this.onClickHintFix}>
+                  {hint.fix.label}
+                </a>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </>

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -5,6 +5,7 @@ import { Plugin } from 'slate';
 import {
   Cascader,
   CascaderOption,
+  FormLabel,
   SlatePrism,
   TypeaheadInput,
   TypeaheadOutput,
@@ -100,6 +101,9 @@ export function willApplySuggestion(suggestion: string, { typeaheadContext, type
 
 interface PromQueryFieldProps extends ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions> {
   history: Array<HistoryItem<PromQuery>>;
+  explore?: boolean;
+  interval?: string;
+  onIntervalChange?: (e: React.SyntheticEvent<HTMLInputElement>) => void;
 }
 
 interface PromQueryFieldState {
@@ -275,7 +279,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   };
 
   render() {
-    const { data, query } = this.props;
+    const { data, query, explore, interval } = this.props;
     const { metricsOptions, syntaxLoaded, hint } = this.state;
     const cleanText = this.languageProvider ? this.languageProvider.cleanText : undefined;
     const chooserText = getChooserText(syntaxLoaded, metricsOptions);
@@ -309,6 +313,21 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
               syntaxLoaded={syntaxLoaded}
             />
           </div>
+          {explore ? (
+            <div className="gf-form-inline explore-input--ml">
+              <div className="gf-form">
+                <FormLabel width={4}>Step</FormLabel>
+                <input
+                  type="text"
+                  className="gf-form-input width-6"
+                  placeholder={'auto'}
+                  onChange={this.props.onIntervalChange}
+                  onBlur={this.props.onRunQuery}
+                  value={interval}
+                />
+              </div>
+            </div>
+          ) : null}
         </div>
         {showError ? <div className="prom-query-field-info text-error">{data.error.message}</div> : null}
         {hint ? (

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -284,7 +284,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
     return (
       <>
-        <div className="gf-form-inline gf-form-inline--nowrap">
+        <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">
           <div className="gf-form flex-shrink-0">
             <Cascader
               options={metricsOptions}

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -3,7 +3,7 @@ import { PrometheusDatasource } from './datasource';
 
 import { PromQueryEditor } from './components/PromQueryEditor';
 import PromCheatSheet from './components/PromCheatSheet';
-import PromQueryField from './components/PromQueryField';
+import { PromExploreQueryEditor } from './components/PromExploreQueryEditor';
 
 import { ConfigEditor } from './configuration/ConfigEditor';
 
@@ -14,6 +14,6 @@ class PrometheusAnnotationsQueryCtrl {
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditor)
   .setConfigEditor(ConfigEditor)
-  .setExploreMetricsQueryField(PromQueryField)
+  .setExploreMetricsQueryField(PromExploreQueryEditor)
   .setAnnotationQueryCtrl(PrometheusAnnotationsQueryCtrl)
   .setExploreStartPage(PromCheatSheet);

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -229,6 +229,10 @@
   }
 }
 
+.explore-input--ml {
+  margin-left: 4px;
+}
+
 .navbar .elapsed-time {
   position: absolute;
   left: 0;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -277,6 +277,11 @@
   flex-grow: 1;
 }
 
+.query-row-break {
+  height: 0;
+  flex-basis: 100%;
+}
+
 .query-transactions {
   display: table;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `PrometheusExploreQueryEditor` wrapping `PromQueryField`, allowing to use step property in Explore.

**Which issue(s) this PR fixes**:

Fixes #13378 