### PR TITLE
FieldConfig: Some name change suggestions and moving defaults to PanelPlugin

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -12,4 +12,4 @@ export * from './datetime';
 export * from './text';
 export * from './valueFormats';
 export * from './field';
-export { PanelPlugin, defaultStandardFieldConfigProperties } from './panel/PanelPlugin';
+export { PanelPlugin } from './panel/PanelPlugin';

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { identityOverrideProcessor, standardEditorsRegistry } from '../field';
 import { PanelPlugin, standardFieldConfigProperties } from './PanelPlugin';
-import { StandardFieldConfigProperty } from '../types';
+import { FieldConfigProperty } from '../types';
 
 describe('PanelPlugin', () => {
   describe('declarative options', () => {
@@ -193,7 +193,7 @@ describe('PanelPlugin', () => {
           return <div>Panel</div>;
         });
 
-        panel.useStandardFieldConfig([StandardFieldConfigProperty.Min, StandardFieldConfigProperty.Thresholds]);
+        panel.useStandardFieldConfig([FieldConfigProperty.Min, FieldConfigProperty.Thresholds]);
         expect(panel.standardFieldConfigProperties).toEqual(['min', 'thresholds']);
       });
 
@@ -203,9 +203,9 @@ describe('PanelPlugin', () => {
             return <div>Panel</div>;
           });
 
-          panel.useStandardFieldConfig([StandardFieldConfigProperty.Color, StandardFieldConfigProperty.Min], {
-            [StandardFieldConfigProperty.Color]: '#ff00ff',
-            [StandardFieldConfigProperty.Min]: 10,
+          panel.useStandardFieldConfig([FieldConfigProperty.Color, FieldConfigProperty.Min], {
+            [FieldConfigProperty.Color]: '#ff00ff',
+            [FieldConfigProperty.Min]: 10,
           });
 
           expect(panel.standardFieldConfigProperties).toEqual(['color', 'min']);
@@ -224,9 +224,9 @@ describe('PanelPlugin', () => {
             return <div>Panel</div>;
           });
 
-          panel.useStandardFieldConfig([StandardFieldConfigProperty.Color], {
-            [StandardFieldConfigProperty.Color]: '#ff00ff',
-            [StandardFieldConfigProperty.Min]: 10,
+          panel.useStandardFieldConfig([FieldConfigProperty.Color], {
+            [FieldConfigProperty.Color]: '#ff00ff',
+            [FieldConfigProperty.Min]: 10,
           });
 
           expect(panel.standardFieldConfigProperties).toEqual(['color']);

--- a/packages/grafana-data/src/panel/PanelPlugin.test.tsx
+++ b/packages/grafana-data/src/panel/PanelPlugin.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { identityOverrideProcessor, standardEditorsRegistry } from '../field';
 import { PanelPlugin, standardFieldConfigProperties } from './PanelPlugin';
-import { StandardFieldConfigProperties } from '../types';
+import { StandardFieldConfigProperty } from '../types';
 
 describe('PanelPlugin', () => {
   describe('declarative options', () => {
@@ -193,7 +193,7 @@ describe('PanelPlugin', () => {
           return <div>Panel</div>;
         });
 
-        panel.useStandardFieldConfig([StandardFieldConfigProperties.Min, StandardFieldConfigProperties.Thresholds]);
+        panel.useStandardFieldConfig([StandardFieldConfigProperty.Min, StandardFieldConfigProperty.Thresholds]);
         expect(panel.standardFieldConfigProperties).toEqual(['min', 'thresholds']);
       });
 
@@ -203,9 +203,9 @@ describe('PanelPlugin', () => {
             return <div>Panel</div>;
           });
 
-          panel.useStandardFieldConfig([StandardFieldConfigProperties.Color, StandardFieldConfigProperties.Min], {
-            [StandardFieldConfigProperties.Color]: '#ff00ff',
-            [StandardFieldConfigProperties.Min]: 10,
+          panel.useStandardFieldConfig([StandardFieldConfigProperty.Color, StandardFieldConfigProperty.Min], {
+            [StandardFieldConfigProperty.Color]: '#ff00ff',
+            [StandardFieldConfigProperty.Min]: 10,
           });
 
           expect(panel.standardFieldConfigProperties).toEqual(['color', 'min']);
@@ -224,9 +224,9 @@ describe('PanelPlugin', () => {
             return <div>Panel</div>;
           });
 
-          panel.useStandardFieldConfig([StandardFieldConfigProperties.Color], {
-            [StandardFieldConfigProperties.Color]: '#ff00ff',
-            [StandardFieldConfigProperties.Min]: 10,
+          panel.useStandardFieldConfig([StandardFieldConfigProperty.Color], {
+            [StandardFieldConfigProperty.Color]: '#ff00ff',
+            [StandardFieldConfigProperty.Min]: 10,
           });
 
           expect(panel.standardFieldConfigProperties).toEqual(['color']);

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -8,7 +8,7 @@ import {
   PanelPluginMeta,
   PanelProps,
   PanelTypeChangedHandler,
-  StandardFieldConfigProperty,
+  FieldConfigProperty,
   ThresholdsMode,
 } from '../types';
 import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/OptionsUIBuilders';
@@ -16,28 +16,28 @@ import { ComponentClass, ComponentType } from 'react';
 import set from 'lodash/set';
 import { deprecationWarning } from '../utils';
 
-export const allStandardFieldConfigProperties: StandardFieldConfigProperty[] = [
-  StandardFieldConfigProperty.Min,
-  StandardFieldConfigProperty.Max,
-  StandardFieldConfigProperty.Title,
-  StandardFieldConfigProperty.Unit,
-  StandardFieldConfigProperty.Decimals,
-  StandardFieldConfigProperty.NoValue,
-  StandardFieldConfigProperty.Color,
-  StandardFieldConfigProperty.Thresholds,
-  StandardFieldConfigProperty.Mappings,
-  StandardFieldConfigProperty.Links,
+export const allStandardFieldConfigProperties: FieldConfigProperty[] = [
+  FieldConfigProperty.Min,
+  FieldConfigProperty.Max,
+  FieldConfigProperty.Title,
+  FieldConfigProperty.Unit,
+  FieldConfigProperty.Decimals,
+  FieldConfigProperty.NoValue,
+  FieldConfigProperty.Color,
+  FieldConfigProperty.Thresholds,
+  FieldConfigProperty.Mappings,
+  FieldConfigProperty.Links,
 ];
 
-export const standardFieldConfigDefaults: Partial<Record<StandardFieldConfigProperty, any>> = {
-  [StandardFieldConfigProperty.Thresholds]: {
+export const standardFieldConfigDefaults: Partial<Record<FieldConfigProperty, any>> = {
+  [FieldConfigProperty.Thresholds]: {
     mode: ThresholdsMode.Absolute,
     steps: [
       { value: -Infinity, color: 'green' },
       { value: 80, color: 'red' },
     ],
   },
-  [StandardFieldConfigProperty.Mappings]: [],
+  [FieldConfigProperty.Mappings]: [],
 };
 
 export const standardFieldConfigProperties = new Map(allStandardFieldConfigProperties.map(p => [p, undefined]));
@@ -46,7 +46,7 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
   PanelPluginMeta
 > {
   private _defaults?: TOptions;
-  private _standardFieldConfigProperties?: Map<StandardFieldConfigProperty, any>;
+  private _standardFieldConfigProperties?: Map<FieldConfigProperty, any>;
 
   private _fieldConfigDefaults: FieldConfigSource<TFieldConfigOptions> = {
     defaults: {},
@@ -282,13 +282,13 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
    * // when plugin should only display specific standard options
    * // note, that options will be displayed in the order they are provided
    * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
-   *  .useStandardFieldConfig([StandardFieldConfigProperty.Min, StandardFieldConfigProperty.Max, StandardFieldConfigProperty.Links]);
+   *  .useStandardFieldConfig([FieldConfigProperty.Min, FieldConfigProperty.Max, FieldConfigProperty.Links]);
    *
    * // when standard option's default value needs to be provided
    * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
-   *  .useStandardFieldConfig([StandardFieldConfigProperty.Min, StandardFieldConfigProperty.Max], {
-   *    [StandardFieldConfigProperty.Min]: 20,
-   *    [StandardFieldConfigProperty.Max]: 100
+   *  .useStandardFieldConfig([FieldConfigProperty.Min, FieldConfigProperty.Max], {
+   *    [FieldConfigProperty.Min]: 20,
+   *    [FieldConfigProperty.Max]: 100
    *  });
    *
    * ```
@@ -296,8 +296,8 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
    * @public
    */
   useStandardFieldConfig(
-    properties?: StandardFieldConfigProperty[] | null,
-    customDefaults?: Partial<Record<StandardFieldConfigProperty, any>>
+    properties?: FieldConfigProperty[] | null,
+    customDefaults?: Partial<Record<FieldConfigProperty, any>>
   ) {
     if (!properties) {
       this._standardFieldConfigProperties = standardFieldConfigProperties;
@@ -310,11 +310,8 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
 
     if (defaults) {
       Object.keys(defaults).map(k => {
-        if (properties.indexOf(k as StandardFieldConfigProperty) > -1) {
-          this._standardFieldConfigProperties!.set(
-            k as StandardFieldConfigProperty,
-            defaults[k as StandardFieldConfigProperty]
-          );
+        if (properties.indexOf(k as FieldConfigProperty) > -1) {
+          this._standardFieldConfigProperties!.set(k as FieldConfigProperty, defaults[k as FieldConfigProperty]);
         }
       });
     }

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -88,7 +88,7 @@ export interface ApplyFieldOverrideOptions {
   custom?: FieldConfigEditorRegistry;
 }
 
-export enum StandardFieldConfigProperty {
+export enum FieldConfigProperty {
   Unit = 'unit',
   Min = 'min',
   Max = 'max',

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -88,7 +88,7 @@ export interface ApplyFieldOverrideOptions {
   custom?: FieldConfigEditorRegistry;
 }
 
-export enum StandardFieldConfigProperties {
+export enum StandardFieldConfigProperty {
   Unit = 'unit',
   Min = 'min',
   Max = 'max',

--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
   standardFieldConfigEditorRegistry,
   PanelPlugin,
   SelectableValue,
-  StandardFieldConfigProperty,
+  FieldConfigProperty,
 } from '@grafana/data';
 import { Forms, fieldMatchersUI, ValuePicker, useTheme } from '@grafana/ui';
 import { getDataLinksVariableSuggestions } from '../../../panel/panellinks/link_srv';
@@ -18,7 +18,7 @@ import { css } from 'emotion';
 interface Props {
   plugin: PanelPlugin;
   config: FieldConfigSource;
-  include?: StandardFieldConfigProperty[]; // Ordered list of which fields should be shown/included
+  include?: FieldConfigProperty[]; // Ordered list of which fields should be shown/included
   onChange: (config: FieldConfigSource) => void;
   /* Helpful for IntelliSense */
   data: DataFrame[];

--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
   standardFieldConfigEditorRegistry,
   PanelPlugin,
   SelectableValue,
-  StandardFieldConfigProperties,
+  StandardFieldConfigProperty,
 } from '@grafana/data';
 import { Forms, fieldMatchersUI, ValuePicker, useTheme } from '@grafana/ui';
 import { getDataLinksVariableSuggestions } from '../../../panel/panellinks/link_srv';
@@ -18,7 +18,7 @@ import { css } from 'emotion';
 interface Props {
   plugin: PanelPlugin;
   config: FieldConfigSource;
-  include?: StandardFieldConfigProperties[]; // Ordered list of which fields should be shown/included
+  include?: StandardFieldConfigProperty[]; // Ordered list of which fields should be shown/included
   onChange: (config: FieldConfigSource) => void;
   /* Helpful for IntelliSense */
   data: DataFrame[];

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -1,6 +1,6 @@
 import { PanelModel } from './PanelModel';
 import { getPanelPlugin } from '../../plugins/__mocks__/pluginMocks';
-import { PanelProps, StandardFieldConfigProperty } from '@grafana/data';
+import { PanelProps, FieldConfigProperty } from '@grafana/data';
 import { ComponentClass } from 'react';
 
 class TablePanelCtrl {}
@@ -79,9 +79,9 @@ describe('PanelModel', () => {
         TablePanelCtrl // angular
       );
       panelPlugin.setDefaults(defaultOptionsMock);
-      panelPlugin.useStandardFieldConfig([StandardFieldConfigProperty.Unit, StandardFieldConfigProperty.Decimals], {
-        [StandardFieldConfigProperty.Unit]: 'flop',
-        [StandardFieldConfigProperty.Decimals]: 2,
+      panelPlugin.useStandardFieldConfig([FieldConfigProperty.Unit, FieldConfigProperty.Decimals], {
+        [FieldConfigProperty.Unit]: 'flop',
+        [FieldConfigProperty.Decimals]: 2,
       });
       model.pluginLoaded(panelPlugin);
     });

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -1,6 +1,6 @@
 import { PanelModel } from './PanelModel';
 import { getPanelPlugin } from '../../plugins/__mocks__/pluginMocks';
-import { PanelProps, StandardFieldConfigProperties } from '@grafana/data';
+import { PanelProps, StandardFieldConfigProperty } from '@grafana/data';
 import { ComponentClass } from 'react';
 
 class TablePanelCtrl {}
@@ -79,9 +79,9 @@ describe('PanelModel', () => {
         TablePanelCtrl // angular
       );
       panelPlugin.setDefaults(defaultOptionsMock);
-      panelPlugin.useStandardFieldConfig([StandardFieldConfigProperties.Unit, StandardFieldConfigProperties.Decimals], {
-        [StandardFieldConfigProperties.Unit]: 'flop',
-        [StandardFieldConfigProperties.Decimals]: 2,
+      panelPlugin.useStandardFieldConfig([StandardFieldConfigProperty.Unit, StandardFieldConfigProperty.Decimals], {
+        [StandardFieldConfigProperty.Unit]: 'flop',
+        [StandardFieldConfigProperty.Decimals]: 2,
       });
       model.pluginLoaded(panelPlugin);
     });

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -1,8 +1,8 @@
 import { sharedSingleStatPanelChangedHandler } from '@grafana/ui';
-import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
+import { PanelPlugin } from '@grafana/data';
 import { BarGaugePanel } from './BarGaugePanel';
 import { BarGaugeOptions, defaults } from './types';
-import { standardFieldConfigDefaults, addStandardDataReduceOptions } from '../stat/types';
+import { addStandardDataReduceOptions } from '../stat/types';
 import { BarGaugePanelEditor } from './BarGaugePanelEditor';
 import { barGaugePanelMigrationHandler } from './BarGaugeMigrations';
 
@@ -33,4 +33,4 @@ export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
   })
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
   .setMigrationHandler(barGaugePanelMigrationHandler)
-  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);
+  .useStandardFieldConfig();

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,8 +1,8 @@
-import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
+import { PanelPlugin } from '@grafana/data';
 import { GaugePanelEditor } from './GaugePanelEditor';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions, defaults } from './types';
-import { standardFieldConfigDefaults, addStandardDataReduceOptions } from '../stat/types';
+import { addStandardDataReduceOptions } from '../stat/types';
 import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMigrations';
 
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
@@ -25,4 +25,4 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   })
   .setPanelChangeHandler(gaugePanelChangedHandler)
   .setMigrationHandler(gaugePanelMigrationHandler)
-  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);
+  .useStandardFieldConfig();

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin, StandardFieldConfigProperty } from '@grafana/data';
+import { PanelPlugin, FieldConfigProperty } from '@grafana/data';
 import { PieChartPanelEditor } from './PieChartPanelEditor';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, defaults } from './types';
@@ -6,6 +6,6 @@ import { PieChartOptions, defaults } from './types';
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .setDefaults(defaults)
   .useStandardFieldConfig(null, {
-    [StandardFieldConfigProperty.Unit]: 'short',
+    [FieldConfigProperty.Unit]: 'short',
   })
   .setEditor(PieChartPanelEditor);

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,11 +1,11 @@
-import { defaultStandardFieldConfigProperties, PanelPlugin, StandardFieldConfigProperties } from '@grafana/data';
+import { PanelPlugin, StandardFieldConfigProperty } from '@grafana/data';
 import { PieChartPanelEditor } from './PieChartPanelEditor';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, defaults } from './types';
 
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .setDefaults(defaults)
-  .useStandardFieldConfig(defaultStandardFieldConfigProperties, {
-    [StandardFieldConfigProperties.Unit]: 'short',
+  .useStandardFieldConfig(null, {
+    [StandardFieldConfigProperty.Unit]: 'short',
   })
   .setEditor(PieChartPanelEditor);

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -1,6 +1,6 @@
 import { sharedSingleStatMigrationHandler, sharedSingleStatPanelChangedHandler } from '@grafana/ui';
-import { defaultStandardFieldConfigProperties, PanelPlugin } from '@grafana/data';
-import { StatPanelOptions, defaults, standardFieldConfigDefaults, addStandardDataReduceOptions } from './types';
+import { PanelPlugin } from '@grafana/data';
+import { StatPanelOptions, defaults, addStandardDataReduceOptions } from './types';
 import { StatPanel } from './StatPanel';
 import { StatPanelEditor } from './StatPanelEditor';
 
@@ -48,4 +48,4 @@ export const plugin = new PanelPlugin<StatPanelOptions>(StatPanel)
   .setNoPadding()
   .setPanelChangeHandler(sharedSingleStatPanelChangedHandler)
   .setMigrationHandler(sharedSingleStatMigrationHandler)
-  .useStandardFieldConfig(defaultStandardFieldConfigProperties, standardFieldConfigDefaults);
+  .useStandardFieldConfig();

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -6,7 +6,7 @@ import {
   SelectableValue,
   ThresholdsMode,
   standardEditorsRegistry,
-  StandardFieldConfigProperty,
+  FieldConfigProperty,
 } from '@grafana/data';
 import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
 
@@ -37,15 +37,15 @@ export const commonValueOptionDefaults: ReduceDataOptions = {
   calcs: [ReducerID.mean],
 };
 
-export const standardFieldConfigDefaults: Partial<Record<StandardFieldConfigProperty, any>> = {
-  [StandardFieldConfigProperty.Thresholds]: {
+export const standardFieldConfigDefaults: Partial<Record<FieldConfigProperty, any>> = {
+  [FieldConfigProperty.Thresholds]: {
     mode: ThresholdsMode.Absolute,
     steps: [
       { value: -Infinity, color: 'green' },
       { value: 80, color: 'red' },
     ],
   },
-  [StandardFieldConfigProperty.Mappings]: [],
+  [FieldConfigProperty.Mappings]: [],
 };
 
 export function addStandardDataReduceOptions(builder: PanelOptionsEditorBuilder<StatPanelOptions>) {

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -6,7 +6,7 @@ import {
   SelectableValue,
   ThresholdsMode,
   standardEditorsRegistry,
-  StandardFieldConfigProperties,
+  StandardFieldConfigProperty,
 } from '@grafana/data';
 import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
 
@@ -37,15 +37,15 @@ export const commonValueOptionDefaults: ReduceDataOptions = {
   calcs: [ReducerID.mean],
 };
 
-export const standardFieldConfigDefaults: Partial<Record<StandardFieldConfigProperties, any>> = {
-  [StandardFieldConfigProperties.Thresholds]: {
+export const standardFieldConfigDefaults: Partial<Record<StandardFieldConfigProperty, any>> = {
+  [StandardFieldConfigProperty.Thresholds]: {
     mode: ThresholdsMode.Absolute,
     steps: [
       { value: -Infinity, color: 'green' },
-      { value: 80, color: 'red' }, // 80%
+      { value: 80, color: 'red' },
     ],
   },
-  [StandardFieldConfigProperties.Mappings]: [],
+  [StandardFieldConfigProperty.Mappings]: [],
 };
 
 export function addStandardDataReduceOptions(builder: PanelOptionsEditorBuilder<StatPanelOptions>) {


### PR DESCRIPTION
Felt like having to import the default config properties as a global array was a bit awkward, as well as having to import the default.

* Moved the defaults to PanelPlugin so you can just call useStandardFieldConfig() to get all properties and core defaults 
* Renamed enum to singular as general enum naming conventions state they should be singular (unless it represents a bit flag)
* made the first param take null as well so you can set defaults without importing the all properties array, just set first param to null (not super great but only other option is to make setting defaults be a separate function) 

Todo:
- set defaults for core react panels via the option builder API instead of using setDefaults 
