### PR TITLE
Docs: Simplify headings and make active #19267

### DIFF
--- a/contribute/style-guides/documentation-style-guide.md
+++ b/contribute/style-guides/documentation-style-guide.md
@@ -58,6 +58,13 @@ For all items not covered in this guide, refer to the [Microsoft Style Guide](ht
 * API names are always Title Case, followed by "API"—for example, "Dashboard Permissions API"
 * Git is always capitalized, unless part of a code block.
 * Abbreviations are always capitalized (such as API, HTTP, ID, JSON, SQL, or URL) unless they are part of a code block.
+* Menu and submenu titles always use sentence case: capitalize the first word, and lowercase the rest.
+  - "Dashboards" when referring to the submenu title.
+  - "Keyboard shortcuts" when referring to the submenu topic.
+* Generic and plural versions are always lowercase.
+  - Lowercase "dashboard" when referring to a dashboard generally.
+  - Lowercase "dashboards" when referring to multiple dashboards.
+* **Exceptions:** If a term is lowercased in the Grafana UI, then match the UI.
 
 ### Links and references
 

--- a/contribute/style-guides/documentation-style-guide.md
+++ b/contribute/style-guides/documentation-style-guide.md
@@ -58,13 +58,6 @@ For all items not covered in this guide, refer to the [Microsoft Style Guide](ht
 * API names are always Title Case, followed by "API"—for example, "Dashboard Permissions API"
 * Git is always capitalized, unless part of a code block.
 * Abbreviations are always capitalized (such as API, HTTP, ID, JSON, SQL, or URL) unless they are part of a code block.
-* Menu and submenu titles always use sentence case: capitalize the first word, and lowercase the rest.
-  - "Dashboards" when referring to the submenu title.
-  - "Keyboard shortcuts" when referring to the submenu topic.
-* Generic and plural versions are always lowercase.
-  - Lowercase "dashboard" when referring to a dashboard generally.
-  - Lowercase "dashboards" when referring to multiple dashboards.
-* **Exceptions:** If a term is lowercased in the Grafana UI, then match the UI.
 
 ### Links and references
 

--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -28,7 +28,7 @@ You can update all plugins using
 grafana-cli plugins update-all
 ```
 
-## Database Backup
+## Database backup
 
 Before upgrading it can be a good idea to backup your Grafana database. This will ensure that you can always rollback to your previous version. During startup, Grafana will automatically migrate the database schema (if there are changes or new tables). Sometimes this can cause issues if you later want to downgrade.
 

--- a/docs/sources/tutorials/api_org_token_howto.md
+++ b/docs/sources/tutorials/api_org_token_howto.md
@@ -1,5 +1,5 @@
 +++
-title = "API Tutorial: How To Create API Tokens And Dashboards For A Specific Organization"
+title = "API Tutorial: Create API tokens and dashboards for an organization"
 type = "docs"
 keywords = ["grafana", "tutorials", "API", "Token", "Org", "Organization"]
 [menu.docs]
@@ -7,7 +7,7 @@ parent = "tutorials"
 weight = 10
 +++
 
-# API Tutorial: How To Create API Tokens And Dashboards For A Specific Organization
+# API Tutorial: Create API tokens and dashboards for an organization
 
 Use the Grafana API to setup new Grafana organizations or to add dynamically generated dashboards to an existing organization.
 
@@ -18,7 +18,7 @@ There are two authentication methods to access the API:
 - Basic authentication: A Grafana Admin user can access some parts of the Grafana API through basic authentication. 
 - API Tokens: All organization actions are accessed through an API Token. An API Token is associated with an organization. It can be used to create dashboards and other components specific for that organization.
 
-## How To Create A New Organization and an API Token
+## How to create a new organization and an API Token
 
 The task is to create a new organization and then add a Token that can be used by other users. In the examples below which use basic auth, the user is `admin` and the password is `admin`.
 
@@ -48,7 +48,7 @@ The task is to create a new organization and then add a Token that can be used b
 
     Save the key returned here in your password manager as it is not possible to fetch again it in the future.
 
-## How To Add A Dashboard
+## How to add a dashboard
 
 Using the Token that was created in the previous step, you can create a dashboard or carry out other actions without having to switch organizations.
 

--- a/docs/sources/tutorials/api_org_token_howto.md
+++ b/docs/sources/tutorials/api_org_token_howto.md
@@ -48,7 +48,7 @@ The task is to create a new organization and then add a Token that can be used b
 
     Save the key returned here in your password manager as it is not possible to fetch again it in the future.
 
-## How to add a dashboard
+## Add a dashboard
 
 Using the Token that was created in the previous step, you can create a dashboard or carry out other actions without having to switch organizations.
 

--- a/docs/sources/tutorials/api_org_token_howto.md
+++ b/docs/sources/tutorials/api_org_token_howto.md
@@ -18,7 +18,7 @@ There are two authentication methods to access the API:
 - Basic authentication: A Grafana Admin user can access some parts of the Grafana API through basic authentication. 
 - API Tokens: All organization actions are accessed through an API Token. An API Token is associated with an organization. It can be used to create dashboards and other components specific for that organization.
 
-## How to create a new organization and an API Token
+## Create a new organization and an API Token
 
 The task is to create a new organization and then add a Token that can be used by other users. In the examples below which use basic auth, the user is `admin` and the password is `admin`.
 

--- a/docs/sources/tutorials/ha_setup.md
+++ b/docs/sources/tutorials/ha_setup.md
@@ -1,5 +1,5 @@
 +++
-title = "Setup Grafana for High availability"
+title = "Setup Grafana for high availability"
 type = "docs"
 keywords = ["grafana", "tutorials", "HA", "high availability"]
 [menu.docs]

--- a/docs/sources/tutorials/ha_setup.md
+++ b/docs/sources/tutorials/ha_setup.md
@@ -1,5 +1,5 @@
 +++
-title = "Setup Grafana for high availability"
+title = "Set up Grafana for high availability"
 type = "docs"
 keywords = ["grafana", "tutorials", "HA", "high availability"]
 [menu.docs]
@@ -46,5 +46,4 @@ You can also choose to store session data in a Redis/Memcache/Postgres/MySQL whi
 If you use MySQL/Postgres for session storage, you first need a table to store the session data in. More details about that in [[sessions]]({{< relref "../installation/configuration.md" >}}#session)
 
 For Grafana itself it doesn't really matter if you store the session data on disk or database/redis/memcache. But we recommend using a database/redis/memcache since it makes it easier manage the grafana servers.
-
 

--- a/docs/sources/tutorials/hubot_howto.md
+++ b/docs/sources/tutorials/hubot_howto.md
@@ -1,5 +1,5 @@
 +++
-title = "How To integrate Hubot and Grafana"
+title = "How to integrate Hubot and Grafana"
 type = "docs"
 keywords = ["grafana", "tutorials", "hubot", "slack", "hipchat", "setup", "install", "config"]
 [menu.docs]

--- a/docs/sources/tutorials/hubot_howto.md
+++ b/docs/sources/tutorials/hubot_howto.md
@@ -1,5 +1,5 @@
 +++
-title = "How to integrate Hubot and Grafana"
+title = "Integrate Hubot and Grafana"
 type = "docs"
 keywords = ["grafana", "tutorials", "hubot", "slack", "hipchat", "setup", "install", "config"]
 [menu.docs]
@@ -135,5 +135,4 @@ Grafana is going to ship with integrated Slack and Hipchat features some day but
 not have to wait for that. Grafana 2 shipped with a very clever server side rendering feature
 that can render any panel to a png using phantomjs. The hubot plugin for Grafana is something
 you can install and use today!
-
 


### PR DESCRIPTION
What I did: 
- Simplified headings to make them more active.
- Converted to sentence case.

Fixes part of "Convert all headings to sentence case #19267"
Relates to "Docs: Simplify headings and make active #19268"