### PR TITLE
Docs: Update email notifier documentation

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -240,7 +240,7 @@ When Grafana starts, it will update/insert all dashboards available in the confi
 It's possible to make changes to a provisioned dashboard in the Grafana UI. However, it is not possible to automatically save the changes back to the provisioning source.
 If `allowUiUpdates` is set to `true` and you make changes to a provisioned dashboard, you can `Save` the dashboard then changes will be persisted to the Grafana database.
 
-> **Note.**
+> **Note:**
 > If a provisioned dashboard is saved from the UI and then later updated from the source, the dashboard stored in the database will always be overwritten. The `version` property in the JSON file will not affect this, even if it is lower than the existing dashboard.
 >
 > If a provisioned dashboard is saved from the UI and the source is removed, the dashboard stored in the database will be deleted unless the configuration option `disableDeletion` is set to true.
@@ -464,4 +464,3 @@ The following sections detail the supported settings for each alert notification
 | Name |
 | ---- |
 | url |
-

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -240,9 +240,9 @@ When Grafana starts, it will update/insert all dashboards available in the confi
 It's possible to make changes to a provisioned dashboard in the Grafana UI. However, it is not possible to automatically save the changes back to the provisioning source.
 If `allowUiUpdates` is set to `true` and you make changes to a provisioned dashboard, you can `Save` the dashboard then changes will be persisted to the Grafana database.
 
-> **Note.** 
+> **Note.**
 > If a provisioned dashboard is saved from the UI and then later updated from the source, the dashboard stored in the database will always be overwritten. The `version` property in the JSON file will not affect this, even if it is lower than the existing dashboard.
-> 
+>
 > If a provisioned dashboard is saved from the UI and the source is removed, the dashboard stored in the database will be deleted unless the configuration option `disableDeletion` is set to true.
 
 If `allowUiUpdates` is configured to `false`, you are not able to make changes to a provisioned dashboard. When you click `Save`, Grafana brings up a *Cannot save provisioned dashboard* dialog. The screenshot below illustrates this behavior.
@@ -250,7 +250,7 @@ If `allowUiUpdates` is configured to `false`, you are not able to make changes t
 Grafana offers options to export the JSON definition of a dashboard. Either `Copy JSON to Clipboard` or `Save JSON to file` can help you synchronize your dashboard changes back to the provisioning source.
 
 Note: The JSON definition in the input field when using `Copy JSON to Clipboard` or `Save JSON to file` will have the `id` field automatically removed to aid the provisioning workflow.
-                                                                                                                                                                 
+
 {{< docs-imagebox img="/img/docs/v51/provisioning_cannot_save_dashboard.png" max-width="500px" class="docs-image--no-shadow" >}}
 
 ### Reusable Dashboard URLs
@@ -415,6 +415,7 @@ The following sections detail the supported settings for each alert notification
 
 | Name |
 | ---- |
+| singleEmail |
 | addresses |
 
 #### Alert notification `hipchat`

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -81,9 +81,9 @@ Addresses | Email addresses to recipients. You can enter multiple email addresse
 {{< imgbox max-width="40%" img="/img/docs/v4/slack_notification.png" caption="Alerting Slack Notification" >}}
 
 To set up Slack, you need to configure an incoming Slack webhook URL. You can follow
-[their guide](https://api.slack.com/incoming-webhooks) on how to do that. If you want to include screenshots of the
+[Sending messages using Incoming Webhooks](https://api.slack.com/incoming-webhooks) on how to do that. If you want to include screenshots of the
 firing alerts in the Slack messages you have to configure either the [external image destination](#external-image-store)
-in Grafana, or a bot integration via Slack Apps. Follow Slack's guide to set up a bot integration and use the token
+in Grafana or a bot integration via Slack Apps. Follow Slack's guide to set up a bot integration and use the token
 provided (https://api.slack.com/bot-users), which starts with "xoxb".
 
 Setting | Description

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -71,14 +71,19 @@ external image destination if available or fallback to attaching the image to th
 Be aware that if you use the `local` image storage email servers and clients might not be
 able to access the image.
 
+Setting | Description
+---------- | -----------
+Single email | Send a single email to all recipients. Disabled per default.
+Addresses | Email addresses to recipients. You can enter multiple email addresses using a ";" separator.
+
 ### Slack
 
 {{< imgbox max-width="40%" img="/img/docs/v4/slack_notification.png" caption="Alerting Slack Notification" >}}
 
-To set up Slack, you need to configure an incoming Slack webhook URL. You can follow 
-[their guide](https://api.slack.com/incoming-webhooks) on how to do that. If you want to include screenshots of the 
-firing alerts in the Slack messages you have to configure either the [external image destination](#external-image-store) 
-in Grafana, or a bot integration via Slack Apps. Follow Slack's guide to set up a bot integration and use the token 
+To set up Slack, you need to configure an incoming Slack webhook URL. You can follow
+[their guide](https://api.slack.com/incoming-webhooks) on how to do that. If you want to include screenshots of the
+firing alerts in the Slack messages you have to configure either the [external image destination](#external-image-store)
+in Grafana, or a bot integration via Slack Apps. Follow Slack's guide to set up a bot integration and use the token
 provided (https://api.slack.com/bot-users), which starts with "xoxb".
 
 Setting | Description
@@ -206,7 +211,7 @@ Webhook | `webhook` | yes, external only | yes
 
 # Enable images in notifications {#external-image-store}
 
-Grafana can render the panel associated with the alert rule as a PNG image and include that in the notification. Read more about the requirements and how to configure 
+Grafana can render the panel associated with the alert rule as a PNG image and include that in the notification. Read more about the requirements and how to configure
 [image rendering]({{< relref "../administration/image_rendering/" >}}).
 
 Most Notification Channels require that this image be publicly accessible (Slack and PagerDuty for example). In order to include images in alert notifications, Grafana can upload the image to an image store. It currently supports


### PR DESCRIPTION
Missed updating alert notifications and provisioning docs when implemented #21091. This should fix this.