### PR TITLE
New Editor: refresh when time values change

### DIFF
--- a/packages/grafana-ui/src/components/FieldConfigs/units.tsx
+++ b/packages/grafana-ui/src/components/FieldConfigs/units.tsx
@@ -11,12 +11,12 @@ export const UnitValueEditor: React.FC<FieldConfigEditorProps<string, UnitFieldC
   value,
   onChange,
 }) => {
-  return <UnitPicker value={value} onChange={onChange} />;
+  return <UnitPicker value={value} onChange={onChange} useNewForms />;
 };
 
 export const UnitOverrideEditor: React.FC<FieldOverrideEditorProps<string, UnitFieldConfigSettings>> = ({
   value,
   onChange,
 }) => {
-  return <UnitPicker value={value} onChange={onChange} />;
+  return <UnitPicker value={value} onChange={onChange} useNewForms />;
 };

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -26,6 +26,8 @@ import { Unsubscribable } from 'rxjs';
 import { PanelTitle } from './PanelTitle';
 import { DisplayMode, displayModes } from './types';
 import { PanelEditorTabs } from './PanelEditorTabs';
+import { DashNavTimeControls } from '../DashNav/DashNavTimeControls';
+import { LocationState } from 'app/types';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const handleColor = selectThemeVariant(
@@ -104,6 +106,7 @@ interface Props {
   dashboard: DashboardModel;
   sourcePanel: PanelModel;
   updateLocation: typeof updateLocation;
+  location: LocationState;
 }
 
 interface State {
@@ -315,6 +318,7 @@ export class PanelEditor extends PureComponent<Props, State> {
   }
 
   render() {
+    const { dashboard, location } = this.props;
     const { panel, mode, showPanelOptions } = this.state;
     const styles = getStyles(config.theme);
 
@@ -341,6 +345,10 @@ export class PanelEditor extends PureComponent<Props, State> {
             <Forms.Button variant="destructive" onClick={this.onDiscard}>
               Discard
             </Forms.Button>
+
+            <div>
+              <DashNavTimeControls dashboard={dashboard} location={location} updateLocation={updateLocation} />
+            </div>
           </div>
         </div>
         <div className={styles.panes}>

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -7,6 +7,7 @@ import {
   DefaultTimeRange,
   PanelEvents,
   SelectableValue,
+  TimeRange,
 } from '@grafana/data';
 import {
   stylesFactory,
@@ -34,7 +35,7 @@ import { PanelTitle } from './PanelTitle';
 import { DisplayMode, displayModes } from './types';
 import { PanelEditorTabs } from './PanelEditorTabs';
 import { DashNavTimeControls } from '../DashNav/DashNavTimeControls';
-import { LocationState } from 'app/types';
+import { LocationState, CoreEvents } from 'app/types';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const handleColor = selectThemeVariant(
@@ -130,6 +131,10 @@ export class PanelEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    props.dashboard.on(CoreEvents.timeRangeUpdated, this.onTimeRangeUpdated);
+
+    //    this.events.emit(, timeRange);
+
     // To ensure visualisation  settings are re-rendered when plugin has loaded
     // panelInitialised event is emmited from PanelChrome
     const panel = props.sourcePanel.getEditClone();
@@ -178,6 +183,14 @@ export class PanelEditor extends PureComponent<Props, State> {
     }
     //this.cleanUpAngularOptions();
   }
+
+  onTimeRangeUpdated = (timeRange: TimeRange) => {
+    const { panel } = this.state;
+    if (panel) {
+      panel.refresh();
+      console.log('TIME Changed (do refresh)', timeRange);
+    }
+  };
 
   onPanelUpdate = () => {
     const { panel } = this.state;


### PR DESCRIPTION
This adds the time picker to the top toolbar and calls `refresh` when the time values change.