### PR TITLE
Table: Make the height of the table include header cells

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { DataFrame } from '@grafana/data';
 import { useSortBy, useTable, useBlockLayout, Cell } from 'react-table';
 import { FixedSizeList } from 'react-window';
+import useMeasure from 'react-use/lib/useMeasure';
 import { getColumns, getTableRows } from './utils';
 import { useTheme } from '../../themes';
 import { TableFilterActionCallback } from './types';
@@ -17,6 +18,7 @@ export interface Props {
 
 export const Table = ({ data, height, onCellClick, width }: Props) => {
   const theme = useTheme();
+  const [ref, headerRowMeasurements] = useMeasure();
   const tableStyles = getTableStyles(theme);
 
   const { getTableProps, headerGroups, rows, prepareRow } = useTable(
@@ -53,12 +55,17 @@ export const Table = ({ data, height, onCellClick, width }: Props) => {
     <div {...getTableProps()} className={tableStyles.table}>
       <div>
         {headerGroups.map((headerGroup: any) => (
-          <div className={tableStyles.thead} {...headerGroup.getHeaderGroupProps()}>
+          <div className={tableStyles.thead} {...headerGroup.getHeaderGroupProps()} ref={ref}>
             {headerGroup.headers.map((column: any) => renderHeaderCell(column, tableStyles.headerCell))}
           </div>
         ))}
       </div>
-      <FixedSizeList height={height} itemCount={rows.length} itemSize={tableStyles.rowHeight} width={width}>
+      <FixedSizeList
+        height={height - headerRowMeasurements.height}
+        itemCount={rows.length}
+        itemSize={tableStyles.rowHeight}
+        width={width}
+      >
         {RenderRow}
       </FixedSizeList>
     </div>

--- a/public/app/plugins/panel/table2/module.tsx
+++ b/public/app/plugins/panel/table2/module.tsx
@@ -4,7 +4,4 @@ import { TablePanelEditor } from './TablePanelEditor';
 import { TablePanel } from './TablePanel';
 import { Options, defaults } from './types';
 
-export const plugin = new PanelPlugin<Options>(TablePanel)
-  .setNoPadding()
-  .setDefaults(defaults)
-  .setEditor(TablePanelEditor);
+export const plugin = new PanelPlugin<Options>(TablePanel).setDefaults(defaults).setEditor(TablePanelEditor);


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/21789

Also, removes no padding option from new table panel