### PR TITLE
Chore: fix typo and remove deprecation

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -80,19 +80,6 @@ describe('toDataFrame', () => {
     ).toThrowError('Expected table rows to be array, got object.');
   });
 
-  it('migrate from 6.3 style rows', () => {
-    const oldDataFrame = {
-      fields: [{ name: 'A' }, { name: 'B' }, { name: 'C' }],
-      rows: [
-        [100, 'A', 1],
-        [200, 'B', 2],
-        [300, 'C', 3],
-      ],
-    };
-    const data = toDataFrame(oldDataFrame);
-    expect(data.length).toBe(oldDataFrame.rows.length);
-  });
-
   it('Guess Colum Types from value', () => {
     expect(guessFieldTypeFromValue(1)).toBe(FieldType.number);
     expect(guessFieldTypeFromValue(1.234)).toBe(FieldType.number);

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -224,7 +224,7 @@ export function guessFieldTypeForField(field: Field): FieldType | undefined {
 export const guessFieldTypes = (series: DataFrame): DataFrame => {
   for (let i = 0; i < series.fields.length; i++) {
     if (!series.fields[i].type) {
-      // Something is missing a type return a modified copy
+      // Something is missing a type, return a modified copy
       return {
         ...series,
         fields: series.fields.map(field => {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -224,7 +224,7 @@ export function guessFieldTypeForField(field: Field): FieldType | undefined {
 export const guessFieldTypes = (series: DataFrame): DataFrame => {
   for (let i = 0; i < series.fields.length; i++) {
     if (!series.fields[i].type) {
-      // Somethign is missing a type return a modified copy
+      // Something is missing a type return a modified copy
       return {
         ...series,
         fields: series.fields.map(field => {
@@ -250,17 +250,6 @@ export const isDataFrame = (data: any): data is DataFrame => data && data.hasOwn
 
 export const toDataFrame = (data: any): DataFrame => {
   if (data.hasOwnProperty('fields')) {
-    // @deprecated -- remove in 6.5
-    if (data.hasOwnProperty('rows')) {
-      const v = new MutableDataFrame(data as DataFrameDTO);
-      const rows = data.rows as any[][];
-      for (let i = 0; i < rows.length; i++) {
-        v.appendRow(rows[i]);
-      }
-      deprecationWarning('DataFrame', '.rows', 'columnar format');
-      return v;
-    }
-
     // DataFrameDTO does not have length
     if (data.hasOwnProperty('length')) {
       return data as DataFrame;

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -16,7 +16,6 @@ import {
   DataFrameDTO,
 } from '../types/index';
 import { isDateTime } from '../datetime/moment_wrapper';
-import { deprecationWarning } from '../utils/deprecationWarning';
 import { ArrayVector } from '../vector/ArrayVector';
 import { MutableDataFrame } from './MutableDataFrame';
 import { SortedVector } from '../vector/SortedVector';

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -700,7 +700,7 @@ function getColorForValue(data: any, value: number) {
 
 //------------------------------------------------
 // Private utility functions
-// Somethign like this should be avaliable in a
+// Something like this should be avaliable in a
 //  DataFrame[] abstraction helper
 //------------------------------------------------
 


### PR DESCRIPTION
This PR fixes spelling is some comments and removes a deprecation path that was valid for 6.4>6.5