### PR TITLE
Add currency support for HUF

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -418,6 +418,10 @@
               "value": "currencyCZK"
             },
             {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
+            },
+            {
               "text": "Swiss franc (CHF)",
               "value": "currencyCHF"
             },
@@ -1517,6 +1521,10 @@
               "value": "currencyCZK"
             },
             {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
+            },
+            {
               "text": "Swiss franc (CHF)",
               "value": "currencyCHF"
             },
@@ -2594,6 +2602,10 @@
             {
               "text": "Czech koruna (czk)",
               "value": "currencyCZK"
+            },
+            {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
             },
             {
               "text": "Swiss franc (CHF)",

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -418,6 +418,10 @@
               "value": "currencyCZK"
             },
             {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
+            },
+            {
               "text": "Swiss franc (CHF)",
               "value": "currencyCHF"
             },
@@ -1517,6 +1521,10 @@
               "value": "currencyCZK"
             },
             {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
+            },
+            {
               "text": "Swiss franc (CHF)",
               "value": "currencyCHF"
             },
@@ -2594,6 +2602,10 @@
             {
               "text": "Czech koruna (czk)",
               "value": "currencyCZK"
+            },
+            {
+              "text": "Hungarian Forint (HUF)",
+              "value": "currencyHUF"
             },
             {
               "text": "Swiss franc (CHF)",

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -112,6 +112,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Norwegian Krone (kr)', id: 'currencyNOK', fn: currency('kr', true) },
       { name: 'Swedish Krona (kr)', id: 'currencySEK', fn: currency('kr', true) },
       { name: 'Czech koruna (czk)', id: 'currencyCZK', fn: currency('czk') },
+      { name: 'Hungarian Forint (HUF)', id: 'currencyHUF', fn: currency('Ft', true) },
       { name: 'Swiss franc (CHF)', id: 'currencyCHF', fn: currency('CHF') },
       { name: 'Polish Złoty (PLN)', id: 'currencyPLN', fn: currency('PLN') },
       { name: 'Bitcoin (฿)', id: 'currencyBTC', fn: currency('฿') },


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for the Hungarian Forint currency.

**Which issue(s) this PR fixes**:

Fixes #10140 (Add supprort for HUF/ft currency)

**Special notes for your reviewer**:

Extended the test code but was not able to run tests due to lack of experience in that.