### PR TITLE
Forms: Fix input suffix position (caret-down in Select) 

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Input/Input.tsx
@@ -47,11 +47,6 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false }: StyleDe
     height: 100%;
     /* Min width specified for prefix/suffix classes used outside React component*/
     min-width: ${prefixSuffixStaticWidth};
-    // Hack to fix font awesome icons
-    > .fa {
-      position: relative;
-      top: 2px;
-    }
   `;
 
   return {

--- a/packages/grafana-ui/src/components/Forms/Select/IndicatorsContainer.tsx
+++ b/packages/grafana-ui/src/components/Forms/Select/IndicatorsContainer.tsx
@@ -14,7 +14,6 @@ export const IndicatorsContainer = React.forwardRef<HTMLDivElement, React.PropsW
         styles.suffix,
         css`
           position: relative;
-          top: 1px;
         `
       )}
       ref={ref}


### PR DESCRIPTION
For some reason this position fix is no longer needed 