### PR TITLE
must publish a dist folder as well

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
@@ -69,7 +69,9 @@ const prepareRelease = useSpinner<any>('Preparing release', async ({ dryrun, ver
     ['git', ['config', 'user.email', GIT_EMAIL]],
     ['git', ['config', 'user.name', GIT_USERNAME]],
     await checkoutBranch(`release-${pluginVersion}`),
+    ['cp', ['-rf', distContentDir, 'dist'], { dryrun }],
     ['git', ['add', '--force', distDir], { dryrun }],
+    ['git', ['add', '--force', 'dist'], { dryrun }],
     [
       'git',
       ['commit', '-m', `automated release ${pluginVersion} [skip ci]`],


### PR DESCRIPTION
Why? Plugins published to grafana.com need a 'dist' folder in the root directory, as well as a build in the ci-folder. This PR adds 2 lines.
1. Copy the contents of the ci-build to the dist folder
2. Checkin the dist folder.