### PR TITLE
AuthProxy: Fixes bug where long username could not be cached.

### DIFF
--- a/pkg/middleware/auth_proxy/auth_proxy_test.go
+++ b/pkg/middleware/auth_proxy/auth_proxy_test.go
@@ -1,7 +1,6 @@
 package authproxy
 
 import (
-	"encoding/base32"
 	"errors"
 	"fmt"
 	"net/http"
@@ -79,7 +78,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 			Convey("with a simple cache key", func() {
 				// Set cache key
-				key := fmt.Sprintf(CachePrefix, base32.StdEncoding.EncodeToString([]byte(name)))
+				key := fmt.Sprintf(CachePrefix, HashCacheKey(name))
 				err := store.Set(key, int64(33), 0)
 				So(err, ShouldBeNil)
 
@@ -88,7 +87,7 @@ func TestMiddlewareContext(t *testing.T) {
 				id, err := auth.Login()
 				So(err, ShouldBeNil)
 
-				So(auth.getKey(), ShouldEqual, "auth-proxy-sync-ttl:NVQXE23FNRXWO===")
+				So(auth.getKey(), ShouldEqual, "auth-proxy-sync-ttl:0a7f3374e9659b10980fd66247b0cf2f")
 				So(id, ShouldEqual, 33)
 			})
 
@@ -97,7 +96,7 @@ func TestMiddlewareContext(t *testing.T) {
 				group := "grafana-core-team"
 				req.Header.Add("X-WEBAUTH-GROUPS", group)
 
-				key := fmt.Sprintf(CachePrefix, base32.StdEncoding.EncodeToString([]byte(name+"-"+group)))
+				key := fmt.Sprintf(CachePrefix, HashCacheKey(name+"-"+group))
 				err := store.Set(key, int64(33), 0)
 				So(err, ShouldBeNil)
 
@@ -105,7 +104,7 @@ func TestMiddlewareContext(t *testing.T) {
 
 				id, err := auth.Login()
 				So(err, ShouldBeNil)
-				So(auth.getKey(), ShouldEqual, "auth-proxy-sync-ttl:NVQXE23FNRXWOLLHOJQWMYLOMEWWG33SMUWXIZLBNU======")
+				So(auth.getKey(), ShouldEqual, "auth-proxy-sync-ttl:14f69b7023baa0ac98c96b31cec07bc0")
 				So(id, ShouldEqual, 33)
 			})
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"encoding/base32"
 	"errors"
 	"fmt"
 	"net/http"
@@ -364,7 +363,7 @@ func TestMiddlewareContext(t *testing.T) {
 					return nil
 				})
 
-				key := fmt.Sprintf(authproxy.CachePrefix, base32.StdEncoding.EncodeToString([]byte(name+"-"+group)))
+				key := fmt.Sprintf(authproxy.CachePrefix, authproxy.HashCacheKey(name+"-"+group))
 				err := sc.remoteCacheService.Set(key, int64(33), 0)
 				So(err, ShouldBeNil)
 				sc.fakeReq("GET", "/")


### PR DESCRIPTION
**What this PR does / why we need it**:

The addition of the distributed cache broke some Grafana users who rely on Auth Proxy. The new cache limits the cache key to 168, but many users had usernames which generated cache keys that were even larger than 168. When such a user tries to log into Grafana, they get denied with a database-level constraint error.

Instead of increasing the maximum size of the cache key, use a consistent hashing scheme. Explicitly, the cache key changes from ``base32(key)`` to ``hex(fnv1a(key))``. Since the key size will always be 32, no need to make any schema changes.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/20809

