### PR TITLE
Devenv: adds grafana block with a customizeable version

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -36,5 +36,7 @@ make devenv sources=influxdb,prometheus2,elastic5
 Some of the blocks support dynamic change of the image version used in the Docker file. The signature looks like this: 
 
 ```bash
-make devenv sources=postgres,openldap postgres_version=9.2
+make devenv sources=postgres,openldap,grafana postgres_version=9.2 grafana_version=6.7.0-beta1
 ```
+
+Note: The grafana block is pre-configured with the dev-datasources and dashboards.

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -1,0 +1,248 @@
+
+apiVersion: 1
+
+datasources:
+  - name: gdev-graphite
+    type: graphite
+    access: proxy
+    url: http://graphite11:80
+    jsonData:
+      graphiteVersion: "1.1"
+
+  - name: gdev-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+
+  - name: gdev-slow-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:3011
+
+  - name: gdev-testdata
+    isDefault: true
+    type: testdata
+
+  - name: gdev-influxdb
+    type: influxdb
+    access: proxy
+    database: site
+    user: grafana
+    url: http://influxdb:8086
+    jsonData:
+      timeInterval: "15s"
+    secureJsonData:
+      password: grafana
+
+  - name: gdev-influxdb-telegraf
+    type: influxdb
+    access: proxy
+    database: telegraf
+    user: grafana
+    url: http://telegraf:8086
+    jsonData:
+      timeInterval: "10s"
+    secureJsonData:
+      password: grafana
+
+  - name: gdev-opentsdb
+    type: opentsdb
+    access: proxy
+    url: http://opentsdb:4242
+    jsonData:
+      tsdbResolution: 1
+      tsdbVersion: 1
+
+  - name: gdev-elasticsearch-v2-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://elasticsearch:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 2
+
+  - name: gdev-elasticsearch-v2-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://elasticsearch:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 2
+
+  - name: gdev-elasticsearch-v5-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://elasticsearch5:10200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 5
+
+  - name: gdev-elasticsearch-v5-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://elasticsearch5:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 5
+
+  - name: gdev-elasticsearch-v6-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://elasticsearch6:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 60
+
+  - name: gdev-elasticsearch-v6-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://elasticsearch6:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 60
+
+  - name: gdev-elasticsearch-v6-filebeat
+    type: elasticsearch
+    access: proxy
+    database: "[filebeat-]YYYY.MM.DD"
+    url: http://elasticsearch6:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 60
+
+  - name: gdev-elasticsearch-v7-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://elasticsearch7:9200
+    jsonData:
+      timeInterval: 10s
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 70
+
+  - name: gdev-elasticsearch-v7-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://elasticsearch7:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 70
+
+  - name: gdev-elasticsearch-v7-filebeat
+    type: elasticsearch
+    access: proxy
+    database: "[filebeat-]YYYY.MM.DD"
+    url: http://elasticsearch7:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 70
+      timeInterval: "10s"
+      logMessageField: message
+      logLevelField: fields.level
+
+  - name: gdev-elasticsearch-v7-metricbeat
+    type: elasticsearch
+    access: proxy
+    database: "[metricbeat-]YYYY.MM.DD"
+    url: http://elasticsearch7:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 70
+      timeInterval: "10s"
+
+  - name: gdev-mysql
+    type: mysql
+    url: mysql:3306
+    database: grafana
+    user: grafana
+    secureJsonData:
+      password: password
+
+  - name: gdev-mysql-ds-tests
+    type: mysql
+    url: mysqltests:3306
+    database: grafana_ds_tests
+    user: grafana
+    secureJsonData:
+      password: password
+
+  - name: gdev-mssql
+    type: mssql
+    url: mssql:1433
+    database: grafana
+    user: grafana
+    secureJsonData:
+      password: Password!
+
+  - name: gdev-mssql-ds-tests
+    type: mssql
+    url: mssqltests:1433
+    database: grafanatest
+    user: grafana
+    secureJsonData:
+      password: Password!
+
+  - name: gdev-postgres
+    type: postgres
+    url: postgres:5432
+    database: grafana
+    user: grafana
+    secureJsonData:
+      password: password
+    jsonData:
+      sslmode: "disable"
+
+  - name: gdev-postgres-ds-tests
+    type: postgres
+    url: postgrestest:5432
+    database: grafanadstest
+    user: grafanatest
+    secureJsonData:
+      password: grafanatest
+    jsonData:
+      sslmode: "disable"
+
+  - name: gdev-cloudwatch
+    type: cloudwatch
+    editable: true
+    jsonData:
+      authType: credentials
+      defaultRegion: eu-west-2
+
+  # Keep to test old /api/prom API
+  - name: gdev-loki-0.3
+    type: loki
+    access: proxy
+    url: http://loki0.3:3100
+    editable: false
+
+  # First version with new v1 API (remove once v1 is out)
+  - name: gdev-loki-0.4
+    type: loki
+    access: proxy
+    url: http://loki0.4:3100
+    editable: false
+
+  - name: gdev-loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/devenv/docker/blocks/grafana/.env
+++ b/devenv/docker/blocks/grafana/.env
@@ -1,0 +1,1 @@
+grafana_version=6.6.2

--- a/devenv/docker/blocks/grafana/docker-compose.yaml
+++ b/devenv/docker/blocks/grafana/docker-compose.yaml
@@ -1,0 +1,8 @@
+  grafana:
+    image: grafana/grafana:${grafana_version}
+    ports:
+      - "3001:3000"
+    volumes:
+      - "./dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml"
+      - "./dev-dashboards:/usr/share/grafana/devenv/dev-dashboards"
+      - "./datasources_docker.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"

--- a/devenv/docker/blocks/prometheus2/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus2/docker-compose.yaml
@@ -1,18 +1,15 @@
   prometheus:
     build: docker/blocks/prometheus2
-    network_mode: host
     ports:
       - "9090:9090"
 
   node_exporter:
     image: prom/node-exporter
-    network_mode: host
     ports:
       - "9100:9100"
 
   fake-prometheus-data:
     image: grafana/fake-data-gen
-    network_mode: host
     ports:
       - "9091:9091"
     environment:
@@ -20,12 +17,10 @@
 
   alertmanager:
     image: quay.io/prometheus/alertmanager
-    network_mode: host
     ports:
       - "9093:9093"
 
   prometheus-random-data:
     build: docker/blocks/prometheus_random_data
-    network_mode: host
     ports:
       - "8081:8080"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a grafana block (running on port `3001`) with the devenv datasources and dashboards provisioned. This makes it easier to do testing with non-master builds of grafana.

To test:
```bash
make devenv sources=graphite11,prometheus2,grafana grafana_version=6.7.0-beta1
```


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I have removed the `network_mode: host` from many blocks as that doesn't work on non-linux systems. I couldn't see any obvious problems with doing this, but there could be something I'm missing.
