### PR TITLE
TimeZones: fix utc test

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.test.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.test.ts
@@ -25,7 +25,7 @@ describe('date time formats', () => {
 
   it('should format as iso date (in UTC)', () => {
     const expected = utcTime.format('YYYY-MM-DD HH:mm:ss');
-    const actual = dateTimeAsIso(epoch, 0, 0);
+    const actual = dateTimeAsIso(epoch, 0, 0, 'utc');
     expect(actual.text).toBe(expected);
   });
 


### PR DESCRIPTION
The changes in #21276 cause a test to fail when running in a non-utc timezone.

since circleci is in UTC we did not catch it automatically 😢 

![image](https://user-images.githubusercontent.com/705951/71932153-25d5bd80-3154-11ea-9cdb-04a367a2b28e.png)
