### PR TITLE
DataLinks: Sanitize data/panel link URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "7.6.0",
+    "@braintree/sanitize-url": "4.0.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@torkelo/react-select": "2.4.1",
     "@types/react-loadable": "5.5.2",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
   },
   "dependencies": {
     "@babel/polyfill": "7.6.0",
-    "@braintree/sanitize-url": "4.0.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@torkelo/react-select": "2.4.1",
     "@types/react-loadable": "5.5.2",

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -11,7 +11,7 @@ export const getConfig = () => {
 };
 
 export const mockConfig = (mock: Partial<GrafanaBootConfig>) => {
-  configMock = mock as GrafanaBootConfig;
+  configMock = mock;
   return () => {
     configMock = null;
   };

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -2,17 +2,17 @@ import { config, GrafanaBootConfig } from '@grafana/runtime';
 // Legacy binding paths
 export { config, GrafanaBootConfig as Settings };
 
-let configMock: Partial<GrafanaBootConfig> | null = null;
+let grafanaConfig: GrafanaBootConfig = config;
 
-export default config;
+export default grafanaConfig;
 
 export const getConfig = () => {
-  return configMock || config;
+  return grafanaConfig;
 };
 
-export const mockConfig = (mock: Partial<GrafanaBootConfig>) => {
-  configMock = mock;
-  return () => {
-    configMock = null;
+export const updateConfig = (update: Partial<GrafanaBootConfig>) => {
+  grafanaConfig = {
+    ...grafanaConfig,
+    ...update,
   };
 };

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -1,5 +1,18 @@
 import { config, GrafanaBootConfig } from '@grafana/runtime';
-
 // Legacy binding paths
 export { config, GrafanaBootConfig as Settings };
+
+let configMock: Partial<GrafanaBootConfig> | null = null;
+
 export default config;
+
+export const getConfig = () => {
+  return configMock || config;
+};
+
+export const mockConfig = (mock: Partial<GrafanaBootConfig>) => {
+  configMock = mock as GrafanaBootConfig;
+  return () => {
+    configMock = null;
+  };
+};

--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -1,4 +1,5 @@
-import xss, { safeAttrValue } from 'xss';
+import xss from 'xss';
+import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 
 const XSSWL = Object.keys(xss.whiteList).reduce((acc, element) => {
   // @ts-ignore
@@ -27,12 +28,7 @@ export function sanitize(unsanitizedString: string): string {
 }
 
 export function sanitizeUrl(url: string): string {
-  try {
-    return safeAttrValue('a', 'href', url, sanitizeXSS);
-  } catch (error) {
-    console.log('Url could not be sanitized', url);
-    return url;
-  }
+  return braintreeSanitizeUrl(url);
 }
 
 export function hasAnsiCodes(input: string): boolean {

--- a/public/app/core/utils/text.ts
+++ b/public/app/core/utils/text.ts
@@ -1,4 +1,4 @@
-import xss from 'xss';
+import xss, { safeAttrValue } from 'xss';
 
 const XSSWL = Object.keys(xss.whiteList).reduce((acc, element) => {
   // @ts-ignore
@@ -23,6 +23,15 @@ export function sanitize(unsanitizedString: string): string {
   } catch (error) {
     console.log('String could not be sanitized', unsanitizedString);
     return unsanitizedString;
+  }
+}
+
+export function sanitizeUrl(url: string): string {
+  try {
+    return safeAttrValue('a', 'href', url, sanitizeXSS);
+  } catch (error) {
+    console.log('Url could not be sanitized', url);
+    return url;
   }
 }
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -276,7 +276,7 @@ export class PanelCtrl {
     let html = '<div class="markdown-html panel-info-content">';
 
     const md = renderMarkdown(interpolatedMarkdown);
-    html += config.disableSanitizeHtml ? md : sanitize(md);
+    html += md;
 
     if (panel.links && panel.links.length > 0) {
       const interpolatedLinks = getPanelLinksSupplier(panel).getLinks();
@@ -297,7 +297,7 @@ export class PanelCtrl {
 
     html += '</div>';
 
-    return html;
+    return config.disableSanitizeHtml ? html : sanitize(html);
   }
 
   // overriden from react

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -280,7 +280,6 @@ export class PanelCtrl {
 
     if (panel.links && panel.links.length > 0) {
       const interpolatedLinks = getPanelLinksSupplier(panel).getLinks();
-
       html += '<ul class="panel-info-corner-links">';
       for (const link of interpolatedLinks) {
         html +=

--- a/public/app/features/panel/panellinks/linkSuppliers.test.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.test.ts
@@ -32,11 +32,11 @@ describe('getLinksFromLogsField', () => {
         links: [
           {
             title: 'title1',
-            url: 'domain.com/${__value.raw}',
+            url: 'http://domain.com/${__value.raw}',
           },
           {
             title: 'title2',
-            url: 'anotherdomain.sk/${__value.raw}',
+            url: 'http://anotherdomain.sk/${__value.raw}',
           },
         ],
       },
@@ -44,8 +44,8 @@ describe('getLinksFromLogsField', () => {
     };
     const links = getLinksFromLogsField(field, 2);
     expect(links.length).toBe(2);
-    expect(links[0].href).toBe('domain.com/3');
-    expect(links[1].href).toBe('anotherdomain.sk/3');
+    expect(links[0].href).toBe('http://domain.com/3');
+    expect(links[1].href).toBe('http://anotherdomain.sk/3');
   });
 
   it('handles zero links', () => {

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { sanitizeUrl } from '@braintree/sanitize-url';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import templateSrv, { TemplateSrv } from 'app/features/templating/template_srv';
 import coreModule from 'app/core/core_module';
 import { appendQueryToUrl, toUrlParams } from 'app/core/utils/url';
+import { sanitizeUrl } from 'app/core/utils/text';
 import { getConfig } from 'app/core/config';
 import { VariableSuggestion, VariableOrigin, DataLinkBuiltInVars } from '@grafana/ui';
 import { DataLink, KeyValue, deprecationWarning, LinkModel, DataFrame, ScopedVars } from '@grafana/data';

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -1,8 +1,10 @@
 import _ from 'lodash';
+import { sanitizeUrl } from '@braintree/sanitize-url';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import templateSrv, { TemplateSrv } from 'app/features/templating/template_srv';
 import coreModule from 'app/core/core_module';
 import { appendQueryToUrl, toUrlParams } from 'app/core/utils/url';
+import { getConfig } from 'app/core/config';
 import { VariableSuggestion, VariableOrigin, DataLinkBuiltInVars } from '@grafana/ui';
 import { DataLink, KeyValue, deprecationWarning, LinkModel, DataFrame, ScopedVars } from '@grafana/data';
 
@@ -210,6 +212,7 @@ export class LinkSrv implements LinkService {
       },
     });
 
+    info.href = getConfig().disableSanitizeHtml ? info.href : sanitizeUrl(info.href);
     return info;
   };
 

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -211,7 +211,6 @@ export class LinkSrv implements LinkService {
         value: variablesQuery,
       },
     });
-
     info.href = getConfig().disableSanitizeHtml ? info.href : sanitizeUrl(info.href);
     return info;
   };

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -140,6 +140,12 @@ describe('linkSrv', () => {
   });
 
   describe('sanitization', () => {
+    let restoreConfig: () => void;
+
+    afterEach(() => {
+      restoreConfig();
+    });
+
     const url = "javascript:alert('broken!);";
     it.each`
       disableSanitizeHtml | expected
@@ -148,7 +154,7 @@ describe('linkSrv', () => {
     `(
       "when disable disableSanitizeHtml set to '$disableSanitizeHtml' then result should be '$expected'",
       ({ disableSanitizeHtml, expected }) => {
-        const restoreConfig = mockConfig({
+        restoreConfig = mockConfig({
           disableSanitizeHtml,
         });
 
@@ -166,9 +172,7 @@ describe('linkSrv', () => {
           {}
         ).href;
 
-        // console.log(link);
         expect(link).toBe(expected);
-        restoreConfig();
       }
     );
   });

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -144,7 +144,7 @@ describe('linkSrv', () => {
     it.each`
       disableSanitizeHtml | expected
       ${true}             | ${url}
-      ${false}            | ${''}
+      ${false}            | ${'about:blank'}
     `(
       "when disable disableSanitizeHtml set to '$disableSanitizeHtml' then result should be '$expected'",
       ({ disableSanitizeHtml, expected }) => {

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { advanceTo } from 'jest-date-mock';
-import { mockConfig } from '../../../../core/config';
+import { updateConfig } from '../../../../core/config';
 
 jest.mock('angular', () => {
   const AngularJSMock = require('test/mocks/angular');
@@ -140,21 +140,15 @@ describe('linkSrv', () => {
   });
 
   describe('sanitization', () => {
-    let restoreConfig: () => void;
-
-    afterEach(() => {
-      restoreConfig();
-    });
-
     const url = "javascript:alert('broken!);";
     it.each`
       disableSanitizeHtml | expected
       ${true}             | ${url}
-      ${false}            | ${'about:blank'}
+      ${false}            | ${''}
     `(
       "when disable disableSanitizeHtml set to '$disableSanitizeHtml' then result should be '$expected'",
       ({ disableSanitizeHtml, expected }) => {
-        restoreConfig = mockConfig({
+        updateConfig({
           disableSanitizeHtml,
         });
 

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { advanceTo } from 'jest-date-mock';
+import { mockConfig } from '../../../../core/config';
 
 jest.mock('angular', () => {
   const AngularJSMock = require('test/mocks/angular');
@@ -136,5 +137,39 @@ describe('linkSrv', () => {
         ).href
       ).toEqual('/d/1?time=1000000001');
     });
+  });
+
+  describe('sanitization', () => {
+    const url = "javascript:alert('broken!);";
+    it.each`
+      disableSanitizeHtml | expected
+      ${true}             | ${url}
+      ${false}            | ${'about:blank'}
+    `(
+      "when disable disableSanitizeHtml set to '$disableSanitizeHtml' then result should be '$expected'",
+      ({ disableSanitizeHtml, expected }) => {
+        const restoreConfig = mockConfig({
+          disableSanitizeHtml,
+        });
+
+        const link = linkSrv.getDataLinkUIModel(
+          {
+            title: 'Any title',
+            url,
+          },
+          {
+            __value: {
+              value: { time: dataPointMock.datapoint[0] },
+              text: 'Value',
+            },
+          },
+          {}
+        ).href;
+
+        // console.log(link);
+        expect(link).toBe(expected);
+        restoreConfig();
+      }
+    );
   });
 });

--- a/public/app/plugins/datasource/loki/configuration/DebugSections.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DebugSections.test.tsx
@@ -46,7 +46,7 @@ describe('DebugSection', () => {
       {
         matcherRegex: 'traceId=(\\w+)',
         name: 'traceIdLink',
-        url: 'localhost/trace/${__value.raw}',
+        url: 'http://localhost/trace/${__value.raw}',
       },
       {
         matcherRegex: 'traceId=(\\w+)',
@@ -70,7 +70,7 @@ describe('DebugSection', () => {
       wrapper
         .find('tr')
         .at(1)
-        .contains('localhost/trace/1234')
+        .contains('http://localhost/trace/1234')
     ).toBeTruthy();
   });
 });

--- a/public/app/types/sanitize-url.d.ts
+++ b/public/app/types/sanitize-url.d.ts
@@ -1,3 +1,0 @@
-declare module '@braintree/sanitize-url' {
-  function sanitizeUrl(url: string): string;
-}

--- a/public/app/types/sanitize-url.d.ts
+++ b/public/app/types/sanitize-url.d.ts
@@ -1,0 +1,3 @@
+declare module '@braintree/sanitize-url' {
+  function sanitizeUrl(url: string): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,11 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
+"@braintree/sanitize-url@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-4.0.0.tgz#2cda79ffd67b6ea919a63b5e1a883b92d636e844"
+  integrity sha512-bOoFoTxuEUuri/v1q0OXN0HIrZ2EiZlRSKdveU8vS5xf2+g0TmpXhmxkTc1s+XWR5xZNoVU4uvf/Mher98tfLw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,11 +1658,6 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@braintree/sanitize-url@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-4.0.0.tgz#2cda79ffd67b6ea919a63b5e1a883b92d636e844"
-  integrity sha512-bOoFoTxuEUuri/v1q0OXN0HIrZ2EiZlRSKdveU8vS5xf2+g0TmpXhmxkTc1s+XWR5xZNoVU4uvf/Mher98tfLw==
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,11 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
+"@braintree/sanitize-url@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-4.0.0.tgz#2cda79ffd67b6ea919a63b5e1a883b92d636e844"
+  integrity sha512-bOoFoTxuEUuri/v1q0OXN0HIrZ2EiZlRSKdveU8vS5xf2+g0TmpXhmxkTc1s+XWR5xZNoVU4uvf/Mher98tfLw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -8556,7 +8561,7 @@ debug@^0.7.2:
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
   integrity sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -11828,7 +11833,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -13824,11 +13829,6 @@ lodash-es@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -13837,29 +13837,12 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -13962,11 +13945,6 @@ lodash.padend@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
   integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -15438,7 +15416,6 @@ npm@6.13.4:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -15453,7 +15430,6 @@ npm@6.13.4:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -15472,14 +15448,8 @@ npm@6.13.4:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
Fixes #20974

Changes introduced:
1. Both panel and data link urls are now sanitized using [@braintree/sanitize-url](https://github.com/braintree/sanitize-url). ~~Unfortunately the xss package we use can't do it on a string that is not a html~~. xss package that we use exposes `safeAttrValue` which could be used, but it also performs html escaping, which we want to delegate to components that actually render the html.
2. Added `sanitize-url.d.ts` file for the package type safety
3. Introduced possibility to mock app config in the tests

