### PR TITLE
Explore: Fix colors for log level when level value is capitalised

### DIFF
--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -6,6 +6,7 @@ import {
   getParser,
   LogsParsers,
   calculateStats,
+  getLogLevelFromKey,
 } from './logs';
 
 describe('getLoglevel()', () => {
@@ -23,6 +24,10 @@ describe('getLoglevel()', () => {
     expect(getLogLevel('[Warn]')).toBe('warning');
   });
 
+  it('returns correct log level when level is capitalized', () => {
+    expect(getLogLevel('WARN')).toBe(LogLevel.warn);
+  });
+
   it('returns log level on line contains a log level', () => {
     expect(getLogLevel('warn: it is looking bad')).toBe(LogLevel.warn);
     expect(getLogLevel('2007-12-12 12:12:12 [WARN]: it is looking bad')).toBe(LogLevel.warn);
@@ -30,6 +35,15 @@ describe('getLoglevel()', () => {
 
   it('returns first log level found', () => {
     expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
+  });
+});
+
+describe('getLogLevelFromKey()', () => {
+  it('returns correct log level', () => {
+    expect(getLogLevelFromKey('info')).toBe(LogLevel.info);
+  });
+  it('returns correct log level when level is capitalized', () => {
+    expect(getLogLevelFromKey('INFO')).toBe(LogLevel.info);
   });
 });
 

--- a/packages/grafana-data/src/utils/logs.ts
+++ b/packages/grafana-data/src/utils/logs.ts
@@ -33,7 +33,7 @@ export function getLogLevel(line: string): LogLevel {
 }
 
 export function getLogLevelFromKey(key: string): LogLevel {
-  const level = (LogLevel as any)[key];
+  const level = (LogLevel as any)[key.toLowerCase()];
   if (level) {
     return level;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
When log level label value was capitalised, it resulted in *unknown* log level. This was due to the fact, that LogLevel can have only [following lower-cased values](https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/logs.ts#L9-L25).

This PR fixes the issue and adds test coverage. 

**Which issue(s) this PR fixes**:

Fixes #21112


