### PR TITLE
Docs: fixed broken doc link for graph and table panels

### DIFF
--- a/public/app/plugins/panel/graph/README.md
+++ b/public/app/plugins/panel/graph/README.md
@@ -4,4 +4,4 @@ This is the main Graph panel and is **included** with Grafana. It provides a ver
 
 For full reference documentation:
 
-[http://docs.grafana.org/reference/graph/](http://docs.grafana.org/reference/graph/)
+[https://grafana.com/docs/grafana/latest/features/panels/graph/](https://grafana.com/docs/grafana/latest/features/panels/graph/)

--- a/public/app/plugins/panel/table/README.md
+++ b/public/app/plugins/panel/table/README.md
@@ -6,4 +6,4 @@ The table panel is very flexible, supporting both multiple modes for time series
 
 Check out the [Table Panel Showcase in the Grafana Playground](http://play.grafana.org/dashboard/db/table-panel-showcase) or read more about it here:
 
-[http://docs.grafana.org/reference/table_panel/](http://docs.grafana.org/reference/table_panel/)
+[https://grafana.com/docs/grafana/latest/features/panels/table_panel/](https://grafana.com/docs/grafana/latest/features/panels/table_panel/)


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR fixes the broken document link used in Graph and Table panel's help section which is giving a bad user experience

**Which issue(s) this PR fixes**:
Fixes #21237

**Special notes for your reviewer**:

