### PR TITLE
CircleCI: Upgrade the build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.2.8
+            VERSION=0.2.9
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the build pipeline tool, so we add the dependency _chkconfig_ to our RPM packages. We need chkconfig, since Linux distros require chkconfig when installing systemd services based on init scripts (such as grafana-server), and Fedora doesn't have chkconfig by default.

**Which issue(s) this PR fixes**:

Fixes #22935.

**Special notes for your reviewer**:

