### PR TITLE
Azure Monitor: Fix Application Insights API key field to allow input

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ConfigEditor.tsx
@@ -296,7 +296,12 @@ export class ConfigEditor extends PureComponent<Props, State> {
           onLoadWorkspaces={this.getWorkspaces}
         />
 
-        <InsightsConfig options={options} onUpdateOption={this.updateOption} onResetOptionKey={this.resetKey} />
+        <InsightsConfig
+          options={options}
+          onUpdateOption={this.updateOption}
+          onUpdateSecureOption={this.updateSecureOption}
+          onResetOptionKey={this.resetKey}
+        />
       </>
     );
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.test.tsx
@@ -35,6 +35,7 @@ const setup = (propOverrides?: object) => {
       readOnly: false,
     },
     onUpdateOption: jest.fn(),
+    onUpdateSecureOption: jest.fn(),
     onResetOptionKey: jest.fn(),
   };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.tsx
@@ -4,16 +4,17 @@ import { AzureDataSourceSettings } from '../types';
 
 export interface Props {
   options: AzureDataSourceSettings;
-  onUpdateOption: (key: string, val: any, secure: boolean) => void;
+  onUpdateOption: (key: string, val: any) => void;
+  onUpdateSecureOption: (key: string, val: any) => void;
   onResetOptionKey: (key: string) => void;
 }
 export class InsightsConfig extends PureComponent<Props> {
   onAppInsightsAppIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    this.props.onUpdateOption('appInsightsAppId', event.target.value, false);
+    this.props.onUpdateOption('appInsightsAppId', event.target.value);
   };
 
   onAppInsightsApiKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
-    this.props.onUpdateOption('appInsightsApiKey', event.target.value, true);
+    this.props.onUpdateSecureOption('appInsightsApiKey', event.target.value);
   };
 
   onAppInsightsResetApiKey = () => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`Render should render component 1`] = `
   <InsightsConfig
     onResetOptionKey={[Function]}
     onUpdateOption={[Function]}
+    onUpdateSecureOption={[Function]}
     options={
       Object {
         "access": "proxy",


### PR DESCRIPTION
Fixes #21737