### PR TITLE
Render: Use https as protocol when rendering if HTTP2 enabled

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -135,8 +135,19 @@ func (rs *RenderingService) getURL(path string) string {
 		return fmt.Sprintf("%s%s&render=1", rs.Cfg.RendererCallbackUrl, path)
 
 	}
+
+	protocol := setting.Protocol
+	switch setting.Protocol {
+	case setting.HTTP:
+		protocol = "http"
+		break
+	case setting.HTTP2, setting.HTTPS:
+		protocol = "https"
+		break
+	}
+
 	// &render=1 signals to the legacy redirect layer to
-	return fmt.Sprintf("%s://%s:%s/%s&render=1", setting.Protocol, rs.domain, setting.HttpPort, path)
+	return fmt.Sprintf("%s://%s:%s/%s&render=1", protocol, rs.domain, setting.HttpPort, path)
 }
 
 func (rs *RenderingService) getRenderKey(orgId, userId int64, orgRole models.RoleType) (string, error) {

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -140,10 +140,8 @@ func (rs *RenderingService) getURL(path string) string {
 	switch setting.Protocol {
 	case setting.HTTP:
 		protocol = "http"
-		break
 	case setting.HTTP2, setting.HTTPS:
 		protocol = "https"
-		break
 	}
 
 	// &render=1 signals to the legacy redirect layer to


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes so that protocol is `https` instead of `h2` when rendering 
image if Grafana is configured  to use HTTP2.

**Which issue(s) this PR fixes**:
Ref https://github.com/grafana/grafana-image-renderer/issues/77

**Special notes for your reviewer**:

