### PR TITLE
Cloudwatch: Fix LaunchTime attribute tag bug

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -551,7 +551,7 @@ func (e *CloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 				if attr, ok := v.Interface().(*string); ok {
 					data = *attr
 				} else if attr, ok := v.Interface().(*time.Time); ok {
-					data = fmt.Sprintf("%s", *attr)
+					data = (*attr).String()
 				} else {
 					return nil, errors.New("invalid attribute path")
 				}

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -550,6 +550,8 @@ func (e *CloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 				}
 				if attr, ok := v.Interface().(*string); ok {
 					data = *attr
+				} else if attr, ok := v.Interface().(*time.Time); ok {
+					data = fmt.Sprintf("%s", *attr)
 				} else {
 					return nil, errors.New("invalid attribute path")
 				}


### PR DESCRIPTION
Cast instance tags of type Time to string

![Skärmavbild 2019-11-07 kl  12 07 37](https://user-images.githubusercontent.com/2388950/68384139-3e772680-0157-11ea-8806-b48c685efc09.png)

@mtanda any change you can review this? I'm not very familiar with templating attributes in CloudWatch.