### PR TITLE
Annotations: Clean up old annotations job

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -230,6 +230,12 @@ snapshot_remove_expired = true
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
 versions_to_keep = 20
 
+#################################### Annotations ##################
+
+[annotations]
+# Number of days of annotations to keep (per alert). Default: 60, Minimum: 1
+days_to_keep = 60
+
 #################################### Users ###############################
 [users]
 # disable user signup / registration

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -233,7 +233,7 @@ versions_to_keep = 20
 #################################### Annotations ##################
 
 [annotations]
-# Number of days of annotations to keep (per alert). Default: 60, Minimum: 1
+# Number of days to keep annotations (per alert). Default: 60, Minimum: 5
 days_to_keep = 60
 
 #################################### Users ###############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -231,7 +231,7 @@
 
 #################################### Annotations ##################
 [annotations]
-# Number of days of annotations to keep (per alert). Default: 60, Minimum: 5
+# Number of days to keep annotations (per alert). Default: 60, Minimum: 5
 ;days_to_keep = 60
 
 #################################### Users ###############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -229,6 +229,11 @@
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
 ;versions_to_keep = 20
 
+#################################### Annotations ##################
+[annotations]
+# Number of days of annotations to keep (per alert). Default: 60, Minimum: 5
+;days_to_keep = 60
+
 #################################### Users ###############################
 [users]
 # disable user signup / registration

--- a/pkg/models/annotations.go
+++ b/pkg/models/annotations.go
@@ -1,6 +1,6 @@
 package models
 
