### PR TITLE
CloudWatch: Auto period snap to next higher period

### DIFF
--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -68,8 +68,15 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 	var period int
 	if strings.ToLower(p) == "auto" || p == "" {
 		deltaInSeconds := endTime.Sub(startTime).Seconds()
-		periods := []int{60, 300, 900, 3600, 21600}
-		period = closest(periods, int(math.Ceil(deltaInSeconds/2000)))
+		periods := []int{60, 300, 900, 3600, 21600, 86400}
+		datapoints := int(math.Ceil(deltaInSeconds / 2000))
+		period = periods[len(periods)-1]
+		for _, value := range periods {
+			if datapoints < value {
+				period = value
+				break
+			}
+		}
 	} else {
 		if regexp.MustCompile(`^\d+$`).Match([]byte(p)) {
 			period, err = strconv.Atoi(p)
@@ -157,26 +164,4 @@ func sortDimensions(dimensions map[string][]string) map[string][]string {
 		sortedDimensions[k] = dimensions[k]
 	}
 	return sortedDimensions
-}
-
-func closest(array []int, num int) int {
-	minDiff := array[len(array)-1]
-	var closest int
-	if num <= array[0] {
-		return array[0]
-	}
-
-	if num >= array[len(array)-1] {
-		return array[len(array)-1]
-	}
-
-	for _, value := range array {
-		var m = int(math.Abs(float64(num - value)))
-		if m <= minDiff {
-			minDiff = m
-			closest = value
-		}
-	}
-
-	return closest
 }

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -72,7 +72,7 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 		datapoints := int(math.Ceil(deltaInSeconds / 2000))
 		period = periods[len(periods)-1]
 		for _, value := range periods {
-			if datapoints < value {
+			if datapoints <= value {
 				period = value
 				break
 			}


### PR DESCRIPTION
The PR [CloudWatch: Calculate period based on time range](#21471) added a feature that would calculate the number of data points based on the time range, and then snap to the closest value in an array of pre-defined period values. After discussions with amazon engineers, we decided it makes more sense to snap to next higher value in the pre-defined period array instead of snapping to the closest value. That way it will be less likely we're requesting too many data points. 