### PR TITLE
WIP: UI: Suggestion of new Manage Dashboard

### DIFF
--- a/public/app/core/components/manage_dashboards/manage_dashboards.html
+++ b/public/app/core/components/manage_dashboards/manage_dashboards.html
@@ -1,19 +1,22 @@
 <div class="dashboard-list">
+<div ng-if="ctrl.sections.length > 0">
+
   <div class="page-action-bar page-action-bar--narrow" ng-hide="ctrl.folderId && !ctrl.hasFilters && ctrl.sections.length === 0">
     <label class="gf-form gf-form--grow gf-form--has-input-icon">
       <input type="text" class="gf-form-input max-width-30" placeholder="Find Dashboard by name" tabindex="1" give-focus="true" ng-model="ctrl.query.query" ng-model-options="{ debounce: 500 }" spellcheck='false' ng-change="ctrl.onQueryChange()" />
       <i class="gf-form-input-icon fa fa-search"></i>
     </label>
-    <div class="page-action-bar__spacer"></div>
-    <a class="btn btn-primary" ng-href="{{ctrl.createDashboardUrl()}}" ng-if="ctrl.hasEditPermissionInFolders || ctrl.canSave">
-      New Dashboard
-    </a>
-    <a class="btn btn-inverse" href="dashboards/folder/new" ng-if="!ctrl.folderId && ctrl.isEditor">
-      New Folder
-    </a>
-    <a class="btn btn-inverse" href="{{ctrl.importDashboardUrl()}}" ng-if="ctrl.hasEditPermissionInFolders || ctrl.canSave">
-      Import
-    </a>
+      <div class="page-action-bar__spacer"></div>
+      <a class="btn btn-primary" ng-href="{{ctrl.createDashboardUrl()}}" ng-if="ctrl.hasEditPermissionInFolders || ctrl.canSave"><span><i class="gicon gicon-dashboard-new"></i></span>
+        New Dashboard
+      </a>
+      <a class="btn btn-primary" href="dashboards/folder/new" ng-if="!ctrl.folderId && ctrl.isEditor"><span><i class="gicon gicon-folder-new"></i></span>
+        New Folder
+      </a>
+      <a class="btn btn-primary" href="{{ctrl.importDashboardUrl()}}" ng-if="ctrl.hasEditPermissionInFolders || ctrl.canSave"><span><i class="gicon gicon-dashboard-import"></i></span>
+        Import
+      </a>
+</div>
   </div>
 
   <div class="page-action-bar page-action-bar--narrow" ng-show="ctrl.hasFilters">
@@ -53,7 +56,7 @@
     </em>
   </div>
 
-	<div class="search-results" ng-show="!ctrl.folderId && !ctrl.hasFilters && ctrl.sections.length === 0">
+        <div class="search-results" ng-show="!ctrl.folderId && !ctrl.hasFilters && ctrl.sections.length > 0">
     <em class="muted">
         No dashboards found.
     </em>
@@ -84,7 +87,7 @@
           />
         </div>
         <div class="gf-form-button-row" ng-show="ctrl.canMove || ctrl.canDelete">
-          <button	type="button"
+          <button       type="button"
             class="btn gf-form-button btn-inverse"
             ng-disabled="!ctrl.canMove"
             ng-click="ctrl.moveTo()"
@@ -113,15 +116,27 @@
 
 </div>
 
+<div ng-if="!ctrl.folderId && ctrl.sections.length === 0">
+  <div style="min-height: 186px; min-width:363px; background-color:#212327;padding:24px" align="center">
+    <div class="css-m2iibx">
+      No dashboards found.
+    </div>
+    <div>
+      <a class="css-11clckl-button" href="dashboard/new" aria-label="Call to action button Create Dashboard"><span class="css-1beih13"><span class="css-1rgbe4"><i class="gicon gicon-dashboard-new"></i></span><span>Create Dashboard</span></span></a>
+      <a class="css-11clckl-button" href="dashboards/folder/new" aria-label="Call to action button Create Folder"><span class="css-1beih13"><span class="css-1rgbe4"><i class="gicon gicon-folder-new"></i></span><span>Create Folder</span></span></a>
+      <a class="css-11clckl-button" href="{{ctrl.importDashboardUrl()}}" aria-label="Call to action button Import Dashboard"><span class="css-1beih13"><span class="css-1rgbe4"><i class="gicon gicon-folder-new"></i></span><span>Import Dashboard</span></span></a>
+    </div>
+  </div>
+</div>
+
 <div ng-if="ctrl.canSave && ctrl.folderId && !ctrl.hasFilters && ctrl.sections.length === 0">
