### PR TITLE
Toolkit: don't create declaration files for plugins (by default)

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -66,6 +66,7 @@ export const lintPlugin = useSpinner<Fixable>('Linting', async ({ fix }) => {
   try {
     // Show a warning if the tslint file exists
     await fs.access(resolvePath(process.cwd(), 'tslint.json'));
+    console.log('\n');
     console.log('--------------------------------------------------------------');
     console.log('NOTE: @grafana/toolkit has migrated to use eslint');
     console.log('Update your configs to use .eslintrc rather than tslint.json');

--- a/packages/grafana-toolkit/src/config/tsconfig.plugin.json
+++ b/packages/grafana-toolkit/src/config/tsconfig.plugin.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "declaration": false
   },
   "extends": "@grafana/tsconfig"
 }


### PR DESCRIPTION
Using toolkit with canary version creates `.d.ts` files for everything in the src folder.

Since we are not using plugins as libs, we don't need the declaration files
