### PR TITLE
Docs: Make upgrading instructions for Docker work

### DIFF
--- a/docs/sources/installation/upgrading.md
+++ b/docs/sources/installation/upgrading.md
@@ -105,10 +105,10 @@ sudo yum update grafana
 This just an example, details depend on how you configured your grafana container.
 
 ```bash
-docker pull grafana
+docker pull grafana/grafana
 docker stop my-grafana-container
 docker rm my-grafana-container
-docker run --name=my-grafana-container --restart=always -v /var/lib/grafana:/var/lib/grafana
+docker run -d --name=my-grafana-container --restart=always -v /var/lib/grafana:/var/lib/grafana grafana/grafana
 ```
 
 ### Windows


### PR DESCRIPTION
**What this PR does / why we need it**:
One has to use "grafana/grafana" image - only using "grafana" will
result in an error message like this:
Error response from daemon: pull access denied for grafana, repository does not exist or may require 'docker login'

It's a good idea to daemonize new container. The install instructions
for Docker do this, and this instructions assume that running container
already is daemonized (otherwise you wouldn't have to stop it).

Best practise would be to create a new container, then stop old one and
start new one - this would reduce downtime. To keep instructions simple
and understandable, I didn't include that.

**Which issue(s) this PR fixes**:
No issue created for it

**Special notes for your reviewer**:
none
