### PR TITLE
Docs: Fix aliases/redirects

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -3,7 +3,7 @@ title = "Grafana documentation"
 description = "Guides, Installation and Feature Documentation"
 keywords = ["grafana", "installation", "documentation"]
 type = "docs"
-aliases = ["/v1.1", "/guides/reference/admin", "/v3.1"]
+aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", "/docs/grafana/v3.1"]
 +++
 
 # Grafana Documentation
@@ -64,7 +64,7 @@ aliases = ["/v1.1", "/guides/reference/admin", "/v3.1"]
         <h4>What's new in v6.5</h4>
         <p>Explore the features and enhancements in the latest release.</p>
     </a>
-  
+
 </div>
 
 <h2>Data Source Guides</h2>

--- a/docs/sources/administration/image_rendering.md
+++ b/docs/sources/administration/image_rendering.md
@@ -3,7 +3,7 @@ title = "Image Rendering"
 description = ""
 keywords = ["grafana", "image", "rendering", "phantomjs"]
 type = "docs"
-aliases = ["/installation/image-rendering"]
+aliases = ["/docs/grafana/latest/installation/image-rendering"]
 [menu.docs]
 parent = "admin"
 weight = 8

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -3,7 +3,7 @@ title = "Provisioning"
 description = ""
 keywords = ["grafana", "provisioning"]
 type = "docs"
-aliases = ["/installation/provisioning"]
+aliases = ["/docs/grafana/latest/installation/provisioning"]
 [menu.docs]
 parent = "admin"
 weight = 8

--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -3,7 +3,7 @@ title = "Auth Proxy"
 description = "Grafana Auth Proxy Guide "
 keywords = ["grafana", "configuration", "documentation", "proxy"]
 type = "docs"
-aliases = ["/tutorials/authproxy/"]
+aliases = ["/docs/grafana/latest/tutorials/authproxy/"]
 [menu.docs]
 name = "Auth Proxy"
 identifier = "auth-proxy"

--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -3,7 +3,7 @@ title = "LDAP Authentication"
 description = "Grafana LDAP Authentication Guide "
 keywords = ["grafana", "configuration", "documentation", "ldap", "active directory"]
 type = "docs"
-aliases = ["/installation/ldap/"]
+aliases = ["/docs/grafana/latest/installation/ldap/"]
 [menu.docs]
 name = "LDAP"
 identifier = "ldap"

--- a/docs/sources/auth/saml.md
+++ b/docs/sources/auth/saml.md
@@ -2,7 +2,7 @@
 title = "SAML Authentication"
 description = "Grafana SAML Authentication"
 keywords = ["grafana", "saml", "documentation", "saml-auth"]
-aliases = ["/auth/saml/"]
+aliases = ["/docs/grafana/latest/auth/saml/"]
 type = "docs"
 [menu.docs]
 name = "SAML"

--- a/docs/sources/auth/team-sync.md
+++ b/docs/sources/auth/team-sync.md
@@ -2,7 +2,7 @@
 title = "Team Sync"
 description = "Grafana Team Sync"
 keywords = ["grafana", "auth", "documentation"]
-aliases = ["/auth/saml/"]
+aliases = ["/docs/grafana/latest/auth/saml/"]
 type = "docs"
 [menu.docs]
 name = "Team Sync"

--- a/docs/sources/contribute/cla.md
+++ b/docs/sources/contribute/cla.md
@@ -2,7 +2,7 @@
 title = "Contributor License Agreement (CLA)"
 description = "Contributor License Agreement (CLA)"
 type = "docs"
-aliases = ["/project/cla", "docs/contributing/cla.html"]
+aliases = ["/docs/grafana/latest/project/cla", "docs/contributing/cla.html"]
 [menu.docs]
 parent = "contribute"
 weight = 1

--- a/docs/sources/features/datasources/_index.md
+++ b/docs/sources/features/datasources/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Data Sources"
 type = "docs"
