### PR TITLE
Datasource: Allow sub-second steps in Prometheus queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -957,14 +957,14 @@ describe('PrometheusDatasource', () => {
       expect(res.url).toBe(urlExpected);
     });
 
-    it('step should never go below 1', async () => {
+    it('step should be fractional for sub second intervals', async () => {
       const query = {
         // 6 minute range
         range: { from: time({ minutes: 1 }), to: time({ minutes: 7 }) },
         targets: [{ expr: 'test' }],
         interval: '100ms',
       };
-      const urlExpected = 'proxied/api/v1/query_range?query=test&start=60&end=420&step=1';
+      const urlExpected = 'proxied/api/v1/query_range?query=test&start=60&end=420&step=0.1';
       datasourceRequestMock.mockImplementation(() => Promise.resolve(response));
       ds.query(query as any);
       const res = datasourceRequestMock.mock.calls[0][0];

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -394,8 +394,13 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   adjustInterval(interval: number, minInterval: number, range: number, intervalFactor: number) {
     // Prometheus will drop queries that might return more than 11000 data points.
     // Calculate a safe interval as an additional minimum to take into account.
-    const safeInterval = Math.ceil(range / 11000);
-    return Math.max(interval * intervalFactor, minInterval, safeInterval, 1);
+    // Fractional safeIntervals are allowed, however serve little purpose if the interval is greater than 1
+    // If this is the case take the ceil of the value.
+    let safeInterval = range / 11000;
+    if (safeInterval > 1) {
+      safeInterval = Math.ceil(safeInterval);
+    }
+    return Math.max(interval * intervalFactor, minInterval, safeInterval);
   }
 
   performTimeSeriesQuery(query: PromQueryRequest, start: number, end: number) {

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -46,7 +46,7 @@ export class ResultTransformer {
 
     metricLabel = this.createMetricLabel(metricData.metric, options);
 
-    const stepMs = parseInt(options.step, 10) * 1000;
+    const stepMs = parseFloat(options.step) * 1000;
     let baseTimestamp = start * 1000;
 
     if (metricData.values === undefined) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I've been playing around with putting data in Cortex with sub-second precision however I discovered Grafana was forcing the `step` in the query to 1s which would prevent me from displaying graphs with the same level of precision.  

After looking around it appears this restriction is arbitrary so I updated the function which adjusts the interval to allow setting an interval (and therefore a step) of a fractional value.


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:


I didn't put a lower bound on how small the step can go (such as forcing it to never go below 1ms), I couldn't think of a reason that this would be necessary.  Likewise there was previously a test that asserted the step should not go below 1s, I modified this test to prove the step could be set to a fractional value.
