### PR TITLE
RichHistory: Design Tweaks 

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { hot } from 'react-hot-loader';
 import { css, cx } from 'emotion';
-import { stylesFactory, useTheme, Forms } from '@grafana/ui';
+import { stylesFactory, useTheme, Forms, styleMixins } from '@grafana/ui';
 import { GrafanaTheme, AppEvents, DataSourceApi } from '@grafana/data';
 import { RichHistoryQuery, ExploreId } from 'app/types/explore';
 import { copyStringToClipboard, createUrlFromRichHistory, createDataQuery } from 'app/core/utils/richHistory';
@@ -22,20 +22,17 @@ interface Props {
 
 const getStyles = stylesFactory((theme: GrafanaTheme, hasComment?: boolean) => {
   const bgColor = theme.isLight ? theme.colors.gray5 : theme.colors.dark4;
-  const cardColor = theme.isLight ? theme.colors.white : theme.colors.dark7;
   const cardBottomPadding = hasComment ? theme.spacing.sm : theme.spacing.xs;
-  const cardBoxShadow = theme.isLight ? `0px 2px 2px ${bgColor}` : `0px 2px 4px black`;
+
   return {
     queryCard: css`
+      ${styleMixins.listItem(theme)}
       display: flex;
-      border: 1px solid ${bgColor};
       padding: ${theme.spacing.sm} ${theme.spacing.sm} ${cardBottomPadding};
       margin: ${theme.spacing.sm} 0;
-      box-shadow: ${cardBoxShadow};
-      background-color: ${cardColor};
-      border-radius: ${theme.border.radius};
+
       .starred {
-        color: ${theme.colors.blue77};
+        color: ${theme.colors.orange};
       }
     `,
     queryCardLeft: css`
@@ -47,16 +44,14 @@ const getStyles = stylesFactory((theme: GrafanaTheme, hasComment?: boolean) => {
       width: 150px;
       display: flex;
       justify-content: flex-end;
+
       i {
-        font-size: ${theme.typography.size.lg};
-        font-weight: ${theme.typography.weight.bold};
-        margin: 3px;
+        margin: ${theme.spacing.xs};
         cursor: pointer;
       }
     `,
     queryRow: css`
       border-top: 1px solid ${bgColor};
-      font-weight: ${theme.typography.weight.bold};
       word-break: break-all;
       padding: 4px 2px;
       :first-child {

--- a/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
@@ -22,10 +22,12 @@ import { RichHistory, Tabs } from './RichHistory';
 import { deleteRichHistory } from '../state/actions';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
-  const bgColor = theme.isLight ? theme.colors.gray5 : theme.colors.dark4;
+  const bgColor = theme.isLight ? theme.colors.gray5 : theme.colors.gray15;
   const bg = theme.isLight ? theme.colors.gray7 : theme.colors.dark2;
   const borderColor = theme.isLight ? theme.colors.gray5 : theme.colors.dark6;
   const handleShadow = theme.isLight ? `0px 2px 2px ${bgColor}` : `0px 2px 4px black`;
+  const handleDots = theme.isLight ? theme.colors.gray70 : theme.colors.gray33;
+
   return {
     container: css`
       position: fixed !important;
@@ -44,9 +46,18 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       opacity: 0;
       transform: translateY(150px);
     `,
+    rzHandle: css`
+      background: transparent;
+      transition: 0.2s border-color ease-in-out;
+      border-top: 1px solid transparent;
+
+      &:hover {
+        border-bottom: 1px solid ${theme.colors.blueLight};
+      }
+    `,
     handle: css`
       background-color: ${borderColor};
-      height: 10px;
+      height: 8px;
       width: 202px;
       border-radius: 10px;
       position: absolute;
@@ -55,8 +66,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       padding: ${theme.spacing.xs};
       box-shadow: ${handleShadow};
       cursor: grab;
+
       hr {
-        border-top: 2px dotted ${theme.colors.gray70};
+        border-top: 2px dotted ${handleDots};
         margin: 0;
       }
     `,
@@ -96,6 +108,7 @@ function RichHistoryContainer(props: Props) {
     <Resizable
       className={cx(styles.container, visible ? styles.drawerActive : styles.drawerNotActive)}
       defaultSize={{ width: drawerWidth, height: '400px' }}
+      handleClasses={{ top: styles.rzHandle }}
       enable={{
         top: true,
         right: false,

--- a/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
@@ -25,8 +25,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const bgColor = theme.isLight ? theme.colors.gray5 : theme.colors.gray15;
   const bg = theme.isLight ? theme.colors.gray7 : theme.colors.dark2;
   const borderColor = theme.isLight ? theme.colors.gray5 : theme.colors.dark6;
-  const handleShadow = theme.isLight ? `0px 2px 2px ${bgColor}` : `0px 2px 4px black`;
+  const handleHover = theme.isLight ? theme.colors.gray10 : theme.colors.gray33;
   const handleDots = theme.isLight ? theme.colors.gray70 : theme.colors.gray33;
+  const handleDotsHover = theme.isLight ? theme.colors.gray33 : theme.colors.dark7;
 
   return {
     container: css`
@@ -47,29 +48,30 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       transform: translateY(150px);
     `,
     rzHandle: css`
-      background: transparent;
-      transition: 0.2s border-color ease-in-out;
-      border-top: 1px solid transparent;
+      background: ${bgColor};
+      transition: 0.3s background ease-in-out;
+      position: relative;
+      width: 200px !important;
+      left: calc(50% - 100px) !important;
+      cursor: grab;
+      border-radius: 4px;
 
       &:hover {
-        border-bottom: 1px solid ${theme.colors.blueLight};
-      }
-    `,
-    handle: css`
-      background-color: ${borderColor};
-      height: 8px;
-      width: 202px;
-      border-radius: 10px;
-      position: absolute;
-      top: -5px;
-      left: calc(50% - 101px);
-      padding: ${theme.spacing.xs};
-      box-shadow: ${handleShadow};
-      cursor: grab;
+        background-color: ${handleHover};
 
-      hr {
-        border-top: 2px dotted ${handleDots};
-        margin: 0;
+        &:after {
+          border-color: ${handleDotsHover};
+        }
+      }
+
+      &:after {
+        content: '';
+        display: block;
+        height: 2px;
+        position: relative;
+        top: 4px;
+        border-top: 4px dotted ${handleDots};
+        margin: 0 4px;
       }
     `,
   };
@@ -98,12 +100,6 @@ function RichHistoryContainer(props: Props) {
   const styles = getStyles(theme);
   const drawerWidth = `${width + 31.5}px`;
 
-  const drawerHandle = (
-    <div className={styles.handle}>
-      <hr />
-    </div>
-  );
-
   return (
     <Resizable
       className={cx(styles.container, visible ? styles.drawerActive : styles.drawerNotActive)}
@@ -123,7 +119,6 @@ function RichHistoryContainer(props: Props) {
       maxWidth={drawerWidth}
       minWidth={drawerWidth}
     >
-      {drawerHandle}
       <RichHistory
         richHistory={richHistory}
         firstTab={firstTab}


### PR DESCRIPTION
Found some design issues with RichHistory that made it feel disconnected from the rest of the Grafana look and feel:

1) Query text was bold (we never use bold text, only semi bold in some places. But we use semibold only for buttons and some small headings. These query texts can long so think it should have normal font-weight. 

2) The icons where bold, we never show bold icons anywhere. And they where too big compared to the rest of the UI so felt inconsistent. 

3) Fixed so that filled star (favorite) color was orange not blue  

4) Modified the resize handle to use the resize handle built into the resize component and added a hover state. Not 100% happy as the hover state disappear when you start dragging but better than before 


Before: 
![image](https://user-images.githubusercontent.com/10999/76359276-3b659000-631b-11ea-85d2-9df74eb1e26f.png)

After: 
![image](https://user-images.githubusercontent.com/10999/76359338-589a5e80-631b-11ea-9d5a-2b7fb8df048e.png)

