### PR TITLE
Prometheus: make $__range more precise

### DIFF
--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -111,7 +111,7 @@ Query: query_result(topk(5, sum(rate(http_requests_total[$__range])) by (instanc
 Regex: /"([^"]+)"/
 ```
 
-Populate a variable with the instances having a certain state over the time range shown in the dashboard, using the more precise `$__range_s`:
+Populate a variable with the instances having a certain state over the time range shown in the dashboard, using `$__range_s`:
 
 ```
 Query: query_result(max_over_time(<metric>[${__range_s}s]) != <state>)

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1423,7 +1423,7 @@ describe('PrometheusDatasource', () => {
 
     it('should use overridden ranges, not dashboard ranges', async () => {
       const expectedRangeSecond = 3600;
-      const expectedRangeString = '1h';
+      const expectedRangeString = '3600s';
       const query = {
         range: {
           from: time({}),

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -512,11 +512,10 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   getRangeScopedVars(range: TimeRange = getTimeSrv().timeRange()) {
     const msRange = range.to.diff(range.from);
     const sRange = Math.round(msRange / 1000);
-    const regularRange = kbn.secondsToHms(msRange / 1000);
     return {
       __range_ms: { text: msRange, value: msRange },
       __range_s: { text: sRange, value: sRange },
-      __range: { text: regularRange, value: regularRange },
+      __range: { text: sRange + 's', value: sRange + 's' },
     };
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It is now always equivalent to `${__range_s}s`, rather than rounding
down to an integer multiple of the biggest possible unit. For example,
a range of 47 hours is now represented as `169200s` rather than `1d`.

**Which issue(s) this PR fixes**:

Closes #21689.

**Special notes for your reviewer**:

It ideally needs a regression test, but I'm not a Javascript or Go developer and don't have the time to learn how to use a new unit test framework. It unfortunately looked like more than just adding a few extra lines because the time range in the current test seems to be shared across a whole bunch of tests. I'm hoping someone else can help out with that part.