### PR TITLE
Graph: Prevent tooltip from being displayed outside of window

### DIFF
--- a/public/app/core/jquery_extended.ts
+++ b/public/app/core/jquery_extended.ts
@@ -42,8 +42,11 @@ $.fn.place_tt = (() => {
       width = $tooltip.outerWidth(true);
       height = $tooltip.outerHeight(true);
 
-      $tooltip.css('left', x + opts.offset + width > $win.width() ? x - opts.offset - width : x + opts.offset);
-      $tooltip.css('top', y + opts.offset + height > $win.height() ? y - opts.offset - height : y + opts.offset);
+      const left = x + opts.offset + width > $win.width() ? x - opts.offset - width : x + opts.offset;
+      const top = y + opts.offset + height > $win.height() ? y - opts.offset - height : y + opts.offset;
+
+      $tooltip.css('left', left > 0 ? left : 0);
+      $tooltip.css('top', top > 0 ? top : 0);
     });
   };
 })();


### PR DESCRIPTION
**What this PR does / why we need it**:
When having multiple series and panel is placed on other than first row, the tooltip can overflow outside of the browser window. This fix prevent that from happening.

**Which issue(s) this PR fixes**:
Fixes #20439

**Special notes for your reviewer**:
Question: this should not be able to happen towards the bottom of the window, right? Because we are always drawing the tooltip upwards when panel placed on other than first row.
