### PR TITLE
Add events per second/minute as throughput options

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -645,6 +645,10 @@
               "value": "wps"
             },
             {
+              "text": "events/sec (eps)",
+              "value": "eps"
+            },
+            {
               "text": "I/O ops/sec (iops)",
               "value": "iops"
             },
@@ -659,6 +663,10 @@
             {
               "text": "writes/min (wpm)",
               "value": "wpm"
+            },
+            {
+              "text": "events/min (epm)",
+              "value": "epm"
             }
           ],
           "text": "throughput"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -645,6 +645,10 @@
               "value": "wps"
             },
             {
+              "text": "events/sec (eps)",
+              "value": "eps"
+            },
+            {
               "text": "I/O ops/sec (iops)",
               "value": "iops"
             },
@@ -659,6 +663,10 @@
             {
               "text": "writes/min (wpm)",
               "value": "wpm"
+            },
+            {
+              "text": "events/min (epm)",
+              "value": "epm"
             }
           ],
           "text": "throughput"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -331,11 +331,13 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'requests/sec (rps)', id: 'reqps', fn: simpleCountUnit('reqps') },
       { name: 'reads/sec (rps)', id: 'rps', fn: simpleCountUnit('rps') },
       { name: 'writes/sec (wps)', id: 'wps', fn: simpleCountUnit('wps') },
+      { name: 'events/sec (eps)', id: 'eps', fn: simpleCountUnit('eps') },
       { name: 'I/O ops/sec (iops)', id: 'iops', fn: simpleCountUnit('iops') },
       { name: 'counts/min (cpm)', id: 'cpm', fn: simpleCountUnit('cpm') },
       { name: 'ops/min (opm)', id: 'opm', fn: simpleCountUnit('opm') },
       { name: 'reads/min (rpm)', id: 'rpm', fn: simpleCountUnit('rpm') },
       { name: 'writes/min (wpm)', id: 'wpm', fn: simpleCountUnit('wpm') },
+      { name: 'events/min (epm)', id: 'epm', fn: simpleCountUnit('epm') },
     ],
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add 'events per second' (eps) and 'events per minute' (epm) as throughput categories. These are useful metrics in event processing systems.

This PR is similar to #11474 (closed without merging).

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None