### PR TITLE
Prometheus: Updates explore query editor to prevent it from throwing error on edit

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { PromExploreExtraField, PromExploreExtraFieldProps } from './PromExploreExtraField';
+
+const setup = (propOverrides?: PromExploreExtraFieldProps) => {
+  const label = 'Prometheus Explore Extra Field';
+  const value = '123';
+  const onChangeFunc = jest.fn();
+  const onKeyDownFunc = jest.fn();
+
+  const props: any = {
+    label,
+    value,
+    onChangeFunc,
+    onKeyDownFunc,
+  };
+
+  Object.assign(props, propOverrides);
+
+  return shallow(<PromExploreExtraField {...props} />);
+};
+
+describe('PrometheusExploreExtraField', () => {
+  it('should render component', () => {
+    const wrapper = setup();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -9,15 +9,19 @@ export interface PromExploreExtraFieldProps {
   onChangeFunc: (e: React.SyntheticEvent<HTMLInputElement>) => void;
   onKeyDownFunc: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   value: string;
+  hasTooltip?: boolean;
+  tooltipContent?: string;
 }
 
 export function PromExploreExtraField(props: PromExploreExtraFieldProps) {
-  const { label, onChangeFunc, onKeyDownFunc, value } = props;
+  const { label, onChangeFunc, onKeyDownFunc, value, hasTooltip, tooltipContent } = props;
 
   return (
     <div className="gf-form-inline explore-input--ml">
       <div className="gf-form">
-        <FormLabel width={4}>{label}</FormLabel>
+        <FormLabel width={5} tooltip={hasTooltip ? tooltipContent : null}>
+          {label}
+        </FormLabel>
         <input
           type={'text'}
           className="gf-form-input width-4"

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -11,7 +11,7 @@ export interface PromExploreExtraFieldProps {
   value: string;
 }
 
-export const PromExploreExtraField = memo(function PromExploreExtraField(props: PromExploreExtraFieldProps) {
+export function PromExploreExtraField(props: PromExploreExtraFieldProps) {
   const { label, onChangeFunc, onKeyDownFunc, value } = props;
 
   return (
@@ -29,6 +29,6 @@ export const PromExploreExtraField = memo(function PromExploreExtraField(props: 
       </div>
     </div>
   );
-});
+}
 
-export default PromExploreExtraField;
+export default memo(PromExploreExtraField);

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -1,0 +1,34 @@
+// Libraries
+import React, { memo } from 'react';
+
+// Types
+import { FormLabel } from '@grafana/ui';
+
+export interface PromExploreExtraFieldProps {
+  label: string;
+  onChangeFunc: (e: React.SyntheticEvent<HTMLInputElement>) => void;
+  onKeyDownFunc: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  value: string;
+}
+
+export const PromExploreExtraField = memo(function PromExploreExtraField(props: PromExploreExtraFieldProps) {
+  const { label, onChangeFunc, onKeyDownFunc, value } = props;
+
+  return (
+    <div className="gf-form-inline explore-input--ml">
+      <div className="gf-form">
+        <FormLabel width={4}>{label}</FormLabel>
+        <input
+          type={'text'}
+          className="gf-form-input width-4"
+          placeholder={'auto'}
+          onChange={onChangeFunc}
+          onKeyDown={onKeyDownFunc}
+          value={value}
+        />
+      </div>
+    </div>
+  );
+});
+
+export default PromExploreExtraField;

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import PromExploreQueryEditor from './PromExploreQueryEditor';
-import PromExploreExtraField from './PromExploreExtraField';
+import { PromExploreExtraField } from './PromExploreExtraField';
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery } from '../types';
 import { PanelData, LoadingState, dateTime } from '@grafana/data';
@@ -62,13 +63,25 @@ const setup = (renderMethod: any, propOverrides?: object) => {
 };
 
 describe('PromExploreQueryEditor', () => {
+  let originalGetSelection: typeof window.getSelection;
+  beforeAll(() => {
+    originalGetSelection = window.getSelection;
+    window.getSelection = () => null;
+  });
+
+  afterAll(() => {
+    window.getSelection = originalGetSelection;
+  });
+
   it('should render component', () => {
     const wrapper = setup(shallow);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render PromQueryField with ExtraFieldElement', () => {
-    const wrapper = setup(mount);
-    expect(wrapper.find(PromExploreExtraField).length).toEqual(1);
+  it('should render PromQueryField with ExtraFieldElement', async () => {
+    await act(async () => {
+      const wrapper = setup(mount);
+      expect(wrapper.find(PromExploreExtraField).length).toBe(1);
+    });
   });
 });

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import PromExploreQueryEditor from './PromExploreQueryEditor';
+import PromExploreExtraField from './PromExploreExtraField';
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery } from '../types';
 import { PanelData, LoadingState, dateTime } from '@grafana/data';
@@ -67,7 +68,7 @@ describe('PromExploreQueryEditor', () => {
   });
 
   it('should render PromQueryField with ExtraFieldElement', () => {
-    const wrapper = setup(render);
-    expect(wrapper.find('.explore-input--ml')).toHaveLength(1);
+    const wrapper = setup(mount);
+    expect(wrapper.find(PromExploreExtraField).length).toEqual(1);
   });
 });

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PromExploreQueryEditor from './PromExploreQueryEditor';
+import { PromExploreExtraField } from './PromExploreExtraField';
+import { PrometheusDatasource } from '../datasource';
+import { PromQuery } from '../types';
+import { PanelData, LoadingState, dateTime } from '@grafana/data';
+
+const setup = (propOverrides?: object) => {
+  const datasourceMock: unknown = {};
+  const datasource: PrometheusDatasource = datasourceMock as PrometheusDatasource;
+  const onRunQuery = jest.fn();
+  const onChange = jest.fn();
+  const query: PromQuery = { expr: '', refId: 'A', interval: '1s' };
+  const data: PanelData = {
+    state: LoadingState.NotStarted,
+    series: [],
+    request: {
+      requestId: '1',
+      dashboardId: 1,
+      interval: '1s',
+      panelId: 1,
+      range: {
+        from: dateTime('2020-01-01', 'YYYY-MM-DD'),
+        to: dateTime('2020-01-02', 'YYYY-MM-DD'),
+        raw: {
+          from: dateTime('2020-01-01', 'YYYY-MM-DD'),
+          to: dateTime('2020-01-02', 'YYYY-MM-DD'),
+        },
+      },
+      scopedVars: {},
+      targets: [],
+      timezone: 'GMT',
+      app: 'Grafana',
+      startTime: 0,
+    },
+    timeRange: {
+      from: dateTime('2020-01-01', 'YYYY-MM-DD'),
+      to: dateTime('2020-01-02', 'YYYY-MM-DD'),
+      raw: {
+        from: dateTime('2020-01-01', 'YYYY-MM-DD'),
+        to: dateTime('2020-01-02', 'YYYY-MM-DD'),
+      },
+    },
+  };
+  const history: any[] = [];
+  const exploreMode = 'Metrics';
+
+  const props: any = {
+    query,
+    data,
+    datasource,
+    exploreMode,
+    history,
+    onChange,
+    onRunQuery,
+  };
+
+  Object.assign(props, propOverrides);
+
+  return shallow(<PromExploreQueryEditor {...props} />);
+};
+
+describe('PromExploreQueryEditor', () => {
+  it('should render component', () => {
+    const wrapper = setup();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render PromQueryField with ExtraFieldElement', () => {
+    const wrapper = setup();
+    const onStepChange = (e: React.SyntheticEvent<HTMLInputElement>) => jest.fn();
+    const onReturnKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => jest.fn();
+
+    // workaround to "Received: serializes to the same string"
+    expect(JSON.stringify(wrapper.prop('ExtraFieldElement'))).toEqual(
+      JSON.stringify(
+        <PromExploreExtraField
+          label={'Step'}
+          onChangeFunc={onStepChange}
+          onKeyDownFunc={onReturnKeyDown}
+          value={'1s'}
+        />
+      )
+    );
+  });
+});

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
 import PromExploreQueryEditor from './PromExploreQueryEditor';
-import { PromExploreExtraField } from './PromExploreExtraField';
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery } from '../types';
 import { PanelData, LoadingState, dateTime } from '@grafana/data';
 
-const setup = (propOverrides?: object) => {
+const setup = (renderMethod: any, propOverrides?: object) => {
   const datasourceMock: unknown = {};
   const datasource: PrometheusDatasource = datasourceMock as PrometheusDatasource;
   const onRunQuery = jest.fn();
@@ -58,30 +57,17 @@ const setup = (propOverrides?: object) => {
 
   Object.assign(props, propOverrides);
 
-  return shallow(<PromExploreQueryEditor {...props} />);
+  return renderMethod(<PromExploreQueryEditor {...props} />);
 };
 
 describe('PromExploreQueryEditor', () => {
   it('should render component', () => {
-    const wrapper = setup();
+    const wrapper = setup(shallow);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render PromQueryField with ExtraFieldElement', () => {
-    const wrapper = setup();
-    const onStepChange = (e: React.SyntheticEvent<HTMLInputElement>) => jest.fn();
-    const onReturnKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => jest.fn();
-
-    // workaround to "Received: serializes to the same string"
-    expect(JSON.stringify(wrapper.prop('ExtraFieldElement'))).toEqual(
-      JSON.stringify(
-        <PromExploreExtraField
-          label={'Step'}
-          onChangeFunc={onStepChange}
-          onKeyDownFunc={onReturnKeyDown}
-          value={'1s'}
-        />
-      )
-    );
+    const wrapper = setup(render);
+    expect(wrapper.find('.explore-input--ml')).toHaveLength(1);
   });
 });

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -45,7 +45,7 @@ export function PromExploreQueryEditor(props: Props) {
           label={'Step'}
           onChangeFunc={onStepChange}
           onKeyDownFunc={onReturnKeyDown}
-          value={query.interval}
+          value={query.interval || ''}
         />
       }
     />

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -46,6 +46,8 @@ export function PromExploreQueryEditor(props: Props) {
           onChangeFunc={onStepChange}
           onKeyDownFunc={onReturnKeyDown}
           value={query.interval || ''}
+          hasTooltip={true}
+          tooltipContent={'Needs to be a valid time unit string, for example 5s, 1m, 3h, 1d, 1y'}
         />
       }
     />

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -41,24 +41,22 @@ export const PromExploreQueryEditor = memo(function PromExploreQueryEditor(props
   }, [step]);
 
   return (
-    <div className="gf-form-inline">
-      <PromQueryField
-        datasource={datasource}
-        query={query}
-        onRunQuery={onRunQuery}
-        onChange={onChange}
-        history={history}
-        data={data}
-        ExtraFieldElement={
-          <PromExploreExtraField
-            label={'Step'}
-            onChangeFunc={onStepChange}
-            onKeyDownFunc={onReturnKeyDown}
-            value={step}
-          />
-        }
-      />
-    </div>
+    <PromQueryField
+      datasource={datasource}
+      query={query}
+      onRunQuery={onRunQuery}
+      onChange={onChange}
+      history={history}
+      data={data}
+      ExtraFieldElement={
+        <PromExploreExtraField
+          label={'Step'}
+          onChangeFunc={onStepChange}
+          onKeyDownFunc={onReturnKeyDown}
+          value={step}
+        />
+      }
+    />
   );
 });
 

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useEffect } from 'react';
+import React, { memo } from 'react';
 
 // Types
 import { ExploreQueryFieldProps } from '@grafana/data';
@@ -13,7 +13,6 @@ export type Props = ExploreQueryFieldProps<PrometheusDatasource, PromQuery, Prom
 
 export function PromExploreQueryEditor(props: Props) {
   const { query, data, datasource, history, onChange, onRunQuery } = props;
-  const [step, setStep] = useState(query.interval || '');
 
   function onChangeQueryStep(value: string) {
     const { query, onChange } = props;
@@ -22,7 +21,9 @@ export function PromExploreQueryEditor(props: Props) {
   }
 
   function onStepChange(e: React.SyntheticEvent<HTMLInputElement>) {
-    setStep(e.currentTarget.value);
+    if (e.currentTarget.value !== query.interval) {
+      onChangeQueryStep(e.currentTarget.value);
+    }
   }
 
   function onReturnKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -30,10 +31,6 @@ export function PromExploreQueryEditor(props: Props) {
       onRunQuery();
     }
   }
-
-  useEffect(() => {
-    onChangeQueryStep(step);
-  }, [step]);
 
   return (
     <PromQueryField
@@ -48,7 +45,7 @@ export function PromExploreQueryEditor(props: Props) {
           label={'Step'}
           onChangeFunc={onStepChange}
           onKeyDownFunc={onReturnKeyDown}
-          value={step}
+          value={query.interval}
         />
       }
     />

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,85 +1,65 @@
-import React, { PureComponent } from 'react';
+import React, { memo, useState, useEffect } from 'react';
 
 // Types
 import { ExploreQueryFieldProps } from '@grafana/data';
-import { FormLabel } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery, PromOptions } from '../types';
 
 import PromQueryField from './PromQueryField';
+import { PromExploreExtraField } from './PromExploreExtraField';
+
 export type Props = ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions>;
 
-interface State {
-  interval: string;
-}
+export const PromExploreQueryEditor = memo(function PromExploreQueryEditor(props: Props) {
+  const { query, data, datasource, history, onChange, onRunQuery } = props;
+  const [step, setStep] = useState(query.interval);
 
-export class PromExploreQueryEditor extends PureComponent<Props, State> {
-  // Query target to be modified and used for queries
-  query: PromQuery;
-
-  constructor(props: Props) {
-    super(props);
-    const { query } = props;
-    this.query = query;
-    // Query target properties that are fully controlled inputs
-    this.state = {
-      // Fully controlled text inputs
-      interval: query.interval,
-    };
-  }
-
-  onFieldChange = (query: PromQuery, override?: any) => {
-    this.query.expr = query.expr;
-  };
-
-  onIntervalChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    const interval = e.currentTarget.value;
-    this.query.interval = interval;
-    this.setState({ interval });
-  };
-
-  onRunQuery = () => {
-    const { query } = this;
-    this.props.onChange(query);
-    this.props.onRunQuery();
-  };
-
-  onReturnKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      this.onRunQuery();
+  function onChangeQueryStep(value: string, override?: boolean) {
+    const { query, onChange, onRunQuery } = props;
+    if (onChange) {
+      const nextQuery = { ...query, interval: step };
+      onChange(nextQuery);
+      if (override && onRunQuery) {
+        onRunQuery();
+      }
     }
-  };
-
-  render() {
-    const { datasource, query, data, history } = this.props;
-    const { interval } = this.state;
-
-    return (
-      <div className="gf-form-inline">
-        <PromQueryField
-          datasource={datasource}
-          query={query}
-          onRunQuery={this.onRunQuery}
-          onChange={this.onFieldChange}
-          history={history}
-          data={data}
-        >
-          <div className="gf-form-inline explore-input--ml">
-            <div className="gf-form">
-              <FormLabel width={4}>Step</FormLabel>
-              <input
-                type="text"
-                className="gf-form-input width-6"
-                placeholder={'auto'}
-                onChange={this.onIntervalChange}
-                onKeyDown={this.onReturnKeyDown}
-                value={interval}
-              />
-            </div>
-          </div>
-        </PromQueryField>
-      </div>
-    );
   }
-}
+
+  function onStepChange(e: React.SyntheticEvent<HTMLInputElement>) {
+    setStep(e.currentTarget.value);
+  }
+
+  function onReturnKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      onRunQuery();
+    }
+  }
+
+  useEffect(() => {
+    onChangeQueryStep(step);
+  }, [step]);
+
+  return (
+    <div className="gf-form-inline">
+      <PromQueryField
+        datasource={datasource}
+        query={query}
+        onRunQuery={onRunQuery}
+        onChange={onChange}
+        history={history}
+        data={data}
+        ExtraFieldElement={
+          <PromExploreExtraField
+            label={'Step'}
+            onChangeFunc={onStepChange}
+            onKeyDownFunc={onReturnKeyDown}
+            value={step}
+          />
+        }
+      />
+    </div>
+  );
+});
+
+export default PromExploreQueryEditor;

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -11,19 +11,14 @@ import { PromExploreExtraField } from './PromExploreExtraField';
 
 export type Props = ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions>;
 
-export const PromExploreQueryEditor = memo(function PromExploreQueryEditor(props: Props) {
+export function PromExploreQueryEditor(props: Props) {
   const { query, data, datasource, history, onChange, onRunQuery } = props;
-  const [step, setStep] = useState(query.interval);
+  const [step, setStep] = useState(query.interval || '');
 
-  function onChangeQueryStep(value: string, override?: boolean) {
-    const { query, onChange, onRunQuery } = props;
-    if (onChange) {
-      const nextQuery = { ...query, interval: value };
-      onChange(nextQuery);
-      if (override && onRunQuery) {
-        onRunQuery();
-      }
-    }
+  function onChangeQueryStep(value: string) {
+    const { query, onChange } = props;
+    const nextQuery = { ...query, interval: value };
+    onChange(nextQuery);
   }
 
   function onStepChange(e: React.SyntheticEvent<HTMLInputElement>) {
@@ -58,6 +53,6 @@ export const PromExploreQueryEditor = memo(function PromExploreQueryEditor(props
       }
     />
   );
-});
+}
 
-export default PromExploreQueryEditor;
+export default memo(PromExploreQueryEditor);

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -18,7 +18,7 @@ export const PromExploreQueryEditor = memo(function PromExploreQueryEditor(props
   function onChangeQueryStep(value: string, override?: boolean) {
     const { query, onChange, onRunQuery } = props;
     if (onChange) {
-      const nextQuery = { ...query, interval: step };
+      const nextQuery = { ...query, interval: value };
       onChange(nextQuery);
       if (override && onRunQuery) {
         onRunQuery();

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Plugin } from 'slate';
 import {
@@ -110,6 +110,7 @@ export function willApplySuggestion(suggestion: string, { typeaheadContext, type
 
 interface PromQueryFieldProps extends ExploreQueryFieldProps<PrometheusDatasource, PromQuery, PromOptions> {
   history: Array<HistoryItem<PromQuery>>;
+  ExtraFieldElement?: ReactNode;
 }
 
 interface PromQueryFieldState {
@@ -291,7 +292,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   };
 
   render() {
-    const { data, query, children } = this.props;
+    const { data, query, ExtraFieldElement } = this.props;
     const { metricsOptions, syntaxLoaded, hint } = this.state;
     const cleanText = this.languageProvider ? this.languageProvider.cleanText : undefined;
     const chooserText = getChooserText(syntaxLoaded, metricsOptions);
@@ -321,7 +322,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
               syntaxLoaded={syntaxLoaded}
             />
           </div>
-          {children}
+          {ExtraFieldElement}
         </div>
         {showError ? (
           <div className="query-row-break">

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreExtraField.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreExtraField.test.tsx.snap
@@ -8,7 +8,8 @@ exports[`PrometheusExploreExtraField should render component 1`] = `
     className="gf-form"
   >
     <Component
-      width={4}
+      tooltip={null}
+      width={5}
     >
       Prometheus Explore Extra Field
     </Component>

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreExtraField.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreExtraField.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrometheusExploreExtraField should render component 1`] = `
+<div
+  className="gf-form-inline explore-input--ml"
+>
+  <div
+    className="gf-form"
+  >
+    <Component
+      width={4}
+    >
+      Prometheus Explore Extra Field
+    </Component>
+    <input
+      className="gf-form-input width-4"
+      onChange={[MockFunction]}
+      onKeyDown={[MockFunction]}
+      placeholder="auto"
+      type="text"
+      value="123"
+    />
+  </div>
+</div>
+`;

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -4,9 +4,11 @@ exports[`PromExploreQueryEditor should render component 1`] = `
 <PromQueryField
   ExtraFieldElement={
     <PromExploreExtraField
+      hasTooltip={true}
       label="Step"
       onChangeFunc={[Function]}
       onKeyDownFunc={[Function]}
+      tooltipContent="Needs to be a valid time unit string, for example 5s, 1m, 3h, 1d, 1y"
       value="1s"
     />
   }

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromExploreQueryEditor should render component 1`] = `
+<PromQueryField
+  ExtraFieldElement={
+    <PromExploreExtraField
+      label="Step"
+      onChangeFunc={[Function]}
+      onKeyDownFunc={[Function]}
+      value="1s"
+    />
+  }
+  data={
+    Object {
+      "request": Object {
+        "app": "Grafana",
+        "dashboardId": 1,
+        "interval": "1s",
+        "panelId": 1,
+        "range": Object {
+          "from": "2019-12-31T23:00:00.000Z",
+          "raw": Object {
+            "from": "2019-12-31T23:00:00.000Z",
+            "to": "2020-01-01T23:00:00.000Z",
+          },
+          "to": "2020-01-01T23:00:00.000Z",
+        },
+        "requestId": "1",
+        "scopedVars": Object {},
+        "startTime": 0,
+        "targets": Array [],
+        "timezone": "GMT",
+      },
+      "series": Array [],
+      "state": "NotStarted",
+      "timeRange": Object {
+        "from": "2019-12-31T23:00:00.000Z",
+        "raw": Object {
+          "from": "2019-12-31T23:00:00.000Z",
+          "to": "2020-01-01T23:00:00.000Z",
+        },
+        "to": "2020-01-01T23:00:00.000Z",
+      },
+    }
+  }
+  datasource={Object {}}
+  history={Array []}
+  onChange={[MockFunction]}
+  onRunQuery={[MockFunction]}
+  query={
+    Object {
+      "expr": "",
+      "interval": "1s",
+      "refId": "A",
+    }
+  }
+/>
+`;

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -18,12 +18,12 @@ exports[`PromExploreQueryEditor should render component 1`] = `
         "interval": "1s",
         "panelId": 1,
         "range": Object {
-          "from": "2019-12-31T23:00:00.000Z",
+          "from": "2020-01-01T00:00:00.000Z",
           "raw": Object {
-            "from": "2019-12-31T23:00:00.000Z",
-            "to": "2020-01-01T23:00:00.000Z",
+            "from": "2020-01-01T00:00:00.000Z",
+            "to": "2020-01-02T00:00:00.000Z",
           },
-          "to": "2020-01-01T23:00:00.000Z",
+          "to": "2020-01-02T00:00:00.000Z",
         },
         "requestId": "1",
         "scopedVars": Object {},
@@ -34,12 +34,12 @@ exports[`PromExploreQueryEditor should render component 1`] = `
       "series": Array [],
       "state": "NotStarted",
       "timeRange": Object {
-        "from": "2019-12-31T23:00:00.000Z",
+        "from": "2020-01-01T00:00:00.000Z",
         "raw": Object {
-          "from": "2019-12-31T23:00:00.000Z",
-          "to": "2020-01-01T23:00:00.000Z",
+          "from": "2020-01-01T00:00:00.000Z",
+          "to": "2020-01-02T00:00:00.000Z",
         },
-        "to": "2020-01-01T23:00:00.000Z",
+        "to": "2020-01-02T00:00:00.000Z",
       },
     }
   }

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -3,7 +3,7 @@ import { PrometheusDatasource } from './datasource';
 
 import { PromQueryEditor } from './components/PromQueryEditor';
 import PromCheatSheet from './components/PromCheatSheet';
-import { PromExploreQueryEditor } from './components/PromExploreQueryEditor';
+import PromExploreQueryEditor from './components/PromExploreQueryEditor';
 
 import { ConfigEditor } from './configuration/ConfigEditor';
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates PromExploreQueryEditor to prevent it from throwing an input error on edit. Moves PromExploreExtraField to a separate file. Refactors PromExploreQueryEditor to functional component.

**Which issue(s) this PR fixes**:

Fixes #21604 