### PR TITLE
DO NOT MERGE: Prometheus: Truncate metric names, labels at 1000 chars

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -5,7 +5,12 @@ import { Value } from 'slate';
 import { dateTime, LanguageProvider, HistoryItem } from '@grafana/data';
 import { CompletionItem, TypeaheadInput, TypeaheadOutput, CompletionItemGroup } from '@grafana/ui';
 
-import { parseSelector, processLabels, processHistogramLabels } from './language_utils';
+import {
+  parseSelector,
+  processLabels,
+  processHistogramLabels,
+  truncateExcessivelyLongMetricNames,
+} from './language_utils';
 import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
 import { PrometheusDatasource } from './datasource';
@@ -116,6 +121,11 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     this.lookupsDisabled = this.metrics.length > this.lookupMetricsThreshold;
     this.metricsMetadata = await this.request('/api/v1/metadata', {});
     this.processHistogramMetrics(this.metrics);
+
+    if (!this.lookupsDisabled) {
+      truncateExcessivelyLongMetricNames(this.metrics, this.metricsMetadata);
+    }
+
     return [];
   };
 


### PR DESCRIPTION
### DRAFT, DO NOT MERGE

**What this PR does / why we need it**:
While investigating [this issue](https://github.com/grafana/grafana/issues/21893), I found that one thing that can introduce "sluggishness" when typing a query in e.g. Explore are extraordinarily long metric/label names.

At only 4 labels but one consisting of 1M characters, each key stroke would take a few seconds.
While at 10K labels and all consisting of 1K characters, the autocomplete experience was smooth.

**Which issue(s) this PR fixes**:
Performance drops due to user error - at least we consider it likely to be an error when names are longer than 1000 characters. At which point they are simply truncated.