### PR TITLE
Server: Don't include trailing slash in cookie path when hosting Grafana in a sub path

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -46,8 +46,12 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 }
 
 func (hs *HTTPServer) cookieOptionsFromCfg() middleware.CookieOptions {
+	path := "/"
+	if len(hs.Cfg.AppSubUrl) > 0 {
+		path = hs.Cfg.AppSubUrl
+	}
 	return middleware.CookieOptions{
-		Path:             hs.Cfg.AppSubUrl + "/",
+		Path:             path,
 		Secure:           hs.Cfg.CookieSecure,
 		SameSiteDisabled: hs.Cfg.CookieSameSiteDisabled,
 		SameSiteMode:     hs.Cfg.CookieSameSiteMode,

--- a/pkg/middleware/cookie.go
+++ b/pkg/middleware/cookie.go
@@ -14,8 +14,12 @@ type CookieOptions struct {
 }
 
 func newCookieOptions() CookieOptions {
+	path := "/"
+	if len(setting.AppSubUrl) > 0 {
+		path = setting.AppSubUrl
+	}
 	return CookieOptions{
-		Path:             setting.AppSubUrl + "/",
+		Path:             path,
 		Secure:           setting.CookieSecure,
 		SameSiteDisabled: setting.CookieSameSiteDisabled,
 		SameSiteMode:     setting.CookieSameSiteMode,

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -264,10 +264,14 @@ func TestMiddlewareContext(t *testing.T) {
 			}
 			for _, sameSitePolicy := range sameSitePolicies {
 				setting.CookieSameSiteMode = sameSitePolicy
+				expectedCookiePath := "/"
+				if len(setting.AppSubUrl) > 0 {
+					expectedCookiePath = setting.AppSubUrl
+				}
 				expectedCookie := &http.Cookie{
 					Name:     setting.LoginCookieName,
 					Value:    "rotated",
-					Path:     setting.AppSubUrl + "/",
+					Path:     expectedCookiePath,
 					HttpOnly: true,
 					MaxAge:   int(maxAge),
 					Secure:   setting.CookieSecure,
@@ -291,10 +295,14 @@ func TestMiddlewareContext(t *testing.T) {
 			Convey("Should not set cookie with SameSite attribute when setting.CookieSameSiteDisabled is true", func() {
 				setting.CookieSameSiteDisabled = true
 				setting.CookieSameSiteMode = http.SameSiteLaxMode
+				expectedCookiePath := "/"
+				if len(setting.AppSubUrl) > 0 {
+					expectedCookiePath = setting.AppSubUrl
+				}
 				expectedCookie := &http.Cookie{
 					Name:     setting.LoginCookieName,
 					Value:    "rotated",
-					Path:     setting.AppSubUrl + "/",
+					Path:     expectedCookiePath,
 					HttpOnly: true,
 					MaxAge:   int(maxAge),
 					Secure:   setting.CookieSecure,


### PR DESCRIPTION
# Updated PR summary

Cookies are snippets of info saved by browsers sent back to web servers with all web requests to certain domains and paths. A logged in grafana user have a cookie that is passed with all requests to grafana, *almost*!

If Grafana is configured to run on a sub path like `/grafana` with authentication, the cookie with proof about who the user is currently configured to not be passed along to a request to `/grafana`, but only to `/grafana/`. This PR only ensures we also configure the cookies to be passed to `/grafana` as well.

Currently (without this PR), a web request by a logged in user to `/grafana`, will make grafana respond by redirecting the user to `/grafana/login`. When this web request is made, the cookie is finally passed, and grafana would understand the user doesn't need to login, and redirects the user to `/grafana/` after deciding `/grafana` was an invalid original path. But, that is a performance loss and comes with consequences like truncated query params (#22724).

Let's not work around this in the `/grafana/login` logic, let us make `/grafana` a valid destination by allowing cookies be passed to both `/grafana` and `/grafana/` and not only the latter.

### Merge benefits
1. Visiting `/grafana` would only lead to one web request (`/grafana`) instead of three (`/grafana` -> `/grafana/login` -> `/grafana/`).
2. Visiting `/grafana?orgId=2` would retain the query parameter, while currently they would only be retained if we visit `/grafana/?orgId=2` that contained a trailing `/` in the path (Fixes #22724).

### Merge drawbacks?
I don't know any, and I have failed to identify any over a long time. If an issue arise from this PR, I would guess it relates to an insecure old browser failing to follow the specifications on how cookies _should be treated_.

### How should cookies be treated?
I've learned that the Internet Engineering Task Force (IETF) have a say about this thanks to @papagian and summarize relevant resources below.

> Engineering contributions to the IETF start as an _Internet Draft_, may be promoted to a _Request for Comments_, and may eventually become an _Internet Standard_.

There is an [Internet Draft, section 5.1.3](https://tools.ietf.org/id/draft-ietf-httpstate-cookie-09.html#cookie-path) and a [RFC (6265, section 5.1.4)](https://tools.ietf.org/html/rfc6265#section-5.1.4), and this RFC is the current proposed standard [according to IETF's RFC index](https://www.rfc-editor.org/rfc-index.html)!

In it, under section 5.1.4, published 2011, we can verify that `/grafana` vs `/grafana/` in the path should only impact if a user visit exactly the path `/grafana` and no other paths like `/grafana-extra`!

```
   A request-path path-matches a given cookie-path if at least one of
   the following conditions holds:

   o  The cookie-path and the request-path are identical.

   o  The cookie-path is a prefix of the request-path, and the last
      character of the cookie-path is %x2F ("/").

   o  The cookie-path is a prefix of the request-path, and the first
      character of the request-path that is not included in the cookie-
      path is a %x2F ("/") character.
```

Since this is from 2011, with a draft from 2009, I'd say we should act confidently about this and merge this PR that simply ensures we remove the trailing `/` in all Grafana's Set-Cookie's Path options.

### References
- [About the `Set-Cookie` response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) - about how a web server can request a browser to store a cookie, don't miss this about the `Set-Cookie` header's `Path` option: `A path that must exist in the requested URL, or the browser won't send the Cookie header.`
- [About the `Cookie` request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) - about how the browser is passing cookies to the web server.
- [RFC (6265, section 5.1.4)](https://tools.ietf.org/html/rfc6265#section-5.1.4) - IETF's proposed internet standard for how to manage cookies' path configuration.

# Below: outdated discussion

## Updated super short summary - 2020-03-05

A user visiting Grafana on a sub path like `/grafana` that have authentication will not be considered authenticated. This happens because any cookies grafana have saved with the visitors browser will only be passed back when the user visit `/grafana/` (with a trailing `/`) path and nested paths, which excludes `/grafana` (without a trailing `/`).

The single change this PR does, is to declare that the cookie should be passed back to us *also* when visiting a `/grafana` subpath. This does not solve all cookie related issues, but it solves #22227 without influencing anything else, and is following a recommended practice.

## Updated summary - 2020-02-20

Cookies are like variables that web servers can save in the visitors browsers. These cookies can then later be read by the web server that receives them in future web requests to the web server.

When a user logs in by providing the required credentials somehow, Grafana will use the cookie mechanism to store a proof of the users identity that the user can pass along with future requests to Grafana. Technically, Grafana will store a cookie in the user browser when the user login that is called `grafana_session` by default, and it does this by responding with a `Set-Cookie` header.

The `Set-Cookie` header have various options, one of them is `Path`. The cookie path value is meant to be used by the browsers to understand when they are supposed to pass a cookie back to the webserver. With this option, it is possible to ask the browser to save a cookie but also to only pass it along with future web request when visiting a certain path. So, it is like a filter when the cookie is to be considered useful.

Grafana is explicitly setting this Path option in the `Set-Cookie` response header, and it does it to `/` and `/grafana/` respectively if Grafana isn't or is configured to serve content under a sub path of `/grafana`. This PR concerns only if Grafana is configured to serve content under a sub path.

The issue this PR fix, is to remove a trailing `/` in the Path option of the `Set-Cookie` responses by Grafana. By doing so, we allow cookies to be passed along to `/grafana` and not only to `/grafana/`, and this is very relevant because users will try visit `/grafana` and not only `/grafana/`.

With help from @papagian, I've learned that the specifications on how a browser should work from 2011 as described in [RFC 6265, section 5.1.4](https://tools.ietf.org/html/rfc6265#section-5.1.4), it seems that avoiding a trailing `/` in the `Set-Cookie` response headers optional Path value is the recommended practice. Further, that the difference in path value from `/grafana/` to `/grafana` will only make a difference to requests to the `/grafana` path - a conclusion drawn from the following text in section 5.1.4:

```
   A request-path path-matches a given cookie-path if at least one of
   the following conditions holds:

   o  The cookie-path and the request-path are identical.

   o  The cookie-path is a prefix of the request-path, and the last
      character of the cookie-path is %x2F ("/").

   o  The cookie-path is a prefix of the request-path, and the first
      character of the request-path that is not included in the cookie-
      path is a %x2F ("/") character.
```

In my understanding, this is an improvement without drawback that fixes #22227, but it is not the solution to other related issues that are considered in #22285 that address more than this PR does.

Thank you for a positive and welcoming atmosphere in the Grafana ecosystem!

#### References:
- [About the `Set-Cookie` response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie). This is the web-servers way of saying that the user should store a cookie to be passed back later.
- [About the `Cookie` request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie). This is the browsers way to pass back cookies.
- [RFC 6265, section 5.1.4](https://tools.ietf.org/html/rfc6265#section-5.1.4)

## Original PR

According to the stackoverflow answer below, it is recommended to not
include a trailing / in cookies' path. By removing the trailing / for
our cookies path value, people's browsers visiting grafana will pass the
cookie not only to /grafana/ sub paths but also to /grafana sub paths.

This commit avoids the situation where a user would visit
http://localhost/grafana, get redirected to
http://localhost/grafana/login, and following login get redirected back
to http://localhost/grafana, but since the grafana_session cookie isn't
passed along get redirected back once more to
http://localhost/grafana/login.

ref: https://stackoverflow.com/questions/36131023/setting-a-slash-on-cookie-path/53784228#53784228

**What this PR does / why we need it**:
We avoid a redirect loop following a visit to `/grafana` when authentication relying on cookies are used.

**Which issue(s) this PR fixes**:
Fixes #22227

**Special notes for your reviewer**:
Thank you @marefr for helping out with https://github.com/grafana/grafana/issues/22227#issuecomment-587390063! :heart: