### PR TITLE
Security: Fix invite link still accessible after completion or revocation

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -132,9 +132,9 @@ func RevokeInvite(c *m.ReqContext) Response {
 	return Success("Invite revoked")
 }
 
-// GetInviteInfoByCode gets a user invite corresponding to a certain code.
+// GetInviteInfoByCode gets a pending user invite corresponding to a certain code.
 // A response containing an InviteInfo object is returned if the invite is found.
-// If the invite is not found, 404 is returned.
+// If a (pending) invite is not found, 404 is returned.
 func GetInviteInfoByCode(c *m.ReqContext) Response {
 	query := m.GetTempUserByCodeQuery{Code: c.Params(":code")}
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -132,9 +132,11 @@ func RevokeInvite(c *m.ReqContext) Response {
 	return Success("Invite revoked")
 }
 
+// GetInviteInfoByCode gets a user invite corresponding to a certain code.
+// A response containing an InviteInfo object is returned if the invite is found.
+// If the invite is not found, 404 is returned.
 func GetInviteInfoByCode(c *m.ReqContext) Response {
 	query := m.GetTempUserByCodeQuery{Code: c.Params(":code")}
-
 	if err := bus.Dispatch(&query); err != nil {
 		if err == m.ErrTempUserNotFound {
 			return Error(404, "Invite not found", nil)
@@ -143,6 +145,9 @@ func GetInviteInfoByCode(c *m.ReqContext) Response {
 	}
 
 	invite := query.Result
+	if invite.Status != m.TmpUserInvitePending {
+		return Error(404, "Invite not found", nil)
+	}
 
 	return JSON(200, dtos.InviteInfo{
 		Email:     invite.Email,

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -121,7 +121,6 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		return err
 
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -121,6 +121,7 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		return err
 
 	})
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, already accepted invites can be accessed again. This PR fixes this by making the API return 404 for non-pending invites.

**Which issue(s) this PR fixes**:
Fixes #20835.

**Special notes for your reviewer**:
I picked 404 as the HTTP status code, but feedback is welcome on this choice. Also, should we add a test for this?
