### PR TITLE
Explore: Replace icons for icon buttons in logDetailsRow

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -10,7 +10,7 @@ import { stylesFactory } from '../../themes/stylesFactory';
 //Components
 import { LogLabelStats } from './LogLabelStats';
 import { LinkButton } from '../Button/Button';
-import { Icon } from '../Icon/Icon';
+import { IconButton } from '../IconButton/IconButton';
 
 export interface Props extends Themeable {
   parsedValue: string;
@@ -95,16 +95,16 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
       <tr className={cx(style.logDetailsValue, { [styles.noHoverBackground]: showFieldsStats })}>
         {/* Action buttons - show stats/filter results */}
         <td className={style.logsDetailsIcon} colSpan={isLabel ? undefined : 3}>
-          <Icon name="signal" title={'Ad-hoc statistics'} onClick={this.showStats} />
+          <IconButton name="signal" title={'Ad-hoc statistics'} onClick={this.showStats} />
         </td>
 
         {isLabel && (
           <>
             <td className={style.logsDetailsIcon}>
-              <Icon name="search-minus" title="Filter for value" onClick={this.filterLabel} />
+              <IconButton name="search-minus" title="Filter for value" onClick={this.filterLabel} />
             </td>
             <td className={style.logsDetailsIcon}>
-              <Icon name="search-plus" title="Filter out value" onClick={this.filterOutLabel} />
+              <IconButton name="search-plus" title="Filter out value" onClick={this.filterOutLabel} />
             </td>
           </>
         )}

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -149,7 +149,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     `,
     logDetailsTable: css`
       label: logs-row-details-table;
-      line-height: 2;
+      line-height: 1.7;
       width: 100%;
       td:last-child {
         width: 100%;
@@ -159,9 +159,8 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       label: logs-row-details__icon;
       position: relative;
       color: ${theme.palette.gray3};
-      svg {
-        margin-right: ${theme.spacing.md};
-      }
+      padding-top: 6px;
+      padding-left: 6px;
     `,
     logDetailsLabel: css`
       label: logs-row-details__label;
@@ -178,7 +177,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     logDetailsValue: css`
       label: logs-row-details__row;
       position: relative;
-      vertical-align: top;
+      vertical-align: middle;
       cursor: default;
       &:hover {
         background-color: ${bgColor};


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace Icon component used in logRowDetails for IconButton.

![image](https://user-images.githubusercontent.com/30407135/79081657-bd344900-7d1f-11ea-9c13-d635db3d6985.png)
![image](https://user-images.githubusercontent.com/30407135/79081660-c4f3ed80-7d1f-11ea-8775-f09be116c86c.png)
![image](https://user-images.githubusercontent.com/30407135/79081663-cc1afb80-7d1f-11ea-98d8-5b2ff2d43a31.png)


