### PR TITLE
Doc: Change inline comment on interface to doc comment

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -281,8 +281,8 @@ export interface QueryEditorProps<
   query: TQuery;
   onRunQuery: () => void;
   onChange: (value: TQuery) => void;
-  /*
-   * Contains query response filtered by refId and possible query error
+  /**
+   * Contains query response filtered by refId of QueryResultBase and possible query error
    */
   data?: PanelData;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Update interface to doc comment to make routing of data in QueryEditor easier to understand. 

**Which issue(s) this PR fixes**:
Should prevent other from running into the same problems as #20749.

Fixes #20749

**Special notes for your reviewer**:

