### PR TITLE
grafana/toolkit: Fix failing linter when there were lint issues

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -149,7 +149,9 @@ export const lintPlugin = useSpinner<Fixable>('Linting', async ({ fix }) => {
 
   if (lintResults.length > 0) {
     console.log('\n');
-    const failures: RuleFailure[] = lintResults.flat();
+    const failures = lintResults.reduce<RuleFailure[]>((failures, result) => {
+      return [...failures, ...result.failures];
+    }, []);
     failures.forEach(f => {
       // tslint:disable-next-line
       console.log(


### PR DESCRIPTION
With https://github.com/grafana/grafana/pull/21441/files#diff-8888649cf7428fa7fef4f50577165949R151 we have introduced bug that made the linting fail when there were any linting issues.

This PR makes the @grafana/toolkit linting work again.