### PR TITLE
DataLinks: make sure we use the correct datapoint when dataset contains null value.

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -308,6 +308,11 @@ class GraphElement {
 
     const ts = datapoint[0];
     const { timeField } = getTimeField(dataFrame);
+
+    if (!timeField || !timeField.values) {
+      return dataIndex;
+    }
+
     const field = timeField.values.get(dataIndex);
 
     if (field === ts) {

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -37,6 +37,8 @@ import {
   PanelEvents,
   formattedValueToString,
   FieldType,
+  DataFrame,
+  getTimeField,
 } from '@grafana/data';
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -254,6 +256,7 @@ class GraphElement {
         const yAxisConfig = this.panel.yaxes[item.series.yaxis.n === 2 ? 1 : 0];
         const dataFrame = this.ctrl.dataList[item.series.dataFrameIndex];
         const field = dataFrame.fields[item.series.fieldIndex];
+        const dataIndex = this.getDataIndexWithNullValuesCorrection(item, dataFrame);
 
         let links = this.panel.options.dataLinks || [];
         if (field.config.links && field.config.links.length) {
@@ -267,13 +270,13 @@ class GraphElement {
         const fieldDisplay = getDisplayProcessor({
           field: { config: fieldConfig, type: FieldType.number },
           theme: getCurrentTheme(),
-        })(field.values.get(item.dataIndex));
+        })(field.values.get(dataIndex));
         linksSupplier = links.length
           ? getFieldLinksSupplier({
               display: fieldDisplay,
               name: field.name,
               view: new DataFrameView(dataFrame),
-              rowIndex: item.dataIndex,
+              rowIndex: dataIndex,
               colIndex: item.series.fieldIndex,
               field: fieldConfig,
             })
@@ -288,6 +291,31 @@ class GraphElement {
         this.contextMenu.toggleMenu(pos);
       });
     }
+  }
+
+  getDataIndexWithNullValuesCorrection(item: any, dataFrame: DataFrame): number {
+    /** This is one added to handle the scenario where we have null values in
+     *  the time series data and the: "visualization options -> null value"
+     *  set to "connected". In this scenario we will get the wrong dataIndex.
+     *
+     *  https://github.com/grafana/grafana/issues/22651
+     */
+    const { datapoint, dataIndex } = item;
+
+    if (!Array.isArray(datapoint) || datapoint.length === 0) {
+      return dataIndex;
+    }
+
+    const ts = datapoint[0];
+    const { timeField } = getTimeField(dataFrame);
+    const field = timeField.values.get(dataIndex);
+
+    if (field === ts) {
+      return dataIndex;
+    }
+
+    const correctIndex = timeField.values.toArray().findIndex(value => value === ts);
+    return correctIndex > -1 ? correctIndex : dataIndex;
   }
 
   shouldAbortRender() {

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -3,7 +3,7 @@
 echo -e "Collecting code stats (typescript errors & more)"
 
 
-ERROR_COUNT_LIMIT=820
+ERROR_COUNT_LIMIT=816
 DIRECTIVES_LIMIT=172
 CONTROLLERS_LIMIT=139
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like we have a problem with generating data links with wrong values when  dataset contains null values and we have the "visualization settings -> null value" set to "connected".

**Which issue(s) this PR fixes**:
Fixes #22651

**Special notes for your reviewer**:
Not sure this is the best way to solve it. I would prefer to fix this at the root so we are not emitting the wrong dataIndex when triggering the event. But after talking a bit with @torkelo we decided it wasn't worth spending too much time on this since this is a legacy component that will be exchanged in a near future.

Please have a look if there is any better way of checking the if we have the correct `dataIndex`. I'm a bit worried about getting the `timeField` twice and also trying to find the index in it might have a negative impact on performance.
