### PR TITLE
API: Fix redirect issues

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,9 +35,7 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
-	// when using a subUrl, the redirect_to should have a relative or absolute path that includes the subUrl, otherwise the redirect
-	// will send the user to the wrong location
-	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl) && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
 		return login.ErrInvalidRedirectTo
 	}
 	return nil
@@ -179,11 +177,6 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 
 	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 		if err := hs.validateRedirectTo(redirectTo); err == nil {
-			// remove subpath if it exists at the beginning of the redirect_to
-			// LoginCtrl.tsx is already prepending the redirectUrl with the subpath
-			if setting.AppSubUrl != "" && strings.Index(redirectTo, setting.AppSubUrl) == 0 {
-				redirectTo = strings.Replace(redirectTo, setting.AppSubUrl, "", 1)
-			}
 			result["redirectUrl"] = redirectTo
 		} else {
 			log.Info("Ignored invalid redirect_to cookie value: %v", redirectTo)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -90,10 +90,10 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 
 		if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
 			if err := hs.validateRedirectTo(redirectTo); err != nil {
-				viewData.Settings["loginError"] = err.Error()
-				c.HTML(200, getViewIndex(), viewData)
-				middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-				return
+				// the user is already logged so instead of rendering the login page with error
+				// it should be redirected to the home page.
+				log.Debug("Ignored invalid redirect_to cookie value: %v", redirectTo)
+				redirectTo = hs.Cfg.AppSubUrl + "/"
 			}
 			middleware.DeleteCookie(c.Resp, "redirect_to", hs.cookieOptionsFromCfg)
 			c.Redirect(redirectTo)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -35,7 +35,9 @@ func (hs *HTTPServer) validateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
-	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, "/"+hs.Cfg.AppSubUrl) {
+	// when using a subUrl, the redirect_to should start with the subUrl (which contains the leading slash), otherwise the redirect
+	// will send the user to the wrong location
+	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl+"/") {
 		return login.ErrInvalidRedirectTo
 	}
 	return nil

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -223,9 +223,12 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	metrics.MApiLoginOAuth.Inc()
 
 	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
