### PR TITLE
Tracing: Add a directory with quick setup demo resource

### DIFF
--- a/traceui/datasources.yaml
+++ b/traceui/datasources.yaml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    isDefault: true
+    jsonData:
+      derivedFields:
+        - datasourceName: Jaeger
+          matcherRegex: "traceID=(\\w+)"
+          name: TraceID
+          url: "http://localhost:16686/trace/${__value.raw}"
+
+  - name: Jaeger
+    type: jaeger
+    access: browser
+    url: http://localhost:16686
+    editable: false

--- a/traceui/docker-compose.yaml
+++ b/traceui/docker-compose.yaml
@@ -1,0 +1,45 @@
+# All services will log to Loki via the loki docker logging plugin.
+# To install run this on the host once:
+# docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+version: '2'
+services:
+  grafana:
+    image: grafana/grafana-dev:explore-trace-ui-demo-42c1bbf43edd8471c102df72f927a50d96eac2e6
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./grafana.ini:/etc/grafana/grafana.ini
+    # logging directly to loki, see file header for details
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  loki:
+    image: grafana/loki:master
+    ports:
+      - '3100:3100'
+    command: -config.file=/etc/loki/local-config.yaml
+    # Sending loki's own traces to jaeger
+    environment:
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=6831
+      - JAEGER_SAMPLER_TYPE=const
+      - JAEGER_SAMPLER_PARAM=1
+    # logging directly to loki, see file header for details
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - '6831:6831'
+      - '16686:16686'
+    # logging directly to loki, see file header for details
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/api/prom/push'

--- a/traceui/grafana.ini
+++ b/traceui/grafana.ini
@@ -1,0 +1,7 @@
+[users]
+# Default UI theme ("dark" or "light")
+default_theme = light
+
+[feature_toggles]
+# enable features, separated by spaces
+enable = tracing_integration


### PR DESCRIPTION
Was part of https://github.com/grafana/grafana/pull/20297 but as that is going to be merged behind a feature flag, this was separated to a new PR.

Do not merge this is just for easier demo setup.