### PR TITLE
Backend Plugin: add a standard function to call the correct resource paths

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -80,6 +80,20 @@ export class DataSourceWithBackend<
     return { data: resultsToDataFrames(rsp) };
   }
 
+  /**
+   * Make a GET request to the datasource resource path
+   */
+  async getResource(path: string, params?: any): Promise<Record<string, any>> {
+    return getBackendSrv().get(`/api/datasources/${this.id}/resources/${path}`, params);
+  }
+
+  /**
+   * Send a POST request to the datasource resource path
+   */
+  async postResource(path: string, body?: any): Promise<Record<string, any>> {
+    return getBackendSrv().post(`/api/datasources/${this.id}/resources/${path}`, { ...body });
+  }
+
   testDatasource() {
     // TODO, this will call the backend healthcheck endpoint
     return Promise.resolve({});


### PR DESCRIPTION
Backend plugins should share a common way to access the resource requests