### PR TITLE
Azure Monitor: Fix app insights source to allow for new __timeFrom and __timeTo

### DIFF
--- a/pkg/tsdb/azuremonitor/macros.go
+++ b/pkg/tsdb/azuremonitor/macros.go
@@ -60,8 +60,10 @@ func (m *kqlMacroEngine) evaluateMacro(name string, args []string) (string, erro
 			timeColumn = args[0]
 		}
 		return fmt.Sprintf("['%s'] >= datetime('%s') and ['%s'] <= datetime('%s')", timeColumn, m.timeRange.GetFromAsTimeUTC().Format(time.RFC3339), timeColumn, m.timeRange.GetToAsTimeUTC().Format(time.RFC3339)), nil
+	case "__timeFrom":
 	case "__from":
 		return fmt.Sprintf("datetime('%s')", m.timeRange.GetFromAsTimeUTC().Format(time.RFC3339)), nil
+	case "__timeTo":
 	case "__to":
 		return fmt.Sprintf("datetime('%s')", m.timeRange.GetToAsTimeUTC().Format(time.RFC3339)), nil
 	case "__interval":

--- a/pkg/tsdb/azuremonitor/macros.go
+++ b/pkg/tsdb/azuremonitor/macros.go
@@ -60,11 +60,9 @@ func (m *kqlMacroEngine) evaluateMacro(name string, args []string) (string, erro
 			timeColumn = args[0]
 		}
 		return fmt.Sprintf("['%s'] >= datetime('%s') and ['%s'] <= datetime('%s')", timeColumn, m.timeRange.GetFromAsTimeUTC().Format(time.RFC3339), timeColumn, m.timeRange.GetToAsTimeUTC().Format(time.RFC3339)), nil
-	case "__timeFrom":
-	case "__from":
+	case "__timeFrom", "__from":
 		return fmt.Sprintf("datetime('%s')", m.timeRange.GetFromAsTimeUTC().Format(time.RFC3339)), nil
-	case "__timeTo":
-	case "__to":
+	case "__timeTo", "__to":
 		return fmt.Sprintf("datetime('%s')", m.timeRange.GetToAsTimeUTC().Format(time.RFC3339)), nil
 	case "__interval":
 		var interval time.Duration


### PR DESCRIPTION

**What this PR does / why we need it**:

the change to the meaning of __from broke the app insights data source

https://github.com/grafana/grafana/issues/21860, the proposed "works as intended" doesn't work.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/21860

