### PR TITLE
Variables: Fixes issue with too many queries being issued for nested template variables after value change

### DIFF
--- a/public/app/features/templating/variable_srv.ts
+++ b/public/app/features/templating/variable_srv.ts
@@ -330,15 +330,23 @@ export class VariableSrv {
     for (const v of this.variables) {
       const key = `var-${v.name}`;
       if (vars.hasOwnProperty(key)) {
-        update.push(v.setValueFromUrl(vars[key]));
+        if (this.isVariableUrlValueDifferentFromCurrent(v, vars[key])) {
+          update.push(v.setValueFromUrl(vars[key]));
+        }
       }
     }
+
     if (update.length) {
       Promise.all(update).then(() => {
         this.dashboard.templateVariableValueUpdated();
         this.dashboard.startRefresh();
       });
     }
+  }
+
+  isVariableUrlValueDifferentFromCurrent(variable: any, urlValue: any) {
+    // lodash _.isEqual handles array of value equality checks as well
+    return !_.isEqual(variable.current.value, urlValue);
   }
 
   updateUrlParamsWithCurrentVariables() {


### PR DESCRIPTION
Fixes issue where changing a template variable that in term updates a variable with "Multi value" enabled. It triggered a change from url which also triggered another round of template variable updates & queries. 

This adds another equality check so that setValueFromUrl is not called if current value is the same 

Would normally add a unit test for this but since this is code that we soon will delete I was less inclined 