### PR TITLE
Server: Improve grafana-server diagnostics configuration for profiling and tracing

### DIFF
--- a/docs/sources/installation/troubleshooting.md
+++ b/docs/sources/installation/troubleshooting.md
@@ -46,6 +46,8 @@ the default HTTP port (`6060`) where the pprof debugging endpoints will be avail
 ./grafana-server -profile -profile-port=8080
 ```
 
+Note that pprof debugging endpoints are served on a different port than the Grafana HTTP server.
+
 You can configure/override profiling settings using environment variables:
 
 ```bash

--- a/docs/sources/installation/troubleshooting.md
+++ b/docs/sources/installation/troubleshooting.md
@@ -30,7 +30,57 @@ If you encounter an error or problem it is a good idea to check the grafana serv
 located at `/var/log/grafana/grafana.log` on Unix systems or in `<grafana_install_dir>/data/log` on
 other platforms and manual installs.
 
-You can enable more logging by changing log level in you grafana configuration file.
+You can enable more logging by changing log level in your grafana configuration file.
+
+## Diagnostics
+
+The `grafana-server` process can be instructued to enable certain diagnostics when it starts. This can be helpful
+when experiencing/investigating certain performance problems. It's `not` recommended to have these enabled per default.
+
+### Profiling
+
+The `grafana-server` can be started with the arguments `-profile` to enable profiling and  `-profile-port` to override
+the default HTTP port (`6060`) where the pprof debugging endpoints will be available, e.g.
+
+```bash
+./grafana-server -profile -profile-port=8080
+```
+
+You can configure/override profiling settings using environment variables:
+
+```bash
+export GF_DIAGNOSTICS_PROFILING_ENABLED=true
+export GF_DIAGNOSTICS_PROFILING_PORT=8080
+```
+
+See [Go command pprof](https://golang.org/cmd/pprof/) for more information about how to collect and analyze profiling data.
+
+### Tracing
+
+The `grafana-server` can be started with the arguments `-tracing` to enable tracing and `-tracing-file` to
+override the default trace file (`trace.out`) where trace result will be written to, e.g.
+
+```bash
+./grafana-server -tracing -tracing-file=/tmp/trace.out
+```
+
+You can configure/override profiling settings using environment variables:
+
+```bash
+export GF_DIAGNOSTICS_TRACING_ENABLED=true
+export GF_DIAGNOSTICS_TRACING_FILE=/tmp/trace.out
+```
+
+View the trace in a web browser (Go required to be installed):
+
+```bash
+go tool trace <trace file>
+2019/11/24 22:20:42 Parsing trace...
+2019/11/24 22:20:42 Splitting trace...
+2019/11/24 22:20:42 Opening browser. Trace viewer is listening on http://127.0.0.1:39735
+```
+
+See [Go command trace](https://golang.org/cmd/trace/) for more information about how to analyze trace files.
 
 ## FAQ
 

--- a/pkg/cmd/grafana-server/diagnostics.go
+++ b/pkg/cmd/grafana-server/diagnostics.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const (
+	profilingEnabledEnvName = "GF_DIAGNOSTICS_PROFILING_ENABLED"
+	profilingPortEnvName    = "GF_DIAGNOSTICS_PROFILING_PORT"
+	tracingEnabledEnvName   = "GF_DIAGNOSTICS_TRACING_ENABLED"
+	tracingFileEnvName      = "GF_DIAGNOSTICS_TRACING_FILE"
+)
+
+type profilingDiagnostics struct {
+	enabled bool
+	port    uint
+}
+
+func newProfilingDiagnostics(enabled bool, port uint) *profilingDiagnostics {
+	return &profilingDiagnostics{
+		enabled: enabled,
+		port:    port,
+	}
+}
+
+func (pd *profilingDiagnostics) overrideWithEnv() error {
+	enabledEnv := os.Getenv(profilingEnabledEnvName)
+	if enabledEnv != "" {
+		enabled, err := strconv.ParseBool(enabledEnv)
+		if err != nil {
+			return fmt.Errorf("Failed to parse %s environment variable as bool", profilingEnabledEnvName)
+		}
+		pd.enabled = enabled
+	}
+
+	portEnv := os.Getenv(profilingPortEnvName)
+	if portEnv != "" {
+		port, parseErr := strconv.ParseUint(portEnv, 0, 64)
+		if parseErr != nil {
+			return fmt.Errorf("Failed to parse %s enviroment variable to unsigned integer", profilingPortEnvName)
+		}
+		pd.port = uint(port)
+	}
+
+	return nil
+}
+
+type tracingDiagnostics struct {
+	enabled bool
+	file    string
+}
+
+func newTracingDiagnostics(enabled bool, file string) *tracingDiagnostics {
+	return &tracingDiagnostics{
+		enabled: enabled,
+		file:    file,
+	}
+}
+
+func (td *tracingDiagnostics) overrideWithEnv() error {
+	enabledEnv := os.Getenv(tracingEnabledEnvName)
+	if enabledEnv != "" {
+		enabled, err := strconv.ParseBool(enabledEnv)
+		if err != nil {
+			return fmt.Errorf("Failed to parse %s environment variable as bool", tracingEnabledEnvName)
+		}
+		td.enabled = enabled
+	}
+
+	fileEnv := os.Getenv(tracingFileEnvName)
+	if fileEnv != "" {
+		td.file = fileEnv
+	}
+
+	return nil
+}

--- a/pkg/cmd/grafana-server/diagnostics_test.go
+++ b/pkg/cmd/grafana-server/diagnostics_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfilingDiagnostics(t *testing.T) {
+	tcs := []struct {
+		defaults   *profilingDiagnostics
+		enabledEnv string
+		portEnv    string
+		expected   *profilingDiagnostics
+	}{
+		{defaults: newProfilingDiagnostics(false, 6060), enabledEnv: "", portEnv: "", expected: newProfilingDiagnostics(false, 6060)},
+		{defaults: newProfilingDiagnostics(true, 8080), enabledEnv: "", portEnv: "", expected: newProfilingDiagnostics(true, 8080)},
+		{defaults: newProfilingDiagnostics(false, 6060), enabledEnv: "false", portEnv: "8080", expected: newProfilingDiagnostics(false, 8080)},
+		{defaults: newProfilingDiagnostics(false, 6060), enabledEnv: "true", portEnv: "8080", expected: newProfilingDiagnostics(true, 8080)},
+		{defaults: newProfilingDiagnostics(false, 6060), enabledEnv: "true", portEnv: "", expected: newProfilingDiagnostics(true, 6060)},
+	}
+
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			os.Clearenv()
+			if tc.enabledEnv != "" {
+				err := os.Setenv(profilingEnabledEnvName, tc.enabledEnv)
+				assert.NoError(t, err)
+			}
+			if tc.portEnv != "" {
+				err := os.Setenv(profilingPortEnvName, tc.portEnv)
+				assert.NoError(t, err)
+			}
+			err := tc.defaults.overrideWithEnv()
+			assert.NoError(t, err)
+			assert.Exactly(t, tc.expected, tc.defaults)
+		})
+	}
+}
+
+func TestTracingDiagnostics(t *testing.T) {
+	tcs := []struct {
+		defaults   *tracingDiagnostics
+		enabledEnv string
+		fileEnv    string
+		expected   *tracingDiagnostics
+	}{
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "", fileEnv: "", expected: newTracingDiagnostics(false, "trace.out")},
+		{defaults: newTracingDiagnostics(true, "/tmp/trace.out"), enabledEnv: "", fileEnv: "", expected: newTracingDiagnostics(true, "/tmp/trace.out")},
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "false", fileEnv: "/tmp/trace.out", expected: newTracingDiagnostics(false, "/tmp/trace.out")},
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "true", fileEnv: "/tmp/trace.out", expected: newTracingDiagnostics(true, "/tmp/trace.out")},
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "true", fileEnv: "", expected: newTracingDiagnostics(true, "trace.out")},
+	}
+
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			os.Clearenv()
+			if tc.enabledEnv != "" {
+				err := os.Setenv(tracingEnabledEnvName, tc.enabledEnv)
+				assert.NoError(t, err)
+			}
+			if tc.fileEnv != "" {
+				err := os.Setenv(tracingFileEnvName, tc.fileEnv)
+				assert.NoError(t, err)
+			}
+			err := tc.defaults.overrideWithEnv()
+			assert.NoError(t, err)
+			assert.Exactly(t, tc.expected, tc.defaults)
+		})
+	}
+}

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -101,13 +101,13 @@ func main() {
 
 	finalProfileEnabled, finalProfilePort, err := getProfilingProps(*profile, *profilePort)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
 	finalTracingEnabled, finalTracingFile, err := getTracingProps(*tracing, *tracingFile)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -79,7 +79,7 @@ func main() {
 		}
 	}
 
