### PR TITLE
Database: Order results in UserSearch by username/email

### DIFF
--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -122,6 +122,10 @@ func addUserMigrations(mg *Migrator) {
 	mg.AddMigration("Add is_disabled column to user", NewAddColumnMigration(userV2, &Column{
 		Name: "is_disabled", Type: DB_Bool, Nullable: false, Default: "0",
 	}))
+
+	mg.AddMigration("Add index user.login/user.email", NewAddIndexMigration(userV2, &Index{
+		Cols: []string{"login", "email"},
+	}))
 }
 
 type AddMissingUserSaltAndRandsMigration struct {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -68,7 +68,6 @@ func (ss *SqlStore) Init() error {
 	ss.readConfig()
 
 	engine, err := ss.getEngine()
-
 	if err != nil {
 		return fmt.Errorf("Fail to connect to database: %v", err)
 	}
@@ -232,7 +231,6 @@ func (ss *SqlStore) buildConnectionString() (string, error) {
 
 func (ss *SqlStore) getEngine() (*xorm.Engine, error) {
 	connectionString, err := ss.buildConnectionString()
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -454,7 +454,7 @@ func SearchUsers(query *models.SearchUsersQuery) error {
 	offset := query.Limit * (query.Page - 1)
 	sess.Limit(query.Limit, offset)
 	sess.Cols("u.id", "u.email", "u.name", "u.login", "u.is_admin", "u.is_disabled", "u.last_seen_at", "user_auth.auth_module")
-	sess.OrderBy("u.id")
+	sess.Asc("u.login", "u.email")
 	if err := sess.Find(&query.Result.Users); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that the user list on the admin page is ordered by username first and email address second.

Also adding an index on (user.login, user.email) for speedy ordering.

I've checked with MariaDB (MySQL compatible) and it looks as if the new index gets used:

```
MariaDB [grafana]> explain select id, login,email from user order by login ASC, email ASC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: user
         type: index
possible_keys: NULL
          key: IDX_user_login_email
      key_len: 1524
          ref: NULL
         rows: 1
        Extra: Using index
1 row in set (0.000 sec)
```

**Which issue(s) this PR fixes**:
Fixes #22348.
