### PR TITLE
Learnings from latest automated git publish. Small tweaks

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/test/docker-compose.yml
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/test/docker-compose.yml
@@ -6,3 +6,5 @@ services:
     volumes:
       - ../scripts:/home/circleci/scripts
       - ../install:/home/circleci/install
+      - ${HOME}/.ssh:/root/.ssh
+      - ../../..:/home/circleci/grafana-toolkit

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/test/start.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/test/start.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+function finish {
+  echo "Exiting and cleaning up docker image"
+  docker-compose down
+}
+trap finish EXIT
+
 # Enter the docker container
 docker-compose run citest bash -c "cd /home/circleci; exec bash --login -i"

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
@@ -69,10 +69,11 @@ const prepareRelease = useSpinner<any>('Preparing release', async ({ dryrun, ver
     ['git', ['config', 'user.email', DEFAULT_EMAIL_ADDRESS]],
     ['git', ['config', 'user.name', DEFAULT_USERNAME]],
     await checkoutBranch(`release-${pluginJson.info.version}`),
-    ['cp', ['-rf', distContentDir, 'dist']],
-    ['git', ['add', '--force', distDir], { dryrun }],
+    ['/bin/rm', ['-rf', 'dist'], { dryrun }],
+    ['mv', ['-v', distContentDir, 'dist']],
     ['git', ['add', '--force', 'dist'], { dryrun }],
     ['/bin/rm', ['-rf', 'src'], { enterprise: true }],
+    ['git', ['rm', '-rf', 'src'], { enterprise: true }],
     [
       'git',
       ['commit', '-m', `automated release ${pluginJson.info.version} [skip ci]`],
@@ -81,8 +82,9 @@ const prepareRelease = useSpinner<any>('Preparing release', async ({ dryrun, ver
         okOnError: [/nothing to commit/g, /nothing added to commit/g, /no changes added to commit/g],
       },
     ],
-    ['git', ['tag', '-f', pluginJson.info.version]],
     ['git', ['push', '-f', 'origin', `release-${pluginJson.info.version}`], { dryrun }],
+    ['git', ['tag', '-f', `v${pluginJson.info.version}`]],
+    ['git', ['push', '-f', 'origin', `v${pluginJson.info.version}`]],
   ];
 
   for (let line of githubPublishScript) {


### PR DESCRIPTION
As more plugins are published, there are more learnings and small tweaks to get us to that elusive "publish all plugins with the same tool" goal.

In this round we learned the following:
- Beef up the testing tools. The circleci testing docker image shuts itself down and cleans up after itself on exit.
- Clean out the dist dir, and move the lastest build into the dist dir when publishing.
- To remove the src dir for enterprise plugins, ensure you not only delete the files, but then `git rm` the files after and then check in
- Checkin the build then tag, then check in the tag.