### PR TITLE
CircleCI: Increase memory/CPU for some jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,6 +641,7 @@ jobs:
           destination: logs
 
   mysql-integration-test:
+    resource_class: large
     docker:
       - image: circleci/golang:1.13.4
       - image: circleci/mysql:5.6-ram
@@ -672,6 +673,7 @@ jobs:
           when: on_success
 
   postgres-integration-test:
+    resource_class: large
     docker:
       - image: circleci/golang:1.13.4
       - image: circleci/postgres:9.3-ram
@@ -744,9 +746,9 @@ jobs:
           name: Lint Go
           command: |
             go vet ./pkg/...
-            golangci-lint run -v -j 2 --config scripts/go/configs/ci/.golangci.yml -E deadcode -E gofmt \
+            golangci-lint run -v -j 4 --config scripts/go/configs/ci/.golangci.yml -E deadcode -E gofmt \
               -E gosimple -E ineffassign -E structcheck -E typecheck ./pkg/...
-            golangci-lint run -v -j 2 --config scripts/go/configs/ci/.golangci.yml -E unconvert -E unused \
+            golangci-lint run -v -j 4 --config scripts/go/configs/ci/.golangci.yml -E unconvert -E unused \
               -E varcheck -E goconst -E errcheck -E staticcheck ./pkg/...
             ./scripts/go/bin/revive -formatter stylish -config ./scripts/go/configs/revive.toml ./pkg/...
             ./scripts/go/bin/revive -formatter stylish ./pkg/services/alerting/...
@@ -1228,6 +1230,7 @@ workflows:
             - end-to-end-tests
       - build-docs-website:
           filters: *filter-not-release-or-master
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
     parameters:
       edition:
         type: string
+    resource_class: large
     executor: grafana-build
     steps:
       - run:
@@ -204,6 +205,7 @@ jobs:
 
   build-oss-windows-installer:
     executor: windows-installer
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -236,6 +238,7 @@ jobs:
 
   build-enterprise-windows-installer:
     executor: windows-installer
+    resource_class: large
     steps:
       - run:
           name: Exit if forked PR
@@ -309,6 +312,7 @@ jobs:
 
   package-oss:
     executor: grafana-build
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -361,6 +365,7 @@ jobs:
 
   package-enterprise:
     executor: grafana-build
+    resource_class: large
     steps:
       - run:
           name: Exit if forked PR
@@ -415,6 +420,7 @@ jobs:
 
   publish-packages:
     description: "Publish packages"
+    resource_class: large
     parameters:
       edition:
         type: string
@@ -497,6 +503,7 @@ jobs:
 
   build-docker-images:
     description: "Build Docker images"
+    resource_class: large
     parameters:
       edition:
         type: string
@@ -553,6 +560,7 @@ jobs:
 
   publish-docker-images:
     description: Publish Docker images
+    resource_class: large
     parameters:
       edition:
         type: string
@@ -597,6 +605,7 @@ jobs:
           when: on_success
 
   end-to-end-tests:
+    resource_class: large
     docker:
       - image: circleci/node:12-browsers
     steps:
@@ -711,6 +720,7 @@ jobs:
   lint-go:
     docker:
       - image: circleci/golang:1.13.4
+    resource_class: large
     working_directory: /go/src/github.com/grafana/grafana
     environment:
       # we need CGO because of go-sqlite3
@@ -744,6 +754,7 @@ jobs:
               -conf=./scripts/go/configs/gosec.json ./pkg/...
 
   test-frontend:
+    resource_class: large
     docker:
       - image: circleci/node:12
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase memory and CPU available to some CircleCI jobs, in order to get rid of out-of-memory failures and hopefully speed things up.

