### PR TITLE
Docs: Fix broken link in debian.md

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -153,7 +153,7 @@ Start Grafana by running:
 
 ## Next steps
 
-Refer to the [Getting Started](/guides/getting_started/) guide for information about logging in, setting up data sources, and so on.
+Refer to the [Getting Started]({{< relref "getting_started.md" >}}) guide for information about logging in, setting up data sources, and so on.
 
 ## Configure Grafana
 


### PR DESCRIPTION
Fixes broken link in Debian installation instructions.

Fixes #21169

**Special notes for your reviewer**:

