### PR TITLE
Select: Fix scroll issue for old component

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -17,6 +17,15 @@ SelectStories.add('default', () => {
   const options = object<Array<SelectableValue<string>>>('Options:', [
     intialState,
     { label: 'Another label', value: 'Another value' },
+
+    { label: 'Another label 1', value: ' 1Another value' },
+    { label: 'Another label 2', value: '2 Another value' },
+    { label: 'Another label 3', value: '3 Another value' },
+    { label: 'Another label 4', value: '4 Another value' },
+    { label: 'Another label 5', value: '5 Another value' },
+    { label: 'Another label 6', value: '6 Another value' },
+    { label: 'Another label 7', value: '7 Another value' },
+    { label: 'Another label 8', value: '8 Another value' },
   ]);
 
   return (

--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -133,6 +133,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
         {(onOpenMenuInternal, onCloseMenuInternal) => {
           return (
             <SelectComponent
+              captureMenuScroll={false}
               classNamePrefix="gf-form-select-box"
               className={selectClassNames}
               components={selectComponents}


### PR DESCRIPTION
Fixes #21777

The same fix as in #21795, which was accidentally only the new form select component. Now it works with the old!