### PR TITLE
Chore: performance.getEntriesByType not supported by Phantomjs

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -175,7 +175,7 @@ export class GrafanaApp {
 
     ttiPolyfill.getFirstConsistentlyInteractive().then((tti: any) => {
       // Collecting paint metrics first
-      const paintMetrics = performance.getEntriesByType('paint');
+      const paintMetrics = performance && performance.getEntriesByType ? performance.getEntriesByType('paint') : [];
 
       for (const metric of paintMetrics) {
         reportPerformance(metric.name, Math.round(metric.startTime + metric.duration));


### PR DESCRIPTION
**What this PR does / why we need it**:
Happened to see the following output when rendered an image using PhantomJS:
```
DBUG[12-10|20:15:05] Phantomjs output                         logger=rendering renderer=phantomJS out="Unhandled promise rejection TypeError: undefined is not a function (evaluating 'perform
ance.getEntriesByType('paint')')\n\n  http://localhost:3000/public/build/vendors~app.c01043c35061f42cba39.js:100242\nLoading a web page: http://localhost:3000/d-solo/5SdHCadmz/panel-tests-gr
aph?orgId=1&from=1575999903939&to=1576003503939&panelId=19&width=1000&height=500&tz=Europe%2FStockholm&render=1 status: success 60000\n" 
```

An image was rendered, but thought it was nice to remove this error when I was at it. 

Maybe something to consider in regards to metrics whether image rendering shouldn't send metrics or handle in some special case?