### PR TITLE
Loki: Fix query error for step parameter

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -55,7 +55,7 @@ import { ExploreMode } from 'app/types';
 import { LegacyTarget, LiveStreams } from './live_streams';
 import LanguageProvider from './language_provider';
 
-type RangeQueryOptions = Pick<DataQueryRequest<LokiQuery>, 'range' | 'intervalMs' | 'maxDataPoints' | 'reverse'>;
+export type RangeQueryOptions = Pick<DataQueryRequest<LokiQuery>, 'range' | 'intervalMs' | 'maxDataPoints' | 'reverse'>;
 export const DEFAULT_MAX_LINES = 1000;
 const LEGACY_QUERY_ENDPOINT = '/api/prom/query';
 const RANGE_QUERY_ENDPOINT = '/loki/api/v1/query_range';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -267,7 +267,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const startNs = this.getTime(options.range.from, false);
       const endNs = this.getTime(options.range.to, true);
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
-      const step = this.adjustInterval(options.intervalMs, rangeMs) / 1000;
+      const step = Math.ceil(this.adjustInterval(options.intervalMs, rangeMs) / 1000);
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),


### PR DESCRIPTION
- Loki does not fully support float steps like prometheus and returns a query error
- this change makes sure that the step parameter is rounded to an integer
- added tests

Fixes grafana/loki#1305

Supersedes #20541 