### PR TITLE
Tooltip: Fix issue with tooltip throwing an error when retrieving values

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -139,7 +139,6 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
 
     // Check if tooltip needs to be rendered with custom tooltip component, otherwise default to GraphTooltip
     const tooltipContentRenderer = tooltipElementProps.tooltipComponent || GraphTooltip;
-
     // Indicates column(field) index in y-axis dimension
     const seriesIndex = activeItem ? activeItem.series.seriesIndex : 0;
     // Indicates row index in active field values
@@ -272,7 +271,11 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
     };
 
     try {
-      $.plot(this.element, series, flotOptions);
+      $.plot(
+        this.element,
+        series.filter(s => s.isVisible),
+        flotOptions
+      );
     } catch (err) {
       console.log('Graph rendering error', err, flotOptions, series);
       throw new Error('Error rendering panel');

--- a/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
@@ -94,7 +94,7 @@ export const GraphWithLegend: React.FunctionComponent<GraphWithLegendProps> = (p
     <div className={wrapper}>
       <div className={graphContainer}>
         <Graph
-          series={series.filter(s => !!s.isVisible)}
+          series={series}
           timeRange={timeRange}
           timeZone={timeZone}
           showLines={showLines}


### PR DESCRIPTION
Fixes #20548 

The error occurred when user i.e. toggled off all but one series on the graph and then tried to interact with the Graph.

New tooltip implementation relies on addressing series by indexes to retrieve datapoint information. These indexes are build based on the field index in data frame. Up until now, when user toggled off the series, the Graph component received only the series that are supposed to be visible. The indexes in the series were not updated according to that change. So, when there were i.e two series and user hid the first one, the tooltip tried to access second series data by it's index(1), while the dimensions passed to the Tooltip were only describing the series being visible (in case of two series it had length of 1). 

With this PR it's up to the Graph component to decide which series to render, rather than rendering all the series passed to it, so that we don't have to update indexes when hiding series for the Tooltip to access correct data.