### PR TITLE
API: Fix importing plugin dashboards

### DIFF
--- a/pkg/api/dtos/plugins.go
+++ b/pkg/api/dtos/plugins.go
@@ -56,7 +56,7 @@ type ImportDashboardCommand struct {
 	PluginId  string                         `json:"pluginId"`
 	Path      string                         `json:"path"`
 	Overwrite bool                           `json:"overwrite"`
-	Dashboard *simplejson.Json               `json:"dashboard" binding:"Required"`
+	Dashboard *simplejson.Json               `json:"dashboard"`
 	Inputs    []plugins.ImportDashboardInput `json:"inputs"`
 	FolderId  int64                          `json:"folderId"`
 }

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -180,7 +180,7 @@ func GetPluginMarkdown(c *m.ReqContext) Response {
 
 func ImportDashboard(c *m.ReqContext, apiCmd dtos.ImportDashboardCommand) Response {
 	if apiCmd.PluginId == "" && apiCmd.Dashboard == nil {
-		return Error(422, "dashboard must be set", nil)
+		return Error(422, "Dashboard must be set", nil)
 	}
 
 	cmd := plugins.ImportDashboardCommand{

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -179,6 +179,10 @@ func GetPluginMarkdown(c *m.ReqContext) Response {
 }
 
 func ImportDashboard(c *m.ReqContext, apiCmd dtos.ImportDashboardCommand) Response {
+	if apiCmd.PluginId == "" && apiCmd.Dashboard == nil {
+		return Error(422, "dashboard must be set", nil)
+	}
+
 	cmd := plugins.ImportDashboardCommand{
 		OrgId:     c.OrgId,
 		User:      c.SignedInUser,


### PR DESCRIPTION
**What this PR does / why we need it**:
#21350 introduced a bug regarding import of plugin dashboards. This should fix this and add custom validation if not importing plugin dashboard and dashboard property is missing.

![image](https://user-images.githubusercontent.com/1668778/72424662-a3b64c00-3786-11ea-98c8-e8443aba950f.png)

**Which issue(s) this PR fixes**:
Ref #21350

**Special notes for your reviewer**:

