### PR TITLE
PhantomJS: Add url-search-params-polyfill to fix PhantomJS rendering of prometheus graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "tether-drop": "https://github.com/torkelo/drop/tarball/master",
     "tinycolor2": "1.4.1",
     "tti-polyfill": "0.2.2",
+    "url-search-params-polyfill": "7.0.1",
     "whatwg-fetch": "3.0.0",
     "xss": "1.0.3"
   },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -1,6 +1,7 @@
 import '@babel/polyfill';
 import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'; // fetch polyfill needed for PhantomJs rendering
+import 'url-search-params-polyfill'; // fetch polyfill needed for PhantomJs rendering
 import 'file-saver';
 import 'lodash';
 import 'jquery';

--- a/yarn.lock
+++ b/yarn.lock
@@ -21744,6 +21744,11 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-search-params-polyfill@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-7.0.1.tgz#b900cd9a0d9d2ff757d500135256f2344879cbff"
+  integrity sha512-bAw7L2E+jn9XHG5P9zrPnHdO0yJub4U+yXJOdpcpkr7OBd9T8oll4lUos0iSGRcDvfZoLUKfx9a6aNmIhJ4+mQ==
+
 url@0.11.0, url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
Fixes #21657

In https://github.com/grafana/grafana/commit/043bb59593cd12b41f609da734a24e34e5d1c936 a `URLSearchParams` usage was introduced which is not supported by PhantomJS. @babel/polyfill(deprecated) does not contain polyfill for `URLSearchParams`, hence the code (and Prometheus graphs rendering) was failing in PhantomJS environment.

The solution is to add https://www.npmjs.com/package/url-search-params-polyfill that takes care of the `URLSearchParams`

### The way forward...
Since recently we had to introduce couple of polyfills to handle PhantomJS compatibility I think we will be able to remove those soon with https://github.com/grafana/grafana/pull/21587 introducing babel as our main Webpack pipeline citizen. Then we will be able to use core-js@3 which should handle most of the needs for polyfills. There is a nice overview of core-js vs babel that is a highly recommended read: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md