### PR TITLE
Arrow: don't export arrow... breaking phantomjs e2e test

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -4,4 +4,6 @@ export * from './CircularDataFrame';
 export * from './MutableDataFrame';
 export * from './processDataFrame';
 export * from './dimensions';
-export * from './ArrowDataFrame';
+
+// Phantom JS :(
+//export * from './ArrowDataFrame';


### PR DESCRIPTION
#21277 tried to export ArrowDataFrame again... but the e2e tests still fail

This reverts the export and then I'll investigate more