### PR TITLE
OAuth: Introduce new setting for configuring max age of OAuth state cookie

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -298,6 +298,9 @@ signout_redirect_url =
 # This setting is ignored if multiple OAuth providers are configured.
 oauth_auto_login = false
 
+# OAuth state max age cookie duration. Defaults to 60 seconds.
+oauth_state_cookie_max_age = 60
+
 # limit of api_key seconds to live before expiration
 api_key_max_seconds_to_live = -1
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -297,6 +297,9 @@
 # This setting is ignored if multiple OAuth providers are configured.
 ;oauth_auto_login = false
 
+# OAuth state max age cookie duration. Defaults to 60 seconds.
+;oauth_state_cookie_max_age = 60
+
 # limit of api_key seconds to live before expiration
 ;api_key_max_seconds_to_live = -1
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -450,6 +450,11 @@ Text used as placeholder text on login page for password input.
 Grafana provides many ways to authenticate users. The docs for authentication has been split in to many different pages
 below.
 
+### oauth_state_cookie_max_age
+
+How long the OAuth state cookie lives before being deleted. Default is `60` (seconds)
+Administrators can increase it if they experience OAuth login state mismatch errors.
+
 - [Authentication Overview]({{< relref "../auth/overview.md" >}}) (anonymous access options, hide login and more)
 - [Google OAuth]({{< relref "../auth/google.md" >}}) (auth.google)
 - [GitHub OAuth]({{< relref "../auth/github.md" >}}) (auth.github)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -70,7 +70,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 		}
 
 		hashedState := hashStatecode(state, setting.OAuthService.OAuthInfos[name].ClientSecret)
-		middleware.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, 500, hs.cookieOptionsFromCfg)
+		middleware.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, hs.Cfg.OAuthCookieMaxAge, hs.cookieOptionsFromCfg)
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
 			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
 		} else {

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -70,7 +70,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 		}
 
 		hashedState := hashStatecode(state, setting.OAuthService.OAuthInfos[name].ClientSecret)
-		middleware.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, 60, hs.cookieOptionsFromCfg)
+		middleware.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, 500, hs.cookieOptionsFromCfg)
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
 			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
 		} else {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -268,6 +268,9 @@ type Cfg struct {
 	LoginMaxLifetimeDays         int
 	TokenRotationIntervalMinutes int
 
+	// OAuth
+	OAuthCookieMaxAge int
+
 	// SAML Auth
 	SAMLEnabled bool
 
@@ -848,6 +851,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 	OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)
+	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(60)
 	SignoutRedirectUrl, err = valueAsString(auth, "signout_redirect_url", "")
 	if err != nil {
 		return err


### PR DESCRIPTION
When using oauth2 authentication with multifactor, the 60s delay may be too short