-aliases = ["/datasources/overview/"]
+aliases = ["/docs/grafana/latest/datasources/overview/"]
 [menu.docs]
 name = "Data Sources"
 identifier = "datasources"

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -3,7 +3,7 @@ title = "Using Azure Monitor in Grafana"
 description = "Guide for using Azure Monitor in Grafana"
 keywords = ["grafana", "microsoft", "azure", "monitor", "application", "insights", "log", "analytics", "guide"]
 type = "docs"
-aliases = ["/datasources/azuremonitor"]
+aliases = ["/docs/grafana/latest/datasources/azuremonitor"]
 [menu.docs]
 name = "Azure Monitor"
 parent = "datasources"

--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -3,7 +3,7 @@ title = "AWS CloudWatch"
 description = "Guide for using CloudWatch in Grafana"
 keywords = ["grafana", "cloudwatch", "guide"]
 type = "docs"
-aliases = ["/datasources/cloudwatch"]
+aliases = ["/docs/grafana/latest/datasources/cloudwatch"]
 [menu.docs]
 name = "AWS Cloudwatch"
 identifier = "cloudwatch"

--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -3,7 +3,7 @@ title = "Using Elasticsearch in Grafana"
 description = "Guide for using Elasticsearch in Grafana"
 keywords = ["grafana", "elasticsearch", "guide"]
 type = "docs"
-aliases = ["/datasources/elasticsearch"]
+aliases = ["/docs/grafana/latest/datasources/elasticsearch"]
 [menu.docs]
 name = "Elasticsearch"
 parent = "datasources"

--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -3,7 +3,7 @@ title = "Using Graphite in Grafana"
 description = "Guide for using graphite in Grafana"
 keywords = ["grafana", "graphite", "guide"]
 type = "docs"
-aliases = ["/datasources/graphite"]
+aliases = ["/docs/grafana/latest/datasources/graphite"]
 [menu.docs]
 name = "Graphite"
 identifier = "graphite"

--- a/docs/sources/features/datasources/influxdb.md
+++ b/docs/sources/features/datasources/influxdb.md
@@ -3,7 +3,7 @@ title = "Using InfluxDB in Grafana"
 description = "Guide for using InfluxDB in Grafana"
 keywords = ["grafana", "influxdb", "guide"]
 type = "docs"
-aliases = ["/datasources/influxdb"]
+aliases = ["/docs/grafana/latest/datasources/influxdb"]
 [menu.docs]
 name = "InfluxDB"
 parent = "datasources"

--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -3,7 +3,7 @@ title = "Using Loki in Grafana"
 description = "Guide for using Loki in Grafana"
 keywords = ["grafana", "loki", "logging", "guide"]
 type = "docs"
-aliases = ["/datasources/loki"]
+aliases = ["/docs/grafana/latest/datasources/loki"]
 [menu.docs]
 name = "Loki"
 parent = "datasources"

--- a/docs/sources/features/datasources/opentsdb.md
+++ b/docs/sources/features/datasources/opentsdb.md
@@ -3,7 +3,7 @@ title = "Using OpenTSDB in Grafana"
 description = "Guide for using OpenTSDB in Grafana"
 keywords = ["grafana", "opentsdb", "guide"]
 type = "docs"
-aliases = ["/datasources/opentsdb",	"docs/features/opentsdb"]
+aliases = ["/docs/grafana/latest/datasources/opentsdb",	"/docs/grafana/latest/features/opentsdb"]
 [menu.docs]
 name = "OpenTSDB"
 parent = "datasources"

--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -3,7 +3,7 @@ title = "Using Prometheus in Grafana"
 description = "Guide for using Prometheus in Grafana"
 keywords = ["grafana", "prometheus", "guide"]
 type = "docs"
-aliases = ["/datasources/prometheus"]
+aliases = ["/docs/grafana/latest/datasources/prometheus"]
 [menu.docs]
 name = "Prometheus"
 parent = "datasources"

