### PR TITLE
Datasource/Loki: Fix issue where annotation query vars weren't being interpolated

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -581,7 +581,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       return [];
     }
 
-    const query = { refId: `annotation-${options.annotation.name}`, expr: options.annotation.expr };
+    const interpolatedExpr = this.templateSrv.replace(options.annotation.expr, {}, this.interpolateQueryExpr);
+    const query = { refId: `annotation-${options.annotation.name}`, expr: interpolatedExpr };
     const { data } = await this.runRangeQueryWithFallback(query, options).toPromise();
     const annotations: AnnotationEvent[] = [];
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed to fix broken annotation queries with loki.

**Which issue(s) this PR fixes**:
Closes #20667 
