### PR TITLE
Core: add active users stat

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -25,6 +25,8 @@ interface LicenseInfo {
   expiry: number;
   licenseUrl: string;
   stateInfo: string;
+  activeUsers?: number;
+  maxUsers?: number;
 }
 
 export class GrafanaBootConfig {

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -89,3 +89,10 @@ type SystemUserCountStats struct {
 type GetSystemUserCountStatsQuery struct {
 	Result *SystemUserCountStats
 }
+
+type ActiveUserCountStats struct {
+	Count int64
+}
+type GetActiveUserCountStatsQuery struct {
+	Result *ActiveUserCountStats
+}

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -13,6 +13,7 @@ func init() {
 	bus.AddHandler("sql", GetDataSourceStats)
 	bus.AddHandler("sql", GetDataSourceAccessStats)
 	bus.AddHandler("sql", GetAdminStats)
+	bus.AddHandler("sql", GetActiveUserCountStats)
 	bus.AddHandlerCtx("sql", GetAlertNotifiersUsageStats)
 	bus.AddHandlerCtx("sql", GetSystemUserCountStats)
 }
@@ -182,4 +183,19 @@ func GetSystemUserCountStats(ctx context.Context, query *models.GetSystemUserCou
 
 		return err
 	})
+}
+
+func GetActiveUserCountStats(query *models.GetActiveUserCountStatsQuery) error {
+	activeEndDate := time.Now().Add(-activeUserTimeLimit)
+
+	var rawSql = `SELECT COUNT(*) AS Count FROM ` + dialect.Quote("user") + ` where last_seen_at > ?`
+	var stats models.ActiveUserCountStats
+	_, err := x.SQL(rawSql, activeEndDate).Get(&stats)
+	if err != nil {
+		return err
+	}
+
+	query.Result = &stats
+
+	return err
 }

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -54,6 +54,13 @@ func TestStatsDataAccess(t *testing.T) {
 			err := GetAdminStats(&query)
 			assert.Nil(t, err)
 		})
+
+		t.Run("Get active user count stats should not result in error", func(t *testing.T) {
+			query := models.GetActiveUserCountStatsQuery{}
+			err := GetActiveUserCountStats(&query)
+			assert.Nil(t, err)
+			assert.Equal(t, query.Result.Count, int64(1))
+		})
 	})
 }
 
@@ -108,5 +115,12 @@ func populateDB(t *testing.T) {
 		Role:   models.ROLE_ADMIN,
 	}
 	err = AddOrgUser(cmd)
+	assert.Nil(t, err)
+
+	// update 1st user last seen at
+	updateUserLastSeenAtCmd := &models.UpdateUserLastSeenAtCommand{
+		UserId: users[0].Id,
+	}
+	err = UpdateUserLastSeenAt(updateUserLastSeenAtCmd)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add a query to get only active users stat
- Add license information

Updates useful to improve Enterprise licensing 

