### PR TITLE
Display Grafana edition in footer

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -22,7 +22,8 @@ interface FeatureToggles {
 interface LicenseInfo {
   hasLicense: boolean;
   expiry: number;
-  detailsLink: string;
+  licenseUrl: string;
+  stateInfo: string;
 }
 
 export class GrafanaBootConfig {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -7,6 +7,7 @@ export interface BuildInfo {
   commit: string;
   isEnterprise: boolean; // deprecated: use licenseInfo.hasLicense instead
   env: string;
+  edition: string;
   latestVersion: string;
   hasUpdate: boolean;
 }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -22,6 +22,7 @@ interface FeatureToggles {
 interface LicenseInfo {
   hasLicense: boolean;
   expiry: number;
+  detailsLink: string;
 }
 
 export class GrafanaBootConfig {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -166,10 +166,10 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 	}
 
 	edition := "Open Source Edition"
-	licenseDetailsLink := hs.Cfg.AppSubUrl + "/admin/upgrading"
+	licenseURL := hs.Cfg.AppSubUrl + "/admin/upgrading"
 	if l, ok := hs.License.(m.Edition); ok {
 		edition = l.Edition()
-		licenseDetailsLink = l.DetailsLink()
+		licenseURL = l.DetailsLink()
 	}
 
 	jsonObj := map[string]interface{}{
@@ -210,7 +210,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 		"licenseInfo": map[string]interface{}{
 			"hasLicense":  hs.License.HasLicense(),
 			"expiry":      hs.License.Expiry(),
-			"detailsLink": licenseDetailsLink,
+			"detailsLink": licenseURL,
 		},
 		"featureToggles": hs.Cfg.FeatureToggles,
 	}

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -165,6 +165,11 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 		}
 	}
 
+	edition := ""
+	if provider, ok := hs.License.(m.Edition); ok {
+		edition = provider.Edition()
+	}
+
 	jsonObj := map[string]interface{}{
 		"defaultDatasource":          defaultDatasource,
 		"datasources":                datasources,
@@ -194,6 +199,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			"version":       setting.BuildVersion,
 			"commit":        setting.BuildCommit,
 			"buildstamp":    setting.BuildStamp,
+			"edition":       edition,
 			"latestVersion": plugins.GrafanaLatestVersion,
 			"hasUpdate":     plugins.GrafanaHasUpdate,
 			"env":           setting.Env,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -165,13 +165,6 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 		}
 	}
 
-	edition := "Open Source Edition"
-	licenseURL := hs.Cfg.AppSubUrl + "/admin/upgrading"
-	if l, ok := hs.License.(m.Edition); ok {
-		edition = l.Edition()
-		licenseURL = l.DetailsLink()
-	}
-
 	jsonObj := map[string]interface{}{
 		"defaultDatasource":          defaultDatasource,
 		"datasources":                datasources,
@@ -201,16 +194,17 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			"version":       setting.BuildVersion,
 			"commit":        setting.BuildCommit,
 			"buildstamp":    setting.BuildStamp,
-			"edition":       edition,
+			"edition":       hs.License.Edition(),
 			"latestVersion": plugins.GrafanaLatestVersion,
 			"hasUpdate":     plugins.GrafanaHasUpdate,
 			"env":           setting.Env,
 			"isEnterprise":  hs.License.HasValidLicense(),
 		},
 		"licenseInfo": map[string]interface{}{
-			"hasLicense":  hs.License.HasLicense(),
-			"expiry":      hs.License.Expiry(),
-			"detailsLink": licenseURL,
+			"hasLicense": hs.License.HasLicense(),
+			"expiry":     hs.License.Expiry(),
+			"stateInfo":  hs.License.StateInfo(),
+			"licenseUrl": hs.License.LicenseURL(c.SignedInUser),
 		},
 		"featureToggles": hs.Cfg.FeatureToggles,
 	}

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -165,9 +165,11 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 		}
 	}
 
