### PR TITLE
AzureMonitor: support workspaces function for template variables

### DIFF
--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -274,6 +274,40 @@ There are also some Grafana variables that can be used in Azure Log Analytics qu
 
 - `$__interval` - Grafana calculates the minimum time grain that can be used to group by time in queries. More details on how it works [here]({{< relref "../../reference/templating.md#interval-variables" >}}). It returns a time grain like `5m` or `1h` that can be used in the bin function. E.g. `summarize count() by bin(TimeGenerated, $__interval)`
 
+### Templating with Variables for Azure Log Analytics
+
+Any Log Analytics query that returns a list of values can be used in the `Query` field in the Variable edit view. There is also one Grafana function for Log Analytics that returns a list of workspaces.
+
+Check out the [Templating]({{< relref "../../reference/templating.md" >}}) documentation for an introduction to the templating feature and the different
+types of template variables.
+
+| Name                                               | Description                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| _workspaces()_                                     | Returns a list of workspaces for the default subscription.                                             |
+| _workspaces(12345678-aaaa-bbbb-cccc-123456789aaa)_ | Returns a list of workspaces for the specified subscription (the parameter can be quoted or unquoted). |
+
+Example variable queries:
+
+- Returns a list of Azure subscriptions: `subscriptions()`
+- Returns a list of workspaces for default subscription: `workspaces()`
+- Returns a list of workspaces for a specified subscription: `workspaces("12345678-aaaa-bbbb-cccc-123456789aaa")`
+- With template variable for the subscription parameter: `workspaces("$subscription")`
+- Returns a list of Virtual Machines: `workspace("myWorkspace").Heartbeat | distinct Computer`
+- Returns alist of Virtual Machines with template variable: `workspace("$workspace").Heartbeat | distinct Computer`
+- Returns a list of objects from the Perf table: `workspace("$workspace").Perf | distinct ObjectName`
+- Returns a list of metric names from the Perf table: `workspace("$workspace").Perf | where ObjectName == "$object" | distinct CounterName`
+
+Example of a time series query using variables:
+
+```
+Perf
+| where ObjectName == "$object" and CounterName == "$metric"
+| where TimeGenerated >= $__timeFrom() and TimeGenerated <= $__timeTo()
+| where  $__contains(Computer, $computer)
+| summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer
+| order by TimeGenerated asc
+```
+
 ### Azure Log Analytics Alerting
 
 Not implemented yet.

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -288,16 +288,19 @@ types of template variables.
 
 Example variable queries:
 
+<!-- prettier-ignore-start -->
 | Query                                                                                   | Description                                               |
 | --------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | _subscriptions()_                                                                       | Returns a list of Azure subscriptions                     |
 | _workspaces()_                                                                          | Returns a list of workspaces for default subscription     |
 | _workspaces("12345678-aaaa-bbbb-cccc-123456789aaa")_                                    | Returns a list of workspaces for a specified subscription |
-| _workspaces("\$subscription")_                                                          | With template variable for the subscription parameter     |
+| _workspaces("$subscription")_                                                           | With template variable for the subscription parameter     |
 | _workspace("myWorkspace").Heartbeat \| distinct Computer_                               | Returns a list of Virtual Machines                        |
-| _workspace("\$workspace").Heartbeat \| distinct Computer_                               | Returns a list of Virtual Machines with template variable |
-| _workspace("\$workspace").Perf \| distinct ObjectName_                                  | Returns a list of objects from the Perf table             |
+| _workspace("$workspace").Heartbeat \| distinct Computer_                                | Returns a list of Virtual Machines with template variable |
+| _workspace("$workspace").Perf \| distinct ObjectName_                                   | Returns a list of objects from the Perf table             |
 | _workspace("$workspace").Perf \| where ObjectName == "$object" \| distinct CounterName_ | Returns a list of metric names from the Perf table        |
+
+<!-- prettier-ignore-end -->
 
 Example of a time series query using variables:
 

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -278,7 +278,7 @@ There are also some Grafana variables that can be used in Azure Log Analytics qu
 
 Any Log Analytics query that returns a list of values can be used in the `Query` field in the Variable edit view. There is also one Grafana function for Log Analytics that returns a list of workspaces.
 
-Check out the [Templating]({{< relref "../../reference/templating.md" >}}) documentation for an introduction to the templating feature and the different
+Refer to the [Variables]({{< relref "../../reference/templating.md" >}}) documentation for an introduction to the templating feature and the different
 types of template variables.
 
 | Name                                               | Description                                                                                            |

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -288,14 +288,16 @@ types of template variables.
 
 Example variable queries:
 
-- Returns a list of Azure subscriptions: `subscriptions()`
-- Returns a list of workspaces for default subscription: `workspaces()`
-- Returns a list of workspaces for a specified subscription: `workspaces("12345678-aaaa-bbbb-cccc-123456789aaa")`
-- With template variable for the subscription parameter: `workspaces("$subscription")`
-- Returns a list of Virtual Machines: `workspace("myWorkspace").Heartbeat | distinct Computer`
-- Returns alist of Virtual Machines with template variable: `workspace("$workspace").Heartbeat | distinct Computer`
-- Returns a list of objects from the Perf table: `workspace("$workspace").Perf | distinct ObjectName`
-- Returns a list of metric names from the Perf table: `workspace("$workspace").Perf | where ObjectName == "$object" | distinct CounterName`
+| Query                                                                                   | Description                                               |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| _subscriptions()_                                                                       | Returns a list of Azure subscriptions                     |
+| _workspaces()_                                                                          | Returns a list of workspaces for default subscription     |
+| _workspaces("12345678-aaaa-bbbb-cccc-123456789aaa")_                                    | Returns a list of workspaces for a specified subscription |
+| _workspaces("\$subscription")_                                                          | With template variable for the subscription parameter     |
+| _workspace("myWorkspace").Heartbeat \| distinct Computer_                               | Returns a list of Virtual Machines                        |
+| _workspace("\$workspace").Heartbeat \| distinct Computer_                               | Returns a list of Virtual Machines with template variable |
+| _workspace("\$workspace").Perf \| distinct ObjectName_                                  | Returns a list of objects from the Perf table             |
+| _workspace("$workspace").Perf \| where ObjectName == "$object" \| distinct CounterName_ | Returns a list of metric names from the Perf table        |
 
 Example of a time series query using variables:
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -160,7 +160,7 @@ describe('AzureMonitorDatasource', () => {
       };
 
       beforeEach(() => {
-        datasourceRequestMock.mockImplementation((options: { url: string }) => Promise.resolve(response));
+        datasourceRequestMock.mockImplementation(() => Promise.resolve(response));
       });
 
       it('should return a list of subscriptions', () => {


### PR DESCRIPTION
There is no support in the Azure Log Analytics query language for returning a list of workspaces that belong to an Azure subscription. A list of workspaces can be retrieved via the Azure Monitor API. A `workspaces()` function for template variable queries enables this. The function can take a subscription id as a parameter if it is not supplied then it will use the default subscription.

Example of a template variable query that returns a list of Log Analytics workspaces:

![image](https://user-images.githubusercontent.com/434655/77011075-5c596100-696b-11ea-90bc-e8be7446ce19.png)

Fixes #18561