### PR TITLE
Alerting: Fixes notifications for alerts with empty message in Google Hangouts notifier

### DIFF
--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -126,13 +126,15 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		gcn.log.Error("evalContext returned an invalid rule URL")
 	}
 
-	// add a text paragraph widget for the message
-	widgets := []widget{
-		textParagraphWidget{
+	var widgets []widget
+	if len(evalContext.Rule.Message) > 0 {
+		// add a text paragraph widget for the message if there is a message
+		// Google Chat API doesn't accept an empty text property
+		widgets = append(widgets, textParagraphWidget{
 			Text: text{
 				Text: evalContext.Rule.Message,
 			},
-		},
+		})
 	}
 
 	// add a text paragraph widget for the fields

--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -126,7 +126,7 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		gcn.log.Error("evalContext returned an invalid rule URL")
 	}
 
-	var widgets []widget
+	widgets := []widget{}
 	if len(evalContext.Rule.Message) > 0 {
 		// add a text paragraph widget for the message if there is a message
 		// Google Chat API doesn't accept an empty text property


### PR DESCRIPTION
**What this PR does / why we need it**:
Google Chat API doesn't accept an empty `text` property, so this makes sure it's only added when a message exists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

