### PR TITLE
CircleCI: Fix strict null that breaks Storybook build

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -69,12 +69,12 @@ describe('BarGauge', () => {
   describe('Get value color', () => {
     it('should get the threshold color if value is same as a threshold', () => {
       const props = getProps();
-      props.value = props.display(70);
+      props.value = props.display!(70);
       expect(getValueColor(props)).toEqual(orange);
     });
     it('should get the base threshold', () => {
       const props = getProps();
-      props.value = props.display(-10);
+      props.value = props.display!(-10);
       expect(getValueColor(props)).toEqual(green);
     });
   });


### PR DESCRIPTION
Feels weird that this error appeared in the first place. There is probably something else to it.