### PR TITLE
Make $__interval and $__interval_ms global variables available to panel title and graph yaxis label

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -330,6 +330,14 @@ export class PanelChrome extends PureComponent<Props, State> {
       'panel-container--no-title': this.hasOverlayHeader(),
     });
 
+    if (data.request) {
+      if (!panel.scopedVars) {
+        panel.scopedVars = {};
+      }
+      panel.scopedVars.__interval = data.request.scopedVars.__interval;
+      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
+    }
+
     return (
       <div className={containerClassNames}>
         <PanelHeader

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -133,6 +133,7 @@ export class PanelChrome extends PureComponent<Props, State> {
       return;
     }
 
+    const { panel } = this.props;
     let { isFirstLoad } = this.state;
     let errorMessage: string | undefined;
 
@@ -161,6 +162,14 @@ export class PanelChrome extends PureComponent<Props, State> {
           isFirstLoad = false;
         }
         break;
+    }
+
+    if (data.request) {
+      if (!panel.scopedVars) {
+        panel.scopedVars = {};
+      }
+      panel.scopedVars.__interval = data.request.scopedVars.__interval;
+      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
     }
 
     this.setState({ isFirstLoad, errorMessage, data });
@@ -329,14 +338,6 @@ export class PanelChrome extends PureComponent<Props, State> {
       'panel-container--transparent': transparent,
       'panel-container--no-title': this.hasOverlayHeader(),
     });
-
-    if (data.request) {
-      if (!panel.scopedVars) {
-        panel.scopedVars = {};
-      }
-      panel.scopedVars.__interval = data.request.scopedVars.__interval;
-      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
-    }
 
     return (
       <div className={containerClassNames}>

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -235,6 +235,14 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
       'panel-content--no-padding': plugin.noPadding,
     });
 
+    if (data.request) {
+      if (!panel.scopedVars) {
+        panel.scopedVars = {};
+      }
+      panel.scopedVars.__interval = data.request.scopedVars.__interval;
+      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
+    }
+
     return (
       <div className={containerClassNames}>
         <PanelHeader

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -105,6 +105,7 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
   };
 
   onPanelDataUpdate(data: PanelData) {
+    const { panel } = this.props;
     let errorMessage: string | undefined;
 
     if (data.state === LoadingState.Error) {
@@ -114,6 +115,14 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
           errorMessage = error.message;
         }
       }
+    }
+
+    if (data.request) {
+      if (!panel.scopedVars) {
+        panel.scopedVars = {};
+      }
+      panel.scopedVars.__interval = data.request.scopedVars.__interval;
+      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
     }
 
     this.setState({ data, errorMessage });
@@ -234,14 +243,6 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
       'panel-content': true,
       'panel-content--no-padding': plugin.noPadding,
     });
-
-    if (data.request) {
-      if (!panel.scopedVars) {
-        panel.scopedVars = {};
-      }
-      panel.scopedVars.__interval = data.request.scopedVars.__interval;
-      panel.scopedVars.__interval_ms = data.request.scopedVars.__interval_ms;
-    }
 
     return (
       <div className={containerClassNames}>

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -45,6 +45,7 @@ import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { ContextSrv } from 'app/core/services/context_srv';
 import { getFieldLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
 import { CoreEvents } from 'app/types';
+import templateSrv from 'app/features/templating/template_srv';
 
 const LegendWithThemeProvider = provideTheme(Legend);
 
@@ -339,14 +340,14 @@ class GraphElement {
     // add left axis labels
     if (this.panel.yaxes[0].label && this.panel.yaxes[0].show) {
       $("<div class='axisLabel left-yaxis-label flot-temp-elem'></div>")
-        .text(this.panel.yaxes[0].label)
+        .text(templateSrv.replaceWithText(this.panel.yaxes[0].label, this.panel.scopedVars))
         .appendTo(this.elem);
     }
 
     // add right axis labels
     if (this.panel.yaxes[1].label && this.panel.yaxes[1].show) {
       $("<div class='axisLabel right-yaxis-label flot-temp-elem'></div>")
-        .text(this.panel.yaxes[1].label)
+        .text(templateSrv.replaceWithText(this.panel.yaxes[1].label, this.panel.scopedVars))
         .appendTo(this.elem);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`$__interval` and `$__interval_ms` cannot be used to dynamically update panel title or yaxis label (for graph panel), and this is an issue we hit again and again for a long time now.

See for references https://community.grafana.com/t/using-the-interval-or-interval-in-panel-title/5612 and #8341.

Tonight, I can't deal with it anymore. So here is an implementation.

**Which issue(s) this PR fixes**:

Fixes #8341

**Special notes for your reviewer**:

I tried the best i could to minimize changes. I'm not familiar with the current code base, and maybe there is a better place somewhere. Please tell me if you think so.