### PR TITLE
Reporting: Handle timeouts in rendering

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -50,7 +50,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		Path:            c.Params("*") + queryParams,
 		Timezone:        queryReader.Get("tz", ""),
 		Encoding:        queryReader.Get("encoding", ""),
-		ConcurrentLimit: 30,
+		ConcurrentLimit: rendering.DefaultConcurrencyLimit,
 	})
 
 	if err != nil && err == rendering.ErrTimeout {

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -40,6 +40,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		return
 	}
 
+	maxConcurrentLimitForApiCalls := 30
 	result, err := hs.RenderService.Render(c.Req.Context(), rendering.Opts{
 		Width:           width,
 		Height:          height,
@@ -50,7 +51,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		Path:            c.Params("*") + queryParams,
 		Timezone:        queryReader.Get("tz", ""),
 		Encoding:        queryReader.Get("encoding", ""),
-		ConcurrentLimit: rendering.DefaultConcurrencyLimit,
+		ConcurrentLimit: maxConcurrentLimitForApiCalls,
 	})
 
 	if err != nil && err == rendering.ErrTimeout {

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -12,6 +12,8 @@ var ErrTimeout = errors.New("Timeout error. You can set timeout in seconds with 
 var ErrNoRenderer = errors.New("No renderer plugin found nor is an external render server configured")
 var ErrPhantomJSNotInstalled = errors.New("PhantomJS executable not found")
 
+const DefaultConcurrencyLimit = 3
+
 type Opts struct {
 	Width           int
 	Height          int
@@ -26,11 +28,13 @@ type Opts struct {
 }
 
 type RenderResult struct {
-	FilePath string
+	FilePath            string
+	KeepFileAfterRender bool
 }
 
 type renderFunc func(ctx context.Context, options Opts) (*RenderResult, error)
 
 type Service interface {
 	Render(ctx context.Context, opts Opts) (*RenderResult, error)
+	RenderErrorImage(error error) (*RenderResult, error)
 }

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -12,8 +12,6 @@ var ErrTimeout = errors.New("Timeout error. You can set timeout in seconds with 
 var ErrNoRenderer = errors.New("No renderer plugin found nor is an external render server configured")
 var ErrPhantomJSNotInstalled = errors.New("PhantomJS executable not found")
 
-const DefaultConcurrencyLimit = 3
-
 type Opts struct {
 	Width           int
 	Height          int

--- a/pkg/services/rendering/plugin_mode.go
+++ b/pkg/services/rendering/plugin_mode.go
@@ -63,7 +63,8 @@ func (rs *RenderingService) renderViaPlugin(ctx context.Context, opts Opts) (*Re
 		return nil, err
 	}
 
-	ctx, _ = context.WithTimeout(ctx, opts.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
 
 	rsp, err := rs.grpcPlugin.Render(ctx, &pluginModel.RenderRequest{
 		Url:       rs.getURL(opts.Path),

--- a/pkg/services/rendering/plugin_mode.go
+++ b/pkg/services/rendering/plugin_mode.go
@@ -63,6 +63,8 @@ func (rs *RenderingService) renderViaPlugin(ctx context.Context, opts Opts) (*Re
 		return nil, err
 	}
 
+	ctx, _ = context.WithTimeout(ctx, opts.Timeout)
+
 	rsp, err := rs.grpcPlugin.Render(ctx, &pluginModel.RenderRequest{
 		Url:       rs.getURL(opts.Path),
 		Width:     int32(opts.Width),

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -3,11 +3,10 @@ package rendering
 import (
 	"context"
 	"fmt"
+	plugin "github.com/hashicorp/go-plugin"
 	"net/url"
 	"os"
 	"path/filepath"
-
-	plugin "github.com/hashicorp/go-plugin"
 
 	pluginModel "github.com/grafana/grafana-plugin-model/go/renderer"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -93,10 +92,20 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	return err
 }
 
+func (rs *RenderingService) RenderErrorImage(err error) (*RenderResult, error) {
+	imgUrl := "public/img/rendering_error.png"
+
+	return &RenderResult{
+		FilePath:            filepath.Join(setting.HomePath, imgUrl),
+		KeepFileAfterRender: true,
+	}, nil
+}
+
 func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResult, error) {
 	if rs.inProgressCount > opts.ConcurrentLimit {
 		return &RenderResult{
-			FilePath: filepath.Join(setting.HomePath, "public/img/rendering_limit.png"),
+			FilePath:            filepath.Join(setting.HomePath, "public/img/rendering_limit.png"),
+			KeepFileAfterRender: true,
 		}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The rendering plugin needs improvement to make sure rendering can proceed after timeouts occur.
* Changed default concurrence to 3 from 30 for performance.
* Added timeout in grpc call to plugins for rendering
