### PR TITLE
WIP: prometheus exemplars integration

### DIFF
--- a/packages/grafana-ui/src/components/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/components/Graph/Graph.tsx
@@ -13,7 +13,7 @@ import {
   dateTime,
 } from '@grafana/data';
 import _ from 'lodash';
-import { FlotPosition, FlotItem } from './types';
+import { FlotPosition, FlotItem, FlotEvents } from './types';
 import { TooltipProps, TooltipContentProps, ActiveDimensions, Tooltip } from '../Chart/Tooltip';
 import { GraphTooltip } from './GraphTooltip/GraphTooltip';
 import { GraphContextMenu, GraphContextMenuProps, ContextDimensions } from './GraphContextMenu';
@@ -27,6 +27,7 @@ export interface GraphProps {
   showLines?: boolean;
   showPoints?: boolean;
   showBars?: boolean;
+  events?: FlotEvents;
   width: number;
   height: number;
   isStacked?: boolean;

--- a/packages/grafana-ui/src/components/Graph/types.ts
+++ b/packages/grafana-ui/src/components/Graph/types.ts
@@ -15,3 +15,19 @@ export interface FlotItem<T> {
   pageX: number;
   pageY: number;
 }
+
+export interface FlotEvent {
+  min: number;
+  max?: number;
+  eventType: string;
+  title: string;
+  description?: string;
+  position?: FlotPosition;
+}
+
+export interface FlotEventType {
+  eventType: string;
+  color?: string;
+}
+
+export type FlotEvents = { data: FlotEvent[]; types: FlotEventType[] };

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -388,8 +388,13 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   }
 
   async metadataRequest(url: string, params?: Record<string, string>) {
-    const res = await this._request(url, params, { silent: true }).toPromise();
-    return res.data.data || res.data.values || [];
+    try {
+      const res = await this._request(url, params, { silent: true }).toPromise();
+      return res.data.data || res.data.values || [];
+    } catch (e) {
+      console.error('metadata request failed', e);
+    }
+    return [];
   }
 
   async metricFindQuery(query: string) {

--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 
 // Types
+import { Switch } from '@grafana/ui';
 import { ExploreQueryFieldProps } from '@grafana/data';
 
 import { PrometheusDatasource } from '../datasource';
@@ -26,6 +27,12 @@ export function PromExploreQueryEditor(props: Props) {
     }
   }
 
+  function onChangeShowingExemplars(e: React.ChangeEvent<HTMLInputElement>) {
+    const { query, onChange } = props;
+    const nextQuery = { ...query, showingExemplars: e.target.checked };
+    onChange(nextQuery);
+  }
+
   function onReturnKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
       onRunQuery();
@@ -42,14 +49,17 @@ export function PromExploreQueryEditor(props: Props) {
       history={history}
       data={data}
       ExtraFieldElement={
-        <PromExploreExtraField
-          label={'Step'}
-          onChangeFunc={onStepChange}
-          onKeyDownFunc={onReturnKeyDown}
-          value={query.interval || ''}
-          hasTooltip={true}
-          tooltipContent={'Needs to be a valid time unit string, for example 5s, 1m, 3h, 1d, 1y'}
-        />
+        <>
+          <PromExploreExtraField
+            label={'Step'}
+            onChangeFunc={onStepChange}
+            onKeyDownFunc={onReturnKeyDown}
+            value={query.interval || ''}
+            hasTooltip={true}
+            tooltipContent={'Needs to be a valid time unit string, for example 5s, 1m, 3h, 1d, 1y'}
+          />
+          <Switch label="Exemplars" checked={query.showingExemplars} onChange={onChangeShowingExemplars} />
+        </>
       }
     />
   );

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -2,6 +2,7 @@ import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
 export interface PromQuery extends DataQuery {
   expr: string;
+  exemplars?: boolean;
   format?: string;
   instant?: boolean;
   hinting?: boolean;
@@ -12,6 +13,7 @@ export interface PromQuery extends DataQuery {
   requestId?: string;
   showingGraph?: boolean;
   showingTable?: boolean;
+  showingExemplars?: boolean;
 }
 
 export interface PromOptions extends DataSourceJsonData {


### PR DESCRIPTION
Piggy-back on time series data
When queries are run, the exemplar toggle state is forwarded to the datasource
In addition to the regular query, the datasource issues an exemplars query
The datasource waits for both queries to return processes the exemplars, and attaches them onto the TimeSeries as a new property
The graph plugin needs to detect that exemplars are attached to the time series and renders them (in addition to the datapoints and the legend).
