### PR TITLE
BackendPlugins: update to sdk v0.42.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/gosimple/slug v1.4.2
 	github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4
-	github.com/grafana/grafana-plugin-sdk-go v0.39.0
+	github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52
 	github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd
 	github.com/hashicorp/go-plugin v1.2.2
 	github.com/hashicorp/go-version v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/gosimple/slug v1.4.2
 	github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4
-	github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52
+	github.com/grafana/grafana-plugin-sdk-go v0.42.0
 	github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd
 	github.com/hashicorp/go-plugin v1.2.2
 	github.com/hashicorp/go-version v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.39.0 h1:tPP83HeY9gN4q8O3tYka1vd82OQ/
 github.com/grafana/grafana-plugin-sdk-go v0.39.0/go.mod h1:xRhfTHl+Dkqf2Py6Lr4pcHBC5pm8/N+IwPJ0R/iAHMM=
 github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52 h1:WEfl8G9uHk31r3pnAmsK+NRcHGpXnXauWmbhic3KuVU=
 github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52/go.mod h1:xRhfTHl+Dkqf2Py6Lr4pcHBC5pm8/N+IwPJ0R/iAHMM=
+github.com/grafana/grafana-plugin-sdk-go v0.42.0 h1:8oiAQa/uABBFT70GDAv3BnqHfdMOxy/P8SzYVURJH6Y=
+github.com/grafana/grafana-plugin-sdk-go v0.42.0/go.mod h1:xRhfTHl+Dkqf2Py6Lr4pcHBC5pm8/N+IwPJ0R/iAHMM=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd h1:rNuUHR+CvK1IS89MMtcF0EpcVMZtjKfPRp4MEmt/aTs=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4 h1:SP
 github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4/go.mod h1:nc0XxBzjeGcrMltCDw269LoWF9S8ibhgxolCdA1R8To=
 github.com/grafana/grafana-plugin-sdk-go v0.39.0 h1:tPP83HeY9gN4q8O3tYka1vd82OQ/3CFdwx4QeEhJ0Qc=
 github.com/grafana/grafana-plugin-sdk-go v0.39.0/go.mod h1:xRhfTHl+Dkqf2Py6Lr4pcHBC5pm8/N+IwPJ0R/iAHMM=
+github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52 h1:WEfl8G9uHk31r3pnAmsK+NRcHGpXnXauWmbhic3KuVU=
+github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52/go.mod h1:xRhfTHl+Dkqf2Py6Lr4pcHBC5pm8/N+IwPJ0R/iAHMM=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd h1:rNuUHR+CvK1IS89MMtcF0EpcVMZtjKfPRp4MEmt/aTs=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=

