### PR TITLE
Improve handling of image renderer not available/installed

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -104,6 +104,7 @@ export class GrafanaBootConfig {
     tracingIntegration: false,
   };
   licenseInfo: LicenseInfo = {} as LicenseInfo;
+  rendererAvailable = false;
 
   constructor(options: GrafanaBootConfig) {
     this.theme = options.bootData.user.lightTheme ? getTheme(GrafanaThemeType.Light) : getTheme(GrafanaThemeType.Dark);

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -210,7 +210,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 			"stateInfo":  hs.License.StateInfo(),
 			"licenseUrl": hs.License.LicenseURL(c.SignedInUser),
 		},
-		"featureToggles": hs.Cfg.FeatureToggles,
+		"featureToggles":    hs.Cfg.FeatureToggles,
+		"rendererAvailable": hs.RenderService.IsAvailable(),
 	}
 
 	return jsonObj, nil

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -68,7 +68,7 @@ func (n *notificationService) SendIfNeeded(evalCtx *EvalContext) error {
 			evalCtx.ImageOnDiskPath = uploadEvalCtx.ImageOnDiskPath
 			evalCtx.ImagePublicURL = uploadEvalCtx.ImagePublicURL
 		} else {
-			n.log.Warn("Couldn't render image for alert notifaction, no image renderer found/installed. " +
+			n.log.Warn("Could not render image for alert notification, no image renderer found/installed. " +
 				"For image rendering support please install the grafana-image-renderer plugin. " +
 				"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
 		}

--- a/pkg/services/alerting/notifier.go
+++ b/pkg/services/alerting/notifier.go
@@ -53,19 +53,25 @@ func (n *notificationService) SendIfNeeded(evalCtx *EvalContext) error {
 	}
 
 	if notifierStates.ShouldUploadImage() {
-		// Create a copy of EvalContext and give it a new, shorter, timeout context to upload the image
-		uploadEvalCtx := *evalCtx
-		timeout := setting.AlertingNotificationTimeout / 2
-		var uploadCtxCancel func()
-		uploadEvalCtx.Ctx, uploadCtxCancel = context.WithTimeout(evalCtx.Ctx, timeout)
+		if n.renderService.IsAvailable() {
+			// Create a copy of EvalContext and give it a new, shorter, timeout context to upload the image
+			uploadEvalCtx := *evalCtx
+			timeout := setting.AlertingNotificationTimeout / 2
+			var uploadCtxCancel func()
+			uploadEvalCtx.Ctx, uploadCtxCancel = context.WithTimeout(evalCtx.Ctx, timeout)
 
-		// Try to upload the image without consuming all the time allocated for EvalContext
-		if err = n.renderAndUploadImage(&uploadEvalCtx, timeout); err != nil {
-			n.log.Error("Failed to render and upload alert panel image.", "ruleId", uploadEvalCtx.Rule.ID, "error", err)
+			// Try to upload the image without consuming all the time allocated for EvalContext
+			if err = n.renderAndUploadImage(&uploadEvalCtx, timeout); err != nil {
+				n.log.Error("Failed to render and upload alert panel image.", "ruleId", uploadEvalCtx.Rule.ID, "error", err)
+			}
+			uploadCtxCancel()
+			evalCtx.ImageOnDiskPath = uploadEvalCtx.ImageOnDiskPath
+			evalCtx.ImagePublicURL = uploadEvalCtx.ImagePublicURL
+		} else {
+			n.log.Warn("Couldn't render image for alert notifaction, no image renderer found/installed. " +
+				"For image rendering support please install the grafana-image-renderer plugin. " +
+				"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
 		}
-		uploadCtxCancel()
-		evalCtx.ImageOnDiskPath = uploadEvalCtx.ImageOnDiskPath
-		evalCtx.ImagePublicURL = uploadEvalCtx.ImagePublicURL
 	}
 
 	return n.sendNotifications(evalCtx, notifierStates)

--- a/pkg/services/alerting/notifier_test.go
+++ b/pkg/services/alerting/notifier_test.go
@@ -44,8 +44,8 @@ func TestNotificationService(t *testing.T) {
 		err := scenarioCtx.notificationService.SendIfNeeded(evalCtx)
 		require.NoError(t, err)
 
-		require.Equalf(t, 0, scenarioCtx.renderCount, "expected render to be called, but wasn't")
-		require.Equalf(t, 0, scenarioCtx.imageUploadCount, "expected image to be uploaded, but wasn't")
+		require.Equalf(t, 0, scenarioCtx.renderCount, "expected render to not be called, but it was")
+		require.Equalf(t, 0, scenarioCtx.imageUploadCount, "expected image to not be uploaded, but it was")
 		require.Truef(t, evalCtx.Ctx.Value(notificationSent{}).(bool), "expected notification to be sent, but wasn't")
 	})
 

--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -32,6 +32,7 @@ type RenderResult struct {
 type renderFunc func(ctx context.Context, renderKey string, options Opts) (*RenderResult, error)
 
 type Service interface {
+	IsAvailable() bool
 	Render(ctx context.Context, opts Opts) (*RenderResult, error)
 	RenderErrorImage(error error) (*RenderResult, error)
 	GetRenderUser(key string) (*RenderUser, bool)

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -96,6 +96,10 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	return nil
 }
 
+func (rs *RenderingService) IsAvailable() bool {
+	return rs.renderAction != nil
+}
+
 func (rs *RenderingService) RenderErrorImage(err error) (*RenderResult, error) {
 	imgUrl := "public/img/rendering_error.png"
 

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -6,6 +6,7 @@ import { SelectableValue, PanelModel, AppEvents } from '@grafana/data';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { buildImageUrl, buildShareUrl } from './utils';
 import { appEvents } from 'app/core/core';
+import config from 'app/core/config';
 
 const themeOptions: Array<SelectableValue<string>> = [
   { label: 'current', value: 'current' },
@@ -127,7 +128,7 @@ export class ShareLink extends PureComponent<Props, State> {
                 </div>
               </div>
             </div>
-            {panel && (
+            {panel && config.rendererAvailable && (
               <div className="gf-form">
                 <a href={imageUrl} target="_blank" aria-label={selectors.linkToRenderedImage}>
                   <Icon name="camera" /> Direct link rendered image


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some improved handling when image renderer not available/installed:
- Logs warning when render image for alert notification
- Hides "Direct link rendered image" link from panel share modal for now

```
Grafana startup:
DBUG[04-15|14:51:55] No image renderer found/installed. For image rendering support please install the grafana-image-renderer plugin. Read more at https://grafana.com/docs/grafana/latest/adm
inistration/image_rendering/ logger=rendering

Alert notification:
INFO[04-15|14:54:54] New state change                         logger=alerting.resultHandler ruleId=1791 newState=alerting prev state=unknown
WARN[04-15|14:54:54] Couldn't render image for alert notifaction, no image renderer found/installed. For image rendering support please install the grafana-image-renderer plugin. Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/ logger=alerting.notifier
``` 

**Which issue(s) this PR fixes**:
Ref #13802
Ref #23460

**Special notes for your reviewer**:
This targeting feature branch. The idea is to merge this PR to feature branch and then merge feature branch to master. After that improve UX where certain features requires an image renderer. 
