### PR TITLE
Date & Time name for dateTimeAsUS format is incorrect

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -165,7 +165,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     name: 'Date & Time',
     formats: [
       { name: 'YYYY-MM-DD HH:mm:ss', id: 'dateTimeAsIso', fn: dateTimeAsIso },
-      { name: 'DD/MM/YYYY h:mm:ss a', id: 'dateTimeAsUS', fn: dateTimeAsUS },
+      { name: 'MM/DD/YYYY h:mm:ss a', id: 'dateTimeAsUS', fn: dateTimeAsUS },
       { name: 'From Now', id: 'dateTimeFromNow', fn: dateTimeFromNow },
     ],
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

Description for format is incorrect.