### PR TITLE
Build: reverting changes that made the e2e tests fail.

### DIFF
--- a/packages/grafana-e2e/cypress/plugins/typescriptPreprocessor.js
+++ b/packages/grafana-e2e/cypress/plugins/typescriptPreprocessor.js
@@ -1,23 +1,13 @@
-const { resolve } = require('path');
 const wp = require('@cypress/webpack-preprocessor');
-
-const packageRoot = resolve(`${__dirname}/../../`);
-const packageModules = `${packageRoot}/node_modules`;
 
 const webpackOptions = {
   module: {
     rules: [
       {
-        include: modulePath => {
-          return modulePath.startsWith(packageRoot) && !modulePath.startsWith(packageModules);
-        },
         test: /\.ts$/,
         use: [
           {
             loader: 'ts-loader',
-            options: {
-              configFile: `${__dirname}/../tsconfig.json`,
-            },
           },
         ],
       },

--- a/packages/grafana-e2e/cypress/tsconfig.json
+++ b/packages/grafana-e2e/cypress/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
     "types": ["cypress"]
   },
-  "extends": "@grafana/tsconfig",
+  "extends": "../tsconfig.json",
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the end-to-end tests are failing due to invalid configuration with cypress.

**Special notes for your reviewer**:
I needed to revert some of the changes @stevenvachon did to get the e2e tests to run again. I am happy to help out getting it work later on so we can run it via the grafana cli.
