### PR TITLE
CircleCI: Fix cross platform Docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,6 +560,9 @@ jobs:
       ubuntu:
         type: boolean
     executor: base
+    environment:
+      # Required for building cross-platform images
+      DOCKER_BUILDKIT: 1
     steps:
       - run:
           name: Exit if enterprise and forked PR
@@ -572,7 +575,9 @@ jobs:
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
-      - setup_remote_docker
+      - setup_remote_docker:
+          # This version is necessary for building cross-platform images
+          version: 18.09.3
       - install-google-cloud-sdk
       - install-grabpl
       - run:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix building of ARM architecture Docker images.

Verified by SSH-ing into a CircleCI job and checking that I can build an ARM64 Docker image.