### PR TITLE
Devenv: Fix integration of postgres and fake-data-gen containers

### DIFF
--- a/devenv/docker/blocks/postgres/docker-compose.yaml
+++ b/devenv/docker/blocks/postgres/docker-compose.yaml
@@ -1,4 +1,4 @@
-  postgrestest:
+  postgres:
     image: postgres:${postgres_version}
     environment:
       POSTGRES_USER: grafana
@@ -8,7 +8,7 @@
       - "5432:5432"
     command: postgres -c log_connections=on -c logging_collector=on -c log_destination=stderr -c log_directory=/var/log/postgresql
     healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-p", "5432",  "-d", "$$POSTGRES_DATABASE", "-U", "$$POSTGRES_USER" ]
+      test: [ "CMD", "pg_isready", "-q", "-d", "$$POSTGRES_DATABASE", "-U", "$$POSTGRES_USER" ]
       timeout: 45s
       interval: 10s
       retries: 10
@@ -20,5 +20,5 @@
       FD_DATASOURCE: postgres
       FD_PORT: 5432
     depends_on:
-      postgrestest:
+      postgres:
         condition: service_healthy

--- a/devenv/docker/blocks/postgres/docker-compose.yaml
+++ b/devenv/docker/blocks/postgres/docker-compose.yaml
@@ -7,6 +7,11 @@
     ports:
       - "5432:5432"
     command: postgres -c log_connections=on -c logging_collector=on -c log_destination=stderr -c log_directory=/var/log/postgresql
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-p", "5432",  "-d", "$$POSTGRES_DATABASE", "-U", "$$POSTGRES_USER" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
 
   fake-postgres-data:
     image: grafana/fake-data-gen
@@ -14,3 +19,6 @@
     environment:
       FD_DATASOURCE: postgres
       FD_PORT: 5432
+    depends_on:
+      postgrestest:
+        condition: service_healthy

--- a/devenv/docker/compose_header.yml
+++ b/devenv/docker/compose_header.yml
@@ -1,2 +1,2 @@
-version: "2"
+version: "2.1"
 services:


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This fix addresses an issue occasionally occurs when `fake-postgres-data` container starts before the `postgrestest` container and hangs while waiting for the connection. A workaround is to restart the `fake-postgres-data` container after the `postgrestest` container is up.
This fix introduces the following modifications:
- Upgrades to 2.1 docker-compose file format
- Adds a health check for determining that `postgrestest` service is healthy
- Modifies the `fake-postgres-data` service to wait for `postgrestest` before starting
- Renames `postgrestest` to `postgres`

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This is a draft until we verify no other devenv docker blocks are affected by upgrading to `2.1` docker compose file format which introduces the `healthcheck` and `depends_on` instructions.