### PR TITLE
Cloudwatch: Fixed crash when switching from cloudwatch data source

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -28,8 +28,8 @@ const idValidationEvents: ValidationEvents = {
 export class QueryEditor extends PureComponent<Props, State> {
   state: State = { regions: [], namespaces: [], metricNames: [], variableOptionGroup: {}, showMeta: false };
 
-  componentWillMount() {
-    const { query } = this.props;
+  static getDerivedStateFromProps(props: Props, state: State) {
+    const { query } = props;
 
     if (!query.namespace) {
       query.namespace = '';
@@ -66,6 +66,8 @@ export class QueryEditor extends PureComponent<Props, State> {
     if (!query.hasOwnProperty('matchExact')) {
       query.matchExact = true;
     }
+
+    return state;
   }
 
   componentDidMount() {


### PR DESCRIPTION
Fixes #21361

Cloudwatch query editor crash when switching from it to another DS, due to query model reset during change and a query editor render that happens before the switch is complete. 