### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Documentation owner: Diana Payton
+/docs/ @oddlittlebird


### PR DESCRIPTION
Per @marefr's suggestion, I am making myself a Codeowner of the `docs` directory.

This means that any PR with a change to the `docs` files will automatically add me as a reviewer. (Assuming I set the syntax right, which I hopefully did.)

This will help to automate the review process and give me visibility to changes occurring to the documentation.

For more information about CODEOWNERS, see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners.