### PR TITLE
TimePicker: Should update after location change

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -30,7 +30,7 @@ export class DashNavTimeControls extends Component<Props> {
 
   componentDidMount() {
     // Only reason for this is that sometimes time updates can happen via redux location changes
-    // and this happends before timeSrv has had chance to update state (as it listens to angular route-updated)
+    // and this happens before timeSrv has had chance to update state (as it listens to angular route-updated)
     // This can be removed after timeSrv listens redux location
     this.props.dashboard.on(CoreEvents.timeRangeUpdated, this.triggerForceUpdate);
   }

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -28,6 +28,21 @@ export class DashNavTimeControls extends Component<Props> {
   timeSrv: TimeSrv = getTimeSrv();
   $rootScope = this.props.$injector.get('$rootScope');
 
+  componentDidMount() {
+    // Only reason for this is that sometimes time updates can happen via redux location changes
+    // and this happends before timeSrv has had chance to update state (as it listens to angular route-updated)
+    // This can be removed after timeSrv listens redux location
+    this.props.dashboard.on(CoreEvents.timeRangeUpdated, this.triggerForceUpdate);
+  }
+
+  componentWillUnmount() {
+    this.props.dashboard.off(CoreEvents.timeRangeUpdated, this.triggerForceUpdate);
+  }
+
+  triggerForceUpdate = () => {
+    this.forceUpdate();
+  };
+
   get refreshParamInUrl(): string {
     return this.props.location.query.refresh as string;
   }

--- a/public/app/plugins/panel/text2/TextPanel.tsx
+++ b/public/app/plugins/panel/text2/TextPanel.tsx
@@ -10,6 +10,7 @@ import config from 'app/core/config';
 // Types
 import { TextOptions } from './types';
 import { PanelProps } from '@grafana/data';
+import { getLocationSrv } from '@grafana/runtime';
 
 interface Props extends PanelProps<TextOptions> {}
 interface State {
@@ -77,9 +78,24 @@ export class TextPanel extends PureComponent<Props, State> {
     return this.prepareText(content);
   }
 
+  onClick = () => {
+    getLocationSrv().update({
+      partial: true,
+      query: {
+        from: 100,
+        to: new Date().valueOf(),
+      },
+    });
+  };
+
   render() {
     const { html } = this.state;
 
-    return <div className="markdown-html panel-text-content" dangerouslySetInnerHTML={{ __html: html }} />;
+    return (
+      <div>
+        <button onClick={this.onClick}>OnClick</button>
+        <div className="markdown-html panel-text-content" dangerouslySetInnerHTML={{ __html: html }} />;
+      </div>
+    );
   }
 }

--- a/public/app/plugins/panel/text2/TextPanel.tsx
+++ b/public/app/plugins/panel/text2/TextPanel.tsx
@@ -10,7 +10,6 @@ import config from 'app/core/config';
 // Types
 import { TextOptions } from './types';
 import { PanelProps } from '@grafana/data';
-import { getLocationSrv } from '@grafana/runtime';
 
 interface Props extends PanelProps<TextOptions> {}
 interface State {
@@ -78,24 +77,9 @@ export class TextPanel extends PureComponent<Props, State> {
     return this.prepareText(content);
   }
 
-  onClick = () => {
-    getLocationSrv().update({
-      partial: true,
-      query: {
-        from: 100,
-        to: new Date().valueOf(),
-      },
-    });
-  };
-
   render() {
     const { html } = this.state;
 
-    return (
-      <div>
-        <button onClick={this.onClick}>OnClick</button>
-        <div className="markdown-html panel-text-content" dangerouslySetInnerHTML={{ __html: html }} />;
-      </div>
-    );
+    return <div className="markdown-html panel-text-content" dangerouslySetInnerHTML={{ __html: html }} />;
   }
 }


### PR DESCRIPTION
Fixes #20424 

Started first on another approach that changed so that TimeSrv uses redux to detect changes in url query time params but that proved to require quite big changes to TimeSrv, something that did not feel good to cherry pick into beta this late in release cycle. 

So switched to this more hacky approach that works around the timing issue between redux state update (that happens first, then birdge srv updates angular url state -> routeUpdated event -> timeSrv state updated -> timeRangeUpdated event emitted) 