### PR TITLE
Elasticsearch: Fix template variables interpolation when redirecting to Explore

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -258,7 +258,6 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   }
 
   interpolateVariablesInQueries(queries: ElasticsearchQuery[]): ElasticsearchQuery[] {
-    console.log(queries);
     let expandedQueries = queries;
     if (queries && queries.length > 0) {
       expandedQueries = queries.map(query => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -258,13 +258,14 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   }
 
   interpolateVariablesInQueries(queries: ElasticsearchQuery[]): ElasticsearchQuery[] {
+    console.log(queries);
     let expandedQueries = queries;
     if (queries && queries.length > 0) {
       expandedQueries = queries.map(query => {
         const expandedQuery = {
           ...query,
           datasource: this.name,
-          query: this.templateSrv.replace(query.query),
+          query: this.templateSrv.replace(query.query, {}, 'lucene'),
         };
         return expandedQuery;
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
Interpolation of multi-value and select-all elastic template variables, when redirecting from dashboard to explore was broken. It was generating non-valid elastic query. This PR fixes it by adding correct format - `lucene` - for replace function.

**Example/how to reproduce bug**:
1. Create template variables and multi-select/select-all them
![image](https://user-images.githubusercontent.com/30407135/68699483-7204e700-0583-11ea-957d-d2ad055002d8.png)
2. Redirect to Explore
- Incorrect interpolation:
![image (2)](https://user-images.githubusercontent.com/30407135/68699504-7d581280-0583-11ea-8f81-4b3a89165802.png)

- Fixed interpolation:
![image (1)](https://user-images.githubusercontent.com/30407135/68699605-be502700-0583-11ea-8d51-16c99f072a7a.png)


