### PR TITLE
What's new in 6.5 - adding CloudWatch topics

### DIFF
--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -62,13 +62,13 @@ By default, the search expression is defined in such a way that the queried metr
 
 You can untoggle `Match Exact` to include metrics that have other dimensions defined. Disabling ‘Match Exact’ also creates a search expression even if you don’t use wildcards. We simply search for any metric that match at least the namespace, metric name, and all defined dimensions.
 
-!!image
+{{< docs-imagebox img="/img/docs/v65/dimension-wildcard.png" caption="CloudWatch dimension wildcard" >}}
 
 #### Deep linking from Grafana panels to the CloudWatch console
 
 Left clicking a time series in the panel shows a context menu with a link to `View in CloudWatch console`. Clicking that link will open a new tab that will take you to the CloudWatch console and display all the metrics for that query. If you are not currently logged in to the CloudWatch console, the link will forward you to the login page. The provided link is valid for any account but will only display the right metrics if you are logged in to the account that corresponds to the selected data source in Grafana.
 
-!!image
+{{< docs-imagebox img="/img/docs/v65/deep-linking.png" caption="CloudWatch deep linking" >}}
 
 This feature is not available for metrics that are based on math expressions.
 
@@ -99,7 +99,8 @@ The updated CloudWatch data source is shipped with pre-configured dashboards for
 - Amazon Relational Database Service `Amazon RDS`.
 
 To import the pre-configured dashboards, go to the configuration page of your CloudWatch data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
-!!image
+
+{{< docs-imagebox img="/img/docs/v65/dashboard-import.png" caption="CloudWatch dashboard import" >}}
 
 ### Dynamic typeahead support in query variables
 

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -84,20 +84,6 @@ Search expressions are currently limited to 1024 characters, so your query may f
 
 The use of multi-valued template variables is only supported for dimension values. Using multi-valued template variables for `Region`, `Namespace`, or `Metric Name` is not supported.
 
