### PR TITLE
Docs: fix of broken doc link in the dashlist panel's help section

### DIFF
--- a/public/app/plugins/panel/dashlist/README.md
+++ b/public/app/plugins/panel/dashlist/README.md
@@ -4,6 +4,4 @@ This Dashlist panel is **included** with Grafana.
 
 The dashboard list panel allows you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, a search query and/or dashboard tags.
 
-Read more about it here:
-
-[http://docs.grafana.org/reference/dashlist/](http://docs.grafana.org/reference/dashlist/)
+Read more about it [here](https://grafana.com/docs/grafana/latest/features/panels/dashlist/)

--- a/public/app/plugins/panel/dashlist/README.md
+++ b/public/app/plugins/panel/dashlist/README.md
@@ -4,4 +4,6 @@ This Dashlist panel is **included** with Grafana.
 
 The dashboard list panel allows you to display dynamic links to other dashboards. The list can be configured to use starred dashboards, a search query and/or dashboard tags.
 
-Read more about it [here](https://grafana.com/docs/grafana/latest/features/panels/dashlist/)
+Read more about it here:
+
+[https://grafana.com/docs/grafana/latest/features/panels/dashlist/](https://grafana.com/docs/grafana/latest/features/panels/dashlist/)


### PR DESCRIPTION
**What this PR does**:
This PR fixes the broken document link used in dashlist panel's help section which is giving a bad user experience

**why do we need it**:
1. It will help in maintaining good user experience.
2. Users will successfully be redirected to correct url for better understanding of dashlist panel usage

**Which issue(s) this PR fixes**:
Fixes #21229

**Special notes for your reviewer**:

