### PR TITLE
Storybook: Add light theme for docs

### DIFF
--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -38,6 +38,7 @@ addParameters({
     light: GrafanaLight,
   },
   options: {
+    theme: GrafanaLight,
     showPanel: true,
     showRoots: true,
     panelPosition: 'bottom',


### PR DESCRIPTION
Theme switcher still does not work for the docs, but with this change we at least get the custom theme with the docs.
