### PR TITLE
Toolkit: plugin ci needs to cooperate better with make/mage

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -168,15 +168,11 @@ export const run = (includeInternalScripts = false) => {
 
   program
     .command('plugin:ci-build')
-    .option('--backend', 'Run Makefile for backend task', false)
+    .option('--finish', 'move all results to the jobs folder', false)
     .description('Build the plugin, leaving results in /dist and /coverage')
     .action(async cmd => {
-      if (typeof cmd === 'string') {
-        console.error(`Invalid argument: ${cmd}\nSee --help for a list of available commands.`);
-        process.exit(1);
-      }
       await execTask(ciBuildPluginTask)({
-        backend: cmd.backend,
+        finish: cmd.finish,
       });
     });
 

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -195,9 +195,7 @@ export const run = (includeInternalScripts = false) => {
     .option('--full', 'run all the tests (even stuff that will break)')
     .description('end-to-end test using bundle in /artifacts')
     .action(async cmd => {
-      await execTask(ciTestPluginTask)({
-        full: cmd.full,
-      });
+      await execTask(ciTestPluginTask)({});
     });
 
   program

--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -31,13 +31,18 @@ const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
 
   const originalDir = __dirname;
   process.chdir(folder);
-  const out = await execa('sha1sum', files);
+  const { stdout } = await execa('sha1sum', files);
 
   // Write the process output
-  fs.writeFileSync(path.join(folder, filename), out.stdout);
+  fs.writeFileSync(path.join(folder, filename), stdout);
 
-  // TODO:
-  // gpg --output doc.sig --sign doc
+  // Call a signing service
+  const GRAFANA_API_KEY = process.env.GRAFANA_API_KEY;
+  if (GRAFANA_API_KEY) {
+    const plugin = require('plugin.json');
+    const url = `https://grafana.com/api/plugins/${plugin.id}/sign`;
+    console.log(`TODO: sign and save: ${url}`);
+  }
 
   // Go back to where you were
   process.chdir(originalDir);

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -31,6 +31,7 @@ const rimraf = promisify(rimrafCallback);
 
 export interface PluginCIOptions {
   finish?: boolean;
+  upload?: boolean;
 }
 
 /**
@@ -306,7 +307,7 @@ export const ciTestPluginTask = new Task<PluginCIOptions>('Test Plugin (e2e)', t
  *
  *  Create a report from all the previous steps
  */
-const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({}) => {
+const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
   const ciDir = path.resolve(process.cwd(), 'ci');
   const packageDir = path.resolve(ciDir, 'packages');
   const packageInfo = require(path.resolve(packageDir, 'info.json')) as PluginPackageDetails;


### PR DESCRIPTION
The current toolkit `plugin:ci-build` expects to handle both frontend & backend together.  This is not how we actually implement things in CI with make/mage

These changes:
1. don't clean dist when things start
2. move things to `ci/jobs/{name}` on demand -- not as part of build
3. more logging on the manifest creation