### PR TITLE
Chore: More robust identification of time/value fields in makeSeriesForLogs

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -140,14 +140,15 @@ export function makeSeriesForLogs(rows: LogRowModel[], intervalMs: number, timeZ
 
     // EEEP: converts GraphSeriesXY to DataFrame and back again!
     const data = toDataFrame(series);
+    const fieldCache = new FieldCache(data);
 
-    const timeField = data.fields.find(field => field.type === FieldType.time);
+    const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
     timeField.display = getDisplayProcessor({
       field: timeField,
       timeZone,
     });
 
-    const valueField = data.fields.find(field => field.type !== FieldType.time);
+    const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
     valueField.config = {
       ...valueField.config,
       color: series.color,

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -136,29 +136,28 @@ export function makeSeriesForLogs(rows: LogRowModel[], intervalMs: number, timeZ
   }
 
   return seriesList.map((series, i) => {
-    series.datapoints.sort((a: number[], b: number[]) => {
-      return a[1] - b[1];
-    });
+    series.datapoints.sort((a: number[], b: number[]) => a[1] - b[1]);
 
     // EEEP: converts GraphSeriesXY to DataFrame and back again!
     const data = toDataFrame(series);
-    const points = getFlotPairs({
-      xField: data.fields[1],
-      yField: data.fields[0],
-      nullValueMode: NullValueMode.Null,
-    });
 
-    const timeField = data.fields[1];
+    const timeField = data.fields.find(field => field.type === FieldType.time);
     timeField.display = getDisplayProcessor({
       field: timeField,
       timeZone,
     });
 
-    const valueField = data.fields[0];
+    const valueField = data.fields.find(field => field.type !== FieldType.time);
     valueField.config = {
       ...valueField.config,
       color: series.color,
     };
+
+    const points = getFlotPairs({
+      xField: timeField,
+      yField: valueField,
+      nullValueMode: NullValueMode.Null,
+    });
 
     const graphSeries: GraphSeriesXY = {
       color: series.color,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue introduced by #23206 where `makeSeriesForLogs` was not updated to handle
new time/value order.
