### PR TITLE
Dashboard link rendering

### DIFF
--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -1,5 +1,6 @@
 import angular, { ILocationService } from 'angular';
 import _ from 'lodash';
+import config from 'app/core/config';
 import { iconMap } from './DashLinksEditorCtrl';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -146,7 +147,7 @@ export class DashLinksContainerCtrl {
       if (linkDef.type === 'rendering') {
         return Promise.resolve([
           {
-            url: '/render' + $location.path(),
+            url: config.appSubUrl + '/render' + $location.path(),
             urlParams: linkDef.urlParams,
             title: linkDef.title,
             // @ts-ignore

--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -146,7 +146,7 @@ export class DashLinksContainerCtrl {
       if (linkDef.type === 'rendering') {
         return Promise.resolve([
           {
-            url: '/render' + $location.url(),
+            url: '/render' + $location.path(),
             urlParams: linkDef.urlParams,
             title: linkDef.title,
             // @ts-ignore

--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -1,4 +1,4 @@
-import angular from 'angular';
+import angular, { ILocationService } from 'angular';
 import _ from 'lodash';
 import { iconMap } from './DashLinksEditorCtrl';
 import { LinkSrv } from 'app/features/panel/panellinks/link_srv';
@@ -95,7 +95,13 @@ function dashLink($compile: any, $sanitize: any, linkSrv: LinkSrv) {
 
 export class DashLinksContainerCtrl {
   /** @ngInject */
-  constructor($scope: any, $rootScope: GrafanaRootScope, dashboardSrv: DashboardSrv, linkSrv: LinkSrv) {
+  constructor(
+    $scope: any,
+    $rootScope: GrafanaRootScope,
+    $location: ILocationService,
+    dashboardSrv: DashboardSrv,
+    linkSrv: LinkSrv
+  ) {
     const currentDashId = dashboardSrv.getCurrent().id;
 
     function buildLinks(linkDef: any) {
@@ -126,6 +132,22 @@ export class DashLinksContainerCtrl {
         return Promise.resolve([
           {
             url: linkDef.url,
+            title: linkDef.title,
+            // @ts-ignore
+            icon: iconMap[linkDef.icon],
+            tooltip: linkDef.tooltip,
+            target: linkDef.targetBlank ? '_blank' : '_self',
+            keepTime: linkDef.keepTime,
+            includeVars: linkDef.includeVars,
+          },
+        ]);
+      }
+
+      if (linkDef.type === 'rendering') {
+        return Promise.resolve([
+          {
+            url: '/render' + $location.url(),
+            urlParams: linkDef.urlParams,
             title: linkDef.title,
             // @ts-ignore
             icon: iconMap[linkDef.icon],

--- a/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksContainerCtrl.ts
@@ -9,6 +9,7 @@ import { PanelEvents } from '@grafana/data';
 import { CoreEvents } from 'app/types';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { promiseToDigest } from '../../../../core/utils/promiseToDigest';
+import { toUrlParams } from '../../../../core/utils/url';
 
 export type DashboardLink = { tags: any; target: string; keepTime: any; includeVars: any };
 
@@ -145,9 +146,15 @@ export class DashLinksContainerCtrl {
       }
 
       if (linkDef.type === 'rendering') {
+        const urlParams = {
+          encoding: linkDef.encoding ? linkDef.encoding : 'png',
+          width: linkDef.width ? linkDef.width : 1000,
+          height: linkDef.height ? linkDef.height : 500,
+        };
+
         return Promise.resolve([
           {
-            url: config.appSubUrl + '/render' + $location.path(),
+            url: config.appSubUrl + '/render' + $location.path() + '?' + toUrlParams(urlParams),
             urlParams: linkDef.urlParams,
             title: linkDef.title,
             // @ts-ignore

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -80,7 +80,7 @@
           <select
             class="gf-form-input"
             ng-model="ctrl.link.type"
-            ng-options="f for f in ['dashboards','link']"
+            ng-options="f for f in ['dashboards','link','rendering']"
           ></select>
         </div>
       </div>
@@ -112,7 +112,15 @@
           <li class="gf-form-label width-8">Url</li>
           <input type="text" ng-model="ctrl.link.url" class="gf-form-input width-20" ng-model-onblur />
         </div>
+      </div>
+      <div ng-show="ctrl.link.type === 'rendering'">
+        <div class="gf-form">
+          <li class="gf-form-label width-8">Url parameters</li>
+          <input type="text" ng-model="ctrl.link.urlParams" class="gf-form-input width-20" ng-model-onblur />
+        </div>
+      </div>
 
+      <div ng-show="ctrl.link.type === 'link' || ctrl.link.type === 'rendering'">
         <div class="gf-form">
           <span class="gf-form-label width-8">Title</span>
           <input type="text" ng-model="ctrl.link.title" class="gf-form-input width-20" ng-model-onblur />

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -115,6 +115,18 @@
       </div>
       <div ng-show="ctrl.link.type === 'rendering'">
         <div class="gf-form">
+          <li class="gf-form-label width-8">Encoding</li>
+          <input type="text" ng-model="ctrl.link.encoding" class="gf-form-input width-20" placeholder="png if not specified" ng-model-onblur />
+        </div>
+        <div class="gf-form">
+          <li class="gf-form-label width-8">Width</li>
+          <input type="number" ng-model="ctrl.link.width" class="gf-form-input width-20" ng-model-onblur />
+        </div>
+        <div class="gf-form">
+          <li class="gf-form-label width-8">Height</li>
+          <input type="number" ng-model="ctrl.link.height" class="gf-form-input width-20" ng-model-onblur />
+        </div>
+        <div class="gf-form">
           <li class="gf-form-label width-8">Url parameters</li>
           <input type="text" ng-model="ctrl.link.urlParams" class="gf-form-input width-20" ng-model-onblur />
         </div>

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -229,7 +229,13 @@ export class LinkSrv implements LinkService {
       this.templateSrv.fillVariableValuesForUrl(params);
     }
 
-    return appendQueryToUrl(url, toUrlParams(params));
+    let res = appendQueryToUrl(url, toUrlParams(params));
+
+    if (link.urlParams) {
+      res = appendQueryToUrl(res, link.urlParams);
+    }
+
+    return res;
   }
 
   getAnchorInfo(link: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new type of dashboard links: rendering links. This allows to create a link to get a PNG rendering of the full dashboard.

**Which issue(s) this PR fixes**:
This is an implementation of feature request #21556.
