### PR TITLE
chore(deps): bump node@12 to 12.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY build.go package.json ./
 RUN go run build.go build
 
 # Node build container
-FROM node:12.13.0-alpine
+FROM node:12.13.1-alpine
 
 # PhantomJS
 RUN apk add --no-cache curl &&\

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -76,7 +76,7 @@ FROM ubuntu:18.04
 ENV GOVERSION=1.13.4 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=12.13.0
+    NODEVERSION=12.13.1
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Relates to #20405

Bump node v12 dependency to the latest v12.13.1

Also relates to https://github.com/Homebrew/homebrew-core/pull/47150