### PR TITLE
WIP: Simplify Redux usage

### DIFF
--- a/public/app/core/components/ReduxComponent/ReduxComponent.tsx
+++ b/public/app/core/components/ReduxComponent/ReduxComponent.tsx
@@ -1,0 +1,57 @@
+import { PureComponent } from 'react';
+import { Observable, Subscriber, Subscription } from 'rxjs';
+
+import { store } from '../../../store/store';
+import { StoreState } from '../../../types';
+import { distinctUntilChanged } from 'rxjs/operators';
+import { bindActionCreators } from 'redux';
+import { isEqual } from 'lodash';
+
+export interface ReduxComponentArguments<Props, ReduxState, ReduxActions> {
+  props: Props;
+  stateSelector: (state: StoreState) => ReduxState;
+  actionsToDispatch: ReduxActions;
+}
+
+export class ReduxComponent<Props, State, ReduxState, ReduxActions> extends PureComponent<Props, State & ReduxState> {
+  protected actions: { [P in keyof ReduxActions]?: ReduxActions[P] } = {};
+  private readonly subscription: Subscription = null;
+  constructor({ props, stateSelector, actionsToDispatch }: ReduxComponentArguments<Props, ReduxState, ReduxActions>) {
+    super(props);
+
+    this.subscription = new Observable((observer: Subscriber<ReduxState>) => {
+      const unsubscribeFromStore = store.subscribe(() => observer.next(stateSelector(store.getState())));
+      observer.next(stateSelector(store.getState()));
+      return function unsubscribe() {
+        unsubscribeFromStore();
+      };
+    })
+      .pipe(
+        distinctUntilChanged<ReduxState>((previous, current) => {
+          const result = isEqual(previous, current);
+          return result;
+        })
+      )
+      .subscribe({
+        next: state => {
+          if (this.state) {
+            this.setState(state);
+            return;
+          }
+
+          this.state = state as State & ReduxState;
+        },
+      });
+
+    Object.keys(actionsToDispatch).map(key => {
+      // @ts-ignore
+      this.actions[key] = bindActionCreators(actionsToDispatch[key], store.dispatch);
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -262,6 +262,7 @@ export class Explore extends ReduxComponent<ExploreProps, ExploreState, ReduxSta
   }
 
   componentWillUnmount() {
+    super.componentWillUnmount();
     this.exploreEvents.removeAllListeners();
   }
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -145,97 +145,99 @@ export class Explore extends ReduxComponent<ExploreProps, ExploreState, ReduxSta
   exploreEvents: Emitter;
 
   constructor(props: ExploreProps) {
-    super({
-      props,
-      stateSelector: (state: StoreState) => {
-        const explore = state.explore;
-        const { split, syncedTimes } = explore;
-        const item: ExploreItemState = explore[props.exploreId];
-        const timeZone = getTimeZone(state.user);
-        const {
-          StartPage,
-          datasourceInstance,
-          datasourceMissing,
-          initialized,
-          showingStartPage,
-          queryKeys,
-          urlState,
-          update,
-          isLive,
-          supportedModes,
-          mode,
-          graphResult,
-          loading,
-          showingGraph,
-          showingTable,
-          absoluteRange,
-          queryResponse,
-        } = item;
-
-        const { datasource, queries, range: urlRange, mode: urlMode, ui, originPanelId } = (urlState ||
-          {}) as ExploreUrlState;
-        const initialDatasource = datasource || store.get(lastUsedDatasourceKeyForOrgId(state.user.orgId));
-        const initialQueries: DataQuery[] = ensureQueriesMemoized(queries);
-        const initialRange = urlRange ? getTimeRangeFromUrlMemoized(urlRange, timeZone).raw : DEFAULT_RANGE;
-
-        let newMode: ExploreMode;
-
-        if (supportedModes.length) {
-          const urlModeIsValid = supportedModes.includes(urlMode);
-          const modeStateIsValid = supportedModes.includes(mode);
-
-          if (modeStateIsValid) {
-            newMode = mode;
-          } else if (urlModeIsValid) {
-            newMode = urlMode;
-          } else {
-            newMode = supportedModes[0];
-          }
-        } else {
-          newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(urlMode) ? urlMode : null;
-        }
-
-        const initialUI = ui || DEFAULT_UI_STATE;
-
-        return {
-          StartPage,
-          datasourceInstance,
-          datasourceMissing,
-          initialized,
-          showingStartPage,
-          split,
-          queryKeys,
-          update,
-          initialDatasource,
-          initialQueries,
-          initialRange,
-          mode: newMode,
-          initialUI,
-          isLive,
-          graphResult,
-          loading,
-          showingGraph,
-          showingTable,
-          absoluteRange,
-          queryResponse,
-          originPanelId,
-          syncedTimes,
-        };
-      },
-      actionsToDispatch: {
-        changeSize,
-        initializeExplore,
-        modifyQueries,
-        refreshExplore: refreshExplore,
-        scanStart,
-        scanStopAction,
-        setQueries,
-        updateTimeRange,
-        toggleGraph,
-      },
-    });
+    super(props);
 
     this.exploreEvents = new Emitter();
+  }
+
+  stateSelector(state: StoreState): ReduxState {
+    const explore = state.explore;
+    const { split, syncedTimes } = explore;
+    const item: ExploreItemState = explore[this.props.exploreId];
+    const timeZone = getTimeZone(state.user);
+    const {
+      StartPage,
+      datasourceInstance,
+      datasourceMissing,
+      initialized,
+      showingStartPage,
+      queryKeys,
+      urlState,
+      update,
+      isLive,
+      supportedModes,
+      mode,
+      graphResult,
+      loading,
+      showingGraph,
+      showingTable,
+      absoluteRange,
+      queryResponse,
+    } = item;
+
+    const { datasource, queries, range: urlRange, mode: urlMode, ui, originPanelId } = (urlState ||
+      {}) as ExploreUrlState;
+    const initialDatasource = datasource || store.get(lastUsedDatasourceKeyForOrgId(state.user.orgId));
+    const initialQueries: DataQuery[] = ensureQueriesMemoized(queries);
+    const initialRange = urlRange ? getTimeRangeFromUrlMemoized(urlRange, timeZone).raw : DEFAULT_RANGE;
+
+    let newMode: ExploreMode;
+
+    if (supportedModes.length) {
+      const urlModeIsValid = supportedModes.includes(urlMode);
+      const modeStateIsValid = supportedModes.includes(mode);
+
+      if (modeStateIsValid) {
+        newMode = mode;
+      } else if (urlModeIsValid) {
+        newMode = urlMode;
+      } else {
+        newMode = supportedModes[0];
+      }
+    } else {
+      newMode = [ExploreMode.Metrics, ExploreMode.Logs].includes(urlMode) ? urlMode : null;
+    }
+
+    const initialUI = ui || DEFAULT_UI_STATE;
+
+    return {
+      StartPage,
+      datasourceInstance,
+      datasourceMissing,
+      initialized,
+      showingStartPage,
+      split,
+      queryKeys,
+      update,
+      initialDatasource,
+      initialQueries,
+      initialRange,
+      mode: newMode,
+      initialUI,
+      isLive,
+      graphResult,
+      loading,
+      showingGraph,
+      showingTable,
+      absoluteRange,
+      queryResponse,
+      originPanelId,
+      syncedTimes,
+    };
+  }
+
+  actionsToDispatch(): ReduxActions {
+    return {
+      changeSize,
+      initializeExplore,
+      modifyQueries,
+      refreshExplore: refreshExplore,
+      scanStart,
+      scanStopAction,
+      setQueries,
+      updateTimeRange,
+      toggleGraph,
+    };
   }
 
   componentDidMount() {

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -23,6 +23,7 @@ export class Wrapper extends ReduxComponent<{}, {}, ExploreState, ReduxActions> 
   }
 
   componentWillUnmount() {
+    super.componentWillUnmount();
     this.actions.resetExploreAction({});
   }
 

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -1,26 +1,33 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { hot } from 'react-hot-loader';
-import { connect } from 'react-redux';
 
-import { StoreState } from 'app/types';
+import { ExploreState, StoreState } from 'app/types';
 import { ExploreId } from 'app/types/explore';
 
 import Explore from './Explore';
 import { CustomScrollbar, ErrorBoundaryAlert } from '@grafana/ui';
 import { resetExploreAction } from './state/actionTypes';
+import { ReduxComponent } from '../../core/components/ReduxComponent/ReduxComponent';
 
-interface WrapperProps {
-  split: boolean;
+interface ReduxActions {
   resetExploreAction: typeof resetExploreAction;
 }
 
-export class Wrapper extends Component<WrapperProps> {
+export class Wrapper extends ReduxComponent<{}, {}, ExploreState, ReduxActions> {
+  constructor(props: {}) {
+    super({
+      props,
+      stateSelector: (state: StoreState) => state.explore,
+      actionsToDispatch: { resetExploreAction },
+    });
+  }
+
   componentWillUnmount() {
-    this.props.resetExploreAction({});
+    this.actions.resetExploreAction({});
   }
 
   render() {
-    const { split } = this.props;
+    const { split } = this.state;
 
     return (
       <div className="page-scrollbar-wrapper">
@@ -41,13 +48,4 @@ export class Wrapper extends Component<WrapperProps> {
   }
 }
 
-const mapStateToProps = (state: StoreState) => {
-  const { split } = state.explore;
-  return { split };
-};
-
-const mapDispatchToProps = {
-  resetExploreAction,
-};
-
-export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(Wrapper));
+export default hot(module)(Wrapper);

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -14,12 +14,12 @@ interface ReduxActions {
 }
 
 export class Wrapper extends ReduxComponent<{}, {}, ExploreState, ReduxActions> {
-  constructor(props: {}) {
-    super({
-      props,
-      stateSelector: (state: StoreState) => state.explore,
-      actionsToDispatch: { resetExploreAction },
-    });
+  stateSelector(state: StoreState): ExploreState {
+    return state.explore;
+  }
+
+  actionsToDispatch(): ReduxActions {
+    return { resetExploreAction };
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Rumors says that using Redux is complicated and introduces some boilerplate. We've already done some work around `actionCreators`, `reducers` and `reducerTesting` so I got this crazy idea today to try simplify React component usage.

This is just a POC and imho it looks like it can reduce some boilerplate with Redux connected React components. I've made 2 examples, one simple and one complex by converting existing React components (`Explore` and `Wrapper`). I would start with the `simple` (`Wrapper`) one to get a feel for the api.

**The good**
- No more connect
- MapStateToProps and MapStateToDispatch are moved into Component

**The bad**
- Inheritance
- `super.componentWillUnmount();`

Love to hear what you think!

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

