### PR TITLE
TablePanel: Prevents crash when data contains mixed data formats

### DIFF
--- a/public/app/core/specs/table_model.test.ts
+++ b/public/app/core/specs/table_model.test.ts
@@ -133,6 +133,18 @@ describe('mergeTables', () => {
     }),
   ];
 
+  const multipleTablesButWithMixedDataFormat = [
+    new TableModel({
+      type: 'table',
+      columns: [{ text: 'Time' }, { text: 'Label Key 1' }, { text: 'Value' }],
+      rows: [[time, 'Label Value 1', 42]],
+    }),
+    ({
+      target: 'series1',
+      datapoints: [[12.12, time], [14.44, time + 1]],
+    } as any) as TableModel,
+  ];
+
   it('should return the single table as is', () => {
     const table = mergeTablesIntoModel(new TableModel(), singleTable);
     expect(table.columns.length).toBe(3);
@@ -195,5 +207,25 @@ describe('mergeTables', () => {
     expect(table.rows[1][3]).toBeUndefined();
     expect(table.rows[1][4]).toBeUndefined();
     expect(table.rows[1][5]).toBe(7);
+  });
+
+  it('should not crash if tables array contain non table data', () => {
+    expect(() => mergeTablesIntoModel(new TableModel(), ...multipleTablesButWithMixedDataFormat)).not.toThrow();
+  });
+
+  it('should should return the single table as is if tables array also contains non table data', () => {
+    const table = mergeTablesIntoModel(new TableModel(), ...multipleTablesButWithMixedDataFormat);
+    expect(table.columns.length).toBe(3);
+    expect(table.columns[0].text).toBe('Time');
+    expect(table.columns[1].text).toBe('Label Key 1');
+    expect(table.columns[2].text).toBe('Value');
+  });
+
+  it('should return 1 row for a single table if tables array also contains non table data', () => {
+    const table = mergeTablesIntoModel(new TableModel(), ...multipleTablesButWithMixedDataFormat);
+    expect(table.rows.length).toBe(1);
+    expect(table.rows[0][0]).toBe(time);
+    expect(table.rows[0][1]).toBe('Label Value 1');
+    expect(table.rows[0][2]).toBe(42);
   });
 });

--- a/public/app/core/table_model.ts
+++ b/public/app/core/table_model.ts
@@ -99,11 +99,14 @@ export function mergeTablesIntoModel(dst?: TableModel, ...tables: TableModel[]):
     return model;
   }
 
+  // Filter out any tables that are not of TableData format
+  const tableDataTables = tables.filter(table => !!table.columns);
+
   // Track column indexes of union: name -> index
   const columnNames: { [key: string]: any } = {};
 
   // Union of all non-value columns
