### PR TITLE
Use regional STS endpoints for CloudWatch datasource

### DIFF
--- a/pkg/tsdb/cloudwatch/credentials.go
+++ b/pkg/tsdb/cloudwatch/credentials.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -62,8 +63,9 @@ func GetCredentials(dsInfo *DatasourceInfo) (*credentials.Credentials, error) {
 				remoteCredProvider(stsSess),
 			})
 		stsConfig := &aws.Config{
-			Region:      aws.String(dsInfo.Region),
-			Credentials: stsCreds,
+			Region:              aws.String(dsInfo.Region),
+			Credentials:         stsCreds,
+			STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 		}
 
 		sess, err := session.NewSession(stsConfig)
@@ -172,8 +174,9 @@ func (e *CloudWatchExecutor) getAwsConfig(dsInfo *DatasourceInfo) (*aws.Config, 
 	}
 
 	cfg := &aws.Config{
-		Region:      aws.String(dsInfo.Region),
-		Credentials: creds,
+		Region:              aws.String(dsInfo.Region),
+		Credentials:         creds,
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
 
 	return cfg, nil

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -724,8 +725,9 @@ func getAllMetrics(cwData *DatasourceInfo) (cloudwatch.ListMetricsOutput, error)
 		return cloudwatch.ListMetricsOutput{}, err
 	}
 	cfg := &aws.Config{
-		Region:      aws.String(cwData.Region),
-		Credentials: creds,
+		Region:              aws.String(cwData.Region),
+		Credentials:         creds,
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
 	sess, err := session.NewSession(cfg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

This PR switches STS AssumeRole actions to use a region endpoint instead of the global us-east-1 endpoint. 

**Why we need It**:

Per the [AWS docs](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html):
> AWS recommends using Regional AWS STS endpoints instead of the global endpoint to reduce latency, build in redundancy, and increase session token validity.

Quoted from someone that works at Amazon:
> Why this is bad
STS regional endpoints have been available since 2015. The usage of a single endpoint in all regions affects latency by causing API calls to travel across to the world unnecessarily. There are also availability concerns since network traffic traveling long distances tends to be a contributing factor to dropped communications, and huge blast radius issues. If your application suddenly fails talking to the single STS global endpoint, all regions you are deployed to will be impacted.

**Special notes for your reviewer**:

If the above is not enough info, please let me know and I'll do what i can to provide more details.

Thank you for considering this improvement!

**Testing**:

Built a new docker image, deployed it to ECS and ran queries against data sources in other accounts. Checked CloudTrail and verified the sts queries happen in the local region (us-west-2) where they used to happen in the global region (us-east-1).