### PR TITLE
Toolkit: add canvas-mock to test setup

### DIFF
--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -62,6 +62,7 @@
     "html-webpack-plugin": "^3.2.0",
     "inquirer": "^6.3.1",
     "jest": "24.8.0",
+    "jest-canvas-mock": "2.1.2",
     "jest-cli": "^24.8.0",
     "jest-coverage-badges": "^1.1.2",
     "jest-junit": "^6.4.0",

--- a/packages/grafana-toolkit/src/config/jest.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.ts
@@ -50,7 +50,7 @@ export const jestConfig = (baseDir: string = process.cwd()) => {
   const setupFile = getSetupFile(setupFilePath);
   const shimsFile = getSetupFile(shimsFilePath);
 
-  const setupFiles = [setupFile, shimsFile].filter(f => f);
+  const setupFiles = [setupFile, shimsFile, 'jest-canvas-mock'].filter(f => f);
   const defaultJestConfig = {
     preset: 'ts-jest',
     verbose: false,


### PR DESCRIPTION
Toolkit jest tests currently fail when including some files from @grafana/ui -- to fix it we need canvas mock in the classpath for plugins... otherwise they see something ugly like:

![image](https://user-images.githubusercontent.com/705951/73116168-99165800-3ee6-11ea-80a8-ede586f25eb8.png)
