### PR TITLE
Admin: fix images on license page

### DIFF
--- a/public/app/features/admin/LicenseChrome.tsx
+++ b/public/app/features/admin/LicenseChrome.tsx
@@ -6,9 +6,7 @@ import { GrafanaTheme } from '@grafana/data';
 const title = { fontWeight: 500, fontSize: '26px', lineHeight: '123%' };
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
-  const backgroundUrl = theme.isDark
-    ? '/public/img/licensing/header_dark.svg'
-    : '/public/img/licensing/header_light.svg';
+  const backgroundUrl = theme.isDark ? 'public/img/licensing/header_dark.svg' : 'public/img/licensing/header_light.svg';
   const footerBg = theme.isDark ? theme.colors.dark9 : theme.colors.gray6;
 
   return {
@@ -57,7 +55,7 @@ export const LicenseChrome: React.FC<Props> = ({ header, editionNotice, subheade
           }}
         >
           <img
-            src="/public/img/grafana_icon.svg"
+            src="public/img/grafana_icon.svg"
             alt="Grafana"
             width="80px"
             style={{ position: 'absolute', left: '23px', top: '20px' }}

--- a/public/app/features/admin/UpgradePage.tsx
+++ b/public/app/features/admin/UpgradePage.tsx
@@ -85,9 +85,9 @@ const ServiceInfo: React.FC = () => {
       <h4>At your service</h4>
 
       <List>
-        <Item title="Enterprise Plugins" image="/public/img/licensing/plugin_enterprise.svg" />
-        <Item title="Critical SLA: 2 hours" image="/public/img/licensing/sla.svg" />
-        <Item title="Unlimited Expert Support" image="/public/img/licensing/customer_support.svg">
+        <Item title="Enterprise Plugins" image="public/img/licensing/plugin_enterprise.svg" />
+        <Item title="Critical SLA: 2 hours" image="public/img/licensing/sla.svg" />
+        <Item title="Unlimited Expert Support" image="public/img/licensing/customer_support.svg">
           24x7x365 support via
           <List nested={true}>
             <Item title="Email" />
@@ -95,7 +95,7 @@ const ServiceInfo: React.FC = () => {
             <Item title="Phone" />
           </List>
         </Item>
-        <Item title="Hand-in-hand support" image="/public/img/licensing/handinhand_support.svg">
+        <Item title="Hand-in-hand support" image="public/img/licensing/handinhand_support.svg">
           in the upgrade process
         </Item>
       </List>
@@ -167,7 +167,7 @@ interface ItemProps {
 }
 
 const Item: React.FC<ItemProps> = ({ children, title, image }) => {
-  const imageUrl = image ? image : '/public/img/licensing/checkmark.svg';
+  const imageUrl = image ? image : 'public/img/licensing/checkmark.svg';
   const itemStyle = css`
     display: flex;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update images path on the license page to render them correctly when using Grafana behind a proxy (with the root_url different from "/")
