### PR TITLE
e2e: Waits for login before moving forward

### DIFF
--- a/packages/grafana-e2e/src/flows/login.ts
+++ b/packages/grafana-e2e/src/flows/login.ts
@@ -8,5 +8,11 @@ export const login = (username: string, password: string) => {
     .type(username);
   e2e.pages.Login.password().type(password);
   e2e.pages.Login.submit().click();
+  e2e.pages.Login.skip()
+    .should('be.visible')
+    .click();
+  e2e()
+    .get('.login-page')
+    .should('not.exist');
   e2e().logToConsole('Logged in with', { username, password });
 };

--- a/packages/grafana-e2e/src/pages/login.ts
+++ b/packages/grafana-e2e/src/pages/login.ts
@@ -6,5 +6,6 @@ export const Login = pageFactory({
     username: 'Username input field',
     password: 'Password input field',
     submit: 'Login button',
+    skip: 'Skip change password button',
   },
 });

--- a/public/app/core/components/Login/ChangePassword.tsx
+++ b/public/app/core/components/Login/ChangePassword.tsx
@@ -1,7 +1,9 @@
-import React, { PureComponent, SyntheticEvent, ChangeEvent } from 'react';
+import React, { ChangeEvent, PureComponent, SyntheticEvent } from 'react';
 import { Tooltip } from '@grafana/ui';
-import appEvents from 'app/core/app_events';
 import { AppEvents } from '@grafana/data';
+import { e2e } from '@grafana/e2e';
+
+import appEvents from 'app/core/app_events';
 
 interface Props {
   onSubmit: (pw: string) => void;
@@ -115,7 +117,7 @@ export class ChangePassword extends PureComponent<Props, State> {
               placement="bottom"
               content="If you skip you will be prompted to change password next time you login."
             >
-              <a className="btn btn-link" onClick={this.onSkip}>
+              <a className="btn btn-link" onClick={this.onSkip} aria-label={e2e.pages.Login.selectors.skip}>
                 Skip
               </a>
             </Tooltip>


### PR DESCRIPTION
**What this PR does / why we need it**:
Yesterday we had yet another flaky e2e test so I looked into that in more detail and this is the flaky scenario:
1. e2e visits login page
2. e2e enters `username` and `password`
3. e2e clicks the `submit` button 
4. e2e navigates to `/dashboard/new`
5. We should end up at `/dashboard/new` but sometimes (rarely) the login request is slow and comes after we navigate to `/dashboard/new` so we actually navigate back to `/`

This is the new solution:
1. e2e visits login page
2. e2e enters `username` and `password`
3. e2e clicks the `submit` button 
4. e2e waits for the `skip` button on the change password page
5. e2e clicks the `skip` button
6. e2e waits for `login` page to dissapear
7. e2e navigates to `/dashboard/new`
8. We should end up at `/dashboard/new`

**Future improvements**
Move the current login flow into a separate test. Use Grafana Api to Login?

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

