### PR TITLE
Cloudwatch : Adds empty series when no matching data is returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ If you're interested in contributing to the Grafana project:
 ## License
 
 Grafana is distributed under the [Apache 2.0 License](https://github.com/grafana/grafana/blob/master/LICENSE).
+
+#

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -13,15 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func (e *CloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMetricDataOutput, queries map[string]*cloudWatchQuery) ([]*cloudwatchResponse, error) {
 	mdr := make(map[string]map[string]*cloudwatch.MetricDataResult)
 

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -1,9 +1,7 @@
 package cloudwatch
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,11 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
-
-func prettyPrint(i interface{}) string {
-	s, _ := json.MarshalIndent(i, "", "\t")
-	return string(s)
-}
 
 func contains(s []string, e string) bool {
 	for _, a := range s {
@@ -84,20 +77,7 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	partialData := false
 	metricDataResultLabels := make([]string, 0)
 
-	// contains(s, s1)
-
-	log.Println("metricDataResults")
-	log.Println(len(metricDataResults))
-	log.Println(prettyPrint(metricDataResults))
-
-	log.Println("query")
-	log.Println(prettyPrint(query))
-
 	if requestAzs, ok := query.Dimensions["AvailabilityZone"]; ok {
-		//do something here
-
-		log.Println("AvailabilityZone len")
-		log.Println(len(requestAzs))
 
 		if len(requestAzs) > len(metricDataResults) {
 			// Data is missing, add empty metrics...
@@ -107,9 +87,6 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 				requestAz := requestAzs[k]
 				metricDataResultLabels = append(metricDataResultLabels, requestAz)
 				if _, ok := metricDataResults[requestAz]; !ok {
-					log.Println("AvailabilityZone not found in results")
-					log.Println(requestAz)
-
 					metricDataResults[requestAz] = &cloudwatch.MetricDataResult{
 						//TODO : we need to use the same id val as that in the existing items. What do we do if results are empty?
 						Id:         aws.String("id1"),
@@ -129,23 +106,11 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 		}
 	}
 
-	log.Println("modified metricDataResults")
-	log.Println(len(metricDataResults))
-	log.Println(prettyPrint(metricDataResults))
-
 	sort.Strings(metricDataResultLabels)
-
-	log.Println("metricDataResultLabels")
-	log.Println(prettyPrint(metricDataResultLabels))
-	// if (len())
 
 	for _, label := range metricDataResultLabels {
 
 		metricDataResult := metricDataResults[label]
-
-		log.Println("iterating labels")
-		log.Println(label)
-		log.Println(prettyPrint(metricDataResult))
 
 		if *metricDataResult.StatusCode != "Complete" {
 			partialData = true
@@ -185,9 +150,6 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 
 		series.Name = formatAlias(query, query.Stats, series.Tags, label)
 
-		log.Println("metricDataResult")
-		log.Println(prettyPrint(metricDataResult))
-
 		for j, t := range metricDataResult.Timestamps {
 			if j > 0 {
 				expectedTimestamp := metricDataResult.Timestamps[j-1].Add(time.Duration(query.Period) * time.Second)
@@ -197,9 +159,6 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 			}
 			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFrom(*metricDataResult.Values[j]), float64((*t).Unix())*1000))
 		}
-
-		log.Println("return series")
-		log.Println(prettyPrint(series))
 
 		result = append(result, &series)
 	}

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -8,10 +9,25 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
+
+func prettyPrint(i interface{}) string {
+	s, _ := json.MarshalIndent(i, "", "\t")
+	return string(s)
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
 
 func (e *CloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMetricDataOutput, queries map[string]*cloudWatchQuery) ([]*cloudwatchResponse, error) {
 	mdr := make(map[string]map[string]*cloudwatch.MetricDataResult)
@@ -67,18 +83,70 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	result := tsdb.TimeSeriesSlice{}
 	partialData := false
 	metricDataResultLabels := make([]string, 0)
-	for k := range metricDataResults {
-		metricDataResultLabels = append(metricDataResultLabels, k)
+
+	// contains(s, s1)
+
+	log.Println("metricDataResults")
+	log.Println(len(metricDataResults))
+	log.Println(prettyPrint(metricDataResults))
+
+	log.Println("query")
+	log.Println(prettyPrint(query))
+
+	if requestAzs, ok := query.Dimensions["AvailabilityZone"]; ok {
+		//do something here
+
+		log.Println("AvailabilityZone len")
+		log.Println(len(requestAzs))
+
+		if len(requestAzs) > len(metricDataResults) {
+			// Data is missing, add empty metrics...
+			// TODO - does this only apply to AZs? Or other dimensions?
+
+			for k := range requestAzs {
+				requestAz := requestAzs[k]
+				metricDataResultLabels = append(metricDataResultLabels, requestAz)
+				if _, ok := metricDataResults[requestAz]; !ok {
+					log.Println("AvailabilityZone not found in results")
+					log.Println(requestAz)
+
+					metricDataResults[requestAz] = &cloudwatch.MetricDataResult{
+						//TODO : we need to use the same id val as that in the existing items. What do we do if results are empty?
+						Id:         aws.String("id1"),
+						Label:      aws.String(requestAz),
+						Timestamps: []*time.Time{},
+						Values:     []*float64{},
+						StatusCode: aws.String("Complete"),
+					}
+				}
+			}
+
+		}
+	} else {
+
+		for k := range metricDataResults {
+			metricDataResultLabels = append(metricDataResultLabels, k)
+		}
 	}
+
+	log.Println("modified metricDataResults")
+	log.Println(len(metricDataResults))
+	log.Println(prettyPrint(metricDataResults))
+
 	sort.Strings(metricDataResultLabels)
 
 	log.Println("metricDataResultLabels")
 	log.Println(prettyPrint(metricDataResultLabels))
-
 	// if (len())
 
 	for _, label := range metricDataResultLabels {
+
 		metricDataResult := metricDataResults[label]
+
+		log.Println("iterating labels")
+		log.Println(label)
+		log.Println(prettyPrint(metricDataResult))
+
 		if *metricDataResult.StatusCode != "Complete" {
 			partialData = true
 		}
@@ -129,6 +197,10 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 			}
 			series.Points = append(series.Points, tsdb.NewTimePoint(null.FloatFrom(*metricDataResult.Values[j]), float64((*t).Unix())*1000))
 		}
+
+		log.Println("return series")
+		log.Println(prettyPrint(series))
+
 		result = append(result, &series)
 	}
 	return &result, partialData, nil

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -71,6 +72,11 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	}
 	sort.Strings(metricDataResultLabels)
 
+	log.Println("metricDataResultLabels")
+	log.Println(prettyPrint(metricDataResultLabels))
+
+	// if (len())
+
 	for _, label := range metricDataResultLabels {
 		metricDataResult := metricDataResults[label]
 		if *metricDataResult.StatusCode != "Complete" {
@@ -110,6 +116,9 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 		}
 
 		series.Name = formatAlias(query, query.Stats, series.Tags, label)
+
+		log.Println("metricDataResult")
+		log.Println(prettyPrint(metricDataResult))
 
 		for j, t := range metricDataResult.Timestamps {
 			if j > 0 {

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -1,8 +1,6 @@
 package cloudwatch
 
 import (
-	"encoding/json"
-	"log"
 	"testing"
 	"time"
 
@@ -11,11 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/null"
 	. "github.com/smartystreets/goconvey/convey"
 )
-
-func prettyPrint(i interface{}) string {
-	s, _ := json.MarshalIndent(i, "", "\t")
-	return string(s)
-}
 
 func TestCloudWatchResponseParser(t *testing.T) {
 	Convey("TestCloudWatchResponseParser", t, func() {
@@ -69,9 +62,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			}
 			series, partialData, err := parseGetMetricDataTimeSeries(resp, query)
 			timeSeries := (*series)[0]
-
-			log.Println("series")
-			log.Println(prettyPrint(series))
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)


### PR DESCRIPTION
Fixes #22204 

Taken a slightly different approach to my first attempt, simply doctoring the cloudwatch response if data is missing, and then allowing the rest of the time series generation to run.

Tests are now passing, and have added two additional tests for the scenarios we've reported.

I did notice a potentials issue in the existing code, documented in PR https://github.com/grafana/grafana/pull/22331