### PR TITLE
e2e: Do not import from indexes

### DIFF
--- a/packages/grafana-data/src/field/FieldConfigOptionsRegistry.tsx
+++ b/packages/grafana-data/src/field/FieldConfigOptionsRegistry.tsx
@@ -1,4 +1,4 @@
-import { Registry } from '../utils';
-import { FieldConfigPropertyItem } from '../types';
+import { Registry } from '../utils/Registry';
+import { FieldConfigPropertyItem } from '../types/fieldOverrides';
 
 export class FieldConfigOptionsRegistry extends Registry<FieldConfigPropertyItem> {}

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -9,7 +9,7 @@ import {
   GrafanaTheme,
   TimeZone,
 } from '../types';
-import { Registry } from '../utils';
+import { Registry } from '../utils/Registry';
 import { InterpolateFunction } from './panel';
 import { StandardEditorProps } from '../field';
 import { OptionsEditorItem } from './OptionsUIRegistryBuilder';

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -24,7 +24,6 @@ export * from './fieldColor';
 export * from './theme';
 export * from './orgs';
 export * from './flot';
-export * from './OptionsUIRegistryBuilder';
 
 import * as AppEvents from './appEvents';
 import { AppEvent } from './appEvents';

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -1,12 +1,7 @@
-import {
-  FieldType,
-  FieldConfigEditorProps,
-  FieldConfigPropertyItem,
-  PanelOptionsEditorConfig,
-  PanelOptionsEditorItem,
-  FieldConfigEditorConfig,
-} from '../types';
+import { FieldConfigEditorProps, FieldConfigPropertyItem, FieldConfigEditorConfig } from '../types/fieldOverrides';
 import { OptionsUIRegistryBuilder } from '../types/OptionsUIRegistryBuilder';
+import { FieldType } from '../types/dataFrame';
+import { PanelOptionsEditorConfig, PanelOptionsEditorItem } from '../types/panel';
 import {
   numberOverrideProcessor,
   selectOverrideProcessor,

--- a/packages/grafana-data/src/utils/index.ts
+++ b/packages/grafana-data/src/utils/index.ts
@@ -8,7 +8,7 @@ export * from './labels';
 export * from './object';
 export * from './namedColorsPalette';
 export * from './series';
-export * from './OptionsUIBuilders';
+export { PanelOptionsEditorBuilder, FieldConfigEditorBuilder } from './OptionsUIBuilders';
 
 export { getMappedValue } from './valueMappings';
 export { getFlotPairs, getFlotPairsConstant } from './flotPairs';


### PR DESCRIPTION
Refactor some imports from index files that might cause circular dependency. This is not a permanent solution as there are a lot of such imports in the packages. This fixes this one particular case with field config registry. We gonna have to come up with some linting or other solution that prevents index imports, as those are usually troublemakers in grafana-data.