-  <empty-list-cta 
-    title="'This folder doesn\'t have any dashboards yet'"
-    buttonIcon="'gicon gicon-dashboard-new'" 
-    buttonLink="'dashboard/new?folderId={{ctrl.folderId}}'"
-    buttonTitle="'Create Dashboard'"  
-    proTip="'Add/move dashboards to your folder at ->'" 
-    proTipLink="'dashboards'" 
-    proTipLinkTitle="'Manage dashboards'" 
-    proTipTarget=""
-  />
+  <div style="min-height: 186px; min-width:363px; background-color:#212327;padding:24px" align="center">
+    <div class="css-m2iibx">
+      No dashboards found.
+    </div>
+    <div>
+      <a class="css-11clckl-button" href="{{ctrl.createDashboardUrl()}}" aria-label="Call to action button Create Dashboard"><span class="css-1beih13"><span class="css-1rgbe4"><i class="gicon gicon-dashboard-new"></i></span><span>Create Dashboard</span></span></a>
+      <a class="css-11clckl-button" href="{{ctrl.importDashboardUrl()}}" aria-label="Call to action button Import Dashboard"><span class="css-1beih13"><span class="css-1rgbe4"><i class="gicon gicon-folder-new"></i></span><span>Import Dashboard</span></span></a>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
**3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.**
I cannot find any screen shots for this

**What this PR does / why we need it**:
It changes the UI for Manage Dashboard
Add Import if viewing a folder
removed Search field if no dashboard exist

Why? to make the view to me more consistent, like Playlist and other views

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/13558

Fixes #
https://github.com/grafana/grafana/issues/13558

**Special notes for your reviewer**:
When Playlist is empty it has a grayblue window with a nice green button to add new Playlist.
When Dashboard is empty it has 3 green small button at the top right, New Dashboard, New Folder, Import
I have now with non Grafana-standard code done the same for view for Dashboard as it is for Playlist

First problem: I have to get the correct view with green buttons, I need to view Playlist first, I think it is some package that the Dashboard page isn't loading?
Second problem: to get rid of No dashboard found below Search field when there is at least one Dashboard

**You MUST look through the code, I am an amateur!!!!
Maybe you can use Grafana standard code and create the same look?**

Old view without any dashboards
![image](https://user-images.githubusercontent.com/21694965/77239011-16540580-6bd6-11ea-9220-9375435ace50.png)

New view without any dashboards
![image](https://user-images.githubusercontent.com/21694965/77239039-4ef3df00-6bd6-11ea-97e1-938717dc8698.png)

Old view with dashboard
![image](https://user-images.githubusercontent.com/21694965/77239015-1fdd6d80-6bd6-11ea-8ea4-f33eb9467f4f.png)

New view with dashboard
![image](https://user-images.githubusercontent.com/21694965/77239036-43a0b380-6bd6-11ea-93b0-706180bd2ab6.png)

Old view inside an folder
![image](https://user-images.githubusercontent.com/21694965/77238916-48189c80-6bd5-11ea-9207-35a0c0fafd42.png)

New view inside an folder
![image](https://user-images.githubusercontent.com/21694965/77238921-5070d780-6bd5-11ea-9542-532924f611cc.png)

If i don't view on Playlists tab before Dashboard it look like this
![image](https://user-images.githubusercontent.com/21694965/77238946-96c63680-6bd5-11ea-93b0-4294c9ce09f3.png)

