### PR TITLE
CircleCI: Don't publish storybook for PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,20 +422,20 @@ jobs:
       - run:
           name: Publish Storybook
           command: |
-            echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
-            gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
             yarn install --frozen-lockfile --no-progress
             yarn storybook:build
             if [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
               echo Testing release
             elif [[ $CIRCLE_BRANCH == "master" ]]; then
+              echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
+              gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
               gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/canary
             elif [[ -n $CIRCLE_TAG ]]; then
+              echo $GCP_GRAFANA_UPLOAD_KEY > /tmp/gcpkey.json
+              gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
               gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/latest
               gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/$CIRCLE_TAG
-            else
-              gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/${CIRCLE_SHA1:0:7}
             fi
       - run:
           name: CI job failed


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't publish StoryBook from the PR pipeline in CircleCI. This should also fix the build of external PRs.