### PR TITLE
Team Sync: Fix URL encode Group IDs for external team sync

### DIFF
--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -149,7 +149,7 @@ export function addTeamGroup(groupId: string): ThunkResult<void> {
 export function removeTeamGroup(groupId: string): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
-    await getBackendSrv().delete(`/api/teams/${team.id}/groups/${groupId}`);
+    await getBackendSrv().delete(`/api/teams/${team.id}/groups/${encodeURI(groupId)}`);
     dispatch(loadTeamGroups());
   };
 }

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -149,7 +149,7 @@ export function addTeamGroup(groupId: string): ThunkResult<void> {
 export function removeTeamGroup(groupId: string): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
-    await getBackendSrv().delete(`/api/teams/${team.id}/groups/${encodeURI(groupId)}`);
+    await getBackendSrv().delete(`/api/teams/${team.id}/groups/${encodeURIComponent(groupId)}`);
     dispatch(loadTeamGroups());
   };
 }


### PR DESCRIPTION
External Group IDs can have special characters. Encode them to make them
URL-safe.

**What this PR does / why we need it**:

Encodes the groupID to make it URL-safe as we issue a deletion 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/281

**Special notes for your reviewer**:

