### PR TITLE
Explore: UI changes for split view and live tailing

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -1,8 +1,8 @@
 // Libraries
 import React, { PureComponent, createRef } from 'react';
 import { css } from 'emotion';
-import memoizeOne from 'memoize-one';
 import classNames from 'classnames';
+import tinycolor from 'tinycolor2';
 
 // Components
 import { ButtonSelect } from '../Select/ButtonSelect';
@@ -11,17 +11,19 @@ import { TimePickerPopover } from './TimePickerPopover';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
 
 // Utils & Services
-import { isDateTime, DateTime } from '@grafana/data';
-import { rangeUtil } from '@grafana/data';
+import { isDateTime, DateTime, rangeUtil } from '@grafana/data';
 import { rawToTimeRange } from './time';
+import { stylesFactory } from '../../themes/stylesFactory';
 import { withTheme } from '../../themes/ThemeContext';
 
 // Types
-import { TimeRange, TimeOption, TimeZone, TIME_FORMAT, SelectableValue, dateMath } from '@grafana/data';
-import { GrafanaTheme } from '@grafana/data';
+import { TimeRange, TimeOption, TimeZone, TIME_FORMAT, SelectableValue, dateMath, GrafanaTheme } from '@grafana/data';
 import { Themeable } from '../../types';
 
-const getStyles = memoizeOne((theme: GrafanaTheme) => {
+const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  const yellowLight = tinycolor(theme.colors.yellow)
+    .lighten(20)
+    .toString();
   return {
     timePickerSynced: css`
       label: timePickerSynced;
@@ -29,6 +31,7 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
       background-image: none;
       background-color: transparent;
       color: ${theme.colors.orangeDark};
+      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus,
       :hover {
         color: ${theme.colors.orangeDark};

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -2,7 +2,6 @@
 import React, { PureComponent, createRef } from 'react';
 import { css } from 'emotion';
 import classNames from 'classnames';
-import tinycolor from 'tinycolor2';
 
 // Components
 import { ButtonSelect } from '../Select/ButtonSelect';
@@ -21,9 +20,6 @@ import { TimeRange, TimeOption, TimeZone, TIME_FORMAT, SelectableValue, dateMath
 import { Themeable } from '../../types';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
-  const yellowLight = tinycolor(theme.colors.yellow)
-    .lighten(20)
-    .toString();
   return {
     timePickerSynced: css`
       label: timePickerSynced;
@@ -31,7 +27,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background-image: none;
       background-color: transparent;
       color: ${theme.colors.orangeDark};
-      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus,
       :hover {
         color: ${theme.colors.orangeDark};
@@ -201,6 +196,7 @@ class UnThemedTimePicker extends PureComponent<Props, State> {
           )}
           <ButtonSelect
             className={classNames('time-picker-button-select', {
+              ['explore-active-button-glow']: timeSyncButton && isSynced,
               [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: timeSyncButton,
               [styles.timePickerSynced]: timeSyncButton ? isSynced : null,
             })}

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -209,7 +209,7 @@ class UnThemedTimePicker extends PureComponent<Props, State> {
             options={options}
             maxMenuHeight={600}
             onChange={this.onSelectChanged}
-            iconClass={classNames('fa fa-clock-o fa-fw', isSynced && 'icon-brand-gradient')}
+            iconClass={classNames('fa fa-clock-o fa-fw', isSynced && timeSyncButton && 'icon-brand-gradient')}
             tooltipContent={<TimePickerTooltipContent timeRange={value} />}
           />
 

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -209,7 +209,7 @@ class UnThemedTimePicker extends PureComponent<Props, State> {
             options={options}
             maxMenuHeight={600}
             onChange={this.onSelectChanged}
-            iconClass={'fa fa-clock-o fa-fw'}
+            iconClass={classNames('fa fa-clock-o fa-fw', isSynced && 'icon-brand-gradient')}
             tooltipContent={<TimePickerTooltipContent timeRange={value} />}
           />
 

--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -187,7 +187,7 @@ $btn-drag-image: '../img/grab_dark.svg';
 
 $navbar-btn-gicon-brightness: brightness(0.5);
 
-$btn-active-box-shadow: 0px 0px 4px rgba(255,120,10,1);
+$btn-active-box-shadow: 0px 0px 4px rgba(255,120,10,0.5);
 
 // Forms
 // -------------------------

--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -187,6 +187,8 @@ $btn-drag-image: '../img/grab_dark.svg';
 
 $navbar-btn-gicon-brightness: brightness(0.5);
 
+$btn-active-box-shadow: 0px 0px 4px rgba(255,120,10,1);
+
 // Forms
 // -------------------------
 $input-bg: $input-black;

--- a/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
@@ -180,6 +180,8 @@ $btn-drag-image: '../img/grab_light.svg';
 
 $navbar-btn-gicon-brightness: brightness(1.5);
 
+$btn-active-box-shadow: 0px 0px 4px rgba(234, 161, 51, 0.6);
+
 // Forms
 // -------------------------
 $input-bg: $white;

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -285,7 +285,6 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                   title="Clear All"
                   onClick={this.onClearAll}
                   iconClassName="fa fa-fw fa-trash icon-margin-right"
-                  disabled={isLive}
                 />
               </div>
             )}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -278,15 +278,17 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
               </div>
             )}
 
-            <div className="explore-toolbar-content-item explore-icon-align">
-              <ResponsiveButton
-                splitted={splitted}
-                title="Clear All"
-                onClick={this.onClearAll}
-                iconClassName="fa fa-fw fa-trash icon-margin-right"
-                disabled={isLive}
-              />
-            </div>
+            {!isLive && (
+              <div className="explore-toolbar-content-item explore-icon-align">
+                <ResponsiveButton
+                  splitted={splitted}
+                  title="Clear All"
+                  onClick={this.onClearAll}
+                  iconClassName="fa fa-fw fa-trash icon-margin-right"
+                  disabled={isLive}
+                />
+              </div>
+            )}
             <div className="explore-toolbar-content-item">
               <RunButton
                 refreshInterval={refreshInterval}

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -128,7 +128,11 @@ export function LiveTailButton(props: LiveTailButtonProps) {
             [styles.isLive]: isLive && !isPaused,
             [styles.isPaused]: isLive && isPaused,
           })}
