### PR TITLE
OpenTSDB: Adds back missing ngInject to make it work again

### DIFF
--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -19,6 +19,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
   aggregatorsPromise: any;
   filterTypesPromise: any;
 
+  /** @ngInject */
   constructor(instanceSettings: any, private templateSrv: TemplateSrv) {
     super(instanceSettings);
     this.type = 'opentsdb';


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds back missing ngInject on datasource constructor 
to make it work again.

**Which issue(s) this PR fixes**:
Fixes #21770 

**Special notes for your reviewer**:

