### PR TITLE
Loki: Fix datasource config page test run

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -261,7 +261,7 @@ describe('LokiDatasource', () => {
             return Promise.resolve({
               status: 200,
               data: {
-                values: ['avalue'],
+                data: ['avalue'],
               },
             });
           },


### PR DESCRIPTION
- since the API update, the URL fallback was working, but the response
format also needed adapting: `data` (v1) vs `values` (pre-v1)
- this change looks for either data or values in the response for test
and metadata requests

Fixes #20970

