### PR TITLE
Devenv: Enable tracing for loki docker block

### DIFF
--- a/devenv/docker/blocks/jaeger/docker-compose.yaml
+++ b/devenv/docker/blocks/jaeger/docker-compose.yaml
@@ -1,6 +1,6 @@
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
-      - "127.0.0.1:6831:6831/udp"
+      - "6831:6831"
       - "16686:16686"
 

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -4,7 +4,12 @@
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
-
+    # Optional jaeger tracing
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
   promtail:
     image: grafana/promtail:master
     volumes:


### PR DESCRIPTION
If the devenv has a jaeger running, this PR enables Loki to send traces to that jaeger. If no jaeger is running, nothing is happening (tracing is UDP, fire and forget)