### PR TITLE
Docs: Add LDAP active sync limitation for single bind

### DIFF
--- a/docs/sources/auth/enhanced_ldap.md
+++ b/docs/sources/auth/enhanced_ldap.md
@@ -58,3 +58,7 @@ sync_cron = "0 0 1 * * *" # This is default value (At 1 am every day)
 # You can also disable active LDAP synchronization
 active_sync_enabled = true # enabled by default
 ```
+
+### Single Blind Exception
+
+Single Bind configuration (as in the [Single Bind Example]({{< relref "ldap.md#single-bind-example">}})) is not supported with active LDAP synchronization because Grafana needs user information to perform LDAP searches.


### PR DESCRIPTION
**What this PR does / why we need it**: Update documentation to add LDAP active sync limitation with single blind configuration

**Which issue(s) this PR fixes**: This PR fixes #384
