### PR TITLE
UI: Segment Input

### DIFF
--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -4,6 +4,8 @@ import { SelectableValue } from '@grafana/data';
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
 
 export interface SegmentSyncProps<T> extends SegmentProps<T> {
+  value?: SelectableValue<T>;
+  onChange: (item: SelectableValue<T>) => void;
   options: Array<SelectableValue<T>>;
 }
 

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -5,7 +5,9 @@ import { SelectableValue } from '@grafana/data';
 import { useExpandableLabel, SegmentProps } from '.';
 
 export interface SegmentAsyncProps<T> extends SegmentProps<T> {
+  value?: SelectableValue<T>;
   loadOptions: (query?: string) => Promise<Array<SelectableValue<T>>>;
+  onChange: (item: SelectableValue<T>) => void;
 }
 
 export function SegmentAsync<T>({

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -7,7 +7,7 @@ import { UseState } from '../../utils/storybook/UseState';
 
 SegmentStories.add('Segment Input', () => {
   return (
-    <UseState initialState={'some text' as string}>
+    <UseState initialState={'some text'}>
       {(value, updateValue) => (
         <>
           <div className="gf-form-inline">
@@ -15,11 +15,10 @@ SegmentStories.add('Segment Input', () => {
               <span className="gf-form-label width-8 query-keyword">Segment Name</span>
             </div>
             <SegmentInput
-              width={20}
               value={value}
-              onChange={item => {
-                updateValue(item as string);
-                action('Segment value changed')(item);
+              onChange={text => {
+                updateValue(text);
+                action('Segment value changed')(text);
               }}
             />
           </div>

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -17,7 +17,7 @@ SegmentStories.add('Segment Input', () => {
             <SegmentInput
               value={value}
               onChange={text => {
-                updateValue(text);
+                updateValue(text as string);
                 action('Segment value changed')(text);
               }}
             />

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -5,7 +5,7 @@ const SegmentStories = storiesOf('UI/Segment/SegmentInput', module);
 import { SegmentInput } from '.';
 import { UseState } from '../../utils/storybook/UseState';
 
-SegmentStories.add('Array Options', () => {
+SegmentStories.add('Segment Input', () => {
   return (
     <UseState initialState={'some text' as string}>
       {(value, updateValue) => (

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+const SegmentStories = storiesOf('UI/Segment/SegmentInput', module);
+import { SegmentInput } from '.';
+import { UseState } from '../../utils/storybook/UseState';
+
+SegmentStories.add('Array Options', () => {
+  return (
+    <UseState initialState={'some text' as string}>
+      {(value, updateValue) => (
+        <>
+          <div className="gf-form-inline">
+            <div className="gf-form">
+              <span className="gf-form-label width-8 query-keyword">Segment Name</span>
+            </div>
+            <SegmentInput
+              width={20}
+              value={value}
+              onChange={item => {
+                updateValue(item as string);
+                action('Segment value changed')(item);
+              }}
+            />
+          </div>
+        </>
+      )}
+    </UseState>
+  );
+});

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -1,0 +1,55 @@
+import React, { useRef, useState } from 'react';
+import { cx, css } from 'emotion';
+import useClickAway from 'react-use/lib/useClickAway';
+import { useExpandableLabel, SegmentProps } from '.';
+
+export interface SegmentInputProps<T> extends SegmentProps<T> {
+  value: string | number;
+  onChange: (item: string | number) => void;
+  width?: number;
+}
+
+const textWidth = (text: string) => {
+  const element = document.createElement('canvas');
+  const context: any = element.getContext('2d');
+  context.font = '14px Roboto';
+  return context.measureText(text).width;
+};
+
+export function SegmentInput<T>({
+  value,
+  onChange,
+  Component,
+  className,
+}: React.PropsWithChildren<SegmentInputProps<T>>) {
+  const ref = useRef(null);
+  const [inputWidth, setInputWidth] = useState<number>(textWidth(value!.toString()));
+  const [Label, , expanded, setExpanded] = useExpandableLabel(false);
+  useClickAway(ref, () => setExpanded(false));
+
+  if (!expanded) {
+    return <Label Component={Component || <a className={cx('gf-form-label', 'query-part', className)}>{value}</a>} />;
+  }
+
+  return (
+    <div className="gf-form">
+      <input
+        ref={ref}
+        autoFocus
+        className={cx(
+          `gf-form-input`,
+          css`
+            width: ${Math.max(inputWidth + 20, 32)}px;
+          `
+        )}
+        value={value}
+        onChange={item => {
+          setInputWidth(textWidth(item.target.value));
+          onChange(item.target.value);
+        }}
+        onBlur={() => setExpanded(false)}
+        onKeyDown={e => e.keyCode === 13 && setExpanded(false)}
+      />
+    </div>
+  );
+}

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -35,19 +35,17 @@ export function SegmentInput<T>({
   `;
 
   return (
-    <div className="gf-form">
-      <input
-        ref={ref}
-        autoFocus
-        className={cx(`gf-form-input`, inputWidthStyle)}
-        value={value}
-        onChange={item => {
-          setInputWidth(textWidth(item.target.value));
-          onChange(item.target.value);
-        }}
-        onBlur={() => setExpanded(false)}
-        onKeyDown={e => e.keyCode === 13 && setExpanded(false)}
-      />
-    </div>
+    <input
+      ref={ref}
+      autoFocus
+      className={cx(`gf-form gf-form-input`, inputWidthStyle)}
+      value={value}
+      onChange={item => {
+        setInputWidth(textWidth(item.target.value));
+        onChange(item.target.value);
+      }}
+      onBlur={() => setExpanded(false)}
+      onKeyDown={e => e.keyCode === 13 && setExpanded(false)}
+    />
   );
 }

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -5,13 +5,12 @@ import { useExpandableLabel, SegmentProps } from '.';
 
 export interface SegmentInputProps<T> extends SegmentProps<T> {
   value: string | number;
-  onChange: (item: string | number) => void;
-  width?: number;
+  onChange: (text: string | number) => void;
 }
 
 const textWidth = (text: string) => {
   const element = document.createElement('canvas');
-  const context: any = element.getContext('2d');
+  const context = element.getContext('2d')!;
   context.font = '14px Roboto';
   return context.measureText(text).width;
 };
@@ -23,7 +22,7 @@ export function SegmentInput<T>({
   className,
 }: React.PropsWithChildren<SegmentInputProps<T>>) {
   const ref = useRef(null);
-  const [inputWidth, setInputWidth] = useState<number>(textWidth(value!.toString()));
+  const [inputWidth, setInputWidth] = useState<number>(textWidth(value.toString()));
   const [Label, , expanded, setExpanded] = useExpandableLabel(false);
   useClickAway(ref, () => setExpanded(false));
 
@@ -31,17 +30,16 @@ export function SegmentInput<T>({
     return <Label Component={Component || <a className={cx('gf-form-label', 'query-part', className)}>{value}</a>} />;
   }
 
+  const inputWidthStyle = css`
+    width: ${Math.max(inputWidth + 20, 32)}px;
+  `;
+
   return (
     <div className="gf-form">
       <input
         ref={ref}
         autoFocus
-        className={cx(
-          `gf-form-input`,
-          css`
-            width: ${Math.max(inputWidth + 20, 32)}px;
-          `
-        )}
+        className={cx(`gf-form-input`, inputWidthStyle)}
         value={value}
         onChange={item => {
           setInputWidth(textWidth(item.target.value));

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { cx, css } from 'emotion';
 import useClickAway from 'react-use/lib/useClickAway';
+import { measureText } from '../../utils/measureText';
 import { useExpandableLabel, SegmentProps } from '.';
 
 export interface SegmentInputProps<T> extends SegmentProps<T> {
@@ -8,12 +9,7 @@ export interface SegmentInputProps<T> extends SegmentProps<T> {
   onChange: (text: string | number) => void;
 }
 
-const textWidth = (text: string) => {
-  const element = document.createElement('canvas');
-  const context = element.getContext('2d')!;
-  context.font = '14px Roboto';
-  return context.measureText(text).width;
-};
+const FONT_SIZE = 14;
 
 export function SegmentInput<T>({
   value,
@@ -22,7 +18,7 @@ export function SegmentInput<T>({
   className,
 }: React.PropsWithChildren<SegmentInputProps<T>>) {
   const ref = useRef(null);
-  const [inputWidth, setInputWidth] = useState<number>(textWidth(value.toString()));
+  const [inputWidth, setInputWidth] = useState<number>(measureText(value.toString(), FONT_SIZE).width);
   const [Label, , expanded, setExpanded] = useExpandableLabel(false);
   useClickAway(ref, () => setExpanded(false));
 
@@ -41,11 +37,12 @@ export function SegmentInput<T>({
       className={cx(`gf-form gf-form-input`, inputWidthStyle)}
       value={value}
       onChange={item => {
-        setInputWidth(textWidth(item.target.value));
+        const { width } = measureText(item.target.value, FONT_SIZE);
+        setInputWidth(width);
         onChange(item.target.value);
       }}
       onBlur={() => setExpanded(false)}
-      onKeyDown={e => e.keyCode === 13 && setExpanded(false)}
+      onKeyDown={e => [13, 27].includes(e.keyCode) && setExpanded(false)}
     />
   );
 }

--- a/packages/grafana-ui/src/components/Segment/index.ts
+++ b/packages/grafana-ui/src/components/Segment/index.ts
@@ -1,5 +1,6 @@
 export { Segment } from './Segment';
 export { SegmentAsync } from './SegmentAsync';
 export { SegmentSelect } from './SegmentSelect';
+export { SegmentInput } from './SegmentInput';
 export { SegmentProps } from './types';
 export { useExpandableLabel } from './useExpandableLabel';

--- a/packages/grafana-ui/src/components/Segment/types.ts
+++ b/packages/grafana-ui/src/components/Segment/types.ts
@@ -1,9 +1,6 @@
 import { ReactElement } from 'react';
-import { SelectableValue } from '@grafana/data';
 
 export interface SegmentProps<T> {
-  onChange: (item: SelectableValue<T>) => void;
-  value?: SelectableValue<T>;
   Component?: ReactElement;
   className?: string;
   allowCustomValue?: boolean;

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -105,7 +105,7 @@ export { DataSourceHttpSettings } from './DataSourceSettings/DataSourceHttpSetti
 export { Spinner } from './Spinner/Spinner';
 export { FadeTransition } from './transitions/FadeTransition';
 export { SlideOutTransition } from './transitions/SlideOutTransition';
-export { Segment, SegmentAsync, SegmentSelect } from './Segment/';
+export { Segment, SegmentAsync, SegmentInput, SegmentSelect } from './Segment/';
 export { default as Chart } from './Chart';
 export { Icon } from './Icon/Icon';
 


### PR DESCRIPTION
In the ServiceNow plugin, where building filters using key value pairs. The value can be a dropdown (i.e normal segment component) or an input field. That unfortunately looks terrible since the input has a fixed width. See example here: 

![Skärmavbild 2019-12-05 kl  16 22 51](https://user-images.githubusercontent.com/2388950/70248678-894a8500-177b-11ea-96b5-d3e151bc0458.png)

This PR wraps the input in a Segment. The input width is dynamic in response to the text width. Initially tried out [react-input-autosize](https://github.com/JedWatson/react-input-autosize) and tried integrating it with our existing Input component, but the existing Input component styling does not go along well with the query editor styles. So for now I calculated the text width using canvas and hardcoded font. I think this needs to be done differently in the future, preferably using react-input-autosize or something similar.  

![segmentinput](https://user-images.githubusercontent.com/2388950/70254211-02020f00-1785-11ea-8888-78b35f5f15bb.gif)
