### PR TITLE
Docs: Add information about license expiration

### DIFF
--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -8,31 +8,31 @@ parent = "enterprise"
 weight = 8
 +++
 
-# Expired License
+# License expiration 
 
-If your license has expired, your Grafana admin needs to upload a new *license.jwt* file to the location in the `enterprise.license_path` directory (default your Grafana data directory). This file can be downloaded from your Grafana Cloud organization’s license page. Restart Grafana once the file is in place.
+If your license has expired, then your Grafana admin needs to upload a new *license.jwt* file to the location in the `enterprise.license_path` directory (default is your Grafana data directory). This file can be downloaded from your Grafana Cloud organization’s license page. Restart Grafana once the file is in place.
 
-Although you'll be able to access most of Grafana as usual, some functionality will stop working when the license expires and a banner will appear informing all users that the license has expired.
+Although you'll be able to access most of Grafana as usual, some functionality stops working when the license expires and a banner informs all users that the license has expired.
 
 > You should replace your license as soon as possible. Running Grafana Enterprise with an expired license is unsupported and can lead to unexpected consequences.
 
-## Datasource Permissions
+## Data source permissions
 
-- Your current data source permissions will keep working as expected, but you'll be unable to add new data source permissions until the license has been replaced.
+Your current data source permissions will keep working as expected, but you'll be unable to add new data source permissions until the license has been renewed.
 
 ## Reporting
 
-- You won't be able to configure new reports or generate previews.
-- Scheduled reports will not be generated or sent.
+You won't be able to configure new reports or generate previews.
+Scheduled reports will not be generated or sent.
 
-## SAML
+## SAML authentication
 
-- SAML is not affected by an expired license.
+SAML is not affected by an expired license.
 
-## Enterprise Plugins 
+## Enterprise plugins
 
-- Enterprise plugins may stop working.
+Enterprise plugins might stop working.
 
 ## White labeling
 
-- The white labeling feature will be disabled, meaning that any white labeling options will not have any effect.
+The white labeling feature is turned off, meaning that any white labeling options will not have any effect.

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -1,0 +1,38 @@
++++
+title = "License Expiration"
+description = ""
+keywords = ["grafana", "licensing"]
+type = "docs"
+[menu.docs]
+parent = "enterprise"
+weight = 8
++++
+
+# Expired License
+
+If your license has expired, your Grafana admin needs to upload a new *license.jwt* file to the location in the `enterprise.license_path` directory (default your Grafana data directory). This file can be downloaded from your Grafana Cloud organization’s license page. Restart Grafana once the file is in place.
+
+Although you'll be able to access most of Grafana as usual, some functionality will stop working when the license expires and a banner will appear informing all users that the license has expired.
+
+> You should replace your license as soon as possible. Running Grafana Enterprise with an expired license is unsupported and can lead to unexpected consequences.
+
+## Datasource Permissions
+
+- Your current data source permissions will keep working as expected, but you'll be unable to add new data source permissions until the license has been replaced.
+
+## Reporting
+
+- You won't be able to configure new reports or generate previews.
+- Scheduled reports will not be generated or sent.
+
+## SAML
+
+- SAML is not affected by an expired license.
+
+## Enterprise Datasources
+
+- Enterprise datasources may stop working.
+
+## Whitelabeling
+
+- The whitelabeling feature will be disabled.

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -10,13 +10,13 @@ weight = 8
 
 # License expiration 
 
-If your license has expired most of Grafana will keep on working with some limited or disabled enterprise functionality and a banner informing all users that the Grafana instance is unlicensed. Your Grafana admin needs to upload a new license file to ensure that all functionality of Grafana Enterprise keeps working properly.
+If your license has expired most of Grafana keeps working as normal. Some enterprise functionality stops or runs with reduced functionality and Grafana displays a banner informing the users that Grafana is running on an expired license. Your Grafana admin needs to upload a new license file to restore full functionality.
 
 > Replace your license as soon as possible. Running Grafana Enterprise with an expired license is unsupported and can lead to unexpected consequences.
 
 ## Replacing your license
 
