### PR TITLE
@grafana/ui: Fix displaying of bars in React Graph

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -319,7 +319,7 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
           // Dividig the width by 1.5 to make the bars not touch each other
           barWidth: showBars ? this.getBarWidth() / 1.5 : 1,
           zero: false,
-          lineWidth: 0,
+          lineWidth: lineWidth,
         },
         shadowSize: 0,
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the https://github.com/grafana/grafana/pull/21922 as it introduces a bug where  Loki and Influx log metrics are not displayed in graph.

**Which issue(s) this PR fixes**:

Fixes bug introduced in https://github.com/grafana/grafana/pull/21922


