### PR TITLE
docs/cli: Fix documentation of reset-admin-password with --homepath

### DIFF
--- a/docs/sources/administration/cli.md
+++ b/docs/sources/administration/cli.md
@@ -125,7 +125,7 @@ Sets the path for the Grafana install/home path, defaults to working directory. 
  
 **Example:**
 ```bash
-grafana-cli admin reset-admin-password --homepath "c:\Program Files\grafana" mynewpassword
+grafana-cli --homepath "c:\Program Files\grafana" admin reset-admin-password mynewpassword
 ```
 
 ### Override config file         


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix administration/cli documentation wrt. overriding homepath when resetting admin password.
