### PR TITLE
Explore/Loki: Filter expression only treated as regex when regex operator is used

### DIFF
--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -92,4 +92,12 @@ describe('getHighlighterExpressionsFromQuery', () => {
   it('returns null if filter term is not wrapped in double quotes', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= x')).toEqual(null);
   });
+
+  it('escapes filter term if regex filter operator is not used', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x[yz].w"')).toEqual(['x\\[yz\\]\\.w']);
+  });
+
+  it('does not escape filter term if regex filter operator is used', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |~ "x[yz].w" |~ "z.+"')).toEqual(['x[yz].w', 'z.+']);
+  });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,4 +1,5 @@
 import { LokiExpression } from './types';
+import escapeRegExp from 'lodash/escapeRegExp';
 
 const selectorRegexp = /(?:^|\s){[^{]*}/g;
 export function parseQuery(input: string): LokiExpression {
@@ -45,6 +46,7 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
       break;
     }
     // Drop terms for negative filters
+    const filterOperator = expression.substr(filterStart, 2);
     const skip = expression.substr(filterStart).search(/!=|!~/) === 0;
     expression = expression.substr(filterStart + 2);
     if (skip) {
@@ -65,7 +67,8 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
 
     if (quotedTerm) {
       const unwrappedFilterTerm = quotedTerm[1];
-      results.push(unwrappedFilterTerm);
+      const regexOperator = filterOperator === '|~';
+      results.push(regexOperator ? unwrappedFilterTerm : escapeRegExp(unwrappedFilterTerm));
     } else {
       return null;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously filter expressions would always be highlighted as if they were regular expressions. This PR makes it so only filter expressions using the regex filter operator `|~` will be treated as regular expressions.

**Which issue(s) this PR fixes**:
Closes #17963 
