### PR TITLE
Elasticsearch: Support rendering in logs panel

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -332,9 +332,11 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       }
 
       let queryObj;
-      if (target.isLogsQuery) {
+      if (target.isLogsQuery || queryDef.hasMetricOfType(target, 'logs')) {
         target.bucketAggs = [queryDef.defaultBucketAgg()];
         target.metrics = [queryDef.defaultMetricAgg()];
+        // Setting this for metrics queries that are typed as logs
+        target.isLogsQuery = true;
         queryObj = this.queryBuilder.getLogsQuery(target, queryString);
       } else {
         if (target.alias) {

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -73,6 +73,7 @@ export const metricAggTypes = [
     minVersion: 2,
   },
   { text: 'Raw Document', value: 'raw_document', requiresField: false },
+  { text: 'Logs', value: 'logs', requiresField: false },
 ];
 
 export const bucketAggTypes = [
@@ -260,3 +261,7 @@ export function defaultBucketAgg() {
 export const findMetricById = (metrics: any[], id: any) => {
   return _.find(metrics, { id: id });
 };
+
+export function hasMetricOfType(target: any, type: string): boolean {
+  return target && target.metrics && target.metrics.some((m: any) => m.type === type);
+}

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
@@ -86,25 +86,25 @@ describe('ElasticQueryDef', () => {
   describe('pipeline aggs depending on esverison', () => {
     describe('using esversion undefined', () => {
       test('should not get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(undefined).length).toBe(9);
+        expect(queryDef.getMetricAggTypes(undefined).length).toBe(10);
       });
     });
 
     describe('using esversion 1', () => {
       test('should not get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(1).length).toBe(9);
+        expect(queryDef.getMetricAggTypes(1).length).toBe(10);
       });
     });
 
     describe('using esversion 2', () => {
       test('should get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(2).length).toBe(12);
+        expect(queryDef.getMetricAggTypes(2).length).toBe(13);
       });
     });
 
     describe('using esversion 5', () => {
       test('should get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(5).length).toBe(12);
+        expect(queryDef.getMetricAggTypes(5).length).toBe(13);
       });
     });
   });


### PR DESCRIPTION
- add "Logs" metric query type so panels can inform the datasource that
the query is a logs query
- datasource modifies target when metric query type `logs` is detected
- then existing log result processing paths are followed

Fixes #19789

**Special notes for your reviewer**:

Select "Logs" in "Metric" field.

If there is time, I'll add some tests and number of docs display as done for Raw Docs.