### PR TITLE
Logs panel: Rename labels column to unique labels

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanelEditor.tsx
+++ b/public/app/plugins/panel/logs/LogsPanelEditor.tsx
@@ -48,7 +48,7 @@ export class LogsPanelEditor extends PureComponent<PanelEditorProps<Options>> {
         <PanelOptionsGrid>
           <PanelOptionsGroup title="Columns">
             <Switch label="Time" labelClass="width-10" checked={showTime} onChange={this.onToggleTime} />
-            <Switch label="Labels" labelClass="width-10" checked={showLabels} onChange={this.onToggleLabels} />
+            <Switch label="Unique labels" labelClass="width-10" checked={showLabels} onChange={this.onToggleLabels} />
             <Switch
               label="Wrap lines"
               labelClass="width-10"


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames *Labels* column to *Unique labels* to make it more obvious what is the column representing and to keep it consistent with Explore. 

