### PR TITLE
grafana/ui: Do not build grafana/ui in strict mode as it depends on non-strict libs

### DIFF
--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -16,6 +16,7 @@ const buildCjsPackage = ({ env }) => {
         name: libraryName,
         format: 'cjs',
         sourcemap: true,
+        strict: false,
         exports: 'named',
         globals: {
           react: 'React',
@@ -23,7 +24,7 @@ const buildCjsPackage = ({ env }) => {
         },
       },
     ],
-    external: ['react', 'react-dom', '@grafana/data'],
+    external: ['react', 'react-dom', '@grafana/data', 'moment'],
     plugins: [
       commonjs({
         include: /node_modules/,


### PR DESCRIPTION
Fixes #20921

grafana/ui depends on BizCharts which contains non-strict code. This PR makes grafana/ui build in non-strict mode as well, as we might include some other code in the future which is non-strict.

It also adds `moment` as an external dependency.