### PR TITLE
Fix: Fixes default visibility to submenu to same as dashboard

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/SubMenuCtrl.ts
+++ b/public/app/features/dashboard/components/SubMenu/SubMenuCtrl.ts
@@ -13,7 +13,7 @@ export class SubMenuCtrl {
   constructor(private variableSrv: VariableSrv, private $location: ILocationService) {
     this.annotations = this.dashboard.templating.list;
     this.variables = this.variableSrv.variables;
-    this.submenuEnabled = false;
+    this.submenuEnabled = this.dashboard.meta.submenuEnabled;
     this.dashboard.events.on(CoreEvents.submenuVisibilityChanged, (enabled: boolean) => {
       this.submenuEnabled = enabled;
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
A previous bugfix to show SubMenu #21017 actually hides all template variables for dashboards that have them already defined. This PR will fix that.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

