### PR TITLE
CircleCI: Pin build pipeline tool to v0.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: Install Grafana Build Pipeline
           command: |
-            curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.0.3/grabpl
+            curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.2.0/grabpl
             chmod +x grabpl
             mkdir bin
             mv grabpl bin/


### PR DESCRIPTION
**What this PR does / why we need it**:
In CircleCI config, pin Grafana build pipeline tool to v0.2.0, according to new version convention.