### PR TITLE
SQLStore: Fix PostgreSQL failure to create organisation for first time

### DIFF
--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -163,7 +163,7 @@ func (db *Postgres) PostInsertId(table string, sess *xorm.Session) error {
 
 	// sync primary key sequence of org table
 	if _, err := sess.Exec("SELECT setval('org_id_seq', (SELECT max(id)+1 FROM org));"); err != nil {
-		return fmt.Errorf("Failed to sync primary key for org table")
+		return fmt.Errorf("Failed to sync primary key for org table: %v", err)
 	}
 	return nil
 }

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -162,7 +162,7 @@ func (db *Postgres) PostInsertId(table string, sess *xorm.Session) error {
 	}
 
 	// sync primary key sequence of org table
-	if _, err := sess.Exec("SELECT setval('org_id_seq', (SELECT max(id)+1 FROM org));"); err != nil {
+	if _, err := sess.Exec("SELECT setval('org_id_seq', (SELECT max(id) FROM org));"); err != nil {
 		return fmt.Errorf("Failed to sync primary key for org table: %v", err)
 	}
 	return nil

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-xorm/xorm"
+	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/lib/pq"
 )
 

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -155,3 +155,15 @@ func (db *Postgres) IsUniqueConstraintViolation(err error) bool {
 func (db *Postgres) IsDeadlock(err error) bool {
 	return db.isThisError(err, "40P01")
 }
+
+func (db *Postgres) PostInsertId(table string, sess *xorm.Session) error {
+	if table != "org" {
+		return nil
+	}
+
+	// sync primary key sequence of org table
+	if _, err := sess.Exec("SELECT setval('org_id_seq', (SELECT max(id)+1 FROM org));"); err != nil {
+		return fmt.Errorf("Failed to sync primary key for org table")
+	}
+	return nil
+}

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -164,7 +164,7 @@ func (db *Postgres) PostInsertId(table string, sess *xorm.Session) error {
 
 	// sync primary key sequence of org table
 	if _, err := sess.Exec("SELECT setval('org_id_seq', (SELECT max(id) FROM org));"); err != nil {
-		return fmt.Errorf("Failed to sync primary key for org table: %v", err)
+		return errutil.Wrapf(err, "failed to sync primary key for org table")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Grafana [explicitly sets](https://github.com/grafana/grafana/blob/421e83f7c45de0baf0c470bbb001fdfb1c10eacb/pkg/services/sqlstore/org.go#L236) the org id when creates the main organisation.  However, this does not work nicely with PostgresSQL because it seems that the primary key sequence is only evaluated when the id field is not set. This fix adds a hook for syncing the sequence for the org table after inserts. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #18628

**Special notes for your reviewer**:

