### PR TITLE
Explore: Fix the width of live-tailing table when short logs

### DIFF
--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -47,6 +47,9 @@ const getStyles = (theme: GrafanaTheme) => ({
   button: css`
     margin-right: ${theme.spacing.sm};
   `,
+  fullWidth: css`
+    width: 100%;
+  `,
 });
 
 export interface Props extends Themeable {
@@ -139,7 +142,7 @@ class LiveLogs extends PureComponent<Props, State> {
 
     return (
       <div>
-        <table>
+        <table className={styles.fullWidth}>
           <tbody
             onScroll={isPaused ? undefined : this.onScroll}
             className={cx(['logs-rows', styles.logsRowsLive])}

--- a/public/app/features/explore/utils/LogsCrossFadeTransition.tsx
+++ b/public/app/features/explore/utils/LogsCrossFadeTransition.tsx
@@ -16,7 +16,7 @@ const getStyles = memoizeOne(() => {
       position: absolute;
       opacity: 0;
       height: auto;
-      width: auto;
+      width: 100%;
     `,
     logsEnterActive: css`
       label: logsEnterActive;
@@ -28,7 +28,7 @@ const getStyles = memoizeOne(() => {
       position: absolute;
       opacity: 1;
       height: auto;
-      width: auto;
+      width: 100%;
     `,
     logsExitActive: css`
       label: logsExitActive;


### PR DESCRIPTION
**What this PR does / why we need it**:
When running live-tailing with very short logs, table with logs had a width of auto. Therefore the table hadn't the full width of div. This PR fixes this. Also I've set **logsEnter** and **logsExit** width to 100%, as it looks much nicer and cleaner, when width doesn't change after render of initial logs. 

**Before:**
![ezgif com-video-to-gif (15)](https://user-images.githubusercontent.com/30407135/71247559-4a8b0200-2319-11ea-9da6-df0651a85b39.gif)

**With fix:**
![ezgif com-video-to-gif (16)](https://user-images.githubusercontent.com/30407135/71247545-4363f400-2319-11ea-8845-c2a43d1ca77d.gif)


