### PR TITLE
Fix: button with icon only was not centered correctly.

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -2,7 +2,6 @@ import React, { AnchorHTMLAttributes, ButtonHTMLAttributes, useContext } from 'r
 import { ThemeContext } from '../../themes';
 import { getButtonStyles } from './styles';
 import { ButtonContent } from './ButtonContent';
-import cx from 'classnames';
 import { ButtonSize, ButtonStyles, ButtonVariant } from './types';
 
 type CommonProps = {
@@ -31,11 +30,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
       theme,
       size: size || 'md',
       variant: variant || 'primary',
+      textAndIcon: !!(children && icon),
     });
 
-  const buttonClassName = cx(styles.button, icon && styles.buttonWithIcon, icon && !children && styles.iconButton);
   return (
-    <button className={buttonClassName} {...buttonProps} ref={ref}>
+    <button className={styles.button} {...buttonProps} ref={ref}>
       <ButtonContent icon={icon}>{children}</ButtonContent>
     </button>
   );
@@ -59,11 +58,11 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>((
       theme,
       size: size || 'md',
       variant: variant || 'primary',
+      textAndIcon: !!(children && icon),
     });
 
-  const buttonClassName = cx(styles.button, icon && styles.buttonWithIcon, icon && !children && styles.iconButton);
   return (
-    <a className={buttonClassName} {...anchorProps} ref={ref}>
+    <a className={styles.button} {...anchorProps} ref={ref}>
       <ButtonContent icon={icon}>{children}</ButtonContent>
     </a>
   );

--- a/packages/grafana-ui/src/components/Button/ButtonContent.tsx
+++ b/packages/grafana-ui/src/components/Button/ButtonContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 import { stylesFactory, useTheme } from '../../themes';
 import { GrafanaTheme } from '@grafana/data';
 import { ButtonSize } from './types';
