### PR TITLE
Fix webpack for enterprise

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -30,7 +30,12 @@ module.exports = {
       // this alias maps that dependency to core-js@t3
       'core-js/library/fn': 'core-js/stable',
     },
-    modules: [path.resolve('public'), 'node_modules'],
+    modules: [
+      'node_modules',
+      path.resolve('public'),
+      // we need full path to root node_modules for grafana-enterprise symlink to work
+      path.resolve('node_modules'),
+    ],
   },
   stats: {
     children: false,


### PR DESCRIPTION
Fixes grafana-enterprise issue introduced with #22806. Fr enterprise (as it's symlinked) we need the absolute path to root node_modules for dependencies to be resolved correctly