### PR TITLE
Dashboard: Try to parse 8 and 15 digit numbers as timestamps if parsing of time range as date fails

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -135,6 +135,38 @@ describe('timeSrv', () => {
       expect(time.to.valueOf()).toEqual(1410337665699);
     });
 
+    it('should handle epochs that look like formatted date without time', () => {
+      location = {
+        search: jest.fn(() => ({
+          from: '20149999',
+          to: '20159999',
+        })),
+      };
+
+      timeSrv = new TimeSrv(rootScope as any, jest.fn() as any, location as any, timer, new ContextSrvStub() as any);
+
+      timeSrv.init(_dashboard);
+      const time = timeSrv.timeRange();
+      expect(time.from.valueOf()).toEqual(20149999);
+      expect(time.to.valueOf()).toEqual(20159999);
+    });
+
+    it('should handle epochs that look like formatted date', () => {
+      location = {
+        search: jest.fn(() => ({
+          from: '201499991234567',
+          to: '201599991234567',
+        })),
+      };
+
+      timeSrv = new TimeSrv(rootScope as any, jest.fn() as any, location as any, timer, new ContextSrvStub() as any);
+
+      timeSrv.init(_dashboard);
+      const time = timeSrv.timeRange();
+      expect(time.from.valueOf()).toEqual(201499991234567);
+      expect(time.to.valueOf()).toEqual(201599991234567);
+    });
+
     it('should handle bad dates', () => {
       location = {
         search: jest.fn(() => ({

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -102,10 +102,15 @@ export class TimeSrv {
       return value;
     }
     if (value.length === 8) {
-      return toUtc(value, 'YYYYMMDD');
-    }
-    if (value.length === 15) {
-      return toUtc(value, 'YYYYMMDDTHHmmss');
+      const utcValue = toUtc(value, 'YYYYMMDD');
+      if (utcValue.isValid()) {
+        return utcValue;
+      }
+    } else if (value.length === 15) {
+      const utcValue = toUtc(value, 'YYYYMMDDTHHmmss');
+      if (utcValue.isValid()) {
+        return utcValue;
+      }
     }
 
     if (!isNaN(value)) {


### PR DESCRIPTION
The `from` and `to` url parameters can be used to set a time range. Values with a length of 8 digits or 15 digits are assumed to be in `YYYYMMDD` or `YYYYMMDDTHHmmss` format. If the numbers are actually ms since epoch of length 8 or 15, this will not parse correctly. The time range on the dashboard will be "Invalid date".

This PR attempts to parse 8 and 15 digit numbers as ms since epoch if the existing behavior does not produce a usable datetime.
Note: If the number is intended as ms since epoch but it can be parsed using the format `YYYYMMDD` or `YYYYMMDDTHHmmss`, it will not be interpreted as ms since epoch.

Fixes #19738.