### PR TITLE
Cascader: Do not override default width behavior

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -8,6 +8,7 @@ import { FormInputSize } from '../Forms/types';
 import { Input } from '../Forms/Input/Input';
 import { SelectableValue } from '@grafana/data';
 import { css } from 'emotion';
+
 interface CascaderProps {
   /** The seperator between levels in the search */
   separator?: string;
@@ -184,7 +185,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
             onChange={this.onSelect}
             onBlur={this.onBlur}
             options={searchableOptions}
-            size={size || 'md'}
+            size={size}
             onCreateOption={this.onCreateOption}
             formatCreateLabel={this.props.formatCreateLabel}
           />
@@ -205,7 +206,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
           >
             <div className={disableDivFocus}>
               <Input
-                size={size || 'md'}
+                size={size}
                 placeholder={placeholder}
                 value={activeLabel}
                 onKeyDown={this.onInputKeyDown}

--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -34,6 +34,7 @@ export const basic = () => {
           <Select
             placeholder="Choose..."
             options={options}
+            width={20}
             onChange={value => {
               action('onChanged fired')(value);
               updateValue(value);
@@ -57,6 +58,7 @@ export const withAllowCustomValue = () => {
             // value={value}
             placeholder="Choose..."
             options={options}
+            width={20}
             allowCustomValue={true}
             onChange={value => {
               action('onChanged fired')(value);
@@ -87,6 +89,7 @@ export const asyncSelect = () => {
     <AsyncSelect
       value={value}
       defaultOptions
+      width={20}
       isLoading={isLoading}
       loadOptions={loadAsyncOptions}
       onChange={value => {


### PR DESCRIPTION
UnitPicker should default to width 100% if no width specified, same for Cascader 