### PR TITLE
OAuth: add possibility to extract roles from access_token

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -55,7 +55,7 @@ Check for the presence of a role using the [JMESPath](http://jmespath.org/exampl
 See [JMESPath examples](#jmespath-examples) for more information.
 
 The `role_attribute_path` JMESPath expression is first applied on the id_token and userinfo by api_url, like all other options. For example, `email_attribute_path`.
-If there is no hit, then the JMESPath expression will be applied to the `access_token`.
+If the `role_attribute_path` JMESPath expression has no match in the id_toke or userinfo, then the expression will be applied to the `access_token`.
 
 ## Set up OAuth2 with Okta
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -54,8 +54,8 @@ Check for the presence of a role using the [JMESPath](http://jmespath.org/exampl
 
 See [JMESPath examples](#jmespath-examples) for more information.
 
-The `role_attribute_path` JMESPath expression will be applied first on the id_toke and userinfo by api_url, like all other options like `email_attribute_path`.
-If there is no hit it will look up the `access_token`.
+The `role_attribute_path` JMESPath expression is first applied on the id_token and userinfo by api_url, like all other options. For example, `email_attribute_path`.
+If there is no hit, then the JMESPath expression will be applied to the `access_token`.
 
 ## Set up OAuth2 with Okta
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -54,6 +54,9 @@ Check for the presence of a role using the [JMESPath](http://jmespath.org/exampl
 
 See [JMESPath examples](#jmespath-examples) for more information.
 
+The `role_attribute_path` JMESPath expression will be applied first on the id_toke and userinfo by api_url, like all other options like `email_attribute_path`.
+If there is no hit it will look up the `access_token`.
+
 ## Set up OAuth2 with Okta
 
 First set up Grafana as an OpenId client "webapplication" in Okta. Then set the Base URIs to `https://<grafana domain>/` and set the Login redirect URIs to `https://<grafana domain>/login/generic_oauth`.

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -161,6 +161,7 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 			Name              string
 			APIURLReponse     interface{}
 			OAuth2Extra       interface{}
+			OAuth2AccessToken string
 			RoleAttributePath string
 			ExpectedEmail     string
 			ExpectedRole      string
@@ -283,6 +284,18 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 				ExpectedEmail:     "john.doe@example.com",
 				ExpectedRole:      "FromResponse",
 			},
+			{
+				Name: "Given a valid id_token with no role, a valid role path, a valid api response with no email, merge",
+				OAuth2Extra: map[string]interface{}{
+					// { "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.k5GwPcZvGe2BE_jgwN0ntz0nz4KlYhEd0hRRLApkTJ4",
+				},
+				// { "role": "Admin" }
+				OAuth2AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiQWRtaW4ifQ.k5GwPcZvGe2BE_jgwN0ntz0nz4KlYhEd0hRRLApkTJ4",
+				RoleAttributePath: "role",
+				ExpectedEmail:     "john.doe@example.com",
+				ExpectedRole:      "Admin",
+			},
 		}
 
 		for _, test := range tests {
@@ -296,7 +309,7 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 				}))
 				provider.apiUrl = ts.URL
 				staticToken := oauth2.Token{
-					AccessToken:  "",
+					AccessToken:  test.OAuth2AccessToken,
 					TokenType:    "",
 					RefreshToken: "",
 					Expiry:       time.Now(),


### PR DESCRIPTION
Not all Oauth implementations (for example Keycloak) provide the groups at the user_info. Those are always at the access_token

Closes #22631