### PR TITLE
Squadcast Alert notification: Image support added

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -203,7 +203,7 @@ Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only | yes
 Pushover | `pushover` | yes | no
 Sensu | `sensu` | yes, external only | no
 Slack | `slack` | yes | no
-Squadcast | `webhook` | no | no
+Squadcast | `webhook` | yes, external only | yes
 Telegram | `telegram` | yes | no
 Threema | `threema` | yes, external only | no
 VictorOps | `victorops` | yes, external only | no


### PR DESCRIPTION
 - Updated Grafana Image & alert rule tags support by Squadcast

**Source:**
https://headwayapp.co/squadcast-updates/grafana-images-are-now-supported-143661
https://support.squadcast.com/docs/grafana


**What this PR does / why we need it**:
The Squadcast alert notification method information is outdated as it started supporting images and alert tags, so keeping the information updated for users.

**Special notes for your reviewer**:
The Squadcast alert notifier via `webhook` has started supporting images and alert tags. Requesting you to approve the PR so the information is accurate. 