-	edition := ""
-	if provider, ok := hs.License.(m.Edition); ok {
-		edition = provider.Edition()
+	edition := "Open Source Edition"
+	licenseDetailsLink := hs.Cfg.AppSubUrl + "/admin/upgrading"
+	if l, ok := hs.License.(m.Edition); ok {
+		edition = l.Edition()
+		licenseDetailsLink = l.DetailsLink()
 	}
 
 	jsonObj := map[string]interface{}{
@@ -206,8 +208,9 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			"isEnterprise":  hs.License.HasValidLicense(),
 		},
 		"licenseInfo": map[string]interface{}{
-			"hasLicense": hs.License.HasLicense(),
-			"expiry":     hs.License.Expiry(),
+			"hasLicense":  hs.License.HasLicense(),
+			"expiry":      hs.License.Expiry(),
+			"detailsLink": licenseDetailsLink,
 		},
 		"featureToggles": hs.Cfg.FeatureToggles,
 	}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -357,7 +357,7 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 		Children:     []*dtos.NavLink{},
 	})
 
-	hs.HooksService.RunIndexDataHooks(&data)
+	hs.HooksService.RunIndexDataHooks(&data, c)
 
 	sort.SliceStable(data.NavTree, func(i, j int) bool {
 		return data.NavTree[i].SortWeight < data.NavTree[j].SortWeight

--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -10,3 +10,7 @@ type Licensing interface {
 	// Expiry returns the unix epoch timestamp when the license expires, or 0 if no valid license is provided
 	Expiry() int64
 }
+
+type Edition interface {
+	Edition() string
+}

--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -13,4 +13,5 @@ type Licensing interface {
 
 type Edition interface {
 	Edition() string
+	DetailsLink() string
 }

--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -9,9 +9,11 @@ type Licensing interface {
 
 	// Expiry returns the unix epoch timestamp when the license expires, or 0 if no valid license is provided
 	Expiry() int64
-}
 
-type Edition interface {
+	// Return edition
 	Edition() string
-	DetailsLink() string
+
+	LicenseURL(user *SignedInUser) string
+
+	StateInfo() string
 }

--- a/pkg/services/hooks/hooks.go
+++ b/pkg/services/hooks/hooks.go
@@ -2,10 +2,11 @@ package hooks
 
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 )
 
-type IndexDataHook func(indexData *dtos.IndexViewData)
+type IndexDataHook func(indexData *dtos.IndexViewData, req *models.ReqContext)
 
 type HooksService struct {
 	indexDataHooks []IndexDataHook
@@ -23,8 +24,8 @@ func (srv *HooksService) AddIndexDataHook(hook IndexDataHook) {
 	srv.indexDataHooks = append(srv.indexDataHooks, hook)
 }
 
-func (srv *HooksService) RunIndexDataHooks(indexData *dtos.IndexViewData) {
+func (srv *HooksService) RunIndexDataHooks(indexData *dtos.IndexViewData, req *models.ReqContext) {
 	for _, hook := range srv.indexDataHooks {
-		hook(indexData)
+		hook(indexData, req)
 	}
 }

--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -2,6 +2,7 @@ package licensing
 
 import (
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -19,14 +20,30 @@ func (*OSSLicensingService) Expiry() int64 {
 	return 0
 }
 
+func (*OSSLicensingService) Edition() string {
+	return "Open Source"
+}
+
+func (*OSSLicensingService) StateInfo() string {
+	return ""
+}
+
+func (l *OSSLicensingService) LicenseURL(user *models.SignedInUser) string {
+	if user.IsGrafanaAdmin {
+		return l.Cfg.AppSubUrl + "/admin/upgrading"
+	}
+
+	return "https://grafana.com/products/enterprise/?utm_source=grafana_footer"
+}
+
 func (l *OSSLicensingService) Init() error {
-	l.HooksService.AddIndexDataHook(func(indexData *dtos.IndexViewData) {
+	l.HooksService.AddIndexDataHook(func(indexData *dtos.IndexViewData, req *models.ReqContext) {
 		for _, node := range indexData.NavTree {
 			if node.Id == "admin" {
 				node.Children = append(node.Children, &dtos.NavLink{
 					Text: "Upgrade",
 					Id:   "upgrading",
-					Url:  l.Cfg.AppSubUrl + "/admin/upgrading",
+					Url:  l.LicenseURL(req.SignedInUser),
 					Icon: "fa fa-fw fa-unlock-alt",
 				})
 			}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -36,11 +36,10 @@ const (
 )
 
 const (
-	DEV                 = "development"
-	PROD                = "production"
-	TEST                = "test"
-	APP_NAME            = "Grafana"
-	APP_NAME_ENTERPRISE = "Grafana Enterprise"
+	DEV      = "development"
+	PROD     = "production"
+	TEST     = "test"
+	APP_NAME = "Grafana"
 )
 
 var (
@@ -619,9 +618,6 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	Raw = cfg.Raw
 
 	ApplicationName = APP_NAME
-	if IsEnterprise {
-		ApplicationName = APP_NAME_ENTERPRISE
-	}
 
 	Env, err = valueAsString(iniFile.Section(""), "app_mode", "development")
 	if err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -36,11 +36,10 @@ const (
 )
 
 const (
-	DEV                 = "development"
-	PROD                = "production"
-	TEST                = "test"
-	APP_NAME            = "Grafana"
-	APP_NAME_ENTERPRISE = "Grafana Enterprise"
+	DEV      = "development"
+	PROD     = "production"
+	TEST     = "test"
+	APP_NAME = "Grafana"
 )
 
 var (
@@ -68,6 +67,7 @@ var (
 	BuildStamp      int64
 	IsEnterprise    bool
 	ApplicationName string
+	Edition         string
 
 	// packaging
 	Packaging = "unknown"
@@ -620,7 +620,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 
 	ApplicationName = APP_NAME
 	if IsEnterprise {
-		ApplicationName = APP_NAME_ENTERPRISE
+		ApplicationName = fmt.Sprintf("%s %s", APP_NAME, Edition)
 	}
 
 	Env, err = valueAsString(iniFile.Section(""), "app_mode", "development")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -36,10 +36,11 @@ const (
 )
 
 const (
-	DEV      = "development"
-	PROD     = "production"
-	TEST     = "test"
-	APP_NAME = "Grafana"
+	DEV                 = "development"
+	PROD                = "production"
+	TEST                = "test"
+	APP_NAME            = "Grafana"
+	APP_NAME_ENTERPRISE = "Grafana Enterprise"
 )
 
 var (
@@ -67,7 +68,6 @@ var (
 	BuildStamp      int64
 	IsEnterprise    bool
 	ApplicationName string
-	Edition         string
 
 	// packaging
 	Packaging = "unknown"
@@ -620,7 +620,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 
 	ApplicationName = APP_NAME
 	if IsEnterprise {
-		ApplicationName = fmt.Sprintf("%s %s", APP_NAME, Edition)
+		ApplicationName = APP_NAME_ENTERPRISE
 	}
 
 	Env, err = valueAsString(iniFile.Section(""), "app_mode", "development")

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -32,7 +32,8 @@ export let getFooterLinks = (): FooterLink[] => {
   ];
 };
 
-export let getVersionLinks = (isGrafanaAdmin: boolean): FooterLink[] => {
+export let getVersionLinks = (): FooterLink[] => {
+  const isGrafanaAdmin = contextSrv.isGrafanaAdmin;
   const { buildInfo, licenseInfo } = config;
   const enterpriseLink = isGrafanaAdmin
     ? licenseInfo.detailsLink
@@ -72,8 +73,7 @@ export function setVersionLinkFn(fn: typeof getFooterLinks) {
 }
 
 export const Footer: FC = React.memo(() => {
-  const isGrafanaAdmin = contextSrv.isGrafanaAdmin;
-  const links = getFooterLinks().concat(getVersionLinks(isGrafanaAdmin));
+  const links = getFooterLinks().concat(getVersionLinks());
 
   return (
     <footer className="footer">

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import config from 'app/core/config';
+import { contextSrv } from 'app/core/core';
 
 export interface FooterLink {
   text: string;
@@ -17,7 +18,7 @@ export let getFooterLinks = (): FooterLink[] => {
       target: '_blank',
     },
     {
-      text: 'Support & Enterprise',
+      text: 'Support',
       icon: 'fa fa-support',
       url: 'https://grafana.com/products/enterprise/?utm_source=grafana_footer',
       target: '_blank',
@@ -31,13 +32,21 @@ export let getFooterLinks = (): FooterLink[] => {
   ];
 };
 
-export let getVersionLinks = (): FooterLink[] => {
-  const { buildInfo } = config;
+export let getVersionLinks = (isGrafanaAdmin: boolean): FooterLink[] => {
+  const { buildInfo, licenseInfo } = config;
+  const enterpriseLink = isGrafanaAdmin
+    ? licenseInfo.detailsLink
+    : 'https://grafana.com/products/enterprise?utm_source=grafana_footer';
 
   const links: FooterLink[] = [
     {
-      text: `Grafana ${buildInfo.edition} v${buildInfo.version} (commit: ${buildInfo.commit})`,
+      text: `Grafana v${buildInfo.version} (commit: ${buildInfo.commit})`,
       url: 'https://grafana.com',
+      target: '_blank',
+    },
+    {
+      text: buildInfo.edition,
+      url: enterpriseLink,
       target: '_blank',
     },
   ];
@@ -63,7 +72,8 @@ export function setVersionLinkFn(fn: typeof getFooterLinks) {
 }
 
 export const Footer: FC = React.memo(() => {
-  const links = getFooterLinks().concat(getVersionLinks());
+  const isGrafanaAdmin = contextSrv.isGrafanaAdmin;
+  const links = getFooterLinks().concat(getVersionLinks(isGrafanaAdmin));
 
   return (
     <footer className="footer">

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -37,7 +37,7 @@ export let getVersionLinks = (): FooterLink[] => {
   const { buildInfo, licenseInfo } = config;
   const enterpriseLink = isGrafanaAdmin
     ? licenseInfo.detailsLink
-    : 'https://grafana.com/products/enterprise?utm_source=grafana_footer';
+    : 'https://grafana.com/enterprise?utm_source=grafana_footer';
 
   const links: FooterLink[] = [
     {

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -36,7 +36,7 @@ export let getVersionLinks = (): FooterLink[] => {
 
   const links: FooterLink[] = [
     {
-      text: `Grafana v${buildInfo.version} (commit: ${buildInfo.commit})`,
+      text: `Grafana ${buildInfo.edition} v${buildInfo.version} (commit: ${buildInfo.commit})`,
       url: 'https://grafana.com',
       target: '_blank',
     },

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 import config from 'app/core/config';
-import { contextSrv } from 'app/core/core';
 
 export interface FooterLink {
   text: string;
   icon?: string;
   url?: string;
-  target: string;
+  target?: string;
 }
 
 export let getFooterLinks = (): FooterLink[] => {
@@ -33,24 +32,12 @@ export let getFooterLinks = (): FooterLink[] => {
 };
 
 export let getVersionLinks = (): FooterLink[] => {
-  const isGrafanaAdmin = contextSrv.isGrafanaAdmin;
   const { buildInfo, licenseInfo } = config;
-  const enterpriseLink = isGrafanaAdmin
-    ? licenseInfo.detailsLink
-    : 'https://grafana.com/enterprise?utm_source=grafana_footer';
+  const links: FooterLink[] = [];
+  const stateInfo = licenseInfo.stateInfo ? ` (${licenseInfo.stateInfo})` : '';
 
-  const links: FooterLink[] = [
-    {
-      text: `Grafana v${buildInfo.version} (commit: ${buildInfo.commit})`,
-      url: 'https://grafana.com',
-      target: '_blank',
-    },
-    {
-      text: buildInfo.edition,
-      url: enterpriseLink,
-      target: '_blank',
-    },
-  ];
+  links.push({ text: `${buildInfo.edition}${stateInfo}`, url: licenseInfo.licenseUrl });
+  links.push({ text: `v${buildInfo.version} (${buildInfo.commit})` });
 
   if (buildInfo.hasUpdate) {
     links.push({

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`ServerStats Should render table with stats 1`] = `
                     className="fa fa-support"
                   />
                    
-                  Support & Enterprise
+                  Support
                 </a>
               </li>
               <li>
@@ -198,13 +198,22 @@ exports[`ServerStats Should render table with stats 1`] = `
               </li>
               <li>
                 <a
-                  href="https://grafana.com"
                   rel="noopener"
                   target="_blank"
                 >
                   <i />
                    
-                  Grafana vv1.0 (commit: 1)
+                  undefined
+                </a>
+              </li>
+              <li>
+                <a
+                  rel="noopener"
+                  target="_blank"
+                >
+                  <i />
+                   
+                  vv1.0 (1)
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
**What this PR does / why we need it**:

With three distinct versions of Grafana with different feature sets being downloadable from grafana.com the user might be confused what edition of Grafana they're running. This feature lists which feature of Grafana the user is using in the footer.

