### PR TITLE
Docs: remove azure and okta from generic oauth page

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -54,24 +54,6 @@ Check for the presence of a role using the [JMESPath](http://jmespath.org/exampl
 
 See [JMESPath examples](#jmespath-examples) for more information.
 
-## Set up OAuth2 with Okta
-
-First set up Grafana as an OpenId client "webapplication" in Okta. Then set the Base URIs to `https://<grafana domain>/` and set the Login redirect URIs to `https://<grafana domain>/login/generic_oauth`.
-
-Finally set up the generic oauth module like this:
-
-```bash
-[auth.generic_oauth]
-name = Okta
-enabled = true
-scopes = openid profile email
-client_id = <okta application Client ID>
-client_secret = <okta application Client Secret>
-auth_url = https://<okta domain>/oauth2/v1/authorize
-token_url = https://<okta domain>/oauth2/v1/token
-api_url = https://<okta domain>/oauth2/v1/userinfo
-```
-
 ## Set up OAuth2 with Bitbucket
 
 ```bash
@@ -149,46 +131,6 @@ allowed_organizations =
     token_url = https://<domain>/oauth/token
     api_url = https://<domain>/userinfo
     ```
-
-## Set up OAuth2 with Azure Active Directory
-
-1.  Log in to portal.azure.com and click "Azure Active Directory" in the side menu, then click the "Properties" sub-menu item.
-
-2.  Copy the "Directory ID", this is needed for setting URLs later
-
-3.  Click "App Registrations" and add a new application registration:
-    - Name: Grafana
-    - Application type: Web app / API
-    - Sign-on URL: `https://<grafana domain>/login/generic_oauth`
-
-4.  Click the name of the new application to open the application details page.
-
-5.  Note down the "Application ID", this will be the OAuth client id.
-
-6.  Click "Certificates & secrets" and add a new entry under Client secrets
-    - Description: Grafana OAuth
-    - Expires: Never
-
-7.  Click Add then copy the key value, this will be the OAuth client secret.
-
-8.  Configure Grafana as follows:
-
-    ```bash
-    [auth.generic_oauth]
-    name = Azure AD
-    enabled = true
-    allow_sign_up = true
-    client_id = <application id>
-    client_secret = <key value>
-    scopes = openid email name
-    auth_url = https://login.microsoftonline.com/<directory id>/oauth2/authorize
-    token_url = https://login.microsoftonline.com/<directory id>/oauth2/token
-    api_url =
-    team_ids =
-    allowed_organizations =
-    ```
-
-> Note: It's important to ensure that the [root_url]({{< relref "../installation/configuration/#root-url" >}}) in Grafana is set in your Azure Application Reply URLs (App -> Settings -> Reply URLs)
 
 ## Set up OAuth2 with Centrify
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR remove unnecessary docs for Azure AD and Okta OAuth from Generic OAuth page, because these providers were implemented separately in #22972 and #20030 with its own docs pages.

**Which issue(s) this PR fixes**:
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

No issue for this.

**Special notes for your reviewer**:

