### PR TITLE
docs: fix influxdb templated dashboard link

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -389,4 +389,4 @@ Variable values are always synced to the URL using the syntax `var-<varname>=val
 
 - [Graphite Templated Dashboard](http://play.grafana.org/dashboard/db/graphite-templated-nested)
 - [Elasticsearch Templated Dashboard](http://play.grafana.org/dashboard/db/elasticsearch-templated)
-- [InfluxDB Templated Dashboard](http://play.grafana.org/dashboard/db/influxdb-templated-queries)
+- [InfluxDB Templated Dashboard](http://play.grafana.org/dashboard/db/influxdb-templated)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix broken dashboard link on https://grafana.com/docs/grafana/latest/reference/templating/#examples

I think it's supposed to link to http://play.grafana.org/dashboard/db/influxdb-templated

**Which issue(s) this PR fixes**:

Fixes #21320