--- a/docs/sources/features/datasources/stackdriver.md
+++ b/docs/sources/features/datasources/stackdriver.md
@@ -3,7 +3,7 @@ title = "Using Stackdriver in Grafana"
 description = "Guide for using Stackdriver in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide"]
 type = "docs"
-aliases = ["/datasources/stackdriver"]
+aliases = ["/docs/grafana/latest/datasources/stackdriver"]
 [menu.docs]
 name = "Google Stackdriver"
 parent = "datasources"

--- a/docs/sources/features/panels/alertlist.md
+++ b/docs/sources/features/panels/alertlist.md
@@ -2,7 +2,7 @@
 title = "Alert List"
 keywords = ["grafana", "alert list", "documentation", "panel", "alertlist"]
 type = "docs"
-aliases = ["/reference/alertlist/"]
+aliases = ["/docs/grafana/latest/reference/alertlist/"]
 [menu.docs]
 name = "Alert list"
 parent = "panels"

--- a/docs/sources/features/panels/dashlist.md
+++ b/docs/sources/features/panels/dashlist.md
@@ -2,7 +2,7 @@
 title = "Dashboard List"
 keywords = ["grafana", "dashboard list", "documentation", "panel", "dashlist"]
 type = "docs"
-aliases = ["/reference/dashlist/"]
+aliases = ["/docs/grafana/latest/reference/dashlist/"]
 [menu.docs]
 name = "Dashboard list"
 parent = "panels"

--- a/docs/sources/features/panels/graph.md
+++ b/docs/sources/features/panels/graph.md
@@ -2,7 +2,7 @@
 title = "Graph Panel"
 keywords = ["grafana", "graph panel", "documentation", "guide", "graph"]
 type = "docs"
-aliases = ["/reference/graph/"]
+aliases = ["/docs/grafana/latest/reference/graph/"]
 [menu.docs]
 name = "Graph"
 parent = "panels"

--- a/docs/sources/features/panels/logs.md
+++ b/docs/sources/features/panels/logs.md
@@ -2,7 +2,7 @@
 title = "Logs Panel"
 keywords = ["grafana", "dashboard", "documentation", "panels", "logs panel"]
 type = "docs"
-aliases = ["/reference/logs/"]
+aliases = ["/docs/grafana/latest/reference/logs/"]
 [menu.docs]
 name = "Logs"
 parent = "panels"

--- a/docs/sources/features/panels/singlestat.md
+++ b/docs/sources/features/panels/singlestat.md
@@ -2,7 +2,7 @@
 title = "Singlestat Panel"
 keywords = ["grafana", "dashboard", "documentation", "panels", "singlestat"]
 type = "docs"
-aliases = ["/reference/singlestat/"]
+aliases = ["/docs/grafana/latest/reference/singlestat/"]
 [menu.docs]
 name = "Singlestat"
 parent = "panels"

--- a/docs/sources/features/panels/table_panel.md
+++ b/docs/sources/features/panels/table_panel.md
@@ -2,7 +2,7 @@
 title = "Table Panel"
 keywords = ["grafana", "dashboard", "documentation", "panels", "table panel"]
 type = "docs"
-aliases = ["/reference/table/"]
+aliases = ["/docs/grafana/latest/reference/table/"]
 [menu.docs]
 name = "Table"
 parent = "panels"

--- a/docs/sources/features/panels/text.md
+++ b/docs/sources/features/panels/text.md
@@ -2,7 +2,7 @@
 title = "Text"
 keywords = ["grafana", "text", "documentation", "panel"]
 type = "docs"
-aliases = ["/reference/alertlist/"]
+aliases = ["/docs/grafana/latest/reference/alertlist/"]
 [menu.docs]
 name = "Text"
 parent = "panels"

