### PR TITLE
Fix: Show correct save modal when dashboard is titled 'New dashboard'

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { NEW_DASHBOARD_DEFAULT_TITLE } from './forms/SaveDashboardAsForm';
 import { SaveProvisionedDashboard } from './SaveProvisionedDashboard';
 import { SaveDashboardAsModal } from './SaveDashboardAsModal';
 import { SaveDashboardModalProps } from './types';
@@ -7,7 +6,7 @@ import { SaveDashboardModal } from './SaveDashboardModal';
 
 export const SaveDashboardModalProxy: React.FC<SaveDashboardModalProps> = ({ dashboard, onDismiss, onSaveSuccess }) => {
   const isProvisioned = dashboard.meta.provisioned;
-  const isNew = dashboard.title === NEW_DASHBOARD_DEFAULT_TITLE || dashboard.version === 0;
+  const isNew = dashboard.version === 0;
   const isChanged = dashboard.version > 0;
 
   const modalProps = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed dashboard title check, which caused "Save dashboard as" modal to show up for existing dashboard titled "New dashboard".

