### PR TITLE
Alerting: Use fully qualified status emoji in Threema notifier

### DIFF
--- a/pkg/services/alerting/notifiers/threema.go
+++ b/pkg/services/alerting/notifiers/threema.go
@@ -132,11 +132,11 @@ func (notifier *ThreemaNotifier) Notify(evalContext *alerting.EvalContext) error
 	stateEmoji := ""
 	switch evalContext.Rule.State {
 	case models.AlertStateOK:
-		stateEmoji = "\u2705 " // White Heavy Check Mark
+		stateEmoji = "\u2705 " // Check Mark Button
 	case models.AlertStateNoData:
-		stateEmoji = "\u2753 " // Black Question Mark Ornament
+		stateEmoji = "\u2753\uFE0F " // Question Mark
 	case models.AlertStateAlerting:
-		stateEmoji = "\u26A0 " // Warning sign
+		stateEmoji = "\u26A0\uFE0F " // Warning sign
 	}
 
 	// Build message


### PR DESCRIPTION
**What this PR does / why we need it**:

The exclamation mark emoji is not fully qualified. This means that Threema will render it as text, since it's a text-default emoji.

To properly render codepoints that are available both in text- and in emoji-representation, the emoji variant selector (https://emojipedia.org/variation-selector-16/) should be used.

https://emojipedia.org/emoji/%E2%9C%85/
https://emojipedia.org/emoji/%E2%9D%93/
https://emojipedia.org/emoji/%E2%9A%A0%EF%B8%8F/