### PR TITLE
CloudWatch: Calculate period based on time range

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_query.go
@@ -1,9 +1,7 @@
 package cloudwatch
 
 import (
-	"math"
 	"strings"
-	"time"
 )
 
 type cloudWatchQuery struct {
@@ -17,7 +15,6 @@ type cloudWatchQuery struct {
 	ReturnData              bool
 	Dimensions              map[string][]string
 	Period                  int
-	RequestedPeriod         int
 	Alias                   string
 	MatchExact              bool
 	UsedExpression          string
@@ -60,36 +57,4 @@ func (q *cloudWatchQuery) isInferredSearchExpression() bool {
 
 func (q *cloudWatchQuery) isMetricStat() bool {
 	return !q.isSearchExpression() && !q.isMathExpression()
-}
-
-func (q *cloudWatchQuery) setPeriod(startTime time.Time, endTime time.Time, batchContainsWildcard bool, noOfQueries int) {
-	if q.RequestedPeriod == 0 {
-		delta := endTime.Sub(startTime)
-		if batchContainsWildcard {
-			if math.Ceil(delta.Hours()) <= 24*15 {
-				// until 15 days
-				if q.Namespace == "AWS/EC2" {
-					q.Period = 300
-				} else {
-					q.Period = 60
-				}
-			} else if math.Ceil(delta.Hours()) <= 24*63 {
-				// until 63 days
-				q.Period = 300
-			} else {
-				// more than 63 days
-				q.Period = 3600
-			}
-		} else {
-			hours := math.Ceil(delta.Hours())
-			datapointsPerSecond := 90000
-			if hours <= 3 {
-				datapointsPerSecond = 180000
-			}
-			q.Period = int(math.Ceil(float64(delta.Milliseconds()/1000/60)/(float64(datapointsPerSecond)/float64(noOfQueries))) * 60)
-		}
-	} else {
-		// period that was specified in the query editor is being used
-		q.Period = q.RequestedPeriod
-	}
 }

--- a/pkg/tsdb/cloudwatch/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_query.go
@@ -1,7 +1,9 @@
 package cloudwatch
 
 import (
+	"math"
 	"strings"
+	"time"
 )
 
 type cloudWatchQuery struct {
@@ -15,6 +17,7 @@ type cloudWatchQuery struct {
 	ReturnData              bool
 	Dimensions              map[string][]string
 	Period                  int
+	RequestedPeriod         int
 	Alias                   string
 	MatchExact              bool
 	UsedExpression          string
@@ -57,4 +60,36 @@ func (q *cloudWatchQuery) isInferredSearchExpression() bool {
 
 func (q *cloudWatchQuery) isMetricStat() bool {
 	return !q.isSearchExpression() && !q.isMathExpression()
+}
+
+func (q *cloudWatchQuery) setPeriod(startTime time.Time, endTime time.Time, batchContainsWildcard bool, noOfQueries int) {
+	if q.RequestedPeriod == 0 {
+		delta := endTime.Sub(startTime)
+		if batchContainsWildcard {
+			if math.Ceil(delta.Hours()) <= 24*15 {
+				// until 15 days
+				if q.Namespace == "AWS/EC2" {
+					q.Period = 300
+				} else {
+					q.Period = 60
+				}
+			} else if math.Ceil(delta.Hours()) <= 24*63 {
+				// until 63 days
+				q.Period = 300
+			} else {
+				// more than 63 days
+				q.Period = 3600
+			}
+		} else {
+			hours := math.Ceil(delta.Hours())
+			datapointsPerSecond := 90000
+			if hours <= 3 {
+				datapointsPerSecond = 180000
+			}
+			q.Period = int(math.Ceil(float64(delta.Milliseconds()/1000/60)/(float64(datapointsPerSecond)/float64(noOfQueries))) * 60)
+		}
+	} else {
+		// period that was specified in the query editor is being used
+		q.Period = q.RequestedPeriod
+	}
 }

--- a/pkg/tsdb/cloudwatch/metric_data_input_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_input_builder.go
@@ -1,27 +1,13 @@
 package cloudwatch
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/grafana/grafana/pkg/tsdb"
 )
 
-func (e *CloudWatchExecutor) buildMetricDataInput(queryContext *tsdb.TsdbQuery, queries map[string]*cloudWatchQuery) (*cloudwatch.GetMetricDataInput, error) {
-	startTime, err := queryContext.TimeRange.ParseFrom()
-	if err != nil {
-		return nil, err
-	}
-
-	endTime, err := queryContext.TimeRange.ParseTo()
-	if err != nil {
-		return nil, err
-	}
-
-	if !startTime.Before(endTime) {
-		return nil, fmt.Errorf("Invalid time range: Start time must be before end time")
-	}
+func (e *CloudWatchExecutor) buildMetricDataInput(startTime time.Time, endTime time.Time, queries map[string]*cloudWatchQuery) (*cloudwatch.GetMetricDataInput, error) {
 
 	metricDataInput := &cloudwatch.GetMetricDataInput{
 		StartTime: aws.Time(startTime),

--- a/pkg/tsdb/cloudwatch/metric_data_input_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_input_builder.go
@@ -8,7 +8,6 @@ import (
 )
 
 func (e *CloudWatchExecutor) buildMetricDataInput(startTime time.Time, endTime time.Time, queries map[string]*cloudWatchQuery) (*cloudwatch.GetMetricDataInput, error) {
-
 	metricDataInput := &cloudwatch.GetMetricDataInput{
 		StartTime: aws.Time(startTime),
 		EndTime:   aws.Time(endTime),

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/tsdb"
@@ -13,8 +14,9 @@ import (
 // has more than one statistic defined, one cloudwatchQuery will be created for each statistic.
 // If the query doesn't have an Id defined by the user, we'll give it an with format `query[RefId]`. In the case
 // the incoming query had more than one stat, it will ge an id like `query[RefId]_[StatName]`, eg queryC_Average
-func (e *CloudWatchExecutor) transformRequestQueriesToCloudWatchQueries(requestQueries []*requestQuery) (map[string]*cloudWatchQuery, error) {
+func (e *CloudWatchExecutor) transformRequestQueriesToCloudWatchQueries(startTime time.Time, endTime time.Time, requestQueries []*requestQuery) (map[string]*cloudWatchQuery, error) {
 	cloudwatchQueries := make(map[string]*cloudWatchQuery)
+	batchContainsWildcard := false
 	for _, requestQuery := range requestQueries {
 		for _, stat := range requestQuery.Statistics {
 			id := requestQuery.Id
@@ -26,19 +28,21 @@ func (e *CloudWatchExecutor) transformRequestQueriesToCloudWatchQueries(requestQ
 			}
 
 			query := &cloudWatchQuery{
-				Id:         id,
-				RefId:      requestQuery.RefId,
-				Region:     requestQuery.Region,
-				Namespace:  requestQuery.Namespace,
-				MetricName: requestQuery.MetricName,
-				Dimensions: requestQuery.Dimensions,
-				Stats:      *stat,
-				Period:     requestQuery.Period,
-				Alias:      requestQuery.Alias,
-				Expression: requestQuery.Expression,
-				ReturnData: requestQuery.ReturnData,
-				MatchExact: requestQuery.MatchExact,
+				Id:              id,
+				RefId:           requestQuery.RefId,
+				Region:          requestQuery.Region,
+				Namespace:       requestQuery.Namespace,
+				MetricName:      requestQuery.MetricName,
+				Dimensions:      requestQuery.Dimensions,
+				Stats:           *stat,
+				RequestedPeriod: requestQuery.Period,
+				Alias:           requestQuery.Alias,
+				Expression:      requestQuery.Expression,
+				ReturnData:      requestQuery.ReturnData,
+				MatchExact:      requestQuery.MatchExact,
 			}
+
+			batchContainsWildcard = batchContainsWildcard || query.isSearchExpression()
 
 			if _, ok := cloudwatchQueries[id]; ok {
 				return nil, fmt.Errorf("Error in query %s. Query id %s is not unique", query.RefId, query.Id)
@@ -46,6 +50,11 @@ func (e *CloudWatchExecutor) transformRequestQueriesToCloudWatchQueries(requestQ
 
 			cloudwatchQueries[id] = query
 		}
+	}
+
+	noOfQueries := len(cloudwatchQueries)
+	for _, query := range cloudwatchQueries {
+		query.setPeriod(startTime, endTime, batchContainsWildcard, noOfQueries)
 	}
 
 	return cloudwatchQueries, nil
@@ -74,6 +83,7 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		partialData := false
 		queryMeta := []struct {
 			Expression, ID string
+			Period         int
 		}{}
 
 		for _, response := range responses {
@@ -82,9 +92,11 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 			partialData = partialData || response.PartialData
 			queryMeta = append(queryMeta, struct {
 				Expression, ID string
+				Period         int
 			}{
 				Expression: response.Expression,
 				ID:         response.Id,
+				Period:     response.Period,
 			})
 		}
 

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -68,7 +68,7 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 	var period int
 	if strings.ToLower(p) == "auto" || p == "" {
 		deltaInSeconds := endTime.Sub(startTime).Seconds()
-		periods := []int{60, 300, 900, 3600, 21600, 86400, 604800, 2592000}
+		periods := []int{60, 300, 900, 3600, 21600}
 		period = closest(periods, int(math.Ceil(deltaInSeconds/2000)))
 	} else {
 		if regexp.MustCompile(`^\d+$`).Match([]byte(p)) {

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -62,13 +63,9 @@ func parseRequestQuery(model *simplejson.Json, refId string) (*requestQuery, err
 		return nil, err
 	}
 
-	p := model.Get("period").MustString("")
-	if p == "" {
-		if namespace == "AWS/EC2" {
-			p = "300"
-		} else {
-			p = "60"
-		}
+	p := model.Get("period").MustString("0")
+	if strings.ToLower(p) == "auto" || p == "" {
+		p = "0"
 	}
 
 	var period int

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -4,11 +4,15 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestRequestParser(t *testing.T) {
 	Convey("TestRequestParser", t, func() {
+		timeRange := tsdb.NewTimeRange("now-1h", "now-2h")
+		from, _ := timeRange.ParseFrom()
+		to, _ := timeRange.ParseTo()
 		Convey("when parsing query editor row json", func() {
 			Convey("using new dimensions structure", func() {
 				query := simplejson.NewFromAny(map[string]interface{}{
@@ -27,7 +31,7 @@ func TestRequestParser(t *testing.T) {
 					"hide":       false,
 				})
 
-				res, err := parseRequestQuery(query, "ref1")
+				res, err := parseRequestQuery(query, "ref1", from, to)
 				So(err, ShouldBeNil)
 				So(res.Region, ShouldEqual, "us-east-1")
 				So(res.RefId, ShouldEqual, "ref1")
@@ -62,7 +66,7 @@ func TestRequestParser(t *testing.T) {
 					"hide":       false,
 				})
 
-				res, err := parseRequestQuery(query, "ref1")
+				res, err := parseRequestQuery(query, "ref1", from, to)
 				So(err, ShouldBeNil)
 				So(res.Region, ShouldEqual, "us-east-1")
 				So(res.RefId, ShouldEqual, "ref1")

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -174,6 +174,18 @@ func TestRequestParser(t *testing.T) {
 				Convey("and input is exactly 50000", func() {
 					So(closest(periods, 50000), ShouldEqual, 21600)
 				})
+
+				Convey("and period isn't shorter than min retension for 15 days", func() {
+					So(closest(periods, (60*60*24*15)+1/2000), ShouldBeGreaterThanOrEqualTo, 300)
+				})
+
+				Convey("and period isn't shorter than min retension for 63 days", func() {
+					So(closest(periods, (60*60*24*63)+1/2000), ShouldBeGreaterThanOrEqualTo, 3600)
+				})
+
+				Convey("and period isn't shorter than min retension for 455 days", func() {
+					So(closest(periods, (60*60*24*455)+1/2000), ShouldBeGreaterThanOrEqualTo, 21600)
+				})
 			})
 		})
 	})

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -48,6 +48,7 @@ func (e *CloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMe
 		}
 
 		response.series = series
+		response.Period = queries[id].Period
 		response.Expression = queries[id].UsedExpression
 		response.RefId = queries[id].RefId
 		response.Id = queries[id].Id

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -66,7 +66,6 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	partialData := false
 	for label, metricDataResult := range metricDataResults {
 		if *metricDataResult.StatusCode != "Complete" {
-			// return nil, fmt.Errorf("too many datapoints requested in query %s. Please try to reduce the time range", query.RefId)
 			partialData = true
 		}
 

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -60,7 +60,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, err := parseGetMetricDataTimeSeries(resp, query)
+			series, _, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)
@@ -116,7 +116,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, err := parseGetMetricDataTimeSeries(resp, query)
+			series, _, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)
@@ -172,7 +172,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, err := parseGetMetricDataTimeSeries(resp, query)
+			series, _, err := parseGetMetricDataTimeSeries(resp, query)
 
 			So(err, ShouldBeNil)
 			So((*series)[0].Name, ShouldEqual, "lb3 Expanded")

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -28,7 +28,7 @@ func (e *CloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 		return nil, fmt.Errorf("Invalid time range: Start time must be before end time")
 	}
 
-	requestQueriesByRegion, err := e.parseQueries(queryContext)
+	requestQueriesByRegion, err := e.parseQueries(queryContext, startTime, endTime)
 	if err != nil {
 		return results, err
 	}
@@ -56,7 +56,7 @@ func (e *CloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 					return err
 				}
 
-				queries, err := e.transformRequestQueriesToCloudWatchQueries(startTime, endTime, requestQueries)
+				queries, err := e.transformRequestQueriesToCloudWatchQueries(requestQueries)
 				if err != nil {
 					for _, query := range requestQueries {
 						resultChan <- &tsdb.QueryResult{

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -8,19 +8,18 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestMetricDataInputBuilder(t *testing.T) {
-	Convey("TestMetricDataInputBuilder", t, func() {
+func TestTimeSeriesQuery(t *testing.T) {
+	Convey("TestTimeSeriesQuery", t, func() {
 		executor := &CloudWatchExecutor{}
-		query := make(map[string]*cloudWatchQuery)
 
 		Convey("Time range is valid", func() {
 			Convey("End time before start time should result in error", func() {
-				_, err := executor.buildMetricDataInput(&tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-2h")}, query)
+				_, err := executor.executeTimeSeriesQuery(nil, &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-2h")})
 				So(err.Error(), ShouldEqual, "Invalid time range: Start time must be before end time")
 			})
 
 			Convey("End time equals start time should result in error", func() {
-				_, err := executor.buildMetricDataInput(&tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-1h")}, query)
+				_, err := executor.executeTimeSeriesQuery(nil, &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-1h")})
 				So(err.Error(), ShouldEqual, "Invalid time range: Start time must be before end time")
 			})
 		})

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/tsdb"
@@ -14,12 +15,12 @@ func TestTimeSeriesQuery(t *testing.T) {
 
 		Convey("Time range is valid", func() {
 			Convey("End time before start time should result in error", func() {
-				_, err := executor.executeTimeSeriesQuery(nil, &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-2h")})
+				_, err := executor.executeTimeSeriesQuery(context.TODO(), &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-2h")})
 				So(err.Error(), ShouldEqual, "Invalid time range: Start time must be before end time")
 			})
 
 			Convey("End time equals start time should result in error", func() {
-				_, err := executor.executeTimeSeriesQuery(nil, &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-1h")})
+				_, err := executor.executeTimeSeriesQuery(context.TODO(), &tsdb.TsdbQuery{TimeRange: tsdb.NewTimeRange("now-1h", "now-1h")})
 				So(err.Error(), ShouldEqual, "Invalid time range: Start time must be before end time")
 			})
 		})

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -37,6 +37,7 @@ type cloudwatchResponse struct {
 	Expression              string
 	RequestExceededMaxLimit bool
 	PartialData             bool
+	Period                  int
 }
 
 type queryError struct {

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.tsx
@@ -165,14 +165,16 @@ export class QueryEditor extends PureComponent<Props, State> {
                 <tr>
                   <th>Metric Data Query ID</th>
                   <th>Metric Data Query Expression</th>
+                  <th>Period</th>
                   <th />
                 </tr>
               </thead>
               <tbody>
-                {data.series[0].meta.gmdMeta.map(({ ID, Expression }: any) => (
+                {data.series[0].meta.gmdMeta.map(({ ID, Expression, Period }: any) => (
                   <tr key={ID}>
                     <td>{ID}</td>
                     <td>{Expression}</td>
+                    <td>{Period}</td>
                   </tr>
                 ))}
               </tbody>

--- a/public/app/plugins/datasource/cloudwatch/components/Stats.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Stats.tsx
@@ -31,17 +31,15 @@ export const Stats: FunctionComponent<Props> = ({ stats, values, onChange, varia
           }
         />
       ))}
-    {values.length !== stats.length && (
-      <Segment
-        Component={
-          <a className="gf-form-label query-part">
-            <i className="fa fa-plus" />
-          </a>
-        }
-        allowCustomValue
-        onChange={({ value }) => onChange([...values, value])}
-        options={[...stats.filter(({ value }) => !values.includes(value)), variableOptionGroup]}
-      />
-    )}
+    <Segment
+      Component={
+        <a className="gf-form-label query-part">
+          <i className="fa fa-plus" />
+        </a>
+      }
+      allowCustomValue
+      onChange={({ value }) => onChange([...values, value])}
+      options={[...stats.filter(({ value }) => !values.includes(value)), variableOptionGroup]}
+    />
   </>
 );

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -125,52 +125,29 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
     return this.templateSrv.variables.map(v => `$${v.name}`);
   }
 
-  getPeriod(target: any, options: any, now?: number) {
-    const start = this.convertToCloudWatchTime(options.range.from, false);
-    now = Math.round((now || Date.now()) / 1000);
-
-    let period;
-    const hourSec = 60 * 60;
-    const daySec = hourSec * 24;
-    if (!target.period) {
-      if (now - start <= daySec * 15) {
-        // until 15 days ago
-        if (target.namespace === 'AWS/EC2') {
-          period = 300;
-        } else {
-          period = 60;
-        }
-      } else if (now - start <= daySec * 63) {
-        // until 63 days ago
-        period = 60 * 5;
-      } else if (now - start <= daySec * 455) {
-        // until 455 days ago
-        period = 60 * 60;
-      } else {
-        // over 455 days, should return error, but try to long period
-        period = 60 * 60;
-      }
-    } else {
-      period = this.templateSrv.replace(target.period, options.scopedVars);
+  getPeriod(target: any, options: any) {
+    let period = this.templateSrv.replace(target.period, options.scopedVars);
+    if (target.period && target.period.toLowerCase() !== 'auto') {
       if (/^\d+$/.test(period)) {
         period = parseInt(period, 10);
       } else {
         period = kbn.interval_to_seconds(period);
       }
-    }
-    if (period < 1) {
-      period = 1;
+
+      if (period < 1) {
+        period = 1;
+      }
     }
 
     return period;
   }
 
   buildCloudwatchConsoleUrl(
-    { region, namespace, metricName, dimensions, statistics, period, expression }: CloudWatchQuery,
+    { region, namespace, metricName, dimensions, statistics, expression }: CloudWatchQuery,
     start: string,
     end: string,
     title: string,
-    gmdMeta: Array<{ Expression: string }>
+    gmdMeta: Array<{ Expression: string; Period: string }>
   ) {
     region = this.getActualRegion(region);
     let conf = {
@@ -204,7 +181,7 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
             ...Object.entries(dimensions).reduce((acc, [key, value]) => [...acc, key, value[0]], []),
             {
               stat,
-              period,
+              period: gmdMeta.length ? gmdMeta[0].Period : 60,
             },
           ]),
         ],

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -127,7 +127,7 @@ export default class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery,
 
   getPeriod(target: any, options: any) {
     let period = this.templateSrv.replace(target.period, options.scopedVars);
-    if (target.period && target.period.toLowerCase() !== 'auto') {
+    if (period && period.toLowerCase() !== 'auto') {
       if (/^\d+$/.test(period)) {
         period = parseInt(period, 10);
       } else {


### PR DESCRIPTION
This PR will add logic that will set a period interval based on the time range in case the period field in the query editor is left blank or has the value `auto`. If the period is actively defined by the user in the query editor, that value will be passed to the GMD api unconditionally. Previously the auto period calculations were made in the frontend, and therefore it didn't work for alerting. This PR moves the period calculation to the backend.  

If the period field is not defined by the user, the period will be calculated the following way:
`periods = [60, 300, 900, 3600, 21600]`
`x = timeRangeDeltaInSeconds / 2000`
x will then snap to the closest number in the periods array

This is an example with a time range of 30 days
`2,592,000 / 2000 = 1296` --> `900 is the closest number`



fixes #20652
fixes #18493