### PR TITLE
Prometheus: Do not show rate hint when increase function is used in query

### DIFF
--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -75,6 +75,19 @@ describe('getQueryHints()', () => {
     expect(hints).toEqual(null);
   });
 
+  it('returns no rate hint for a counter metric that already has an increase', () => {
+    const series = [
+      {
+        datapoints: [
+          [23, 1000],
+          [24, 1001],
+        ],
+      },
+    ];
+    const hints = getQueryHints('increase(metric_total[1m])', series);
+    expect(hints).toEqual(null);
+  });
+
   it('returns a rate hint w/o action for a complex counter metric', () => {
     const series = [
       {

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -28,7 +28,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
   }
 
   // Check for need of rate()
-  if (query.indexOf('rate(') === -1) {
+  if (query.indexOf('rate(') === -1 && query.indexOf('increase(') === -1) {
     // Use metric metadata for exact types
     const nameMatch = query.match(/\b(\w+_(total|sum|count))\b/);
     let counterNameMetric = nameMatch ? nameMatch[1] : '';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
minor bug fix. rate hint shows up when increase (syntax sugar for rate) is already applied

**Which issue(s) this PR fixes**:
Closes #21938

**Special notes for your reviewer**:

