### PR TITLE
Grafana/ui: Fix button when only icon is present

### DIFF
--- a/packages/grafana-ui/src/components/Button/ButtonContent.tsx
+++ b/packages/grafana-ui/src/components/Button/ButtonContent.tsx
@@ -18,13 +18,22 @@ type Props = {
 export function ButtonContent(props: Props) {
   const { icon, className, iconClassName, children } = props;
   const styles = getStyles();
-  return icon ? (
-    <span className={cx(styles.content, className)}>
-      <i className={cx([icon, iconClassName])} />
-      &nbsp; &nbsp;
-      <span>{children}</span>
-    </span>
-  ) : (
-    <span className={styles.content}>{children}</span>
-  );
+  if (icon && children) {
+    return (
+      <span className={cx(styles.content, className)}>
+        <i className={cx([icon, iconClassName])} />
+        &nbsp; &nbsp;
+        <span>{children}</span>
+      </span>
+    );
+  }
+  if (icon) {
+    return (
+      <span className={cx(styles.content, className)}>
+        <i className={cx([icon, iconClassName])} />
+      </span>
+    );
+  }
+
+  return <span className={styles.content}>{children}</span>;
 }


### PR DESCRIPTION
Last time I actually did not manage to fix this so this is second try.
before:
<img width="110" alt="Screenshot 2019-11-06 at 15 26 42" src="https://user-images.githubusercontent.com/1014802/68306743-665c8080-00aa-11ea-84ae-2fa6a205bf76.png">
after:
<img width="115" alt="Screenshot 2019-11-06 at 15 21 54" src="https://user-images.githubusercontent.com/1014802/68306742-65c3ea00-00aa-11ea-87ea-5b435b68ff2c.png">

