### PR TITLE
Singlestat: Support empty value map texts

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -46,6 +46,10 @@ describe('Process simple display values', () => {
     assertSame('3', processors, { text: '3', numeric: 3 });
   });
 
+  it('Empty string is NaN', () => {
+    assertSame('', processors, { text: '', numeric: NaN });
+  });
+
   it('Simple String', () => {
     assertSame('hello', processors, { text: 'hello', numeric: NaN });
   });
@@ -167,8 +171,19 @@ describe('Format value', () => {
     expect(instance(value).text).toEqual('1-20');
   });
 
+  it('should return mapped value and leave numeric value in tact if value mapping maps to empty string', () => {
+    const valueMappings: ValueMapping[] = [
+      { id: 1, operator: '', text: '', type: MappingType.ValueToText, value: '1' },
+    ];
+    const value = '1';
+    const instance = getDisplayProcessor({ config: { decimals: 1, mappings: valueMappings } });
+
+    expect(instance(value).text).toEqual('');
+    expect(instance(value).numeric).toEqual(1);
+  });
+
   //
-  // Below is current behavior but I it's clearly not working great
+  // Below is current behavior but it's clearly not working great
   //
 
   it('with value 1000 and unit short', () => {

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -112,7 +112,7 @@ function toNumber(value: any): number {
   if (typeof value === 'number') {
     return value;
   }
-  if (value === null || value === undefined || Array.isArray(value)) {
+  if (value === '' || value === null || value === undefined || Array.isArray(value)) {
     return NaN; // lodash calls them 0
   }
   if (typeof value === 'boolean') {


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in #20886, threshold-based coloring does not work correctly when mapping values to empty text in Singlestat.

**Which issue(s) this PR fixes**:
Fixes #20886

**Special notes for your reviewer**:
I think what happens here is:

1. In [`displayProcessor:65`](https://github.com/grafana/grafana/blob/4ad8b6f030273b40ea22ab9486ca8739af7a7b9b/packages/grafana-data/src/field/displayProcessor.ts#L65) we try to convert our text data to a number using toNumber().
2. toNumber incorrectly converts an empty string `""` to `0` instead of `NaN`.
3. We override the numeric value in our data with `0`.
4. Colour mappings based on the numeric value of `0` results in the incorrect colour being shown.

I updated `toNumber()` to interpret empty strings as `NaN` instead of `0`. If this might have unintended side effects, I can also make the change in the calling function.

Mapping and colouring working after the change:
![after](https://user-images.githubusercontent.com/965952/70398667-78716c00-1a26-11ea-9d61-3e8014c7d8d3.gif)
