### PR TITLE
Lower log level for some startup logs statements

### DIFF
--- a/pkg/api/live/stream_manager.go
+++ b/pkg/api/live/stream_manager.go
@@ -27,7 +27,7 @@ func NewStreamManager() *StreamManager {
 }
 
 func (sm *StreamManager) Run(context context.Context) {
-	log.Info("Initializing Stream Manager")
+	log.Debug("Initializing Stream Manager")
 
 	go func() {
 		sm.hub.run(context)

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -135,7 +135,7 @@ func (s *Server) Run() (err error) {
 					// Server has crashed.
 					s.log.Error("Stopped "+descriptor.Name, "reason", err)
 				} else {
-					s.log.Info("Stopped "+descriptor.Name, "reason", err)
+					s.log.Debug("Stopped "+descriptor.Name, "reason", err)
 				}
 
 				return err

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -100,7 +100,7 @@ func (s *Server) Run() (err error) {
 			continue
 		}
 
-		s.log.Info("Initializing " + service.Name)
+		s.log.Debug("Initializing " + service.Name)
 
 		if err := service.Instance.Init(); err != nil {
 			return errutil.Wrapf(err, "Service init failed")


### PR DESCRIPTION
The goal is to make deprecations etc more prominent. Regular operators dont care if certain services are Initializiced in Grafana.