### PR TITLE
Docs: Document default limit of /api/folders

### DIFF
--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -28,7 +28,7 @@ that you cannot use this API for retrieving information about the General folder
 
 `GET /api/folders`
 
-Returns all folders that the authenticated user has permission to view.
+Returns all folders that the authenticated user has permission to view. You can control the maximum number of folders returned through the `limit` query parameter, the default is 1000.
 
 **Example Request**:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Document the default limit (1000) of the API endpoint /api/folders.

**Which issue(s) this PR fixes**:

Fixes #23407.

