### PR TITLE
AngularPanels: Check for digest cycle on root scope

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -118,7 +118,7 @@ class MetricsPanelCtrl extends PanelCtrl {
   }
 
   angularDirtyCheck() {
-    if (!this.$scope.$$phase) {
+    if (!this.$scope.$root.$$phase) {
       this.$scope.$digest();
     }
   }


### PR DESCRIPTION
A better fix, checking digest cycle on local scope was fragile here.