### PR TITLE
Gauge/BarGauge: Added support for value mapping of "no data"-state to text/value

### DIFF
--- a/docs/sources/features/panels/singlestat.md
+++ b/docs/sources/features/panels/singlestat.md
@@ -9,7 +9,6 @@ parent = "panels"
 weight = 4
 +++
 
-
 # Singlestat Panel
 
 {{< docs-imagebox img="/img/docs/v45/singlestat-panel.png" class="docs-image--no-shadow" max-width="900px" >}}
@@ -23,17 +22,17 @@ The singlestat panel has a normal query editor to allow you define your exact me
 {{< docs-imagebox img="/img/docs/v45/singlestat-value-options.png" class="docs-image--no-shadow" max-width="900px" >}}
 
 1. **Stats**: The Stats field let you set the function (min, max, average, current, total, first, delta, range) that your entire query is reduced into a single value with. This reduces the entire query into a single summary value that is displayed.
-   * **min** - The smallest value in the series
-   * **max** - The largest value in the series
-   * **avg** - The average of all the non-null values in the series
-   * **current** - The last value in the series. If the series ends on null the previous value will be used.
-   * **total** - The sum of all the non-null values in the series
-   * **first** - The first value in the series
-   * **delta** - The total incremental increase (of a counter) in the series. An attempt is made to account for counter resets, but this will only be accurate for single instance metrics. Used to show total counter increase in time series.
-   * **diff** - The difference between 'current' (last value) and 'first'.
-   * **range** - The difference between 'min' and 'max'. Useful the show the range of change for a gauge.
-2. **Prefix/Postfix**: The Prefix/Postfix fields let you define a custom label to appear *before/after* the value. The `$__name` variable can be used here to use the series name or alias from the metric query.
-3. **Units**: Units are appended to the the Singlestat  within the panel, and will respect the color and threshold settings for the value.
+   - **min** - The smallest value in the series
+   - **max** - The largest value in the series
+   - **avg** - The average of all the non-null values in the series
+   - **current** - The last value in the series. If the series ends on null the previous value will be used.
+   - **total** - The sum of all the non-null values in the series
+   - **first** - The first value in the series
+   - **delta** - The total incremental increase (of a counter) in the series. An attempt is made to account for counter resets, but this will only be accurate for single instance metrics. Used to show total counter increase in time series.
+   - **diff** - The difference between 'current' (last value) and 'first'.
+   - **range** - The difference between 'min' and 'max'. Useful the show the range of change for a gauge.
+2. **Prefix/Postfix**: The Prefix/Postfix fields let you define a custom label to appear _before/after_ the value. The `$__name` variable can be used here to use the series name or alias from the metric query.
+3. **Units**: Units are appended to the the Singlestat within the panel, and will respect the color and threshold settings for the value.
 4. **Decimals**: The Decimal field allows you to override the automatic decimal precision, and set it explicitly.
 5. **Font Size**: You can use this section to select the font size of the different texts in the Singlestat Panel, i.e. prefix, value and postfix.
 
@@ -64,7 +63,7 @@ Sparklines are a great way of seeing the historical data related to the summary 
 
 <div class="clearfix"></div>
 
-> ***Pro-tip:*** Reduce the opacity on  fill colors for nice looking panels.
+> **_Pro-tip:_** Reduce the opacity on fill colors for nice looking panels.
 
 ### Gauge
 
@@ -85,6 +84,8 @@ Gauges gives a clear picture of how high a value is in it's context. It's a grea
 
 Value/Range to text mapping allows you to translate the value of the summary stat into explicit text. The text will respect all styling, thresholds and customization defined for the value. This can be useful to translate the number of the main Singlestat value into a context-specific human-readable word or message.
 
+If you want to replace the default "No data" text being displayed when no data is available. You can do this by adding a `value to text mapping` from `null` to your preferred custom text value.
+
 <div class="clearfix"></div>
 
 ## Troubleshooting
