### PR TITLE
Toolkit: Update @grafana/toolkit path to fix Windows error

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -15,7 +15,7 @@ const isLinkedMode = () => {
   }
 
   try {
-    return fs.lstatSync(`${pwd}/node_modules/@grafana/toolkit`.replace('~', process.env.HOME)).isSymbolicLink();
+    return fs.lstatSync(`${__dirname}/../../../node_modules/@grafana/toolkit`).isSymbolicLink();
   } catch {
     return false;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
`process.env.PWD` on Windows is not returning correct values
- On PowerShell, it's `undefined`
- On Git Bash it's ` /c/Users/...` instead of `C:/Users...`

So the current version of `grafana-toolkit` make local Grafana start crash.

This PR is just a replacement of PWD usage.

**Special notes for your reviewer**:
This is a fix that is working on Windows, if it has other side effect on different OS, I can close this PR and just open an issue for that.
