### PR TITLE
Fix ButtonCascade error in Explore

### DIFF
--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.story.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.story.tsx
@@ -29,5 +29,9 @@ const getKnobs = () => {
 
 export const simple = () => {
   const { disabled, text, options } = getKnobs();
-  return <ButtonCascader disabled={disabled} options={options} value={['A']} expandIcon={null} buttonText={text} />;
+  return (
+    <ButtonCascader disabled={disabled} options={options} value={['A']}>
+      {text}
+    </ButtonCascader>
+  );
 };

--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from '../Forms/Button';
 import { Icon } from '../Icon/Icon';
 
 // @ts-ignore
@@ -20,8 +19,8 @@ export interface ButtonCascaderProps {
 
 export const ButtonCascader: React.FC<ButtonCascaderProps> = props => (
   <RCCascader {...props} expandIcon={null}>
-    <Button variant="secondary" disabled={props.disabled}>
+    <button className="gf-form-label gf-form-label--btn" disabled={props.disabled}>
       {props.children} <Icon name="caret-down" />
-    </Button>
+    </button>
   </RCCascader>
 );

--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
@@ -10,7 +10,7 @@ export interface ButtonCascaderProps {
   children: string;
   disabled?: boolean;
   value?: string[];
-  fieldNames?: any;
+  fieldNames?: { label: string; value: string; children: string };
 
   loadData?: (selectedOptions: CascaderOption[]) => void;
   onChange?: (value: string[], selectedOptions: CascaderOption[]) => void;

--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
@@ -11,6 +11,7 @@ export interface ButtonCascaderProps {
   children: string;
   disabled?: boolean;
   value?: string[];
+  fieldNames?: any;
 
   loadData?: (selectedOptions: CascaderOption[]) => void;
   onChange?: (value: string[], selectedOptions: CascaderOption[]) => void;
@@ -18,7 +19,7 @@ export interface ButtonCascaderProps {
 }
 
 export const ButtonCascader: React.FC<ButtonCascaderProps> = props => (
-  <RCCascader {...props} fieldNames={{ label: 'label', value: 'value', children: 'items' }} expandIcon={null}>
+  <RCCascader {...props} expandIcon={null}>
     <Button variant="secondary" disabled={props.disabled}>
       {props.children} <Icon name="caret-down" />
     </Button>

--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.tsx
@@ -8,9 +8,8 @@ import { CascaderOption } from '../Cascader/Cascader';
 
 export interface ButtonCascaderProps {
   options: CascaderOption[];
-  buttonText: string;
+  children: string;
   disabled?: boolean;
-  expandIcon?: React.ReactNode;
   value?: string[];
 
   loadData?: (selectedOptions: CascaderOption[]) => void;
@@ -19,9 +18,9 @@ export interface ButtonCascaderProps {
 }
 
 export const ButtonCascader: React.FC<ButtonCascaderProps> = props => (
-  <RCCascader {...props} fieldNames={{ label: 'label', value: 'value', children: 'items' }}>
+  <RCCascader {...props} fieldNames={{ label: 'label', value: 'value', children: 'items' }} expandIcon={null}>
     <Button variant="secondary" disabled={props.disabled}>
-      {props.buttonText} <Icon name="caret-down" />
+      {props.children} <Icon name="caret-down" />
     </Button>
   </RCCascader>
 );

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -32,7 +32,7 @@ export interface CascaderOption {
   items?: CascaderOption[];
   disabled?: boolean;
   title?: string;
-  [key: string]: any;
+  children?: CascaderOption[];
 }
 
 const disableDivFocus = css(`

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -32,6 +32,7 @@ export interface CascaderOption {
   items?: CascaderOption[];
   disabled?: boolean;
   title?: string;
+  [key: string]: any;
 }
 
 const disableDivFocus = css(`

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -186,6 +186,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
             onBlur={this.onBlurCascade}
             value={rcValue}
             fieldNames={{ label: 'label', value: 'value', children: 'items' }}
+            expandIcon={null}
           >
             <div className={disableDivFocus}>
               <Input

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -135,13 +135,13 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
       <div className="gf-form-inline gf-form-inline--nowrap">
         <div className="gf-form flex-shrink-0">
           <ButtonCascader
-            buttonText={cascadeText}
             options={measurements}
             disabled={!hasMeasurement}
             value={[measurement, field]}
             onChange={this.onMeasurementsChange}
-            expandIcon={null}
-          />
+          >
+            {cascadeText}
+          </ButtonCascader>
         </div>
         <div className="flex-shrink-1 flex-flow-column-nowrap">
           {measurement && (

--- a/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryFieldForm.tsx
@@ -151,12 +151,12 @@ export class LokiQueryFieldForm extends React.PureComponent<LokiQueryFieldFormPr
             <ButtonCascader
               options={logLabelOptions || []}
               disabled={buttonDisabled}
-              buttonText={chooserText}
               onChange={this.onChangeLogLabels}
               loadData={onLoadOptions}
-              expandIcon={null}
               onPopupVisibleChange={isVisible => isVisible && onLabelsRefresh && onLabelsRefresh()}
-            />
+            >
+              {chooserText}
+            </ButtonCascader>
           </div>
           <div className="gf-form gf-form--grow">
             <QueryField

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -9,7 +9,7 @@ describe('groupMetricsByPrefix()', () => {
     expect(groupMetricsByPrefix(['foo_metric'])).toMatchObject([
       {
         value: 'foo',
-        items: [
+        children: [
           {
             value: 'foo_metric',
           },
@@ -22,7 +22,7 @@ describe('groupMetricsByPrefix()', () => {
     expect(groupMetricsByPrefix(['foo_metric'], { foo_metric: [{ type: 'TYPE', help: 'my help' }] })).toMatchObject([
       {
         value: 'foo',
-        items: [
+        children: [
           {
             value: 'foo_metric',
             title: 'foo_metric\nTYPE\nmy help',
@@ -44,7 +44,7 @@ describe('groupMetricsByPrefix()', () => {
     expect(groupMetricsByPrefix([':foo_metric:'])).toMatchObject([
       {
         value: RECORDING_RULES_GROUP,
-        items: [
+        children: [
           {
             value: ':foo_metric:',
           },

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -299,13 +299,9 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
       <>
         <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">
           <div className="gf-form flex-shrink-0">
-            <ButtonCascader
-              options={metricsOptions}
-              buttonText={chooserText}
-              disabled={buttonDisabled}
-              onChange={this.onChangeMetrics}
-              expandIcon={null}
-            />
+            <ButtonCascader options={metricsOptions} disabled={buttonDisabled} onChange={this.onChangeMetrics}>
+              {chooserText}
+            </ButtonCascader>
           </div>
           <div className="gf-form gf-form--grow flex-shrink-1">
             <QueryField

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -52,7 +52,7 @@ export function groupMetricsByPrefix(metrics: string[], metadata?: PromMetricsMe
   const rulesOption = {
     label: 'Recording rules',
     value: RECORDING_RULES_GROUP,
-    items: ruleNames
+    children: ruleNames
       .slice()
       .sort()
       .map(name => ({ label: name, value: name })),
@@ -69,7 +69,7 @@ export function groupMetricsByPrefix(metrics: string[], metadata?: PromMetricsMe
         const prefixIsMetric = metricsForPrefix.length === 1 && metricsForPrefix[0] === prefix;
         const children = prefixIsMetric ? [] : metricsForPrefix.sort().map(m => addMetricsMetadata(m, metadata));
         return {
-          items: children,
+          children,
           label: prefix,
           value: prefix,
         };
@@ -198,7 +198,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   onChangeMetrics = (values: string[], selectedOptions: CascaderOption[]) => {
     let query;
     if (selectedOptions.length === 1) {
-      if (selectedOptions[0].items.length === 0) {
+      if (selectedOptions[0].children.length === 0) {
         query = selectedOptions[0].value;
       } else {
         // Ignore click on group
@@ -254,7 +254,10 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     const histogramOptions = histogramMetrics.map((hm: any) => ({ label: hm, value: hm }));
     const metricsOptions =
       histogramMetrics.length > 0
-        ? [{ label: 'Histograms', value: HISTOGRAM_GROUP, items: histogramOptions, isLeaf: false }, ...metricsByPrefix]
+        ? [
+            { label: 'Histograms', value: HISTOGRAM_GROUP, children: histogramOptions, isLeaf: false },
+            ...metricsByPrefix,
+          ]
         : metricsByPrefix;
 
     // Hint for big disabled lookups


### PR DESCRIPTION
Started doing a basic cleanup of the ButtonCascader. While doing that an issue was reported in Explore that children weren't loaded properly. This is beacuse the data format of the cascader alternatives had been changed to `{label: 'label', value:'value', children:'items'}`. The problem was fixed by letting it take the default {label: 'label', value:'value', children:'children'}. Might look into this in the future.

See the `fieldNames` prop.