--- a/docs/sources/features/reporting.md
+++ b/docs/sources/features/reporting.md
@@ -3,7 +3,7 @@ title = "Reporting"
 description = ""
 keywords = ["grafana", "reporting"]
 type = "docs"
-aliases = ["/administration/reports"]
+aliases = ["/docs/grafana/latest/administration/reports"]
 [menu.docs]
 parent = "features"
 weight = 8

--- a/docs/sources/guides/getting_started.md
+++ b/docs/sources/guides/getting_started.md
@@ -3,7 +3,7 @@ title = "Getting Started"
 description = "Getting started with Grafana guide"
 keywords = ["grafana", "intro", "guide", "started"]
 type = "docs"
-aliases = ["/guides/gettingstarted"]
+aliases = ["/docs/grafana/latest/guides/gettingstarted"]
 [menu.docs]
 name = "Getting Started"
 identifier = "getting_started_guide"

--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -2,7 +2,7 @@
 title = "HTTP API"
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "overview"]
-aliases = ["/overview"]
+aliases = ["/docs/grafana/latest/overview"]
 type = "docs"
 [menu.docs]
 name = "HTTP API"

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -2,7 +2,7 @@
 title = "Admin HTTP API "
 description = "Grafana Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "admin"]
-aliases = ["/http_api/admin/"]
+aliases = ["/docs/grafana/latest/http_api/admin/"]
 type = "docs"
 [menu.docs]
 name = "Admin"

--- a/docs/sources/http_api/alerting.md
+++ b/docs/sources/http_api/alerting.md
@@ -2,7 +2,7 @@
 title = "Alerting HTTP API "
 description = "Grafana Alerts HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "alerting", "alerts"]
-aliases = ["/http_api/alerting/"]
+aliases = ["/docs/grafana/latest/http_api/alerting/"]
 type = "docs"
 [menu.docs]
 name = "Alerting"

--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -2,7 +2,7 @@
 title = "Annotations HTTP API "
 description = "Grafana Annotations HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "annotation", "annotations", "comment"]
-aliases = ["/http_api/annotations/"]
+aliases = ["/docs/grafana/latest/http_api/annotations/"]
 type = "docs"
 [menu.docs]
 name = "Annotations"

--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -2,7 +2,7 @@
 title = "Authentication HTTP API "
 description = "Grafana Authentication HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "authentication"]
-aliases = ["/http_api/authentication/"]
+aliases = ["/docs/grafana/latest/http_api/authentication/"]
 type = "docs"
 [menu.docs]
 name = "Authentication HTTP API"

--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -2,7 +2,7 @@
 title = "Dashboard HTTP API "
 description = "Grafana Dashboard HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard"]
-aliases = ["/http_api/dashboard/"]
+aliases = ["/docs/grafana/latest/http_api/dashboard/"]
 type = "docs"
 [menu.docs]
 name = "Dashboard"

--- a/docs/sources/http_api/dashboard_permissions.md
+++ b/docs/sources/http_api/dashboard_permissions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Permissions HTTP API "
 description = "Grafana Dashboard Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "permission", "permissions", "acl"]
