### PR TITLE
Alerting: Unpausing a non-paused alert rule should not change status to Unknown

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -353,11 +353,12 @@ func NotificationTest(c *models.ReqContext, dto dtos.NotificationTestCommand) Re
 
 //POST /api/alerts/:alertId/pause
 func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
+	const Pause = "paused"
 	alertID := c.ParamsInt64("alertId")
 	result := make(map[string]interface{})
 	result["alertId"] = alertID
-	query := models.GetAlertByIdQuery{Id: alertID}
 
+	query := models.GetAlertByIdQuery{Id: alertID}
 	if err := bus.Dispatch(&query); err != nil {
 		return Error(500, "Get Alert failed", err)
 	}
@@ -372,12 +373,12 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	}
 
 	// Alert state validation
-	if query.Result.State != "paused" && !dto.Paused {
+	if query.Result.State != Pause && !dto.Paused {
 		result["state"] = "un-paused"
 		result["message"] = "Alert is already un-paused"
 		return JSON(200, result)
-	} else if query.Result.State == "paused" && dto.Paused {
-		result["state"] = "paused"
+	} else if query.Result.State == Pause && dto.Paused {
+		result["state"] = Pause
 		result["message"] = "Alert is already paused"
 		return JSON(200, result)
 	}
@@ -396,7 +397,7 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	pausedState := "un-paused"
 	if cmd.Paused {
 		response = models.AlertStatePaused
-		pausedState = "paused"
+		pausedState = Pause
 	}
 
 	result["state"] = response

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -353,7 +353,6 @@ func NotificationTest(c *models.ReqContext, dto dtos.NotificationTestCommand) Re
 
 //POST /api/alerts/:alertId/pause
 func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
-	const Pause = "paused"
 	alertID := c.ParamsInt64("alertId")
 	result := make(map[string]interface{})
 	result["alertId"] = alertID
@@ -373,12 +372,12 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	}
 
 	// Alert state validation
-	if query.Result.State != Pause && !dto.Paused {
+	if query.Result.State != models.AlertStatePaused && !dto.Paused {
 		result["state"] = "un-paused"
 		result["message"] = "Alert is already un-paused"
 		return JSON(200, result)
-	} else if query.Result.State == Pause && dto.Paused {
-		result["state"] = Pause
+	} else if query.Result.State == models.AlertStatePaused && dto.Paused {
+		result["state"] = models.AlertStatePaused
 		result["message"] = "Alert is already paused"
 		return JSON(200, result)
 	}
@@ -397,7 +396,7 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	pausedState := "un-paused"
 	if cmd.Paused {
 		response = models.AlertStatePaused
-		pausedState = Pause
+		pausedState = "paused"
 	}
 
 	result["state"] = response

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -354,7 +354,8 @@ func NotificationTest(c *models.ReqContext, dto dtos.NotificationTestCommand) Re
 //POST /api/alerts/:alertId/pause
 func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	alertID := c.ParamsInt64("alertId")
-
+	result := make(map[string]interface{})
+	result["alertId"] = alertID
 	query := models.GetAlertByIdQuery{Id: alertID}
 
 	if err := bus.Dispatch(&query); err != nil {
@@ -368,6 +369,17 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 		}
 
 		return Error(403, "Access denied to this dashboard and alert", nil)
+	}
+
+	// Alert state validation
+	if query.Result.State != "paused" && dto.Paused == false {
+		result["state"] = "un-paused"
+		result["message"] = "Alert is already un-paused"
+		return JSON(200, result)
+	} else if query.Result.State == "paused" && dto.Paused == true {
+		result["state"] = "paused"
+		result["message"] = "Alert is already paused"
+		return JSON(200, result)
 	}
 
 	cmd := models.PauseAlertCommand{
@@ -387,12 +399,8 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 		pausedState = "paused"
 	}
 
-	result := map[string]interface{}{
-		"alertId": alertID,
-		"state":   response,
-		"message": "Alert " + pausedState,
-	}
-
+	result["state"] = response
+	result["message"] = "Alert " + pausedState
 	return JSON(200, result)
 }
 

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -372,11 +372,11 @@ func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) Response {
 	}
 
 	// Alert state validation
-	if query.Result.State != "paused" && dto.Paused == false {
+	if query.Result.State != "paused" && !dto.Paused {
 		result["state"] = "un-paused"
 		result["message"] = "Alert is already un-paused"
 		return JSON(200, result)
-	} else if query.Result.State == "paused" && dto.Paused == true {
+	} else if query.Result.State == "paused" && dto.Paused {
 		result["state"] = "paused"
 		result["message"] = "Alert is already paused"
 		return JSON(200, result)


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR validates alert's current state before making any change which helps in avoiding issues due to
-> Pausing the already paused alert (or)
-> Un-pausing the already up-paused alert 

**Which issue(s) this PR fixes**:

Fixes #21330 

**Special notes for your reviewer**:

