### PR TITLE
NewPanelEditor: Alternative options pane layout

### DIFF
--- a/public/app/core/components/BackButton/BackButton.tsx
+++ b/public/app/core/components/BackButton/BackButton.tsx
@@ -21,7 +21,7 @@ export const BackButton: React.FC<Props> = props => {
 BackButton.displayName = 'BackButton';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
-  const hoverColor = selectThemeVariant({ dark: theme.colors.gray25, light: theme.colors.gray85 }, theme.type);
+  const hoverColor = selectThemeVariant({ dark: theme.colors.gray15, light: theme.colors.gray85 }, theme.type);
 
   return {
     wrapper: css`

--- a/public/app/core/components/BackButton/BackButton.tsx
+++ b/public/app/core/components/BackButton/BackButton.tsx
@@ -56,7 +56,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       }
 
       .gicon {
-        opacity: 0.9;
         font-size: 26px;
       }
 
@@ -67,11 +66,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
           box-shadow: none;
           opacity: 1;
           transform: scale(0.8);
-        }
-
-        .gicon {
-          opacity: 1;
-          transition: opacity 0.2s ease-in-out;
         }
       }
     `,

--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -24,7 +24,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     container: css`
       position: relative;
       display: flex;
-      padding: 2px 2px;
     `,
   };
 });

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { FieldConfigSource, GrafanaTheme, PanelData, PanelPlugin, SelectableValue } from '@grafana/data';
-import { CustomScrollbar, Forms, selectThemeVariant, stylesFactory } from '@grafana/ui';
+import { CustomScrollbar, Forms, selectThemeVariant, stylesFactory, TabsBar, Tab, TabContent } from '@grafana/ui';
 import { css, cx } from 'emotion';
 import config from 'app/core/config';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -175,9 +175,8 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     updatePanelEditorUIState({ isPanelOptionsVisible: !uiState.isPanelOptionsVisible });
   };
 
