### PR TITLE
Telegram: Check if error before deferring close of file

### DIFF
--- a/pkg/services/alerting/notifiers/telegram.go
+++ b/pkg/services/alerting/notifiers/telegram.go
@@ -137,16 +137,16 @@ func (tn *TelegramNotifier) buildMessageInlineImage(evalContext *alerting.EvalCo
 	var err error
 
 	imageFile, err = os.Open(evalContext.ImageOnDiskPath)
+	if err != nil {
+		return nil, err
+	}
+
 	defer func() {
 		err := imageFile.Close()
 		if err != nil {
 			tn.log.Error("Could not close Telegram inline image.", "err", err)
 		}
 	}()
-
-	if err != nil {
-		return nil, err
-	}
 
 	ruleURL, err := evalContext.GetRuleURL()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly handles file opening error and returns before deferring close of file.

**Which issue(s) this PR fixes**:
Fixes #20156 

**Special notes for your reviewer**:

