### PR TITLE
Explore: Fix 100% height of graph and table panel

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -66,6 +66,7 @@ const getStyles = stylesFactory(() => {
       label: logsMain;
       // Is needed for some transition animations to work.
       position: relative;
+      margin-top: 21px;
     `,
     button: css`
       margin: 1em 4px 0 0;
@@ -349,7 +350,6 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                 return (
                   <main
                     className={cx(
-                      'm-t-2',
                       styles.logsMain,
                       // We need height to be 100% for tracing iframe to look good but in case of metrics mode
                       // it makes graph and table also full page high when they do not need to be.

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -347,7 +347,16 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                 }
 
                 return (
-                  <main className={cx('m-t-2', styles.logsMain, styles.fullHeight)} style={{ width }}>
+                  <main
+                    className={cx(
+                      'm-t-2',
+                      styles.logsMain,
+                      // We need height to be 100% for tracing iframe to look good but in case of metrics mode
+                      // it makes graph and table also full page high when they do not need to be.
+                      mode === ExploreMode.Tracing && styles.fullHeight
+                    )}
+                    style={{ width }}
+                  >
                     <ErrorBoundaryAlert>
                       {showStartPage && StartPage && (
                         <div className={'grafana-info-box grafana-info-box--max-lg'}>


### PR DESCRIPTION
Fix styling after https://github.com/grafana/grafana/pull/20297 where there was too much vertical white space in graph and table panel.

![Screenshot from 2020-03-26 11-03-14](https://user-images.githubusercontent.com/1014802/77634549-6f62c700-6f51-11ea-92e6-2610e0877d4b.png)
