### PR TITLE
Runtime: make sure we don't lose nested default config values

### DIFF
--- a/e2e/suite1/specs/queryVariableCrud.spec.ts
+++ b/e2e/suite1/specs/queryVariableCrud.spec.ts
@@ -617,11 +617,5 @@ e2e.scenario({
 
     // assert that move up works
     assertMoveUpItem(queryVariables);
-
-    e2e()
-      .window()
-      .then((win: any) => {
-        logSection('This scenario ran with these featureToggles', win.grafanaBootData.settings.featureToggles);
-      });
   },
 });

--- a/e2e/suite1/specs/queryVariableCrud.spec.ts
+++ b/e2e/suite1/specs/queryVariableCrud.spec.ts
@@ -24,12 +24,8 @@ const assertDefaultsForNewVariable = () => {
   e2e()
     .window()
     .then((win: any) => {
-      let chainer = 'not.exist';
-      let value: string = undefined;
-      if (win.grafanaBootData.settings.featureToggles.newVariables) {
-        chainer = 'have.text';
-        value = '';
-      }
+      const chainer = 'have.text';
+      const value = '';
 
       e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsDataSourceSelect().within(select => {
         e2e()
@@ -85,10 +81,8 @@ const createQueryVariable = ({ name, label, dataSourceName, query }: CreateQuery
   e2e()
     .window()
     .then((win: any) => {
-      let text = `string:${dataSourceName}`;
-      if (win.grafanaBootData.settings.featureToggles.newVariables) {
-        text = `${dataSourceName}`;
-      }
+      const text = `${dataSourceName}`;
+
       e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsDataSourceSelect()
         .select(text)
         .blur();
@@ -352,11 +346,7 @@ const assertUpdateItem = (data: QueryVariableData[]) => {
   e2e()
     .window()
     .then((win: any) => {
-      if (win.grafanaBootData.settings.featureToggles.newVariables) {
-        queryVariables[1].selectedOption = 'A constant';
-      } else {
-        queryVariables[1].selectedOption = 'undefined';
-      }
+      queryVariables[1].selectedOption = 'A constant';
       assertVariableLabelAndComponent(queryVariables[1]);
     });
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -111,4 +111,3 @@ const options = bootData.settings;
 options.bootData = bootData;
 
 export const config = new GrafanaBootConfig(options);
-console.log('config', config);

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,4 +1,4 @@
-import extend from 'lodash/extend';
+import merge from 'lodash/merge';
 import { getTheme } from '@grafana/ui';
 import { DataSourceInstanceSettings, GrafanaTheme, GrafanaThemeType, PanelPluginMeta } from '@grafana/data';
 
@@ -97,7 +97,7 @@ export class GrafanaBootConfig {
       disableSanitizeHtml: false,
     };
 
-    extend(this, defaults, options);
+    merge(this, defaults, options);
   }
 }
 
@@ -111,3 +111,4 @@ const options = bootData.settings;
 options.bootData = bootData;
 
 export const config = new GrafanaBootConfig(options);
+console.log('config', config);


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this PR we will lose all nested default values if parts of the nested object is set in the override configuration.

**Special notes for your reviewer**:
I just changed to `merge` instead of `extend` which will merge all of the source objects into the current object and skip everything form the source objects that is undefined or not set.
