### PR TITLE
Devenv: fix connection in elastic 5 and 6 blocks

### DIFF
--- a/devenv/docker/blocks/elastic5/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic5/docker-compose.yaml
@@ -9,7 +9,7 @@
     image: grafana/fake-data-gen
     links:
       - elasticsearch5
-    # network_mode: bridge
     environment:
+      FD_SERVER: elasticsearch5
       FD_DATASOURCE: elasticsearch
-      FD_PORT: 10200
+      FD_PORT: 9200

--- a/devenv/docker/blocks/elastic6/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic6/docker-compose.yaml
@@ -9,10 +9,12 @@
 
   fake-elastic6-data:
     image: grafana/fake-data-gen
-    network_mode: bridge
+    links:
+      - elasticsearch6 
     environment:
+      FD_SERVER: elasticsearch6
       FD_DATASOURCE: elasticsearch6
-      FD_PORT: 11200
+      FD_PORT: 9200
 
   filebeat6:
     image: docker.elastic.co/beats/filebeat-oss:6.7.1

--- a/devenv/docker/blocks/elastic7/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic7/docker-compose.yaml
@@ -9,10 +9,12 @@
 
   fake-elastic7-data:
     image: grafana/fake-data-gen
-    network_mode: bridge
+    links:
+      - elasticsearch7
     environment:
+      FD_SERVER: elasticsearch7
       FD_DATASOURCE: elasticsearch7
-      FD_PORT: 12200
+      FD_PORT: 9200
 
   filebeat7:
     image: docker.elastic.co/beats/filebeat-oss:7.0.0


### PR DESCRIPTION
The block was using the host IP, which is not the same as the container IP. This PR uses the container's DNS name instead.
