### PR TITLE
 Docs: Add "milliseconds" error to Troubleshooting

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -202,6 +202,14 @@ find ./conf ./pkg ./public/views | wc -l
 
 Another alternative is to limit the files being watched. The directories that are watched for changes are listed in the `.bra.toml` file in the root directory. 
 
+### Error "q.Interval.Milliseconds undefined" when running `make run`
+
+If you get an error similar to the following when running `make run`, you might be running an unsupported version of Go. See [go.mod](../go.mod#L3) for the minimum required version.
+
+```
+vendor/github.com/grafana/grafana-plugin-sdk-go/transform/transform.go:128:29: q.Interval.Milliseconds undefined (type time.Duration has no field or method Milliseconds)
+```
+
 ## Next steps
 
 - Read our [style guides](/contribute/style-guides).


### PR DESCRIPTION
Adds the troubleshooting section, 'Error "q.Interval.Milliseconds undefined" when running `make run`' to the [Developer guide](https://github.com/grafana/grafana/blob/master/contribute/developer-guide.md). I wanted to add this here because it took me a while to figure out how to fix this before finally landing on https://github.com/grafana/grafana/issues/20462 .

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

See above

**Which issue(s) this PR fixes**:

N/a

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