-aliases = ["/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
 type = "docs"
 [menu.docs]
 name = "Dashboard Permissions"

--- a/docs/sources/http_api/dashboard_versions.md
+++ b/docs/sources/http_api/dashboard_versions.md
@@ -2,7 +2,7 @@
 title = "Dashboard Versions HTTP API "
 description = "Grafana Dashboard Versions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "dashboard", "versions"]
-aliases = ["/http_api/dashboardversions/"]
+aliases = ["/docs/grafana/latest/http_api/dashboardversions/"]
 type = "docs"
 [menu.docs]
 name = "Dashboard Versions"

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -2,7 +2,7 @@
 title = "Data source HTTP API "
 description = "Grafana Data source HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "data source"]
-aliases = ["/http_api/datasource/"]
+aliases = ["/docs/grafana/latest/http_api/datasource/"]
 type = "docs"
 [menu.docs]
 name = "Data source"

--- a/docs/sources/http_api/datasource_permissions.md
+++ b/docs/sources/http_api/datasource_permissions.md
@@ -2,7 +2,7 @@
 title = "Datasource Permissions HTTP API "
 description = "Data Source Permissions API"
 keywords = ["grafana", "http", "documentation", "api", "datasource", "permission", "permissions", "acl", "enterprise"]
-aliases = ["/http_api/datasourcepermissions/"]
+aliases = ["/docs/grafana/latest/http_api/datasourcepermissions/"]
 type = "docs"
 [menu.docs]
 name = "Datasource Permissions"

--- a/docs/sources/http_api/external_group_sync.md
+++ b/docs/sources/http_api/external_group_sync.md
@@ -2,7 +2,7 @@
 title = "External Group Sync HTTP API "
 description = "Grafana External Group Sync HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group", "member", "enterprise"]
-aliases = ["/http_api/external_group_sync/"]
+aliases = ["/docs/grafana/latest/http_api/external_group_sync/"]
 type = "docs"
 [menu.docs]
 name = "External Group Sync"

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -2,7 +2,7 @@
 title = "Folder HTTP API "
 description = "Grafana Folder HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder"]
-aliases = ["/http_api/folder/"]
+aliases = ["/docs/grafana/latest/http_api/folder/"]
 type = "docs"
 [menu.docs]
 name = "Folder"

--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -2,7 +2,7 @@
 title = "Folder/Dashboard Search HTTP API "
 description = "Grafana Folder/Dashboard Search HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "search", "folder", "dashboard"]
-aliases = ["/http_api/folder_dashboard_search/"]
+aliases = ["/docs/grafana/latest/http_api/folder_dashboard_search/"]
 type = "docs"
 [menu.docs]
 name = "Folder/dashboard search"

--- a/docs/sources/http_api/folder_permissions.md
+++ b/docs/sources/http_api/folder_permissions.md
@@ -2,7 +2,7 @@
 title = "Folder Permissions HTTP API "
 description = "Grafana Folder Permissions HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "folder", "permission", "permissions", "acl"]
-aliases = ["/http_api/dashboardpermissions/"]
+aliases = ["/docs/grafana/latest/http_api/dashboardpermissions/"]
 type = "docs"
 [menu.docs]
 name = "Folder Permissions"

--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -2,7 +2,7 @@
 title = "Organization HTTP API "
 description = "Grafana Organization HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "organization"]
-aliases = ["/http_api/organization/"]
+aliases = ["/docs/grafana/latest/http_api/organization/"]
 type = "docs"
 [menu.docs]
 name = "Organization"

--- a/docs/sources/http_api/other.md
+++ b/docs/sources/http_api/other.md
@@ -2,7 +2,7 @@
 title = "Other HTTP API "
 description = "Grafana Other HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "other"]
-aliases = ["/http_api/other/"]
+aliases = ["/docs/grafana/latest/http_api/other/"]
 type = "docs"
 [menu.docs]
 name = "Other"

--- a/docs/sources/http_api/playlist.md
+++ b/docs/sources/http_api/playlist.md
@@ -2,7 +2,7 @@
 title = "Playlist HTTP API "
 description = "Playlist Admin HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "playlist"]
-aliases = ["/http_api/playlist/"]
+aliases = ["/docs/grafana/latest/http_api/playlist/"]
 type = "docs"
 [menu.docs]
 name = "Playlist"

--- a/docs/sources/http_api/preferences.md
+++ b/docs/sources/http_api/preferences.md
@@ -2,7 +2,7 @@
 title = "HTTP Preferences API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "preferences"]
-aliases = ["/http_api/preferences/"]
+aliases = ["/docs/grafana/latest/http_api/preferences/"]
 type = "docs"
 [menu.docs]
 name = "Preferences"

