### PR TITLE
Docs: Add a note about how to access grafana

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -40,6 +40,10 @@ Start Grafana using Homebrew services:
 brew services start grafana
 ```
 
+## 3. Sign in and start using Grafana 
+
+Grafana is available in your browser at [http://localhost:3000](http://localhost:3000).  Use login `admin` and password `admin` the first time you login
+
 ## Upgrade with Homebrew
 
 To upgrade Grafana, use the reinstall command:


### PR DESCRIPTION
The installation page for Mac includes instructions for starting the Grafana server, but doesn't tell the reader how to access the grafana UI.  As a new user, I had to continue searching to learn what the default port and login credentials were.

This PR adds a simple note about how to access Grafana after it's been started.

