### PR TITLE
Explore: Remove destructuring of empty state in LogRowMessage

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -84,7 +84,7 @@ class UnThemedLogRowMessage extends PureComponent<Props, State> {
       wrapLogMessage,
       onToggleContext,
     } = this.props;
-    const {} = this.state;
+
     const style = getLogRowStyles(theme, row.logLevel);
     const { entry, hasAnsi, raw } = row;
 

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -30,8 +30,6 @@ interface Props extends Themeable {
   updateLimit?: () => void;
 }
 
-interface State {}
-
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const outlineColor = selectThemeVariant(
     {
@@ -65,7 +63,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   };
 });
 
-class UnThemedLogRowMessage extends PureComponent<Props, State> {
+class UnThemedLogRowMessage extends PureComponent<Props> {
   onContextToggle = (e: React.SyntheticEvent<HTMLElement>) => {
     e.stopPropagation();
     this.props.onToggleContext();


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes destructuring of empty state in LogRowMessage that was introduced in [#20034](https://github.com/grafana/grafana/pull/20034/files#diff-1b6d7fbf1f03a3c50ce5a333b7c47acbR81). 
