### PR TITLE
Explore: Fix interpolation or error message

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/ElasticsearchQueryField.tsx
@@ -77,7 +77,7 @@ class ElasticsearchQueryField extends React.PureComponent<Props, State> {
             />
           </div>
         </div>
-        {data && data.error ? <div className="prom-query-field-info text-error"> data.error.message}</div> : null}
+        {data && data.error ? <div className="prom-query-field-info text-error">{data.error.message}</div> : null}
       </>
     );
   }


### PR DESCRIPTION
Simple error here but tbh not sure if this should be here at all, seems like it usually just duplicates the error message (maybe the alert is not showed every time?)
<img width="513" alt="Screenshot 2019-11-11 at 13 46 31" src="https://user-images.githubusercontent.com/1014802/68588554-1c004880-048a-11ea-884c-cf4f407f5207.png">
