### PR TITLE
Datasource/Loki: Simplifies autocompletion

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -9,6 +9,7 @@ import { beforeEach } from 'test/lib/common';
 
 import { makeMockLokiDatasource } from './mocks';
 import LokiDatasource from './datasource';
+import { FUNCTIONS } from './syntax';
 
 jest.mock('app/store/store', () => ({
   store: {
@@ -31,16 +32,17 @@ describe('Language completion provider', () => {
   };
 
   describe('empty query suggestions', () => {
-    it('returns no suggestions on empty context', async () => {
+    it('returns function suggestions on empty context', async () => {
       const instance = new LanguageProvider(datasource);
       const value = Plain.deserialize('');
       const result = await instance.provideCompletionItems({ text: '', prefix: '', value, wrapperClasses: [] });
       expect(result.context).toBeUndefined();
 
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions.length).toEqual(1);
+      expect(result.suggestions[0].label).toEqual('Functions');
     });
 
-    it('returns default suggestions with history on empty context when history was provided', async () => {
+    it('returns function suggestions with history on empty context when history was provided', async () => {
       const instance = new LanguageProvider(datasource);
       const value = Plain.deserialize('');
       const history: LokiHistoryItem[] = [
@@ -64,10 +66,14 @@ describe('Language completion provider', () => {
             },
           ],
         },
+        {
+          label: 'Functions',
+          items: FUNCTIONS,
+        },
       ]);
     });
 
-    it('returns no suggestions within regexp', async () => {
+    it('returns function suggestions within regexp', async () => {
       const instance = new LanguageProvider(datasource);
       const input = createTypeaheadInput('{} ()', '', undefined, 4, []);
       const history: LokiHistoryItem[] = [
@@ -78,8 +84,8 @@ describe('Language completion provider', () => {
       ];
       const result = await instance.provideCompletionItems(input, { history });
       expect(result.context).toBeUndefined();
-
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions.length).toEqual(1);
+      expect(result.suggestions[0].label).toEqual('Functions');
     });
   });
 

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -3,7 +3,6 @@ import _ from 'lodash';
 
 // Services & Utils
 import { parseSelector, labelRegexp, selectorRegexp } from 'app/plugins/datasource/prometheus/language_utils';
-import { store } from 'app/store/store';
 import syntax, { FUNCTIONS } from './syntax';
 
 // Types
@@ -113,16 +112,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * @param context.history Optional used only in getEmptyCompletionItems
    */
   async provideCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
-    const exploreMode = store.getState().explore.left.mode;
-
-    if (exploreMode === ExploreMode.Logs) {
-      return this.provideLogCompletionItems(input, context);
-    }
-
-    return this.provideMetricsCompletionItems(input, context);
-  }
-
-  async provideMetricsCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
     const { wrapperClasses, value, prefix, text } = input;
 
     // Local text properties
@@ -160,23 +149,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     } else if ((prefixUnrecognized && noSuffix) || safeEmptyPrefix || isNextOperand) {
       // Show term suggestions in a couple of scenarios
       return this.getTermCompletionItems();
-    }
-
-    return {
-      suggestions: [],
-    };
-  }
-
-  async provideLogCompletionItems(input: TypeaheadInput, context?: TypeaheadContext): Promise<TypeaheadOutput> {
-    const { wrapperClasses, value } = input;
-    // Local text properties
-    const empty = value.document.text.length === 0;
-    // Determine candidates by CSS context
-    if (wrapperClasses.includes('context-labels')) {
-      // Suggestions for {|} and {foo=|}
-      return await this.getLabelCompletionItems(input, context);
-    } else if (empty) {
-      return this.getEmptyCompletionItems(context || {}, ExploreMode.Logs);
     }
 
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:
Unifies loki autocomplete so behavior isn't different across explore modes.

**Which issue(s) this PR fixes**:
Closes #20769