### PR TITLE
Docs: Added release notes tag

### DIFF
--- a/docs/sources/guides/whats-new-in-v2-1.md
+++ b/docs/sources/guides/whats-new-in-v2-1.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v2.1"
+title = "What's new in Grafana v2.1"
 description = "Feature and improvement highlights for Grafana v2.1"
-keywords = ["grafana", "new", "documentation", "2.1"]
+keywords = ["grafana", "new", "documentation", "2.1", "release notes"]
 type = "docs"
 +++
 

--- a/docs/sources/guides/whats-new-in-v2-5.md
+++ b/docs/sources/guides/whats-new-in-v2-5.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v2.5"
+title = "What's new in Grafana v2.5"
 description = "Feature and improvement highlights for Grafana v2.5"
-keywords = ["grafana", "new", "documentation", "2.5"]
+keywords = ["grafana", "new", "documentation", "2.5", "release notes"]
 type = "docs"
 +++
 
@@ -103,4 +103,3 @@ view the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG
 - - -
 
 ### <a href="https://grafana.com/get">Download Grafana 2.5 now</a>
-

--- a/docs/sources/guides/whats-new-in-v2-6.md
+++ b/docs/sources/guides/whats-new-in-v2-6.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v2.6"
+title = "What's new in Grafana v2.6"
 description = "Feature and improvement highlights for Grafana v2.6"
-keywords = ["grafana", "new", "documentation", "2.6"]
+keywords = ["grafana", "new", "documentation", "2.6", "release notes"]
 type = "docs"
 +++
 
@@ -122,4 +122,3 @@ view the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG
 - - -
 
 <a href="http://grafana.org/download">Download Grafana 2.6 now</a>
-

--- a/docs/sources/guides/whats-new-in-v2.md
+++ b/docs/sources/guides/whats-new-in-v2.md
@@ -1,11 +1,11 @@
 +++
-title = "What's New in Grafana v2.0"
+title = "What's new in Grafana v2.0"
 description = "Feature and improvement highlights for Grafana v2.0"
-keywords = ["grafana", "new", "documentation", "2.0"]
+keywords = ["grafana", "new", "documentation", "2.0", "release notes"]
 type = "docs"
 +++
 
-# What's New in Grafana v2.0
+# What's new in Grafana v2.0
 
 Grafana 2.0 represents months of work by the Grafana team and the community. We are pleased to be able to
 release the Grafana 2.0 beta. This is a guide that describes some of changes and new features that can
@@ -173,5 +173,3 @@ Grafana now supports server-side PNG rendering. From the Panel share dialog you 
 > **Note** This requires that your Data Source is accessible from your Grafana instance.
 
 ![](/img/docs/v2/share_dialog_image_highlight.jpg)
-
-

--- a/docs/sources/guides/whats-new-in-v3-1.md
+++ b/docs/sources/guides/whats-new-in-v3-1.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v3.1"
+title = "What's new in Grafana v3.1"
 description = "Feature and improvement highlights for Grafana v3.1"
-keywords = ["grafana", "new", "documentation", "3.1"]
+keywords = ["grafana", "new", "documentation", "3.1", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 3.1"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = 5
 +++
 
-# What's New in Grafana v3.1
+# What's new in Grafana v3.1
 
 ## Dashboard Export and Import
 
@@ -59,6 +59,4 @@ Switched logging framework to log15 to enable key value per logging and filterin
 
 ## CHANGELOG
 
-For a detailed list and link to github issues for everything included
-in the 3.1 release please view the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
-file.
+For a detailed list and link to github issues for everything included in the 3.1 release please view the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md) file.

--- a/docs/sources/guides/whats-new-in-v3.md
+++ b/docs/sources/guides/whats-new-in-v3.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v3.0"
+title = "What's new in Grafana v3.0"
 description = "Feature and improvement highlights for Grafana v3.0"
