### PR TITLE
Storybook: Change default theme and fix favicon issue

### DIFF
--- a/packages/grafana-ui/.storybook/manager-head.html
+++ b/packages/grafana-ui/.storybook/manager-head.html
@@ -1,1 +1,1 @@
-<link rel="icon" href="/fav32.png" />
+<link rel="icon" href="./fav32.png" />

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -38,7 +38,7 @@ addParameters({
     light: GrafanaLight,
   },
   options: {
-    theme: GrafanaLight,
+    theme: GrafanaDark,
     showPanel: true,
     showRoots: true,
     panelPosition: 'bottom',


### PR DESCRIPTION
The favicon is currently not displaying on https://developers.grafana.com/ui/canary/index.html?path=/story/* This PR fixes that.

To double check that the default theme work, clear the localStorage. Docs theme will now just be dark - is this a problem? Does it look fine?
