### PR TITLE
Docker: Update Dockerfile to use UID for runAsNonRoot PSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,5 +97,7 @@ EXPOSE 3000
 
 COPY ./packaging/docker/run.sh /run.sh
 
-USER grafana
+# UID 472 is the grafana user added abov
+USER 472
+
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ EXPOSE 3000
 
 COPY ./packaging/docker/run.sh /run.sh
 
-# UID 472 is the grafana user added abov
-USER 472
+# UID 472 is the grafana user added above
+USER $GF_UID
 
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -81,7 +81,7 @@ COPY --from=js-builder /usr/src/app/tools tools
 COPY tools/phantomjs/render.js tools/phantomjs/
 COPY packaging/docker/run.sh /
 
-# UID 472 is the grafana user added abov
-USER 472
+# UID 472 is the grafana user added above
+USER $GF_UID
 
 ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -81,5 +81,7 @@ COPY --from=js-builder /usr/src/app/tools tools
 COPY tools/phantomjs/render.js tools/phantomjs/
 COPY packaging/docker/run.sh /
 
-USER grafana
+# UID 472 is the grafana user added abov
+USER 472
+
 ENTRYPOINT [ "/run.sh" ]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -59,5 +59,7 @@ EXPOSE 3000
 
 COPY ./run.sh /run.sh
 
-USER grafana
+# UID 472 is the grafana user added above
+USER $GF_UID
+
 ENTRYPOINT [ "/run.sh" ]

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -54,5 +54,7 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
 
 COPY ./run.sh /run.sh
 
-USER grafana
+# UID 472 is the grafana user added above
+USER $GF_UID
+
 ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In a Kubernetes environment with PodSecurityPolicies (PSPs) enabled, it's common to prevent containers running as root. Although the Grafana container _doesn't_ run as root, it's not possible for the PSP Admission Controller to verify this when the `USER` directive in the `Dockerfile` is an alphanumeric username:

Example PSP error below:
```
3s          Warning   Failed             pod/grafana-685b9f879-p8mww    Error: container has runAsNonRoot and image has non-numeric user (grafana), cannot verify user is non-root
```

This PR addresses this by substituting `USER grafana` with `USER 472`, which is the UID created explicitly for Grafana earlier in the Dockerfile

**Special notes for your reviewer**:

A test image is available at https://hub.docker.com/repository/docker/funkypenguin/grafana, and I've confirmed the updated image works on the same PSP-enabled cluster which generated the above example error message.
