### PR TITLE
UX: Fixes sidebar hover

### DIFF
--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -22,7 +22,6 @@ $mobile-menu-breakpoint: md;
   }
 
   @include media-breakpoint-up($mobile-menu-breakpoint) {
-    border-right: $side-menu-border;
     height: auto;
     box-shadow: $side-menu-shadow;
     position: relative;


### PR DESCRIPTION
Due to 1px border the hover menu could be dismissed if you do not move your mouse fast:
![Peek 2020-04-03 15-33](https://user-images.githubusercontent.com/1014802/78366206-74aeba00-75c0-11ea-9343-b7b4f9d1c2be.gif)
