### PR TITLE
CircleCI: Reduce memory usage of golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ jobs:
           name: Lint Go
           command: |
             make scripts/go/bin/golangci-lint
-            ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 2 pkg
+            ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 2 ./pkg/...
 
   test-frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ jobs:
           name: Lint Go
           command: |
             make scripts/go/bin/golangci-lint
-            ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 2 ./pkg/...
+            ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 1 ./pkg/...
 
   test-frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -722,8 +722,15 @@ jobs:
       - run:
           name: Lint Go
           command: |
-            make scripts/go/bin/golangci-lint
+            # Build linters
+            make scripts/go/bin/golangci-lint scripts/go/bin/revive scripts/go/bin/gosec
+            go vet ./pkg/...
+            # Avoid golangci-lint concurrency since it tends to run out of memory
             ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 1 ./pkg/...
+            ./scripts/go/bin/revive -formatter stylish -config ./scripts/go/configs/revive.toml ./pkg/...
+            ./scripts/go/bin/revive -formatter stylish ./pkg/services/alerting/...
+            ./scripts/go/bin/gosec -quiet -exclude=G104,G107,G108,G201,G202,G204,G301,G304,G401,G402,G501 \
+              -conf=./scripts/go/configs/gosec.json ./pkg/...
 
   test-frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,7 +719,9 @@ jobs:
       - checkout
       - run:
           name: Lint Go
-          command: "make lint-go"
+          command: |
+            make scripts/go/bin/golangci-lint
+            ./scripts/go/bin/golangci-lint run --config scripts/go/configs/.golangci.yml -j 2 pkg
 
   test-frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,6 +714,8 @@ jobs:
         environment:
           # we need CGO because of go-sqlite3
           CGO_ENABLED: 1
+          # Reduce golangci-lint memory usage (default is 100)
+          GOGC: 20
     working_directory: /go/src/github.com/grafana/grafana
     steps:
       - checkout


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce memory usage of golangci-lint within CircleCI, as it tends to run out of memory.
