### PR TITLE
Alertmanager: Basic auth should not be required.

### DIFF
--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -26,11 +26,11 @@ func init() {
 		</div>
 		<div class="gf-form">
         	<span class="gf-form-label width-10">Basic Auth User</span>
-        	<input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.basicAuthUser" placeholder=""></input>
+        	<input type="text" class="gf-form-input max-width-26" ng-model="ctrl.model.settings.basicAuthUser" placeholder=""></input>
 		</div>
 		<div class="gf-form">
         	<span class="gf-form-label width-10">Basic Auth Password</span>
-        	<input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.basicAuthPassword" placeholder=""></input>
+        	<input type="text" class="gf-form-input max-width-26" ng-model="ctrl.model.settings.basicAuthPassword" placeholder=""></input>
 		</div>
       </div>
     `,


### PR DESCRIPTION
Found this bug when preparing a demo for using Grafana alerting with Prometheus AlertManager