### PR TITLE
LDAP: Add fallback to search_base_dns if group_search_base_dns is undefined.

### DIFF
--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -189,6 +189,8 @@ Setting | Required | Description | Default
 Users with nested/recursive group membership must have an LDAP server that supports `LDAP_MATCHING_RULE_IN_CHAIN`
 and configure `group_search_filter` in a way that it returns the groups the submitted username is a member of.
 
+To configure `group_search_filter` you can use `group_search_base_dns` to define where the matching groups are defined. Otherwise the previously defined `search_base_dns` will be used.
+
 **Active Directory example:**
 
 Active Directory groups store the Distinguished Names (DNs) of members, so your filter will need to know the DN for the user based only on the submitted username.
@@ -198,6 +200,13 @@ Multiple DN templates can be searched by combining filters with the LDAP OR-oper
 group_search_filter = "(member:1.2.840.113556.1.4.1941:=CN=%s,[user container/OU])"
 group_search_filter = "(|(member:1.2.840.113556.1.4.1941:=CN=%s,[user container/OU])(member:1.2.840.113556.1.4.1941:=CN=%s,[another user container/OU]))"
 group_search_filter_user_attribute = "cn"
+```
+
+This config should work out of the box
+```bash
+group_search_filter = "(member:1.2.840.113556.1.4.1941:=%s)"
+group_search_base_dns = ["DC=mycorp,DC=mytld"]
+group_search_filter_user_attribute = "dn"
 ```
 For more information on AD searches see [Microsoft's Search Filter Syntax](https://docs.microsoft.com/en-us/windows/desktop/adsi/search-filter-syntax) documentation.
 

--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -189,12 +189,20 @@ Setting | Required | Description | Default
 Users with nested/recursive group membership must have an LDAP server that supports `LDAP_MATCHING_RULE_IN_CHAIN`
 and configure `group_search_filter` in a way that it returns the groups the submitted username is a member of.
 
-To configure `group_search_filter` you can use `group_search_base_dns` to define where the matching groups are defined. Otherwise the previously defined `search_base_dns` will be used.
+To configure `group_search_filter`:
+* You can set `group_search_base_dns` to specify where the matching groups are defined.
+* If you do not use `group_search_base_dns`, then the previously defined `search_base_dns` is used.
 
 **Active Directory example:**
 
 Active Directory groups store the Distinguished Names (DNs) of members, so your filter will need to know the DN for the user based only on the submitted username.
-Multiple DN templates can be searched by combining filters with the LDAP OR-operator. Examples:
+Multiple DN templates can be searched by combining filters with the LDAP OR-operator. Two examples:
+
+```bash
+group_search_filter = "(member:1.2.840.113556.1.4.1941:=%s)"
+group_search_base_dns = ["DC=mycorp,DC=mytld"]
+group_search_filter_user_attribute = "dn"
+```
 
 ```bash
 group_search_filter = "(member:1.2.840.113556.1.4.1941:=CN=%s,[user container/OU])"
@@ -202,12 +210,6 @@ group_search_filter = "(|(member:1.2.840.113556.1.4.1941:=CN=%s,[user container/
 group_search_filter_user_attribute = "cn"
 ```
 
-This config should work out of the box
-```bash
-group_search_filter = "(member:1.2.840.113556.1.4.1941:=%s)"
-group_search_base_dns = ["DC=mycorp,DC=mytld"]
-group_search_filter_user_attribute = "dn"
-```
 For more information on AD searches see [Microsoft's Search Filter Syntax](https://docs.microsoft.com/en-us/windows/desktop/adsi/search-filter-syntax) documentation.
 
 For troubleshooting, by changing `member_of` in `[servers.attributes]` to "dn" it will show you more accurate group memberships when [debug is enabled](#troubleshooting).

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -477,8 +477,16 @@ func (server *Server) userBind(path, password string) error {
 func (server *Server) requestMemberOf(entry *ldap.Entry) ([]string, error) {
 	var memberOf []string
 	var config = server.Config
+	var searchBaseDNs []string
 
-	for _, groupSearchBase := range config.GroupSearchBaseDNs {
+
+	if len(config.GroupSearchBaseDNs) > 0 {
+		searchBaseDNs = config.GroupSearchBaseDNs
+	} else {
+		searchBaseDNs = config.SearchBaseDNs
+	}
+
+	for _, groupSearchBase := range searchBaseDNs {
 		var filterReplace string
 		if config.GroupSearchFilterUserAttribute == "" {
 			filterReplace = getAttribute(config.Attr.Username, entry)

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -479,7 +479,6 @@ func (server *Server) requestMemberOf(entry *ldap.Entry) ([]string, error) {
 	var config = server.Config
 	var searchBaseDNs []string
 
-
 	if len(config.GroupSearchBaseDNs) > 0 {
 		searchBaseDNs = config.GroupSearchBaseDNs
 	} else {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

This PR adds a fallback to `search_base_dns` for `group_search_base_dns` in ldap.toml. This will add better support for nested groups configurations.


Fixes #20862


**Special notes for your reviewer**:
Theses are my first steps in Go. Please review properly.
