### PR TITLE
DisplayProcessor: improve time field support

### DIFF
--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -1,7 +1,6 @@
 import { TimeZone } from '../types/time';
 /* tslint:disable:import-blacklist ban ban-types */
 import moment, { Moment, MomentInput, DurationInputArg1 } from 'moment';
-import { DEFAULT_DATE_TIME_FORMAT } from './formats';
 export interface DateTimeBuiltinFormat {
   __momentBuiltinFormatBrand: any;
 }
@@ -38,7 +37,6 @@ export type DurationUnit =
   | 'quarters'
   | 'Q';
 
-export type DateFormatter = (date: DateTimeInput, format?: string) => string;
 export interface DateTimeLocale {
   firstDayOfWeek: () => number;
 }
@@ -114,11 +112,4 @@ export const dateTimeForTimeZone = (
   }
 
   return dateTime(input, formatInput);
-};
-
-export const getTimeZoneDateFormatter: (timezone?: TimeZone) => DateFormatter = timezone => (date, format) => {
-  date = isDateTime(date) ? date : dateTime(date);
-  format = format || DEFAULT_DATE_TIME_FORMAT;
-
-  return timezone === 'browser' ? dateTime(date).format(format) : toUtc(date).format(format);
 };

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -1,6 +1,7 @@
 import { getDisplayProcessor, getColorFromThreshold } from './displayProcessor';
 import { DisplayProcessor, DisplayValue } from '../types/displayValue';
 import { ValueMapping, MappingType } from '../types/valueMapping';
+import { FieldType } from '../types';
 
 function assertSame(input: any, processors: DisplayProcessor[], match: DisplayValue) {
   processors.forEach(processor => {
@@ -190,5 +191,40 @@ describe('Format value', () => {
     const value = 1000000;
     const instance = getDisplayProcessor({ config: { decimals: null, unit: 'short' } });
     expect(instance(value).text).toEqual('1.000 Mil');
+  });
+});
+
+describe('Date display options', () => {
+  it('should format UTC dates', () => {
+    const processor = getDisplayProcessor({
+      type: FieldType.time,
+      isUtc: true,
+      config: {
+        unit: 'xyz', // ignore non-date formats
+      },
+    });
+    expect(processor(0).text).toEqual('1970-01-01 00:00:00');
+  });
+
+  it('should pick configured time format', () => {
+    const processor = getDisplayProcessor({
+      type: FieldType.time,
+      isUtc: true,
+      config: {
+        unit: 'dateTimeAsUS', // A configurable date format
+      },
+    });
+    expect(processor(0).text).toEqual('01/01/1970 12:00:00 am');
+  });
+
+  it('respect the configured date format', () => {
+    const processor = getDisplayProcessor({
+      type: FieldType.time,
+      isUtc: true,
+      config: {
+        dateDisplayFormat: 'YYYY',
+      },
+    });
+    expect(processor(0).text).toEqual('1970');
   });
 });


### PR DESCRIPTION
This PR revisits some of the changes in #20174

Specifically, this:
1. picks the formatter on init, not in the inner loop.  inner loop just calls format :)
2. respects calls where the unit is reasonable for time values
3. adds some tests

This reverts the changes to moment_wrapper.ts from #20174 since it does not use them
