### PR TITLE
FieldOverrides: Fix issue with same series name for every display value

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -185,6 +185,7 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         config,
         type,
       };
+
       // and set the display processor using it
       f.display = getDisplayProcessor({
         field: f,

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -69,7 +69,6 @@ export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
  * Return a copy of the DataFrame with all rules applied
  */
 export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFrame[] {
-  const scopedVars: ScopedVars = {};
   if (!options.data) {
     return [];
   }
@@ -100,7 +99,10 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
     if (!name) {
       name = `Series[${index}]`;
     }
-    scopedVars['__series'] = { text: 'Series', value: { name } };
+
+    const scopedVars: ScopedVars = {
+      __series: { text: 'Series', value: { name } },
+    };
 
     const fields: Field[] = frame.fields.map((field, fieldIndex) => {
       // Config is mutable within this scope


### PR DESCRIPTION
In master right now all series get the same name due to scopedVars instance being shared, and last one overwrites and is used by all data frames & fields. 

Todo: 
- [x] Add unit test for fieldOverrides that will catch this, I was pretty sure we had a couple of unit tests for applyFieldOverrides but could not find any now, strange. 