### PR TITLE
FontSize: Change body font size to 14px

### DIFF
--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -19,7 +19,6 @@ export interface GrafanaThemeCommons {
       monospace: string;
     };
     size: {
-      root: string;
       base: string;
       xs: string;
       sm: string;

--- a/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.scss.tmpl.ts
@@ -99,7 +99,6 @@ $height-lg: ${theme.height.lg};
 $font-family-sans-serif: ${theme.typography.fontFamily.sansSerif};
 $font-family-monospace: ${theme.typography.fontFamily.monospace};
 
-$font-size-root: ${theme.typography.size.root} !default;
 $font-size-base: ${theme.typography.size.base} !default;
 
 $font-size-lg: ${theme.typography.size.lg} !default;

--- a/packages/grafana-ui/src/themes/default.ts
+++ b/packages/grafana-ui/src/themes/default.ts
@@ -31,8 +31,7 @@ const theme: GrafanaThemeCommons = {
       monospace: "Menlo, Monaco, Consolas, 'Courier New', monospace",
     },
     size: {
-      root: '14px',
-      base: '13px',
+      base: '14px',
       xs: '10px',
       sm: '12px',
       md: '14px',

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -102,8 +102,7 @@ $height-lg: 48px;
 $font-family-sans-serif: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
 $font-family-monospace: Menlo, Monaco, Consolas, 'Courier New', monospace;
 
-$font-size-root: 14px !default;
-$font-size-base: 13px !default;
+$font-size-base: 14px !default;
 
 $font-size-lg: 18px !default;
 $font-size-md: 14px !default;

--- a/public/sass/base/_reboot.scss
+++ b/public/sass/base/_reboot.scss
@@ -55,7 +55,7 @@ html {
 
 html {
   // Sets a specific default `font-size` for user with `rem` type scales.
-  font-size: $font-size-root;
+  font-size: $font-size-base;
   // As a side-effect of setting the @viewport above,
   // IE11 & Edge make the scrollbar overlap the content and automatically hide itself when not in use.
   // Unfortunately, the auto-showing of the scrollbar is sometimes too sensitive,
@@ -69,7 +69,6 @@ html {
 }
 
 body {
-  // Make the `body` use the `font-size-root`
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   line-height: $line-height-base;

--- a/public/sass/components/_modals.scss
+++ b/public/sass/components/_modals.scss
@@ -110,7 +110,7 @@
   }
 
   .confirm-modal-text2 {
-    font-size: $font-size-root;
+    font-size: $font-size-base;
     padding-top: $spacer;
   }
 

--- a/public/sass/components/_slate_editor.scss
+++ b/public/sass/components/_slate_editor.scss
@@ -1,5 +1,5 @@
 .slate-query-field {
-  font-size: $font-size-root;
+  font-size: $font-size-base;
   font-family: $font-family-monospace;
   height: auto;
   word-break: break-word;


### PR DESCRIPTION
Change body font size from 13px to 14px. 

Fixes some big issues with the fontsizes where small was 12px, and medium was 14px (for form labels and buttons for example) but default page text was 13px creating this strange small difference.

A lot had manually set font size to 14px. The biggest impact this has is

* Slight increase in Panel Title font size from 13px to 14px
* Slight increase in Graph legend font size from 13px to 14px
* Slight increase in Table text (Users & team lists etc) from 13px to 14px. 

Can't see that much else being impacted 