### PR TITLE
Update streaming.json

### DIFF
--- a/public/app/plugins/datasource/testdata/dashboards/streaming.json
+++ b/public/app/plugins/datasource/testdata/dashboards/streaming.json
@@ -24,7 +24,7 @@
     },
     {
       "type": "panel",
-      "id": "graph2",
+      "id": "graph",
       "name": "React Graph",
       "version": ""
     },
@@ -187,7 +187,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Simple dummy streaming example",
-      "type": "graph2"
+      "type": "graph"
     }
   ],
   "schemaVersion": 18,


### PR DESCRIPTION
Changed `graph2` to `graph` in two places.

Because "graph2" is not actually a thing that Grafana recognizes, so when you imported the Simple Streaming Example, it currently comes in with a broken graph. I am hoping this fixes that issue.

