### PR TITLE
Devenv: Fix loki block

### DIFF
--- a/devenv/docker/blocks/jaeger/docker-compose.yaml
+++ b/devenv/docker/blocks/jaeger/docker-compose.yaml
@@ -3,4 +3,25 @@
     ports:
       - "6831:6831"
       - "16686:16686"
+  # Additional loki to generate some traces
+  # datasource URL: http://localhost:3100/
+  loki:
+    image: grafana/loki:master
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    # Optional jaeger tracing
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
+  promtail:
+    image: grafana/promtail:master
+    volumes:
+      - ./docker/blocks/loki/config.yaml:/etc/promtail/docker-config.yaml
+      - /var/log:/var/log
+      - ../data/log:/var/log/grafana
+    command:
+      -config.file=/etc/promtail/docker-config.yaml
 

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -4,12 +4,6 @@
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
-    # Optional jaeger tracing
-    environment:
-      - JAEGER_AGENT_HOST=jaeger
-      - JAEGER_AGENT_PORT=6831
-      - JAEGER_SAMPLER_TYPE=const
-      - JAEGER_SAMPLER_PARAM=1
   promtail:
     image: grafana/promtail:master
     volumes:


### PR DESCRIPTION
- Loki block had jaeger settings in env vars, which made Loki exit if jaeger was not present.
- removed jaeger setting loki
- added loki to jaeger block, so it can supply traces (otherwise the jaeger instance has no trace content)
