### PR TITLE
Storybook: Add relative logo url

### DIFF
--- a/packages/grafana-ui/.storybook/storybookTheme.ts
+++ b/packages/grafana-ui/.storybook/storybookTheme.ts
@@ -39,7 +39,7 @@ const createTheme = (theme: GrafanaTheme) => {
 
     brandTitle: 'Grafana UI',
     brandUrl: '/',
-    brandImage: '/grafana_icon.svg',
+    brandImage: './grafana_icon.svg',
   });
 };
 


### PR DESCRIPTION
Since Storybook is served from a subpath on GCP, it was failing. This should fix the issue.

Fixes #22785