### PR TITLE
Alert: Set time range in alerting rule URL

### DIFF
--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -124,7 +124,14 @@ func (c *EvalContext) GetRuleURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(urlFormat, models.GetFullDashboardUrl(ref.Uid, ref.Slug), c.Rule.PanelID, c.Rule.OrgID), nil
+
+	u := fmt.Sprintf(urlFormat, models.GetFullDashboardUrl(ref.Uid, ref.Slug), c.Rule.PanelID, c.Rule.OrgID)
+	if c.Rule != nil {
+		from := c.Rule.LastStateChange
+		to := from.Add(c.Rule.For)
+		u += fmt.Sprintf("&from=%d&to=%d", from.UnixNano()/int64(time.Millisecond), to.UnixNano()/int64(time.Millisecond))
+	}
+	return u, nil
 }
 
 // GetNewState returns the new state from the alert rule evaluation.

--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -113,6 +113,7 @@ func (c *EvalContext) GetDashboardUID() (*models.DashboardRef, error) {
 }
 
 const urlFormat = "%s?fullscreen&edit&tab=alert&panelId=%d&orgId=%d"
+const alertPadding = 5 * time.Minute
 
 // GetRuleURL returns the url to the dashboard containing the alert.
 func (c *EvalContext) GetRuleURL() (string, error) {
@@ -129,7 +130,7 @@ func (c *EvalContext) GetRuleURL() (string, error) {
 	if c.Rule != nil {
 		from := c.Rule.LastStateChange
 		to := from.Add(c.Rule.For)
-		u += fmt.Sprintf("&from=%d&to=%d", from.UnixNano()/int64(time.Millisecond), to.UnixNano()/int64(time.Millisecond))
+		u += fmt.Sprintf("&from=%d&to=%d", from.Add(-alertPadding).UnixNano()/int64(time.Millisecond), to.Add(alertPadding).UnixNano()/int64(time.Millisecond))
 	}
 	return u, nil
 }

--- a/pkg/services/alerting/eval_context_test.go
+++ b/pkg/services/alerting/eval_context_test.go
@@ -216,13 +216,12 @@ func TestGetRuleURL(t *testing.T) {
 		return nil
 	})
 	lastStateChange := time.Date(2019, 12, 30, 17, 34, 11, 0, time.UTC)
-	from := lastStateChange.Unix() * 1000
 	forDuration := 1 * time.Minute
-	to := lastStateChange.Add(forDuration).Unix() * 1000
+	to := lastStateChange.Add(forDuration)
 
 	ctx := NewEvalContext(context.TODO(), &Rule{PanelID: 1, OrgID: 2, LastStateChange: lastStateChange, For: forDuration})
 	u, err := ctx.GetRuleURL()
 	assert.NoError(t, err)
-	expected := fmt.Sprintf(urlFormat+"&from=%d&to=%d", models.GetFullDashboardUrl(dashboardRef, dashboardSlug), 1, 2, from, to)
+	expected := fmt.Sprintf(urlFormat+"&from=%d&to=%d", models.GetFullDashboardUrl(dashboardRef, dashboardSlug), 1, 2, lastStateChange.Add(-alertPadding).Unix()*1000, to.Add(alertPadding).Unix()*1000)
 	assert.Equal(t, expected, u)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The time range of the dashboard is set to the duration of the rule that triggered the alert, i.e. the the link opens the dashboard showing the metrics where the alert happened.
Otherwise the dashboard was opened with the default time range, e.g. last 6 hours, which meant that one had to look for the error or even adjust the time range to make it visible.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #21292

**Special notes for your reviewer**:

