### PR TITLE
Explore: Sync timepicker and logs after live-tailing stops

### DIFF
--- a/public/app/features/explore/LiveTailButton.tsx
+++ b/public/app/features/explore/LiveTailButton.tsx
@@ -24,7 +24,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     liveButton: css`
       label: liveButton;
-      transition: background-color 1s, border-color 1s, color 1s;
       margin: 0;
     `,
     isLive: css`
@@ -84,7 +83,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: stopButtonEnterActive;
       opacity: 1;
       width: 32px;
-      transition: opacity 500ms ease-in 50ms, width 500ms ease-in 50ms;
     `,
     stopButtonExit: css`
       label: stopButtonExit;
@@ -96,7 +94,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: stopButtonExitActive;
       opacity: 0;
       width: 0;
-      transition: opacity 500ms ease-in 50ms, width 500ms ease-in 50ms;
     `,
   };
 });

--- a/public/app/features/explore/useLiveTailControls.ts
+++ b/public/app/features/explore/useLiveTailControls.ts
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { changeRefreshInterval } from './state/actions';
+import { changeRefreshInterval, runQueries } from './state/actions';
 import { setPausedStateAction } from './state/actionTypes';
 import { RefreshPicker } from '@grafana/ui';
 import { ExploreId } from '../../types';
@@ -29,6 +29,7 @@ export function useLiveTailControls(exploreId: ExploreId) {
     // TODO referencing this from perspective of refresh picker when there is designated button for it now is not
     //  great. Needs a bit of refactoring.
     dispatch(changeRefreshInterval(exploreId, RefreshPicker.offOption.value));
+    dispatch(runQueries(exploreId));
   }, [exploreId, dispatch, pause]);
 
   const start = useCallback(() => {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [Design doc](https://docs.google.com/document/d/18HjaTS1ZJ2wqpJVt4Z3tbgNi7QaSWGofByU0J8Bh6B0/edit#heading=h.ejymv9t9d80r)

In Explore, after live-tailing stops, logs from previously selected timepicker range are not displayed. Instead of that, we display logs that were shown in live-tailing. This means, that timepicker and displayed logs are not synced. This PR fixes the issue by running the new runQueries function with range from timepicker. Secondly, it removes the live-tailing button animation, as it was quite often _slow_/_out of sync_ with other parts of the button. This was even more visible after implementation of `runQueries function`.

![ezgif com-video-to-gif (13)](https://user-images.githubusercontent.com/30407135/70454926-9a610200-1aab-11ea-9d22-4ed19b7bef4e.gif)

**Which issue(s) this PR fixes**:

Fixes #19954
Fixes #20628


