### PR TITLE
Explore: Fix display of multiline logs in log panel and explore

### DIFF
--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -135,6 +135,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     `,
     logsRowMessage: css`
       label: logs-row__message;
+      white-space: pre-wrap;
       word-break: break-all;
     `,
     //Log details sepcific CSS


### PR DESCRIPTION
Logs that contained line breaks were displayed in a single wrapped
line and not respecting the line break characters.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: In the "Explore"-view or the logs-panel, logs containing a line break were displayed in one line. Line breaks were just ignored. This made reading stack traces for example very hard.

**Which issue(s) this PR fixes**: #20865

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20865

**Special notes for your reviewer**:

