### PR TITLE
WIP: Redux Toolkit evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
   "dependencies": {
     "@babel/polyfill": "7.6.0",
     "@grafana/slate-react": "0.22.9-grafana",
+    "@reduxjs/toolkit": "^1.0.4",
     "@torkelo/react-select": "2.4.1",
     "@types/react-loadable": "5.5.2",
     "angular": "1.6.9",

--- a/public/app/core/reducers/root.test.ts
+++ b/public/app/core/reducers/root.test.ts
@@ -3,10 +3,9 @@ import { describe, expect } from '../../../test/lib/common';
 import { NavModelItem } from '@grafana/data';
 import { reducerTester } from '../../../test/core/redux/reducerTester';
 import { StoreState } from '../../types/store';
-import { ActionTypes } from '../../features/teams/state/actions';
-import { Team } from '../../types';
+import { Team, TeamPermissionLevel } from '../../types';
 import { cleanUpAction } from '../actions/cleanUp';
-import { initialTeamsState } from '../../features/teams/state/reducers';
+import { initialTeamsState, loadTeamsAction } from '../../features/teams/state/reducers';
 
 jest.mock('@grafana/runtime', () => ({
   config: {
@@ -56,17 +55,16 @@ describe('rootReducer', () => {
 
   describe('when called with any action except cleanUpAction', () => {
     it('then it should not clean state', () => {
-      const teams = [{ id: 1 }];
+      const teams: Team[] = [
+        { id: 1, avatarUrl: '', email: '', memberCount: 1, name: 'Jane Doe', permission: TeamPermissionLevel.Admin },
+      ];
       const state = {
         teams: { ...initialTeamsState },
       } as StoreState;
 
       reducerTester<StoreState>()
         .givenReducer(rootReducer, state)
-        .whenActionIsDispatched({
-          type: ActionTypes.LoadTeams,
-          payload: teams,
-        })
+        .whenActionIsDispatched(loadTeamsAction(teams))
         .thenStatePredicateShouldEqual(resultingState => {
           expect(resultingState.teams).toEqual({
             hasFetched: true,

--- a/public/app/core/redux/actionCreatorFactory.ts
+++ b/public/app/core/redux/actionCreatorFactory.ts
@@ -60,5 +60,9 @@ export const mockActionCreator = (creator: ActionCreator<any>) => {
   return Object.assign(jest.fn(), creator);
 };
 
+export const mockPayloadActionCreator = (creator: any) => {
+  return Object.assign(jest.fn(), creator);
+};
+
 // Should only be used by tests
 export const resetAllActionCreatorTypes = () => allActionCreators.clear();

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Props, TeamList } from './TeamList';
-import { Team, OrgRole } from '../../types';
+import { OrgRole, Team } from '../../types';
 import { getMockTeam, getMultipleMockTeams } from './__mocks__/teamMocks';
 import { User } from 'app/core/services/context_srv';
 import { NavModel } from '@grafana/data';
+import { mockPayloadActionCreator } from '../../core/redux';
+import { setSearchQueryAction } from './state/reducers';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -19,7 +21,7 @@ const setup = (propOverrides?: object) => {
     teams: [] as Team[],
     loadTeams: jest.fn(),
     deleteTeam: jest.fn(),
-    setSearchQuery: jest.fn(),
+    setSearchQuery: mockPayloadActionCreator(setSearchQueryAction),
     searchQuery: '',
     teamsCount: 0,
     hasFetched: false,

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -4,14 +4,15 @@ import Page from 'app/core/components/Page/Page';
 import { DeleteButton } from '@grafana/ui';
 import { NavModel } from '@grafana/data';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
-import { Team, OrgRole, StoreState } from 'app/types';
-import { loadTeams, deleteTeam, setSearchQuery } from './state/actions';
+import { OrgRole, StoreState, Team } from 'app/types';
+import { deleteTeam, loadTeams } from './state/actions';
 import { getSearchQuery, getTeams, getTeamsCount, isPermissionTeamAdmin } from './state/selectors';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { FilterInput } from 'app/core/components/FilterInput/FilterInput';
 import { config } from 'app/core/config';
 import { contextSrv, User } from 'app/core/services/context_srv';
 import { connectWithCleanUp } from '../../core/components/connectWithCleanUp';
+import { setSearchQueryAction } from './state/reducers';
 
 export interface Props {
   navModel: NavModel;
@@ -21,7 +22,7 @@ export interface Props {
   hasFetched: boolean;
   loadTeams: typeof loadTeams;
   deleteTeam: typeof deleteTeam;
-  setSearchQuery: typeof setSearchQuery;
+  setSearchQuery: typeof setSearchQueryAction;
   editorsCanAdmin?: boolean;
   signedInUser?: User;
 }
@@ -167,7 +168,7 @@ function mapStateToProps(state: StoreState) {
 const mapDispatchToProps = {
   loadTeams,
   deleteTeam,
-  setSearchQuery,
+  setSearchQuery: setSearchQueryAction,
 };
 
 export default hot(module)(connectWithCleanUp(mapStateToProps, mapDispatchToProps, state => state.teams)(TeamList));

--- a/public/app/features/teams/TeamMembers.test.tsx
+++ b/public/app/features/teams/TeamMembers.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { TeamMembers, Props, State } from './TeamMembers';
-import { TeamMember, OrgRole } from '../../types';
+import { Props, State, TeamMembers } from './TeamMembers';
+import { OrgRole, TeamMember } from '../../types';
 import { getMockTeamMembers } from './__mocks__/teamMocks';
 import { User } from 'app/core/services/context_srv';
+import { mockPayloadActionCreator } from '../../core/redux';
+import { setSearchMemberQueryAction } from './state/reducers';
 
 const signedInUserId = 1;
 
@@ -11,7 +13,7 @@ const setup = (propOverrides?: object) => {
   const props: Props = {
     members: [] as TeamMember[],
     searchMemberQuery: '',
-    setSearchMemberQuery: jest.fn(),
+    setSearchMemberQuery: mockPayloadActionCreator(setSearchMemberQueryAction),
     addTeamMember: jest.fn(),
     syncEnabled: false,
     editorsCanAdmin: false,

--- a/public/app/features/teams/TeamMembers.tsx
+++ b/public/app/features/teams/TeamMembers.tsx
@@ -4,19 +4,20 @@ import { SlideDown } from 'app/core/components/Animations/SlideDown';
 import { UserPicker } from 'app/core/components/Select/UserPicker';
 import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
 import { TeamMember, User } from 'app/types';
-import { addTeamMember, setSearchMemberQuery } from './state/actions';
+import { addTeamMember } from './state/actions';
 import { getSearchMemberQuery, isSignedInUserTeamAdmin } from './state/selectors';
 import { FilterInput } from 'app/core/components/FilterInput/FilterInput';
 import { WithFeatureToggle } from 'app/core/components/WithFeatureToggle';
 import { config } from 'app/core/config';
 import { contextSrv, User as SignedInUser } from 'app/core/services/context_srv';
 import TeamMemberRow from './TeamMemberRow';
+import { setSearchMemberQueryAction } from './state/reducers';
 
 export interface Props {
   members: TeamMember[];
   searchMemberQuery: string;
   addTeamMember: typeof addTeamMember;
-  setSearchMemberQuery: typeof setSearchMemberQuery;
+  setSearchMemberQuery: typeof setSearchMemberQueryAction;
   syncEnabled: boolean;
   editorsCanAdmin?: boolean;
   signedInUser?: SignedInUser;
@@ -154,7 +155,7 @@ function mapStateToProps(state: any) {
 
 const mapDispatchToProps = {
   addTeamMember,
-  setSearchMemberQuery,
+  setSearchMemberQuery: setSearchMemberQueryAction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TeamMembers);

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -1,99 +1,24 @@
 import { ThunkAction } from 'redux-thunk';
 import { getBackendSrv } from '@grafana/runtime';
-import { StoreState, Team, TeamGroup, TeamMember } from 'app/types';
+import { StoreState, TeamMember } from 'app/types';
 import { updateNavIndex, UpdateNavIndexAction } from 'app/core/actions';
 import { buildNavModel } from './navModel';
+import { loadTeamAction, loadTeamGroupsAction, loadTeamMembersAction, loadTeamsAction } from './reducers';
+import { PayloadAction } from '@reduxjs/toolkit';
 
-export enum ActionTypes {
-  LoadTeams = 'LOAD_TEAMS',
-  LoadTeam = 'LOAD_TEAM',
-  SetSearchQuery = 'SET_TEAM_SEARCH_QUERY',
-  SetSearchMemberQuery = 'SET_TEAM_MEMBER_SEARCH_QUERY',
-  LoadTeamMembers = 'TEAM_MEMBERS_LOADED',
-  LoadTeamGroups = 'TEAM_GROUPS_LOADED',
-}
-
-export interface LoadTeamsAction {
-  type: ActionTypes.LoadTeams;
-  payload: Team[];
-}
-
-export interface LoadTeamAction {
-  type: ActionTypes.LoadTeam;
-  payload: Team;
-}
-
-export interface LoadTeamMembersAction {
-  type: ActionTypes.LoadTeamMembers;
-  payload: TeamMember[];
-}
-
-export interface LoadTeamGroupsAction {
-  type: ActionTypes.LoadTeamGroups;
-  payload: TeamGroup[];
-}
-
-export interface SetSearchQueryAction {
-  type: ActionTypes.SetSearchQuery;
-  payload: string;
-}
-
-export interface SetSearchMemberQueryAction {
-  type: ActionTypes.SetSearchMemberQuery;
-  payload: string;
-}
-
-export type Action =
-  | LoadTeamsAction
-  | SetSearchQueryAction
-  | LoadTeamAction
-  | LoadTeamMembersAction
-  | SetSearchMemberQueryAction
-  | LoadTeamGroupsAction;
-
-type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action | UpdateNavIndexAction>;
-
-const teamsLoaded = (teams: Team[]): LoadTeamsAction => ({
-  type: ActionTypes.LoadTeams,
-  payload: teams,
-});
-
-const teamLoaded = (team: Team): LoadTeamAction => ({
-  type: ActionTypes.LoadTeam,
-  payload: team,
-});
-
-const teamMembersLoaded = (teamMembers: TeamMember[]): LoadTeamMembersAction => ({
-  type: ActionTypes.LoadTeamMembers,
-  payload: teamMembers,
-});
-
-const teamGroupsLoaded = (teamGroups: TeamGroup[]): LoadTeamGroupsAction => ({
-  type: ActionTypes.LoadTeamGroups,
-  payload: teamGroups,
-});
-
-export const setSearchMemberQuery = (searchQuery: string): SetSearchMemberQueryAction => ({
-  type: ActionTypes.SetSearchMemberQuery,
-  payload: searchQuery,
-});
-
-export const setSearchQuery = (searchQuery: string): SetSearchQueryAction => ({
-  type: ActionTypes.SetSearchQuery,
-  payload: searchQuery,
-});
+type ThunkResult<R> = ThunkAction<R, StoreState, undefined, PayloadAction<any> | UpdateNavIndexAction>;
 
 export function loadTeams(): ThunkResult<void> {
   return async dispatch => {
     const response = await getBackendSrv().get('/api/teams/search', { perpage: 1000, page: 1 });
-    dispatch(teamsLoaded(response.teams));
+    dispatch(loadTeamsAction(response.teams));
   };
 }
 
 export function loadTeam(id: number): ThunkResult<void> {
   return async dispatch => {
     const response = await getBackendSrv().get(`/api/teams/${id}`);
-    dispatch(teamLoaded(response));
+    dispatch(loadTeamAction(response));
     dispatch(updateNavIndex(buildNavModel(response)));
   };
 }
@@ -102,7 +27,7 @@ export function loadTeamMembers(): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
     const response = await getBackendSrv().get(`/api/teams/${team.id}/members`);
-    dispatch(teamMembersLoaded(response));
+    dispatch(loadTeamMembersAction(response));
   };
 }
 
@@ -134,7 +59,7 @@ export function loadTeamGroups(): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
     const response = await getBackendSrv().get(`/api/teams/${team.id}/groups`);
-    dispatch(teamGroupsLoaded(response));
+    dispatch(loadTeamGroupsAction(response));
   };
 }
 

--- a/public/app/features/teams/state/reducers.test.ts
+++ b/public/app/features/teams/state/reducers.test.ts
@@ -1,17 +1,21 @@
-import { Action, ActionTypes } from './actions';
-import { initialTeamsState, initialTeamState, teamReducer, teamsReducer } from './reducers';
+import {
+  initialTeamsState,
+  initialTeamState,
+  loadTeamAction,
+  loadTeamMembersAction,
+  loadTeamsAction,
+  setSearchMemberQueryAction,
+  setSearchQueryAction,
+  teamSlice,
+  teamsSlice,
+} from './reducers';
 import { getMockTeam, getMockTeamMember } from '../__mocks__/teamMocks';
 
 describe('teams reducer', () => {
   it('should set teams', () => {
     const payload = [getMockTeam()];
 
-    const action: Action = {
-      type: ActionTypes.LoadTeams,
-      payload,
-    };
-
-    const result = teamsReducer(initialTeamsState, action);
+    const result = teamsSlice.reducer(initialTeamsState, loadTeamsAction(payload));
 
     expect(result.teams).toEqual(payload);
   });
@@ -19,12 +23,7 @@ describe('teams reducer', () => {
   it('should set search query', () => {
     const payload = 'test';
 
-    const action: Action = {
-      type: ActionTypes.SetSearchQuery,
-      payload,
-    };
-
-    const result = teamsReducer(initialTeamsState, action);
+    const result = teamsSlice.reducer(initialTeamsState, setSearchQueryAction(payload));
 
     expect(result.searchQuery).toEqual('test');
   });
@@ -34,12 +33,7 @@ describe('team reducer', () => {
   it('should set team', () => {
     const payload = getMockTeam();
 
-    const action: Action = {
-      type: ActionTypes.LoadTeam,
-      payload,
-    };
-
-    const result = teamReducer(initialTeamState, action);
+    const result = teamSlice.reducer(initialTeamState, loadTeamAction(payload));
 
     expect(result.team).toEqual(payload);
   });
@@ -47,12 +41,7 @@ describe('team reducer', () => {
   it('should set team members', () => {
     const mockTeamMember = getMockTeamMember();
 
-    const action: Action = {
-      type: ActionTypes.LoadTeamMembers,
-      payload: [mockTeamMember],
-    };
-
-    const result = teamReducer(initialTeamState, action);
+    const result = teamSlice.reducer(initialTeamState, loadTeamMembersAction([mockTeamMember]));
 
     expect(result.members).toEqual([mockTeamMember]);
   });
@@ -60,12 +49,7 @@ describe('team reducer', () => {
   it('should set member search query', () => {
     const payload = 'member';
 
-    const action: Action = {
-      type: ActionTypes.SetSearchMemberQuery,
-      payload,
-    };
-
-    const result = teamReducer(initialTeamState, action);
+    const result = teamSlice.reducer(initialTeamState, setSearchMemberQueryAction(payload));
 
     expect(result.searchMemberQuery).toEqual('member');
   });

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -1,5 +1,5 @@
 import { Team, TeamGroup, TeamMember, TeamsState, TeamState } from 'app/types';
-import { Action, ActionTypes } from './actions';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', hasFetched: false };
 export const initialTeamState: TeamState = {
@@ -9,36 +9,73 @@ export const initialTeamState: TeamState = {
   searchMemberQuery: '',
 };
 
-export const teamsReducer = (state = initialTeamsState, action: Action): TeamsState => {
-  switch (action.type) {
-    case ActionTypes.LoadTeams:
+interface TeamsStateReducers<S> extends Record<string, any> {
+  loadTeamsAction: (state: S, action: PayloadAction<Team[]>) => S;
+  setSearchQueryAction: (state: S, action: PayloadAction<string>) => S;
+}
+
+export const teamsSlice = createSlice<TeamsState, TeamsStateReducers<TeamsState>>({
+  name: 'teams',
+  initialState: initialTeamsState,
+  reducers: {
+    // https://redux-starter-kit.js.org/tutorials/advanced-tutorial/#declaring-types-for-slice-state-and-actions
+    // createSlice tries to infer types from two sources:
+    // The state type is based on the type of the initialState field
+    // Each reducer needs to declare the type of the action it expects to handle
+    // We don't have to declare a type for state, because createSlice already knows that this should be the same type as our initialState
+    // Didn't work with our TypeScript settings so I had to declare TeamsState in the state prop for each reducer
+    // and without declaring TeamsState as return type the typings don't work in the return (same issue with our home grown solution)
+    loadTeamsAction(state, action) {
       return { ...state, hasFetched: true, teams: action.payload };
-
-    case ActionTypes.SetSearchQuery:
+    },
+    setSearchQueryAction(state, action) {
       return { ...state, searchQuery: action.payload };
-  }
-  return state;
-};
+    },
+  },
+});
 
-export const teamReducer = (state = initialTeamState, action: Action): TeamState => {
-  switch (action.type) {
-    case ActionTypes.LoadTeam:
+interface TeamStateReducers<S> extends Record<string, any> {
+  loadTeamAction: (state: S, action: PayloadAction<Team>) => S;
+  loadTeamMembersAction: (state: S, action: PayloadAction<TeamMember[]>) => S;
+  setSearchMemberQueryAction: (state: S, action: PayloadAction<string>) => S;
+  loadTeamGroupsAction: (state: S, action: PayloadAction<TeamGroup[]>) => S;
+}
+
+export const teamSlice = createSlice<TeamState, TeamStateReducers<TeamState>>({
+  name: 'team',
+  initialState: initialTeamState,
+  reducers: {
+    // https://redux-starter-kit.js.org/tutorials/advanced-tutorial/#declaring-types-for-slice-state-and-actions
+    // createSlice tries to infer types from two sources:
+    // The state type is based on the type of the initialState field
+    // Each reducer needs to declare the type of the action it expects to handle
+    // We don't have to declare a type for state, because createSlice already knows that this should be the same type as our initialState
+    // Didn't work with our TypeScript settings so I had to declare TeamsState in the state prop for each reducer
+    // and without declaring TeamsState as return type the typings don't work in the return (same issue with our home grown solution)
+    loadTeamAction(state, action: PayloadAction<Team>): TeamState {
       return { ...state, team: action.payload };
-
-    case ActionTypes.LoadTeamMembers:
+    },
+    loadTeamMembersAction(state, action: PayloadAction<TeamMember[]>): TeamState {
       return { ...state, members: action.payload };
-
-    case ActionTypes.SetSearchMemberQuery:
+    },
+    setSearchMemberQueryAction(state, action: PayloadAction<string>): TeamState {
       return { ...state, searchMemberQuery: action.payload };
-
-    case ActionTypes.LoadTeamGroups:
+    },
+    loadTeamGroupsAction(state, action: PayloadAction<TeamGroup[]>): TeamState {
       return { ...state, groups: action.payload };
-  }
+    },
+  },
+});
 
-  return state;
-};
+export const { loadTeamsAction, setSearchQueryAction } = teamsSlice.actions;
+export const {
+  loadTeamAction,
+  loadTeamGroupsAction,
+  loadTeamMembersAction,
+  setSearchMemberQueryAction,
+} = teamSlice.actions;
 
 export default {
-  teams: teamsReducer,
-  team: teamReducer,
+  teams: teamsSlice.reducer,
+  team: teamSlice.reducer,
 };

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -1,12 +1,12 @@
-import { applyMiddleware, compose, createStore } from 'redux';
+import { configureStore as rtkConfigureStore } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
-import { createLogger } from 'redux-logger';
 
 import { setStore } from './store';
 import { StoreState } from 'app/types/store';
-import { toggleLogActionsMiddleware } from 'app/core/middlewares/application';
 import { addReducer, createRootReducer } from '../core/reducers/root';
 import { ActionOf } from 'app/core/redux';
+import { toggleLogActionsMiddleware } from '../core/middlewares/application';
+import { createLogger } from 'redux-logger';
 
 export function addRootReducer(reducers: any) {
   // this is ok now because we add reducers before configureStore is called
@@ -16,23 +16,17 @@ export function addRootReducer(reducers: any) {
 }
 
 export function configureStore() {
-  const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-
   const logger = createLogger({
     predicate: (getState: () => StoreState) => {
       return getState().application.logActions;
     },
   });
-  const storeEnhancers =
-    process.env.NODE_ENV !== 'production'
-      ? applyMiddleware(toggleLogActionsMiddleware, thunk, logger)
-      : applyMiddleware(thunk);
 
-  const store = createStore<StoreState, ActionOf<any>, any, any>(
-    createRootReducer(),
-    {},
-    composeEnhancers(storeEnhancers)
-  );
+  const store = rtkConfigureStore<StoreState, ActionOf<any>>({
+    reducer: createRootReducer(),
+    middleware: process.env.NODE_ENV !== 'production' ? [toggleLogActionsMiddleware, thunk, logger] : [thunk],
+  });
+
   setStore(store);
   return store;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,18 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@reduxjs/toolkit@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.0.4.tgz#cec88446a22a98b48808af7ab19a58aa93e6f5f9"
+  integrity sha512-nyCZ9/CpnMXFZ//0wm1mNPSEl0J0bCghY2qeHM8zuubaBBMBr6KsIaLLms1jThbOJ1O+Ej0Tl11z5naE9czfzA==
+  dependencies:
+    immer "^4.0.1"
+    redux "^4.0.0"
+    redux-devtools-extension "^2.13.8"
+    redux-immutable-state-invariant "^2.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@rtsao/plugin-proposal-class-properties@7.0.1-patch.1":
   version "7.0.1-patch.1"
   resolved "https://registry.yarnpkg.com/@rtsao/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.1-patch.1.tgz#ac0f758a25a85b5be0e70a25f6e5b58103c58391"
@@ -10975,6 +10987,11 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immer@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-4.0.2.tgz#9ff0fcdf88e06f92618a5978ceecb5884e633559"
+  integrity sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w==
+
 immutable@3.8.2, immutable@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
@@ -11182,7 +11199,7 @@ interpret@^1.0.0, interpret@^1.1.0, interpret@^1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -17672,6 +17689,19 @@ reduce-flatten@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
   integrity sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=
 
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
+redux-immutable-state-invariant@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz#308fd3cc7415a0e7f11f51ec997b6379c7055ce1"
+  integrity sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==
+  dependencies:
+    invariant "^2.1.0"
+    json-stringify-safe "^5.0.1"
+
 redux-logger@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -17686,7 +17716,7 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-thunk@2.3.0:
+redux-thunk@2.3.0, redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
@@ -18001,7 +18031,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@*, reselect@4.0.0:
+reselect@*, reselect@4.0.0, reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==


### PR DESCRIPTION
**What this PR does / why we need it**:
For someone with a strong passion for Redux as myself the release of the official [Redux Toolkit](https://redux-toolkit.js.org/) looks very promising.  

This PR was made as part of a `Hack Day` to see if we can use this lib instead of our [home grown solution](https://github.com/grafana/grafana/blob/master/contribute/style-guides/redux.md) to reduce boilerplate even further and lower the complexity for writing Redux in Grafana even more.

**The Good**
One of Redux Toolkit missions is to reduce boilerplate and I think that it does a great job with this.
Let's start with the `configureStore` function where initialize Redux in Grafana and compare `before` and `after`.

**`configureStore` function before**
```typescript
export function configureStore() {
  const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

  const logger = createLogger({
    predicate: (getState: () => StoreState) => {
      return getState().application.logActions;
    },
  });
  const storeEnhancers =
    process.env.NODE_ENV !== 'production'
      ? applyMiddleware(toggleLogActionsMiddleware, thunk, logger)
      : applyMiddleware(thunk);

  const store = createStore<StoreState, ActionOf<any>, any, any>(
    createRootReducer(),
    {},
    composeEnhancers(storeEnhancers)
  );
  setStore(store);
  return store;
}
```

**`configureStore` function after**
```typescript
export function configureStore() {
  const logger = createLogger({
    predicate: (getState: () => StoreState) => {
      return getState().application.logActions;
    },
  });

  const store = rtkConfigureStore<StoreState, ActionOf<any>>({
    reducer: createRootReducer(),
    middleware: process.env.NODE_ENV !== 'production' ? [toggleLogActionsMiddleware, thunk, logger] : [thunk],
  });

  setStore(store);
  return store;
}
```

Let's compare a simple reducer called `teamsReducer` before and after. For a correct comparison I will include content from actions also (might not transpile).

**`teamsReducer` before**
```typescript
export enum ActionTypes {
  LoadTeams = 'LOAD_TEAMS',
  SetSearchQuery = 'SET_TEAM_SEARCH_QUERY',
}

export interface LoadTeamsAction {
  type: ActionTypes.LoadTeams;
  payload: Team[];
}

export interface SetSearchQueryAction {
  type: ActionTypes.SetSearchQuery;
  payload: string;
}

export type Action =
  | LoadTeamsAction
  | SetSearchQueryAction;

type ThunkResult<R> = ThunkAction<R, StoreState, undefined, Action | UpdateNavIndexAction>;

const teamsLoaded = (teams: Team[]): LoadTeamsAction => ({
  type: ActionTypes.LoadTeams,
  payload: teams,
});

export const setSearchQuery = (searchQuery: string): SetSearchQueryAction => ({
  type: ActionTypes.SetSearchQuery,
  payload: searchQuery,
});

export function loadTeams(): ThunkResult<void> {
  return async dispatch => {
    const response = await getBackendSrv().get('/api/teams/search', { perpage: 1000, page: 1 });
    dispatch(teamsLoaded(response.teams));
  };
}

export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', hasFetched: false };

export const teamsReducer = (state = initialTeamsState, action: Action): TeamsState => {
  switch (action.type) {
    case ActionTypes.LoadTeams:
      return { ...state, hasFetched: true, teams: action.payload };

    case ActionTypes.SetSearchQuery:
      return { ...state, searchQuery: action.payload };
  }
  return state;
};
```

**`teamsReducer` with home grown solution**
```typescript
export const loadTeamsAction = actionCreatorFactory<Team[]>('loadTeamsAction').create();

export const setSearchQueryAction = actionCreatorFactory<string>('setSearchQueryAction').create();

export function loadTeams(): ThunkResult<void> {
  return async dispatch => {
    const response = await getBackendSrv().get('/api/teams/search', { perpage: 1000, page: 1 });
    dispatch(loadTeamsAction(response.teams));
  };
}

export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', hasFetched: false };

export const teamsReducer = reducerFactory<TeamsState>(initialTeamsState)
  .addMapper({
    filter: loadTeamsAction,
    mapper: (state, action): TeamsState => {
      return { ...state, hasFetched: true, teams: action.payload };
    },
  })
  .addMapper({
    filter: setSearchQueryAction,
    mapper: (state, action): TeamsState => {
      return { ...state, searchQuery: action.payload };
    },
  })
  .create();
```

**`teamsReducer` with Redux Toolkit**
```typescript
export function loadTeams(): ThunkResult<void> {
  return async dispatch => {
    const response = await getBackendSrv().get('/api/teams/search', { perpage: 1000, page: 1 });
    dispatch(loadTeamsAction(response.teams));
  };
}

export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', hasFetched: false };

interface TeamsStateReducers<S> extends Record<string, any> {
  loadTeamsAction: (state: S, action: PayloadAction<Team[]>) => S;
  setSearchQueryAction: (state: S, action: PayloadAction<string>) => S;
}

export const teamsSlice = createSlice<TeamsState, TeamsStateReducers<TeamsState>>({
  name: 'teams',
  initialState: initialTeamsState,
  reducers: {
    loadTeamsAction(state, action) {
      return { ...state, hasFetched: true, teams: action.payload };
    },
    setSearchQueryAction(state, action) {
      return { ...state, searchQuery: action.payload };
    },
  },
});

export const { loadTeamsAction, setSearchQueryAction } = teamsSlice.actions;
```

I find the Redux Toolkit solution with `createSlice` to be very elegant and short but for usage with `TypeScript` there are some improvements left to really convince me to change.

**The Could Improve**
As I've already stated there are some weird things that are kind of frustrating when using Redux Toolkit with TypeScript with Grafanas config. From the docs [here](https://redux-starter-kit.js.org/tutorials/advanced-tutorial/#declaring-types-for-slice-state-and-actions) I would expect more intellisense and better help with types.
> **createSlice** tries to infer types from two sources:
The state type is based on the type of the initialState field
Each reducer needs to declare the type of the action it expects to handle
The state type is used as the type for the state parameter in each of the case reducers and the return type for the generated reducer function, and the action types are used for the corresponding generated action creators.
We don't have to declare a type for **state**, because **createSlice** already knows that this should be the same type as our **initialState**

With our setup I couldn't get the inference of state to work without specifying the following interface:
```typescript
interface TeamsStateReducers<S> extends Record<string, any> {
  loadTeamsAction: (state: S, action: PayloadAction<Team[]>) => S;
  setSearchQueryAction: (state: S, action: PayloadAction<string>) => S;
}
```
and even so you have to specify the state type as the return type for all functions or else you'll have issues as described [here](https://github.com/grafana/grafana/blob/master/contribute/style-guides/redux.md#typing-limitations). Someday I would like to take a deep dive into why this is not working, is it because of Grafanas TypeScript config or is it just not working.

Another funny thing is when specifying the `TeamsStateReducers` interface above I'd to extend `Record` or `{[key:string]:any}` because that's what `createSlice` expects.

**Recommendation**
I would wait and see if the typings for Redux Toolkit could be improved or investigate why the docs for Redux Toolkit don't work in our setup.

