### PR TITLE
Provisioning: Start provision dashboards after Grafana server have started

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -69,15 +69,15 @@ func (ps *provisioningServiceImpl) Init() error {
 		return err
 	}
 
-	err = ps.ProvisionDashboards()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (ps *provisioningServiceImpl) Run(ctx context.Context) error {
+	err := ps.ProvisionDashboards()
+	if err != nil {
+		ps.log.Error("Failed to provision dashboard", "error", err)
+	}
+
 	for {
 
 		// Wait for unlock. This is tied to new dashboardProvisioner to be instantiated before we start polling.


### PR DESCRIPTION
**What this PR does / why we need it**:
6.2-beta1 changed so that data sources, dashboards and alert notifiers are provisioned on service `Init` where's before only data sources and alert notifiers was provisioned on service `Init`, see 42b745a#diff-a9672f54b84e56c5da85374613c77bd7R57, and dashboards was first provisioned in service `Run` which happens after Grafana server have started. 
This change reverts so that dashboard provisioning are first happening in service `Run`. 

**Which issue(s) this PR fixes**:
Fixes #21133 

**Special notes for your reviewer**:
Would like to get this included in 6.6 beta1, if possible.