### PR TITLE
Toolkit: wrap plugin signing stub with error checking

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -39,7 +39,8 @@ const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
   // Call a signing service
   const GRAFANA_API_KEY = process.env.GRAFANA_API_KEY;
   if (GRAFANA_API_KEY) {
-    const plugin = require('plugin.json');
+    const pluginPath = path.join(folder, 'plugin.json');
+    const plugin = require(pluginPath);
     const url = `https://grafana.com/api/plugins/${plugin.id}/sign`;
     console.log(`TODO: sign and save: ${url}`);
   }

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -160,7 +160,11 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
   });
 
   // Write a manifest.txt file in the dist folder
-  await execTask(manifestTask)({ folder: distContentDir });
+  try {
+    await execTask(manifestTask)({ folder: distContentDir });
+  } catch (err) {
+    console.warn(`Error signing manifest: ${distContentDir}`, err);
+  }
 
   console.log('Building ZIP');
   let zipName = pluginInfo.id + '-' + pluginInfo.info.version + '.zip';


### PR DESCRIPTION
minor fix to catch (and debug) errors while trying to sign plugin manifests