### PR TITLE
Graph: Fixed no value in graph tooltip

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -257,7 +257,7 @@ export default function GraphTooltip(this: any, elem: any, dashboard: any, scope
 
         series = seriesList[hoverInfo.index];
 
-        value = series.formatValue(sanitize(hoverInfo.value));
+        value = series.formatValue(hoverInfo.value);
         const color = sanitize(hoverInfo.color);
         const label = sanitize(hoverInfo.label);
 


### PR DESCRIPTION
Removed the sanitize of value restored the value to the tooltip. not sure why. But do think we need this sanitize right now. 