### PR TITLE
Settings: Env override support for dynamic settings

### DIFF
--- a/pkg/setting/dynamic_settings_test.go
+++ b/pkg/setting/dynamic_settings_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDynamicSettingsSupport(t *testing.T) {
+func TestDynamicSettingsSupport_Override(t *testing.T) {
 	cfg := NewCfg()
 
 	envKey := "GF_FOO_BAR"
@@ -18,6 +18,17 @@ func TestDynamicSettingsSupport(t *testing.T) {
 	os.Setenv(envKey, expected)
 	defer func() { os.Unsetenv(envKey) }()
 
-	value := cfg.DynamicSection(sectionName).Key(keyName).MustString("default value")
+	value := cfg.SectionWithEnvOverrides(sectionName).Key(keyName).MustString("default value")
+	require.Equal(t, expected, value)
+}
+
+func TestDynamicSettingsSupport_NoOverride(t *testing.T) {
+	cfg := NewCfg()
+	sectionName := "foo"
+	keyName := "bar"
+	expected := "default value"
+
+	cfg.Raw.Section(sectionName).NewKey(keyName, expected)
+	value := cfg.SectionWithEnvOverrides(sectionName).Key(keyName).String()
 	require.Equal(t, expected, value)
 }

--- a/pkg/setting/dynamic_settings_test.go
+++ b/pkg/setting/dynamic_settings_test.go
@@ -28,7 +28,8 @@ func TestDynamicSettingsSupport_NoOverride(t *testing.T) {
 	keyName := "bar"
 	expected := "default value"
 
-	cfg.Raw.Section(sectionName).NewKey(keyName, expected)
+	_, err := cfg.Raw.Section(sectionName).NewKey(keyName, expected)
+	require.NoError(t, err)
 	value := cfg.SectionWithEnvOverrides(sectionName).Key(keyName).String()
 	require.Equal(t, expected, value)
 }

--- a/pkg/setting/dynamic_settings_test.go
+++ b/pkg/setting/dynamic_settings_test.go
@@ -1,0 +1,23 @@
+package setting
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicSettingsSupport(t *testing.T) {
+	cfg := NewCfg()
+
+	envKey := "GF_FOO_BAR"
+	sectionName := "foo"
+	keyName := "bar"
+	expected := "dynamic value"
+
+	os.Setenv(envKey, expected)
+	defer func() { os.Unsetenv(envKey) }()
+
+	value := cfg.DynamicSection(sectionName).Key(keyName).MustString("default value")
+	require.Equal(t, expected, value)
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -32,6 +32,7 @@ const (
 	HTTP2             Scheme = "h2"
 	SOCKET            Scheme = "socket"
 	DEFAULT_HTTP_ADDR string = "0.0.0.0"
+	REDACTED_PASSWORD string = "*********"
 )
 
 const (
@@ -333,7 +334,7 @@ func applyEnvVariableOverrides(file *ini.File) error {
 			if len(envValue) > 0 {
 				key.SetValue(envValue)
 				if shouldRedactKey(envKey) {
-					envValue = "*********"
+					envValue = REDACTED_PASSWORD
 				}
 				if shouldRedactURLKey(envKey) {
 					u, err := url.Parse(envValue)
@@ -373,7 +374,7 @@ func applyCommandLineDefaultProperties(props map[string]string, file *ini.File) 
 			if exists {
 				key.SetValue(value)
 				if shouldRedactKey(keyString) {
-					value = "*********"
+					value = REDACTED_PASSWORD
 				}
 				appliedCommandLineProperties = append(appliedCommandLineProperties, fmt.Sprintf("%s=%s", keyString, value))
 			}
@@ -1137,7 +1138,7 @@ func (s *DynamicSection) Key(k string) *ini.Key {
 
 	key.SetValue(envValue)
 	if shouldRedactKey(envKey) {
-		envValue = "*********"
+		envValue = REDACTED_PASSWORD
 	}
 	s.Logger.Info("Config overridden from Environment variable", "var", fmt.Sprintf("%s=%s", envKey, envValue))
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Makes it possible to use environment overrides for dynamic settings. This adds a new way to read settings that will override values for keys with environment variables in for settings that are not available in default.ini (normally only settings in default.ini get these overrides). 


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

