### PR TITLE
Explore: updates explore table container to show a span on 0 series returned

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -19,6 +19,7 @@ import { Switch, LogLabels, ToggleButtonGroup, ToggleButton, LogRows } from '@gr
 import store from 'app/core/store';
 
 import { ExploreGraphPanel } from './ExploreGraphPanel';
+import { MetaInfoText } from './MetaInfoText';
 
 const SETTINGS_KEYS = {
   showLabels: 'grafana.explore.logs.showLabels',
@@ -219,14 +220,14 @@ export class Logs extends PureComponent<Props, State> {
         </div>
 
         {hasData && meta && (
-          <div className="logs-panel-meta">
-            {meta.map(item => (
-              <div className="logs-panel-meta__item" key={item.label}>
-                <span className="logs-panel-meta__label">{item.label}:</span>
-                <span className="logs-panel-meta__value">{renderMetaItem(item.value, item.kind)}</span>
-              </div>
-            ))}
-          </div>
+          <MetaInfoText
+            metaItems={meta.map(item => {
+              return {
+                label: item.label,
+                value: renderMetaItem(item.value, item.kind),
+              };
+            })}
+          />
         )}
 
         <LogRows

--- a/public/app/features/explore/MetaInfoText.test.tsx
+++ b/public/app/features/explore/MetaInfoText.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow, render } from 'enzyme';
+import { MetaInfoText, MetaItemProps } from './MetaInfoText';
+describe('MetaInfoText', () => {
+  it('should render component', () => {
+    const items: MetaItemProps[] = [
+      { label: 'label', value: 'value' },
+      { label: 'label2', value: 'value2' },
+    ];
+    const wrapper = shallow(<MetaInfoText metaItems={items} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render items', () => {
+    const items: MetaItemProps[] = [
+      { label: 'label', value: 'value' },
+      { label: 'label2', value: 'value2' },
+    ];
+
+    const wrapper = render(<MetaInfoText metaItems={items} />);
+    expect(wrapper.find('label')).toBeTruthy();
+    expect(wrapper.find('value')).toBeTruthy();
+    expect(wrapper.find('label2')).toBeTruthy();
+    expect(wrapper.find('value2')).toBeTruthy();
+  });
+
+  it('should render no items when the array is empty', () => {
+    const items: MetaItemProps[] = [];
+
+    const wrapper = shallow(<MetaInfoText metaItems={items} />);
+    expect(wrapper.find('div').exists()).toBeTruthy();
+    expect(wrapper.find('div').children()).toHaveLength(0);
+  });
+});

--- a/public/app/features/explore/MetaInfoText.tsx
+++ b/public/app/features/explore/MetaInfoText.tsx
@@ -1,0 +1,65 @@
+import React, { memo, useContext } from 'react';
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+import { stylesFactory, ThemeContext } from '@grafana/ui';
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+  metaContainer: css`
+    flex: 1;
+    color: ${theme.colors.textWeak};
+    margin-bottom: ${theme.spacing.d};
+    min-width: 30%;
+    display: flex;
+  `,
+  metaItem: css`
+    margin-right: ${theme.spacing.d};
+    display: flex;
+    align-items: baseline;
+  `,
+  metaLabel: css`
+    margin-right: calc(${theme.spacing.d} / 2);
+    font-size: ${theme.typography.size.sm};
+    font-weight: ${theme.typography.weight.semibold};
+  `,
+  metaValue: css`
+    font-family: ${theme.typography.fontFamily.monospace};
+  `,
+}));
+
+interface MetaItemProps {
+  label?: string;
+  value: string;
+}
+
+const MetaInfoItem = memo(function MetaInfoItem(props: MetaItemProps) {
+  const theme = useContext(ThemeContext);
+  const style = getStyles(theme);
+  const { label, value } = props;
+
+  return (
+    <div className={style.metaItem}>
+      {label && <span className={style.metaLabel}>{label}:</span>}
+      <span className={style.metaValue}>{value}</span>
+    </div>
+  );
+});
+
+export interface MetaInfoTextProps {
+  metaItems: MetaItemProps[];
+}
+
+export const MetaInfoText = memo(function MetaInfoText(props: MetaInfoTextProps) {
+  const theme = useContext(ThemeContext);
+  const style = getStyles(theme);
+  const { metaItems } = props;
+
+  return (
+    <div className={style.metaContainer}>
+      {metaItems.map((item, index) => (
+        <MetaInfoItem key={`${index}-${item.label}`} label={item.label} value={item.value} />
+      ))}
+    </div>
+  );
+});
+
+export default MetaInfoText;

