### PR TITLE
CloudWatch: Remove illegal character escaping in inferred expressions

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_data_query_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder.go
@@ -78,7 +78,7 @@ func buildSearchExpression(query *cloudWatchQuery, stat string) string {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		values := escape(knownDimensions[key])
+		values := escapeDoubleQuotes(knownDimensions[key])
 		valueExpression := join(values, " OR ", `"`, `"`)
 		if len(knownDimensions[key]) > 1 {
 			valueExpression = fmt.Sprintf(`(%s)`, valueExpression)
@@ -102,12 +102,9 @@ func buildSearchExpression(query *cloudWatchQuery, stat string) string {
 	return fmt.Sprintf(`REMOVE_EMPTY(SEARCH('Namespace="%s" %s', '%s', %s))`, query.Namespace, searchTerm, stat, strconv.Itoa(query.Period))
 }
 
-func escape(arr []string) []string {
+func escapeDoubleQuotes(arr []string) []string {
 	result := []string{}
 	for _, value := range arr {
-		value = strings.ReplaceAll(value, `\`, `\\`)
-		value = strings.ReplaceAll(value, ")", `\)`)
-		value = strings.ReplaceAll(value, "(", `\(`)
 		value = strings.ReplaceAll(value, `"`, `\"`)
 		result = append(result, value)
 	}

--- a/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
@@ -166,17 +166,12 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 			})
 		})
 
-		Convey("and query has has invalid characters in dimension values", func() {
+		Convey("and query has invalid characters in dimension values", func() {
 			query := &cloudWatchQuery{
 				Namespace:  "AWS/EC2",
 				MetricName: "CPUUtilization",
 				Dimensions: map[string][]string{
-					"lb1": {`lb\1\`},
-					"lb2": {`)lb2`},
-					"lb3": {`l(b3`},
 					"lb4": {`lb4""`},
-					"lb5": {`l\(b5"`},
-					"lb6": {`l\\(b5"`},
 				},
 				Period:     300,
 				Expression: "",
@@ -184,20 +179,8 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 			}
 			res := buildSearchExpression(query, "Average")
 
-			Convey("it should escape backslash", func() {
-				So(res, ShouldContainSubstring, `"lb1"="lb\\1\\"`)
-			})
-
-			Convey("it should escape closing parenthesis", func() {
-				So(res, ShouldContainSubstring, `"lb2"="\)lb2"`)
-			})
-
-			Convey("it should escape open parenthesis", func() {
-				So(res, ShouldContainSubstring, `"lb3"="l\(b3"`)
-			})
-
 			Convey("it should escape double quotes", func() {
-				So(res, ShouldContainSubstring, `"lb6"="l\\\\\(b5\""`)
+				So(res, ShouldContainSubstring, `lb4\"\"`)
 			})
 
 		})


### PR DESCRIPTION
According to the [CloudWatch docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html#search-expression-syntax-characters), the following characters must be escaped with a backslash `" \ ( )`. So whenever Grafana generates a search expression, we'll simply insert a backslash before the illegal character. 

However, it's been [reported](#20704) that queries that include parenthesis don't work. The reasons seems to be the escaping. I've been in contact with an amazon engineer, and according to him we should only escape double quotes - the go-sdk takes care of escaping all other illegal characters. 


fixes #20704