### PR TITLE
Docs: Use HTTPS scheme for Grafana playground links

### DIFF
--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -168,7 +168,7 @@ In the above example, we have a lucene query that filters documents based on the
 a variable in the *Terms* group by field input box. This allows you to use a variable to quickly change how the data is grouped.
 
 Example dashboard:
-[Elasticsearch Templated Dashboard](http://play.grafana.org/dashboard/db/elasticsearch-templated)
+[Elasticsearch Templated Dashboard](https://play.grafana.org/dashboard/db/elasticsearch-templated)
 
 ## Annotations
 

--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -147,7 +147,7 @@ Why two ways? The first syntax is easier to read and write but does not allow yo
 the second syntax in expressions like  `my.server[[serverNumber]].count`.
 
 Example:
-[Graphite Templated Dashboard](http://play.grafana.org/dashboard/db/graphite-templated-nested)
+[Graphite Templated Dashboard](https://play.grafana.org/dashboard/db/graphite-templated-nested)
 
 ### Variable Usage in Tag Queries
 

--- a/docs/sources/features/panels/table_panel.md
+++ b/docs/sources/features/panels/table_panel.md
@@ -17,7 +17,7 @@ weight = 4
 The table panel is very flexible, supporting both multiple modes for time series as well as for
 table, annotation and raw JSON data. It also provides date formatting and value formatting and coloring options.
 
-To view table panels in action and test different configurations with sample data, check out the [Table Panel Showcase in the Grafana Playground](http://play.grafana.org/dashboard/db/table-panel-showcase).
+To view table panels in action and test different configurations with sample data, check out the [Table Panel Showcase in the Grafana Playground](https://play.grafana.org/dashboard/db/table-panel-showcase).
 
 ## Querying Data
 

--- a/docs/sources/guides/whats-new-in-v2-5.md
+++ b/docs/sources/guides/whats-new-in-v2-5.md
@@ -37,7 +37,7 @@ and complex queries for logs or metrics.
 - Query only relevant indices based on time pattern
 - Alias patterns for short readable series names
 
-Try the new Elasticsearch query editor on the [play.grafana.org](http://play.grafana.org/dashboard/db/elasticsearch-metrics) site.
+Try the new Elasticsearch query editor on the [play.grafana.org](https://play.grafana.org/dashboard/db/elasticsearch-metrics) site.
 
 ### CloudWatch
 

--- a/docs/sources/guides/whats-new-in-v3.md
+++ b/docs/sources/guides/whats-new-in-v3.md
@@ -128,7 +128,7 @@ And here's the new look for Dashboard settings:
 
 <img src="/img/docs/v3/dashboard_settings.png">
 
-Check out the <a href="http://play.grafana.org" target="_blank">Play
+Check out the <a href="https://play.grafana.org" target="_blank">Play
 Site</a> to get a feel for some of the UI changes.
 
 ## Improved Annotations

--- a/docs/sources/guides/whats-new-in-v4-3.md
+++ b/docs/sources/guides/whats-new-in-v4-3.md
@@ -23,7 +23,7 @@ Grafana v4.3 Beta is now [available for download](https://grafana.com/grafana/do
 - New [MySQL Data Source](http://docs.grafana.org/features/datasources/mysql/) (alpha version to get some early feedback)
 - 60+ small fixes and improvements, most of them contributed by our fantastic community!
 
-Check out the [New Features in v4.3 Dashboard](http://play.grafana.org/dashboard/db/new-features-in-v4-3?orgId=1) on the Grafana Play site for a showcase of these new features.
+Check out the [New Features in v4.3 Dashboard](https://play.grafana.org/dashboard/db/new-features-in-v4-3?orgId=1) on the Grafana Play site for a showcase of these new features.
 
 ## Histogram Support
 

--- a/docs/sources/guides/whats-new-in-v5.md
+++ b/docs/sources/guides/whats-new-in-v5.md
@@ -37,7 +37,7 @@ This is the most substantial update that Grafana has ever seen. This article wil
 The new dashboard layout engine allows for much easier movement and sizing of panels, as other panels now move out of the way in
 a very intuitive way. Panels are sized independently, so rows are no longer necessary to create layouts. This opens
 up many new types of layouts where panels of different heights can be aligned easily. Check out the new grid in the video
-above or on the [play site](http://play.grafana.org). All your existing dashboards will automatically migrate to the
+above or on the [play site](https://play.grafana.org). All your existing dashboards will automatically migrate to the
 new position system and look close to identical. The new panel position makes dashboards saved in v5.0 incompatible
 with older versions of Grafana.
 

--- a/docs/sources/reference/playlist.md
+++ b/docs/sources/reference/playlist.md
@@ -148,5 +148,5 @@ You can share a playlist by copying the link address on the view mode you prefer
 1. Click **Copy Link Address** to copy the URL to your clipboard. 
 
     Example: The URL for the first playlist on the Grafana Play site in Kiosk mode will look like this:
-[http://play.grafana.org/playlists/play/1?kiosk](http://play.grafana.org/playlists/play/1?kiosk).
+[https://play.grafana.org/playlists/play/1?kiosk](https://play.grafana.org/playlists/play/1?kiosk).
 1. Paste the URL to your destination.

--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -114,7 +114,7 @@ String to interpolate: '${servers:percentencode}'
 Interpolation result: 'foo%28%29bar%20BAZ%2Ctest2'
 ```
 
-Test the formatting options on the [Grafana Play site](http://play.grafana.org/d/cJtIfcWiz/template-variable-formatting-options?orgId=1).
+Test the formatting options on the [Grafana Play site](https://play.grafana.org/d/cJtIfcWiz/template-variable-formatting-options?orgId=1).
 
 If any invalid formatting option is specified, then `glob` is the default/fallback option.
 
@@ -379,7 +379,7 @@ you want to repeat the row for.
 
 It may be a good idea to use a variable in the row title as well.
 
-Example: [Repeated Rows Dashboard](http://play.grafana.org/dashboard/db/repeated-rows)
+Example: [Repeated Rows Dashboard](https://play.grafana.org/dashboard/db/repeated-rows)
 
 ## URL state
 
@@ -387,6 +387,6 @@ Variable values are always synced to the URL using the syntax `var-<varname>=val
 
 ## Examples
 
-- [Graphite Templated Dashboard](http://play.grafana.org/dashboard/db/graphite-templated-nested)
-- [Elasticsearch Templated Dashboard](http://play.grafana.org/dashboard/db/elasticsearch-templated)
-- [InfluxDB Templated Dashboard](http://play.grafana.org/dashboard/db/influxdb-templated)
+- [Graphite Templated Dashboard](https://play.grafana.org/dashboard/db/graphite-templated-nested)
+- [Elasticsearch Templated Dashboard](https://play.grafana.org/dashboard/db/elasticsearch-templated)
+- [InfluxDB Templated Dashboard](https://play.grafana.org/dashboard/db/influxdb-templated)

--- a/docs/sources/tutorials/hubot_howto.md
+++ b/docs/sources/tutorials/hubot_howto.md
@@ -57,7 +57,7 @@ Edit the file external-scripts.json, and add hubot-grafana to the list of plugin
 The `hubot-grafana` plugin requires a number of environment variables to be set in order to work properly.
 
 ```bash
-export HUBOT_GRAFANA_HOST=http://play.grafana.org
+export HUBOT_GRAFANA_HOST=https://play.grafana.org
 export HUBOT_GRAFANA_API_KEY=abcd01234deadbeef01234
 export HUBOT_GRAFANA_S3_BUCKET=mybucket
 export HUBOT_GRAFANA_S3_ACCESS_KEY_ID=ABCDEF123456XYZ


### PR DESCRIPTION
**What this PR does / why we need it**:

All playground links with a HTTP scheme is redirected to HTTPS. We can link to HTTPS instead, to skip the HTTP->HTTPS redirect flow.