### PR TITLE
Docs: Fix developer guide link

### DIFF
--- a/docs/sources/project/building_from_source.md
+++ b/docs/sources/project/building_from_source.md
@@ -8,4 +8,4 @@ weight = 700
 
 # Building Grafana from source
 
-Refer to the [Grafana developer guide](contribute\developer-guide.md) for information about building Grafana from the source code.
+Refer to the [Grafana developer guide](https://github.com/grafana/grafana/blob/master/contribute/developer-guide.md) for information about building Grafana from the source code.


### PR DESCRIPTION
**What this PR does / why we need it**:
resolve 404

**Which issue(s) this PR fixes**:
Fixes #20410

**Special notes for your reviewer**:

Since the docs docker image is private for the migration -- I cannot verify that this fixes the 404.

