### PR TITLE
Explore: updates breakpoint used to collapse datasource picker

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -169,7 +169,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
       'navbar-button navbar-button--border-right-0': originDashboardIsEditable,
     });
 
-    const showSmallDataSourcePicker = (splitted ? containerWidth < 690 : containerWidth < 800) || false;
+    const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const showSmallTimePicker = splitted || containerWidth < 1210;
 
     return (


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates a breakpoint used to collapse datasource picker while in split screen.

**Which issue(s) this PR fixes**:

Fixes #20336 