### PR TITLE
Dashboard edit: Fix 404 when making dashboard editable

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
+++ b/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
@@ -12,6 +12,7 @@ import { CoreEvents } from 'app/types';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { AppEvents } from '@grafana/data';
 import { promiseToDigest } from '../../../../core/utils/promiseToDigest';
+import locationUtil from 'app/core/utils/location_util';
 
 export class SettingsCtrl {
   dashboard: DashboardModel;
@@ -184,7 +185,7 @@ export class SettingsCtrl {
     this.buildSectionList();
 
     const currentSection: any = _.find(this.sections, { id: this.viewId } as any);
-    this.$location.url(currentSection.url);
+    this.$location.url(locationUtil.stripBaseFromUrl(currentSection.url));
   }
 
   deleteDashboard() {


### PR DESCRIPTION
Reopened #21935 as CLA failed reporting status

Fixes #21910

Not sure what is the underlying issue. I have suspected $q -> Promise migration and some digest problems, but it's not it. I have noticed that in the previous versions the 404 was shown too, but only for a short time and then the redirect was correct. As a fix for the 404 the redirect url when making the dashboard editable is now updated to have the base url stripped what results in a correct redirect.

@alexanderzobnin I see you have been working on this #10236 some time ago. Would you mind reviewing and checking if this doesn't introduce any flow changes?