### PR TITLE
grafana/toolkit: Smaller output after successful upload

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -348,9 +348,13 @@ const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
   console.log('Sending report to:', url);
   const axios = require('axios');
   const info = await axios.post(url, report, {
-    headers: { Authorization: 'bearer ' + GRAFANA_API_KEY },
+    headers: { Authorization: 'Bearer ' + GRAFANA_API_KEY },
   });
-  console.log('RESULT: ', info);
+  if (info.status === 200) {
+    console.log('OK: ', info.data);
+  } else {
+    console.warn('Error: ', info);
+  }
 };
 
 export const ciPluginReportTask = new Task<PluginCIOptions>('Generate Plugin Report', pluginReportRunner);


### PR DESCRIPTION
After toolkit uploads a report successfully, it should only show the response data, not the whole request info.

```
     { slug: 'ryantxu-ajax-panel',
       hash: '62bf41ef26c45a8642dc4a0ccfb6739afb53a4e3',
       ETag: '"6b15ba0213125c60d7055f482490fd9f"' }
```

NOTE the upload enpoint is now alive and working in grafana.com!
