### PR TITLE
Toolkit: Fix error for running in linked mode vs non-linked mode

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
@@ -1,28 +1,3 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-
-const entrypoint = () => {
-  const defaultEntryPoint = '../src/cli/index.js';
-  const toolkitDirectory = `${process.env['PWD']}/node_modules/@grafana/toolkit`;
-
-  // IF we have a toolkit directory AND linked grafana toolkit AND the toolkit dir is a symbolic lik
-  // THEN run everything in linked mode
-  if (fs.existsSync(toolkitDirectory)) {
-    const tkStat = fs.lstatSync(toolkitDirectory);
-    if (tkStat.isSymbolicLink()) {
-      console.log('Running in linked mode', `${__dirname}/grafana-toolkit.js`);
-      return `${__dirname}/grafana-toolkit.js`;
-    }
-  }
-
-  // We are using npx, and a relative path does not find index.js
-  if (!fs.existsSync(defaultEntryPoint) && fs.existsSync(`${__dirname}/../dist/src/cli/index.js`)) {
-    return `${__dirname}/../dist/src/cli/index.js`;
-  }
-
-  // The default entrypoint must exist, return it now.
-  return defaultEntryPoint;
-};
-
-require(entrypoint()).run();
+require(`${__dirname}/grafana-toolkit.js`);

--- a/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
@@ -25,4 +25,4 @@ const entrypoint = () => {
   return defaultEntryPoint;
 };
 
-require(entrypoint());
+require(entrypoint()).run();


### PR DESCRIPTION
In linked mode, requiring grafana-toolkit.js had an error. The run called was handled by grafana-toolkit.js, and therefore returned undefined to grafana-toolkit.dist.js. 

This PR moves all of the legwork to grafana-toolkit.js (are we running in linked mode etc) and dist just now calls grafana-toolkit.js.