### PR TITLE
MixedQuery: refactor so other components could also batch queries

### DIFF
--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -47,5 +47,6 @@ describe('MixedDatasource', () => {
     expect(results[1].data).toEqual(['BBBB']);
     expect(results[2].data).toEqual(['CCCC']);
     expect(results[2].state).toEqual(LoadingState.Done);
+    expect(results.length).toBe(3);
   });
 });

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -16,6 +16,9 @@ import { mergeMap, map } from 'rxjs/operators';
 
 export const MIXED_DATASOURCE_NAME = '-- Mixed --';
 
+/**
+ * Key is the datasource name, DataQuery[] lets you run
+ */
 export type MixedQuerySets = { [key: string]: DataQuery[] };
 
 export class MixedDatasource extends DataSourceApi<DataQuery> {
@@ -33,10 +36,10 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
       return of({ data: [] } as DataQueryResponse); // nothing
     }
 
-    return groupBy(queries, 'datasource');
+    return this.querySets(groupBy(queries, 'datasource'), request);
   }
 
-  querySets(sets: MixedQuerySets): Observable<DataQueryResponse> {
+  querySets(sets: MixedQuerySets, request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {
     const observables: Array<Observable<DataQueryResponse>> = [];
     let runningSubRequests = 0;
 

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -16,6 +16,8 @@ import { mergeMap, map } from 'rxjs/operators';
 
 export const MIXED_DATASOURCE_NAME = '-- Mixed --';
 
+export type MixedQuerySets = { [key: string]: DataQuery[] };
+
 export class MixedDatasource extends DataSourceApi<DataQuery> {
   constructor(instanceSettings: DataSourceInstanceSettings) {
     super(instanceSettings);
@@ -31,7 +33,10 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
       return of({ data: [] } as DataQueryResponse); // nothing
     }
 
-    const sets: { [key: string]: DataQuery[] } = groupBy(queries, 'datasource');
+    return groupBy(queries, 'datasource');
+  }
+
+  querySets(sets: MixedQuerySets): Observable<DataQueryResponse> {
     const observables: Array<Observable<DataQueryResponse>> = [];
     let runningSubRequests = 0;
 


### PR DESCRIPTION
it would be nice to let other datassource split their requests across multiple requests... mixed datasource already does this, so we could just expose it :)

also fixes a bug in master!!!  #20088 introduced a regression by not setting up the [targets properly](https://github.com/grafana/grafana/commit/2bb46847416037f144d4f7940d3f838901f356cf#diff-555b761a41360a0856e0082fa8968a8dL46)