### PR TITLE
Alerting: Add diff_signed and percent_diff_signed to alerting redurcer types

### DIFF
--- a/pkg/services/alerting/conditions/reducer.go
+++ b/pkg/services/alerting/conditions/reducer.go
@@ -146,7 +146,7 @@ func calculateDiff(series *tsdb.TimeSeries, allNull bool, value float64, fn func
 			if points[i][0].Valid {
 				allNull = false
 				val := fn(first, points[i][0].Float64)
-				if signed == false {
+				if !signed {
 					value = math.Abs(val)
 				} else {
 					value = val

--- a/pkg/services/alerting/conditions/reducer.go
+++ b/pkg/services/alerting/conditions/reducer.go
@@ -95,9 +95,13 @@ func (s *queryReducer) Reduce(series *tsdb.TimeSeries) null.Float {
 			}
 		}
 	case "diff":
-		allNull, value = calculateDiff(series, allNull, value, diff)
+		allNull, value = calculateDiff(series, allNull, value, diff, false)
+	case "diff_signed":
+		allNull, value = calculateDiff(series, allNull, value, diff, true)
 	case "percent_diff":
-		allNull, value = calculateDiff(series, allNull, value, percentDiff)
+		allNull, value = calculateDiff(series, allNull, value, percentDiff, false)
+	case "percent_diff_signed":
+		allNull, value = calculateDiff(series, allNull, value, percentDiff, true)
 	case "count_non_null":
 		for _, v := range series.Points {
 			if v[0].Valid {
@@ -121,7 +125,7 @@ func newSimpleReducer(t string) *queryReducer {
 	return &queryReducer{Type: t}
 }
 
-func calculateDiff(series *tsdb.TimeSeries, allNull bool, value float64, fn func(float64, float64) float64) (bool, float64) {
+func calculateDiff(series *tsdb.TimeSeries, allNull bool, value float64, fn func(float64, float64) float64, signed bool) (bool, float64) {
 	var (
 		points = series.Points
 		first  float64
@@ -142,7 +146,11 @@ func calculateDiff(series *tsdb.TimeSeries, allNull bool, value float64, fn func
 			if points[i][0].Valid {
 				allNull = false
 				val := fn(first, points[i][0].Float64)
-				value = math.Abs(val)
+				if signed == false {
+					value = math.Abs(val)
+				} else {
+					value = val
+				}
 				break
 			}
 		}

--- a/pkg/services/alerting/conditions/reducer_test.go
+++ b/pkg/services/alerting/conditions/reducer_test.go
@@ -189,12 +189,12 @@ func TestSimpleReducer(t *testing.T) {
 
 		Convey("percent_diff two points", func() {
 			result := testReducer("percent_diff", 30, 40)
-			So(result, ShouldEqual, float64(-33.33333333333333))
+			So(result, ShouldEqual, float64(33.33333333333333))
 		})
 
 		Convey("percent_diff three points", func() {
 			result := testReducer("percent_diff", 30, 40, 40)
-			So(result, ShouldEqual, float64(-33.33333333333333))
+			So(result, ShouldEqual, float64(33.33333333333333))
 		})
 
 		Convey("percent_diff with only nulls", func() {

--- a/pkg/services/alerting/conditions/reducer_test.go
+++ b/pkg/services/alerting/conditions/reducer_test.go
@@ -155,6 +155,33 @@ func TestSimpleReducer(t *testing.T) {
 			So(reducer.Reduce(series).Valid, ShouldEqual, false)
 		})
 
+		Convey("diff_signed one point", func() {
+			result := testReducer("diff_signed", 30)
+			So(result, ShouldEqual, float64(0))
+		})
+
+		Convey("diff_signed two points", func() {
+			result := testReducer("diff_signed", 30, 40)
+			So(result, ShouldEqual, float64(10))
+		})
+
+		Convey("diff_signed three points", func() {
+			result := testReducer("diff_signed", 30, 40, 40)
+			So(result, ShouldEqual, float64(10))
+		})
+
+		Convey("diff_signed with only nulls", func() {
+			reducer := newSimpleReducer("diff_signed")
+			series := &tsdb.TimeSeries{
+				Name: "test time serie",
+			}
+
+			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFromPtr(nil), 1))
+			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFromPtr(nil), 2))
+
+			So(reducer.Reduce(series).Valid, ShouldEqual, false)
+		})
+
 		Convey("percent_diff one point", func() {
 			result := testReducer("percent_diff", 40)
 			So(result, ShouldEqual, float64(0))
@@ -162,12 +189,12 @@ func TestSimpleReducer(t *testing.T) {
 
 		Convey("percent_diff two points", func() {
 			result := testReducer("percent_diff", 30, 40)
-			So(result, ShouldEqual, float64(33.33333333333333))
+			So(result, ShouldEqual, float64(-33.33333333333333))
 		})
 
 		Convey("percent_diff three points", func() {
 			result := testReducer("percent_diff", 30, 40, 40)
-			So(result, ShouldEqual, float64(33.33333333333333))
+			So(result, ShouldEqual, float64(-33.33333333333333))
 		})
 
 		Convey("percent_diff with only nulls", func() {
@@ -181,6 +208,34 @@ func TestSimpleReducer(t *testing.T) {
 
 			So(reducer.Reduce(series).Valid, ShouldEqual, false)
 		})
+
+		Convey("percent_diff_signed one point", func() {
+			result := testReducer("percent_diff_signed", 40)
+			So(result, ShouldEqual, float64(0))
+		})
+
+		Convey("percent_diff_signed two points", func() {
+			result := testReducer("percent_diff_signed", 30, 40)
+			So(result, ShouldEqual, float64(33.33333333333333))
+		})
+
+		Convey("percent_diff_signed three points", func() {
+			result := testReducer("percent_diff_signed", 30, 40, 40)
+			So(result, ShouldEqual, float64(33.33333333333333))
+		})
+
+		Convey("percent_diff_signed with only nulls", func() {
+			reducer := newSimpleReducer("percent_diff_signed")
+			series := &tsdb.TimeSeries{
+				Name: "test time serie",
+			}
+
+			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFromPtr(nil), 1))
+			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFromPtr(nil), 2))
+
+			So(reducer.Reduce(series).Valid, ShouldEqual, false)
+		})
+
 	})
 }
 

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -47,7 +47,9 @@ const reducerTypes = [
   { text: 'last()', value: 'last' },
   { text: 'median()', value: 'median' },
   { text: 'diff()', value: 'diff' },
+  { text: 'diff_signed()', value: 'diff_signed' },
   { text: 'percent_diff()', value: 'percent_diff' },
+  { text: 'percent_diff_signed()', value: 'percent_diff_signed' },
   { text: 'count_non_null()', value: 'count_non_null' },
 ];
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds two new functions **diff_signed** & **percent_diff_signed** to returned signed values. This keeps the existing **diff** and **percent_diff** functionality for backwards compatibility. 

**Which issue(s) this PR fixes**:
Fixes #10129 #16270 

Thanks!