### PR TITLE
Docs: Fix example jaeger agent port 

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -849,7 +849,7 @@ for the full list. Environment variables will override any settings provided her
 
 ### address
 
-The host:port destination for reporting spans. (ex: `localhost:6381`)
+The host:port destination for reporting spans. (ex: `localhost:6831`)
 
 Can be set with the environment variables `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT`.
 


### PR DESCRIPTION
Fixed jaeger port in docs according to jaeger documentation here https://www.jaegertracing.io/docs/1.17/deployment/#agent

