### PR TITLE
grafana/ui: Add synced timepickers styling to TimePicker

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, { PureComponent, memo, FormEvent } from 'react';
-import { css } from 'emotion';
-import classNames from 'classnames';
+import { css, cx } from 'emotion';
 
 // Components
 import { Tooltip } from '../Tooltip/Tooltip';
@@ -158,9 +157,9 @@ export class UnthemedTimePicker extends PureComponent<Props, State> {
     const styles = getStyles(theme);
     const hasAbsolute = isDateTime(value.raw.from) || isDateTime(value.raw.to);
     const syncedTimePicker = timeSyncButton && isSynced;
-    const timePickerIconClass = classNames('fa fa-clock-o fa-fw', { ['icon-brand-gradient']: syncedTimePicker });
-    const timePickerButtonClass = classNames('btn navbar-button navbar-button--zoom', {
-      [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: timeSyncButton,
+    const timePickerIconClass = cx('fa fa-clock-o fa-fw', { ['icon-brand-gradient']: syncedTimePicker });
+    const timePickerButtonClass = cx('btn navbar-button navbar-button--zoom', {
+      [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: !!timeSyncButton,
       [`explore-active-button-glow ${styles.syncedTimePicker}`]: syncedTimePicker,
     });
 

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -70,6 +70,23 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
         font-size: ${theme.typography.size.md};
       }
     `,
+    syncedTimePicker: css`
+      label: syncedTimePicker;
+      border-color: ${theme.colors.orangeDark};
+      background-image: none;
+      background-color: transparent;
+      color: ${theme.colors.orangeDark};
+      &:focus,
+      :hover {
+        color: ${theme.colors.orangeDark};
+        background-image: none;
+        background-color: transparent;
+      }
+    `,
+    noRightBorderStyle: css`
+      label: noRightBorderStyle;
+      border-right: 0;
+    `,
   };
 });
 
@@ -140,6 +157,11 @@ export class UnthemedTimePicker extends PureComponent<Props, State> {
     const { isOpen } = this.state;
     const styles = getStyles(theme);
     const hasAbsolute = isDateTime(value.raw.from) || isDateTime(value.raw.to);
+    const timePickerButtonClass = classNames('btn navbar-button navbar-button--zoom', {
+      [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: timeSyncButton,
+      [styles.syncedTimePicker]: timeSyncButton ? isSynced : null,
+    });
+    const timePickerIconClass = classNames('fa fa-clock-o fa-fw', isSynced && timeSyncButton && 'icon-brand-gradient');
 
     return (
       <div className={styles.container}>
@@ -151,12 +173,8 @@ export class UnthemedTimePicker extends PureComponent<Props, State> {
           )}
           <div>
             <Tooltip content={<TimePickerTooltip timeRange={value} />} placement="bottom">
-              <button
-                aria-label="TimePicker Open Button"
-                className="btn navbar-button navbar-button--zoom"
-                onClick={this.onOpen}
-              >
-                <i className={classNames('fa fa-clock-o fa-fw', isSynced && timeSyncButton && 'icon-brand-gradient')} />
+              <button aria-label="TimePicker Open Button" className={timePickerButtonClass} onClick={this.onOpen}>
+                <i className={timePickerIconClass} />
                 <TimePickerButtonLabel {...this.props} />
                 <span className={styles.caretIcon}>
                   {isOpen ? <i className="fa fa-caret-up fa-fw" /> : <i className="fa fa-caret-down fa-fw" />}

--- a/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimePicker.tsx
@@ -157,11 +157,12 @@ export class UnthemedTimePicker extends PureComponent<Props, State> {
     const { isOpen } = this.state;
     const styles = getStyles(theme);
     const hasAbsolute = isDateTime(value.raw.from) || isDateTime(value.raw.to);
+    const syncedTimePicker = timeSyncButton && isSynced;
+    const timePickerIconClass = classNames('fa fa-clock-o fa-fw', { ['icon-brand-gradient']: syncedTimePicker });
     const timePickerButtonClass = classNames('btn navbar-button navbar-button--zoom', {
       [`btn--radius-right-0 ${styles.noRightBorderStyle}`]: timeSyncButton,
-      [styles.syncedTimePicker]: timeSyncButton ? isSynced : null,
+      [`explore-active-button-glow ${styles.syncedTimePicker}`]: syncedTimePicker,
     });
-    const timePickerIconClass = classNames('fa fa-clock-o fa-fw', isSynced && timeSyncButton && 'icon-brand-gradient');
 
     return (
       <div className={styles.container}>

--- a/public/app/features/explore/TimeSyncButton.tsx
+++ b/public/app/features/explore/TimeSyncButton.tsx
@@ -24,6 +24,14 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: noRightBorderStyle;
       border-right: 0;
     `,
+    /*
+     * Required top-padding, otherwise is fa-link icon in active state
+     * cut off on top due to fontAwesome icon position
+     */
+    topPadding: css`
+      label: topPadding;
+      padding-top: 1px;
+    `,
   };
 });
 
@@ -52,7 +60,7 @@ export function TimeSyncButton(props: TimeSyncButtonProps) {
         aria-label={isSynced ? 'Synced times' : 'Unsynced times'}
         onClick={() => onClick()}
       >
-        <i className={classNames('fa fa-link', isSynced && 'icon-brand-gradient')} />
+        <i className={classNames('fa fa-link', styles.topPadding, isSynced && 'icon-brand-gradient')} />
       </button>
     </Tooltip>
   );

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`TimeSyncButton should render component 1`] = `
         onMouseLeave={[Function]}
       >
         <i
-          className="fa fa-link icon-brand-gradient"
+          className="fa fa-link css-xmj56l-topPadding icon-brand-gradient"
         />
       </button>
     </PopoverController>


### PR DESCRIPTION
**What this PR does / why we need it**:
I have noticed that after the recent [TimePicker upgrade](https://github.com/grafana/grafana/pulls?q=is%3Apr+is%3Aclosed+author%3Amckn), some styling that was used mainly in Explore was lost. I am specifically talking about css for synced timepickers introduced [here](https://github.com/grafana/grafana/pull/19274). 

This PR fixes this and reintroduces this styling.

Current master:
![image](https://user-images.githubusercontent.com/30407135/72686616-d2218780-3af6-11ea-9b17-cdf13ed219d3.png)

Fixed: 
![image](https://user-images.githubusercontent.com/30407135/72686600-ba4a0380-3af6-11ea-900f-02418ec1b9a7.png)


