### PR TITLE
Testing code owners for backend code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,8 @@
 # Documentation owner: Diana Payton
 /docs/ @oddlittlebird
 /contribute/ @oddlittlebird  @marcusolsson
+
+# Backend code
+*.go @grafana/backend-platform
+go.mod @grafana/backend-platform
+go.sum @grafana/backend-platform


### PR DESCRIPTION
Would like to merge this so I can test open some PR's that changes backend code and docs and see if GitHub assigns the expected reviewers. The expected behavior is that one member of the  `@grafana/backend-platform` should be assigned as reviewer based on team auto review assignment settings.

Not sure exactly what happens if a PR is opened that changes for example both backend code and documentation. Given [this](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file) I would expect review be required by the last matching pattern which would be `@grafana/backend-platform`.