### PR TITLE
Explore: Fix always disabled QueryField for InfluxDB

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -133,6 +133,7 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     const { datasource } = this.props;
     const { measurements, measurement, field, error } = this.state;
     const cascadeText = getChooserText({ measurement, field, error });
+    const hasMeasurement = measurements && measurements.length > 0;
 
     return (
       <div className="gf-form-inline gf-form-inline--nowrap">
@@ -143,7 +144,7 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
             onChange={this.onMeasurementsChange}
             expandIcon={null}
           >
-            <button className="gf-form-label gf-form-label--btn" disabled={!measurement}>
+            <button className="gf-form-label gf-form-label--btn" disabled={!hasMeasurement}>
               {cascadeText} <i className="fa fa-caret-down" />
             </button>
           </Cascader>

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -130,9 +130,7 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     }
   };
 
-  makeHasMeasurement = memoizeOne((measurements: CascaderOption[]) => {
-    return () => measurements && measurements.length > 0;
-  });
+  makeHasMeasurement = memoizeOne((measurements: CascaderOption[]) => measurements && measurements.length > 0);
 
   render() {
     const { datasource } = this.props;

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import memoizeOne from 'memoize-one';
 import { ExploreQueryFieldProps } from '@grafana/data';
 // @ts-ignore
 import Cascader from 'rc-cascader';
@@ -130,13 +129,11 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     }
   };
 
-  makeHasMeasurement = memoizeOne((measurements: CascaderOption[]) => measurements && measurements.length > 0);
-
   render() {
     const { datasource } = this.props;
     const { measurements, measurement, field, error } = this.state;
     const cascadeText = getChooserText({ measurement, field, error });
-    const hasMeasurement = this.makeHasMeasurement(measurements);
+    const hasMeasurement = measurements && measurements.length > 0;
 
     return (
       <div className="gf-form-inline gf-form-inline--nowrap">

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import memoizeOne from 'memoize-one';
 import { ExploreQueryFieldProps } from '@grafana/data';
 // @ts-ignore
 import Cascader from 'rc-cascader';
@@ -129,11 +130,15 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     }
   };
 
+  makeHasMeasurement = memoizeOne((measurements: CascaderOption[]) => {
+    return () => measurements && measurements.length > 0;
+  });
+
   render() {
     const { datasource } = this.props;
     const { measurements, measurement, field, error } = this.state;
     const cascadeText = getChooserText({ measurement, field, error });
-    const hasMeasurement = measurements && measurements.length > 0;
+    const hasMeasurement = this.makeHasMeasurement(measurements);
 
     return (
       <div className="gf-form-inline gf-form-inline--nowrap">


### PR DESCRIPTION
**What this PR does / why we need it**:
When InfluxDB has been selected as a datasource for Logs in Explore, QueryField button with Measurements has been disabled, even though, InfluxDB had measurements.  This was due to the fact, that `disabled={!measurement}` [was used](https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx#L146) to determine this. However, we setState of measurement only in `onMeasurementsChange` that is passed to Cascader and its value is changed only if user selects one of the values. This is not possible, as QueryField button is disabled. 

This PR fixes this by determining, if QueryField button based on the fact, if measurments are present. 

