### PR TITLE
@grafana/data: don't export ArrowDataFram

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -4,4 +4,10 @@ export * from './CircularDataFrame';
 export * from './MutableDataFrame';
 export * from './processDataFrame';
 export * from './dimensions';
-export * from './arrow/ArrowDataFrame';
+
+// NOTE: We can not export arrow in the global scope because it will crash phantomjs
+// In core, this is loaded async.  In plugins you can import using:
+//
+// import { resultsToDataFrames } from '@grafana/data/dataframe/arrow/ArrowDataFrame'
+//
+// export * from './arrow/ArrowDataFrame';


### PR DESCRIPTION
revert #20832

phantomjs dies with this export... we we will leave it out for now