### PR TITLE
NewPanelEditor: Use panel plugin name in options header 

### DIFF
--- a/packages/grafana-ui/src/components/FieldConfigs/number.tsx
+++ b/packages/grafana-ui/src/components/FieldConfigs/number.tsx
@@ -42,6 +42,7 @@ export const NumberValueEditor: React.FC<FieldConfigEditorProps<number, NumberFi
       max={settings.max}
       type="number"
       step={settings.step}
+      placeholder={settings.placeholder}
       onChange={e => {
         onChange(
           settings.integer ? toIntegerOrUndefined(e.currentTarget.value) : toFloatOrUndefined(e.currentTarget.value)
@@ -64,6 +65,7 @@ export const NumberOverrideEditor: React.FC<FieldOverrideEditorProps<number, Num
       max={settings.max}
       type="number"
       step={settings.step}
+      placeholder={settings.placeholder}
       onChange={e => {
         onChange(
           settings.integer ? toIntegerOrUndefined(e.currentTarget.value) : toFloatOrUndefined(e.currentTarget.value)

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -110,7 +110,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     return (
       <FieldConfigEditor
         config={fieldOptions}
-        custom={plugin.customFieldConfigs}
+        plugin={plugin}
         onChange={this.onFieldConfigsChange}
         data={data.series}
       />


### PR DESCRIPTION
Minor change to make plugin name available in visualization options header, and moved this header to the top.

Feels more natural to have this order

* `<plugin name>` options
* Field defaults
* Field overrides 

Also fixed missing placeholder forwarding 