### PR TITLE
Toolkit: copyIfNonExistent order swapped

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -40,13 +40,13 @@ export const prepare = useSpinner<void>('Preparing', async () => {
   await Promise.all([
     // Copy only if local tsconfig does not exist.  Otherwise this will work, but have odd behavior
     copyIfNonExistent(
-      resolvePath(process.cwd(), 'tsconfig.json'),
-      resolvePath(__dirname, '../../config/tsconfig.plugin.local.json')
+      resolvePath(__dirname, '../../config/tsconfig.plugin.local.json'),
+      resolvePath(process.cwd(), 'tsconfig.json')
     ),
     // Copy only if local prettierrc does not exist.  Otherwise this will work, but have odd behavior
     copyIfNonExistent(
-      resolvePath(process.cwd(), '.prettierrc.js'),
-      resolvePath(__dirname, '../../config/prettier.plugin.rc.js')
+      resolvePath(__dirname, '../../config/prettier.plugin.rc.js'),
+      resolvePath(process.cwd(), '.prettierrc.js')
     ),
   ]);
 


### PR DESCRIPTION
Dooh... the copyIfNonExistent had the order wrong so it does not copy unless the file exists.

See:
https://circleci.com/gh/grafana/grafana-polystat-panel/495?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

That now passes when the .prettierrc.js is committed with the project