### PR TITLE
Explore: removes handling onBlur action in Explore for Loki and Prometheus

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -66,6 +66,7 @@ export function LokiExploreQueryEditor(props: Props) {
       datasource={datasource}
       query={query}
       onChange={onChange}
+      onBlur={() => {}}
       onRunQuery={onRunQuery}
       history={history}
       data={data}

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
     }
   }
   history={Array []}
+  onBlur={[Function]}
   onChange={[MockFunction]}
   onRunQuery={[MockFunction]}
   query={

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -38,6 +38,7 @@ export function PromExploreQueryEditor(props: Props) {
       query={query}
       onRunQuery={onRunQuery}
       onChange={onChange}
+      onBlur={() => {}}
       history={history}
       data={data}
       ExtraFieldElement={

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`PromExploreQueryEditor should render component 1`] = `
   }
   datasource={Object {}}
   history={Array []}
+  onBlur={[Function]}
   onChange={[MockFunction]}
   onRunQuery={[MockFunction]}
   query={


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes handling onBlur actions in Explore for Loki and Prometheus. Now queries in those QueryEditors are going to be executed only after user hits a return key.