### PR TITLE
Revert "Graph: canvas's Stroke is executed after loop"

### DIFF
--- a/public/vendor/flot/jquery.flot.js
+++ b/public/vendor/flot/jquery.flot.js
@@ -2621,8 +2621,8 @@ Licensed under the MIT license.
                         ctx.fillStyle = fillStyle;
                         ctx.fill();
                     }
+                    ctx.stroke();
                 }
-                ctx.stroke();
             }
 
             ctx.save();


### PR DESCRIPTION
Reverts grafana/grafana#22610 as it broke fill rendering without line width 