### PR TITLE
ReactTable: moves alignment to different component types

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -1,14 +1,27 @@
 import React, { FC } from 'react';
 import { TableCellProps } from './types';
 import { formattedValueToString } from '@grafana/data';
+import { css } from 'emotion';
 
 export const DefaultCell: FC<TableCellProps> = props => {
-  const { field, cell, tableStyles } = props;
-
+  const { field, cell, tableStyles, textAlign } = props;
   if (!field.display) {
     return null;
   }
 
+  const style = css`
+    ${tableStyles.tableCell};
+    text-align: ${textAlign};
+  `;
   const displayValue = field.display(cell.value);
-  return <div className={tableStyles.tableCell}>{formattedValueToString(displayValue)}</div>;
+
+  return <div className={style}>{formattedValueToString(displayValue)}</div>;
+};
+
+export const RightAlignedCell: FC<TableCellProps> = props => {
+  return <DefaultCell {...props} textAlign={'right'} />;
+};
+
+export const CenterAlignedCell: FC<TableCellProps> = props => {
+  return <DefaultCell {...props} textAlign={'center'} />;
 };

--- a/packages/grafana-ui/src/components/Table/DefaultHeader.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultHeader.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+import { TableHeaderProps } from './types';
+import { css } from 'emotion';
+import { Icon } from '..';
+
+export const DefaultHeader: FC<TableHeaderProps> = ({ field, tableStyles, textAlign, isSorted, isSortedDesc }) => {
+  const style = css`
+    ${tableStyles.headerCell};
+    text-align: ${textAlign};
+  `;
+
+  return (
+    <div className={style}>
+      {field.name}
+      {isSorted && (isSortedDesc ? <Icon name="caret-down" /> : <Icon name="caret-up" />)}
+    </div>
+  );
+};
+
+export const RightAlignedHeader: FC<TableHeaderProps> = props => {
+  return <DefaultHeader {...props} textAlign={'right'} />;
+};
+
+export const CenterAlignedHeader: FC<TableHeaderProps> = props => {
+  return <DefaultHeader {...props} textAlign={'center'} />;
+};

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -1,15 +1,15 @@
 import React, { FC, memo, useMemo } from 'react';
-import { DataFrame, Field } from '@grafana/data';
+import { DataFrame } from '@grafana/data';
 import { Cell, Column, HeaderGroup, useBlockLayout, useSortBy, useTable } from 'react-table';
 import { FixedSizeList } from 'react-window';
 import useMeasure from 'react-use/lib/useMeasure';
-import { getColumns, getTableRows, getTextAlign } from './utils';
+import { getColumns, getTableRows } from './utils';
 import { useTheme } from '../../themes';
 import { TableFilterActionCallback } from './types';
 import { getTableStyles } from './styles';
 import { TableCell } from './TableCell';
