### PR TITLE
API: Optionally list expired API keys

### DIFF
--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -67,6 +67,10 @@ Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 ```
 
+Query Parameters:
+
+- `IncludeExpired`: boolean. enable listing of expired keys. Optional.
+
 **Example Response**:
 
 ```http

--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -69,7 +69,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 Query Parameters:
 
-- `IncludeExpired`: boolean. enable listing of expired keys. Optional.
+- `includeExpired`: boolean. enable listing of expired keys. Optional.
 
 **Example Response**:
 

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetAPIKeys(c *models.ReqContext) Response {
-	query := models.GetApiKeysQuery{OrgId: c.OrgId, IncludeExpired: c.QueryBool("IncludeExpired")}
+	query := models.GetApiKeysQuery{OrgId: c.OrgId, IncludeExpired: c.QueryBool("includeExpired")}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return Error(500, "Failed to list api keys", err)

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetAPIKeys(c *models.ReqContext) Response {
-	query := models.GetApiKeysQuery{OrgId: c.OrgId}
+	query := models.GetApiKeysQuery{OrgId: c.OrgId, IncludeInvalid: c.QueryBool("include_invalid")}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return Error(500, "Failed to list api keys", err)

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetAPIKeys(c *models.ReqContext) Response {
-	query := models.GetApiKeysQuery{OrgId: c.OrgId, IncludeInvalid: c.QueryBool("include_invalid")}
+	query := models.GetApiKeysQuery{OrgId: c.OrgId, IncludeExpired: c.QueryBool("IncludeExpired")}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return Error(500, "Failed to list api keys", err)

--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -50,7 +50,7 @@ type DeleteApiKeyCommand struct {
 
 type GetApiKeysQuery struct {
 	OrgId          int64
-	IncludeInvalid bool
+	IncludeExpired bool
 	Result         []*ApiKey
 }
 

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -19,7 +19,7 @@ func init() {
 func GetApiKeys(query *models.GetApiKeysQuery) error {
 	sess := x.Limit(100, 0).Where("org_id=? and ( expires IS NULL or expires >= ?)",
 		query.OrgId, timeNow().Unix()).Asc("name")
-	if query.IncludeInvalid {
+	if query.IncludeExpired {
 		sess = x.Limit(100, 0).Where("org_id=?", query.OrgId).Asc("name")
 	}
 

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -91,7 +91,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 			// advance mocked getTime by 1s
 			timeNow()
 
-			query := models.GetApiKeysQuery{OrgId: 1, IncludeInvalid: false}
+			query := models.GetApiKeysQuery{OrgId: 1, IncludeExpired: false}
 			err = GetApiKeys(&query)
 			assert.Nil(t, err)
 
@@ -101,7 +101,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 				}
 			}
 
-			query = models.GetApiKeysQuery{OrgId: 1, IncludeInvalid: true}
+			query = models.GetApiKeysQuery{OrgId: 1, IncludeExpired: true}
 			err = GetApiKeys(&query)
 			assert.Nil(t, err)
 

--- a/public/app/features/api-keys/ApiKeysPage.test.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.test.tsx
@@ -23,6 +23,7 @@ const setup = (propOverrides?: object) => {
     setSearchQuery: jest.fn(),
     addApiKey: jest.fn(),
     apiKeysCount: 0,
+    includeInvalid: false,
   };
 
   Object.assign(props, propOverrides);
@@ -63,7 +64,7 @@ describe('Life cycle', () => {
 
     instance.componentDidMount();
 
-    expect(instance.props.loadApiKeys).toHaveBeenCalled();
+    expect(instance.props.loadApiKeys).toHaveBeenCalledWith(false);
   });
 });
 
@@ -72,7 +73,7 @@ describe('Functions', () => {
     it('should call delete team', () => {
       const { instance } = setup();
       instance.onDeleteApiKey(getMockKey());
-      expect(instance.props.deleteApiKey).toHaveBeenCalledWith(1);
+      expect(instance.props.deleteApiKey).toHaveBeenCalledWith(1, false);
     });
   });
 

--- a/public/app/features/api-keys/ApiKeysPage.test.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.test.tsx
@@ -23,7 +23,7 @@ const setup = (propOverrides?: object) => {
     setSearchQuery: jest.fn(),
     addApiKey: jest.fn(),
     apiKeysCount: 0,
-    includeInvalid: false,
+    includeExpired: false,
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/api-keys/ApiKeysPage.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.tsx
@@ -51,7 +51,7 @@ export interface Props {
   setSearchQuery: typeof setSearchQuery;
   addApiKey: typeof addApiKey;
   apiKeysCount: number;
-  includeInvalid: boolean;
+  includeExpired: boolean;
 }
 
 export interface State {
@@ -77,7 +77,7 @@ const tooltipText =
 export class ApiKeysPage extends PureComponent<Props, any> {
   constructor(props: Props) {
     super(props);
-    this.state = { isAdding: false, newApiKey: initialApiKeyState, includeInvalid: false };
+    this.state = { isAdding: false, newApiKey: initialApiKeyState, includeExpired: false };
   }
 
   componentDidMount() {
@@ -85,19 +85,19 @@ export class ApiKeysPage extends PureComponent<Props, any> {
   }
 
   async fetchApiKeys() {
-    await this.props.loadApiKeys(this.state.includeInvalid);
+    await this.props.loadApiKeys(this.state.includeExpired);
   }
 
   onDeleteApiKey(key: ApiKey) {
-    this.props.deleteApiKey(key.id, this.props.includeInvalid);
+    this.props.deleteApiKey(key.id, this.props.includeExpired);
   }
 
   onSearchQueryChange = (value: string) => {
     this.props.setSearchQuery(value);
   };
 
-  onIncludeInvalidChange = (value: boolean) => {
-    this.setState({ hasFetched: false, includeInvalid: value }, this.fetchApiKeys);
+  onIncludeExpiredChange = (value: boolean) => {
+    this.setState({ hasFetched: false, includeExpired: value }, this.fetchApiKeys);
   };
 
   onToggleAdding = () => {
@@ -119,7 +119,7 @@ export class ApiKeysPage extends PureComponent<Props, any> {
     // make sure that secondsToLive is number or null
     const secondsToLive = this.state.newApiKey['secondsToLive'];
     this.state.newApiKey['secondsToLive'] = secondsToLive ? kbn.interval_to_seconds(secondsToLive) : null;
-    this.props.addApiKey(this.state.newApiKey, openModal, this.props.includeInvalid);
+    this.props.addApiKey(this.state.newApiKey, openModal, this.props.includeExpired);
     this.setState((prevState: State) => {
       return {
         ...prevState,
@@ -237,7 +237,7 @@ export class ApiKeysPage extends PureComponent<Props, any> {
 
   renderApiKeyList() {
     const { isAdding } = this.state;
-    const { apiKeys, searchQuery, includeInvalid } = this.props;
+    const { apiKeys, searchQuery, includeExpired } = this.props;
 
     return (
       <>
@@ -263,10 +263,10 @@ export class ApiKeysPage extends PureComponent<Props, any> {
         <h3 className="page-heading">Existing Keys</h3>
         <Switch
           label="Show expired"
-          checked={includeInvalid}
+          checked={includeExpired}
           onChange={event => {
             // @ts-ignore
-            this.onIncludeInvalidChange(event.target.checked);
+            this.onIncludeExpiredChange(event.target.checked);
           }}
         />
         <table className="filter-table">
@@ -317,7 +317,7 @@ function mapStateToProps(state: any) {
     navModel: getNavModel(state.navIndex, 'apikeys'),
     apiKeys: getApiKeys(state.apiKeys),
     searchQuery: state.apiKeys.searchQuery,
-    includeInvalid: state.includeInvalid,
+    includeExpired: state.includeExpired,
     apiKeysCount: getApiKeysCount(state.apiKeys),
     hasFetched: state.apiKeys.hasFetched,
   };

--- a/public/app/features/api-keys/state/actions.ts
+++ b/public/app/features/api-keys/state/actions.ts
@@ -29,28 +29,28 @@ const apiKeysLoaded = (apiKeys: ApiKey[]): LoadApiKeysAction => ({
 export function addApiKey(
   apiKey: ApiKey,
   openModal: (key: string) => void,
-  includeInvalid: boolean
+  includeExpired: boolean
 ): ThunkResult<void> {
   return async dispatch => {
     const result = await getBackendSrv().post('/api/auth/keys', apiKey);
     dispatch(setSearchQuery(''));
-    dispatch(loadApiKeys(includeInvalid));
+    dispatch(loadApiKeys(includeExpired));
     openModal(result.key);
   };
 }
 
-export function loadApiKeys(includeInvalid: boolean): ThunkResult<void> {
+export function loadApiKeys(includeExpired: boolean): ThunkResult<void> {
   return async dispatch => {
-    const response = await getBackendSrv().get('/api/auth/keys?include_invalid=' + includeInvalid);
+    const response = await getBackendSrv().get('/api/auth/keys?IncludeExpired=' + includeExpired);
     dispatch(apiKeysLoaded(response));
   };
 }
 
-export function deleteApiKey(id: number, includeInvalid: boolean): ThunkResult<void> {
+export function deleteApiKey(id: number, includeExpired: boolean): ThunkResult<void> {
   return async dispatch => {
     getBackendSrv()
       .delete('/api/auth/keys/' + id)
-      .then(dispatch(loadApiKeys(includeInvalid)));
+      .then(dispatch(loadApiKeys(includeExpired)));
   };
 }
 

--- a/public/app/features/api-keys/state/actions.ts
+++ b/public/app/features/api-keys/state/actions.ts
@@ -26,27 +26,31 @@ const apiKeysLoaded = (apiKeys: ApiKey[]): LoadApiKeysAction => ({
   payload: apiKeys,
 });
 
-export function addApiKey(apiKey: ApiKey, openModal: (key: string) => void): ThunkResult<void> {
+export function addApiKey(
+  apiKey: ApiKey,
+  openModal: (key: string) => void,
+  includeInvalid: boolean
+): ThunkResult<void> {
   return async dispatch => {
     const result = await getBackendSrv().post('/api/auth/keys', apiKey);
     dispatch(setSearchQuery(''));
-    dispatch(loadApiKeys());
+    dispatch(loadApiKeys(includeInvalid));
     openModal(result.key);
   };
 }
 
-export function loadApiKeys(): ThunkResult<void> {
+export function loadApiKeys(includeInvalid: boolean): ThunkResult<void> {
   return async dispatch => {
-    const response = await getBackendSrv().get('/api/auth/keys');
+    const response = await getBackendSrv().get('/api/auth/keys?include_invalid=' + includeInvalid);
     dispatch(apiKeysLoaded(response));
   };
 }
 
-export function deleteApiKey(id: number): ThunkResult<void> {
+export function deleteApiKey(id: number, includeInvalid: boolean): ThunkResult<void> {
   return async dispatch => {
     getBackendSrv()
       .delete('/api/auth/keys/' + id)
-      .then(dispatch(loadApiKeys()));
+      .then(dispatch(loadApiKeys(includeInvalid)));
   };
 }
 

--- a/public/app/features/api-keys/state/actions.ts
+++ b/public/app/features/api-keys/state/actions.ts
@@ -41,7 +41,7 @@ export function addApiKey(
 
 export function loadApiKeys(includeExpired: boolean): ThunkResult<void> {
   return async dispatch => {
-    const response = await getBackendSrv().get('/api/auth/keys?IncludeExpired=' + includeExpired);
+    const response = await getBackendSrv().get('/api/auth/keys?includeExpired=' + includeExpired);
     dispatch(apiKeysLoaded(response));
   };
 }

--- a/public/app/features/api-keys/state/reducers.ts
+++ b/public/app/features/api-keys/state/reducers.ts
@@ -5,7 +5,7 @@ export const initialApiKeysState: ApiKeysState = {
   keys: [],
   searchQuery: '',
   hasFetched: false,
-  includeInvalid: false,
+  includeExpired: false,
 };
 
 export const apiKeysReducer = (state = initialApiKeysState, action: Action): ApiKeysState => {

--- a/public/app/features/api-keys/state/reducers.ts
+++ b/public/app/features/api-keys/state/reducers.ts
@@ -5,6 +5,7 @@ export const initialApiKeysState: ApiKeysState = {
   keys: [],
   searchQuery: '',
   hasFetched: false,
+  includeInvalid: false,
 };
 
 export const apiKeysReducer = (state = initialApiKeysState, action: Action): ApiKeysState => {

--- a/public/app/features/api-keys/state/selectors.test.ts
+++ b/public/app/features/api-keys/state/selectors.test.ts
@@ -7,7 +7,7 @@ describe('API Keys selectors', () => {
     const mockKeys = getMultipleMockKeys(5);
 
     it('should return all keys if no search query', () => {
-      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '', hasFetched: false, includeInvalid: false };
+      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '', hasFetched: false, includeExpired: false };
 
       const keys = getApiKeys(mockState);
 
@@ -15,7 +15,7 @@ describe('API Keys selectors', () => {
     });
 
     it('should filter keys if search query exists', () => {
-      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '5', hasFetched: false, includeInvalid: false };
+      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '5', hasFetched: false, includeExpired: false };
 
       const keys = getApiKeys(mockState);
 

--- a/public/app/features/api-keys/state/selectors.test.ts
+++ b/public/app/features/api-keys/state/selectors.test.ts
@@ -7,7 +7,7 @@ describe('API Keys selectors', () => {
     const mockKeys = getMultipleMockKeys(5);
 
     it('should return all keys if no search query', () => {
-      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '', hasFetched: false };
+      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '', hasFetched: false, includeInvalid: false };
 
       const keys = getApiKeys(mockState);
 
@@ -15,7 +15,7 @@ describe('API Keys selectors', () => {
     });
 
     it('should filter keys if search query exists', () => {
-      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '5', hasFetched: false };
+      const mockState: ApiKeysState = { keys: mockKeys, searchQuery: '5', hasFetched: false, includeInvalid: false };
 
       const keys = getApiKeys(mockState);
 

--- a/public/app/types/apiKeys.ts
+++ b/public/app/types/apiKeys.ts
@@ -18,5 +18,5 @@ export interface ApiKeysState {
   keys: ApiKey[];
   searchQuery: string;
   hasFetched: boolean;
-  includeInvalid: boolean;
+  includeExpired: boolean;
 }

--- a/public/app/types/apiKeys.ts
+++ b/public/app/types/apiKeys.ts
@@ -18,4 +18,5 @@ export interface ApiKeysState {
   keys: ApiKey[];
   searchQuery: string;
   hasFetched: boolean;
+  includeInvalid: boolean;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The API key name is part of a unique index therefore it was not possible to create an API key having the same name as an expired API key.
This fix optionally lists expired keys to permit the org admin to remove them manually.
More specifically:
* It changes the API call to take under consideration the `IncludeExpired` query parameter.
* It modifies the UI to optionally list the expired keys.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19327

**Special notes for your reviewer**:

