### PR TITLE
CloudWatch: Expand dimension value in alias correctly

### DIFF
--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -100,7 +100,7 @@ func (e *CloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchRespo
 		}
 
 		if partialData {
-			queryResult.ErrorString = "Cloudwatch GetMetricData error: Too many datapoints requested - your search have been limited. Please try to reduce the time range"
+			queryResult.ErrorString = "Cloudwatch GetMetricData error: Too many datapoints requested - your search has been limited. Please try to reduce the time range"
 		}
 
 		queryResult.Series = append(queryResult.Series, timeSeries...)

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -100,8 +100,10 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 				series.Tags[key] = values[0]
 			} else {
 				for _, value := range values {
-					if value == label || value == "*" || strings.Contains(label, value) {
+					if value == label || value == "*" {
 						series.Tags[key] = label
+					} else if strings.Contains(label, value) {
+						series.Tags[key] = value
 					}
 				}
 			}

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -53,7 +53,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Namespace:  "AWS/ApplicationELB",
 				MetricName: "TargetResponseTime",
 				Dimensions: map[string][]string{
-					"LoadBalancer": {"lb2"},
+					"LoadBalancer": {"lb1", "lb2"},
 					"TargetGroup":  {"tg"},
 				},
 				Stats:  "Average",
@@ -65,8 +65,12 @@ func TestCloudWatchResponseParser(t *testing.T) {
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
-			So(timeSeries.Name, ShouldEqual, "lb2 Expanded")
-			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb2")
+			So(timeSeries.Name, ShouldEqual, "lb1 Expanded")
+			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb1")
+
+			timeSeries2 := (*series)[1]
+			So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
+			So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
 		})
 
 		Convey("can expand dimension value using substring", func() {
@@ -110,7 +114,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Namespace:  "AWS/ApplicationELB",
 				MetricName: "TargetResponseTime",
 				Dimensions: map[string][]string{
-					"LoadBalancer": {"lb1"},
+					"LoadBalancer": {"lb1", "lb2"},
 					"TargetGroup":  {"tg"},
 				},
 				Stats:  "Average",
@@ -119,11 +123,14 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			}
 			series, partialData, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
-
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
 			So(timeSeries.Name, ShouldEqual, "lb1 Expanded")
 			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb1")
+
+			timeSeries2 := (*series)[1]
+			So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
+			So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
 		})
 
 		Convey("can expand dimension value using wildcard", func() {


### PR DESCRIPTION
PR #21541 did not solve the whole problem. This PR makes sure only the dimension value is being expanded, and not the whole label. 

fixes #21625