### PR TITLE
Docker: Update Alpine to 3.11

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.10
+ARG BASE_IMAGE=alpine:3.11
 FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the base image to Alpine 3.11 which is the most recent version.