### PR TITLE
Datasource: Show access (Browser/Server) select on the Prometheus datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -12,6 +12,7 @@ export const ConfigEditor = (props: Props) => {
       <DataSourceHttpSettings
         defaultUrl="http://localhost:9090"
         dataSourceConfig={options}
+        showAccessOptions={true}
         onChange={onOptionsChange}
       />
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the datasource configuration of the Prometheus datasource was migrated to React on PR #20248 the access options (Browser/Server) are no longer visible/configurable.

I found that in #12757 there was a proposal of removing entirely the Browser/Direct option (for Elasticsearch) but I could see the reasoning extending to all other datasources as well. Nevertheless, I didn't find anything specifically about the removal of the options in the CHANGELOG and [the documentation for the current release (v6.6.0) still mentions the Access option](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/).

Also, the ES datasource was already migrated to React and kept the Access option as well.

**Special notes for your reviewer**:

If the final decision of the Grafana team is to remove the option altogether feel free to close this PR. In that case, a new PR updating the documentation should be opened.