### PR TITLE
Editor: Ignore closing brace when it was added by editor

### DIFF
--- a/packages/grafana-ui/src/slate-plugins/braces.test.tsx
+++ b/packages/grafana-ui/src/slate-plugins/braces.test.tsx
@@ -37,4 +37,13 @@ describe('braces', () => {
     const handled = handler(event as Event, editor.instance().moveForward(5) as any, nextMock);
     expect(handled).toBeFalsy();
   });
+
+  it('overrides an automatically inserted brace', () => {
+    const value = Plain.deserialize('()');
+    const editor = shallow<Editor>(<Editor value={value} />);
+    const event = new window.KeyboardEvent('keydown', { key: ')' });
+    const handled = handler(event as Event, editor.instance().moveForward(1) as any, nextMock);
+    expect(handled).toBeTruthy();
+    expect(Plain.serialize(editor.instance().value)).toEqual('()');
+  });
 });

--- a/packages/grafana-ui/src/slate-plugins/braces.test.tsx
+++ b/packages/grafana-ui/src/slate-plugins/braces.test.tsx
@@ -18,7 +18,7 @@ describe('braces', () => {
     const value = Plain.deserialize('');
     const editor = shallow<Editor>(<Editor value={value} />);
     const event = new window.KeyboardEvent('keydown', { key: '(' });
-    handler(event as Event, editor.instance() as any, nextMock);
+    expect(handler(event as Event, editor.instance() as any, nextMock)).toBeTruthy();
     expect(Plain.serialize(editor.instance().value)).toEqual('()');
   });
 
@@ -39,11 +39,22 @@ describe('braces', () => {
   });
 
   it('overrides an automatically inserted brace', () => {
-    const value = Plain.deserialize('()');
+    const value = Plain.deserialize('');
     const editor = shallow<Editor>(<Editor value={value} />);
-    const event = new window.KeyboardEvent('keydown', { key: ')' });
-    const handled = handler(event as Event, editor.instance().moveForward(1) as any, nextMock);
-    expect(handled).toBeTruthy();
+    const opening = new window.KeyboardEvent('keydown', { key: '(' });
+    expect(handler(opening as Event, editor.instance() as any, nextMock)).toBeTruthy();
+    const closing = new window.KeyboardEvent('keydown', { key: ')' });
+    expect(handler(closing as Event, editor.instance() as any, nextMock)).toBeTruthy();
     expect(Plain.serialize(editor.instance().value)).toEqual('()');
+  });
+
+  it.skip('does not override manually inserted braces', () => {
+    const value = Plain.deserialize('');
+    const editor = shallow<Editor>(<Editor value={value} />);
+    const event1 = new window.KeyboardEvent('keydown', { key: ')' });
+    expect(handler(event1 as Event, editor.instance() as any, nextMock)).toBeFalsy();
+    const event2 = new window.KeyboardEvent('keydown', { key: ')' });
+    expect(handler(event2 as Event, editor.instance().moveBackward(1) as any, nextMock)).toBeFalsy();
+    expect(Plain.serialize(editor.instance().value)).toEqual('))');
   });
 });

--- a/packages/grafana-ui/src/slate-plugins/braces.ts
+++ b/packages/grafana-ui/src/slate-plugins/braces.ts
@@ -39,12 +39,19 @@ export function BracesPlugin(): Plugin {
             text[focusOffset] === ' ' ||
             Object.values(BRACES).includes(text[focusOffset])
           ) {
-            editor
-              .insertText(`${keyEvent.key}${BRACES[keyEvent.key]}`)
-              .moveAnchorBackward(1)
-              .addMark(MATCH_MARK)
-              .moveAnchorForward(1)
-              .moveBackward(1);
+            editor.insertText(`${keyEvent.key}${BRACES[keyEvent.key]}`).moveBackward(1);
+            editor.value.anchorBlock.createDecoration({
+              object: 'decoration',
+              anchor: {
+                key: value.anchorText.key,
+                offset: startOffset,
+              },
+              focus: {
+                key: value.anchorText.key,
+                offset: startOffset + 1,
+              },
+              type: MATCH_MARK,
+            });
           } else {
             editor.insertText(keyEvent.key);
           }


### PR DESCRIPTION
- brace completion gets annoying if the user still types closing brace
- this change marks automatically added closing braces and when the user
types a closing brace at that position, it will be overridden instead of
added

Fixes #21161
Fixes #14553
Fixes #18787

