### PR TITLE
CircleCI: Upgrade Ubuntu base image to 19.10 also for enterprise in build-pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,11 +515,11 @@ jobs:
             pushd packaging/docker
             docker build -t "grafana/grafana-enterprise:master-ubuntu" --no-cache=true -f ubuntu.Dockerfile .
             docker build -t "grafana/grafana-enterprise-arm32v7-linux:master-ubuntu" \
-              --build-arg BASE_IMAGE=arm32v7/ubuntu:18.10 \
+              --build-arg BASE_IMAGE=arm32v7/ubuntu:19.10 \
               --build-arg GRAFANA_TGZ=grafana-latest.linux-armv7.tar.gz \
               --no-cache=true -f ubuntu.Dockerfile .
             docker build -t "grafana/grafana-enterprise-arm64v8-linux:master-ubuntu" \
-              --build-arg BASE_IMAGE=arm64v8/ubuntu:18.10 \
+              --build-arg BASE_IMAGE=arm64v8/ubuntu:19.10 \
               --build-arg GRAFANA_TGZ=grafana-latest.linux-arm64.tar.gz \
               --no-cache=true -f ubuntu.Dockerfile .
             popd


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade Ubuntu base image to 19.10 also for enterprise in CircleCI's build-pipeline.
