### PR TITLE
Fix: Hide Tabs on Page header on small screens

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
@@ -1,11 +1,12 @@
 import React, { FC, ReactNode } from 'react';
 import { stylesFactory, useTheme } from '../../themes';
 import { GrafanaTheme } from '@grafana/data';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 export interface Props {
   /** Children should be a single <Tab /> or an array of <Tab /> */
   children: ReactNode;
+  className?: string;
 }
 
 const getTabsBarStyles = stylesFactory((theme: GrafanaTheme) => {
@@ -23,12 +24,12 @@ const getTabsBarStyles = stylesFactory((theme: GrafanaTheme) => {
   };
 });
 
-export const TabsBar: FC<Props> = ({ children }) => {
+export const TabsBar: FC<Props> = ({ children, className }) => {
   const theme = useTheme();
   const tabsStyles = getTabsBarStyles(theme);
 
   return (
-    <div className={tabsStyles.tabsWrapper}>
+    <div className={cx(tabsStyles.tabsWrapper, className)}>
       <ul className={tabsStyles.tabs}>{children}</ul>
     </div>
   );

--- a/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
@@ -7,15 +7,19 @@ export interface Props {
   /** Children should be a single <Tab /> or an array of <Tab /> */
   children: ReactNode;
   className?: string;
+  /** For hiding the bottom border (on PageHeader for example) */
+  hideBorder?: boolean;
 }
 
-const getTabsBarStyles = stylesFactory((theme: GrafanaTheme) => {
+const getTabsBarStyles = stylesFactory((theme: GrafanaTheme, hideBorder = false) => {
   const colors = theme.colors;
 
   return {
-    tabsWrapper: css`
-      border-bottom: 1px solid ${colors.pageHeaderBorder};
-    `,
+    tabsWrapper:
+      !hideBorder &&
+      css`
+        border-bottom: 1px solid ${colors.pageHeaderBorder};
+      `,
     tabs: css`
       position: relative;
       top: 1px;
@@ -24,9 +28,9 @@ const getTabsBarStyles = stylesFactory((theme: GrafanaTheme) => {
   };
 });
 
-export const TabsBar: FC<Props> = ({ children, className }) => {
+export const TabsBar: FC<Props> = ({ children, className, hideBorder }) => {
   const theme = useTheme();
-  const tabsStyles = getTabsBarStyles(theme);
+  const tabsStyles = getTabsBarStyles(theme, hideBorder);
 
   return (
     <div className={cx(tabsStyles.tabsWrapper, className)}>

--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -57,7 +57,7 @@ const Navigation = ({ main }: { main: NavModelItem }) => {
   return (
     <nav>
       <SelectNav customCss="page-header__select-nav" main={main} />
-      <TabsBar>
+      <TabsBar className="page-header__tabs">
         {main.children.map((child, index) => {
           return (
             <Tab

--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -57,7 +57,7 @@ const Navigation = ({ main }: { main: NavModelItem }) => {
   return (
     <nav>
       <SelectNav customCss="page-header__select-nav" main={main} />
-      <TabsBar className="page-header__tabs">
+      <TabsBar className="page-header__tabs" hideBorder={true}>
         {main.children.map((child, index) => {
           return (
             <Tab

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`ServerStats Should render table with stats 1`] = `
                   </select>
                 </div>
                 <div
-                  className="css-yuafq3 page-header__tabs"
+                  className="page-header__tabs"
                 >
                   <ul
                     className="css-13jkosq"

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`ServerStats Should render table with stats 1`] = `
                   </select>
                 </div>
                 <div
-                  className="css-yuafq3"
+                  className="css-yuafq3 page-header__tabs"
                 >
                   <ul
                     className="css-13jkosq"

--- a/public/sass/components/_page_header.scss
+++ b/public/sass/components/_page_header.scss
@@ -1,7 +1,6 @@
 .page-header-canvas {
   background: $page-header-bg;
   box-shadow: $page-header-shadow;
-  border-bottom: 1px solid $page-header-border-color;
 }
 
 .page-header {

--- a/public/sass/components/_page_header.scss
+++ b/public/sass/components/_page_header.scss
@@ -1,6 +1,7 @@
 .page-header-canvas {
   background: $page-header-bg;
   box-shadow: $page-header-shadow;
+  border-bottom: 1px solid $page-header-border-color;
 }
 
 .page-header {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds back a className prop on Tabs, this way we can hide tabs on page header on small screent. Also noticed an issue with double borders on PageHeader. It was moved to Tabs in grafana/ui, decided to remove the border on `.pager-header__canvas`.

**Which issue(s) this PR fixes**:
Fixes #21487

**Special notes for your reviewer**:

