### PR TITLE
CircleCI: Install build pipeline tool from GitHub repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,17 +43,19 @@ executors:
 jobs:
   install-grabpl:
     description: Install the Grafana Build Pipeline tool
-    executor: cloud-sdk
+    executor: grafana-build
     steps:
+      - run:
+          name: Clone repo
+          command: |
+            mkdir -p ~/.ssh
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+            git clone -b v0.0.2 git@github.com:grafana/build-pipeline.git
       - run:
           name: Install Grafana Build Pipeline
           command: |
-            echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
-            gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
-
-            mkdir bin
-            gsutil cp gs://grafana-build-pipeline/grafana-build-pipeline-0.0.2/grabpl bin/grabpl
-            chmod +x bin/grabpl
+            cd build-pipeline
+            go build -o ../bin/grabpl ./cmd/grabpl
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert to installing build pipeline tool from GitHub repo, although pinned to v0.0.2.

The reason for reverting to installing from GitHub is that I found out that we can't download the binary from Google Cloud Storage for builds of forked PRs, since they don't have access to the $GCP_GRAFANA_UPLOAD_KEY environment variable. I wasn't aware of this until now, but it is most probably a security measure so that externals can't access our environment variables, which does make sense.