### PR TITLE
Datasource/Loki: Loki now goes to Logs mode when importing prom queries

### DIFF
--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -178,6 +178,7 @@ export interface UpdateDatasourceInstancePayload {
   exploreId: ExploreId;
   datasourceInstance: DataSourceApi;
   version?: string;
+  mode?: ExploreMode;
 }
 
 export interface ToggleLogLevelPayload {

--- a/public/app/features/explore/state/actions.test.ts
+++ b/public/app/features/explore/state/actions.test.ts
@@ -1,4 +1,5 @@
-import { loadDatasource, navigateToExplore, refreshExplore } from './actions';
+import { changeDatasource, loadDatasource, navigateToExplore, refreshExplore } from './actions';
+import * as Actions from './actions';
 import { ExploreId, ExploreMode, ExploreUpdateState, ExploreUrlState } from 'app/types';
 import { thunkTester } from 'test/core/thunk/thunkTester';
 import {
@@ -8,6 +9,7 @@ import {
   loadDatasourceReadyAction,
   setQueriesAction,
   updateUIStateAction,
+  updateDatasourceInstanceAction,
 } from './actionTypes';
 import { Emitter } from 'app/core/core';
 import { ActionOf } from 'app/core/redux/actionCreatorFactory';
@@ -16,16 +18,24 @@ import { DataQuery, DefaultTimeZone, LogsDedupStrategy, RawTimeRange, toUtc } fr
 import { PanelModel } from 'app/features/dashboard/state';
 import { updateLocation } from '../../../core/actions';
 import { MockDataSourceApi } from '../../../../test/mocks/datasource_srv';
+import * as DatasourceSrv from 'app/features/plugins/datasource_srv';
 
-jest.mock('app/features/plugins/datasource_srv', () => ({
-  getDatasourceSrv: () => ({
-    getExternal: jest.fn().mockReturnValue([]),
-    get: jest.fn().mockReturnValue({
-      testDatasource: jest.fn(),
-      init: jest.fn(),
-    }),
-  }),
-}));
+jest.mock('app/features/plugins/datasource_srv');
+const getDatasourceSrvMock = (DatasourceSrv.getDatasourceSrv as any) as jest.Mock<DatasourceSrv.DatasourceSrv>;
+
+beforeEach(() => {
+  getDatasourceSrvMock.mockClear();
+  getDatasourceSrvMock.mockImplementation(
+    () =>
+      ({
+        getExternal: jest.fn().mockReturnValue([]),
+        get: jest.fn().mockReturnValue({
+          testDatasource: jest.fn(),
+          init: jest.fn(),
+        }),
+      } as any)
+  );
+});
 
 jest.mock('../../dashboard/services/TimeSrv', () => ({
   getTimeSrv: jest.fn().mockReturnValue({
@@ -160,6 +170,62 @@ describe('refreshExplore', () => {
 
       expect(dispatchedActions).toEqual([]);
     });
+  });
+});
+
+describe('changing datasource', () => {
+  it('should switch to logs mode when changing from prometheus to loki', async () => {
+    const lokiMock = {
+      testDatasource: () => Promise.resolve({ status: 'success' }),
+      name: 'Loki',
+      init: jest.fn(),
+      meta: { id: 'some id', name: 'Loki' },
+    };
+
+    getDatasourceSrvMock.mockImplementation(
+      () =>
+        ({
+          getExternal: jest.fn().mockReturnValue([]),
+          get: jest.fn().mockReturnValue(lokiMock),
+        } as any)
+    );
+
+    const exploreId = ExploreId.left;
+    const name = 'Prometheus';
+    const mockPromDatasourceInstance = {
+      testDatasource: () => Promise.resolve({ status: 'success' }),
+      name,
+      init: jest.fn(),
+      meta: { id: 'some id', name },
+    };
+
+    const initialState = {
+      explore: {
+        [exploreId]: {
+          requestedDatasourceName: name,
+          datasourceInstance: mockPromDatasourceInstance,
+        },
+      },
+      user: {
+        orgId: 1,
+      },
+    };
+
+    jest.spyOn(Actions, 'importQueries').mockImplementationOnce(() => jest.fn);
+    jest.spyOn(Actions, 'loadDatasource').mockImplementationOnce(() => jest.fn);
+    jest.spyOn(Actions, 'runQueries').mockImplementationOnce(() => jest.fn);
+    const dispatchedActions = await thunkTester(initialState)
+      .givenThunk(changeDatasource)
+      .whenThunkIsDispatched(exploreId, name);
+
+    expect(dispatchedActions).toEqual([
+      updateDatasourceInstanceAction({
+        exploreId,
+        datasourceInstance: lokiMock as any,
+        version: undefined,
+        mode: ExploreMode.Logs,
+      }),
+    ]);
   });
 });
 

--- a/public/app/features/explore/state/actions.test.ts
+++ b/public/app/features/explore/state/actions.test.ts
@@ -202,7 +202,7 @@ describe('changing datasource', () => {
     const initialState = {
       explore: {
         [exploreId]: {
-          requestedDatasourceName: name,
+          requestedDatasourceName: 'Loki',
           datasourceInstance: mockPromDatasourceInstance,
         },
       },

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -269,7 +269,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
   .addMapper({
     filter: updateDatasourceInstanceAction,
     mapper: (state, action): ExploreItemState => {
-      const { datasourceInstance, version } = action.payload;
+      const { datasourceInstance, version, mode } = action.payload;
 
       // Custom components
       stopQueryState(state.querySubscription);
@@ -291,7 +291,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
       }
 
       const updatedDatasourceInstance = Object.assign(datasourceInstance, { meta: newMetadata });
-      const [supportedModes, mode] = getModesForDatasource(updatedDatasourceInstance, state.mode);
+      const [supportedModes, newMode] = getModesForDatasource(updatedDatasourceInstance, state.mode);
 
       return {
         ...state,
@@ -304,7 +304,7 @@ export const itemReducer = reducerFactory<ExploreItemState>({} as ExploreItemSta
         loading: false,
         queryKeys: [],
         supportedModes,
-        mode,
+        mode: mode ?? newMode,
         originPanelId: state.urlState && state.urlState.originPanelId,
       };
     },
@@ -657,7 +657,7 @@ const getModesForDatasource = (dataSource: DataSourceApi, currentMode: ExploreMo
 
   // HACK: Used to set Loki's default explore mode to Logs mode.
   // A better solution would be to introduce a "default" or "preferred" mode to the datasource config
-  if (dataSource.meta.name === 'Loki') {
+  if (dataSource.meta.name === 'Loki' && !currentMode) {
     mode = ExploreMode.Logs;
   }
 

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -657,7 +657,7 @@ const getModesForDatasource = (dataSource: DataSourceApi, currentMode: ExploreMo
 
   // HACK: Used to set Loki's default explore mode to Logs mode.
   // A better solution would be to introduce a "default" or "preferred" mode to the datasource config
-  if (dataSource.meta.name === 'Loki' && !currentMode) {
+  if (dataSource.meta.name === 'Loki') {
     mode = ExploreMode.Logs;
   }
 

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -190,9 +190,9 @@ export class DatasourceSrv implements DataSourceService {
   }
 }
 
-export function getDatasourceSrv(): DatasourceSrv {
+export const getDatasourceSrv = (): DatasourceSrv => {
   return getDataSourceService() as DatasourceSrv;
-}
+};
 
 coreModule.service('datasourceSrv', DatasourceSrv);
 export default DatasourceSrv;


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki now goes to Logs mode when importing prom queries.

**Which issue(s) this PR fixes**:
Closes #20831 

