### PR TITLE
Toolkit: add git log info to the plugin build report

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -9,7 +9,7 @@ import { PluginMeta } from '@grafana/data';
 import execa = require('execa');
 import path = require('path');
 import fs from 'fs';
-import { getPackageDetails, findImagesInFolder, getGrafanaVersions } from '../../plugins/utils';
+import { getPackageDetails, findImagesInFolder, getGrafanaVersions, readGitLog } from '../../plugins/utils';
 import {
   job,
   getJobFolder,
@@ -324,6 +324,7 @@ const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
     tests: agregateTestInfo(),
     artifactsBaseURL: await getCircleDownloadBaseURL(),
     grafanaVersion: getGrafanaVersions(),
+    git: await readGitLog(),
   };
   const pr = getPullRequestNumber();
   if (pr) {

--- a/packages/grafana-toolkit/src/plugins/types.ts
+++ b/packages/grafana-toolkit/src/plugins/types.ts
@@ -75,6 +75,7 @@ export interface ZipFileInfo {
 interface UserInfo {
   name: string;
   email: string;
+  time?: number;
 }
 
 export interface GitLogInfo {

--- a/packages/grafana-toolkit/src/plugins/types.ts
+++ b/packages/grafana-toolkit/src/plugins/types.ts
@@ -11,6 +11,7 @@ export interface PluginBuildReport {
   workflow: WorkflowInfo;
   coverage: CoverageInfo[];
   tests: TestResultsInfo[];
+  git?: GitLogInfo;
   pullRequest?: number;
   artifactsBaseURL?: string;
   grafanaVersion?: KeyValue<string>;
@@ -69,4 +70,19 @@ export interface ZipFileInfo {
   contents: ExtensionSize;
   sha1?: string;
   md5?: string;
+}
+
+interface UserInfo {
+  name: string;
+  email: string;
+}
+
+export interface GitLogInfo {
+  commit: string;
+  tree: string;
+  subject: string;
+  body?: string;
+  notes?: string;
+  author: UserInfo;
+  commiter: UserInfo;
 }

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -98,7 +98,7 @@ export async function readGitLog(): Promise<GitLogInfo | undefined> {
     let exe = await execa('git', [
       'log',
       '-1', // last line
-      '--pretty=format:\'{%n  "commit": "%H",%n  "tree": "%T",%n  "subject": "%s",%n  "author": {%n    "name": "%aN",%n    "email": "%aE"  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE"  }%n}\'',
+      '--pretty=format:\'{%n  "commit": "%H",%n  "tree": "%T",%n  "subject": "%s",%n  "author": {%n    "name": "%aN",%n    "email": "%aE", "time":"%at"  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE", "time":"%ct"  }%n}\'',
     ]);
     const info = JSON.parse(exe.stdout) as GitLogInfo;
 

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import path from 'path';
 import fs from 'fs';
 import { KeyValue } from '@grafana/data';
-import { ExtensionSize, ZipFileInfo } from './types';
+import { ExtensionSize, ZipFileInfo, GitLogInfo } from './types';
 
 const md5File = require('md5-file');
 
@@ -91,4 +91,40 @@ export function findImagesInFolder(dir: string, prefix = '', append?: string[]):
   }
 
   return imgs;
+}
+
+export async function readGitLog(): Promise<GitLogInfo | undefined> {
+  try {
+    let exe = await execa('git', [
+      'log',
+      '-1', // last line
+      '--pretty=format:\'{%n  "commit": "%H",%n  "tree": "%T",%n  "subject": "%s",%n  "author": {%n    "name": "%aN",%n    "email": "%aE"  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE"  }%n}\'',
+    ]);
+    const info = JSON.parse(exe.stdout) as GitLogInfo;
+
+    // Read the body
+    exe = await execa('git', [
+      'log',
+      '-1', // last line
+      "--pretty=format:'%b'", // Just the body (with newlines!)
+    ]);
+    if (exe.stdout && exe.stdout.length) {
+      info.body = exe.stdout.trim();
+    }
+
+    // Read any commit notes
+    exe = await execa('git', [
+      'log',
+      '-1', // last line
+      "--pretty=format:'%N'", // commit notes (with newlines!)
+    ]);
+    if (exe.stdout && exe.stdout.length) {
+      info.notes = exe.stdout.trim();
+    }
+
+    return info;
+  } catch (err) {
+    console.warn('Error REading Git log info', err);
+  }
+  return undefined;
 }

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -98,7 +98,7 @@ export async function readGitLog(): Promise<GitLogInfo | undefined> {
     let exe = await execa('git', [
       'log',
       '-1', // last line
-      '--pretty=format:\'{%n  "commit": "%H",%n  "tree": "%T",%n  "subject": "%s",%n  "author": {%n    "name": "%aN",%n    "email": "%aE", "time":"%at"  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE", "time":"%ct"  }%n}\'',
+      '--pretty=format:{%n  "commit": "%H",%n  "tree": "%T",%n  "subject": "%s",%n  "author": {%n    "name": "%aN",%n    "email": "%aE",%n    "time":"%at"  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE",%n    "time":"%ct"  }%n}',
     ]);
     const info = JSON.parse(exe.stdout) as GitLogInfo;
 
@@ -106,7 +106,7 @@ export async function readGitLog(): Promise<GitLogInfo | undefined> {
     exe = await execa('git', [
       'log',
       '-1', // last line
-      "--pretty=format:'%b'", // Just the body (with newlines!)
+      '--pretty=format:%b', // Just the body (with newlines!)
     ]);
     if (exe.stdout && exe.stdout.length) {
       info.body = exe.stdout.trim();
@@ -116,7 +116,7 @@ export async function readGitLog(): Promise<GitLogInfo | undefined> {
     exe = await execa('git', [
       'log',
       '-1', // last line
-      "--pretty=format:'%N'", // commit notes (with newlines!)
+      '--pretty=format:%N', // commit notes (with newlines!)
     ]);
     if (exe.stdout && exe.stdout.length) {
       info.notes = exe.stdout.trim();


### PR DESCRIPTION
This adds a section to the report with more detailed git log info:

```
{
    "commit": "de3093b7e408ba3f5cda8a8627b21f68deed9993",
    "tree": "20e2b88670fda31f16e4b681d880a6f21f561eae",
    "subject": "update to latest",
    "author": {
      "name": "ryan",
      "email": "ryantxu@xxxx.com",
      "time":"1569972978"  },
    "commiter": {
      "name": "ryan",
      "email": "ryantxu@xxx.com",
      "time":"1569972978"  }
  }
```