--- a/docs/sources/http_api/snapshot.md
+++ b/docs/sources/http_api/snapshot.md
@@ -2,7 +2,7 @@
 title = "HTTP Snapshot API "
 description = "Grafana HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "snapshot"]
-aliases = ["/http_api/snapshot/"]
+aliases = ["/docs/grafana/latest/http_api/snapshot/"]
 type = "docs"
 [menu.docs]
 name = "Snapshot"

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -2,7 +2,7 @@
 title = "Team HTTP API "
 description = "Grafana Team HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "team", "teams", "group"]
-aliases = ["/http_api/team/"]
+aliases = ["/docs/grafana/latest/http_api/team/"]
 type = "docs"
 [menu.docs]
 name = "Teams"

--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -2,7 +2,7 @@
 title = "User HTTP API "
 description = "Grafana User HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "user"]
-aliases = ["/http_api/user/"]
+aliases = ["/docs/grafana/latest/http_api/user/"]
 type = "docs"
 [menu.docs]
 name = "Users"

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -3,7 +3,7 @@ title = "Installation"
 description = "Install guide for Grafana"
 keywords = ["grafana", "installation", "documentation"]
 type = "docs"
-aliases = ["installation/installation/", "v2.1/installation/install/", "install"]
+aliases = ["/docs/grafana/latest/installation/installation/", "/docs/grafana/v2.1/installation/install/", "/docs/grafana/latest/install"]
 [menu.docs]
 name = "Installation"
 identifier = "installation"

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -3,7 +3,7 @@ title = "Install on Debian/Ubuntu"
 description = "Install guide for Grafana on Debian or Ubuntu"
 keywords = ["grafana", "installation", "documentation"]
 type = "docs"
-aliases = ["/installation/installation/debian"]
+aliases = ["/docs/grafana/latest/installation/installation/debian"]
 [menu.docs]
 name = "Install on Ubuntu/Debian"
 identifier = "debian"

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -2,7 +2,7 @@
 title = "Installing on RPM-based Linux"
 description = "Grafana Installation guide for Centos, Fedora, OpenSuse, Redhat."
 keywords = ["grafana", "installation", "documentation", "centos", "fedora", "opensuse", "redhat"]
-aliases = ["installation/installation/rpm"]
+aliases = ["/docs/grafana/latest/installation/installation/rpm"]
 type = "docs"
 [menu.docs]
 name = "Installing on Centos / Redhat"

--- a/docs/sources/permissions/overview.md
+++ b/docs/sources/permissions/overview.md
@@ -3,7 +3,7 @@ title = "Overview"
 description = "Overview for permissions"
 keywords = ["grafana", "configuration", "documentation", "admin", "users", "datasources", "permissions"]
 type = "docs"
-aliases = ["/reference/admin", "/administration/permissions/"]
+aliases = ["/docs/grafana/latest/reference/admin", "/docs/grafana/latest/administration/permissions/"]
 [menu.docs]
 name = "Overview"
 identifier = "overview-permissions"

--- a/docs/sources/plugins/developing/development.md
+++ b/docs/sources/plugins/developing/development.md
@@ -1,7 +1,7 @@
 +++
 title = "Developer Guide"
 type = "docs"
-aliases = ["/plugins/development/", "/plugins/datasources/", "/plugins/apps/", "/plugins/panels/"]
+aliases = ["/docs/grafana/latest/plugins/development/", "/docs/grafana/latest/plugins/datasources/", "/docs/grafana/latest/plugins/apps/", "/docs/grafana/latest/plugins/panels/"]
 [menu.docs]
 name = "Developer Guide"
 parent = "developing"


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes all aliases rooted to /docs/grafana/latest. Using `grep --include=\*.md -rnwl docs/ -e 'aliases =' | xargs sed -i 's/aliases = \[\"/aliases = \[\"\/docs\/grafana\/latest/g'` together with some manual edits.

**Which issue(s) this PR fixes**:
Fixes #21240