### PR TITLE
Basic skeleton for a resource card component

### DIFF
--- a/packages/grafana-ui/src/components/ResourceCard/ResourceCard.story.tsx
+++ b/packages/grafana-ui/src/components/ResourceCard/ResourceCard.story.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
+import { ResourceCard } from './ResourceCard';
+
+export default {
+  title: 'UI/ResourceCard',
+  component: ResourceCard,
+  decorators: [withCenteredStory],
+  parameters: {},
+};
+
+export const simple = () => {
+  // const data = [
+  //   {
+  //     name: 'Production database',
+  //     meta: []
+  //   }
+  // ];
+
+  return <ResourceCard name="" />;
+};

--- a/packages/grafana-ui/src/components/ResourceCard/ResourceCard.tsx
+++ b/packages/grafana-ui/src/components/ResourceCard/ResourceCard.tsx
@@ -1,0 +1,58 @@
+import React, { PureComponent, FC, ReactNode } from 'react';
+
+export interface Props {
+  name: JSX.Element;
+  figure?: JSX.Element;
+  description?: JSX.Element;
+  infoItems?: JSX.Element[];
+  actions?: JSX.Element;
+  childen?: ReactNode;
+}
+
+export class ResourceCard extends PureComponent<Props> {
+  render() {
+    const { name, figure, description, actions, childen, infoItems } = this.props;
+
+    const figurePart = figure && <div className="resource-card__figure">{figure}</div>;
+
+    const descriptionRow = description && (
+      <div className="resource-card__row">
+        <div className="resource-card__description">{description}</div>
+      </div>
+    );
+
+    const infoRow = infoItems && (
+      <div className="resource-card__row">
+        {React.Children.map(infoItems, (item: JSX.Element) => (
+          <div className="resource-card__info-item">{item}</div>
+        ))}
+      </div>
+    );
+    const actionParts = actions && <div className="resource-card__actions">{actions}</div>;
+
+    return (
+      <div className="resource-card">
+        {figure}
+        <div className="resource-card__body">
+          <div className="resource-card__row">
+            <div className="resource-card__name">{name}</div>
+          </div>
+          {descriptionRow}
+          {infoRow}
+          {childen}
+        </div>
+        {actionParts}
+      </div>
+    );
+  }
+}
+
+export interface ResourceCardNameProps {
+  name: string;
+}
+
+export const ResourceCardName: React.FC<ResourceCardNameProps> = ({ name }) => {
+  return <div className="resource-card__name">{name}</div>;
+};
+
+ResourceCardName.displayName = 'ResourceCardName';


### PR DESCRIPTION
Get a shared resource card component that we can use in datasource list, plugin list, add data source list, etc. 

* Use sass for now (copy styles from cards.css and reuse card-shadow & card-background etc). Let's focus on getting a reusable component first that uses existing card variables and look. We can tweak styles & move to emotion in a later step when know the design. Think this will be faster as we do not have all the current card variables accessible to emotion yet. 
* [ ] Add ResourceCardList component (simple flex list layout only) 
* [ ] Use ResourceCardList in data datasource list page
* [ ] Use ResourceCardList in data plugin list page
* [ ] Use ResourceCardList in add data source page

Simple design to begin with:
Logo | Name (ResourceCardName | ResourceCardNameLink) 
          | Description (optional)
          | info attributes, example: Type: elasticsearch   | URL: http://localhost:9090  

The actions I think we can absolutely position to the right of the card.