### PR TITLE
TestData: New dashboard that tests variables that update on time range change

### DIFF
--- a/devenv/dev-dashboards/feature-templating/testdata-variables-that-update-on-time-change.json
+++ b/devenv/dev-dashboards/feature-templating/testdata-variables-that-update-on-time-change.json
@@ -1,0 +1,195 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1584435937931,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 19,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "updatesOnTime: $updatesOnTime",
+          "refId": "A",
+          "scenarioId": "random_walk"
+        },
+        {
+          "alias": "dependsOnFirst: $dependsOnFirst",
+          "refId": "B",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": ["gdev", "templating"],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "value.1584434137814",
+          "value": "value.1584434137814"
+        },
+        "datasource": "gdev-testdata",
+        "definition": "value.$__from",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": null,
+        "multi": false,
+        "name": "updatesOnTime",
+        "options": [],
+        "query": "value.$__from",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "value.value.1584434072074",
+          "value": "value.value.1584434072074"
+        },
+        "datasource": "gdev-testdata",
+        "definition": "value.$updatesOnTime",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": null,
+        "multi": false,
+        "name": "dependsOnFirst",
+        "options": [
+          {
+            "selected": true,
+            "text": "value.value.1584434072074",
+            "value": "value.value.1584434072074"
+          }
+        ],
+        "query": "value.$updatesOnTime",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+  },
+  "timezone": "",
+  "title": "Templating - Variables That Refresh On Time Change",
+  "uid": "HeUnbEuZk",
+  "variables": {
+    "list": []
+  },
+  "version": 13
+}

--- a/public/app/plugins/datasource/testdata/metricTree.ts
+++ b/public/app/plugins/datasource/testdata/metricTree.ts
@@ -70,6 +70,10 @@ function queryTree(children: TreeNode[], query: string[], queryIndex: number): T
 }
 
 export function queryMetricTree(query: string): TreeNode[] {
+  if (query.indexOf('value') === 0) {
+    return [{ name: query, children: [] }];
+  }
+
   const children = buildMetricTree('', 0);
   return queryTree(children, query.split('.'), 0);
 }


### PR DESCRIPTION
A test dashboard with two variables.

1) updatesOnTime: single.$__from    & refresh: on time range change so value will always update on time range change
2) dependsOnFirst: single.$__updatesOnTime     This just tests that the time range change triggers cascading updates. This actually shows a bug, for some reason cascading updates are not triggered for variables that are set to Refresh: Never  during dashboard load, so this variable does not update when you first load dashboard (bug in existing template system), but will update when you hit refresh button (or change time range). 

![image](https://user-images.githubusercontent.com/10999/76840329-4c406500-6837-11ea-8608-07c329ddf92c.png)
