### PR TITLE
@grafana/ui: Fix time range when only partial datetime is provided

### DIFF
--- a/packages/grafana-ui/src/components/TimePicker/TimePickerContent/mapper.ts
+++ b/packages/grafana-ui/src/components/TimePicker/TimePickerContent/mapper.ts
@@ -40,25 +40,16 @@ export const mapStringsToTimeRange = (from: string, to: string, roundup?: boolea
   const fromDate = stringToDateTimeType(from, roundup, timeZone);
   const toDate = stringToDateTimeType(to, roundup, timeZone);
 
-  if (dateMath.isMathString(from) || dateMath.isMathString(to)) {
-    return {
-      from: fromDate,
-      to: toDate,
-      raw: {
-        from,
-        to,
-      },
-    };
-  }
-
-  return {
+  const timeRangeObject: any = {
     from: fromDate,
     to: toDate,
     raw: {
-      from: fromDate,
-      to: toDate,
+      from: dateMath.isMathString(from) ? from : fromDate,
+      to: dateMath.isMathString(to) ? to : toDate,
     },
   };
+
+  return timeRangeObject;
 };
 
 const stringToDateTime = (value: string | DateTime, roundUp?: boolean, timeZone?: TimeZone): DateTime => {


### PR DESCRIPTION
**What this PR does / why we need it**:

When user selects absolute time range and one of the selected times is **math string** (now/now-1h/...) and the second one is **incomplete datetime**, we use incomplete datetime string in raw range. Incomplete datetime string can be used to create valid datetime, however as a string in raw range it can create issues such as breaking url.

This issue was brought up by @Duologic. When he manually set an absolute and incomplete date from in the timepicker and then reload the page from the URL, it showed an unexpected error. 

**Buggy 🐞:** 
![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/30407135/77682078-a1e2e300-6f96-11ea-8d90-24f743a1ffc6.gif)

**Fixed:**
![ezgif com-video-to-gif (8)](https://user-images.githubusercontent.com/30407135/77682093-a7402d80-6f96-11ea-860d-15e774fa20ed.gif)

