### PR TITLE
Plugins: fix debug formatting when scanning for files

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -182,11 +182,11 @@ func (pm *PluginManager) scan(pluginDir string) error {
 
 	if err := util.Walk(pluginDir, true, true, scanner.walker); err != nil {
 		if xerrors.Is(err, os.ErrNotExist) {
-			pm.log.Debug("Couldn't scan dir '%s' since it doesn't exist")
+			pm.log.Debug("Couldn't scan directory since it doesn't exist", "pluginDir", pluginDir)
 			return nil
 		}
 		if xerrors.Is(err, os.ErrPermission) {
-			pm.log.Debug("Couldn't scan dir '%s' due to lack of permissions")
+			pm.log.Debug("Couldn't scan directory due to lack of permissions", "pluginDir", pluginDir)
 			return nil
 		}
 		if pluginDir != "data/plugins" {


### PR DESCRIPTION
The current logger prints a message with %s rather than showing the folder that failed 