### PR TITLE
API: Validate redirect_to cookie has valid (Grafana) url 

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
@@ -25,6 +26,20 @@ var setIndexViewData = (*HTTPServer).setIndexViewData
 
 var getViewIndex = func() string {
 	return ViewIndex
+}
+
+func validateRedirectTo(redirectTo string) error {
+	to, err := url.Parse(redirectTo)
+	if err != nil {
+		return login.ErrInvalidRedirectTo
+	}
+	if to.IsAbs() {
+		return login.ErrAbsoluteRedirectTo
+	}
+	if setting.AppSubUrl != "" && !strings.HasPrefix(to.Path, "/"+setting.AppSubUrl) {
+		return login.ErrInvalidRedirectTo
+	}
+	return nil
 }
 
 func (hs *HTTPServer) LoginView(c *models.ReqContext) {
@@ -64,6 +79,12 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 		}
 
 		if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
+			if err := validateRedirectTo(redirectTo); err != nil {
+				viewData.Settings["loginError"] = err.Error()
+				c.HTML(200, ViewIndex, viewData)
+				c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
+				return
+			}
 			c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
 			c.Redirect(redirectTo)
 			return
@@ -147,7 +168,11 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 	}
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		result["redirectUrl"] = redirectTo
+		if err := validateRedirectTo(redirectTo); err == nil {
+			result["redirectUrl"] = redirectTo
+		} else {
+			log.Info("Ignored invalid redirect_to cookie value: %v", redirectTo)
+		}
 		c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
 	}
 

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -81,7 +81,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 		if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 			if err := validateRedirectTo(redirectTo); err != nil {
 				viewData.Settings["loginError"] = err.Error()
-				c.HTML(200, ViewIndex, viewData)
+				c.HTML(200, getViewIndex(), viewData)
 				c.SetCookie("redirect_to", "", -1, setting.AppSubUrl+"/")
 				return
 			}
@@ -94,7 +94,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 		return
 	}
 
