### PR TITLE
NewPanelEditor: Comment out the color editor as it was crashing new edit mode 

### DIFF
--- a/packages/grafana-ui/src/components/OptionsUI/color.tsx
+++ b/packages/grafana-ui/src/components/OptionsUI/color.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { FieldConfigEditorProps, ColorFieldConfigSettings } from '@grafana/data';
-import { ColorPicker } from '../ColorPicker/ColorPicker';
+/* import { ColorPicker } from '../ColorPicker/ColorPicker'; */
 
 export const ColorValueEditor: React.FC<FieldConfigEditorProps<string, ColorFieldConfigSettings>> = ({
   value,
   onChange,
   item,
 }) => {
-  return <ColorPicker color={value} onChange={onChange} enableNamedColors={!!item.settings.enableNamedColors} />;
+  return <div>todo</div>;
 };


### PR DESCRIPTION
Recent PR added a color editor but it was just using the color picker, the model did not match so caused a crash 