### PR TITLE
CloudWatch: dimension_values templating fix

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -419,6 +419,13 @@ func (e *CloudWatchExecutor) handleGetDimensionValues(ctx context.Context, param
 				Name:  aws.String(k),
 				Value: aws.String(vv),
 			})
+		} else if vv, ok := v.([]interface{}); ok {
+			for _, v := range vv {
+				dimensions = append(dimensions, &cloudwatch.DimensionFilter{
+					Name:  aws.String(k),
+					Value: aws.String(v.(string)),
+				})
+			}
 		}
 	}
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -161,7 +161,11 @@ export class QueryEditor extends PureComponent<Props, State> {
                   datasource.getDimensionKeys(query.namespace, query.region).then(this.appendTemplateVariables)
                 }
                 loadValues={newKey => {
-                  const { [newKey]: value, ...newDimensions } = query.dimensions;
+                  const { [newKey]: value, ...dim } = query.dimensions;
+                  const newDimensions = Object.entries(dim).reduce(
+                    (result, [key, value]) => (value === '*' ? result : { ...result, [key]: value }),
+                    {}
+                  );
                   return datasource
                     .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
                     .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -106,6 +106,21 @@ export class QueryEditor extends PureComponent<Props, State> {
     onRunQuery();
   }
 
+  // Load dimension values based on current selected dimensions.
+  // Remove the new dimension key and all dimensions that has a wildcard as selected value
+  loadDimensionValues = (newKey: string) => {
+    const { datasource, query } = this.props;
+    const { [newKey]: value, ...dim } = query.dimensions;
+    const newDimensions = Object.entries(dim).reduce(
+      (result, [key, value]) => (value === '*' ? result : { ...result, [key]: value }),
+      {}
+    );
+    return datasource
+      .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
+      .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))
+      .then(this.appendTemplateVariables);
+  };
+
   render() {
     const { query, datasource, onChange, onRunQuery, data } = this.props;
     const { regions, namespaces, variableOptionGroup: variableOptionGroup, showMeta } = this.state;
@@ -160,17 +175,7 @@ export class QueryEditor extends PureComponent<Props, State> {
                 loadKeys={() =>
                   datasource.getDimensionKeys(query.namespace, query.region).then(this.appendTemplateVariables)
                 }
-                loadValues={newKey => {
-                  const { [newKey]: value, ...dim } = query.dimensions;
-                  const newDimensions = Object.entries(dim).reduce(
-                    (result, [key, value]) => (value === '*' ? result : { ...result, [key]: value }),
-                    {}
-                  );
-                  return datasource
-                    .getDimensionValues(query.region, query.namespace, query.metricName, newKey, newDimensions)
-                    .then(values => (values.length ? [{ value: '*', text: '*', label: '*' }, ...values] : values))
-                    .then(this.appendTemplateVariables);
-                }}
+                loadValues={this.loadDimensionValues}
               />
             </QueryInlineField>
           </>


### PR DESCRIPTION
In Grafana 6.5, dimension values is an array instead of a string. This PR makes sure that the backend interpret the dimension value as an array, and also it makes sure that the wildcard (`*`) is never being passed to the templating function. 

fixes #21215