### PR TITLE
Docs: add LDAP active sync limitation for single bind configuration

### DIFF
--- a/docs/sources/auth/enhanced_ldap.md
+++ b/docs/sources/auth/enhanced_ldap.md
@@ -59,6 +59,6 @@ sync_cron = "0 0 1 * * *" # This is default value (At 1 am every day)
 active_sync_enabled = true # enabled by default
 ```
 
-### Single Blind Exception
+### Not compatible with Single Bind
 
 Single Bind configuration (as in the [Single Bind Example]({{< relref "ldap.md#single-bind-example">}})) is not supported with active LDAP synchronization because Grafana needs user information to perform LDAP searches.

--- a/docs/sources/auth/enhanced_ldap.md
+++ b/docs/sources/auth/enhanced_ldap.md
@@ -58,3 +58,7 @@ sync_cron = "0 0 1 * * *" # This is default value (At 1 am every day)
 # You can also disable active LDAP synchronization
 active_sync_enabled = true # enabled by default
 ```
+
+### Single Blind Exception
+
+Single Bind configuration (as in the [Single Bind Example]({{< relref "ldap.md#single-bind-example">}})) is not supported with active LDAP synchronization because Grafana needs user information to perform LDAP searches.


### PR DESCRIPTION
**What this PR does / why we need it**: Update documentation to add LDAP active sync limitation with single bind configuration