### PR TITLE
Fix instructions to use @grafana/toolkit package

### DIFF
--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -9,7 +9,7 @@ grafana-toolkit is a CLI that enables efficient development of Grafana plugins. 
 Set up a new plugin with `grafana-toolkit plugin:create` command:
 
 ```sh
-npx grafana-toolkit plugin:create my-grafana-plugin
+npx @grafana/toolkit plugin:create my-grafana-plugin
 cd my-grafana-plugin
 yarn install
 yarn dev


### PR DESCRIPTION
`npx grafana-toolkit plugin:create my-grafana-plugin` as described in the readme fails with 

```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/grafana-toolkit - Not found
npm ERR! 404
npm ERR! 404  'grafana-toolkit@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

This PR fixes that to allow copy-paste usage.