### PR TITLE
PanelLinks: Fixed issue with old panel links schema migration and Grafana behind a sub path

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -438,7 +438,7 @@ describe('DashboardModel', () => {
     });
 
     it('should slugify dashboard name', () => {
-      expect(model.panels[0].links[3].url).toBe(`/dashboard/db/my-other-dashboard`);
+      expect(model.panels[0].links[3].url).toBe(`dashboard/db/my-other-dashboard`);
     });
   });
 

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -685,11 +685,11 @@ function upgradePanelLink(link: any): DataLink {
   let url = link.url;
 
   if (!url && link.dashboard) {
-    url = `/dashboard/db/${kbn.slugifyForUrl(link.dashboard)}`;
+    url = `dashboard/db/${kbn.slugifyForUrl(link.dashboard)}`;
   }
 
   if (!url && link.dashUri) {
-    url = `/dashboard/${link.dashUri}`;
+    url = `dashboard/${link.dashUri}`;
   }
 
   // some models are incomplete and have no dashboard or dashUri


### PR DESCRIPTION
While migrating old schema panel links Grafana behind a subpath was not considered. 

Fixes #20276