### PR TITLE
LDAP: Last org admin can login but wont be removed

### DIFF
--- a/pkg/services/login/login.go
+++ b/pkg/services/login/login.go
@@ -230,7 +230,12 @@ func syncOrgRoles(user *models.User, extUser *models.ExternalUserInfo) error {
 	// delete any removed org roles
 	for _, orgId := range deleteOrgIds {
 		cmd := &models.RemoveOrgUserCommand{OrgId: orgId, UserId: user.Id}
-		if err := bus.Dispatch(cmd); err != nil {
+		err := bus.Dispatch(cmd)
+		if err == models.ErrLastOrgAdmin {
+			logger.Error(err.Error(), "userId", cmd.UserId, "orgId", cmd.OrgId)
+			continue
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/pkg/services/login/login_test.go
+++ b/pkg/services/login/login_test.go
@@ -5,63 +5,23 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	log "github.com/inconshreveable/log15"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_syncOrgRoles_doesNotBreakWhenTryingToRemoveLastOrgAdminButLogsInstead(t *testing.T) {
-	user := models.User{
-		Id: 1,
-	}
-	externalUser := models.ExternalUserInfo{
-		AuthModule: "ldap",
-		OrgRoles: map[int64]models.RoleType{
-			1: models.ROLE_VIEWER,
-		},
-	}
+func Test_syncOrgRoles_doesNotBreakWhenTryingToRemoveLastOrgAdmin(t *testing.T) {
+	user := createSimpleUser()
+	externalUser := createSimpleExternalUser()
+	remResp := createResponseWithOneErrLastOrgAdminItem()
 
 	bus.ClearBusHandlers()
 	defer bus.ClearBusHandlers()
 	bus.AddHandler("test", func(q *models.GetUserOrgListQuery) error {
-		q.Result = []*models.UserOrgDTO{
-			{
-				OrgId: 1,
-				Name:  "Bar",
-				Role:  models.ROLE_VIEWER,
-			},
-			{
-				OrgId: 10,
-				Name:  "Foo",
-				Role:  models.ROLE_ADMIN,
-			},
-			{
-				OrgId: 11,
-				Name:  "Stuff",
-				Role:  models.ROLE_VIEWER,
-			},
-		}
+
+		q.Result = createUserOrgDTO()
 
 		return nil
 	})
-	bus.AddHandler("test", func(cmd *models.UpdateOrgUserCommand) error {
-		return nil
-	})
-	bus.AddHandler("test", func(cmd *models.AddOrgUserCommand) error {
-		return nil
-	})
-
-	remResp := []struct {
-		orgId    int64
-		response error
-	}{
-		{
-			orgId:    10,
-			response: models.ErrLastOrgAdmin,
-		},
-		{
-			orgId:    11,
-			response: nil,
-		},
-	}
 
 	bus.AddHandler("test", func(cmd *models.RemoveOrgUserCommand) error {
 		testData := remResp[0]
@@ -77,4 +37,99 @@ func Test_syncOrgRoles_doesNotBreakWhenTryingToRemoveLastOrgAdminButLogsInstead(
 	err := syncOrgRoles(&user, &externalUser)
 	require.Empty(t, remResp)
 	require.NoError(t, err)
+}
+
+func Test_syncOrgRoles_whenTryingToRemoveLastOrgLogsError(t *testing.T) {
+	var logOutput string
+	logger.SetHandler(log.FuncHandler(func(r *log.Record) error {
+		logOutput = r.Msg
+		return nil
+	}))
+
+	user := createSimpleUser()
+	externalUser := createSimpleExternalUser()
+	remResp := createResponseWithOneErrLastOrgAdminItem()
+
+	bus.ClearBusHandlers()
+	defer bus.ClearBusHandlers()
+	bus.AddHandler("test", func(q *models.GetUserOrgListQuery) error {
+
+		q.Result = createUserOrgDTO()
+
+		return nil
+	})
+
+	bus.AddHandler("test", func(cmd *models.RemoveOrgUserCommand) error {
+		testData := remResp[0]
+		remResp = remResp[1:]
+
+		require.Equal(t, testData.orgId, cmd.OrgId)
+		return testData.response
+	})
+	bus.AddHandler("test", func(cmd *models.SetUsingOrgCommand) error {
+		return nil
+	})
+
+	syncOrgRoles(&user, &externalUser)
+	require.Equal(t, models.ErrLastOrgAdmin.Error(), logOutput)
+}
+
+func createSimpleUser() models.User {
+	user := models.User{
+		Id: 1,
+	}
+
+	return user
+}
+
+func createUserOrgDTO() []*models.UserOrgDTO {
+	users := []*models.UserOrgDTO{
+		{
+			OrgId: 1,
+			Name:  "Bar",
+			Role:  models.ROLE_VIEWER,
+		},
+		{
+			OrgId: 10,
+			Name:  "Foo",
+			Role:  models.ROLE_ADMIN,
+		},
+		{
+			OrgId: 11,
+			Name:  "Stuff",
+			Role:  models.ROLE_VIEWER,
+		},
+	}
+	return users
+}
+
+func createSimpleExternalUser() models.ExternalUserInfo {
+	externalUser := models.ExternalUserInfo{
+		AuthModule: "ldap",
+		OrgRoles: map[int64]models.RoleType{
+			1: models.ROLE_VIEWER,
+		},
+	}
+
+	return externalUser
+}
+
+func createResponseWithOneErrLastOrgAdminItem() []struct {
+	orgId    int64
+	response error
+} {
+	remResp := []struct {
+		orgId    int64
+		response error
+	}{
+		{
+			orgId:    10,
+			response: models.ErrLastOrgAdmin,
+		},
+		{
+			orgId:    11,
+			response: nil,
+		},
+	}
+	return remResp
 }

--- a/pkg/services/login/login_test.go
+++ b/pkg/services/login/login_test.go
@@ -1,0 +1,80 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_syncOrgRoles_doesNotBreakWhenTryingToRemoveLastOrgAdminButLogsInstead(t *testing.T) {
+	user := models.User{
+		Id: 1,
+	}
+	externalUser := models.ExternalUserInfo{
+		AuthModule: "ldap",
+		OrgRoles: map[int64]models.RoleType{
+			1: models.ROLE_VIEWER,
+		},
+	}
+
+	bus.ClearBusHandlers()
+	defer bus.ClearBusHandlers()
+	bus.AddHandler("test", func(q *models.GetUserOrgListQuery) error {
+		q.Result = []*models.UserOrgDTO{
+			{
+				OrgId: 1,
+				Name:  "Bar",
+				Role:  models.ROLE_VIEWER,
+			},
+			{
+				OrgId: 10,
+				Name:  "Foo",
+				Role:  models.ROLE_ADMIN,
+			},
+			{
+				OrgId: 11,
+				Name:  "Stuff",
+				Role:  models.ROLE_VIEWER,
+			},
+		}
+
+		return nil
+	})
+	bus.AddHandler("test", func(cmd *models.UpdateOrgUserCommand) error {
+		return nil
+	})
+	bus.AddHandler("test", func(cmd *models.AddOrgUserCommand) error {
+		return nil
+	})
+
+	remResp := []struct {
+		orgId    int64
+		response error
+	}{
+		{
+			orgId:    10,
+			response: models.ErrLastOrgAdmin,
+		},
+		{
+			orgId:    11,
+			response: nil,
+		},
+	}
+
+	bus.AddHandler("test", func(cmd *models.RemoveOrgUserCommand) error {
+		testData := remResp[0]
+		remResp = remResp[1:]
+
+		require.Equal(t, testData.orgId, cmd.OrgId)
+		return testData.response
+	})
+	bus.AddHandler("test", func(cmd *models.SetUsingOrgCommand) error {
+		return nil
+	})
+
+	err := syncOrgRoles(&user, &externalUser)
+	require.Empty(t, remResp)
+	require.NoError(t, err)
+}

--- a/pkg/services/login/login_test.go
+++ b/pkg/services/login/login_test.go
@@ -70,7 +70,8 @@ func Test_syncOrgRoles_whenTryingToRemoveLastOrgLogsError(t *testing.T) {
 		return nil
 	})
 
-	syncOrgRoles(&user, &externalUser)
+	err := syncOrgRoles(&user, &externalUser)
+	require.NoError(t, err)
 	require.Equal(t, models.ErrLastOrgAdmin.Error(), logOutput)
 }
 


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When an LDAP user has been made the (only) org admin of an org but will lose that role on sync they are not able to login (sync happens on login).

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #14724

**Special notes for your reviewer**:

