### PR TITLE
SaveDashboard: Updated modal design/layout a bit

### DIFF
--- a/packages/grafana-ui/src/components/Forms/index.ts
+++ b/packages/grafana-ui/src/components/Forms/index.ts
@@ -10,6 +10,7 @@ import { Field } from './Field';
 import { Button, LinkButton } from './Button';
 import { Switch } from './Switch';
 import { TextArea } from './TextArea/TextArea';
+import { Checkbox } from './Checkbox';
 
 const Forms = {
   RadioButtonGroup,
@@ -26,6 +27,7 @@ const Forms = {
   InputControl,
   AsyncSelect,
   TextArea,
+  Checkbox,
 };
 
 export { ButtonVariant } from './Button';

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+
 import { Forms, Button, HorizontalGroup } from '@grafana/ui';
 import { e2e } from '@grafana/e2e';
 import { SaveDashboardFormProps } from '../types';
@@ -30,32 +31,32 @@ export const SaveDashboardForm: React.FC<SaveDashboardFormProps> = ({ dashboard,
     >
       {({ register, errors }) => (
         <>
-          <Forms.Field label="Changes description">
+          <div className="gf-form-group">
+            {hasTimeChanged && (
+              <Forms.Checkbox
+                label="Save current time range as dashboard default"
+                name="saveTimerange"
+                ref={register}
+                aria-label={e2e.pages.SaveDashboardModal.selectors.saveTimerange}
+              />
+            )}
+            {hasVariableChanged && (
+              <Forms.Checkbox
+                label="Save current variable values as dashboard default"
+                name="saveVariables"
+                ref={register}
+                aria-label={e2e.pages.SaveDashboardModal.selectors.saveVariables}
+              />
+            )}
+            {(hasVariableChanged || hasTimeChanged) && <div className="gf-form-group" />}
+
             <Forms.TextArea
               name="message"
               ref={register}
               placeholder="Add a note to describe your changes..."
               autoFocus
             />
-          </Forms.Field>
-          {hasTimeChanged && (
-            <Forms.Field label="Save current time range" description="Dashboard time range has changed">
-              <Forms.Switch
-                name="saveTimerange"
-                ref={register}
-                aria-label={e2e.pages.SaveDashboardModal.selectors.saveTimerange}
-              />
-            </Forms.Field>
-          )}
-          {hasVariableChanged && (
-            <Forms.Field label="Save current variables" description="Dashboard variables have changed">
-              <Forms.Switch
-                name="saveVariables"
-                ref={register}
-                aria-label={e2e.pages.SaveDashboardModal.selectors.saveVariables}
-              />
-            </Forms.Field>
-          )}
+          </div>
 
           <HorizontalGroup>
             <Button type="submit" aria-label={e2e.pages.SaveDashboardModal.selectors.save}>


### PR DESCRIPTION
Current: 
![image](https://user-images.githubusercontent.com/10999/76763523-9112c000-6793-11ea-836a-943963e03832.png)

Updated the design a bit to use checkboxes, and move them above the description box: 

![image](https://user-images.githubusercontent.com/10999/76763475-7b04ff80-6793-11ea-8c68-f9cce4ff64e6.png)

Think checkboxes work better for this as there is no visible change taking place (unlike visualization toggles). 