-          iconClassName={classNames('fa', isPaused || !isLive ? 'fa-play' : 'fa-pause')}
+          iconClassName={classNames(
+            'fa',
+            isPaused || !isLive ? 'fa-play' : 'fa-pause',
+            isLive && 'icon-brand-gradient'
+          )}
           onClick={onClickMain}
           title={'\xa0Live'}
         />
@@ -147,7 +151,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
       >
         <div>
           <button className={`btn navbar-button navbar-button--attached ${styles.isLive}`} onClick={stop}>
-            <i className={'fa fa-stop'} />
+            <i className={classNames('fa fa-stop icon-brand-gradient')} />
           </button>
         </div>
       </CSSTransition>

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -3,13 +3,14 @@ import classNames from 'classnames';
 import tinycolor from 'tinycolor2';
 import { css } from 'emotion';
 import { CSSTransition } from 'react-transition-group';
-import { useTheme, Tooltip, stylesFactory } from '@grafana/ui';
+import { useTheme, Tooltip, stylesFactory, selectThemeVariant } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
 
 //Components
 import { ResponsiveButton } from './ResponsiveButton';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  const bgColor = selectThemeVariant({ light: theme.colors.gray5, dark: theme.colors.dark1 }, theme.type);
   const orangeLighter = tinycolor(theme.colors.orangeDark)
     .lighten(10)
     .toString();
