### PR TITLE
Toolkit: support sass style for plugins

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -4,7 +4,7 @@ import { getPluginId } from '../utils/getPluginId';
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const supportedExtensions = ['css', 'scss', 'less'];
+const supportedExtensions = ['css', 'scss', 'less', 'sass'];
 
 const getStylesheetPaths = (root: string = process.cwd()) => {
   return [`${root}/src/styles/light`, `${root}/src/styles/dark`];
@@ -110,7 +110,7 @@ export const getStyleLoaders = () => {
       exclude: [`${styleDir}light.css`, `${styleDir}dark.css`],
     },
     {
-      test: /\.scss$/,
+      test: /\.s[ac]ss$/,
       use: ['style-loader', ...cssLoaders, 'sass-loader'],
       exclude: [`${styleDir}light.scss`, `${styleDir}dark.scss`],
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
To support sass style. 

**Which issue(s) this PR fixes**:
The sass file is not supported for plugin.

