### PR TITLE
Security: Fix for dashboard snapshot original dashboard link could contain XSS vulnerability in url

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -17,6 +17,7 @@ import { DashboardModel } from '../../state';
 import { CoreEvents, StoreState } from 'app/types';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
+import { sanitizeUrl } from 'app/core/utils/text';
 
 export interface OwnProps {
   dashboard: DashboardModel;
@@ -134,6 +135,7 @@ export class DashNav extends PureComponent<Props> {
     const { canStar, canSave, canShare, showSettings, isStarred } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
+
     return (
       <div className="navbar">
         {isFullscreen && this.renderBackButton()}
@@ -222,7 +224,7 @@ export class DashNav extends PureComponent<Props> {
               tooltip="Open original dashboard"
               classSuffix="snapshot-origin"
               icon="gicon gicon-link"
-              href={snapshotUrl}
+              href={sanitizeUrl(snapshotUrl)}
             />
           )}
 


### PR DESCRIPTION

By manuall,y using the API, creating a dashboard snapshot a user could inject XSS in the original url . This fix make sure the url is sanitized before rendering the link. 