### PR TITLE
Fix: when reloading page make sure that time picker history is converted to dateTime.

### DIFF
--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LocalStorageValueProvider } from '../LocalStorageValueProvider';
-import { TimeRange, isDateTime } from '@grafana/data';
+import { TimeRange, isDateTime, dateTime } from '@grafana/data';
 import { Props as TimePickerProps, TimePicker } from '@grafana/ui/src/components/TimePicker/TimePicker';
 
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
@@ -14,7 +14,7 @@ export const TimePickerWithHistory: React.FC<Props> = props => {
         return (
           <TimePicker
             {...props}
-            history={values}
+            history={convertIfJson(values)}
             onChange={value => {
               onAppendToHistory(value, values, onSaveToStore);
               props.onChange(value);
@@ -25,6 +25,21 @@ export const TimePickerWithHistory: React.FC<Props> = props => {
     </LocalStorageValueProvider>
   );
 };
+
+function convertIfJson(history: TimeRange[]): TimeRange[] {
+  return history.map(time => {
+    if (isDateTime(time.from)) {
+      return time;
+    }
+
+    return {
+      from: dateTime(time.from),
+      to: dateTime(time.to),
+      raw: time.raw,
+    };
+  });
+}
+
 function onAppendToHistory(toAppend: TimeRange, values: TimeRange[], onSaveToStore: (values: TimeRange[]) => void) {
   if (!isAbsolute(toAppend)) {
     return;


### PR DESCRIPTION
**What this PR does / why we need it**:
When you filter the dashboard by absolute time range via the TimePicker. Those values are stored in the TimePicker history. Everything works as planned until you refresh the page. Then we read the new values from local storage without converting those values to the DateTime (moment) type. 

So later when displaying the value to the user the timeZone isn't respected. This should be fixed by making sure that we always sends DateTime (moment) values to the TimePicker. Regardless if we do a page reload or adding new values.

**Which issue(s) this PR fixes**:
Fixes #22289

**Special notes for your reviewer**:
Maybe not super good that we need to iterate the history list on each `TimePickerWithHistory` rendering but it is only 4 items so I don't this this should be to much of an performance hit.
