### PR TITLE
Logs: Fix error when non-string log level supplied

### DIFF
--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -46,6 +46,9 @@ describe('getLogLevelFromKey()', () => {
   it('returns correct log level when level is capitalized', () => {
     expect(getLogLevelFromKey('INFO')).toBe(LogLevel.info);
   });
+  it('returns unknown log level when level is integer', () => {
+    expect(getLogLevelFromKey(1)).toBe(LogLevel.unknown);
+  });
 });
 
 describe('calculateLogsLabelStats()', () => {

--- a/packages/grafana-data/src/utils/logs.ts
+++ b/packages/grafana-data/src/utils/logs.ts
@@ -37,8 +37,8 @@ export function getLogLevel(line: string): LogLevel {
   return level;
 }
 
-export function getLogLevelFromKey(key: string): LogLevel {
-  const level = (LogLevel as any)[key.toLowerCase()];
+export function getLogLevelFromKey(key: string | number): LogLevel {
+  const level = (LogLevel as any)[key.toString().toLowerCase()];
   if (level) {
     return level;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
When log level is non-string (e.g. number), error is thrown as [getLogLevelFromKey](https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/utils/logs.ts#L41) expects strings and then uses `toLowerCase()` method. This PR fixes this by adding `toString()` before running `toLowerCase()`. Also, I have added test coverage for this. 

**Which issue(s) this PR fixes**:
Fixes #22409


