### PR TITLE
Align Prefences

### DIFF
--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -94,7 +94,7 @@
 
       .gicon {
         opacity: 0.7;
-        width: 14px;
+        width: 18px;
         height: 14px;
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Move Preferences little to the right/Preferences was more to the left then other menu items

**Which issue(s) this PR fixes**:
doesn't exist

Old view
![image](https://user-images.githubusercontent.com/21694965/77224903-65fce780-6b6a-11ea-9fc5-11235bd7ec93.png)

new view
![image](https://user-images.githubusercontent.com/21694965/77224907-6c8b5f00-6b6a-11ea-9943-c02ebc53d7e1.png)
