### PR TITLE
tsconfig: set `jsx` option to "react"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "baseUrl": "public/",
     "outDir": "public/dist",
     "paths": {


### PR DESCRIPTION
**What this PR does / why we need it:**
Explicit setting of this option helps to code editors ([at least vscode](https://github.com/Microsoft/vscode/issues/15814)) properly work with .tsx files 


