### PR TITLE
Docs: Change Grafana.net to Grafana.com/plugins

### DIFF
--- a/docs/sources/features/datasources/_index.md
+++ b/docs/sources/features/datasources/_index.md
@@ -38,4 +38,4 @@ The following data sources are officially supported:
 
 ## Data source plugins
 
-Since Grafana 3.0 you can install data sources as plugins. Check out [Grafana.net](https://grafana.com/plugins) for more data sources.
+Since Grafana 3.0 you can install data sources as plugins. Check out [Grafana.com/plugins](https://grafana.com/plugins) for more data sources.


### PR DESCRIPTION
This already linked to grafana.com, I just changed the text of the link to reflect where the link actually directs you to.