### PR TITLE
Units: Support dynamic count and currency units

### DIFF
--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -53,6 +53,14 @@ const formatTests: ValueFormatTest[] = [
   { id: 'si:µF', value: 1234000000, decimals: 2, result: '1.23 kF' },
   { id: 'si:µF', value: 1234000000000000, decimals: 2, result: '1.23 GF' },
 
+  // Counts (suffix)
+  { id: 'count:xpm', value: 1234567, decimals: 2, result: '1.23M xpm' },
+  { id: 'count:x/min', value: 1234, decimals: 2, result: '1.23K x/min' },
+
+  // Currency (prefix)
+  { id: 'currency:@', value: 1234567, decimals: 2, result: '@1.23M' },
+  { id: 'currency:@', value: 1234, decimals: 2, result: '@1.23K' },
+
   // Time format
   { id: 'time:YYYY', decimals: 0, value: dateTime(new Date(1999, 6, 2)).valueOf(), result: '1999' },
   { id: 'time:YYYY.MM', decimals: 0, value: dateTime(new Date(2010, 6, 2)).valueOf(), result: '2010.07' },

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -1,7 +1,7 @@
 import { getCategories } from './categories';
 import { DecimalCount } from '../types/displayValue';
 import { toDateTimeValueFormatter } from './dateTimeFormatters';
-import { getOffsetFromSIPrefix, decimalSIPrefix } from './symbolFormatters';
+import { getOffsetFromSIPrefix, decimalSIPrefix, currency } from './symbolFormatters';
 
 export interface FormattedValue {
   text: string;
@@ -196,6 +196,12 @@ export function getValueFormat(id: string): ValueFormatter {
         const offset = getOffsetFromSIPrefix(sub.charAt(0));
         const unit = offset === 0 ? sub : sub.substring(1);
         return decimalSIPrefix(unit, offset);
+      }
+      if (key === 'count') {
+        return simpleCountUnit(sub);
+      }
+      if (key === 'currency') {
+        return currency(sub);
       }
     }
     return toFixedUnit(id);


### PR DESCRIPTION
This now lets you specify count or currency units using:
`count:XXX` or `currency:YYY`

