### PR TITLE
Data proxy: Log proxy errors using Grafana logger

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -99,7 +99,7 @@ func (proxy *DataSourceProxy) HandleRequest() {
 	reverseProxy := &httputil.ReverseProxy{
 		Director:      proxy.getDirector(),
 		FlushInterval: time.Millisecond * 200,
-		ErrorLog:      log.New(&logWrapper{logger: glog.New("reverseProxy")}, "", 0),
+		ErrorLog:      log.New(&logWrapper{logger: logger}, "", 0),
 	}
 
 	transport, err := proxy.ds.GetHttpTransport()

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -65,7 +65,7 @@ type logWrapper struct {
 // Write writes log messages as bytes from proxy
 func (lw *logWrapper) Write(p []byte) (n int, err error) {
 	withoutNewline := strings.TrimSuffix(string(p), "\n")
-	lw.logger.Error(withoutNewline)
+	lw.logger.Error("Data proxy error", "error", withoutNewline)
 	return len(p), nil
 }
 
@@ -96,10 +96,12 @@ func (proxy *DataSourceProxy) HandleRequest() {
 		return
 	}
 
+	proxyErrorLogger := logger.New("userId", proxy.ctx.UserId, "orgId", proxy.ctx.OrgId, "uname", proxy.ctx.Login, "path", proxy.ctx.Req.URL.Path, "remote_addr", proxy.ctx.RemoteAddr(), "referer", proxy.ctx.Req.Referer())
+
 	reverseProxy := &httputil.ReverseProxy{
 		Director:      proxy.getDirector(),
 		FlushInterval: time.Millisecond * 200,
-		ErrorLog:      log.New(&logWrapper{logger: logger}, "", 0),
+		ErrorLog:      log.New(&logWrapper{logger: proxyErrorLogger}, "", 0),
 	}
 
 	transport, err := proxy.ds.GetHttpTransport()


### PR DESCRIPTION
This way the reverse proxy error logs are marked as error.