### PR TITLE
Explore: Create basic E2E test

### DIFF
--- a/e2e/suite1/specs/explore.spec.ts
+++ b/e2e/suite1/specs/explore.spec.ts
@@ -1,0 +1,19 @@
+import { e2e } from '@grafana/e2e';
+
+e2e.scenario({
+  describeName: 'Explore',
+  itName: 'Basic path through Explore.',
+  addScenarioDataSource: true,
+  addScenarioDashBoard: false,
+  skipScenario: false,
+  scenario: () => {
+    e2e.pages.Explore.visit();
+    e2e.pages.Explore.General.container().should('have.length', 1);
+    e2e.pages.Explore.General.runButton().should('have.length', 1);
+
+    const canvases = e2e().get('canvas');
+    canvases.should('have.length', 2);
+
+    e2e.components.QueryEditors.TestData.noise().should('have.length', 1);
+  },
+});

--- a/packages/grafana-e2e/index.js
+++ b/packages/grafana-e2e/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 if (process.env.NODE_ENV === 'production') {
   module.exports = require('./index.production.js');

--- a/packages/grafana-e2e/src/components/index.ts
+++ b/packages/grafana-e2e/src/components/index.ts
@@ -1,0 +1,7 @@
+import { TestDataQueryEditor } from './queryEditors/testdata';
+
+export const Components = {
+  QueryEditors: {
+    TestData: TestDataQueryEditor,
+  },
+};

--- a/packages/grafana-e2e/src/components/queryEditors/testdata/index.ts
+++ b/packages/grafana-e2e/src/components/queryEditors/testdata/index.ts
@@ -1,0 +1,12 @@
+import { componentFactory } from '../../../support';
+
+export const TestDataQueryEditor = componentFactory({
+  selectors: {
+    max: 'TestData max',
+    min: 'TestData min',
+    noise: 'TestData noise',
+    seriesCount: 'TestData series count',
+    spread: 'TestData spread',
+    startValue: 'TestData start value',
+  },
+});

--- a/packages/grafana-e2e/src/noTypeCheck.ts
+++ b/packages/grafana-e2e/src/noTypeCheck.ts
@@ -4,15 +4,13 @@
 // toBe, toEqual and so forth. That's why this file is not type checked and will be so until we
 // can solve the above mentioned issue with Cypress/Jest.
 import { e2eScenario, ScenarioArguments } from './support/scenario';
-import { Pages } from './pages';
+import { Components } from './components';
 import { Flows } from './flows';
+import { Pages } from './pages';
 import { getScenarioContext, setScenarioContext } from './support/scenarioContext';
 
 export type SelectorFunction = (text?: string) => Cypress.Chainable<JQuery<HTMLElement>>;
-export type SelectorObject<S> = {
-  visit: (args?: string) => Cypress.Chainable<Window>;
-  selectors: S;
-};
+export type VisitFunction = (args?: string) => Cypress.Chainable<Window>;
 
 const e2eObject = {
   env: (args: string) => Cypress.env(args),
@@ -20,8 +18,9 @@ const e2eObject = {
   blobToBase64String: (blob: any) => Cypress.Blob.blobToBase64String(blob),
   imgSrcToBlob: (url: string) => Cypress.Blob.imgSrcToBlob(url),
   scenario: (args: ScenarioArguments) => e2eScenario(args),
-  pages: Pages,
+  components: Components,
   flows: Flows,
+  pages: Pages,
   getScenarioContext,
   setScenarioContext,
 };

--- a/packages/grafana-e2e/src/pages/explore.ts
+++ b/packages/grafana-e2e/src/pages/explore.ts
@@ -1,0 +1,9 @@
+import { pageFactory } from '../support';
+
+export const Explore = pageFactory({
+  url: '/explore',
+  selectors: {
+    container: 'Explore',
+    runButton: 'Run button',
+  },
+});

--- a/packages/grafana-e2e/src/pages/index.ts
+++ b/packages/grafana-e2e/src/pages/index.ts
@@ -9,6 +9,7 @@ import { SaveDashboardAsModal } from './saveDashboardAsModal';
 import { Dashboards } from './dashboards';
 import { DashboardSettings } from './dashboardSettings';
 import { EditPanel } from './editPanel';
+import { Explore } from './explore';
 import { TestData } from './testdata';
 import { Graph } from './graph';
 import { SaveDashboardModal } from './saveDashboardModal';
@@ -60,5 +61,9 @@ export const Pages = {
         backArrow: 'Go Back button',
       },
     }),
+  },
+  Explore: {
+    visit: () => Explore.visit(),
+    General: Explore,
   },
 };

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -61,6 +61,7 @@ import { scanStopAction } from './state/actionTypes';
 import { ExploreGraphPanel } from './ExploreGraphPanel';
 import { TraceView } from './TraceView/TraceView';
 import { SecondaryActions } from './SecondaryActions';
