### PR TITLE
Datasource: Azure Monitor - Fix 401 due to missing authorization header for existing datasources

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -21,7 +21,9 @@ export default class AzureLogAnalyticsDatasource {
     private templateSrv: TemplateSrv
   ) {
     this.id = instanceSettings.id;
-    this.baseUrl = '/loganalyticsazure';
+    this.baseUrl = this.instanceSettings.jsonData.azureLogAnalyticsSameAs
+      ? '/sameasloganalyticsazure'
+      : `/loganalyticsazure`;
     this.url = instanceSettings.url;
     this.defaultOrFirstWorkspace = this.instanceSettings.jsonData.logAnalyticsDefaultWorkspace;
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
@@ -131,6 +131,25 @@
         { "name": "Cache-Control", "content": "public, max-age=60" },
         { "name": "Accept-Encoding", "content": "gzip" }
       ]
+    },
+    {
+      "path": "sameasloganalyticsazure",
+      "method": "GET",
+      "url": "https://api.loganalytics.io/v1/workspaces",
+      "tokenAuth": {
+        "url": "https://login.microsoftonline.com/{{.JsonData.tenantId}}/oauth2/token",
+        "params": {
+          "grant_type": "client_credentials",
+          "client_id": "{{.JsonData.clientId}}",
+          "client_secret": "{{.SecureJsonData.clientSecret}}",
+          "resource": "https://api.loganalytics.io"
+        }
+      },
+      "headers": [
+        { "name": "x-ms-app", "content": "Grafana" },
+        { "name": "Cache-Control", "content": "public, max-age=60" },
+        { "name": "Accept-Encoding", "content": "gzip" }
+      ]
     }
   ],
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes an issue in 6.6.0/6.6.1 where existing Azure Monitor sources that have been configured with provisioning fail to authenticate due to a missing authorization header.

Older datasources still expect the `sameasloganalyticsazure` route. Re adding this allows the correct settings to be retrieved and the authorization header is built as expected.

**Which issue(s) this PR fixes**:
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #21868

**Special notes for your reviewer**:

