### PR TITLE
Infra: Add relative node_modules path to webpack config

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -30,7 +30,7 @@ module.exports = {
       // this alias maps that dependency to core-js@t3
       'core-js/library/fn': 'core-js/stable',
     },
-    modules: [path.resolve('public'), path.resolve('node_modules')],
+    modules: [path.resolve('public'), 'node_modules'],
   },
   stats: {
     children: false,


### PR DESCRIPTION
While adding some new package to packages I had errors with module resolution. Reason was that in webpack we had aboslute path to root node_modules as a resolve path so each package was looking only into root node_modules. This probably wasn't noticed because most packages have common dependencies lifted to root dir but with the new packages there were few which were only installed in the package's node_modules.  