### PR TITLE
CircleCI: Reduce packaging concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,16 +330,16 @@ jobs:
 
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition oss $CIRCLE_TAG
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition oss $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition oss v6.7.0-beta1
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition oss v6.7.0-beta1
             elif [[ $CIRCLE_BRANCH == "master" ]]; then
               # A master build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition oss --build-id $CIRCLE_WORKFLOW_ID
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition oss --build-id $CIRCLE_WORKFLOW_ID
             else
               # A PR build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition oss --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition oss --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             fi
       - run:
@@ -384,16 +384,16 @@ jobs:
           command: |
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition enterprise $CIRCLE_TAG
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition enterprise $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition enterprise v6.7.0-beta1
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition enterprise v6.7.0-beta1
             elif [[ $CIRCLE_BRANCH == "master" ]]; then
               # A master build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID
             else
               # A PR build
-              /tmp/workspace/bin/grabpl package --jobs 4 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/workspace/bin/grabpl package --jobs 2 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             fi
       - run:


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed that packaging in CircleCI still sometimes fails, due to what is probably running out of memory. This PR reduces the packaging concurrency to 2 goroutines, so hopefully that'll stop it from running out of memory. If not, we can try going down to 1.