-type DeleteExpiredVAnnotationsCommand struct {
+type DeleteExpiredAnnotationsCommand struct {
 	DaysToKeep  int
 	DeletedRows int64
 }

--- a/pkg/models/annotations.go
+++ b/pkg/models/annotations.go
@@ -1,5 +1,6 @@
 package models
 
 type DeleteExpiredVAnnotationsCommand struct {
+	DaysToKeep  int
 	DeletedRows int64
 }

--- a/pkg/models/annotations.go
+++ b/pkg/models/annotations.go
@@ -1,0 +1,5 @@
+package models
+
+type DeleteExpiredVAnnotationsCommand struct {
+	DeletedRows int64
+}

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -127,7 +127,11 @@ func (srv *CleanUpService) deleteOldLoginAttempts() {
 }
 
 func (srv *CleanUpService) deleteExpiredAnnotations() {
-	cmd := m.DeleteExpiredVAnnotationsCommand{}
+	daysToKeep := setting.DaysToKeepAnnotations
+	if daysToKeep < 5 {
+		daysToKeep = 5
+	}
+	cmd := m.DeleteExpiredVAnnotationsCommand{DaysToKeep: daysToKeep}
 	if err := bus.Dispatch(&cmd); err != nil {
 		srv.log.Error("Failed to delete expired annotations", "error", err.Error())
 	} else {

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -131,7 +131,7 @@ func (srv *CleanUpService) deleteExpiredAnnotations() {
 	if daysToKeep < 5 {
 		daysToKeep = 5
 	}
-	cmd := m.DeleteExpiredVAnnotationsCommand{DaysToKeep: daysToKeep}
+	cmd := m.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeep}
 	if err := bus.Dispatch(&cmd); err != nil {
 		srv.log.Error("Failed to delete expired annotations", "error", err.Error())
 	} else {

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -126,12 +126,9 @@ func (srv *CleanUpService) deleteOldLoginAttempts() {
 	}
 }
 
+// deleteExpiredAnnotations removes expired annotations from the database.
 func (srv *CleanUpService) deleteExpiredAnnotations() {
-	daysToKeep := setting.DaysToKeepAnnotations
-	if daysToKeep < 5 {
-		daysToKeep = 5
-	}
-	cmd := m.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeep}
+	cmd := m.DeleteExpiredAnnotationsCommand{DaysToKeep: setting.DaysToKeepAnnotations}
 	if err := bus.Dispatch(&cmd); err != nil {
 		srv.log.Error("Failed to delete expired annotations", "error", err.Error())
 	} else {

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -135,6 +135,6 @@ func (srv *CleanUpService) deleteExpiredAnnotations() {
 	if err := bus.Dispatch(&cmd); err != nil {
 		srv.log.Error("Failed to delete expired annotations", "error", err.Error())
 	} else {
-		srv.log.Debug("Deleted old/expired annotations", "rows affected", cmd.DeletedRows)
+		srv.log.Debug("Deleted expired annotations", "rows affected", cmd.DeletedRows)
 	}
 }

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -40,6 +40,7 @@ func (srv *CleanUpService) Run(ctx context.Context) error {
 			srv.cleanUpTmpFiles()
 			srv.deleteExpiredSnapshots()
 			srv.deleteExpiredDashboardVersions()
+			srv.deleteExpiredAnnotations()
 			err := srv.ServerLockService.LockAndExecute(ctx, "delete old login attempts",
 				time.Minute*10, func() {
 					srv.deleteOldLoginAttempts()
@@ -122,5 +123,14 @@ func (srv *CleanUpService) deleteOldLoginAttempts() {
 		srv.log.Error("Problem deleting expired login attempts", "error", err.Error())
 	} else {
 		srv.log.Debug("Deleted expired login attempts", "rows affected", cmd.DeletedRows)
+	}
+}
+
+func (srv *CleanUpService) deleteExpiredAnnotations() {
+	cmd := m.DeleteExpiredVAnnotationsCommand{}
+	if err := bus.Dispatch(&cmd); err != nil {
+		srv.log.Error("Failed to delete expired annotations", "error", err.Error())
+	} else {
+		srv.log.Debug("Deleted old/expired annotations", "rows affected", cmd.DeletedRows)
 	}
 }

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -10,12 +10,12 @@ import (
 )
 
 func init() {
-	bus.AddHandler("sql", DeleteExpiredAnnotations)
+	bus.AddHandler("sql", deleteExpiredAnnotations)
 }
 
 const MAX_HISTORY_ENTRIES_TO_DELETE = 900
 
-func DeleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
+func deleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		daysToKeep := setting.AnnotationsDaysToKeep
 		if daysToKeep < 5 {

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func init() {
@@ -17,12 +16,7 @@ const MAX_HISTORY_ENTRIES_TO_DELETE = 900
 
 func deleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
-		daysToKeep := setting.DaysToKeepAnnotations
-		if daysToKeep < 5 {
-			daysToKeep = 5
-		}
-
-		historyTimeStamp := (time.Now().Unix() - int64(daysToKeep*86400)) * 1000
+		historyTimeStamp := (time.Now().Unix() - int64(cmd.DaysToKeep*86400)) * 1000
 
 		annotationsIdsToDeleteQuery := `SELECT id FROM annotation WHERE created <= ? ORDER BY id LIMIT ?`
 

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -17,7 +17,7 @@ const MAX_HISTORY_ENTRIES_TO_DELETE = 900
 
 func deleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
-		daysToKeep := setting.AnnotationsDaysToKeep
+		daysToKeep := setting.DaysToKeepAnnotations
 		if daysToKeep < 5 {
 			daysToKeep = 5
 		}

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -1,0 +1,55 @@
+package sqlstore
+
+import (
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/bus"
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func init() {
+	bus.AddHandler("sql", DeleteExpiredAnnotations)
+}
+
+const MAX_HISTORY_ENTRIES_TO_DELETE = 900
+
+func DeleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
+	return inTransaction(func(sess *DBSession) error {
+		daysToKeep := setting.AnnotationsDaysToKeep
+		if daysToKeep < 5 {
+			daysToKeep = 5
+		}
+
+		historyTimeStamp := (time.Now().Unix() - int64(daysToKeep*86400)) * 1000
+
+		annotationsIdsToDeleteQuery := `SELECT id FROM annotation WHERE created <= ? ORDER BY id LIMIT ?`
+
+		var annotationsIdsToDelete []interface{}
+		err := sess.SQL(annotationsIdsToDeleteQuery, historyTimeStamp, MAX_HISTORY_ENTRIES_TO_DELETE).Find(&annotationsIdsToDelete)
+		if err != nil {
+			return err
+		}
+
+		if len(annotationsIdsToDelete) > 0 {
+
+			deleteExpiredTagsSql := `DELETE FROM annotation_tag WHERE annotation_id IN (?` + strings.Repeat(",?", len(annotationsIdsToDelete)-1) + `)`
+			sqlOrArgsTags := append([]interface{}{deleteExpiredTagsSql}, annotationsIdsToDelete...)
+			_, err := sess.Exec(sqlOrArgsTags...)
+			if err != nil {
+				return err
+			}
+
+			deleteExpiredSql := `DELETE FROM annotation WHERE id IN (?` + strings.Repeat(",?", len(annotationsIdsToDelete)-1) + `)`
+			sqlOrArgs := append([]interface{}{deleteExpiredSql}, annotationsIdsToDelete...)
+			expiredResponse, err := sess.Exec(sqlOrArgs...)
+			if err != nil {
+				return err
+			}
+			cmd.DeletedRows, _ = expiredResponse.RowsAffected()
+		}
+
+		return nil
+	})
+}

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -14,7 +14,7 @@ func init() {
 
 const MAX_HISTORY_ENTRIES_TO_DELETE = 900
 
-func deleteExpiredAnnotations(cmd *m.DeleteExpiredVAnnotationsCommand) error {
+func deleteExpiredAnnotations(cmd *m.DeleteExpiredAnnotationsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		historyTimeStamp := (time.Now().Unix() - int64(cmd.DaysToKeep*86400)) * 1000
 

--- a/pkg/services/sqlstore/annotations_cleanup.go
+++ b/pkg/services/sqlstore/annotations_cleanup.go
@@ -14,7 +14,7 @@ func init() {
 	bus.AddHandler("sql", deleteExpiredAnnotations)
 }
 
-const MAX_HISTORY_ENTRIES_TO_DELETE = 900
+const MAX_EXPIRED_ANNOTATIONS_TO_DELETE = 900
 
 func deleteExpiredAnnotations(cmd *m.DeleteExpiredAnnotationsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
@@ -22,7 +22,7 @@ func deleteExpiredAnnotations(cmd *m.DeleteExpiredAnnotationsCommand) error {
 
 		query := "SELECT id FROM annotation WHERE created <= ? ORDER BY id LIMIT ?"
 		var annotationIdsToDelete []interface{}
-		if err := sess.SQL(query, historyTimeStamp, MAX_HISTORY_ENTRIES_TO_DELETE).Find(&annotationIdsToDelete); err != nil {
+		if err := sess.SQL(query, historyTimeStamp, MAX_EXPIRED_ANNOTATIONS_TO_DELETE).Find(&annotationIdsToDelete); err != nil {
 			return errutil.Wrapf(err, "failed to query for expired annotations")
 		}
 		if len(annotationIdsToDelete) == 0 {

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -51,13 +51,13 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 	Convey("Testing annotations history clean up", t, func() {
 		InitTestDB(t)
 		repo := SqlAnnotationRepo{}
-		annotationsDaysToKeep := 5
+		daysToKeepAnnotations := 5
 		annotationsToWrite := 10
-		setting.AnnotationsDaysToKeep = annotationsDaysToKeep
+		setting.DaysToKeepAnnotations = daysToKeepAnnotations
 
 		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
 		for i := 0; i < annotationsToWrite-1; i++ {
-			err := repo.addTestAnnotation(savedDash, repo, annotationsDaysToKeep, &annotations.Item{OrgId: 1})
+			err := repo.addTestAnnotation(savedDash, repo, daysToKeepAnnotations, &annotations.Item{OrgId: 1})
 			So(err, ShouldBeNil)
 		}
 
@@ -86,7 +86,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		})
 
 		Convey("Don't delete anything if there're no expired versions", func() {
-			setting.AnnotationsDaysToKeep = annotationsToWrite
+			setting.DaysToKeepAnnotations = annotationsToWrite
 
 			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
 			So(err, ShouldBeNil)
@@ -102,7 +102,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		Convey("Don't delete more than MAX_VERSIONS_TO_DELETE per iteration", func() {
 			annotationsToWriteBigNumber := MAX_HISTORY_ENTRIES_TO_DELETE + annotationsToWrite
 			for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
-				err := repo.addTestAnnotation(savedDash, repo, annotationsDaysToKeep, &annotations.Item{OrgId: 1})
+				err := repo.addTestAnnotation(savedDash, repo, daysToKeepAnnotations, &annotations.Item{OrgId: 1})
 				So(err, ShouldBeNil)
 			}
 
@@ -114,8 +114,8 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 				DashboardId: 1,
 			})
 
-			// Ensure we have at least annotationsDaysToKeep versions
-			So(len(items), ShouldBeGreaterThanOrEqualTo, annotationsDaysToKeep)
+			// Ensure we have at least daysToKeepAnnotations versions
+			So(len(items), ShouldBeGreaterThanOrEqualTo, daysToKeepAnnotations)
 			// Ensure we haven't deleted more than MAX_VERSIONS_TO_DELETE rows
 			So(annotationsToWriteBigNumber-len(items), ShouldBeLessThanOrEqualTo, MAX_HISTORY_ENTRIES_TO_DELETE)
 		})

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -51,7 +51,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 	annotationsToWrite := 10
 
 	InitTestDB(t)
-	savedDash := insertNewTestDashboard(t,"test dash 111", 1, 0, false, "this-is-fun")
+	savedDash := insertNewTestDashboard(t, "test dash 111", 1, 0, false, "this-is-fun")
 
 	expiredCreated := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
 	err := inTransaction(func(sess *DBSession) error {
@@ -67,8 +67,6 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-
-
 	err = deleteExpiredAnnotations(&models.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
 	assert.Nil(t, err)
 
@@ -80,8 +78,6 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 
 	assert.Equal(t, len(items), 1)
 	assert.ElementsMatch(t, items[0].Tags, []string{"outage", "error", "type:outage", "server:server-1"}, "Can read tags")
-
-
 
 	err = deleteExpiredAnnotations(&models.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
 	assert.Nil(t, err)
@@ -101,7 +97,7 @@ func TestDeleteExpiredAnnotationsMax(t *testing.T) {
 	repo := SqlAnnotationRepo{}
 
 	InitTestDB(t)
-	savedDash := insertNewTestDashboard(t,"test dash 111", 1, 0, false, "this-is-fun")
+	savedDash := insertNewTestDashboard(t, "test dash 111", 1, 0, false, "this-is-fun")
 
 	numAnnotations := MAX_EXPIRED_ANNOTATIONS_TO_DELETE + 10
 	err := inTransaction(func(sess *DBSession) error {
@@ -127,7 +123,7 @@ func TestDeleteExpiredAnnotationsMax(t *testing.T) {
 	assert.Equal(t, len(items), numAnnotations-MAX_EXPIRED_ANNOTATIONS_TO_DELETE)
 }
 
-func insertNewTestDashboard(t *testing.T,title string, orgId int64, folderId int64, isFolder bool, tags ...interface{}) *models.Dashboard {
+func insertNewTestDashboard(t *testing.T, title string, orgId int64, folderId int64, isFolder bool, tags ...interface{}) *models.Dashboard {
 	cmd := models.SaveDashboardCommand{
 		OrgId:    orgId,
 		FolderId: folderId,

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -1,0 +1,124 @@
+package sqlstore
+
+import (
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func (r *SqlAnnotationRepo) addTestAnnotation(dashboard *m.Dashboard, repo SqlAnnotationRepo, daysToKeep int, item *annotations.Item) error {
+
+	return inTransaction(func(sess *DBSession) error {
+		tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
+		item.Tags = m.JoinTagPairs(tags)
+		item.Text = "hello"
+		item.Type = "alert"
+		item.UserId = 1
+		item.OrgId = dashboard.OrgId
+		item.DashboardId = dashboard.Id
+		item.Created = (time.Now().Unix() - int64(daysToKeep*2*86400)) * 1000
+		item.Updated = item.Created
+		if item.Epoch == 0 {
+			item.Epoch = item.Created
+			item.EpochEnd = item.Created
+		}
+
+		_, err := sess.Table("annotation").Insert(item)
+		if err != nil {
+			return err
+		}
+
+		if item.Tags != nil {
+			tags, err := EnsureTagsExist(sess, tags)
+			if err != nil {
+				return err
+			}
+			for _, tag := range tags {
+				if _, err := sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", item.Id, tag.Id); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func TestDeleteExpiredAnnotations(t *testing.T) {
+	Convey("Testing annotations history clean up", t, func() {
+		InitTestDB(t)
+		repo := SqlAnnotationRepo{}
+		annotationsDaysToKeep := 5
+		annotationsToWrite := 10
+		setting.AnnotationsDaysToKeep = annotationsDaysToKeep
+
+		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
+		for i := 0; i < annotationsToWrite-1; i++ {
+			err := repo.addTestAnnotation(savedDash, repo, annotationsDaysToKeep, &annotations.Item{OrgId: 1})
+			So(err, ShouldBeNil)
+		}
+
+		// add one recent
+		err := repo.addTestAnnotation(savedDash, repo, 1, &annotations.Item{OrgId: 1})
+		So(err, ShouldBeNil)
+
+		Convey("Clean up old annotations", func() {
+			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			So(err, ShouldBeNil)
+
+			from := (time.Now().Unix() - int64(annotationsToWrite*86400)) * 1000
+			to := time.Now().Unix() * 1000
+
+			items, _ := repo.Find(&annotations.ItemQuery{
+				OrgId:       1,
+				DashboardId: 1,
+				From:        from,
+				To:          to,
+			})
+
+			So(len(items), ShouldEqual, 1)
+			Convey("Can read tags", func() {
+				So(items[0].Tags, ShouldResemble, []string{"outage", "error", "type:outage", "server:server-1"})
+			})
+		})
+
+		Convey("Don't delete anything if there're no expired versions", func() {
+			setting.AnnotationsDaysToKeep = annotationsToWrite
+
+			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			So(err, ShouldBeNil)
+
+			items, _ := repo.Find(&annotations.ItemQuery{
+				OrgId:       1,
+				DashboardId: 1,
+			})
+
+			So(len(items), ShouldEqual, 1)
+		})
+
+		Convey("Don't delete more than MAX_VERSIONS_TO_DELETE per iteration", func() {
+			annotationsToWriteBigNumber := MAX_HISTORY_ENTRIES_TO_DELETE + annotationsToWrite
+			for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
+				err := repo.addTestAnnotation(savedDash, repo, annotationsDaysToKeep, &annotations.Item{OrgId: 1})
+				So(err, ShouldBeNil)
+			}
+
+			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			So(err, ShouldBeNil)
+
+			items, _ := repo.Find(&annotations.ItemQuery{
+				OrgId:       1,
+				DashboardId: 1,
+			})
+
+			// Ensure we have at least annotationsDaysToKeep versions
+			So(len(items), ShouldBeGreaterThanOrEqualTo, annotationsDaysToKeep)
+			// Ensure we haven't deleted more than MAX_VERSIONS_TO_DELETE rows
+			So(annotationsToWriteBigNumber-len(items), ShouldBeLessThanOrEqualTo, MAX_HISTORY_ENTRIES_TO_DELETE)
+		})
+	})
+}

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -67,7 +67,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Clean up old annotations", func() {
-			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
 			So(err, ShouldBeNil)
 
 			from := (time.Now().Unix() - int64(annotationsToWrite*86400)) * 1000
@@ -89,7 +89,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		Convey("Don't delete anything if there're no expired versions", func() {
 			setting.AnnotationsDaysToKeep = annotationsToWrite
 
-			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
 			So(err, ShouldBeNil)
 
 			items, _ := repo.Find(&annotations.ItemQuery{
@@ -107,7 +107,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 				So(err, ShouldBeNil)
 			}
 
-			err := DeleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
 			So(err, ShouldBeNil)
 
 			items, _ := repo.Find(&annotations.ItemQuery{

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func (r *SqlAnnotationRepo) addTestAnnotation(dashboard *m.Dashboard, repo SqlAnnotationRepo, daysToKeep int, item *annotations.Item) error {
-
 	return inTransaction(func(sess *DBSession) error {
 		tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
 		item.Tags = m.JoinTagPairs(tags)

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -100,7 +100,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		InitTestDB(t)
 		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
 
-		numAnnotations := MAX_HISTORY_ENTRIES_TO_DELETE + 10
+		numAnnotations := MAX_EXPIRED_ANNOTATIONS_TO_DELETE + 10
 		err := inTransaction(func(sess *DBSession) error {
 			created := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
 			for i := 0; i < numAnnotations; i++ {
@@ -121,6 +121,6 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		})
 		So(err, ShouldBeNil)
 
-		So(len(items), ShouldEqual, numAnnotations-MAX_HISTORY_ENTRIES_TO_DELETE)
+		So(len(items), ShouldEqual, numAnnotations-MAX_EXPIRED_ANNOTATIONS_TO_DELETE)
 	})
 }

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -99,7 +99,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		Convey("Don't delete more than MAX_VERSIONS_TO_DELETE per iteration", func() {
 			annotationsToWriteBigNumber := MAX_HISTORY_ENTRIES_TO_DELETE + annotationsToWrite
 			err := inTransaction(func(sess *DBSession) error {
-				created := (time.Now().Unix() - int64(daysToKeepAnnotations*2*86400))
+				created := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
 				for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
 					if err := addTestAnnotation(savedDash, created, sess); err != nil {
 						return err

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -10,61 +10,61 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func addTestAnnotation(dashboard *m.Dashboard, created int64) error {
-	return inTransaction(func(sess *DBSession) error {
-		created *= 1000
-		tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
+func addTestAnnotation(dashboard *m.Dashboard, created int64, sess *DBSession) error {
+	created *= 1000
+	tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
 
-		item := annotations.Item{
-			Tags:        m.JoinTagPairs(tags),
-			Text:        "hello",
-			Type:        "alert",
-			UserId:      1,
-			OrgId:       dashboard.OrgId,
-			DashboardId: dashboard.Id,
-			Created:     created,
-			Updated:     created,
-			Epoch:       created,
-			EpochEnd:    created,
-		}
-		if _, err := sess.Table("annotation").Insert(&item); err != nil {
+	item := annotations.Item{
+		Tags:        m.JoinTagPairs(tags),
+		Text:        "hello",
+		Type:        "alert",
+		UserId:      1,
+		OrgId:       dashboard.OrgId,
+		DashboardId: dashboard.Id,
+		Created:     created,
+		Updated:     created,
+		Epoch:       created,
+		EpochEnd:    created,
+	}
+	if _, err := sess.Table("annotation").Insert(&item); err != nil {
+		return err
+	}
+
+	// Get tag IDs
+	tags, err := EnsureTagsExist(sess, tags)
+	if err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		if _, err := sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", item.Id, tag.Id); err != nil {
 			return err
 		}
+	}
 
-		// Get tag IDs
-		tags, err := EnsureTagsExist(sess, tags)
-		if err != nil {
-			return err
-		}
-		for _, tag := range tags {
-			if _, err := sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", item.Id, tag.Id); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
+	return nil
 }
 
 func TestDeleteExpiredAnnotations(t *testing.T) {
-	Convey("Testing annotations history clean up", t, func() {
+	Convey("Deletion of expired annotations", t, func() {
 		InitTestDB(t)
 		repo := SqlAnnotationRepo{}
 		daysToKeepAnnotations := 5
 		annotationsToWrite := 10
 
 		expiredCreated := (time.Now().Unix() - int64(daysToKeepAnnotations*2*86400))
-		// TODO: Insert all annotations in one transaction, for speed * 1000
 		// Add expired annotations
 		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
-		for i := 0; i < annotationsToWrite-1; i++ {
-			err := addTestAnnotation(savedDash, expiredCreated)
-			So(err, ShouldBeNil)
-		}
+		err := inTransaction(func(sess *DBSession) error {
+			for i := 0; i < annotationsToWrite-1; i++ {
+				if err := addTestAnnotation(savedDash, expiredCreated, sess); err != nil {
+					return err
+				}
+			}
 
-		// add one recent
-		newCreated := (time.Now().Unix() - int64(2*86400))
-		err := addTestAnnotation(savedDash, newCreated)
+			// Add one recent
+			newCreated := (time.Now().Unix() - int64(2*86400))
+			return addTestAnnotation(savedDash, newCreated, sess)
+		})
 		So(err, ShouldBeNil)
 
 		Convey("Clean up expired annotations", func() {
@@ -98,19 +98,25 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 
 		Convey("Don't delete more than MAX_VERSIONS_TO_DELETE per iteration", func() {
 			annotationsToWriteBigNumber := MAX_HISTORY_ENTRIES_TO_DELETE + annotationsToWrite
-			for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
+			err := inTransaction(func(sess *DBSession) error {
 				created := (time.Now().Unix() - int64(daysToKeepAnnotations*2*86400))
-				err := addTestAnnotation(savedDash, created)
-				So(err, ShouldBeNil)
-			}
-
-			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{})
+				for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
+					if err := addTestAnnotation(savedDash, created, sess); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
 			So(err, ShouldBeNil)
 
-			items, _ := repo.Find(&annotations.ItemQuery{
+			err = deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{})
+			So(err, ShouldBeNil)
+
+			items, err := repo.Find(&annotations.ItemQuery{
 				OrgId:       1,
 				DashboardId: 1,
 			})
+			So(err, ShouldBeNil)
 
 			// Ensure we have at least daysToKeepAnnotations versions
 			So(len(items), ShouldBeGreaterThanOrEqualTo, daysToKeepAnnotations)

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -10,40 +10,38 @@ import (
 	m "github.com/grafana/grafana/pkg/models"
 )
 
-func (r *SqlAnnotationRepo) addTestAnnotation(dashboard *m.Dashboard, repo SqlAnnotationRepo, created int64, item *annotations.Item) error {
-	created *= 1000
-
+func addTestAnnotation(dashboard *m.Dashboard, created int64) error {
 	return inTransaction(func(sess *DBSession) error {
+		created *= 1000
 		tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
-		item.Tags = m.JoinTagPairs(tags)
-		item.Text = "hello"
-		item.Type = "alert"
-		item.UserId = 1
-		item.OrgId = dashboard.OrgId
-		item.DashboardId = dashboard.Id
-		item.Created = created
-		item.Updated = created
-		if item.Epoch == 0 {
-			item.Epoch = created
-			item.EpochEnd = created
-		}
 
-		_, err := sess.Table("annotation").Insert(item)
-		if err != nil {
+		item := annotations.Item{
+			Tags:        m.JoinTagPairs(tags),
+			Text:        "hello",
+			Type:        "alert",
+			UserId:      1,
+			OrgId:       dashboard.OrgId,
+			DashboardId: dashboard.Id,
+			Created:     created,
+			Updated:     created,
+			Epoch:       created,
+			EpochEnd:    created,
+		}
+		if _, err := sess.Table("annotation").Insert(&item); err != nil {
 			return err
 		}
 
-		if len(item.Tags) > 0 {
-			tags, err := EnsureTagsExist(sess, tags)
-			if err != nil {
+		// Get tag IDs
+		tags, err := EnsureTagsExist(sess, tags)
+		if err != nil {
+			return err
+		}
+		for _, tag := range tags {
+			if _, err := sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", item.Id, tag.Id); err != nil {
 				return err
 			}
-			for _, tag := range tags {
-				if _, err := sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", item.Id, tag.Id); err != nil {
-					return err
-				}
-			}
 		}
+
 		return nil
 	})
 }
@@ -60,13 +58,13 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		// Add expired annotations
 		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
 		for i := 0; i < annotationsToWrite-1; i++ {
-			err := repo.addTestAnnotation(savedDash, repo, expiredCreated, &annotations.Item{OrgId: 1})
+			err := addTestAnnotation(savedDash, expiredCreated)
 			So(err, ShouldBeNil)
 		}
 
 		// add one recent
 		newCreated := (time.Now().Unix() - int64(2*86400))
-		err := repo.addTestAnnotation(savedDash, repo, newCreated, &annotations.Item{OrgId: 1})
+		err := addTestAnnotation(savedDash, newCreated)
 		So(err, ShouldBeNil)
 
 		Convey("Clean up expired annotations", func() {
@@ -102,7 +100,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 			annotationsToWriteBigNumber := MAX_HISTORY_ENTRIES_TO_DELETE + annotationsToWrite
 			for i := 0; i < annotationsToWriteBigNumber-annotationsToWrite; i++ {
 				created := (time.Now().Unix() - int64(daysToKeepAnnotations*2*86400))
-				err := repo.addTestAnnotation(savedDash, repo, created, &annotations.Item{OrgId: 1})
+				err := addTestAnnotation(savedDash, created)
 				So(err, ShouldBeNil)
 			}
 

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -70,7 +70,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("Clean up expired annotations", func() {
-			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
 			So(err, ShouldBeNil)
 
 			items, err := repo.Find(&annotations.ItemQuery{
@@ -86,7 +86,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 		})
 
 		Convey("Don't delete anything if there're no expired versions", func() {
-			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{DaysToKeep: annotationsToWrite})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{DaysToKeep: annotationsToWrite})
 			So(err, ShouldBeNil)
 
 			items, err := repo.Find(&annotations.ItemQuery{
@@ -106,7 +106,7 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 				So(err, ShouldBeNil)
 			}
 
-			err := deleteExpiredAnnotations(&m.DeleteExpiredVAnnotationsCommand{})
+			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{})
 			So(err, ShouldBeNil)
 
 			items, _ := repo.Find(&annotations.ItemQuery{

--- a/pkg/services/sqlstore/annotations_cleanup_test.go
+++ b/pkg/services/sqlstore/annotations_cleanup_test.go
@@ -1,21 +1,21 @@
 package sqlstore
 
 import (
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
-
-	m "github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/assert"
 )
 
-func addTestAnnotation(dashboard *m.Dashboard, created int64, sess *DBSession) error {
+func addTestAnnotation(dashboard *models.Dashboard, created int64, sess *DBSession) error {
 	created *= 1000
-	tags := m.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
+	tags := models.ParseTagPairs([]string{"outage", "error", "type:outage", "server:server-1"})
 
 	item := annotations.Item{
-		Tags:        m.JoinTagPairs(tags),
+		Tags:        models.JoinTagPairs(tags),
 		Text:        "hello",
 		Type:        "alert",
 		UserId:      1,
@@ -48,79 +48,102 @@ func TestDeleteExpiredAnnotations(t *testing.T) {
 	daysToKeepAnnotations := 5
 	repo := SqlAnnotationRepo{}
 
-	Convey("Deletion of expired annotations", t, func() {
-		annotationsToWrite := 10
+	annotationsToWrite := 10
 
-		InitTestDB(t)
-		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
+	InitTestDB(t)
+	savedDash := insertNewTestDashboard(t,"test dash 111", 1, 0, false, "this-is-fun")
 
-		expiredCreated := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
-		err := inTransaction(func(sess *DBSession) error {
-			for i := 0; i < annotationsToWrite-1; i++ {
-				if err := addTestAnnotation(savedDash, expiredCreated, sess); err != nil {
-					return err
-				}
+	expiredCreated := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
+	err := inTransaction(func(sess *DBSession) error {
+		for i := 0; i < annotationsToWrite-1; i++ {
+			if err := addTestAnnotation(savedDash, expiredCreated, sess); err != nil {
+				return err
 			}
+		}
 
-			// Add a non-expired one
-			newCreated := (time.Now().Unix() - int64(2*86400))
-			return addTestAnnotation(savedDash, newCreated, sess)
-		})
-		So(err, ShouldBeNil)
-
-		Convey("Expired annotations should be deleted", func() {
-			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
-			So(err, ShouldBeNil)
-
-			items, err := repo.Find(&annotations.ItemQuery{
-				OrgId:       savedDash.OrgId,
-				DashboardId: savedDash.Id,
-			})
-			So(err, ShouldBeNil)
-
-			So(len(items), ShouldEqual, 1)
-			So(items[0].Tags, ShouldResemble, []string{"outage", "error", "type:outage", "server:server-1"})
-		})
-
-		Convey("Don't delete anything if there're no expired versions", func() {
-			err := deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
-			So(err, ShouldBeNil)
-
-			items, err := repo.Find(&annotations.ItemQuery{
-				OrgId:       savedDash.OrgId,
-				DashboardId: savedDash.Id,
-			})
-			So(err, ShouldBeNil)
-
-			So(len(items), ShouldEqual, 1)
-		})
+		// Add a non-expired one
+		newCreated := (time.Now().Unix() - int64(2*86400))
+		return addTestAnnotation(savedDash, newCreated, sess)
 	})
+	assert.Nil(t, err)
 
-	Convey("No more than MAX_VERSIONS_TO_DELETE annotations should be deleted per iteration", t, func() {
-		InitTestDB(t)
-		savedDash := insertTestDashboard("test dash 111", 1, 0, false, "this-is-fun")
 
-		numAnnotations := MAX_EXPIRED_ANNOTATIONS_TO_DELETE + 10
-		err := inTransaction(func(sess *DBSession) error {
-			created := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
-			for i := 0; i < numAnnotations; i++ {
-				if err := addTestAnnotation(savedDash, created, sess); err != nil {
-					return err
-				}
+
+	err = deleteExpiredAnnotations(&models.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
+	assert.Nil(t, err)
+
+	items, err := repo.Find(&annotations.ItemQuery{
+		OrgId:       savedDash.OrgId,
+		DashboardId: savedDash.Id,
+	})
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(items), 1)
+	assert.ElementsMatch(t, items[0].Tags, []string{"outage", "error", "type:outage", "server:server-1"}, "Can read tags")
+
+
+
+	err = deleteExpiredAnnotations(&models.DeleteExpiredAnnotationsCommand{DaysToKeep: daysToKeepAnnotations})
+	assert.Nil(t, err)
+
+	items, err = repo.Find(&annotations.ItemQuery{
+		OrgId:       savedDash.OrgId,
+		DashboardId: savedDash.Id,
+	})
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(items), 1)
+
+}
+
+func TestDeleteExpiredAnnotationsMax(t *testing.T) {
+	daysToKeepAnnotations := 5
+	repo := SqlAnnotationRepo{}
+
+	InitTestDB(t)
+	savedDash := insertNewTestDashboard(t,"test dash 111", 1, 0, false, "this-is-fun")
+
+	numAnnotations := MAX_EXPIRED_ANNOTATIONS_TO_DELETE + 10
+	err := inTransaction(func(sess *DBSession) error {
+		created := (time.Now().Unix() - int64(daysToKeepAnnotations*86400))
+		for i := 0; i < numAnnotations; i++ {
+			if err := addTestAnnotation(savedDash, created, sess); err != nil {
+				return err
 			}
-			return nil
-		})
-		So(err, ShouldBeNil)
-
-		err = deleteExpiredAnnotations(&m.DeleteExpiredAnnotationsCommand{})
-		So(err, ShouldBeNil)
-
-		items, err := repo.Find(&annotations.ItemQuery{
-			OrgId:       savedDash.OrgId,
-			DashboardId: savedDash.Id,
-		})
-		So(err, ShouldBeNil)
-
-		So(len(items), ShouldEqual, numAnnotations-MAX_EXPIRED_ANNOTATIONS_TO_DELETE)
+		}
+		return nil
 	})
+	assert.Nil(t, err)
+
+	err = deleteExpiredAnnotations(&models.DeleteExpiredAnnotationsCommand{})
+	assert.Nil(t, err)
+
+	items, err := repo.Find(&annotations.ItemQuery{
+		OrgId:       savedDash.OrgId,
+		DashboardId: savedDash.Id,
+	})
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(items), numAnnotations-MAX_EXPIRED_ANNOTATIONS_TO_DELETE)
+}
+
+func insertNewTestDashboard(t *testing.T,title string, orgId int64, folderId int64, isFolder bool, tags ...interface{}) *models.Dashboard {
+	cmd := models.SaveDashboardCommand{
+		OrgId:    orgId,
+		FolderId: folderId,
+		IsFolder: isFolder,
+		Dashboard: simplejson.NewFromAny(map[string]interface{}{
+			"id":    nil,
+			"title": title,
+			"tags":  tags,
+		}),
+	}
+
+	err := SaveDashboard(&cmd)
+	assert.Nil(t, err)
+
+	cmd.Result.Data.Set("id", cmd.Result.Id)
+	cmd.Result.Data.Set("uid", cmd.Result.Uid)
+
+	return cmd.Result
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -120,6 +120,9 @@ var (
 	// Dashboard history
 	DashboardVersionsToKeep int
 
+	// Annotations history
+	AnnotationsDaysToKeep int
+
 	// User settings
 	AllowUserSignUp         bool
 	AllowUserOrgCreate      bool
@@ -763,6 +766,10 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	// read dashboard settings
 	dashboards := iniFile.Section("dashboards")
 	DashboardVersionsToKeep = dashboards.Key("versions_to_keep").MustInt(20)
+
+	// read dashboard settings
+	annotations := iniFile.Section("annotations")
+	AnnotationsDaysToKeep = annotations.Key("days_to_keep").MustInt(60)
 
 	//  read data source proxy white list
 	DataProxyWhiteList = make(map[string]bool)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -770,6 +770,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	// read dashboard settings
 	annotations := iniFile.Section("annotations")
 	DaysToKeepAnnotations = annotations.Key("days_to_keep").MustInt(60)
+	if DaysToKeepAnnotations < 5 {
+		DaysToKeepAnnotations = 5
+	}
 
 	//  read data source proxy white list
 	DataProxyWhiteList = make(map[string]bool)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -121,7 +121,7 @@ var (
 	DashboardVersionsToKeep int
 
 	// Annotations history
-	AnnotationsDaysToKeep int
+	DaysToKeepAnnotations int
 
 	// User settings
 	AllowUserSignUp         bool
@@ -769,7 +769,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 
 	// read dashboard settings
 	annotations := iniFile.Section("annotations")
-	AnnotationsDaysToKeep = annotations.Key("days_to_keep").MustInt(60)
+	DaysToKeepAnnotations = annotations.Key("days_to_keep").MustInt(60)
 
 	//  read data source proxy white list
 	DataProxyWhiteList = make(map[string]bool)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds automatic clean up job to remove expired annotations and fixes existing issue #8224
Current number of days back to clean annotations is set to 60 and could be updated in defaults.ini settings. 
This PR is not distinguishing between types of annotations. Any alerts or user created annotations treated the same.
This PR is also increasing the size of `annotation.tags` field as we encountered issues with `VARCHAR(500)` as a limit on our instance.

**Which issue(s) this PR fixes**:

Fixes #8224

**Special notes for your reviewer**:

