### PR TITLE
Toolkit: remove unused plugin-ci report types

### DIFF
--- a/packages/grafana-toolkit/src/plugins/types.ts
+++ b/packages/grafana-toolkit/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import { PluginMeta, PluginBuildInfo, DataFrame, KeyValue } from '@grafana/data';
+import { PluginMeta, KeyValue } from '@grafana/data';
 
 export interface PluginPackageDetails {
   plugin: ZipFileInfo;
@@ -53,44 +53,6 @@ export interface TestResultsInfo {
   failed: number;
   screenshots: string[];
 }
-
-// Saved at the folder level
-export interface PluginHistory {
-  last: {
-    info: PluginDevInfo;
-    report: PluginBuildReport;
-  };
-  size: DataFrame[]; // New frame for each package
-  coverage: DataFrame[]; // New frame for each job
-  timing: DataFrame[]; // New frame for each job/workflow
-}
-
-export interface PluginDevInfo {
-  pluginId: string;
-  name: string;
-  logo?: string; // usually logo.svg or logo.png
-  build: PluginBuildInfo;
-  version: string;
-}
-
-export interface DevSummary {
-  [key: string]: PluginDevInfo;
-}
-
-export interface PluginDevSummary {
-  branch: DevSummary;
-  pr: DevSummary;
-}
-
-export const defaultPluginHistory: PluginHistory = {
-  last: {
-    info: {} as PluginDevInfo,
-    report: {} as PluginBuildReport,
-  },
-  size: [],
-  coverage: [],
-  timing: [],
-};
 
 export interface CountAndSize {
   count: number;

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import path from 'path';
 import fs from 'fs';
 import { KeyValue } from '@grafana/data';
-import { PluginDevInfo, ExtensionSize, ZipFileInfo, PluginBuildReport, PluginHistory } from './types';
+import { ExtensionSize, ZipFileInfo } from './types';
 
 const md5File = require('md5-file');
 
@@ -91,17 +91,4 @@ export function findImagesInFolder(dir: string, prefix = '', append?: string[]):
   }
 
   return imgs;
-}
-
-export function appendPluginHistory(report: PluginBuildReport, info: PluginDevInfo, history: PluginHistory) {
-  history.last = {
-    info,
-    report,
-  };
-
-  if (!history.size) {
-    history.size = [];
-  }
-
-  console.log('TODO, append build stats to the last one');
 }


### PR DESCRIPTION
Originally the CI report task also generated its own history... that is now (rather will be) generated on the server side processes.

This PR just cleans up old code we are no longer using