### PR TITLE
Forms migration: Select namespace remove old exports

### DIFF
--- a/packages/grafana-ui/src/components/Forms/index.ts
+++ b/packages/grafana-ui/src/components/Forms/index.ts
@@ -9,8 +9,6 @@ import { Switch } from './Switch';
 import { Legend } from './Legend';
 import { TextArea } from './TextArea/TextArea';
 import { Checkbox } from './Checkbox';
-//Remove after Enterprise migrations have been merged
-import { Select } from '../Select/Select';
 
 const Forms = {
   RadioButtonGroup,
@@ -24,7 +22,6 @@ const Forms = {
   TextArea,
   Checkbox,
   Legend,
-  Select,
 };
 
 export default Forms;

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -18,8 +18,6 @@ export interface SelectCommonProps<T> {
   onKeyDown?: (event: React.KeyboardEvent) => void;
   placeholder?: string;
   disabled?: boolean;
-  //To be removed, is here to make Enterprise mergable
-  isDisabled?: boolean;
   isSearchable?: boolean;
   isClearable?: boolean;
   autoFocus?: boolean;


### PR DESCRIPTION
Remove exports required for the Enterprise merge.