### PR TITLE
Chore: Remove angular dependency from prometheus datasource

### DIFF
--- a/public/app/core/services/__mocks__/backend_srv.ts
+++ b/public/app/core/services/__mocks__/backend_srv.ts
@@ -1,3 +1,25 @@
+/**
+ * Creates a pretty bogus prom response. Definitelly needs more work but right now we do not test the contents of the
+ * messages anyway.
+ */
+function makePromResponse() {
+  return {
+    data: {
+      data: {
+        result: [
+          {
+            metric: {
+              __name__: 'test_metric',
+            },
+            values: [[1568369640, 1]],
+          },
+        ],
+        resultType: 'matrix',
+      },
+    },
+  };
+}
+
 export const backendSrv = {
   get: jest.fn(),
   getDashboard: jest.fn(),
@@ -5,7 +27,7 @@ export const backendSrv = {
   getFolderByUid: jest.fn(),
   post: jest.fn(),
   resolveCancelerIfExists: jest.fn(),
-  datasourceRequest: jest.fn(),
+  datasourceRequest: jest.fn(() => Promise.resolve(makePromResponse())),
 };
 
 export const getBackendSrv = jest.fn().mockReturnValue(backendSrv);

--- a/public/app/core/services/__mocks__/backend_srv.ts
+++ b/public/app/core/services/__mocks__/backend_srv.ts
@@ -1,12 +1,11 @@
-const backendSrv = {
+export const backendSrv = {
   get: jest.fn(),
   getDashboard: jest.fn(),
   getDashboardByUid: jest.fn(),
   getFolderByUid: jest.fn(),
   post: jest.fn(),
   resolveCancelerIfExists: jest.fn(),
+  datasourceRequest: jest.fn(),
 };
 
-export function getBackendSrv() {
-  return backendSrv;
-}
+export const getBackendSrv = jest.fn().mockReturnValue(backendSrv);

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -2,46 +2,62 @@ import { PrometheusDatasource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { PromContext, PromOptions } from './types';
 import { dateTime, LoadingState } from '@grafana/data';
+import * as Backend from 'app/core/services/backend_srv';
+
+jest.mock('app/core/services/backend_srv');
+
+jest.mock('app/features/dashboard/services/TimeSrv', () => ({
+  __esModule: true,
+  getTimeSrv: jest.fn().mockReturnValue({
+    timeRange(): any {
+      return {
+        from: dateTime(),
+        to: dateTime(),
+      };
+    },
+  }),
+}));
+
+jest.mock('app/features/templating/template_srv', () => {
+  return {
+    replace: jest.fn(() => null),
+    getAdhocFilters: jest.fn((): any[] => []),
+  };
+});
+
+const getBackendSrvMock = (Backend.getBackendSrv as any) as jest.Mock<Backend.BackendSrv>;
+
+beforeEach(() => {
+  getBackendSrvMock.mockClear();
+});
 
 const defaultInstanceSettings: DataSourceInstanceSettings<PromOptions> = {
   url: 'test_prom',
   jsonData: {},
 } as any;
 
-const backendSrvMock: any = {
-  datasourceRequest: jest.fn(),
-};
-
-const templateSrvMock: any = {
-  replace(): null {
-    return null;
-  },
-  getAdhocFilters(): any[] {
-    return [];
-  },
-};
-
-const timeSrvMock: any = {
-  timeRange(): any {
-    return {
-      from: dateTime(),
-      to: dateTime(),
-    };
-  },
-};
-
 describe('datasource', () => {
   describe('query', () => {
-    const ds = new PrometheusDatasource(
-      defaultInstanceSettings,
-      {} as any,
-      backendSrvMock,
-      templateSrvMock,
-      timeSrvMock
-    );
+    let ds: PrometheusDatasource;
+    beforeEach(() => {
+      ds = new PrometheusDatasource(defaultInstanceSettings);
+    });
 
     it('returns empty array when no queries', done => {
       expect.assertions(2);
+      getBackendSrvMock.mockImplementation(
+        () =>
+          ({
+            get: jest.fn(),
+            getDashboard: jest.fn(),
+            getDashboardByUid: jest.fn(),
+            getFolderByUid: jest.fn(),
+            post: jest.fn(),
+            resolveCancelerIfExists: jest.fn(),
+            datasourceRequest: () => Promise.resolve(makePromResponse()),
+          } as any)
+      );
+
       ds.query(makeQuery([])).subscribe({
         next(next) {
           expect(next.data).toEqual([]);
@@ -55,7 +71,6 @@ describe('datasource', () => {
 
     it('performs time series queries', done => {
       expect.assertions(2);
-      backendSrvMock.datasourceRequest.mockReturnValueOnce(Promise.resolve(makePromResponse()));
       ds.query(makeQuery([{}])).subscribe({
         next(next) {
           expect(next.data.length).not.toBe(0);
@@ -69,7 +84,19 @@ describe('datasource', () => {
 
     it('with 2 queries and used from Explore, sends results as they arrive', done => {
       expect.assertions(4);
-      backendSrvMock.datasourceRequest.mockReturnValue(Promise.resolve(makePromResponse()));
+      getBackendSrvMock.mockImplementation(
+        () =>
+          ({
+            get: jest.fn(),
+            getDashboard: jest.fn(),
+            getDashboardByUid: jest.fn(),
+            getFolderByUid: jest.fn(),
+            post: jest.fn(),
+            resolveCancelerIfExists: jest.fn(),
+            datasourceRequest: () => Promise.resolve(makePromResponse()),
+          } as any)
+      );
+
       const responseStatus = [LoadingState.Loading, LoadingState.Done];
       ds.query(makeQuery([{ context: PromContext.Explore }, { context: PromContext.Explore }])).subscribe({
         next(next) {
@@ -84,7 +111,18 @@ describe('datasource', () => {
 
     it('with 2 queries and used from Panel, waits for all to finish until sending Done status', done => {
       expect.assertions(2);
-      backendSrvMock.datasourceRequest.mockReturnValue(Promise.resolve(makePromResponse()));
+      getBackendSrvMock.mockImplementation(
+        () =>
+          ({
+            get: jest.fn(),
+            getDashboard: jest.fn(),
+            getDashboardByUid: jest.fn(),
+            getFolderByUid: jest.fn(),
+            post: jest.fn(),
+            resolveCancelerIfExists: jest.fn(),
+            datasourceRequest: () => Promise.resolve(makePromResponse()),
+          } as any)
+      );
       ds.query(makeQuery([{ context: PromContext.Panel }, { context: PromContext.Panel }])).subscribe({
         next(next) {
           expect(next.data.length).not.toBe(0);

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -1,5 +1,6 @@
 // Libraries
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import chain from 'lodash/chain';
 import $ from 'jquery';
 // Services & Utils
 import kbn from 'app/core/utils/kbn';
@@ -23,16 +24,28 @@ import { filter, map, tap } from 'rxjs/operators';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { ResultTransformer } from './result_transformer';
 import PrometheusLanguageProvider from './language_provider';
-import { BackendSrv } from 'app/core/services/backend_srv';
+import { getBackendSrv } from 'app/core/services/backend_srv';
 import addLabelToQuery from './add_label_to_query';
 import { getQueryHints } from './query_hints';
 import { expandRecordingRules } from './language_utils';
 // Types
 import { PromContext, PromOptions, PromQuery, PromQueryRequest } from './types';
 import { safeStringifyValue } from 'app/core/utils/explore';
-import { TemplateSrv } from 'app/features/templating/template_srv';
-import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import templateSrv from 'app/features/templating/template_srv';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import TableModel from 'app/core/table_model';
+import _ from 'lodash';
+
+interface RequestOptions {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  transformRequest?: (data: any) => string;
+  data?: any;
+  withCredentials?: boolean;
+  silent?: boolean;
+  requestId?: string;
+}
 
 export interface PromDataQueryResponse {
   data: {
@@ -42,6 +55,14 @@ export interface PromDataQueryResponse {
       results?: DataQueryResponseData[];
       result?: DataQueryResponseData[];
     };
+  };
+  cancelled?: boolean;
+}
+
+export interface PromLabelQueryResponse {
+  data: {
+    status: string;
+    data: string[];
   };
   cancelled?: boolean;
 }
@@ -62,14 +83,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   resultTransformer: ResultTransformer;
   customQueryParameters: any;
 
-  /** @ngInject */
-  constructor(
-    instanceSettings: DataSourceInstanceSettings<PromOptions>,
-    private $q: angular.IQService,
-    private backendSrv: BackendSrv,
-    private templateSrv: TemplateSrv,
-    private timeSrv: TimeSrv
-  ) {
+  constructor(instanceSettings: DataSourceInstanceSettings<PromOptions>) {
     super(instanceSettings);
 
     this.type = 'prometheus';
@@ -95,8 +109,8 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     return query.expr;
   }
 
-  _addTracingHeaders(httpOptions: any, options: any) {
-    httpOptions.headers = options.headers || {};
+  _addTracingHeaders(httpOptions: PromQueryRequest, options: DataQueryRequest<PromQuery>) {
+    httpOptions.headers = {};
     const proxyMode = !this.url.match(/^http/);
     if (proxyMode) {
       httpOptions.headers['X-Dashboard-Id'] = options.dashboardId;
@@ -104,7 +118,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     }
   }
 
-  _request(url: string, data?: any, options?: any) {
+  _request(url: string, data: Record<string, string> = {}, options?: RequestOptions) {
     options = _.defaults(options || {}, {
       url: this.url + url,
       method: this.httpMethod,
@@ -112,19 +126,17 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     });
 
     if (options.method === 'GET') {
-      if (!_.isEmpty(data)) {
+      if (data && Object.keys(data).length) {
         options.url =
           options.url +
           '?' +
-          _.map(data, (v, k) => {
-            return encodeURIComponent(k) + '=' + encodeURIComponent(v);
-          }).join('&');
+          Object.entries(data)
+            .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+            .join('&');
       }
     } else {
       options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-      options.transformRequest = (data: any) => {
-        return $.param(data);
-      };
+      options.transformRequest = (data: any) => $.param(data);
       options.data = data;
     }
 
@@ -136,7 +148,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       options.headers.Authorization = this.basicAuth;
     }
 
-    return this.backendSrv.datasourceRequest(options);
+    return getBackendSrv().datasourceRequest(options as Required<RequestOptions>);
   }
 
   // Use this for tab completion features, wont publish response to other components
@@ -144,7 +156,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     return this._request(url, null, { method: 'GET', silent: true });
   }
 
-  interpolateQueryExpr(value: any, variable: any, defaultFormatFn: any) {
+  interpolateQueryExpr(value: string | string[], variable: any) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
       return prometheusRegularEscape(value);
@@ -154,12 +166,12 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       return prometheusSpecialRegexEscape(value);
     }
 
-    const escapedValues = _.map(value, prometheusSpecialRegexEscape);
+    const escapedValues = value.map(val => prometheusSpecialRegexEscape(val));
     return escapedValues.join('|');
   }
 
   targetContainsTemplate(target: PromQuery) {
-    return this.templateSrv.variableExists(target.expr);
+    return templateSrv.variableExists(target.expr);
   }
 
   processResult = (response: any, query: PromQueryRequest, target: PromQuery, responseListLength: number) => {
@@ -199,7 +211,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
       if (target.showingTable) {
         // create instant target only if Table is showed in Explore
-        const instantTarget: any = _.cloneDeep(target);
+        const instantTarget: any = cloneDeep(target);
         instantTarget.format = 'table';
         instantTarget.instant = true;
         instantTarget.valueWithRefId = true;
@@ -227,14 +239,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   };
 
   calledFromExplore = (options: DataQueryRequest<PromQuery>): boolean => {
-    let exploreTargets = 0;
-    for (let index = 0; index < options.targets.length; index++) {
-      const target = options.targets[index];
-      if (target.context === PromContext.Explore) {
-        exploreTargets++;
-      }
-    }
-
+    const exploreTargets = options.targets.filter(target => target.context === PromContext.Explore).length;
     return exploreTargets === options.targets.length;
   };
 
@@ -244,7 +249,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     const { queries, activeTargets } = this.prepareTargets(options, start, end);
 
     // No valid targets, return the empty result to save a round trip.
-    if (_.isEmpty(queries)) {
+    if (!queries || !queries.length) {
       return of({
         data: [],
         state: LoadingState.Done,
@@ -340,9 +345,9 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     let interval = kbn.interval_to_seconds(options.interval);
     // Minimum interval ("Min step"), if specified for the query or datasource. or same as interval otherwise
     const minInterval = kbn.interval_to_seconds(
-      this.templateSrv.replace(target.interval, options.scopedVars) || options.interval
+      templateSrv.replace(target.interval, options.scopedVars) || options.interval
     );
-    const intervalFactor = target.intervalFactor || 1;
+    const intervalFactor = target.intervalFactor ?? 1;
     // Adjust the interval to take into account any specified minimum and interval factor plus Prometheus limits
     const adjustedInterval = this.adjustInterval(interval, minInterval, range, intervalFactor);
     let scopedVars = { ...options.scopedVars, ...this.getRangeScopedVars(options.range) };
@@ -360,7 +365,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     let expr = target.expr;
 
     // Apply adhoc filters
-    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+    const adhocFilters = templateSrv.getAdhocFilters(this.name);
     expr = adhocFilters.reduce((acc: string, filter: { key?: any; operator?: any; value?: any }) => {
       const { key, operator } = filter;
       let { value } = filter;
@@ -371,11 +376,18 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     }, expr);
 
     // Only replace vars in expression after having (possibly) updated interval vars
-    query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
+    query.expr = templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
 
     // Align query interval with step to allow query caching and to ensure
     // that about-same-time query results look the same.
-    const adjusted = alignRange(start, end, query.step, this.timeSrv.timeRange().to.utcOffset() * 60);
+    const adjusted = alignRange(
+      start,
+      end,
+      query.step,
+      getTimeSrv()
+        .timeRange()
+        .to.utcOffset() * 60
+    );
     query.start = adjusted.start;
     query.end = adjusted.end;
     this._addTracingHeaders(query, options);
@@ -474,45 +486,36 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     return error;
   };
 
-  performSuggestQuery(query: string, cache = false) {
-    const url = '/api/v1/label/__name__/values';
-
-    if (cache && this.metricsNameCache && this.metricsNameCache.expire > Date.now()) {
-      return this.$q.when(
-        _.filter(this.metricsNameCache.data, metricName => {
-          return metricName.indexOf(query) !== 1;
-        })
-      );
+  async performSuggestQuery(query: string, cache = false) {
+    if (cache && this.metricsNameCache?.expire > Date.now()) {
+      return this.metricsNameCache.data.filter((metricName: any) => metricName.indexOf(query) !== 1);
     }
 
-    return this.metadataRequest(url).then((result: PromDataQueryResponse) => {
-      this.metricsNameCache = {
-        data: result.data.data,
-        expire: Date.now() + 60 * 1000,
-      };
-      return _.filter(result.data.data, metricName => {
-        return metricName.indexOf(query) !== 1;
-      });
-    });
+    const response: PromLabelQueryResponse = await this.metadataRequest('/api/v1/label/__name__/values');
+    this.metricsNameCache = {
+      data: response.data.data,
+      expire: Date.now() + 60 * 1000,
+    };
+
+    return response.data.data.filter(metricName => metricName.indexOf(query) !== 1);
   }
 
   metricFindQuery(query: string) {
     if (!query) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     const scopedVars = {
       __interval: { text: this.interval, value: this.interval },
       __interval_ms: { text: kbn.interval_to_ms(this.interval), value: kbn.interval_to_ms(this.interval) },
-      ...this.getRangeScopedVars(this.timeSrv.timeRange()),
+      ...this.getRangeScopedVars(getTimeSrv().timeRange()),
     };
-    const interpolated = this.templateSrv.replace(query, scopedVars, this.interpolateQueryExpr);
-    const metricFindQuery = new PrometheusMetricFindQuery(this, interpolated, this.timeSrv);
+    const interpolated = templateSrv.replace(query, scopedVars, this.interpolateQueryExpr);
+    const metricFindQuery = new PrometheusMetricFindQuery(this, interpolated);
     return metricFindQuery.process();
   }
 
-  getRangeScopedVars(range: TimeRange) {
-    range = range || this.timeSrv.timeRange();
+  getRangeScopedVars(range: TimeRange = getTimeSrv().timeRange()) {
     const msRange = range.to.diff(range.from);
     const sRange = Math.round(msRange / 1000);
     const regularRange = kbn.secondsToHms(msRange / 1000);
@@ -523,18 +526,14 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     };
   }
 
-  annotationQuery(options: any) {
+  async annotationQuery(options: any) {
     const annotation = options.annotation;
-    const expr = annotation.expr || '';
-    let tagKeys = annotation.tagKeys || '';
-    const titleFormat = annotation.titleFormat || '';
-    const textFormat = annotation.textFormat || '';
+    const { expr = '', tagKeys = '', titleFormat = '', textFormat = '', step = '60s' } = annotation;
 
     if (!expr) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
-    const step = annotation.step || '60s';
     const start = this.getPrometheusTime(options.range.from, false);
     const end = this.getPrometheusTime(options.range.to, true);
     const queryOptions = {
@@ -554,89 +553,79 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     const query = this.createQuery(queryModel, queryOptions, start, end);
 
     const self = this;
-    return this.performTimeSeriesQuery(query, query.start, query.end).then((results: PromDataQueryResponse) => {
-      const eventList: AnnotationEvent[] = [];
-      tagKeys = tagKeys.split(',');
+    const response: PromDataQueryResponse = await this.performTimeSeriesQuery(query, query.start, query.end);
+    const eventList: AnnotationEvent[] = [];
+    const splitKeys = tagKeys.split(',');
 
-      if (results.cancelled) {
-        return [];
-      }
-      _.each(results.data.data.result, series => {
-        const tags = _.chain(series.metric)
-          .filter((v, k) => {
-            return _.includes(tagKeys, k);
-          })
-          .value();
+    if (response.cancelled) {
+      return [];
+    }
 
-        const dupCheck: { [key: number]: boolean } = {};
-        for (const value of series.values) {
-          const valueIsTrue = value[1] === '1'; // e.g. ALERTS
-          if (valueIsTrue || annotation.useValueForTime) {
-            const event: AnnotationEvent = {
-              annotation: annotation,
-              title: self.resultTransformer.renderTemplate(titleFormat, series.metric),
-              tags: tags,
-              text: self.resultTransformer.renderTemplate(textFormat, series.metric),
-            };
+    response.data.data.result.forEach(series => {
+      const tags = chain(series.metric)
+        .filter((v, k) => {
+          return splitKeys.includes(k);
+        })
+        .value();
 
-            if (annotation.useValueForTime) {
-              const timestampValue = Math.floor(parseFloat(value[1]));
-              if (dupCheck[timestampValue]) {
-                continue;
-              }
-              dupCheck[timestampValue] = true;
-              event.time = timestampValue;
-            } else {
-              event.time = Math.floor(parseFloat(value[0])) * 1000;
+      const dupCheck: Record<number, boolean> = {};
+      for (const value of series.values) {
+        const valueIsTrue = value[1] === '1'; // e.g. ALERTS
+        if (valueIsTrue || annotation.useValueForTime) {
+          const event: AnnotationEvent = {
+            annotation,
+            title: self.resultTransformer.renderTemplate(titleFormat, series.metric),
+            tags,
+            text: self.resultTransformer.renderTemplate(textFormat, series.metric),
+          };
+
+          if (annotation.useValueForTime) {
+            const timestampValue = Math.floor(parseFloat(value[1]));
+            if (dupCheck[timestampValue]) {
+              continue;
             }
-
-            eventList.push(event);
+            dupCheck[timestampValue] = true;
+            event.time = timestampValue;
+          } else {
+            event.time = Math.floor(parseFloat(value[0])) * 1000;
           }
+
+          eventList.push(event);
         }
-      });
-
-      return eventList;
+      }
     });
+
+    return eventList;
   }
 
-  getTagKeys(options: any = {}) {
-    const url = '/api/v1/labels';
-    return this.metadataRequest(url).then((result: any) => {
-      return _.map(result.data.data, value => {
-        return { text: value };
-      });
-    });
+  async getTagKeys() {
+    const result = await this.metadataRequest('/api/v1/labels');
+    return result.data.data.map((value: any) => ({ text: value }));
   }
 
-  getTagValues(options: any = {}) {
-    const url = '/api/v1/label/' + options.key + '/values';
-    return this.metadataRequest(url).then((result: any) => {
-      return _.map(result.data.data, value => {
-        return { text: value };
-      });
-    });
+  async getTagValues(options: any = {}) {
+    const result = await this.metadataRequest(`/api/v1/label/${options.key}/values`);
+    return result.data.data.map((value: any) => ({ text: value }));
   }
 
   testDatasource() {
     const now = new Date().getTime();
     const query = { expr: '1+1' } as PromQueryRequest;
-    return this.performInstantQuery(query, now / 1000).then((response: any) => {
-      if (response.data.status === 'success') {
-        return { status: 'success', message: 'Data source is working' };
-      } else {
-        return { status: 'error', message: response.error };
-      }
-    });
+    return this.performInstantQuery(query, now / 1000).then((response: any) =>
+      response.data.status === 'success'
+        ? { status: 'success', message: 'Data source is working' }
+        : { status: 'error', message: response.error }
+    );
   }
 
   interpolateVariablesInQueries(queries: PromQuery[]): PromQuery[] {
     let expandedQueries = queries;
-    if (queries && queries.length > 0) {
+    if (queries && queries.length) {
       expandedQueries = queries.map(query => {
         const expandedQuery = {
           ...query,
           datasource: this.name,
-          expr: this.templateSrv.replace(query.expr, {}, this.interpolateQueryExpr),
+          expr: templateSrv.replace(query.expr, {}, this.interpolateQueryExpr),
         };
         return expandedQuery;
       });
@@ -645,26 +634,26 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   }
 
   getQueryHints(query: PromQuery, result: any[]) {
-    return getQueryHints(query.expr || '', result, this);
+    return getQueryHints(query.expr ?? '', result, this);
   }
 
-  loadRules() {
-    this.metadataRequest('/api/v1/rules')
-      .then((res: any) => res.data || res.json())
-      .then((body: any) => {
-        const groups = _.get(body, ['data', 'groups']);
-        if (groups) {
-          this.ruleMappings = extractRuleMappingFromGroups(groups);
-        }
-      })
-      .catch((e: any) => {
-        console.log('Rules API is experimental. Ignore next error.');
-        console.error(e);
-      });
+  async loadRules() {
+    try {
+      const res = await this.metadataRequest('/api/v1/rules');
+      const body = res.data || res.json();
+
+      const groups = body?.data?.groups;
+      if (groups) {
+        this.ruleMappings = extractRuleMappingFromGroups(groups);
+      }
+    } catch (e) {
+      console.log('Rules API is experimental. Ignore next error.');
+      console.error(e);
+    }
   }
 
   modifyQuery(query: PromQuery, action: any): PromQuery {
-    let expression = query.expr || '';
+    let expression = query.expr ?? '';
     switch (action.type) {
       case 'ADD_FILTER': {
         expression = addLabelToQuery(expression, action.key, action.value);
@@ -695,14 +684,15 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   }
 
   getPrometheusTime(date: string | DateTime, roundUp: boolean) {
-    if (_.isString(date)) {
+    if (typeof date === 'string') {
       date = dateMath.parse(date, roundUp);
     }
+
     return Math.ceil(date.valueOf() / 1000);
   }
 
   getTimeRange(): { start: number; end: number } {
-    const range = this.timeSrv.timeRange();
+    const range = getTimeSrv().timeRange();
     return {
       start: this.getPrometheusTime(range.from, false),
       end: this.getPrometheusTime(range.to, true),
@@ -753,15 +743,11 @@ export function extractRuleMappingFromGroups(groups: any[]) {
 }
 
 export function prometheusRegularEscape(value: any) {
-  if (typeof value === 'string') {
-    return value.replace(/'/g, "\\\\'");
-  }
-  return value;
+  return typeof value === 'string' ? value.replace(/'/g, "\\\\'") : value;
 }
 
 export function prometheusSpecialRegexEscape(value: any) {
-  if (typeof value === 'string') {
-    return prometheusRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
-  }
-  return value;
+  return typeof value === 'string'
+    ? prometheusRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'))
+    : value;
 }

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -1,16 +1,16 @@
 import _ from 'lodash';
 import { TimeRange } from '@grafana/data';
-import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { PrometheusDatasource, PromDataQueryResponse } from './datasource';
 import { PromQueryRequest } from './types';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 export default class PrometheusMetricFindQuery {
   range: TimeRange;
 
-  constructor(private datasource: PrometheusDatasource, private query: string, timeSrv: TimeSrv) {
+  constructor(private datasource: PrometheusDatasource, private query: string) {
     this.datasource = datasource;
     this.query = query;
-    this.range = timeSrv.timeRange();
+    this.range = getTimeSrv().timeRange();
   }
 
   process() {
@@ -18,7 +18,6 @@ export default class PrometheusMetricFindQuery {
     const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
     const metricNamesRegex = /^metrics\((.+)\)\s*$/;
     const queryResultRegex = /^query_result\((.+)\)\s*$/;
-
     const labelNamesQuery = this.query.match(labelNamesRegex);
     if (labelNamesQuery) {
       return this.labelNamesQuery();

--- a/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/datasource.test.ts
@@ -693,165 +693,160 @@ describe('PrometheusDatasource', () => {
     });
   });
 
-  // describe('When performing annotationQuery', () => {
-  //   let results: any;
-  //   let ds: PrometheusDatasource;
-  //   const options: any = {
-  //     annotation: {
-  //       expr: 'ALERTS{alertstate="firing"}',
-  //       tagKeys: 'job',
-  //       titleFormat: '{{alertname}}',
-  //       textFormat: '{{instance}}',
-  //     },
-  //     range: {
-  //       from: time({ seconds: 63 }),
-  //       to: time({ seconds: 123 }),
-  //     },
-  //   };
+  describe('When performing annotationQuery', () => {
+    let results: any;
+    const options: any = {
+      annotation: {
+        expr: 'ALERTS{alertstate="firing"}',
+        tagKeys: 'job',
+        titleFormat: '{{alertname}}',
+        textFormat: '{{instance}}',
+      },
+      range: {
+        from: time({ seconds: 63 }),
+        to: time({ seconds: 123 }),
+      },
+    };
 
-  //   const response = {
-  //     status: 'success',
-  //     data: {
-  //       data: {
-  //         resultType: 'matrix',
-  //         result: [
-  //           {
-  //             metric: {
-  //               __name__: 'ALERTS',
-  //               alertname: 'InstanceDown',
-  //               alertstate: 'firing',
-  //               instance: 'testinstance',
-  //               job: 'testjob',
-  //             },
-  //             values: [[123, '1']],
-  //           },
-  //         ],
-  //       },
-  //     },
-  //   };
+    const response = {
+      status: 'success',
+      data: {
+        data: {
+          resultType: 'matrix',
+          result: [
+            {
+              metric: {
+                __name__: 'ALERTS',
+                alertname: 'InstanceDown',
+                alertstate: 'firing',
+                instance: 'testinstance',
+                job: 'testjob',
+              },
+              values: [[123, '1']],
+            },
+          ],
+        },
+      },
+    };
 
-  //   describe('when time series query is cancelled', () => {
-  //     it('should return empty results', async () => {
-  //       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve({ cancelled: true }));
-  //       ds = new PrometheusDatasource(instanceSettings);
+    describe('when time series query is cancelled', () => {
+      it('should return empty results', async () => {
+        getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve({ cancelled: true }));
 
-  //       await ds.annotationQuery(options).then((data: any) => {
-  //         results = data;
-  //       });
+        await ds.annotationQuery(options).then((data: any) => {
+          results = data;
+        });
 
-  //       expect(results).toEqual([]);
-  //     });
-  //   });
+        expect(results).toEqual([]);
+      });
+    });
 
-  //   describe('not use useValueForTime', () => {
-  //     beforeEach(async () => {
-  //       options.annotation.useValueForTime = false;
-  //       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
-  //       ds = new PrometheusDatasource(instanceSettings);
+    describe('not use useValueForTime', () => {
+      beforeEach(async () => {
+        options.annotation.useValueForTime = false;
+        getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
 
-  //       await ds.annotationQuery(options).then((data: any) => {
-  //         results = data;
-  //       });
-  //     });
+        await ds.annotationQuery(options).then((data: any) => {
+          results = data;
+        });
+      });
 
-  //     it('should return annotation list', () => {
-  //       expect(results.length).toBe(1);
-  //       expect(results[0].tags).toContain('testjob');
-  //       expect(results[0].title).toBe('InstanceDown');
-  //       expect(results[0].text).toBe('testinstance');
-  //       expect(results[0].time).toBe(123 * 1000);
-  //     });
-  //   });
+      it('should return annotation list', () => {
+        expect(results.length).toBe(1);
+        expect(results[0].tags).toContain('testjob');
+        expect(results[0].title).toBe('InstanceDown');
+        expect(results[0].text).toBe('testinstance');
+        expect(results[0].time).toBe(123 * 1000);
+      });
+    });
 
-  //   describe('use useValueForTime', () => {
-  //     beforeEach(async () => {
-  //       options.annotation.useValueForTime = true;
-  //       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
-  //       ds = new PrometheusDatasource(instanceSettings);
+    describe('use useValueForTime', () => {
+      beforeEach(async () => {
+        options.annotation.useValueForTime = true;
+        getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
 
-  //       await ds.annotationQuery(options).then((data: any) => {
-  //         results = data;
-  //       });
-  //     });
+        await ds.annotationQuery(options).then((data: any) => {
+          results = data;
+        });
+      });
 
-  //     it('should return annotation list', () => {
-  //       expect(results[0].time).toEqual(1);
-  //     });
-  //   });
+      it('should return annotation list', () => {
+        expect(results[0].time).toEqual(1);
+      });
+    });
 
-  //   describe('step parameter', () => {
-  //     beforeEach(() => {
-  //       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
-  //       ds = new PrometheusDatasource(instanceSettings);
-  //     });
+    describe('step parameter', () => {
+      beforeEach(() => {
+        getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
+      });
 
-  //     it('should use default step for short range if no interval is given', () => {
-  //       const query = {
-  //         ...options,
-  //         range: {
-  //           from: time({ seconds: 63 }),
-  //           to: time({ seconds: 123 }),
-  //         },
-  //       };
-  //       ds.annotationQuery(query);
-  //       const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
-  //       expect(req.url).toContain('step=60');
-  //     });
+      it('should use default step for short range if no interval is given', () => {
+        const query = {
+          ...options,
+          range: {
+            from: time({ seconds: 63 }),
+            to: time({ seconds: 123 }),
+          },
+        };
+        ds.annotationQuery(query);
+        const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
+        expect(req.url).toContain('step=60');
+      });
 
-  //     it('should use custom step for short range', () => {
-  //       const annotation = {
-  //         ...options.annotation,
-  //         step: '10s',
-  //       };
-  //       const query = {
-  //         ...options,
-  //         annotation,
-  //         range: {
-  //           from: time({ seconds: 63 }),
-  //           to: time({ seconds: 123 }),
-  //         },
-  //       };
-  //       ds.annotationQuery(query);
-  //       const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
-  //       expect(req.url).toContain('step=10');
-  //     });
+      it('should use custom step for short range', () => {
+        const annotation = {
+          ...options.annotation,
+          step: '10s',
+        };
+        const query = {
+          ...options,
+          annotation,
+          range: {
+            from: time({ seconds: 63 }),
+            to: time({ seconds: 123 }),
+          },
+        };
+        ds.annotationQuery(query);
+        const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
+        expect(req.url).toContain('step=10');
+      });
 
-  //     it('should use custom step for short range', () => {
-  //       const annotation = {
-  //         ...options.annotation,
-  //         step: '10s',
-  //       };
-  //       const query = {
-  //         ...options,
-  //         annotation,
-  //         range: {
-  //           from: time({ seconds: 63 }),
-  //           to: time({ seconds: 123 }),
-  //         },
-  //       };
-  //       ds.annotationQuery(query);
-  //       const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
-  //       expect(req.url).toContain('step=10');
-  //     });
+      it('should use custom step for short range', () => {
+        const annotation = {
+          ...options.annotation,
+          step: '10s',
+        };
+        const query = {
+          ...options,
+          annotation,
+          range: {
+            from: time({ seconds: 63 }),
+            to: time({ seconds: 123 }),
+          },
+        };
+        ds.annotationQuery(query);
+        const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
+        expect(req.url).toContain('step=10');
+      });
 
-  //     it('should use dynamic step on long ranges if no option was given', () => {
-  //       const query = {
-  //         ...options,
-  //         range: {
-  //           from: time({ seconds: 63 }),
-  //           to: time({ hours: 24 * 30, seconds: 63 }),
-  //         },
-  //       };
-  //       ds.annotationQuery(query);
-  //       const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
-  //       // Range in seconds: (to - from) / 1000
-  //       // Max_datapoints: 11000
-  //       // Step: range / max_datapoints
-  //       const step = 236;
-  //       expect(req.url).toContain(`step=${step}`);
-  //     });
-  //   });
-  // });
+      it('should use dynamic step on long ranges if no option was given', () => {
+        const query = {
+          ...options,
+          range: {
+            from: time({ seconds: 63 }),
+            to: time({ hours: 24 * 30, seconds: 63 }),
+          },
+        };
+        ds.annotationQuery(query);
+        const req = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
+        // Range in seconds: (to - from) / 1000
+        // Max_datapoints: 11000
+        // Step: range / max_datapoints
+        const step = 236;
+        expect(req.url).toContain(`step=${step}`);
+      });
+    });
+  });
 
   describe('When resultFormat is table and instant = true', () => {
     let results: any;

--- a/public/app/plugins/datasource/prometheus/specs/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/metric_find_query.test.ts
@@ -1,51 +1,86 @@
 import { PrometheusDatasource } from '../datasource';
 import PrometheusMetricFindQuery from '../metric_find_query';
-//@ts-ignore
-import q from 'q';
 import { toUtc, DataSourceInstanceSettings } from '@grafana/data';
 import { PromOptions } from '../types';
 
-describe('PrometheusMetricFindQuery', () => {
-  const instanceSettings = ({
-    url: 'proxied',
-    directUrl: 'direct',
-    user: 'test',
-    password: 'mupp',
-    jsonData: { httpMethod: 'GET' },
-  } as unknown) as DataSourceInstanceSettings<PromOptions>;
-  const raw = {
-    from: toUtc('2018-04-25 10:00'),
-    to: toUtc('2018-04-25 11:00'),
+import templateSrv from 'app/features/templating/template_srv';
+import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import * as Backend from 'app/core/services/backend_srv';
+import { BackendSrv } from '@grafana/runtime/src/services/backendSrv';
+
+jest.mock('app/features/templating/template_srv', () => {
+  return {
+    getAdhocFilters: jest.fn(() => [] as any[]),
+    replace: jest.fn((a: string) => a),
   };
-  const ctx: any = {
-    backendSrvMock: {
-      datasourceRequest: jest.fn(() => Promise.resolve({})),
-    },
-    templateSrvMock: {
-      replace: (a: string) => a,
-    },
-    timeSrvMock: {
-      timeRange: () => ({
+});
+
+const getAdhocFiltersMock = (templateSrv.getAdhocFilters as any) as jest.Mock<any>;
+const replaceMock = (templateSrv.replace as any) as jest.Mock<any>;
+jest.mock('app/core/services/backend_srv');
+
+const backendSrvMock = {
+  datasourceRequest: jest.fn(() => Promise.resolve({})),
+};
+const getBackendSrvMock = (Backend.getBackendSrv as any) as jest.Mock<BackendSrv>;
+getBackendSrvMock.mockImplementation(() => backendSrvMock as any);
+
+const instanceSettings = ({
+  url: 'proxied',
+  directUrl: 'direct',
+  user: 'test',
+  password: 'mupp',
+  jsonData: { httpMethod: 'GET' },
+} as unknown) as DataSourceInstanceSettings<PromOptions>;
+const raw = {
+  from: toUtc('2018-04-25 10:00'),
+  to: toUtc('2018-04-25 11:00'),
+};
+
+jest.mock('app/features/dashboard/services/TimeSrv', () => ({
+  __esModule: true,
+  getTimeSrv: jest.fn().mockReturnValue({
+    timeRange(): any {
+      return {
         from: raw.from,
         to: raw.to,
         raw: raw,
-      }),
+      };
     },
-  };
+  }),
+}));
 
-  ctx.setupMetricFindQuery = (data: any) => {
-    ctx.backendSrvMock.datasourceRequest.mockReturnValue(Promise.resolve({ status: 'success', data: data.response }));
-    return new PrometheusMetricFindQuery(ctx.ds, data.query, ctx.timeSrvMock);
-  };
+const getTimeSrvMock = (getTimeSrv as any) as jest.Mock<TimeSrv>;
 
+beforeEach(() => {
+  getBackendSrvMock.mockClear();
+  getAdhocFiltersMock.mockClear();
+  replaceMock.mockClear();
+  getAdhocFiltersMock.mockClear();
+  getTimeSrvMock.mockClear();
+});
+
+describe('PrometheusMetricFindQuery', () => {
+  let datasourceRequestMock: any;
+  let ds: PrometheusDatasource;
   beforeEach(() => {
-    ctx.backendSrvMock.datasourceRequest.mockReset();
-    ctx.ds = new PrometheusDatasource(instanceSettings, q, ctx.backendSrvMock, ctx.templateSrvMock, ctx.timeSrvMock);
+    ds = new PrometheusDatasource(instanceSettings);
   });
+
+  const setupMetricFindQuery = (data: any) => {
+    datasourceRequestMock = jest.fn(() => Promise.resolve({ status: 'success', data: data.response }));
+    getBackendSrvMock.mockImplementation(
+      () =>
+        ({
+          datasourceRequest: datasourceRequestMock,
+        } as any)
+    );
+    return new PrometheusMetricFindQuery(ds, data.query);
+  };
 
   describe('When performing metricFindQuery', () => {
     it('label_names() should generate label name search query', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'label_names()',
         response: {
           data: ['name1', 'name2', 'name3'],
@@ -54,8 +89,8 @@ describe('PrometheusMetricFindQuery', () => {
       const results = await query.process();
 
       expect(results).toHaveLength(3);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/labels',
         silent: true,
@@ -64,7 +99,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('label_values(resource) should generate label search query', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'label_values(resource)',
         response: {
           data: ['value1', 'value2', 'value3'],
@@ -73,8 +108,8 @@ describe('PrometheusMetricFindQuery', () => {
       const results = await query.process();
 
       expect(results).toHaveLength(3);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/label/resource/values',
         silent: true,
@@ -83,7 +118,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('label_values(metric, resource) should generate series query with correct time', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
           data: [
@@ -96,8 +131,8 @@ describe('PrometheusMetricFindQuery', () => {
       const results = await query.process();
 
       expect(results).toHaveLength(3);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
@@ -106,7 +141,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate series query with correct time', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'label_values(metric{label1="foo", label2="bar", label3="baz"}, resource)',
         response: {
           data: [
@@ -119,8 +154,8 @@ describe('PrometheusMetricFindQuery', () => {
       const results = await query.process();
 
       expect(results).toHaveLength(3);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `proxied/api/v1/series?match[]=${encodeURIComponent(
           'metric{label1="foo", label2="bar", label3="baz"}'
@@ -131,7 +166,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('label_values(metric, resource) result should not contain empty string', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
           data: [
@@ -146,8 +181,8 @@ describe('PrometheusMetricFindQuery', () => {
       expect(results).toHaveLength(2);
       expect(results[0].text).toBe('value1');
       expect(results[1].text).toBe('value2');
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
@@ -156,7 +191,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('metrics(metric.*) should generate metric name query', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'metrics(metric.*)',
         response: {
           data: ['metric1', 'metric2', 'metric3', 'nomatch'],
@@ -165,8 +200,8 @@ describe('PrometheusMetricFindQuery', () => {
       const results = await query.process();
 
       expect(results).toHaveLength(3);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/label/__name__/values',
         silent: true,
@@ -175,7 +210,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('query_result(metric) should generate metric name query', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'query_result(metric)',
         response: {
           data: {
@@ -193,8 +228,8 @@ describe('PrometheusMetricFindQuery', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].text).toBe('metric{job="testjob"} 3846 1443454528000');
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `proxied/api/v1/query?query=metric&time=${raw.to.unix()}`,
         requestId: undefined,
@@ -203,7 +238,7 @@ describe('PrometheusMetricFindQuery', () => {
     });
 
     it('up{job="job1"} should fallback using generate series query', async () => {
-      const query = ctx.setupMetricFindQuery({
+      const query = setupMetricFindQuery({
         query: 'up{job="job1"}',
         response: {
           data: [
@@ -219,8 +254,8 @@ describe('PrometheusMetricFindQuery', () => {
       expect(results[0].text).toBe('up{instance="127.0.0.1:1234",job="job1"}');
       expect(results[1].text).toBe('up{instance="127.0.0.1:5678",job="job1"}');
       expect(results[2].text).toBe('up{instance="127.0.0.1:9102",job="job1"}');
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledTimes(1);
-      expect(ctx.backendSrvMock.datasourceRequest).toHaveBeenCalledWith({
+      expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
+      expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: `proxied/api/v1/series?match[]=${encodeURIComponent(
           'up{job="job1"}'


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes angular dependency from prometheus datasource, also updates tests in light of these changes.
