### PR TITLE
Units: support farenheit (existing misspelling)

### DIFF
--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -123,4 +123,12 @@ describe('valueFormats', () => {
       expect(str).toBe('186');
     });
   });
+
+  describe('Resolve old units', () => {
+    it('resolve farenheit', () => {
+      const fmt0 = getValueFormat('farenheit');
+      const fmt1 = getValueFormat('fahrenheit');
+      expect(fmt0).toEqual(fmt1);
+    });
+  });
 });

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -164,6 +164,14 @@ function buildFormats() {
     }
   }
 
+  // Resolve units pointing to old IDs
+  [{ from: 'farenheit', to: 'fahrenheit' }].forEach(alias => {
+    const f = index[alias.to];
+    if (f) {
+      index[alias.from] = f;
+    }
+  });
+
   hasBuiltIndex = true;
 }
 


### PR DESCRIPTION
In #20040 we fixed a misspelling in the unit for fahrenheit.... but this breaks any existing dashboards with the id already saved.

This PR will resolve both 'farenheit' and 'fahrenheit' to the same unit



