### PR TITLE
@grafana/data: export ArrowDataFrame

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -4,3 +4,4 @@ export * from './CircularDataFrame';
 export * from './MutableDataFrame';
 export * from './processDataFrame';
 export * from './dimensions';
+export * from './arrow/ArrowDataFrame';


### PR DESCRIPTION
I think in order to make use of the functions added in https://github.com/grafana/grafana/pull/20813 then they need to be in the index somehow?

Perhaps the arrow folder should have its own index.ts ?

I don't know what I am doing here, but to get the functions this change using the toolkit to build grafana/data, and then changing my package json to have `"@grafana/data": "file:../grafana/packages/grafana-data/dist",` to give me access to resultsToDataFrames , for https://github.com/grafana/grafana/issues/20328

Or perhaps I'm not getting something :P 
