### PR TITLE
CloudWatch: Prefer webIdentity over EC2 role

### DIFF
--- a/pkg/components/imguploader/s3uploader.go
+++ b/pkg/components/imguploader/s3uploader.go
@@ -58,8 +58,8 @@ func (u *S3Uploader) Upload(ctx context.Context, imageDiskPath string) (string, 
 				SecretAccessKey: u.secretKey,
 			}},
 			&credentials.EnvProvider{},
-			remoteCredProvider(sess),
 			webIdentityProvider(sess),
+			remoteCredProvider(sess),
 		})
 	cfg := &aws.Config{
 		Region:           aws.String(u.region),

--- a/pkg/tsdb/cloudwatch/credentials.go
+++ b/pkg/tsdb/cloudwatch/credentials.go
@@ -106,8 +106,8 @@ func GetCredentials(dsInfo *DatasourceInfo) (*credentials.Credentials, error) {
 				SecretAccessKey: dsInfo.SecretKey,
 			}},
 			&credentials.SharedCredentialsProvider{Filename: "", Profile: dsInfo.Profile},
-			remoteCredProvider(sess),
 			webIdentityProvider(sess),
+			remoteCredProvider(sess),
 		})
 
 	credentialCacheLock.Lock()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The order of the credentials is meaningful. As pods run on EC2 instances that have EC2 roles attached, this change prioritises the Pod IAM Role over the EC2 IAM role.

**Which issue(s) this PR fixes**:
Pod IAM role is being ignored if the EC2 instance has a role attached.

Improves: https://github.com/grafana/grafana/pull/21594 

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
