### PR TITLE
Docs: Alphabetize datasource names in sidebar under docs/Features/Dat…

### DIFF
--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -131,34 +131,34 @@
   - name: Data Sources
     link: /features/datasources/
     children:
-    - link: /features/datasources/graphite/
-      name: Graphite
-    - link: /features/datasources/prometheus/
-      name: Prometheus
-    - link: /features/datasources/influxdb/
-      name: InfluxDB
-    - link: /features/datasources/elasticsearch/
-      name: Elasticsearch
-    - link: /features/datasources/stackdriver/
-      name: Google Stackdriver
     - link: /features/datasources/cloudwatch/
       name: AWS Cloudwatch
     - link: /features/datasources/azuremonitor/
       name: Azure Monitor
+    - link: /features/datasources/elasticsearch/
+      name: Elasticsearch
+    - link: /features/datasources/stackdriver/
+      name: Google Stackdriver
+    - link: /features/datasources/graphite/
+      name: Graphite
+    - link: /features/datasources/influxdb/
+      name: InfluxDB
     - link: /features/datasources/loki/
       name: Loki
-    - link: /features/datasources/mysql/
-      name: MySQL
-    - link: /features/datasources/postgres/
-      name: PostgreSQL
     - link: /features/datasources/mssql/
       name: Microsoft SQL Server
-    - link: /features/datasources/opentsdb/
-      name: OpenTSDB
     - link: /features/datasources/mixed/
       name: MixedData
+    - link: /features/datasources/mysql/
+      name: MySQL
+    - link: /features/datasources/opentsdb/
+      name: OpenTSDB
+    - link: /features/datasources/postgres/
+      name: PostgreSQL
+    - link: /features/datasources/prometheus/
+      name: Prometheus
     - link: /features/datasources/testdata/
-      name: TestData
+      name: Testdata
   - name: Explore
     link: /features/explore/
   - name: Alerting


### PR DESCRIPTION
**What this PR does / why we need it**:

This alphabetises the datasources names in the sidebar under docs Features/ Data Sources
Also, this includes a fix for typo for the list item "Test Data".

**Which issue(s) this PR fixes**:
Fixes #19289 

**Special notes for your reviewer**:

Testing: asserted all the list items with the items under https://github.com/grafana/grafana/blob/master/docs/sources/features/datasources/_index.md

Also verified by clicking each link and asserting if they are being redirected to the correct location.

Attaching screenshot of the change deployed on a local docker instance.


<img width="1355" alt="Screenshot 2020-01-25 at 1 31 42 PM" src="https://user-images.githubusercontent.com/5098875/73118292-25bd2680-3f78-11ea-92da-cb434f3b44c2.png">



