### PR TITLE
Server: Defer wg.Done call to ensure it's called

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -135,11 +135,12 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 
 	// handle http shutdown on server context done
 	go func() {
+		defer wg.Done()
+
 		<-ctx.Done()
 		if err := hs.httpSrv.Shutdown(context.Background()); err != nil {
 			hs.log.Error("Failed to shutdown server", "error", err)
 		}
-		wg.Done()
 	}()
 
 	switch setting.Protocol {


### PR DESCRIPTION
**What this PR does / why we need it**:
As @marefr pointed out, we should defer the call to `wg.Done()` in the goroutine handling server shutdown to ensure that it always gets called.
