### PR TITLE
grafana/toolkit: Resolve modules correctly 

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -29,18 +29,20 @@ export const findModuleFiles = async (base: string, files?: string[], result?: s
   result = result || [];
 
   if (files) {
-    files.forEach(async file => {
-      const newbase = path.join(base, file);
-      if (fs.statSync(newbase).isDirectory()) {
-        result = await findModuleFiles(newbase, await readdirPromise(newbase), result);
-      } else {
-        const filename = path.basename(file);
-        if (/^module.(t|j)sx?$/.exec(filename)) {
-          // @ts-ignore
-          result.push(newbase);
+    await Promise.all(
+      files.map(async file => {
+        const newbase = path.join(base, file);
+        if (fs.statSync(newbase).isDirectory()) {
+          result = await findModuleFiles(newbase, await readdirPromise(newbase), result);
+        } else {
+          const filename = path.basename(file);
+          if (/^module.(t|j)sx?$/.exec(filename)) {
+            // @ts-ignore
+            result.push(newbase);
+          }
         }
-      }
-    });
+      })
+    );
   }
   return result;
 };


### PR DESCRIPTION
This fixes regression introduced in f1845d808449a16bc1512c11dc48b8efd2c65411. Now the async lookup for module files is performed in the correct way.