### PR TITLE
@grafana/runtime: expose datasourceRequest()

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -12,6 +12,13 @@ export type BackendSrvRequest = {
   // Show a message with the result
   showSuccessAlert?: boolean;
 
+  // A requestID is provided by the datasource as a unique identifier for a
+  // particular query. If the requestID exists, the promise it is keyed to
+  // is canceled, canceling the previous datasource request if it is still
+  // in-flight.
+  requestId?: string;
+
+  // Allow any other parameters
   [key: string]: any;
 };
 
@@ -29,6 +36,9 @@ export interface BackendSrv {
   // If there is an error, set: err.isHandled = true
   // otherwise the backend will show a message for you
   request(options: BackendSrvRequest): Promise<any>;
+
+  // DataSource requests add hooks into the query inspector
+  datasourceRequest(options: BackendSrvRequest): Promise<any>;
 }
 
 let singletonInstance: BackendSrv;

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -143,7 +143,7 @@ export class BackendSrv implements BackendService {
     }
   }
 
-  datasourceRequest(options: any) {
+  datasourceRequest(options: BackendSrvRequest) {
     let canceler: angular.IDeferred<any> = null;
     options.retry = options.retry || 0;
 


### PR DESCRIPTION
Datasource plugins can currently use `request(options: BackendSrvRequest)`, but they should really use `datasourceRequest(options: BackendSrvRequest)` to all the headers set up properly