### PR TITLE
docs/installations/windows: Fix port config list formatting

### DIFF
--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -47,6 +47,7 @@ To run Grafana, open your browser and go to the Grafana port (http://localhost:3
 To run Grafana, open your browser and go to the Grafana port (http://localhost:3000/ is default) and then follow the instructions in [Getting Started]({{< relref "../guides/getting_started/" >}}).
 
 > **Note:** The default Grafana port is `3000`. This port might require extra permissions on Windows. If it does not appear in the default port, you can try changing to a different port.
-> 1. Go into the `conf` directory and copy `sample.ini` to `custom.ini`. **Note:** You should edit `custom.ini`, never `defaults.ini`.
-> 1.  Edit `custom.ini` and uncomment the `http_port` configuration option (`;` is the comment character in ini files) and change it to something like `8080` or similar. That port should not require extra Windows privileges.
+>
+> 1. Go into the `conf` directory and copy `sample.ini` to `custom.ini`.  **Note:** You should edit `custom.ini`, never `defaults.ini`.
+> 1. Edit `custom.ini` and uncomment the `http_port` configuration option (`;` is the comment character in ini files) and change it to something like `8080` or similar. That port should not require extra Windows privileges.
 > Read more about the [configuration options]({{< relref "configuration.md" >}}).


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix list formatting in section about configuring Grafana port, within Windows installation documentation. While it's not noticeable when reading the Markdown, the list isn't correctly formatted in HTML without this change.

