### PR TITLE
NewPanelEditor Render search results in front of the list of plugins

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
@@ -34,6 +34,13 @@ export const VisualizationTabUnconnected: FC<Props> = ({ panel, plugin, changePa
   const onPluginTypeChange = (meta: PanelPluginMeta) => {
     changePanelPlugin(panel, meta.id);
   };
+  const suffix =
+    searchQuery !== '' ? (
+      <span className={styles.searchClear} onClick={() => setSearchQuery('')}>
+        <Icon name="times" />
+        Clear filter
+      </span>
+    ) : null;
 
   return (
     <div className={styles.wrapper}>
@@ -42,6 +49,7 @@ export const VisualizationTabUnconnected: FC<Props> = ({ panel, plugin, changePa
           value={searchQuery}
           onChange={e => setSearchQuery(e.currentTarget.value)}
           prefix={<Icon name="filter" className={styles.icon} />}
+          suffix={suffix}
           placeholder="Filter visualisations"
           autoFocus
         />
@@ -76,6 +84,10 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       flex-grow: 0;
       flex-shrink: 1;
       margin-bottom: ${theme.spacing.sm};
+    `,
+    searchClear: css`
+      color: ${theme.colors.gray60};
+      cursor: pointer;
     `,
     visList: css`
       flex-grow: 1;

--- a/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
+++ b/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import config from 'app/core/config';
 import VizTypePickerPlugin from './VizTypePickerPlugin';
@@ -41,22 +41,22 @@ export const VizTypePicker: React.FC<Props> = ({ searchQuery, onTypeChange, curr
     );
   };
 
-  const getFilteredPluginList = (): PanelPluginMeta[] => {
+  const getFilteredPluginList = useCallback((): PanelPluginMeta[] => {
     const regex = new RegExp(searchQuery, 'i');
-
     return pluginsList.filter(item => {
       return regex.test(item.name);
     });
-  };
+  }, [searchQuery]);
 
   const filteredPluginList = getFilteredPluginList();
   const hasResults = filteredPluginList.length > 0;
+  const renderList = filteredPluginList.concat(pluginsList.filter(p => filteredPluginList.indexOf(p) === -1));
 
   return (
     <div className={styles.wrapper}>
       <div className={styles.grid}>
         {hasResults ? (
-          pluginsList.map((plugin, index) => renderVizPlugin(plugin, index))
+          renderList.map((plugin, index) => renderVizPlugin(plugin, index))
         ) : (
           <EmptySearchResult>Could not find anything matching your query</EmptySearchResult>
         )}

--- a/public/app/features/dashboard/panel_editor/VizTypePickerPlugin.tsx
+++ b/public/app/features/dashboard/panel_editor/VizTypePickerPlugin.tsx
@@ -29,10 +29,11 @@ const VizTypePickerPlugin: React.FC<Props> = ({ isCurrent, plugin, onClick, disa
 };
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  const itemBorder = `1px solid ${theme.isLight ? theme.colors.gray3 : theme.colors.dark10}`;
   return {
     item: css`
       background: ${theme.isLight ? theme.colors.white : theme.colors.gray05};
-      border: 1px solid ${theme.isLight ? theme.colors.gray3 : theme.colors.dark10};
+      border: ${itemBorder};
       border-radius: 3px;
       height: 100px;
       width: 100%;
@@ -68,7 +69,11 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     disabled: css`
       opacity: 0.2;
       filter: grayscale(1);
-      cursor: pointer;
+      cursor: default;
+      &:hover {
+        box-shadow: none;
+        border: ${itemBorder};
+      }
     `,
     name: css`
       text-overflow: ellipsis;


### PR DESCRIPTION
Next iteration of https://github.com/grafana/grafana/pull/23253, now the search results are displayed first, but the rest of the available panels are still visible, but dimmed:

![image](https://user-images.githubusercontent.com/2376619/78267483-533dc780-7507-11ea-90b4-170cd8621dbe.png)

cc @jessover9000 @sarlinska @ryantxu 