### PR TITLE
Redux: Added config to redux development middlewares that checks for mutations and serializability

### DIFF
--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -31,7 +31,7 @@ export function configureStore() {
 
   const store = reduxConfigureStore<StoreState>({
     reducer: createRootReducer(),
-    middleware: [...reduxDefaultMiddlewars, ...middleware] as [ThunkMiddleware<StoreState>],
+    middleware: [... reduxDefaultMiddleware, ...middleware] as [ThunkMiddleware<StoreState>],
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: {
       navIndex: buildInitialState(),

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -23,7 +23,7 @@ export function configureStore() {
 
   const middleware = process.env.NODE_ENV !== 'production' ? [toggleLogActionsMiddleware, logger] : [];
 
-  const reduxDefaultMiddlewars = getDefaultMiddleware<StoreState>({
+  const reduxDefaultMiddleware = getDefaultMiddleware<StoreState>({
     thunk: true,
     serializableCheck: false,
     immutableCheck: false,

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -25,13 +25,8 @@ export function configureStore() {
 
   const reduxDefaultMiddlewars = getDefaultMiddleware<StoreState>({
     thunk: true,
-    serializableCheck: {
-      ignoredActions: getActionsToIgnoreSerializableCheckOn(),
-      ignoredPaths: getPathsToIgnoreMutationAndSerializableCheckOn(),
-    },
-    immutableCheck: {
-      ignoredPaths: getPathsToIgnoreMutationAndSerializableCheckOn(),
-    },
+    serializableCheck: false,
+    immutableCheck: false,
   } as any);
 
   const store = reduxConfigureStore<StoreState>({
@@ -47,6 +42,7 @@ export function configureStore() {
   return store;
 }
 
+/* 
 function getActionsToIgnoreSerializableCheckOn() {
   return [
     'dashboard/setPanelAngularComponent',
@@ -62,7 +58,7 @@ function getActionsToIgnoreSerializableCheckOn() {
 }
 
 function getPathsToIgnoreMutationAndSerializableCheckOn() {
-  return [
+  return [    
     'plugins.panels',
     'dashboard.panels',
     'dashboard.getModel',
@@ -70,6 +66,8 @@ function getPathsToIgnoreMutationAndSerializableCheckOn() {
     'panelEditorNew.getPanel',
     'panelEditorNew.getSourcePanel',
     'panelEditorNew.getData',
+    'explore.left.queryResponse',
+    'explore.right.queryResponse',
     'explore.left.datasourceInstance',
     'explore.right.datasourceInstance',
     'explore.left.range',
@@ -77,7 +75,7 @@ function getPathsToIgnoreMutationAndSerializableCheckOn() {
     'explore.right.eventBridge',
     'explore.right.range',
     'explore.left.querySubscription',
-    'explore.right.querySubscription',
-    'explore/queryStreamUpdated',
+    'explore.right.querySubscription',    
   ];
 }
+*/

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -31,7 +31,7 @@ export function configureStore() {
 
   const store = reduxConfigureStore<StoreState>({
     reducer: createRootReducer(),
-    middleware: [... reduxDefaultMiddleware, ...middleware] as [ThunkMiddleware<StoreState>],
+    middleware: [...reduxDefaultMiddleware, ...middleware] as [ThunkMiddleware<StoreState>],
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: {
       navIndex: buildInitialState(),


### PR DESCRIPTION
A recent redux toolkit & redux upgrade merged this morning broke dashboards and explore (Strange that it passed e2e tests). 

This upgrade added stricter development middleware config that throws errors when detecting actions or states that contain non serializable state, as well as detection for state mutations. 

We store quite a bit of non seralizable things in state (for what I think are mostly good reasons), things like rxjs query subscriptions, data source instance, dashboard, panel models, plugin models. They all have some mutation or nonserializable parts to them. Think some can be refactored to be immutable in the future but that will take time. 

This adds a bunch of config to ignore some actions and state paths from these checks (these checks only run in development) 