### PR TITLE
Rendering: Fix panel PNG rendering when using sub url & serve_from_sub_path = true

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -43,7 +43,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 	appSubURL := setting.AppSubUrl
 
 	// special case when doing localhost call from phantomjs
-	if c.IsRenderCall {
+	if c.IsRenderCall && !hs.Cfg.ServeFromSubPath {
 		appURL = fmt.Sprintf("%s://localhost:%s", setting.Protocol, setting.HttpPort)
 		appSubURL = ""
 		settings["appSubUrl"] = ""

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -10,7 +10,6 @@ import (
 
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -41,11 +40,6 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		return
 	}
 
-	path := c.Params("*") + queryParams
-	if setting.ServeFromSubPath {
-		path = strings.TrimPrefix(setting.AppSubUrl+"/"+path, "/")
-	}
-
 	maxConcurrentLimitForApiCalls := 30
 	result, err := hs.RenderService.Render(c.Req.Context(), rendering.Opts{
 		Width:           width,
@@ -54,7 +48,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		OrgId:           c.OrgId,
 		UserId:          c.UserId,
 		OrgRole:         c.OrgRole,
-		Path:            path,
+		Path:            c.Params("*") + queryParams,
 		Timezone:        queryReader.Get("tz", ""),
 		Encoding:        queryReader.Get("encoding", ""),
 		ConcurrentLimit: maxConcurrentLimitForApiCalls,

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -10,6 +10,7 @@ import (
 
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -40,6 +41,11 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		return
 	}
 
+	path := c.Params("*") + queryParams
+	if setting.ServeFromSubPath {
+		path = strings.TrimPrefix(setting.AppSubUrl+"/"+path, "/")
+	}
+
 	maxConcurrentLimitForApiCalls := 30
 	result, err := hs.RenderService.Render(c.Req.Context(), rendering.Opts{
 		Width:           width,
@@ -48,7 +54,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		OrgId:           c.OrgId,
 		UserId:          c.UserId,
 		OrgRole:         c.OrgRole,
-		Path:            c.Params("*") + queryParams,
+		Path:            path,
 		Timezone:        queryReader.Get("tz", ""),
 		Encoding:        queryReader.Get("encoding", ""),
 		ConcurrentLimit: maxConcurrentLimitForApiCalls,


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an improvement to allow rendering dashboards (phantomjs or grafana-image-renderer) when a sub url is configured. The setting 'serve_from_sub_path' must be set to true.

Example:
```
[server]
domain = bgr-dev.iv.local
root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
serve_from_sub_path = true

[rendering]
server_url = http://bgr-dev.iv.local:8081/render
callback_url = http://bgr-dev.iv.local:3000/grafana/
```

An nginx reverse proxy is set up as described in documentation. The following URL gives a rendering of a dashboard:

[http://bgr-dev.iv.local/grafana/render/d/vmie2cmWz/bar-gauge-demo?orgId=1&refresh=10s&from=1577776682916&to=1577798282916&width=1000&height=1500&tz=Europe%2FParis](http://bgr-dev.iv.local/grafana/render/d/vmie2cmWz/bar-gauge-demo?orgId=1&refresh=10s&from=1577776682916&to=1577798282916&width=1000&height=1500&tz=Europe%2FParis)

