### PR TITLE
Webpack: Do not clean webpack output on every rebuild

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -94,7 +94,9 @@ module.exports = (env = {}) =>
     },
 
     plugins: [
-      new CleanWebpackPlugin(),
+      new CleanWebpackPlugin({
+        cleanStaleWebpackAssets: false,
+      }),
       env.noTsCheck
         ? new webpack.DefinePlugin({}) // bogus plugin to satisfy webpack API
         : new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
Found it annoying that all the files are removed when webpack rebuilds. Makes it hard sometimes to compare different branches when your tab with the previous branch cannot open a page in grafana because the chunk was never loaded and is now gone. 

cleanStaleWebpackAssets: true seems to fix it :) 
