### PR TITLE
CloudWatch: Multi-valued template variable dimension alias fix

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -82,7 +82,7 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 				series.Tags[key] = values[0]
 			} else {
 				for _, value := range values {
-					if value == label || value == "*" {
+					if value == label || value == "*" || strings.Contains(label, value) {
 						series.Tags[key] = label
 					}
 				}


### PR DESCRIPTION
In Grafana 6.5 we switched from using the GMS api to the GMD api. That meant we had to change the way we handled multi-valued template variables in dimensions. Instead of making one query per dimension value, we instead use search expressions. For example like this: 
`SEARCH('{AWS/EC2,InstanceId} MetricName="CPUUtilization" "InstanceId"=("i-123" OR "i-456")', 'Sum', 300)`
When a search expression is used, the returned time series will get a label name. If the GMD request only contained one query, the search expression above, the two time series that were returned would be named ì-123`and ì-456`. But in case there were one more search expression present in the GMD request, like this one: 
`SEARCH('{AWS/EC2,InstanceId} MetricName="CPUUtilization" "InstanceId"=("i-123" OR "i-456")', 'Average', 300)`
Then GMD would make the label unique. It could for example combine dimension value with the stat or the metric name, e.g `i-123 Sum` and `i-123 Average`. 

When expanding the alias legend in the Cloudwatch datasource, we try to match dimension values with the label that was returned from GMD, so in case there are more than one query that use that use the same dimension key in a multi-valued template variable, it's not possible to find a matching label. The suggested solution to that is to perform a substring match on label. 
`label = i-123 Sum`
`dimensionValue = i-123`
expand variable if label contains substring dimensionValue

fixes #20927
fixes #20729