@@ -97,10 +98,11 @@ Grafana 2.5 introduced stricter checking for multiple-series on singlestat panel
 
 To fix your singlestat panel:
 
-- Edit your panel by clicking the Panel Title and selecting *Edit*.
+- Edit your panel by clicking the Panel Title and selecting _Edit_.
 
 - Do you have multiple queries in the metrics tab?
-    - Solution: Select a single query to visualize. You can toggle whether a query is visualized by clicking the eye icon on each line. If the error persists, continue to the next solution.
+
+  - Solution: Select a single query to visualize. You can toggle whether a query is visualized by clicking the eye icon on each line. If the error persists, continue to the next solution.
 
 - Do you have one query?
-    - Solution: This likely means your query is returning multiple series. You will want to reduce this down to a single series. This can be accomplished in many ways, depending on your data source. Some common practices include summing the series, averaging or any number of other functions. Consult the documentation for your data source for additional information.
+  - Solution: This likely means your query is returning multiple series. You will want to reduce this down to a single series. This can be accomplished in many ways, depending on your data source. Some common practices include summing the series, averaging or any number of other functions. Consult the documentation for your data source for additional information.

--- a/docs/sources/features/panels/singlestat.md
+++ b/docs/sources/features/panels/singlestat.md
@@ -9,6 +9,7 @@ parent = "panels"
 weight = 4
 +++
 
+
 # Singlestat Panel
 
 {{< docs-imagebox img="/img/docs/v45/singlestat-panel.png" class="docs-image--no-shadow" max-width="900px" >}}
@@ -22,17 +23,17 @@ The singlestat panel has a normal query editor to allow you define your exact me
 {{< docs-imagebox img="/img/docs/v45/singlestat-value-options.png" class="docs-image--no-shadow" max-width="900px" >}}
 
 1. **Stats**: The Stats field let you set the function (min, max, average, current, total, first, delta, range) that your entire query is reduced into a single value with. This reduces the entire query into a single summary value that is displayed.
-   - **min** - The smallest value in the series
-   - **max** - The largest value in the series
-   - **avg** - The average of all the non-null values in the series
-   - **current** - The last value in the series. If the series ends on null the previous value will be used.
-   - **total** - The sum of all the non-null values in the series
-   - **first** - The first value in the series
-   - **delta** - The total incremental increase (of a counter) in the series. An attempt is made to account for counter resets, but this will only be accurate for single instance metrics. Used to show total counter increase in time series.
-   - **diff** - The difference between 'current' (last value) and 'first'.
-   - **range** - The difference between 'min' and 'max'. Useful the show the range of change for a gauge.
-2. **Prefix/Postfix**: The Prefix/Postfix fields let you define a custom label to appear _before/after_ the value. The `$__name` variable can be used here to use the series name or alias from the metric query.
-3. **Units**: Units are appended to the the Singlestat within the panel, and will respect the color and threshold settings for the value.
+   * **min** - The smallest value in the series
+   * **max** - The largest value in the series
+   * **avg** - The average of all the non-null values in the series
+   * **current** - The last value in the series. If the series ends on null the previous value will be used.
+   * **total** - The sum of all the non-null values in the series
+   * **first** - The first value in the series
+   * **delta** - The total incremental increase (of a counter) in the series. An attempt is made to account for counter resets, but this will only be accurate for single instance metrics. Used to show total counter increase in time series.
+   * **diff** - The difference between 'current' (last value) and 'first'.
+   * **range** - The difference between 'min' and 'max'. Useful the show the range of change for a gauge.
+2. **Prefix/Postfix**: The Prefix/Postfix fields let you define a custom label to appear *before/after* the value. The `$__name` variable can be used here to use the series name or alias from the metric query.
+3. **Units**: Units are appended to the the Singlestat  within the panel, and will respect the color and threshold settings for the value.
 4. **Decimals**: The Decimal field allows you to override the automatic decimal precision, and set it explicitly.
 5. **Font Size**: You can use this section to select the font size of the different texts in the Singlestat Panel, i.e. prefix, value and postfix.
 
