### PR TITLE
Toolkit: Copy config files to dist for plugin use/Fix circleci build errors

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
@@ -1,28 +1,3 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-
-const entrypoint = () => {
-  const defaultEntryPoint = '../src/cli/index.js';
-  const toolkitDirectory = `${process.env['PWD']}/node_modules/@grafana/toolkit`;
-
-  // IF we have a toolkit directory AND linked grafana toolkit AND the toolkit dir is a symbolic lik
-  // THEN run everything in linked mode
-  if (fs.existsSync(toolkitDirectory)) {
-    const tkStat = fs.lstatSync(toolkitDirectory);
-    if (tkStat.isSymbolicLink()) {
-      console.log('Running in linked mode', `${__dirname}/grafana-toolkit.js`);
-      return `${__dirname}/grafana-toolkit.js`;
-    }
-  }
-
-  // We are using npx, and a relative path does not find index.js
-  if (!fs.existsSync(defaultEntryPoint) && fs.existsSync(`${__dirname}/../dist/src/cli/index.js`)) {
-    return `${__dirname}/../dist/src/cli/index.js`;
-  }
-
-  // The default entrypoint must exist, return it now.
-  return defaultEntryPoint;
-};
-
-require(entrypoint()).run();
+require(`${__dirname}/grafana-toolkit.js`);

--- a/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
@@ -25,4 +25,4 @@ const entrypoint = () => {
   return defaultEntryPoint;
 };
 
-require(entrypoint());
+require(entrypoint()).run();

