### PR TITLE
@grafana/e2e: select specific datasource option element

### DIFF
--- a/packages/grafana-e2e/src/flows/addPanel.ts
+++ b/packages/grafana-e2e/src/flows/addPanel.ts
@@ -23,7 +23,7 @@ export const addPanel = (config?: Partial<AddPanelConfig>) => {
     e2e()
       .get('.ds-picker')
       .click()
-      .contains(dataSourceName)
+      .contains('.gf-form-select-box__desc-option', dataSourceName)
       .click();
     queriesForm();
   });


### PR DESCRIPTION
... because, oddly, the previous selection worked locally but not in CI