### PR TITLE
CloudWatch: Remove template variable error message

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -79,8 +79,8 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
       item.dimensions = this.convertDimensionFormat(item.dimensions, options.scopedVars);
       item.statistics = item.statistics.map(stat => this.replace(stat, options.scopedVars, true, 'statistics'));
       item.period = String(this.getPeriod(item, options)); // use string format for period in graph query, and alerting
-      item.id = this.replace(item.id, options.scopedVars, true, 'id');
-      item.expression = this.replace(item.expression, options.scopedVars, true, 'expression');
+      item.id = this.templateSrv.replace(item.id, options.scopedVars);
+      item.expression = this.templateSrv.replace(item.expression, options.scopedVars);
 
       // valid ExtendedStatistics is like p90.00, check the pattern
       const hasInvalidStatistics = item.statistics.some(s => {


### PR DESCRIPTION
When a multi-valued template variable is being used in the expression field, an error message was displayed on the top right of the panel. However it is actually possible to use a multi-valued template variable in the expression field if repeating is turned on. This pr removed that error message, not only for the expression field but also for the id field. 

fixes #20839