### PR TITLE
Table: Support duplicate field names, and use data frame directly instead of copying data and other improvements

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -9,7 +9,6 @@ export const DefaultCell: FC<TableCellProps> = props => {
     return null;
   }
 
-  const value = field.values.get(cell.row.index);
-  const displayValue = field.display(value);
+  const displayValue = field.display(cell.value);
   return <div className={tableStyles.tableCell}>{formattedValueToString(displayValue)}</div>;
 };

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -9,6 +9,7 @@ export const DefaultCell: FC<TableCellProps> = props => {
     return null;
   }
 
-  const displayValue = field.display(cell.value);
+  console.log(cell);
+  const displayValue = field.display(field.values.get(cell.row.index));
   return <div className={tableStyles.tableCell}>{formattedValueToString(displayValue)}</div>;
 };

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -9,7 +9,7 @@ export const DefaultCell: FC<TableCellProps> = props => {
     return null;
   }
 
-  console.log(cell);
-  const displayValue = field.display(field.values.get(cell.row.index));
+  const value = field.values.get(cell.row.index);
+  const displayValue = field.display(value);
   return <div className={tableStyles.tableCell}>{formattedValueToString(displayValue)}</div>;
 };

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -55,7 +55,7 @@ export const Table: FC<Props> = memo((props: Props) => {
   const theme = useTheme();
   const tableStyles = getTableStyles(theme);
   const memoizedColumns = useMemo(() => getColumns(data, width, columnMinWidth), [data, width, columnMinWidth]);
-  const memoizedData = useMemo(() => getTableRows(data), [data]);
+  const memoizedData = data.fields[0].values.toArray();
   const stateReducer = useTableStateReducer(props);
 
   const options: any = useMemo(

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
   UseSortByState,
 } from 'react-table';
 import { FixedSizeList } from 'react-window';
-import { getColumns, getTableRows, getTextAlign } from './utils';
+import { getColumns, getTextAlign } from './utils';
 import { useTheme } from '../../themes';
 import { ColumnResizeActionCallback, TableFilterActionCallback } from './types';
 import { getTableStyles, TableStyles } from './styles';
@@ -45,6 +45,7 @@ function useTableStateReducer(props: Props) {
         const width = Math.round(newState.columnResizing.columnWidths[name] as number);
         props.onColumnResize(name, width);
       }
+      console.log(action);
     },
     [props.onColumnResize]
   );
@@ -54,8 +55,17 @@ export const Table: FC<Props> = memo((props: Props) => {
   const { data, height, onCellClick, width, columnMinWidth = COLUMN_MIN_WIDTH, noHeader, resizable = true } = props;
   const theme = useTheme();
   const tableStyles = getTableStyles(theme);
+
+  // React table data array. This data acts just like a dummy array to let react-table know how many rows exist
+  // The cells use the field to look up values
+  const memoizedData = useMemo(() => {
+    return data.fields.length > 0 ? data.fields[0].values.toArray() : [];
+  }, [data]);
+
+  // React-table column definitions
   const memoizedColumns = useMemo(() => getColumns(data, width, columnMinWidth), [data, width, columnMinWidth]);
-  const memoizedData = data.fields[0].values.toArray();
+
+  // Internal react table state reducer
   const stateReducer = useTableStateReducer(props);
 
   const options: any = useMemo(

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -24,7 +24,13 @@ export interface TableRow {
 }
 
 export type TableFilterActionCallback = (key: string, value: string) => void;
-export type ColumnResizeActionCallback = (name: string, width: number) => void;
+export type TableColumnResizeActionCallback = (fieldIndex: number, width: number) => void;
+export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
+
+export interface TableSortByFieldState {
+  fieldIndex: number;
+  desc?: boolean;
+}
 
 export interface TableCellProps extends CellProps<any> {
   tableStyles: TableStyles;

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -3,25 +3,10 @@ import { DataFrame, Field, FieldType } from '@grafana/data';
 import { Column } from 'react-table';
 import { DefaultCell } from './DefaultCell';
 import { BarGaugeCell } from './BarGaugeCell';
-import { TableCellDisplayMode, TableCellProps, TableFieldOptions, TableRow } from './types';
+import { TableCellDisplayMode, TableCellProps, TableFieldOptions } from './types';
 import { css, cx } from 'emotion';
 import { withTableStyles } from './withTableStyles';
 import tinycolor from 'tinycolor2';
-
-export function getTableRows(data: DataFrame): TableRow[] {
-  const tableData = [];
-
-  for (let i = 0; i < data.length; i++) {
-    const row: { [key: string]: string | number } = {};
-    for (let j = 0; j < data.fields.length; j++) {
-      const prop = data.fields[j].name;
-      row[prop] = data.fields[j].values.get(i);
-    }
-    tableData.push(row);
-  }
-
-  return tableData;
-}
 
 export function getTextAlign(field?: Field): TextAlignProperty {
   if (!field) {

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -37,8 +37,10 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
   const columns: Column[] = [];
   let fieldCountWithoutWidth = data.fields.length;
 
-  for (const field of data.fields) {
+  for (let fieldIndex = 0; fieldIndex < data.fields.length; fieldIndex++) {
+    const field = data.fields[fieldIndex];
     const fieldTableOptions = (field.config.custom || {}) as TableFieldOptions;
+
     if (fieldTableOptions.width) {
       availableWidth -= fieldTableOptions.width;
       fieldCountWithoutWidth -= 1;
@@ -48,9 +50,11 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
 
     columns.push({
       Cell,
-      id: field.name,
+      id: fieldIndex.toString(),
       Header: field.config.title ?? field.name,
-      accessor: field.name,
+      accessor: (row: any, i: number) => {
+        return field.values.get(i);
+      },
       width: fieldTableOptions.width,
       minWidth: 50,
     });


### PR DESCRIPTION
* [x] Switches to use data frame data directly, need to pass an array to react-table so passing it the first field array. Then using accessor function to get values. This way the react-table sort hook still works
* [x] Switches the column id to be the field index instead of the field name, so now the Table handles fields with the same name. 

Leaving sort by persisting to later PR as for that we need to decide if sorting:
* Should be done outside Table component or not
* Should we support multiple field sorting (works really well with current internal table sorting). Persisted as a simple array `[{id: 'columnId', desc: true}, {id: 'second-columnId', desc: false}]` 
* How should we persist sort state, we have multiple options
  * **A** As an internal table panel option (not even shown in UI, sort of like old angular panel). We can continue to use table panel internal sort if we want for now with this option. 
  * **B** As a field config override rule
  * **C** As a transformation (need to add function to change to PanelProps)

The problem with B & C is clean-up if you switch to another visualization the transform & potentially the override will remain. (And we have to implement multi-field sort if we want to support it but that should relatively easy) 