### PR TITLE
Dashboard: Disable draggable panels on small devices

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -58,7 +58,10 @@ function GridWrapper({
     }
   }
 
-  // Disable draggable if mobile device
+  /*
+    Disable draggable if mobile device, solving an issue with unintentionally
+     moving panels. https://github.com/grafana/grafana/issues/18497
+  */
   const draggable = width <= 420 ? false : isDraggable;
 
   return (

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -58,11 +58,14 @@ function GridWrapper({
     }
   }
 
+  // Disable draggable if mobile device
+  const draggable = width <= 420 ? false : isDraggable;
+
   return (
     <ReactGridLayout
       width={lastGridWidth}
       className={className}
-      isDraggable={isDraggable}
+      isDraggable={draggable}
       isResizable={isResizable}
       containerPadding={[0, 0]}
       useCSSTransforms={false}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where if you touched panel headers on a touch device and moved you finger the panels could get repositioned. See link to issue below.

**Which issue(s) this PR fixes**:

Fixes #18497

**Special notes for your reviewer**:
To test locally on a device, run grafana on your computer and go to <your ip>:3000 on your mobile. Navigate to a dashboard with > 1 panel. Touch (and briefly hold) a panel header and move your finger up or down (while still pressing). The panel should reposition on master but stay put when on this branch.

