### PR TITLE
Explore: Fix showing of results in selected timezone (UTC/local)

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -420,6 +420,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     queryResponse,
     originPanelId,
     syncedTimes,
+    timeZone,
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Timezone wasn't exported from `mapStateToProps` in Explore. Therefore timezone passed to Graphs and Tables was always `undefined` (this wasn't a case for Logs where everything was correct as timezone was correctly passed in `LogsContainer`). This resulted in not using UTC, when UTC was selected in preferences.  This PR fixes this by exporting timezone from `mapStateToProps` in Explore.

**Which issue(s) this PR fixes**:
Fixes #19978
Fixes #20834

