### PR TITLE
Chore: fix moment import in alerting tests

### DIFF
--- a/public/app/features/alerting/state/reducers.test.ts
+++ b/public/app/features/alerting/state/reducers.test.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment'; // eslint-disable-line no-restricted-imports
 import { alertRulesReducer, initialState, loadAlertRules, loadedAlertRules, setSearchQuery } from './reducers';
 import { AlertRuleDTO, AlertRulesState } from 'app/types';
 import { reducerTester } from '../../../../test/core/redux/reducerTester';

--- a/public/app/features/alerting/state/reducers.test.ts
+++ b/public/app/features/alerting/state/reducers.test.ts
@@ -1,10 +1,10 @@
-import moment from 'moment'; // eslint-disable-line no-restricted-imports
+import { dateTime } from '@grafana/data';
 import { alertRulesReducer, initialState, loadAlertRules, loadedAlertRules, setSearchQuery } from './reducers';
 import { AlertRuleDTO, AlertRulesState } from 'app/types';
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 
 describe('Alert rules', () => {
-  const newStateDate = moment()
+  const newStateDate = dateTime()
     .subtract(1, 'y')
     .format('YYYY-MM-DD');
   const payload: AlertRuleDTO[] = [


### PR DESCRIPTION
Add missing `// eslint-disable-line no-restricted-imports` for `moment` import, fix enterprise build.