### PR TITLE
Dashboard links: option to add local timezone to URL

### DIFF
--- a/public/app/core/utils/timezone.ts
+++ b/public/app/core/utils/timezone.ts
@@ -1,0 +1,24 @@
+import { dateTime } from '@grafana/data';
+
+// This function will try to return the proper full name of the local timezone
+// Chrome does not handle the timezone offset (but phantomjs does)
+export function getLocalTimeZone(): string {
+  const utcOffset = 'UTC' + dateTime().format('Z');
+
+  // Older browser does not the internationalization API
+  if (!(window as any).Intl) {
+    return utcOffset;
+  }
+
+  const dateFormat = (window as any).Intl.DateTimeFormat();
+  if (!dateFormat.resolvedOptions) {
+    return utcOffset;
+  }
+
+  const options = dateFormat.resolvedOptions();
+  if (!options.timeZone) {
+    return utcOffset;
+  }
+
+  return options.timeZone;
+}

--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -8,7 +8,7 @@ import { PanelEvents } from '@grafana/data';
 import { CoreEvents } from 'app/types';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 
-export type DashboardLink = { tags: any; target: string; keepTime: any; includeVars: any };
+export type DashboardLink = { tags: any; target: string; keepTime: any; includeVars: any; timezone: any };
 
 function dashLinksContainer() {
   return {
@@ -116,6 +116,7 @@ export class DashLinksContainerCtrl {
               title: linkDef.title,
               tags: linkDef.tags,
               keepTime: linkDef.keepTime,
+              timezone: linkDef.timezone,
               includeVars: linkDef.includeVars,
               target: linkDef.targetBlank ? '_blank' : '_self',
               icon: 'fa fa-bars',
@@ -137,6 +138,7 @@ export class DashLinksContainerCtrl {
             tooltip: linkDef.tooltip,
             target: linkDef.targetBlank ? '_blank' : '_self',
             keepTime: linkDef.keepTime,
+            timezone: linkDef.timezone,
             includeVars: linkDef.includeVars,
           },
         ]);
@@ -166,6 +168,7 @@ export class DashLinksContainerCtrl {
                 target: link.target === '_self' ? '' : link.target,
                 icon: 'fa fa-th-large',
                 keepTime: link.keepTime,
+                timezone: link.timezone,
                 includeVars: link.includeVars,
               });
             }

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -161,6 +161,13 @@
         ></gf-form-switch>
         <gf-form-switch
           class="gf-form"
+          label="Timezone"
+          checked="ctrl.link.timezone"
+          switch-class="max-width-6"
+          label-class="width-9"
+        ></gf-form-switch>
+        <gf-form-switch
+          class="gf-form"
           label="Open in new tab"
           checked="ctrl.link.targetBlank"
           switch-class="max-width-6"

--- a/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.ts
+++ b/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.ts
@@ -1,9 +1,9 @@
 import angular, { ILocationService } from 'angular';
-import { dateTime } from '@grafana/data';
 import { e2e } from '@grafana/e2e';
 
 import config from 'app/core/config';
 import { appendQueryToUrl, toUrlParams } from 'app/core/utils/url';
+import { getLocalTimeZone } from 'app/core/utils/timezone';
 import { TimeSrv } from '../../services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
@@ -103,30 +103,7 @@ export function ShareModalCtrl(
       config.appSubUrl + '/render/dashboard-solo/'
     );
     $scope.imageUrl = $scope.imageUrl.replace(config.appSubUrl + '/d-solo/', config.appSubUrl + '/render/d-solo/');
-    $scope.imageUrl += '&width=1000&height=500' + $scope.getLocalTimeZone();
-  };
-
-  // This function will try to return the proper full name of the local timezone
-  // Chrome does not handle the timezone offset (but phantomjs does)
-  $scope.getLocalTimeZone = () => {
-    const utcOffset = '&tz=UTC' + encodeURIComponent(dateTime().format('Z'));
-
-    // Older browser does not the internationalization API
-    if (!(window as any).Intl) {
-      return utcOffset;
-    }
-
-    const dateFormat = (window as any).Intl.DateTimeFormat();
-    if (!dateFormat.resolvedOptions) {
-      return utcOffset;
-    }
-
-    const options = dateFormat.resolvedOptions();
-    if (!options.timeZone) {
-      return utcOffset;
-    }
-
-    return '&tz=' + encodeURIComponent(options.timeZone);
+    $scope.imageUrl += '&width=1000&height=500&tz=' + encodeURIComponent(getLocalTimeZone());
   };
 
   $scope.getShareUrl = () => {

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -5,6 +5,7 @@ import coreModule from 'app/core/core_module';
 import { appendQueryToUrl, toUrlParams } from 'app/core/utils/url';
 import { sanitizeUrl } from 'app/core/utils/text';
 import { getConfig } from 'app/core/config';
+import { getLocalTimeZone } from 'app/core/utils/timezone';
 import { VariableSuggestion, VariableOrigin, DataLinkBuiltInVars } from '@grafana/ui';
 import { DataLink, KeyValue, deprecationWarning, LinkModel, DataFrame, ScopedVars } from '@grafana/data';
 
@@ -148,6 +149,10 @@ export class LinkSrv implements LinkService {
       const range = this.timeSrv.timeRangeForUrl();
       params['from'] = range.from;
       params['to'] = range.to;
+    }
+
+    if (link.timezone) {
+      params['tz'] = getLocalTimeZone();
     }
 
     if (link.includeVars) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an option in dashboard links to build URL with a parameter 'tz' containing the local timezone. This is needed to configure links to render a dashboard.

Note: I didn't add this timezone parameter to data links.
