### PR TITLE
WIP: Back-end plugins: Unregister plugins that fail to start

### DIFF
--- a/pkg/plugins/backendplugin/manager.go
+++ b/pkg/plugins/backendplugin/manager.go
@@ -98,12 +98,13 @@ func (m *manager) Register(descriptor PluginDescriptor) error {
 func (m *manager) start(ctx context.Context) {
 	m.pluginsMu.RLock()
 	defer m.pluginsMu.RUnlock()
-	for _, p := range m.plugins {
+	for pID, p := range m.plugins {
 		if !p.managed {
 			continue
 		}
 
 		if err := startPluginAndRestartKilledProcesses(ctx, p); err != nil {
+			delete(m.plugins, pID)
 			p.logger.Error("Failed to start plugin", "error", err)
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
If a back-end data source plugin fails to start, unregister it. Before this fix, a segfault occurs if the user tries to add the data source.

**Special notes for your reviewer**:
How do I ensure that the plugin doesn't show up among available data sources??