### PR TITLE
DataFrame processing: Require table rows to be array

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -59,6 +59,15 @@ describe('toDataFrame', () => {
     expect(again).toBe(input);
   });
 
+  it('throws when table rows is not array', () => {
+    expect(() =>
+      toDataFrame({
+        columns: [],
+        rows: {},
+      })
+    ).toThrowError('Expected table rows to be array, got object.');
+  });
+
   it('migrate from 6.3 style rows', () => {
     const oldDataFrame = {
       fields: [{ name: 'A' }, { name: 'B' }, { name: 'C' }],

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -1,7 +1,5 @@
 // Libraries
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
-import isBoolean from 'lodash/isBoolean';
+import { isArray, isBoolean, isNumber, isString } from 'lodash';
 
 // Types
 import {
@@ -33,6 +31,10 @@ function convertTableToDataFrame(table: TableData): DataFrame {
       type: FieldType.other,
     };
   });
+
+  if (!isArray(table.rows)) {
+    throw new Error(`Expected table rows to be array, got ${typeof table.rows}.`);
+  }
 
   for (const row of table.rows) {
     for (let i = 0; i < fields.length; i++) {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -33,7 +33,7 @@ function convertTableToDataFrame(table: TableData): DataFrame {
   });
 
   if (!isArray(table.rows)) {
-    throw new Error(`Expected xtable rows to be array, got ${typeof table.rows}.`);
+    throw new Error(`Expected table rows to be array, got ${typeof table.rows}.`);
   }
 
   for (const row of table.rows) {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -33,7 +33,7 @@ function convertTableToDataFrame(table: TableData): DataFrame {
   });
 
   if (!isArray(table.rows)) {
-    throw new Error(`Expected table rows to be array, got ${typeof table.rows}.`);
+    throw new Error(`Expected xtable rows to be array, got ${typeof table.rows}.`);
   }
 
   for (const row of table.rows) {


### PR DESCRIPTION
Similar to https://github.com/grafana/grafana/pull/18504

Causes infinite loop when invalid data provided. (`rows = {}`)