### PR TITLE
Templating: Fixes digest issues in Template Variable Editor

### DIFF
--- a/public/app/core/utils/promiseToDigest.test.ts
+++ b/public/app/core/utils/promiseToDigest.test.ts
@@ -1,0 +1,27 @@
+import { IScope } from 'angular';
+import { promiseToDigest } from './promiseToDigest';
+
+describe('promiseToDigest', () => {
+  describe('when called with a promise that resolves', () => {
+    it('then evalAsync should be called on $scope', async () => {
+      const $scope: IScope = ({ $evalAsync: jest.fn() } as any) as IScope;
+
+      await promiseToDigest($scope)(Promise.resolve(123));
+
+      expect($scope.$evalAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when called with a promise that rejects', () => {
+    it('then evalAsync should be called on $scope', async () => {
+      const $scope: IScope = ({ $evalAsync: jest.fn() } as any) as IScope;
+
+      try {
+        await promiseToDigest($scope)(Promise.reject(123));
+      } catch (error) {
+        expect(error).toEqual(123);
+        expect($scope.$evalAsync).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+});

--- a/public/app/core/utils/promiseToDigest.ts
+++ b/public/app/core/utils/promiseToDigest.ts
@@ -1,0 +1,3 @@
+import { IScope } from 'angular';
+
+export const promiseToDigest = ($scope: IScope) => (promise: Promise<any>) => promise.finally($scope.$evalAsync);

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -6,6 +6,7 @@ import DatasourceSrv from '../plugins/datasource_srv';
 import { VariableSrv } from './all';
 import { TemplateSrv } from './template_srv';
 import { AppEvents } from '@grafana/data';
+import { promiseToDigest } from '../../core/utils/promiseToDigest';
 
 export class VariableEditorCtrl {
   /** @ngInject */
@@ -122,12 +123,13 @@ export class VariableEditorCtrl {
       $scope.infoText = '';
       if ($scope.current.type === 'adhoc' && $scope.current.datasource !== null) {
         $scope.infoText = 'Adhoc filters are applied automatically to all queries that target this datasource';
-        datasourceSrv.get($scope.current.datasource).then(ds => {
-          if (!ds.getTagKeys) {
-            $scope.infoText = 'This datasource does not support adhoc filters yet.';
-            $scope.$evalAsync();
-          }
-        });
+        promiseToDigest($scope)(
+          datasourceSrv.get($scope.current.datasource).then(ds => {
+            if (!ds.getTagKeys) {
+              $scope.infoText = 'This datasource does not support adhoc filters yet.';
+            }
+          })
+        );
       }
     };
 
@@ -155,10 +157,11 @@ export class VariableEditorCtrl {
       $scope.currentIsNew = false;
       $scope.mode = 'edit';
       $scope.validate();
-      datasourceSrv.get($scope.current.datasource).then(ds => {
-        $scope.currentDatasource = ds;
-        $scope.$evalAsync();
-      });
+      promiseToDigest($scope)(
+        datasourceSrv.get($scope.current.datasource).then(ds => {
+          $scope.currentDatasource = ds;
+        })
+      );
     };
 
     $scope.duplicate = (variable: { getSaveModel: () => void; name: string }) => {
@@ -170,12 +173,13 @@ export class VariableEditorCtrl {
 
     $scope.update = () => {
       if ($scope.isValid()) {
-        $scope.runQuery().then(() => {
-          $scope.reset();
-          $scope.mode = 'list';
-          templateSrv.updateIndex();
-          $scope.$evalAsync();
-        });
+        promiseToDigest($scope)(
+          $scope.runQuery().then(() => {
+            $scope.reset();
+            $scope.mode = 'list';
+            templateSrv.updateIndex();
+          })
+        );
       }
     };
 
@@ -221,11 +225,12 @@ export class VariableEditorCtrl {
     };
 
     $scope.datasourceChanged = async () => {
-      datasourceSrv.get($scope.current.datasource).then(ds => {
-        $scope.current.query = '';
-        $scope.currentDatasource = ds;
-        $scope.$evalAsync();
-      });
+      promiseToDigest($scope)(
+        datasourceSrv.get($scope.current.datasource).then(ds => {
+          $scope.current.query = '';
+          $scope.currentDatasource = ds;
+        })
+      );
     };
   }
 }

--- a/public/app/features/templating/editor_ctrl.ts
+++ b/public/app/features/templating/editor_ctrl.ts
@@ -125,6 +125,7 @@ export class VariableEditorCtrl {
         datasourceSrv.get($scope.current.datasource).then(ds => {
           if (!ds.getTagKeys) {
             $scope.infoText = 'This datasource does not support adhoc filters yet.';
+            $scope.$evalAsync();
           }
         });
       }
@@ -156,6 +157,7 @@ export class VariableEditorCtrl {
       $scope.validate();
       datasourceSrv.get($scope.current.datasource).then(ds => {
         $scope.currentDatasource = ds;
+        $scope.$evalAsync();
       });
     };
 
@@ -172,6 +174,7 @@ export class VariableEditorCtrl {
           $scope.reset();
           $scope.mode = 'list';
           templateSrv.updateIndex();
+          $scope.$evalAsync();
         });
       }
     };
@@ -221,6 +224,7 @@ export class VariableEditorCtrl {
       datasourceSrv.get($scope.current.datasource).then(ds => {
         $scope.current.query = '';
         $scope.currentDatasource = ds;
+        $scope.$evalAsync();
       });
     };
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
When we removed `$q` in `datasourceSrv` the Template Variable Editor got a couple of `digest` issues because we change scope properties within promises. This PR will remedy this and introduce a small utility function that can be used in other situations where this problem will occur. There is probably a better way to solve this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

