### PR TITLE
Update root_url to reflect the default value

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -46,7 +46,7 @@
 
 # The full public facing url you use in browser, used for redirects and emails
 # If you use reverse proxy and sub path specify full url (with sub path)
-;root_url = http://localhost:3000
+;root_url = %(protocol)s://%(domain)s:%(http_port)s/
 
 # Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
 ;serve_from_sub_path = false


### PR DESCRIPTION
**What this PR does / why we need it**:

It does reflect the default config value of `root_url` in the sample config

Shouldn't that be the case for all config parameters?