### PR TITLE
Docker: Upgrade Ubuntu to 19.10

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -27,14 +27,14 @@ COPY packages packages
 RUN yarn install --pure-lockfile
 
 COPY Gruntfile.js tsconfig.json .eslintrc .browserslistrc ./
-COPY public public 
+COPY public public
 COPY scripts scripts
 COPY emails emails
 
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 EXPOSE 3000

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -64,7 +64,7 @@ docker_build () {
   else
     libc=""
     dockerfile="ubuntu.Dockerfile"
-    base_image="${base_arch}ubuntu:18.10"
+    base_image="${base_arch}ubuntu:19.10"
   fi
 
   grafana_tgz="grafana-latest.linux-${arch}${libc}.tar.gz"

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:18.10
+ARG BASE_IMAGE=ubuntu:19.10
 FROM ${BASE_IMAGE} AS grafana-builder
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade our Dockerfiles to latest Ubuntu version (19.10). Hoping it will fix our CircleCI build failures.
