### PR TITLE
Image Rendering: Store render key in remote cache to enable renderer to callback to public/load balancer URL when running in HA mode

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -143,7 +143,7 @@ func setupScenarioContext(url string) *scenarioContext {
 		Delims:    macaron.Delims{Left: "[[", Right: "]]"},
 	}))
 
-	sc.m.Use(middleware.GetContextHandler(nil, nil))
+	sc.m.Use(middleware.GetContextHandler(nil, nil, nil))
 
 	return sc
 }

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -316,6 +316,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m.Use(middleware.GetContextHandler(
 		hs.AuthTokenService,
 		hs.RemoteCacheService,
+		hs.RenderService,
 	))
 	m.Use(middleware.OrgRedirect())
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -38,6 +39,7 @@ var (
 func GetContextHandler(
 	ats models.UserTokenService,
 	remoteCache *remotecache.RemoteCache,
+	renderService rendering.Service,
 ) macaron.Handler {
 	return func(c *macaron.Context) {
 		ctx := &models.ReqContext{
@@ -61,7 +63,7 @@ func GetContextHandler(
 		// then look for api key in session (special case for render calls via api)
 		// then test if anonymous access is enabled
 		switch {
-		case initContextWithRenderAuth(ctx):
+		case initContextWithRenderAuth(ctx, renderService):
 		case initContextWithApiKey(ctx):
 		case initContextWithBasicAuth(ctx, orgId):
 		case initContextWithAuthProxy(remoteCache, ctx, orgId):

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -553,7 +553,7 @@ func middlewareScenario(t *testing.T, desc string, fn scenarioFunc) {
 		sc.userAuthTokenService = auth.NewFakeUserAuthTokenService()
 		sc.remoteCacheService = remotecache.NewFakeStore(t)
 
-		sc.m.Use(GetContextHandler(sc.userAuthTokenService, sc.remoteCacheService))
+		sc.m.Use(GetContextHandler(sc.userAuthTokenService, sc.remoteCacheService, nil))
 
 		sc.m.Use(OrgRedirect())
 

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -68,7 +68,7 @@ func recoveryScenario(t *testing.T, desc string, url string, fn scenarioFunc) {
 		sc.userAuthTokenService = auth.NewFakeUserAuthTokenService()
 		sc.remoteCacheService = remotecache.NewFakeStore(t)
 
-		sc.m.Use(GetContextHandler(sc.userAuthTokenService, sc.remoteCacheService))
+		sc.m.Use(GetContextHandler(sc.userAuthTokenService, sc.remoteCacheService, nil))
 		// mock out gc goroutine
 		sc.m.Use(OrgRedirect())
 

--- a/pkg/middleware/render_auth.go
+++ b/pkg/middleware/render_auth.go
@@ -1,59 +1,32 @@
 package middleware
 
 import (
-	"sync"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/rendering"
+
 	m "github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/util"
 )
 
-var renderKeysLock sync.Mutex
-var renderKeys map[string]*m.SignedInUser = make(map[string]*m.SignedInUser)
-
-func initContextWithRenderAuth(ctx *m.ReqContext) bool {
+func initContextWithRenderAuth(ctx *m.ReqContext, renderService rendering.Service) bool {
 	key := ctx.GetCookie("renderKey")
 	if key == "" {
 		return false
 	}
 
-	renderKeysLock.Lock()
-	defer renderKeysLock.Unlock()
-
-	renderUser, exists := renderKeys[key]
+	renderUser, exists := renderService.GetRenderUser(key)
 	if !exists {
 		ctx.JsonApiErr(401, "Invalid Render Key", nil)
 		return true
 	}
 
 	ctx.IsSignedIn = true
-	ctx.SignedInUser = renderUser
+	ctx.SignedInUser = &m.SignedInUser{
+		OrgId:   renderUser.OrgID,
+		UserId:  renderUser.UserID,
+		OrgRole: m.RoleType(renderUser.OrgRole),
+	}
 	ctx.IsRenderCall = true
 	ctx.LastSeenAt = time.Now()
 	return true
-}
-
-func AddRenderAuthKey(orgId int64, userId int64, orgRole m.RoleType) (string, error) {
-	renderKeysLock.Lock()
-	defer renderKeysLock.Unlock()
-
-	key, err := util.GetRandomString(32)
-	if err != nil {
-		return "", err
-	}
-
-	renderKeys[key] = &m.SignedInUser{
-		OrgId:   orgId,
-		OrgRole: orgRole,
-		UserId:  userId,
-	}
-
-	return key, nil
-}
-
-func RemoveRenderAuthKey(key string) {
-	renderKeysLock.Lock()
-	defer renderKeysLock.Unlock()
-
-	delete(renderKeys, key)
 }

--- a/pkg/services/alerting/notifier_test.go
+++ b/pkg/services/alerting/notifier_test.go
@@ -304,6 +304,10 @@ func (s *testRenderService) RenderErrorImage(err error) (*rendering.RenderResult
 	return &rendering.RenderResult{FilePath: "image.png"}, nil
 }
 
+func (s *testRenderService) GetRenderUser(key string) (*rendering.RenderUser, bool) {
+	return nil, false
+}
+
 var _ rendering.Service = &testRenderService{}
 
 type testImageUploader struct {

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -26,18 +26,13 @@ var netClient = &http.Client{
 	Transport: netTransport,
 }
 
-func (rs *RenderingService) renderViaHttp(ctx context.Context, opts Opts) (*RenderResult, error) {
+func (rs *RenderingService) renderViaHttp(ctx context.Context, renderKey string, opts Opts) (*RenderResult, error) {
 	filePath, err := rs.getFilePathForNewImage()
 	if err != nil {
 		return nil, err
 	}
 
 	rendererUrl, err := url.Parse(rs.Cfg.RendererUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	renderKey, err := rs.getRenderKey(opts.OrgId, opts.UserId, opts.OrgRole)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -29,9 +29,10 @@ type RenderResult struct {
 	FilePath string
 }
 
-type renderFunc func(ctx context.Context, options Opts) (*RenderResult, error)
+type renderFunc func(ctx context.Context, renderKey string, options Opts) (*RenderResult, error)
 
 type Service interface {
 	Render(ctx context.Context, opts Opts) (*RenderResult, error)
 	RenderErrorImage(error error) (*RenderResult, error)
+	GetRenderUser(key string) (*RenderUser, bool)
 }

--- a/pkg/services/rendering/phantomjs.go
+++ b/pkg/services/rendering/phantomjs.go
@@ -11,10 +11,9 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/middleware"
 )
 
-func (rs *RenderingService) renderViaPhantomJS(ctx context.Context, opts Opts) (*RenderResult, error) {
+func (rs *RenderingService) renderViaPhantomJS(ctx context.Context, renderKey string, opts Opts) (*RenderResult, error) {
 	var executable = "phantomjs"
 	if runtime.GOOS == "windows" {
 		executable = executable + ".exe"
@@ -32,12 +31,6 @@ func (rs *RenderingService) renderViaPhantomJS(ctx context.Context, opts Opts) (
 	if err != nil {
 		return nil, err
 	}
-
-	renderKey, err := middleware.AddRenderAuthKey(opts.OrgId, opts.UserId, opts.OrgRole)
-	if err != nil {
-		return nil, err
-	}
-	defer middleware.RemoveRenderAuthKey(renderKey)
 
 	phantomDebugArg := "--debug=false"
 	if log.GetLogLevelFor("rendering") >= log.LvlDebug {

--- a/pkg/services/rendering/plugin_mode.go
+++ b/pkg/services/rendering/plugin_mode.go
@@ -12,13 +12,8 @@ func (rs *RenderingService) startPlugin(ctx context.Context) error {
 	return rs.pluginInfo.Start(ctx)
 }
 
-func (rs *RenderingService) renderViaPlugin(ctx context.Context, opts Opts) (*RenderResult, error) {
+func (rs *RenderingService) renderViaPlugin(ctx context.Context, renderKey string, opts Opts) (*RenderResult, error) {
 	pngPath, err := rs.getFilePathForNewImage()
-	if err != nil {
-		return nil, err
-	}
-
-	renderKey, err := rs.getRenderKey(opts.OrgId, opts.UserId, opts.OrgRole)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
By storing render key in remote cache it will enable
image renderer to use public facing url or load
balancer url to render images and thereby remove
the requirement of image renderer having to use the
url of the originating Grafana instance when running
HA setup (multiple Grafana instances).

**Which issue(s) this PR fixes**:
Fixes #17704
Ref https://github.com/grafana/grafana-image-renderer/issues/91

**Special notes for your reviewer**:
- With this, do we want to change the url used by renderer to include the public url?
- Do you see any risks with having database/cache systems write in the render path given alerting?