### PR TITLE
NewPanelEditor: Options/FieldConfig API for defaults and common options selection

### DIFF
--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -67,6 +67,9 @@ export const stringOverrideProcessor = (
   context: FieldOverrideContext,
   settings?: StringFieldConfigSettings
 ) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
   if (settings && settings.expandTemplateVars && context.replaceVariables) {
     return context.replaceVariables(value, context.field!.config.scopedVars);
   }

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -12,4 +12,4 @@ export * from './datetime';
 export * from './text';
 export * from './valueFormats';
 export * from './field';
-export { PanelPlugin } from './panel/PanelPlugin';
+export { PanelPlugin, defaultStandardFieldConfig } from './panel/PanelPlugin';

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -12,4 +12,4 @@ export * from './datetime';
 export * from './text';
 export * from './valueFormats';
 export * from './field';
-export { PanelPlugin, defaultStandardFieldConfig } from './panel/PanelPlugin';
+export { PanelPlugin, defaultStandardFieldConfigProperties } from './panel/PanelPlugin';

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { identityOverrideProcessor, standardEditorsRegistry } from '../field';
-import { PanelPlugin } from './PanelPlugin';
+import { PanelPlugin, standardFieldConfigProperties } from './PanelPlugin';
+import { StandardFieldConfigProperties } from '../types';
 
 describe('PanelPlugin', () => {
   describe('declarative options', () => {
@@ -174,6 +175,47 @@ describe('PanelPlugin', () => {
         };
 
         expect(panel.fieldConfigDefaults.defaults.custom).toEqual(expectedDefaults);
+      });
+    });
+
+    describe('standard field config options', () => {
+      test('standard config', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.useStandardFieldConfig();
+        expect(panel.standardFieldConfigProperties).toEqual(Array.from(standardFieldConfigProperties.keys()));
+      });
+
+      test('selected standard config', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.useStandardFieldConfig([StandardFieldConfigProperties.Min, StandardFieldConfigProperties.Thresholds]);
+        expect(panel.standardFieldConfigProperties).toEqual(['min', 'thresholds']);
+      });
+
+      test('default values', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.useStandardFieldConfig({
+          [StandardFieldConfigProperties.Color]: '#ff00ff',
+          [StandardFieldConfigProperties.Min]: 10,
+        });
+
+        expect(panel.standardFieldConfigProperties).toEqual(['color', 'min']);
+
+        expect(panel.fieldConfigDefaults).toEqual({
+          defaults: {
+            min: 10,
+            color: '#ff00ff',
+          },
+          overrides: [],
+        });
       });
     });
   });

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -53,41 +53,128 @@ describe('PanelPlugin', () => {
       expect(panel.optionEditors).toBeDefined();
       expect(panel.optionEditors!.list()).toHaveLength(1);
     });
+  });
 
