### PR TITLE
Promtheus: Fix hint and error display for query rows

### DIFF
--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -278,7 +278,6 @@
 }
 
 .query-row-break {
-  height: 0;
   flex-basis: 100%;
 }
 


### PR DESCRIPTION
- prometheus explore editor introduced new styles for the hint display
- when multiple rows are rendered the hints are covered because they are
forced to have 0 height
- this change removes the 0-height

Fixes #21243

CC @Estrax 