### PR TITLE
Tracing: Fix failing test

### DIFF
--- a/packages/jaeger-ui-components/src/selectors/trace.test.js
+++ b/packages/jaeger-ui-components/src/selectors/trace.test.js
@@ -166,10 +166,8 @@ it('getTraceServices() should return an unique array of all services in the trac
 
 it('getTraceServiceCount() should return the length of the service list', () => {
   expect(traceSelectors.getTraceServiceCount(generatedTrace)).toBe(
-    generatedTrace.spans.reduce(
-      (results, { processID }) => results.add(generatedTrace.processes[processID].serviceName),
-      new Set()
-    ).size
+    Object.values(generatedTrace.processes).reduce((results, process) => results.add(process.serviceName), new Set())
+      .size
   );
 });
 


### PR DESCRIPTION
The test in question is pretty weird, the whole suite uses randomly generated trace with random number of spans, processes etc and then test things by to some extent reimplementing the functionality in the test.

Here I am not sure why it fails, could not reproduce locally. I assume in CI it got stuck on some seed that produced permutation that failed. Also it sort of tested whether the random generated data was valid not so much the function in question. This should fix it probably though the test is still not very meaningful as it basically tests whether implementation of the function is the same as implementation in the test.