### PR TITLE
SQLStore: Add migration for adding index on annotation.alert_id

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -145,6 +145,10 @@ func addAnnotationMig(mg *Migrator) {
 	mg.AddMigration("Remove index org_id_epoch_epoch_end from annotation table", NewDropIndexMigration(table, &Index{
 		Cols: []string{"org_id", "epoch", "epoch_end"}, Type: IndexType,
 	}))
+
+	mg.AddMigration("Add index for alert_id on annotation table", NewAddIndexMigration(table, &Index{
+		Cols: []string{"alert_id"}, Type: IndexType,
+	}))
 }
 
 type AddMakeRegionSingleRowMigration struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add migration for adding index on column `alert_id` on the `annotation` table, in order to speed up queries (e.g. deletions) involving it.

Analyzed MySQL query before adding the index:
```
mysql root@localhost:grafana> explain delete from annotation where alert_id = 100;
+----+-------------+------------+------+---------------+--------+---------+--------+----------+-------------+
| id | select_type | table      | type | possible_keys | key    | key_len | ref    | rows     | Extra       |
+----+-------------+------------+------+---------------+--------+---------+--------+----------+-------------+
| 1  | SIMPLE      | annotation | ALL  | <null>        | <null> | <null>  | <null> | 12416988 | Using where |
+----+-------------+------------+------+---------------+--------+---------+--------+----------+-------------+
```

Analyzed MySQL query after adding the index:

```
mysql root@localhost:grafana> explain delete from annotation where alert_id = 100;
+----+-------------+------------+-------+---------------------+---------------------+---------+-------+------+----------+-------------+
| id | select_type | table      | type  | possible_keys       | key                 | key_len | ref   | rows | filtered | Extra       |
+----+-------------+------------+-------+---------------------+---------------------+---------+-------+------+----------+-------------+
| 1  | SIMPLE      | annotation | range | annotation_alert_id | annotation_alert_id | 9       | const | 1    | 100.0    | Using where |
+----+-------------+------------+-------+---------------------+---------------------+---------+-------+------+----------+-------------+
```

**Which issue(s) this PR fixes**:
Fixes #22799.