### PR TITLE
@grafana/ui: Fix displaying of bars in React Graph

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -319,7 +319,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
           // Dividig the width by 1.5 to make the bars not touch each other
           barWidth: showBars ? this.getBarWidth() / 1.5 : 1,
           zero: false,
-          lineWidth: lineWidth,
+          lineWidth: 0,
         },
         shadowSize: 0,
       },


### PR DESCRIPTION
*What this PR does / why we need it*:
Sets lineWidth to 0 for bars in React Graph as lineWidth is [correctly set for lines](https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/Graph/Graph.tsx#L307) and for [bars should be 0](https://github.com/grafana/grafana/blob/master/public/app/plugins/panel/graph/graph.ts#L532). 

**Broken:** 
![image](https://user-images.githubusercontent.com/30407135/73770517-dac3c000-477c-11ea-9345-06751aa0d0df.png)

**Fixed:**
![image](https://user-images.githubusercontent.com/30407135/73770657-0cd52200-477d-11ea-9ba6-2a24914dfe53.png)

**Angular Graph Panel for comparison:**
![image](https://user-images.githubusercontent.com/30407135/73770789-53c31780-477d-11ea-86f6-3409de745750.png)