-    test('default option values', () => {
-      const panel = new PanelPlugin(() => {
-        return <div>Panel</div>;
+  describe('default options', () => {
+    describe('panel options', () => {
+      test('default values', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.setPanelOptions(builder => {
+          builder
+            .addNumberInput({
+              id: 'numericOption',
+              name: 'Option editor',
+              description: 'Option editor description',
+              defaultValue: 10,
+            })
+            .addNumberInput({
+              id: 'numericOptionNoDefault',
+              name: 'Option editor',
+              description: 'Option editor description',
+            })
+            .addCustomEditor({
+              id: 'customOption',
+              name: 'Option editor',
+              description: 'Option editor description',
+              editor: () => <div>Editor</div>,
+              settings: {},
+              defaultValue: { value: 'Custom default value' },
+            });
+        });
+
+        const expectedDefaults = {
+          numericOption: 10,
+          customOption: { value: 'Custom default value' },
+        };
+
+        expect(panel.defaults).toEqual(expectedDefaults);
       });
 
-      panel.setPanelOptions(builder => {
-        builder
-          .addNumberInput({
-            id: 'numericOption',
+      test('default values for nested paths', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.setPanelOptions(builder => {
+          builder.addNumberInput({
+            id: 'numericOption.nested',
             name: 'Option editor',
             description: 'Option editor description',
             defaultValue: 10,
-          })
-          .addNumberInput({
-            id: 'numericOptionNoDefault',
-            name: 'Option editor',
-            description: 'Option editor description',
-          })
-          .addCustomEditor({
-            id: 'customOption',
-            name: 'Option editor',
-            description: 'Option editor description',
-            editor: () => <div>Editor</div>,
-            settings: {},
-            defaultValue: { value: 'Custom default value' },
           });
+        });
+
+        const expectedDefaults = {
+          numericOption: { nested: 10 },
+        };
+
+        expect(panel.defaults).toEqual(expectedDefaults);
+      });
+    });
+
+    describe('field config options', () => {
+      test('default values', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
+
+        panel.setCustomFieldOptions(builder => {
+          builder
+            .addNumberInput({
+              id: 'numericOption',
+              name: 'Option editor',
+              description: 'Option editor description',
+              defaultValue: 10,
+            })
+            .addNumberInput({
+              id: 'numericOptionNoDefault',
+              name: 'Option editor',
+              description: 'Option editor description',
+            })
+            .addCustomEditor({
+              id: 'customOption',
+              name: 'Option editor',
+              description: 'Option editor description',
+              editor: () => <div>Editor</div>,
+              override: () => <div>Override editor</div>,
+              process: identityOverrideProcessor,
+              shouldApply: () => true,
+              settings: {},
+              defaultValue: { value: 'Custom default value' },
+            });
+        });
+
+        const expectedDefaults = {
+          numericOption: 10,
+          customOption: { value: 'Custom default value' },
+        };
+
+        expect(panel.fieldConfigDefaults.defaults.custom).toEqual(expectedDefaults);
       });
 
-      const expectedDefaults = {
-        numericOption: 10,
-        customOption: { value: 'Custom default value' },
-      };
+      test('default values for nested paths', () => {
+        const panel = new PanelPlugin(() => {
+          return <div>Panel</div>;
+        });
 
-      expect(panel.defaults).toEqual(expectedDefaults);
+        panel.setCustomFieldOptions(builder => {
+          builder.addNumberInput({
+            id: 'numericOption.nested',
+            name: 'Option editor',
+            description: 'Option editor description',
+            defaultValue: 10,
+          });
+        });
+
+        const expectedDefaults = {
+          numericOption: { nested: 10 },
+        };
+
+        expect(panel.fieldConfigDefaults.defaults.custom).toEqual(expectedDefaults);
+      });
     });
   });
 });

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
-import { identityOverrideProcessor } from '../field';
+import { identityOverrideProcessor, standardEditorsRegistry } from '../field';
 import { PanelPlugin } from './PanelPlugin';
 
 describe('PanelPlugin', () => {
   describe('declarative options', () => {
+    beforeAll(() => {
+      standardEditorsRegistry.setInit(() => {
+        return [
+          {
+            id: 'number',
+          },
+        ] as any;
+      });
+    });
     test('field config UI API', () => {
       const panel = new PanelPlugin(() => {
         return <div>Panel</div>;
@@ -43,6 +52,42 @@ describe('PanelPlugin', () => {
 
       expect(panel.optionEditors).toBeDefined();
       expect(panel.optionEditors!.list()).toHaveLength(1);
+    });
+
+    test('default option values', () => {
+      const panel = new PanelPlugin(() => {
+        return <div>Panel</div>;
+      });
+
+      panel.setPanelOptions(builder => {
+        builder
+          .addNumberInput({
+            id: 'numericOption',
+            name: 'Option editor',
+            description: 'Option editor description',
+            defaultValue: 10,
+          })
+          .addNumberInput({
+            id: 'numericOptionNoDefault',
+            name: 'Option editor',
+            description: 'Option editor description',
+          })
+          .addCustomEditor({
+            id: 'customOption',
+            name: 'Option editor',
+            description: 'Option editor description',
+            editor: () => <div>Editor</div>,
+            settings: {},
+            defaultValue: { value: 'Custom default value' },
+          });
+      });
+
+      const expectedDefaults = {
+        numericOption: 10,
+        customOption: { value: 'Custom default value' },
+      };
+
+      expect(panel.defaults).toEqual(expectedDefaults);
     });
   });
 });

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -197,24 +197,46 @@ describe('PanelPlugin', () => {
         expect(panel.standardFieldConfigProperties).toEqual(['min', 'thresholds']);
       });
 
-      test('default values', () => {
-        const panel = new PanelPlugin(() => {
-          return <div>Panel</div>;
+      describe('default values', () => {
+        test('setting default values', () => {
+          const panel = new PanelPlugin(() => {
+            return <div>Panel</div>;
+          });
+
+          panel.useStandardFieldConfig([StandardFieldConfigProperties.Color, StandardFieldConfigProperties.Min], {
+            [StandardFieldConfigProperties.Color]: '#ff00ff',
+            [StandardFieldConfigProperties.Min]: 10,
+          });
+
+          expect(panel.standardFieldConfigProperties).toEqual(['color', 'min']);
+
+          expect(panel.fieldConfigDefaults).toEqual({
+            defaults: {
+              min: 10,
+              color: '#ff00ff',
+            },
+            overrides: [],
+          });
         });
 
-        panel.useStandardFieldConfig({
-          [StandardFieldConfigProperties.Color]: '#ff00ff',
-          [StandardFieldConfigProperties.Min]: 10,
-        });
+        it('should ignore defaults that are not specified as availeble properties', () => {
+          const panel = new PanelPlugin(() => {
+            return <div>Panel</div>;
+          });
 
-        expect(panel.standardFieldConfigProperties).toEqual(['color', 'min']);
+          panel.useStandardFieldConfig([StandardFieldConfigProperties.Color], {
+            [StandardFieldConfigProperties.Color]: '#ff00ff',
+            [StandardFieldConfigProperties.Min]: 10,
+          });
 
-        expect(panel.fieldConfigDefaults).toEqual({
-          defaults: {
-            min: 10,
-            color: '#ff00ff',
-          },
-          overrides: [],
+          expect(panel.standardFieldConfigProperties).toEqual(['color']);
+
+          expect(panel.fieldConfigDefaults).toEqual({
+            defaults: {
+              color: '#ff00ff',
+            },
+            overrides: [],
+          });
         });
       });
     });

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -240,7 +240,7 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions = any> extends Graf
    *
    * interface ShapePanelOptions {}
    *
-   * // when plugin should use only specific common options
+   * // when plugin should only display specific common options
    * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
    *  .useCommonFieldConfig([StandardFieldConfigProperties.Min, StandardFieldConfigProperties.Max, StandardFieldConfigProperties.Links]);
    *

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -2,7 +2,6 @@ import {
   FieldConfigEditorRegistry,
   FieldConfigSource,
   GrafanaPlugin,
-  KeyValue,
   PanelEditorProps,
   PanelMigrationHandler,
   PanelOptionEditorsRegistry,
@@ -16,18 +15,25 @@ import { ComponentClass, ComponentType } from 'react';
 import set from 'lodash/set';
 import { deprecationWarning } from '../utils';
 
-export const standardFieldConfigProperties = new Map([
-  [StandardFieldConfigProperties.Title, undefined],
-  [StandardFieldConfigProperties.Decimals, undefined],
-  [StandardFieldConfigProperties.Max, undefined],
-  [StandardFieldConfigProperties.Min, undefined],
-  [StandardFieldConfigProperties.NoValue, undefined],
-  [StandardFieldConfigProperties.Links, undefined],
-  [StandardFieldConfigProperties.Unit, undefined],
-  [StandardFieldConfigProperties.Thresholds, undefined],
-  [StandardFieldConfigProperties.Mappings, undefined],
-  [StandardFieldConfigProperties.Color, undefined],
-]);
+export const defaultStandardFieldConfig: Record<StandardFieldConfigProperties, any> = {
+  [StandardFieldConfigProperties.Min]: undefined,
+  [StandardFieldConfigProperties.Max]: undefined,
+  [StandardFieldConfigProperties.Title]: undefined,
+  [StandardFieldConfigProperties.Unit]: undefined,
+  [StandardFieldConfigProperties.Decimals]: undefined,
+  [StandardFieldConfigProperties.NoValue]: undefined,
+  [StandardFieldConfigProperties.Color]: undefined,
+  [StandardFieldConfigProperties.Thresholds]: undefined,
+  [StandardFieldConfigProperties.Mappings]: undefined,
+  [StandardFieldConfigProperties.Links]: undefined,
+};
+
+export const standardFieldConfigProperties = new Map(
+  Object.keys(defaultStandardFieldConfig).map(k => [
+    k as StandardFieldConfigProperties,
+    (defaultStandardFieldConfig as any)[k],
+  ])
+);
 
 export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = any> extends GrafanaPlugin<
   PanelPluginMeta
@@ -120,21 +126,6 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
   setDefaults(defaults: TOptions) {
     deprecationWarning('PanelPlugin', 'setDefaults', 'setPanelOptions');
     this._defaults = defaults;
-    return this;
-  }
-
-  /**
-   * Enables configuration of panel's default field config
-   *
-   * @deprecated setFieldConfigDefaults is deprecated in favor of setCustomFieldOptions
-   */
-  setFieldConfigDefaults(defaultConfig: Partial<FieldConfigSource<TFieldConfigOptions>>) {
-    this._fieldConfigDefaults = {
-      defaults: {},
-      overrides: [],
-      ...defaultConfig,
-    };
-
     return this;
   }
 
@@ -296,7 +287,9 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
    *
    * @public
    */
-  useStandardFieldConfig(properties?: StandardFieldConfigProperties[] | KeyValue<any>) {
+  useStandardFieldConfig(
+    properties?: StandardFieldConfigProperties[] | Partial<Record<StandardFieldConfigProperties, any>>
+  ) {
     if (!properties) {
       this._standardFieldConfigProperties = standardFieldConfigProperties;
       return this;
@@ -308,7 +301,7 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
       );
     } else {
       this._standardFieldConfigProperties = new Map(
-        Object.keys(properties).map(k => [k as StandardFieldConfigProperties, properties[k]])
+        Object.keys(properties).map(k => [k as StandardFieldConfigProperties, (properties as any)[k]])
       );
     }
     return this;

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -12,14 +12,14 @@ import {
 import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/OptionsUIBuilders';
 import { ComponentClass, ComponentType } from 'react';
 
-export class PanelPlugin<TOptions = any> extends GrafanaPlugin<PanelPluginMeta> {
-  private customFieldConfigsUIBuilder = new FieldConfigEditorBuilder();
+export class PanelPlugin<TOptions = any, TFieldConfigOptions = any> extends GrafanaPlugin<PanelPluginMeta> {
+  private customFieldConfigsUIBuilder = new FieldConfigEditorBuilder<TFieldConfigOptions>();
   private _customFieldConfigs?: FieldConfigEditorRegistry;
-  private registerCustomFieldConfigs?: (builder: FieldConfigEditorBuilder) => void;
+  private registerCustomFieldConfigs?: (builder: FieldConfigEditorBuilder<TFieldConfigOptions>) => void;
 
-  private optionsUIBuilder = new PanelOptionsEditorBuilder();
+  private optionsUIBuilder = new PanelOptionsEditorBuilder<TOptions>();
   private _optionEditors?: PanelOptionEditorsRegistry;
-  private registerOptionEditors?: (builder: PanelOptionsEditorBuilder) => void;
+  private registerOptionEditors?: (builder: PanelOptionsEditorBuilder<TOptions>) => void;
 
   panel: ComponentType<PanelProps<TOptions>>;
   editor?: ComponentClass<PanelEditorProps<TOptions>>;
@@ -134,7 +134,7 @@ export class PanelPlugin<TOptions = any> extends GrafanaPlugin<PanelPluginMeta> 
    *
    * @public
    **/
-  setCustomFieldOptions(builder: (builder: FieldConfigEditorBuilder) => void) {
+  setCustomFieldOptions(builder: (builder: FieldConfigEditorBuilder<TFieldConfigOptions>) => void) {
     // builder is applied lazily when custom field configs are accessed
     this.registerCustomFieldConfigs = builder;
     return this;
@@ -170,7 +170,7 @@ export class PanelPlugin<TOptions = any> extends GrafanaPlugin<PanelPluginMeta> 
    *
    * @public
    **/
-  setPanelOptions(builder: (builder: PanelOptionsEditorBuilder) => void) {
+  setPanelOptions(builder: (builder: PanelOptionsEditorBuilder<TOptions>) => void) {
     // builder is applied lazily when options UI is created
     this.registerOptionEditors = builder;
     return this;

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -1,7 +1,6 @@
 import { ComponentType } from 'react';
 import { RegistryItem, Registry } from '../utils/Registry';
 import { NumberFieldConfigSettings, SelectFieldConfigSettings, StringFieldConfigSettings } from '../field';
-import { SelectableValue } from './select';
 
 /**
  * Option editor registry item
@@ -41,15 +40,11 @@ export interface OptionsUIRegistryBuilderAPI<
   ): this;
 
   addSelect?<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: Omit<OptionEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
+    config: OptionEditorConfig<TOptions, TSettings, TOption>
   ): this;
 
   addRadio?<TOption, TSettings extends SelectFieldConfigSettings<TOption> = SelectFieldConfigSettings<TOption>>(
-    config: Omit<OptionEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
+    config: OptionEditorConfig<TOptions, TSettings, TOption>
   ): this;
 
   addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings, boolean>): this;

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -5,7 +5,8 @@ import { NumberFieldConfigSettings, SelectFieldConfigSettings, StringFieldConfig
 /**
  * Option editor registry item
  */
-export interface OptionsEditorItem<TSettings, TEditorProps> extends RegistryItem {
+export interface OptionsEditorItem<TOptions, TSettings, TEditorProps> extends RegistryItem {
+  id: (keyof TOptions & string) | string;
   editor: ComponentType<TEditorProps>;
   settings?: TSettings;
 }
@@ -13,8 +14,8 @@ export interface OptionsEditorItem<TSettings, TEditorProps> extends RegistryItem
 /**
  * Configuration of option editor registry item
  */
-interface OptionEditorConfig<TSettings> {
-  id: string;
+interface OptionEditorConfig<TOptions, TSettings> {
+  id: keyof TOptions & string;
   name: string;
   description: string;
   settings?: TSettings;
@@ -23,34 +24,38 @@ interface OptionEditorConfig<TSettings> {
 /**
  * Describes an API for option editors UI builder
  */
-export interface OptionsUIRegistryBuilderAPI<TEditorProps, T extends OptionsEditorItem<any, TEditorProps>> {
+export interface OptionsUIRegistryBuilderAPI<
+  TOptions,
+  TEditorProps,
+  T extends OptionsEditorItem<TOptions, any, TEditorProps>
+> {
   addNumberInput?<TSettings extends NumberFieldConfigSettings = NumberFieldConfigSettings>(
-    config: OptionEditorConfig<TSettings>
+    config: OptionEditorConfig<TOptions, TSettings>
   ): this;
 
   addTextInput?<TSettings extends StringFieldConfigSettings = StringFieldConfigSettings>(
-    config: OptionEditorConfig<TSettings>
+    config: OptionEditorConfig<TOptions, TSettings>
   ): this;
 
   addSelect?<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TSettings>
+    config: OptionEditorConfig<TOptions, TSettings>
   ): this;
 
   addRadio?<TOption, TSettings extends SelectFieldConfigSettings<TOption> = SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TSettings>
+    config: OptionEditorConfig<TOptions, TSettings>
   ): this;
 
-  addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TSettings>): this;
+  addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
 
-  addUnitPicker?<TSettings = any>(config: OptionEditorConfig<TSettings>): this;
+  addUnitPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
 
-  addColorPicker?<TSettings = any>(config: OptionEditorConfig<TSettings>): this;
+  addColorPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
 
   /**
    * Enables custom editor definition
    * @param config
    */
-  addCustomEditor<TSettings>(config: OptionsEditorItem<TSettings, TEditorProps>): this;
+  addCustomEditor<TSettings>(config: OptionsEditorItem<TOptions, TSettings, TEditorProps>): this;
 
   /**
    * Returns registry of option editors
@@ -58,11 +63,14 @@ export interface OptionsUIRegistryBuilderAPI<TEditorProps, T extends OptionsEdit
   getRegistry: () => Registry<T>;
 }
 
-export abstract class OptionsUIRegistryBuilder<TEditorProps, T extends OptionsEditorItem<any, TEditorProps>>
-  implements OptionsUIRegistryBuilderAPI<TEditorProps, T> {
+export abstract class OptionsUIRegistryBuilder<
+  TOptions,
+  TEditorProps,
+  T extends OptionsEditorItem<TOptions, any, TEditorProps>
+> implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T> {
   private properties: T[] = [];
 
-  addCustomEditor<TValue>(config: T & OptionsEditorItem<TValue, TEditorProps>): this {
+  addCustomEditor<TValue>(config: T & OptionsEditorItem<TOptions, TValue, TEditorProps>): this {
     this.properties.push(config);
     return this;
   }

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -1,6 +1,7 @@
 import { ComponentType } from 'react';
 import { RegistryItem, Registry } from '../utils/Registry';
 import { NumberFieldConfigSettings, SelectFieldConfigSettings, StringFieldConfigSettings } from '../field';
+import { SelectableValue } from './select';
 
 /**
  * Option editor registry item
@@ -40,11 +41,15 @@ export interface OptionsUIRegistryBuilderAPI<
   ): this;
 
   addSelect?<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TOptions, TSettings, TOption>
+    config: Omit<OptionEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ): this;
 
   addRadio?<TOption, TSettings extends SelectFieldConfigSettings<TOption> = SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TOptions, TSettings, TOption>
+    config: Omit<OptionEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ): this;
 
   addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings, boolean>): this;

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -5,20 +5,22 @@ import { NumberFieldConfigSettings, SelectFieldConfigSettings, StringFieldConfig
 /**
  * Option editor registry item
  */
-export interface OptionsEditorItem<TOptions, TSettings, TEditorProps> extends RegistryItem {
+export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue> extends RegistryItem {
   id: (keyof TOptions & string) | string;
   editor: ComponentType<TEditorProps>;
   settings?: TSettings;
+  defaultValue?: TValue;
 }
 
 /**
  * Configuration of option editor registry item
  */
-interface OptionEditorConfig<TOptions, TSettings> {
+interface OptionEditorConfig<TOptions, TSettings, TValue = any> {
   id: keyof TOptions & string;
   name: string;
   description: string;
   settings?: TSettings;
+  defaultValue?: TValue;
 }
 
 /**
@@ -27,35 +29,35 @@ interface OptionEditorConfig<TOptions, TSettings> {
 export interface OptionsUIRegistryBuilderAPI<
   TOptions,
   TEditorProps,
-  T extends OptionsEditorItem<TOptions, any, TEditorProps>
+  T extends OptionsEditorItem<TOptions, any, TEditorProps, any>
 > {
   addNumberInput?<TSettings extends NumberFieldConfigSettings = NumberFieldConfigSettings>(
-    config: OptionEditorConfig<TOptions, TSettings>
+    config: OptionEditorConfig<TOptions, TSettings, number>
   ): this;
 
   addTextInput?<TSettings extends StringFieldConfigSettings = StringFieldConfigSettings>(
-    config: OptionEditorConfig<TOptions, TSettings>
+    config: OptionEditorConfig<TOptions, TSettings, string>
   ): this;
 
   addSelect?<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TOptions, TSettings>
+    config: OptionEditorConfig<TOptions, TSettings, TOption>
   ): this;
 
   addRadio?<TOption, TSettings extends SelectFieldConfigSettings<TOption> = SelectFieldConfigSettings<TOption>>(
-    config: OptionEditorConfig<TOptions, TSettings>
+    config: OptionEditorConfig<TOptions, TSettings, TOption>
   ): this;
 
-  addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
+  addBooleanSwitch?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings, boolean>): this;
 
-  addUnitPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
+  addUnitPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings, string>): this;
 
-  addColorPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings>): this;
+  addColorPicker?<TSettings = any>(config: OptionEditorConfig<TOptions, TSettings, string>): this;
 
   /**
    * Enables custom editor definition
    * @param config
    */
-  addCustomEditor<TSettings>(config: OptionsEditorItem<TOptions, TSettings, TEditorProps>): this;
+  addCustomEditor<TSettings, TValue>(config: OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this;
 
   /**
    * Returns registry of option editors
@@ -66,11 +68,11 @@ export interface OptionsUIRegistryBuilderAPI<
 export abstract class OptionsUIRegistryBuilder<
   TOptions,
   TEditorProps,
-  T extends OptionsEditorItem<TOptions, any, TEditorProps>
+  T extends OptionsEditorItem<TOptions, any, TEditorProps, any>
 > implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T> {
   private properties: T[] = [];
 
-  addCustomEditor<TValue>(config: T & OptionsEditorItem<TOptions, TValue, TEditorProps>): this {
+  addCustomEditor<TSettings, TValue>(config: T & OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this {
     this.properties.push(config);
     return this;
   }

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -21,7 +21,7 @@ export enum FieldType {
  *
  * Plugins may extend this with additional properties. Something like series overrides
  */
-export interface FieldConfig {
+export interface FieldConfig<TOptions extends object = any> {
   title?: string; // The display value for this field.  This supports template variables blank is auto
   filterable?: boolean;
 
@@ -50,7 +50,7 @@ export interface FieldConfig {
   noValue?: string;
 
   // Panel Specific Values
-  custom?: Record<string, any>;
+  custom?: TOptions;
 
   scopedVars?: ScopedVars;
 }

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -63,7 +63,7 @@ export interface FieldConfigEditorConfig<TOptions, TSettings = any> {
 }
 
 export interface FieldPropertyEditorItem<TOptions = any, TValue = any, TSettings extends {} = any>
-  extends OptionsEditorItem<TOptions, TSettings, FieldConfigEditorProps<TValue, TSettings>> {
+  extends OptionsEditorItem<TOptions, TSettings, FieldConfigEditorProps<TValue, TSettings>, TValue> {
   // An editor that can be filled in with context info (template variables etc)
   override: ComponentType<FieldOverrideEditorProps<TValue, TSettings>>;
 
@@ -85,4 +85,17 @@ export interface ApplyFieldOverrideOptions {
   autoMinMax?: boolean;
   standard?: FieldConfigEditorRegistry;
   custom?: FieldConfigEditorRegistry;
+}
+
+export enum StandardFieldConfigProperties {
+  Unit = 'unit',
+  Min = 'min',
+  Max = 'max',
+  Decimals = 'decimals',
+  Title = 'title',
+  NoValue = 'noValue',
+  Thresholds = 'thresholds',
+  Mappings = 'mappings',
+  Links = 'links',
+  Color = 'color',
 }

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -54,16 +54,16 @@ export interface FieldOverrideEditorProps<TValue, TSettings> extends Omit<Standa
   context: FieldOverrideContext;
 }
 
-export interface FieldConfigEditorConfig<TSettings = any> {
-  id: string;
+export interface FieldConfigEditorConfig<TOptions, TSettings = any> {
+  id: (keyof TOptions & string) | string;
   name: string;
   description: string;
   settings?: TSettings;
   shouldApply?: (field: Field) => boolean;
 }
 
-export interface FieldPropertyEditorItem<TValue = any, TSettings extends {} = any>
-  extends OptionsEditorItem<TSettings, FieldConfigEditorProps<TValue, TSettings>> {
+export interface FieldPropertyEditorItem<TOptions = any, TValue = any, TSettings extends {} = any>
+  extends OptionsEditorItem<TOptions, TSettings, FieldConfigEditorProps<TValue, TSettings>> {
   // An editor that can be filled in with context info (template variables etc)
   override: ComponentType<FieldOverrideEditorProps<TValue, TSettings>>;
 

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -25,9 +25,9 @@ export interface ConfigOverrideRule {
   properties: DynamicConfigValue[];
 }
 
-export interface FieldConfigSource {
+export interface FieldConfigSource<TOptions extends object = any> {
   // Defatuls applied to all numeric fields
-  defaults: FieldConfig;
+  defaults: FieldConfig<TOptions>;
 
   // Rules to override individual values
   overrides: ConfigOverrideRule[];
@@ -54,12 +54,13 @@ export interface FieldOverrideEditorProps<TValue, TSettings> extends Omit<Standa
   context: FieldOverrideContext;
 }
 
-export interface FieldConfigEditorConfig<TOptions, TSettings = any> {
+export interface FieldConfigEditorConfig<TOptions, TSettings = any, TValue = any> {
   id: (keyof TOptions & string) | string;
   name: string;
   description: string;
   settings?: TSettings;
   shouldApply?: (field: Field) => boolean;
+  defaultValue?: TValue;
 }
 
 export interface FieldPropertyEditorItem<TOptions = any, TValue = any, TSettings extends {} = any>

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -115,11 +115,11 @@ export type PanelOptionEditorsRegistry = Registry<PanelOptionsEditorItem>;
 
 export interface PanelOptionsEditorProps<TValue> extends StandardEditorProps<TValue> {}
 
-export interface PanelOptionsEditorItem<TValue = any, TSettings = any>
-  extends OptionsEditorItem<TSettings, PanelOptionsEditorProps<TValue>> {}
+export interface PanelOptionsEditorItem<TOptions = any, TValue = any, TSettings = any>
+  extends OptionsEditorItem<TOptions, TSettings, PanelOptionsEditorProps<TValue>> {}
 
-export interface PanelOptionsEditorConfig<TSettings = any> {
-  id: string;
+export interface PanelOptionsEditorConfig<TOptions, TSettings = any> {
+  id: (keyof TOptions & string) | string;
   name: string;
   description: string;
   settings?: TSettings;

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -116,13 +116,14 @@ export type PanelOptionEditorsRegistry = Registry<PanelOptionsEditorItem>;
 export interface PanelOptionsEditorProps<TValue> extends StandardEditorProps<TValue> {}
 
 export interface PanelOptionsEditorItem<TOptions = any, TValue = any, TSettings = any>
-  extends OptionsEditorItem<TOptions, TSettings, PanelOptionsEditorProps<TValue>> {}
+  extends OptionsEditorItem<TOptions, TSettings, PanelOptionsEditorProps<TValue>, TValue> {}
 
-export interface PanelOptionsEditorConfig<TOptions, TSettings = any> {
+export interface PanelOptionsEditorConfig<TOptions, TSettings = any, TValue = any> {
   id: (keyof TOptions & string) | string;
   name: string;
   description: string;
   settings?: TSettings;
+  defaultValue?: TValue;
 }
 
 export interface PanelMenuItem {

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -5,7 +5,6 @@ import {
   PanelOptionsEditorConfig,
   PanelOptionsEditorItem,
   FieldConfigEditorConfig,
-  SelectableValue,
 } from '../types';
 import { OptionsUIRegistryBuilder } from '../types/OptionsUIRegistryBuilder';
 import {
@@ -55,9 +54,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 
   addSelect<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: Omit<FieldConfigEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
+    config: FieldConfigEditorConfig<TOptions, TSettings, TOption>
   ) {
     return this.addCustomEditor({
       ...config,
@@ -70,11 +67,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addRadio<TOption, TSettings = any>(
-    config: Omit<FieldConfigEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
-  ) {
+  addRadio<TOption, TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings, TOption>) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('radio').editor as any,
@@ -147,9 +140,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addSelect<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: Omit<PanelOptionsEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
+    config: PanelOptionsEditorConfig<TOptions, TSettings, TOption>
   ) {
     return this.addCustomEditor({
       ...config,
@@ -158,9 +149,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addRadio<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: Omit<PanelOptionsEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
-      defaultValue?: SelectableValue<TOption>;
-    }
+    config: PanelOptionsEditorConfig<TOptions, TSettings, TOption>
   ) {
     return this.addCustomEditor({
       ...config,

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -26,11 +26,12 @@ import {
 /**
  * Fluent API for declarative creation of field config option editors
  */
-export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
+export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder<
+  TOptions,
   FieldConfigEditorProps<any, any>,
-  FieldPropertyEditorItem
+  FieldPropertyEditorItem<TOptions>
 > {
-  addNumberInput<TSettings>(config: FieldConfigEditorConfig<TSettings & NumberFieldConfigSettings>) {
+  addNumberInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & NumberFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('number').editor as any,
@@ -41,7 +42,7 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addTextInput<TSettings>(config: FieldConfigEditorConfig<TSettings & StringFieldConfigSettings>) {
+  addTextInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & StringFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('text').editor as any,
@@ -52,7 +53,9 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addSelect<TOption, TSettings = any>(config: FieldConfigEditorConfig<TSettings & SelectFieldConfigSettings<TOption>>) {
+  addSelect<TOption, TSettings = any>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+  ) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('select').editor as any,
@@ -64,7 +67,9 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addRadio<TOption, TSettings = any>(config: FieldConfigEditorConfig<TSettings & SelectFieldConfigSettings<TOption>>) {
+  addRadio<TOption, TSettings = any>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+  ) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('radio').editor as any,
@@ -76,7 +81,7 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addBooleanSwitch<TSettings = any>(config: FieldConfigEditorConfig<TSettings>) {
+  addBooleanSwitch<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('boolean').editor as any,
@@ -87,7 +92,7 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addColorPicker<TSettings = any>(config: FieldConfigEditorConfig<TSettings & ColorFieldConfigSettings>) {
+  addColorPicker<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings & ColorFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('color').editor as any,
@@ -98,7 +103,7 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
     });
   }
 
-  addUnitPicker<TSettings = any>(config: FieldConfigEditorConfig<TSettings & UnitFieldConfigSettings>) {
+  addUnitPicker<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings & UnitFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('unit').editor as any,
@@ -113,43 +118,53 @@ export class FieldConfigEditorBuilder extends OptionsUIRegistryBuilder<
 /**
  * Fluent API for declarative creation of panel options
  */
-export class PanelOptionsEditorBuilder extends OptionsUIRegistryBuilder<StandardEditorProps, PanelOptionsEditorItem> {
-  addNumberInput<TSettings>(config: PanelOptionsEditorConfig<TSettings & NumberFieldConfigSettings>) {
+export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilder<
+  TOptions,
+  StandardEditorProps,
+  PanelOptionsEditorItem<TOptions>
+> {
+  addNumberInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & NumberFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('number').editor as any,
     });
   }
 
-  addTextInput<TSettings>(config: PanelOptionsEditorConfig<TSettings & StringFieldConfigSettings>) {
+  addTextInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & StringFieldConfigSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('text').editor as any,
     });
   }
 
-  addSelect<TOption, TSettings>(config: PanelOptionsEditorConfig<TSettings & SelectFieldConfigSettings<TOption>>) {
+  addSelect<TOption, TSettings>(
+    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+  ) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('select').editor as any,
     });
   }
 
-  addRadio<TOption, TSettings>(config: PanelOptionsEditorConfig<TSettings & SelectFieldConfigSettings<TOption>>) {
+  addRadio<TOption, TSettings>(
+    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+  ) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('radio').editor as any,
     });
   }
 
-  addBooleanSwitch<TSettings = any>(config: PanelOptionsEditorConfig<TSettings>) {
+  addBooleanSwitch<TSettings = any>(config: PanelOptionsEditorConfig<TOptions, TSettings>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('boolean').editor as any,
     });
   }
 
-  addColorPicker<TSettings = any>(config: PanelOptionsEditorConfig<TSettings & ColorFieldConfigSettings>): this {
+  addColorPicker<TSettings = any>(
+    config: PanelOptionsEditorConfig<TOptions, TSettings & ColorFieldConfigSettings>
+  ): this {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('color').editor as any,
@@ -157,7 +172,9 @@ export class PanelOptionsEditorBuilder extends OptionsUIRegistryBuilder<Standard
     });
   }
 
-  addUnitPicker<TSettings = any>(config: PanelOptionsEditorConfig<TSettings & UnitFieldConfigSettings>): this {
+  addUnitPicker<TSettings = any>(
+    config: PanelOptionsEditorConfig<TOptions, TSettings & UnitFieldConfigSettings>
+  ): this {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('unit').editor as any,

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -5,6 +5,7 @@ import {
   PanelOptionsEditorConfig,
   PanelOptionsEditorItem,
   FieldConfigEditorConfig,
+  SelectableValue,
 } from '../types';
 import { OptionsUIRegistryBuilder } from '../types/OptionsUIRegistryBuilder';
 import {
@@ -31,7 +32,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   FieldConfigEditorProps<any, any>,
   FieldPropertyEditorItem<TOptions>
 > {
-  addNumberInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & NumberFieldConfigSettings>) {
+  addNumberInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & NumberFieldConfigSettings, number>) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('number').editor as any,
@@ -42,7 +43,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addTextInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & StringFieldConfigSettings>) {
+  addTextInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & StringFieldConfigSettings, string>) {
     return this.addCustomEditor({
       ...config,
       override: standardEditorsRegistry.get('text').editor as any,
@@ -53,8 +54,10 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addSelect<TOption, TSettings = any>(
-    config: FieldConfigEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+  addSelect<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
+    config: Omit<FieldConfigEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ) {
     return this.addCustomEditor({
       ...config,
@@ -68,7 +71,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 
   addRadio<TOption, TSettings = any>(
-    config: FieldConfigEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+    config: Omit<FieldConfigEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ) {
     return this.addCustomEditor({
       ...config,
@@ -81,7 +86,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addBooleanSwitch<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings>) {
+  addBooleanSwitch<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings, boolean>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('boolean').editor as any,
@@ -92,7 +97,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addColorPicker<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings & ColorFieldConfigSettings>) {
+  addColorPicker<TSettings = any>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & ColorFieldConfigSettings, string>
+  ) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('color').editor as any,
@@ -103,7 +110,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addUnitPicker<TSettings = any>(config: FieldConfigEditorConfig<TOptions, TSettings & UnitFieldConfigSettings>) {
+  addUnitPicker<TSettings = any>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & UnitFieldConfigSettings, string>
+  ) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('unit').editor as any,
@@ -137,8 +146,10 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
     });
   }
 
-  addSelect<TOption, TSettings>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>, TOption>
+  addSelect<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
+    config: Omit<PanelOptionsEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ) {
     return this.addCustomEditor({
       ...config,
@@ -146,8 +157,10 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
     });
   }
 
-  addRadio<TOption, TSettings>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>, TOption>
+  addRadio<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
+    config: Omit<PanelOptionsEditorConfig<TOptions, TSettings, TOption>, 'defaultValue'> & {
+      defaultValue?: SelectableValue<TOption>;
+    }
   ) {
     return this.addCustomEditor({
       ...config,

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -123,14 +123,14 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   StandardEditorProps,
   PanelOptionsEditorItem<TOptions>
 > {
-  addNumberInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & NumberFieldConfigSettings>) {
+  addNumberInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & NumberFieldConfigSettings, number>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('number').editor as any,
     });
   }
 
-  addTextInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & StringFieldConfigSettings>) {
+  addTextInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & StringFieldConfigSettings, string>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('text').editor as any,
@@ -138,7 +138,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addSelect<TOption, TSettings>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>, TOption>
   ) {
     return this.addCustomEditor({
       ...config,
@@ -147,7 +147,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addRadio<TOption, TSettings>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>>
+    config: PanelOptionsEditorConfig<TOptions, TSettings & SelectFieldConfigSettings<TOption>, TOption>
   ) {
     return this.addCustomEditor({
       ...config,
@@ -155,7 +155,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
     });
   }
 
-  addBooleanSwitch<TSettings = any>(config: PanelOptionsEditorConfig<TOptions, TSettings>) {
+  addBooleanSwitch<TSettings = any>(config: PanelOptionsEditorConfig<TOptions, TSettings, boolean>) {
     return this.addCustomEditor({
       ...config,
       editor: standardEditorsRegistry.get('boolean').editor as any,
@@ -163,7 +163,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addColorPicker<TSettings = any>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & ColorFieldConfigSettings>
+    config: PanelOptionsEditorConfig<TOptions, TSettings & ColorFieldConfigSettings, string>
   ): this {
     return this.addCustomEditor({
       ...config,
@@ -173,7 +173,7 @@ export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilde
   }
 
   addUnitPicker<TSettings = any>(
-    config: PanelOptionsEditorConfig<TOptions, TSettings & UnitFieldConfigSettings>
+    config: PanelOptionsEditorConfig<TOptions, TSettings & UnitFieldConfigSettings, string>
   ): this {
     return this.addCustomEditor({
       ...config,

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -6,7 +6,7 @@ const history: KeyValue<number> = {};
 export const deprecationWarning = (file: string, oldName: string, newName?: string) => {
   let message = `[Deprecation warning] ${file}: ${oldName} is deprecated`;
   if (newName) {
-    message += `.  Use ${newName} instead`;
+    message += `. Use ${newName} instead`;
   }
   const now = Date.now();
   const last = history[message];

--- a/packages/grafana-ui/src/components/OptionsUI/string.tsx
+++ b/packages/grafana-ui/src/components/OptionsUI/string.tsx
@@ -5,6 +5,13 @@ import Forms from '../Forms';
 export const StringValueEditor: React.FC<FieldConfigEditorProps<string, StringFieldConfigSettings>> = ({
   value,
   onChange,
+  item,
 }) => {
-  return <Forms.Input value={value || ''} onChange={e => onChange(e.currentTarget.value)} />;
+  return (
+    <Forms.Input
+      placeholder={item.settings?.placeholder}
+      value={value || ''}
+      onChange={e => onChange(e.currentTarget.value)}
+    />
+  );
 };

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -30,7 +30,7 @@ import { StatsPickerEditor } from '../components/OptionsUI/stats';
  * Returns collection of common field config properties definitions
  */
 export const getStandardFieldConfigs = () => {
-  const title: FieldPropertyEditorItem<string, StringFieldConfigSettings> = {
+  const title: FieldPropertyEditorItem<any, string, StringFieldConfigSettings> = {
     id: 'title',
     name: 'Title',
     description: "Field's title",
@@ -44,7 +44,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type !== FieldType.time,
   };
 
-  const unit: FieldPropertyEditorItem<string, StringFieldConfigSettings> = {
+  const unit: FieldPropertyEditorItem<any, string, StringFieldConfigSettings> = {
     id: 'unit',
     name: 'Unit',
     description: 'Value units',
@@ -60,7 +60,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const min: FieldPropertyEditorItem<number, NumberFieldConfigSettings> = {
+  const min: FieldPropertyEditorItem<any, number, NumberFieldConfigSettings> = {
     id: 'min',
     name: 'Min',
     description: 'Minimum expected value',
@@ -75,7 +75,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const max: FieldPropertyEditorItem<number, NumberFieldConfigSettings> = {
+  const max: FieldPropertyEditorItem<any, number, NumberFieldConfigSettings> = {
     id: 'max',
     name: 'Max',
     description: 'Maximum expected value',
@@ -91,7 +91,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const decimals: FieldPropertyEditorItem<number, NumberFieldConfigSettings> = {
+  const decimals: FieldPropertyEditorItem<any, number, NumberFieldConfigSettings> = {
     id: 'decimals',
     name: 'Decimals',
     description: 'Number of decimal to be shown for a value',
@@ -110,7 +110,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const thresholds: FieldPropertyEditorItem<ThresholdsConfig, ThresholdsFieldConfigSettings> = {
+  const thresholds: FieldPropertyEditorItem<any, ThresholdsConfig, ThresholdsFieldConfigSettings> = {
     id: 'thresholds',
     name: 'Thresholds',
     description: 'Manage thresholds',
@@ -126,7 +126,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const mappings: FieldPropertyEditorItem<ValueMapping[], ValueMappingFieldConfigSettings> = {
+  const mappings: FieldPropertyEditorItem<any, ValueMapping[], ValueMappingFieldConfigSettings> = {
     id: 'mappings',
     name: 'Value mappings',
     description: 'Manage value mappings',
@@ -141,7 +141,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: field => field.type === FieldType.number,
   };
 
-  const noValue: FieldPropertyEditorItem<string, StringFieldConfigSettings> = {
+  const noValue: FieldPropertyEditorItem<any, string, StringFieldConfigSettings> = {
     id: 'noValue',
     name: 'No Value',
     description: 'What to show when there is no value',
@@ -157,7 +157,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: () => true,
   };
 
-  const links: FieldPropertyEditorItem<DataLink[], StringFieldConfigSettings> = {
+  const links: FieldPropertyEditorItem<any, DataLink[], StringFieldConfigSettings> = {
     id: 'links',
     name: 'DataLinks',
     description: 'Manage date links',
@@ -170,7 +170,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: () => true,
   };
 
-  const color: FieldPropertyEditorItem<string, StringFieldConfigSettings> = {
+  const color: FieldPropertyEditorItem<any, string, StringFieldConfigSettings> = {
     id: 'color',
     name: 'Color',
     description: 'Customise color',

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -38,7 +38,7 @@ export const getStandardFieldConfigs = () => {
     override: standardEditorsRegistry.get('text').editor as any,
     process: stringOverrideProcessor,
     settings: {
-      placeholder: 'auto',
+      placeholder: 'none',
       expandTemplateVars: true,
     },
     shouldApply: field => field.type !== FieldType.time,

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -217,7 +217,7 @@ export const getStandardOptionEditors = () => {
     description: 'Allows option selection',
     editor: props => (
       <Forms.Select
-        defaultValue={props.value}
+        value={props.value}
         onChange={e => props.onChange(e.value)}
         options={props.item.settings?.options}
       />

--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -8,6 +8,7 @@ import {
   standardFieldConfigEditorRegistry,
   PanelPlugin,
   SelectableValue,
+  StandardFieldConfigProperties,
 } from '@grafana/data';
 import { Forms, fieldMatchersUI, ValuePicker, useTheme } from '@grafana/ui';
 import { getDataLinksVariableSuggestions } from '../../../panel/panellinks/link_srv';
@@ -17,7 +18,7 @@ import { css } from 'emotion';
 interface Props {
   plugin: PanelPlugin;
   config: FieldConfigSource;
-  include?: string[]; // Ordered list of which fields should be shown/included
+  include?: StandardFieldConfigProperties[]; // Ordered list of which fields should be shown/included
   onChange: (config: FieldConfigSource) => void;
   /* Helpful for IntelliSense */
   data: DataFrame[];
@@ -67,12 +68,15 @@ export const OverrideFieldConfigEditor: React.FC<Props> = props => {
       return null;
     }
 
-    let configPropertiesOptions = standardFieldConfigEditorRegistry.list().map(i => ({
-      label: i.name,
-      value: i.id,
-      description: i.description,
-      custom: false,
-    }));
+    let configPropertiesOptions = plugin.commonFieldConfigProperties.map(i => {
+      const editor = standardFieldConfigEditorRegistry.get(i);
+      return {
+        label: editor.name,
+        value: editor.id,
+        description: editor.description,
+        custom: false,
+      };
+    });
 
     if (customFieldConfigs) {
       configPropertiesOptions = configPropertiesOptions.concat(

--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -68,7 +68,7 @@ export const OverrideFieldConfigEditor: React.FC<Props> = props => {
       return null;
     }
 
-    let configPropertiesOptions = plugin.commonFieldConfigProperties.map(i => {
+    let configPropertiesOptions = plugin.standardFieldConfigProperties.map(i => {
       const editor = standardFieldConfigEditorRegistry.get(i);
       return {
         label: editor.name,
@@ -188,6 +188,9 @@ export const DefaultFieldConfigEditor: React.FC<Props> = ({ include, data, onCha
   );
 
   const renderStandardConfigs = useCallback(() => {
+    if (include && include.length === 0) {
+      return null;
+    }
     if (include) {
       return <>{include.map(f => renderEditor(standardFieldConfigEditorRegistry.get(f), false))}</>;
     }

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -36,7 +36,7 @@ export const OptionsPaneContent: React.FC<{
             plugin={plugin}
             onChange={onFieldConfigsChange}
             data={data.series}
-            include={plugin.commonFieldConfigProperties}
+            include={plugin.standardFieldConfigProperties}
           />
         </Container>
       );

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -36,6 +36,7 @@ export const OptionsPaneContent: React.FC<{
             plugin={plugin}
             onChange={onFieldConfigsChange}
             data={data.series}
+            include={plugin.commonFieldConfigProperties}
           />
         </Container>
       );

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -1,6 +1,6 @@
 import { PanelModel } from './PanelModel';
 import { getPanelPlugin } from '../../plugins/__mocks__/pluginMocks';
-import { ConfigOverrideRule, PanelProps } from '@grafana/data';
+import { PanelProps, StandardFieldConfigProperties } from '@grafana/data';
 import { ComponentClass } from 'react';
 
 class TablePanelCtrl {}
@@ -70,13 +70,6 @@ describe('PanelModel', () => {
       };
 
       model = new PanelModel(modelJson);
-      const overrideMock: ConfigOverrideRule = {
-        matcher: {
-          id: '2',
-          options: {},
-        },
-        properties: [],
-      };
 
       const panelPlugin = getPanelPlugin(
         {
@@ -86,12 +79,9 @@ describe('PanelModel', () => {
         TablePanelCtrl // angular
       );
       panelPlugin.setDefaults(defaultOptionsMock);
-      panelPlugin.setFieldConfigDefaults({
-        defaults: {
-          unit: 'flop',
-          decimals: 2,
-        },
-        overrides: [overrideMock],
+      panelPlugin.useStandardFieldConfig({
+        [StandardFieldConfigProperties.Unit]: 'flop',
+        [StandardFieldConfigProperties.Decimals]: 2,
       });
       model.pluginLoaded(panelPlugin);
     });
@@ -106,10 +96,6 @@ describe('PanelModel', () => {
 
     it('should apply option defaults but not override if array is changed', () => {
       expect(model.getOptions().arrayWith2Values.length).toBe(1);
-    });
-
-    it('should merge override field config options', () => {
-      expect(model.getFieldOverrideOptions().fieldOptions.overrides.length).toBe(2);
     });
 
     it('should apply field config defaults', () => {

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -79,7 +79,7 @@ describe('PanelModel', () => {
         TablePanelCtrl // angular
       );
       panelPlugin.setDefaults(defaultOptionsMock);
-      panelPlugin.useStandardFieldConfig({
+      panelPlugin.useStandardFieldConfig([StandardFieldConfigProperties.Unit, StandardFieldConfigProperties.Decimals], {
         [StandardFieldConfigProperties.Unit]: 'flop',
         [StandardFieldConfigProperties.Decimals]: 2,
       });

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -1,5 +1,5 @@
 import { sharedSingleStatPanelChangedHandler } from '@grafana/ui';
-import { PanelPlugin } from '@grafana/data';
+import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
 import { BarGaugePanel } from './BarGaugePanel';
 import { BarGaugeOptions, defaults } from './types';
 import { standardFieldConfigDefaults, addStandardDataReduceOptions } from '../stat/types';
@@ -33,4 +33,4 @@ export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
   })
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
   .setMigrationHandler(barGaugePanelMigrationHandler)
-  .useStandardFieldConfig(standardFieldConfigDefaults);
+  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -2,14 +2,13 @@ import { sharedSingleStatPanelChangedHandler } from '@grafana/ui';
 import { PanelPlugin } from '@grafana/data';
 import { BarGaugePanel } from './BarGaugePanel';
 import { BarGaugeOptions, defaults } from './types';
-import { standardFieldConfig, addStandardDataReduceOptions } from '../stat/types';
+import { standardFieldConfigDefaults, addStandardDataReduceOptions } from '../stat/types';
 import { BarGaugePanelEditor } from './BarGaugePanelEditor';
 import { barGaugePanelMigrationHandler } from './BarGaugeMigrations';
 
 export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
   .setDefaults(defaults)
   .setEditor(BarGaugePanelEditor)
-  .setFieldConfigDefaults(standardFieldConfig)
   .setPanelOptions(builder => {
     addStandardDataReduceOptions(builder);
 
@@ -33,4 +32,5 @@ export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
       });
   })
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
-  .setMigrationHandler(barGaugePanelMigrationHandler);
+  .setMigrationHandler(barGaugePanelMigrationHandler)
+  .useStandardFieldConfig(standardFieldConfigDefaults);

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -2,12 +2,11 @@ import { PanelPlugin } from '@grafana/data';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
-import { standardFieldConfig, addStandardDataReduceOptions } from '../stat/types';
+import { standardFieldConfigDefaults, addStandardDataReduceOptions } from '../stat/types';
 import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMigrations';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .setDefaults(defaults)
-  .setFieldConfigDefaults(standardFieldConfig)
   .setEditor(GaugePanelEditor)
   .setPanelOptions(builder => {
     addStandardDataReduceOptions(builder);
@@ -25,4 +24,5 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
       });
   })
   .setPanelChangeHandler(gaugePanelChangedHandler)
-  .setMigrationHandler(gaugePanelMigrationHandler);
+  .setMigrationHandler(gaugePanelMigrationHandler)
+  .useStandardFieldConfig(standardFieldConfigDefaults);

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin } from '@grafana/data';
+import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
@@ -25,4 +25,4 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   })
   .setPanelChangeHandler(gaugePanelChangedHandler)
   .setMigrationHandler(gaugePanelMigrationHandler)
-  .useStandardFieldConfig(standardFieldConfigDefaults);
+  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,9 +1,12 @@
-import { PanelPlugin } from '@grafana/data';
+import { defaultStandardFieldConfig, PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
 import { PieChartPanelEditor } from './PieChartPanelEditor';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, defaults } from './types';
 
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .setDefaults(defaults)
-  .setFieldConfigDefaults({ defaults: { unit: 'short' } })
+  .useStandardFieldConfig({
+    ...defaultStandardFieldConfig,
+    [StandardFieldConfigProperties.Unit]: 'short',
+  })
   .setEditor(PieChartPanelEditor);

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,12 +1,11 @@
-import { defaultStandardFieldConfig, PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
+import { defaultStandardFieldConfigProperties, PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
 import { PieChartPanelEditor } from './PieChartPanelEditor';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, defaults } from './types';
 
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .setDefaults(defaults)
-  .useStandardFieldConfig({
-    ...defaultStandardFieldConfig,
+  .useStandardFieldConfig(defaultStandardFieldConfigProperties, {
     [StandardFieldConfigProperties.Unit]: 'short',
   })
   .setEditor(PieChartPanelEditor);

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -1,12 +1,11 @@
 import { sharedSingleStatMigrationHandler, sharedSingleStatPanelChangedHandler } from '@grafana/ui';
 import { PanelPlugin } from '@grafana/data';
-import { StatPanelOptions, defaults, standardFieldConfig, addStandardDataReduceOptions } from './types';
+import { StatPanelOptions, defaults, standardFieldConfigDefaults, addStandardDataReduceOptions } from './types';
 import { StatPanel } from './StatPanel';
 import { StatPanelEditor } from './StatPanelEditor';
 
 export const plugin = new PanelPlugin<StatPanelOptions>(StatPanel)
   .setDefaults(defaults)
-  .setFieldConfigDefaults(standardFieldConfig)
   .setEditor(StatPanelEditor)
   .setPanelOptions(builder => {
     addStandardDataReduceOptions(builder);
@@ -48,4 +47,5 @@ export const plugin = new PanelPlugin<StatPanelOptions>(StatPanel)
   })
   .setNoPadding()
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
-  .setMigrationHandler(sharedSingleStatMigrationHandler);
+  .setMigrationHandler(sharedSingleStatMigrationHandler)
+  .useStandardFieldConfig(standardFieldConfigDefaults);

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -1,5 +1,5 @@
 import { sharedSingleStatMigrationHandler, sharedSingleStatPanelChangedHandler } from '@grafana/ui';
-import { PanelPlugin } from '@grafana/data';
+import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
 import { StatPanelOptions, defaults, standardFieldConfigDefaults, addStandardDataReduceOptions } from './types';
 import { StatPanel } from './StatPanel';
 import { StatPanelEditor } from './StatPanelEditor';
@@ -48,4 +48,4 @@ export const plugin = new PanelPlugin<StatPanelOptions>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
   .setMigrationHandler(sharedSingleStatMigrationHandler)
-  .useStandardFieldConfig(standardFieldConfigDefaults);
+  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -4,9 +4,10 @@ import {
   ReducerID,
   ReduceDataOptions,
   SelectableValue,
-  FieldConfigSource,
   ThresholdsMode,
   standardEditorsRegistry,
+  StandardFieldConfigProperties,
+  defaultStandardFieldConfig,
 } from '@grafana/data';
 import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
 
@@ -37,18 +38,16 @@ export const commonValueOptionDefaults: ReduceDataOptions = {
   calcs: [ReducerID.mean],
 };
 
-export const standardFieldConfig: FieldConfigSource = {
-  defaults: {
-    thresholds: {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: 'green' },
-        { value: 80, color: 'red' }, // 80%
-      ],
-    },
-    mappings: [],
+export const standardFieldConfigDefaults: Record<StandardFieldConfigProperties, any> = {
+  ...defaultStandardFieldConfig,
+  [StandardFieldConfigProperties.Thresholds]: {
+    mode: ThresholdsMode.Absolute,
+    steps: [
+      { value: -Infinity, color: 'green' },
+      { value: 80, color: 'red' }, // 80%
+    ],
   },
-  overrides: [],
+  [StandardFieldConfigProperties.Mappings]: [],
 };
 
 export function addStandardDataReduceOptions(builder: PanelOptionsEditorBuilder<StatPanelOptions>) {

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -51,7 +51,7 @@ export const standardFieldConfig: FieldConfigSource = {
   overrides: [],
 };
 
-export function addStandardDataReduceOptions(builder: PanelOptionsEditorBuilder) {
+export function addStandardDataReduceOptions(builder: PanelOptionsEditorBuilder<StatPanelOptions>) {
   builder.addRadio({
     id: 'reduceOptions.values',
     name: 'Show',

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -7,7 +7,6 @@ import {
   ThresholdsMode,
   standardEditorsRegistry,
   StandardFieldConfigProperties,
-  defaultStandardFieldConfig,
 } from '@grafana/data';
 import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
 
@@ -38,8 +37,7 @@ export const commonValueOptionDefaults: ReduceDataOptions = {
   calcs: [ReducerID.mean],
 };
 
-export const standardFieldConfigDefaults: Record<StandardFieldConfigProperties, any> = {
-  ...defaultStandardFieldConfig,
+export const standardFieldConfigDefaults: Partial<Record<StandardFieldConfigProperties, any>> = {
   [StandardFieldConfigProperties.Thresholds]: {
     mode: ThresholdsMode.Absolute,
     steps: [

--- a/public/app/plugins/panel/table2/module.tsx
+++ b/public/app/plugins/panel/table2/module.tsx
@@ -1,6 +1,6 @@
 import { PanelPlugin } from '@grafana/data';
 import { TablePanel } from './TablePanel';
-import { Options, defaults, CustomFieldConfig } from './types';
+import { CustomFieldConfig, defaults, Options } from './types';
 
 export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
   .setDefaults(defaults)
@@ -29,7 +29,6 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
             { value: 'lcd-gauge', label: 'LCD gauge' },
           ],
         },
-        defaultValue: { value: 'lcd-gauge', label: 'LCD gauge' },
       });
   })
   .setPanelOptions(builder => {
@@ -37,6 +36,5 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
       id: 'showHeader',
       name: 'Show header',
       description: "To display table's header or not to display",
-      defaultValue: true,
     });
   });

--- a/public/app/plugins/panel/table2/module.tsx
+++ b/public/app/plugins/panel/table2/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
+import { PanelPlugin } from '@grafana/data';
 import { TablePanel } from './TablePanel';
 import { Options, defaults, CustomFieldConfig } from './types';
 
@@ -15,6 +15,7 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
           min: 20,
           max: 300,
         },
+        defaultValue: 1,
       })
       .addSelect({
         id: 'displayMode',
@@ -28,6 +29,7 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
             { value: 'lcd-gauge', label: 'LCD gauge' },
           ],
         },
+        defaultValue: { value: 'lcd-gauge', label: 'LCD gauge' },
       });
   })
   .setPanelOptions(builder => {
@@ -37,5 +39,4 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
       description: "To display table's header or not to display",
       defaultValue: true,
     });
-  })
-  .useCommonFieldConfig([StandardFieldConfigProperties.Thresholds]);
+  });

--- a/public/app/plugins/panel/table2/module.tsx
+++ b/public/app/plugins/panel/table2/module.tsx
@@ -1,8 +1,8 @@
 import { PanelPlugin } from '@grafana/data';
 import { TablePanel } from './TablePanel';
-import { Options, defaults } from './types';
+import { Options, defaults, CustomFieldConfig } from './types';
 
-export const plugin = new PanelPlugin<Options>(TablePanel)
+export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
   .setDefaults(defaults)
   .setCustomFieldOptions(builder => {
     builder

--- a/public/app/plugins/panel/table2/module.tsx
+++ b/public/app/plugins/panel/table2/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin } from '@grafana/data';
+import { PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
 import { TablePanel } from './TablePanel';
 import { Options, defaults, CustomFieldConfig } from './types';
 
@@ -35,5 +35,7 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
       id: 'showHeader',
       name: 'Show header',
       description: "To display table's header or not to display",
+      defaultValue: true,
     });
-  });
+  })
+  .useCommonFieldConfig([StandardFieldConfigProperties.Thresholds]);

--- a/public/app/plugins/panel/table2/types.ts
+++ b/public/app/plugins/panel/table2/types.ts
@@ -2,6 +2,11 @@ export interface Options {
   showHeader: boolean;
 }
 
+export interface CustomFieldConfig {
+  width: number;
+  displayMode: string;
+}
+
 export const defaults: Options = {
   showHeader: true,
 };


### PR DESCRIPTION
This PR introduces improves PanelPlugin API:
- adds `useCommonFieldConfig` method - consumer can now select which field config properties panel should support. See docs for example
- adds `devaultValue` to `OptionsEditorItem` interface to allow inline defaults when using options API 
```ts
.addNumberInput({
  id: 'width',
  name: 'Column width',
  description: 'column width (for table)',
  defaultValue: 100, // defaultValue can be now specified inline for panel options
  settings: {
    placeholder: 'auto',
    min: 20,
    max: 300,
  },
})
```
- deprecates `setDafaults` method on `PluginPanel` API
- adds type safety for options API: `id` are now type checked, unfortunately only one level deep as TS does not allow path inferring. Nested paths can still be specified, but they are not typesafe

TODO:
- [x] add defaults support for field config properties