### PR TITLE
Build: prevent changes to pkg/extentions/main.go from throwing error on merge 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ profile.cov
 /pkg/cmd/grafana-server/grafana-server
 /pkg/cmd/grafana-server/debug
 /pkg/extensions
+!/pkg/extensions/main.go
 /public/app/extensions
 debug.test
 /examples/*/dist


### PR DESCRIPTION
**What this PR does / why we need it**:
If a commit with changes to `/pkg/extensions/main.go` is merged you will receive the following error because the file is added to the `.gitignore` file. 

![error](https://i.imgur.com/CE6ja6E.png)

**Special notes for your reviewer**:
Not sure how often we do changes to this file but since it is added to git we probably don't want to ignore it? Right?
