### PR TITLE
CloudWatch: Display partial result in graph when max DP/call limit is reached 

### DIFF
--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -97,7 +97,7 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		}
 
 		if partialData {
-			queryResult.ErrorString = "Cloudwatch GetMetricData error: Too many datapoints requested - your search may have been limited. Please try to reduce the time range"
+			queryResult.ErrorString = "Cloudwatch GetMetricData error: Too many datapoints requested - your search have been limited. Please try to reduce the time range"
 		}
 
 		queryResult.Series = append(queryResult.Series, timeSeries...)

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -71,6 +71,7 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		timeSeries := make(tsdb.TimeSeriesSlice, 0)
 
 		requestExceededMaxLimit := false
+		partialData := false
 		queryMeta := []struct {
 			Expression, ID string
 		}{}
@@ -78,6 +79,7 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		for _, response := range responses {
 			timeSeries = append(timeSeries, *response.series...)
 			requestExceededMaxLimit = requestExceededMaxLimit || response.RequestExceededMaxLimit
+			partialData = partialData || response.PartialData
 			queryMeta = append(queryMeta, struct {
 				Expression, ID string
 			}{
@@ -93,6 +95,11 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		if requestExceededMaxLimit {
 			queryResult.ErrorString = "Cloudwatch GetMetricData error: Maximum number of allowed metrics exceeded. Your search may have been limited."
 		}
+
+		if partialData {
+			queryResult.ErrorString = "Cloudwatch GetMetricData error: Too many datapoints requested - your search may have been limited. Please try to reduce the time range"
+		}
+
 		queryResult.Series = append(queryResult.Series, timeSeries...)
 		queryResult.Meta.Set("gmdMeta", queryMeta)
 		results[refID] = queryResult

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -46,7 +46,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{namespace}}_{{metric}}_{{stat}}",
 			}
-			series, err := parseGetMetricDataTimeSeries(resp, query)
+			series, _, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -36,6 +36,7 @@ type cloudwatchResponse struct {
 	RefId                   string
 	Expression              string
 	RequestExceededMaxLimit bool
+	PartialData             bool
 }
 
 type queryError struct {


### PR DESCRIPTION
The GetMetricData api has a limit of 100,800 data points per request. In case all queries in the GMD call are metric stat (not using math expressions), grafana will paginate the response until all data points are received. But in case a math expression is being used, GMD doesn't support pagination so in that case it's not possible to receive more than 100,800 data points. If that limit is reached, we display an error too many datapoints requested in query x. Please try to reduce the time range, and the 100,800 data points that were received will not be displayed in the graph.

It's good that the error/warning is shown, but there's no good reason to not display the data points, so this PR changes that.

![dplimit](https://user-images.githubusercontent.com/2388950/72514875-4cc87980-384f-11ea-94fa-f9bf4f3df2a6.png)
