### PR TITLE
Explore: Fix reset reducer duplication

### DIFF
--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -55,7 +55,6 @@ import {
   updateUIStateAction,
   toggleLogLevelAction,
   changeLoadingStateAction,
-  resetExploreAction,
   queryStreamUpdatedAction,
   QueryEndedPayload,
   queryStoreSubscriptionAction,
@@ -727,6 +726,11 @@ export const exploreReducer = (state = initialExploreState, action: HigherOrderA
     }
 
     case ActionTypes.ResetExplore: {
+      const leftState = state[ExploreId.left];
+      const rightState = state[ExploreId.right];
+      stopQueryState(leftState.querySubscription);
+      stopQueryState(rightState.querySubscription);
+
       if (action.payload.force || !Number.isInteger(state.left.originPanelId)) {
         return initialExploreState;
       }
@@ -754,19 +758,6 @@ export const exploreReducer = (state = initialExploreState, action: HigherOrderA
       return {
         ...state,
         split,
-        [ExploreId.left]: updateChildRefreshState(leftState, action.payload, ExploreId.left),
-        [ExploreId.right]: updateChildRefreshState(rightState, action.payload, ExploreId.right),
-      };
-    }
-
-    case resetExploreAction.type: {
-      const leftState = state[ExploreId.left];
-      const rightState = state[ExploreId.right];
-      stopQueryState(leftState.querySubscription);
-      stopQueryState(rightState.querySubscription);
-
-      return {
-        ...state,
         [ExploreId.left]: updateChildRefreshState(leftState, action.payload, ExploreId.left),
         [ExploreId.right]: updateChildRefreshState(rightState, action.payload, ExploreId.right),
       };

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -118,15 +118,24 @@ describe('GraphCtrl', () => {
       const data = [
         {
           target: 'test.normal',
-          datapoints: [[10, 1], [10, 2]],
+          datapoints: [
+            [10, 1],
+            [10, 2],
+          ],
         },
         {
           target: 'test.nulls',
-          datapoints: [[null, 1], [null, 2]],
+          datapoints: [
+            [null, 1],
+            [null, 2],
+          ],
         },
         {
           target: 'test.zeros',
-          datapoints: [[0, 1], [0, 2]],
+          datapoints: [
+            [0, 1],
+            [0, 2],
+          ],
         },
       ];
       ctx.ctrl.onDataSnapshotLoad(data);


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/20766
ResetExplore action had 2 handlers in a switch which meant that the second one was not executed and so we did not call `stopQueryState` when leaving the explore page.