### PR TITLE
Graph: Add fill gradient option to series override line fill

### DIFF
--- a/public/app/core/specs/time_series.test.ts
+++ b/public/app/core/specs/time_series.test.ts
@@ -276,6 +276,19 @@ describe('TimeSeries', () => {
       });
     });
 
+    describe('fillGradient', () => {
+      beforeEach(() => {
+        series.alias = 'test';
+        series.applySeriesOverrides([{ alias: 'test', fill: 10, fillGradient: 10 }]);
+      });
+
+      it('should set fillcolor to gradient', () => {
+        expect(series.lines.fillColor).toMatchObject({
+          colors: [{ opacity: 0.0 }, { opacity: 1 }],
+        });
+      });
+    });
+
     describe('series option overrides, bars, true & lines false', () => {
       beforeEach(() => {
         series.alias = 'test';

--- a/public/app/core/time_series2.ts
+++ b/public/app/core/time_series2.ts
@@ -19,6 +19,16 @@ function translateFillOption(fill: number) {
   return fill === 0 ? 0.001 : fill / 10;
 }
 
+function getFillGradient(amount: number) {
+  if (!amount) {
+    return null;
+  }
+
+  return {
+    colors: [{ opacity: 0.0 }, { opacity: amount / 10 }],
+  };
+}
+
 /**
  * Calculate decimals for legend and update values for each series.
  * @param data series data
@@ -156,6 +166,9 @@ export default class TimeSeries {
       }
       if (override.fill !== void 0) {
         this.lines.fill = translateFillOption(override.fill);
+      }
+      if (override.fillGradient !== void 0) {
+        this.lines.fillColor = getFillGradient(override.fillGradient);
       }
       if (override.stack !== void 0) {
         this.stack = override.stack;

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -79,7 +79,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     lines: true,
     // fill factor
     fill: 1,
-    // fill factor
+    // fill gradient
     fillGradient: 0,
     // line width in pixels
     linewidth: 1,

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.ts
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.ts
@@ -101,6 +101,7 @@ export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: a
   $scope.addOverrideOption('Bars', 'bars', [true, false]);
   $scope.addOverrideOption('Lines', 'lines', [true, false]);
   $scope.addOverrideOption('Line fill', 'fill', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  $scope.addOverrideOption('Fill gradient', 'fillGradient', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   $scope.addOverrideOption('Line width', 'linewidth', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   $scope.addOverrideOption('Null point mode', 'nullPointMode', ['connected', 'null', 'null as zero']);
   $scope.addOverrideOption('Fill below to', 'fillBelowTo', $scope.getSeriesNames());


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a series override for fill gradient. As discussed in #18445, this allows a user to individually control series gradients and draw graphs such as this:

![overrided-gradient](https://user-images.githubusercontent.com/965952/70359034-7e7b1780-1883-11ea-9c89-13b13ff90663.png)

**Which issue(s) this PR fixes**:
Fixes #18445

**Special notes for your reviewer**:

Graph without override:
![no-override](https://user-images.githubusercontent.com/965952/70359544-d5352100-1884-11ea-97d6-674986b06b2a.png)

Graph with override:
![override](https://user-images.githubusercontent.com/965952/70359551-d8301180-1884-11ea-81d5-beb9518cd985.png)
