### PR TITLE
Image-rendering: Cleanup of rendering code

### DIFF
--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -26,8 +26,7 @@ type Opts struct {
 }
 
 type RenderResult struct {
-	FilePath            string
-	KeepFileAfterRender bool
+	FilePath string
 }
 
 type renderFunc func(ctx context.Context, options Opts) (*RenderResult, error)

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -96,16 +96,14 @@ func (rs *RenderingService) RenderErrorImage(err error) (*RenderResult, error) {
 	imgUrl := "public/img/rendering_error.png"
 
 	return &RenderResult{
-		FilePath:            filepath.Join(setting.HomePath, imgUrl),
-		KeepFileAfterRender: true,
+		FilePath: filepath.Join(setting.HomePath, imgUrl),
 	}, nil
 }
 
 func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResult, error) {
 	if rs.inProgressCount > opts.ConcurrentLimit {
 		return &RenderResult{
-			FilePath:            filepath.Join(setting.HomePath, "public/img/rendering_limit.png"),
-			KeepFileAfterRender: true,
+			FilePath: filepath.Join(setting.HomePath, "public/img/rendering_limit.png"),
 		}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some cleanup is needed in the RenderResult struct