### PR TITLE
POC: doing a first stab at emitting an analytics event

### DIFF
--- a/packages/grafana-data/src/types/analytics.ts
+++ b/packages/grafana-data/src/types/analytics.ts
@@ -1,0 +1,40 @@
+import { eventFactory } from './utils';
+
+export interface AnalyticsEvent {
+  userLogin: string;
+  userId: number;
+  userSignedIn: boolean;
+  timestamp: number;
+  /**
+   * Event name
+   */
+  eventName: string;
+  /**
+   * A unique browser session
+   */
+  sessionId: string;
+  /**
+   * Originating Grafana app, dashboard | explore
+   */
+  app: string;
+  /**
+   * if > 1 the event represents a combined number of events
+   */
+  count: number;
+}
+
+export interface DataRequestAnalyticsEvent extends AnalyticsEvent {
+  dashboardId?: number;
+  dashboardUid?: string;
+  dashboardName?: string;
+  folderName?: string;
+  panelId?: number;
+  panelName?: string;
+  datasourceName: string;
+  datasourceId?: number;
+  error?: string;
+  requestMs: number;
+  dataSize: number;
+}
+
+export const dataRequestAnalyticsEvent = eventFactory<DataRequestAnalyticsEvent>('data-request-analytics');

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -18,6 +18,7 @@ export * from './datasource';
 export * from './panel';
 export * from './plugin';
 export * from './theme';
+export * from './analytics';
 
 import * as AppEvents from './appEvents';
 import { AppEvent } from './appEvents';

--- a/public/app/core/components/sidemenu/BottomNavLinks.test.tsx
+++ b/public/app/core/components/sidemenu/BottomNavLinks.test.tsx
@@ -21,6 +21,7 @@ const setup = (propOverrides?: object) => {
         orgCount: 2,
         orgRole: '',
         orgId: 1,
+        login: 'hello',
         orgName: 'Grafana',
         timezone: 'UTC',
         helpFlags1: 1,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -9,6 +9,7 @@ export class User {
   orgRole: any;
   orgId: number;
   orgName: string;
+  login: string;
   orgCount: number;
   timezone: string;
   helpFlags1: number;

--- a/public/app/features/dashboard/state/analyticsProcessor.ts
+++ b/public/app/features/dashboard/state/analyticsProcessor.ts
@@ -1,0 +1,67 @@
+import { appEvents } from 'app/core/app_events';
+import { contextSrv } from 'app/core/services/context_srv';
+import { getDashboardSrv } from '../services/DashboardSrv';
+
+import {
+  PanelData,
+  LoadingState,
+  DataSourceApi,
+  DataRequestAnalyticsEvent,
+  dataRequestAnalyticsEvent,
+} from '@grafana/data';
+
+export function getAnalyticsProcessor(datasource: DataSourceApi) {
+  let done = false;
+
+  return (data: PanelData) => {
+    if (!data.request || done) {
+      return;
+    }
+
+    if (data.state !== LoadingState.Done && data.state !== LoadingState.Error) {
+      return;
+    }
+
+    const eventData: DataRequestAnalyticsEvent = {
+      userId: contextSrv.user.id,
+      userLogin: contextSrv.user.login,
+      userSignedIn: contextSrv.user.isSignedIn,
+      timestamp: new Date().getTime(),
+      datasourceName: datasource.name,
+      datasourceId: datasource.id,
+      panelId: data.request.panelId,
+      dashboardId: data.request.dashboardId,
+      app: 'dashboard',
+      count: 1,
+      dataSize: 0,
+      requestMs: data.request.endTime - data.request.startTime,
+      eventName: 'data-request',
+      sessionId: '',
+    };
+
+    // enrich with dashboard info
+    const dashboard = getDashboardSrv().getCurrent();
+    if (dashboard) {
+      eventData.dashboardId = dashboard.id;
+      eventData.dashboardName = dashboard.title;
+      eventData.dashboardUid = dashboard.uid;
+      eventData.folderName = dashboard.meta.folderTitle;
+    }
+
+    if (data.series.length > 0) {
+      // estimate size
+      eventData.dataSize = data.series.length * data.series[0].length;
+    }
+
+    if (data.error) {
+      eventData.error = data.error.message;
+    }
+
+    console.log('analytics event', eventData);
+    appEvents.emit(dataRequestAnalyticsEvent, eventData);
+
+    // this done check is to make sure we do not double emit events in case
+    // there are multiple responses with done state
+    done = true;
+  };
+}

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -1,7 +1,7 @@
 // Libraries
 import { Observable, of, timer, merge, from } from 'rxjs';
 import { flatten, map as lodashMap, isArray, isString } from 'lodash';
-import { map, catchError, takeUntil, mapTo, share, finalize } from 'rxjs/operators';
+import { map, catchError, takeUntil, mapTo, share, finalize, tap } from 'rxjs/operators';
 // Utils & Services
 import { getBackendSrv } from 'app/core/services/backend_srv';
 // Types
@@ -18,6 +18,7 @@ import {
   DataFrame,
   guessFieldTypes,
 } from '@grafana/data';
+import { getAnalyticsProcessor } from './analyticsProcessor';
 import { ExpressionDatasourceID, expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
@@ -119,6 +120,7 @@ export function runRequest(datasource: DataSourceApi, request: DataQueryRequest)
         error: processQueryError(err),
       })
     ),
+    tap(getAnalyticsProcessor(datasource)),
     // finalize is triggered when subscriber unsubscribes
     // This makes sure any still running network requests are cancelled
     finalize(cancelNetworkRequestsOnUnsubscribe(request)),


### PR DESCRIPTION
A first stab at publishing a rich event that can be consumed by meta analytics app. 

Will need further refactoring to reduce duplication once we add more events. 

Did not really see how I could use the EchoSrv (https://github.com/grafana/grafana/pull/20365) with the publish/consumer model for these events. 