### PR TITLE
FieldOverride: Fixed number override so that it return undefined for null/undefined values and not NaN 

### DIFF
--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -17,11 +17,11 @@ export const numberOverrideProcessor = (
   context: FieldOverrideContext,
   settings?: NumberFieldConfigSettings
 ) => {
-  const v = parseFloat(`${value}`);
-  if (settings && settings.max && v > settings.max) {
-    // ????
+  if (value === undefined || value === null) {
+    return undefined;
   }
-  return v;
+
+  return parseFloat(value);
 };
 
 export interface DataLinksFieldConfigSettings {}

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -69,7 +69,7 @@ export interface FieldPropertyEditorItem<TOptions = any, TValue = any, TSettings
   override: ComponentType<FieldOverrideEditorProps<TValue, TSettings>>;
 
   // Convert the override value to a well typed value
-  process: (value: any, context: FieldOverrideContext, settings?: TSettings) => TValue;
+  process: (value: any, context: FieldOverrideContext, settings?: TSettings) => TValue | undefined | null;
 
   // Checks if field should be processed
   shouldApply: (field: Field) => boolean;


### PR DESCRIPTION
Stat panel graph was broken due to min/max being evaluated to NaN after passing through fieldOverride system 