### PR TITLE
Logs: Guess severity as the first appearing severity

### DIFF
--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -35,6 +35,7 @@ describe('getLoglevel()', () => {
 
   it('returns first log level found', () => {
     expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
+    expect(getLogLevel('WARN this is a non-critical message')).toBe(LogLevel.warn);
   });
 });
 

--- a/packages/grafana-data/src/utils/logs.ts
+++ b/packages/grafana-data/src/utils/logs.ts
@@ -20,16 +20,21 @@ export function getLogLevel(line: string): LogLevel {
   if (!line) {
     return LogLevel.unknown;
   }
+  let level = LogLevel.unknown;
+  let currentIndex: number | undefined = undefined;
+
   for (const key of Object.keys(LogLevel)) {
     const regexp = new RegExp(`\\b${key}\\b`, 'i');
-    if (regexp.test(line)) {
-      const level = (LogLevel as any)[key];
-      if (level) {
-        return level;
+    const result = regexp.exec(line);
+
+    if (result) {
+      if (currentIndex === undefined || result.index < currentIndex) {
+        level = (LogLevel as any)[key];
+        currentIndex = result.index;
       }
     }
   }
-  return LogLevel.unknown;
+  return level;
 }
 
 export function getLogLevelFromKey(key: string): LogLevel {


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of taking the first matching log level based on the ordering of the log levels (they're almost ordered by severity) we look at the index of the matching severity and takes the severity with the lowest index (i.e. first appearance on line) as our guess for what severity a log line is. This seems in line with the expectation expressed in the modified test (which happened to work because `warn` comes before `debug`, the newly added test will fail without the changes in `logs.ts` since `critical` > `warn`).

**Which issue(s) this PR fixes**:

Fixes #22075

**Special notes for your reviewer**:

