### PR TITLE
Alerting: Only include image in notifier when enabled

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -114,7 +114,7 @@ func (dd *DingDingNotifier) genBody(evalContext *alerting.EvalContext, messageUR
 	var bodyMsg map[string]interface{}
 	if dd.MsgType == "actionCard" {
 		// Embed the pic into the markdown directly because actionCard doesn't have a picUrl field
-		if picURL != "" {
+		if dd.NeedsImage() && picURL != "" {
 			message = "![](" + picURL + ")\\n\\n" + message
 		}
 
@@ -128,14 +128,19 @@ func (dd *DingDingNotifier) genBody(evalContext *alerting.EvalContext, messageUR
 			},
 		}
 	} else {
+		link := map[string]string{
+			"text":       message,
+			"title":      title,
+			"messageUrl": messageURL,
+		}
+
+		if dd.NeedsImage() {
+			link["picUrl"] = picURL
+		}
+
 		bodyMsg = map[string]interface{}{
 			"msgtype": "link",
-			"link": map[string]string{
-				"text":       message,
-				"title":      title,
-				"picUrl":     picURL,
-				"messageUrl": messageURL,
-			},
+			"link":    link,
 		}
 	}
 	return json.Marshal(bodyMsg)

--- a/pkg/services/alerting/notifiers/discord.go
+++ b/pkg/services/alerting/notifiers/discord.go
@@ -115,17 +115,19 @@ func (dn *DiscordNotifier) Notify(evalContext *alerting.EvalContext) error {
 	var image map[string]interface{}
 	var embeddedImage = false
 
-	if evalContext.ImagePublicURL != "" {
-		image = map[string]interface{}{
-			"url": evalContext.ImagePublicURL,
+	if dn.NeedsImage() {
+		if evalContext.ImagePublicURL != "" {
+			image = map[string]interface{}{
+				"url": evalContext.ImagePublicURL,
+			}
+			embed.Set("image", image)
+		} else {
+			image = map[string]interface{}{
+				"url": "attachment://graph.png",
+			}
+			embed.Set("image", image)
+			embeddedImage = true
 		}
-		embed.Set("image", image)
-	} else {
-		image = map[string]interface{}{
-			"url": "attachment://graph.png",
-		}
-		embed.Set("image", image)
-		embeddedImage = true
 	}
 
 	bodyJSON.Set("embeds", []interface{}{embed})

--- a/pkg/services/alerting/notifiers/email.go
+++ b/pkg/services/alerting/notifiers/email.go
@@ -110,13 +110,15 @@ func (en *EmailNotifier) Notify(evalContext *alerting.EvalContext) error {
 		},
 	}
 
-	if evalContext.ImagePublicURL != "" {
-		cmd.Data["ImageLink"] = evalContext.ImagePublicURL
-	} else {
-		file, err := os.Stat(evalContext.ImageOnDiskPath)
-		if err == nil {
-			cmd.EmbededFiles = []string{evalContext.ImageOnDiskPath}
-			cmd.Data["EmbeddedImage"] = file.Name()
+	if en.NeedsImage() {
+		if evalContext.ImagePublicURL != "" {
+			cmd.Data["ImageLink"] = evalContext.ImagePublicURL
+		} else {
+			file, err := os.Stat(evalContext.ImageOnDiskPath)
+			if err == nil {
+				cmd.EmbededFiles = []string{evalContext.ImageOnDiskPath}
+				cmd.Data["EmbeddedImage"] = file.Name()
+			}
 		}
 	}
 

--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -152,15 +152,17 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 	widgets = append(widgets, fields)
 
-	// if an image exists, add it as an image widget
-	if evalContext.ImagePublicURL != "" {
-		widgets = append(widgets, imageWidget{
-			Image: image{
-				ImageURL: evalContext.ImagePublicURL,
-			},
-		})
-	} else {
-		gcn.log.Info("Could not retrieve a public image URL.")
+	if gcn.NeedsImage() {
+		// if an image exists, add it as an image widget
+		if evalContext.ImagePublicURL != "" {
+			widgets = append(widgets, imageWidget{
+				Image: image{
+					ImageURL: evalContext.ImagePublicURL,
+				},
+			})
+		} else {
+			gcn.log.Info("Could not retrieve a public image URL.")
+		}
 	}
 
 	// add a button widget (link to Grafana)

--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -148,7 +148,7 @@ func (hc *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"date":       evalContext.EndTime.Unix(),
 		"attributes": attributes,
 	}
-	if evalContext.ImagePublicURL != "" {
+	if hc.NeedsImage() && evalContext.ImagePublicURL != "" {
 		card["thumbnail"] = map[string]interface{}{
 			"url":    evalContext.ImagePublicURL,
 			"url@2x": evalContext.ImagePublicURL,

--- a/pkg/services/alerting/notifiers/kafka.go
+++ b/pkg/services/alerting/notifiers/kafka.go
@@ -89,7 +89,7 @@ func (kn *KafkaNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 	bodyJSON.Set("client_url", ruleURL)
 
-	if evalContext.ImagePublicURL != "" {
+	if kn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		contexts := make([]interface{}, 1)
 		imageJSON := simplejson.New()
 		imageJSON.Set("type", "image")

--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -78,7 +78,7 @@ func (ln *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
 	body := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleURL, evalContext.Rule.Message)
 	form.Add("message", body)
 
-	if evalContext.ImagePublicURL != "" {
+	if ln.NeedsImage() && evalContext.ImagePublicURL != "" {
 		form.Add("imageThumbnail", evalContext.ImagePublicURL)
 		form.Add("imageFullsize", evalContext.ImagePublicURL)
 	}

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -123,7 +123,7 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 
 	details := simplejson.New()
 	details.Set("url", ruleURL)
-	if evalContext.ImagePublicURL != "" {
+	if on.NeedsImage() && evalContext.ImagePublicURL != "" {
 		details.Set("image", evalContext.ImagePublicURL)
 	}
 

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -160,7 +160,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 	links[0] = linkJSON
 	bodyJSON.Set("links", links)
 
-	if evalContext.ImagePublicURL != "" {
+	if pn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		contexts := make([]interface{}, 1)
 		imageJSON := simplejson.New()
 		imageJSON.Set("src", evalContext.ImagePublicURL)

--- a/pkg/services/alerting/notifiers/sensu.go
+++ b/pkg/services/alerting/notifiers/sensu.go
@@ -111,7 +111,7 @@ func (sn *SensuNotifier) Notify(evalContext *alerting.EvalContext) error {
 		bodyJSON.Set("ruleUrl", ruleURL)
 	}
 
-	if evalContext.ImagePublicURL != "" {
+	if sn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		bodyJSON.Set("imageUrl", evalContext.ImagePublicURL)
 	}
 

--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -287,7 +287,7 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"footer_icon": "https://grafana.com/assets/img/fav32.png",
 		"ts":          time.Now().Unix(),
 	}
-	if imageURL != "" {
+	if sn.NeedsImage() && imageURL != "" {
 		attachment["image_url"] = imageURL
 	}
 	body := map[string]interface{}{

--- a/pkg/services/alerting/notifiers/teams.go
+++ b/pkg/services/alerting/notifiers/teams.go
@@ -83,7 +83,7 @@ func (tn *TeamsNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	images := make([]map[string]interface{}, 0)
-	if evalContext.ImagePublicURL != "" {
+	if tn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		images = append(images, map[string]interface{}{
 			"image": evalContext.ImagePublicURL,
 		})

--- a/pkg/services/alerting/notifiers/threema.go
+++ b/pkg/services/alerting/notifiers/threema.go
@@ -147,7 +147,7 @@ func (notifier *ThreemaNotifier) Notify(evalContext *alerting.EvalContext) error
 	if err == nil {
 		message = message + fmt.Sprintf("*URL:* %s\n", ruleURL)
 	}
-	if evalContext.ImagePublicURL != "" {
+	if notifier.NeedsImage() && evalContext.ImagePublicURL != "" {
 		message = message + fmt.Sprintf("*Image:* %s\n", evalContext.ImagePublicURL)
 	}
 	data.Set("text", message)

--- a/pkg/services/alerting/notifiers/victorops.go
+++ b/pkg/services/alerting/notifiers/victorops.go
@@ -116,7 +116,7 @@ func (vn *VictoropsNotifier) Notify(evalContext *alerting.EvalContext) error {
 		bodyJSON.Set("error_message", evalContext.Error.Error())
 	}
 
-	if evalContext.ImagePublicURL != "" {
+	if vn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		bodyJSON.Set("image_url", evalContext.ImagePublicURL)
 	}
 

--- a/pkg/services/alerting/notifiers/webhook.go
+++ b/pkg/services/alerting/notifiers/webhook.go
@@ -97,7 +97,7 @@ func (wn *WebhookNotifier) Notify(evalContext *alerting.EvalContext) error {
 		bodyJSON.Set("ruleUrl", ruleURL)
 	}
 
-	if evalContext.ImagePublicURL != "" {
+	if wn.NeedsImage() && evalContext.ImagePublicURL != "" {
 		bodyJSON.Set("imageUrl", evalContext.ImagePublicURL)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug when you had multiple notifiers for a rule, but not all had enabled to include image.

**Which issue(s) this PR fixes**:
Fixes #22883 

**Special notes for your reviewer**:

