### PR TITLE
Datasource/Loki: Fixes issue where time range wasn't being supplied with annotation query

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -68,7 +68,9 @@ describe('LokiDatasource', () => {
         range,
       };
 
-      ds.createRangeQuery(target, options);
+      const req = ds.createRangeQuery(target, options);
+      expect(req.start).toBeDefined();
+      expect(req.end).toBeDefined();
       expect(adjustIntervalSpy).toHaveBeenCalledWith(1000, expect.anything());
     });
 
@@ -81,7 +83,9 @@ describe('LokiDatasource', () => {
         intervalMs: 2000,
       };
 
-      ds.createRangeQuery(target, options);
+      const req = ds.createRangeQuery(target, options);
+      expect(req.start).toBeDefined();
+      expect(req.end).toBeDefined();
       expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -50,6 +50,42 @@ describe('LokiDatasource', () => {
     replace: (a: string) => a,
   } as unknown) as TemplateSrv;
 
+  describe('when creating range query', () => {
+    let ds: LokiDatasource;
+    let adjustIntervalSpy: jest.SpyInstance;
+    beforeEach(() => {
+      const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+      const customSettings = { ...instanceSettings, jsonData: customData };
+      ds = new LokiDatasource(customSettings, backendSrv, templateSrvMock);
+      adjustIntervalSpy = jest.spyOn(ds, 'adjustInterval');
+    });
+
+    it('should use default intervalMs if one is not provided', () => {
+      const target = { expr: '{job="grafana"}', refId: 'B' };
+      const raw = { from: 'now', to: 'now-1h' };
+      const range = { from: dateTime(), to: dateTime(), raw: raw };
+      const options = {
+        range,
+      };
+
+      ds.createRangeQuery(target, options);
+      expect(adjustIntervalSpy).toHaveBeenCalledWith(1000, expect.anything());
+    });
+
+    it('should use provided intervalMs', () => {
+      const target = { expr: '{job="grafana"}', refId: 'B' };
+      const raw = { from: 'now', to: 'now-1h' };
+      const range = { from: dateTime(), to: dateTime(), raw: raw };
+      const options = {
+        range,
+        intervalMs: 2000,
+      };
+
+      ds.createRangeQuery(target, options);
+      expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
+    });
+  });
+
   describe('when running range query with fallback', () => {
     let ds: LokiDatasource;
     beforeEach(() => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -236,11 +236,11 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   createRangeQuery(target: LokiQuery, options: RangeQueryOptions): LokiRangeQueryRequest {
     const { query } = parseQuery(target.expr);
     let range: { start?: number; end?: number; step?: number } = {};
-    if (options.range && options.intervalMs) {
+    if (options.range) {
       const startNs = this.getTime(options.range.from, false);
       const endNs = this.getTime(options.range.to, true);
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
-      const step = Math.ceil(this.adjustInterval(options.intervalMs, rangeMs) / 1000);
+      const step = Math.ceil(this.adjustInterval(options.intervalMs || 1000, rangeMs) / 1000);
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where because a default query step wasn't supplied, no time range was supplied with loki annotation queries.

**Which issue(s) this PR fixes**:
Closes #20667 

