### PR TITLE
Prometheus datasource: Simplify adjustInterval

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1130,9 +1130,10 @@ describe('PrometheusDatasource', () => {
         ],
         interval: '5s',
       };
-      const end = 7 * 24 * 60 * 60;
+      let end = 7 * 24 * 60 * 60;
+      end -= end % 55;
       const start = 0;
-      const urlExpected = 'proxied/api/v1/query_range?query=test' + '&start=' + start + '&end=' + end + '&step=60';
+      const urlExpected = 'proxied/api/v1/query_range?query=test' + '&start=' + start + '&end=' + end + '&step=55';
       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
       ds.query(query as any);
       const res = (getBackendSrvMock().datasourceRequest as jest.Mock<any>).mock.calls[0][0];
@@ -1379,7 +1380,8 @@ describe('PrometheusDatasource', () => {
           __interval_ms: { text: 5 * 1000, value: 5 * 1000 },
         },
       };
-      const end = 7 * 24 * 60 * 60;
+      let end = 7 * 24 * 60 * 60;
+      end -= end % 55;
       const start = 0;
       const urlExpected =
         'proxied/api/v1/query_range?query=' +
@@ -1388,7 +1390,7 @@ describe('PrometheusDatasource', () => {
         start +
         '&end=' +
         end +
-        '&step=60';
+        '&step=55';
       getBackendSrvMock().datasourceRequest = jest.fn(() => Promise.resolve(response));
       templateSrv.replace = jest.fn(str => str);
       ds.query(query as any);

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -396,11 +396,9 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
   adjustInterval(interval: number, minInterval: number, range: number, intervalFactor: number) {
     // Prometheus will drop queries that might return more than 11000 data points.
-    // Calibrate interval if it is too small.
-    if (interval !== 0 && range / intervalFactor / interval > 11000) {
-      interval = Math.ceil(range / intervalFactor / 11000);
-    }
-    return Math.max(interval * intervalFactor, minInterval, 1);
+    // Calculate a safe interval as an additional minimum to take into account.
+    const safeInterval = Math.ceil(range / 11000);
+    return Math.max(interval * intervalFactor, minInterval, safeInterval, 1);
   }
 
   performTimeSeriesQuery(query: PromQueryRequest, start: number, end: number) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Much easier to wrap one's head around it if adjustInterval is expressed more
directly.

This is not mathematically the same as the previous version involved
more rounding than necessary because of the way the intervalFactor was
handled. I'd argue the new version is better because it gets closer to
the 11,000 points limit and thus approaches better what the user
wanted within the limits of Prometheus.

Note that in practice, the 11,000 points limit should never be of
relevance. (Even a 4k screen doesn't have 11k points on the x axis.)

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

@davkal This is the first action item from our discussion on Thursday.
