### PR TITLE
Toolkit: don't clean dist folder before build

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -109,7 +109,6 @@ export const lintPlugin = useSpinner<Fixable>('Linting', async ({ fix } = {}) =>
 });
 
 export const pluginBuildRunner: TaskRunner<PluginBuildOptions> = async ({ coverage }) => {
-  await clean();
   await prepare();
   await lintPlugin({ fix: false });
   await testPlugin({ updateSnapshot: false, coverage, watch: false });

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -25,6 +25,9 @@ import { runEndToEndTests } from '../../plugins/e2e/launcher';
 import { getEndToEndSettings } from '../../plugins/index';
 import { manifestTask } from './manifest';
 import { execTask } from '../utils/execTask';
+import rimrafCallback from 'rimraf';
+import { promisify } from 'util';
+const rimraf = promisify(rimrafCallback);
 
 export interface PluginCIOptions {
   backend?: boolean;
@@ -46,7 +49,9 @@ export interface PluginCIOptions {
 const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ backend }) => {
   const start = Date.now();
   const workDir = getJobFolder();
-  await execa('rimraf', [workDir]);
+
+  await rimraf(`${process.cwd()}/dist`);
+  await rimraf(workDir);
   fs.mkdirSync(workDir);
 
   if (backend) {


### PR DESCRIPTION
The current toolkit build first cleans the dist... this is fine when not building a backend also.  But can be super confusing when doing both.

This PR removes `clean` from the script -- and adds it to the beginning of the ci-build process