### PR TITLE
ArrowDataFrame: allow empty results

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.test.ts
@@ -37,6 +37,13 @@ describe('GEL Utils', () => {
     const norm = frames.map(f => toDataFrameDTO(f));
     expect(norm).toMatchSnapshot();
   });
+
+  test('processEmptyResults', () => {
+    const frames = resultsToDataFrames({
+      results: { '': { refId: '', meta: null, series: null, tables: null, dataframes: null } },
+    });
+    expect(frames.length).toEqual(0);
+  });
 });
 
 describe('Read/Write arrow Table to DataFrame', () => {

--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
@@ -146,9 +146,12 @@ export function grafanaDataFrameToArrowTable(data: DataFrame): Table {
 export function resultsToDataFrames(rsp: any): DataFrame[] {
   const frames: DataFrame[] = [];
   for (const res of Object.values(rsp.results)) {
-    for (const b of (res as any).dataframes) {
-      const t = base64StringToArrowTable(b as string);
-      frames.push(arrowTableToDataFrame(t));
+    const r = res as any;
+    if (r.dataframes) {
+      for (const b of r.dataframes) {
+        const t = base64StringToArrowTable(b as string);
+        frames.push(arrowTableToDataFrame(t));
+      }
     }
   }
   return frames;


### PR DESCRIPTION
When [DataSourceWithBackend](https://github.com/grafana/grafana/blob/master/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts) gets an empty result it current explodes.... this makes sure we don't iterate the empty results

Avoid:
![image](https://user-images.githubusercontent.com/705951/75728926-1e3b1c80-5c9e-11ea-92eb-9b6340c7bf71.png)