--- a/public/app/features/explore/MetaInfoText.tsx
+++ b/public/app/features/explore/MetaInfoText.tsx
@@ -26,12 +26,12 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => ({
   `,
 }));
 
-interface MetaItemProps {
+export interface MetaItemProps {
   label?: string;
   value: string;
 }
 
-const MetaInfoItem = memo(function MetaInfoItem(props: MetaItemProps) {
+export const MetaInfoItem = memo(function MetaInfoItem(props: MetaItemProps) {
   const theme = useContext(ThemeContext);
   const style = getStyles(theme);
   const { label, value } = props;

--- a/public/app/features/explore/TableContainer.test.tsx
+++ b/public/app/features/explore/TableContainer.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow, render } from 'enzyme';
+import { TableContainer } from './TableContainer';
+import { DataFrame } from '@grafana/data';
+import { toggleTable } from './state/actions';
+import { ExploreId } from 'app/types/explore';
+
+describe('TableContainer', () => {
+  it('should render component', () => {
+    const props = {
+      exploreId: ExploreId.left as ExploreId,
+      loading: false,
+      width: 800,
+      onClickCell: jest.fn(),
+      showingTable: true,
+      tableResult: {} as DataFrame,
+      toggleTable: {} as typeof toggleTable,
+    };
+
+    const wrapper = shallow(<TableContainer {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render 0 series returned on no items', () => {
+    const props = {
+      exploreId: ExploreId.left as ExploreId,
+      loading: false,
+      width: 800,
+      onClickCell: jest.fn(),
+      showingTable: true,
+      tableResult: {
+        name: 'TableResultName',
+        fields: [],
+        length: 0,
+      } as DataFrame,
+      toggleTable: {} as typeof toggleTable,
+    };
+
+    const wrapper = render(<TableContainer {...props} />);
+    expect(wrapper.find('0 series returned')).toBeTruthy();
+  });
+});

--- a/public/app/features/explore/TableContainer.tsx
+++ b/public/app/features/explore/TableContainer.tsx
@@ -8,6 +8,7 @@ import { StoreState } from 'app/types';
 import { toggleTable } from './state/actions';
 import { config } from 'app/core/config';
 import { PANEL_BORDER } from 'app/core/constants';
+import { MetaInfoText } from './MetaInfoText';
 
 interface TableContainerProps {
   exploreId: ExploreId;
@@ -47,11 +48,7 @@ export class TableContainer extends PureComponent<TableContainerProps> {
         {hasTableResult ? (
           <Table data={tableResult} width={tableWidth} height={height} onCellClick={onClickCell} />
         ) : (
-          <div className="logs-panel-meta">
-            <div className="logs-panel-meta__item">
-              <span className="logs-panel-meta__value">0 series returned</span>
-            </div>
-          </div>
+          <MetaInfoText metaItems={[{ value: '0 series returned' }]} />
         )}
       </Collapse>
     );

--- a/public/app/features/explore/TableContainer.tsx
+++ b/public/app/features/explore/TableContainer.tsx
@@ -43,6 +43,13 @@ export class TableContainer extends PureComponent<TableContainerProps> {
 
     return (
       <Collapse label="Table" loading={loading} collapsible isOpen={showingTable} onToggle={this.onClickTableButton}>
+        {!tableResult?.length && (
+          <div className="logs-panel-meta">
+            <div className="logs-panel-meta__item">
+              <span className="logs-panel-meta__value">0 series returned</span>
+            </div>
+          </div>
+        )}
         {tableResult && <Table data={tableResult} width={tableWidth} height={height} onCellClick={onClickCell} />}
       </Collapse>
     );

--- a/public/app/features/explore/TableContainer.tsx
+++ b/public/app/features/explore/TableContainer.tsx
@@ -40,17 +40,19 @@ export class TableContainer extends PureComponent<TableContainerProps> {
 
     const height = this.getTableHeight();
     const tableWidth = width - config.theme.panelPadding * 2 - PANEL_BORDER;
+    const hasTableResult = tableResult?.length;
 
     return (
       <Collapse label="Table" loading={loading} collapsible isOpen={showingTable} onToggle={this.onClickTableButton}>
-        {!tableResult?.length && (
+        {hasTableResult ? (
+          <Table data={tableResult} width={tableWidth} height={height} onCellClick={onClickCell} />
+        ) : (
           <div className="logs-panel-meta">
             <div className="logs-panel-meta__item">
               <span className="logs-panel-meta__value">0 series returned</span>
             </div>
           </div>
         )}
-        {tableResult && <Table data={tableResult} width={tableWidth} height={height} onCellClick={onClickCell} />}
       </Collapse>
     );
   }

--- a/public/app/features/explore/__snapshots__/MetaInfoText.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/MetaInfoText.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetaInfoText should render component 1`] = `
+<div
+  className="css-mi7ebz"
+>
+  <Component
+    key="0-label"
+    label="label"
+    value="value"
+  />
+  <Component
+    key="1-label2"
+    label="label2"
+    value="value2"
+  />
+</div>
+`;

--- a/public/app/features/explore/__snapshots__/TableContainer.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TableContainer.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableContainer should render component 1`] = `
+<Collapse
+  collapsible={true}
+  isOpen={true}
+  label="Table"
+  loading={false}
+  onToggle={[Function]}
+>
+  <Component
+    metaItems={
+      Array [
+        Object {
+          "value": "0 series returned",
+        },
+      ]
+    }
+  />
+</Collapse>
+`;

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -26,33 +26,3 @@ $column-horizontal-spacing: 10px;
     margin-left: 0.5em;
   }
 }
-
-.logs-panel-meta {
-  flex: 1;
-  color: $text-color-weak;
-  margin-bottom: $spacer;
-  min-width: 30%;
-  display: flex;
-}
-
-.logs-panel-meta__item {
-  margin-right: $spacer;
-  display: flex;
-  align-items: baseline;
-}
-
-.logs-panel-meta__label {
-  margin-right: $spacer / 2;
-  font-size: $font-size-sm;
-  font-weight: $font-weight-semi-bold;
-}
-
-.logs-panel-meta__value {
-  font-family: $font-family-monospace;
-}
-
-.logs-panel-meta-item__labels {
-  // compensate for the labels padding
-  position: relative;
-  top: 4px;
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates explore table container to display a span when no series are returned.

![Screenshot](https://user-images.githubusercontent.com/6322797/72697882-ea6ac400-3b41-11ea-9769-19c125297136.png)

**Which issue(s) this PR fixes**:

Fixes #21476 