### PR TITLE
Documentation: document folder api limit

### DIFF
--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -28,7 +28,11 @@ that you cannot use this API for retrieving information about the General folder
 
 `GET /api/folders`
 
-Returns all folders that the authenticated user has permission to view.
+Returns all folders that the authenticated user has permission to view. 
+
+**Query parameters**:
+
+* **limit**: Number of results to return. Defaults to `1000`
 
 **Example Request**:
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
Adds a note about the default limit on `/api/folders` (1000).

**Which issue(s) this PR fixes**:

Fixes: #23407 


