### PR TITLE
NavLinks: Make ordering in navigation configurable

### DIFF
--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -32,7 +32,7 @@ const (
 	// These weights may be used by an extension to reliably place
 	// itself below a particular item in the menu.
 
-	WeightCreate = iota + defaultNavLinkOffset
+	WeightCreate = (iota - 20) * 100
 	WeightDashboard
 	WeightExplore
 	WeightProfile

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -22,17 +22,39 @@ type PluginCss struct {
 	Dark  string `json:"dark"`
 }
 
+type NavLinkWeight int64
+
+// A sufficiently large negative offset to make it unlikely for
+// plugins to end up placed above either of the default navlinks.
+const defaultNavLinkOffset = -64
+
+const (
+	// These weights may be used by an extension to reliably place
+	// itself below a particular item in the menu.
+
+	WeightCreate = iota + defaultNavLinkOffset
+	WeightDashboard
+	WeightExplore
+	WeightProfile
+	WeightAlerting
+	WeightPlugin
+	WeightConfig
+	WeightAdmin
+	WeightHelp
+)
+
 type NavLink struct {
-	Id           string     `json:"id,omitempty"`
-	Text         string     `json:"text,omitempty"`
-	Description  string     `json:"description,omitempty"`
-	SubTitle     string     `json:"subTitle,omitempty"`
-	Icon         string     `json:"icon,omitempty"`
-	Img          string     `json:"img,omitempty"`
-	Url          string     `json:"url,omitempty"`
-	Target       string     `json:"target,omitempty"`
-	Divider      bool       `json:"divider,omitempty"`
-	HideFromMenu bool       `json:"hideFromMenu,omitempty"`
-	HideFromTabs bool       `json:"hideFromTabs,omitempty"`
-	Children     []*NavLink `json:"children,omitempty"`
+	Id           string        `json:"id,omitempty"`
+	Text         string        `json:"text,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	SubTitle     string        `json:"subTitle,omitempty"`
+	Icon         string        `json:"icon,omitempty"`
+	Img          string        `json:"img,omitempty"`
+	Url          string        `json:"url,omitempty"`
+	Target       string        `json:"target,omitempty"`
+	SortWeight   NavLinkWeight `json:"sortWeight,omitempty"`
+	Divider      bool          `json:"divider,omitempty"`
+	HideFromMenu bool          `json:"hideFromMenu,omitempty"`
+	HideFromTabs bool          `json:"hideFromTabs,omitempty"`
+	Children     []*NavLink    `json:"children,omitempty"`
 }

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -22,8 +22,6 @@ type PluginCss struct {
 	Dark  string `json:"dark"`
 }
 
-type NavLinkWeight int64
-
 const (
 	// These weights may be used by an extension to reliably place
 	// itself in relation to a particular item in the menu. The weights
@@ -42,17 +40,17 @@ const (
 )
 
 type NavLink struct {
-	Id           string        `json:"id,omitempty"`
-	Text         string        `json:"text,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	SubTitle     string        `json:"subTitle,omitempty"`
-	Icon         string        `json:"icon,omitempty"`
-	Img          string        `json:"img,omitempty"`
-	Url          string        `json:"url,omitempty"`
-	Target       string        `json:"target,omitempty"`
-	SortWeight   NavLinkWeight `json:"sortWeight,omitempty"`
-	Divider      bool          `json:"divider,omitempty"`
-	HideFromMenu bool          `json:"hideFromMenu,omitempty"`
-	HideFromTabs bool          `json:"hideFromTabs,omitempty"`
-	Children     []*NavLink    `json:"children,omitempty"`
+	Id           string     `json:"id,omitempty"`
+	Text         string     `json:"text,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	SubTitle     string     `json:"subTitle,omitempty"`
+	Icon         string     `json:"icon,omitempty"`
+	Img          string     `json:"img,omitempty"`
+	Url          string     `json:"url,omitempty"`
+	Target       string     `json:"target,omitempty"`
+	SortWeight   int64      `json:"sortWeight,omitempty"`
+	Divider      bool       `json:"divider,omitempty"`
+	HideFromMenu bool       `json:"hideFromMenu,omitempty"`
+	HideFromTabs bool       `json:"hideFromTabs,omitempty"`
+	Children     []*NavLink `json:"children,omitempty"`
 }

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -24,13 +24,11 @@ type PluginCss struct {
 
 type NavLinkWeight int64
 
-// A sufficiently large negative offset to make it unlikely for
-// plugins to end up placed above either of the default navlinks.
-const defaultNavLinkOffset = -64
-
 const (
 	// These weights may be used by an extension to reliably place
-	// itself below a particular item in the menu.
+	// itself in relation to a particular item in the menu. The weights
+	// are negative to ensure that the default items are placed above
+	// any items with default weight.
 
 	WeightCreate = (iota - 20) * 100
 	WeightDashboard

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -115,11 +116,12 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 		children = append(children, &dtos.NavLink{Text: "Import", SubTitle: "Import dashboard from file or Grafana.com", Id: "import", Icon: "gicon gicon-dashboard-import", Url: setting.AppSubUrl + "/dashboard/import"})
 
 		data.NavTree = append(data.NavTree, &dtos.NavLink{
-			Text:     "Create",
-			Id:       "create",
-			Icon:     "fa fa-fw fa-plus",
-			Url:      setting.AppSubUrl + "/dashboard/new",
-			Children: children,
+			Text:       "Create",
+			Id:         "create",
+			Icon:       "fa fa-fw fa-plus",
+			Url:        setting.AppSubUrl + "/dashboard/new",
+			Children:   children,
+			SortWeight: dtos.WeightCreate,
 		})
 	}
 
@@ -132,21 +134,23 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	}
 
 	data.NavTree = append(data.NavTree, &dtos.NavLink{
-		Text:     "Dashboards",
-		Id:       "dashboards",
-		SubTitle: "Manage dashboards & folders",
-		Icon:     "gicon gicon-dashboard",
-		Url:      setting.AppSubUrl + "/",
-		Children: dashboardChildNavs,
+		Text:       "Dashboards",
+		Id:         "dashboards",
+		SubTitle:   "Manage dashboards & folders",
+		Icon:       "gicon gicon-dashboard",
+		Url:        setting.AppSubUrl + "/",
+		SortWeight: dtos.WeightDashboard,
+		Children:   dashboardChildNavs,
 	})
 
 	if setting.ExploreEnabled && (c.OrgRole == m.ROLE_ADMIN || c.OrgRole == m.ROLE_EDITOR || setting.ViewersCanEdit) {
 		data.NavTree = append(data.NavTree, &dtos.NavLink{
-			Text:     "Explore",
-			Id:       "explore",
-			SubTitle: "Explore your data",
-			Icon:     "gicon gicon-explore",
-			Url:      setting.AppSubUrl + "/explore",
+			Text:       "Explore",
+			Id:         "explore",
+			SubTitle:   "Explore your data",
+			Icon:       "gicon gicon-explore",
+			SortWeight: dtos.WeightExplore,
+			Url:        setting.AppSubUrl + "/explore",
 		})
 	}
 
@@ -163,6 +167,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 			Img:          data.User.GravatarUrl,
 			Url:          setting.AppSubUrl + "/profile",
 			HideFromMenu: true,
+			SortWeight:   dtos.WeightProfile,
 			Children: []*dtos.NavLink{
 				{Text: "Preferences", Id: "profile-settings", Url: setting.AppSubUrl + "/profile", Icon: "gicon gicon-preferences"},
 				{Text: "Change Password", Id: "change-password", Url: setting.AppSubUrl + "/profile/password", Icon: "fa fa-fw fa-lock", HideFromMenu: true},
@@ -186,12 +191,13 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 		}
 
 		data.NavTree = append(data.NavTree, &dtos.NavLink{
-			Text:     "Alerting",
-			SubTitle: "Alert rules & notifications",
-			Id:       "alerting",
-			Icon:     "gicon gicon-alert",
-			Url:      setting.AppSubUrl + "/alerting/list",
-			Children: alertChildNavs,
+			Text:       "Alerting",
+			SubTitle:   "Alert rules & notifications",
+			Id:         "alerting",
+			Icon:       "gicon gicon-alert",
+			Url:        setting.AppSubUrl + "/alerting/list",
+			Children:   alertChildNavs,
+			SortWeight: dtos.WeightAlerting,
 		})
 	}
 
@@ -203,10 +209,11 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	for _, plugin := range enabledPlugins.Apps {
 		if plugin.Pinned {
 			appLink := &dtos.NavLink{
-				Text: plugin.Name,
-				Id:   "plugin-page-" + plugin.Id,
-				Url:  plugin.DefaultNavUrl,
-				Img:  plugin.Info.Logos.Small,
+				Text:       plugin.Name,
+				Id:         "plugin-page-" + plugin.Id,
+				Url:        plugin.DefaultNavUrl,
+				Img:        plugin.Info.Logos.Small,
+				SortWeight: dtos.WeightPlugin,
 			}
 
 			for _, include := range plugin.Includes {
@@ -297,12 +304,13 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	}
 
 	data.NavTree = append(data.NavTree, &dtos.NavLink{
-		Id:       "cfg",
-		Text:     "Configuration",
-		SubTitle: "Organization: " + c.OrgName,
-		Icon:     "gicon gicon-cog",
-		Url:      configNodes[0].Url,
-		Children: configNodes,
+		Id:         "cfg",
+		Text:       "Configuration",
+		SubTitle:   "Organization: " + c.OrgName,
+		Icon:       "gicon gicon-cog",
+		Url:        configNodes[0].Url,
+		SortWeight: dtos.WeightConfig,
+		Children:   configNodes,
 	})
 
 	if c.IsGrafanaAdmin {
@@ -326,6 +334,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 			Id:           "admin",
 			Icon:         "gicon gicon-shield",
 			Url:          setting.AppSubUrl + "/admin/users",
+			SortWeight:   dtos.WeightAdmin,
 			Children:     adminNavLinks,
 		})
 	}
@@ -337,6 +346,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 		Url:          "#",
 		Icon:         "gicon gicon-question",
 		HideFromMenu: true,
+		SortWeight:   dtos.WeightHelp,
 		Children: []*dtos.NavLink{
 			{Text: "Keyboard shortcuts", Url: "/shortcuts", Icon: "fa fa-fw fa-keyboard-o", Target: "_self"},
 			{Text: "Community site", Url: "http://community.grafana.com", Icon: "fa fa-fw fa-comment", Target: "_blank"},
@@ -345,6 +355,10 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	})
 
 	hs.HooksService.RunIndexDataHooks(&data)
+
+	sort.SliceStable(data.NavTree, func(i, j int) bool {
+		return data.NavTree[i].SortWeight < data.NavTree[j].SortWeight
+	})
 	return &data, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

The ordering of links in the navigation bar is currently based the order of the slice containing the navigation tree. Since Grafana supports adding more links to the navigation bar with `RunIndexDataHooks` which runs at the very end of the function this means that any link registered through a hook will be placed last in the slice and be displayed last in the menu. With this PR the ordering can be specified with a weight which allows for placing links created by extensions in a more intuitive place where applicable.

Stable sorting is used to ensure that the current FIFO ordering is preserved when either no weight is set or two items shares the same weight.