-keywords = ["grafana", "new", "documentation", "3.0"]
+keywords = ["grafana", "new", "documentation", "3.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 3.0"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = 6
 +++
 
-# What's New in Grafana v3.0
+# What's new in Grafana v3.0
 
 ## Commercial Support
 
@@ -64,7 +64,6 @@ perform Dashboard backups, and more.
 Grafana.net will officially launch along with the stable version of
 Grafana 3.0, but go to <a href=https://grafana.com> and check out the preview
 and sign up for an account</a> in the meantime.
-
 
 ## grafana-cli
 
@@ -225,5 +224,4 @@ Check out the full list of plugins on [Grafana.com](https://grafana.com/plugins)
 
 For a detailed list and link to github issues for everything included
 in the 3.0 release please view the
-[CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
-file.
+[CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md) file.

--- a/docs/sources/guides/whats-new-in-v4-1.md
+++ b/docs/sources/guides/whats-new-in-v4-1.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.1"
+title = "What's new in Grafana v4.1"
 description = "Feature and improvement highlights for Grafana v4.1"
-keywords = ["grafana", "new", "documentation", "4.1.0"]
+keywords = ["grafana", "new", "documentation", "4.1.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.1"
@@ -9,7 +9,6 @@ identifier = "v4.1"
 parent = "whatsnew"
 weight = 3
 +++
-
 
 ## What's new in Grafana v4.1
 - **Graph**: Support for shared tooltip on all graphs as you hover over one graph. [#1578](https://github.com/grafana/grafana/pull/1578), [#6274](https://github.com/grafana/grafana/pull/6274)
@@ -41,7 +40,6 @@ You can set a help text in the general tab on any panel. The help text is using 
 
 Panels with a help text available have a little indicator in the top left corner. You can show the help text by hovering the icon.
 <div class="clearfix"></div>
-
 
 ### Easier Cloudwatch configuration
 

--- a/docs/sources/guides/whats-new-in-v4-2.md
+++ b/docs/sources/guides/whats-new-in-v4-2.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.2"
+title = "What's new in Grafana v4.2"
 description = "Feature and improvement highlights for Grafana v4.2"
-keywords = ["grafana", "new", "documentation", "4.2.0"]
+keywords = ["grafana", "new", "documentation", "4.2.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.2"

--- a/docs/sources/guides/whats-new-in-v4-3.md
+++ b/docs/sources/guides/whats-new-in-v4-3.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.3"
+title = "What's new in Grafana v4.3"
 description = "Feature and improvement highlights for Grafana v4.3"
-keywords = ["grafana", "new", "documentation", "4.3.0"]
+keywords = ["grafana", "new", "documentation", "4.3.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.3"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -2
 +++
 
-## What's New in Grafana v4.3
+## What's new in Grafana v4.3
 
 Grafana v4.3 Beta is now [available for download](https://grafana.com/grafana/download/4.3.0-beta1).
 
@@ -102,4 +102,3 @@ Head to the [v4.3 download page](https://grafana.com/grafana/download) for downl
 ## Thanks
 
 A big thanks to all the Grafana users who contribute by submitting PRs, bug reports, helping out on our [community site](https://community.grafana.com/) and providing feedback!
-

--- a/docs/sources/guides/whats-new-in-v4-4.md
+++ b/docs/sources/guides/whats-new-in-v4-4.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.4"
+title = "What's new in Grafana v4.4"
 description = "Feature and improvement highlights for Grafana v4.4"
-keywords = ["grafana", "new", "documentation", "4.4.0"]
+keywords = ["grafana", "new", "documentation", "4.4.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.4"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -3
 +++
 
-## What's New in Grafana v4.4
+## What's new in Grafana v4.4
 
 Grafana v4.4 is now [available for download](https://grafana.com/grafana/download/4.4.0).
 
@@ -47,4 +47,3 @@ Head to the [v4.4 download page](https://grafana.com/grafana/download) for downl
 ## Thanks
 
 A big thanks to all the Grafana users who contribute by submitting PRs, bug reports, helping out on our [community site](https://community.grafana.com/) and providing feedback!
-

--- a/docs/sources/guides/whats-new-in-v4-5.md
+++ b/docs/sources/guides/whats-new-in-v4-5.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.5"
+title = "What's new in Grafana v4.5"
 description = "Feature and improvement highlights for Grafana v4.5"
-keywords = ["grafana", "new", "documentation", "4.5"]
+keywords = ["grafana", "new", "documentation", "4.5", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.5"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -4
 +++
 
-# What's New in Grafana v4.5
+# What's new in Grafana v4.5
 
 ## Highlights
 
@@ -68,4 +68,3 @@ Data source selection and options and help are now above your metric queries.
 
 * **Modals**: Maintain scroll position after opening/leaving modal [#8800](https://github.com/grafana/grafana/issues/8800)
 * **Templating**: You cannot select data source variables as data source for other template variables [#7510](https://github.com/grafana/grafana/issues/7510)
-

--- a/docs/sources/guides/whats-new-in-v4-6.md
+++ b/docs/sources/guides/whats-new-in-v4-6.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.6"
+title = "What's new in Grafana v4.6"
 description = "Feature and improvement highlights for Grafana v4.6"
-keywords = ["grafana", "new", "documentation", "4.6"]
+keywords = ["grafana", "new", "documentation", "4.6", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.6"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -5
 +++
 
-# What's New in Grafana v4.6
+# What's new in Grafana v4.6
 
 Grafana v4.6 brings many enhancements to Annotations, Cloudwatch and Prometheus. It also adds support for Postgres as metric and table data source!
 
@@ -72,4 +72,3 @@ This makes exploring and filtering Prometheus data much easier.
 
 ### Tech
 * **Go**: Grafana is now built using golang 1.9
-

--- a/docs/sources/guides/whats-new-in-v4.md
+++ b/docs/sources/guides/whats-new-in-v4.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v4.0"
+title = "What's new in Grafana v4.0"
 description = "Feature and improvement highlights for Grafana v4.0"
-keywords = ["grafana", "new", "documentation", "4.0"]
+keywords = ["grafana", "new", "documentation", "4.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 4.0"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = 4
 +++
 
-# What's New in Grafana v4.0
+# What's new in Grafana v4.0
 
 As usual this release contains a ton of minor new features, fixes and improved UX. But on top of the usual new goodies
 is a core new feature: Alerting! Read on below for a detailed description of what's new in v4.0.
@@ -92,7 +92,6 @@ dynamically add filters to any log property!
 We always try to bring some UX/UI refinements and polish in every release.
 
 ### TV-mode and Kiosk mode
-
 
 <div class="row">
   <div class="medium-6 columns">
@@ -177,4 +176,3 @@ You can update plugins using grafana-cli
 
 Check out the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md) file for a complete list
 of new features, changes, and bug fixes.
-

--- a/docs/sources/guides/whats-new-in-v5-1.md
+++ b/docs/sources/guides/whats-new-in-v5-1.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v5.1"
+title = "What's new in Grafana v5.1"
 description = "Feature and improvement highlights for Grafana v5.1"
-keywords = ["grafana", "new", "documentation", "5.1"]
+keywords = ["grafana", "new", "documentation", "5.1", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 5.1"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -7
 +++
 
-# What's New in Grafana v5.1
+# What's new in Grafana v5.1
 
 Grafana v5.1 brings new features, many enhancements and bug fixes. This article will detail the major new features and enhancements.
 
@@ -29,7 +29,7 @@ the native scrolling functionality. Grafana v5.1 ships with a native scrollbar f
 the dashboard grid and panels that's not overriding the native scrolling functionality. We hope that these changes and improvements should
 make the Grafana user experience much better!
 
-## Improved docker image (breaking change)
+## Improved Docker image (breaking change)
 
 Grafana v5.1 brings an improved official docker image which should make it easier to run and use the Grafana docker image and at the same time give more control to the user how to use/run it.
 

--- a/docs/sources/guides/whats-new-in-v5-2.md
+++ b/docs/sources/guides/whats-new-in-v5-2.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v5.2"
+title = "What's new in Grafana v5.2"
 description = "Feature and improvement highlights for Grafana v5.2"
-keywords = ["grafana", "new", "documentation", "5.2"]
+keywords = ["grafana", "new", "documentation", "5.2", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 5.2"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -8
 +++
 
-# What's New in Grafana v5.2
+# What's new in Grafana v5.2
 
 Grafana v5.2 brings new features, many enhancements and bug fixes. This article will detail the major new features and enhancements.
 

--- a/docs/sources/guides/whats-new-in-v5-3.md
+++ b/docs/sources/guides/whats-new-in-v5-3.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v5.3"
+title = "What's new in Grafana v5.3"
 description = "Feature and improvement highlights for Grafana v5.3"
-keywords = ["grafana", "new", "documentation", "5.3"]
+keywords = ["grafana", "new", "documentation", "5.3", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 5.3"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -9
 +++
 
-# What's New in Grafana v5.3
+# What's new in Grafana v5.3
 
 Grafana v5.3 brings new features, many enhancements and bug fixes. This article will detail the major new features and enhancements.
 

--- a/docs/sources/guides/whats-new-in-v5-4.md
+++ b/docs/sources/guides/whats-new-in-v5-4.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v5.4"
+title = "What's new in Grafana v5.4"
 description = "Feature and improvement highlights for Grafana v5.4"
-keywords = ["grafana", "new", "documentation", "5.4"]
+keywords = ["grafana", "new", "documentation", "5.4", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 5.4"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -10
 +++
 
-# What's New in Grafana v5.4
+# What's new in Grafana v5.4
 
 Grafana v5.4 brings new features, many enhancements and bug fixes. This article will detail the major new features and enhancements.
 

--- a/docs/sources/guides/whats-new-in-v5.md
+++ b/docs/sources/guides/whats-new-in-v5.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v5.0"
+title = "What's new in Grafana v5.0"
 description = "Feature and improvement highlights for Grafana v5.0"
-keywords = ["grafana", "new", "documentation", "5.0"]
+keywords = ["grafana", "new", "documentation", "5.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 5.0"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -6
 +++
 
-# What's New in Grafana v5.0
+# What's new in Grafana v5.0
 
 This is the most substantial update that Grafana has ever seen. This article will detail the major new features and enhancements.
 
@@ -148,5 +148,3 @@ much easier to manage, collaborate and navigate between dashboards.
 ### API changes
 New uid-based routes in the dashboard API have been introduced to retrieve and delete dashboards.
 The corresponding slug-based routes have been deprecated and will be removed in a future release.
-
-

--- a/docs/sources/guides/whats-new-in-v6-0.md
+++ b/docs/sources/guides/whats-new-in-v6-0.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.0"
+title = "What's new in Grafana v6.0"
 description = "Feature and improvement highlights for Grafana v6.0"
-keywords = ["grafana", "new", "documentation", "6.0"]
+keywords = ["grafana", "new", "documentation", "6.0", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.0"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -11
 +++
 
-# What's New in Grafana v6.0
+# What's new in Grafana v6.0
 
 This update to Grafana introduces a new way of exploring your data, support for log data, and tons of other features.
 

--- a/docs/sources/guides/whats-new-in-v6-1.md
+++ b/docs/sources/guides/whats-new-in-v6-1.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.1"
+title = "What's new in Grafana v6.1"
 description = "Feature and improvement highlights for Grafana v6.1"
-keywords = ["grafana", "new", "documentation", "6.1"]
+keywords = ["grafana", "new", "documentation", "6.1", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.1"
@@ -10,7 +10,7 @@ parent = "whatsnew"
 weight = -12
 +++
 
-# What's New in Grafana v6.1
+# What's new in Grafana v6.1
 
 ## Highlights
 

--- a/docs/sources/guides/whats-new-in-v6-2.md
+++ b/docs/sources/guides/whats-new-in-v6-2.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.2"
+title = "What's new in Grafana v6.2"
 description = "Feature and improvement highlights for Grafana v6.2"
-keywords = ["grafana", "new", "documentation", "6.2"]
+keywords = ["grafana", "new", "documentation", "6.2", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.2"
@@ -10,9 +10,9 @@ parent = "whatsnew"
 weight = -13
 +++
 
-# What's New in Grafana v6.2
+# What's new in Grafana v6.2
 
-For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
+For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 If you use a password for your data sources please read the [upgrade notes](/installation/upgrading/#upgrading-to-v6-2).
 

--- a/docs/sources/guides/whats-new-in-v6-3.md
+++ b/docs/sources/guides/whats-new-in-v6-3.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.3"
+title = "What's new in Grafana v6.3"
 description = "Feature and improvement highlights for Grafana v6.3"
-keywords = ["grafana", "new", "documentation", "6.3"]
+keywords = ["grafana", "new", "documentation", "6.3", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.3"
@@ -10,9 +10,9 @@ parent = "whatsnew"
 weight = -14
 +++
 
-# What's New in Grafana v6.3
+# What's new in Grafana v6.3
 
-For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
+For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 ## Highlights
 
@@ -124,7 +124,7 @@ wait for the user to logout or the session to expire for the Grafana permissions
 With active sync the user would be automatically removed from the corresponding team in Grafana or even logged out and disabled if no longer
 belonging to an LDAP group that gives them access to Grafana.
 
-[Read more](/auth/enhanced_ldap/#active-ldap-synchronization)
+[Read more](/auth/enhanced_ldap/#active-ldap-synchronization).
 
 ### SAML Authentication
 
@@ -143,4 +143,4 @@ When setting up OAuth with GitHub it's now possible to sync GitHub teams with Te
 We've added support for enriching the Auth Proxy headers with Teams information, which makes it possible
 to use Team Sync with Auth Proxy.
 
-[See docs](/auth/auth-proxy/#auth-proxy-authentication)
+[See docs](/auth/auth-proxy/#auth-proxy-authentication).

--- a/docs/sources/guides/whats-new-in-v6-4.md
+++ b/docs/sources/guides/whats-new-in-v6-4.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.4"
+title = "What's new in Grafana v6.4"
 description = "Feature and improvement highlights for Grafana v6.4"
-keywords = ["grafana", "new", "documentation", "6.4"]
+keywords = ["grafana", "new", "documentation", "6.4", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.4"
@@ -10,9 +10,9 @@ parent = "whatsnew"
 weight = -15
 +++
 
-# What's New in Grafana v6.4
+# What's new in Grafana v6.4
 
-For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
+For all details please read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 ## Highlights
 
@@ -109,9 +109,9 @@ You can read more about the grafana-toolkit [in the Readme](https://github.com/g
 
 Please consider migrating from PhantomJS to the [Grafana Image Renderer plugin](https://grafana.com/grafana/plugins/grafana-image-renderer).
 
-## Alpine based docker image
+## Alpine-based Docker image
 
-Grafana’s docker image is now based on Alpine 3.10 and should from now on report zero vulnerabilities when scanning the image for security vulnerabilities.
+Grafana’s Docker image is now based on Alpine 3.10 and should from now on report zero vulnerabilities when scanning the image for security vulnerabilities.
 
 ## LDAP Debug UI
 
@@ -137,7 +137,7 @@ This feature is currently limited to Organization Admins.
 
 GitLab OAuth gets support for Team Sync, making it possible to synchronize your GitLab Groups with Teams in Grafana.
 
-[Read more about Team Sync](https://grafana.com/docs/auth/team-sync/)
+[Read more about Team Sync](https://grafana.com/docs/auth/team-sync/).
 
 ## Upgrading
 
@@ -146,4 +146,3 @@ See [upgrade notes](/installation/upgrading/#upgrading-to-v6-4).
 ## Changelog
 
 Check out the [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md) file for a complete list of new features, changes, and bug fixes.
-

--- a/docs/sources/guides/whats-new-in-v6-5.md
+++ b/docs/sources/guides/whats-new-in-v6-5.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.5"
+title = "What's new in Grafana v6.5"
 description = "Feature and improvement highlights for Grafana v6.5"
-keywords = ["grafana", "new", "documentation", "6.5"]
+keywords = ["grafana", "new", "documentation", "6.5", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.5"
@@ -10,9 +10,9 @@ parent = "whatsnew"
 weight = -16
 +++
 
-# What's New in Grafana v6.5
+# What's new in Grafana v6.5
 
-For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
+For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 ## Highlights
 

--- a/docs/sources/guides/whats-new-in-v6-6.md
+++ b/docs/sources/guides/whats-new-in-v6-6.md
@@ -1,7 +1,7 @@
 +++
-title = "What's New in Grafana v6.6"
+title = "What's new in Grafana v6.6"
 description = "Feature and improvement highlights for Grafana v6.6"
-keywords = ["grafana", "new", "documentation", "6.6"]
+keywords = ["grafana", "new", "documentation", "6.6", "release notes"]
 type = "docs"
 [menu.docs]
 name = "Version 6.6"
@@ -10,9 +10,9 @@ parent = "whatsnew"
 weight = -16
 +++
 
-# What's New in Grafana v6.6
+# What's new in Grafana v6.6
 
-For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md)
+For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 ## Highlights
 
@@ -218,4 +218,3 @@ backendSrv.get(‘http://your.url/api’).then(result => {
     this.$scope.$digest();
 });
 ```
-


### PR DESCRIPTION
**What this PR does / why we need it**: Adds the `release notes` tag to all the release notes that currently exist in the documentation. Also fixed some minor format issues, mostly capitalization.

Hopefully this will improve the searchability of the release notes. Currently, if you Google "Grafana release notes," you get almost nothing useful. This is a low-effort, simple attempt to improve that situation.

