### PR TITLE
Cleanup: move interface ProvisioningService into provisioning package

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -987,7 +987,8 @@ func TestDashboardApiEndpoint(t *testing.T) {
 	})
 }
 
-func GetDashboardShouldReturn200WithConfig(sc *scenarioContext, provisioningService ProvisioningService) dtos.DashboardFullWithMeta {
+func GetDashboardShouldReturn200WithConfig(sc *scenarioContext, provisioningService provisioning.ProvisioningService) dtos.
+	DashboardFullWithMeta {
 	if provisioningService == nil {
 		provisioningService = provisioning.NewProvisioningServiceMock()
 	}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
@@ -44,14 +45,6 @@ func init() {
 	})
 }
 
-type ProvisioningService interface {
-	ProvisionDatasources() error
-	ProvisionNotifications() error
-	ProvisionDashboards() error
-	GetDashboardProvisionerResolvedPath(name string) string
-	GetAllowUiUpdatesFromConfig(name string) bool
-}
-
 type HTTPServer struct {
 	log           log.Logger
 	macaron       *macaron.Macaron
@@ -59,21 +52,21 @@ type HTTPServer struct {
 	streamManager *live.StreamManager
 	httpSrv       *http.Server
 
-	RouteRegister        routing.RouteRegister    `inject:""`
-	Bus                  bus.Bus                  `inject:""`
-	RenderService        rendering.Service        `inject:""`
-	Cfg                  *setting.Cfg             `inject:""`
-	HooksService         *hooks.HooksService      `inject:""`
-	CacheService         *localcache.CacheService `inject:""`
-	DatasourceCache      datasources.CacheService `inject:""`
-	AuthTokenService     models.UserTokenService  `inject:""`
-	QuotaService         *quota.QuotaService      `inject:""`
-	RemoteCacheService   *remotecache.RemoteCache `inject:""`
-	ProvisioningService  ProvisioningService      `inject:""`
-	Login                *login.LoginService      `inject:""`
-	License              models.Licensing         `inject:""`
-	BackendPluginManager backendplugin.Manager    `inject:""`
-	PluginManager        *plugins.PluginManager   `inject:""`
+	RouteRegister        routing.RouteRegister            `inject:""`
+	Bus                  bus.Bus                          `inject:""`
+	RenderService        rendering.Service                `inject:""`
+	Cfg                  *setting.Cfg                     `inject:""`
+	HooksService         *hooks.HooksService              `inject:""`
+	CacheService         *localcache.CacheService         `inject:""`
+	DatasourceCache      datasources.CacheService         `inject:""`
+	AuthTokenService     models.UserTokenService          `inject:""`
+	QuotaService         *quota.QuotaService              `inject:""`
+	RemoteCacheService   *remotecache.RemoteCache         `inject:""`
+	ProvisioningService  provisioning.ProvisioningService `inject:""`
+	Login                *login.LoginService              `inject:""`
+	License              models.Licensing                 `inject:""`
+	BackendPluginManager backendplugin.Manager            `inject:""`
+	PluginManager        *plugins.PluginManager           `inject:""`
 }
 
 func (hs *HTTPServer) Init() error {

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -9,6 +9,15 @@ import (
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
+type DashboardProvisioner interface {
+	Provision() error
+	PollChanges(ctx context.Context)
+	GetProvisionerResolvedPath(name string) string
+	GetAllowUiUpdatesFromConfig(name string) bool
+}
+
+type DashboardProvisionerFactory func(string) (DashboardProvisioner, error)
+
 type DashboardProvisionerImpl struct {
 	log         log.Logger
 	fileReaders []*fileReader

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -15,18 +15,17 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type DashboardProvisioner interface {
-	Provision() error
-	PollChanges(ctx context.Context)
-	GetProvisionerResolvedPath(name string) string
+type ProvisioningService interface {
+	ProvisionDatasources() error
+	ProvisionNotifications() error
+	ProvisionDashboards() error
+	GetDashboardProvisionerResolvedPath(name string) string
 	GetAllowUiUpdatesFromConfig(name string) bool
 }
 
-type DashboardProvisionerFactory func(string) (DashboardProvisioner, error)
-
 func init() {
 	registry.RegisterService(NewProvisioningServiceImpl(
-		func(path string) (DashboardProvisioner, error) {
+		func(path string) (dashboards.DashboardProvisioner, error) {
 			return dashboards.NewDashboardProvisionerImpl(path)
 		},
 		notifiers.Provision,
@@ -35,7 +34,7 @@ func init() {
 }
 
 func NewProvisioningServiceImpl(
-	newDashboardProvisioner DashboardProvisionerFactory,
+	newDashboardProvisioner dashboards.DashboardProvisionerFactory,
 	provisionNotifiers func(string) error,
 	provisionDatasources func(string) error,
 ) *provisioningServiceImpl {
@@ -51,8 +50,8 @@ type provisioningServiceImpl struct {
 	Cfg                     *setting.Cfg `inject:""`
 	log                     log.Logger
 	pollingCtxCancel        context.CancelFunc
-	newDashboardProvisioner DashboardProvisionerFactory
-	dashboardProvisioner    DashboardProvisioner
+	newDashboardProvisioner dashboards.DashboardProvisionerFactory
+	dashboardProvisioner    dashboards.DashboardProvisioner
 	provisionNotifiers      func(string) error
 	provisionDatasources    func(string) error
 	mutex                   sync.Mutex

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -92,7 +92,7 @@ func setup() *serviceTestStruct {
 	}
 
 	serviceTest.service = NewProvisioningServiceImpl(
-		func(path string) (DashboardProvisioner, error) {
+		func(path string) (dashboards.DashboardProvisioner, error) {
 			return serviceTest.mock, nil
 		},
 		nil,


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
To make code style consistent, I think we could move interface definition for `ProvisioningService` into its own package, instead of dropping it in `pkg/api/http_server.go`.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

