### PR TITLE
App Plugins: support react pages in nav

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -230,9 +230,20 @@ func (hs *HTTPServer) setIndexViewData(c *m.ReqContext) (*dtos.IndexViewData, er
 				}
 
 				if include.Type == "page" && include.AddToNav {
-					link := &dtos.NavLink{
-						Url:  setting.AppSubUrl + "/plugins/" + plugin.Id + "/page/" + include.Slug,
-						Text: include.Name,
+					var link *dtos.NavLink
+					if len(include.Path) > 0 {
+						link = &dtos.NavLink{
+							Url:  setting.AppSubUrl + include.Path,
+							Text: include.Name,
+						}
+						if include.DefaultNav {
+							appLink.Url = link.Url // Overwrite the hardcoded page logic
+						}
+					} else {
+						link = &dtos.NavLink{
+							Url:  setting.AppSubUrl + "/plugins/" + plugin.Id + "/page/" + include.Slug,
+							Text: include.Name,
+						}
 					}
 					appLink.Children = append(appLink.Children, link)
 				}


### PR DESCRIPTION
Related to #21390

This will use the configured path for included pages like:
https://github.com/grafana/simple-app-plugin/blob/master/src/plugin.json#L23

![image](https://user-images.githubusercontent.com/705951/75318370-17845380-581f-11ea-998a-f7b8c75eb9af.png)

-----

In 7.0 I think we should get rid of all the server side page handling and do that from the plugin itself!