### PR TITLE
22227 fix redirect to trailing slash

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -37,7 +37,7 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	}
 	// when using a subUrl, the redirect_to should have a relative or absolute path that includes the subUrl, otherwise the redirect
 	// will send the user to the wrong location
-	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl+"/") && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
 		return login.ErrInvalidRedirectTo
 	}
 	return nil

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -75,6 +75,11 @@ func RoleAuth(roles ...m.RoleType) macaron.Handler {
 
 func Auth(options *AuthOptions) macaron.Handler {
 	return func(c *m.ReqContext) {
+		if setting.AppSubUrl == c.Req.RequestURI {
+			c.Redirect(setting.AppSubUrl + "/")
+			return
+		}
+
 		if !c.IsSignedIn && options.ReqSignedIn && !c.AllowAnonymous {
 			notAuthorized(c)
 			return

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -75,7 +75,7 @@ func RoleAuth(roles ...m.RoleType) macaron.Handler {
 
 func Auth(options *AuthOptions) macaron.Handler {
 	return func(c *m.ReqContext) {
-		if setting.AppSubUrl == c.Req.RequestURI {
+		if setting.AppSubUrl != "" && setting.AppSubUrl == c.Req.RequestURI {
 			c.Redirect(setting.AppSubUrl + "/")
 			return
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When there is subpath and the user requests `/<appSubUrl>` instead of `/<appSubUrl>/` is redirected to `/<appSubUrl>/login` and `redirect_to` cookie is set to `/<appSubUrl>`.
After authenticating successfully using generic_auth is redirected back to `/<appSubUrl>` but the session cookie path is `/<appSubUrl>/` so it's not sent and it assumes that is not signed in so is redirected back to `/<appSubUrl>/login` and enters in a loop.

This fix redirects requests `/<appSubUrl>`  to `/<appSubUrl>/` before checking for authenticated user.

In addition to the above, it enters in redirect loop if the user requests `/<appSubUrl>other characters` (i.e. `/grafanagrafana`)

This fix modifies the `validateRedirectTo` require a trailing slash if the requested path starts with `appSubUrl` without leading slash.
 
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I have tested the following scenarios:
- [with subpath:
    - base auth:
        - [X] http://localhost:3000/grafana/d/dFcV-J4Zz/16707?orgId=1
        - [X] http://localhost:3000/grafana/
        - [X] http://localhost:3000/grafana
        - [X] http://localhost:3000/grafanagrafana (logins the user but ignores the invalid path)
    - oauth:
        - [X] http://localhost:3000/grafana/d/dFcV-J4Zz/16707?orgId=1
        - [X] http://localhost:3000/grafana/
        - [X] http://localhost:3000/grafana
        - [X] http://localhost:3000/grafanagrafana (logins the user but renders the login page with invalid redirect_to)

- without subpath:
    - base auth:
        - [X] http://localhost:3000/d/dFcV-J4Zz/16707?orgId=1
        - [X] http://localhost:3000/
        - [X] http://localhost:3000
        - [X] http://localhost:3000/grafanagrafana
    - oauth:
        - [X] http://localhost:3000/d/dFcV-J4Zz/16707?orgId=1
        - [X] http://localhost:3000/
        - [X] http://localhost:3000
        - [X] http://localhost:3000/grafanagrafana