### PR TITLE
Metrics: Adds back missing summary quantiles

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -154,6 +154,8 @@ var (
 
 func init() {
 	httpStatusCodes := []string{"200", "404", "500", "unknown"}
+	objectiveMap := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
+
 	MInstanceStart = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "instance_start_total",
 		Help:      "counter for started instances",
@@ -191,8 +193,9 @@ func init() {
 
 	MHttpRequestSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "http_request_duration_milliseconds",
-			Help: "http request summary",
+			Name:       "http_request_duration_milliseconds",
+			Help:       "http request summary",
+			Objectives: objectiveMap,
 		},
 		[]string{"handler", "statuscode", "method"},
 	)
@@ -216,21 +219,24 @@ func init() {
 	})
 
 	MApiDashboardSave = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_save_milliseconds",
-		Help:      "summary for dashboard save duration",
-		Namespace: exporterName,
+		Name:       "api_dashboard_save_milliseconds",
+		Help:       "summary for dashboard save duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MApiDashboardGet = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_get_milliseconds",
-		Help:      "summary for dashboard get duration",
-		Namespace: exporterName,
+		Name:       "api_dashboard_get_milliseconds",
+		Help:       "summary for dashboard get duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MApiDashboardSearch = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dashboard_search_milliseconds",
-		Help:      "summary for dashboard search duration",
-		Namespace: exporterName,
+		Name:       "api_dashboard_search_milliseconds",
+		Help:       "summary for dashboard search duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MApiAdminUserCreate = newCounterStartingAtZero(prometheus.CounterOpts{
@@ -330,21 +336,24 @@ func init() {
 	})
 
 	LDAPUsersSyncExecutionTime = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "ldap_users_sync_execution_time",
-		Help:      "summary for LDAP users sync execution duration",
-		Namespace: exporterName,
+		Name:       "ldap_users_sync_execution_time",
+		Help:       "summary for LDAP users sync execution duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MDataSourceProxyReqTimer = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "api_dataproxy_request_all_milliseconds",
-		Help:      "summary for dataproxy request duration",
-		Namespace: exporterName,
+		Name:       "api_dataproxy_request_all_milliseconds",
+		Help:       "summary for dataproxy request duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MAlertingExecutionTime = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:      "alerting_execution_time_milliseconds",
-		Help:      "summary of alert exeuction duration",
-		Namespace: exporterName,
+		Name:       "alerting_execution_time_milliseconds",
+		Help:       "summary of alert exeuction duration",
+		Objectives: objectiveMap,
+		Namespace:  exporterName,
 	})
 
 	MAlertingActiveAlerts = prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the `Objectives` for summaries to the defaults previously supplied by the client library:
[summary_test.go#L281](https://github.com/prometheus/client_golang/blob/761a2ff07c763475bff727730e823a8f4d501f36/prometheus/summary_test.go#L281)
[summary_test.go#L302](https://github.com/prometheus/client_golang/blob/761a2ff07c763475bff727730e823a8f4d501f36/prometheus/summary_test.go#L302)

**Which issue(s) this PR fixes**:
Fixes #21857

**Special notes for your reviewer**:
This just restores the default objects back to the existing Summary metrics.  I think long term this would be better as histograms so that aggregating across a cluster of grafana instances would be possible. 