### PR TITLE
Update contributing doc to install node@12.

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -20,7 +20,7 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 ```
 brew install git
 brew install go
-brew install node
+brew install node@12
 
 npm install -g yarn
 ```


### PR DESCRIPTION
Node > 13 doesn't work to build grafana and is the new default in brew.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>