@@ -63,7 +64,7 @@ Sparklines are a great way of seeing the historical data related to the summary 
 
 <div class="clearfix"></div>
 
-> **_Pro-tip:_** Reduce the opacity on fill colors for nice looking panels.
+> ***Pro-tip:*** Reduce the opacity on  fill colors for nice looking panels.
 
 ### Gauge
 
@@ -84,7 +85,7 @@ Gauges gives a clear picture of how high a value is in it's context. It's a grea
 
 Value/Range to text mapping allows you to translate the value of the summary stat into explicit text. The text will respect all styling, thresholds and customization defined for the value. This can be useful to translate the number of the main Singlestat value into a context-specific human-readable word or message.
 
-If you want to replace the default "No data" text being displayed when no data is available. You can do this by adding a `value to text mapping` from `null` to your preferred custom text value.
+If you want to replace the default "No data" text being displayed when no data is available, add a `value to text mapping` from `null` to your preferred custom text value.
 
 <div class="clearfix"></div>
 
@@ -98,11 +99,10 @@ Grafana 2.5 introduced stricter checking for multiple-series on singlestat panel
 
 To fix your singlestat panel:
 
-- Edit your panel by clicking the Panel Title and selecting _Edit_.
+- Edit your panel by clicking the Panel Title and selecting *Edit*.
 
 - Do you have multiple queries in the metrics tab?
-
-  - Solution: Select a single query to visualize. You can toggle whether a query is visualized by clicking the eye icon on each line. If the error persists, continue to the next solution.
+    - Solution: Select a single query to visualize. You can toggle whether a query is visualized by clicking the eye icon on each line. If the error persists, continue to the next solution.
 
 - Do you have one query?
-  - Solution: This likely means your query is returning multiple series. You will want to reduce this down to a single series. This can be accomplished in many ways, depending on your data source. Some common practices include summing the series, averaging or any number of other functions. Consult the documentation for your data source for additional information.
+    - Solution: This likely means your query is returning multiple series. You will want to reduce this down to a single series. This can be accomplished in many ways, depending on your data source. Some common practices include summing the series, averaging or any number of other functions. Consult the documentation for your data source for additional information.

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -3,6 +3,7 @@ import { toDataFrame } from '../dataframe/processDataFrame';
 import { ReducerID } from '../transformations/fieldReducer';
 import { Threshold } from '../types/threshold';
 import { GrafanaTheme } from '../types/theme';
