### PR TITLE
Elasticsearch: Fix auto interval for date histogram in explore logs mode

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -430,7 +430,7 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
       minInterval,
       // This is used for logs streaming for buffer size, with undefined it falls back to datasource config if it
       // supports that.
-      maxDataPoints: mode === ExploreMode.Logs ? undefined : containerWidth,
+      maxDataPoints: mode === ExploreMode.Logs && datasourceInstance.name === 'Loki' ? undefined : containerWidth,
       liveStreaming: live,
       showingGraph,
       showingTable,

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -431,7 +431,7 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
       // maxDataPoints is used in:
       // Loki - used for logs streaming for buffer size, with undefined it falls back to datasource config if it supports that.
       // Elastic - limits the number of datapoints for the counts query and for logs it has hardcoded limit.
-      // Influx - used to correctly display logs ingraph
+      // Influx - used to correctly display logs in graph
       maxDataPoints: mode === ExploreMode.Logs && datasourceInstance.name === 'Loki' ? undefined : containerWidth,
       liveStreaming: live,
       showingGraph,

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -428,8 +428,10 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
 
     const queryOptions: QueryOptions = {
       minInterval,
-      // This is used for logs streaming for buffer size, with undefined it falls back to datasource config if it
-      // supports that.
+      // maxDataPoints is used in:
+      // Loki - used for logs streaming for buffer size, with undefined it falls back to datasource config if it supports that.
+      // Elastic - limits the number of datapoints for the counts query and for logs it has hardcoded limit.
+      // Influx - used to correctly display logs ingraph
       maxDataPoints: mode === ExploreMode.Logs && datasourceInstance.name === 'Loki' ? undefined : containerWidth,
       liveStreaming: live,
       showingGraph,


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit the number of datapoints for the counts query to container width.

**Which issue(s) this PR fixes**:
Fixes #21285