### PR TITLE
DevEnv: Simplify Contributions By Automing Setup

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,11 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+ENV NODE_VERSION=v12.15.0
+
+RUN bash -c ". .nvm/nvm.sh \
+             && nvm install ${NODE_VERSION} \
+             && nvm alias default ${NODE_VERSION} \
+             && npm install -g yarn"
+ENV PATH=/home/gitpod/.nvm/versions/node/${NODE_VERSION}/bin:$PATH

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,17 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - name: frontend
+    init: |
+      echo 'app_mode = development' > ./conf/custom.ini &&
+      make deps-js build-js &&
+      yarn dev
+    command: make run-frontend
+  - name: backend
+    init: make build-go build-server build-cli
+    command: make run
+    openMode: split-right
+
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ Unsure where to begin contributing to Grafana? Start by browsing issues labeled 
 - [Beginner-friendly](https://github.com/grafana/grafana/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) issues are generally straightforward to complete.
 - [Help wanted](https://github.com/grafana/grafana/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues are problems we would like the community to help us with regardless of complexity.
 
-If you're looking to make a code change, see how to set up your environment for [local development](contribute/developer-guide.md).
+If you're looking to make a code change, you can either use an online dev environment by pressing the button below or see how to set up your environment for [local development](contribute/developer-guide.md).
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/grafana/grafana)
 
 When you're ready to contribute, it's time to [Create a pull request](/contribute/create-pull-request.md).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The open-source platform for monitoring and observability.
 [![License](https://img.shields.io/github/license/grafana/grafana)](LICENSE)
 [![Circle CI](https://img.shields.io/circleci/build/gh/grafana/grafana)](https://circleci.com/gh/grafana/grafana)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana)](https://goreportcard.com/report/github.com/grafana/grafana)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/grafana/grafana) 
 
 Grafana allows you to query, visualize, alert on and understand your metrics no matter where they are stored. Create, explore, and share dashboards with your team and foster a data driven culture:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
👋 We are on a mission to simplify open-source work through automated dev environments. This PR adds a minimal config to the grafana repo, which allows your community to quickly spin up a ready-to-code dev environment. Please note, that this not only automates the setup of a dev environment but also builds the project before users open it - think CI for dev environments.

You can try the current state using this URL: 
https://gitpod.io/#https://github.com/svenefftinge/grafana/tree/svenefftinge/gitpod-setup

I configured to open two terminals side-by-side. One for the frontend, one for the backend.

**Questions**
Things listed in the 'init' phase are executed on our servers when ever a branch has new commits. When a user starts a workspace all that work is done already and only the `command` phase is executed. I added `yarn dev` to init, in hope that it would speed up the startup of `make run-frontend`. But webpack keeps rebuilding and analyzing everything. 
**Do you know how we can tell webpack not to build everything a second time on startup?**
Currently it delays the 'ready-to-code' state for another minute unecessrily.

We could initialize a postgres (or mysql) instead of the sqllite if that helps for development. Are there any other tools or tasks you'd need to get a full functional dev environment for this project?

<img width="1440" alt="Screenshot 2020-02-09 at 14 26 22" src="https://user-images.githubusercontent.com/372735/74103091-825c3c00-4b49-11ea-8221-f75b34758a65.png">

