### PR TITLE
DataLinks: fix syntax highlighting not being applied on first render

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksEditor.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksEditor.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { FC, useContext, useEffect } from 'react';
+import React, { FC, useContext } from 'react';
 // @ts-ignore
 import Prism from 'prismjs';
 // Components
@@ -27,10 +27,7 @@ export const enableDatalinksPrismSyntax = () => {
 
 export const DataLinksEditor: FC<DataLinksEditorProps> = React.memo(({ value, onChange, suggestions, maxLinks }) => {
   const theme = useContext(ThemeContext);
-
-  useEffect(() => {
-    enableDatalinksPrismSyntax();
-  });
+  enableDatalinksPrismSyntax();
 
   const onAdd = () => {
     onChange(value ? [...value, { url: '', title: '' }] : [{ url: '', title: '' }]);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinksEditor.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksEditor.tsx
@@ -1,14 +1,14 @@
 // Libraries
-import React, { FC, useContext } from 'react';
+import React, { FC } from 'react';
 // @ts-ignore
 import Prism from 'prismjs';
 // Components
 import { css } from 'emotion';
 import { DataLink } from '@grafana/data';
-import { ThemeContext } from '../../index';
 import { Button } from '../index';
 import { DataLinkEditor } from './DataLinkEditor';
 import { VariableSuggestion } from './DataLinkSuggestions';
+import { useTheme } from '../../themes/ThemeContext';
 
 interface DataLinksEditorProps {
   value: DataLink[];
@@ -26,7 +26,7 @@ export const enableDatalinksPrismSyntax = () => {
 };
 
 export const DataLinksEditor: FC<DataLinksEditorProps> = React.memo(({ value, onChange, suggestions, maxLinks }) => {
-  const theme = useContext(ThemeContext);
+  const theme = useTheme();
   enableDatalinksPrismSyntax();
 
   const onAdd = () => {


### PR DESCRIPTION
Fixes #20122 

Regression was introduced in https://github.com/grafana/grafana/pull/19930. Enabling data link's syntax in useEffect hook made the syntax not available for prism on first render. 