### PR TITLE
Toolkit: catch errors from signing service

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/manifest.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/manifest.ts
@@ -77,18 +77,23 @@ const manifestRunner: TaskRunner<ManifestOptions> = async ({ folder }) => {
 
   console.log('Request Signature:', url);
   const axios = require('axios');
-  const info = await axios.post(url, manifest, {
-    headers: { Authorization: 'Bearer ' + GRAFANA_API_KEY },
-    responseType: 'arraybuffer',
-  });
-  if (info.status === 200) {
-    console.log('OK: ', info.data);
-    const buffer = new Buffer(info.data, 'binary');
-    fs.writeFileSync(outputPath, buffer);
-  } else {
-    console.warn('Error: ', info);
-    console.log('Saving the unsigned manifest');
-    fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+
+  try {
+    const info = await axios.post(url, manifest, {
+      headers: { Authorization: 'Bearer ' + GRAFANA_API_KEY },
+      responseType: 'arraybuffer',
+    });
+    if (info.status === 200) {
+      console.log('OK: ', info.data);
+      const buffer = new Buffer(info.data, 'binary');
+      fs.writeFileSync(outputPath, buffer);
+    } else {
+      console.warn('Error: ', info);
+      console.log('Saving the unsigned manifest');
+      fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+    }
+  } catch (err) {
+    console.log('ERROR Fetching response', err);
   }
 };
 


### PR DESCRIPTION
don't explode if signing service fails