### PR TITLE
Config: add meta feature toggle

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -17,6 +17,7 @@ interface FeatureToggles {
   inspect: boolean;
   expressions: boolean;
   newEdit: boolean;
+  meta: boolean;
 }
 
 interface LicenseInfo {
@@ -63,6 +64,7 @@ export class GrafanaBootConfig {
     inspect: false,
     expressions: false,
     newEdit: false,
+    meta: false,
   };
   licenseInfo: LicenseInfo = {} as LicenseInfo;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `meta` feature toggle to the frontend `config` object which allows it to be picked up by the Meta Analytics feature off-tree and disable MA entirely if it's false.
