### PR TITLE
Alerting: Add more information to webhook notifications

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -114,28 +114,24 @@ Example json body:
   "dashboardId":1,
   "evalMatches":[
     {
-      "value":100,
-      "metric":"High value",
-      "tags":null
-    },
-    {
-      "value":200,
-      "metric":"Higher Value",
-      "tags":null
+      "value":1,
+      "metric":"Count",
+      "tags":{}
     }
   ],
   "imageUrl":"https://grafana.com/assets/img/blog/mixed_styles.png",
-  "message":"Someone is testing the alert notification within grafana.",
-  "orgId":0,
-  "panelId":1,
-  "ruleId":0,
-  "ruleName":"Test notification",
-  "ruleUrl":"http://localhost:3000/",
+  "message":"Notification Message",
+  "orgId":1,
+  "panelId":2,
+  "ruleId":1,
+  "ruleName":"Panel Title alert",
+  "ruleUrl":"http://localhost:3000/d/hZ7BuVbWz/test-dashboard?fullscreen\u0026edit\u0026tab=alert\u0026panelId=2\u0026orgId=1",
   "state":"alerting",
-  "tags":{},
-  "title":"[Alerting] Test notification"
-}
-```
+  "tags":{
+    "tag name":"tag value"
+  },
+  "title":"[Alerting] Panel Title alert"
+}```
 
 - **state** - The possible values for alert state are: `ok`, `paused`, `alerting`, `pending`, `no_data`.
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -111,20 +111,29 @@ Example json body:
 
 ```json
 {
-  "title": "My alert",
-  "ruleId": 1,
-  "ruleName": "Load peaking!",
-  "ruleUrl": "http://url.to.grafana/db/dashboard/my_dashboard?panelId=2",
-  "state": "alerting",
-  "imageUrl": "http://s3.image.url",
-  "message": "Load is peaking. Make sure the traffic is real and spin up more webfronts",
-  "evalMatches": [
+  "dashboardId":1,
+  "evalMatches":[
     {
-      "metric": "requests",
-      "tags": {},
-      "value": 122
+      "value":100,
+      "metric":"High value",
+      "tags":null
+    },
+    {
+      "value":200,
+      "metric":"Higher Value",
+      "tags":null
     }
-  ]
+  ],
+  "imageUrl":"https://grafana.com/assets/img/blog/mixed_styles.png",
+  "message":"Someone is testing the alert notification within grafana.",
+  "orgId":0,
+  "panelId":1,
+  "ruleId":0,
+  "ruleName":"Test notification",
+  "ruleUrl":"http://localhost:3000/",
+  "state":"alerting",
+  "tags":{},
+  "title":"[Alerting] Test notification"
 }
 ```
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -112,30 +112,29 @@ Example json body:
 ```json
 {
   "dashboardId":1,
+  "dashboardUid":{
+    "Uid":"hZ7BuVbWz",
+    "Slug":"test-dashboard"
+  },
   "evalMatches":[
     {
-      "value":100,
-      "metric":"High value",
-      "tags":null
-    },
-    {
-      "value":200,
-      "metric":"Higher Value",
-      "tags":null
+      "value":1,
+      "metric":"Count",
+      "tags":{}
     }
   ],
-  "imageUrl":"https://grafana.com/assets/img/blog/mixed_styles.png",
-  "message":"Someone is testing the alert notification within grafana.",
-  "orgId":0,
-  "panelId":1,
-  "ruleId":0,
-  "ruleName":"Test notification",
-  "ruleUrl":"http://localhost:3000/",
+  "message":"Notification Message",
+  "orgId":1,
+  "panelId":2,
+  "ruleId":1,
+  "ruleName":"Panel Title alert",
+  "ruleUrl":"http://localhost:3000/d/hZ7BuVbWz/test-dashboard?fullscreen\u0026edit\u0026tab=alert\u0026panelId=2\u0026orgId=1",
   "state":"alerting",
-  "tags":{},
-  "title":"[Alerting] Test notification"
-}
-```
+  "tags":{
+    "tag name":"tag value"
+  },
+  "title":"[Alerting] Panel Title alert"
+}```
 
 - **state** - The possible values for alert state are: `ok`, `paused`, `alerting`, `pending`, `no_data`.
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -112,29 +112,30 @@ Example json body:
 ```json
 {
   "dashboardId":1,
-  "dashboardUid":{
-    "Uid":"hZ7BuVbWz",
-    "Slug":"test-dashboard"
-  },
   "evalMatches":[
     {
-      "value":1,
-      "metric":"Count",
-      "tags":{}
+      "value":100,
+      "metric":"High value",
+      "tags":null
+    },
+    {
+      "value":200,
+      "metric":"Higher Value",
+      "tags":null
     }
   ],
-  "message":"Notification Message",
-  "orgId":1,
-  "panelId":2,
-  "ruleId":1,
-  "ruleName":"Panel Title alert",
-  "ruleUrl":"http://localhost:3000/d/hZ7BuVbWz/test-dashboard?fullscreen\u0026edit\u0026tab=alert\u0026panelId=2\u0026orgId=1",
+  "imageUrl":"https://grafana.com/assets/img/blog/mixed_styles.png",
+  "message":"Someone is testing the alert notification within grafana.",
+  "orgId":0,
+  "panelId":1,
+  "ruleId":0,
+  "ruleName":"Test notification",
+  "ruleUrl":"http://localhost:3000/",
   "state":"alerting",
-  "tags":{
-    "tag name":"tag value"
-  },
-  "title":"[Alerting] Panel Title alert"
-}```
+  "tags":{},
+  "title":"[Alerting] Test notification"
+}
+```
 
 - **state** - The possible values for alert state are: `ok`, `paused`, `alerting`, `pending`, `no_data`.
 

