### PR TITLE
Tooltip: Adjust the max-width

### DIFF
--- a/packages/grafana-ui/src/components/Chart/TooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/Chart/TooltipContainer.tsx
@@ -18,8 +18,8 @@ const getTooltipContainerStyles = stylesFactory((theme: GrafanaTheme) => {
     wrapper: css`
       overflow: hidden;
       background: ${bgColor};
-      /* 30% is an arbitrary choice. We can be more clever about calculating tooltip\'s width */
-      max-width: 30%;
+      /* max-width is set up based on .grafana-tooltip class that's used in dashboard */
+      max-width: 800px;
       padding: ${theme.spacing.sm};
       border-radius: ${theme.border.radius.sm};
     `,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjusts the max-width of tooltip based on [grafana-tooltip](https://github.com/grafana/grafana/blob/master/public/sass/components/_tooltip.scss#L106) class that is used for tooltips in dashboards. This fixes an issue where, when hovered over graph in Explore, no value was shown and it was weirdly cropped:

![image](https://user-images.githubusercontent.com/30407135/69656561-10f80b80-1079-11ea-9f4c-342dc0969897.png)


**Fixed examples:**

![image](https://user-images.githubusercontent.com/30407135/69654347-ea37d600-1074-11ea-9ab7-5bd41528a8c4.png)

![image](https://user-images.githubusercontent.com/30407135/69654370-f4f26b00-1074-11ea-8625-e817317f2ca2.png)

![image](https://user-images.githubusercontent.com/30407135/69654452-1e12fb80-1075-11ea-90c2-687c87821589.png)

**Which issue(s) this PR fixes**:
Fixes #20569
