### PR TITLE
Prometheus: Display HELP and TYPE of metrics if available

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -9,6 +9,8 @@ export interface CascaderOption {
 
   children?: CascaderOption[];
   disabled?: boolean;
+  // Undocumented tooltip API
+  title?: string;
 }
 
 export interface CascaderProps {

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -18,6 +18,20 @@ describe('groupMetricsByPrefix()', () => {
     ]);
   });
 
+  it('returns options grouped by prefix with metadata', () => {
+    expect(groupMetricsByPrefix(['foo_metric'], { foo_metric: [{ type: 'TYPE', help: 'my help' }] })).toMatchObject([
+      {
+        value: 'foo',
+        children: [
+          {
+            value: 'foo_metric',
+            title: 'foo_metric\nTYPE\nmy help',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('returns options without prefix as toplevel option', () => {
     expect(groupMetricsByPrefix(['metric'])).toMatchObject([
       {

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -45,7 +45,7 @@ function addMetricsMetadata(metric: string, metadata?: PromMetricsMetadata): Cas
   return option;
 }
 
-export function groupMetricsByPrefix(metrics: string[], metadata: PromMetricsMetadata): CascaderOption[] {
+export function groupMetricsByPrefix(metrics: string[], metadata?: PromMetricsMetadata): CascaderOption[] {
   // Filter out recording rules and insert as first option
   const ruleRegex = /:\w+:/;
   const ruleNames = metrics.filter(metric => ruleRegex.test(metric));

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -15,7 +15,7 @@ import {
 import Prism from 'prismjs';
 
 // dom also includes Element polyfills
-import { PromQuery, PromContext, PromOptions } from '../types';
+import { PromQuery, PromContext, PromOptions, PromMetricsMetadata } from '../types';
 import { CancelablePromise, makePromiseCancelable } from 'app/core/utils/CancelablePromise';
 import { ExploreQueryFieldProps, QueryHint, isDataFrame, toLegacyResponseData, HistoryItem } from '@grafana/data';
 import { DOMUtil, SuggestionsState } from '@grafana/ui';
@@ -36,7 +36,16 @@ function getChooserText(hasSyntax: boolean, metrics: string[]) {
   return 'Metrics';
 }
 
-export function groupMetricsByPrefix(metrics: string[], delimiter = '_'): CascaderOption[] {
+function addMetricsMetadata(metric: string, metadata?: PromMetricsMetadata): CascaderOption {
+  const option: CascaderOption = { label: metric, value: metric };
+  if (metadata && metadata[metric]) {
+    const { type = '', help } = metadata[metric][0];
+    option.title = [metric, type.toUpperCase(), help].join('\n');
+  }
+  return option;
+}
+
+export function groupMetricsByPrefix(metrics: string[], metadata: PromMetricsMetadata): CascaderOption[] {
   // Filter out recording rules and insert as first option
   const ruleRegex = /:\w+:/;
   const ruleNames = metrics.filter(metric => ruleRegex.test(metric));
@@ -51,13 +60,14 @@ export function groupMetricsByPrefix(metrics: string[], delimiter = '_'): Cascad
 
   const options = ruleNames.length > 0 ? [rulesOption] : [];
 
+  const delimiter = '_';
   const metricsOptions = _.chain(metrics)
     .filter((metric: string) => !ruleRegex.test(metric))
     .groupBy((metric: string) => metric.split(delimiter)[0])
     .map(
       (metricsForPrefix: string[], prefix: string): CascaderOption => {
         const prefixIsMetric = metricsForPrefix.length === 1 && metricsForPrefix[0] === prefix;
-        const children = prefixIsMetric ? [] : metricsForPrefix.sort().map(m => ({ label: m, value: m }));
+        const children = prefixIsMetric ? [] : metricsForPrefix.sort().map(m => addMetricsMetadata(m, metadata));
         return {
           children,
           label: prefix,
@@ -228,13 +238,19 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   };
 
   onUpdateLanguage = () => {
-    const { histogramMetrics, metrics, lookupsDisabled, lookupMetricsThreshold } = this.languageProvider;
+    const {
+      histogramMetrics,
+      metrics,
+      metricsMetadata,
+      lookupsDisabled,
+      lookupMetricsThreshold,
+    } = this.languageProvider;
     if (!metrics) {
       return;
     }
 
     // Build metrics tree
-    const metricsByPrefix = groupMetricsByPrefix(metrics);
+    const metricsByPrefix = groupMetricsByPrefix(metrics, metricsMetadata);
     const histogramOptions = histogramMetrics.map((hm: any) => ({ label: hm, value: hm }));
     const metricsOptions =
       histogramMetrics.length > 0

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -526,9 +526,11 @@ describe('Language completion provider', () => {
       expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
       await instance.start();
       expect(instance.lookupsDisabled).toBeTruthy();
-      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(1);
+      // Capture request count to metadata
+      const callCount = (datasource.metadataRequest as Mock).mock.calls.length;
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBeGreaterThan(0);
       await instance.provideCompletionItems(args);
-      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(1);
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(callCount);
     });
   });
 });

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -35,3 +35,13 @@ export interface PromQueryRequest extends PromQuery {
   end: number;
   headers?: any;
 }
+
+export interface PromMetricsMetadataItem {
+  type: string;
+  help: string;
+  unit: string;
+}
+
+export interface PromMetricsMetadata {
+  [metric: string]: PromMetricsMetadataItem[];
+}

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -39,7 +39,7 @@ export interface PromQueryRequest extends PromQuery {
 export interface PromMetricsMetadataItem {
   type: string;
   help: string;
-  unit: string;
+  unit?: string;
 }
 
 export interface PromMetricsMetadata {


### PR DESCRIPTION
- Prometheus recently added a metadata API around HELP and TYPE of
metrics, see https://github.com/prometheus/prometheus/pull/6442
- request metadata when datasource instance is created
- use metadata to show help and type in typeahead suggestions and in
metrics selector as tooltip

![Screenshot 2019-12-16 at 17 45 53](https://user-images.githubusercontent.com/859729/70926015-9cd3d680-202c-11ea-9e6c-da44f5fc13ae.png)

