### PR TITLE
StatPanels: Fixed change from singlestat to Gauge / BarGauge / Stat where default min & max (0, 100) was copied 

### DIFF
--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -86,7 +86,7 @@ export function sharedSingleStatPanelChangedHandler(
       defaults.mappings = mappings;
     }
 
-    if (panel.gauge) {
+    if (panel.gauge && panel.gauge.show) {
       defaults.min = panel.gauge.minValue;
       defaults.max = panel.gauge.maxValue;
     }

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -103,4 +103,23 @@ describe('Gauge Panel Migrations', () => {
     expect(newOptions.showThresholdMarkers).toBe(true);
     expect(newOptions.showThresholdLabels).toBe(true);
   });
+
+  it('change from angular singlestatt with no enabled gauge', () => {
+    const old: any = {
+      angular: {
+        format: 'ms',
+        decimals: 7,
+        gauge: {
+          maxValue: 150,
+          minValue: -10,
+          show: false,
+        },
+      },
+    };
+
+    const newOptions = gaugePanelChangedHandler({} as any, 'singlestat', old);
+    expect(newOptions.fieldOptions.defaults.unit).toBe('ms');
+    expect(newOptions.fieldOptions.defaults.min).toBe(undefined);
+    expect(newOptions.fieldOptions.defaults.max).toBe(undefined);
+  });
 });


### PR DESCRIPTION
Fixes #21818

The panel change hander did copy default gauge min and max from the angular singlestat even when not enabled. So when switching between visualizations the new react panels picked up min: 0 and max: 100 when switching from the singlestat panel 