+import { MappingType } from '../types';
 
 describe('FieldDisplay', () => {
   it('Construct simple field properties', () => {
@@ -155,5 +156,65 @@ describe('FieldDisplay', () => {
 
     const display = getFieldDisplayValues(options);
     expect(display[0].field.thresholds!.length).toEqual(1);
+  });
+
+  it('Should return field mapped value when there is no data', () => {
+    const mapEmptyToText = '0';
+
+    const options: GetFieldDisplayValuesOptions = {
+      data: [
+        {
+          name: 'No data',
+          fields: [],
+          length: 0,
+        },
+      ],
+      replaceVariables: (value: string) => {
+        return value;
+      },
+      fieldOptions: {
+        calcs: [],
+        override: {
+          mappings: [
+            {
+              id: 1,
+              operator: '',
+              text: mapEmptyToText,
+              type: MappingType.ValueToText,
+              value: 'null',
+            },
+          ],
+        },
+        defaults: {},
+      },
+      theme: {} as GrafanaTheme,
+    };
+
+    const display = getFieldDisplayValues(options);
+    expect(display[0].display.text).toEqual(mapEmptyToText);
+  });
+
+  it('Should return field with default text when no mapping available and no data', () => {
+    const options: GetFieldDisplayValuesOptions = {
+      data: [
+        {
+          name: 'No data',
+          fields: [],
+          length: 0,
+        },
+      ],
+      replaceVariables: (value: string) => {
+        return value;
+      },
+      fieldOptions: {
+        calcs: [],
+        override: {},
+        defaults: {},
+      },
+      theme: {} as GrafanaTheme,
+    };
+
+    const display = getFieldDisplayValues(options);
+    expect(display[0].display.text).toEqual('No data');
   });
 });

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -1,4 +1,5 @@
-import { getFieldProperties, getFieldDisplayValues, GetFieldDisplayValuesOptions } from './fieldDisplay';
+import merge from 'lodash/merge';
+import { getFieldProperties, getFieldDisplayValues, GetFieldDisplayValuesOptions, FieldDisplay } from './fieldDisplay';
 import { toDataFrame } from '../dataframe/processDataFrame';
 import { ReducerID } from '../transformations/fieldReducer';
 import { Threshold } from '../types/threshold';
@@ -33,33 +34,8 @@ describe('FieldDisplay', () => {
     expect(field.unit).toEqual('ms');
   });
 
-  // Simple test dataset
-
-  const options: GetFieldDisplayValuesOptions = {
-    data: [
-      toDataFrame({
-        name: 'Series Name',
-        fields: [
-          { name: 'Field 1', values: ['a', 'b', 'c'] },
-          { name: 'Field 2', values: [1, 3, 5] },
-          { name: 'Field 3', values: [2, 4, 6] },
-        ],
-      }),
-    ],
-    replaceVariables: (value: string) => {
-      return value; // Return it unchanged
-    },
-    fieldOptions: {
-      calcs: [],
-      override: {},
-      defaults: {},
-    },
-    theme: {} as GrafanaTheme,
-  };
-
   it('show first numeric values', () => {
-    const display = getFieldDisplayValues({
-      ...options,
+    const options = createDisplayOptions({
       fieldOptions: {
         calcs: [ReducerID.first],
         override: {},
@@ -68,28 +44,24 @@ describe('FieldDisplay', () => {
         },
       },
     });
+    const display = getFieldDisplayValues(options);
     expect(display.map(v => v.display.text)).toEqual(['1', '2']);
-    // expect(display.map(v => v.display.title)).toEqual([
-    //   'a * Field 1 * Series Name', // 0
-    //   'b * Field 2 * Series Name', // 1
-    // ]);
   });
 
   it('show last numeric values', () => {
-    const display = getFieldDisplayValues({
-      ...options,
+    const options = createDisplayOptions({
       fieldOptions: {
         calcs: [ReducerID.last],
         override: {},
         defaults: {},
       },
     });
+    const display = getFieldDisplayValues(options);
     expect(display.map(v => v.display.numeric)).toEqual([5, 6]);
   });
 
   it('show all numeric values', () => {
-    const display = getFieldDisplayValues({
-      ...options,
+    const options = createDisplayOptions({
       fieldOptions: {
         values: true, //
         limit: 1000,
@@ -98,12 +70,12 @@ describe('FieldDisplay', () => {
         defaults: {},
       },
     });
+    const display = getFieldDisplayValues(options);
     expect(display.map(v => v.display.numeric)).toEqual([1, 3, 5, 2, 4, 6]);
   });
 
   it('show 2 numeric values (limit)', () => {
-    const display = getFieldDisplayValues({
-      ...options,
+    const options = createDisplayOptions({
       fieldOptions: {
         values: true, //
         limit: 2,
@@ -112,6 +84,7 @@ describe('FieldDisplay', () => {
         defaults: {},
       },
     });
+    const display = getFieldDisplayValues(options);
     expect(display.map(v => v.display.numeric)).toEqual([1, 3]); // First 2 are from the first field
   });
 
@@ -133,48 +106,30 @@ describe('FieldDisplay', () => {
   });
 
   it('Should return field thresholds when there is no data', () => {
-    const options: GetFieldDisplayValuesOptions = {
-      data: [
-        {
-          name: 'No data',
-          fields: [],
-          length: 0,
-        },
-      ],
-      replaceVariables: (value: string) => {
-        return value;
-      },
+    const options = createEmptyDisplayOptions({
       fieldOptions: {
-        calcs: [],
-        override: {},
         defaults: {
           thresholds: [{ color: '#F2495C', value: 50 }],
         },
       },
-      theme: {} as GrafanaTheme,
-    };
+    });
 
     const display = getFieldDisplayValues(options);
     expect(display[0].field.thresholds!.length).toEqual(1);
     expect(display[0].display.numeric).toEqual(0);
   });
 
+  it('Should return field with default text when no mapping or data available', () => {
+    const options = createEmptyDisplayOptions();
+    const display = getFieldDisplayValues(options);
+    expect(display[0].display.text).toEqual('No data');
+    expect(display[0].display.numeric).toEqual(0);
+  });
+
   it('Should return field mapped value when there is no data', () => {
     const mapEmptyToText = '0';
-
-    const options: GetFieldDisplayValuesOptions = {
-      data: [
-        {
-          name: 'No data',
-          fields: [],
-          length: 0,
-        },
-      ],
-      replaceVariables: (value: string) => {
-        return value;
-      },
+    const options = createEmptyDisplayOptions({
       fieldOptions: {
-        calcs: [],
         override: {
           mappings: [
             {
@@ -186,57 +141,18 @@ describe('FieldDisplay', () => {
             },
           ],
         },
-        defaults: {},
       },
-      theme: {} as GrafanaTheme,
-    };
+    });
 
     const display = getFieldDisplayValues(options);
     expect(display[0].display.text).toEqual(mapEmptyToText);
     expect(display[0].display.numeric).toEqual(0);
   });
 
-  it('Should return field with default text when no mapping available and no data', () => {
-    const options: GetFieldDisplayValuesOptions = {
-      data: [
-        {
-          name: 'No data',
-          fields: [],
-          length: 0,
-        },
-      ],
-      replaceVariables: (value: string) => {
-        return value;
-      },
-      fieldOptions: {
-        calcs: [],
-        override: {},
-        defaults: {},
-      },
-      theme: {} as GrafanaTheme,
-    };
-
-    const display = getFieldDisplayValues(options);
-    expect(display[0].display.text).toEqual('No data');
-    expect(display[0].display.numeric).toEqual(0);
-  });
-
   it('Should always return display numeric 0 when there is no data', () => {
     const mapEmptyToText = '0';
-
-    const options: GetFieldDisplayValuesOptions = {
-      data: [
-        {
-          name: 'No data',
-          fields: [],
-          length: 0,
-        },
-      ],
-      replaceVariables: (value: string) => {
-        return value;
-      },
+    const options = createEmptyDisplayOptions({
       fieldOptions: {
-        calcs: [],
         override: {
           mappings: [
             {
@@ -248,12 +164,50 @@ describe('FieldDisplay', () => {
             },
           ],
         },
-        defaults: {},
       },
-      theme: {} as GrafanaTheme,
-    };
+    });
 
     const display = getFieldDisplayValues(options);
     expect(display[0].display.numeric).toEqual(0);
   });
 });
+
+function createEmptyDisplayOptions(extend = {}): GetFieldDisplayValuesOptions {
+  const options = createDisplayOptions(extend);
+
+  return Object.assign(options, {
+    data: [
+      {
+        name: 'No data',
+        fields: [],
+        length: 0,
+      },
+    ],
+  });
+}
+
+function createDisplayOptions(extend = {}): GetFieldDisplayValuesOptions {
+  const options: GetFieldDisplayValuesOptions = {
+    data: [
+      toDataFrame({
+        name: 'Series Name',
+        fields: [
+          { name: 'Field 1', values: ['a', 'b', 'c'] },
+          { name: 'Field 2', values: [1, 3, 5] },
+          { name: 'Field 3', values: [2, 4, 6] },
+        ],
+      }),
+    ],
+    replaceVariables: (value: string) => {
+      return value;
+    },
+    fieldOptions: {
+      calcs: [],
+      override: {},
+      defaults: {},
+    },
+    theme: {} as GrafanaTheme,
+  };
+
+  return merge<GetFieldDisplayValuesOptions, any>(options, extend);
+}

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -1,5 +1,5 @@
 import merge from 'lodash/merge';
-import { getFieldProperties, getFieldDisplayValues, GetFieldDisplayValuesOptions, FieldDisplay } from './fieldDisplay';
+import { getFieldProperties, getFieldDisplayValues, GetFieldDisplayValuesOptions } from './fieldDisplay';
 import { toDataFrame } from '../dataframe/processDataFrame';
 import { ReducerID } from '../transformations/fieldReducer';
 import { Threshold } from '../types/threshold';

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -156,6 +156,7 @@ describe('FieldDisplay', () => {
 
     const display = getFieldDisplayValues(options);
     expect(display[0].field.thresholds!.length).toEqual(1);
+    expect(display[0].display.numeric).toEqual(0);
   });
 
   it('Should return field mapped value when there is no data', () => {
@@ -192,6 +193,7 @@ describe('FieldDisplay', () => {
 
     const display = getFieldDisplayValues(options);
     expect(display[0].display.text).toEqual(mapEmptyToText);
+    expect(display[0].display.numeric).toEqual(0);
   });
 
   it('Should return field with default text when no mapping available and no data', () => {
@@ -216,5 +218,42 @@ describe('FieldDisplay', () => {
 
     const display = getFieldDisplayValues(options);
     expect(display[0].display.text).toEqual('No data');
+    expect(display[0].display.numeric).toEqual(0);
+  });
+
+  it('Should always return display numeric 0 when there is no data', () => {
+    const mapEmptyToText = '0';
+
+    const options: GetFieldDisplayValuesOptions = {
+      data: [
+        {
+          name: 'No data',
+          fields: [],
+          length: 0,
+        },
+      ],
+      replaceVariables: (value: string) => {
+        return value;
+      },
+      fieldOptions: {
+        calcs: [],
+        override: {
+          mappings: [
+            {
+              id: 1,
+              operator: '',
+              text: mapEmptyToText,
+              type: MappingType.ValueToText,
+              value: 'null',
+            },
+          ],
+        },
+        defaults: {},
+      },
+      theme: {} as GrafanaTheme,
+    };
+
+    const display = getFieldDisplayValues(options);
+    expect(display[0].display.numeric).toEqual(0);
   });
 });

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -85,7 +85,7 @@ export const getMappedValue = (valueMappings: ValueMapping[], value: TimeSeriesV
   return getAllFormattedValueMappings(valueMappings, value)[0];
 };
 
-export const isNullValueMap = (mapping: ValueMap): boolean => {
+const isNullValueMap = (mapping: ValueMap): boolean => {
   if (!mapping || !mapping.value) {
     return false;
   }

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -11,7 +11,7 @@ const addValueToTextMappingText = (
     return allValueMappings;
   }
 
-  if (value === null && valueToTextMapping.value && valueToTextMapping.value.toLowerCase() === 'null') {
+  if (value === null && isNullValueMap(valueToTextMapping)) {
     return allValueMappings.concat(valueToTextMapping);
   }
 
@@ -83,4 +83,11 @@ const getAllFormattedValueMappings = (valueMappings: ValueMapping[], value: Time
 
 export const getMappedValue = (valueMappings: ValueMapping[], value: TimeSeriesValue): ValueMapping => {
   return getAllFormattedValueMappings(valueMappings, value)[0];
+};
+
+export const isNullValueMap = (mapping: ValueMap): boolean => {
+  if (!mapping || !mapping.value) {
+    return false;
+  }
+  return mapping.value.toLowerCase() === 'null';
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables our users to map a "no data"-state and display an value/text instead of the "no data" text. I tried to prevent breaking and old behaviour by checking for mappings of null. The only case where this might happen is if null already is mapped to another value then "no data". 

**Which issue(s) this PR fixes**:
Fixes #20706

**Special notes for your reviewer**:
I wanted to move the factory method into its own module but that would require some more refactoring due to the current dependency graph. So I just settled with this solution. 
