### PR TITLE
CircleCI: Fix deploying to k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,6 +847,8 @@ jobs:
     description: "Deploy Grafana master Docker image to Kubernetes"
     executor: grafana-build
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Deploy to Kubernetes
           command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix deploying to Kubernetes from master CI pipeline.
