### PR TITLE
Dashboard Migrator: persist thresholds param if already set

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -139,6 +139,27 @@ describe('DashboardModel', () => {
       expect(graph.thresholds[1].value).toBe(400);
       expect(graph.thresholds[1].fillColor).toBe('red');
     });
+
+    it('graph thresholds should be migrated onto specified thresholds', () => {
+      model = new DashboardModel({
+        panels: [
+          {
+            type: 'graph',
+            y_formats: ['kbyte', 'ms'],
+            grid: {
+              threshold1: 200,
+              threshold2: 400,
+            },
+            thresholds: [{ value: 100 }],
+          },
+        ],
+      });
+      graph = model.panels[0];
+      expect(graph.thresholds.length).toBe(3);
+      expect(graph.thresholds[0].value).toBe(100);
+      expect(graph.thresholds[1].value).toBe(200);
+      expect(graph.thresholds[2].value).toBe(400);
+    });
   });
 
   describe('when migrating to the grid layout', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -316,7 +316,9 @@ export class DashboardMigrator {
           return;
         }
 
-        panel.thresholds = [];
+        if (!panel.thresholds) {
+          panel.thresholds = [];
+        }
         const t1: any = {},
           t2: any = {};
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the `thresholds` param to not be unnecessarily overwritten for schema versions below 13 when importing a dashboard json schema.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/20457

**Special notes for your reviewer**:
Open to feedback and suggestions!
