### PR TITLE
CloudWatch: Annotation Editor rewrite

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -54,7 +54,7 @@ func (e *CloudWatchExecutor) executeAnnotationQuery(ctx context.Context, queryCo
 		alarmNames = filterAlarms(resp, namespace, metricName, dimensions, statistics, period)
 	} else {
 		if region == "" || namespace == "" || metricName == "" || len(statistics) == 0 {
-			return result, nil
+			return result, errors.New("Invalid annotations query")
 		}
 
 		var qd []*cloudwatch.Dimension

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -59,11 +59,15 @@ func (e *CloudWatchExecutor) executeAnnotationQuery(ctx context.Context, queryCo
 
 		var qd []*cloudwatch.Dimension
 		for k, v := range dimensions {
-			if vv, ok := v.(string); ok {
-				qd = append(qd, &cloudwatch.Dimension{
-					Name:  aws.String(k),
-					Value: aws.String(vv),
-				})
+			if vv, ok := v.([]interface{}); ok {
+				for _, vvv := range vv {
+					if vvvv, ok := vvv.(string); ok {
+						qd = append(qd, &cloudwatch.Dimension{
+							Name:  aws.String(k),
+							Value: aws.String(vvvv),
+						})
+					}
+				}
 			}
 		}
 		for _, s := range statistics {

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -97,7 +97,6 @@ export function registerAngularDirectives() {
   react2AngularDirective('cloudwatchAnnotationQueryEditor', CloudWatchAnnotationQueryEditor, [
     'query',
     'onChange',
-    'onRunQuery',
     ['datasource', { watchDepth: 'reference' }],
   ]);
   react2AngularDirective('secretFormField', SecretFormField, [

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -1,6 +1,7 @@
 import { react2AngularDirective } from 'app/core/utils/react2angular';
 import { QueryEditor as StackdriverQueryEditor } from 'app/plugins/datasource/stackdriver/components/QueryEditor';
 import { AnnotationQueryEditor as StackdriverAnnotationQueryEditor } from 'app/plugins/datasource/stackdriver/components/AnnotationQueryEditor';
+import { AnnotationQueryEditor as CloudWatchAnnotationQueryEditor } from 'app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor';
 import PageHeader from './components/PageHeader/PageHeader';
 import EmptyListCTA from './components/EmptyListCTA/EmptyListCTA';
 import { TagFilter } from './components/TagFilter/TagFilter';
@@ -92,6 +93,12 @@ export function registerAngularDirectives() {
     'onExecuteQuery',
     ['datasource', { watchDepth: 'reference' }],
     ['templateSrv', { watchDepth: 'reference' }],
+  ]);
+  react2AngularDirective('cloudwatchAnnotationQueryEditor', CloudWatchAnnotationQueryEditor, [
+    'query',
+    'onChange',
+    'onRunQuery',
+    ['datasource', { watchDepth: 'reference' }],
   ]);
   react2AngularDirective('secretFormField', SecretFormField, [
     'value',

--- a/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { AnnotationQuery } from './types';
 
 export class CloudWatchAnnotationsQueryCtrl {
@@ -6,11 +7,34 @@ export class CloudWatchAnnotationsQueryCtrl {
 
   /** @ngInject */
   constructor() {
-    this.annotation.target = this.annotation.target || {};
+    // this.annotation = {
+    //   namespace: '',
+    //   metricName: '',
+    //   expression: '',
+    //   dimensions: {},
+    //   region: 'default',
+    //   id: '',
+    //   alias: '',
+    //   statistics: ['Average'],
+    //   matchExact: true,
+    //   ...this.annotation,
+    // };
+    _.defaultsDeep(this.annotation, {
+      namespace: '',
+      metricName: '',
+      expression: '',
+      dimensions: {},
+      region: 'default',
+      id: '',
+      alias: '',
+      statistics: ['Average'],
+      matchExact: true,
+    });
+
     this.onChange = this.onChange.bind(this);
   }
 
-  onChange(target: AnnotationQuery) {
-    Object.assign(this.annotation.target, target);
+  onChange(query: AnnotationQuery) {
+    Object.assign(this.annotation, query);
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
@@ -7,18 +7,6 @@ export class CloudWatchAnnotationsQueryCtrl {
 
   /** @ngInject */
   constructor() {
-    // this.annotation = {
-    //   namespace: '',
-    //   metricName: '',
-    //   expression: '',
-    //   dimensions: {},
-    //   region: 'default',
-    //   id: '',
-    //   alias: '',
-    //   statistics: ['Average'],
-    //   matchExact: true,
-    //   ...this.annotation,
-    // };
     _.defaultsDeep(this.annotation, {
       namespace: '',
       metricName: '',
@@ -29,6 +17,9 @@ export class CloudWatchAnnotationsQueryCtrl {
       alias: '',
       statistics: ['Average'],
       matchExact: true,
+      prefixMatching: false,
+      actionPrefix: '',
+      alarmNamePrefix: '',
     });
 
     this.onChange = this.onChange.bind(this);

--- a/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
@@ -1,0 +1,16 @@
+import { AnnotationQuery } from './types';
+
+export class CloudWatchAnnotationsQueryCtrl {
+  static templateUrl = 'partials/annotations.editor.html';
+  annotation: any;
+
+  /** @ngInject */
+  constructor() {
+    this.annotation.target = this.annotation.target || {};
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(target: AnnotationQuery) {
+    Object.assign(this.annotation.target, target);
+  }
+}

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -37,6 +37,7 @@ export class AnnotationQueryEditor extends PureComponent<AnnotationQueryEditorPr
         <QueryFieldsEditor
           {...this.props}
           onChange={(editorQuery: CloudWatchQuery) => onChange({ ...query, ...editorQuery })}
+          hideWilcard
           onRunQuery={() => {}}
         ></QueryFieldsEditor>
         <div className="gf-form-inline">
@@ -50,6 +51,7 @@ export class AnnotationQueryEditor extends PureComponent<AnnotationQueryEditorPr
           <div className="gf-form gf-form--grow">
             <QueryField className="query-keyword" label="Action">
               <input
+                disabled={!query.prefixMatching}
                 className="gf-form-input width-12"
                 value={query.actionPrefix || ''}
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -59,6 +61,7 @@ export class AnnotationQueryEditor extends PureComponent<AnnotationQueryEditorPr
             </QueryField>
             <QueryField className="query-keyword" label="Alarm Name">
               <input
+                disabled={!query.prefixMatching}
                 className="gf-form-input width-12"
                 value={query.alarmNamePrefix || ''}
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { Switch } from '@grafana/ui';
+import { PanelData } from '@grafana/data';
 import { CloudWatchQuery, AnnotationQuery } from '../types';
 import CloudWatchDatasource from '../datasource';
 import { QueryField, QueryFieldsEditor } from './';
@@ -8,6 +9,7 @@ export type Props = {
   query: AnnotationQuery;
   datasource: CloudWatchDatasource;
   onChange: (value: AnnotationQuery) => void;
+  data?: PanelData;
 };
 
 export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -20,7 +20,6 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
         {...props}
         onChange={(editorQuery: CloudWatchQuery) => onChange({ ...query, ...editorQuery })}
         hideWilcard
-        onRunQuery={() => {}}
       ></QueryFieldsEditor>
       <div className="gf-form-inline">
         <Switch

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -1,0 +1,77 @@
+import React, { PureComponent, ChangeEvent } from 'react';
+import { PanelData } from '@grafana/data';
+import { Switch } from '@grafana/ui';
+import { CloudWatchQuery, AnnotationQuery } from '../types';
+import { QueryField } from './';
+import CloudWatchDatasource from '../datasource';
+import { QueryFieldsEditor } from './QueryFieldsEditor';
+
+export type AnnotationQueryEditorProps = {
+  datasource: CloudWatchDatasource;
+  query: AnnotationQuery;
+  onChange: (value: AnnotationQuery) => void;
+  data?: PanelData;
+};
+
+export class AnnotationQueryEditor extends PureComponent<AnnotationQueryEditorProps> {
+  componentWillMount() {
+    const { query } = this.props;
+
+    if (!query.hasOwnProperty('prefixMatching')) {
+      query.prefixMatching = false;
+    }
+
+    if (!query.actionPrefix) {
+      query.actionPrefix = '';
+    }
+
+    if (!query.alarmNamePrefix) {
+      query.alarmNamePrefix = '';
+    }
+  }
+
+  render() {
+    const { query, onChange } = this.props;
+    return (
+      <>
+        <QueryFieldsEditor
+          {...this.props}
+          onChange={(editorQuery: CloudWatchQuery) => onChange({ ...query, ...editorQuery })}
+          onRunQuery={() => {}}
+        ></QueryFieldsEditor>
+        <div className="gf-form-inline">
+          <Switch
+            label="Enable Prefix Matching"
+            labelClass="query-keyword"
+            checked={query.prefixMatching}
+            onChange={() => onChange({ ...query, prefixMatching: !query.prefixMatching })}
+          />
+
+          <div className="gf-form gf-form--grow">
+            <QueryField className="query-keyword" label="Action">
+              <input
+                className="gf-form-input width-12"
+                value={query.actionPrefix || ''}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  onChange({ ...query, actionPrefix: event.target.value })
+                }
+              />
+            </QueryField>
+            <QueryField className="query-keyword" label="Alarm Name">
+              <input
+                className="gf-form-input width-12"
+                value={query.alarmNamePrefix || ''}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  onChange({ ...query, alarmNamePrefix: event.target.value })
+                }
+              />
+            </QueryField>
+            <div className="gf-form gf-form--grow">
+              <div className="gf-form-label gf-form-label--grow" />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -29,7 +29,7 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
         />
 
         <div className="gf-form gf-form--grow">
-          <QueryField className="query-keyword" label="Action">
+          <QueryField label="Action">
             <input
               disabled={!query.prefixMatching}
               className="gf-form-input width-12"
@@ -39,7 +39,7 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
               }
             />
           </QueryField>
-          <QueryField className="query-keyword" label="Alarm Name">
+          <QueryField label="Alarm Name">
             <input
               disabled={!query.prefixMatching}
               className="gf-form-input width-12"

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -1,80 +1,59 @@
-import React, { PureComponent, ChangeEvent } from 'react';
-import { PanelData } from '@grafana/data';
+import React, { ChangeEvent } from 'react';
 import { Switch } from '@grafana/ui';
 import { CloudWatchQuery, AnnotationQuery } from '../types';
-import { QueryField } from './';
 import CloudWatchDatasource from '../datasource';
-import { QueryFieldsEditor } from './QueryFieldsEditor';
+import { QueryField, QueryFieldsEditor } from './';
 
-export type AnnotationQueryEditorProps = {
-  datasource: CloudWatchDatasource;
+export type Props = {
   query: AnnotationQuery;
+  datasource: CloudWatchDatasource;
   onChange: (value: AnnotationQuery) => void;
-  data?: PanelData;
 };
 
-export class AnnotationQueryEditor extends PureComponent<AnnotationQueryEditorProps> {
-  componentWillMount() {
-    const { query } = this.props;
+export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
+  const { query, onChange } = props;
+  return (
+    <>
+      <QueryFieldsEditor
+        {...props}
+        onChange={(editorQuery: CloudWatchQuery) => onChange({ ...query, ...editorQuery })}
+        hideWilcard
+        onRunQuery={() => {}}
+      ></QueryFieldsEditor>
+      <div className="gf-form-inline">
+        <Switch
+          label="Enable Prefix Matching"
+          labelClass="query-keyword"
+          checked={query.prefixMatching}
+          onChange={() => onChange({ ...query, prefixMatching: !query.prefixMatching })}
+        />
 
-    if (!query.hasOwnProperty('prefixMatching')) {
-      query.prefixMatching = false;
-    }
-
-    if (!query.actionPrefix) {
-      query.actionPrefix = '';
-    }
-
-    if (!query.alarmNamePrefix) {
-      query.alarmNamePrefix = '';
-    }
-  }
-
-  render() {
-    const { query, onChange } = this.props;
-    return (
-      <>
-        <QueryFieldsEditor
-          {...this.props}
-          onChange={(editorQuery: CloudWatchQuery) => onChange({ ...query, ...editorQuery })}
-          hideWilcard
-          onRunQuery={() => {}}
-        ></QueryFieldsEditor>
-        <div className="gf-form-inline">
-          <Switch
-            label="Enable Prefix Matching"
-            labelClass="query-keyword"
-            checked={query.prefixMatching}
-            onChange={() => onChange({ ...query, prefixMatching: !query.prefixMatching })}
-          />
-
+        <div className="gf-form gf-form--grow">
+          <QueryField className="query-keyword" label="Action">
+            <input
+              disabled={!query.prefixMatching}
+              className="gf-form-input width-12"
+              value={query.actionPrefix || ''}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onChange({ ...query, actionPrefix: event.target.value })
+              }
+            />
+          </QueryField>
+          <QueryField className="query-keyword" label="Alarm Name">
+            <input
+              disabled={!query.prefixMatching}
+              className="gf-form-input width-12"
+              value={query.alarmNamePrefix || ''}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onChange({ ...query, alarmNamePrefix: event.target.value })
+              }
+            />
+          </QueryField>
           <div className="gf-form gf-form--grow">
-            <QueryField className="query-keyword" label="Action">
-              <input
-                disabled={!query.prefixMatching}
-                className="gf-form-input width-12"
-                value={query.actionPrefix || ''}
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                  onChange({ ...query, actionPrefix: event.target.value })
-                }
-              />
-            </QueryField>
-            <QueryField className="query-keyword" label="Alarm Name">
-              <input
-                disabled={!query.prefixMatching}
-                className="gf-form-input width-12"
-                value={query.alarmNamePrefix || ''}
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                  onChange({ ...query, alarmNamePrefix: event.target.value })
-                }
-              />
-            </QueryField>
-            <div className="gf-form gf-form--grow">
-              <div className="gf-form-label gf-form-label--grow" />
-            </div>
+            <div className="gf-form-label gf-form-label--grow" />
           </div>
         </div>
-      </>
-    );
-  }
+      </div>
+    </>
+  );
 }

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -3,11 +3,22 @@ import { SelectableValue, ExploreQueryFieldProps } from '@grafana/data';
 import { Input, Segment, SegmentAsync, ValidationEvents, EventsWithValidation, Switch } from '@grafana/ui';
 import { CloudWatchQuery } from '../types';
 import CloudWatchDatasource from '../datasource';
-import { QueryFieldsEditor } from './QueryFieldsEditor';
+import { QueryField, Alias, QueryFieldsEditor } from './';
 
 export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery>;
 
-interface State {}
+interface State {
+  showMeta: boolean;
+}
+
+const idValidationEvents: ValidationEvents = {
+  [EventsWithValidation.onBlur]: [
+    {
+      rule: value => new RegExp(/^$|^[a-z][a-zA-Z0-9_]*$/).test(value),
+      errorMessage: 'Invalid format. Only alphanumeric characters and underscores are allowed',
+    },
+  ],
+};
 
 export class QueryEditor extends PureComponent<Props, State> {
   state: State = { regions: [], namespaces: [], metricNames: [], variableOptionGroup: {}, showMeta: false };

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -179,7 +179,6 @@ export class QueryEditor extends PureComponent<Props, State> {
           <div className="gf-form-inline">
             <div className="gf-form">
               <QueryField
-                className="query-keyword"
                 label="Id"
                 tooltip="Id can include numbers, letters, and underscore, and must start with a lowercase letter."
               >
@@ -212,7 +211,7 @@ export class QueryEditor extends PureComponent<Props, State> {
         )}
         <div className="gf-form-inline">
           <div className="gf-form">
-            <QueryField className="query-keyword" label="Period" tooltip="Minimum interval between points in seconds">
+            <QueryField label="Period" tooltip="Minimum interval between points in seconds">
               <Input
                 className="gf-form-input width-8"
                 value={query.period || ''}
@@ -224,7 +223,6 @@ export class QueryEditor extends PureComponent<Props, State> {
           </div>
           <div className="gf-form">
             <QueryField
-              className="query-keyword"
               label="Alias"
               tooltip="Alias replacement variables: {{metric}}, {{stat}}, {{namespace}}, {{region}}, {{period}}, {{label}}, {{YOUR_DIMENSION_NAME}}"
             >

--- a/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
@@ -1,10 +1,10 @@
-import React, { PureComponent, ChangeEvent } from 'react';
+import React, { useState, useEffect } from 'react';
 import { SelectableValue, PanelData } from '@grafana/data';
-import { Input, Segment, SegmentAsync, ValidationEvents, EventsWithValidation, Switch } from '@grafana/ui';
+import { Segment, SegmentAsync } from '@grafana/ui';
 import { CloudWatchQuery } from '../types';
 import CloudWatchDatasource from '../datasource';
 import { SelectableStrings } from '../types';
-import { Stats, Dimensions, QueryInlineField, QueryField, Alias } from './';
+import { Stats, Dimensions, QueryInlineField } from './';
 
 export type Props = {
   query: CloudWatchQuery;
@@ -12,7 +12,7 @@ export type Props = {
   onRunQuery: () => void;
   onChange: (value: CloudWatchQuery) => void;
   data?: PanelData;
-  hideWilcard: boolean;
+  hideWilcard?: boolean;
 };
 
 interface State {
@@ -23,259 +23,116 @@ interface State {
   showMeta: boolean;
 }
 
-const idValidationEvents: ValidationEvents = {
-  [EventsWithValidation.onBlur]: [
-    {
-      rule: value => new RegExp(/^$|^[a-z][a-zA-Z0-9_]*$/).test(value),
-      errorMessage: 'Invalid format. Only alphanumeric characters and underscores are allowed',
-    },
-  ],
-};
+export function QueryFieldsEditor({
+  query,
+  datasource,
+  onRunQuery,
+  onChange,
+  data,
+  hideWilcard = false,
+}: React.PropsWithChildren<Props>) {
+  const [state, setState] = useState<State>({
+    regions: [],
+    namespaces: [],
+    metricNames: [],
+    variableOptionGroup: {},
+    showMeta: false,
+  });
 
-export class QueryFieldsEditor extends PureComponent<Props, State> {
-  state: State = { regions: [], namespaces: [], metricNames: [], variableOptionGroup: {}, showMeta: false };
-
-  componentWillMount() {
-    const { query } = this.props;
-
-    if (!query.namespace) {
-      query.namespace = '';
-    }
-
-    if (!query.metricName) {
-      query.metricName = '';
-    }
-
-    if (!query.expression) {
-      query.expression = '';
-    }
-
-    if (!query.dimensions) {
-      query.dimensions = {};
-    }
-
-    if (!query.region) {
-      query.region = 'default';
-    }
-
-    if (!query.id) {
-      query.id = '';
-    }
-
-    if (!query.alias) {
-      query.alias = '';
-    }
-
-    if (!query.statistics || !query.statistics.length) {
-      query.statistics = ['Average'];
-    }
-
-    if (!query.hasOwnProperty('matchExact')) {
-      query.matchExact = true;
-    }
-  }
-
-  componentDidMount() {
-    const { datasource } = this.props;
+  useEffect(() => {
     const variableOptionGroup = {
       label: 'Template Variables',
-      options: this.props.datasource.variables.map(this.toOption),
+      options: datasource.variables.map(toOption),
     };
+
     Promise.all([datasource.metricFindQuery('regions()'), datasource.metricFindQuery('namespaces()')]).then(
       ([regions, namespaces]) => {
-        this.setState({
-          ...this.state,
+        setState({
+          ...state,
           regions: [...regions, variableOptionGroup],
           namespaces: [...namespaces, variableOptionGroup],
           variableOptionGroup,
         });
       }
     );
-  }
+  }, []);
 
-  loadMetricNames = async () => {
-    const { namespace, region } = this.props.query;
-    return this.props.datasource.metricFindQuery(`metrics(${namespace},${region})`).then(this.appendTemplateVariables);
+  const loadMetricNames = async () => {
+    const { namespace, region } = query;
+    return datasource.metricFindQuery(`metrics(${namespace},${region})`).then(appendTemplateVariables);
   };
 
-  appendTemplateVariables = (values: SelectableValue[]) => [
+  const appendTemplateVariables = (values: SelectableValue[]) => [
     ...values,
-    { label: 'Template Variables', options: this.props.datasource.variables.map(this.toOption) },
+    { label: 'Template Variables', options: datasource.variables.map(toOption) },
   ];
 
-  toOption = (value: any) => ({ label: value, value });
+  const toOption = (value: any) => ({ label: value, value });
 
-  onChange(query: CloudWatchQuery) {
-    const { onChange, onRunQuery } = this.props;
+  const onQueryChange = (query: CloudWatchQuery) => {
     onChange(query);
     onRunQuery();
-  }
+  };
 
-  render() {
-    const { query, datasource, onChange, onRunQuery, data, hideWilcard } = this.props;
-    const { regions, namespaces, variableOptionGroup: variableOptionGroup, showMeta } = this.state;
-    const metaDataExist = data && Object.values(data).length && data.state === 'Done';
-    return (
-      <>
-        <QueryInlineField label="Region">
-          <Segment
-            value={query.region || 'Select region'}
-            options={regions}
-            allowCustomValue
-            onChange={region => this.onChange({ ...query, region })}
-          />
-        </QueryInlineField>
+  const { regions, namespaces, variableOptionGroup } = state;
+  return (
+    <>
+      <QueryInlineField label="Region">
+        <Segment
+          value={query.region || 'Select region'}
+          options={regions}
+          allowCustomValue
+          onChange={region => onQueryChange({ ...query, region })}
+        />
+      </QueryInlineField>
 
-        {query.expression.length === 0 && (
-          <>
-            <QueryInlineField label="Namespace">
-              <Segment
-                value={query.namespace || 'Select namespace'}
-                allowCustomValue
-                options={namespaces}
-                onChange={namespace => this.onChange({ ...query, namespace })}
-              />
-            </QueryInlineField>
-
-            <QueryInlineField label="Metric Name">
-              <SegmentAsync
-                value={query.metricName || 'Select metric name'}
-                allowCustomValue
-                loadOptions={this.loadMetricNames}
-                onChange={metricName => this.onChange({ ...query, metricName })}
-              />
-            </QueryInlineField>
-
-            <QueryInlineField label="Stats">
-              <Stats
-                stats={datasource.standardStatistics.map(this.toOption)}
-                values={query.statistics}
-                onChange={statistics => this.onChange({ ...query, statistics })}
-                variableOptionGroup={variableOptionGroup}
-              />
-            </QueryInlineField>
-
-            <QueryInlineField label="Dimensions">
-              <Dimensions
-                dimensions={query.dimensions}
-                onChange={dimensions => this.onChange({ ...query, dimensions })}
-                loadKeys={() =>
-                  datasource.getDimensionKeys(query.namespace, query.region).then(this.appendTemplateVariables)
-                }
-                loadValues={newKey => {
-                  const { [newKey]: value, ...newDimensions } = query.dimensions;
-                  return datasource
-                    .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
-                    .then(values =>
-                      values.length && !hideWilcard ? [{ value: '*', text: '*', label: '*' }, ...values] : values
-                    )
-                    .then(this.appendTemplateVariables);
-                }}
-              />
-            </QueryInlineField>
-          </>
-        )}
-        {query.statistics.length <= 1 && (
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <QueryField
-                className="query-keyword"
-                label="Id"
-                tooltip="Id can include numbers, letters, and underscore, and must start with a lowercase letter."
-              >
-                <Input
-                  className="gf-form-input width-8"
-                  onBlur={onRunQuery}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...query, id: event.target.value })}
-                  validationEvents={idValidationEvents}
-                  value={query.id || ''}
-                />
-              </QueryField>
-            </div>
-            <div className="gf-form gf-form--grow">
-              <QueryField
-                className="gf-form--grow"
-                label="Expression"
-                tooltip="Optionally you can add an expression here. Please note that if a math expression that is referencing other queries is being used, it will not be possible to create an alert rule based on this query"
-              >
-                <Input
-                  className="gf-form-input"
-                  onBlur={onRunQuery}
-                  value={query.expression || ''}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                    onChange({ ...query, expression: event.target.value })
-                  }
-                />
-              </QueryField>
-            </div>
-          </div>
-        )}
-        <div className="gf-form-inline">
-          <div className="gf-form">
-            <QueryField className="query-keyword" label="Period" tooltip="Minimum interval between points in seconds">
-              <Input
-                className="gf-form-input width-8"
-                value={query.period || ''}
-                placeholder="auto"
-                onBlur={onRunQuery}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...query, period: event.target.value })}
-              />
-            </QueryField>
-          </div>
-          <div className="gf-form">
-            <QueryField
-              className="query-keyword"
-              label="Alias"
-              tooltip="Alias replacement variables: {{metric}}, {{stat}}, {{namespace}}, {{region}}, {{period}}, {{label}}, {{YOUR_DIMENSION_NAME}}"
-            >
-              <Alias value={query.alias} onChange={(value: string) => this.onChange({ ...query, alias: value })} />
-            </QueryField>
-            <Switch
-              label="Match Exact"
-              labelClass="query-keyword"
-              tooltip="Only show metrics that exactly match all defined dimension names."
-              checked={query.matchExact}
-              onChange={() => this.onChange({ ...query, matchExact: !query.matchExact })}
+      {query.expression.length === 0 && (
+        <>
+          <QueryInlineField label="Namespace">
+            <Segment
+              value={query.namespace || 'Select namespace'}
+              allowCustomValue
+              options={namespaces}
+              onChange={namespace => onQueryChange({ ...query, namespace })}
             />
-            <label className="gf-form-label">
-              <a
-                onClick={() =>
-                  metaDataExist &&
-                  this.setState({
-                    ...this.state,
-                    showMeta: !showMeta,
-                  })
-                }
-              >
-                <i className={`fa fa-caret-${showMeta ? 'down' : 'right'}`} /> {showMeta ? 'Hide' : 'Show'} Query
-                Preview
-              </a>
-            </label>
-          </div>
-          <div className="gf-form gf-form--grow">
-            <div className="gf-form-label gf-form-label--grow" />
-          </div>
-          {showMeta && metaDataExist && (
-            <table className="filter-table form-inline">
-              <thead>
-                <tr>
-                  <th>Metric Data Query ID</th>
-                  <th>Metric Data Query Expression</th>
-                  <th />
-                </tr>
-              </thead>
-              <tbody>
-                {data.series[0].meta.gmdMeta.map(({ ID, Expression }: any) => (
-                  <tr key={ID}>
-                    <td>{ID}</td>
-                    <td>{Expression}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
-      </>
-    );
-  }
+          </QueryInlineField>
+
+          <QueryInlineField label="Metric Name">
+            <SegmentAsync
+              value={query.metricName || 'Select metric name'}
+              allowCustomValue
+              loadOptions={loadMetricNames}
+              onChange={metricName => onQueryChange({ ...query, metricName })}
+            />
+          </QueryInlineField>
+
+          <QueryInlineField label="Stats">
+            <Stats
+              stats={datasource.standardStatistics.map(toOption)}
+              values={query.statistics}
+              onChange={statistics => onQueryChange({ ...query, statistics })}
+              variableOptionGroup={variableOptionGroup}
+            />
+          </QueryInlineField>
+
+          <QueryInlineField label="Dimensions">
+            <Dimensions
+              dimensions={query.dimensions}
+              onChange={dimensions => onQueryChange({ ...query, dimensions })}
+              loadKeys={() => datasource.getDimensionKeys(query.namespace, query.region).then(appendTemplateVariables)}
+              loadValues={newKey => {
+                const { [newKey]: value, ...newDimensions } = query.dimensions;
+                return datasource
+                  .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
+                  .then(values =>
+                    values.length && !hideWilcard ? [{ value: '*', text: '*', label: '*' }, ...values] : values
+                  )
+                  .then(appendTemplateVariables);
+              }}
+            />
+          </QueryInlineField>
+        </>
+      )}
+    </>
+  );
 }

--- a/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
@@ -1,17 +1,15 @@
 import React, { useState, useEffect } from 'react';
-import { SelectableValue, PanelData } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { Segment, SegmentAsync } from '@grafana/ui';
-import { CloudWatchQuery } from '../types';
+import { CloudWatchQuery, SelectableStrings } from '../types';
 import CloudWatchDatasource from '../datasource';
-import { SelectableStrings } from '../types';
 import { Stats, Dimensions, QueryInlineField } from './';
 
 export type Props = {
   query: CloudWatchQuery;
   datasource: CloudWatchDatasource;
-  onRunQuery: () => void;
+  onRunQuery?: () => void;
   onChange: (value: CloudWatchQuery) => void;
-  data?: PanelData;
   hideWilcard?: boolean;
 };
 
@@ -26,9 +24,8 @@ interface State {
 export function QueryFieldsEditor({
   query,
   datasource,
-  onRunQuery,
   onChange,
-  data,
+  onRunQuery = () => {},
   hideWilcard = false,
 }: React.PropsWithChildren<Props>) {
   const [state, setState] = useState<State>({

--- a/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
@@ -12,6 +12,7 @@ export type Props = {
   onRunQuery: () => void;
   onChange: (value: CloudWatchQuery) => void;
   data?: PanelData;
+  hideWilcard: boolean;
 };
 
 interface State {
@@ -111,7 +112,7 @@ export class QueryFieldsEditor extends PureComponent<Props, State> {
   }
 
   render() {
-    const { query, datasource, onChange, onRunQuery, data } = this.props;
+    const { query, datasource, onChange, onRunQuery, data, hideWilcard } = this.props;
     const { regions, namespaces, variableOptionGroup: variableOptionGroup, showMeta } = this.state;
     const metaDataExist = data && Object.values(data).length && data.state === 'Done';
     return (
@@ -165,7 +166,9 @@ export class QueryFieldsEditor extends PureComponent<Props, State> {
                   const { [newKey]: value, ...newDimensions } = query.dimensions;
                   return datasource
                     .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
-                    .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))
+                    .then(values =>
+                      values.length && !hideWilcard ? [{ value: '*', text: '*', label: '*' }, ...values] : values
+                    )
                     .then(this.appendTemplateVariables);
                 }}
               />

--- a/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
@@ -76,10 +76,11 @@ export function QueryFieldsEditor({
     <>
       <QueryInlineField label="Region">
         <Segment
-          value={query.region || 'Select region'}
+          value={query.region}
+          placeholder="Select region"
           options={regions}
           allowCustomValue
-          onChange={region => onQueryChange({ ...query, region })}
+          onChange={({ value: region }) => onChange({ ...query, region })}
         />
       </QueryInlineField>
 
@@ -87,19 +88,21 @@ export function QueryFieldsEditor({
         <>
           <QueryInlineField label="Namespace">
             <Segment
-              value={query.namespace || 'Select namespace'}
+              value={query.namespace}
+              placeholder="Select namespace"
               allowCustomValue
               options={namespaces}
-              onChange={namespace => onQueryChange({ ...query, namespace })}
+              onChange={({ value: namespace }) => onChange({ ...query, namespace })}
             />
           </QueryInlineField>
 
           <QueryInlineField label="Metric Name">
             <SegmentAsync
-              value={query.metricName || 'Select metric name'}
+              value={query.metricName}
+              placeholder="Select metric name"
               allowCustomValue
               loadOptions={loadMetricNames}
-              onChange={metricName => onQueryChange({ ...query, metricName })}
+              onChange={({ value: metricName }) => onChange({ ...query, metricName })}
             />
           </QueryInlineField>
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryFieldsEditor.tsx
@@ -1,19 +1,41 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { SelectableValue, ExploreQueryFieldProps } from '@grafana/data';
+import { SelectableValue, PanelData } from '@grafana/data';
 import { Input, Segment, SegmentAsync, ValidationEvents, EventsWithValidation, Switch } from '@grafana/ui';
 import { CloudWatchQuery } from '../types';
 import CloudWatchDatasource from '../datasource';
-import { QueryFieldsEditor } from './QueryFieldsEditor';
+import { SelectableStrings } from '../types';
+import { Stats, Dimensions, QueryInlineField, QueryField, Alias } from './';
 
-export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery>;
+export type Props = {
+  query: CloudWatchQuery;
+  datasource: CloudWatchDatasource;
+  onRunQuery: () => void;
+  onChange: (value: CloudWatchQuery) => void;
+  data?: PanelData;
+};
 
-interface State {}
+interface State {
+  regions: SelectableStrings;
+  namespaces: SelectableStrings;
+  metricNames: SelectableStrings;
+  variableOptionGroup: SelectableValue<string>;
+  showMeta: boolean;
+}
 
-export class QueryEditor extends PureComponent<Props, State> {
+const idValidationEvents: ValidationEvents = {
+  [EventsWithValidation.onBlur]: [
+    {
+      rule: value => new RegExp(/^$|^[a-z][a-zA-Z0-9_]*$/).test(value),
+      errorMessage: 'Invalid format. Only alphanumeric characters and underscores are allowed',
+    },
+  ],
+};
+
+export class QueryFieldsEditor extends PureComponent<Props, State> {
   state: State = { regions: [], namespaces: [], metricNames: [], variableOptionGroup: {}, showMeta: false };
 
-  static getDerivedStateFromProps(props: Props, state: State) {
-    const { query } = props;
+  componentWillMount() {
+    const { query } = this.props;
 
     if (!query.namespace) {
       query.namespace = '';
@@ -50,8 +72,6 @@ export class QueryEditor extends PureComponent<Props, State> {
     if (!query.hasOwnProperty('matchExact')) {
       query.matchExact = true;
     }
-
-    return state;
   }
 
   componentDidMount() {
@@ -90,21 +110,6 @@ export class QueryEditor extends PureComponent<Props, State> {
     onRunQuery();
   }
 
-  // Load dimension values based on current selected dimensions.
-  // Remove the new dimension key and all dimensions that has a wildcard as selected value
-  loadDimensionValues = (newKey: string) => {
-    const { datasource, query } = this.props;
-    const { [newKey]: value, ...dim } = query.dimensions;
-    const newDimensions = Object.entries(dim).reduce(
-      (result, [key, value]) => (value === '*' ? result : { ...result, [key]: value }),
-      {}
-    );
-    return datasource
-      .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
-      .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))
-      .then(this.appendTemplateVariables);
-  };
-
   render() {
     const { query, datasource, onChange, onRunQuery, data } = this.props;
     const { regions, namespaces, variableOptionGroup: variableOptionGroup, showMeta } = this.state;
@@ -113,11 +118,10 @@ export class QueryEditor extends PureComponent<Props, State> {
       <>
         <QueryInlineField label="Region">
           <Segment
-            value={query.region}
-            placeholder="Select region"
+            value={query.region || 'Select region'}
             options={regions}
             allowCustomValue
-            onChange={({ value: region }) => this.onChange({ ...query, region })}
+            onChange={region => this.onChange({ ...query, region })}
           />
         </QueryInlineField>
 
@@ -125,21 +129,19 @@ export class QueryEditor extends PureComponent<Props, State> {
           <>
             <QueryInlineField label="Namespace">
               <Segment
-                value={query.namespace}
-                placeholder="Select namespace"
+                value={query.namespace || 'Select namespace'}
                 allowCustomValue
                 options={namespaces}
-                onChange={({ value: namespace }) => this.onChange({ ...query, namespace })}
+                onChange={namespace => this.onChange({ ...query, namespace })}
               />
             </QueryInlineField>
 
             <QueryInlineField label="Metric Name">
               <SegmentAsync
-                value={query.metricName}
-                placeholder="Select metric name"
+                value={query.metricName || 'Select metric name'}
                 allowCustomValue
                 loadOptions={this.loadMetricNames}
-                onChange={({ value: metricName }) => this.onChange({ ...query, metricName })}
+                onChange={metricName => this.onChange({ ...query, metricName })}
               />
             </QueryInlineField>
 
@@ -159,7 +161,13 @@ export class QueryEditor extends PureComponent<Props, State> {
                 loadKeys={() =>
                   datasource.getDimensionKeys(query.namespace, query.region).then(this.appendTemplateVariables)
                 }
-                loadValues={this.loadDimensionValues}
+                loadValues={newKey => {
+                  const { [newKey]: value, ...newDimensions } = query.dimensions;
+                  return datasource
+                    .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
+                    .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))
+                    .then(this.appendTemplateVariables);
+                }}
               />
             </QueryInlineField>
           </>

--- a/public/app/plugins/datasource/cloudwatch/components/index.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/index.ts
@@ -2,3 +2,4 @@ export { Stats } from './Stats';
 export { Dimensions } from './Dimensions';
 export { QueryInlineField, QueryField } from './Forms';
 export { Alias } from './Alias';
+export { QueryFieldsEditor } from './QueryFieldsEditor';

--- a/public/app/plugins/datasource/cloudwatch/module.tsx
+++ b/public/app/plugins/datasource/cloudwatch/module.tsx
@@ -3,11 +3,8 @@ import { DataSourcePlugin } from '@grafana/data';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
 import CloudWatchDatasource from './datasource';
+import { CloudWatchAnnotationsQueryCtrl } from './annotations_query_ctrl';
 import { CloudWatchJsonData, CloudWatchQuery } from './types';
-
-class CloudWatchAnnotationsQueryCtrl {
-  static templateUrl = 'partials/annotations.editor.html';
-}
 
 export const plugin = new DataSourcePlugin<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>(
   CloudWatchDatasource

--- a/public/app/plugins/datasource/cloudwatch/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/annotations.editor.html
@@ -1,4 +1,10 @@
-<cloudwatch-query-parameter target="ctrl.annotation" datasource="ctrl.datasource"></cloudwatch-query-parameter>
+<cloudwatch-annotation-query-editor
+  datasource="ctrl.datasource"
+  on-change="ctrl.onChange"
+  query="ctrl.annotation.target"
+></cloudwatch-annotation-query-editor>
+
+<!-- <cloudwatch-query-parameter target="ctrl.annotation" datasource="ctrl.datasource"></cloudwatch-query-parameter>
 
 <div class="editor-row" style="padding: 2rem 0">
 	<div class="section">
@@ -15,4 +21,4 @@
 			</div>
 		</div>
 	</div>
-</div>
+</div> -->

--- a/public/app/plugins/datasource/cloudwatch/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/cloudwatch/partials/annotations.editor.html
@@ -1,24 +1,5 @@
 <cloudwatch-annotation-query-editor
   datasource="ctrl.datasource"
   on-change="ctrl.onChange"
-  query="ctrl.annotation.target"
+  query="ctrl.annotation"
 ></cloudwatch-annotation-query-editor>
-
-<!-- <cloudwatch-query-parameter target="ctrl.annotation" datasource="ctrl.datasource"></cloudwatch-query-parameter>
-
-<div class="editor-row" style="padding: 2rem 0">
-	<div class="section">
-		<h5>Prefix matching</h5>
-		<div class="gf-form-inline">
-			<gf-form-switch class="gf-form" label="Enable" checked="ctrl.annotation.prefixMatching" switch-class="max-width-6"></gf-form-switch>
-			<div class="gf-form" ng-if="ctrl.annotation.prefixMatching">
-				<span class="gf-form-label">Action</span>
-				<input type="text" class="gf-form-input" ng-model='ctrl.annotation.actionPrefix'></input>
-			</div>
-			<div class="gf-form" ng-if="ctrl.annotation.prefixMatching">
-				<span class="gf-form-label">Alarm Name</span>
-				<input type="text" class="gf-form-input" ng-model='ctrl.annotation.alarmNamePrefix'></input>
-			</div>
-		</div>
-	</div>
-</div> -->

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -13,6 +13,12 @@ export interface CloudWatchQuery extends DataQuery {
   matchExact: boolean;
 }
 
+export interface AnnotationQuery extends CloudWatchQuery {
+  prefixMatching: boolean;
+  actionPrefix: string;
+  alarmNamePrefix: string;
+}
+
 export type SelectableStrings = Array<SelectableValue<string>>;
 
 export interface CloudWatchJsonData extends DataSourceJsonData {


### PR DESCRIPTION
In the cloudwatch datasource, the annotation editor and the query editor share about 70% of all the features. This PR breaks out the shared features into a new component, QueryFieldsEditor, and rewrites all annotation editor code from angular to react. At the moment, the framework has no support for exporting annotation editors as react components, so the AnnotationQueryEditor is wrapped in an angular directive. 

When reviewing this PR, please take an extra look at the AnnotationsQueryEditor props and make sure they look right, i.e that they are somewhat similar to what we'll have in the future when the framework support exporting annotation editors as react components.  

fixes #19888