### PR TITLE
NewPanelEditor: Fixes issue of re-rendering / updating panel after making changes in edit mode 

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -45,7 +45,12 @@ export function panelEditorCleanUp(): ThunkResult<void> {
       modifiedSaveModel.id = sourcePanel.id;
 
       sourcePanel.restoreModel(modifiedSaveModel);
-      sourcePanel.getQueryRunner().pipeDataToSubject(panel.getQueryRunner().getLastResult());
+
+      // Resend last query result on source panel query runner
+      // But do this after the panel edit editor exit process has completed
+      setTimeout(() => {
+        sourcePanel.getQueryRunner().pipeDataToSubject(panel.getQueryRunner().getLastResult());
+      });
     }
 
     dashboard.exitPanelEditor();


### PR DESCRIPTION
Wait a bit before resending query result during panel editor close, this make sure the panel editor open state is completely cleared when resending query (so isInView is not false in PanelChrome ) 