### PR TITLE
Build: Added devenv docker block for testing grafana with traefik.

### DIFF
--- a/devenv/docker/blocks/traefik/configs/subpath_no_rewrite.yml
+++ b/devenv/docker/blocks/traefik/configs/subpath_no_rewrite.yml
@@ -1,0 +1,19 @@
+http:
+  middlewares:
+    compress-response:
+      compress: {}
+
+  services:
+    grafana-subpath:
+      loadBalancer:
+        servers:
+          - url: 'http://grafana-subpath:3000/'
+
+  routers:
+    grafana-subpath:
+      entryPoints:
+        - web
+      middlewares:
+        - compress-response
+      rule: 'Path(`/grafana`) || PathPrefix(`/grafana/`)'
+      service: grafana-subpath

--- a/devenv/docker/blocks/traefik/docker-compose.yml
+++ b/devenv/docker/blocks/traefik/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  traefik:
+    image: traefik:v2.1
+    volumes:
+      - './traefik.yml:/etc/traefik/traefik.yml'
+      - './configs:/etc/traefik/configs'
+    ports:
+      - '80:80'
+      - '8080:8080'
+    links:
+      - grafana-subpath
+
+  grafana-subpath:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SERVER_ROOT_URL=/grafana
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true

--- a/devenv/docker/blocks/traefik/traefik.yml
+++ b/devenv/docker/blocks/traefik/traefik.yml
@@ -1,0 +1,18 @@
+## traefik.yml
+
+# Entrypoints enabled
+entryPoints:
+  web:
+    address: ':80'
+
+# API and dashboard configuration
+api:
+  insecure: true
+
+# Loggings
+log: {}
+
+# File configurations folder
+providers:
+  file:
+    directory: /etc/traefik/configs


### PR DESCRIPTION
**What this PR does / why we need it**:
If you want to test out Grafana with the awesome reverse proxy [Traefik](https://containo.us/traefik/) you just have to run the docker-compse up command and an environment with Grafana and Traefik will be started.

I created this when doing some debugging for this community issue and thought it might be valid if some other similar issue/questions occurs:

https://community.grafana.com/t/using-traefik-with-grafana-causes-infinite-302-redirects-to-login/24776