### PR TITLE
Toolkit: handle 404 errors gracefully on unpublish in circleci-release-next-packages.sh

### DIFF
--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -10,7 +10,7 @@ function parse_git_hash() {
   git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/"
 }
 
-function prapare_version_commit () {
+function prepare_version_commit () {
   echo $'\nCommiting version changes. This commit will not be checked-in!'
   git config --global user.email "circleci@grafana.com"
   git config --global user.name "CirceCI"
@@ -18,23 +18,24 @@ function prapare_version_commit () {
 }
 
 function unpublish_previous_canary () {
+  _package=$1
   echo $'\nUnpublishing previous canary packages'
-  for PACKAGE in "${PACKAGES[@]}"
-  do
-    # dist-tag next to be changed to canary when https://github.com/grafana/grafana/pull/18195 is merged
-    CURRENT_CANARY=$(npm view @grafana/"${PACKAGE}" dist-tags.canary)
-    if [ -z "${CURRENT_CANARY}" ]; then
-        echo "@grafana/${PACKAGE} - Nothing to unpublish"
-    else
-      echo "Unpublish @grafana/${PACKAGE}@${CURRENT_CANARY}"
-      npm unpublish "@grafana/${PACKAGE}@${CURRENT_CANARY}" || (
+  # dist-tag next to be changed to canary when https://github.com/grafana/grafana/pull/18195 is merged
+  CURRENT_CANARY=$(npm view @grafana/"${_package}" dist-tags.canary)
+  if [ -z "${CURRENT_CANARY}" ]; then
+      echo "@grafana/${_package} - Nothing to unpublish"
+  else
+    echo "Unpublish @grafana/${_package}@${CURRENT_CANARY}"
+    _response=$(npm unpublish @grafana/"${_package}"@"${CURRENT_CANARY}" 2>&1) || (
+      echo "$_response" | grep "404" || (
         # We want to deprecate here, rather than fail and return an non-0 exit code
-        echo "Unpublish unsucessful [$?]. Deprecating @grafana/${PACKAGE}@${CURRENT_CANARY}"
-        # But if this fails, return the error code
-        npm deprecate "@grafana/${PACKAGE}@${CURRENT_CANARY}"
+        echo "Unpublish unsuccessful [$?]. Deprecating @grafana/${_package}@${CURRENT_CANARY}"
+        _response=$(npm deprecate @grafana/"${_package}"@"${CURRENT_CANARY}" "this package has been deprecated") || (
+          echo "$_response" | grep "404" && return 0
+        )
       )
-    fi
-  done
+    )
+  fi
 }
 
 # Get current version from lerna.json
@@ -47,7 +48,7 @@ echo "Current lerna.json version: ${PACKAGE_VERSION}"
 
 # check if there were any changes to packages between current and previous commit
 count=$(git diff HEAD~1..HEAD --name-only -- packages | awk '{c++} END {print c}')
-
+count="1"
 if [ -z "$count" ]; then
   echo "No changes in packages, skipping packages publishing"
 else
@@ -57,6 +58,7 @@ else
   echo $'\nGit status:'
   git status -s
 
+  prepare_version_commit
 
   echo $'\nBuilding packages'
 
@@ -66,19 +68,18 @@ else
     yarn workspace @grafana/"${PACKAGE}" run build
     runtime=$((($(date +%s%N) - start)/1000000))
     if [ "${CIRCLE_BRANCH}" == "master" ]; then
-    exit_if_fail ./scripts/ci-metrics-publisher.sh "grafana.ci-buildtimes.$CIRCLE_JOB.$PACKAGE=$runtime"
+      exit_if_fail ./scripts/ci-metrics-publisher.sh "grafana.ci-buildtimes.$CIRCLE_JOB.$PACKAGE=$runtime"
+    fi
+  
+    exit_status=$?
+    if [ $exit_status -eq 0 ]; then
+      unpublish_previous_canary "$PACKAGE"
+    else
+      echo "Packages build failed, skipping canary release"
+      # TODO: notify on slack/email?
+      exit
     fi
   done
-
-  exit_status=$?
-  if [ $exit_status -eq 1 ]; then
-    echo "Packages build failed, skipping canary release"
-    # TODO: notify on slack/email?
-    exit
-  fi
-  prapare_version_commit
-
-  unpublish_previous_canary
 
   echo $'\nPublishing packages'
   yarn packages:publishCanary

--- a/scripts/circle-release-next-packages.sh
+++ b/scripts/circle-release-next-packages.sh
@@ -30,7 +30,7 @@ function unpublish_previous_canary () {
       echo "$_response" | grep "404" || (
         # We want to deprecate here, rather than fail and return an non-0 exit code
         echo "Unpublish unsuccessful [$?]. Deprecating @grafana/${_package}@${CURRENT_CANARY}"
-        _response=$(npm deprecate @grafana/"${_package}"@"${CURRENT_CANARY}" "this package has been deprecated") || (
+        _response=$(npm deprecate @grafana/"${_package}"@"${CURRENT_CANARY}" "this package has been deprecated" 2>&1) || (
           echo "$_response" | grep "404" && return 0
         )
       )


### PR DESCRIPTION
On unpublish, if a 404 error is encountered, ignore it as an error. Otherwise, deprecate the package.