### PR TITLE
Docs: removed menu links to SDK Reference until we are ready for 7.0

### DIFF
--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -343,17 +343,6 @@
     link: /http_api/team/
   - name: Users
     link: /http_api/user/
-- name: SDK Reference
-  link: /packages_api/
-  children:
-  - name: "@grafana/data"
-    link: /packages_api/data/
-  - name: "@grafana/e2e"
-    link: /packages_api/e2e/
-  - name: "@grafana/runtime"
-    link: /packages_api/runtime/
-  - name: "@grafana/ui"
-    link: /packages_api/ui/
 - name: Developers
   link: /developers/
   children:


### PR DESCRIPTION
**What this PR does / why we need it**:
It hides the SDK Reference links until we have moved the SDK Reference docs from draft to live. This will probably be done in 7.0.
