### PR TITLE
PanelEditorTabs: adds counter to Query, Alert and Transform

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -67,7 +67,7 @@ export const Tab: FC<TabProps> = ({ label, active, icon, onChangeTab, counter })
     <li className={cx(tabsStyles.tabItem, active && tabsStyles.activeStyle)} onClick={onChangeTab}>
       {icon && <Icon name={icon} />}
       {label}
-      {!!counter && <Counter value={counter} />}
+      {typeof counter === 'number' && <Counter value={counter} />}
     </li>
   );
 };

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { config } from 'app/core/config';
 import { css } from 'emotion';
 import { IconName, stylesFactory, Tab, TabContent, TabsBar } from '@grafana/ui';
@@ -22,6 +22,22 @@ interface PanelEditorTabsProps {
 export const PanelEditorTabs: React.FC<PanelEditorTabsProps> = ({ panel, dashboard, tabs, data, onChangeTab }) => {
   const styles = getPanelEditorTabsStyles();
   const activeTab = tabs.find(item => item.active);
+  const getCounter = useCallback(
+    (tab: PanelEditorTab) => {
+      switch (tab.id) {
+        case PanelEditorTabId.Query:
+          return panel.targets.length;
+        case PanelEditorTabId.Alert:
+          return panel.alert ? 1 : 0;
+        case PanelEditorTabId.Transform:
+          const transformations = panel.getTransformations() ?? [];
+          return transformations.length;
+      }
+
+      return null;
+    },
+    [panel]
+  );
 
   if (tabs.length === 0) {
     return null;
@@ -42,6 +58,7 @@ export const PanelEditorTabs: React.FC<PanelEditorTabsProps> = ({ panel, dashboa
               active={tab.active}
               onChangeTab={() => onChangeTab(tab)}
               icon={tab.icon as IconName}
+              counter={getCounter(tab)}
             />
           );
         })}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds counter to Query, Transform and Alert tabs.
![image](https://user-images.githubusercontent.com/562238/79568026-747ce700-80b5-11ea-88e0-f7da03d0c5d4.png)

**Which issue(s) this PR fixes**:
Relates #23551

**Special notes for your reviewer**:
Wasn't sure what is better choice here:  to show `0` or not show the counter at all when counter === 0. I went with showing `0`.
