### PR TITLE
Explore: Keep logQL filters when selecting labels in log row details

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -5,7 +5,7 @@ import { map, filter, catchError, switchMap, mergeMap } from 'rxjs/operators';
 
 // Services & Utils
 import { dateMath } from '@grafana/data';
-import { addLabelToSelector } from 'app/plugins/datasource/prometheus/add_label_to_query';
+import { addLabelToSelector, keepSelectorFilters } from 'app/plugins/datasource/prometheus/add_label_to_query';
 import { BackendSrv, DatasourceRequestOptions } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { safeStringifyValue, convertToWebSocketUrl } from 'app/core/utils/explore';
@@ -413,13 +413,18 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   modifyQuery(query: LokiQuery, action: any): LokiQuery {
     const parsed = parseQuery(query.expr || '');
     let { query: selector } = parsed;
+    let selectorLabels, selectorFilters;
     switch (action.type) {
       case 'ADD_FILTER': {
-        selector = addLabelToSelector(selector, action.key, action.value);
+        selectorLabels = addLabelToSelector(selector, action.key, action.value);
+        selectorFilters = keepSelectorFilters(selector);
+        selector = `${selectorLabels} ${selectorFilters}`;
         break;
       }
       case 'ADD_FILTER_OUT': {
-        selector = addLabelToSelector(selector, action.key, action.value, '!=');
+        selectorLabels = addLabelToSelector(selector, action.key, action.value, '!=');
+        selectorFilters = keepSelectorFilters(selector);
+        selector = `${selectorLabels} ${selectorFilters}`;
         break;
       }
       default:

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -65,6 +65,7 @@ const labelRegexp = /(\w+)\s*(=|!=|=~|!~)\s*("[^"]*")/g;
 
 export function addLabelToSelector(selector: string, labelKey: string, labelValue: string, labelOperator?: string) {
   const parsedLabels = [];
+  const parsedFilters = [];
 
   // Split selector into labels
   if (selector) {
@@ -80,7 +81,7 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
   parsedLabels.push({ key: labelKey, operator: operatorForLabelKey, value: `"${labelValue}"` });
 
   // Sort labels by key and put them together
-  const formatted = _.chain(parsedLabels)
+  const formattedLabels = _.chain(parsedLabels)
     .uniqWith(_.isEqual)
     .compact()
     .sortBy('key')
@@ -88,7 +89,20 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
     .value()
     .join(',');
 
-  return `{${formatted}}`;
+  // Add filters
+  const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
+
+  if (selector) {
+    let match = filterRegexp.exec(selector);
+    while (match) {
+      parsedFilters.push(match[0]);
+      match = filterRegexp.exec(selector);
+    }
+  }
+  const formattedFilter = parsedFilters.join(' ');
+
+  // Return logQL with labels and filters
+  return `{${formattedLabels}} ${formattedFilter}`;
 }
 
 function isPositionInsideChars(text: string, position: number, openChar: string, closeChar: string) {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -58,14 +58,26 @@ export function addLabelToQuery(query: string, key: string, value: string, opera
   }
 
   parts.push(suffix);
+  console.log(parts);
   return parts.join('');
 }
 
 const labelRegexp = /(\w+)\s*(=|!=|=~|!~)\s*("[^"]*")/g;
+const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
 
 export function addLabelToSelector(selector: string, labelKey: string, labelValue: string, labelOperator?: string) {
-  const parsedLabels = [];
   const parsedFilters = [];
+  const parsedLabels = [];
+
+  // Keep filters
+  if (selector) {
+    let match = filterRegexp.exec(selector);
+    while (match) {
+      parsedFilters.push(match[0]);
+      match = filterRegexp.exec(selector);
+    }
+  }
+  const formattedFilters = parsedFilters.join(' ');
 
   // Split selector into labels
   if (selector) {
@@ -89,20 +101,8 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
     .value()
     .join(',');
 
-  // Add filters
-  const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
-
-  if (selector) {
-    let match = filterRegexp.exec(selector);
-    while (match) {
-      parsedFilters.push(match[0]);
-      match = filterRegexp.exec(selector);
-    }
-  }
-  const formattedFilter = parsedFilters.join(' ');
-
-  // Return logQL with labels and filters
-  return `{${formattedLabels}} ${formattedFilter}`;
+  // Return valid logQL with labels and filters
+  return `{${formattedLabels}} ${formattedFilters}`;
 }
 
 function isPositionInsideChars(text: string, position: number, openChar: string, closeChar: string) {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -93,7 +93,7 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
 
 export function keepSelectorFilters(selector: string) {
   // Remove all label-key between {} and return filters. If first character is space, remove it.
-  let filters = selector.replace(/\{(.*?)\}/g, '').replace(/^ /, '');
+  const filters = selector.replace(/\{(.*?)\}/g, '').replace(/^ /, '');
   return filters;
 }
 

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -80,7 +80,7 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
   parsedLabels.push({ key: labelKey, operator: operatorForLabelKey, value: `"${labelValue}"` });
 
   // Sort labels by key and put them together
-  const formattedLabels = _.chain(parsedLabels)
+  const formatted = _.chain(parsedLabels)
     .uniqWith(_.isEqual)
     .compact()
     .sortBy('key')
@@ -88,24 +88,13 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
     .value()
     .join(',');
 
-  // Return valid logQL with labels and filters
-  return `{${formattedLabels}}`;
+  return `{${formatted}}`;
 }
 
 export function keepSelectorFilters(selector: string) {
-  const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
-  const parsedFilters = [];
-
-  // Keep filters when adding label
-  if (selector) {
-    let match = filterRegexp.exec(selector);
-    while (match) {
-      parsedFilters.push(match[0]);
-      match = filterRegexp.exec(selector);
-    }
-  }
-  const formattedFilters = parsedFilters.join(' ');
-  return formattedFilters;
+  // Remove all label-key between {} and return filters. If first character is space, remove it.
+  let filters = selector.replace(/\{(.*?)\}/g, '').replace(/^ /, '');
+  return filters;
 }
 
 function isPositionInsideChars(text: string, position: number, openChar: string, closeChar: string) {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -58,26 +58,13 @@ export function addLabelToQuery(query: string, key: string, value: string, opera
   }
 
   parts.push(suffix);
-  console.log(parts);
   return parts.join('');
 }
 
 const labelRegexp = /(\w+)\s*(=|!=|=~|!~)\s*("[^"]*")/g;
-const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
 
 export function addLabelToSelector(selector: string, labelKey: string, labelValue: string, labelOperator?: string) {
-  const parsedFilters = [];
   const parsedLabels = [];
-
-  // Keep filters
-  if (selector) {
-    let match = filterRegexp.exec(selector);
-    while (match) {
-      parsedFilters.push(match[0]);
-      match = filterRegexp.exec(selector);
-    }
-  }
-  const formattedFilters = parsedFilters.join(' ');
 
   // Split selector into labels
   if (selector) {
@@ -102,7 +89,23 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
     .join(',');
 
   // Return valid logQL with labels and filters
-  return `{${formattedLabels}} ${formattedFilters}`;
+  return `{${formattedLabels}}`;
+}
+
+export function keepSelectorFilters(selector: string) {
+  const filterRegexp = /(\|=|\|~|!=|!~)\s*("[^"]*")/g;
+  const parsedFilters = [];
+
+  // Keep filters when adding label
+  if (selector) {
+    let match = filterRegexp.exec(selector);
+    while (match) {
+      parsedFilters.push(match[0]);
+      match = filterRegexp.exec(selector);
+    }
+  }
+  const formattedFilters = parsedFilters.join(' ');
+  return formattedFilters;
 }
 
 function isPositionInsideChars(text: string, position: number, openChar: string, closeChar: string) {

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -1,4 +1,4 @@
-import { addLabelToQuery, addLabelToSelector } from '../add_label_to_query';
+import { addLabelToQuery, addLabelToSelector, keepSelectorFilters } from '../add_label_to_query';
 
 describe('addLabelToQuery()', () => {
   it('should add label to simple query', () => {
@@ -44,7 +44,7 @@ describe('addLabelToQuery()', () => {
     );
   });
 
-  it('should not add duplicate labels to aquery', () => {
+  it('should not add duplicate labels to a query', () => {
     expect(addLabelToQuery(addLabelToQuery('foo{x="yy"}', 'bar', 'baz', '!='), 'bar', 'baz', '!=')).toBe(
       'foo{bar!="baz",x="yy"}'
     );
@@ -70,5 +70,17 @@ describe('addLabelToSelector()', () => {
   });
   test('should add a label to a selector with custom operator', () => {
     expect(addLabelToSelector('{}', 'baz', '42', '!=')).toBe('{baz!="42"}');
+  });
+});
+
+describe('keepSelectorFilters()', () => {
+  test('should return empty string if no filter is in selector', () => {
+    expect(keepSelectorFilters('{foo="bar"}')).toBe('');
+  });
+  test('should return a filter if filter is in selector', () => {
+    expect(keepSelectorFilters('{foo="bar"} |="baz"')).toBe('|="baz"');
+  });
+  test('should return multiple filters if multiple filters are in selector', () => {
+    expect(keepSelectorFilters('{foo="bar"} hello|="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
   });
 });

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -81,6 +81,6 @@ describe('keepSelectorFilters()', () => {
     expect(keepSelectorFilters('{foo="bar"} |="baz"')).toBe('|="baz"');
   });
   test('should return multiple filters if multiple filters are in selector', () => {
-    expect(keepSelectorFilters('{foo="bar"} |="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
+    expect(keepSelectorFilters('{foo!="bar"} |="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
   });
 });

--- a/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/specs/add_label_to_query.test.ts
@@ -81,6 +81,6 @@ describe('keepSelectorFilters()', () => {
     expect(keepSelectorFilters('{foo="bar"} |="baz"')).toBe('|="baz"');
   });
   test('should return multiple filters if multiple filters are in selector', () => {
-    expect(keepSelectorFilters('{foo="bar"} hello|="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
+    expect(keepSelectorFilters('{foo="bar"} |="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
When selecting labels from log row details (Explore + Loki), logQL filters were removed from the query. This PR fixes this and adds unit tests.

**Which issue(s) this PR fixes**:
Fixes #20553
Fixes #19512

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/30407135/69359145-58048c00-0c88-11ea-9a58-d1ba838f46a5.gif)