--- a/pkg/plugins/transform_plugin.go
+++ b/pkg/plugins/transform_plugin.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -198,7 +197,7 @@ func (s *transformCallback) QueryData(ctx context.Context, req *pluginv2.QueryDa
 			if err != nil {
 				return nil, err
 			}
-			encFrame, err := data.MarshalArrow(frame)
+			encFrame, err := frame.MarshalArrow()
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +206,7 @@ func (s *transformCallback) QueryData(ctx context.Context, req *pluginv2.QueryDa
 		if res.Meta != nil {
 			b, err := res.Meta.MarshalJSON()
 			if err != nil {
-				s.logger.Error("failed to marhsal json metadata", err)
+				s.logger.Error("failed to marshal json metadata", err)
 			}
 			pRes.JsonMeta = b
 		}

--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -7,6 +7,7 @@ import (
 
 	gocontext "context"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -173,7 +174,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 		useDataframes := v.Dataframes != nil && (v.Series == nil || len(v.Series) == 0)
 
 		if useDataframes { // convert the dataframes to tsdb.TimeSeries
-			frames, err := tsdb.FramesFromBytes(v.Dataframes)
+			frames, err := data.UnmarshalArrowFrames(v.Dataframes)
 			if err != nil {
 				return nil, errutil.Wrap("tsdb.HandleRequest() failed to unmarshal arrow dataframes from bytes", err)
 			}

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -198,7 +198,7 @@ func (ctx *queryConditionTestContext) exec() (*alerting.ConditionResult, error) 
 	}
 
 	if ctx.frame != nil {
-		bFrame, err := data.MarshalArrow(ctx.frame)
+		bFrame, err := ctx.frame.MarshalArrow()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/frame_util.go
+++ b/pkg/tsdb/frame_util.go
@@ -94,16 +94,3 @@ func FrameToSeriesSlice(frame *data.Frame) (TimeSeriesSlice, error) {
 	return seriesSlice, nil
 
 }
-
-// FramesFromBytes returns a data.Frame slice from marshalled arrow dataframes.
-func FramesFromBytes(bFrames [][]byte) ([]*data.Frame, error) {
-	frames := make([]*data.Frame, len(bFrames))
-	for i, bFrame := range bFrames {
-		var err error
-		frames[i], err = data.UnmarshalArrow(bFrame)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return frames, nil
-}

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/data/arrow.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/data/arrow.go
@@ -711,7 +711,7 @@ func UnmarshalArrowFrames(bFrames [][]byte) (Frames, error) {
 
 // MarshalArrow encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
 // If an error occurs [][]byte will be nil.
-// See BytesSliceToFrames for the inverse operation.
+// See UnmarshalArrowFrames for the inverse operation.
 func (frames Frames) MarshalArrow() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/data/conversion_input.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/data/conversion_input.go
@@ -46,16 +46,16 @@ func NewFrameInputConverter(fieldConvs []FieldConverter, rowLen int) (*FrameInpu
 // Converter is not nil, then the Converter function is called before setting the value (otherwise Frame.Set is called directly).
 // If an error is returned from the Converter function this function returns that error.
 // Like Frame.Set and Field.Set, it will panic if fieldIdx or rowIdx are out of range.
-func (fcb *FrameInputConverter) Set(fieldIdx, rowIdx int, val interface{}) error {
-	if fcb.fieldConverters[fieldIdx].Converter == nil {
-		fcb.Frame.Set(fieldIdx, rowIdx, val)
+func (fic *FrameInputConverter) Set(fieldIdx, rowIdx int, val interface{}) error {
+	if fic.fieldConverters[fieldIdx].Converter == nil {
+		fic.Frame.Set(fieldIdx, rowIdx, val)
 		return nil
 	}
-	convertedVal, err := fcb.fieldConverters[fieldIdx].Converter(val)
+	convertedVal, err := fic.fieldConverters[fieldIdx].Converter(val)
 	if err != nil {
 		return err
 	}
-	fcb.Frame.Set(fieldIdx, rowIdx, convertedVal)
+	fic.Frame.Set(fieldIdx, rowIdx, convertedVal)
 	return nil
 }
 

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/data/frame.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/data/frame.go
@@ -43,7 +43,7 @@ type Frame struct {
 	Warnings []Warning // TODO: Remove, will be replaced with FrameMeta.Notices.
 }
 
-// Frames is a a collection of Frames as a slice of Frame pointers.
+// Frames is a slice of Frame pointers.
 // It is the main data container within a backend.DataResponse.
 type Frames []*Frame
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/gosimple/slug
 ## explicit
 github.com/grafana/grafana-plugin-model/go/datasource
 github.com/grafana/grafana-plugin-model/go/renderer
-# github.com/grafana/grafana-plugin-sdk-go v0.39.0
+# github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52
 ## explicit
 github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin
 github.com/grafana/grafana-plugin-sdk-go/data

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/gosimple/slug
 ## explicit
 github.com/grafana/grafana-plugin-model/go/datasource
 github.com/grafana/grafana-plugin-model/go/renderer
-# github.com/grafana/grafana-plugin-sdk-go v0.40.1-0.20200409163705-fd66aee09a52
+# github.com/grafana/grafana-plugin-sdk-go v0.42.0
 ## explicit
 github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin
 github.com/grafana/grafana-plugin-sdk-go/data


### PR DESCRIPTION
goes with https://github.com/grafana/grafana-plugin-sdk-go/pull/126

Will be wip until that is merged and tagged, and this is updated against that tag. Shouldn't break existing plugins.