--- a/pkg/services/alerting/notifiers/webhook.go
+++ b/pkg/services/alerting/notifiers/webhook.go
@@ -80,6 +80,9 @@ func (wn *WebhookNotifier) Notify(evalContext *alerting.EvalContext) error {
 	bodyJSON.Set("ruleName", evalContext.Rule.Name)
 	bodyJSON.Set("state", evalContext.Rule.State)
 	bodyJSON.Set("evalMatches", evalContext.EvalMatches)
+	bodyJSON.Set("orgId", evalContext.Rule.OrgID)
+	bodyJSON.Set("dashboardId", evalContext.Rule.DashboardID)
+	bodyJSON.Set("panelId", evalContext.Rule.PanelID)
 
 	tags := make(map[string]string)
 

--- a/pkg/services/alerting/notifiers/webhook.go
+++ b/pkg/services/alerting/notifiers/webhook.go
@@ -84,9 +84,6 @@ func (wn *WebhookNotifier) Notify(evalContext *alerting.EvalContext) error {
 	bodyJSON.Set("dashboardId", evalContext.Rule.DashboardID)
 	bodyJSON.Set("panelId", evalContext.Rule.PanelID)
 
-	dashboardUid, _ := evalContext.GetDashboardUID()
-	bodyJSON.Set("dashboardUid", dashboardUid)
-
 	tags := make(map[string]string)
 
 	for _, tag := range evalContext.Rule.AlertRuleTags {

--- a/pkg/services/alerting/notifiers/webhook.go
+++ b/pkg/services/alerting/notifiers/webhook.go
@@ -84,6 +84,9 @@ func (wn *WebhookNotifier) Notify(evalContext *alerting.EvalContext) error {
 	bodyJSON.Set("dashboardId", evalContext.Rule.DashboardID)
 	bodyJSON.Set("panelId", evalContext.Rule.PanelID)
 
+	dashboardUid, _ := evalContext.GetDashboardUID()
+	bodyJSON.Set("dashboardUid", dashboardUid)
+
 	tags := make(map[string]string)
 
 	for _, tag := range evalContext.Rule.AlertRuleTags {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the orgId, dashboardId and panelId of the alerting panel to the Webhook notification.

---

_changes to the documentation would be necessary: https://grafana.com/docs/alerting/notifications/#webhook_