### PR TITLE
Docs: Fixed broken links of Datasource doc at Grafana plugin page

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/README.md
+++ b/public/app/plugins/datasource/cloudwatch/README.md
@@ -4,4 +4,4 @@ Grafana ships with **built in** support for CloudWatch. You just have to add it 
 
 Read more about it here:
 
-[http://docs.grafana.org/datasources/cloudwatch/](http://docs.grafana.org/datasources/cloudwatch/)
+[https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/](https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/)

--- a/public/app/plugins/datasource/elasticsearch/README.md
+++ b/public/app/plugins/datasource/elasticsearch/README.md
@@ -4,4 +4,4 @@ Grafana ships with **advanced support** for Elasticsearch. You can do many types
 
 Read more about it here:
 
-[http://docs.grafana.org/datasources/elasticsearch/](http://docs.grafana.org/datasources/elasticsearch/)
+[https://grafana.com/docs/grafana/latest/features/datasources/elasticsearch/](https://grafana.com/docs/grafana/latest/features/datasources/elasticsearch/)


### PR DESCRIPTION
**What this PR does / why we need it**:
It Fixes the broken doc links

**Which issue(s) this PR fixes**:

Fixes #21362 

**Special notes for your reviewer**:

