### PR TITLE
Chore/Tech debt: Remove (most) instances of $q angular service use

### DIFF
--- a/public/app/core/components/form_dropdown/form_dropdown.ts
+++ b/public/app/core/components/form_dropdown/form_dropdown.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import coreModule from '../../core_module';
-import { ISCEService, IQService } from 'angular';
+import { ISCEService } from 'angular';
 
 function typeaheadMatcher(this: any, item: string) {
   let str = this.query;
@@ -38,13 +38,7 @@ export class FormDropdownCtrl {
   debounce: number;
 
   /** @ngInject */
-  constructor(
-    private $scope: any,
-    $element: JQLite,
-    private $sce: ISCEService,
-    private templateSrv: any,
-    private $q: IQService
-  ) {
+  constructor(private $scope: any, $element: JQLite, private $sce: ISCEService, private templateSrv: any) {
     this.inputElement = $element.find('input').first();
     this.linkElement = $element.find('a').first();
     this.linkMode = true;
@@ -108,10 +102,7 @@ export class FormDropdownCtrl {
 
   getOptionsInternal(query: string) {
     const result = this.getOptions({ $query: query });
-    if (this.isPromiseLike(result)) {
-      return result;
-    }
-    return this.$q.when(result);
+    return Promise.resolve(result);
   }
 
   isPromiseLike(obj: any) {

--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -186,8 +186,7 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
   };
 }
 
-/** @ngInject */
-export function metricSegmentModel(uiSegmentSrv: any, $q: any) {
+export function metricSegmentModel(uiSegmentSrv: any) {
   return {
     template:
       '<metric-segment segment="segment" get-options="getOptionsInternal()" on-change="onSegmentChange()"></metric-segment>',
@@ -217,7 +216,7 @@ export function metricSegmentModel(uiSegmentSrv: any, $q: any) {
         $scope.getOptionsInternal = () => {
           if ($scope.options) {
             cachedOptions = $scope.options;
-            return $q.when(
+            return Promise.resolve(
               _.map($scope.options, option => {
                 return { value: option.text };
               })

--- a/public/app/core/directives/value_select_dropdown.ts
+++ b/public/app/core/directives/value_select_dropdown.ts
@@ -28,7 +28,7 @@ export class ValueSelectDropdownCtrl {
   debouncedQueryChanged: Function;
 
   /** @ngInject */
-  constructor(private $q: any, private $scope: IScope) {
+  constructor(private $scope: IScope) {
     this.queryHasSearchFilter = this.variable ? containsSearchFilter(this.variable.query) : false;
     this.debouncedQueryChanged = debounce(this.queryChanged.bind(this), 200);
   }
@@ -114,7 +114,7 @@ export class ValueSelectDropdownCtrl {
     if (!tag.values) {
       tagValuesPromise = this.variable.getValuesForTag(tag.text);
     } else {
-      tagValuesPromise = this.$q.when(tag.values);
+      tagValuesPromise = Promise.resolve(tag.values);
     }
 
     return tagValuesPromise.then((values: any) => {

--- a/public/app/core/services/search_srv.ts
+++ b/public/app/core/services/search_srv.ts
@@ -1,6 +1,4 @@
 import _ from 'lodash';
-// @ts-ignore
-import { IQService } from 'angular';
 
 import coreModule from 'app/core/core_module';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -19,7 +17,7 @@ export class SearchSrv {
   starredIsOpen: boolean;
 
   /** @ngInject */
-  constructor(private backendSrv: BackendSrv, private $q: IQService) {
+  constructor(private backendSrv: BackendSrv) {
     this.recentIsOpen = store.getBool('search.sections.recent', true);
     this.starredIsOpen = store.getBool('search.sections.starred', true);
   }
@@ -123,7 +121,7 @@ export class SearchSrv {
       })
     );
 
-    return this.$q.all(promises).then(() => {
+    return Promise.all(promises).then(() => {
       return _.sortBy(_.values(sections), 'score');
     });
   }

--- a/public/app/core/specs/search_srv.test.ts
+++ b/public/app/core/specs/search_srv.test.ts
@@ -1,6 +1,3 @@
-// @ts-ignore
-import { IQService } from 'angular';
-
 import { SearchSrv } from 'app/core/services/search_srv';
 import { BackendSrvMock } from 'test/mocks/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -26,7 +23,7 @@ describe('SearchSrv', () => {
 
   beforeEach(() => {
     backendSrvMock = new BackendSrvMock();
-    searchSrv = new SearchSrv(backendSrvMock as BackendSrv, (Promise as any) as IQService);
+    searchSrv = new SearchSrv(backendSrvMock as BackendSrv);
 
     contextSrv.isSignedIn = true;
     impressionSrv.getDashboardOpened = jest.fn().mockReturnValue([]);

--- a/public/app/core/specs/value_select_dropdown.test.ts
+++ b/public/app/core/specs/value_select_dropdown.test.ts
@@ -1,7 +1,5 @@
 import 'app/core/directives/value_select_dropdown';
 import { ValueSelectDropdownCtrl } from '../directives/value_select_dropdown';
-// @ts-ignore
-import q from 'q';
 import { IScope } from 'angular';
 
 describe('SelectDropdownCtrl', () => {
@@ -13,7 +11,7 @@ describe('SelectDropdownCtrl', () => {
 
   describe('Given simple variable', () => {
     beforeEach(() => {
-      ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.variable = {
         current: { text: 'hej', value: 'hej' },
         getValuesForTag: (key: string) => {
@@ -30,7 +28,7 @@ describe('SelectDropdownCtrl', () => {
 
   describe('Given variable with tags and dropdown is opened', () => {
     beforeEach(() => {
-      ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.variable = {
         current: { text: 'server-1', value: 'server-1' },
         options: [
@@ -133,7 +131,7 @@ describe('SelectDropdownCtrl', () => {
 
   describe('Given variable with selected tags', () => {
     beforeEach(() => {
-      ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.variable = {
         current: {
           text: 'server-1',
@@ -165,7 +163,7 @@ describe('queryChanged', () => {
   describe('when called and variable query contains search filter', () => {
     it('then it should use lazy loading', async () => {
       const $scope = {} as IScope;
-      const ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      const ctrl = new ValueSelectDropdownCtrl($scope);
       const options = [
         { text: 'server-1', value: 'server-1' },
         { text: 'server-2', value: 'server-2' },
@@ -190,7 +188,7 @@ describe('queryChanged', () => {
   describe('when called and variable query does not contain search filter', () => {
     it('then it should not use lazy loading', async () => {
       const $scope = {} as IScope;
-      const ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      const ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.lazyLoadOptions = jest.fn().mockResolvedValue([]);
       ctrl.updateUIBoundOptions = jest.fn();
       ctrl.search = {
@@ -210,7 +208,7 @@ describe('lazyLoadOptions', () => {
   describe('when called with a query', () => {
     it('then the variables updateOptions should be called with the query', async () => {
       const $scope = {} as IScope;
-      const ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      const ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.variable = {
         updateOptions: jest.fn(),
         options: [
@@ -244,7 +242,7 @@ describe('updateUIBoundOptions', () => {
       for (let index = 0; index < 1001; index++) {
         options.push({ text: `server-${index}`, value: `server-${index}` });
       }
-      ctrl = new ValueSelectDropdownCtrl(q, $scope);
+      ctrl = new ValueSelectDropdownCtrl($scope);
       ctrl.highlightIndex = 0;
       ctrl.options = [];
       ctrl.search = {

--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -38,7 +38,6 @@ export class AlertTabCtrl {
     private backendSrv: BackendSrv,
     private dashboardSrv: DashboardSrv,
     private uiSegmentSrv: any,
-    private $q: any,
     private datasourceSrv: DatasourceSrv
   ) {
     this.panelCtrl = $scope.ctrl;
@@ -121,7 +120,7 @@ export class AlertTabCtrl {
   }
 
   getNotifications() {
-    return this.$q.when(
+    return Promise.resolve(
       this.notifications.map((item: any) => {
         return this.uiSegmentSrv.newSegment(item.name);
       })
@@ -305,7 +304,7 @@ export class AlertTabCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([]);
+        return Promise.resolve([]);
       }
       case 'part-param-changed': {
         this.validateModel();
@@ -315,9 +314,14 @@ export class AlertTabCtrl {
           return this.uiSegmentSrv.newSegment({ value: target.refId });
         });
 
-        return this.$q.when(result);
+        return Promise.resolve(result);
+      }
+      default: {
+        return Promise.resolve();
       }
     }
+
+    return Promise.resolve();
   }
 
   handleReducerPartEvent(conditionModel: any, evt: any) {
@@ -334,9 +338,11 @@ export class AlertTabCtrl {
             result.push(type);
           }
         }
-        return this.$q.when(result);
+        return Promise.resolve(result);
       }
     }
+
+    return Promise.resolve();
   }
 
   addCondition(type: string) {

--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -1,5 +1,5 @@
 // Libaries
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 
 // Components
@@ -25,7 +25,6 @@ export class AnnotationsSrv {
   /** @ngInject */
   constructor(
     private $rootScope: GrafanaRootScope,
-    private $q: IQService,
     private datasourceSrv: DatasourceSrv,
     private backendSrv: BackendSrv,
     private timeSrv: TimeSrv
@@ -45,8 +44,7 @@ export class AnnotationsSrv {
   }
 
   getAnnotations(options: { dashboard: DashboardModel; panel: PanelModel; range: TimeRange }) {
-    return this.$q
-      .all([this.getGlobalAnnotations(options), this.getAlertStates(options)])
+    return Promise.all([this.getGlobalAnnotations(options), this.getAlertStates(options)])
       .then(results => {
         // combine the annotations and flatten results
         let annotations: AnnotationEvent[] = _.flattenDeep(results[0]);
@@ -82,16 +80,16 @@ export class AnnotationsSrv {
 
   getAlertStates(options: any) {
     if (!options.dashboard.id) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     // ignore if no alerts
     if (options.panel && !options.panel.alert) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     if (options.range.raw.to !== 'now') {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     if (this.alertStatesPromise) {
@@ -146,8 +144,8 @@ export class AnnotationsSrv {
           })
       );
     }
-    this.datasourcePromises = this.$q.all(dsPromises);
-    this.globalAnnotationsPromise = this.$q.all(promises);
+    this.datasourcePromises = Promise.all(dsPromises);
+    this.globalAnnotationsPromise = Promise.all(promises);
     return this.globalAnnotationsPromise;
   }
 

--- a/public/app/features/annotations/specs/annotations_srv.test.ts
+++ b/public/app/features/annotations/specs/annotations_srv.test.ts
@@ -5,7 +5,7 @@ describe('AnnotationsSrv', () => {
     onAppEvent: jest.fn(),
   };
 
-  const annotationsSrv = new AnnotationsSrv($rootScope, null, null, null, null);
+  const annotationsSrv = new AnnotationsSrv($rootScope, null, null, null);
 
   describe('When translating the query result', () => {
     const annotationSource = {

--- a/public/app/features/dashboard/components/AdHocFilters/AdHocFiltersCtrl.ts
+++ b/public/app/features/dashboard/components/AdHocFilters/AdHocFiltersCtrl.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import coreModule from 'app/core/core_module';
 import { DashboardModel } from 'app/features/dashboard/state';
 import DatasourceSrv from 'app/features/plugins/datasource_srv';
@@ -16,7 +16,6 @@ export class AdHocFiltersCtrl {
   constructor(
     private uiSegmentSrv: any,
     private datasourceSrv: DatasourceSrv,
-    private $q: IQService,
     private variableSrv: VariableSrv,
     $scope: any
   ) {
@@ -51,11 +50,11 @@ export class AdHocFiltersCtrl {
 
   getOptions(segment: { type: string }, index: number) {
     if (segment.type === 'operator') {
-      return this.$q.when(this.uiSegmentSrv.newOperators(['=', '!=', '<', '>', '=~', '!~']));
+      return Promise.resolve(this.uiSegmentSrv.newOperators(['=', '!=', '<', '>', '=~', '!~']));
     }
 
     if (segment.type === 'condition') {
-      return this.$q.when([this.uiSegmentSrv.newSegment('AND')]);
+      return Promise.resolve([this.uiSegmentSrv.newSegment('AND')]);
     }
 
     return this.datasourceSrv.get(this.variable.datasource).then(ds => {

--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 import { iconMap } from './DashLinksEditorCtrl';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
@@ -97,7 +97,6 @@ export class DashLinksContainerCtrl {
   constructor(
     $scope: any,
     $rootScope: GrafanaRootScope,
-    $q: IQService,
     backendSrv: BackendSrv,
     dashboardSrv: DashboardSrv,
     linkSrv: LinkSrv
@@ -108,11 +107,11 @@ export class DashLinksContainerCtrl {
       if (linkDef.type === 'dashboards') {
         if (!linkDef.tags) {
           console.log('Dashboard link missing tag');
-          return $q.when([]);
+          return Promise.resolve([]);
         }
 
         if (linkDef.asDropdown) {
-          return $q.when([
+          return Promise.resolve([
             {
               title: linkDef.title,
               tags: linkDef.tags,
@@ -129,7 +128,7 @@ export class DashLinksContainerCtrl {
       }
 
       if (linkDef.type === 'link') {
-        return $q.when([
+        return Promise.resolve([
           {
             url: linkDef.url,
             title: linkDef.title,
@@ -143,13 +142,13 @@ export class DashLinksContainerCtrl {
         ]);
       }
 
-      return $q.when([]);
+      return Promise.resolve([]);
     }
 
     function updateDashLinks() {
       const promises = _.map($scope.links, buildLinks);
 
-      $q.all(promises).then(results => {
+      Promise.all(promises).then(results => {
         $scope.generatedLinks = _.flatten(results);
       });
     }

--- a/public/app/features/dashboard/components/VersionHistory/HistoryListCtrl.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistoryListCtrl.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import angular, { ILocationService, IQService } from 'angular';
+import angular, { ILocationService } from 'angular';
 
 import locationUtil from 'app/core/utils/location_util';
 import { DashboardModel } from '../../state/DashboardModel';
@@ -29,7 +29,6 @@ export class HistoryListCtrl {
     private $route: any,
     private $rootScope: GrafanaRootScope,
     private $location: ILocationService,
-    private $q: IQService,
     private historySrv: HistorySrv,
     public $scope: any
   ) {
@@ -81,15 +80,13 @@ export class HistoryListCtrl {
     return then.from(now);
   }
 
-  getDiff(diff: string) {
+  getDiff(diff: 'basic' | 'json') {
     this.diff = diff;
     this.mode = 'compare';
 
-    // have it already been fetched?
-    // @ts-ignore
-    if (this.delta[this.diff]) {
-      // @ts-ignore
-      return this.$q.when(this.delta[this.diff]);
+    // has it already been fetched?
+    if (this.delta[diff]) {
+      return Promise.resolve(this.delta[diff]);
     }
 
     const selected = _.filter(this.revisions, { checked: true });

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:import-blacklist */
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import moment from 'moment';
 import _ from 'lodash';
 import $ from 'jquery';
@@ -19,7 +19,6 @@ export class DashboardLoaderSrv {
     private dashboardSrv: DashboardSrv,
     private datasourceSrv: DatasourceSrv,
     private $http: any,
-    private $q: IQService,
     private $timeout: any,
     contextSrv: any,
     private $routeParams: any,
@@ -108,7 +107,6 @@ export class DashboardLoaderSrv {
     const services = {
       dashboardSrv: this.dashboardSrv,
       datasourceSrv: this.datasourceSrv,
-      $q: this.$q,
     };
 
     /*jshint -W054 */
@@ -129,13 +127,13 @@ export class DashboardLoaderSrv {
 
     // Handle async dashboard scripts
     if (_.isFunction(scriptResult)) {
-      const deferred = this.$q.defer();
-      scriptResult((dashboard: any) => {
-        this.$timeout(() => {
-          deferred.resolve({ data: dashboard });
+      return new Promise(resolve => {
+        scriptResult((dashboard: any) => {
+          this.$timeout(() => {
+            resolve({ data: dashboard });
+          });
         });
       });
-      return deferred.promise;
     }
 
     return { data: scriptResult };

--- a/public/app/features/dashboard/services/UnsavedChangesSrv.ts
+++ b/public/app/features/dashboard/services/UnsavedChangesSrv.ts
@@ -1,4 +1,4 @@
-import angular, { IQService, ILocationService } from 'angular';
+import angular, { ILocationService } from 'angular';
 import { ChangeTracker } from './ChangeTracker';
 import { ContextSrv } from 'app/core/services/context_srv';
 import { DashboardSrv } from './DashboardSrv';
@@ -8,7 +8,6 @@ import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 export function unsavedChangesSrv(
   this: any,
   $rootScope: GrafanaRootScope,
-  $q: IQService,
   $location: ILocationService,
   $timeout: any,
   contextSrv: ContextSrv,

--- a/public/app/features/manage-dashboards/services/ValidationSrv.ts
+++ b/public/app/features/manage-dashboards/services/ValidationSrv.ts
@@ -1,5 +1,4 @@
 import coreModule from 'app/core/core_module';
-import { IQService } from 'angular';
 import { BackendSrv } from 'app/core/services/backend_srv';
 
 const hitTypes = {
@@ -10,8 +9,7 @@ const hitTypes = {
 export class ValidationSrv {
   rootName = 'general';
 
-  /** @ngInject */
-  constructor(private $q: IQService, private backendSrv: BackendSrv) {}
+  constructor(private backendSrv: BackendSrv) {}
 
   validateNewDashboardName(folderId: any, name: string) {
     return this.validate(folderId, name, 'A dashboard in this folder with the same name already exists');
@@ -26,26 +24,24 @@ export class ValidationSrv {
     const nameLowerCased = name.toLowerCase();
 
     if (name.length === 0) {
-      return this.$q.reject({
+      return Promise.reject({
         type: 'REQUIRED',
         message: 'Name is required',
       });
     }
 
     if (folderId === 0 && nameLowerCased === this.rootName) {
-      return this.$q.reject({
+      return Promise.reject({
         type: 'EXISTING',
         message: 'This is a reserved name and cannot be used for a folder.',
       });
     }
 
-    const deferred = this.$q.defer();
-
     const promises = [];
     promises.push(this.backendSrv.search({ type: hitTypes.FOLDER, folderIds: [folderId], query: name }));
     promises.push(this.backendSrv.search({ type: hitTypes.DASHBOARD, folderIds: [folderId], query: name }));
 
-    this.$q.all(promises).then(res => {
+    return Promise.all(promises).then(res => {
       let hits: any[] = [];
 
       if (res.length > 0 && res[0].length > 0) {
@@ -58,18 +54,15 @@ export class ValidationSrv {
 
       for (const hit of hits) {
         if (nameLowerCased === hit.title.toLowerCase()) {
-          deferred.reject({
+          throw {
             type: 'EXISTING',
             message: existingErrorMessage,
-          });
-          break;
+          };
         }
       }
 
-      deferred.resolve();
+      return;
     });
-
-    return deferred.promise;
   }
 }
 

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -25,7 +25,6 @@ import { CoreEvents } from 'app/types';
 class MetricsPanelCtrl extends PanelCtrl {
   scope: any;
   datasource: DataSourceApi;
-  $q: any;
   $timeout: any;
   contextSrv: ContextSrv;
   datasourceSrv: any;
@@ -44,7 +43,6 @@ class MetricsPanelCtrl extends PanelCtrl {
   constructor($scope: any, $injector: any) {
     super($scope, $injector);
 
-    this.$q = $injector.get('$q');
     this.contextSrv = $injector.get('contextSrv');
     this.datasourceSrv = $injector.get('datasourceSrv');
     this.timeSrv = $injector.get('timeSrv');

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -21,7 +21,6 @@ export class DatasourceSrv implements DataSourceService {
 
   /** @ngInject */
   constructor(
-    private $q: any,
     private $injector: auto.IInjectorService,
     private $rootScope: GrafanaRootScope,
     private templateSrv: TemplateSrv
@@ -51,7 +50,7 @@ export class DatasourceSrv implements DataSourceService {
     }
 
     if (this.datasources[name]) {
-      return this.$q.when(this.datasources[name]);
+      return Promise.resolve(this.datasources[name]);
     }
 
     return this.loadDatasource(name);
@@ -61,22 +60,19 @@ export class DatasourceSrv implements DataSourceService {
     // Expression Datasource (not a real datasource)
     if (name === expressionDatasource.name) {
       this.datasources[name] = expressionDatasource as any;
-      return this.$q.when(expressionDatasource);
+      return Promise.resolve(expressionDatasource);
     }
 
     const dsConfig = config.datasources[name];
     if (!dsConfig) {
-      return this.$q.reject({ message: `Datasource named ${name} was not found` });
+      return Promise.reject({ message: `Datasource named ${name} was not found` });
     }
 
-    const deferred = this.$q.defer();
-
-    importDataSourcePlugin(dsConfig.meta)
+    return importDataSourcePlugin(dsConfig.meta)
       .then(dsPlugin => {
         // check if its in cache now
         if (this.datasources[name]) {
-          deferred.resolve(this.datasources[name]);
-          return;
+          return this.datasources[name];
         }
 
         // If there is only one constructor argument it is instanceSettings
@@ -92,13 +88,12 @@ export class DatasourceSrv implements DataSourceService {
 
         // store in instance cache
         this.datasources[name] = instance;
-        deferred.resolve(instance);
+        return instance;
       })
       .catch(err => {
         this.$rootScope.appEvent(AppEvents.alertError, [dsConfig.name + ' plugin failed', err.toString()]);
+        return undefined;
       });
-
-    return deferred.promise;
   }
 
   getAll() {

--- a/public/app/features/plugins/plugin_component.ts
+++ b/public/app/features/plugins/plugin_component.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 
 import config from 'app/core/config';
@@ -14,18 +14,17 @@ function pluginDirectiveLoader(
   $compile: any,
   datasourceSrv: DatasourceSrv,
   $rootScope: GrafanaRootScope,
-  $q: IQService,
   $http: any,
   $templateCache: any,
   $timeout: any
 ) {
   function getTemplate(component: { template: any; templateUrl: any }) {
     if (component.template) {
-      return $q.when(component.template);
+      return Promise.resolve(component.template);
     }
     const cached = $templateCache.get(component.templateUrl);
     if (cached) {
-      return $q.when(cached);
+      return Promise.resolve(cached);
     }
     return $http.get(component.templateUrl).then((res: any) => {
       return res.data;
@@ -113,7 +112,7 @@ function pluginDirectiveLoader(
       case 'query-ctrl': {
         const ds: DataSourceApi = scope.ctrl.datasource as DataSourceApi;
 
-        return $q.when({
+        return Promise.resolve({
           baseUrl: ds.meta.baseUrl,
           name: 'query-ctrl-' + ds.meta.id,
           bindings: { target: '=', panelCtrl: '=', datasource: '=' },
@@ -192,7 +191,7 @@ function pluginDirectiveLoader(
         return loadPanelComponentInfo(scope, attrs);
       }
       default: {
-        return $q.reject({
+        return Promise.reject({
           message: 'Could not find component type: ' + attrs.type,
         });
       }

--- a/public/app/features/plugins/plugin_page_ctrl.ts
+++ b/public/app/features/plugins/plugin_page_ctrl.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 
 import { getPluginSettings } from './PluginSettingsCache';
@@ -14,16 +14,10 @@ export class AppPageCtrl {
   navModel: any;
 
   /** @ngInject */
-  constructor(
-    private $routeParams: any,
-    private $rootScope: GrafanaRootScope,
-    private navModelSrv: NavModelSrv,
-    private $q: IQService
-  ) {
+  constructor(private $routeParams: any, private $rootScope: GrafanaRootScope, private navModelSrv: NavModelSrv) {
     this.pluginId = $routeParams.pluginId;
 
-    this.$q
-      .when(getPluginSettings(this.pluginId))
+    Promise.resolve(getPluginSettings(this.pluginId))
       .then(settings => {
         this.initPage(settings);
       })

--- a/public/app/features/plugins/specs/datasource_srv.test.ts
+++ b/public/app/features/plugins/specs/datasource_srv.test.ts
@@ -17,7 +17,7 @@ const templateSrv: any = {
 };
 
 describe('datasource_srv', () => {
-  const _datasourceSrv = new DatasourceSrv({}, {} as any, {} as any, templateSrv);
+  const _datasourceSrv = new DatasourceSrv({} as any, {} as any, templateSrv);
 
   describe('when loading external datasources', () => {
     beforeEach(() => {

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
@@ -31,8 +31,8 @@ const setup = () => {
     ),
   ]);
 
-  const datasource = new CloudWatchDatasource(instanceSettings, {} as any, {} as any, templateSrv as any, {} as any);
-  datasource.metricFindQuery = async param => [{ value: 'test', label: 'test' }];
+  const datasource = new CloudWatchDatasource(instanceSettings, {} as any, templateSrv as any, {} as any);
+  datasource.metricFindQuery = async () => [{ value: 'test', label: 'test' }];
 
   const props: Props = {
     query: {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -48,7 +48,6 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
   /** @ngInject */
   constructor(
     instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>,
-    private $q: IQService,
     private backendSrv: BackendSrv,
     private templateSrv: TemplateSrv,
     private timeSrv: TimeSrv
@@ -110,9 +109,7 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
 
     // No valid targets, return the empty result to save a round trip.
     if (_.isEmpty(queries)) {
-      const d = this.$q.defer();
-      d.resolve({ data: [] });
-      return d.promise;
+      return Promise.resolve({ data: [] });
     }
 
     const request = {
@@ -475,7 +472,7 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
       return this.standardStatistics.map((s: string) => ({ value: s, label: s, text: s }));
     }
 
-    return this.$q.when([]);
+    return Promise.resolve([]);
   }
 
   annotationQuery(options: any) {

--- a/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/query_parameter_ctrl.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import coreModule from 'app/core/core_module';
 import _ from 'lodash';
 import { TemplateSrv } from 'app/features/templating/template_srv';
@@ -6,7 +6,7 @@ import DatasourceSrv from 'app/features/plugins/datasource_srv';
 
 export class CloudWatchQueryParameterCtrl {
   /** @ngInject */
-  constructor($scope: any, templateSrv: TemplateSrv, uiSegmentSrv: any, datasourceSrv: DatasourceSrv, $q: IQService) {
+  constructor($scope: any, templateSrv: TemplateSrv, uiSegmentSrv: any, datasourceSrv: DatasourceSrv) {
     $scope.init = () => {
       const target = $scope.target;
       target.namespace = target.namespace || '';
@@ -58,7 +58,7 @@ export class CloudWatchQueryParameterCtrl {
     };
 
     $scope.getStatSegments = () => {
-      return $q.when(
+      return Promise.resolve(
         _.flatten([
           angular.copy($scope.removeStatSegment),
           _.map($scope.datasource.standardStatistics, s => {
@@ -102,11 +102,11 @@ export class CloudWatchQueryParameterCtrl {
 
     $scope.getDimSegments = (segment: any, $index: number) => {
       if (segment.type === 'operator') {
-        return $q.when([]);
+        return Promise.resolve([]);
       }
 
       const target = $scope.target;
-      let query = $q.when([]);
+      let query = Promise.resolve([]);
 
       if (segment.type === 'key' || segment.type === 'plus-button') {
         query = $scope.datasource.getDimensionKeys($scope.target.namespace, $scope.target.region);

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -313,7 +313,7 @@ describe('CloudWatchDatasource', () => {
         ctx.backendSrv.datasourceRequest = jest.fn(() => {
           return Promise.resolve({});
         });
-        ctx.ds = new CloudWatchDatasource(instanceSettings, {} as any, backendSrv, templateSrv, timeSrv);
+        ctx.ds = new CloudWatchDatasource(instanceSettings, backendSrv, templateSrv, timeSrv);
         ctx.ds.doMetricQueryRequest = jest.fn(() => []);
       });
       describe('and region param is left out', () => {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -36,7 +36,7 @@ describe('CloudWatchDatasource', () => {
   } as any;
 
   beforeEach(() => {
-    ctx.ds = new CloudWatchDatasource(instanceSettings, {} as any, backendSrv, templateSrv, timeSrv);
+    ctx.ds = new CloudWatchDatasource(instanceSettings, backendSrv, templateSrv, timeSrv);
   });
 
   describe('When performing CloudWatch query', () => {

--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
@@ -1,13 +1,12 @@
 import coreModule from 'app/core/core_module';
 import _ from 'lodash';
 import * as queryDef from './query_def';
-import { IQService } from 'angular';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { CoreEvents } from 'app/types';
 
 export class ElasticBucketAggCtrl {
   /** @ngInject */
-  constructor($scope: any, uiSegmentSrv: any, $q: IQService, $rootScope: GrafanaRootScope) {
+  constructor($scope: any, uiSegmentSrv: any, $rootScope: GrafanaRootScope) {
     const bucketAggs = $scope.target.bucketAggs;
 
     $scope.orderByOptions = [];
@@ -182,7 +181,7 @@ export class ElasticBucketAggCtrl {
     };
 
     $scope.getIntervalOptions = () => {
-      return $q.when(uiSegmentSrv.transformToSegments(true, 'interval')(queryDef.intervalOptions));
+      return Promise.resolve(uiSegmentSrv.transformToSegments(true, 'interval')(queryDef.intervalOptions));
     };
 
     $scope.addBucketAgg = () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse } from '@grafana/data';
 import { ElasticResponse } from './elastic_response';
@@ -29,7 +29,6 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   /** @ngInject */
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
-    private $q: IQService,
     private backendSrv: BackendSrv,
     private templateSrv: TemplateSrv,
     private timeSrv: TimeSrv
@@ -501,7 +500,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   metricFindQuery(query: any) {
     query = angular.fromJson(query);
     if (!query) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     if (query.find === 'fields') {

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -2,13 +2,12 @@ import coreModule from 'app/core/core_module';
 import _ from 'lodash';
 import * as queryDef from './query_def';
 import { ElasticsearchAggregation } from './types';
-import { IQService } from 'angular';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { CoreEvents } from 'app/types';
 
 export class ElasticMetricAggCtrl {
   /** @ngInject */
-  constructor($scope: any, uiSegmentSrv: any, $q: IQService, $rootScope: GrafanaRootScope) {
+  constructor($scope: any, uiSegmentSrv: any, $rootScope: GrafanaRootScope) {
     const metricAggs: ElasticsearchAggregation[] = $scope.target.metrics;
     $scope.metricAggTypes = queryDef.getMetricAggTypes($scope.esVersion);
     $scope.extendedStats = queryDef.extendedStats;

--- a/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/datasource.test.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import { dateMath } from '@grafana/data';
 import _ from 'lodash';
 import { ElasticDatasource } from '../datasource';
@@ -52,7 +52,6 @@ describe('ElasticDatasource', function(this: any) {
     instanceSettings.jsonData = instanceSettings.jsonData || ({} as ElasticsearchOptions);
     ctx.ds = new ElasticDatasource(
       instanceSettings,
-      {} as IQService,
       backendSrv as BackendSrv,
       templateSrv as TemplateSrv,
       timeSrv as TimeSrv

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/app_insights/app_insights_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/app_insights/app_insights_datasource.test.ts
@@ -1,8 +1,6 @@
 import Datasource from '../datasource';
 import { DataFrame, toUtc } from '@grafana/data';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-// @ts-ignore
-import Q from 'q';
 
 describe('AppInsightsDatasource', () => {
   const ctx: any = {
@@ -11,13 +9,12 @@ describe('AppInsightsDatasource', () => {
   };
 
   beforeEach(() => {
-    ctx.$q = Q;
     ctx.instanceSettings = {
       jsonData: { appInsightsAppId: '3ad4400f-ea7d-465d-a8fb-43fb20555d85' },
       url: 'http://appinsightsapi',
     };
 
-    ctx.ds = new Datasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
+    ctx.ds = new Datasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When performing testDatasource', () => {
@@ -42,7 +39,7 @@ describe('AppInsightsDatasource', () => {
 
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -67,7 +64,7 @@ describe('AppInsightsDatasource', () => {
 
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.reject(error);
+          return Promise.reject(error);
         };
       });
 
@@ -95,7 +92,7 @@ describe('AppInsightsDatasource', () => {
 
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.reject(error);
+          return Promise.reject(error);
         };
       });
 
@@ -162,7 +159,7 @@ describe('AppInsightsDatasource', () => {
           expect(options.data.queries[0].appInsights.timeColumn).toEqual('timestamp');
           expect(options.data.queries[0].appInsights.valueColumn).toEqual('max');
           expect(options.data.queries[0].appInsights.segmentColumn).toBeUndefined();
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -205,7 +202,7 @@ describe('AppInsightsDatasource', () => {
           expect(options.data.queries[0].appInsights.timeColumn).toEqual('timestamp');
           expect(options.data.queries[0].appInsights.valueColumn).toEqual('max');
           expect(options.data.queries[0].appInsights.segmentColumn).toEqual('partition');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -266,7 +263,7 @@ describe('AppInsightsDatasource', () => {
           expect(options.data.queries[0].refId).toBe('A');
           expect(options.data.queries[0].appInsights.rawQueryString).toBeUndefined();
           expect(options.data.queries[0].appInsights.metricName).toBe('exceptions/server');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -309,7 +306,7 @@ describe('AppInsightsDatasource', () => {
           expect(options.data.queries[0].appInsights.rawQueryString).toBeUndefined();
           expect(options.data.queries[0].appInsights.metricName).toBe('exceptions/server');
           expect(options.data.queries[0].appInsights.timeGrain).toBe('PT30M');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -363,7 +360,7 @@ describe('AppInsightsDatasource', () => {
             expect(options.data.queries[0].appInsights.rawQueryString).toBeUndefined();
             expect(options.data.queries[0].appInsights.metricName).toBe('exceptions/server');
             expect(options.data.queries[0].appInsights.dimension).toBe('client/city');
-            return ctx.$q.when({ data: response, status: 200 });
+            return Promise.resolve({ data: response, status: 200 });
           };
         });
 
@@ -402,7 +399,7 @@ describe('AppInsightsDatasource', () => {
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
           expect(options.url).toContain('/metrics/metadata');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -440,7 +437,7 @@ describe('AppInsightsDatasource', () => {
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
           expect(options.url).toContain('/metrics/metadata');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -468,7 +465,7 @@ describe('AppInsightsDatasource', () => {
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         expect(options.url).toContain('/metrics/metadata');
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
     });
 
@@ -506,7 +503,7 @@ describe('AppInsightsDatasource', () => {
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         expect(options.url).toContain('/metrics/metadata');
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
     });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -1,7 +1,6 @@
 import AzureMonitorDatasource from '../datasource';
 import FakeSchemaData from './__mocks__/schema';
-// @ts-ignore
-import Q from 'q';
+
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { KustoSchema } from '../types';
 import { toUtc } from '@grafana/data';
@@ -13,13 +12,12 @@ describe('AzureLogAnalyticsDatasource', () => {
   };
 
   beforeEach(() => {
-    ctx.$q = Q;
     ctx.instanceSettings = {
       jsonData: { logAnalyticsSubscriptionId: 'xxx' },
       url: 'http://azureloganalyticsapi',
     };
 
-    ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
+    ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When the config option "Same as Azure Monitor" has been chosen', () => {
@@ -58,15 +56,15 @@ describe('AzureLogAnalyticsDatasource', () => {
       ctx.instanceSettings.jsonData.tenantId = 'xxx';
       ctx.instanceSettings.jsonData.clientId = 'xxx';
       ctx.instanceSettings.jsonData.azureLogAnalyticsSameAs = true;
-      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
 
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         if (options.url.indexOf('Microsoft.OperationalInsights/workspaces') > -1) {
           workspacesUrl = options.url;
-          return ctx.$q.when({ data: workspaceResponse, status: 200 });
+          return Promise.resolve({ data: workspaceResponse, status: 200 });
         } else {
           azureLogAnalyticsUrl = options.url;
-          return ctx.$q.when({ data: tableResponseWithOneColumn, status: 200 });
+          return Promise.resolve({ data: tableResponseWithOneColumn, status: 200 });
         }
       };
 
@@ -97,7 +95,7 @@ describe('AzureLogAnalyticsDatasource', () => {
         ctx.instanceSettings.jsonData.logAnalyticsTenantId = 'xxx';
         ctx.instanceSettings.jsonData.logAnalyticsClientId = 'xxx';
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.reject(error);
+          return Promise.reject(error);
         };
       });
 
@@ -170,7 +168,7 @@ describe('AzureLogAnalyticsDatasource', () => {
         beforeEach(() => {
           ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
             expect(options.url).toContain('query=AzureActivity');
-            return ctx.$q.when({ data: response, status: 200 });
+            return Promise.resolve({ data: response, status: 200 });
           };
         });
 
@@ -209,7 +207,7 @@ describe('AzureLogAnalyticsDatasource', () => {
           };
           ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
             expect(options.url).toContain('query=AzureActivity');
-            return ctx.$q.when({ data: invalidResponse, status: 200 });
+            return Promise.resolve({ data: invalidResponse, status: 200 });
           };
         });
 
@@ -226,7 +224,7 @@ describe('AzureLogAnalyticsDatasource', () => {
         options.targets[0].azureLogAnalytics.resultFormat = 'table';
         ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
           expect(options.url).toContain('query=AzureActivity');
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -253,7 +251,7 @@ describe('AzureLogAnalyticsDatasource', () => {
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         expect(options.url).toContain('metadata');
-        return ctx.$q.when({ data: FakeSchemaData.getlogAnalyticsFakeMetadata(), status: 200 });
+        return Promise.resolve({ data: FakeSchemaData.getlogAnalyticsFakeMetadata(), status: 200 });
       };
     });
 
@@ -306,9 +304,9 @@ describe('AzureLogAnalyticsDatasource', () => {
     beforeEach(async () => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         if (options.url.indexOf('Microsoft.OperationalInsights/workspaces') > -1) {
-          return ctx.$q.when({ data: workspaceResponse, status: 200 });
+          return Promise.resolve({ data: workspaceResponse, status: 200 });
         } else {
-          return ctx.$q.when({ data: tableResponseWithOneColumn, status: 200 });
+          return Promise.resolve({ data: tableResponseWithOneColumn, status: 200 });
         }
       };
 
@@ -368,9 +366,9 @@ describe('AzureLogAnalyticsDatasource', () => {
     beforeEach(async () => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         if (options.url.indexOf('Microsoft.OperationalInsights/workspaces') > -1) {
-          return ctx.$q.when({ data: workspaceResponse, status: 200 });
+          return Promise.resolve({ data: workspaceResponse, status: 200 });
         } else {
-          return ctx.$q.when({ data: tableResponse, status: 200 });
+          return Promise.resolve({ data: tableResponse, status: 200 });
         }
       };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -1,6 +1,5 @@
 import AzureMonitorDatasource from '../datasource';
-// @ts-ignore
-import Q from 'q';
+
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { toUtc, DataFrame } from '@grafana/data';
 
@@ -11,14 +10,13 @@ describe('AzureMonitorDatasource', () => {
   };
 
   beforeEach(() => {
-    ctx.$q = Q;
     ctx.instanceSettings = {
       url: 'http://azuremonitor.com',
       jsonData: { subscriptionId: '9935389e-9122-4ef9-95f9-1513dd24753f' },
       cloudName: 'azuremonitor',
     };
 
-    ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
+    ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When performing testDatasource', () => {
@@ -38,7 +36,7 @@ describe('AzureMonitorDatasource', () => {
         ctx.instanceSettings.jsonData.tenantId = 'xxx';
         ctx.instanceSettings.jsonData.clientId = 'xxx';
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.reject(error);
+          return Promise.reject(error);
         };
       });
 
@@ -65,7 +63,7 @@ describe('AzureMonitorDatasource', () => {
         ctx.instanceSettings.jsonData.tenantId = 'xxx';
         ctx.instanceSettings.jsonData.clientId = 'xxx';
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.when({ data: response, status: 200 });
+          return Promise.resolve({ data: response, status: 200 });
         };
       });
 
@@ -128,7 +126,7 @@ describe('AzureMonitorDatasource', () => {
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
         expect(options.url).toContain('/api/tsdb/query');
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
     });
 
@@ -160,7 +158,7 @@ describe('AzureMonitorDatasource', () => {
 
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -186,7 +184,7 @@ describe('AzureMonitorDatasource', () => {
 
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = () => {
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -213,7 +211,7 @@ describe('AzureMonitorDatasource', () => {
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = (options: { url: string }) => {
           expect(options.url).toContain('11112222-eeee-4949-9b2d-9106972f9123');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -249,7 +247,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/9935389e-9122-4ef9-95f9-1513dd24753f/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodesapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -283,7 +281,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/11112222-eeee-4949-9b2d-9106972f9123/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodesapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -321,7 +319,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/9935389e-9122-4ef9-95f9-1513dd24753f/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodeapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -359,7 +357,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/11112222-eeee-4949-9b2d-9106972f9123/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodeapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -407,7 +405,7 @@ describe('AzureMonitorDatasource', () => {
               '/nodeapp/providers/microsoft.insights/components/rn/providers/microsoft.insights/' +
               'metricdefinitions?api-version=2018-01-01&metricnamespace=default'
           );
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -456,7 +454,7 @@ describe('AzureMonitorDatasource', () => {
               '/nodeapp/providers/microsoft.insights/components/rn/providers/microsoft.insights/' +
               'metricdefinitions?api-version=2018-01-01&metricnamespace=default'
           );
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -506,7 +504,7 @@ describe('AzureMonitorDatasource', () => {
             baseUrl +
               '/nodeapp/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metricNamespaces?api-version=2017-12-01-preview'
           );
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -554,7 +552,7 @@ describe('AzureMonitorDatasource', () => {
             baseUrl +
               '/nodeapp/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metricNamespaces?api-version=2017-12-01-preview'
           );
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -604,7 +602,7 @@ describe('AzureMonitorDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = () => {
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 
@@ -628,7 +626,7 @@ describe('AzureMonitorDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = () => {
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 
@@ -680,7 +678,7 @@ describe('AzureMonitorDatasource', () => {
         const baseUrl =
           'http://azuremonitor.com/azuremonitor/subscriptions/9935389e-9122-4ef9-95f9-1513dd24753f/resourceGroups';
         expect(options.url).toBe(baseUrl + '/nodesapp/resources?api-version=2018-01-01');
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 
@@ -731,7 +729,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/9935389e-9122-4ef9-95f9-1513dd24753f/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodeapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -769,7 +767,7 @@ describe('AzureMonitorDatasource', () => {
           const baseUrl =
             'http://azuremonitor.com/azuremonitor/subscriptions/9935389e-9122-4ef9-95f9-1513dd24753f/resourceGroups';
           expect(options.url).toBe(baseUrl + '/nodeapp/resources?api-version=2018-01-01');
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -838,7 +836,7 @@ describe('AzureMonitorDatasource', () => {
           '/providers/microsoft.insights/components/resource1' +
           '/providers/microsoft.insights/metricdefinitions?api-version=2018-01-01&metricnamespace=default';
         expect(options.url).toBe(expected);
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 
@@ -910,7 +908,7 @@ describe('AzureMonitorDatasource', () => {
           '/providers/microsoft.insights/components/resource1' +
           '/providers/microsoft.insights/metricdefinitions?api-version=2018-01-01&metricnamespace=default';
         expect(options.url).toBe(expected);
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 
@@ -984,7 +982,7 @@ describe('AzureMonitorDatasource', () => {
           '/providers/microsoft.insights/components/resource1' +
           '/providers/microsoft.insights/metricdefinitions?api-version=2018-01-01&metricnamespace=default';
         expect(options.url).toBe(expected);
-        return ctx.$q.when(response);
+        return Promise.resolve(response);
       };
     });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -6,7 +6,6 @@ import { AzureMonitorQuery, AzureDataSourceJsonData } from './types';
 import { DataSourceApi, DataQueryRequest, DataSourceInstanceSettings } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { IQService } from 'angular';
 
 export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDataSourceJsonData> {
   azureMonitorDatasource: AzureMonitorDatasource;
@@ -17,8 +16,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
   constructor(
     instanceSettings: DataSourceInstanceSettings<AzureDataSourceJsonData>,
     private backendSrv: BackendSrv,
-    private templateSrv: TemplateSrv,
-    private $q: IQService
+    private templateSrv: TemplateSrv
   ) {
     super(instanceSettings);
     this.azureMonitorDatasource = new AzureMonitorDatasource(instanceSettings, this.backendSrv, this.templateSrv);
@@ -63,7 +61,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
     }
 
     if (promises.length === 0) {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     return Promise.all(promises).then(results => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.test.ts
@@ -18,7 +18,6 @@ describe('AzureMonitorQueryCtrl', () => {
     };
     AzureMonitorQueryCtrl.prototype.target = {} as any;
     AzureMonitorQueryCtrl.prototype.datasource = {
-      $q: Q,
       appInsightsDatasource: { isConfigured: () => false },
       azureMonitorDatasource: { isConfigured: () => false },
     };
@@ -54,7 +53,7 @@ describe('AzureMonitorQueryCtrl', () => {
 
       beforeEach(() => {
         queryCtrl.datasource.getResourceGroups = () => {
-          return queryCtrl.datasource.$q.when(response);
+          return Promise.resolve(response);
         };
         queryCtrl.datasource.azureMonitorDatasource = {
           isConfigured: () => {
@@ -80,10 +79,10 @@ describe('AzureMonitorQueryCtrl', () => {
         beforeEach(() => {
           queryCtrl.target.subscription = 'sub1';
           queryCtrl.target.azureMonitor.resourceGroup = 'test';
-          queryCtrl.datasource.getMetricDefinitions = function(subscriptionId: any, query: any) {
+          queryCtrl.datasource.getMetricDefinitions = (subscriptionId: any, query: any) => {
             expect(subscriptionId).toBe('sub1');
             expect(query).toBe('test');
-            return this.$q.when(response);
+            return Promise.resolve(response);
           };
         });
 
@@ -117,15 +116,11 @@ describe('AzureMonitorQueryCtrl', () => {
           queryCtrl.target.subscription = 'sub1';
           queryCtrl.target.azureMonitor.resourceGroup = 'test';
           queryCtrl.target.azureMonitor.metricDefinition = 'Microsoft.Compute/virtualMachines';
-          queryCtrl.datasource.getResourceNames = function(
-            subscriptionId: any,
-            resourceGroup: any,
-            metricDefinition: any
-          ) {
+          queryCtrl.datasource.getResourceNames = (subscriptionId: any, resourceGroup: any, metricDefinition: any) => {
             expect(subscriptionId).toBe('sub1');
             expect(resourceGroup).toBe('test');
             expect(metricDefinition).toBe('Microsoft.Compute/virtualMachines');
-            return this.$q.when(response);
+            return Promise.resolve(response);
           };
         });
 
@@ -162,19 +157,19 @@ describe('AzureMonitorQueryCtrl', () => {
           queryCtrl.target.azureMonitor.metricDefinition = 'Microsoft.Compute/virtualMachines';
           queryCtrl.target.azureMonitor.resourceName = 'test';
           queryCtrl.target.azureMonitor.metricNamespace = 'test';
-          queryCtrl.datasource.getMetricNames = function(
+          queryCtrl.datasource.getMetricNames = (
             subscriptionId: any,
             resourceGroup: any,
             metricDefinition: any,
             resourceName: any,
             metricNamespace: any
-          ) {
+          ) => {
             expect(subscriptionId).toBe('sub1');
             expect(resourceGroup).toBe('test');
             expect(metricDefinition).toBe('Microsoft.Compute/virtualMachines');
             expect(resourceName).toBe('test');
             expect(metricNamespace).toBe('test');
-            return this.$q.when(response);
+            return Promise.resolve(response);
           };
         });
 
@@ -218,21 +213,21 @@ describe('AzureMonitorQueryCtrl', () => {
         queryCtrl.target.azureMonitor.resourceName = 'test';
         queryCtrl.target.azureMonitor.metricNamespace = 'test';
         queryCtrl.target.azureMonitor.metricName = 'Percentage CPU';
-        queryCtrl.datasource.getMetricMetadata = function(
+        queryCtrl.datasource.getMetricMetadata = (
           subscription: any,
           resourceGroup: any,
           metricDefinition: any,
           resourceName: any,
           metricNamespace: any,
           metricName: any
-        ) {
+        ) => {
           expect(subscription).toBe('sub1');
           expect(resourceGroup).toBe('test');
           expect(metricDefinition).toBe('Microsoft.Compute/virtualMachines');
           expect(resourceName).toBe('test');
           expect(metricNamespace).toBe('test');
           expect(metricName).toBe('Percentage CPU');
-          return this.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -289,7 +284,7 @@ describe('AzureMonitorQueryCtrl', () => {
       beforeEach(() => {
         queryCtrl.datasource.appInsightsDatasource.isConfigured = () => true;
         queryCtrl.datasource.getAppInsightsMetricNames = () => {
-          return queryCtrl.datasource.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 
@@ -324,9 +319,9 @@ describe('AzureMonitorQueryCtrl', () => {
 
       beforeEach(() => {
         queryCtrl.target.appInsights.metricName = 'requests/failed';
-        queryCtrl.datasource.getAppInsightsMetricMetadata = function(metricName: string) {
+        queryCtrl.datasource.getAppInsightsMetricMetadata = (metricName: string) => {
           expect(metricName).toBe('requests/failed');
-          return this.$q.when(response);
+          return Promise.resolve(response);
         };
       });
 

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -1,11 +1,10 @@
 import _ from 'lodash';
 import { BackendSrv } from 'app/core/services/backend_srv';
-import { IQService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 class GrafanaDatasource {
   /** @ngInject */
-  constructor(private backendSrv: BackendSrv, private $q: IQService, private templateSrv: TemplateSrv) {}
+  constructor(private backendSrv: BackendSrv, private templateSrv: TemplateSrv) {}
 
   query(options: any) {
     return this.backendSrv
@@ -34,7 +33,7 @@ class GrafanaDatasource {
   }
 
   metricFindQuery(options: any) {
-    return this.$q.when({ data: [] });
+    return Promise.resolve({ data: [] });
   }
 
   annotationQuery(options: any) {
@@ -49,7 +48,7 @@ class GrafanaDatasource {
     if (options.annotation.type === 'dashboard') {
       // if no dashboard id yet return
       if (!options.dashboard.id) {
-        return this.$q.when([]);
+        return Promise.resolve([]);
       }
       // filter by dashboard id
       params.dashboardId = options.dashboard.id;
@@ -58,7 +57,7 @@ class GrafanaDatasource {
     } else {
       // require at least one tag
       if (!_.isArray(options.annotation.tags) || options.annotation.tags.length === 0) {
-        return this.$q.when([]);
+        return Promise.resolve([]);
       }
       const delimiter = '__delimiter__';
       const tags = [];

--- a/public/app/plugins/datasource/grafana/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana/specs/datasource.test.ts
@@ -19,7 +19,7 @@ describe('grafana data source', () => {
       },
     };
 
-    const ds = new GrafanaDatasource(backendSrvStub as any, q, templateSrvStub as any);
+    const ds = new GrafanaDatasource(backendSrvStub as any, templateSrvStub as any);
 
     describe('with tags that have template variables', () => {
       const options = setupAnnotationQueryOptions({ tags: ['tag1:$var'] });

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -10,7 +10,6 @@ import {
 } from '@grafana/data';
 import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
 import gfunc from './gfunc';
-import { IQService } from 'angular';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 //Types
@@ -31,12 +30,7 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
   _seriesRefLetters: string;
 
   /** @ngInject */
-  constructor(
-    instanceSettings: any,
-    private $q: IQService,
-    private backendSrv: BackendSrv,
-    private templateSrv: TemplateSrv
-  ) {
+  constructor(instanceSettings: any, private backendSrv: BackendSrv, private templateSrv: TemplateSrv) {
     super(instanceSettings);
     this.basicAuth = instanceSettings.basicAuth;
     this.url = instanceSettings.url;
@@ -76,7 +70,7 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
 
     const params = this.buildGraphiteParams(graphOptions, options.scopedVars);
     if (params.length === 0) {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     if (this.isMetricTank) {
@@ -242,7 +236,7 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
           tags,
       });
     } catch (err) {
-      return this.$q.reject(err);
+      return Promise.reject(err);
     }
   }
 

--- a/public/app/plugins/datasource/graphite/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/datasource.test.ts
@@ -1,14 +1,12 @@
 import { GraphiteDatasource } from '../datasource';
 import _ from 'lodash';
-// @ts-ignore
-import $q from 'q';
+
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { dateTime } from '@grafana/data';
 
 describe('graphiteDatasource', () => {
   const ctx: any = {
     backendSrv: {},
-    $q,
     // @ts-ignore
     templateSrv: new TemplateSrv(),
     instanceSettings: { url: 'url', name: 'graphiteProd', jsonData: {} },
@@ -17,7 +15,7 @@ describe('graphiteDatasource', () => {
   beforeEach(() => {
     ctx.instanceSettings.url = '/api/datasources/proxy/1';
     // @ts-ignore
-    ctx.ds = new GraphiteDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+    ctx.ds = new GraphiteDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When querying graphite with one target using query editor target spec', () => {
@@ -35,7 +33,7 @@ describe('graphiteDatasource', () => {
     beforeEach(async () => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
         requestOptions = options;
-        return ctx.$q.when({
+        return Promise.resolve({
           data: [
             {
               target: 'prod1.count',
@@ -118,7 +116,7 @@ describe('graphiteDatasource', () => {
 
       beforeEach(async () => {
         ctx.backendSrv.datasourceRequest = (options: any) => {
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
 
         await ctx.ds.annotationQuery(options).then((data: any) => {
@@ -148,7 +146,7 @@ describe('graphiteDatasource', () => {
       };
       beforeEach(() => {
         ctx.backendSrv.datasourceRequest = (options: any) => {
-          return ctx.$q.when(response);
+          return Promise.resolve(response);
         };
 
         ctx.ds.annotationQuery(options).then((data: any) => {
@@ -267,7 +265,7 @@ describe('graphiteDatasource', () => {
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
         requestOptions = options;
-        return ctx.$q.when({
+        return Promise.resolve({
           data: ['backend_01', 'backend_02'],
         });
       };
@@ -393,7 +391,6 @@ function accessScenario(name: string, url: string, fn: any) {
   describe('access scenario ' + name, () => {
     const ctx: any = {
       backendSrv: {},
-      $q,
       // @ts-ignore
       templateSrv: new TemplateSrv(),
       instanceSettings: { url: 'url', name: 'graphiteProd', jsonData: {} },
@@ -409,7 +406,7 @@ function accessScenario(name: string, url: string, fn: any) {
       it('tracing headers should be added', () => {
         ctx.instanceSettings.url = url;
         // @ts-ignore
-        const ds = new GraphiteDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+        const ds = new GraphiteDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
         ds.addTracingHeaders(httpOptions, options);
         fn(httpOptions);
       });

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -8,7 +8,6 @@ import { InfluxQueryBuilder } from './query_builder';
 import { InfluxQuery, InfluxOptions } from './types';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { IQService } from 'angular';
 
 export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxOptions> {
   type: string;
@@ -26,7 +25,6 @@ export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxO
   /** @ngInject */
   constructor(
     instanceSettings: DataSourceInstanceSettings<InfluxOptions>,
-    private $q: IQService,
     private backendSrv: BackendSrv,
     private templateSrv: TemplateSrv
   ) {
@@ -76,7 +74,7 @@ export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxO
     });
 
     if (allQueries === '') {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     // add global adhoc filters to timeFilter
@@ -135,7 +133,7 @@ export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxO
 
   annotationQuery(options: any) {
     if (!options.annotation.query) {
-      return this.$q.reject({
+      return Promise.reject({
         message: 'Query missing in annotation definition',
       });
     }
@@ -227,7 +225,7 @@ export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxO
 
   _seriesQuery(query: string, options?: any) {
     if (!query) {
-      return this.$q.when({ results: [] });
+      return Promise.resolve({ results: [] });
     }
 
     if (options && options.range) {

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -1,4 +1,4 @@
-import angular, { auto, IQService } from 'angular';
+import angular, { auto } from 'angular';
 import _ from 'lodash';
 import { InfluxQueryBuilder } from './query_builder';
 import InfluxQueryModel from './influx_query_model';
@@ -25,7 +25,6 @@ export class InfluxQueryCtrl extends QueryCtrl {
     $scope: any,
     $injector: auto.IInjectorService,
     private templateSrv: TemplateSrv,
-    private $q: IQService,
     private uiSegmentSrv: any
   ) {
     super($scope, $injector);
@@ -180,7 +179,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -204,7 +203,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -285,14 +284,14 @@ export class InfluxQueryCtrl extends QueryCtrl {
 
   getTagsOrValues(segment: { type: string }, index: number) {
     if (segment.type === 'condition') {
-      return this.$q.when([this.uiSegmentSrv.newSegment('AND'), this.uiSegmentSrv.newSegment('OR')]);
+      return Promise.resolve([this.uiSegmentSrv.newSegment('AND'), this.uiSegmentSrv.newSegment('OR')]);
     }
     if (segment.type === 'operator') {
       const nextValue = this.tagSegments[index + 1].value;
       if (/^\/.*\/$/.test(nextValue)) {
-        return this.$q.when(this.uiSegmentSrv.newOperators(['=~', '!~']));
+        return Promise.resolve(this.uiSegmentSrv.newOperators(['=~', '!~']));
       } else {
-        return this.$q.when(this.uiSegmentSrv.newOperators(['=', '!=', '<>', '<', '>']));
+        return Promise.resolve(this.uiSegmentSrv.newOperators(['=', '!=', '<>', '<', '>']));
       }
     }
 

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -1,12 +1,10 @@
 import InfluxDatasource from '../datasource';
-//@ts-ignore
-import $q from 'q';
+
 import { TemplateSrvStub } from 'test/specs/helpers';
 
 describe('InfluxDataSource', () => {
   const ctx: any = {
     backendSrv: {},
-    $q: $q,
     //@ts-ignore
     templateSrv: new TemplateSrvStub(),
     instanceSettings: { url: 'url', name: 'influxDb', jsonData: { httpMode: 'GET' } },
@@ -14,7 +12,7 @@ describe('InfluxDataSource', () => {
 
   beforeEach(() => {
     ctx.instanceSettings.url = '/api/datasources/proxy/1';
-    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When issuing metricFindQuery', () => {
@@ -32,7 +30,7 @@ describe('InfluxDataSource', () => {
         requestMethod = req.method;
         requestQuery = req.params.q;
         requestData = req.data;
-        return ctx.$q.when({
+        return Promise.resolve({
           results: [
             {
               series: [
@@ -67,7 +65,6 @@ describe('InfluxDataSource', () => {
 describe('InfluxDataSource in POST query mode', () => {
   const ctx: any = {
     backendSrv: {},
-    $q,
     //@ts-ignore
     templateSrv: new TemplateSrvStub(),
     instanceSettings: { url: 'url', name: 'influxDb', jsonData: { httpMode: 'POST' } },
@@ -75,7 +72,7 @@ describe('InfluxDataSource in POST query mode', () => {
 
   beforeEach(() => {
     ctx.instanceSettings.url = '/api/datasources/proxy/1';
-    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv);
+    ctx.ds = new InfluxDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When issuing metricFindQuery', () => {
@@ -88,7 +85,7 @@ describe('InfluxDataSource in POST query mode', () => {
         requestMethod = req.method;
         requestQueryParameter = req.params;
         requestQuery = req.data;
-        return ctx.$q.when({
+        return Promise.resolve({
           results: [
             {
               series: [

--- a/public/app/plugins/datasource/influxdb/specs/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_ctrl.test.ts
@@ -21,7 +21,6 @@ describe('InfluxDBQueryCtrl', () => {
       {},
       {} as any,
       {} as any,
-      {} as any,
       //@ts-ignore
       new uiSegmentSrv({ trustAsHtml: (html: any) => html }, { highlightVariablesAsHtml: () => {} })
     );

--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import ResponseParser from './response_parser';
 import { BackendSrv } from 'app/core/services/backend_srv';
-import { IQService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
@@ -17,13 +16,12 @@ export class MssqlDatasource {
   constructor(
     instanceSettings: any,
     private backendSrv: BackendSrv,
-    private $q: IQService,
     private templateSrv: TemplateSrv,
     private timeSrv: TimeSrv
   ) {
     this.name = instanceSettings.name;
     this.id = instanceSettings.id;
-    this.responseParser = new ResponseParser(this.$q);
+    this.responseParser = new ResponseParser();
     this.interval = (instanceSettings.jsonData || {}).timeInterval || '1m';
   }
 
@@ -80,7 +78,7 @@ export class MssqlDatasource {
     });
 
     if (queries.length === 0) {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     return this.backendSrv
@@ -98,7 +96,7 @@ export class MssqlDatasource {
 
   annotationQuery(options: any) {
     if (!options.annotation.rawQuery) {
-      return this.$q.reject({ message: 'Query missing in annotation definition' });
+      return Promise.reject({ message: 'Query missing in annotation definition' });
     }
 
     const query = {

--- a/public/app/plugins/datasource/mssql/response_parser.ts
+++ b/public/app/plugins/datasource/mssql/response_parser.ts
@@ -1,9 +1,6 @@
 import _ from 'lodash';
-import { IQService } from 'angular';
 
 export default class ResponseParser {
-  constructor(private $q: IQService) {}
-
   processQueryResult(res: any) {
     const data: any[] = [];
 
@@ -121,7 +118,7 @@ export default class ResponseParser {
     }
 
     if (timeColumnIndex === -1) {
-      return this.$q.reject({ message: 'Missing mandatory time column (with time column alias) in annotation query.' });
+      return Promise.reject({ message: 'Missing mandatory time column (with time column alias) in annotation query.' });
     }
 
     const list = [];

--- a/public/app/plugins/datasource/mssql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mssql/specs/datasource.test.ts
@@ -1,8 +1,7 @@
 import { MssqlDatasource } from '../datasource';
 import { TimeSrvStub } from 'test/specs/helpers';
 import { CustomVariable } from 'app/features/templating/custom_variable';
-// @ts-ignore
-import q from 'q';
+
 import { dateTime } from '@grafana/data';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
@@ -15,10 +14,9 @@ describe('MSSQLDatasource', () => {
   };
 
   beforeEach(() => {
-    ctx.$q = q;
     ctx.instanceSettings = { name: 'mssql' };
 
-    ctx.ds = new MssqlDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.$q, templateSrv, ctx.timeSrv);
+    ctx.ds = new MssqlDatasource(ctx.instanceSettings, ctx.backendSrv, templateSrv, ctx.timeSrv);
   });
 
   describe('When performing annotationQuery', () => {
@@ -57,7 +55,7 @@ describe('MSSQLDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
 
       return ctx.ds.annotationQuery(options).then((data: any) => {
@@ -105,7 +103,7 @@ describe('MSSQLDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
 
       return ctx.ds.metricFindQuery(query).then((data: any) => {
@@ -146,7 +144,7 @@ describe('MSSQLDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
 
       return ctx.ds.metricFindQuery(query).then((data: any) => {
@@ -189,7 +187,7 @@ describe('MSSQLDatasource', () => {
 
     beforeEach(() => {
       ctx.backendSrv.datasourceRequest = (options: any) => {
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
 
       return ctx.ds.metricFindQuery(query).then((data: any) => {
@@ -233,7 +231,7 @@ describe('MSSQLDatasource', () => {
 
       ctx.backendSrv.datasourceRequest = (options: any) => {
         results = options.data;
-        return ctx.$q.when({ data: response, status: 200 });
+        return Promise.resolve({ data: response, status: 200 });
       };
 
       return ctx.ds.metricFindQuery(query);

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import ResponseParser from './response_parser';
 import MysqlQuery from 'app/plugins/datasource/mysql/mysql_query';
 import { BackendSrv } from 'app/core/services/backend_srv';
-import { IQService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
@@ -20,13 +19,12 @@ export class MysqlDatasource {
   constructor(
     instanceSettings: any,
     private backendSrv: BackendSrv,
-    private $q: IQService,
     private templateSrv: TemplateSrv,
     private timeSrv: TimeSrv
   ) {
     this.name = instanceSettings.name;
     this.id = instanceSettings.id;
-    this.responseParser = new ResponseParser(this.$q);
+    this.responseParser = new ResponseParser();
     this.queryModel = new MysqlQuery({});
     this.interval = (instanceSettings.jsonData || {}).timeInterval || '1m';
   }
@@ -82,7 +80,7 @@ export class MysqlDatasource {
     });
 
     if (queries.length === 0) {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     return this.backendSrv
@@ -100,7 +98,7 @@ export class MysqlDatasource {
 
   annotationQuery(options: any) {
     if (!options.annotation.rawQuery) {
-      return this.$q.reject({
+      return Promise.reject({
         message: 'Query missing in annotation definition',
       });
     }

--- a/public/app/plugins/datasource/mysql/query_ctrl.ts
+++ b/public/app/plugins/datasource/mysql/query_ctrl.ts
@@ -5,7 +5,7 @@ import { QueryCtrl } from 'app/plugins/sdk';
 import { SqlPart } from 'app/core/components/sql_part/sql_part';
 import MysqlQuery from './mysql_query';
 import sqlPart from './sql_part';
-import { auto, IQService } from 'angular';
+import { auto } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { CoreEvents } from 'app/types';
 import { PanelEvents } from '@grafana/data';
@@ -49,7 +49,6 @@ export class MysqlQueryCtrl extends QueryCtrl {
     $scope: any,
     $injector: auto.IInjectorService,
     private templateSrv: TemplateSrv,
-    private $q: IQService,
     private uiSegmentSrv: any
   ) {
     super($scope, $injector);
@@ -217,7 +216,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
       }
     });
 
-    this.$q.all([task1, task2]).then(() => {
+    Promise.all([task1, task2]).then(() => {
       this.updateRawSqlAndRefresh();
     });
   }
@@ -449,7 +448,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -473,7 +472,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -536,7 +535,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
           case 'right':
             if (['int', 'bigint', 'double', 'datetime'].indexOf(part.datatype) > -1) {
               // don't do value lookups for numerical fields
-              return this.$q.when([]);
+              return Promise.resolve([]);
             } else {
               return this.datasource
                 .metricFindQuery(this.metaBuilder.buildValueQuery(part.params[0]))
@@ -551,9 +550,9 @@ export class MysqlQueryCtrl extends QueryCtrl {
                 .catch(this.handleQueryError.bind(this));
             }
           case 'op':
-            return this.$q.when(this.uiSegmentSrv.newOperators(this.metaBuilder.getOperators(part.datatype)));
+            return Promise.resolve(this.uiSegmentSrv.newOperators(this.metaBuilder.getOperators(part.datatype)));
           default:
-            return this.$q.when([]);
+            return Promise.resolve([]);
         }
       }
       case 'part-param-changed': {
@@ -574,7 +573,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -587,7 +586,7 @@ export class MysqlQueryCtrl extends QueryCtrl {
       options.push(this.uiSegmentSrv.newSegment({ type: 'macro', value: '$__timeFilter' }));
     }
     options.push(this.uiSegmentSrv.newSegment({ type: 'expression', value: 'Expression' }));
-    return this.$q.when(options);
+    return Promise.resolve(options);
   }
 
   addWhereAction(part: any, index: number) {

--- a/public/app/plugins/datasource/mysql/response_parser.ts
+++ b/public/app/plugins/datasource/mysql/response_parser.ts
@@ -1,9 +1,6 @@
 import _ from 'lodash';
-import { IQService } from 'angular';
 
 export default class ResponseParser {
-  constructor(private $q: IQService) {}
-
   processQueryResult(res: any) {
     const data: any[] = [];
 
@@ -117,7 +114,7 @@ export default class ResponseParser {
       if (table.columns[i].text === 'time_sec' || table.columns[i].text === 'time') {
         timeColumnIndex = i;
       } else if (table.columns[i].text === 'title') {
-        return this.$q.reject({
+        return Promise.reject({
           message: 'The title column for annotations is deprecated, now only a column named text is returned',
         });
       } else if (table.columns[i].text === 'text') {
@@ -128,7 +125,7 @@ export default class ResponseParser {
     }
 
     if (timeColumnIndex === -1) {
-      return this.$q.reject({
+      return Promise.reject({
         message: 'Missing mandatory time column (with time_sec column alias) in annotation query.',
       });
     }

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -25,7 +25,7 @@ describe('MySQLDatasource', () => {
   } as any;
 
   beforeEach(() => {
-    ctx.ds = new MysqlDatasource(instanceSettings, backendSrv as BackendSrv, {} as any, templateSrv, ctx.timeSrvMock);
+    ctx.ds = new MysqlDatasource(instanceSettings, backendSrv as BackendSrv, templateSrv, ctx.timeSrvMock);
   });
 
   describe('When performing annotationQuery', () => {

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -1,4 +1,4 @@
-import angular, { IQService } from 'angular';
+import angular from 'angular';
 import _ from 'lodash';
 import { dateMath, DataQueryRequest, DataSourceApi } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
@@ -18,14 +18,9 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
   aggregatorsPromise: any;
   filterTypesPromise: any;
 
-  /** @ngInject */
-  constructor(
-    instanceSettings: any,
-    private $q: IQService,
-    private backendSrv: BackendSrv,
-    private templateSrv: TemplateSrv
-  ) {
+  constructor(instanceSettings: any, private backendSrv: BackendSrv, private templateSrv: TemplateSrv) {
     super(instanceSettings);
+
     this.type = 'opentsdb';
     this.url = instanceSettings.url;
     this.name = instanceSettings.name;
@@ -57,9 +52,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
 
     // No valid targets, return the empty result to save a round trip.
     if (_.isEmpty(queries)) {
-      const d = this.$q.defer();
-      d.resolve({ data: [] });
-      return d.promise;
+      return Promise.resolve({ data: [] });
     }
 
     const groupByTags: any = {};
@@ -177,7 +170,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
   }
 
   suggestTagKeys(metric: string | number) {
-    return this.$q.when(this.tagKeys[metric] || []);
+    return Promise.resolve(this.tagKeys[metric] || []);
   }
 
   _saveTagKeys(metricData: { tags: {}; aggregateTags: any; metric: string | number }) {
@@ -197,7 +190,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
 
   _performMetricKeyValueLookup(metric: string, keys: any) {
     if (!metric || !keys) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     const keysArray = keys.split(',').map((key: any) => {
@@ -226,7 +219,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
 
   _performMetricKeyLookup(metric: any) {
     if (!metric) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     return this._get('/api/search/lookup', { m: metric, limit: 1000 }).then((result: any) => {
@@ -266,14 +259,14 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
 
   metricFindQuery(query: string) {
     if (!query) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
 
     let interpolated;
     try {
       interpolated = this.templateSrv.replace(query, {}, 'distributed');
     } catch (err) {
-      return this.$q.reject(err);
+      return Promise.reject(err);
     }
 
     const responseTransform = (result: any) => {
@@ -313,7 +306,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
       return this._performSuggestQuery(tagValuesSuggestQuery[1], 'tagv').then(responseTransform);
     }
 
-    return this.$q.when([]);
+    return Promise.resolve([]);
   }
 
   testDatasource() {

--- a/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
@@ -1,6 +1,4 @@
 import OpenTsDatasource from '../datasource';
-// @ts-ignore
-import $q from 'q';
 
 describe('opentsdb', () => {
   const ctx = {
@@ -13,7 +11,7 @@ describe('opentsdb', () => {
   const instanceSettings = { url: '', jsonData: { tsdbVersion: 1 } };
 
   beforeEach(() => {
-    ctx.ctrl = new OpenTsDatasource(instanceSettings, $q, ctx.backendSrv, ctx.templateSrv);
+    ctx.ctrl = new OpenTsDatasource(instanceSettings, ctx.backendSrv, ctx.templateSrv);
   });
 
   describe('When performing metricFindQuery', () => {

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import ResponseParser from './response_parser';
 import PostgresQuery from 'app/plugins/datasource/postgres/postgres_query';
-import { IQService } from 'angular';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -21,14 +20,13 @@ export class PostgresDatasource {
   constructor(
     instanceSettings: { name: any; id?: any; jsonData?: any },
     private backendSrv: BackendSrv,
-    private $q: IQService,
     private templateSrv: TemplateSrv,
     private timeSrv: TimeSrv
   ) {
     this.name = instanceSettings.name;
     this.id = instanceSettings.id;
     this.jsonData = instanceSettings.jsonData;
-    this.responseParser = new ResponseParser(this.$q);
+    this.responseParser = new ResponseParser();
     this.queryModel = new PostgresQuery({});
     this.interval = (instanceSettings.jsonData || {}).timeInterval || '1m';
   }
@@ -84,7 +82,7 @@ export class PostgresDatasource {
     });
 
     if (queries.length === 0) {
-      return this.$q.when({ data: [] });
+      return Promise.resolve({ data: [] });
     }
 
     return this.backendSrv
@@ -102,7 +100,7 @@ export class PostgresDatasource {
 
   annotationQuery(options: any) {
     if (!options.annotation.rawQuery) {
-      return this.$q.reject({
+      return Promise.reject({
         message: 'Query missing in annotation definition',
       });
     }

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -5,7 +5,7 @@ import { QueryCtrl } from 'app/plugins/sdk';
 import { SqlPart } from 'app/core/components/sql_part/sql_part';
 import PostgresQuery from './postgres_query';
 import sqlPart from './sql_part';
-import { auto, IQService } from 'angular';
+import { auto } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { CoreEvents } from 'app/types';
 import { PanelEvents } from '@grafana/data';
@@ -48,7 +48,6 @@ export class PostgresQueryCtrl extends QueryCtrl {
     $scope: any,
     $injector: auto.IInjectorService,
     private templateSrv: TemplateSrv,
-    private $q: IQService,
     private uiSegmentSrv: any
   ) {
     super($scope, $injector);
@@ -248,7 +247,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
       }
     });
 
-    this.$q.all([task1, task2]).then(() => {
+    Promise.all([task1, task2]).then(() => {
       this.updateRawSqlAndRefresh();
     });
   }
@@ -481,7 +480,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -505,7 +504,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -568,7 +567,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
           case 'right':
             if (['int4', 'int8', 'float4', 'float8', 'timestamp', 'timestamptz'].indexOf(part.datatype) > -1) {
               // don't do value lookups for numerical fields
-              return this.$q.when([]);
+              return Promise.resolve([]);
             } else {
               return this.datasource
                 .metricFindQuery(this.metaBuilder.buildValueQuery(part.params[0]))
@@ -583,9 +582,9 @@ export class PostgresQueryCtrl extends QueryCtrl {
                 .catch(this.handleQueryError.bind(this));
             }
           case 'op':
-            return this.$q.when(this.uiSegmentSrv.newOperators(this.metaBuilder.getOperators(part.datatype)));
+            return Promise.resolve(this.uiSegmentSrv.newOperators(this.metaBuilder.getOperators(part.datatype)));
           default:
-            return this.$q.when([]);
+            return Promise.resolve([]);
         }
       }
       case 'part-param-changed': {
@@ -606,7 +605,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
         break;
       }
       case 'get-part-actions': {
-        return this.$q.when([{ text: 'Remove', value: 'remove-part' }]);
+        return Promise.resolve([{ text: 'Remove', value: 'remove-part' }]);
       }
     }
   }
@@ -619,7 +618,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
       options.push(this.uiSegmentSrv.newSegment({ type: 'macro', value: '$__timeFilter' }));
     }
     options.push(this.uiSegmentSrv.newSegment({ type: 'expression', value: 'Expression' }));
-    return this.$q.when(options);
+    return Promise.resolve(options);
   }
 
   addWhereAction(part: any, index: any) {

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -1,9 +1,6 @@
 import _ from 'lodash';
-import { IQService } from 'angular';
 
 export default class ResponseParser {
-  constructor(private $q: IQService) {}
-
   processQueryResult(res: any) {
     const data: any[] = [];
 
@@ -125,7 +122,7 @@ export default class ResponseParser {
     }
 
     if (timeColumnIndex === -1) {
-      return this.$q.reject({
+      return Promise.reject({
         message: 'Missing mandatory time column in annotation query.',
       });
     }

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -2,7 +2,6 @@ import { PostgresDatasource } from '../datasource';
 import { CustomVariable } from 'app/features/templating/custom_variable';
 import { dateTime, toUtc } from '@grafana/data';
 import { BackendSrv } from 'app/core/services/backend_srv';
-import { IQService } from 'angular';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 describe('PostgreSQLDatasource', () => {
@@ -26,13 +25,7 @@ describe('PostgreSQLDatasource', () => {
   } as any;
 
   beforeEach(() => {
-    ctx.ds = new PostgresDatasource(
-      instanceSettings,
-      backendSrv as BackendSrv,
-      {} as IQService,
-      templateSrv,
-      ctx.timeSrvMock
-    );
+    ctx.ds = new PostgresDatasource(instanceSettings, backendSrv as BackendSrv, templateSrv, ctx.timeSrvMock);
   });
 
   describe('When performing annotationQuery', () => {

--- a/public/app/plugins/panel/table/column_options.ts
+++ b/public/app/plugins/panel/table/column_options.ts
@@ -145,8 +145,7 @@ export class ColumnOptionsCtrl {
   }
 }
 
-/** @ngInject */
-export function columnOptionsTab($q: any, uiSegmentSrv: any) {
+export function columnOptionsTab(uiSegmentSrv: any) {
   'use strict';
   return {
     restrict: 'E',

--- a/public/app/plugins/panel/table/editor.ts
+++ b/public/app/plugins/panel/table/editor.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import { transformers } from './transformers';
-import { IQService } from 'angular';
 import { Column } from 'react-virtualized';
 
 export class TablePanelEditorCtrl {
@@ -14,7 +13,7 @@ export class TablePanelEditorCtrl {
   columnsHelpMessage: string;
 
   /** @ngInject */
-  constructor($scope: any, private $q: IQService, private uiSegmentSrv: any) {
+  constructor($scope: any, private uiSegmentSrv: any) {
     $scope.editor = this;
     this.panelCtrl = $scope.ctrl;
     this.panel = this.panelCtrl.panel;
@@ -45,11 +44,11 @@ export class TablePanelEditorCtrl {
 
   getColumnOptions() {
     if (!this.panelCtrl.dataRaw) {
-      return this.$q.when([]);
+      return Promise.resolve([]);
     }
     const columns = this.transformers[this.panel.transform].getColumns(this.panelCtrl.dataRaw);
     const segments = _.map(columns, (c: any) => this.uiSegmentSrv.newSegment({ value: c.text }));
-    return this.$q.when(segments);
+    return Promise.resolve(segments);
   }
 
   addColumn() {
@@ -86,8 +85,7 @@ export class TablePanelEditorCtrl {
   }
 }
 
-/** @ngInject */
-export function tablePanelEditor($q: IQService, uiSegmentSrv: any) {
+export function tablePanelEditor(uiSegmentSrv: any) {
   'use strict';
   return {
     restrict: 'E',

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -47,67 +47,61 @@ export function ControllerTestContext(this: any) {
   };
 
   this.createPanelController = (Ctrl: any) => {
-    return angularMocks.inject(
-      ($controller: any, $rootScope: GrafanaRootScope, $q: any, $location: any, $browser: any) => {
-        self.scope = $rootScope.$new();
-        self.$location = $location;
-        self.$browser = $browser;
-        self.$q = $q;
-        self.panel = new PanelModel({ type: 'test' });
-        self.dashboard = { meta: {} };
-        self.isUtc = false;
-        self.dashboard.isTimezoneUtc = () => {
-          return self.isUtc;
-        };
+    return angularMocks.inject(($controller: any, $rootScope: GrafanaRootScope, $location: any, $browser: any) => {
+      self.scope = $rootScope.$new();
+      self.$location = $location;
+      self.$browser = $browser;
+      self.panel = new PanelModel({ type: 'test' });
+      self.dashboard = { meta: {} };
+      self.isUtc = false;
+      self.dashboard.isTimezoneUtc = () => {
+        return self.isUtc;
+      };
 
-        $rootScope.appEvent = sinon.spy();
-        $rootScope.onAppEvent = sinon.spy();
-        $rootScope.colors = [];
+      $rootScope.appEvent = sinon.spy();
+      $rootScope.onAppEvent = sinon.spy();
+      $rootScope.colors = [];
 
-        for (let i = 0; i < 50; i++) {
-          $rootScope.colors.push('#' + i);
-        }
-
-        config.panels['test'] = { info: {} } as PanelPluginMeta;
-        self.ctrl = $controller(
-          Ctrl,
-          { $scope: self.scope },
-          {
-            panel: self.panel,
-            dashboard: self.dashboard,
-          }
-        );
+      for (let i = 0; i < 50; i++) {
+        $rootScope.colors.push('#' + i);
       }
-    );
+
+      config.panels['test'] = { info: {} } as PanelPluginMeta;
+      self.ctrl = $controller(
+        Ctrl,
+        { $scope: self.scope },
+        {
+          panel: self.panel,
+          dashboard: self.dashboard,
+        }
+      );
+    });
   };
 
   this.createControllerPhase = (controllerName: string) => {
-    return angularMocks.inject(
-      ($controller: any, $rootScope: GrafanaRootScope, $q: any, $location: any, $browser: any) => {
-        self.scope = $rootScope.$new();
-        self.$location = $location;
-        self.$browser = $browser;
-        self.scope.contextSrv = {};
-        self.scope.panel = {};
-        self.scope.dashboard = { meta: {} };
-        self.scope.dashboardMeta = {};
-        self.scope.dashboardViewState = DashboardViewStateStub();
-        self.scope.appEvent = sinon.spy();
-        self.scope.onAppEvent = sinon.spy();
+    return angularMocks.inject(($controller: any, $rootScope: GrafanaRootScope, $location: any, $browser: any) => {
+      self.scope = $rootScope.$new();
+      self.$location = $location;
+      self.$browser = $browser;
+      self.scope.contextSrv = {};
+      self.scope.panel = {};
+      self.scope.dashboard = { meta: {} };
+      self.scope.dashboardMeta = {};
+      self.scope.dashboardViewState = DashboardViewStateStub();
+      self.scope.appEvent = sinon.spy();
+      self.scope.onAppEvent = sinon.spy();
 
-        $rootScope.colors = [];
-        for (let i = 0; i < 50; i++) {
-          $rootScope.colors.push('#' + i);
-        }
-
-        self.$q = $q;
-        self.scope.skipDataOnInit = true;
-        self.scope.skipAutoInit = true;
-        self.controller = $controller(controllerName, {
-          $scope: self.scope,
-        });
+      $rootScope.colors = [];
+      for (let i = 0; i < 50; i++) {
+        $rootScope.colors.push('#' + i);
       }
-    );
+
+      self.scope.skipDataOnInit = true;
+      self.scope.skipAutoInit = true;
+      self.controller = $controller(controllerName, {
+        $scope: self.scope,
+      });
+    });
   };
 
   this.setIsUtc = (isUtc: any = false) => {
@@ -134,8 +128,7 @@ export function ServiceTestContext(this: any) {
   this.createService = (name: string) => {
     // @ts-ignore
     return angularMocks.inject(
-      ($q: any, $rootScope: GrafanaRootScope, $httpBackend: any, $injector: any, $location: any, $timeout: any) => {
-        self.$q = $q;
+      ($rootScope: GrafanaRootScope, $httpBackend: any, $injector: any, $location: any, $timeout: any) => {
         self.$rootScope = $rootScope;
         self.$httpBackend = $httpBackend;
         self.$location = $location;


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes instances where the angular $q service is used and replaces them with native Promises.
Still used in template_srv and backend_srv, which I'll try to address in individual refactors of those
services.
