### PR TITLE
Stackdriver: Fix GCE auth bug when creating new data source

### DIFF
--- a/public/app/plugins/datasource/stackdriver/config_ctrl.ts
+++ b/public/app/plugins/datasource/stackdriver/config_ctrl.ts
@@ -1,6 +1,4 @@
 import DatasourceSrv from 'app/features/plugins/datasource_srv';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-import StackdriverDatasource from './datasource';
 import { AuthType, authTypes } from './types';
 
 export interface JWT {

--- a/public/app/plugins/datasource/stackdriver/config_ctrl.ts
+++ b/public/app/plugins/datasource/stackdriver/config_ctrl.ts
@@ -21,10 +21,9 @@ export class StackdriverConfigCtrl {
   authenticationTypes: Array<{ key: AuthType; value: string }>;
   defaultAuthenticationType: string;
   name: string;
-  gceError: string;
 
   /** @ngInject */
-  constructor(datasourceSrv: DatasourceSrv, private $scope: any) {
+  constructor(datasourceSrv: DatasourceSrv) {
     this.defaultAuthenticationType = AuthType.JWT;
     this.datasourceSrv = datasourceSrv;
     this.name = this.meta.name;
@@ -97,20 +96,5 @@ export class StackdriverConfigCtrl {
     this.current.jsonData = Object.assign({}, { authenticationType: this.current.jsonData.authenticationType });
     this.current.secureJsonData = {};
     this.current.secureJsonFields = {};
-  }
-
-  async loadGCEDefaultAccount() {
-    this.gceError = '';
-    const ds = (await getDatasourceSrv().loadDatasource(this.name)) as StackdriverDatasource;
-    try {
-      const defaultProject = await ds.getGCEDefaultProject();
-      this.$scope.$apply(() => {
-        this.current.jsonData.gceDefaultProject = defaultProject;
-      });
-    } catch (error) {
-      this.$scope.$apply(() => {
-        this.gceError = error;
-      });
-    }
   }
 }

--- a/public/app/plugins/datasource/stackdriver/datasource.ts
+++ b/public/app/plugins/datasource/stackdriver/datasource.ts
@@ -22,6 +22,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
   authenticationType: string;
   queryPromise: Promise<any>;
   metricTypesCache: { [key: string]: MetricDescriptor[] };
+  gceDefaultProject: string;
 
   /** @ngInject */
   constructor(
@@ -324,7 +325,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
   getDefaultProject(): string {
     const { defaultProject, authenticationType, gceDefaultProject } = this.instanceSettings.jsonData;
     if (authenticationType === 'gce') {
-      return gceDefaultProject || '';
+      return gceDefaultProject || this.gceDefaultProject;
     }
 
     return defaultProject || '';
@@ -333,7 +334,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
   async ensureGCEDefaultProject() {
     const { authenticationType, gceDefaultProject } = this.instanceSettings.jsonData;
     if (authenticationType === 'gce' && !gceDefaultProject) {
-      this.instanceSettings.jsonData.gceDefaultProject = await this.getGCEDefaultProject();
+      this.gceDefaultProject = await this.getGCEDefaultProject();
     }
   }
 

--- a/public/app/plugins/datasource/stackdriver/datasource.ts
+++ b/public/app/plugins/datasource/stackdriver/datasource.ts
@@ -229,6 +229,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
     let status, message;
     const defaultErrorMessage = 'Cannot connect to Stackdriver API';
     try {
+      this.ensureGCEDefaultProject();
       const path = `v3/projects/${this.getDefaultProject()}/metricDescriptors`;
       const response = await this.doRequest(`${this.baseUrl}${path}`);
       if (response.status === 200) {

--- a/public/app/plugins/datasource/stackdriver/datasource.ts
+++ b/public/app/plugins/datasource/stackdriver/datasource.ts
@@ -230,7 +230,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
     let status, message;
     const defaultErrorMessage = 'Cannot connect to Stackdriver API';
     try {
-      this.ensureGCEDefaultProject();
+      await this.ensureGCEDefaultProject();
       const path = `v3/projects/${this.getDefaultProject()}/metricDescriptors`;
       const response = await this.doRequest(`${this.baseUrl}${path}`);
       if (response.status === 200) {
@@ -325,7 +325,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
   getDefaultProject(): string {
     const { defaultProject, authenticationType, gceDefaultProject } = this.instanceSettings.jsonData;
     if (authenticationType === 'gce') {
-      return gceDefaultProject || this.gceDefaultProject;
+      return gceDefaultProject || '';
     }
 
     return defaultProject || '';
@@ -334,7 +334,7 @@ export default class StackdriverDatasource extends DataSourceApi<StackdriverQuer
   async ensureGCEDefaultProject() {
     const { authenticationType, gceDefaultProject } = this.instanceSettings.jsonData;
     if (authenticationType === 'gce' && !gceDefaultProject) {
-      this.gceDefaultProject = await this.getGCEDefaultProject();
+      this.instanceSettings.jsonData.gceDefaultProject = await this.getGCEDefaultProject();
     }
   }
 

--- a/public/app/plugins/datasource/stackdriver/partials/config.html
+++ b/public/app/plugins/datasource/stackdriver/partials/config.html
@@ -65,22 +65,6 @@
   </div>
 
   <div
-    class="gf-form-inline"
-    ng-if="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType && ctrl.current.jsonData.gceDefaultProject"
-  >
-    <div class="gf-form">
-      <span class="gf-form-label width-10">Project</span>
-      <input class="gf-form-input width-40" disabled type="text" ng-model="ctrl.current.jsonData.gceDefaultProject" />
-    </div>
-
-    <div class="gf-form width-18">
-      <a class="btn btn-secondary gf-form-btn" style="margin-top: 2px;" href="#" ng-click="ctrl.loadGCEDefaultAccount()"
-        >Reload project name
-      </a>
-    </div>
-  </div>
-
-  <div
     ng-if="ctrl.current.jsonData.authenticationType === ctrl.defaultAuthenticationType && !ctrl.current.jsonData.clientEmail && !ctrl.inputDataValid"
   >
     <div class="gf-form-group" ng-if="!ctrl.inputDataValid">

--- a/public/app/plugins/datasource/stackdriver/partials/config.html
+++ b/public/app/plugins/datasource/stackdriver/partials/config.html
@@ -64,7 +64,10 @@
     </div>
   </div>
 
-  <div class="gf-form-inline" ng-if="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType">
+  <div
+    class="gf-form-inline"
+    ng-if="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType && ctrl.current.jsonData.gceDefaultProject"
+  >
     <div class="gf-form">
       <span class="gf-form-label width-10">Project</span>
       <input class="gf-form-input width-40" disabled type="text" ng-model="ctrl.current.jsonData.gceDefaultProject" />
@@ -72,7 +75,7 @@
 
     <div class="gf-form width-18">
       <a class="btn btn-secondary gf-form-btn" style="margin-top: 2px;" href="#" ng-click="ctrl.loadGCEDefaultAccount()"
-        >{{ctrl.current.jsonData.gceDefaultProject ? 'Reload project name' : 'Load project name'}}
+        >Reload project name
       </a>
     </div>
   </div>
@@ -146,20 +149,10 @@
   <i class="fa fa-save"></i> Do not forget to save your changes after uploading a file.
 </p>
 
-<p
-  class="gf-form-label"
-  ng-show="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType && !ctrl.current.jsonData.gceDefaultProject"
->
-  <i class="fa fa-warning"></i> Before saving, load the Project name that is associated with the default service account
-</p>
-
 <div class="gf-form" ng-if="ctrl.gceError">
   <pre class="gf-form-pre alert alert-error">{{ctrl.gceError}}</pre>
 </div>
 
-<p
-  class="gf-form-label"
-  ng-show="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType && ctrl.current.jsonData.gceDefaultProject"
->
+<p class="gf-form-label" ng-show="ctrl.current.jsonData.authenticationType !== ctrl.defaultAuthenticationType">
   <i class="fa fa-save"></i> Verify GCE default service account by clicking Save & Test
 </p>


### PR DESCRIPTION
A bug was reported in #22747, saying that it's only possible to use GCE when the datasource is named `Stackdriver`. The root cause of the problem is that we're trying to load project name from the backend before the new datasource is actually saved and stored in the Grafana database. This is sort of a chicken and egg situation that highlights the problems that we have with the config page - the config page frontend needs access to the backend before it really exist. 

Solution: Rollback to the way it was before the project selector PR - in case GCE auth, ensure default project exist before attempting to load data from external API:s in the frontend. 

related to #22447
fixes #22747