### PR TITLE
Inspector: find the datasource from the refId, not the metadata

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -20,10 +20,6 @@ export interface QueryResultMeta {
   // Used in Explore to show limit applied to search result
   limit?: number;
 
-  // HACK: save the datassource name in the meta so we can load it from the response
-  // we should be able to find the datasource from the refId
-  datasource?: string;
-
   // DatasSource Specific Values
   custom?: Record<string, any>;
 }

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -124,7 +124,6 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
       // Metrictank metadata
       if (s.meta) {
         frame.meta = {
-          datasource: this.name,
           custom: {
             request: result.data.meta, // info for the whole request
             info: s.meta, // Array of metadata


### PR DESCRIPTION
Rather than having each datasource identify itself in the response metadata, we can figure out which one it is using the `refId`

Graphite/metrictank was the only datasource to fill in the property