### PR TITLE
Chore: Pin Grafana build pipeline tool version for 6.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,16 +46,12 @@ jobs:
     executor: grafana-build
     steps:
       - run:
-          name: Clone repo
-          command: |
-            mkdir -p ~/.ssh
-            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
-            git clone git@github.com:grafana/build-pipeline.git
-      - run:
           name: Install Grafana Build Pipeline
           command: |
-            cd build-pipeline
-            go build -o ../bin/grabpl ./cmd/grabpl
+            curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.1.0/grabpl
+            chmod +x grabpl
+            mkdir bin
+            mv grabpl bin/
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin Grafana build pipeline tool in CircleCI config to 0.1.0 for v6.7.x.

The latest version of the tool has changes incompatible with v6.7.x builds.