### PR TITLE
UI: Segment improvements

### DIFF
--- a/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
@@ -23,10 +23,19 @@ export function SegmentSelect<T>({
   noOptionsMessage = '',
   allowCustomValue = false,
 }: React.PropsWithChildren<Props<T>>) {
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useClickAway(ref, () => {
-    onClickOutside();
+    if (ref && ref.current) {
+      // https://github.com/JedWatson/react-select/issues/188#issuecomment-279240292
+      // Unfortunately there's no other way of retrieving the (not yet) created new option
+      const input = ref.current.querySelector('input[id^="react-select-"]') as HTMLInputElement;
+      if (input && input.value) {
+        onChange({ value: input.value as any, label: input.value });
+      } else {
+        onClickOutside();
+      }
+    }
   });
 
   return (
@@ -37,6 +46,7 @@ export function SegmentSelect<T>({
             width: ${width > 120 ? width : 120}px;
           `
         )}
+        noOptionsMessage={() => noOptionsMessage}
         placeholder=""
         autoFocus={true}
         isOpen={true}

--- a/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
+++ b/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
@@ -11,7 +11,7 @@ export const useExpandableLabel = (initialExpanded: boolean) => {
       onClick={() => {
         setExpanded(true);
         if (ref && ref.current) {
-          setWidth(ref.current.clientWidth);
+          setWidth(ref.current.clientWidth * 1.25);
         }
         if (onClick) {
           onClick();


### PR DESCRIPTION
This PR contains two fixes. 
* In case a user added a custom value for a Segment/SegmentAsync, it would only be accepted if the user hit enter or tab. The segment component should also accept the new custom value in case the user clicks somewhere outside the react-select dropdown. 
* In case the Segment is not focused, a label is rendered. Once clicked, the label is hidden and a react select input is displayed instead. The label width is measured so that the same width can be applied to the react select input. However, the react select input font is larger than the label font so it could be the case that there wasn't room for the text within the input. Solution to this problem is to set the width of the react select input to 1.25 x the width of the label. 