### PR TITLE
Replace "API" by "Integration" key for PagerDuty

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -97,7 +97,7 @@ If you are using the token for a slack bot, then you have to invite the bot to t
 
 ### PagerDuty
 
-To set up PagerDuty, all you have to do is to provide an API key.
+To set up PagerDuty, all you have to do is to provide an Integration key.
 
 Setting | Description
 ---------- | -----------

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -97,7 +97,7 @@ If you are using the token for a slack bot, then you have to invite the bot to t
 
 ### PagerDuty
 
-To set up PagerDuty, all you have to do is to provide an Integration key.
+To set up PagerDuty, all you have to do is to provide an integration key.
 
 Setting | Description
 ---------- | -----------


### PR DESCRIPTION
**What this PR does / why we need it**:
In the instructions for setting up a PagerDuty Alert Notification there is a reference to an API key in the text but an Integration key in the table.  They are different in PagerDuty, it should be "Integration" in both places.  
It would also be helpful to also reference that "Integration" keys are per "Service" in PagerDuty so people know where to look for them.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

