### PR TITLE
Elasticsearch: Fix adhoc variable filtering for logs query

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -344,7 +344,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
         target.metrics = [queryDef.defaultMetricAgg()];
         // Setting this for metrics queries that are typed as logs
         target.isLogsQuery = true;
-        queryObj = this.queryBuilder.getLogsQuery(target, queryString);
+        queryObj = this.queryBuilder.getLogsQuery(target, adhocFilters, queryString);
       } else {
         if (target.alias) {
           target.alias = this.templateSrv.replace(target.alias, options.scopedVars, 'lucene');

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -379,7 +379,7 @@ export class ElasticQueryBuilder {
     return query;
   }
 
-  getLogsQuery(target: any, querystring: string) {
+  getLogsQuery(target: any, adhocFilters?: any, querystring?: string) {
     let query: any = {
       size: 0,
       query: {
@@ -388,6 +388,8 @@ export class ElasticQueryBuilder {
         },
       },
     };
+
+    this.addAdhocFilters(query, adhocFilters);
 
     if (target.query) {
       query.query.bool.filter.push({


### PR DESCRIPTION
**What this PR does / why we need it**:

The Elasticsearch data source plugin currently doesn't apply adhoc variable filters, which means that it is not possible to use adhoc variables to filter data in for example a logs panel. See also #21086

This PR fixes that by adding the adhoc filters to the logs query.

**Which issue(s) this PR fixes**:

Fixes #21086
