### PR TITLE
Docs: Remove Mention of Live Tailing in Dashboard

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -125,7 +125,7 @@ The following filter types are currently supported:
 
 ## Live tailing
 
-Loki supports Live tailing which displays logs in real-time. This feature is supported in [Explore]({{< relref "../explore/#loki-specific-features" >}}) and in dashboards with a Live toggle in the query editor.
+Loki supports Live tailing which displays logs in real-time. This feature is supported in [Explore]({{< relref "../explore/#loki-specific-features" >}}).
 
 Note that Live Tailing relies on two Websocket connections: one between the browser and the Grafana server, and another between the Grafana server and the Loki server. If you run any reverse proxies, please configure them accordingly.
 


### PR DESCRIPTION
The live tailing option was removed with Pull 19533 per some outstanding issues. It should no be mentioned in the docs as a feature. 

https://github.com/grafana/grafana/pull/19533

**Special notes for your reviewer**:
My first PR apologies if any issues. 