@@ -47,7 +47,7 @@ export function ButtonContent(props: Props) {
   );
 
   return (
-    <span className={cx(styles.content)}>
+    <span className={styles.content}>
       {iconElement}
       <span>{children}</span>
     </span>

--- a/packages/grafana-ui/src/components/Button/ButtonContent.tsx
+++ b/packages/grafana-ui/src/components/Button/ButtonContent.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { stylesFactory, useTheme } from '../../themes';
 import { GrafanaTheme } from '@grafana/data';
+import { ButtonSize } from './types';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => ({
   content: css`
@@ -23,11 +24,21 @@ type Props = {
   icon?: string;
   className?: string;
   children: React.ReactNode;
+  size?: ButtonSize;
 };
+
 export function ButtonContent(props: Props) {
   const { icon, children } = props;
   const theme = useTheme();
   const styles = getStyles(theme);
+
+  if (!children) {
+    return (
+      <span className={styles.content}>
+        <i className={icon} />
+      </span>
+    );
+  }
 
   const iconElement = icon && (
     <span className={styles.icon}>
@@ -36,7 +47,7 @@ export function ButtonContent(props: Props) {
   );
 
   return (
-    <span className={styles.content}>
+    <span className={cx(styles.content)}>
       {iconElement}
       <span>{children}</span>
     </span>

--- a/packages/grafana-ui/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/grafana-ui/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button renders correct html 1`] = `"<button class=\\"css-1ffx2x7-button css-5383lb\\" type=\\"button\\"><span class=\\"css-1beih13\\"><span class=\\"css-xhe2zh\\"><i class=\\"fa fa-plus\\"></i></span><span>Click me</span></span></button>"`;
+exports[`Button renders correct html 1`] = `"<button class=\\"css-uzitec-button\\" type=\\"button\\"><span class=\\"css-1beih13\\"><span class=\\"css-xhe2zh\\"><i class=\\"fa fa-plus\\"></i></span><span>Click me</span></span></button>"`;
 
-exports[`LinkButton renders correct html 1`] = `"<a class=\\"css-1ffx2x7-button css-5383lb\\"><span class=\\"css-1beih13\\"><span class=\\"css-xhe2zh\\"><i class=\\"fa fa-plus\\"></i></span><span>Click me</span></span></a>"`;
+exports[`LinkButton renders correct html 1`] = `"<a class=\\"css-uzitec-button\\"><span class=\\"css-1beih13\\"><span class=\\"css-xhe2zh\\"><i class=\\"fa fa-plus\\"></i></span><span>Click me</span></span></a>"`;

--- a/packages/grafana-ui/src/components/Button/styles.ts
+++ b/packages/grafana-ui/src/components/Button/styles.ts
@@ -112,10 +112,8 @@ type ButtonMeasures = {
 const calculateMeasures = (theme: GrafanaTheme, size: ButtonSize, textAndIcon: boolean): ButtonMeasures => {
   switch (size) {
     case 'sm': {
-      const leftPadding = textAndIcon ? theme.spacing.xs : theme.spacing.sm;
-
       return {
-        padding: `${theme.spacing.xs} ${leftPadding} ${theme.spacing.xs} ${theme.spacing.sm}`,
+        padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
         fontSize: theme.typography.size.sm,
         height: theme.height.sm,
         fontWeight: theme.typography.weight.semibold,
@@ -126,7 +124,7 @@ const calculateMeasures = (theme: GrafanaTheme, size: ButtonSize, textAndIcon: b
       const leftPadding = textAndIcon ? theme.spacing.sm : theme.spacing.md;
 
       return {
-        padding: `${theme.spacing.sm} ${leftPadding} ${theme.spacing.sm} ${theme.spacing.md}`,
+        padding: `${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.sm} ${leftPadding}`,
         fontSize: theme.typography.size.md,
         height: theme.height.md,
         fontWeight: theme.typography.weight.semibold,
@@ -137,7 +135,7 @@ const calculateMeasures = (theme: GrafanaTheme, size: ButtonSize, textAndIcon: b
       const leftPadding = textAndIcon ? theme.spacing.md : theme.spacing.lg;
 
       return {
-        padding: `${theme.spacing.md} ${leftPadding} ${theme.spacing.md} ${theme.spacing.lg}`,
+        padding: `${theme.spacing.md} ${theme.spacing.lg} ${theme.spacing.md} ${leftPadding}`,
         fontSize: theme.typography.size.lg,
         height: theme.height.lg,
         fontWeight: theme.typography.weight.regular,
@@ -148,7 +146,7 @@ const calculateMeasures = (theme: GrafanaTheme, size: ButtonSize, textAndIcon: b
       const leftPadding = textAndIcon ? theme.spacing.sm : theme.spacing.md;
 
       return {
-        padding: `${theme.spacing.sm} ${leftPadding} ${theme.spacing.sm} ${theme.spacing.md}`,
+        padding: `${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.sm} ${leftPadding}`,
         fontSize: theme.typography.size.base,
         height: theme.height.md,
         fontWeight: theme.typography.weight.regular,

--- a/packages/grafana-ui/src/components/Button/styles.ts
+++ b/packages/grafana-ui/src/components/Button/styles.ts
@@ -1,7 +1,8 @@
 import tinycolor from 'tinycolor2';
 import { css } from 'emotion';
 import { selectThemeVariant, stylesFactory } from '../../themes';
-import { StyleDeps } from './types';
+import { StyleDeps, ButtonSize } from './types';
+import { GrafanaTheme } from '@grafana/data';
 
 const buttonVariantStyles = (
   from: string,
@@ -24,39 +25,11 @@ const buttonVariantStyles = (
   }
 `;
 
-export const getButtonStyles = stylesFactory(({ theme, size, variant }: StyleDeps) => {
+export const getButtonStyles = stylesFactory(({ theme, size, variant, textAndIcon }: StyleDeps) => {
   const borderRadius = theme.border.radius.sm;
-  let padding,
-    background,
-    fontSize,
-    height,
-    fontWeight = theme.typography.weight.semibold;
+  const { padding, fontSize, height, fontWeight } = calculateMeasures(theme, size, !!textAndIcon);
 
-  switch (size) {
-    case 'sm':
-      padding = `${theme.spacing.xs} ${theme.spacing.sm}`;
-      fontSize = theme.typography.size.sm;
-      height = theme.height.sm;
-      break;
-
-    case 'md':
-      padding = `${theme.spacing.sm} ${theme.spacing.md}`;
-      fontSize = theme.typography.size.md;
-      height = theme.height.md;
-      break;
-
-    case 'lg':
-      padding = `${theme.spacing.md} ${theme.spacing.lg}`;
-      fontSize = theme.typography.size.lg;
-      fontWeight = theme.typography.weight.regular;
-      height = theme.height.lg;
-      break;
-
-    default:
-      padding = `${theme.spacing.sm} ${theme.spacing.md}`;
-      fontSize = theme.typography.size.base;
-      height = theme.height.md;
-  }
+  let background;
 
   switch (variant) {
     case 'primary':
@@ -120,13 +93,6 @@ export const getButtonStyles = stylesFactory(({ theme, size, variant }: StyleDep
         box-shadow: none;
       }
     `,
-    buttonWithIcon: css`
-      padding-left: ${theme.spacing.sm};
-    `,
-    // used for buttons with icon onlys
-    iconButton: css`
-      padding-right: 0;
-    `,
     iconWrap: css`
       label: button-icon-wrap;
       & + * {
@@ -135,3 +101,58 @@ export const getButtonStyles = stylesFactory(({ theme, size, variant }: StyleDep
     `,
   };
 });
+
+type ButtonMeasures = {
+  padding: string;
+  fontSize: string;
+  height: string;
+  fontWeight: number;
+};
+
+const calculateMeasures = (theme: GrafanaTheme, size: ButtonSize, textAndIcon: boolean): ButtonMeasures => {
+  switch (size) {
+    case 'sm': {
+      const leftPadding = textAndIcon ? theme.spacing.xs : theme.spacing.sm;
+
+      return {
+        padding: `${theme.spacing.xs} ${leftPadding} ${theme.spacing.xs} ${theme.spacing.sm}`,
+        fontSize: theme.typography.size.sm,
+        height: theme.height.sm,
+        fontWeight: theme.typography.weight.semibold,
+      };
+    }
+
+    case 'md': {
+      const leftPadding = textAndIcon ? theme.spacing.sm : theme.spacing.md;
+
+      return {
+        padding: `${theme.spacing.sm} ${leftPadding} ${theme.spacing.sm} ${theme.spacing.md}`,
+        fontSize: theme.typography.size.md,
+        height: theme.height.md,
+        fontWeight: theme.typography.weight.semibold,
+      };
+    }
+
+    case 'lg': {
+      const leftPadding = textAndIcon ? theme.spacing.md : theme.spacing.lg;
+
+      return {
+        padding: `${theme.spacing.md} ${leftPadding} ${theme.spacing.md} ${theme.spacing.lg}`,
+        fontSize: theme.typography.size.lg,
+        height: theme.height.lg,
+        fontWeight: theme.typography.weight.regular,
+      };
+    }
+
+    default: {
+      const leftPadding = textAndIcon ? theme.spacing.sm : theme.spacing.md;
+
+      return {
+        padding: `${theme.spacing.sm} ${leftPadding} ${theme.spacing.sm} ${theme.spacing.md}`,
+        fontSize: theme.typography.size.base,
+        height: theme.height.md,
+        fontWeight: theme.typography.weight.regular,
+      };
+    }
+  }
+};

--- a/packages/grafana-ui/src/components/Button/types.ts
+++ b/packages/grafana-ui/src/components/Button/types.ts
@@ -8,12 +8,11 @@ export interface StyleDeps {
   theme: GrafanaTheme;
   size: ButtonSize;
   variant: ButtonVariant;
+  textAndIcon?: boolean;
 }
 
 export interface ButtonStyles {
   button: string;
-  buttonWithIcon: string;
-  iconButton: string;
   iconWrap: string;
   icon?: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The new button from `@grafana-ui` didn't center the icon when creating an icon only button. This should now be fixed and work as expected.

**Which issue(s) this PR fixes**:
Fixes #21402 

**Special notes for your reviewer**:
The reason why we got this issue is that we want to have a different padding to the left if we have a button with icon + text (@dprokop - correct?).

So I did some refactorings when calculating the button styles instead of trying to apply a new style in that scenario. I preferred to do it this way because I didn't want to bloat the `ButtonStyles` with an internal class name since it is part of the public api.

Not super happy about the naming or solution but when doing pros/cons this was the solution with least negative impact. Please come with suggestions on how to improve it.