### PR TITLE
DataSource: remove delta option

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -424,16 +424,6 @@ export interface DataStreamState {
   error?: DataQueryError;
 
   /**
-   * @deprecated: DO NOT USE IN ANYTHING NEW!!!!
-   *
-   * merging streaming rows should be handled in the DataSource
-   * and/or we should add metadata to this state event that
-   * indicates that the PanelQueryRunner should manage the row
-   * additions.
-   */
-  delta?: DataFrame[];
-
-  /**
    * Stop listening to this stream
    */
   unsubscribe: () => void;


### PR DESCRIPTION
Our first version of streaming optionally returned just the rows that changed.  when we switched to a columnar format, we mostly removed it.

We may still want to add this, but lets be more clear what the semantics are/would be