### PR TITLE
CloudWatch: Surround dimension names with double quotes

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_data_query_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder.go
@@ -91,7 +91,7 @@ func buildSearchExpression(query *cloudWatchQuery, stat string) string {
 		schema := query.Namespace
 		if len(dimensionNames) > 0 {
 			sort.Strings(dimensionNames)
-			schema += fmt.Sprintf(",%s", join(dimensionNames, ",", "", ""))
+			schema += fmt.Sprintf(",%s", join(dimensionNames, ",", `"`, `"`))
 		}
 
 		return fmt.Sprintf("REMOVE_EMPTY(SEARCH('{%s} %s', '%s', %s))", schema, searchTerm, stat, strconv.Itoa(query.Period))

--- a/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder_test.go
@@ -24,7 +24,7 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 					}
 
 					res := buildSearchExpression(query, "Average")
-					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,LoadBalancer} MetricName="CPUUtilization" "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
+					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,"LoadBalancer"} MetricName="CPUUtilization" "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
 				})
 
 				Convey("and query has three dimension values for two given dimension keys", func() {
@@ -42,7 +42,7 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 					}
 
 					res := buildSearchExpression(query, "Average")
-					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,InstanceId,LoadBalancer} MetricName="CPUUtilization" "InstanceId"=("i-123" OR "i-456" OR "i-789") "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
+					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,"InstanceId","LoadBalancer"} MetricName="CPUUtilization" "InstanceId"=("i-123" OR "i-456" OR "i-789") "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
 				})
 
 				Convey("and no OR operator was added if a star was used for dimension value", func() {
@@ -74,7 +74,7 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 					}
 
 					res := buildSearchExpression(query, "Average")
-					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,LoadBalancer} MetricName="CPUUtilization"', 'Average', 300))`)
+					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,"LoadBalancer"} MetricName="CPUUtilization"', 'Average', 300))`)
 				})
 
 				Convey("and query has three dimension values for two given dimension keys, and one value is a star", func() {
@@ -91,7 +91,23 @@ func TestMetricDataQueryBuilder(t *testing.T) {
 					}
 
 					res := buildSearchExpression(query, "Average")
-					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,InstanceId,LoadBalancer} MetricName="CPUUtilization" "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
+					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/EC2,"InstanceId","LoadBalancer"} MetricName="CPUUtilization" "LoadBalancer"=("lb1" OR "lb2" OR "lb3")', 'Average', 300))`)
+				})
+
+				Convey("and query has a dimension key with a space", func() {
+					query := &cloudWatchQuery{
+						Namespace:  "AWS/Kafka",
+						MetricName: "CpuUser",
+						Dimensions: map[string][]string{
+							"Cluster Name": {"dev-cluster"},
+						},
+						Period:     300,
+						Expression: "",
+						MatchExact: matchExact,
+					}
+
+					res := buildSearchExpression(query, "Average")
+					So(res, ShouldEqual, `REMOVE_EMPTY(SEARCH('{AWS/Kafka,"Cluster Name"} MetricName="CpuUser" "Cluster Name"="dev-cluster"', 'Average', 300))`)
 				})
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Places double quotes around the dimension names in the generated CloudWatch query.

**Which issue(s) this PR fixes**:
Fixes #22104.
