### PR TITLE
UsersPage: Removed icon in external button

### DIFF
--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -69,7 +69,7 @@ export class UsersActionBar extends PureComponent<Props> {
           )}
           {externalUserMngLinkUrl && (
             <a className="btn btn-primary" href={externalUserMngLinkUrl} target="_blank" rel="noopener">
-              <i className="fa fa-external-link-square" /> {externalUserMngLinkName}
+              {externalUserMngLinkName}
             </a>
           )}
         </div>

--- a/public/app/features/users/__snapshots__/UsersActionBar.test.tsx.snap
+++ b/public/app/features/users/__snapshots__/UsersActionBar.test.tsx.snap
@@ -88,12 +88,7 @@ exports[`Render should show external user management button 1`] = `
       href="some/url"
       rel="noopener"
       target="_blank"
-    >
-      <i
-        className="fa fa-external-link-square"
-      />
-       
-    </a>
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
Icons to the left of button lack any right padding (so look terrible) and we have tried to move away from having icons in buttons to opted to remove it here. 