### PR TITLE
Template variables: Add error for failed query variable on time range update

### DIFF
--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -11,9 +11,10 @@ import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 
 // Types
-import { TimeRange } from '@grafana/data';
+import { TimeRange, AppEvents } from '@grafana/data';
 import { CoreEvents } from 'app/types';
 import { UrlQueryMap } from '@grafana/runtime';
+import { appEvents } from 'app/core/core';
 
 export class VariableSrv {
   dashboard: DashboardModel;
@@ -71,9 +72,14 @@ export class VariableSrv {
         });
       });
 
-    return this.$q.all(promises).then(() => {
-      this.dashboard.startRefresh();
-    });
+    return this.$q
+      .all(promises)
+      .then(() => {
+        this.dashboard.startRefresh();
+      })
+      .catch(e => {
+        appEvents.emit(AppEvents.alertError, ['Template variable service failed', e.message]);
+      });
   }
 
   processVariable(variable: any, queryParams: any) {


### PR DESCRIPTION
Fixes #21680 (ish)

We decided that the best current solution would be to display an error as the query variable query fails. Any thoughts on alternative solutions?