### PR TITLE
LogPanel: Allow using Elastic

### DIFF
--- a/packages/grafana-data/src/types/vector.ts
+++ b/packages/grafana-data/src/types/vector.ts
@@ -7,7 +7,7 @@ export interface Vector<T = any> {
   get(index: number): T;
 
   /**
-   * Get the resutls as an array.
+   * Get the results as an array.
    */
   toArray(): T[];
 }


### PR DESCRIPTION
Quick temp fix for: https://github.com/grafana/grafana/issues/19789 that does not need discussion about changes to how panel config works or refactoring elastic and the logs data transforms. Is kinda additive only, only tries harder to get some data from the dataframe that could be usable for logs panel.

At the same time not sure how much value this will have right now. Usage looks like this:
<img width="963" alt="Screenshot 2019-11-06 at 22 47 23" src="https://user-images.githubusercontent.com/1014802/68341140-1a303100-00e8-11ea-9d83-cc7bd6f236d7.png">

You need to query for `raw docs` and then that is what you get so it is hard to look at and at the same time as we do not have log details in panel you can't make it better.

