### PR TITLE
TeamPicker: Increase size limit from 10 to 100

### DIFF
--- a/public/app/core/components/Select/TeamPicker.tsx
+++ b/public/app/core/components/Select/TeamPicker.tsx
@@ -42,7 +42,7 @@ export class TeamPicker extends Component<Props, State> {
       query = '';
     }
 
-    return backendSrv.get(`/api/teams/search?perpage=10&page=1&query=${query}`).then((result: any) => {
+    return backendSrv.get(`/api/teams/search?perpage=100&page=1&query=${query}`).then((result: any) => {
       const teams = result.teams.map((team: any) => {
         return {
           id: team.id,


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for organisations with more than 10 teams by allowing the teampicker to show more than 10 teams.

**Which issue(s) this PR fixes**:
Fixes #20824 .

**Special notes for your reviewer**:
More than 10 teams are now correctly added. I opted to not change the size of the dropdown, bur rather let the user scroll.
![teampicker](https://user-images.githubusercontent.com/965952/70186647-041c8d00-16f5-11ea-9504-d2b46954bfff.png)

