### PR TITLE
Submenu: Changed location for Current Org:

### DIFF
--- a/public/app/core/components/sidemenu/BottomNavLinks.tsx
+++ b/public/app/core/components/sidemenu/BottomNavLinks.tsx
@@ -60,8 +60,8 @@ class BottomNavLinks extends PureComponent<Props, State> {
             <li className="sidemenu-org-switcher">
               <a onClick={this.toggleSwitcherModal}>
                 <div>
+                  <div className="sidemenu-org-switcher__org-current">Current Org.:</div>
                   <div className="sidemenu-org-switcher__org-name">{user.orgName}</div>
-                  <div className="sidemenu-org-switcher__org-current">Current Org:</div>
                 </div>
                 <div className="sidemenu-org-switcher__switch">
                   <i className="fa fa-fw fa-random" />

--- a/public/app/core/components/sidemenu/__snapshots__/BottomNavLinks.test.tsx.snap
+++ b/public/app/core/components/sidemenu/__snapshots__/BottomNavLinks.test.tsx.snap
@@ -105,14 +105,14 @@ exports[`Render should render organization switcher 1`] = `
       >
         <div>
           <div
+            className="sidemenu-org-switcher__org-current"
+          >
+            Current Org.:
+          </div>
+          <div
             className="sidemenu-org-switcher__org-name"
           >
             Grafana
-          </div>
-          <div
-            className="sidemenu-org-switcher__org-current"
-          >
-            Current Org:
           </div>
         </div>
         <div


### PR DESCRIPTION
**What this PR does / why we need it**:
"Current Org:" was below the current Org.

I changed it so you can decide what looks correct.

I also put an "." after Org, since it is a shorting

**Which issue(s) this PR fixes**:
None

Before
![image](https://user-images.githubusercontent.com/21694965/77225222-7a8eaf00-6b6d-11ea-8193-6925f7af972d.png)

After
![image](https://user-images.githubusercontent.com/21694965/77225323-4ebff900-6b6e-11ea-8dd0-30ed6def76ce.png)
