### PR TITLE
ColorPicker: Fixes issue with ColorPicker disappearing too quickly 

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/_ColorPicker.scss
+++ b/packages/grafana-ui/src/components/ColorPicker/_ColorPicker.scss
@@ -2,6 +2,9 @@ $arrowSize: 15px;
 .ColorPicker {
   @extend .popper;
   font-size: 12px;
+  // !important because these styles are also provided to popper via .popper classes from Tooltip component
+  // hope to get rid of those soon
+  padding: $arrowSize !important;
 }
 
 .ColorPicker__arrow {
@@ -75,32 +78,19 @@ $arrowSize: 15px;
   border-color: #1e2028;
 }
 
-// Top
-.ColorPicker[data-placement^='top'] {
-  padding-bottom: $arrowSize;
-}
-
-// Bottom
+// !important because these styles are also provided to popper via .popper classes from Tooltip component
+// hope to get rid of those soon
+.ColorPicker[data-placement^='top'],
 .ColorPicker[data-placement^='bottom'] {
-  padding-top: $arrowSize;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
-.ColorPicker[data-placement^='bottom-start'] {
-  padding-top: $arrowSize;
-}
-
-.ColorPicker[data-placement^='bottom-end'] {
-  padding-top: $arrowSize;
-}
-
-// Right
+// !important because these styles are also provided to popper via .popper classes from Tooltip component
+// hope to get rid of those soon
+.ColorPicker[data-placement^='left'],
 .ColorPicker[data-placement^='right'] {
-  padding-left: $arrowSize;
-}
-
-// Left
-.ColorPicker[data-placement^='left'] {
-  padding-right: $arrowSize;
+  padding-top: 0 !important;
 }
 
 .ColorPickerPopover {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/20050

Not sure what was the underlying change in Chrome that made this bug to surface, but here's some reasoning about what happened in our code that caused it. 

When we open the colour picker, popper.js assignes `data-placement` attribute to the div wrapping the picker. Based on that attribute we were setting paddings to give some spacing between the popover and it's trigger. 

So, first calculation from popper did not include the required padding and first render (it was painted, but the opacity was 0, we animate this element!). Then, popper.js calculated the position one more time, this time with padding applied, what made the popover move and tigger the `onMouseLeave` callback, which made the popover to hide... 

In this PR instead of setting the padding when necessary, I'm reseting the default applied padding on the axis that does not influence measurement that applies to the axis on which the tooltip is positioned (i.e. for left, light I'm reseting vertical padding)

We also have an issue with styles being applied from .popper classes that are implemented in Tooltip component. That's why there are some `!important` statements introduced. I'm gonna fix that in a followup PR.

@hugohaggmark @peterholmberg please test this when you do the review. I have tested it but another pair of eyes would be useful :)