-		middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.cookieOptionsFromCfg)
-		ctx.Redirect(redirectTo)
-		return
+		if err := hs.validateRedirectTo(redirectTo); err == nil {
+			middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.cookieOptionsFromCfg)
+			ctx.Redirect(redirectTo)
+			return
+		}
+		log.Debug("Ignored invalid redirect_to cookie value: %v", redirectTo)
 	}
 
 	ctx.Redirect(setting.AppSubUrl + "/")

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -72,7 +72,6 @@ type redirectCase struct {
 	err       error
 	appURL    string
 	appSubURL string
-	path      string
 }
 
 func TestLoginErrorCookieApiEndpoint(t *testing.T) {
@@ -155,7 +154,6 @@ func TestLoginViewRedirect(t *testing.T) {
 			desc:   "grafana relative url without subpath",
 			url:    "/profile",
 			appURL: "http://localhost:3000",
-			path:   "/",
 			status: 302,
 		},
 		{
@@ -163,15 +161,6 @@ func TestLoginViewRedirect(t *testing.T) {
 			url:       "/grafana/profile",
 			appURL:    "http://localhost:3000",
 			appSubURL: "grafana",
-			path:      "grafana/",
-			status:    302,
-		},
-		{
-			desc:      "grafana slashed relative url with subpath",
-			url:       "/grafana/profile",
-			appURL:    "http://localhost:3000",
-			appSubURL: "grafana",
-			path:      "/grafana/",
 			status:    302,
 		},
 		{
@@ -179,23 +168,13 @@ func TestLoginViewRedirect(t *testing.T) {
 			url:       "/profile",
 			appURL:    "http://localhost:3000",
 			appSubURL: "grafana",
-			path:      "grafana/",
 			status:    200,
 			err:       login.ErrInvalidRedirectTo,
-		},
-		{
-			desc:      "grafana subpath absolute url",
-			url:       "http://localhost:3000/grafana/profile",
-			appURL:    "http://localhost:3000",
-			appSubURL: "grafana",
-			path:      "/grafana/profile",
-			status:    200,
 		},
 		{
 			desc:   "grafana absolute url",
 			url:    "http://localhost:3000/profile",
 			appURL: "http://localhost:3000",
-			path:   "/",
 			status: 200,
 			err:    login.ErrAbsoluteRedirectTo,
 		},
@@ -203,7 +182,6 @@ func TestLoginViewRedirect(t *testing.T) {
 			desc:   "non grafana absolute url",
 			url:    "http://example.com",
 			appURL: "http://localhost:3000",
-			path:   "/",
 			status: 200,
 			err:    login.ErrAbsoluteRedirectTo,
 		},
@@ -211,7 +189,6 @@ func TestLoginViewRedirect(t *testing.T) {
 			desc:   "invalid url",
 			url:    ":foo",
 			appURL: "http://localhost:3000",
-			path:   "/",
 			status: 200,
 			err:    login.ErrInvalidRedirectTo,
 		},
@@ -226,7 +203,7 @@ func TestLoginViewRedirect(t *testing.T) {
 				MaxAge:   60,
 				Value:    c.url,
 				HttpOnly: true,
-				Path:     c.path,
+				Path:     hs.Cfg.AppSubUrl + "/",
 				Secure:   hs.Cfg.CookieSecure,
 				SameSite: hs.Cfg.CookieSameSiteMode,
 			}
@@ -242,7 +219,7 @@ func TestLoginViewRedirect(t *testing.T) {
 				assert.True(t, ok, "Set-Cookie exists")
 				assert.Greater(t, len(setCookie), 0)
 				var redirectToCookieFound bool
-				expCookieValue := fmt.Sprintf("redirect_to=%v; Path=%v; Max-Age=60; HttpOnly; Secure", c.url, c.path)
+				expCookieValue := fmt.Sprintf("redirect_to=%v; Path=%v; Max-Age=60; HttpOnly; Secure", c.url, hs.Cfg.AppSubUrl+"/")
 				for _, cookieValue := range setCookie {
 					if cookieValue == expCookieValue {
 						redirectToCookieFound = true
@@ -301,12 +278,6 @@ func TestLoginPostRedirect(t *testing.T) {
 		{
 			desc:      "grafana relative url with subpath",
 			url:       "/grafana/profile",
-			appURL:    "https://localhost:3000",
-			appSubURL: "grafana",
-		},
-		{
-			desc:      "grafana no slash relative url with subpath",
-			url:       "grafana/profile",
 			appURL:    "https://localhost:3000",
 			appSubURL: "grafana",
 		},

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -4,12 +4,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/grafana/grafana/pkg/services/licensing"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/grafana/grafana/pkg/services/licensing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
@@ -153,42 +154,50 @@ func TestLoginViewRedirect(t *testing.T) {
 		{
 			desc:   "grafana relative url without subpath",
 			url:    "/profile",
-			appURL: "http://localhost:3000",
+			appURL: "http://localhost:3000/",
 			status: 302,
 		},
 		{
-			desc:      "grafana relative url with subpath",
+			desc:      "grafana invalid relative url starting with the subpath",
+			url:       "/grafanablah",
+			appURL:    "http://localhost:3000/",
+			appSubURL: "/grafana",
+			status:    200,
+			err:       login.ErrInvalidRedirectTo,
+		},
+		{
+			desc:      "grafana relative url with subpath with leading slash",
 			url:       "/grafana/profile",
-			appURL:    "http://localhost:3000",
-			appSubURL: "grafana",
+			appURL:    "http://localhost:3000/",
+			appSubURL: "/grafana",
 			status:    302,
 		},
 		{
 			desc:      "relative url with missing subpath",
 			url:       "/profile",
-			appURL:    "http://localhost:3000",
-			appSubURL: "grafana",
+			appURL:    "http://localhost:3000/",
+			appSubURL: "/grafana",
 			status:    200,
 			err:       login.ErrInvalidRedirectTo,
 		},
 		{
 			desc:   "grafana absolute url",
 			url:    "http://localhost:3000/profile",
-			appURL: "http://localhost:3000",
+			appURL: "http://localhost:3000/",
 			status: 200,
 			err:    login.ErrAbsoluteRedirectTo,
 		},
 		{
 			desc:   "non grafana absolute url",
 			url:    "http://example.com",
-			appURL: "http://localhost:3000",
+			appURL: "http://localhost:3000/",
 			status: 200,
 			err:    login.ErrAbsoluteRedirectTo,
 		},
 		{
 			desc:   "invalid url",
 			url:    ":foo",
-			appURL: "http://localhost:3000",
+			appURL: "http://localhost:3000/",
 			status: 200,
 			err:    login.ErrInvalidRedirectTo,
 		},
@@ -273,31 +282,38 @@ func TestLoginPostRedirect(t *testing.T) {
 		{
 			desc:   "grafana relative url without subpath",
 			url:    "/profile",
-			appURL: "https://localhost:3000",
+			appURL: "https://localhost:3000/",
 		},
 		{
-			desc:      "grafana relative url with subpath",
+			desc:      "grafana relative url with subpath with leading slash",
 			url:       "/grafana/profile",
-			appURL:    "https://localhost:3000",
-			appSubURL: "grafana",
+			appURL:    "https://localhost:3000/",
+			appSubURL: "/grafana",
+		},
+		{
+			desc:      "grafana invalid relative url starting with subpath",
+			url:       "/grafanablah",
+			appURL:    "https://localhost:3000/",
+			appSubURL: "/grafana",
+			err:       login.ErrInvalidRedirectTo,
 		},
 		{
 			desc:      "relative url with missing subpath",
 			url:       "/profile",
-			appURL:    "https://localhost:3000",
-			appSubURL: "grafana",
+			appURL:    "https://localhost:3000/",
+			appSubURL: "/grafana",
 			err:       login.ErrInvalidRedirectTo,
 		},
 		{
 			desc:   "grafana absolute url",
 			url:    "http://localhost:3000/profile",
-			appURL: "http://localhost:3000",
+			appURL: "http://localhost:3000/",
 			err:    login.ErrAbsoluteRedirectTo,
 		},
 		{
 			desc:   "non grafana absolute url",
 			url:    "http://example.com",
-			appURL: "https://localhost:3000",
+			appURL: "https://localhost:3000/",
 			err:    login.ErrAbsoluteRedirectTo,
 		},
 	}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -47,7 +47,7 @@ func notAuthorized(c *models.ReqContext) {
 		return
 	}
 
-	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(c.Req.RequestURI), 0, newCookieOptions)
+	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, newCookieOptions)
 
 	c.Redirect(setting.AppSubUrl + "/login")
 }

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -47,7 +47,11 @@ func notAuthorized(c *models.ReqContext) {
 		return
 	}
 
-	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, newCookieOptions)
+	redirectTo := c.Req.RequestURI
+	if setting.AppSubUrl != "" && !strings.HasPrefix(redirectTo, setting.AppSubUrl) {
+		redirectTo = setting.AppSubUrl + c.Req.RequestURI
+	}
+	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, newCookieOptions)
 
 	c.Redirect(setting.AppSubUrl + "/login")
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"gopkg.in/ini.v1"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -297,4 +299,29 @@ func TestLoadingSettings(t *testing.T) {
 		})
 
 	})
