### PR TITLE
OAuth: Added support for "token_url_params" configuration

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -234,6 +234,26 @@ send via POST body, which can be enabled via the following settings:
 send_client_credentials_via_post = true
 ```
 
+## Additional Token Exchange Parameters
+
+Some OAuth 2.0 providers require additional posted form parameters as part of the token retrieval.
+For example, Auth0 requires an "audience" parameter be sent with the token exchange.  
+
+To specify this use the `token_url_params` configuration and provide values in a query string format.
+Be sure to url encode any parameter values that may contain url escapable characters.
+
+```bash
+[auth.generic_oauth]
+token_url_params = audience=https%3A%2F%2Fmy.custom.domain.com%2Fapi%2Fv1
+```
+
+Note: even though it is possible to configure more than one parameter with a given name, only the first value
+specified for each named parameter is sent to the oauth2 `token_url`.
+```bash
+[auth.generic_oauth]
+token_url_params = some_param=a_value&another_param=another_value&another_param=ignored_value
+```
+
 ## JMESPath examples
 
 To ease configuring a proper JMESPath expression you can test/evaluate expression with a custom payload at http://jmespath.org/.

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -133,8 +133,16 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 
 	oauthCtx := context.WithValue(context.Background(), oauth2.HTTPClient, oauthClient)
 
+	var opts []oauth2.AuthCodeOption
+	if setting.OAuthService.OAuthInfos[name].TokenUrlParams != nil {
+		params := setting.OAuthService.OAuthInfos[name].TokenUrlParams
+		for k := range params {
+			opts = append(opts, oauth2.SetAuthURLParam(k, params.Get(k)))
+		}
+	}
+
 	// get token from provider
-	token, err := connect.Exchange(oauthCtx, code)
+	token, err := connect.Exchange(oauthCtx, code, opts...)
 	if err != nil {
 		ctx.Handle(500, "login.OAuthLogin(NewTransportWithCode)", err)
 		return

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"context"
@@ -84,6 +85,12 @@ func NewOAuthService() {
 			TlsClientCa:                  sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:                sec.Key("tls_skip_verify_insecure").MustBool(),
 			SendClientCredentialsViaPost: sec.Key("send_client_credentials_via_post").MustBool(),
+		}
+
+		if params := sec.Key("token_url_params").String(); params != "" {
+			if values, err := url.ParseQuery(params); err == nil {
+				info.TokenUrlParams = values
+			}
 		}
 
 		if !info.Enabled {

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,9 +1,12 @@
 package setting
 
+import "net/url"
+
 type OAuthInfo struct {
 	ClientId, ClientSecret       string
 	Scopes                       []string
 	AuthUrl, TokenUrl            string
+	TokenUrlParams               url.Values
 	Enabled                      bool
 	EmailAttributeName           string
 	EmailAttributePath           string


### PR DESCRIPTION
Some OAuth 2.0 providers require additional posted form parameters as part of the token retrieval.
For example, Auth0 requires an "audience" parameter be sent with the token exchange.

This PR adds support for a new "token_url_params" configuration property to any "oauth" configuration section that adds additional static form parameter values to the oauth token exchange.  This allows for the above use case and any other use case that may require additional custom static parameters.