### PR TITLE
Explore: UI improvements for log details

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -70,18 +70,23 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     return (
       <div className={style.logsRowDetailsValue}>
         {/* Action buttons - show stats/filter results */}
-        <div onClick={this.showStats} aria-label={'Field stats'} className={style.logsRowDetailsIcon}>
+        <div
+          title="Ad-hoc statistics"
+          onClick={this.showStats}
+          aria-label={'Field stats'}
+          className={style.logsRowDetailsIcon}
+        >
           <i className={'fa fa-signal'} />
         </div>
         {isLabel ? (
-          <div onClick={() => this.filterLabel()} className={style.logsRowDetailsIcon}>
+          <div title="Filter for value" onClick={() => this.filterLabel()} className={style.logsRowDetailsIcon}>
             <i className={'fa fa-search-plus'} />
           </div>
         ) : (
           <div className={style.logsRowDetailsIcon} />
         )}
         {isLabel ? (
-          <div onClick={() => this.filterOutLabel()} className={style.logsRowDetailsIcon}>
+          <div title="Filter out value" onClick={() => this.filterOutLabel()} className={style.logsRowDetailsIcon}>
             <i className={'fa fa-search-minus'} />
           </div>
         ) : (

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -1,9 +1,11 @@
 import React, { PureComponent } from 'react';
-import { LogLabelStatsModel } from '@grafana/data';
+import { css, cx } from 'emotion';
+import { LogLabelStatsModel, GrafanaTheme } from '@grafana/data';
 
 import { Themeable } from '../../types/theme';
 import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
+import { stylesFactory } from '../../themes/stylesFactory';
 
 //Components
 import { LogLabelStats } from './LogLabelStats';
@@ -23,6 +25,17 @@ interface State {
   fieldCount: number;
   fieldStats: LogLabelStatsModel[] | null;
 }
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  return {
+    noHoverEffect: css`
+      label: noHoverEffect;
+      :hover {
+        background-color: transparent;
+      }
+    `,
+  };
+});
 
 class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   state: State = {
@@ -66,9 +79,10 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   render() {
     const { theme, parsedKey, parsedValue, isLabel, links } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
+    const styles = getStyles(theme);
     const style = getLogRowStyles(theme);
     return (
-      <div className={style.logsRowDetailsValue}>
+      <div className={cx(style.logsRowDetailsValue, { [styles.noHoverEffect]: showFieldsStats })}>
         {/* Action buttons - show stats/filter results */}
         <div
           title="Ad-hoc statistics"

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Field, LinkModel, LogRowModel, TimeZone, DataQueryResponse } from '@grafana/data';
+import { Field, LinkModel, LogRowModel, TimeZone, DataQueryResponse, GrafanaTheme } from '@grafana/data';
 import { cx, css } from 'emotion';
 
 import {
@@ -9,8 +9,10 @@ import {
   LogRowContextProvider,
 } from './LogRowContextProvider';
 import { Themeable } from '../../types/theme';
+import { selectThemeVariant } from '../../index';
 import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
+import { stylesFactory } from '../../themes/stylesFactory';
 
 //Components
 import { LogDetails } from './LogDetails';
@@ -36,6 +38,14 @@ interface State {
   showDetails: boolean;
 }
 
+const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  return {
+    topVerticalAlign: css`
+      label: topVerticalAlign;
+      vertical-align: top;
+    `,
+  };
+});
 /**
  * Renders a log line.
  *
@@ -58,6 +68,9 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   };
 
   toggleDetails = () => {
+    if (this.props.isLogsPanel) {
+      return;
+    }
     this.setState(state => {
       return {
         showDetails: !state.showDetails,
@@ -86,21 +99,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     } = this.props;
     const { showDetails, showContext } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
+    const styles = getStyles(theme);
     const showUtc = timeZone === 'utc';
     const showDetailsClassName = showDetails
-      ? cx([
-          'fa fa-chevron-up',
-          css`
-            vertical-align: top;
-          `,
-        ])
-      : cx([
-          'fa fa-chevron-down',
-          css`
-            vertical-align: top;
-          `,
-        ]);
-
+      ? cx(['fa fa-chevron-up', styles.topVerticalAlign])
+      : cx(['fa fa-chevron-down', styles.topVerticalAlign]);
     return (
       <div className={style.logsRow}>
         {showDuplicates && (
@@ -119,7 +122,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           </div>
         )}
         <div>
-          <div>
+          <div onClick={this.toggleDetails}>
             {showTime && showUtc && (
               <div className={style.logsRowLocalTime} title={`Local: ${row.timeLocal} (${row.timeFromNow})`}>
                 {row.timeUtc}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -101,8 +101,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const styles = getStyles(theme);
     const showUtc = timeZone === 'utc';
     const showDetailsClassName = showDetails
-      ? cx(['fa fa-chevron-up', styles.topVerticalAlign])
-      : cx(['fa fa-chevron-down', styles.topVerticalAlign]);
+      ? cx(['fa fa-chevron-down', styles.topVerticalAlign])
+      : cx(['fa fa-chevron-right', styles.topVerticalAlign]);
     return (
       <div className={style.logsRow}>
         {showDuplicates && (

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -9,7 +9,6 @@ import {
   LogRowContextProvider,
 } from './LogRowContextProvider';
 import { Themeable } from '../../types/theme';
-import { selectThemeVariant } from '../../index';
 import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
 import { stylesFactory } from '../../themes/stylesFactory';

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -23,7 +23,7 @@ interface Props extends Themeable {
   showDuplicates: boolean;
   showTime: boolean;
   timeZone: TimeZone;
-  isLogsPanel?: boolean;
+  allowDetails?: boolean;
   getRows: () => LogRowModel[];
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
@@ -67,7 +67,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   };
 
   toggleDetails = () => {
-    if (this.props.isLogsPanel) {
+    if (this.props.allowDetails) {
       return;
     }
     this.setState(state => {
@@ -88,7 +88,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       onClickFilterLabel,
       onClickFilterOutLabel,
       highlighterExpressions,
-      isLogsPanel,
+      allowDetails,
       row,
       showDuplicates,
       timeZone,
@@ -111,7 +111,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           </div>
         )}
         <div className={style.logsRowLevel} />
-        {!isLogsPanel && (
+        {!allowDetails && (
           <div
             title={showDetails ? 'Hide log details' : 'See log details'}
             onClick={this.toggleDetails}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -96,7 +96,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
         )}
         <div className={style.logsRowLevel} />
         {!isLogsPanel && (
-          <div title="See log details" onClick={this.toggleDetails} className={style.logsRowToggleDetails}>
+          <div
+            title={showDetails ? 'Hide log details' : 'See log details'}
+            onClick={this.toggleDetails}
+            className={style.logsRowToggleDetails}
+          >
             <i className={showDetails ? 'fa fa-chevron-up' : 'fa fa-chevron-down'} />
           </div>
         )}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Field, LinkModel, LogRowModel, TimeZone, DataQueryResponse } from '@grafana/data';
+import { cx, css } from 'emotion';
 
 import {
   LogRowContextRows,
@@ -86,6 +87,19 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const { showDetails, showContext } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
     const showUtc = timeZone === 'utc';
+    const showDetailsClassName = showDetails
+      ? cx([
+          'fa fa-chevron-up',
+          css`
+            vertical-align: top;
+          `,
+        ])
+      : cx([
+          'fa fa-chevron-down',
+          css`
+            vertical-align: top;
+          `,
+        ]);
 
     return (
       <div className={style.logsRow}>
@@ -97,7 +111,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
         <div className={style.logsRowLevel} />
         {!isLogsPanel && (
           <div title="See log details" onClick={this.toggleDetails} className={style.logsRowToggleDetails}>
-            <i className={showDetails ? 'fa fa-chevron-up' : 'fa fa-chevron-down'} />
+            <i className={showDetailsClassName} />
           </div>
         )}
         <div>

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -57,6 +57,12 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: whiteSpacePreWrap;
       white-space: pre-wrap;
     `,
+    hoverColor: css`
+      label: hoverColor;
+      &:hover {
+        color: ${theme.colors.yellow};
+      }
+    `,
   };
 });
 
@@ -124,18 +130,21 @@ class UnThemedLogRowMessage extends PureComponent<Props, State> {
           {row.searchWords && row.searchWords.length > 0 && (
             <span
               onClick={this.onContextToggle}
-              className={css`
-                visibility: hidden;
-                white-space: nowrap;
-                position: relative;
-                z-index: ${showContext ? 1 : 0};
-                cursor: pointer;
-                .${style.logsRow}:hover & {
-                  visibility: visible;
-                  margin-left: 10px;
-                  text-decoration: underline;
-                }
-              `}
+              className={cx(
+                styles.hoverColor,
+                css`
+                  visibility: hidden;
+                  white-space: nowrap;
+                  position: relative;
+                  z-index: ${showContext ? 1 : 0};
+                  cursor: pointer;
+                  .${style.logsRow}:hover & {
+                    visibility: visible;
+                    margin-left: 10px;
+                    text-decoration: underline;
+                  }
+                `
+              )}
             >
               {showContext ? 'Hide' : 'Show'} context
             </span>

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -57,12 +57,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: whiteSpacePreWrap;
       white-space: pre-wrap;
     `,
-    context: css`
-      label: context;
-      visibility: hidden;
-      white-space: nowrap;
-      position: relative;
-    `,
   };
 });
 
@@ -128,7 +122,7 @@ class UnThemedLogRowMessage extends PureComponent<Props, State> {
             )}
           </span>
           {row.searchWords && row.searchWords.length > 0 && (
-            <span onClick={this.onContextToggle} className={cx('show-context', styles.context)}>
+            <span onClick={this.onContextToggle} className={cx(style.context)}>
               {showContext ? 'Hide' : 'Show'} context
             </span>
           )}

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -57,11 +57,11 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: whiteSpacePreWrap;
       white-space: pre-wrap;
     `,
-    hoverColor: css`
-      label: hoverColor;
-      &:hover {
-        color: ${theme.colors.yellow};
-      }
+    context: css`
+      label: context;
+      visibility: hidden;
+      white-space: nowrap;
+      position: relative;
     `,
   };
 });
@@ -128,24 +128,7 @@ class UnThemedLogRowMessage extends PureComponent<Props, State> {
             )}
           </span>
           {row.searchWords && row.searchWords.length > 0 && (
-            <span
-              onClick={this.onContextToggle}
-              className={cx(
-                styles.hoverColor,
-                css`
-                  visibility: hidden;
-                  white-space: nowrap;
-                  position: relative;
-                  z-index: ${showContext ? 1 : 0};
-                  cursor: pointer;
-                  .${style.logsRow}:hover & {
-                    visibility: visible;
-                    margin-left: 10px;
-                    text-decoration: underline;
-                  }
-                `
-              )}
-            >
+            <span onClick={this.onContextToggle} className={cx('show-context', styles.context)}>
               {showContext ? 'Hide' : 'Show'} context
             </span>
           )}

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -20,7 +20,7 @@ export interface Props extends Themeable {
   showTime: boolean;
   timeZone: TimeZone;
   rowLimit?: number;
-  isLogsPanel?: boolean;
+  allowDetails?: boolean;
   previewLimit?: number;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
@@ -79,7 +79,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       onClickFilterOutLabel,
       rowLimit,
       theme,
-      isLogsPanel,
+      allowDetails,
       previewLimit,
       getFieldLinks,
     } = this.props;
@@ -115,7 +115,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               showDuplicates={showDuplicates}
               showTime={showTime}
               timeZone={timeZone}
-              isLogsPanel={isLogsPanel}
+              allowDetails={allowDetails}
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
               getFieldLinks={getFieldLinks}
@@ -132,7 +132,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               showDuplicates={showDuplicates}
               showTime={showTime}
               timeZone={timeZone}
-              isLogsPanel={isLogsPanel}
+              allowDetails={allowDetails}
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
               getFieldLinks={getFieldLinks}

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -60,6 +60,18 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       display: table-row;
       cursor: pointer;
 
+      &:hover {
+        .show-context {
+          visibility: visible;
+          z-index: 1;
+          margin-left: 10px;
+          text-decoration: underline;
+          &:hover {
+            color: ${theme.colors.yellow};
+          }
+        }
+      }
+
       > div {
         display: table-cell;
         padding-right: ${theme.spacing.sm};

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -7,7 +7,8 @@ import { stylesFactory } from '../../themes';
 
 export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: LogLevel) => {
   let logColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.gray2 }, theme.type);
-  const bgColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.gray2 }, theme.type);
+  const borderColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.gray2 }, theme.type);
+  const bgColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.dark4 }, theme.type);
   switch (logLevel) {
     case LogLevel.crit:
     case LogLevel.critical:
@@ -123,7 +124,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     logsRowDetailsTable: css`
       label: logs-row-details-table;
       display: table;
-      border: 1px solid ${bgColor};
+      border: 1px solid ${borderColor};
       border-radius: 3px;
       margin: 20px 0;
       padding: ${theme.spacing.sm};
@@ -133,7 +134,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       label: logs-row-details-table__section;
       display: table;
       table-layout: fixed;
-      margin: 5px 0;
+      margin: 0;
       width: 100%;
     `,
     logsRowDetailsIcon: css`
@@ -145,14 +146,13 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       color: ${theme.colors.gray3};
       &:hover {
         cursor: pointer;
-        color: ${theme.colors.yellow};
       }
     `,
     logsRowDetailsLabel: css`
       label: logs-row-details__label;
       display: table-cell;
       padding: 0 ${theme.spacing.md} 0 ${theme.spacing.md};
-      width: 12.5em;
+      width: 14em;
       word-break: break-all;
     `,
     logsRowDetailsHeading: css`
@@ -170,7 +170,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       cursor: default;
 
       &:hover {
-        color: ${theme.colors.yellow};
+        background-color: ${bgColor};
       }
     `,
   };

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -59,6 +59,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     logsRow: css`
       label: logs-row;
       display: table-row;
+      cursor: pointer;
 
       > div {
         display: table-cell;
@@ -76,11 +77,13 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       label: logs-row__duplicates;
       text-align: right;
       width: 4em;
+      cursor: default;
     `,
     logsRowLevel: css`
       label: logs-row__level;
       position: relative;
       width: 10px;
+      cursor: default;
 
       &::after {
         content: '';
@@ -103,7 +106,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       width: 15px;
       padding-right: ${theme.spacing.sm};
       font-size: 9px;
-      cursor: pointer;
     `,
     logsRowLocalTime: css`
       label: logs-row__localtime;
@@ -129,6 +131,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       margin: 20px 0;
       padding: ${theme.spacing.sm};
       width: 100%;
+      cursor: default;
     `,
     logsRowDetailsSectionTable: css`
       label: logs-row-details-table__section;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -40,7 +40,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       padding: inherit;
 
       color: ${theme.colors.yellow};
-      border-bottom: ${theme.border.width.sm} solid ${theme.colors.yellow};
       background-color: rgba(${theme.colors.yellow}, 0.1);
     `,
     logsRowMatchHighLightPreview: css`

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -151,6 +151,9 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       table-layout: fixed;
       margin: 0;
       width: 100%;
+      &:first-of-type {
+        margin-bottom: ${theme.spacing.xs};
+      }
     `,
     logsRowDetailsIcon: css`
       label: logs-row-details__icon;
@@ -173,7 +176,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     logsRowDetailsHeading: css`
       label: logs-row-details__heading;
       display: table-caption;
-      margin: 12px 0 7px;
+      margin: ${theme.spacing.sm} 0 ${theme.spacing.xs};
       font-weight: ${theme.typography.weight.bold};
     `,
     logsRowDetailsValue: css`

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -62,9 +62,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       table-layout: fixed;
       width: 100%;
     `,
-    context: css`
-      ${context}
-    `,
+    context: context,
     logsRow: css`
       label: logs-row;
       display: table-row;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -141,6 +141,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       border-radius: 3px;
       margin: 20px 0;
       padding: ${theme.spacing.sm};
+      padding-top: 0;
       width: 100%;
       cursor: default;
     `,
@@ -172,7 +173,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     logsRowDetailsHeading: css`
       label: logs-row-details__heading;
       display: table-caption;
-      margin: 5px 0 7px;
+      margin: 12px 0 7px;
       font-weight: ${theme.typography.weight.bold};
     `,
     logsRowDetailsValue: css`

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -9,6 +9,13 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
   let logColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.gray2 }, theme.type);
   const borderColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.gray2 }, theme.type);
   const bgColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.dark4 }, theme.type);
+  const context = css`
+    label: context;
+    visibility: hidden;
+    white-space: nowrap;
+    position: relative;
+  `;
+
   switch (logLevel) {
     case LogLevel.crit:
     case LogLevel.critical:
@@ -55,13 +62,15 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       table-layout: fixed;
       width: 100%;
     `,
+    context: css`
+      ${context}
+    `,
     logsRow: css`
       label: logs-row;
       display: table-row;
       cursor: pointer;
-
       &:hover {
-        .show-context {
+        .${context} {
           visibility: visible;
           z-index: 1;
           margin-left: 10px;

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -32,7 +32,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
         highlighterExpressions={[]}
         showTime={showTime}
         timeZone={timeZone}
-        isLogsPanel={true}
+        allowDetails={true}
       />
     </CustomScrollbar>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR follows up on https://github.com/grafana/grafana/pull/20034 and includes following UI/UX fixes:

- [x] Centers carret alignment
- [x] Removes unnecessary 5px margin-top on `logs-row-details-table__section`
- [x] Hover color has been changed to background color - according to design 
- [x] Add functionality to toggle log details to full log row, not just chevron (@torkelo's feedback)
- [x] Add hover state for Show/Hide context and remove underline for not clickable elements
- [x] Changes chevrons
- [x] Titles have been added for following buttons (for better understandability for user) : 
- Filter for value 
- Filter out value 
- Ad-hoc statistics
- Show log details & hide log details

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/30407135/69186874-b9f2b380-0b19-11ea-9d79-a2a07a0d9b82.gif)

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/30407135/69186887-bf4ffe00-0b19-11ea-9f53-9cfc87b30415.gif)