-  const columnsUnion = tables.slice().reduce(
+  const columnsUnion = tableDataTables.slice().reduce(
     (acc, series) => {
       series.columns.forEach(col => {
         const { text } = col;
@@ -120,10 +123,10 @@ export function mergeTablesIntoModel(dst?: TableModel, ...tables: TableModel[]):
   // Map old column index to union index per series, e.g.,
   // given columnNames {A: 0, B: 1} and
   // data [{columns: [{ text: 'A' }]}, {columns: [{ text: 'B' }]}] => [[0], [1]]
-  const columnIndexMapper = tables.map(series => series.columns.map(col => columnNames[col.text]));
+  const columnIndexMapper = tableDataTables.map(series => series.columns.map(col => columnNames[col.text]));
 
   // Flatten rows of all series and adjust new column indexes
-  const flattenedRows = tables.reduce(
+  const flattenedRows = tableDataTables.reduce(
     (acc, series, seriesIndex) => {
       const mapper = columnIndexMapper[seriesIndex];
       series.rows.forEach(row => {

--- a/public/app/plugins/panel/table/specs/transformers.test.ts
+++ b/public/app/plugins/panel/table/specs/transformers.test.ts
@@ -1,4 +1,4 @@
-import { tableReducer, timeSeriesReducer, transformDataToTable, transformers } from '../transformers';
+import { tableDataFormatFilterer, timeSeriesFormatFilterer, transformDataToTable, transformers } from '../transformers';
 
 describe('when transforming time series table', () => {
   let table: any;
@@ -401,12 +401,12 @@ describe('when transforming time series table', () => {
   });
 });
 
-describe('timeSeriesReducer', () => {
+describe('timeSeriesFormatFilterer', () => {
   describe('when called with an object that contains datapoints property', () => {
     it('then it should return same object in array', () => {
       const data: any = { datapoints: [] };
 
-      const result = timeSeriesReducer(data);
+      const result = timeSeriesFormatFilterer(data);
 
       expect(result).toEqual([data]);
     });
@@ -416,7 +416,7 @@ describe('timeSeriesReducer', () => {
     it('then it should return empty array', () => {
       const data: any = { prop: [] };
 
-      const result = timeSeriesReducer(data);
+      const result = timeSeriesFormatFilterer(data);
 
       expect(result).toEqual([]);
     });
@@ -445,7 +445,7 @@ describe('timeSeriesReducer', () => {
         },
       ];
 
-      const result = timeSeriesReducer(data);
+      const result = timeSeriesFormatFilterer(data);
 
       expect(result).toEqual([
         {
@@ -457,12 +457,12 @@ describe('timeSeriesReducer', () => {
   });
 });
 
-describe('tableReducer', () => {
+describe('tableDataFormatFilterer', () => {
   describe('when called with an object that contains columns property', () => {
     it('then it should return same object in array', () => {
       const data: any = { columns: [] };
 
-      const result = tableReducer(data);
+      const result = tableDataFormatFilterer(data);
 
       expect(result).toEqual([data]);
     });
@@ -472,7 +472,7 @@ describe('tableReducer', () => {
     it('then it should return empty array', () => {
       const data: any = { prop: [] };
 
-      const result = tableReducer(data);
+      const result = tableDataFormatFilterer(data);
 
       expect(result).toEqual([]);
     });
@@ -501,7 +501,7 @@ describe('tableReducer', () => {
         },
       ];
 
-      const result = tableReducer(data);
+      const result = tableDataFormatFilterer(data);
 
       expect(result).toEqual([
         {

--- a/public/app/plugins/panel/table/specs/transformers.test.ts
+++ b/public/app/plugins/panel/table/specs/transformers.test.ts
@@ -1,4 +1,4 @@
-import { transformers, transformDataToTable } from '../transformers';
+import { transformDataToTable, transformers } from '../transformers';
 
 describe('when transforming time series table', () => {
   let table: any;
@@ -297,6 +297,105 @@ describe('when transforming time series table', () => {
       it('should return 1 rows', () => {
         expect(table.rows.length).toBe(1);
         expect(table.rows[0][0]).toBe(1000);
+      });
+    });
+  });
+
+  describe('given time series and table data', () => {
+    const time = new Date().getTime();
+    const data = [
+      {
+        target: 'series1',
+        datapoints: [[12.12, time], [14.44, time + 1]],
+      },
+      {
+        columns: [
+          {
+            type: 'time',
+            text: 'Time',
+          },
+          {
+            text: 'mean',
+          },
+        ],
+        type: 'table',
+        rows: [[time, 13.13], [time + 1, 26.26]],
+      },
+    ];
+
+    describe('timeseries_to_rows', () => {
+      const panel = {
+        transform: 'timeseries_to_rows',
+        sort: { col: 0, desc: true },
+      };
+
+      beforeEach(() => {
+        table = transformDataToTable(data, panel);
+      });
+
+      it('should return 2 rows', () => {
+        expect(table.rows.length).toBe(2);
+        expect(table.rows[0][1]).toBe('series1');
+        expect(table.rows[1][1]).toBe('series1');
+        expect(table.rows[0][2]).toBe(12.12);
+      });
+
+      it('should return 3 columns', () => {
+        expect(table.columns.length).toBe(3);
+        expect(table.columns[0].text).toBe('Time');
+        expect(table.columns[1].text).toBe('Metric');
+        expect(table.columns[2].text).toBe('Value');
+      });
+    });
+
+    describe('timeseries_to_columns', () => {
+      const panel = {
+        transform: 'timeseries_to_columns',
+      };
+
+      beforeEach(() => {
+        table = transformDataToTable(data, panel);
+      });
+
+      it('should return 2 columns', () => {
+        expect(table.columns.length).toBe(2);
+        expect(table.columns[0].text).toBe('Time');
+        expect(table.columns[1].text).toBe('series1');
+      });
+
+      it('should return 2 rows', () => {
+        expect(table.rows.length).toBe(2);
+        expect(table.rows[0][1]).toBe(12.12);
+      });
+
+      it('should be undefined when no value for timestamp', () => {
+        expect(table.rows[1][2]).toBe(undefined);
+      });
+    });
+
+    describe('timeseries_aggregations', () => {
+      const panel = {
+        transform: 'timeseries_aggregations',
+        sort: { col: 0, desc: true },
+        columns: [{ text: 'Max', value: 'max' }, { text: 'Min', value: 'min' }],
+      };
+
+      beforeEach(() => {
+        table = transformDataToTable(data, panel);
+      });
+
+      it('should return 1 row', () => {
+        expect(table.rows.length).toBe(1);
+        expect(table.rows[0][0]).toBe('series1');
+        expect(table.rows[0][1]).toBe(14.44);
+        expect(table.rows[0][2]).toBe(12.12);
+      });
+
+      it('should return 2 columns', () => {
+        expect(table.columns.length).toBe(3);
+        expect(table.columns[0].text).toBe('Metric');
+        expect(table.columns[1].text).toBe('Max');
+        expect(table.columns[2].text).toBe('Min');
       });
     });
   });

--- a/public/app/plugins/panel/table/specs/transformers.test.ts
+++ b/public/app/plugins/panel/table/specs/transformers.test.ts
@@ -1,4 +1,4 @@
-import { transformDataToTable, transformers } from '../transformers';
+import { tableReducer, timeSeriesReducer, transformDataToTable, transformers } from '../transformers';
 
 describe('when transforming time series table', () => {
   let table: any;
@@ -397,6 +397,127 @@ describe('when transforming time series table', () => {
         expect(table.columns[1].text).toBe('Max');
         expect(table.columns[2].text).toBe('Min');
       });
+    });
+  });
+});
+
+describe('timeSeriesReducer', () => {
+  describe('when called with an object that contains datapoints property', () => {
+    it('then it should return same object in array', () => {
+      const data: any = { datapoints: [] };
+
+      const result = timeSeriesReducer(data);
+
+      expect(result).toEqual([data]);
+    });
+  });
+
+  describe('when called with an object that does not contain datapoints property', () => {
+    it('then it should return empty array', () => {
+      const data: any = { prop: [] };
+
+      const result = timeSeriesReducer(data);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when called with an array of series with both timeseries and table data', () => {
+    it('then it should return an array with timeseries', () => {
+      const time = new Date().getTime();
+      const data: any[] = [
+        {
+          target: 'series1',
+          datapoints: [[12.12, time], [14.44, time + 1]],
+        },
+        {
+          columns: [
+            {
+              type: 'time',
+              text: 'Time',
+            },
+            {
+              text: 'mean',
+            },
+          ],
+          type: 'table',
+          rows: [[time, 13.13], [time + 1, 26.26]],
+        },
+      ];
+
+      const result = timeSeriesReducer(data);
+
+      expect(result).toEqual([
+        {
+          target: 'series1',
+          datapoints: [[12.12, time], [14.44, time + 1]],
+        },
+      ]);
+    });
+  });
+});
+
+describe('tableReducer', () => {
+  describe('when called with an object that contains columns property', () => {
+    it('then it should return same object in array', () => {
+      const data: any = { columns: [] };
+
+      const result = tableReducer(data);
+
+      expect(result).toEqual([data]);
+    });
+  });
+
+  describe('when called with an object that does not contain columns property', () => {
+    it('then it should return empty array', () => {
+      const data: any = { prop: [] };
+
+      const result = tableReducer(data);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when called with an array of series with both timeseries and table data', () => {
+    it('then it should return an array with table data', () => {
+      const time = new Date().getTime();
+      const data: any[] = [
+        {
+          target: 'series1',
+          datapoints: [[12.12, time], [14.44, time + 1]],
+        },
+        {
+          columns: [
+            {
+              type: 'time',
+              text: 'Time',
+            },
+            {
+              text: 'mean',
+            },
+          ],
+          type: 'table',
+          rows: [[time, 13.13], [time + 1, 26.26]],
+        },
+      ];
+
+      const result = tableReducer(data);
+
+      expect(result).toEqual([
+        {
+          columns: [
+            {
+              type: 'time',
+              text: 'Time',
+            },
+            {
+              text: 'mean',
+            },
+          ],
+          type: 'table',
+          rows: [[time, 13.13], [time + 1, 26.26]],
+        },
+      ]);
     });
   });
 });

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -6,7 +6,7 @@ import { TableTransform } from './types';
 import { Column, TableData } from '@grafana/data';
 
 const transformers: { [key: string]: TableTransform } = {};
-const timeSeriesReducer = (data: any): any[] => {
+export const timeSeriesReducer = (data: any): any[] => {
   if (!Array.isArray(data)) {
     return data.datapoints ? [data] : [];
   }
@@ -20,7 +20,7 @@ const timeSeriesReducer = (data: any): any[] => {
   }, []);
 };
 
-const tableReducer = (data: any): any[] => {
+export const tableReducer = (data: any): any[] => {
   if (!Array.isArray(data)) {
     return data.columns ? [data] : [];
   }

--- a/public/app/plugins/panel/table/transformers.ts
+++ b/public/app/plugins/panel/table/transformers.ts
@@ -170,11 +170,13 @@ transformers['table'] = {
       return [...data[0].columns];
     }
 
+    const filteredData = tableDataFormatFilterer(data);
+
     // Track column indexes: name -> index
     const columnNames: any = {};
 
     // Union of all columns
-    const columns = data.reduce((acc: Column[], series: TableData) => {
+    const columns = filteredData.reduce((acc: Column[], series: TableData) => {
       series.columns.forEach(col => {
         const { text } = col;
         if (columnNames[text] === undefined) {
@@ -192,7 +194,7 @@ transformers['table'] = {
       return;
     }
     const filteredData = tableDataFormatFilterer(data);
-    const noTableIndex = _.findIndex(data, d => 'columns' in d && 'rows' in d);
+    const noTableIndex = _.findIndex(filteredData, d => 'columns' in d && 'rows' in d);
     if (noTableIndex < 0) {
       throw {
         message: `Result of query #${String.fromCharCode(

--- a/public/app/plugins/panel/table/types.ts
+++ b/public/app/plugins/panel/table/types.ts
@@ -6,7 +6,6 @@ export interface TableTransform {
   description: string;
   getColumns(data?: any): any[];
   transform(data: any, panel: any, model: TableModel): void;
-  dataFormatReducer?(data: any): any[];
 }
 
 export interface ColumnRender extends Column {

--- a/public/app/plugins/panel/table/types.ts
+++ b/public/app/plugins/panel/table/types.ts
@@ -6,6 +6,7 @@ export interface TableTransform {
   description: string;
   getColumns(data?: any): any[];
   transform(data: any, panel: any, model: TableModel): void;
+  dataFormatReducer?(data: any): any[];
 }
 
 export interface ColumnRender extends Column {


### PR DESCRIPTION
**What this PR does / why we need it**:
In the reported issue #20075 there are 2 issues, the first one is that the `SafeDynamicImport` component catched all errors so the user received an unrelated error message. The fix for this was merged with #20170. This PR handles the error thrown in the Table Panel transformers. 

Just to clarify the Table Panel doesn't support having different data formats in the queries so the results could potentially be misleading. It would be nice if we could show somehow in the UI that the data has mixed data formats. This is out of scope for this PR.

**Which issue(s) this PR fixes**:
Fixes #20075

**Special notes for your reviewer**:

