### PR TITLE
Graphite: Do not change query when opening the query editor and there is no data

### DIFF
--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -37,7 +37,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
 
     this.datasource.waitForFuncDefsLoaded().then(() => {
       this.queryModel = new GraphiteQuery(this.datasource, this.target, templateSrv);
-      this.buildSegments();
+      this.buildSegments(false);
     });
 
     this.removeTagValue = '-- remove tag --';
@@ -53,13 +53,13 @@ export class GraphiteQueryCtrl extends QueryCtrl {
     this.parseTarget();
   }
 
-  buildSegments() {
+  buildSegments(modifyLastSegment = true) {
     this.segments = _.map(this.queryModel.segments, segment => {
       return this.uiSegmentSrv.newSegment(segment);
     });
 
     const checkOtherSegmentsIndex = this.queryModel.checkOtherSegmentsIndex || 0;
-    this.checkOtherSegments(checkOtherSegmentsIndex);
+    this.checkOtherSegments(checkOtherSegmentsIndex, modifyLastSegment);
 
     if (this.queryModel.seriesByTagUsed) {
       this.fixTagSegments();
@@ -71,7 +71,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
     this.segments.push(this.uiSegmentSrv.newSelectMetric());
   }
 
-  checkOtherSegments(fromIndex: number) {
+  checkOtherSegments(fromIndex: number, modifyLastSegment = true) {
     if (this.queryModel.segments.length === 1 && this.queryModel.segments[0].type === 'series-ref') {
       return;
     }
@@ -90,7 +90,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
       .metricFindQuery(path)
       .then((segments: any) => {
         if (segments.length === 0) {
-          if (path !== '') {
+          if (path !== '' && modifyLastSegment) {
             this.queryModel.segments = this.queryModel.segments.splice(0, fromIndex);
             this.segments = this.segments.splice(0, fromIndex);
             this.addSelectMetricSegment();

--- a/public/app/plugins/datasource/graphite/specs/query_ctrl.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/query_ctrl.test.ts
@@ -43,7 +43,52 @@ describe('GraphiteQueryCtrl', () => {
       expect(ctx.datasource.metricFindQuery.mock.calls[0][0]).toBe('test.prod.*');
     });
 
+    it('should not delete last segment if no metrics are found', () => {
+      expect(ctx.ctrl.segments[2].value).not.toBe('select metric');
+      expect(ctx.ctrl.segments[2].value).toBe('*');
+    });
+
+    it('should parse expression and build function model', () => {
+      expect(ctx.ctrl.queryModel.functions.length).toBe(2);
+    });
+  });
+
+  describe('when toggling edit mode to raw and back again', () => {
+    beforeEach(() => {
+      ctx.ctrl.toggleEditorMode();
+      ctx.ctrl.toggleEditorMode();
+    });
+
+    it('should validate metric key exists', () => {
+      const lastCallIndex = ctx.datasource.metricFindQuery.mock.calls.length - 1;
+      expect(ctx.datasource.metricFindQuery.mock.calls[lastCallIndex][0]).toBe('test.prod.*');
+    });
+
     it('should delete last segment if no metrics are found', () => {
+      expect(ctx.ctrl.segments[0].value).toBe('test');
+      expect(ctx.ctrl.segments[1].value).toBe('prod');
+      expect(ctx.ctrl.segments[2].value).toBe('select metric');
+    });
+
+    it('should parse expression and build function model', () => {
+      expect(ctx.ctrl.queryModel.functions.length).toBe(2);
+    });
+  });
+
+  describe('when middle segment value of test.prod.* is changed', () => {
+    beforeEach(() => {
+      const segment = { type: 'segment', value: 'test', expandable: true };
+      ctx.ctrl.segmentValueChanged(segment, 1);
+    });
+
+    it('should validate metric key exists', () => {
+      const lastCallIndex = ctx.datasource.metricFindQuery.mock.calls.length - 1;
+      expect(ctx.datasource.metricFindQuery.mock.calls[lastCallIndex][0]).toBe('test.test.*');
+    });
+
+    it('should delete last segment if no metrics are found', () => {
+      expect(ctx.ctrl.segments[0].value).toBe('test');
+      expect(ctx.ctrl.segments[1].value).toBe('test');
       expect(ctx.ctrl.segments[2].value).toBe('select metric');
     });
 


### PR DESCRIPTION
This changes the logic of the Graphite query editor so that it does not modify the metric path when a user opens the query editor. The old behavior was to execute a find query for the last part of the metric path and if there was no data, then it would change the value to be `select metric`.

The old behavior is still in place when toggling edit mode or for any other action that parses the metric path.

Fixes #21563



