### PR TITLE
Alerting: Fix custom_details to be a JSON object instead of a string in PagerDuty notifier

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	"fmt"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -80,9 +78,9 @@ func (pn *PagerdutyNotifier) Notify(evalContext *alerting.EvalContext) error {
 	if evalContext.Rule.State == models.AlertStateOK {
 		eventType = "resolve"
 	}
-	customData := triggMetrString
+	customData := simplejson.New()
 	for _, evt := range evalContext.EvalMatches {
-		customData = customData + fmt.Sprintf("%s: %v\n", evt.Metric, evt.Value)
+		customData.Set(evt.Metric, evt.Value)
 	}
 
 	pn.log.Info("Notifying Pagerduty", "event_type", eventType)


### PR DESCRIPTION

**What this PR does / why we need it**:

Enables the PagerDuty notification channel to include custom details that can be used in PagerDuty for further filtering and processing.

For PagerDuty API documentation see: https://v2.developer.pagerduty.com/v2/docs/send-an-event-events-api-v2

**Which issue(s) this PR fixes**:

Fixes #12115 
