### PR TITLE
CircleCI: Make k8s deployment depend on enterprise Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: Install Grafana Build Pipeline
           command: |
-            curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.2.3/grabpl
+            curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.2.4/grabpl
             chmod +x grabpl
             mkdir bin
             mv grabpl bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1244,7 +1244,7 @@ workflows:
       - deploy-to-kubernetes:
           filters: *filter-only-master
           requires:
-            - publish-oss-docker-images
+            - publish-enterprise-docker-images
 
   nightly:
     triggers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the CircleCI job for deploying to Kubernetes depend on the job for publishing enterprise Docker images, since we deploy enterprise images to Kubernetes.

Also upgrading the build pipeline tool, since I found out we can't upload enterprise development Docker images for non-AMD64 architectures (repositories haven't been made for these yet). The new version has this fix.

**Special notes for your reviewer**:
I didn't think about doing this also earlier, when switching from OSS to enterprise images in k8s.