### PR TITLE
DevEnv: updates prometheus random data golang image to 1.13.0

### DIFF
--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image for a client_golang example.
 
 # Builder image, where we build the example.
-FROM golang:1.9.0 AS builder
+FROM golang:1.13.0 AS builder
 # Download prometheus/client_golang/examples/random first
 RUN go get github.com/prometheus/client_golang/examples/random
 WORKDIR /go/src/github.com/prometheus/client_golang


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `prometheus_random_data` golang image version to 1.13.0. Allows devenv to build properly, without the error caused by the lack of `xxhash/v2` package.

**Which issue(s) this PR fixes**:

Fixes #20203 