-	ultimateTracingEnabled := *tracing || ultimateProfileEnabled
+	ultimateTracingEnabled := *tracing
 	tracingEnv, exists := os.LookupEnv("GF_PROCESS_TRACING")
 	if exists {
 		enabled, parseErr := strconv.ParseBool(tracingEnv)
@@ -98,26 +98,26 @@ func main() {
 				panic(err)
 			}
 		}()
+	}
 
-		if ultimateTracingEnabled {
-			ultimateTracingFile := *tracingFile
-			tracingFileEnv, exists := os.LookupEnv("GF_PROCESS_TRACING_OUTPUT")
-			if exists {
-				ultimateTracingFile = tracingFileEnv
-			}
-
-			f, err := os.Create(ultimateTracingFile)
-			if err != nil {
-				panic(err)
-			}
-			defer f.Close()
-
-			err = trace.Start(f)
-			if err != nil {
-				panic(err)
-			}
-			defer trace.Stop()
+	if ultimateTracingEnabled {
+		ultimateTracingFile := *tracingFile
+		tracingFileEnv, exists := os.LookupEnv("GF_PROCESS_TRACING_OUTPUT")
+		if exists {
+			ultimateTracingFile = tracingFileEnv
 		}
+
+		f, err := os.Create(ultimateTracingFile)
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+
+		err = trace.Start(f)
+		if err != nil {
+			panic(err)
+		}
+		defer trace.Stop()
 	}
 
 	buildstampInt64, _ := strconv.ParseInt(buildstamp, 10, 64)

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -38,7 +38,7 @@ var commit = "NA"
 var buildBranch = "master"
 var buildstamp string
 
-func getProfilingProps(profileFlag bool, profilePortFlag int) (bool, int, error) {
+func getProfilingProps(profileFlag bool, profilePortFlag uint) (bool, uint, error) {
 	profileEnabled := profileFlag
 	profilePort := profilePortFlag
 	profileEnv := os.Getenv("GF_PROCESS_PROFILE")
@@ -50,11 +50,11 @@ func getProfilingProps(profileFlag bool, profilePortFlag int) (bool, int, error)
 		profileEnabled = enabled
 		profilePortEnv := os.Getenv("GF_PROCESS_PROFILE_PORT")
 		if profilePortEnv != "" {
-			port, parseErr := strconv.ParseInt(profilePortEnv, 0, 64)
+			port, parseErr := strconv.ParseUint(profilePortEnv, 0, 64)
 			if parseErr != nil {
 				return false, 0, errors.New("Failed to parse GF_PROCESS_PROFILE_PORT enviroment variable")
 			}
-			profilePort = int(port)
+			profilePort = uint(port)
 		}
 	}
 	return profileEnabled, profilePort, nil
@@ -87,7 +87,7 @@ func main() {
 
 		v           = flag.Bool("v", false, "prints current version and exits")
 		profile     = flag.Bool("profile", false, "Turn on pprof profiling")
-		profilePort = flag.Int("profile-port", 6060, "Define custom port for profiling")
+		profilePort = flag.Uint("profile-port", 6060, "Define custom port for profiling")
 		tracing     = flag.Bool("tracing", false, "Turn on tracing")
 		tracingFile = flag.String("tracing-file", "trace.out", "Define tracing output file")
 	)

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -56,10 +56,31 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *profile {
+	ultimateProfileEnabled := *profile
+	ultimateProfilePort := *profilePort
+	profileEnv, exists := os.LookupEnv("GF_PROCESS_PROFILE")
+	if exists {
+		enabled, parseErr := strconv.ParseBool(profileEnv)
+		if parseErr != nil {
+			panic(parseErr)
+		} else {
+			ultimateProfileEnabled = enabled
+			profilePortEnv, exists := os.LookupEnv("GF_PROCESS_PROFILE_PORT")
+			if exists {
+				port, parseErr := strconv.ParseInt(profilePortEnv, 0, 64)
+				if parseErr != nil {
+					panic(parseErr)
+				} else {
+					ultimateProfilePort = int(port)
+				}
+			}
+		}
+	}
+
+	if ultimateProfileEnabled {
 		runtime.SetBlockProfileRate(1)
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", *profilePort), nil)
+			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", ultimateProfilePort), nil)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently when the profiling is enabled, tracing is also enabled. With this fix:
* tracing can be enabled/disabled separately
* profiling can be managed (on top of using server flags) using the environmental variables `GF_DIAGNOSTICS_PROFILING_ENABLED` and `GF_DIAGNOSTICS_PROFILING_PORT`
* testing can be managed (on top of using server flags) using the environmental variables `GF_DIAGNOSTICS_TRACING_ENABLED` and `GF_DIAGNOSTICS_TRACING_FILE`

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20576

**Special notes for your reviewer**:

