### PR TITLE
API: Improve recovery middleware when response already been written

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -236,6 +236,12 @@ func initContextWithToken(authTokenService models.UserTokenService, ctx *models.
 
 func rotateEndOfRequestFunc(ctx *models.ReqContext, authTokenService models.UserTokenService, token *models.UserToken) macaron.BeforeFunc {
 	return func(w macaron.ResponseWriter) {
+		ctx.Logger.Info("rotateEndOfRequestFunc - begin")
+		// if response have already been written, skip.
+		if w.Written() {
+			return
+		}
+
 		// if the request is cancelled by the client we should not try
 		// to rotate the token since the client would not accept any result.
 		if ctx.Context.Req.Context().Err() == context.Canceled {
@@ -273,6 +279,11 @@ func WriteSessionCookie(ctx *models.ReqContext, value string, maxLifetimeDays in
 func AddDefaultResponseHeaders() macaron.Handler {
 	return func(ctx *macaron.Context) {
 		ctx.Resp.Before(func(w macaron.ResponseWriter) {
+			// if response have already been written, skip.
+			if w.Written() {
+				return
+			}
+
 			if !strings.HasPrefix(ctx.Req.URL.Path, "/api/datasources/proxy/") {
 				AddNoCacheHeaders(ctx.Resp)
 			}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -236,7 +236,6 @@ func initContextWithToken(authTokenService models.UserTokenService, ctx *models.
 
 func rotateEndOfRequestFunc(ctx *models.ReqContext, authTokenService models.UserTokenService, token *models.UserToken) macaron.BeforeFunc {
 	return func(w macaron.ResponseWriter) {
-		ctx.Logger.Info("rotateEndOfRequestFunc - begin")
 		// if response have already been written, skip.
 		if w.Written() {
 			return

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -236,7 +236,7 @@ func initContextWithToken(authTokenService models.UserTokenService, ctx *models.
 
 func rotateEndOfRequestFunc(ctx *models.ReqContext, authTokenService models.UserTokenService, token *models.UserToken) macaron.BeforeFunc {
 	return func(w macaron.ResponseWriter) {
-		// if response have already been written, skip.
+		// if response has already been written, skip.
 		if w.Written() {
 			return
 		}
@@ -278,7 +278,7 @@ func WriteSessionCookie(ctx *models.ReqContext, value string, maxLifetimeDays in
 func AddDefaultResponseHeaders() macaron.Handler {
 	return func(ctx *macaron.Context) {
 		ctx.Resp.Before(func(w macaron.ResponseWriter) {
-			// if response have already been written, skip.
+			// if response has already been written, skip.
 			if w.Written() {
 				return
 			}

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"runtime"
 
 	"gopkg.in/macaron.v1"
@@ -102,8 +103,6 @@ func Recovery() macaron.Handler {
 	return func(c *macaron.Context) {
 		defer func() {
 			if err := recover(); err != nil {
-				stack := stack(3)
-
 				panicLogger := log.Root
 				// try to get request logger
 				if ctx, ok := c.Data["ctx"]; ok {
@@ -111,7 +110,21 @@ func Recovery() macaron.Handler {
 					panicLogger = ctxTyped.Logger
 				}
 
+				// http.ErrAbortHandler is suppressed by default in the http package
+				// and used as a signal for aborting requests. Suppresses stacktrace
+				// since it doesn't add any important information.
+				if err == http.ErrAbortHandler {
+					panicLogger.Error("Request error", "error", err)
+					return
+				}
+
+				stack := stack(3)
 				panicLogger.Error("Request error", "error", err, "stack", string(stack))
+
+				// if response have already been written, skip.
+				if c.Written() {
+					return
+				}
 
 				c.Data["Title"] = "Server Error"
 				c.Data["AppSubUrl"] = setting.AppSubUrl

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -121,7 +121,7 @@ func Recovery() macaron.Handler {
 				stack := stack(3)
 				panicLogger.Error("Request error", "error", err, "stack", string(stack))
 
-				// if response have already been written, skip.
+				// if response has already been written, skip.
 				if c.Written() {
 					return
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppresses stacktrace in recovery middleware if error is
http.ErrAbortHandler.
Skips writing response error in recovery middleware if
resoonse have already been written.
Skips try rotate of auth token if response have already
been written.
Skips adding default response headers if response have
already been written.

Go 1.11 added a new [behavior](https://github.com/golang/go/commit/eab57b27f5460a7e6b87fff95ce2948b7812ce05) - return panic if reverseproxy fails to read response body. That's why I've added a special rule to the recovery middleware to suppress the stacktrace of this error. More details about http.ErrAbortHandler [here](https://github.com/golang/go/blob/bbbc6589dfbc05be2bfa59f51c20f9eaa8d0c531/src/net/http/server.go#L1741).

At first I thought that the recovery middleware did write the response and this would stop the auth token rotation not being able to write the cookie to the response. But seems like problem is that recovery middleware tries to write response after response already have been written and auth token been rotated.

Tested with the following slow proxy changes:
```diff
diff --git a/devenv/docker/blocks/slow_proxy/main.go b/devenv/docker/blocks/slow_proxy/main.go
index 0db8008..90986b0 100644
--- a/devenv/docker/blocks/slow_proxy/main.go
+++ b/devenv/docker/blocks/slow_proxy/main.go
@@ -16,7 +16,7 @@ func main() {
                origin = "http://localhost:9090/"
        }
 
-       sleep := time.Minute
+       sleep := 5 * time.Second
 
        originURL, _ := url.Parse(origin)
        proxy := httputil.NewSingleHostReverseProxy(originURL)
@@ -24,6 +24,11 @@ func main() {
        http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
                fmt.Printf("sleeping for %s then proxying request: %s", sleep.String(), r.RequestURI)
                <-time.After(sleep)
+               out := "this call was relayed by the reverse proxy"
+               // Coerce a wrong content length to induce io.ErrUnexpectedEOF
+               w.Header().Set("Content-Length", fmt.Sprintf("%d", len(out)*2))
+               fmt.Fprintln(w, out)
+               return
                proxy.ServeHTTP(w, r)
        })
```

```
Current:
2020/02/17 18:09:38 httputil: ReverseProxy read error during body copy: unexpected EOF
EROR[02-17|18:09:38] Request error                            logger=context userId=1 orgId=1 uname=admin error="net/http: abort Handler" stack="/usr/local/go/src/net/http/httputil/reverseproxy.go:299 (0xabfa28)\n\t(*ReverseProxy).ServeHTTP: panic(http.ErrAbortHandler)\n/home/marcus/go/src/github.com/grafana/grafana/pkg/api/pluginproxy/ds_proxy.go:122 (0x10337f1)\n\t(*DataSourceProxy).HandleRequest: reverseProxy.ServeHTTP(proxy.ctx.Resp, proxy.ctx.Req.Request)\n/home/marcus/go/src/github.com/grafana/grafana/pkg/api/dataproxy.go:35 (0x1446998)\n\t(*HTTPServer).ProxyDataSourceRequest: proxy.HandleRequest()\n/usr/local/go/src/reflect/value.go:460 (0x49bb25)\n\tValue.call: call(frametype, fn, args, uint32(frametype.size), uint32(retOffset))\n/usr/local/go/src/reflect/value.go:321 (0x49b2e3)\n\tValue.Call: return v.call(\"Call\", in)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:177 (0x978379)\n\t(*injector).callInvoke: return reflect.ValueOf(f).Call(in), nil\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:137 (0x977d29)\n\t(*injector).Invoke: return inj.callInvoke(f, t, t.NumIn())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:121 (0x979318)\n\t(*Context).run: vals, err := c.Invoke(c.handler())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:112 (0xdbe145)\n\t(*Context).Next: c.run()\n/home/marcus/go/src/github.com/grafana/grafana/pkg/middleware/request_tracing.go:25 (0xdbe138)\n\tRequestTracing.func1: c.Next()\n/usr/local/go/src/reflect/value.go:460 (0x49bb25)\n\tValue.call: call(frametype, fn, args, uint32(frametype.size), uint32(retOffset))\n/usr/local/go/src/reflect/value.go:321 (0x49b2e3)\n\tValue.Call: return v.call(\"Call\", in)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:177 (0x978379)\n\t(*injector).callInvoke: return reflect.ValueOf(f).Call(in), nil\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:137 (0x977d29)\n\t(*injector).Invoke: return inj.callInvoke(f, t, t.NumIn())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:121 (0x979318)\n\t(*Context).run: vals, err := c.Invoke(c.handler())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:112 (0xdbd93c)\n\t(*Context).Next: c.run()\n/home/marcus/go/src/github.com/grafana/grafana/pkg/middleware/request_metrics.go:17 (0xdbd927)\n\tRequestMetrics.func1: c.Next()\n/usr/local/go/src/reflect/value.go:460 (0x49bb25)\n\tValue.call: call(frametype, fn, args, uint32(frametype.size), uint32(retOffset))\n/usr/local/go/src/reflect/value.go:321 (0x49b2e3)\n\tValue.Call: return v.call(\"Call\", in)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:177 (0x978379)\n\t(*injector).callInvoke: return reflect.ValueOf(f).Call(in), nil\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:137 (0x977d29)\n\t(*injector).Invoke: return inj.callInvoke(f, t, t.NumIn())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:121 (0x979318)\n\t(*Context).run: vals, err := c.Invoke(c.handler())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:112 (0xdbd84f)\n\t(*Context).Next: c.run()\n/home/marcus/go/src/github.com/grafana/grafana/pkg/middleware/recovery.go:147 (0xdbd83d)\n\tRecovery.func1: c.Next()\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:79 (0x9791c0)\n\tContextInvoker.Invoke: invoke(params[0].(*Context))\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:157 (0x978089)\n\t(*injector).fastInvoke: return f.Invoke(in)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:135 (0x977e18)\n\t(*injector).Invoke: return inj.fastInvoke(v, t, t.NumIn())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:121 (0x979318)\n\t(*Context).run: vals, err := c.Invoke(c.handler())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:112 (0xdbad7b)\n\t(*Context).Next: c.run()\n/home/marcus/go/src/github.com/grafana/grafana/pkg/middleware/logger.go:34 (0xdbad66)\n\tLogger.func1: c.Next()\n/usr/local/go/src/reflect/value.go:460 (0x49bb25)\n\tValue.call: call(frametype, fn, args, uint32(frametype.size), uint32(retOffset))\n/usr/local/go/src/reflect/value.go:321 (0x49b2e3)\n\tValue.Call: return v.call(\"Call\", in)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:177 (0x978379)\n\t(*injector).callInvoke: return reflect.ValueOf(f).Call(in), nil\n/home/marcus/go/src/github.com/grafana/grafana/vendor/github.com/go-macaron/inject/inject.go:137 (0x977d29)\n\t(*injector).Invoke: return inj.callInvoke(f, t, t.NumIn())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/context.go:121 (0x979318)\n\t(*Context).run: vals, err := c.Invoke(c.handler())\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/router.go:187 (0x98a476)\n\t(*Router).Handle.func1: c.run()\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/router.go:303 (0x984d45)\n\t(*Router).ServeHTTP: h(rw, req, p)\n/home/marcus/go/src/github.com/grafana/grafana/vendor/gopkg.in/macaron.v1/macaron.go:220 (0x97e20a)\n\t(*Macaron).ServeHTTP: m.Router.ServeHTTP(rw, req)\n/usr/local/go/src/net/http/server.go:2802 (0x70ad13)\n\tserverHandler.ServeHTTP: handler.ServeHTTP(rw, req)\n/usr/local/go/src/net/http/server.go:1890 (0x7066b4)\n\t(*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)\n/usr/local/go/src/runtime/asm_amd64.s:1357 (0x46af00)\n\tgoexit: BYTE\t$0x90\t// NOP\n"
2020/02/17 18:09:38 http: superfluous response.WriteHeader call from gopkg.in/macaron%2ev1.(*responseWriter).WriteHeader (response_writer.go:59)
EROR[02-17|18:09:38] Request Completed                        logger=context userId=1 orgId=1 uname=admin method=POST path=/api/datasources/proxy/194/api/v1/query_range status=500 remote_addr=[::1] time_ms=5030 size=43 referer="http://localhost:3000/d/hMkk45wWk/slow-prometheus?orgId=1"

With changes:
2020/02/17 18:11:42 httputil: ReverseProxy read error during body copy: unexpected EOF
DBUG[02-17|18:11:42] Request error                            logger=context userId=1 orgId=1 uname=admin error="net/http: abort Handler"
```

With both current and changes in this PR, status 200 is returned in browser (net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)).

**Which issue(s) this PR fixes**:
Fixes #15728
Ref #18082
