### PR TITLE
ShareModal: able to extend tabs

### DIFF
--- a/packages/grafana-ui/src/components/Modal/ModalTabContent.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalTabContent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IconType } from '../Icon/types';
+import { Icon } from '../Icon/Icon';
+
+interface Props {
+  icon?: IconType;
+  iconClass?: string;
+}
+
+export const ModalTabContent: React.FC<Props> = ({ icon, iconClass, children }) => {
+  let iconElem;
+  const showIcon = icon || iconClass;
+  if (iconClass) {
+    iconElem = <i className={iconClass}></i>;
+  }
+  if (icon) {
+    iconElem = <Icon name={icon} />;
+  }
+
+  return (
+    <div className="share-modal-body">
+      <div className="share-modal-header">
+        {showIcon && <div className="share-modal-big-icon">{iconElem}</div>}
+        <div className="share-modal-content">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -48,6 +48,7 @@ export { QueryField } from './QueryField/QueryField';
 export { Modal } from './Modal/Modal';
 export { ModalHeader } from './Modal/ModalHeader';
 export { ModalTabsHeader } from './Modal/ModalTabsHeader';
+export { ModalTabContent } from './Modal/ModalTabContent';
 export { ModalsProvider, ModalRoot, ModalsController } from './Modal/ModalsContext';
 
 // Renderless

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -15,7 +15,7 @@ import { ILocationService, IRootScopeService, ITimeoutService } from 'angular';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { getLocationSrv } from '@grafana/runtime';
 import { DashboardModel } from '../../features/dashboard/state';
-import { ShareModal } from 'app/features/dashboard/components/ShareModal/ShareModal';
+import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from '../../features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
 
 export class KeybindingSrv {

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -15,7 +15,7 @@ import { updateLocation } from 'app/core/actions';
 // Types
 import { DashboardModel } from '../../state';
 import { CoreEvents, StoreState } from 'app/types';
-import { ShareModal } from '../ShareModal/ShareModal';
+import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
 
 export interface OwnProps {

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -12,7 +12,7 @@ const themeOptions: Array<SelectableValue<string>> = [
 ];
 
 export interface Props {
-  dashboard?: DashboardModel;
+  dashboard: DashboardModel;
   panel?: PanelModel;
 }
 

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -5,12 +5,13 @@ import { ShareLink } from './ShareLink';
 import { ShareSnapshot } from './ShareSnapshot';
 import { ShareExport } from './ShareExport';
 import { ShareEmbed } from './ShareEmbed';
+import { ShareModalTabModel } from './types';
 
-const shareModalTabs = [
-  { label: 'Link', value: 'link' },
-  { label: 'Embed', value: 'embed' },
-  { label: 'Snapshot', value: 'snapshot' },
-  { label: 'Export', value: 'export' },
+const shareModalTabs: ShareModalTabModel[] = [
+  { label: 'Link', value: 'link', component: ShareLink },
+  { label: 'Embed', value: 'embed', component: ShareEmbed },
+  { label: 'Snapshot', value: 'snapshot', component: ShareSnapshot },
+  { label: 'Export', value: 'export', component: ShareExport },
 ];
 
 interface Props {
@@ -57,6 +58,11 @@ export class ShareModal extends PureComponent<Props, State> {
     });
   }
 
+  getActiveTab() {
+    const { tab } = this.state;
+    return shareModalTabs.find(t => t.value === tab);
+  }
+
   renderTitle() {
     const { panel } = this.props;
     const { tab } = this.state;
@@ -70,15 +76,13 @@ export class ShareModal extends PureComponent<Props, State> {
 
   render() {
     const { dashboard, panel } = this.props;
-    const { tab } = this.state;
+    const activeTabModel = this.getActiveTab();
+    const ActiveTab = activeTabModel?.component;
 
     return (
       <Modal isOpen={true} title={this.renderTitle()} onDismiss={this.onDismiss}>
         <TabContent>
-          {tab === 'link' && <ShareLink dashboard={dashboard} panel={panel} />}
-          {tab === 'embed' && panel && <ShareEmbed dashboard={dashboard} panel={panel} />}
-          {tab === 'snapshot' && <ShareSnapshot dashboard={dashboard} panel={panel} onDismiss={this.onDismiss} />}
-          {tab === 'export' && !panel && <ShareExport dashboard={dashboard} panel={panel} onDismiss={this.onDismiss} />}
+          <ActiveTab dashboard={dashboard} panel={panel} onDismiss={this.onDismiss} />
         </TabContent>
       </Modal>
     );

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -14,6 +14,10 @@ const shareModalTabs: ShareModalTabModel[] = [
   { label: 'Export', value: 'export', component: ShareExport },
 ];
 
+export function addShareTab(tab: ShareModalTabModel) {
+  shareModalTabs.push(tab);
+}
+
 interface Props {
   dashboard: DashboardModel;
   panel?: PanelModel;

--- a/public/app/features/dashboard/components/ShareModal/index.ts
+++ b/public/app/features/dashboard/components/ShareModal/index.ts
@@ -1,0 +1,2 @@
+export { ShareModal, addShareTab } from './ShareModal';
+export * from './types';

--- a/public/app/features/dashboard/components/ShareModal/index.ts
+++ b/public/app/features/dashboard/components/ShareModal/index.ts
@@ -1,2 +1,2 @@
-export { ShareModal, addShareTab } from './ShareModal';
+export { ShareModal, addDashboardShareTab, addPanelShareTab } from './ShareModal';
 export * from './types';

--- a/public/app/features/dashboard/components/ShareModal/types.ts
+++ b/public/app/features/dashboard/components/ShareModal/types.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PanelModel } from '@grafana/data';
+import { DashboardModel } from 'app/features/dashboard/state';
+
+export interface ShareModalTabProps {
+  dashboard: DashboardModel;
+  panel?: PanelModel;
+  onDismiss?(): void;
+}
+
+export type ShareModalTab = React.ComponentType<ShareModalTabProps>;
+
+export interface ShareModalTabModel {
+  label: string;
+  value: string;
+  component: ShareModalTab;
+}

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -20,7 +20,7 @@ import templateSrv from 'app/features/templating/template_srv';
 import { LS_PANEL_COPY_KEY, PANEL_BORDER } from 'app/core/constants';
 import { CoreEvents } from 'app/types';
 
-import { ShareModal } from 'app/features/dashboard/components/ShareModal/ShareModal';
+import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion


### PR DESCRIPTION
This PR allows to add share modal tabs from external modules. This useful for Enterprise if we want to add more sharing options, like PDF. Use `addShareTab()` function to extend ShareModal:
```ts
addShareTab({
  label: 'Custom Tab',
  value: 'custom',
  component: CustomTabComponent,
})
```
where `CustomTabComponent` takes props
```ts
export interface ShareModalTabProps {
  dashboard: DashboardModel;
  panel?: PanelModel;
  onDismiss?(): void;
}
```