-  renderHorizontalSplit() {
+  renderHorizontalSplit(styles: any) {
     const { dashboard, panel, tabs, data, uiState } = this.props;
-    const styles = getStyles(config.theme);
 
     return (
       <SplitPane
@@ -263,9 +262,24 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     );
   }
 
-  renderWithOptionsPane() {
+  renderOptionsPane(styles: any) {
+    return (
+      <div className={styles.panelOptionsPane}>
+        <TabsBar>
+          <Tab label="Visualization options" active={true} />
+        </TabsBar>
+        <TabContent className={styles.panelOptionsPaneTabContent}>
+          <CustomScrollbar>
+            {this.renderFieldOptions()}
+            <OptionsGroup title="Old settings">{this.renderVisSettings()}</OptionsGroup>
+          </CustomScrollbar>
+        </TabContent>
+      </div>
+    );
+  }
+
+  renderWithOptionsPane(styles: any) {
     const { uiState } = this.props;
-    const styles = getStyles(config.theme);
 
     return (
       <SplitPane
@@ -278,13 +292,8 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
         onDragStarted={() => (document.body.style.cursor = 'col-resize')}
         onDragFinished={size => this.onDragFinished(Pane.Right, size)}
       >
-        {this.renderHorizontalSplit()}
-        <div className={styles.panelOptionsPane}>
-          <CustomScrollbar>
-            {this.renderFieldOptions()}
-            <OptionsGroup title="Old settings">{this.renderVisSettings()}</OptionsGroup>
-          </CustomScrollbar>
-        </div>
+        {this.renderHorizontalSplit(styles)}
+        {this.renderOptionsPane(styles)}
       </SplitPane>
     );
   }
@@ -299,7 +308,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
 
     return (
       <div className={styles.wrapper}>
-        {uiState.isPanelOptionsVisible ? this.renderWithOptionsPane() : this.renderHorizontalSplit()}
+        {uiState.isPanelOptionsVisible ? this.renderWithOptionsPane(styles) : this.renderHorizontalSplit(styles)}
       </div>
     );
   }
@@ -403,8 +412,13 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     panelOptionsPane: css`
       height: 100%;
       width: 100%;
+      padding-top: 6px;
+    `,
+    panelOptionsPaneTabContent: css`
+      height: 100%;
+      width: 100%;
+      padding: 0;
       background: ${theme.colors.pageBg};
-      border-bottom: none;
     `,
     toolbar: css`
       display: flex;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -299,9 +299,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
 
     return (
       <div className={styles.wrapper}>
-        <div className={styles.editorBody}>
-          {uiState.isPanelOptionsVisible ? this.renderWithOptionsPane() : this.renderHorizontalSplit()}
-        </div>
+        {uiState.isPanelOptionsVisible ? this.renderWithOptionsPane() : this.renderHorizontalSplit()}
       </div>
     );
   }
@@ -413,10 +411,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       padding: ${theme.spacing.sm};
       padding-right: 0;
       justify-content: space-between;
-    `,
-    editorBody: css`
-      height: calc(100% - 55px);
-      position: relative;
     `,
     toolbarLeft: css`
       padding-left: ${theme.spacing.sm};

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { FieldConfigSource, GrafanaTheme, PanelData, PanelPlugin, SelectableValue } from '@grafana/data';
-import { CustomScrollbar, Forms, selectThemeVariant, stylesFactory, TabsBar, Tab, TabContent } from '@grafana/ui';
+import { CustomScrollbar, Forms, selectThemeVariant, stylesFactory } from '@grafana/ui';
 import { css, cx } from 'emotion';
 import config from 'app/core/config';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -265,15 +265,10 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   renderOptionsPane(styles: any) {
     return (
       <div className={styles.panelOptionsPane}>
-        <TabsBar>
-          <Tab label="Visualization options" active={true} />
-        </TabsBar>
-        <TabContent className={styles.panelOptionsPaneTabContent}>
-          <CustomScrollbar>
-            {this.renderFieldOptions()}
-            <OptionsGroup title="Old settings">{this.renderVisSettings()}</OptionsGroup>
-          </CustomScrollbar>
-        </TabContent>
+        <CustomScrollbar>
+          {this.renderFieldOptions()}
+          <OptionsGroup title="Old settings">{this.renderVisSettings()}</OptionsGroup>
+        </CustomScrollbar>
       </div>
     );
   }
@@ -412,13 +407,8 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     panelOptionsPane: css`
       height: 100%;
       width: 100%;
-      padding-top: 6px;
-    `,
-    panelOptionsPaneTabContent: css`
-      height: 100%;
-      width: 100%;
-      padding: 0;
       background: ${theme.colors.pageBg};
+      border-bottom: none;
     `,
     toolbar: css`
       display: flex;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -62,7 +62,9 @@ const getPanelEditorTabsStyles = stylesFactory(() => {
       flex-direction: column;
       height: 100%;
     `,
-    tabBar: css``,
+    tabBar: css`
+      padding-left: ${theme.spacing.sm};
+    `,
     tabContent: css`
       padding: 0;
       display: flex;
@@ -70,8 +72,6 @@ const getPanelEditorTabsStyles = stylesFactory(() => {
       flex-grow: 1;
       min-height: 0;
       background: ${theme.colors.pageBg};
-      border-right: 1px solid ${theme.colors.pageHeaderBorder};
-      border-left: 1px solid ${theme.colors.pageHeaderBorder};
 
       .toolbar {
         background: transparent;


### PR DESCRIPTION
Struggling with aligning things, want the side box to be full flush with the rigth side but then the top navbar/toolbar button do not align with the options box. 

Tested moving the buttons to be aligned with the visualization and the options pane to be full height. Think it has promise. We could need some top heading in the options pane like "Visualization options". 

Also removed some borders as the current borders around the query & options pane made the UI too busy I felt. 

![image](https://user-images.githubusercontent.com/10999/75099365-21a91680-55c1-11ea-9805-b90ddfc5e993.png)
