### PR TITLE
Docs: Add access field to provisioning example

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -408,6 +408,7 @@ datasources:
   - name: Postgres
     type: postgres
     url: localhost:5432
+    access: proxy
     database: grafana
     user: grafana
     secureJsonData:


### PR DESCRIPTION
Added "access: proxy" to the example file. Using the most recent version of Grafana, the datasource would not provision correctly without this field, although earlier versions seemed to be more lax.
