### PR TITLE
Reporting: Update docs with correct logger name

### DIFF
--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -60,5 +60,5 @@ To troubleshoot and get more log information, enable debug logging in the config
 
 ```bash
 [log]
-filters = saml.auth:debug
+filters = report:debug
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
The docs are currently setting the SAML logger to print debug messages, not the Reporting logger.