### PR TITLE
Explore: Configure explore series colors via field config

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -63,10 +63,9 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
       type: FieldType.number,
       config: {
         unit: timeSeries.unit,
-        color: timeSeries.color,
       },
       values: new ArrayVector<TimeSeriesValue>(),
-    } as Field<TimeSeriesValue, ArrayVector<TimeSeriesValue>>,
+    },
     {
       name: 'Time',
       type: FieldType.time,
@@ -74,7 +73,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
         unit: 'dateTimeAsIso',
       },
       values: new ArrayVector<number>(),
-    } as Field<number, ArrayVector<number>>,
+    },
   ];
 
   for (const point of timeSeries.datapoints) {

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -58,7 +58,6 @@ export interface TimeSeries extends QueryResultBase {
   target: string;
   datapoints: TimeSeriesPoints;
   unit?: string;
-  color?: string;
   tags?: Labels;
 }
 

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -149,12 +149,17 @@ export function makeSeriesForLogs(rows: LogRowModel[], intervalMs: number, timeZ
     });
 
     const timeField = data.fields[1];
-
     timeField.display = getDisplayProcessor({
       config: timeField.config,
       type: timeField.type,
       isUtc: timeZone === 'utc',
     });
+
+    const valueField = data.fields[0];
+    valueField.config = {
+      ...valueField.config,
+      color: series.color,
+    };
 
     const graphSeries: GraphSeriesXY = {
       color: series.color,
@@ -168,7 +173,7 @@ export function makeSeriesForLogs(rows: LogRowModel[], intervalMs: number, timeZ
       },
       seriesIndex: i,
       timeField,
-      valueField: data.fields[0],
+      valueField,
       // for now setting the time step to be 0,
       // and handle the bar width by setting lineWidth instead of barWidth in flot options
       timeStep: 0,
@@ -197,7 +202,6 @@ export function dataFrameToLogsModel(dataFrame: DataFrame[], intervalMs: number,
       // Create metrics from logs
       logsModel.series = makeSeriesForLogs(logsModel.rows, intervalMs, timeZone);
     } else {
-      // We got metrics in the dataFrame so process those
       logsModel.series = getGraphSeriesModel(
         metricSeries,
         timeZone,

--- a/public/app/plugins/panel/graph2/getGraphSeriesModel.ts
+++ b/public/app/plugins/panel/graph2/getGraphSeriesModel.ts
@@ -74,10 +74,16 @@ export const getGraphSeriesModel = (
           });
         }
 
-        const seriesColor =
-          seriesOptions[field.name] && seriesOptions[field.name].color
-            ? getColorFromHexRgbOrName(seriesOptions[field.name].color)
-            : colors[graphs.length % colors.length];
+        let seriesColor;
+        if (seriesOptions[field.name] && seriesOptions[field.name].color) {
+          // Case when panel has settings provided via SeriesOptions, i.e. graph panel
+          seriesColor = getColorFromHexRgbOrName(seriesOptions[field.name].color);
+        } else if (field.config && field.config.color) {
+          // Case when color settings are set on field, i.e. Explore logs histogram (see makeSeriesForLogs)
+          seriesColor = field.config.color;
+        } else {
+          seriesColor = colors[graphs.length % colors.length];
+        }
 
         field.config = fieldOptions
           ? {
@@ -86,7 +92,7 @@ export const getGraphSeriesModel = (
               decimals: fieldOptions.defaults.decimals,
               color: seriesColor,
             }
-          : { ...field.config };
+          : { ...field.config, color: seriesColor };
 
         field.display = getDisplayProcessor({ config: { ...field.config }, type: field.type });
 


### PR DESCRIPTION
In #20046 I have introduced `color?: string` property to TimeSeries and then I have configured the field config in https://github.com/grafana/grafana/compare/explore/tooltip?expand=1#diff-0600e6a1b61c8024cc2e5cc95d22c54b. This is not the best way - TimeSeries type should not be modified in this case, but the field configs should be provided when building GraphSeriesXY models. 

For metrics graph in explore the field config was ignored though, as `getGraphSeriesModel` only cared about series options[1] provided when configuring field's colour, and ignored the fact, that field may have the colour configured already. This PR takes care of that.

---
**(1)** This is specific to graph panel. We could probably refactor this so that series options are no longer passed into getGraphSeries model, but the fields have colour already provided when passing data frames to getGraphSeriesModel. But this ain't in the scope of this PR.