-	c.HTML(200, ViewIndex, viewData)
+	c.HTML(200, getViewIndex(), viewData)
 }
 
 func (hs *HTTPServer) loginAuthProxyUser(c *models.ReqContext) {

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/setting"
@@ -51,6 +54,22 @@ func getBody(resp *httptest.ResponseRecorder) (string, error) {
 		return "", err
 	}
 	return string(responseData), nil
+}
+
+type FakeLogger struct {
+	log.Logger
+}
+
+func (stub *FakeLogger) Info(testMessage string, ctx ...interface{}) {
+}
+
+type redirectCase struct {
+	desc      string
+	url       string
+	status    int
+	err       error
+	appURL    string
+	appSubURL string
 }
 
 func TestLoginErrorCookieApiEndpoint(t *testing.T) {
@@ -102,6 +121,197 @@ func TestLoginErrorCookieApiEndpoint(t *testing.T) {
 	responseString, err := getBody(sc.resp)
 	assert.Nil(t, err)
 	assert.True(t, strings.Contains(responseString, oauthError.Error()))
+}
+
+func TestLoginViewRedirect(t *testing.T) {
+	mockSetIndexViewData()
+	defer resetSetIndexViewData()
+
+	mockViewIndex()
+	defer resetViewIndex()
+	sc := setupScenarioContext("/login")
+	hs := &HTTPServer{
+		Cfg:     setting.NewCfg(),
+		License: models.OSSLicensingService{},
+	}
+
+	sc.defaultHandler = Wrap(func(w http.ResponseWriter, c *models.ReqContext) {
+		c.IsSignedIn = true
+		c.SignedInUser = &models.SignedInUser{
+			UserId: 10,
+		}
+		hs.LoginView(c)
+	})
+
+	setting.OAuthService = &setting.OAuther{}
+	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
+
+	redirectCases := []redirectCase{
+		{
+			desc:   "grafana relative url without subpath",
+			url:    "/profile",
+			appURL: "http://localhost:3000",
+			status: 302,
+		},
+		{
+			desc:      "grafana relative url with subpath",
+			url:       "/grafana/profile",
+			appURL:    "http://localhost:3000",
+			appSubURL: "grafana",
+			status:    302,
+		},
+		{
+			desc:      "relative url with missing subpath",
+			url:       "/profile",
+			appURL:    "http://localhost:3000",
+			appSubURL: "grafana",
+			status:    200,
+			err:       login.ErrInvalidRedirectTo,
+		},
+		{
+			desc:   "grafana absolute url",
+			url:    "http://localhost:3000/profile",
+			appURL: "http://localhost:3000",
+			status: 200,
+			err:    login.ErrAbsoluteRedirectTo,
+		},
+		{
+			desc:   "non grafana absolute url",
+			url:    "http://example.com",
+			appURL: "http://localhost:3000",
+			status: 200,
+			err:    login.ErrAbsoluteRedirectTo,
+		},
+		{
+			desc:   "invalid url",
+			url:    ":foo",
+			appURL: "http://localhost:3000",
+			status: 200,
+			err:    login.ErrInvalidRedirectTo,
+		},
+	}
+
+	for _, c := range redirectCases {
+		setting.AppUrl = c.appURL
+		setting.AppSubUrl = c.appSubURL
+		t.Run(c.desc, func(t *testing.T) {
+			cookie := http.Cookie{
+				Name:     "redirect_to",
+				MaxAge:   60,
+				Value:    c.url,
+				HttpOnly: true,
+				Path:     setting.AppSubUrl + "/",
+				Secure:   hs.Cfg.CookieSecure,
+				SameSite: hs.Cfg.CookieSameSite,
+			}
+			sc.m.Get(sc.url, sc.defaultHandler)
+			sc.fakeReqNoAssertionsWithCookie("GET", sc.url, cookie).exec()
+			assert.Equal(t, c.status, sc.resp.Code)
+			if c.status == 302 {
+				location, ok := sc.resp.Header()["Location"]
+				assert.True(t, ok)
+				assert.Equal(t, location[0], c.url)
+			}
+
+			responseString, err := getBody(sc.resp)
+			assert.Nil(t, err)
+			if c.err != nil {
+				assert.True(t, strings.Contains(responseString, c.err.Error()))
+			}
+		})
+	}
+}
+
+func TestLoginPostRedirect(t *testing.T) {
+	mockSetIndexViewData()
+	defer resetSetIndexViewData()
+
+	mockViewIndex()
+	defer resetViewIndex()
+	sc := setupScenarioContext("/login")
+	hs := &HTTPServer{
+		log:              &FakeLogger{},
+		Cfg:              setting.NewCfg(),
+		License:          models.OSSLicensingService{},
+		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+	}
+
+	sc.defaultHandler = Wrap(func(w http.ResponseWriter, c *models.ReqContext) Response {
+		cmd := dtos.LoginCommand{
+			User:     "admin",
+			Password: "admin",
+		}
+		return hs.LoginPost(c, cmd)
+	})
+
+	bus.AddHandler("grafana-auth", func(query *models.LoginUserQuery) error {
+		query.User = &models.User{
+			Id:    42,
+			Email: "",
+		}
+		return nil
+	})
+
+	redirectCases := []redirectCase{
+		{
+			desc:   "grafana relative url without subpath",
+			url:    "/profile",
+			appURL: "https://localhost:3000",
+		},
+		{
+			desc:      "grafana relative url with subpath",
+			url:       "/grafana/profile",
+			appURL:    "https://localhost:3000",
+			appSubURL: "grafana",
+		},
+		{
+			desc:      "relative url with missing subpath",
+			url:       "/profile",
+			appURL:    "https://localhost:3000",
+			appSubURL: "grafana",
+			err:       login.ErrInvalidRedirectTo,
+		},
+		{
+			desc:   "grafana absolute url",
+			url:    "http://localhost:3000/profile",
+			appURL: "http://localhost:3000",
+			err:    login.ErrAbsoluteRedirectTo,
+		},
+		{
+			desc:   "non grafana absolute url",
+			url:    "http://example.com",
+			appURL: "https://localhost:3000",
+			err:    login.ErrAbsoluteRedirectTo,
+		},
+	}
+
+	for _, c := range redirectCases {
+		setting.AppUrl = c.appURL
+		setting.AppSubUrl = c.appSubURL
+		t.Run(c.desc, func(t *testing.T) {
+			cookie := http.Cookie{
+				Name:     "redirect_to",
+				MaxAge:   60,
+				Value:    c.url,
+				HttpOnly: true,
+				Path:     setting.AppSubUrl + "/",
+				Secure:   hs.Cfg.CookieSecure,
+				SameSite: hs.Cfg.CookieSameSite,
+			}
+			sc.m.Post(sc.url, sc.defaultHandler)
+			sc.fakeReqNoAssertionsWithCookie("POST", sc.url, cookie).exec()
+			assert.Equal(t, sc.resp.Code, 200)
+
+			respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
+			assert.Nil(t, err)
+			redirectURL := respJSON.Get("redirectUrl").MustString()
+			if c.err != nil {
+				assert.Equal(t, "", redirectURL)
+			} else {
+				assert.Equal(t, c.url, redirectURL)
+			}
+		})
+	}
 }
 
 func TestLoginOAuthRedirect(t *testing.T) {

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -119,7 +119,7 @@ func TestLoginErrorCookieApiEndpoint(t *testing.T) {
 	assert.Equal(t, sc.resp.Code, 200)
 
 	responseString, err := getBody(sc.resp)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(responseString, oauthError.Error()))
 }
 
@@ -214,7 +214,7 @@ func TestLoginViewRedirect(t *testing.T) {
 			}
 
 			responseString, err := getBody(sc.resp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			if c.err != nil {
 				assert.True(t, strings.Contains(responseString, c.err.Error()))
 			}
@@ -303,7 +303,7 @@ func TestLoginPostRedirect(t *testing.T) {
 			assert.Equal(t, sc.resp.Code, 200)
 
 			respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			redirectURL := respJSON.Get("redirectUrl").MustString()
 			if c.err != nil {
 				assert.Equal(t, "", redirectURL)

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -18,6 +18,8 @@ var (
 	ErrTooManyLoginAttempts  = errors.New("Too many consecutive incorrect login attempts for user. Login for user temporarily blocked")
 	ErrPasswordEmpty         = errors.New("No password provided")
 	ErrUserDisabled          = errors.New("User is disabled")
+	ErrAbsoluteRedirectTo    = errors.New("Absolute urls are not allowed for redirect_to cookie value")
+	ErrInvalidRedirectTo     = errors.New("Invalid redirect_to cookie value")
 )
 
 var loginLogger = log.New("login")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This fix adds validation for the `redirect_to` cookie value and ignores invalid ones.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20641

**Special notes for your reviewer**:
Contrary to the indication in the issue description (proposing to check that the value starts with the Grafana app url), this fix allows only relative paths starting with Grafana app sub url (if that exists). The reason is that only the relative path is [set](https://github.com/grafana/grafana/blob/master/pkg/middleware/auth.go#L50) to the cookie. However, maybe there is a use case, that I'm not aware of, which requires an absolute url in the `redirect_to`.