### PR TITLE
DevEnv: updates build-ci-deploy dockerfile and CI config to include yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
       - image: grafana/build-container:1.2.13
   grafana-publish:
     docker:
-      - image: grafana/grafana-ci-deploy:1.2.3
+      - image: grafana/grafana-ci-deploy:1.2.4
   docker:
     machine:
       image: circleci/classic:201808-01

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -6,7 +6,7 @@ RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-de
     git reset --hard a64807efdaf5e380bfa878c71bc88eae10d62be1 && \
     make install
 
-FROM circleci/python:2.7-stretch
+FROM circleci/python:2.7-stretch-node
 
 USER root
 

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_version="1.2.3"
+_version="1.2.4"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates build-ci-deploy dockerfile and CI config for deployment - changes an image to include nodejs with yarn.