### PR TITLE
Prometheus: Fixes default step value for annotation query

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -7,11 +7,11 @@ import {
   prometheusSpecialRegexEscape,
 } from './datasource';
 import {
-  DataSourceInstanceSettings,
-  DataQueryResponseData,
-  DataQueryRequest,
-  dateTime,
   CoreApp,
+  DataQueryRequest,
+  DataQueryResponseData,
+  DataSourceInstanceSettings,
+  dateTime,
   LoadingState,
 } from '@grafana/data';
 import { PromOptions, PromQuery } from './types';
@@ -835,6 +835,23 @@ describe('PrometheusDatasource', () => {
         expect(req.url).toContain('step=60');
       });
 
+      it('should use default step for short range when annotation step is empty string', () => {
+        const query = {
+          ...options,
+          annotation: {
+            ...options.annotation,
+            step: '',
+          },
+          range: {
+            from: time({ seconds: 63 }),
+            to: time({ seconds: 123 }),
+          },
+        };
+        ds.annotationQuery(query);
+        const req = datasourceRequestMock.mock.calls[0][0];
+        expect(req.url).toContain('step=60');
+      });
+
       it('should use custom step for short range', () => {
         const annotation = {
           ...options.annotation,
@@ -887,6 +904,22 @@ describe('PrometheusDatasource', () => {
         const step = 236;
         expect(req.url).toContain(`step=${step}`);
       });
+    });
+  });
+
+  describe('createAnnotationQueryOptions', () => {
+    it.each`
+      options                                | expected
+      ${{}}                                  | ${{ interval: '60s' }}
+      ${{ annotation: {} }}                  | ${{ annotation: {}, interval: '60s' }}
+      ${{ annotation: { step: undefined } }} | ${{ annotation: { step: undefined }, interval: '60s' }}
+      ${{ annotation: { step: null } }}      | ${{ annotation: { step: null }, interval: '60s' }}
+      ${{ annotation: { step: '' } }}        | ${{ annotation: { step: '' }, interval: '60s' }}
+      ${{ annotation: { step: 0 } }}         | ${{ annotation: { step: 0 }, interval: '60s' }}
+      ${{ annotation: { step: 5 } }}         | ${{ annotation: { step: 5 }, interval: '60s' }}
+      ${{ annotation: { step: '5m' } }}      | ${{ annotation: { step: '5m' }, interval: '5m' }}
+    `("when called with options: '$options'", ({ options, expected }) => {
+      expect(ds.createAnnotationQueryOptions(options)).toEqual(expected);
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/module.test.ts
+++ b/public/app/plugins/datasource/prometheus/module.test.ts
@@ -1,8 +1,14 @@
 import { plugin as PrometheusDatasourcePlugin } from './module';
+import { ANNOTATION_QUERY_STEP_DEFAULT } from './datasource';
 
 describe('module', () => {
   it('should have metrics query field in panels and Explore', () => {
     expect(PrometheusDatasourcePlugin.components.ExploreMetricsQueryField).toBeDefined();
     expect(PrometheusDatasourcePlugin.components.QueryEditor).toBeDefined();
+  });
+  it('should have stepDefaultValuePlaceholder set in annotations ctrl', () => {
+    expect(PrometheusDatasourcePlugin.components.AnnotationsQueryCtrl).toBeDefined();
+    const annotationsCtrl = new PrometheusDatasourcePlugin.components.AnnotationsQueryCtrl();
+    expect(annotationsCtrl.stepDefaultValuePlaceholder).toEqual(ANNOTATION_QUERY_STEP_DEFAULT);
   });
 });

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -1,5 +1,5 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { PrometheusDatasource } from './datasource';
+import { ANNOTATION_QUERY_STEP_DEFAULT, PrometheusDatasource } from './datasource';
 
 import { PromQueryEditor } from './components/PromQueryEditor';
 import PromCheatSheet from './components/PromCheatSheet';
@@ -9,6 +9,7 @@ import { ConfigEditor } from './configuration/ConfigEditor';
 
 class PrometheusAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
+  stepDefaultValuePlaceholder = ANNOTATION_QUERY_STEP_DEFAULT;
 }
 
 export const plugin = new DataSourcePlugin(PrometheusDatasource)

--- a/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/prometheus/partials/annotations.editor.html
@@ -5,7 +5,7 @@
 	</div>
 	<div class="gf-form">
 		<span class="gf-form-label width-10">step</span>
-		<input type="text" class="gf-form-input max-width-6" ng-model='ctrl.annotation.step' placeholder="60s"></input>
+		<input type="text" class="gf-form-input max-width-6" ng-model='ctrl.annotation.step' placeholder="{{::ctrl.stepDefaultValuePlaceholder}}"></input>
 	</div>
 </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced during a refactor here #20536. 
When the step is removed in the Annotation Editor the `annotation.step` is an empty string `''`. The original code `annotation.step || '60s'` handled this but in the refactor we use destructuring with a default value `, step = '60s' } = annotation` which only applies if `step` is `null` or `undefined`.

This PR adds a method to handle this case and make it easier to test. PR also adds a constant used in both Angular view code and in datasource.
 
**Which issue(s) this PR fixes**:
Closes #21914

**Special notes for your reviewer**:

