### PR TITLE
Rendering: send extra parameters to renderer and allow other formats than PNG

### DIFF
--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -52,6 +52,7 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		Timezone:        queryReader.Get("tz", ""),
 		Encoding:        queryReader.Get("encoding", ""),
 		ConcurrentLimit: maxConcurrentLimitForApiCalls,
+		JsonData:        queryReader.Get("jsonData", ""),
 	})
 
 	if err != nil && err == rendering.ErrTimeout {
@@ -73,6 +74,11 @@ func (hs *HTTPServer) RenderToPng(c *m.ReqContext) {
 		return
 	}
 
-	c.Resp.Header().Set("Content-Type", "image/png")
+	contentType := result.ContentType
+	if contentType == "" {
+		contentType = "image/png"
+	}
+
+	c.Resp.Header().Set("Content-Type", contentType)
 	http.ServeFile(c.Resp, c.Req.Request, result.FilePath)
 }

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -51,6 +51,7 @@ func (rs *RenderingService) renderViaHttp(ctx context.Context, opts Opts) (*Rend
 	queryParams.Add("timezone", isoTimeOffsetToPosixTz(opts.Timezone))
 	queryParams.Add("encoding", opts.Encoding)
 	queryParams.Add("timeout", strconv.Itoa(int(opts.Timeout.Seconds())))
+	queryParams.Add("jsonData", opts.JsonData)
 	rendererUrl.RawQuery = queryParams.Encode()
 
 	req, err := http.NewRequest("GET", rendererUrl.String(), nil)
@@ -105,5 +106,5 @@ func (rs *RenderingService) renderViaHttp(ctx context.Context, opts Opts) (*Rend
 		return nil, fmt.Errorf("Remote rendering request failed.  %s", err)
 	}
 
-	return &RenderResult{FilePath: filePath}, err
+	return &RenderResult{FilePath: filePath, ContentType: resp.Header.Get("Content-Type")}, err
 }

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -23,10 +23,12 @@ type Opts struct {
 	Encoding        string
 	Timezone        string
 	ConcurrentLimit int
+	JsonData        string
 }
 
 type RenderResult struct {
-	FilePath string
+	FilePath    string
+	ContentType string
 }
 
 type renderFunc func(ctx context.Context, options Opts) (*RenderResult, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to send extra parameters to HTTP renderer in a generic way and get a response which can be something else than a PNG. 

**Special notes for your reviewer**:
I have started working on changes to grafana-image-renderer to be able to generate PDF.