### PR TITLE
CircleCI: Push master Docker images without revision in tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,20 +558,21 @@ jobs:
           name: Publish Docker images
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker tag "grafana/grafana:master-${CIRCLE_SHA1}" "grafana/grafana:master-${CIRCLE_SHA1}-new-pipeline"
-            docker push "grafana/grafana:master-${CIRCLE_SHA1}-new-pipeline"
-            docker tag "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}" "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-new-pipeline"
-            docker push "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-new-pipeline"
-            docker tag "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}" "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-new-pipeline"
-            docker push "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-new-pipeline"
+            docker tag "grafana/grafana:master-${CIRCLE_SHA1}" "grafana/grafana:master-new-pipeline"
+            docker push "grafana/grafana:master-new-pipeline"
+            docker tag "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}" "grafana/grafana-arm32v7-linux:master-new-pipeline"
+            docker push "grafana/grafana-arm32v7-linux:master-new-pipeline"
+            docker tag "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}" "grafana/grafana-arm64v8-linux:master-new-pipeline"
+            docker push "grafana/grafana-arm64v8-linux:master-new-pipeline"
       - run:
           name: Publish Docker manifest
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker manifest create "grafana/grafana:master-${CIRCLE_SHA1}-new-pipeline" "grafana/grafana:master-${CIRCLE_SHA1}-new-pipeline" \
-              "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-new-pipeline" \
-              "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-new-pipeline"
-            docker manifest push "grafana/grafana:master-${CIRCLE_SHA1}-new-pipeline"
+            docker manifest create "grafana/grafana:master-new-pipeline" \
+              "grafana/grafana:master-new-pipeline" \
+              "grafana/grafana-arm32v7-linux:master-new-pipeline" \
+              "grafana/grafana-arm64v8-linux:master-new-pipeline"
+            docker manifest push "grafana/grafana:master-new-pipeline"
       - run:
           name: CI job failed
           command: ./scripts/ci-job-failed.sh
@@ -604,20 +605,21 @@ jobs:
           name: Publish Docker images
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker tag "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker push "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker tag "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker push "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker tag "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker push "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
+            docker tag "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana:master-ubuntu-new-pipeline"
+            docker push "grafana/grafana:master-ubuntu-new-pipeline"
+            docker tag "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana-arm32v7-linux:master-ubuntu-new-pipeline"
+            docker push "grafana/grafana-arm32v7-linux:master-ubuntu-new-pipeline"
+            docker tag "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-ubuntu" "grafana/grafana-arm64v8-linux:master-ubuntu-new-pipeline"
+            docker push "grafana/grafana-arm64v8-linux:master-ubuntu-new-pipeline"
       - run:
           name: Publish Docker manifest
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker manifest create "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu-new-pipeline" "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu-new-pipeline" \
-              "grafana/grafana-arm32v7-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline" \
-              "grafana/grafana-arm64v8-linux:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
-            docker manifest push "grafana/grafana:master-${CIRCLE_SHA1}-ubuntu-new-pipeline"
+            docker manifest create "grafana/grafana:master-ubuntu-new-pipeline" \
+              "grafana/grafana:master-ubuntu-new-pipeline" \
+              "grafana/grafana-arm32v7-linux:master-ubuntu-new-pipeline" \
+              "grafana/grafana-arm64v8-linux:master-ubuntu-new-pipeline"
+            docker manifest push "grafana/grafana:master-ubuntu-new-pipeline"
       - run:
           name: CI job failed
           command: ./scripts/ci-job-failed.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove revision component of tag of Docker images pushed for master builds. Adding the revision component was a bug when designing the new master build pipeline.
