### PR TITLE
Alerting: Enable setting of OpsGenie priority via a tag

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -430,6 +430,7 @@ The following sections detail the supported settings for each alert notification
 | apiKey |
 | apiUrl |
 | autoClose |
+| overridePriority |
 
 #### Alert notification `telegram`
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -67,12 +67,12 @@ func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, er
 	}
 
 	return &OpsGenieNotifier{
-		NotifierBase: NewNotifierBase(model),
-		APIKey:       apiKey,
-		APIUrl:       apiURL,
-		AutoClose:    autoClose,
+		NotifierBase:     NewNotifierBase(model),
+		APIKey:           apiKey,
+		APIUrl:           apiURL,
+		AutoClose:        autoClose,
 		OverridePriority: overridePriority,
-		log:          log.New("alerting.notifier.opsgenie"),
+		log:              log.New("alerting.notifier.opsgenie"),
 	}, nil
 }
 
@@ -80,11 +80,11 @@ func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, er
 // alert notifications to OpsGenie
 type OpsGenieNotifier struct {
 	NotifierBase
-	APIKey    string
-	APIUrl    string
-	AutoClose bool
+	APIKey           string
+	APIUrl           string
+	AutoClose        bool
 	OverridePriority bool
-	log       log.Logger
+	log              log.Logger
 }
 
 // Notify sends an alert notification to OpsGenie.
@@ -137,9 +137,9 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 			tags = append(tags, tag.Key)
 		}
 		if tag.Key == "og_priority" {
-			if on.OverridePriority == true {
-				validPriorities := map[string]bool{"P1": true,"P2": true,"P3": true,"P4": true,"P5": true}
-				if validPriorities[tag.Value] == true {
+			if on.OverridePriority {
+				validPriorities := map[string]bool{"P1": true, "P2": true, "P3": true, "P4": true, "P5": true}
+				if validPriorities[tag.Value] {
 					bodyJSON.Set("priority", tag.Value)
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

OpsGenie's model works heavily off of the priority of an alert (e.g. routing and escalation). Currently this plugin only supports the default "P3".

Grafana does not support alert level config for an alert plugin, therefore I'm using (maybe abusing) tags.

Setting a tag _og_priority_ to the correct P-value (e.g. P1, P2, P3, P4 or P5) will call the OpsGenie API with the correct priority value set.

