### PR TITLE
DataLinks: Refactor title state

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkEditor.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent, useContext } from 'react';
+import React, { ChangeEvent, useContext } from 'react';
 import { DataLink } from '@grafana/data';
 import { FormField, Switch } from '../index';
 import { VariableSuggestion } from './DataLinkSuggestions';
@@ -31,17 +31,12 @@ export const DataLinkEditor: React.FC<DataLinkEditorProps> = React.memo(
   ({ index, value, onChange, onRemove, suggestions, isLast }) => {
     const theme = useContext(ThemeContext);
     const styles = getStyles(theme);
-    const [title, setTitle] = useState(value.title);
 
     const onUrlChange = (url: string, callback?: () => void) => {
       onChange(index, { ...value, url }, callback);
     };
     const onTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
-      setTitle(event.target.value);
-    };
-
-    const onTitleBlur = () => {
-      onChange(index, { ...value, title: title });
+      onChange(index, { ...value, title: event.target.value });
     };
 
     const onRemoveClick = () => {
@@ -58,9 +53,8 @@ export const DataLinkEditor: React.FC<DataLinkEditorProps> = React.memo(
           <FormField
             className="gf-form--grow"
             label="Title"
-            value={title}
+            value={value.title}
             onChange={onTitleChange}
-            onBlur={onTitleBlur}
             inputWidth={0}
             labelWidth={5}
             placeholder="Show details"


### PR DESCRIPTION
~~Fixes: https://github.com/grafana/grafana/issues/19477~~

~~As mentioned in the issue seems like the blur handler on the title input (which is just a basic `<input />`) in connection to clicking into the graph, somehow messes up the `window.getSelection()` so that nothing is selectable afterwards. No idea how that is possible, I assume it some weird interaction between angular and react event handlers and the event is somewhere `preventDefault()`ed or something like that.~~

~~This removes the onBlur and changes parent state directly on title change. Seems like it is not a perf problem.~~

The problem this was meant to fix was fixed in different PR so this is just a small refactor of state in dataLinks where the title state is not duplicated locally and just uses value from parent.