### PR TITLE
DataLinks: Make data links input grow again

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -124,6 +124,7 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
           'gf-form-input',
           css`
             position: relative;
+            height: auto;
           `
         )}
       >


### PR DESCRIPTION
Fixes #21217

Reverting change introduced by 569c81d07e17878fb71effb31a25fd5f5f88be62, it made the data links input have a static height inherited from `gf-form-input`. 
