### PR TITLE
Image Rendering: Fix render of graph panel legend aligned to the right using Grafana image renderer plugin/service

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -67,6 +67,7 @@ export class GrafanaBootConfig {
     meta: false,
   };
   licenseInfo: LicenseInfo = {} as LicenseInfo;
+  phantomJSRenderer = false;
 
   constructor(options: GrafanaBootConfig) {
     this.theme = options.bootData.user.lightTheme ? getTheme(GrafanaThemeType.Light) : getTheme(GrafanaThemeType.Dark);

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -3,6 +3,8 @@ package api
 import (
 	"strconv"
 
+	"github.com/grafana/grafana/pkg/services/rendering"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/util"
 
@@ -206,7 +208,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *m.ReqContext) (map[string]interf
 			"stateInfo":  hs.License.StateInfo(),
 			"licenseUrl": hs.License.LicenseURL(c.SignedInUser),
 		},
-		"featureToggles": hs.Cfg.FeatureToggles,
+		"featureToggles":    hs.Cfg.FeatureToggles,
+		"phantomJSRenderer": rendering.IsPhantomJSEnabled,
 	}
 
 	return jsonObj, nil

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -20,6 +20,8 @@ func init() {
 	registry.RegisterService(&RenderingService{})
 }
 
+var IsPhantomJSEnabled = false
+
 type RenderingService struct {
 	log             log.Logger
 	pluginInfo      *plugins.RendererPlugin
@@ -69,6 +71,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 			"You should consider migrating from phantomJS to grafana-image-renderer plugin. " +
 			"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
 		rs.renderAction = rs.renderViaPhantomJS
+		IsPhantomJSEnabled = true
 		<-ctx.Done()
 		return nil
 	}

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -167,7 +167,7 @@ export function grafanaAppDirective(
       });
 
       // check if we are in server side render
-      if (document.cookie.indexOf('renderKey') !== -1) {
+      if (config.phantomJSRenderer && document.cookie.indexOf('renderKey') !== -1) {
         body.addClass('body--phantomjs');
       }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't render class `body--phantomjs` on body element when PhantomJS renderer not is in use.

**Which issue(s) this PR fixes**:
Fixes #21830 

**Special notes for your reviewer**:
What about my naming of variables?
