### PR TITLE
Toolkit: Fix - 404 is returned as an exception. Handle properly

### DIFF
--- a/packages/grafana-toolkit/src/cli/utils/githubRelease.ts
+++ b/packages/grafana-toolkit/src/cli/utils/githubRelease.ts
@@ -77,7 +77,14 @@ class GitHubRelease {
       if (latestRelease.data.tag_name === `v${pluginInfo.version}`) {
         await this.git.client.delete(`releases/${latestRelease.data.id}`);
       }
+    } catch (reason) {
+      if (reason.response.status !== 404) {
+        // 404 just means no release found. Not an error. Anything else though, re throw the error
+        throw reason;
+      }
+    }
 
+    try {
       // Now make the release
       const newReleaseResponse = await this.git.client.post('releases', {
         tag_name: `v${pluginInfo.version}`,


### PR DESCRIPTION
Why?

If a previous release is not found, the githubClient throws an exception rather than returning "not found". Well, it returns it as an exception, which causes the publish to fail.

So...

This fix makes it so the 404 does not crash the publish, but still will throw exceptions for everything else.
