### PR TITLE
Docs: Fix Azure ad generic OAuth code markdown formatting

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -183,6 +183,7 @@ allowed_organizations =
     scopes = openid email name
     auth_url = https://login.microsoftonline.com/<directory id>/oauth2/authorize
     token_url = https://login.microsoftonline.com/<directory id>/oauth2/token
+    signout_redirect_url = https://login.microsoftonline.com/<directory id>/oauth2/logout?post_logout_redirect_uri=https://<grafana domain>
     api_url =
     team_ids =
     allowed_organizations =

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -220,6 +220,7 @@ allowed_organizations =
     auth_url = https://<your domain>.my.centrify.com/OAuth2/Authorize/<Application ID>
     token_url = https://<your domain>.my.centrify.com/OAuth2/Token/<Application ID>
     api_url = https://<your domain>.my.centrify.com/OAuth2/UserInfo/<Application ID>
+    ```
 
 ## JMESPath examples
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -183,7 +183,6 @@ allowed_organizations =
     scopes = openid email name
     auth_url = https://login.microsoftonline.com/<directory id>/oauth2/authorize
     token_url = https://login.microsoftonline.com/<directory id>/oauth2/token
-    signout_redirect_url = https://login.microsoftonline.com/<directory id>/oauth2/logout?post_logout_redirect_uri=https://<grafana domain>
     api_url =
     team_ids =
     allowed_organizations =


### PR DESCRIPTION
For Azure AD oauth authentication,  `signout_redirect_url` needs to be specified for the user to be properly signed out.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

