### PR TITLE
Docs: fix formatting typo

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -134,7 +134,8 @@ Example json body:
     "tag name":"tag value"
   },
   "title":"[Alerting] Panel Title alert"
-}```
+}
+```
 
 - **state** - The possible values for alert state are: `ok`, `paused`, `alerting`, `pending`, `no_data`.
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes formatting typo in `notifications.md`.