### PR TITLE
Datasource/Loki: Empty metric name no longer replaced by query

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -284,7 +284,7 @@ function createMetricLabel(labelData: { [key: string]: string }, options?: Trans
       ? getOriginalMetricName(labelData)
       : renderTemplate(templateSrv.replace(options.legendFormat), labelData);
 
-  if (!label || label === '{}') {
+  if (!label) {
     label = options.query;
   }
   return label;


### PR DESCRIPTION
**What this PR does / why we need it**:
Empty metric names are no longer replaced by the full query as graph labels.

**Which issue(s) this PR fixes**:
Closes #20762

