### PR TITLE
NewPanelEdit: Side options collapse/expand design update

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Input/Input.tsx
@@ -211,7 +211,7 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false }: StyleDe
 });
 
 export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { addonAfter, addonBefore, prefix, suffix, invalid, loading, size = 'auto', ...restProps } = props;
+  const { className, addonAfter, addonBefore, prefix, suffix, invalid, loading, size = 'auto', ...restProps } = props;
   /**
    * Prefix & suffix are positioned absolutely within inputWrapper. We use client rects below to apply correct padding to the input
    * when prefix/suffix is larger than default (28px = 16px(icon) + 12px(left/right paddings)).
@@ -224,7 +224,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const styles = getInputStyles({ theme, invalid: !!invalid });
 
   return (
-    <div className={cx(styles.wrapper, inputSizes()[size])}>
+    <div className={cx(styles.wrapper, inputSizes()[size], className)}>
       {!!addonBefore && <div className={styles.addon}>{addonBefore}</div>}
 
       <div className={styles.inputWrapper}>

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -13,11 +13,13 @@ export interface IconProps {
 const getIconStyles = stylesFactory(() => {
   return {
     icon: css`
-      display: inline-block;
+      display: inline-flex;
       width: 16px;
+      align-items: center;
       height: 16px;
       text-align: center;
       font-size: 14px;
+
       &:before {
         vertical-align: middle;
       }

--- a/packages/grafana-ui/src/components/Icon/types.ts
+++ b/packages/grafana-ui/src/components/Icon/types.ts
@@ -89,6 +89,7 @@ export type IconType =
   | 'times-circle-o'
   | 'check-circle-o'
   | 'ban'
+  | 'remove'
   | 'arrow-left'
   | 'arrow-right'
   | 'arrow-up'

--- a/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
@@ -19,11 +19,13 @@ const getTabsBarStyles = stylesFactory((theme: GrafanaTheme, hideBorder = false)
       !hideBorder &&
       css`
         border-bottom: 1px solid ${colors.pageHeaderBorder};
+        // Sometimes TabsBar is rendered without any tabs, and should preserve height
       `,
     tabs: css`
       position: relative;
       top: 1px;
       display: flex;
+      height: 41px;
     `,
   };
 });

--- a/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
+++ b/packages/grafana-ui/src/components/Tabs/TabsBar.tsx
@@ -19,12 +19,12 @@ const getTabsBarStyles = stylesFactory((theme: GrafanaTheme, hideBorder = false)
       !hideBorder &&
       css`
         border-bottom: 1px solid ${colors.pageHeaderBorder};
-        // Sometimes TabsBar is rendered without any tabs, and should preserve height
       `,
     tabs: css`
       position: relative;
       top: 1px;
       display: flex;
+      // Sometimes TabsBar is rendered without any tabs, and should preserve height
       height: 41px;
     `,
   };

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ServerStats Should render table with stats 1`] = `
                   className="page-header__tabs"
                 >
                   <ul
-                    className="css-13jkosq"
+                    className="css-1osza3s"
                   >
                     <li
                       className="css-1aiaexb"

--- a/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
+++ b/public/app/features/admin/__snapshots__/ServerStats.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ServerStats Should render table with stats 1`] = `
                   className="page-header__tabs"
                 >
                   <ul
-                    className="css-1osza3s"
+                    className="css-payll4"
                   >
                     <li
                       className="css-1aiaexb"

--- a/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
@@ -5,32 +5,35 @@ import { Tooltip } from '@grafana/ui';
 import { e2e } from '@grafana/e2e';
 
 interface Props {
-  icon: string;
+  icon?: string;
   tooltip: string;
-  classSuffix: string;
+  classSuffix?: string;
   onClick?: () => void;
   href?: string;
+  children?: JSX.Element;
 }
 
-export const DashNavButton: FunctionComponent<Props> = ({ icon, tooltip, classSuffix, onClick, href }) => {
+export const DashNavButton: FunctionComponent<Props> = ({ icon, tooltip, classSuffix, onClick, href, children }) => {
   if (onClick) {
     return (
-      <Tooltip content={tooltip}>
+      <Tooltip content={tooltip} placement="bottom">
         <button
           className={`btn navbar-button navbar-button--${classSuffix}`}
           onClick={onClick}
           aria-label={e2e.pages.Dashboard.Toolbar.selectors.toolbarItems(tooltip)}
         >
-          <i className={icon} />
+          {icon && <i className={icon} />}
+          {children}
         </button>
       </Tooltip>
     );
   }
 
   return (
-    <Tooltip content={tooltip}>
+    <Tooltip content={tooltip} placement="bottom">
       <a className={`btn navbar-button navbar-button--${classSuffix}`} href={href}>
-        <i className={icon} />
+        {icon && <i className={icon} />}
+        {children}
       </a>
     </Tooltip>
   );

--- a/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
@@ -10,7 +10,7 @@ interface Props {
   classSuffix?: string;
   onClick?: () => void;
   href?: string;
-  children?: JSX.Element;
+  children?: React.ReactNode;
 }
 
 export const DashNavButton: FunctionComponent<Props> = ({ icon, tooltip, classSuffix, onClick, href, children }) => {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -136,11 +136,7 @@ export const OptionsPaneContent: React.FC<{
           <TabsBar className={styles.tabsBar}>
             {isSearching && (
               <>
-                <Tab
-                  label="All options"
-                  active={activeTab === 'defaults'}
-                  onChangeTab={() => setActiveTab('defaults')}
-                />
+                <Tab label="Options" active={activeTab === 'defaults'} onChangeTab={() => setActiveTab('defaults')} />
                 <Forms.Input
                   className={styles.searchInput}
                   type="text"

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -131,13 +131,12 @@ export const OptionsPaneContent: React.FC<{
 
   const renderSearchInput = useCallback(() => {
     const defaultStyles = {
-      transition: 'width 100ms ease-in-out',
+      transition: 'width 50ms ease-in-out',
       width: '50%',
       display: 'flex',
     };
 
     const transitionStyles: { [str: string]: CSSProperties } = {
-      entering: { width: '50%' },
       entered: { width: '100%' },
     };
 

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -1,22 +1,43 @@
 import React, { useCallback, useState } from 'react';
 import { FieldConfigSource, GrafanaTheme, PanelData, PanelPlugin } from '@grafana/data';
 import { DashboardModel, PanelModel } from '../../state';
-import { CustomScrollbar, stylesFactory, Tab, TabContent, TabsBar, useTheme, Container } from '@grafana/ui';
+import {
+  CustomScrollbar,
+  stylesFactory,
+  Tab,
+  TabContent,
+  TabsBar,
+  useTheme,
+  Container,
+  Forms,
+  Icon,
+} from '@grafana/ui';
 import { DefaultFieldConfigEditor, OverrideFieldConfigEditor } from './FieldConfigEditor';
 import { AngularPanelOptions } from './AngularPanelOptions';
 import { css } from 'emotion';
 import { GeneralPanelOptions } from './GeneralPanelOptions';
 import { PanelOptionsEditor } from './PanelOptionsEditor';
+import { DashNavButton } from 'app/features/dashboard/components/DashNav/DashNavButton';
 
 export const OptionsPaneContent: React.FC<{
   plugin?: PanelPlugin;
   panel: PanelModel;
   data: PanelData;
   dashboard: DashboardModel;
+  onClose: () => void;
   onFieldConfigsChange: (config: FieldConfigSource) => void;
   onPanelOptionsChanged: (options: any) => void;
   onPanelConfigChange: (configKey: string, value: any) => void;
-}> = ({ plugin, panel, data, onFieldConfigsChange, onPanelOptionsChanged, onPanelConfigChange, dashboard }) => {
+}> = ({
+  plugin,
+  panel,
+  data,
+  onFieldConfigsChange,
+  onPanelOptionsChanged,
+  onPanelConfigChange,
+  onClose,
+  dashboard,
+}) => {
   const theme = useTheme();
   const styles = getStyles(theme);
 
@@ -106,15 +127,60 @@ export const OptionsPaneContent: React.FC<{
   );
 
   const [activeTab, setActiveTab] = useState('defaults');
+  const [isSearching, setSearchMode] = useState(false);
 
   return (
     <div className={styles.panelOptionsPane}>
       {plugin && (
         <div className={styles.wrapper}>
-          <TabsBar>
-            <Tab label="Options" active={activeTab === 'defaults'} onChangeTab={() => setActiveTab('defaults')} />
-            <Tab label="Overrides" active={activeTab === 'overrides'} onChangeTab={() => setActiveTab('overrides')} />
-            <Tab label="General" active={activeTab === 'panel'} onChangeTab={() => setActiveTab('panel')} />
+          <TabsBar className={styles.tabsBar}>
+            {isSearching && (
+              <>
+                <Tab
+                  label="All options"
+                  active={activeTab === 'defaults'}
+                  onChangeTab={() => setActiveTab('defaults')}
+                />
+                <Forms.Input
+                  className={styles.searchInput}
+                  type="text"
+                  prefix={<Icon name="search" />}
+                  ref={elem => elem && elem.focus()}
+                  placeholder="Search all options"
+                  suffix={
+                    <Icon name="remove" onClick={() => setSearchMode(false)} className={styles.searchRemoveIcon} />
+                  }
+                />
+              </>
+            )}
+            {!isSearching && (
+              <>
+                <Tab label="Options" active={activeTab === 'defaults'} onChangeTab={() => setActiveTab('defaults')} />
+                <Tab
+                  label="Overrides"
+                  active={activeTab === 'overrides'}
+                  onChangeTab={() => setActiveTab('overrides')}
+                />
+                <Tab label="General" active={activeTab === 'panel'} onChangeTab={() => setActiveTab('panel')} />
+                <div className="flex-grow-1" />
+                <div className={styles.tabsButtton}>
+                  <DashNavButton
+                    icon="fa fa-search"
+                    tooltip="Search all options"
+                    classSuffix="search-options"
+                    onClick={() => setSearchMode(true)}
+                  />
+                </div>
+                <div className={styles.tabsButtton}>
+                  <DashNavButton
+                    icon="fa fa-chevron-right"
+                    tooltip="Close options pane"
+                    classSuffix="close-options"
+                    onClick={onClose}
+                  />
+                </div>
+              </>
+            )}
           </TabsBar>
           <TabContent className={styles.tabContent}>
             <CustomScrollbar>
@@ -135,11 +201,22 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       display: flex;
       flex-direction: column;
       height: 100%;
+      padding-top: ${theme.spacing.sm};
     `,
     panelOptionsPane: css`
       height: 100%;
       width: 100%;
       border-bottom: none;
+    `,
+    tabsBar: css`
+      padding-right: ${theme.spacing.sm};
+    `,
+    searchInput: css`
+      color: ${theme.colors.textWeak};
+      flex-grow: 1;
+    `,
+    searchRemoveIcon: css`
+      cursor: pointer;
     `,
     tabContent: css`
       padding: 0;
@@ -150,6 +227,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background: ${theme.colors.pageBg};
       border-left: 1px solid ${theme.colors.pageHeaderBorder};
     `,
+    tabsButton: css``,
     legacyOptions: css`
       label: legacy-options;
       .panel-options-grid {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -163,7 +163,7 @@ export const OptionsPaneContent: React.FC<{
                 />
                 <Tab label="General" active={activeTab === 'panel'} onChangeTab={() => setActiveTab('panel')} />
                 <div className="flex-grow-1" />
-                <div className={styles.tabsButtton}>
+                <div className={styles.tabsButton}>
                   <DashNavButton
                     icon="fa fa-search"
                     tooltip="Search all options"
@@ -171,7 +171,7 @@ export const OptionsPaneContent: React.FC<{
                     onClick={() => setSearchMode(true)}
                   />
                 </div>
-                <div className={styles.tabsButtton}>
+                <div className={styles.tabsButton}>
                   <DashNavButton
                     icon="fa fa-chevron-right"
                     tooltip="Close options pane"

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { FieldConfigSource, GrafanaTheme, PanelData, PanelPlugin, SelectableValue } from '@grafana/data';
-import { Forms, stylesFactory, Button, Icon } from '@grafana/ui';
+import { Forms, stylesFactory, Icon } from '@grafana/ui';
 import { css, cx } from 'emotion';
 import config from 'app/core/config';
 import AutoSizer from 'react-virtualized-auto-sizer';

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -217,11 +217,12 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
           {!uiState.isPanelOptionsVisible && (
             <div className={styles.toolbarItem}>
               <DashNavButton
-                icon="fa fa-chevron-left"
                 onClick={this.onTogglePanelOptions}
                 tooltip="Open options pane"
                 classSuffix="close-options"
-              />
+              >
+                <Icon name="chevron-left" /> <span style={{ paddingLeft: '6px' }}>Show options</span>
+              </DashNavButton>
             </div>
           )}
         </div>
@@ -237,32 +238,16 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     }
 
     return (
-      <div className={styles.optionsPaneWrapper}>
-        <div className={styles.optionsPaneToolbar}>
-          <div className={styles.toolbarItem} style={{ flexGrow: 1 }}>
-            <Forms.Input prefix={<Icon name="search" />} type="text" placeholder="Search options" />
-          </div>
-          <div className={styles.toolbarItem}>
-            <DashNavButton
-              icon="fa fa-chevron-right"
-              onClick={this.onTogglePanelOptions}
-              tooltip="Close options pane"
-              classSuffix="close-options"
-            />
-          </div>
-        </div>
-        <div className={styles.optionsPaneBody}>
-          <OptionsPaneContent
-            plugin={plugin}
-            dashboard={dashboard}
-            data={data}
-            panel={panel}
-            onFieldConfigsChange={this.onFieldConfigChange}
-            onPanelOptionsChanged={this.onPanelOptionsChanged}
-            onPanelConfigChange={this.onPanelConfigChanged}
-          />
-        </div>
-      </div>
+      <OptionsPaneContent
+        plugin={plugin}
+        dashboard={dashboard}
+        data={data}
+        panel={panel}
+        onClose={this.onTogglePanelOptions}
+        onFieldConfigsChange={this.onFieldConfigChange}
+        onPanelOptionsChanged={this.onPanelOptionsChanged}
+        onPanelConfigChange={this.onPanelConfigChanged}
+      />
     );
   }
 
@@ -366,13 +351,13 @@ const getStyles = stylesFactory((theme: GrafanaTheme, props: Props) => {
       background: ${theme.colors.bodyBg};
       display: flex;
       flex-direction: column;
-      padding-right: ${uiState.isPanelOptionsVisible ? 0 : paneSpaceing};
     `,
     mainPaneWrapper: css`
       display: flex;
       flex-direction: column;
       height: 100%;
       width: 100%;
+      padding-right: ${uiState.isPanelOptionsVisible ? 0 : paneSpaceing};
     `,
     panelWrapper: css`
       flex: 1 1 0;
@@ -420,20 +405,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme, props: Props) => {
       &:last-child {
         margin-right: 0;
       }
-    `,
-    optionsPaneWrapper: css`
-      display: flex;
-      flex-direction: column;
-    `,
-    optionsPaneToolbar: css`
-      display: flex;
-      padding: ${theme.spacing.sm} ${theme.spacing.sm} ${theme.spacing.sm} 0;
-      color: ${theme.colors.textWeak};
-    `,
-    optionsPaneBody: css`
-      flex: 1 1 0;
-      min-height: 0;
-      width: 100%;
     `,
     centeringContainer: css`
       display: flex;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -200,9 +200,9 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
         </div>
         <div className={styles.toolbarLeft}>
           <div className={styles.toolbarItem}>
-            <Button className={styles.toolbarItem} variant="secondary" onClick={this.onDiscard}>
-              Discard
-            </Button>
+            <DashNavButton tooltip="Discard all changes and return to dashboard" onClick={this.onDiscard}>
+              Discard changes
+            </DashNavButton>
           </div>
           <div className={styles.toolbarItem}>
             <Forms.Select

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -80,6 +80,7 @@ const getPanelEditorTabsStyles = stylesFactory(() => {
       flex-grow: 1;
       min-height: 0;
       background: ${theme.colors.panelBg};
+      border-right: 1px solid ${theme.colors.pageHeaderBorder};
 
       .toolbar {
         background: transparent;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -71,7 +71,7 @@ const getPanelEditorTabsStyles = stylesFactory(() => {
       height: 100%;
     `,
     tabBar: css`
-      padding-left: ${theme.spacing.sm};
+      padding-left: ${theme.spacing.md};
     `,
     tabContent: css`
       padding: 0;


### PR DESCRIPTION
Moves the sidebar options toggle to the tabs bar. Adds search button & search state (no search implemented yet):

![image](https://user-images.githubusercontent.com/10999/77828350-265e6e80-711b-11ea-807b-2ca1116e104d.png)

