### PR TITLE
DashboardListPanel: Fixed problem with empty panel after going into edit mode (General folder filter being automatically added) 

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -110,7 +110,7 @@ export class FolderPicker extends PureComponent<Props, State> {
 
     let folder: SelectableValue<number> = { value: -1 };
 
-    if (initialFolderId !== undefined && initialFolderId > -1) {
+    if (initialFolderId !== undefined && initialFolderId !== null && initialFolderId > -1) {
       folder = options.find(option => option.value === initialFolderId) || { value: -1 };
     } else if (enableReset && initialTitle) {
       folder = resetFolder;


### PR DESCRIPTION
Discovered that the dashboard list panel was broken in master/6.7 with the change to the folder picker (the default null / all state to the folder picker did not work and it always added a folderId: 0 filter after going into edit mode) 