-1. Identify the location of your current `license.jwt` file. In a standard installation it is stored inside Grafana's data directory, which on a typical Linux installation is in `/var/lib/grafana/data`. This location might be overridden in the ini file [Configuration](https://grafana.com/docs/grafana/latest/installation/configuration/)
+1. Locate your current `license.jwt` file. In a standard installation it is stored inside Grafana's data directory, which on a typical Linux installation is in `/var/lib/grafana/data`. This location might be overridden in the ini file [Configuration](https://grafana.com/docs/grafana/latest/installation/configuration/)
 ```
 [enterprise]
 license_path = /path/to/your/license.jwt
@@ -34,7 +34,7 @@ Your current data source permissions will keep working as expected, but you'll b
 ## Reporting
 
 You won't be able to configure new reports or generate previews.
-Scheduled reports will not be generated or sent.
+Scheduled reports are not generated or sent.
 
 ## SAML authentication
 

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -33,12 +33,17 @@ Your current data source permissions will keep working as expected, but you'll b
 
 ## Reporting
 
-You won't be able to configure new reports or generate previews.
-Scheduled reports are not generated or sent.
+- You're unable to configure new reports or generate previews.
+- Scheduled reports are not generated or sent.
 
 ## SAML authentication
 
 SAML is not affected by an expired license.
+
+## LDAP authentication
+
+- LDAP synchronization is not affected by an expired license.
+- Enhanced LDAP debugging is unavailable.
 
 ## Enterprise plugins
 

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -10,11 +10,22 @@ weight = 8
 
 # License expiration 
 
-If your license has expired, then your Grafana admin needs to upload a new *license.jwt* file to the location in the `enterprise.license_path` directory (default is your Grafana data directory). This file can be downloaded from your Grafana Cloud organization’s license page. Restart Grafana once the file is in place.
+If your license has expired most of Grafana will keep on working with some limited or disabled enterprise functionality and a banner informing all users that the Grafana instance is unlicensed. Your Grafana admin needs to upload a new license file to ensure that all functionality of Grafana Enterprise keeps working properly.
 
-Although you'll be able to access most of Grafana as usual, some functionality stops working when the license expires and a banner informs all users that the license has expired.
+> Replace your license as soon as possible. Running Grafana Enterprise with an expired license is unsupported and can lead to unexpected consequences.
 
-> You should replace your license as soon as possible. Running Grafana Enterprise with an expired license is unsupported and can lead to unexpected consequences.
+## Replacing your license
+
+1. Identify the location of your current `license.jwt` file. In a standard installation it is stored inside Grafana's data directory, which on a typical Linux installation is in `/var/lib/grafana/data`. This location might be overridden in the ini file [Configuration](https://grafana.com/docs/grafana/latest/installation/configuration/)
+```
+[enterprise]
+license_path = /path/to/your/license.jwt
+```
+The configuration file's location may also be overridden by the `GF_ENTERPRISE_LICENSE_PATH` environment variable.
+2. Log in to your [Grafana.com](https://grafana.com/login) user and make sure you're in the correct organization in the dropdown at the top of the page.
+3. Under the **Grafana Enterprise** section in the menu bar to the left, choose licenses and download the currently valid license with which you want to run Grafana. If you cannot see a valid license on Grafana.com, please contact your account manager at Grafana Labs to renew your subscription.
+4. Replace the current `license.jwt`-file with the one you've just downloaded.
+5. Restart Grafana.
 
 ## Data source permissions
 

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -29,10 +29,10 @@ Although you'll be able to access most of Grafana as usual, some functionality w
 
 - SAML is not affected by an expired license.
 
-## Enterprise Datasources
+## Enterprise Plugins 
 
-- Enterprise datasources may stop working.
+- Enterprise plugins may stop working.
 
-## Whitelabeling
+## White labeling
 
-- The whitelabeling feature will be disabled.
+- The white labeling feature will be disabled, meaning that any white labeling options will not have any effect.

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -239,6 +239,8 @@
     name: Team Sync
   - link: /enterprise/white-labeling/
     name: White labeling
+  - link: /enterprise/license-expiration/
+    name: License expiration
 - name: Tutorials
   link: /tutorials/
   children:


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the docs page which enterprise customers are directed to when their licenses have expired.

**Special notes for your reviewer**:

- @torkelo Is this ~ the information we want to convey? There should be a text about how the renewal process works, but I'm uncertain about that so I didn't add anything.
- @oddlittlebird Feel free to edit the PR to your liking 🙂 