### PR TITLE
Use configuration to determine plugins directory

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -53,6 +53,23 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 func runPluginCommand(command func(commandLine utils.CommandLine) error) func(context *cli.Context) error {
 	return func(context *cli.Context) error {
 		cmd := &utils.ContextCommandLine{Context: context}
+		debug := cmd.Bool("debug")
+
+		cfg := setting.NewCfg()
+
+		configOptions := strings.Split(cmd.String("configOverrides"), " ")
+		if err := cfg.Load(&setting.CommandLineArgs{
+			Config:   cmd.ConfigFile(),
+			HomePath: cmd.HomePath(),
+			Args:     append(configOptions, cmd.Args().Slice()...), // tailing arguments have precedence over the options string
+		}); err != nil {
+			return errutil.Wrap("failed to load configuration", err)
+		}
+
+		if debug {
+			cfg.LogConfigSources()
+		}
+
 		if err := command(cmd); err != nil {
 			return err
 		}

--- a/pkg/cmd/grafana-cli/commands/ls_command.go
+++ b/pkg/cmd/grafana-cli/commands/ls_command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var ls_getPlugins func(path string) []models.InstalledPlugin = services.GetLocalPlugins
@@ -31,12 +32,12 @@ var validateLsCommand = func(pluginDir string) error {
 }
 
 func (cmd Command) lsCommand(c utils.CommandLine) error {
-	pluginDir := c.PluginDirectory()
-	if err := validateLsCommand(pluginDir); err != nil {
+	pluginsDir := setting.PluginsPath
+	if err := validateLsCommand(pluginsDir); err != nil {
 		return err
 	}
 
-	plugins := ls_getPlugins(pluginDir)
+	plugins := ls_getPlugins(pluginsDir)
 
 	if len(plugins) > 0 {
 		logger.Info("installed plugins:\n")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -462,7 +462,7 @@ func loadSpecifiedConfigFile(configFile string, masterFile *ini.File) error {
 		}
 	}
 
-	userConfig, err := ini.Load(configFile)
+	userConfig, err := ini.Load(makeAbsolute(configFile, HomePath))
 	if err != nil {
 		return fmt.Errorf("Failed to parse %v, %v", configFile, err)
 	}


### PR DESCRIPTION
- The `grafana-cli` oddly does not use supplied configuration to check for the plugins directory and solely use its `pluginsDir` option
- On top of that, it does not compute the configuration location (`config` option) relatively to the `homepath` one
- Finally, the variable containing the plugins directory is improperly reused/propagated in the `install` command code, resulting in the `pluginFolder` parameter of the `validateInput` procedure not being used