### PR TITLE
Chore: export OptionsUIRegistryBuilder on grafana/data

### DIFF
--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -24,6 +24,7 @@ export * from './fieldColor';
 export * from './theme';
 export * from './orgs';
 export * from './flot';
+export * from './OptionsUIRegistryBuilder';
 
 import * as AppEvents from './appEvents';
 import { AppEvent } from './appEvents';

--- a/packages/grafana-data/src/utils/index.ts
+++ b/packages/grafana-data/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './labels';
 export * from './object';
 export * from './namedColorsPalette';
 export * from './series';
+export * from './OptionsUIBuilders';
 
 export { getMappedValue } from './valueMappings';
 export { getFlotPairs, getFlotPairsConstant } from './flotPairs';

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -1,6 +1,6 @@
 import { SingleStatBaseOptions, BigValueColorMode, BigValueGraphMode, BigValueJustifyMode } from '@grafana/ui';
 import { ReducerID, SelectableValue, standardEditorsRegistry } from '@grafana/data';
-import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
+import { PanelOptionsEditorBuilder } from '@grafana/data';
 
 // Structure copied from angular
 export interface StatPanelOptions extends SingleStatBaseOptions {


### PR DESCRIPTION
this avoids importing from:
```
import { PanelOptionsEditorBuilder } from '@grafana/data/src/utils/OptionsUIBuilders';
```