### PR TITLE
API: Fix redirect issue when configured to use a subpath

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,10 +35,8 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
-	if hs.Cfg.AppSubUrl != "" {
-		if !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
-			return login.ErrInvalidRedirectTo
-		}
+	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+		return login.ErrInvalidRedirectTo
 	}
 	return nil
 }

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,6 +35,8 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
+	// when using a subUrl, the redirect_to should have a relative or absolute path that includes the subUrl, otherwise the redirect
+	// will send the user to the wrong location
 	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
 		return login.ErrInvalidRedirectTo
 	}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -96,6 +96,10 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 				return
 			}
 			middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
+			// remove subpath if it exists at the beginning of the redirect_to
+			if setting.AppSubUrl != "" && strings.Index(redirectTo, setting.AppSubUrl) == 0 {
+				redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
+			}
 			c.Redirect(redirectTo)
 			return
 		}
@@ -179,7 +183,10 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		if err := hs.validateRedirectTo(redirectTo); err == nil {
-			redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
+			// remove subpath if it exists at the beginning of the redirect_to
+			if setting.AppSubUrl != "" && strings.Index(redirectTo, setting.AppSubUrl) == 0 {
+				redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
+			}
 			result["redirectUrl"] = redirectTo
 		} else {
 			log.Info("Ignored invalid redirect_to cookie value: %v", redirectTo)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -96,8 +96,6 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 				return
 			}
 			middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-			// remove subpath if it exists
-			redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
 			c.Redirect(redirectTo)
 			return
 		}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -96,10 +96,6 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 				return
 			}
 			middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-			// remove subpath if it exists at the beginning of the redirect_to
-			if setting.AppSubUrl != "" && strings.Index(redirectTo, setting.AppSubUrl) == 0 {
-				redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
-			}
 			c.Redirect(redirectTo)
 			return
 		}
@@ -184,6 +180,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		if err := hs.validateRedirectTo(redirectTo); err == nil {
 			// remove subpath if it exists at the beginning of the redirect_to
+			// LoginCtrl.tsx is already prepending the redirectUrl with the subpath
 			if setting.AppSubUrl != "" && strings.Index(redirectTo, setting.AppSubUrl) == 0 {
 				redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
 			}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,7 +35,7 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
-	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) {
 		return login.ErrInvalidRedirectTo
 	}
 	return nil
@@ -177,6 +177,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		if err := hs.validateRedirectTo(redirectTo); err == nil {
+			redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
 			result["redirectUrl"] = redirectTo
 		} else {
 			log.Info("Ignored invalid redirect_to cookie value: %v", redirectTo)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,8 +35,10 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
-	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) {
-		return login.ErrInvalidRedirectTo
+	if hs.Cfg.AppSubUrl != "" {
+		if !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+			return login.ErrInvalidRedirectTo
+		}
 	}
 	return nil
 }
@@ -94,6 +96,8 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 				return
 			}
 			middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
+			// remove subpath if it exists
+			redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
 			c.Redirect(redirectTo)
 			return
 		}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -219,7 +218,10 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-		redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
+		// if there is a sub_url, prepend it
+		if setting.AppSubUrl != "" {
+			redirectTo = setting.AppSubUrl + redirectTo
+		}
 		ctx.Redirect(redirectTo)
 		return
 	}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -218,10 +218,6 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-		// if there is a sub_url, prepend it
-		if setting.AppSubUrl != "" {
-			redirectTo = setting.AppSubUrl + redirectTo
-		}
 		ctx.Redirect(redirectTo)
 		return
 	}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -218,6 +219,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.cookieOptionsFromCfg)
+		redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
 		ctx.Redirect(redirectTo)
 		return
 	}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -47,7 +47,7 @@ func notAuthorized(c *m.ReqContext) {
 		return
 	}
 
-	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, newCookieOptions)
+	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(c.Req.RequestURI), 0, newCookieOptions)
 
 	c.Redirect(setting.AppSubUrl + "/login")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

redirect_to cookie handling needs to account for subpath already inside request during login.


**Which issue(s) this PR fixes**:
Fixes #21651 

**Special notes for your reviewer**:

This fix works, but one change has not been tested with OAuth (see login_oauth.go)
