### PR TITLE
Alerting: Update the types of recipient supported by the Slack notifier

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -85,7 +85,7 @@ Setting | Description
 ---------- | -----------
 Url | Slack incoming webhook URL.
 Username | Set the username for the bot's message.
-Recipient | Allows you to override the Slack recipient.
+Recipient | Allows you to override the Slack recipient. You must either provide a channel Slack ID, a user Slack ID, a username reference (@&lt;user&gt;, all lowercase, no whitespace), or a channel reference (#&lt;channel&gt;, all lowercase, no whitespace).
 Icon emoji | Provide an emoji to use as the icon for the bot's message. Ex :smile:
 Icon URL | Provide a url to an image to use as the icon for the bot's message.
 Mention Users | Optionally mention one or more users in the Slack notification sent by Grafana. You have to refer to users, comma-separated, via their corresponding Slack IDs (which you can find by clicking the overflow button on each user's Slack profile).

--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -39,7 +39,7 @@ func init() {
           data-placement="right">
         </input>
         <info-popover mode="right-absolute">
-          Override default channel or user, use #channel-name, @username or user/channel ID
+          Override default channel or user, use #channel-name, @username (has to be all lowercase, no whitespace), or user/channel Slack ID
         </info-popover>
       </div>
       <div class="gf-form max-width-30">


### PR DESCRIPTION
**What this PR does / why we need it**:
The Slack API has changed a bit in terms of the formats it supports wrt. specification of a message's recipient. I've found it supports \@username (lowercase, no spaces), \#channel and channel/user ID. This PR enforces that the Slack notification recipient field takes one of these formats.

**Which issue(s) this PR fixes**:
Fixes #21933

