### PR TITLE
Postgres: Adds support for region annotations

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -370,6 +370,7 @@ WHERE
 Name | Description
 ------------ | -------------
 time | The name of the date/time field. Could be a column with a native sql date/time data type or epoch value.
+timeend | Optional name of the time end field, needs to be date/time data type. If set, then annotations will be marked as a regions between time and time-end.
 text | Event description field.
 tags | Optional field name to use for event tags as a comma separated string.
 

--- a/public/app/plugins/datasource/postgres/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/annotations.editor.html
@@ -18,9 +18,10 @@
 
   <div class="gf-form"  ng-show="ctrl.showHelp">
 		<pre class="gf-form-pre alert alert-info"><h6>Annotation Query Format</h6>
-An annotation is an event that is overlaid on top of graphs. The query can have up to three columns per row, the time column is mandatory. Annotation rendering is expensive so it is important to limit the number of rows returned.
+An annotation is an event that is overlaid on top of graphs. The query can have up to four columns per row, the time column is mandatory. Annotation rendering is expensive so it is important to limit the number of rows returned.
 
 - column with alias: <b>time</b> for the annotation event time. Use epoch time or any native date data type.
+- column with alias: <b>timeend</b> for the annotation event time-end. Use epoch time or any native date data type.
 - column with alias: <b>text</b> for the annotation text
 - column with alias: <b>tags</b> for annotation tags. This is a comma separated string of tags e.g. 'tag1,tag2'
 

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { IQService } from 'angular';
+import { toUtc } from '@grafana/data';
 
 export default class ResponseParser {
   constructor(private $q: IQService) {}
@@ -110,6 +111,7 @@ export default class ResponseParser {
     const table = data.data.results[options.annotation.name].tables[0];
 
     let timeColumnIndex = -1;
+    let timeEndColumnIndex = -1;
     const titleColumnIndex = -1;
     let textColumnIndex = -1;
     let tagsColumnIndex = -1;
@@ -117,6 +119,8 @@ export default class ResponseParser {
     for (let i = 0; i < table.columns.length; i++) {
       if (table.columns[i].text === 'time') {
         timeColumnIndex = i;
+      } else if (table.columns[i].text === 'timeend') {
+        timeEndColumnIndex = i;
       } else if (table.columns[i].text === 'text') {
         textColumnIndex = i;
       } else if (table.columns[i].text === 'tags') {
@@ -133,9 +137,14 @@ export default class ResponseParser {
     const list = [];
     for (let i = 0; i < table.rows.length; i++) {
       const row = table.rows[i];
+      const timeEnd =
+        timeEndColumnIndex !== -1 && row[timeEndColumnIndex]
+          ? Math.floor(toUtc(row[timeEndColumnIndex]).valueOf())
+          : undefined;
       list.push({
         annotation: options.annotation,
         time: Math.floor(row[timeColumnIndex]),
+        timeEnd,
         title: row[titleColumnIndex],
         text: row[textColumnIndex],
         tags: row[tagsColumnIndex] ? row[tagsColumnIndex].trim().split(/\s*,\s*/) : [],


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for region annotations for Postgres data source. I took ElasticSearch one as an example and followed roughly same conventions: https://github.com/grafana/grafana/pull/17602

**Special notes for your reviewer**:

This is my first pull request to Grafana and I'm not very familiar with the code base, so highly likely there are something I've missed here. For example I wasn't fully sure how to handle date type from query, I used same approach here as in ElasticSearches case, which differs from how "time" is handled since that conversion is done on backend side. I didn't want to go poking into backend and create special case for "timeEnd", so opted for client side conversion.