### PR TITLE
Migration: Remove Button from Forms namespace

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -61,7 +61,7 @@ Used for removing or deleting entities.
 
 ## Link
 
-Used for for hyperlinks.
+Used for hyperlinks.
 
 <Preview>
   <div>

--- a/packages/grafana-ui/src/components/Forms/index.ts
+++ b/packages/grafana-ui/src/components/Forms/index.ts
@@ -10,13 +10,9 @@ import { Field } from './Field';
 import { Switch } from './Switch';
 import { TextArea } from './TextArea/TextArea';
 import { Checkbox } from './Checkbox';
-//Will be removed after Enterprise changes have been merged
-import { Button, LinkButton } from '../Button';
 
 const Forms = {
   RadioButtonGroup,
-  Button,
-  LinkButton,
   Switch,
   getFormStyles,
   Label,

--- a/packages/grafana-ui/src/components/Layout/Layout.story.tsx
+++ b/packages/grafana-ui/src/components/Layout/Layout.story.tsx
@@ -11,7 +11,7 @@ export default {
   decorators: [withStoryContainer, withCenteredStory, withHorizontallyCenteredStory],
 };
 
-const justifyVariants = ['flex-start', 'flex-end', 'space-betw  een'];
+const justifyVariants = ['flex-start', 'flex-end', 'space-between'];
 
 const spacingVariants = ['xs', 'sm', 'md', 'lg'];
 

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -98,7 +98,7 @@ export { LogLabels } from './Logs/LogLabels';
 export { LogRows } from './Logs/LogRows';
 export { getLogRowStyles } from './Logs/getLogRowStyles';
 export { ToggleButtonGroup, ToggleButton } from './ToggleButtonGroup/ToggleButtonGroup';
-// Panel editors./Forms/Legacy/Button/FullWidthButtonContainer
+// Panel editors
 export { FullWidthButtonContainer } from './Button/FullWidthButtonContainer';
 export { ThresholdsEditor } from './ThresholdsEditor/ThresholdsEditor';
 export { ClickOutsideWrapper } from './ClickOutsideWrapper/ClickOutsideWrapper';


### PR DESCRIPTION
Small fixes after
https://github.com/grafana/grafana/pull/23019 