### PR TITLE
CircleCI: Testing upgrade to CircleCI 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2.1
+
 aliases:
   # Workflow filters
   - &filter-only-release
@@ -13,8 +15,6 @@ aliases:
   - &filter-only-master
     branches:
       only: master
-
-version: 2
 
 jobs:
   mysql-integration-test:
@@ -1071,7 +1071,6 @@ jobs:
             - $HOME/.cache/trivy
 
 workflows:
-  version: 2
   build-master:
     jobs:
       - build-all:


### PR DESCRIPTION
Closes #18401

Testing upgrading to v2.1, could not find any info on breaking changes other than removing version from workflows. 

In 2.1 we can start using commands & steps to get rid of all the circle ci started, stopped failed that make up 20% of our circleci config :) 

https://circleci.com/docs/2.0/reusing-config/#steps