### PR TITLE
Admin: Viewer should not see link to teams in side menu

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -275,7 +275,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 		})
 	}
 
-	if c.OrgRole == m.ROLE_ADMIN || hs.Cfg.EditorsCanAdmin {
+	if c.OrgRole == m.ROLE_ADMIN || (hs.Cfg.EditorsCanAdmin && c.OrgRole == m.ROLE_EDITOR) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Teams",
 			Id:          "teams",


### PR DESCRIPTION
Fixes so that viewers don't see a link to teams in side menu when
editors_can_admin setting is enabled.

Before: 
![image](https://user-images.githubusercontent.com/1668778/73062150-03ee7180-3e9c-11ea-9b76-c9fd49f94c54.png)
![image](https://user-images.githubusercontent.com/1668778/73062160-0781f880-3e9c-11ea-8e4a-a7e981d1e52c.png)

After: Teams link in side menu not shown for viewers