### PR TITLE
Remove reference to jquery.flot.pie file from storybook config

### DIFF
--- a/packages/grafana-ui/.storybook/config.ts
+++ b/packages/grafana-ui/.storybook/config.ts
@@ -3,7 +3,6 @@ import '../../../public/vendor/flot/jquery.flot.js';
 import '../../../public/vendor/flot/jquery.flot.selection';
 import '../../../public/vendor/flot/jquery.flot.time';
 import '../../../public/vendor/flot/jquery.flot.stack';
-import '../../../public/vendor/flot/jquery.flot.pie';
 import '../../../public/vendor/flot/jquery.flot.stackpercent';
 import '../../../public/vendor/flot/jquery.flot.fillbelow';
 import '../../../public/vendor/flot/jquery.flot.crosshair';


### PR DESCRIPTION
jquery.flot.pie.js file was removed in https://github.com/grafana/grafana/commit/f93f1c4b51f00d380ba180c5b867140ba81761e3 . This made storybook to fail building