-import { Icon } from '../Icon/Icon';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
+import { TableHeaderCell } from './TableHeaderCell';
 
 export interface Props {
   data: DataFrame;
@@ -73,9 +73,16 @@ export const Table: FC<Props> = memo(({ data, height, onCellClick, width, column
           <div>
             {headerGroups.map((headerGroup: HeaderGroup) => (
               <div className={tableStyles.thead} {...headerGroup.getHeaderGroupProps()} ref={ref}>
-                {headerGroup.headers.map((column: Column, index: number) =>
-                  renderHeaderCell(column, tableStyles.headerCell, data.fields[index])
-                )}
+                {headerGroup.headers.map((column: Column, index) => {
+                  return (
+                    <TableHeaderCell
+                      key={`column-${column.id}`}
+                      tableStyles={tableStyles}
+                      column={column}
+                      field={data.fields[index]}
+                    />
+                  );
+                })}
               </div>
             ))}
           </div>
@@ -93,19 +100,3 @@ export const Table: FC<Props> = memo(({ data, height, onCellClick, width, column
     </div>
   );
 });
-
-function renderHeaderCell(column: any, className: string, field?: Field) {
-  const headerProps = column.getHeaderProps(column.getSortByToggleProps());
-  const fieldTextAlign = getTextAlign(field);
-
-  if (fieldTextAlign) {
-    headerProps.style.textAlign = fieldTextAlign;
-  }
-
-  return (
-    <div className={className} {...headerProps}>
-      {column.render('Header')}
-      {column.isSorted && (column.isSortedDesc ? <Icon name="caret-down" /> : <Icon name="caret-up" />)}
-    </div>
-  );
-}

--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { Cell } from 'react-table';
 import { Field } from '@grafana/data';
-import { getTextAlign } from './utils';
 import { TableFilterActionCallback } from './types';
 import { TableStyles } from './styles';
 
@@ -24,11 +23,6 @@ export const TableCell: FC<Props> = ({ cell, field, tableStyles, onCellClick }) 
     }
 
     onClick = () => onCellClick(cell.column.Header as string, cell.value);
-  }
-
-  const fieldTextAlign = getTextAlign(field);
-  if (fieldTextAlign && cellProps.style) {
-    cellProps.style.textAlign = fieldTextAlign;
   }
 
   return (

--- a/packages/grafana-ui/src/components/Table/TableHeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableHeaderCell.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react';
+import { Column } from 'react-table';
+import { TableStyles } from './styles';
+import { Field } from '@grafana/data';
+
+interface Props {
+  field: Field;
+  column: Column;
+  tableStyles: TableStyles;
+}
+
+export const TableHeaderCell: FC<Props> = ({ field, column, tableStyles }) => {
+  const columnAsAny: any = column;
+  const headerProps = columnAsAny.getHeaderProps(columnAsAny.getSortByToggleProps());
+  const isSorted = columnAsAny.isSorted;
+  const isSortedDesc = columnAsAny.isSortedDesc;
+
+  return <div {...headerProps}>{columnAsAny.render('Header', { field, tableStyles, isSorted, isSortedDesc })}</div>;
+};

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -1,6 +1,7 @@
 import { CellProps } from 'react-table';
 import { Field } from '@grafana/data';
 import { TableStyles } from './styles';
+import { TextAlignProperty } from 'csstype';
 
 export interface TableFieldOptions {
   width: number;
@@ -27,4 +28,13 @@ export type TableFilterActionCallback = (key: string, value: string) => void;
 export interface TableCellProps extends CellProps<any> {
   tableStyles: TableStyles;
   field: Field;
+  textAlign: TextAlignProperty;
+}
+
+export interface TableHeaderProps {
+  tableStyles: TableStyles;
+  field: Field;
+  textAlign: TextAlignProperty;
+  isSorted: boolean;
+  isSortedDesc: boolean | undefined;
 }

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -1,10 +1,11 @@
 import { TextAlignProperty } from 'csstype';
 import { DataFrame, Field, FieldType } from '@grafana/data';
 import { Column } from 'react-table';
-import { DefaultCell } from './DefaultCell';
+import { CenterAlignedCell, DefaultCell, RightAlignedCell } from './DefaultCell';
 import { BarGaugeCell } from './BarGaugeCell';
 import { BackgroundColoredCell } from './BackgroundColorCell';
 import { TableCellDisplayMode, TableFieldOptions, TableRow } from './types';
+import { CenterAlignedHeader, DefaultHeader, RightAlignedHeader } from './DefaultHeader';
 
 export function getTableRows(data: DataFrame): TableRow[] {
   const tableData = [];
@@ -57,12 +58,13 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
       fieldCountWithoutWidth -= 1;
     }
 
-    const Cell = getCellComponent(fieldTableOptions.displayMode);
+    const Cell = getCellComponent(field);
+    const Header = getHeaderComponent(field);
 
     columns.push({
       Cell,
       id: field.name,
-      Header: field.name,
+      Header,
       accessor: field.name,
       width: fieldTableOptions.width,
     });
@@ -79,14 +81,40 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
   return columns;
 }
 
-function getCellComponent(displayMode: TableCellDisplayMode) {
-  switch (displayMode) {
-    case TableCellDisplayMode.ColorBackground:
-      return BackgroundColoredCell;
-    case TableCellDisplayMode.LcdGauge:
-    case TableCellDisplayMode.GradientGauge:
-      return BarGaugeCell;
-    default:
-      return DefaultCell;
+function getCellComponent(field: Field) {
+  const fieldTableOptions = (field.config.custom || {}) as TableFieldOptions;
+  const { displayMode } = fieldTableOptions;
+  const textAlign = getTextAlign(field);
+
+  if (displayMode === TableCellDisplayMode.ColorBackground) {
+    return BackgroundColoredCell;
   }
+
+  if (displayMode === TableCellDisplayMode.LcdGauge || displayMode === TableCellDisplayMode.GradientGauge) {
+    return BarGaugeCell;
+  }
+
+  if (textAlign === 'right') {
+    return RightAlignedCell;
+  }
+
+  if (textAlign === 'center') {
+    return CenterAlignedCell;
+  }
+
+  return DefaultCell;
+}
+
+function getHeaderComponent(field: Field) {
+  const textAlign = getTextAlign(field);
+
+  if (textAlign === 'right') {
+    return RightAlignedHeader;
+  }
+
+  if (textAlign === 'center') {
+    return CenterAlignedHeader;
+  }
+
+  return DefaultHeader;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before moving to the resizing of table component, I found that it would be good to move alignment logic into different components instead. I might miss something important because I have yet grasped the whole table panel concept.

**Which issue(s) this PR fixes**:
Relates #20709

**Special notes for your reviewer**:
I haven't implemented the logic for BackgroundColoredCell and BarGaugeCell yet (in `getCellComponent`),  I'll do this if this turns out to be a refactor that makes sense.
