### PR TITLE
Server: Exit Grafana with status code 0 if no error

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -115,8 +115,10 @@ func main() {
 	go listenToSystemSignals(server)
 
 	err := server.Run()
-
-	code := server.ExitCode(err)
+	code := 0
+	if err != nil {
+		code = server.ExitCode(err)
+	}
 	trace.Stop()
 	log.Close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make grafana-server exit with 0 if no error occurred.

**Which issue(s) this PR fixes**:

Fixes #23309.

