### PR TITLE
Fix: Adding missing named export that made the rollup to fail

### DIFF
--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -59,6 +59,7 @@ const buildCjsPackage = ({ env }) => {
           'node_modules/immutable/dist/immutable.js': ['Record', 'Set', 'Map', 'List', 'OrderedSet', 'is', 'Stack'],
           '../../node_modules/esrever/esrever.js': ['reverse'],
           '../../node_modules/react-table/index.js': ['useTable', 'useSortBy', 'useBlockLayout', 'Cell'],
+          '../../node_modules/react-is/index.js': ['isValidElementType', 'isContextConsumer'],
         },
       }),
       resolve(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the master release build is failing due to the dnd package is depending on the react-is package.