-#### Curated Dashboards
-
-The updated CloudWatch data source is shipped with pre-configured dashboards for five of the most popular AWS services:
-
-- Amazon Elastic Compute Cloud `Amazon EC2`,
-- Amazon Elastic Block Store `Amazon EBS`,
-- AWS Lambda `AWS Lambda`,
-- Amazon CloudWatch Logs `Amazon CloudWatch Logs`, and
-- Amazon Relational Database Service `Amazon RDS`.
-
-To import the pre-configured dashboards, go to the configuration page of your CloudWatch data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
-
-{{< docs-imagebox img="/img/docs/v65/cloudwatch-dashboard-import.png" caption="CloudWatch dashboard import" >}}
-
 ### Dynamic typeahead support in query variables
 
 If you have a query variable that has many thousands of values it can be quite slow to search for a specific value in the dropdown. This is due to the fact that all that search filtering is happening in the browser.

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -19,13 +19,7 @@ For all details please read the full [CHANGELOG.md](https://github.com/grafana/g
 Grafana 6.5 comes with a lot of new features and enhancements.
 
 - [**Docker:** Ubuntu-based images and more]({{< relref "#ubuntu-based-docker-images" >}})
-- [**CloudWatch:** GetMetricData API]({{< relref "#getmetricdata-api" >}})
-- [**CloudWatch:** Dynamic queries using dimension wildcards]({{< relref "#dynamic queries-using-dimension-wildcards" >}})
-- [**CloudWatch:** Deep linking from Grafana panels to the CloudWatch console]({{< relref "#deep-linking-from-grafana-panels-to-the-cloudwatch-console" >}})
-- [**CloudWatch:** Improved feedback when throttling occurs]({{< relref "#improved-feedback-when-throttling-occurs" >}})
-- [**CloudWatch:** Angular to React migration]({{< relref "#angular-to-react-migration" >}})
-- [**CloudWatch:** Multi-value template variables now use search expressions]({{< relref "#multi-value-template-variables-now-use-search-expressions" >}})
-- [**CloudWatch:** Curated Dashboards]({{< relref "#curated-dashboards" >}})
+- [**CloudWatch:** Major rewrite and lots of enhancements]({{< relref "#cloudWatch-data-source-improvements" >}})
 - [**Templating:** Dynamic typeahead queries using $__searchFilter]({{< relref "#dynamic-typeahead-support-in-query-variables" >}})
 - [**Explore:** New log row details view]({{< relref "#explore-logs-log-row-details" >}})
 - [**Explore:** Turn parts of log message into a link using derived fields]({{< relref "#loki-explore-derived-fields" >}})
@@ -37,6 +31,16 @@ Grafana 6.5 comes with a lot of new features and enhancements.
 - **OAuth:** Generic OAuth now supports role mapping
 
 More details of above and highlights will be added as we're getting closer to the stable release.
+
+### Ubuntu-based docker images
+
+In Grafana [v6.4](/guides/whats-new-in-v6-4/#alpine-based-docker-image) we switched the Grafana docker image from Ubuntu to Alpine. The main reason for this change was to be able to provide a more secure and lightweight docker image.
+
+This change has received both negative and positive feedback as well as some bug reports. Based on this, one of the conclusions and learnings is that switching to an Alpine based docker image was a big breaking change for a lot of users and this change should have been more clearly highlighted in blog post, release notes, changelog and the [Docker Hub readme](https://hub.docker.com/r/grafana/grafana).
+
+One additional mistake we did was to break the Docker images for ARM. Good news, in Grafana v6.5 this have been fixed.
+
+Grafana docker images should be as secure as possible by default and that’s why the Alpine based docker images will continue to be provided as Grafana’s default (`grafana/grafana:<version>`). With that said, it’s good to give users options and that’s why starting from Grafana v6.5 there’re also Ubuntu based docker images (`grafana/grafana:<version>-ubuntu`) available.
 
 ### CloudWatch data source improvements
 
@@ -50,9 +54,9 @@ While GetMetricStatistics qualified for the CloudWatch API free tier, this is no
 
 #### Dynamic queries using dimension wildcards
 
-In Grafana 6.5 or higher, you’re able to monitor a dynamic list of metrics by using the asterisk (\*) wildcard for any one or multiple dimension values.
+In Grafana 6.5 or higher, you’re able to monitor a dynamic list of metrics by using the asterisk (\*) wildcard for one or more dimension values.
 
-In the example below, all metrics in the namespace `AWS/EC2` with a metric name of `CPUUtilization` and ANY value for the `InstanceId` dimension are queried. This can help you monitor metrics for AWS resources, like EC2 instances or containers. For example, when new instances get created as part of an auto scaling event, they will automatically appear in the graph without you having to track the new instance IDs. This capability is currently limited to retrieving up to 100 metrics. You can click on `Show Query Preview` to see the search expression that is automatically built to support wildcards. To learn more about search expressions, visit the [CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html).
+In the example below, all metrics in the namespace `AWS/EC2` with a metric name of `CPUUtilization` and ANY value for the `InstanceId` dimension are queried. This can help you monitor metrics for AWS resources, like EC2 instances or containers. For example, when new instances get created as part of an auto scaling event, they will automatically appear in the graph without you having to track the new instance IDs. You can click on `Show Query Preview` to see the search expression that is automatically built to support wildcards. To learn more about search expressions, visit the [CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html).
 
 By default, the search expression is defined in such a way that the queried metrics must match the defined dimension names exactly. This means that in the example below only metrics with exactly one dimension with name ‘InstanceId’ will be returned.
 
@@ -96,16 +100,6 @@ The updated CloudWatch data source is shipped with pre-configured dashboards for
 
 To import the pre-configured dashboards, go to the configuration page of your CloudWatch data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 !!image
-
-### Ubuntu-based docker images
-
-In Grafana [v6.4](/guides/whats-new-in-v6-4/#alpine-based-docker-image) we switched the Grafana docker image from Ubuntu to Alpine. The main reason for this change was to be able to provide a more secure and lightweight docker image.
-
-This change has received both negative and positive feedback as well as some bug reports. Based on this, one of the conclusions and learnings is that switching to an Alpine based docker image was a big breaking change for a lot of users and this change should have been more clearly highlighted in blog post, release notes, changelog and the [Docker Hub readme](https://hub.docker.com/r/grafana/grafana).
-
-One additional mistake we did was to break the Docker images for ARM. Good news, in Grafana v6.5 this have been fixed.
-
-Grafana docker images should be as secure as possible by default and that’s why the Alpine based docker images will continue to be provided as Grafana’s default (`grafana/grafana:<version>`). With that said, it’s good to give users options and that’s why starting from Grafana v6.5 there’re also Ubuntu based docker images (`grafana/grafana:<version>-ubuntu`) available.
 
 ### Dynamic typeahead support in query variables
 

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -76,10 +76,6 @@ This feature is not available for metrics that are based on math expressions.
 
 If the [limit of the GetMetricData API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html) is reached (either the transactions per second limit or the data points per second limit), a throttling error will be returned by the CloudWatch API. Throttling limits are defined per account and region, so the alert modal will indicate which data source got throttled in which region. A link to request a limit increase will be provided for the affected region, but you will have to log in to the correct account. For example, for us-east-1, a limit increase can be requested [here](https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/monitoring/quotas/L-5E141212).
 
-#### Angular to React migration
-
-In this release, the datasource config editor and the query editor has been completely rewritten in react. The functionality is basically the same as before, but it has a new look and feel to it.
-
 #### Multi-value template variables now use search expressions
 
 When defining dimension values based on multi-valued template variables, we now use search expressions to query for the matching metrics. This enables the use of multiple template variables in one query and also allows you to use template variables for queries that have the `Match Exact` option disabled.

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -19,10 +19,13 @@ For all details please read the full [CHANGELOG.md](https://github.com/grafana/g
 Grafana 6.5 comes with a lot of new features and enhancements.
 
 - [**Docker:** Ubuntu-based images and more]({{< relref "#ubuntu-based-docker-images" >}})
-- **CloudWatch:** Use GetMetricData API instead of GetMetricStatistics API
-- **CloudWatch:** Dynamic queries using wildcards for dimension values
-- **CloudWatch:** Deep linking from Grafana panels to the CloudWatch console
-- **CloudWatch:** Improved feedback when throttling occurs
+- [**CloudWatch:** GetMetricData API]({{< relref "#getmetricdata-api" >}})
+- [**CloudWatch:** Dynamic queries using dimension wildcards]({{< relref "#dynamic queries-using-dimension-wildcards" >}})
+- [**CloudWatch:** Deep linking from Grafana panels to the CloudWatch console]({{< relref "#deep-linking-from-grafana-panels-to-the-cloudwatch-console" >}})
+- [**CloudWatch:** Improved feedback when throttling occurs]({{< relref "#improved-feedback-when-throttling-occurs" >}})
+- [**CloudWatch:** Angular to React migration]({{< relref "#angular-to-react-migration" >}})
+- [**CloudWatch:** Multi-value template variables now use search expressions]({{< relref "#multi-value-template-variables-now-use-search-expressions" >}})
+- [**CloudWatch:** Curated Dashboards]({{< relref "#curated-dashboards" >}})
 - [**Templating:** Dynamic typeahead queries using $__searchFilter]({{< relref "#dynamic-typeahead-support-in-query-variables" >}})
 - [**Explore:** New log row details view]({{< relref "#explore-logs-log-row-details" >}})
 - [**Explore:** Turn parts of log message into a link using derived fields]({{< relref "#loki-explore-derived-fields" >}})
@@ -35,6 +38,65 @@ Grafana 6.5 comes with a lot of new features and enhancements.
 
 More details of above and highlights will be added as we're getting closer to the stable release.
 
+### CloudWatch data source improvements
+
+In this release, several feature improvements and additions were made in the CloudWatch data source. This work has been done in collaboration with the Amazon CloudWatch team.
+
+#### GetMetricData API
+
+For Grafana version 6.5 or higher, all API requests to GetMetricStatistics have been replaced with calls to GetMetricData, following Amazon’s [best practice to use the GetMetricData API](https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-getmetricdata-api) instead of GetMetricStatistics, because data can be retrieved faster at scale with GetMetricData. This change provides better support for CloudWatch metric math and enables the use of automatic search expressions.
+
+While GetMetricStatistics qualified for the CloudWatch API free tier, this is not the case for GetMetricData calls. For more information, please refer to the [CloudWatch pricing page](https://aws.amazon.com/cloudwatch/pricing/).
+
+#### Dynamic queries using dimension wildcards
+
+In Grafana 6.5 or higher, you’re able to monitor a dynamic list of metrics by using the asterisk (\*) wildcard for any one or multiple dimension values.
+
+In the example below, all metrics in the namespace `AWS/EC2` with a metric name of `CPUUtilization` and ANY value for the `InstanceId` dimension are queried. This can help you monitor metrics for AWS resources, like EC2 instances or containers. For example, when new instances get created as part of an auto scaling event, they will automatically appear in the graph without you having to track the new instance IDs. This capability is currently limited to retrieving up to 100 metrics. You can click on `Show Query Preview` to see the search expression that is automatically built to support wildcards. To learn more about search expressions, visit the [CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html).
+
+By default, the search expression is defined in such a way that the queried metrics must match the defined dimension names exactly. This means that in the example below only metrics with exactly one dimension with name ‘InstanceId’ will be returned.
+
+You can untoggle `Match Exact` to include metrics that have other dimensions defined. Disabling ‘Match Exact’ also creates a search expression even if you don’t use wildcards. We simply search for any metric that match at least the namespace, metric name, and all defined dimensions.
+
+!!image
+
+#### Deep linking from Grafana panels to the CloudWatch console
+
+Left clicking a time series in the panel shows a context menu with a link to `View in CloudWatch console`. Clicking that link will open a new tab that will take you to the CloudWatch console and display all the metrics for that query. If you are not currently logged in to the CloudWatch console, the link will forward you to the login page. The provided link is valid for any account but will only display the right metrics if you are logged in to the account that corresponds to the selected data source in Grafana.
+
+!!image
+
+This feature is not available for metrics that are based on math expressions.
+
+#### Improved feedback when throttling occurs
+
+If the [limit of the GetMetricData API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html) is reached (either the transactions per second limit or the data points per second limit), a throttling error will be returned by the CloudWatch API. Throttling limits are defined per account and region, so the alert modal will indicate which data source got throttled in which region. A link to request a limit increase will be provided for the affected region, but you will have to log in to the correct account. For example, for us-east-1, a limit increase can be requested [here](https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/monitoring/quotas/L-5E141212).
+
+#### Angular to React migration
+
+In this release, the datasource config editor and the query editor has been completely rewritten in react. The functionality is basically the same as before, but it has a new look and feel to it.
+
+#### Multi-value template variables now use search expressions
+
+When defining dimension values based on multi-valued template variables, we now use search expressions to query for the matching metrics. This enables the use of multiple template variables in one query and also allows you to use template variables for queries that have the `Match Exact` option disabled.
+
+Search expressions are currently limited to 1024 characters, so your query may fail if you have a long list of values. We recommend using the asterisk (\*) wildcard instead of the `All` option if you want to query all metrics that have any value for a certain dimension name.
+
+The use of multi-valued template variables is only supported for dimension values. Using multi-valued template variables for `Region`, `Namespace`, or `Metric Name` is not supported.
+
+#### Curated Dashboards
+
+The updated CloudWatch data source is shipped with pre-configured dashboards for five of the most popular AWS services:
+
+- Amazon Elastic Compute Cloud `Amazon EC2`,
+- Amazon Elastic Block Store `Amazon EBS`,
+- AWS Lambda `AWS Lambda`,
+- Amazon CloudWatch Logs `Amazon CloudWatch Logs`, and
+- Amazon Relational Database Service `Amazon RDS`.
+
+To import the pre-configured dashboards, go to the configuration page of your CloudWatch data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+!!image
+
 ### Ubuntu-based docker images
 
 In Grafana [v6.4](/guides/whats-new-in-v6-4/#alpine-based-docker-image) we switched the Grafana docker image from Ubuntu to Alpine. The main reason for this change was to be able to provide a more secure and lightweight docker image.
@@ -43,7 +105,7 @@ This change has received both negative and positive feedback as well as some bug
 
 One additional mistake we did was to break the Docker images for ARM. Good news, in Grafana v6.5 this have been fixed.
 
-Grafana docker images should be as secure as possible by default and that’s why the Alpine based docker images will continue to be provided as Grafana’s default (`grafana/grafana:<version>`).  With that said, it’s good to give users options and that’s why starting from Grafana v6.5 there’re also Ubuntu based docker images (`grafana/grafana:<version>-ubuntu`) available.
+Grafana docker images should be as secure as possible by default and that’s why the Alpine based docker images will continue to be provided as Grafana’s default (`grafana/grafana:<version>`). With that said, it’s good to give users options and that’s why starting from Grafana v6.5 there’re also Ubuntu based docker images (`grafana/grafana:<version>-ubuntu`) available.
 
 ### Dynamic typeahead support in query variables
 
@@ -51,16 +113,18 @@ If you have a query variable that has many thousands of values it can be quite s
 
 Using `__searchFilter` in the template variable query field you can filter the query results based on what the user types in the variable dropdown input.
 
-When nothing has been entered by the user the default value for `__searchFilter` is `*` ,  `.*` or  `%`  depending on data source and formatting option.
+When nothing has been entered by the user the default value for `__searchFilter` is `*` , `.*` or `%` depending on data source and formatting option.
 
 The example below shows how to use `__searchFilter` as part of the query field to enable searching for `server` while the user types in the dropdown select box.
 
 Query
+
 ```bash
 apps.$app.servers.$__searchFilter
 ```
 
 TagValues
+
 ```bash
 tag_values(server, server=~${__searchFilter:regex})
 ```

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -62,13 +62,13 @@ By default, the search expression is defined in such a way that the queried metr
 
 You can untoggle `Match Exact` to include metrics that have other dimensions defined. Disabling ‘Match Exact’ also creates a search expression even if you don’t use wildcards. We simply search for any metric that match at least the namespace, metric name, and all defined dimensions.
 
-{{< docs-imagebox img="/img/docs/v65/dimension-wildcard.png" caption="CloudWatch dimension wildcard" >}}
+{{< docs-imagebox img="/img/docs/v65/cloudwatch-dimension-wildcard.png" caption="CloudWatch dimension wildcard" >}}
 
 #### Deep linking from Grafana panels to the CloudWatch console
 
 Left clicking a time series in the panel shows a context menu with a link to `View in CloudWatch console`. Clicking that link will open a new tab that will take you to the CloudWatch console and display all the metrics for that query. If you are not currently logged in to the CloudWatch console, the link will forward you to the login page. The provided link is valid for any account but will only display the right metrics if you are logged in to the account that corresponds to the selected data source in Grafana.
 
-{{< docs-imagebox img="/img/docs/v65/deep-linking.png" caption="CloudWatch deep linking" >}}
+{{< docs-imagebox img="/img/docs/v65/cloudwatch-deep-linking.png" caption="CloudWatch deep linking" >}}
 
 This feature is not available for metrics that are based on math expressions.
 
@@ -100,7 +100,7 @@ The updated CloudWatch data source is shipped with pre-configured dashboards for
 
 To import the pre-configured dashboards, go to the configuration page of your CloudWatch data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 
-{{< docs-imagebox img="/img/docs/v65/dashboard-import.png" caption="CloudWatch dashboard import" >}}
+{{< docs-imagebox img="/img/docs/v65/cloudwatch-dashboard-import.png" caption="CloudWatch dashboard import" >}}
 
 ### Dynamic typeahead support in query variables
 


### PR DESCRIPTION
PR to add images to website: 
https://github.com/grafana/website/pull/607


Question: Should Cloudwatch topics go in the bottom of the document so that not all other topics drown in all the CloudWatch features? 