### PR TITLE
Explore: Fix conversion of log message ANSI css properties

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.test.tsx
@@ -33,4 +33,20 @@ describe('<LogMessageAnsi />', () => {
         .text()
     ).toBe('ipsum');
   });
+  it('renders string with ANSI codes with correctly converted css classnames', () => {
+    const value = 'Lorem [1;32mIpsum';
+    const wrapper = shallow(<LogMessageAnsi value={value} />);
+
+    expect(wrapper.find('span')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('span')
+        .first()
+        .prop('style')
+    ).toMatchObject(
+      expect.objectContaining({
+        fontWeight: expect.any(String),
+      })
+    );
+  });
 });

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -15,7 +15,7 @@ function convertCSSToStyle(css: string): Style {
     const match = line.match(/([^:\s]+)\s*:\s*(.+)/);
 
     if (match && match[1] && match[2]) {
-      const key = match[1].replace(/-(a-z)/g, (_, character) => character.toUpperCase());
+      const key = match[1].replace(/-([a-z])/g, (_, character) => character.toUpperCase());
       // @ts-ignore
       accumulated[key] = match[2];
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes regex in `convertCSSToStyle` function that is used to convert css properties to styles (e.g.  *font-weight* to *fontWeight*). It also adds test coverage for this.

Warning in console in current master: 
![image](https://user-images.githubusercontent.com/30407135/72437723-a8d5c400-37a3-11ea-841a-d742acea2b79.png)
