### PR TITLE
DataLinks: Do not full page reload data links clicks

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -218,7 +218,7 @@ const ContextMenuItem: React.FC<ContextMenuItemProps> = React.memo(
       <div className={styles.item}>
         <a
           href={url ? url : undefined}
-          target={target || '_self'}
+          target={target}
           className={cx(className, styles.link)}
           onClick={e => {
             if (onClick) {


### PR DESCRIPTION
Fixes #23399

this full page reload is no longer needed as we now support reloading template variables via url 