### PR TITLE
Document required Go version in developer guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -10,7 +10,7 @@ Before you begin, you might want to read [How to contribute to Grafana as a juni
 Make sure you have the following dependencies installed before setting up your developer environment:
 
 - [Git](https://git-scm.com/)
-- [Go](https://golang.org/dl/) (see go.mod for required version)
+- [Go](https://golang.org/dl/) (see [go.mod](../go.mod#L3) for minimum required version)
 - [Node.js (Long Term Support)](https://nodejs.org)
 - [Yarn](https://yarnpkg.com)
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -10,7 +10,7 @@ Before you begin, you might want to read [How to contribute to Grafana as a juni
 Make sure you have the following dependencies installed before setting up your developer environment:
 
 - [Git](https://git-scm.com/)
-- [Go](https://golang.org/dl/)
+- [Go](https://golang.org/dl/) (see go.mod for required version)
 - [Node.js (Long Term Support)](https://nodejs.org)
 - [Yarn](https://yarnpkg.com)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Document the required Go version, by pointing to the one encoded in go.mod, in the developer guide. This is a good idea since several people have recently created issues about not being able to build Grafana with outdated Go versions.
