### PR TITLE
Stats: Fix active admins/editors/viewers stats are counted more than once if the user is part of more than one org

### DIFF
--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -95,12 +95,12 @@ func GetSystemStats(query *m.GetSystemStatsQuery) error {
 func roleCounterSQL(role, alias string) string {
 	return `
 		(
-			SELECT COUNT(*)
+			SELECT COUNT(DISTINCT u.id)
 			FROM ` + dialect.Quote("user") + ` as u, org_user
 			WHERE ( org_user.user_id=u.id AND org_user.role='` + role + `' )
 		) as ` + alias + `,
 		(
-			SELECT COUNT(*)
+			SELECT COUNT(DISTINCT u.id)
 			FROM ` + dialect.Quote("user") + ` as u, org_user
 			WHERE u.last_seen_at>? AND ( org_user.user_id=u.id AND org_user.role='` + role + `' )
 		) as active_` + alias


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fix system statistics query to count only once users that are part of several organisations.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20681

**Special notes for your reviewer**:

