### PR TITLE
Datasource: making sure we are having the same data field order when using mixed data sources.

### DIFF
--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import groupBy from 'lodash/groupBy';
 import { from, of, Observable, forkJoin } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { map, mergeMap, mergeAll } from 'rxjs/operators';
 
 import {
   LoadingState,
@@ -12,7 +12,6 @@ import {
   DataSourceInstanceSettings,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import { mergeMap, map } from 'rxjs/operators';
 
 export const MIXED_DATASOURCE_NAME = '-- Mixed --';
 
@@ -51,76 +50,46 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
   }
 
   batchQueries(mixed: BatchedQueries[], request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {
-    const observables: Array<Observable<DataQueryResponse>> = [];
-    let runningSubRequests = 0;
+    const runningQueries = mixed.filter(this.isQueryable).map((query, i) =>
+      from(query.datasource).pipe(
+        mergeMap((api: DataSourceApi) => {
+          const dsRequest = cloneDeep(request);
+          dsRequest.requestId = `mixed-${i}-${dsRequest.requestId || ''}`;
+          dsRequest.targets = query.targets;
 
-    for (let i = 0; i < mixed.length; i++) {
-      const query = mixed[i];
-      if (!query.targets || !query.targets.length) {
-        continue;
-      }
-      const observable = from(query.datasource).pipe(
-        mergeMap((dataSourceApi: DataSourceApi) => {
-          const datasourceRequest = cloneDeep(request);
-
-          datasourceRequest.requestId = `mixed-${i}-${datasourceRequest.requestId || ''}`;
-          datasourceRequest.targets = query.targets;
-
-          runningSubRequests++;
-          let hasCountedAsDone = false;
-
-          return from(dataSourceApi.query(datasourceRequest)).pipe(
-            tap(
-              (response: DataQueryResponse) => {
-                if (
-                  hasCountedAsDone ||
-                  response.state === LoadingState.Streaming ||
-                  response.state === LoadingState.Loading
-                ) {
-                  return;
-                }
-                runningSubRequests--;
-                hasCountedAsDone = true;
-              },
-              () => {
-                if (hasCountedAsDone) {
-                  return;
-                }
-                hasCountedAsDone = true;
-                runningSubRequests--;
-              }
-            ),
-            map((response: DataQueryResponse) => {
+          return from(api.query(dsRequest)).pipe(
+            map(response => {
               return {
                 ...response,
                 data: response.data || [],
-                state: runningSubRequests === 0 ? LoadingState.Done : LoadingState.Loading,
+                state: LoadingState.Loading,
                 key: `mixed-${i}-${response.key || ''}`,
               } as DataQueryResponse;
             })
           );
         })
-      );
-
-      observables.push(observable);
-    }
-
-    return forkJoin(observables).pipe(
-      map(responses => {
-        const data = responses.reduce((result, response) => {
-          return [...result, ...response.data];
-        }, []);
-
-        return {
-          data,
-          key: request.requestId,
-          state: LoadingState.Done,
-        };
-      })
+      )
     );
+
+    return forkJoin(runningQueries).pipe(map(this.markAsDone), mergeAll());
   }
 
   testDatasource() {
     return Promise.resolve({});
+  }
+
+  private isQueryable(query: BatchedQueries): boolean {
+    return query && Array.isArray(query.targets) && query.targets.length > 0;
+  }
+
+  private markAsDone(responses: Array<DataQueryResponse>): Array<DataQueryResponse> {
+    const { length } = responses;
+
+    if (length === 0) {
+      return responses;
+    }
+
+    responses[length - 1].state = LoadingState.Done;
+    return responses;
   }
 }

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -82,7 +82,7 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
     return query && Array.isArray(query.targets) && query.targets.length > 0;
   }
 
-  private markAsDone(responses: Array<DataQueryResponse>): Array<DataQueryResponse> {
+  private markAsDone(responses: DataQueryResponse[]): DataQueryResponse[] {
     const { length } = responses;
 
     if (length === 0) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When having a panel that uses queries from multiple datasources the order of the data fields will be displayed on the order of how the datasource responses is received. When having datasources that varies in the response times this makes the data fields to change places.

It is really good described in the referenced issue.

**Which issue(s) this PR fixes**:
Fixes #20555 

**Special notes for your reviewer**:
Instead of using merge we are using forkJoin. 

- Is it okay to use the `request.requestId` as the key for the response being returned? Or can this cause any issues?

- Didn't really looked into how we handle errors. But that might also be affected by this change. 