### PR TITLE
Elastic: Fix multiselect variable interpolation for logs

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -393,7 +393,7 @@ export class ElasticQueryBuilder {
       query.query.bool.filter.push({
         query_string: {
           analyze_wildcard: true,
-          query: target.query,
+          query: querystring,
         },
       });
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using log panel with elasticsearch data source and multi-value variable, it was interpolated incorrectly. This PR fixes this. 
![image](https://user-images.githubusercontent.com/30407135/70228248-50e38080-1754-11ea-87a8-02d787293497.png)

**Which issue(s) this PR fixes**:
Fixes #20621

