### PR TITLE
QueryEditors/AlertingUI: Fix metric segment UI crash in prod builds

### DIFF
--- a/public/app/core/directives/metric_segment.ts
+++ b/public/app/core/directives/metric_segment.ts
@@ -186,6 +186,7 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
   };
 }
 
+/** @ngInject */
 export function metricSegmentModel(uiSegmentSrv: any) {
   return {
     template:


### PR DESCRIPTION
A PR merged a few days ago accidentally removed an` /** @ngInject */` comment on metricSegmentModel directive making this UI component not work in production builds. 
