### PR TITLE
Plugins: Allow overriding Prometheus URL in query editor link

### DIFF
--- a/docs/sources/features/datasources/prometheus.md
+++ b/docs/sources/features/datasources/prometheus.md
@@ -35,6 +35,7 @@ Grafana includes built-in support for Prometheus.
 | _User_                    | User name for basic authentication.                                                                                                   |
 | _Password_                | Password for basic authentication.                                                                                                    |
 | _Scrape interval_         | Set this to the typical scrape and evaluation interval configured in Prometheus. Defaults to 15s.                                     |
+| _Direct URL Override_     | Override the link to the Prometheus graph in the query editor.                                                                        |
 | _Custom Query Parameters_ | Add custom parameters to the Prometheus query URL. For example `timeout`, `partial_response`, `dedup` or `max_source_resolution`. Multiple parameters should be concatenated together with an '&amp;'. |
 
 ## Query editor

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -72,6 +72,23 @@ export const PromSettings = (props: Props) => {
             width={7}
           />
         </div>
+        <div className="gf-form-inline">
+          <div className="gf-form">
+            <FormField
+              label="Direct URL Override"
+              labelWidth={13}
+              inputEl={
+                <Input
+                  className="width-20"
+                  value={value.jsonData.directUrlOverride}
+                  onChange={onChangeHandler('directUrlOverride', value, onChange)}
+                  spellCheck={false}
+                />
+              }
+              tooltip="Override the direct link to the Prometheus graph in the query editor."
+            />
+          </div>
+        </div>
       </div>
       <h3 className="page-heading">Misc</h3>
       <div className="gf-form-group">

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -76,6 +76,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   ruleMappings: { [index: string]: string };
   url: string;
   directUrl: string;
+  directUrlOverride: string;
   basicAuth: any;
   withCredentials: any;
   metricsNameCache: any;
@@ -97,7 +98,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
-    this.directUrl = instanceSettings.jsonData.directUrl;
+    this.directUrl = instanceSettings.jsonData.directUrlOverride || instanceSettings.jsonData.directUrl;
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
     this.languageProvider = new PrometheusLanguageProvider(this);

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -19,6 +19,7 @@ export interface PromOptions extends DataSourceJsonData {
   queryTimeout: string;
   httpMethod: string;
   directUrl: string;
+  directUrlOverride: string;
   customQueryParameters?: string;
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR allows for the "Link to Graph in Prometheus" in the query editor to use a different URL than the Prometheus datasource itself.

**Which issue(s) this PR fixes**:
When using a Prometheus datasource in "Server" (proxied) mode, it may be
desirable to have different URLs for the datasource itself used by
Grafana and the "Link to Graph in Prometheus" button in the query editor
UI. That is useful, in particular, when the Prometheus endpoints are under
different forms of authentication for service users (e.g. Grafana) and
other user-agents (e.g. a person with a browser).
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

