### PR TITLE
Export dashboard to PDF

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.ts
+++ b/public/app/features/dashboard/components/ShareModal/ShareModalCtrl.ts
@@ -31,6 +31,7 @@ export function ShareModalCtrl(
     $scope.panel = $scope.model && $scope.model.panel ? $scope.model.panel : $scope.panel; // React pass panel and dashboard in the "model" property
     $scope.dashboard = $scope.model && $scope.model.dashboard ? $scope.model.dashboard : $scope.dashboard; // ^
     $scope.modeSharePanel = $scope.panel ? true : false;
+    $scope.showLinkToPDF = config.licenseInfo.hasLicense;
 
     $scope.tabs = [{ title: 'Link', src: 'shareLink.html' }];
 
@@ -104,6 +105,15 @@ export function ShareModalCtrl(
     );
     $scope.imageUrl = $scope.imageUrl.replace(config.appSubUrl + '/d-solo/', config.appSubUrl + '/render/d-solo/');
     $scope.imageUrl += '&width=1000&height=500' + $scope.getLocalTimeZone();
+
+    if ($scope.showLinkToPDF) {
+      const dashboardId = $scope.dashboard.id;
+      let rootPath = window.location.origin + config.appSubUrl;
+      if (rootPath.endsWith('/')) {
+        rootPath.slice(0, -1);
+      }
+      $scope.pdfUrl = `${rootPath}/api/reports/render/pdf/${dashboardId}`;
+    }
   };
 
   // This function will try to return the proper full name of the local timezone

--- a/public/app/features/dashboard/components/ShareModal/template.html
+++ b/public/app/features/dashboard/components/ShareModal/template.html
@@ -94,6 +94,9 @@
   		<div class="gf-form" ng-show="modeSharePanel">
   			<a href="{{imageUrl}}" target="_blank" aria-label={{selectors.linkToRenderedImage}}><i class="fa fa-camera"></i> Direct link rendered image</a>
   		</div>
+  		<div class="gf-form" ng-show="showLinkToPDF">
+  			<a href="{{pdfUrl}}" target="_blank" aria-label={{selectors.linkToRenderedPDF}}><i class="fa fa-camera"></i> Direct link rendered PDF</a>
+  		</div>
   	</div>
 </script>
 


### PR DESCRIPTION
This PR uses PDF rendering endpoint (available in Enterprise) to share dashboard as a PDF file.