### PR TITLE
Devenv: fix kibana in elastic7 docker block

### DIFF
--- a/devenv/docker/blocks/elastic7/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic7/docker-compose.yaml
@@ -37,5 +37,7 @@
     image: docker.elastic.co/kibana/kibana-oss:7.0.0
     ports:
       - "5601:5601"
+    links:
+      - elasticsearch7
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch7:9200

--- a/devenv/docker/blocks/elastic7/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic7/docker-compose.yaml
@@ -26,7 +26,6 @@
 
   metricbeat7:
     image: docker.elastic.co/beats/metricbeat-oss:7.0.0
-    network_mode: host
     command: metricbeat -e -strict.perms=false
     user: root
     volumes:

--- a/devenv/docker/blocks/elastic7/metricbeat.yml
+++ b/devenv/docker/blocks/elastic7/metricbeat.yml
@@ -28,7 +28,7 @@ processors:
   - add_cloud_metadata: ~
 
 output.elasticsearch:
-  hosts: ["localhost:12200"]
+  hosts: ["elasticsearch7:9200"]
   index: "metricbeat-%{+yyyy.MM.dd}"
 
 setup.template.name: "metricbeat"


### PR DESCRIPTION
Fixes access to kibana of the elastic7 docker block at http://localhost:5601
