### PR TITLE
Timespan Left/Right

### DIFF
--- a/public/app/core/utils/timePicker.ts
+++ b/public/app/core/utils/timePicker.ts
@@ -6,7 +6,7 @@ export const getShiftedTimeRange = (direction: number, origRange: TimeRange): Ab
     to: toUtc(origRange.to),
   };
 
-  const timespan = (range.to.valueOf() - range.from.valueOf()) / 2;
+  const timespan = (range.to.valueOf() - range.from.valueOf()) / 1;
   let to: number, from: number;
 
   if (direction === -1) {


### PR DESCRIPTION
Change so if you go Left or Right you move time with full time range.
Before is was: if I selected last Hour it only moved 30 left
**What this PR does / why we need it**:
Move time with same span as selected

Why do you only want to move half of your selection, you will then data that you already seen