### PR TITLE
Fix: Added missing "remove"-icon for light theme.

### DIFF
--- a/public/img/icons_light_theme/icon_remove.svg
+++ b/public/img/icons_light_theme/icon_remove.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#52545c" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x">
+    <line x1="18" y1="6" x2="6" y2="18"></line>
+    <line x1="6" y1="6" x2="18" y2="18"></line>
+</svg>


### PR DESCRIPTION
**What this PR does / why we need it**:
Storybook is currently failing due to this image being missing:

```bash
ERROR in /Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass/grafana.light.scss (/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/css-loader/dist/cjs.js??ref--14-1!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/postcss-loader/src??ref--14-2!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/sass-loader/lib/loader.js??ref--14-3!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass/grafana.light.scss)
Module not found: Error: Can't resolve '../img/icons_light_theme/icon_remove.svg' in '/Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass'
 @ /Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass/grafana.light.scss (/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/css-loader/dist/cjs.js??ref--14-1!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/postcss-loader/src??ref--14-2!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/sass-loader/lib/loader.js??ref--14-3!/Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass/grafana.light.scss) 57:42-93
 @ /Users/marcusandersson/development/go/src/github.com/grafana/grafana/public/sass/grafana.light.scss
 @ ./.storybook/preview.ts
 @ multi /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/@storybook/core/dist/server/common/polyfills.js /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/@storybook/core/dist/server/preview/globals.js /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/@storybook/addon-docs/dist/frameworks/common/config.js /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/@storybook/addon-docs/dist/frameworks/react/config.js ./.storybook/preview.ts /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/@storybook/addon-knobs/dist/preset/addDecorator.js ./.storybook/generated-entry.js /Users/marcusandersson/development/go/src/github.com/grafana/grafana/node_modules/webpack-hot-middleware/client.js?reload=true&quiet=true

```

**Special notes for your reviewer**:
I just copied the dark theme icon but changed so it has the same color as the other icons in the light theme.
