### PR TITLE
Heatmap: fix formatting

### DIFF
--- a/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_tooltip.ts
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import $ from 'jquery';
 import _ from 'lodash';
 import { getValueBucketBound } from './heatmap_data_converter';
-import { getValueFormat } from '@grafana/data';
+import { getValueFormat, formattedValueToString } from '@grafana/data';
 
 const TOOLTIP_PADDING_X = 30;
 const TOOLTIP_PADDING_Y = 5;
@@ -273,9 +273,9 @@ export class HeatmapTooltip {
   }
 
   countValueFormatter(decimals: number, scaledDecimals: any = null) {
-    const format = 'short';
+    const fmt = getValueFormat('short');
     return (value: number) => {
-      return getValueFormat(format)(value, decimals, scaledDecimals);
+      return formattedValueToString(fmt(value, decimals, scaledDecimals));
     };
   }
 }

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -362,13 +362,11 @@ export class HeatmapRenderer {
         // Try to format numeric tick labels
         valueFormatted = tickValueFormatter(decimals)(_.toNumber(valueFormatted));
       }
-      console.log('valueFormatted', valIndex, valueFormatted);
       return valueFormatted;
     }
 
     const tsBucketsFormatted = _.map(tsBuckets, (v, i) => tickFormatter(i));
     this.data.tsBucketsFormatted = tsBucketsFormatted;
-    console.log('tsBucketsFormatted', tsBucketsFormatted);
 
     const yAxis = d3
       .axisLeft(this.yScale)

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -6,7 +6,14 @@ import * as ticksUtils from 'app/core/utils/ticks';
 import { HeatmapTooltip } from './heatmap_tooltip';
 import { mergeZeroBuckets } from './heatmap_data_converter';
 import { getColorScale, getOpacityScale } from './color_scale';
-import { toUtc, PanelEvents, GrafanaThemeType, getColorFromHexRgbOrName, getValueFormat } from '@grafana/data';
+import {
+  toUtc,
+  PanelEvents,
+  GrafanaThemeType,
+  getColorFromHexRgbOrName,
+  getValueFormat,
+  formattedValueToString,
+} from '@grafana/data';
 import { CoreEvents } from 'app/types';
 
 const MIN_CARD_SIZE = 1,
@@ -355,11 +362,13 @@ export class HeatmapRenderer {
         // Try to format numeric tick labels
         valueFormatted = tickValueFormatter(decimals)(_.toNumber(valueFormatted));
       }
+      console.log('valueFormatted', valIndex, valueFormatted);
       return valueFormatted;
     }
 
     const tsBucketsFormatted = _.map(tsBuckets, (v, i) => tickFormatter(i));
     this.data.tsBucketsFormatted = tsBucketsFormatted;
+    console.log('tsBucketsFormatted', tsBucketsFormatted);
 
     const yAxis = d3
       .axisLeft(this.yScale)
@@ -441,11 +450,14 @@ export class HeatmapRenderer {
     const format = this.panel.yAxis.format;
     return (value: any) => {
       try {
-        return format !== 'none' ? getValueFormat(format)(value, decimals, scaledDecimals) : value;
+        if (format !== 'none') {
+          const v = getValueFormat(format)(value, decimals, scaledDecimals);
+          return formattedValueToString(v);
+        }
       } catch (err) {
         console.error(err.message || err);
-        return value;
       }
+      return value;
     };
   }
 


### PR DESCRIPTION
The heatmap display is broken in master:
![image](https://user-images.githubusercontent.com/705951/72135997-a0613180-333c-11ea-9189-8b638ca04c71.png)

this make sure to call `formattedValueToString` on the values before display