### PR TITLE
Templating: Prevents crash when $__searchFilter is not a string

### DIFF
--- a/public/app/features/templating/specs/variable.test.ts
+++ b/public/app/features/templating/specs/variable.test.ts
@@ -85,6 +85,14 @@ describe('containsSearchFilter', () => {
     });
   });
 
+  describe('when called with an object', () => {
+    it('then it should return false', () => {
+      const result = containsSearchFilter({});
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe(`when called with a query without ${SEARCH_FILTER_VARIABLE}`, () => {
     it('then it should return false', () => {
       const result = containsSearchFilter('$app.*');

--- a/public/app/features/templating/variable.ts
+++ b/public/app/features/templating/variable.ts
@@ -18,8 +18,8 @@ export const variableRegexExec = (variableString: string) => {
 
 export const SEARCH_FILTER_VARIABLE = '__searchFilter';
 
-export const containsSearchFilter = (query: string): boolean =>
-  query ? query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
+export const containsSearchFilter = (query: string | unknown): boolean =>
+  query && typeof query === 'string' ? query.indexOf(SEARCH_FILTER_VARIABLE) !== -1 : false;
 
 export const getSearchFilterScopedVar = (args: {
   query: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #20525

**Special notes for your reviewer**:

