### PR TITLE
Prometheus: improve tooltips

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -128,9 +128,12 @@ export class PromQueryEditor extends PureComponent<Props, State> {
           <div className="gf-form">
             <FormLabel
               width={7}
-              tooltip="Leave blank for auto handling based on time range and panel width.
-            Note that the actual dates used in the query will be adjusted
-        to a multiple of the interval step."
+              tooltip={
+                <>
+                  An additional lower limit for the step parameter of the Prometheus query and for the{' '}
+                  <code>$__interval</code> variable. The limit is absolute and not modified by the "Resolution" setting.
+                </>
+              }
             >
               Min step
             </FormLabel>

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -44,9 +44,16 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
       className="gf-form"
     >
       <Component
-        tooltip="Leave blank for auto handling based on time range and panel width.
-            Note that the actual dates used in the query will be adjusted
-        to a multiple of the interval step."
+        tooltip={
+          <React.Fragment>
+            An additional lower limit for the step parameter of the Prometheus query and for the
+
+            <code>
+              $__interval
+            </code>
+             variable. The limit is absolute and not modified by the "Resolution" setting.
+          </React.Fragment>
+        }
         width={7}
       >
         Min step

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
         tooltip={
           <React.Fragment>
             An additional lower limit for the step parameter of the Prometheus query and for the
-
+             
             <code>
               $__interval
             </code>

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -34,8 +34,7 @@ export const PromSettings = (props: Props) => {
                   validationEvents={promSettingsValidationEvents}
                 />
               }
-              tooltip="Set this to your global scrape interval defined in your Prometheus config file. This will be used as a lower limit for the
-        Prometheus step query parameter."
+              tooltip="Set this to the typical scrape and evaluation interval configured in Prometheus. Defaults to 15s."
             />
           </div>
         </div>


### PR DESCRIPTION
@davkal this is addressing the next action item from our whiteboarding session: Improving the tool tips.

See the commit descriptions for detailed reasoning.

TODO: I also want to update the _Min time interval_ tool tip, but it is defined globally. Data sources simply elect if they want to display that option or not. Is there an easy way for a data source to override just the tool tip? For Prometheus, the explanation has to be very different (resolution factor, impact on queries with range selectors, defaults to the scrape interval configured in the data source, adjustment of the queried times to a multiple of the final step). 