+}
+
+func TestParseAppUrlAndSubUrl(t *testing.T) {
+	testCases := []struct {
+		rootURL           string
+		expectedAppURL    string
+		expectedAppSubURL string
+	}{
+		{rootURL: "http://localhost:3000/", expectedAppURL: "http://localhost:3000/"},
+		{rootURL: "http://localhost:3000", expectedAppURL: "http://localhost:3000/"},
+		{rootURL: "http://localhost:3000/grafana", expectedAppURL: "http://localhost:3000/grafana/", expectedAppSubURL: "/grafana"},
+		{rootURL: "http://localhost:3000/grafana/", expectedAppURL: "http://localhost:3000/grafana/", expectedAppSubURL: "/grafana"},
+	}
+
+	for _, tc := range testCases {
+		f := ini.Empty()
+		s, err := f.NewSection("server")
+		require.NoError(t, err)
+		_, err = s.NewKey("root_url", tc.rootURL)
+		require.NoError(t, err)
+		appURL, appSubURL, err := parseAppUrlAndSubUrl(s)
+		require.NoError(t, err)
+		require.Equal(t, tc.expectedAppURL, appURL)
+		require.Equal(t, tc.expectedAppSubURL, appSubURL)
+	}
 }

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -104,9 +104,17 @@ export class LoginCtrl extends PureComponent<Props, State> {
     const params = this.props.routeParams;
     // Use window.location.href to force page reload
     if (params.redirect && params.redirect[0] === '/') {
-      window.location.href = config.appSubUrl + params.redirect;
+      if (config.appSubUrl !== '' && !params.redirect.startsWith(config.appSubUrl)) {
+        window.location.href = config.appSubUrl + params.redirect;
+      } else {
+        window.location.href = params.redirect;
+      }
     } else if (this.result.redirectUrl) {
-      window.location.href = config.appSubUrl + this.result.redirectUrl;
+      if (config.appSubUrl !== '' && !this.result.redirectUrl.startsWith(config.appSubUrl)) {
+        window.location.href = config.appSubUrl + this.result.redirectUrl;
+      } else {
+        window.location.href = this.result.redirectUrl;
+      }
     } else {
       window.location.href = config.appSubUrl + '/';
     }

--- a/public/sass/components/_buttons.scss
+++ b/public/sass/components/_buttons.scss
@@ -209,7 +209,7 @@ $btn-service-icon-width: 35px;
 
 .btn-service--grafanacom {
   .btn-service-icon {
-    background-image: url(/public/img/grafana_mask_icon_white.svg);
+    background-image: url(../img/grafana_mask_icon_white.svg);
     background-repeat: no-repeat;
     background-position: 50%;
     background-size: 60%;
@@ -218,7 +218,7 @@ $btn-service-icon-width: 35px;
 
 .btn-service--azuread {
   .btn-service-icon {
-    background-image: url(/public/img/microsoft_auth_icon.svg);
+    background-image: url(../img/microsoft_auth_icon.svg);
     background-repeat: no-repeat;
     background-position: 50%;
     background-size: 60%;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The 6.6.1 has the following issues:
- In [this](https://github.com/grafana/grafana/pull/21057) modification I had made the wrong assumption that the appSubUrl does not include the leading slash. As a result the redirect validation is not correct. In addition to this, validation should not consider correct paths like `/<appSubUrl>blahblah`.
- Frontend prepends the subpath to redirects in addition to the backend (`/grafana` ends up to `/grafana/grafana`)

[This](https://github.com/grafana/grafana/pull/21652) fix addresses the above issues by [removing](https://github.com/grafana/grafana/pull/21652/files#diff-c6731ee8c1631796c076df9ae9e4d2c7R50) the subpath from redirects in the backend.
However it does not work optimally when redirects occur in the backend before reaching the frontend ([like in the OAuth flow](https://github.com/grafana/grafana/issues/22227)) because the session cookie path is set to `appSubUrl/` and requests without the appSubUrl can not read it.

[This](https://github.com/grafana/grafana/pull/22265/) fixes the above issue by removing the trailing slash from the cookie path.

The reason for this is that addresses the causes of the problem instead of the symptoms.

This PR:
- [X] Reverts [this](https://github.com/grafana/grafana/pull/22265/) (#22671)
- [X] Fixes redirect validation and tests (#22675)
- [X] Modifies the backend and the frontend to prepend the appSubUrl only if it’s missing from the redirect URL (#22676)
- [X] Validates the redirect URL in OAuth login (#22677)
- [X] Fixes login view if `redirect_to` value is invalid but the user is authenticated so as the user is navigated to the home page instead of rendering login page with error. (#22678)

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #22227
Fixes #22461

**Special notes for your reviewer**:

I have tested it with  the following scenarios:
- with subpath `/grafana`:
    - base auth:
        - [X] Dashboard URL (http://localhost:3000/grafana/d/dFcV-J4Zz/16707?orgId=1)
        - [X] http://localhost:3000/grafana/
        - [X] http://localhost:3000/grafana
        - [X] http://localhost:3000/grafanagrafana
    - oauth:
        - [X] Dashboard URL (http://localhost:3000/grafana/d/dFcV-J4Zz/16707?orgId=1)
        - [X] http://localhost:3000/grafana/
        - [X] http://localhost:3000/grafana
        - [X] http://localhost:3000/grafanagrafana

- without subpath:
    - base auth:
        - [X]  Dashboard URL (http://localhost:3000/d/dFcV-J4Zz/16707?orgId=1)
        - [X] http://localhost:3000/
        - [X] http://localhost:3000
        - [X] http://localhost:3000/grafanagrafana
    - oauth:
        - [X]  Dashboard URL (http://localhost:3000/d/dFcV-J4Zz/16707?orgId=1)
        - [X] http://localhost:3000/
        - [X] http://localhost:3000
        - [X] http://localhost:3000/grafanagrafana