### PR TITLE
Fix: all tests are green when running on non english os

### DIFF
--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 
 // Services & Utils
-import { DataQuery, ExploreMode } from '@grafana/data';
+import { DataQuery, ExploreMode, dateTime } from '@grafana/data';
 import { renderUrl } from 'app/core/utils/url';
 import store from 'app/core/store';
 import { serializeStateToUrlParam, SortOrder } from './explore';
@@ -212,10 +212,7 @@ export const createRetentionPeriodBoundary = (days: number, isLastTs: boolean) =
 };
 
 export function createDateStringFromTs(ts: number) {
-  const date = new Date(ts);
-  const month = date.toLocaleString('default', { month: 'long' });
-  const day = date.getDate();
-  return `${month} ${day}`;
+  return dateTime(ts).format('MMMM D');
 }
 
 export function getQueryDisplayText(query: DataQuery): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed that when running the tests locally some tests fails due to datetime formatting. The reason is that I am using a Swedish os. 

**Special notes for your reviewer**:
There are a couple of ways to solve this but I noticed that we have [momentjs](https://momentjs.com/) as a dependency and we are wrapping that one in `@grafana/data`. So I went with that approach.

An alternative would be to use the `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat` but then you have the problem with all browsers not supporting it.

I hope that I have understood how this should work 🙏  