### PR TITLE
DataSourceWithBackend: resources response

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -104,14 +104,14 @@ export class DataSourceWithBackend<
   /**
    * Make a GET request to the datasource resource path
    */
-  async getResource(path: string, params?: any): Promise<Record<string, any>> {
+  async getResource(path: string, params?: any): Promise<any> {
     return getBackendSrv().get(`/api/datasources/${this.id}/resources/${path}`, params);
   }
 
   /**
    * Send a POST request to the datasource resource path
    */
-  async postResource(path: string, body?: any): Promise<Record<string, any>> {
+  async postResource(path: string, body?: any): Promise<any> {
     return getBackendSrv().post(`/api/datasources/${this.id}/resources/${path}`, { ...body });
   }
 


### PR DESCRIPTION
The current typing assume all resource responses are an object -- this allows anything to be returned.