### PR TITLE
Prometheus: Fix caching for default labels request

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -308,12 +308,17 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const existingKeys = parsedSelector ? parsedSelector.labelKeys : [];
 
     // Query labels for selector
-    if (selector && (!this.labelValues[selector] || this.timeRangeChanged())) {
+    if (selector) {
       if (selector === EMPTY_SELECTOR) {
-        // Query label values for default labels
-        await Promise.all(DEFAULT_KEYS.map(key => this.fetchLabelValues(key)));
+        // For empty selector we do not need to check range
+        if (!this.labelValues[selector]) {
+          // Query label values for default labels
+          await Promise.all(DEFAULT_KEYS.map(key => this.fetchLabelValues(key)));
+        }
       } else {
-        await this.fetchSeriesLabels(selector, !containsMetric);
+        if (!this.labelValues[selector] || this.timeRangeChanged()) {
+          await this.fetchSeriesLabels(selector, !containsMetric);
+        }
       }
     }
 


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/20512

The default labels query does not use timeRange in any way, but for caching the timeRange was checked. As it wasn't actually updated after the request it was always different than the initial timeRange.

This removes the timeRange check for the default labels request.