### PR TITLE
Get UserInfo if role_attribute_path is specified.

### DIFF
--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -217,7 +217,7 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 	var rawUserInfoResponse HttpGetResponse
 	var err error
 
-	if !s.extractToken(&data, token) {
+	if !s.extractToken(&data, token) || s.roleAttributePath != "" {
 		rawUserInfoResponse, err = HttpGet(client, s.apiUrl)
 		if err != nil {
 			return nil, fmt.Errorf("Error getting user info: %s", err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Scenario: User is using Generic OAuth for authentication, and has a defined `role_attribute_path` to assign roles on login. With the current code, if a valid idToken is presented, Grafana will not query the UserInfo endpoint of the OAuth provider - meaning that the `Role` parameter will never be set. 

Per the [docs](https://grafana.com/docs/auth/generic-oauth/#generic-oauth-authentication) -  "Check for the presence of an role using the JMESPath specified via the role_attribute_path configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the api_url configuration option.".

This PR just adds a check to ensure that if a `role_attribute_path` is specified, Grafana should always query the UserInfo endpoint, ensuring that the proper claims can be retrieved for matching against this config parameter.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/20383
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20383 

**Special notes for your reviewer**:

