### PR TITLE
CloudWatch: Fix high resolution mode without expression

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -31,6 +31,9 @@ func (e *CloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMe
 			} else {
 				mdr[*r.Id][*r.Label].Timestamps = append(mdr[*r.Id][*r.Label].Timestamps, r.Timestamps...)
 				mdr[*r.Id][*r.Label].Values = append(mdr[*r.Id][*r.Label].Values, r.Values...)
+				if *r.StatusCode == "Complete" {
+					mdr[*r.Id][*r.Label].StatusCode = r.StatusCode
+				}
 			}
 			queries[*r.Id].RequestExceededMaxLimit = requestExceededMaxLimit
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Current implementation check NextToken, but it doesn't handle `PartialData` status.
https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDataResult.html

The merged MetricDataResults contains `PartialData` status, it cause error response.
https://github.com/grafana/grafana/pull/20268/files#diff-69b4b9c9421d68c60f9fdab354eacfe9R62

If the next response contains `Complete` status, the status should be overwritten by `Complete` status. 

**Which issue(s) this PR fixes**:
partialfix of https://github.com/grafana/grafana/issues/20436