### PR TITLE
Dashboard: add fields in DashboardMeta

### DIFF
--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -31,6 +31,9 @@ export interface DashboardMeta {
   folderTitle?: string;
   folderUrl?: string;
   created?: string;
+  createdBy?: string;
+  updated?: string;
+  updatedBy?: string;
 }
 
 export interface DashboardDataDTO {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add available fields in the DashboardMeta as they are sent by the backend API.
It will be used to display more information on the dashboard in the analytics drawer.



