### PR TITLE
@grafana/e2e: fix empty bundle files

### DIFF
--- a/packages/grafana-e2e/bin/grafana-e2e.js
+++ b/packages/grafana-e2e/bin/grafana-e2e.js
@@ -1,10 +1,3 @@
 #!/usr/bin/env node
 
-// This file is used only for internal executions
-
-require('ts-node').register({
-  project: `${__dirname}/../tsconfig.json`,
-  transpileOnly: true,
-});
-
-require('../src/cli/index.ts').default();
+require('../cli')();

--- a/packages/grafana-e2e/cli.js
+++ b/packages/grafana-e2e/cli.js
@@ -1,16 +1,15 @@
-import execa, { Options } from 'execa';
-import program from 'commander';
-import { resolve, sep } from 'path';
+const execa = require('execa');
+const program = require('commander');
+const { resolve, sep } = require('path');
 
-const cypress = (commandName: string) => {
+const cypress = commandName => {
   // Support running an unpublished dev build
-  const parentPath = resolve(`${__dirname}/../`);
-  const parentDirname = parentPath.split(sep).pop();
-  const projectPath = resolve(`${parentPath}${parentDirname === 'dist' ? '/..' : ''}`);
+  const dirname = __dirname.split(sep).pop();
+  const projectPath = resolve(`${__dirname}${dirname === 'dist' ? '/..' : ''}`);
 
   const cypressOptions = [commandName, '--env', `CWD=${process.cwd()}`, `--project=${projectPath}`];
 
-  const execaOptions: Options = {
+  const execaOptions = {
     cwd: __dirname,
     stdio: 'inherit',
   };
@@ -20,7 +19,7 @@ const cypress = (commandName: string) => {
     .catch(error => console.error(error.message));
 };
 
-export default () => {
+module.exports = () => {
   const configOption = '-c, --config <path>';
   const configDescription = 'path to JSON file where configuration values are set; defaults to "cypress.json"';
 

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -5,6 +5,7 @@
   "version": "6.7.0-pre",
   "description": "Grafana End-to-End Test Library",
   "keywords": [
+    "cli",
     "grafana",
     "e2e",
     "typescript"

--- a/packages/grafana-e2e/rollup.config.ts
+++ b/packages/grafana-e2e/rollup.config.ts
@@ -20,8 +20,8 @@ const buildCjsPackage = ({ env }) => ({
     copy({
       flatten: false,
       targets: [
-        { src: 'compiled/bin/**/*.*', dest: 'dist/' },
-        { src: 'compiled/cli/**/*.*', dest: 'dist/' },
+        { src: 'bin/**/*.*', dest: 'dist/bin/' },
+        { src: 'cli.js', dest: 'dist/' },
         { src: 'cypress.json', dest: 'dist/' },
         { src: 'cypress/**/*.+(js|ts)', dest: 'dist/cypress/' },
       ],

--- a/packages/grafana-e2e/src/bin/grafana-e2e.ts
+++ b/packages/grafana-e2e/src/bin/grafana-e2e.ts
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-import cli from '../cli/index';
-
-cli();

--- a/packages/grafana-e2e/src/cli/index.ts
+++ b/packages/grafana-e2e/src/cli/index.ts
@@ -1,6 +1,6 @@
-import { resolve, sep } from 'path';
 import execa, { Options } from 'execa';
 import program from 'commander';
+import { resolve, sep } from 'path';
 
 const cypress = (commandName: string) => {
   // Support running an unpublished dev build

--- a/packages/grafana-e2e/tsconfig.json
+++ b/packages/grafana-e2e/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declarationDir": "dist",
-    "module": "commonjs",
     "outDir": "compiled",
     "rootDirs": ["."],
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
_Pretty sure_ this fixes the broken builds caused by #22546. It's difficult to test locally as it wants to import packages from my project `node_modules/` instead of from the monorepo. We'll know for sure when published to canary.

~~**Edit**: the build is likely failing because of the incremental build change to toolkit's `package:build` use of `tsc`. I'll have to dig into each package.~~