### PR TITLE
TemplateSrv: A way to support object syntax for global vars

### DIFF
--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -31,6 +31,14 @@ describe('templateSrv', () => {
       expect(target).toBe('Server1 nested');
     });
 
+    it('built in vars should support objects', () => {
+      _templateSrv.setGlobalVariable('__dashboard', {
+        value: { name: 'hello' },
+      });
+      const target = _templateSrv.replace('${__dashboard.name}');
+      expect(target).toBe('hello');
+    });
+
     it('scoped vars should support objects with propert names with dot', () => {
       const target = _templateSrv.replace('${series.name} ${series.nested["field.with.dot"]}', {
         series: { value: { name: 'Server1', nested: { 'field.with.dot': 'nested' } } },

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -195,6 +195,15 @@ export class TemplateSrv {
     this.grafanaVariables[name] = value;
   }
 
+  setGlobalVariable(name: string, variable: any) {
+    this.index = {
+      ...this.index,
+      [name]: {
+        current: variable,
+      },
+    };
+  }
+
   getVariableName(expression: string) {
     this.regex.lastIndex = 0;
     const match = this.regex.exec(expression);
@@ -292,6 +301,15 @@ export class TemplateSrv {
         // skip formatting of custom all values
         if (variable.allValue) {
           return this.replace(value);
+        }
+      }
+
+      if (fieldPath) {
+        const fieldValue = this.getVariableValue(variableName, fieldPath, {
+          [variableName]: { value: value, text: '' },
+        });
+        if (fieldValue !== null && fieldValue !== undefined) {
+          return this.formatValue(fieldValue, fmt, variable);
         }
       }
 


### PR DESCRIPTION
With this change we can support global vars with object notation like `${dashboard.name}` and `${user.id} ` abd `${user.login} `