### PR TITLE
PanelData: Support showing data and errors in angular panels

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -106,7 +106,6 @@ class MetricsPanelCtrl extends PanelCtrl {
       return;
     }
 
-    this.loading = false;
     this.error = err.message || 'Request Error';
 
     if (err.data) {
@@ -116,10 +115,6 @@ class MetricsPanelCtrl extends PanelCtrl {
         this.error = err.data.error;
       }
     }
-
-    return this.$timeout(() => {
-      this.events.emit(PanelEvents.dataError, err);
-    });
   }
 
   // Updates the response with information from the stream
@@ -128,10 +123,6 @@ class MetricsPanelCtrl extends PanelCtrl {
       if (data.state === LoadingState.Error) {
         this.loading = false;
         this.processDataError(data.error);
-        if (!data.series) {
-          // keep current data if the response is empty
-          return;
-        }
       }
 
       // Ignore data in loading state

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -153,7 +153,6 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     this.events.on(PanelEvents.render, this.onRender.bind(this));
     this.events.on(CoreEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
-    this.events.on(PanelEvents.dataError, this.onDataError.bind(this));
     this.events.on(PanelEvents.dataSnapshotLoad, this.onDataSnapshotLoad.bind(this));
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
     this.events.on(PanelEvents.initPanelActions, this.onInitPanelActions.bind(this));
@@ -207,12 +206,6 @@ class GraphCtrl extends MetricsPanelCtrl {
 
     const frames = getProcessedDataFrames(snapshotData);
     this.onDataFramesReceived(frames);
-  }
-
-  onDataError(err: any) {
-    this.seriesList = [];
-    this.annotations = [];
-    this.render([]);
   }
 
   onDataFramesReceived(data: DataFrame[]) {

--- a/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
@@ -144,7 +144,6 @@ export class HeatmapCtrl extends MetricsPanelCtrl {
     // Bind grafana panel events
     this.events.on(PanelEvents.render, this.onRender.bind(this));
     this.events.on(CoreEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
-    this.events.on(PanelEvents.dataError, this.onDataError.bind(this));
     this.events.on(PanelEvents.dataSnapshotLoad, this.onSnapshotLoad.bind(this));
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
 

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -121,7 +121,6 @@ class SingleStatCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel, this.panelDefaults);
 
     this.events.on(CoreEvents.dataFramesReceived, this.onFramesReceived.bind(this));
-    this.events.on(PanelEvents.dataError, this.onDataError.bind(this));
     this.events.on(PanelEvents.dataSnapshotLoad, this.onSnapshotLoad.bind(this));
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
 
@@ -150,10 +149,6 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   setUnitFormat(subItem: { value: any }) {
     this.panel.format = subItem.value;
     this.refresh();
-  }
-
-  onDataError(err: any) {
-    this.handleDataFrames([]);
   }
 
   onSnapshotLoad(dataList: LegacyResponseData[]) {

--- a/public/app/plugins/panel/table/module.ts
+++ b/public/app/plugins/panel/table/module.ts
@@ -71,7 +71,6 @@ class TablePanelCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel, this.panelDefaults);
 
     this.events.on(PanelEvents.dataReceived, this.onDataReceived.bind(this));
-    this.events.on(PanelEvents.dataError, this.onDataError.bind(this));
     this.events.on(PanelEvents.dataSnapshotLoad, this.onDataReceived.bind(this));
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
     this.events.on(PanelEvents.initPanelActions, this.onInitPanelActions.bind(this));
@@ -106,11 +105,6 @@ class TablePanelCtrl extends MetricsPanelCtrl {
     }
 
     return super.issueQueries(datasource);
-  }
-
-  onDataError(err: any) {
-    this.dataRaw = [];
-    this.render();
   }
 
   onDataReceived(dataList: any) {


### PR DESCRIPTION
Angular panels emit the data-error event that clear the data & re-render empty panels. 

This changes things so that this handler / event is no longer needed. (it's needed to pipe error to old angular editors but QueryEditorRow is handling that). 

