### PR TITLE
Chore: Improve rendering logging

### DIFF
--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -61,6 +61,8 @@ func (rs *RenderingService) renderViaHttp(ctx context.Context, opts Opts) (*Rend
 
 	req = req.WithContext(reqContext)
 
+	rs.log.Debug("calling remote rendering service", "url", rendererUrl)
+
 	// make request to renderer server
 	resp, err := netClient.Do(req)
 	if err != nil {

--- a/pkg/services/rendering/phantomjs.go
+++ b/pkg/services/rendering/phantomjs.go
@@ -15,8 +15,6 @@ import (
 )
 
 func (rs *RenderingService) renderViaPhantomJS(ctx context.Context, opts Opts) (*RenderResult, error) {
-	rs.log.Info("Rendering", "path", opts.Path)
-
 	var executable = "phantomjs"
 	if runtime.GOOS == "windows" {
 		executable = executable + ".exe"

--- a/pkg/services/rendering/plugin_mode.go
+++ b/pkg/services/rendering/plugin_mode.go
@@ -66,7 +66,7 @@ func (rs *RenderingService) renderViaPlugin(ctx context.Context, opts Opts) (*Re
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
-	rsp, err := rs.grpcPlugin.Render(ctx, &pluginModel.RenderRequest{
+	req := &pluginModel.RenderRequest{
 		Url:       rs.getURL(opts.Path),
 		Width:     int32(opts.Width),
 		Height:    int32(opts.Height),
@@ -76,7 +76,10 @@ func (rs *RenderingService) renderViaPlugin(ctx context.Context, opts Opts) (*Re
 		Encoding:  opts.Encoding,
 		Timezone:  isoTimeOffsetToPosixTz(opts.Timezone),
 		Domain:    rs.domain,
-	})
+	}
+	rs.log.Debug("calling renderer plugin", "req", req)
+
+	rsp, err := rs.grpcPlugin.Render(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -77,7 +77,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 		return nil
 	}
 
-	rs.log = rs.log.New("renderer", plugins.Renderer.Id)
+	rs.log = rs.log.New("renderer", "plugin")
 	rs.pluginInfo = plugins.Renderer
 
 	if err := rs.startPlugin(ctx); err != nil {

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -3,10 +3,11 @@ package rendering
 import (
 	"context"
 	"fmt"
-	plugin "github.com/hashicorp/go-plugin"
 	"net/url"
 	"os"
 	"path/filepath"
+
+	plugin "github.com/hashicorp/go-plugin"
 
 	pluginModel "github.com/grafana/grafana-plugin-model/go/renderer"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -59,6 +60,7 @@ func (rs *RenderingService) Init() error {
 
 func (rs *RenderingService) Run(ctx context.Context) error {
 	if rs.Cfg.RendererUrl != "" {
+		rs.log = rs.log.New("renderer", "http")
 		rs.log.Info("Backend rendering via external http server")
 		rs.renderAction = rs.renderViaHttp
 		<-ctx.Done()
@@ -66,6 +68,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	}
 
 	if plugins.Renderer == nil {
+		rs.log = rs.log.New("renderer", "phantomJS")
 		rs.log.Info("Backend rendering via phantomJS")
 		rs.log.Warn("phantomJS is deprecated and will be removed in a future release. " +
 			"You should consider migrating from phantomJS to grafana-image-renderer plugin.")
@@ -74,6 +77,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 		return nil
 	}
 
+	rs.log = rs.log.New("renderer", plugins.Renderer.Id)
 	rs.pluginInfo = plugins.Renderer
 
 	if err := rs.startPlugin(ctx); err != nil {
@@ -114,6 +118,7 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	rs.inProgressCount += 1
 
 	if rs.renderAction != nil {
+		rs.log.Info("Rendering", "path", opts.Path)
 		return rs.renderAction(ctx, opts)
 	}
 	return nil, fmt.Errorf("No renderer found")


### PR DESCRIPTION
**What this PR does / why we need it**:
- Moving info log from phantomjs to rendering service so it's logged for all kinds of renderers.
- Add debug log for image renderer plugin and remote renderer