### PR TITLE
Docs: misc. nitpicks to the HTTP API docs

### DIFF
--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -30,6 +30,7 @@ dashboards, creating users and updating data sources.
 * [Organization API]({{< relref "org.md" >}})
 * [Snapshot API]({{< relref "snapshot.md" >}})
 * [Annotations API]({{< relref "annotations.md" >}})
+* [Playlists API]({{< relref "playlist.md" >}})
 * [Alerting API]({{< relref "alerting.md" >}})
 * [Alert Notification Channels API]({{< relref "alerting_notification_channels.md" >}})
 * [User API]({{< relref "user.md" >}})
@@ -37,3 +38,8 @@ dashboards, creating users and updating data sources.
 * [Admin API]({{< relref "admin.md" >}})
 * [Preferences API]({{< relref "preferences.md" >}})
 * [Other API]({{< relref "other.md" >}})
+
+### Grafana Enterprise HTTP APIs
+
+* [Data Source Permissions API]({{< relref "datasource_permissions.md" >}})
+* [External Group Sync API]({{< relref "external_group_sync.md" >}})

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -23,7 +23,7 @@ Only works with Basic Authentication (username and password). See [introduction]
 
 **Example Request**:
 
-```bash
+```http
 GET /api/admin/settings
 Accept: application/json
 Content-Type: application/json
@@ -31,7 +31,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```bash
+```http
 HTTP/1.1 200
 Content-Type: application/json
 
@@ -181,7 +181,7 @@ Only works with Basic Authentication (username and password). See [introduction]
 
 **Example Request**:
 
-```bash
+```http
 GET /api/admin/stats
 Accept: application/json
 Content-Type: application/json
@@ -189,7 +189,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 
@@ -214,8 +214,8 @@ Content-Type: application/json
 Create new user. Only works with Basic Authentication (username and password). See [introduction](http://docs.grafana.org/http_api/admin/#admin-api) for an explanation.
 
 **Example Request**:
-```json
 
+```http
 POST /api/admin/users HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -230,7 +230,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 
@@ -246,7 +246,7 @@ Change password for a specific user.
 
 **Example Request**:
 
-```json
+```http
 PUT /api/admin/users/2/password HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -256,7 +256,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 
@@ -271,7 +271,7 @@ Only works with Basic Authentication (username and password). See [introduction]
 
 **Example Request**:
 
-```json
+```http
 PUT /api/admin/users/2/permissions HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -281,7 +281,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 
@@ -296,7 +296,7 @@ Only works with Basic Authentication (username and password). See [introduction]
 
 **Example Request**:
 
-```json
+```http
 DELETE /api/admin/users/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -304,7 +304,7 @@ Content-Type: application/json
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 

--- a/docs/sources/http_api/playlist.md
+++ b/docs/sources/http_api/playlist.md
@@ -20,7 +20,7 @@ Get all existing playlist for the current organization using pagination
 
 **Example Request**:
 
-```bash
+```http
 GET /api/playlists HTTP/1.1
 Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -35,7 +35,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 [
@@ -53,7 +53,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 GET /api/playlists/1 HTTP/1.1
 Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -61,7 +61,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 {
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 GET /api/playlists/1/items HTTP/1.1
 Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -104,7 +104,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 [
@@ -133,7 +133,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 GET /api/playlists/1/dashboards HTTP/1.1
 Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -141,7 +141,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 [
@@ -165,7 +165,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 PUT /api/playlists/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -192,7 +192,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
   {
@@ -208,7 +208,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 PUT /api/playlists/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
@@ -237,7 +237,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 {
@@ -272,7 +272,7 @@ Content-Type: application/json
 
 **Example Request**:
 
-```bash
+```http
 DELETE /api/playlists/1 HTTP/1.1
 Accept: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -280,7 +280,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 **Example Response**:
 
-```json
+```http
 HTTP/1.1 200
 Content-Type: application/json
 {}

--- a/docs/sources/reference/annotations.md
+++ b/docs/sources/reference/annotations.md
@@ -17,7 +17,7 @@ you can get event description and event tags. The text field can include links t
 
 ## Native annotations
 
-Grafana v4.6+ comes with a native annotation store and the ability to add annotation events directly from the graph panel or via the [HTTP API]({{< relref "annotations.md" >}}).
+Grafana v4.6+ comes with a native annotation store and the ability to add annotation events directly from the graph panel or via the [HTTP API]({{< relref "../http_api/annotations.md" >}}).
 
 ## Adding annotations
 

--- a/docs/sources/reference/export_import.md
+++ b/docs/sources/reference/export_import.md
@@ -9,7 +9,7 @@ weight = 8
 
 # Export and Import
 
-Grafana Dashboards can easily be exported and imported, either from the UI or from the HTTP API.
+Grafana Dashboards can easily be exported and imported, either from the UI or from the [HTTP API]({{< relref "../http_api/dashboard.md#create-update-dashboard" >}}).
 
 ## Exporting a dashboard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix the API reference on [Features / Dashboard Features / Annotations](https://grafana.com/docs/grafana/latest/reference/annotations/)
- Replace `json` and `bash` for `http` as syntax for request/response code blocks on the `http_api` dir. 
- Add missing features to the [HTTP API Reference](https://grafana.com/docs/grafana/latest/http_api/) index. 
