### PR TITLE
Adds cloudwatch points length test

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -1,7 +1,9 @@
 package cloudwatch
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +13,11 @@ import (
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
+
+func prettyPrint(i interface{}) string {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	return string(s)
+}
 
 func (e *CloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMetricDataOutput, queries map[string]*cloudWatchQuery) ([]*cloudwatchResponse, error) {
 	mdr := make(map[string]map[string]*cloudwatch.MetricDataResult)
@@ -71,6 +78,11 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	}
 	sort.Strings(metricDataResultLabels)
 
+	log.Println("metricDataResultLabels")
+	log.Println(prettyPrint(metricDataResultLabels))
+
+	// if (len())
+
 	for _, label := range metricDataResultLabels {
 		metricDataResult := metricDataResults[label]
 		if *metricDataResult.StatusCode != "Complete" {
@@ -110,6 +122,9 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 		}
 
 		series.Name = formatAlias(query, query.Stats, series.Tags, label)
+
+		log.Println("metricDataResult")
+		log.Println(prettyPrint(metricDataResult))
 
 		for j, t := range metricDataResult.Timestamps {
 			if j > 0 {

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"log"
 	"testing"
 	"time"
 
@@ -11,8 +12,8 @@ import (
 )
 
 func TestCloudWatchResponseParser(t *testing.T) {
-	Convey("TestCloudWatchResponseParser", t, func() {
-		Convey("can expand dimension value using exact match", func() {
+	FocusConvey("TestCloudWatchResponseParser", t, func() {
+		FocusConvey("can expand dimension value using exact match", func() {
 			timestamp := time.Unix(0, 0)
 			resp := map[string]*cloudwatch.MetricDataResult{
 				"lb1": {
@@ -63,14 +64,19 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			series, partialData, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
 
+			log.Println("series")
+			log.Println(prettyPrint(series))
+
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
 			So(timeSeries.Name, ShouldEqual, "lb1 Expanded")
 			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb1")
+			So(timeSeries.Points, ShouldHaveLength, 3)
 
 			timeSeries2 := (*series)[1]
 			So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
 			So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
+			So(timeSeries2.Points, ShouldHaveLength, 3)
 		})
 
 		Convey("can expand dimension value using substring", func() {
@@ -131,6 +137,87 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			timeSeries2 := (*series)[1]
 			So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
 			So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
+		})
+
+		Convey("can expand alias when there's no data returned", func() {
+			resp := map[string]*cloudwatch.MetricDataResult{}
+			query := &cloudWatchQuery{
+				RefId:      "refId1",
+				Region:     "us-east-1",
+				Namespace:  "AWS/ApplicationELB",
+				MetricName: "TargetResponseTime",
+				Dimensions: map[string][]string{
+					"LoadBalancer": {"lb1", "lb2"},
+					"TargetGroup":  {"tg"},
+				},
+				Stats:  "Average",
+				Period: 60,
+				Alias:  "{{LoadBalancer}} Expanded",
+			}
+			series, partialData, err := parseGetMetricDataTimeSeries(resp, query)
+
+			log.Println("series")
+			log.Println(prettyPrint(series))
+
+			timeSeries := (*series)[0]
+			So(err, ShouldBeNil)
+			So(partialData, ShouldBeFalse)
+			So(timeSeries.Name, ShouldEqual, "lb1 Expanded")
+			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb1")
+
+			timeSeries2 := (*series)[1]
+			So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
+			So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
+
+		})
+
+		Convey("can expand alias when there's partial data returned", func() {
+			timestamp := time.Unix(0, 0)
+			resp := map[string]*cloudwatch.MetricDataResult{
+				"lb1": {
+					Id:    aws.String("id1"),
+					Label: aws.String("lb1"),
+					Timestamps: []*time.Time{
+						aws.Time(timestamp),
+						aws.Time(timestamp.Add(60 * time.Second)),
+						aws.Time(timestamp.Add(180 * time.Second)),
+					},
+					Values: []*float64{
+						aws.Float64(10),
+						aws.Float64(20),
+						aws.Float64(30),
+					},
+					StatusCode: aws.String("Complete"),
+				},
+			}
+			query := &cloudWatchQuery{
+				RefId:      "refId1",
+				Region:     "us-east-1",
+				Namespace:  "AWS/ApplicationELB",
+				MetricName: "TargetResponseTime",
+				Dimensions: map[string][]string{
+					"LoadBalancer": {"lb1", "lb2"},
+					"TargetGroup":  {"tg"},
+				},
+				Stats:  "Average",
+				Period: 60,
+				Alias:  "{{LoadBalancer}} Expanded",
+			}
+			series, partialData, err := parseGetMetricDataTimeSeries(resp, query)
+
+			log.Println("series")
+			log.Println(prettyPrint(series))
+
+			timeSeries := (*series)[0]
+			So(err, ShouldBeNil)
+			So(partialData, ShouldBeFalse)
+			So(timeSeries.Name, ShouldEqual, "lb1 Expanded")
+			So(timeSeries.Tags["LoadBalancer"], ShouldEqual, "lb1")
+
+			// timeSeries2 := (*series)[1]
+			// So(timeSeries2.Name, ShouldEqual, "lb2 Expanded")
+			// So(timeSeries2.Tags["LoadBalancer"], ShouldEqual, "lb2")
+
 		})
 
 		Convey("can expand dimension value using wildcard", func() {


### PR DESCRIPTION
Just trying to look at #22204 - with the latest code, i noticed that something weird is going on with parseGetMetricDataTimeSeries - an additional item is present in the points list, with null as its value: 

![image](https://user-images.githubusercontent.com/1453591/74919732-f2c55180-53c2-11ea-9853-16ed4e3ec690.png)

I've added some additional assertions to the test to highlight it, and have also added additional tests for #22204

![image](https://user-images.githubusercontent.com/1453591/74919674-d6c1b000-53c2-11ea-9877-591a7a79ab53.png)

Is the extra point expected? If so, what purpose does it serve? I was wondering if the second "series.Points = append(" call should be in an else statement?

![image](https://user-images.githubusercontent.com/1453591/74920022-623b4100-53c3-11ea-8afe-26f1ccabcede.png)

