### PR TITLE
CloudWatch: Fix query editor does not render in Explore

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
@@ -49,6 +49,7 @@ const setup = () => {
       matchExact: true,
     },
     datasource,
+    history: [],
     onChange: jest.fn(),
     onRunQuery: jest.fn(),
   };

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -1,12 +1,12 @@
 import React, { PureComponent, ChangeEvent } from 'react';
-import { SelectableValue, QueryEditorProps } from '@grafana/data';
+import { SelectableValue, ExploreQueryFieldProps } from '@grafana/data';
 import { Input, Segment, SegmentAsync, ValidationEvents, EventsWithValidation, Switch } from '@grafana/ui';
 import { CloudWatchQuery } from '../types';
 import CloudWatchDatasource from '../datasource';
 import { SelectableStrings } from '../types';
 import { Stats, Dimensions, QueryInlineField, QueryField, Alias } from './';
 
-export type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery>;
+export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery>;
 
 interface State {
   regions: SelectableStrings;

--- a/public/app/plugins/datasource/cloudwatch/module.tsx
+++ b/public/app/plugins/datasource/cloudwatch/module.tsx
@@ -14,4 +14,5 @@ export const plugin = new DataSourcePlugin<CloudWatchDatasource, CloudWatchQuery
 )
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor)
+  .setExploreQueryField(QueryEditor)
   .setAnnotationQueryCtrl(CloudWatchAnnotationsQueryCtrl);


### PR DESCRIPTION
- the datasource plugin module API was changed recently so that it no longer falls back on the panel editor in Explore, now it needs to be explicitly set
- this PR sets the cloudwatch explore query field to be the same as the query editor
- needed to change editor types to satisfy explore query field interface

Fixes: #20805