### PR TITLE
CircleCI: Download grabpl from GCS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,11 @@ jobs:
           name: Install Grafana Build Pipeline
           command: |
             echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
-            /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
+            gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
 
             mkdir bin
-            /opt/google-cloud-sdk/bin/gsutil cp gs://grafana-build-pipeline/grafana-build-pipeline-0.0.2/grabpl \
-              bin/grabpl
+            gsutil cp gs://grafana-build-pipeline/grafana-build-pipeline-0.0.2/grabpl bin/grabpl
+            chmod +x bin/grabpl
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,19 +43,17 @@ executors:
 jobs:
   install-grabpl:
     description: Install the Grafana Build Pipeline tool
-    executor: grafana-build
+    executor: cloud-sdk
     steps:
-      - run:
-          name: Clone repo
-          command: |
-            mkdir -p ~/.ssh
-            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
-            git clone git@github.com:grafana/build-pipeline.git
       - run:
           name: Install Grafana Build Pipeline
           command: |
-            cd build-pipeline
-            go build -o ../bin/grabpl ./cmd/grabpl
+            echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
+            /opt/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
+
+            mkdir bin
+            /opt/google-cloud-sdk/bin/gsutil cp gs://grafana-build-pipeline/grafana-build-pipeline-0.0.2/grabpl \
+              bin/grabpl
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
**What this PR does / why we need it**:
Download Grafana Build Pipeline tool from GCS instead of cloning from GitHub, since we are having permissions problems.