+import { e2e } from '@grafana/e2e';
 
 const getStyles = stylesFactory(() => {
   return {
@@ -303,7 +304,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const queryError = getFirstNonQueryRowSpecificError(queryErrors);
 
     return (
-      <div className={exploreClass} ref={this.getRef}>
+      <div className={exploreClass} ref={this.getRef} aria-label={e2e.pages.Explore.General.selectors.container}>
         <ExploreToolbar exploreId={exploreId} onChangeTime={this.onChangeTime} />
         {datasourceMissing ? this.renderEmptyState() : null}
         {datasourceInstance && (

--- a/public/app/features/explore/RunButton.tsx
+++ b/public/app/features/explore/RunButton.tsx
@@ -3,6 +3,7 @@ import { RefreshPicker } from '@grafana/ui';
 import memoizeOne from 'memoize-one';
 import { css } from 'emotion';
 import classNames from 'classnames';
+import { e2e } from '@grafana/e2e';
 
 import { ResponsiveButton } from './ResponsiveButton';
 
@@ -42,6 +43,7 @@ export function RunButton(props: Props) {
       })}
       icon={loading ? 'fa fa-spinner' : 'sync'}
       iconClassName={loading && ' fa-spin run-icon'}
+      aria-label={e2e.pages.Explore.General.selectors.runButton}
     />
   );
 

--- a/public/app/plugins/datasource/testdata/partials/query.editor.html
+++ b/public/app/plugins/datasource/testdata/partials/query.editor.html
@@ -57,7 +57,9 @@
 				ng-model="ctrl.target.seriesCount"
 				min="1"
 				step="1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()"
+				aria-label="{{::selectors.seriesCount}}"
+			/>
 		</div>
     <div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Start value</label>
@@ -66,7 +68,9 @@
 				placeholder="auto"
 				ng-model="ctrl.target.startValue"
 				step="1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()"
+				aria-label="{{::selectors.startValue}}"
+			/>
 		</div>
 		<div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Spread</label>
@@ -76,7 +80,9 @@
 				ng-model="ctrl.target.spread"
 				min="0.5"
 				step="0.1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()"
+				aria-label="{{::selectors.spread}}"
+			/>
 		</div>
 		<div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Noise</label>
@@ -86,7 +92,9 @@
 				ng-model="ctrl.target.noise"
 				min="0"
 				step="0.1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()"
+				aria-label="{{::selectors.noise}}"
+			/>
 		</div>
     <div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Min</label>
@@ -95,7 +103,9 @@
 				placeholder="none"
 				ng-model="ctrl.target.min"
 				step="0.1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()" 
+				aria-label="{{::selectors.min}}"
+			/>
 		</div>
     <div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Max</label>
@@ -104,7 +114,9 @@
 				placeholder="none"
 				ng-model="ctrl.target.max"
 				step="0.1"
-				ng-change="ctrl.refresh()" />
+				ng-change="ctrl.refresh()"
+				aria-label="{{::selectors.max}}"
+			/>
 		</div>
   </div>
 	<div class="gf-form-inline" ng-if="ctrl.scenario.id === 'streaming_client'">
@@ -127,7 +139,8 @@
 				ng-model="ctrl.target.stream.speed"
 				min="10"
 				step="10"
-				ng-change="ctrl.streamChanged()" />
+				ng-change="ctrl.streamChanged()"
+				/>
 		</div>
 		<div class="gf-form" ng-if="ctrl.target.stream.type === 'signal'">
 			<label class="gf-form-label query-keyword">Spread</label>

--- a/public/app/plugins/datasource/testdata/query_ctrl.ts
+++ b/public/app/plugins/datasource/testdata/query_ctrl.ts
@@ -6,7 +6,6 @@ import { QueryCtrl } from 'app/plugins/sdk';
 import { defaultQuery } from './runStreams';
 import { getBackendSrv } from '@grafana/runtime';
 import { promiseToDigest } from 'app/core/utils/promiseToDigest';
-import { IScope } from 'angular';
 
 export const defaultPulse: any = {
   timeStep: 60,
@@ -37,8 +36,12 @@ export class TestDataQueryCtrl extends QueryCtrl {
   selectors: typeof e2e.pages.Dashboard.Panels.DataSource.TestData.QueryTab.selectors;
 
   /** @ngInject */
-  constructor($scope: IScope, $injector: any) {
+  constructor($scope: any, $injector: any) {
     super($scope, $injector);
+
+    $scope.selectors = {
+      ...e2e.components.QueryEditors.TestData.selectors,
+    };
 
     this.target.scenarioId = this.target.scenarioId || 'random_walk';
     this.scenarioList = [];


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a basic E2E test for Explore.
- Since one of the elements that I wanted to check (a query form field) is also used in the Dashboard, only `pages` and `flows` didn't seem enough to me. So I added `components` on the same level.
- Added a `componentFactory` and refactored types around the area a bit (minor simplification and naming aspects).

**Which issue(s) this PR fixes**:
- Not having any E2E test for Explore. :wink:
