### PR TITLE
Chore: export arrow dataframe utilities

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
@@ -112,7 +112,13 @@ function toArrowVector(field: Field): ArrowVector {
 }
 
 export function grafanaDataFrameToArrowTable(data: DataFrame): Table {
-  const table = Table.new(
+  // Return the original table
+  let table = (data as any).table;
+  if (table instanceof Table) {
+    return table as Table;
+  }
+
+  table = Table.new(
     data.fields.map(field => {
       const column = Column.new(field.name, toArrowVector(field));
       if (field.labels) {

--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -4,6 +4,4 @@ export * from './CircularDataFrame';
 export * from './MutableDataFrame';
 export * from './processDataFrame';
 export * from './dimensions';
-
-// Phantom JS :(
-//export * from './ArrowDataFrame';
+export * from './ArrowDataFrame';


### PR DESCRIPTION
Previously we had trouble with exporting arrow and that clobbering phantomJS imports.

This PR tries again... this time with with the ES6-ES5 rewrite