### PR TITLE
Templating: Made default template variable query editor field a textarea with automatic height

### DIFF
--- a/public/app/features/templating/DefaultVariableQueryEditor.tsx
+++ b/public/app/features/templating/DefaultVariableQueryEditor.tsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import { Input } from '@grafana/ui';
 import { VariableQueryProps } from 'app/types/plugins';
 
 export default class DefaultVariableQueryEditor extends PureComponent<VariableQueryProps, any> {
@@ -8,20 +7,30 @@ export default class DefaultVariableQueryEditor extends PureComponent<VariableQu
     this.state = { value: props.query };
   }
 
-  onChange = (event: React.FormEvent<HTMLInputElement>) => {
+  onChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     this.setState({ value: event.currentTarget.value });
   };
 
-  onBlur = (event: React.FormEvent<HTMLInputElement>) => {
+  onBlur = (event: React.FormEvent<HTMLTextAreaElement>) => {
     this.props.onChange(event.currentTarget.value, event.currentTarget.value);
   };
+
+  getLineCount() {
+    const { value } = this.state;
+
+    if (typeof value === 'string') {
+      return value.split('\n').length;
+    }
+
+    return 1;
+  }
 
   render() {
     return (
       <div className="gf-form">
         <span className="gf-form-label width-10">Query</span>
-        <Input
-          type="text"
+        <textarea
+          rows={this.getLineCount()}
           className="gf-form-input"
           value={this.state.value}
           onChange={this.onChange}


### PR DESCRIPTION
Changes the default query variable editor from a simple text input to a text area. 

Height (rows) it automatically based on number of newlines in the query. So it starts looking the same as today with just one row height. But expands automatically as you hit enter / add new lines. 

![image](https://user-images.githubusercontent.com/10999/68488234-ecacca00-0244-11ea-8732-248e26606394.png)
