### PR TITLE
Graph Panel: Fix typo in thresholds form

### DIFF
--- a/public/app/plugins/panel/graph/thresholds_form.html
+++ b/public/app/plugins/panel/graph/thresholds_form.html
@@ -1,7 +1,7 @@
 <div class="gf-form-group">
   <p class="muted" ng-show="ctrl.disabled">
     Visual thresholds options <strong>disabled.</strong>
-    Visit the Alert tab update your thresholds. <br>
+    Visit the Alert tab to update your thresholds.<br>
     To re-enable thresholds, the alert rule must be deleted from this panel.
   </p>
   <div ng-class="{'thresholds-form-disabled': ctrl.disabled}">


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo (missing word "to") and removes a redundant space.  After running into this dozens of time it bugged me enough to hop on and submit a quick fix 😉.

**Which issue(s) this PR fixes**:

N/A

**Rendering of fix**:
![Screen Shot 2020-02-03 at 1 00 15 PM](https://user-images.githubusercontent.com/1426304/73694780-a45b4780-468d-11ea-8498-952070c16569.png)
