### PR TITLE
Clean up scripts/grunt/options/phantomjs.js

### DIFF
--- a/scripts/grunt/options/phantomjs.js
+++ b/scripts/grunt/options/phantomjs.js
@@ -2,7 +2,6 @@ module.exports = function(config,grunt) {
   'use strict';
 
   grunt.registerTask('phantomjs', 'Copy phantomjs binary to vendor/', function() {
-
     var dest = './tools/phantomjs/phantomjs';
     var confDir = './node_modules/phantomjs-prebuilt/lib/';
 
@@ -10,12 +9,10 @@ module.exports = function(config,grunt) {
       dest += ".exe";
     }
 
-    src = config.phjs
-
-    if (!src){
-      var m=grunt.file.read(confDir+"location.js")
-      var src=/= \"([^\"]*)\"/.exec(m)[1];
-
+    var src = config.phjs;
+    if (!src) {
+      var m = grunt.file.read(confDir+"location.js");
+      src = /= \"([^\"]*)\"/.exec(m)[1];
       if (!grunt.file.isPathAbsolute(src)) {
         src = confDir+src;
       }
@@ -32,6 +29,5 @@ module.exports = function(config,grunt) {
       grunt.verbose.writeln(err);
       grunt.fail.warn('No working Phantomjs binary available')
     }
-
   });
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Clean up the code in scripts/grunt/options/phantomjs.js, to make it more readable.