--- a/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.dist.js
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require(`${__dirname}/grafana-toolkit.js`);

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -6,24 +6,18 @@ const path = require('path');
 let includeInternalScripts = false;
 
 const isLinkedMode = () => {
-  let pwd = process.env['PWD'];
-
   // In circleci we are in linked mode. Detect by using the circle working directory,
   // rather than the present working directory.
-  if (process.env['CIRCLE_WORKING_DIRECTORY']) {
-    pwd = process.env['CIRCLE_WORKING_DIRECTORY'];
-  }
+  const pwd = process.env.CIRCLE_WORKING_DIRECTORY || process.env.PWD;
 
   if (path.basename(pwd) === 'grafana-toolkit') {
     return true;
   }
 
-  const linkedDir = `${pwd}/node_modules/@grafana/toolkit`.replace('~', process.env.HOME);
-  if (fs.existsSync(linkedDir)) {
-    const tkStat = fs.lstatSync(linkedDir);
-    if (tkStat.isSymbolicLink()) {
-      return true;
-    }
+  try {
+    return fs.lstatSync(`${pwd}/node_modules/@grafana/toolkit`.replace('~', process.env.HOME)).isSymbolicLink();
+  } catch {
+    return false;
   }
 
   return false;

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -3,28 +3,48 @@
 const fs = require('fs');
 const path = require('path');
 
-let includeInternalScripts = false;
+let includeInternalScripts = true;
+
+const isLinkedMode = () => {
+  let pwd = process.env['PWD'];
+
+  // In circleci we are in linked mode. Detect by using the circle working directory,
+  // rather than the present working directory.
+  if (process.env['CIRCLE_WORKING_DIRECTORY']) {
+    pwd = process.env['CIRCLE_WORKING_DIRECTORY'];
+  }
+
+  if (path.basename(pwd) === 'grafana-toolkit') {
+    return true;
+  }
+
+  const linkedDir = `${pwd}/node_modules/@grafana/toolkit`.replace('~', process.env.HOME);
+  if (fs.existsSync(linkedDir)) {
+    const tkStat = fs.lstatSync(linkedDir);
+    if (tkStat.isSymbolicLink()) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 const entrypoint = () => {
-  const defaultEntryPoint = '../src/cli/index.js';
-  const toolkitDirectory = `${process.env['PWD']}/node_modules/@grafana/toolkit`;
+  const defaultEntryPoint = `${__dirname}/../src/cli/index.js`;
 
   // IF we have a toolkit directory AND linked grafana toolkit AND the toolkit dir is a symbolic lik
   // THEN run everything in linked mode
-  if (fs.existsSync(toolkitDirectory)) {
-    const tkStat = fs.lstatSync(toolkitDirectory);
-    if (tkStat.isSymbolicLink()) {
-      console.log('Running in linked mode');
-      // This bin is used for cli executed internally
-      var tsProjectPath = path.resolve(__dirname, '../tsconfig.json');
-      require('ts-node').register({
-        project: tsProjectPath,
-        transpileOnly: true,
-      });
+  if (isLinkedMode()) {
+    console.log('Running in typescript/linked mode');
+    // This bin is used for cli executed internally
+    var tsProjectPath = path.resolve(__dirname, '../tsconfig.json');
+    require('ts-node').register({
+      project: tsProjectPath,
+      transpileOnly: true,
+    });
 
-      includeInternalScripts = true;
-      return '../src/cli/index.ts';
-    }
+    includeInternalScripts = true;
+    return '../src/cli/index.ts';
   }
 
   // We are using npx, and a relative path does not find index.js

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -19,8 +19,6 @@ const isLinkedMode = () => {
   } catch {
     return false;
   }
-
-  return false;
 };
 
 const entrypoint = () => {

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-let includeInternalScripts = true;
+let includeInternalScripts = false;
 
 const isLinkedMode = () => {
   let pwd = process.env['PWD'];

--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -35,7 +35,7 @@ const entrypoint = () => {
   // IF we have a toolkit directory AND linked grafana toolkit AND the toolkit dir is a symbolic lik
   // THEN run everything in linked mode
   if (isLinkedMode()) {
-    console.log('Running in typescript/linked mode');
+    console.log('Running in local/linked mode');
     // This bin is used for cli executed internally
     var tsProjectPath = path.resolve(__dirname, '../tsconfig.json');
     require('ts-node').register({

--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -40,7 +40,7 @@ export const savePackage = useSpinner<{
 
 const preparePackage = async (pkg: any) => {
   pkg.bin = {
-    'grafana-toolkit': './bin/grafana-toolkit.dist.js',
+    'grafana-toolkit': './bin/grafana-toolkit.js',
   };
 
   await savePackage({
@@ -54,7 +54,6 @@ const copyFiles = () => {
     'README.md',
     'CHANGELOG.md',
     'config/circleci/config.yml',
-    'bin/grafana-toolkit.dist.js',
     'bin/grafana-toolkit.js',
     'src/config/prettier.plugin.config.json',
     'src/config/prettier.plugin.rc.js',

--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -53,6 +53,7 @@ const copyFiles = () => {
   const files = [
     'README.md',
     'CHANGELOG.md',
+    'config/circleci/config.yml',
     'bin/grafana-toolkit.dist.js',
     'src/config/prettier.plugin.config.json',
     'src/config/prettier.plugin.rc.js',
@@ -66,6 +67,10 @@ const copyFiles = () => {
   return useSpinner<void>(`Moving ${files.join(', ')} files`, async () => {
     const promises = files.map(file => {
       return new Promise((resolve, reject) => {
+        const basedir = path.dirname(`${distDir}/${file}`);
+        if (!fs.existsSync(basedir)) {
+          fs.mkdirSync(basedir, { recursive: true });
+        }
         fs.copyFile(`${cwd}/${file}`, `${distDir}/${file}`, err => {
           if (err) {
             reject(err);

--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -55,6 +55,7 @@ const copyFiles = () => {
     'CHANGELOG.md',
     'config/circleci/config.yml',
     'bin/grafana-toolkit.dist.js',
+    'bin/grafana-toolkit.js',
     'src/config/prettier.plugin.config.json',
     'src/config/prettier.plugin.rc.js',
     'src/config/tsconfig.plugin.json',


### PR DESCRIPTION
1. Need to explicitly copy circleci config to dist
   so that it's published
2. Detect build directory, and use "local" or "linked"
   mode for local builds.