### PR TITLE
Fix RPM verification of signed packages

### DIFF
--- a/scripts/build/verify_signed_packages.sh
+++ b/scripts/build/verify_signed_packages.sh
@@ -13,7 +13,7 @@ curl -s https://packages.grafana.com/gpg.key > ~/.rpmdb/pubkeys/grafana.key
 ALL_SIGNED=0
 
 for file in $_files; do
-  if rpm -K "$file" | grep "pgp.*OK" -q ; then
+  if rpm -K "$file" | grep "digests signatures OK" -q ; then
     echo "$file" OK
   else
     ALL_SIGNED=1


### PR DESCRIPTION
**What this PR does / why we need it**:
The master build is currently breaking on verification of RPM package signatures. From what I can tell, it's because RPM has changed its textual output in our upgraded build-container Docker images. With this PR I check for the current successful output from `rpm -K <package>`.
