### PR TITLE
Alerting: Add support for sending tags in OpsGenie notifier

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -177,7 +177,7 @@ Hipchat | `hipchat` | yes, external only | no
 Kafka | `kafka` | yes, external only | no
 Line | `line` | yes, external only | no
 Microsoft Teams | `teams` | yes, external only | no
-OpsGenie | `opsgenie` | yes, external only | no
+OpsGenie | `opsgenie` | yes, external only | yes
 Pagerduty | `pagerduty` | yes, external only | no
 Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only | yes
 Pushover | `pushover` | yes | no

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -122,7 +122,7 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 		if len(tag.Value) > 0 {
 			tags = append(tags, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
 		} else {
-			tags = append(tags, fmt.Sprintf("%s", tag.Key))
+			tags = append(tags, tag.Key)
 		}
 
 	}

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -116,6 +116,18 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 	}
 
 	bodyJSON.Set("details", details)
+
+	tags := make([]string, 0)
+	for _, tag := range evalContext.Rule.AlertRuleTags {
+		if len(tag.Value) > 0 {
+			tags = append(tags, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
+		} else {
+			tags = append(tags, fmt.Sprintf("%s", tag.Key))
+		}
+
+	}
+	bodyJSON.Set("tags", tags)
+
 	body, _ := bodyJSON.MarshalJSON()
 
 	cmd := &models.SendWebhookSync{

--- a/pkg/services/alerting/notifiers/opsgenie_test.go
+++ b/pkg/services/alerting/notifiers/opsgenie_test.go
@@ -1,11 +1,13 @@
 package notifiers
 
 import (
-	"testing"
-
+	"context"
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestOpsGenieNotifier(t *testing.T) {
@@ -46,6 +48,53 @@ func TestOpsGenieNotifier(t *testing.T) {
 				So(opsgenieNotifier.Name, ShouldEqual, "opsgenie_testing")
 				So(opsgenieNotifier.Type, ShouldEqual, "opsgenie")
 				So(opsgenieNotifier.APIKey, ShouldEqual, "abcdefgh0123456789")
+			})
+
+			Convey("alert payload should include tag pairs in a ['key1:value1'] format when a value exists and in ['key2'] format when a value is absent", func() {
+				json := `
+				{
+          "apiKey": "abcdefgh0123456789"
+				}`
+
+				tagPairs := []*models.Tag{
+					{Key: "keyOnly"},
+					{Key: "aKey", Value: "aValue"},
+				}
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "opsgenie_testing",
+					Type:     "opsgenie",
+					Settings: settingsJSON,
+				}
+
+				notifier, notifierErr := NewOpsGenieNotifier(model) //unhandled error
+
+				opsgenieNotifier := notifier.(*OpsGenieNotifier)
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:            0,
+					Name:          "someRule",
+					Message:       "someMessage",
+					State:         models.AlertStateAlerting,
+					AlertRuleTags: tagPairs,
+				})
+				evalContext.IsTestRun = true
+
+				receivedTags := make([]string, 0)
+				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+					bodyJson, err := simplejson.NewJson([]byte(cmd.Body))
+					if err == nil {
+						receivedTags = bodyJson.Get("tags").MustStringArray([]string{})
+					}
+					return err
+				})
+
+				alertErr := opsgenieNotifier.createAlert(evalContext)
+
+				So(notifierErr, ShouldBeNil)
+				So(alertErr, ShouldBeNil)
+				So(receivedTags, ShouldResemble, []string{"keyOnly", "aKey:aValue"})
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds alert tags support to OpsGenie notifier

**Which issue(s) this PR fixes**:
Fixes #20796 

**Special notes for your reviewer**:

