### PR TITLE
Datasource: fixes prometheus metrics query query field definition

### DIFF
--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -14,6 +14,6 @@ class PrometheusAnnotationsQueryCtrl {
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryCtrl(PromQueryEditor)
   .setConfigEditor(ConfigEditor)
-  .setExploreLogsQueryField(PromQueryField)
+  .setExploreMetricsQueryField(PromQueryField)
   .setAnnotationQueryCtrl(PrometheusAnnotationsQueryCtrl)
   .setExploreStartPage(PromCheatSheet);

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -12,7 +12,7 @@ class PrometheusAnnotationsQueryCtrl {
 }
 
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
-  .setQueryCtrl(PromQueryEditor)
+  .setQueryEditor(PromQueryEditor)
   .setConfigEditor(ConfigEditor)
   .setExploreMetricsQueryField(PromQueryField)
   .setAnnotationQueryCtrl(PrometheusAnnotationsQueryCtrl)

--- a/public/app/plugins/datasource/prometheus/specs/module.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/module.test.ts
@@ -1,0 +1,8 @@
+import { plugin as PrometheusDatasourcePlugin } from '../module';
+
+describe('module', () => {
+  it('should have an Explore metrics uqery field', () => {
+    expect(PrometheusDatasourcePlugin).toBeTruthy();
+    expect(PrometheusDatasourcePlugin.components.ExploreMetricsQueryField).toBeDefined();
+  });
+});

--- a/public/app/plugins/datasource/prometheus/specs/module.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/module.test.ts
@@ -1,8 +1,8 @@
 import { plugin as PrometheusDatasourcePlugin } from '../module';
 
 describe('module', () => {
-  it('should have an Explore metrics uqery field', () => {
-    expect(PrometheusDatasourcePlugin).toBeTruthy();
+  it('should have metrics query field in panels and Explore', () => {
     expect(PrometheusDatasourcePlugin.components.ExploreMetricsQueryField).toBeDefined();
+    expect(PrometheusDatasourcePlugin.components.QueryEditor).toBeDefined();
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates prometheus module definition from logs to metrics.

**Which issue(s) this PR fixes**:

Fixes #20272
