### PR TITLE
Prometheus: Fix term completion that contain keywords

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -49,6 +49,7 @@ describe('Language completion provider', () => {
       expect(cleanText('foo < bar')).toBe('bar');
       expect(cleanText('foo >= bar')).toBe('bar');
       expect(cleanText('foo <= bar')).toBe('bar');
+      expect(cleanText('memory')).toBe('memory');
     });
 
     it('removes aggregation syntax', () => {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -51,7 +51,7 @@ function addMetricsMetadata(metric: string, metadata?: PromMetricsMetadata): Com
   return item;
 }
 
-const PREFIX_DELIMITER_REGEX = /(="|!="|=~"|!~"|\{|\[|\(|\+|-|\/|\*|%|\^|and|or|unless|==|>=|!=|<=|>|<|=|~|,)/;
+const PREFIX_DELIMITER_REGEX = /(="|!="|=~"|!~"|\{|\[|\(|\+|-|\/|\*|%|\^|\band\b|\bor\b|\bunless\b|==|>=|!=|<=|>|<|=|~|,)/;
 
 export default class PromQlLanguageProvider extends LanguageProvider {
   histogramMetrics?: string[];


### PR DESCRIPTION
- `unless`, `or` and `and` are binary operators
- if they appear in a query the query was broken up so the suggestor
only works on the current term
- this change fixes the splitter logic to make sure those keywords are
not inside a word

Fixes #21219