### PR TITLE
Fix: Icons not showing on Tabs

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -1,14 +1,12 @@
 import React, { FC } from 'react';
 import { cx } from 'emotion';
-import { Icon } from '..';
 import { useTheme } from '../../themes';
-import { IconType } from '../Icon/types';
 import { getTabsStyle } from './styles';
 
 export interface TabProps {
   label: string;
   active?: boolean;
-  icon?: IconType;
+  icon?: string;
   onChangeTab: () => void;
 }
 
@@ -18,7 +16,7 @@ export const Tab: FC<TabProps> = ({ label, active, icon, onChangeTab }) => {
 
   return (
     <li className={cx(tabsStyles.tabItem, active && tabsStyles.activeStyle)} onClick={onChangeTab}>
-      {icon && <Icon name={icon} />}
+      {icon && <i className={icon} />}
       {label}
     </li>
   );

--- a/packages/grafana-ui/src/components/Tabs/TabsBar.story.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.story.tsx
@@ -26,7 +26,12 @@ const tabs = [
 export const Simple = () => {
   const VISUAL_GROUP = 'Visual options';
   // ---
-  const icon = select('Icon', { None: undefined, Heart: 'heart', Star: 'star', User: 'user' }, undefined, VISUAL_GROUP);
+  const icon = select(
+    'Icon',
+    { None: undefined, Heart: 'fa fa-heart', Star: 'fa fa-star', User: 'fa fa-user' },
+    undefined,
+    VISUAL_GROUP
+  );
   return (
     <UseState initialState={tabs}>
       {(state, updateState) => {

--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -64,6 +64,7 @@ const Navigation = ({ main }: { main: NavModelItem }) => {
               label={child.text}
               active={child.active}
               key={`${child.url}-${index}`}
+              icon={child.icon}
               onChangeTab={() => goToUrl(index)}
             />
           );

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -100,6 +100,9 @@ exports[`ServerStats Should render table with stats 1`] = `
                     className="css-b418eg"
                     onClick={[Function]}
                   >
+                    <i
+                      className="icon"
+                    />
                     Admin
                   </li>
                 </ul>


### PR DESCRIPTION
**What this PR does / why we need it**:
In the recent Tabs component PR (https://github.com/grafana/grafana/pull/21328) we introduced a bug where icons did not show in Tabs. This PR removes the use for the Icon component for icons as NavModelItems have different types of icons (fa or gicon).

