### PR TITLE
DOCS - Repeating panels require variable to have one or more items

### DIFF
--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -407,7 +407,7 @@ By choosing `vertical` the panels will be arranged from top to bottom in a colum
 Only make changes to the first panel (the original template). To have the changes take effect on all panels you need to trigger a dynamic dashboard re-build.
 You can do this by either changing the variable value (that is the basis for the repeat) or reload the dashboard.
 
-Repeating panels require variables to have one or more items selected; you can not repeat a panel zero times to hide it.
+> **Note:** Repeating panels require variables to have one or more items selected; you cannot repeat a panel zero times to hide it.
 
 ## Repeating Rows
 

--- a/docs/sources/reference/templating.md
+++ b/docs/sources/reference/templating.md
@@ -407,6 +407,8 @@ By choosing `vertical` the panels will be arranged from top to bottom in a colum
 Only make changes to the first panel (the original template). To have the changes take effect on all panels you need to trigger a dynamic dashboard re-build.
 You can do this by either changing the variable value (that is the basis for the repeat) or reload the dashboard.
 
+Repeating panels require variables to have one or more items selected; you can not repeat a panel zero times to hide it.
+
 ## Repeating Rows
 
 As seen above with the *Panels* you can also repeat *Rows* if you have variables set with  `Multi-value` or


### PR DESCRIPTION
This is a doc update to clarify an edge case of repeating panels that I previously reported as issue #23036 

It seems that repeating panels are only supported with multi-value variables that contain one or more selected items. I'd like to make the documentation reflect this.

I previously read this documentation and believed that I'd be able to repeat a panel zero or more times. In fact, you can only repeat at minimum one time.

Signed-off-by: David Ellis <ellisda@gmail.com>
