### PR TITLE
Fix redirect: prepend subpath only if it's missing

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -47,7 +47,11 @@ func notAuthorized(c *models.ReqContext) {
 		return
 	}
 
-	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(setting.AppSubUrl+c.Req.RequestURI), 0, newCookieOptions)
+	redirectTo := c.Req.RequestURI
+	if setting.AppSubUrl != "" && !strings.HasPrefix(redirectTo, setting.AppSubUrl) {
+		redirectTo = setting.AppSubUrl + c.Req.RequestURI
+	}
+	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, newCookieOptions)
 
 	c.Redirect(setting.AppSubUrl + "/login")
 }

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -104,9 +104,17 @@ export class LoginCtrl extends PureComponent<Props, State> {
     const params = this.props.routeParams;
     // Use window.location.href to force page reload
     if (params.redirect && params.redirect[0] === '/') {
-      window.location.href = config.appSubUrl + params.redirect;
+      if (config.appSubUrl !== '' && !params.redirect.startsWith(config.appSubUrl)) {
+        window.location.href = config.appSubUrl + params.redirect;
+      } else {
+        window.location.href = params.redirect;
+      }
     } else if (this.result.redirectUrl) {
-      window.location.href = config.appSubUrl + this.result.redirectUrl;
+      if (config.appSubUrl !== '' && !this.result.redirectUrl.startsWith(config.appSubUrl)) {
+        window.location.href = config.appSubUrl + this.result.redirectUrl;
+      } else {
+        window.location.href = this.result.redirectUrl;
+      }
     } else {
       window.location.href = config.appSubUrl + '/';
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The frontend prepends the subpath to redirects in addition to the backend (`/grafana` ends up to `/grafana/grafana`).
This fix modifies the backend and the frontend to prepend the appSubUrl only if it’s missing from the redirect URL.
A more detailed description of the issues is [here](https://github.com/grafana/grafana/pull/22285).

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This fix targets [`22227_fix`](https://github.com/grafana/grafana/tree/22227_fix) branch