@@ -32,8 +33,12 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       color: ${theme.colors.orangeDark};
       background: transparent;
       &:focus {
+        background: transparent;
         border-color: ${theme.colors.orangeDark};
         color: ${theme.colors.orangeDark};
+      }
+      &:hover {
+        background-color: ${bgColor};
       }
       &:active,
       &:hover {
@@ -47,7 +52,11 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background: transparent;
       animation: pulse 3s ease-out 0s infinite normal forwards;
       &:focus {
+        background: transparent;
         border-color: ${theme.colors.orangeDark};
+      }
+      &:hover {
+        background-color: ${bgColor};
       }
       &:active,
       &:hover {

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -13,6 +13,9 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
   const orangeLighter = tinycolor(theme.colors.orangeDark)
     .lighten(10)
     .toString();
+  const yellowLight = tinycolor(theme.colors.yellow)
+    .lighten(20)
+    .toString();
   const pulseTextColor = tinycolor(theme.colors.orangeDark)
     .desaturate(90)
     .toString();
@@ -32,6 +35,7 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
       border-color: ${theme.colors.orangeDark};
       color: ${theme.colors.orangeDark};
       background: transparent;
+      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus {
         border-color: ${theme.colors.orangeDark};
         color: ${theme.colors.orangeDark};
@@ -47,6 +51,7 @@ const getStyles = memoizeOne((theme: GrafanaTheme) => {
       border-color: ${theme.colors.orangeDark};
       background: transparent;
       animation: pulse 3s ease-out 0s infinite normal forwards;
+      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus {
         border-color: ${theme.colors.orangeDark};
       }

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
-import { css } from 'emotion';
-import memoizeOne from 'memoize-one';
 import tinycolor from 'tinycolor2';
+import { css } from 'emotion';
 import { CSSTransition } from 'react-transition-group';
-import { ResponsiveButton } from './ResponsiveButton';
-
-import { useTheme, Tooltip } from '@grafana/ui';
+import { useTheme, Tooltip, stylesFactory } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
 
-const getStyles = memoizeOne((theme: GrafanaTheme) => {
+//Components
+import { ResponsiveButton } from './ResponsiveButton';
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const orangeLighter = tinycolor(theme.colors.orangeDark)
     .lighten(10)
     .toString();

--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -13,13 +13,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const orangeLighter = tinycolor(theme.colors.orangeDark)
     .lighten(10)
     .toString();
-  const yellowLight = tinycolor(theme.colors.yellow)
-    .lighten(20)
-    .toString();
   const pulseTextColor = tinycolor(theme.colors.orangeDark)
     .desaturate(90)
     .toString();
-
   return {
     noRightBorderStyle: css`
       label: noRightBorderStyle;
@@ -35,7 +31,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       border-color: ${theme.colors.orangeDark};
       color: ${theme.colors.orangeDark};
       background: transparent;
-      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus {
         border-color: ${theme.colors.orangeDark};
         color: ${theme.colors.orangeDark};
@@ -51,7 +46,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       border-color: ${theme.colors.orangeDark};
       background: transparent;
       animation: pulse 3s ease-out 0s infinite normal forwards;
-      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus {
         border-color: ${theme.colors.orangeDark};
       }
@@ -124,7 +118,7 @@ export function LiveTailButton(props: LiveTailButtonProps) {
         <ResponsiveButton
           splitted={splitted}
           buttonClassName={classNames('btn navbar-button', styles.liveButton, {
-            [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: isLive,
+            [`btn--radius-right-0 explore-active-button-glow ${styles.noRightBorderStyle}`]: isLive,
             [styles.isLive]: isLive && !isPaused,
             [styles.isPaused]: isLive && isPaused,
           })}
@@ -150,7 +144,10 @@ export function LiveTailButton(props: LiveTailButtonProps) {
         }}
       >
         <div>
-          <button className={`btn navbar-button navbar-button--attached ${styles.isLive}`} onClick={stop}>
+          <button
+            className={`btn navbar-button navbar-button--attached explore-active-button-glow ${styles.isLive}`}
+            onClick={stop}
+          >
             <i className={classNames('fa fa-stop icon-brand-gradient')} />
           </button>
         </div>

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import { css } from 'emotion';
-import tinycolor from 'tinycolor2';
 
 import { Tooltip, useTheme, stylesFactory } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
-  const yellowLight = tinycolor(theme.colors.yellow)
-    .lighten(20)
-    .toString();
   return {
     timePickerSynced: css`
       label: timePickerSynced;
@@ -17,7 +13,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background-image: none;
       background-color: transparent;
       color: ${theme.colors.orangeDark};
-      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus,
       :hover {
         color: ${theme.colors.orangeDark};
@@ -52,7 +47,7 @@ export function TimeSyncButton(props: TimeSyncButtonProps) {
     <Tooltip content={syncTimesTooltip} placement="bottom">
       <button
         className={classNames('btn navbar-button navbar-button--attached', {
-          [styles.timePickerSynced]: isSynced,
+          [`explore-active-button-glow ${styles.timePickerSynced}`]: isSynced,
         })}
         aria-label={isSynced ? 'Synced times' : 'Unsynced times'}
         onClick={() => onClick()}

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -57,7 +57,7 @@ export function TimeSyncButton(props: TimeSyncButtonProps) {
         aria-label={isSynced ? 'Synced times' : 'Unsynced times'}
         onClick={() => onClick()}
       >
-        <i className="fa fa-link" />
+        <i className={classNames('fa fa-link', isSynced && 'icon-brand-gradient')} />
       </button>
     </Tooltip>
   );

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
 import { css } from 'emotion';
+import tinycolor from 'tinycolor2';
 
 import { Tooltip, useTheme, stylesFactory } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  const yellowLight = tinycolor(theme.colors.yellow)
+    .lighten(20)
+    .toString();
   return {
     timePickerSynced: css`
       label: timePickerSynced;
@@ -13,6 +17,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background-image: none;
       background-color: transparent;
       color: ${theme.colors.orangeDark};
+      box-shadow: 0px 0px 4px ${yellowLight};
       &:focus,
       :hover {
         color: ${theme.colors.orangeDark};

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -15,13 +15,13 @@ exports[`TimeSyncButton should render component 1`] = `
     >
       <button
         aria-label="Synced times"
-        className="btn navbar-button navbar-button--attached css-14r9fpj-timePickerSynced"
+        className="btn navbar-button navbar-button--attached css-1fi5cmv-timePickerSynced"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <i
-          className="fa fa-link"
+          className="fa fa-link icon-brand-gradient"
         />
       </button>
     </PopoverController>

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TimeSyncButton should render component 1`] = `
     >
       <button
         aria-label="Synced times"
-        className="btn navbar-button navbar-button--attached css-1fi5cmv-timePickerSynced"
+        className="btn navbar-button navbar-button--attached explore-active-button-glow css-14r9fpj-timePickerSynced"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -190,6 +190,8 @@ $btn-drag-image: '../img/grab_dark.svg';
 
 $navbar-btn-gicon-brightness: brightness(0.5);
 
+$btn-active-box-shadow: 0px 0px 4px rgba(255, 120, 10, 1);
+
 // Forms
 // -------------------------
 $input-bg: $input-black;

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -190,7 +190,7 @@ $btn-drag-image: '../img/grab_dark.svg';
 
 $navbar-btn-gicon-brightness: brightness(0.5);
 
-$btn-active-box-shadow: 0px 0px 4px rgba(255, 120, 10, 1);
+$btn-active-box-shadow: 0px 0px 4px rgba(255, 120, 10, 0.5);
 
 // Forms
 // -------------------------

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -183,6 +183,8 @@ $btn-drag-image: '../img/grab_light.svg';
 
 $navbar-btn-gicon-brightness: brightness(1.5);
 
+$btn-active-box-shadow: 0px 0px 4px rgba(234, 161, 51, 0.6);
+
 // Forms
 // -------------------------
 $input-bg: $white;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -6,6 +6,14 @@
   }
 }
 
+.icon-brand-gradient {
+  text-shadow: none;
+  background: linear-gradient(180deg, #f05a28 30%, #fbca0a 100%);
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  -moz-text-fill-color: transparent;
+}
+
 .icon-margin-left {
   margin-left: 0.25em;
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -22,6 +22,9 @@
   }
 }
 
+.explore-active-button-glow {
+  box-shadow: $btn-active-box-shadow;
+}
 .explore-ds-picker {
   min-width: 200px;
   max-width: 300px;


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x]  Give the icons of the active toggle button state (orange) the brand gradient - `icon-brand-gradient` class has been created as it is used in different components across Explore.
- [x]  Give the icons of the active toggle button glow - `explore-active-button-glow` class has been created as it is used in different components across Explore.
- [x] Hides  “delete query” button when in live-tailing mode

Examples:
![image](https://user-images.githubusercontent.com/30407135/69243828-1ac6ce00-0ba4-11ea-9577-af57ca0397d2.png)
![image](https://user-images.githubusercontent.com/30407135/69243842-22867280-0ba4-11ea-93f3-9042db51fa3a.png)
![image](https://user-images.githubusercontent.com/30407135/69243865-2c0fda80-0ba4-11ea-9b21-d8734143c1ac.png)
![image](https://user-images.githubusercontent.com/30407135/69254279-51a5df80-0bb6-11ea-9b26-56d58a980250.png)






