### PR TITLE
toDataFrame: detect field properties using in rather than hasOwnProperty

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -10,6 +10,7 @@ import {
 import { DataFrameDTO, FieldType, TableData, TimeSeries } from '../types/index';
 import { dateTime } from '../datetime/moment_wrapper';
 import { MutableDataFrame } from './MutableDataFrame';
+import { ArrayDataFrame } from './ArrayDataFrame';
 
 describe('toDataFrame', () => {
   it('converts timeseries to series', () => {
@@ -71,6 +72,16 @@ describe('toDataFrame', () => {
     // If the object is alreay a DataFrame, it should not change
     const again = toDataFrame(input);
     expect(again).toBe(input);
+  });
+
+  it('ArrayDataFrame toDataFrame', () => {
+    const orig = [
+      { a: 1, b: 2 },
+      { a: 3, b: 4 },
+    ];
+    const frame = toDataFrame(new ArrayDataFrame(orig));
+    expect(frame.length).toEqual(orig.length);
+    expect(frame.fields.map(f => f.name)).toEqual(['a', 'b']);
   });
 
   it('throws when table rows is not array', () => {

--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -74,12 +74,15 @@ describe('toDataFrame', () => {
     expect(again).toBe(input);
   });
 
-  it('ArrayDataFrame toDataFrame', () => {
+  it('Make sure ArrayDataFrame is used as a DataFrame without modification', () => {
     const orig = [
       { a: 1, b: 2 },
       { a: 3, b: 4 },
     ];
-    const frame = toDataFrame(new ArrayDataFrame(orig));
+    const array = new ArrayDataFrame(orig);
+    const frame = toDataFrame(array);
+    expect(frame).toEqual(array);
+    expect(frame instanceof ArrayDataFrame).toEqual(true);
     expect(frame.length).toEqual(orig.length);
     expect(frame.fields.map(f => f.name)).toEqual(['a', 'b']);
   });

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -261,9 +261,9 @@ export const isTableData = (data: any): data is DataFrame => data && data.hasOwn
 export const isDataFrame = (data: any): data is DataFrame => data && data.hasOwnProperty('fields');
 
 export const toDataFrame = (data: any): DataFrame => {
-  if (data.hasOwnProperty('fields')) {
+  if ('fields' in data) {
     // DataFrameDTO does not have length
-    if (data.hasOwnProperty('length')) {
+    if ('length' in data) {
       return data as DataFrame;
     }
 


### PR DESCRIPTION
The current detection to check if something implements a DataFrame checks that real properties exist.  This does not work when the properties are defined like:
```
  get fields(): Field[] {
``` 
This switches our detection logic to use `in` rather than `hasOwnProperty()`