### PR TITLE
Alerting: Added fallbackText to Google Chat notifier

### DIFF
--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -55,7 +55,8 @@ Structs used to build a custom Google Hangouts Chat message card.
 See: https://developers.google.com/hangouts/chat/reference/message-formats/cards
 */
 type outerStruct struct {
-	Cards []card `json:"cards"`
+	FallbackText string `json:"fallbackText"`
+	Cards []card        `json:"cards"`
 }
 
 type card struct {
@@ -187,6 +188,7 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	// nest the required structs
 	res1D := &outerStruct{
+		FallbackText: evalContext.GetNotificationTitle(),
 		Cards: []card{
 			{
 				Header: header{

--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -56,7 +56,7 @@ See: https://developers.google.com/hangouts/chat/reference/message-formats/cards
 */
 type outerStruct struct {
 	FallbackText string `json:"fallbackText"`
-	Cards []card        `json:"cards"`
+	Cards        []card `json:"cards"`
 }
 
 type card struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add fallbackText to Google Chat notifications.
Definition of fallbackText: A plain-text description of the message's cards, used when the actual cards cannot be displayed (e.g. mobile notifications). (https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages)

**Which issue(s) this PR fixes**:
Very useful when a notification is received in a mobile device, the notification in a blocked screen show the fallbackText.


Fixes #21463

**Special notes for your reviewer**:

