### PR TITLE
Plugins: add a deprecated state

### DIFF
--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -4,6 +4,7 @@ import { KeyValue } from './data';
 export enum PluginState {
   alpha = 'alpha', // Only included it `enable_alpha` is true
   beta = 'beta', // Will show a warning banner
+  deprecated = 'deprecated', // Will continue to work -- but not show up in the the options to add
 }
 
 export enum PluginType {

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
@@ -41,7 +41,7 @@ export const VisualizationTabUnconnected: FC<Props> = ({ panel, plugin, changePa
       if (e.key === 'Enter') {
         const query = e.currentTarget.value;
         const plugins = getAllPanelPluginMeta();
-        const match = filterPluginList(plugins, query);
+        const match = filterPluginList(plugins, query, plugin.meta);
         if (match && match.length) {
           onPluginTypeChange(match[0]);
         }

--- a/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
+++ b/public/app/features/dashboard/panel_editor/VizTypePicker.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 import config from 'app/core/config';
 import VizTypePickerPlugin from './VizTypePickerPlugin';
 import { EmptySearchResult, stylesFactory, useTheme } from '@grafana/ui';
-import { GrafanaTheme, PanelPluginMeta } from '@grafana/data';
+import { GrafanaTheme, PanelPluginMeta, PluginState } from '@grafana/data';
 import { css } from 'emotion';
 
 export interface Props {
@@ -22,14 +22,26 @@ export function getAllPanelPluginMeta(): PanelPluginMeta[] {
     .sort((a: PanelPluginMeta, b: PanelPluginMeta) => a.sort - b.sort);
 }
 
-export function filterPluginList(pluginsList: PanelPluginMeta[], searchQuery: string): PanelPluginMeta[] {
+export function filterPluginList(
+  pluginsList: PanelPluginMeta[],
+  searchQuery: string,
+  current: PanelPluginMeta
+): PanelPluginMeta[] {
   if (!searchQuery.length) {
-    return pluginsList;
+    return pluginsList.filter(p => {
+      if (p.state === PluginState.deprecated) {
+        return current.id === p.id;
+      }
+      return true;
+    });
   }
   const query = searchQuery.toLowerCase();
   const first: PanelPluginMeta[] = [];
   const match: PanelPluginMeta[] = [];
   for (const item of pluginsList) {
+    if (item.state === PluginState.deprecated && current.id !== item.id) {
+      continue;
+    }
     const name = item.name.toLowerCase();
     const idx = name.indexOf(query);
     if (idx === 0) {
@@ -65,7 +77,7 @@ export const VizTypePicker: React.FC<Props> = ({ searchQuery, onTypeChange, curr
   };
 
   const getFilteredPluginList = useCallback((): PanelPluginMeta[] => {
-    return filterPluginList(pluginsList, searchQuery);
+    return filterPluginList(pluginsList, searchQuery, current);
   }, [searchQuery]);
 
   const filteredPluginList = getFilteredPluginList();

--- a/public/app/plugins/panel/singlestat/plugin.json
+++ b/public/app/plugins/panel/singlestat/plugin.json
@@ -2,6 +2,7 @@
   "type": "panel",
   "name": "Singlestat",
   "id": "singlestat",
+  "state": "deprecated",
 
   "info": {
     "description": "Singlestat Panel for Grafana",


### PR DESCRIPTION
We need a panel state that will allow existing dashboards to keep working, but not allow people to create new panels with that visualization.  In particular the `singlestat` and angular `table` panels should prefer the `stat` panel or the react table panel.

This PR adds a `deprecated` state and applies it to the singlestat panel