### PR TITLE
Build: Verify checksums when downloading PhantomJS

### DIFF
--- a/scripts/build/download-phantomjs.sh
+++ b/scripts/build/download-phantomjs.sh
@@ -5,11 +5,11 @@ if [ ! -d '/tmp/phantomjs' ]; then
   _version="2.1.1"
 
   curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-windows.zip -o /tmp/phantomjs-win.zip
-  [ $(sha256sum /tmp/phantomjs-win.zip | cut -d' ' -f1) = \
+  [ "$(sha256sum /tmp/phantomjs-win.zip | cut -d' ' -f1)" = \
     "d9fb05623d6b26d3654d008eab3adafd1f6350433dfd16138c46161f42c7dcc8" ] || \
     (echo "Checksum mismatch phantomjs-$_version-windows.zip"; exit 1)
   curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-macosx.zip -o /tmp/phantomjs-mac.zip
-  [ $(sha256sum /tmp/phantomjs-mac.zip | cut -d' ' -f1) = \
+  [ "$(sha256sum /tmp/phantomjs-mac.zip | cut -d' ' -f1)" = \
     "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1" ] || \
     (echo "Checksum mismatch phantomjs-$_version-mac.zip"; exit 1)
 

--- a/scripts/build/download-phantomjs.sh
+++ b/scripts/build/download-phantomjs.sh
@@ -5,7 +5,13 @@ if [ ! -d '/tmp/phantomjs' ]; then
   _version="2.1.1"
 
   curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-windows.zip -o /tmp/phantomjs-win.zip
+  [ $(sha256sum /tmp/phantomjs-win.zip | cut -d' ' -f1) = \
+    "d9fb05623d6b26d3654d008eab3adafd1f6350433dfd16138c46161f42c7dcc8" ] || \
+    (echo "Checksum mismatch phantomjs-$_version-windows.zip"; exit 1)
   curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-macosx.zip -o /tmp/phantomjs-mac.zip
+  [ $(sha256sum /tmp/phantomjs-mac.zip | cut -d' ' -f1) = \
+    "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1" ] || \
+    (echo "Checksum mismatch phantomjs-$_version-mac.zip"; exit 1)
 
   cd /tmp
   unzip /tmp/phantomjs-win.zip

--- a/scripts/build/download-phantomjs.sh
+++ b/scripts/build/download-phantomjs.sh
@@ -1,10 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
+set -eo pipefail
 
 if [ ! -d '/tmp/phantomjs' ]; then
   _version="2.1.1"
 
-  curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-windows.zip > /tmp/phantomjs-win.zip
-  curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-macosx.zip > /tmp/phantomjs-mac.zip
+  curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-windows.zip -o /tmp/phantomjs-win.zip
+  curl -fL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$_version-macosx.zip -o /tmp/phantomjs-mac.zip
 
   cd /tmp
   unzip /tmp/phantomjs-win.zip


### PR DESCRIPTION
**What this PR does / why we need it**:
Verify checksums of PhantomJS zips in scripts/build/download-phantomjs.sh, to ensure downloads were OK. Also tell curl to exit with non-zero status if downloads fail.
