### PR TITLE
Alerting: Enable setting of OpsGenie priority via a tag

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -430,6 +430,7 @@ The following sections detail the supported settings for each alert notification
 | apiKey |
 | apiUrl |
 | autoClose |
+| overridePriority |
 
 #### Alert notification `telegram`
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -36,7 +36,16 @@ func init() {
            tooltip="Automatically close alerts in OpsGenie once the alert goes back to ok.">
         </gf-form-switch>
       </div>
-    `,
+      <div class="gf-form">
+        <gf-form-switch
+           class="gf-form"
+           label="Override priority"
+           label-class="width-14"
+           checked="ctrl.model.settings.overridePriority"
+           tooltip="Allow the alert priority to be set using the og_priority tag">
+        </gf-form-switch>
+  </div>
+`,
 	})
 }
 
@@ -47,6 +56,7 @@ var (
 // NewOpsGenieNotifier is the constructor for OpsGenie.
 func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
 	autoClose := model.Settings.Get("autoClose").MustBool(true)
+	overridePriority := model.Settings.Get("overridePriority").MustBool(true)
 	apiKey := model.Settings.Get("apiKey").MustString()
 	apiURL := model.Settings.Get("apiUrl").MustString()
 	if apiKey == "" {
@@ -57,11 +67,12 @@ func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, er
 	}
 
 	return &OpsGenieNotifier{
-		NotifierBase: NewNotifierBase(model),
-		APIKey:       apiKey,
-		APIUrl:       apiURL,
-		AutoClose:    autoClose,
-		log:          log.New("alerting.notifier.opsgenie"),
+		NotifierBase:     NewNotifierBase(model),
+		APIKey:           apiKey,
+		APIUrl:           apiURL,
+		AutoClose:        autoClose,
+		OverridePriority: overridePriority,
+		log:              log.New("alerting.notifier.opsgenie"),
 	}, nil
 }
 
@@ -69,10 +80,11 @@ func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, er
 // alert notifications to OpsGenie
 type OpsGenieNotifier struct {
 	NotifierBase
-	APIKey    string
-	APIUrl    string
-	AutoClose bool
-	log       log.Logger
+	APIKey           string
+	APIUrl           string
+	AutoClose        bool
+	OverridePriority bool
+	log              log.Logger
 }
 
 // Notify sends an alert notification to OpsGenie.
@@ -124,7 +136,14 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 		} else {
 			tags = append(tags, tag.Key)
 		}
-
+		if tag.Key == "og_priority" {
+			if on.OverridePriority {
+				validPriorities := map[string]bool{"P1": true, "P2": true, "P3": true, "P4": true, "P5": true}
+				if validPriorities[tag.Value] {
+					bodyJSON.Set("priority", tag.Value)
+				}
+			}
+		}
 	}
 	bodyJSON.Set("tags", tags)
 


### PR DESCRIPTION
What this PR does / why we need it:

OpsGenie's model works heavily off of the priority of an alert (e.g. routing and escalation). Currently this plugin only supports the default "P3".

Grafana does not support alert level config for an alert plugin, therefore I'm using (maybe abusing) tags.

Setting a tag og_priority to the correct P-value (e.g. P1, P2, P3, P4 or P5) will call the OpsGenie API with the correct priority value set.