### PR TITLE
Templating: highlight first item when searching a variable dropdown

### DIFF
--- a/public/app/core/directives/value_select_dropdown.ts
+++ b/public/app/core/directives/value_select_dropdown.ts
@@ -279,7 +279,7 @@ export class ValueSelectDropdownCtrl {
   }
 
   updateUIBoundOptions($scope: IScope, options: any[]) {
-    this.highlightIndex = -1;
+    this.highlightIndex = 0;
     this.search.options = options.slice(0, Math.min(options.length, 1000));
     $scope.$apply();
   }

--- a/public/app/core/specs/value_select_dropdown.test.ts
+++ b/public/app/core/specs/value_select_dropdown.test.ts
@@ -253,8 +253,8 @@ describe('updateUIBoundOptions', () => {
       ctrl.updateUIBoundOptions($scope, options);
     });
 
-    it('then highlightIndex should be reset', () => {
-      expect(ctrl.highlightIndex).toEqual(-1);
+    it('then highlightIndex should be reset to first item', () => {
+      expect(ctrl.highlightIndex).toEqual(0);
     });
 
     it('then search.options should be same as options but capped to 1000', () => {


### PR DESCRIPTION
By highlighting first you can hit enter to select the first item (or only match if only one matches). 