### PR TITLE
Toolkit: create manifest files for plugins

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { startTask } from './tasks/core.start';
 import { changelogTask } from './tasks/changelog';
 import { cherryPickTask } from './tasks/cherrypick';
+import { manifestTask } from './tasks/manifest';
 import { precommitTask } from './tasks/precommit';
 import { templateTask } from './tasks/template';
 import { pluginBuildTask } from './tasks/plugin.build';
@@ -211,6 +212,14 @@ export const run = (includeInternalScripts = false) => {
       await execTask(ciPluginReportTask)({
         upload: cmd.upload,
       });
+    });
+
+  // Test the manifest creation
+  program
+    .command('manifest')
+    .description('create a manifest file in the cwd')
+    .action(async cmd => {
+      await execTask(manifestTask)({ folder: process.cwd() });
     });
 
   program.on('command:*', () => {

--- a/packages/grafana-toolkit/src/cli/tasks/manifest.test.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.test.ts
@@ -1,0 +1,32 @@
+import { getFilePaths } from './manifest';
+
+describe('Manifest', () => {
+  it('should collect file paths', () => {
+    const info = getFilePaths(__dirname);
+    expect(info).toMatchInlineSnapshot(`
+      Array [
+        "changelog.ts",
+        "cherrypick.ts",
+        "closeMilestone.ts",
+        "core.start.ts",
+        "manifest.test.ts",
+        "manifest.ts",
+        "nodeVersionChecker.ts",
+        "package.build.ts",
+        "plugin/bundle.ts",
+        "plugin/create.ts",
+        "plugin/tests.ts",
+        "plugin.build.ts",
+        "plugin.ci.ts",
+        "plugin.create.ts",
+        "plugin.dev.ts",
+        "plugin.tests.ts",
+        "precommit.ts",
+        "searchTestDataSetup.ts",
+        "task.ts",
+        "template.ts",
+        "toolkit.build.ts",
+      ]
+    `);
+  });
+});

--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -26,8 +26,6 @@ export function getFilePaths(root: string, work?: string, acc?: string[]): strin
 }
 
 const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
-  console.log('Building file manifest...');
-
   const filename = 'MANIFEST.txt';
   const files = getFilePaths(folder).filter(f => f !== filename);
 

--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -1,0 +1,39 @@
+import { Task, TaskRunner } from './task';
+import fs from 'fs';
+import path from 'path';
+
+interface ManifestOptions {
+  folder: string;
+}
+
+function getFileHashes(root: string, name: string, info: string): string {
+  if (!info) {
+    info = `# Manifest`;
+  }
+
+  const files = fs.readdirSync(path.join(root, name));
+  files.forEach(file => {
+    const abs = path.join(root, file);
+    if (fs.statSync(abs).isDirectory()) {
+      info = getFileHashes(root, file, info);
+    } else {
+      const hash = 'xxxx'; // TODO get the file hash
+      info += hash + ' ' + file + '\r\n';
+    }
+  });
+
+  return info;
+}
+
+const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
+  console.log('--------------------------------------------------------------------');
+  console.log('Scanning files');
+  console.log('--------------------------------------------------------------------');
+
+  const info = getFileHashes(folder, '', '');
+
+  console.log(info);
+  console.log('TODO... sign and save it...');
+};
+
+export const manifestTask = new Task<ManifestOptions>('Build Manifest', manifestRunner);

--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -1,39 +1,49 @@
 import { Task, TaskRunner } from './task';
 import fs from 'fs';
 import path from 'path';
+import execa from 'execa';
 
 interface ManifestOptions {
   folder: string;
 }
 
-function getFileHashes(root: string, name: string, info: string): string {
-  if (!info) {
-    info = `# Manifest`;
+export function getFilePaths(root: string, work?: string, acc?: string[]): string[] {
+  if (!acc) {
+    acc = [];
   }
-
-  const files = fs.readdirSync(path.join(root, name));
+  let abs = work ?? root;
+  const files = fs.readdirSync(abs);
   files.forEach(file => {
-    const abs = path.join(root, file);
-    if (fs.statSync(abs).isDirectory()) {
-      info = getFileHashes(root, file, info);
+    const f = path.join(abs, file);
+    const stat = fs.statSync(f);
+    if (stat.isDirectory()) {
+      acc = getFilePaths(root, f, acc);
     } else {
-      const hash = 'xxxx'; // TODO get the file hash
-      info += hash + ' ' + file + '\r\n';
+      acc!.push(f.substring(root.length + 1).replace('\\', '/'));
     }
   });
-
-  return info;
+  return acc;
 }
 
 const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
-  console.log('--------------------------------------------------------------------');
-  console.log('Scanning files');
-  console.log('--------------------------------------------------------------------');
+  console.log('Building file manifest...');
 
-  const info = getFileHashes(folder, '', '');
+  const filename = 'MANIFEST.txt';
+  const files = getFilePaths(folder).filter(f => f !== filename);
 
-  console.log(info);
-  console.log('TODO... sign and save it...');
+  const originalDir = __dirname;
+  process.chdir(folder);
+  const out = await execa('sha1sum', files);
+
+  // Write the process output
+  fs.writeFileSync(path.join(folder, filename), out.stdout);
+
+  // TODO:
+  // gpg --output doc.sig --sign doc
+
+  // Go back to where you were
+  process.chdir(originalDir);
+  console.log('Wrote manifest: ', filename);
 };
 
 export const manifestTask = new Task<ManifestOptions>('Build Manifest', manifestRunner);

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -23,6 +23,8 @@ import { agregateWorkflowInfo, agregateCoverageInfo, agregateTestInfo } from '..
 import { PluginPackageDetails, PluginBuildReport, TestResultsInfo } from '../../plugins/types';
 import { runEndToEndTests } from '../../plugins/e2e/launcher';
 import { getEndToEndSettings } from '../../plugins/index';
+import { manifestTask } from './manifest';
+import { execTask } from '../utils/execTask';
 
 export interface PluginCIOptions {
   backend?: boolean;
@@ -161,6 +163,9 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
       throw new Error('Error writing: ' + pluginJsonFile);
     }
   });
+
+  console.log('Create a file manifest');
+  await execTask(manifestTask)({ folder: distContentDir });
 
   console.log('Building ZIP');
   let zipName = pluginInfo.id + '-' + pluginInfo.info.version + '.zip';

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -164,7 +164,7 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
     }
   });
 
-  console.log('Create a file manifest');
+  // Write a manifest.txt file in the dist folder
   await execTask(manifestTask)({ folder: distContentDir });
 
   console.log('Building ZIP');


### PR DESCRIPTION
As a first step towards supporting signed plugins, we need a way to verify what is in a plugin.  This adds a manifest step to the plugin build process