### PR TITLE
Tests: We should not click on default button when there is only one ds

### DIFF
--- a/public/e2e-test/pages/datasources/editDataSourcePage.ts
+++ b/public/e2e-test/pages/datasources/editDataSourcePage.ts
@@ -11,7 +11,6 @@ import {
 
 export interface EditDataSourcePage {
   name: InputPageObjectType;
-  default: ClickablePageObjectType;
   delete: ClickablePageObjectType;
   saveAndTest: ClickablePageObjectType;
   alert: PageObjectType;
@@ -21,9 +20,6 @@ export interface EditDataSourcePage {
 export const editDataSourcePage = new TestPage<EditDataSourcePage>({
   pageObjects: {
     name: new InputPageObject(Selector.fromAriaLabel('Datasource settings page name input field')),
-    default: new ClickablePageObject(
-      Selector.fromSelector('[aria-label="Datasource settings page basic settings"] .gf-form-switch')
-    ),
     delete: new ClickablePageObject(Selector.fromAriaLabel('Delete button')),
     saveAndTest: new ClickablePageObject(Selector.fromAriaLabel('Save and Test button')),
     alert: new PageObject(Selector.fromAriaLabel('Datasource settings page Alert')),

--- a/public/e2e-test/scenarios/smoke.test.ts
+++ b/public/e2e-test/scenarios/smoke.test.ts
@@ -25,7 +25,6 @@ const addTestDataSourceAndVerify = async (page: Page) => {
   await editDataSourcePage.init(page);
   await editDataSourcePage.waitForNavigation();
   await editDataSourcePage.pageObjects.name.enter(testDataSourceName);
-  await editDataSourcePage.pageObjects.default.click();
   await editDataSourcePage.pageObjects.saveAndTest.click();
   await editDataSourcePage.pageObjects.alert.exists();
   await editDataSourcePage.pageObjects.alertMessage.containsText('Data source is working');


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the click on the default button as this will not work in a clean environment when creating first data source.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

