### PR TITLE
Explore: Allows a user to cancel a running query

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -13,6 +13,7 @@ import { DataSourcePicker } from 'app/core/components/Select/DataSourcePicker';
 import { StoreState } from 'app/types/store';
 import {
   changeDatasource,
+  cancelQueries,
   clearQueries,
   splitClose,
   runQueries,
@@ -72,6 +73,7 @@ interface StateProps {
 interface DispatchProps {
   changeDatasource: typeof changeDatasource;
   clearAll: typeof clearQueries;
+  cancelQueries: typeof cancelQueries;
   runQueries: typeof runQueries;
   closeSplit: typeof splitClose;
   split: typeof splitOpen;
@@ -93,8 +95,12 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
     this.props.clearAll(this.props.exploreId);
   };
 
-  onRunQuery = () => {
-    return this.props.runQueries(this.props.exploreId);
+  onRunQuery = (loading = false) => {
+    if (loading) {
+      return this.props.cancelQueries(this.props.exploreId);
+    } else {
+      return this.props.runQueries(this.props.exploreId);
+    }
   };
 
   onChangeRefreshInterval = (item: string) => {
@@ -388,6 +394,7 @@ const mapDispatchToProps: DispatchProps = {
   updateLocation,
   changeRefreshInterval,
   clearAll: clearQueries,
+  cancelQueries,
   runQueries,
   closeSplit: splitClose,
   split: splitOpen,

--- a/public/app/features/explore/RunButton.tsx
+++ b/public/app/features/explore/RunButton.tsx
@@ -20,7 +20,7 @@ const getStyles = memoizeOne(() => {
 type Props = {
   splitted: boolean;
   loading: boolean;
-  onRun: () => void;
+  onRun: (loading: boolean) => void;
   refreshInterval?: string;
   onChangeRefreshInterval: (interval: string) => void;
   showDropdown: boolean;
@@ -29,12 +29,17 @@ type Props = {
 export function RunButton(props: Props) {
   const { splitted, loading, onRun, onChangeRefreshInterval, refreshInterval, showDropdown } = props;
   const styles = getStyles();
+
   const runButton = (
     <ResponsiveButton
       splitted={splitted}
-      title="Run Query"
-      onClick={onRun}
-      buttonClassName={classNames('navbar-button--secondary', { 'btn--radius-right-0': showDropdown })}
+      title={loading ? 'Cancel' : 'Run Query'}
+      onClick={() => onRun(loading)}
+      buttonClassName={classNames({
+        'navbar-button--secondary': !loading,
+        'navbar-button--danger': loading,
+        'btn--radius-right-0': showDropdown,
+      })}
       iconClassName={loading ? 'fa fa-spinner fa-fw fa-spin run-icon' : 'fa fa-refresh fa-fw'}
     />
   );
@@ -44,7 +49,9 @@ export function RunButton(props: Props) {
       <RefreshPicker
         onIntervalChanged={onChangeRefreshInterval}
         value={refreshInterval}
-        buttonSelectClassName={`navbar-button--secondary ${styles.selectButtonOverride}`}
+        buttonSelectClassName={`${loading ? 'navbar-button--danger' : 'navbar-button--secondary'} ${
+          styles.selectButtonOverride
+        }`}
         refreshButton={runButton}
       />
     );

--- a/public/app/features/explore/state/actionTypes.ts
+++ b/public/app/features/explore/state/actionTypes.ts
@@ -218,6 +218,11 @@ export const changeRefreshIntervalAction = createAction<ChangeRefreshIntervalPay
 export const clearQueriesAction = createAction<ClearQueriesPayload>('explore/clearQueries');
 
 /**
+ * Cancel running queries.
+ */
+export const cancelQueriesAction = createAction<ClearQueriesPayload>('explore/cancelQueries');
+
+/**
  * Highlight expressions in the log results
  */
 export const highlightLogsExpressionAction = createAction<HighlightLogsExpressionPayload>(

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -85,6 +85,8 @@ import {
   ToggleTablePayload,
   updateDatasourceInstanceAction,
   updateUIStateAction,
+  changeLoadingStateAction,
+  cancelQueriesAction,
 } from './actionTypes';
 import { getTimeZone } from 'app/features/profile/state/selectors';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
@@ -238,6 +240,17 @@ export function clearQueries(exploreId: ExploreId): ThunkResult<void> {
   return dispatch => {
     dispatch(scanStopAction({ exploreId }));
     dispatch(clearQueriesAction({ exploreId }));
+    dispatch(stateSave());
+  };
+}
+
+/**
+ * Cancel running queries
+ */
+export function cancelQueries(exploreId: ExploreId): ThunkResult<void> {
+  return dispatch => {
+    dispatch(scanStopAction({ exploreId }));
+    dispatch(cancelQueriesAction({ exploreId }));
     dispatch(stateSave());
   };
 }
@@ -460,6 +473,7 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
     const transaction = buildQueryTransaction(queries, queryOptions, range, scanning);
 
     let firstResponse = true;
+    dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
 
     const newQuerySub = runRequest(datasourceInstance, transaction.request)
       .pipe(

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -65,6 +65,7 @@ import {
   toggleTableAction,
   updateDatasourceInstanceAction,
   updateUIStateAction,
+  cancelQueriesAction,
 } from './actionTypes';
 import { ResultProcessor } from '../utils/ResultProcessor';
 import { updateLocation } from '../../../core/actions';
@@ -232,6 +233,14 @@ export const itemReducer = (state: ExploreItemState = makeExploreItemState(), ac
       logsResult: null,
       queryKeys: getQueryKeys(queries, state.datasourceInstance),
       queryResponse: createEmptyQueryResponse(),
+      loading: false,
+    };
+  }
+
+  if (cancelQueriesAction.match(action)) {
+    stopQueryState(state.querySubscription);
+    return {
+      ...state,
       loading: false,
     };
   }

--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -155,6 +155,7 @@ i.navbar-page-btn__search {
     .gicon {
       filter: $navbar-btn-gicon-brightness;
     }
+
     &:hover {
       .gicon {
         filter: brightness(0.8);
@@ -178,6 +179,10 @@ i.navbar-page-btn__search {
     .fa {
       color: $text-color;
     }
+  }
+
+  &--danger {
+    @include buttonBackground($red-base, $red-shade);
   }
 
   @include media-breakpoint-down(lg) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows a user to cancel a running query. Useful for datasources that may have long-running queries.