### PR TITLE
UI: Adds a flot plot component

### DIFF
--- a/packages/grafana-data/src/types/graph.ts
+++ b/packages/grafana-data/src/types/graph.ts
@@ -26,6 +26,263 @@ export interface GraphSeriesXY {
   info?: DisplayValue[]; // Legend info
 }
 
+interface FlotFont {
+  size: number; // in pixels
+  lineHeight: number; // in pixels
+  style: string;
+  weight: string;
+  family: string;
+  variant: string;
+  color: string;
+}
+
+interface FlotCrosshairOptions {
+  mode?: null | 'x' | 'y' | 'xy';
+  color?: string;
+  lineWidth?: number;
+}
+
+interface FlotSelectionOptions {
+  mode?: null | 'x' | 'y' | 'xy';
+  color?: string;
+  shape?: 'round' | 'miter' | 'bevel';
+  minSize?: number;
+}
+
+export interface FlotPlotOptions {
+  colors?: string[];
+  legend?: FlotLegend;
+  xaxis?: FlotAxis;
+  yaxis?: FlotAxis;
+  xaxes?: FlotAxis[];
+  yaxes?: FlotAxis[];
+  series?: Partial<FlotSeries>;
+  grid?: GridOptions;
+  interaction?: {
+    redrawOverlayInterval?: number;
+  };
+  hooks?: FlotHooks;
+
+  crosshair?: FlotCrosshairOptions;
+
+  selection?: FlotSelectionOptions;
+}
+
+export interface FlotPlot {
+  // public functions
+  setData: (data: Array<Array<[number, number]> | FlotSeries>) => void;
+  setupGrid: () => void;
+  draw: () => void;
+  getPlaceHolder: () => HTMLElement;
+  getCanvas: () => HTMLCanvasElement;
+  getPlotOffset: () => { left: number; right: number; top: number; bottom: number };
+  width: () => number;
+  height: () => number;
+  offset: () => { left: number; top: number };
+  getData: () => FlotSeries[];
+  getAxes: () => {
+    [key: string]: FlotAxis;
+    xaxis: FlotAxis;
+    yaxis: FlotAxis;
+  };
+  getXAxes: () => FlotAxis[];
+  getYAxes: () => FlotAxis[];
+  c2p: (pos: { left: number; top: number }) => { x: number; y: number };
+  p2c: any;
+  getOptions: () => FlotPlotOptions;
+  highlight: any;
+  unhighlight: any;
+  triggerRedrawOverlay: any;
+  pointOffset: any;
+  shutdown: any;
+  destroy: any;
+  resize: any;
+
+  // public attributes
+  hooks: FlotHooks;
+}
+
+interface FlotDatapoints {
+  points: number[];
+  format?: {
+    number: boolean;
+    required: boolean;
+    x?: boolean;
+    y?: boolean;
+    defaultValue?: number;
+    autoscale?: boolean;
+  };
+  pointsize?: number;
+}
+
+interface FlotHooks {
+  processOptions?: (plot: FlotPlot, options: FlotPlotOptions) => void;
+  processRawData?: (
+    plot: FlotPlot,
+    series: FlotSeries,
+    data: Array<[number, number]>,
+    datapoints: FlotDatapoints
+  ) => void;
+  processDatapoints?: (plot: FlotPlot, series: FlotSeries, datapoints: Required<FlotDatapoints>) => void;
+  processOffset?: (plot: FlotPlot, offset: { left: number; right: number; top: number; bottom: number }) => void;
+  drawBackground?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  drawSeries?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D, series: FlotSeries) => void;
+  draw?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  bindEvents?: (plot: FlotPlot, eventHolder: JQuery) => void;
+  drawOverlay?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  shutdown?: (plot: FlotPlot, eventHolder: JQuery) => void;
+}
+
+interface FlotAxisCommon {
+  show?: null | boolean;
+  position?: 'bottom' | 'top' | 'left' | 'right';
+
+  color?: null | string;
+  tickColor?: null | string;
+  font?: null | FlotFont;
+
+  min?: null | number;
+  max?: null | number;
+  autoscaleMargin?: null | number;
+
+  transform?: null | ((v: number) => number);
+  inverseTransform?: null | ((v: number) => number);
+
+  ticks?:
+    | null
+    | number
+    | number[]
+    | Array<[number, string]>
+    | ((axis: { min: number; max: number }) => number[] | Array<[number, string]>);
+  tickSize?: number | [number, string];
+  minTickSize?: number | [number, string];
+  tickFormatter?: ((val: number, b: Pick<FlotAxis, 'min' | 'max' | 'tickDecimals' | 'tickSize'>) => string) | string;
+  tickDecimals?: null | number;
+
+  labelWidth?: null | number;
+  labelHeight?: null | number;
+  reserveSpace?: null | true;
+
+  tickLength?: null | number; // in pixels
+
+  alignTicksWithAxis?: null | number;
+}
+
+interface FlotAxisDefaultMode extends FlotAxisCommon {
+  mode?: null; // null means data are interpreted as decimal numbers
+}
+
+interface FlotAxisTS extends FlotAxisCommon {
+  mode?: 'time';
+  timezone?: null | 'browser' | string; // only makes sense for mode 'time'
+
+  minTickSize?: [number, 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'];
+  timeformat?: null | string;
+  monthNames?: null | [string, string, string, string, string, string, string, string, string, string, string, string];
+  dayNames?: null | [string, string, string, string, string, string, string];
+  twelveHourClock?: boolean;
+}
+
+export type FlotAxis = FlotAxisDefaultMode | FlotAxisTS;
+
+interface FlotGradient {
+  colors: Array<
+    | {
+        opacity?: number;
+        brightness?: number;
+      }
+    | string
+  >;
+}
+export interface FlotGridMarking {
+  xaxis?: { from: number; to: number };
+  yaxis?: { from: number; to: number };
+  x2axis?: { from: number; to: number };
+  y2axis?: { from: number; to: number };
+  color?: string;
+}
+
+interface GridOptions {
+  show?: boolean;
+  aboveData?: boolean;
+  color?: string;
+  backgroundColor?: FlotGradient | string | null;
+  margin?: number | { top?: number; right?: number; bottom?: number; left?: number };
+  labelMargin?: number;
+  axisMargin?: number;
+  markings?: FlotGridMarking[] | ((axes: Record<'xaxis' | 'yaxis', FlotAxis>) => FlotGridMarking[]);
+  borderWidth?: number | { top?: number; right?: number; bottom?: number; left?: number };
+  borderColor?: string | null | { top?: string; right?: string; bottom?: string; left?: string };
+  minBorderMargin?: number | null;
+  clickable?: boolean;
+  hoverable?: boolean;
+  autoHighlight?: boolean;
+  mouseActiveRadius?: number;
+}
+
+interface DisplayOptions {
+  show?: boolean;
+  lineWidth?: number;
+  fill?: boolean | number;
+}
+
+interface FlotLineOptions extends DisplayOptions {
+  zero?: boolean;
+  steps?: boolean;
+  fillColor?: null | false | string;
+}
+
+interface FlotBarOptions extends DisplayOptions {
+  zero?: boolean;
+  barWidth?: number; // in units of x-axis
+  align?: 'left' | 'right' | 'center';
+  horizontal?: boolean;
+  fillColor?: null | false | string | FlotGradient;
+}
+
+interface FlotPointOptions extends DisplayOptions {
+  radius?: number;
+  symbol?: 'circle' | ((ctx: any, x: number, y: number, radius: number, shadow: boolean) => void);
+  fillColor?: null | false | string;
+}
+
+export interface FlotSeries {
+  data: Array<[number, number]>;
+
+  color?: string | number;
+  label?: string;
+  lines?: FlotLineOptions;
+  bars?: FlotBarOptions;
+  points?: FlotPointOptions;
+  xaxis?: number; // ID of x-axis to plot series against
+  yaxis?: number; // ID of y-axis to plot series against
+  clickable?: boolean;
+  hoverable?: boolean;
+  shadowSize?: number;
+  highlightColor?: string | number;
+
+  // Stack options
+  stack?: null | boolean | number | string;
+}
+
+interface FlotLegend {
+  show?: boolean;
+  labelFormatter?: (label: string, series: FlotSeries) => string;
+  labelBoxBorderColor?: string;
+  noColumns?: number;
+  position?: 'ne' | 'nw' | 'se' | 'sw';
+  margin?: number | [number, number];
+  backgroundColor?: string;
+  backgroundOpacity?: number; // [0,1]
+  container?: Element;
+  sorted?:
+    | boolean
+    | 'ascending'
+    | 'descending'
+    | 'reverse'
+    | ((a: { label: string; color: string }, b: { label: string; color: string }) => number);
+}
+
 export interface CreatePlotOverlay {
   (element: JQuery, event: any, plot: { getOptions: () => { events: { manager: any } } }): any;
 }

--- a/packages/grafana-ui/src/components/FlotGraph/FlotGraph.story.tsx
+++ b/packages/grafana-ui/src/components/FlotGraph/FlotGraph.story.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { FlotGraph, GraphProps } from './FlotGraph';
+import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
+import { number, boolean, select, color, date } from '@storybook/addon-knobs';
+
+export default {
+  title: 'Visualizations/FlotGraph/FlotGraph',
+  component: FlotGraph,
+  decorators: [withCenteredStory],
+};
+
+const dynamic = (boolName: string, boolDefault: boolean, knob: () => any, invert?: boolean, groupId?: string) => {
+  const boolKnob = boolean(boolName, boolDefault, groupId);
+  if ((invert && !boolKnob) || (!invert && boolKnob)) {
+    return knob();
+  } else {
+    return null;
+  }
+};
+
+const getProps = (): GraphProps => {
+  const generalKnobs = 'General';
+  const crosshairKnobs = 'Crosshair';
+  const xaxisKnobs = 'X-Axis';
+  const yaxisKnobs = 'Y-Axis';
+  const gridKnobs = 'Grid';
+  const selectionKnobs = 'Selection';
+  const legendKnobs = 'Legend';
+
+  const cosData: Array<[number, number]> = new Array(100)
+    .fill(1)
+    .map((_, i) => [1546372800000 + i * 10000, Math.cos((i / 100) * 2 * Math.PI)]);
+
+  const sinData: Array<[number, number]> = new Array(100)
+    .fill(1)
+    .map((_, i) => [1546372800000 + i * 10000, Math.sin((i / 100) * 2 * Math.PI - Math.PI / 2)]);
+
+  return {
+    data: [
+      {
+        data: cosData,
+        label: 'cos(x)',
+      },
+      {
+        data: sinData,
+        label: 'sin(y)',
+      },
+    ],
+    width: number('Plot Width', 800, {}, generalKnobs),
+    height: number('Plot Height', 500, {}, generalKnobs),
+
+    crosshair: {
+      mode: select('Mode', { Default: null, X: 'x', Y: 'y', XY: 'xy' }, null, crosshairKnobs),
+      color: color('Color', '#ffffff', crosshairKnobs),
+      lineWidth: number('Line Width', 1, {}, crosshairKnobs),
+    },
+
+    xaxis: {
+      show: boolean('Show', true, xaxisKnobs),
+      mode: 'time',
+      position: select('Position', { Bottom: 'bottom', Top: 'top' }, 'bottom', xaxisKnobs),
+      min: dynamic(
+        'Automatic Minimum',
+        true,
+        () => date('Minimum', new Date(1546372800000), xaxisKnobs),
+        true,
+        xaxisKnobs
+      ),
+      max: dynamic(
+        'Automatic Maximum',
+        true,
+        () => date('Maximum', new Date(1546380000000), xaxisKnobs),
+        true,
+        xaxisKnobs
+      ),
+    },
+
+    yaxis: {
+      show: boolean('Show', true, yaxisKnobs),
+      position: select('Position', { Left: 'left', Right: 'right' }, 'left', yaxisKnobs),
+      min: dynamic('Automatic Minimum', true, () => number('Minimum', 10, {}, yaxisKnobs), true, yaxisKnobs),
+      max: dynamic('Automatic Maximum', true, () => number('Maximum', 22, {}, yaxisKnobs), true, yaxisKnobs),
+    },
+
+    grid: {
+      show: boolean('Show', true, gridKnobs),
+      aboveData: boolean('Above Data', false, gridKnobs),
+      color: color('Color', '#C6C6C6', gridKnobs),
+      backgroundColor: color('Background Color', '#000000', gridKnobs),
+      margin: number('Margin', 1, {}, gridKnobs),
+      labelMargin: number('Label Margin', 1, {}, gridKnobs),
+      axisMargin: number('Axis Margin', 1, {}, gridKnobs),
+      borderWidth: number('Border Width', 1, {}, gridKnobs),
+      borderColor: color('Background Color', '#000000', gridKnobs),
+      minBorderMargin: number('Min Border Margin', 1, {}, gridKnobs),
+      // clickable: boolean('Clickable', false, gridKnobs),
+      // hoverable: boolean('Hoverable', false, gridKnobs),
+      // autoHighlight: boolean('Auto-Highlight', false, gridKnobs),
+      // mouseActiveRadius: number('Mouse Active Radius', 5, {}, gridKnobs),
+    },
+
+    selection: {
+      mode: select('Mode', { Default: null, X: 'x', Y: 'y', XY: 'xy' }, null, selectionKnobs),
+      color: color('Color', '#e8cfac', selectionKnobs),
+      shape: select('Shape', { Round: 'round', Miter: 'miter', Bevel: 'bevel' }, 'round', selectionKnobs),
+      minSize: number('Min Size', 5, {}, selectionKnobs),
+    },
+
+    legend: {
+      show: boolean('Show', true, legendKnobs),
+      labelBoxBorderColor: color('Label Border Color', '#ffffff', legendKnobs),
+      noColumns: number('No. Columns', 1, {}, legendKnobs),
+      position: select('Position', { NE: 'ne', NW: 'nw', SE: 'se', SW: 'sw' }, 'ne', legendKnobs),
+      backgroundColor: color('Background Color', '#ffffff', legendKnobs),
+      backgroundOpacity: number('Background Opacity', 0.3, { range: true, min: 0, max: 1, step: 0.01 }, legendKnobs),
+      margin: [number('X Margin', 5, {}, legendKnobs), number('Y Margin', 5, {}, legendKnobs)] as [number, number],
+    },
+  };
+};
+
+export const flotGraph = () => {
+  const { data, width, height, xaxis, yaxis, crosshair, grid, selection, legend } = getProps();
+
+  return (
+    <FlotGraph
+      data={data}
+      width={width}
+      height={height}
+      xaxis={xaxis}
+      yaxis={yaxis}
+      crosshair={crosshair}
+      grid={grid}
+      selection={selection}
+      legend={legend}
+    />
+  );
+};

--- a/packages/grafana-ui/src/components/FlotGraph/FlotGraph.tsx
+++ b/packages/grafana-ui/src/components/FlotGraph/FlotGraph.tsx
@@ -1,0 +1,59 @@
+// Libraries
+import $ from 'jquery';
+import React, { PureComponent, ReactChildren } from 'react';
+
+// Types
+import { FlotPlotOptions, FlotSeries } from '@grafana/data';
+
+export interface GraphProps extends FlotPlotOptions {
+  data: Array<Array<[number, number]> | FlotSeries>;
+  width: number;
+  height: number;
+  children?: ReactChildren;
+}
+
+export class FlotGraph extends PureComponent<GraphProps> {
+  element: HTMLElement | null = null;
+  $element: any;
+
+  componentDidUpdate(prevProps: GraphProps) {
+    if (prevProps !== this.props) {
+      this.draw();
+    }
+  }
+
+  componentDidMount() {
+    this.draw();
+    if (this.element) {
+      this.$element = $(this.element);
+    }
+  }
+
+  draw() {
+    if (this.element === null) {
+      return;
+    }
+
+    try {
+      $.plot(this.element, this.props.data, this.props);
+    } catch (err) {
+      console.log('Graph rendering error', err, this.props);
+      throw new Error('Error rendering panel');
+    }
+  }
+
+  render() {
+    const { data, width, height, children } = this.props;
+    const noDataToBeDisplayed = data.length === 0;
+
+    return (
+      <div className="graph-panel">
+        <div className="graph-panel__chart" ref={e => (this.element = e)} style={{ width, height }} />
+        {noDataToBeDisplayed && <div className="datapoints-warning">No data</div>}
+        {children}
+      </div>
+    );
+  }
+}
+
+export default FlotGraph;


### PR DESCRIPTION
**What this PR does / why we need it**:
Current usage of flot in Grafana is largely ad hoc, resulting in components like `Graph` dealing in multiple levels of abstraction.
As a step towards simplifying how we work with flot in the future, I thought it might be a good idea to create a thin React wrapper around flot that can be built upon for more complex cases

**Special notes for your reviewer**:
Making this a draft PR as there are still some interfaces that need to have their typing improved (e.g. `FlotPlot`), and I want to get people's feedback
