### PR TITLE
Cascader: Fix issue where the dropdown wouldn't show

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -7,7 +7,7 @@ import { Select } from '../Forms/Select/Select';
 import { FormInputSize } from '../Forms/types';
 import { Input } from '../Forms/Input/Input';
 import { SelectableValue } from '@grafana/data';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 interface CascaderProps {
   /** The seperator between levels in the search */
   separator?: string;

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -7,7 +7,7 @@ import { Select } from '../Forms/Select/Select';
 import { FormInputSize } from '../Forms/types';
 import { Input } from '../Forms/Input/Input';
 import { SelectableValue } from '@grafana/data';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 interface CascaderProps {
   /** The seperator between levels in the search */
   separator?: string;
@@ -198,6 +198,12 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
             value={rcValue}
             fieldNames={{ label: 'label', value: 'value', children: 'items' }}
             expandIcon={null}
+            // Required, otherwise the portal that the popup is shown in will render under other components
+            popupClassName={cx(
+              css`
+                z-index: 9999;
+              `
+            )}
           >
             <div className={disableDivFocus}>
               <Input

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -199,11 +199,9 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
             fieldNames={{ label: 'label', value: 'value', children: 'items' }}
             expandIcon={null}
             // Required, otherwise the portal that the popup is shown in will render under other components
-            popupClassName={cx(
-              css`
-                z-index: 9999;
-              `
-            )}
+            popupClassName={css`
+              z-index: 9999;
+            `}
           >
             <div className={disableDivFocus}>
               <Input

--- a/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -1,13 +1,12 @@
 import React, { ChangeEvent } from 'react';
 import { mount } from 'enzyme';
-import { GrafanaThemeType, GrafanaTheme, ThresholdsMode } from '@grafana/data';
+import { GrafanaThemeType, ThresholdsMode } from '@grafana/data';
 import { ThresholdsEditor, Props, thresholdsWithoutKey } from './ThresholdsEditor';
 import { colors } from '../../utils';
 import { mockThemeContext } from '../../themes/ThemeContext';
 
 const setup = (propOverrides?: Partial<Props>) => {
   const props: Props = {
-    theme: { type: GrafanaThemeType.Dark, isDark: true, isLight: false } as GrafanaTheme,
     onChange: jest.fn(),
     thresholds: { mode: ThresholdsMode.Absolute, steps: [] },
   };


### PR DESCRIPTION
The portal that the actual menu was rendered in showed up under other components. So I simply bumped the z-index.