### PR TITLE
Explore: adds show more logs functionality, fixes few strict-null errors.

### DIFF
--- a/public/app/core/components/Login/ChangePassword.tsx
+++ b/public/app/core/components/Login/ChangePassword.tsx
@@ -97,7 +97,7 @@ export class ChangePassword extends PureComponent<Props, State> {
               placeholder="New password"
               onChange={this.onNewPasswordChange}
               ref={input => {
-                this.userInput = input;
+                this.userInput = input as HTMLInputElement;
               }}
             />
           </div>

--- a/public/app/core/components/Login/LoginForm.tsx
+++ b/public/app/core/components/Login/LoginForm.tsx
@@ -67,7 +67,7 @@ export class LoginForm extends PureComponent<Props, State> {
         <div className="login-form">
           <input
             ref={input => {
-              this.userInput = input;
+              this.userInput = input as HTMLInputElement;
             }}
             type="text"
             name="user"

--- a/public/app/core/components/OrgActionBar/OrgActionBar.test.tsx
+++ b/public/app/core/components/OrgActionBar/OrgActionBar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import OrgActionBar, { Props } from './OrgActionBar';
+import { LayoutModes } from '../LayoutSelector/LayoutSelector';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -8,6 +9,8 @@ const setup = (propOverrides?: object) => {
     setSearchQuery: jest.fn(),
     target: '_blank',
     linkButton: { href: 'some/url', title: 'test' },
+    layoutMode: LayoutModes.Grid,
+    onSetLayoutMode: jest.fn(),
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/core/components/OrgActionBar/OrgActionBar.tsx
+++ b/public/app/core/components/OrgActionBar/OrgActionBar.tsx
@@ -4,8 +4,8 @@ import { FilterInput } from '../FilterInput/FilterInput';
 
 export interface Props {
   searchQuery: string;
-  layoutMode?: LayoutMode;
-  onSetLayoutMode?: (mode: LayoutMode) => {};
+  layoutMode: LayoutMode;
+  onSetLayoutMode: (mode: LayoutMode) => {};
   setSearchQuery: (value: string) => {};
   linkButton: { href: string; title: string };
   target?: string;

--- a/public/app/core/components/OrgActionBar/__snapshots__/OrgActionBar.test.tsx.snap
+++ b/public/app/core/components/OrgActionBar/__snapshots__/OrgActionBar.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Render should render component 1`] = `
       value=""
     />
     <LayoutSelector
+      mode="grid"
       onLayoutModeChanged={[Function]}
     />
   </div>

--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -10,7 +10,7 @@ export interface Props {
 }
 
 const SelectNav = ({ main, customCss }: { main: NavModelItem; customCss: string }) => {
-  const defaultSelectedItem = main.children.find(navItem => {
+  const defaultSelectedItem = main.children?.find(navItem => {
     return navItem.active === true;
   });
 
@@ -22,15 +22,18 @@ const SelectNav = ({ main, customCss }: { main: NavModelItem; customCss: string 
 
   return (
     <div className={`gf-form-select-wrapper width-20 ${customCss}`}>
-      <label className={`gf-form-select-icon ${defaultSelectedItem.icon}`} htmlFor="page-header-select-nav" />
+      <label
+        className={`gf-form-select-icon ${defaultSelectedItem ? defaultSelectedItem?.icon : ''}`}
+        htmlFor="page-header-select-nav"
+      />
       {/* Label to make it clickable */}
       <select
         className="gf-select-nav gf-form-input"
-        value={defaultSelectedItem.url}
+        value={defaultSelectedItem?.url ?? ''}
         onChange={gotoUrl}
         id="page-header-select-nav"
       >
-        {main.children.map((navItem: NavModelItem) => {
+        {main.children?.map((navItem: NavModelItem) => {
           if (navItem.hideFromTabs) {
             // TODO: Rename hideFromTabs => hideFromNav
             return null;
@@ -48,7 +51,7 @@ const SelectNav = ({ main, customCss }: { main: NavModelItem; customCss: string 
 
 const Navigation = ({ main }: { main: NavModelItem }) => {
   const goToUrl = (index: number) => {
-    main.children.forEach((child, i) => {
+    main.children?.forEach((child, i) => {
       if (i === index) {
         appEvents.emit(CoreEvents.locationChange, { href: child.url });
       }
@@ -59,7 +62,7 @@ const Navigation = ({ main }: { main: NavModelItem }) => {
     <nav>
       <SelectNav customCss="page-header__select-nav" main={main} />
       <TabsBar className="page-header__tabs" hideBorder={true}>
-        {main.children.map((child, index) => {
+        {main.children?.map((child, index) => {
           return (
             !child.hideFromTabs && (
               <Tab
@@ -131,7 +134,7 @@ export default class PageHeader extends React.Component<Props, any> {
         </span>
 
         <div className="page-header__info-block">
-          {this.renderTitle(main.text, main.breadcrumbs)}
+          {this.renderTitle(main.text, main.breadcrumbs ?? [])}
           {main.subTitle && <div className="page-header__sub-title">{main.subTitle}</div>}
         </div>
       </div>

--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -64,7 +64,7 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
   };
 
   onPermissionChanged = (permission: SelectableValue<PermissionLevel>) => {
-    this.setState({ permission: permission.value });
+    this.setState({ permission: permission.value ?? PermissionLevel.View });
   };
 
   onSubmit = async (evt: React.SyntheticEvent) => {

--- a/public/app/core/components/PermissionList/PermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/PermissionListItem.tsx
@@ -42,7 +42,7 @@ interface Props {
 
 export default class PermissionsListItem extends PureComponent<Props> {
   onPermissionChanged = (option: SelectableValue<PermissionLevel>) => {
-    this.props.onPermissionChanged(this.props.item, option.value);
+    this.props.onPermissionChanged(this.props.item, option.value ?? PermissionLevel.View);
   };
 
   onRemoveItem = () => {
@@ -55,7 +55,7 @@ export default class PermissionsListItem extends PureComponent<Props> {
     const currentPermissionLevel = dashboardPermissionLevels.find(dp => dp.value === item.permission);
 
     return (
-      <tr className={setClassNameHelper(item.inherited)}>
+      <tr className={setClassNameHelper(Boolean(item?.inherited))}>
         <td style={{ width: '1%' }}>
           <ItemAvatar item={item} />
         </td>

--- a/public/app/core/components/Select/MetricSelect.tsx
+++ b/public/app/core/components/Select/MetricSelect.tsx
@@ -37,7 +37,7 @@ export class MetricSelect extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.options.length > 0 || nextProps.variables.length) {
+    if (nextProps.options.length > 0 || nextProps.variables?.length) {
       this.setState({ options: this.buildOptions(nextProps) });
     }
   }
@@ -54,7 +54,7 @@ export class MetricSelect extends React.Component<Props, State> {
   getVariablesGroup() {
     return {
       label: 'Template Variables',
-      options: this.props.variables.map(v => ({
+      options: this.props.variables?.map(v => ({
         label: `$${v.name}`,
         value: `$${v.name}`,
       })),
@@ -77,7 +77,7 @@ export class MetricSelect extends React.Component<Props, State> {
         isMulti={false}
         isClearable={false}
         backspaceRemovesValue={false}
-        onChange={item => onChange(item.value)}
+        onChange={item => onChange(item.value ?? '')}
         options={options}
         isSearchable={isSearchable}
         maxMenuHeight={500}

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -121,7 +121,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
             isSearchable={false}
             value={themes.find(item => item.value === theme)}
             options={themes}
-            onChange={theme => this.onThemeChanged(theme.value)}
+            onChange={theme => this.onThemeChanged(theme.value ?? '')}
             width={20}
           />
         </div>
@@ -147,7 +147,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
           <Select
             isSearchable={false}
             value={timezones.find(item => item.value === timezone)}
-            onChange={timezone => this.onTimeZoneChanged(timezone.value)}
+            onChange={timezone => this.onTimeZoneChanged(timezone.value ?? '')}
             options={timezones}
             width={20}
           />

--- a/public/app/core/components/search/search.ts
+++ b/public/app/core/components/search/search.ts
@@ -111,7 +111,7 @@ export class SearchCtrl {
     this.results = [];
     this.query = {
       query: payload.query ? `${payload.query} ` : '',
-      parsedQuery: this.queryParser.parse(payload.query),
+      parsedQuery: this.queryParser.parse(payload.query ?? ''),
       tags: [],
       starred: false,
     };

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -22,6 +22,7 @@ import {
   toUtc,
   ExploreMode,
   urlUtil,
+  DateTime,
 } from '@grafana/data';
 import store from 'app/core/store';
 import kbn from 'app/core/utils/kbn';
@@ -284,12 +285,12 @@ export function generateKey(index = 0): string {
 }
 
 export function generateEmptyQuery(queries: DataQuery[], index = 0): DataQuery {
-  return { refId: getNextRefIdChar(queries), key: generateKey(index) };
+  return { refId: getNextRefIdChar(queries) ?? '', key: generateKey(index) };
 }
 
 export const generateNewKeyAndAddRefIdIfMissing = (target: DataQuery, queries: DataQuery[], index = 0): DataQuery => {
   const key = generateKey(index);
-  const refId = target.refId || getNextRefIdChar(queries);
+  const refId = (target.refId || getNextRefIdChar(queries)) ?? '';
 
   return { ...target, refId, key };
 };
@@ -305,7 +306,7 @@ export function ensureQueries(queries?: DataQuery[]): DataQuery[] {
       const key = generateKey(index);
       let refId = query.refId;
       if (!refId) {
-        refId = getNextRefIdChar(allQueries);
+        refId = getNextRefIdChar(allQueries) ?? '';
       }
 
       allQueries.push({
@@ -316,7 +317,7 @@ export function ensureQueries(queries?: DataQuery[]): DataQuery[] {
     }
     return allQueries;
   }
-  return [{ ...generateEmptyQuery(queries) }];
+  return [{ ...generateEmptyQuery(queries ?? []) }] as DataQuery[];
 }
 
 /**
@@ -375,8 +376,8 @@ export const getQueryKeys = (queries: DataQuery[], datasourceInstance: DataSourc
 
 export const getTimeRange = (timeZone: TimeZone, rawRange: RawTimeRange): TimeRange => {
   return {
-    from: dateMath.parse(rawRange.from, false, timeZone as any),
-    to: dateMath.parse(rawRange.to, true, timeZone as any),
+    from: dateMath.parse(rawRange.from, false, timeZone as any) as DateTime,
+    to: dateMath.parse(rawRange.to, true, timeZone as any) as DateTime,
     raw: rawRange,
   };
 };
@@ -415,9 +416,9 @@ export const getTimeRangeFromUrl = (range: RawTimeRange, timeZone: TimeZone): Ti
   };
 
   return {
-    from: dateMath.parse(raw.from, false, timeZone as any),
-    to: dateMath.parse(raw.to, true, timeZone as any),
-    raw,
+    from: dateMath.parse(raw.from, false, timeZone as any) as DateTime,
+    to: dateMath.parse(raw.to, true, timeZone as any) as DateTime,
+    raw: raw as RawTimeRange,
   };
 };
 

--- a/public/app/core/utils/flatten.ts
+++ b/public/app/core/utils/flatten.ts
@@ -9,16 +9,16 @@ export default function flatten(target: object, opts?: { delimiter?: any; maxDep
   let currentDepth = 1;
   const output: any = {};
 
-  function step(object: any, prev: string) {
+  function step(object: any, prev: string | null) {
     Object.keys(object).forEach(key => {
       const value = object[key];
-      const isarray = opts.safe && Array.isArray(value);
+      const isarray = opts?.safe && Array.isArray(value);
       const type = Object.prototype.toString.call(value);
       const isobject = type === '[object Object]';
 
       const newKey = prev ? prev + delimiter + key : key;
 
-      if (!opts.maxDepth) {
+      if (!opts?.maxDepth) {
         maxDepth = currentDepth + 1;
       }
 

--- a/public/app/features/dashboard/panel_editor/EditorTabBody.tsx
+++ b/public/app/features/dashboard/panel_editor/EditorTabBody.tsx
@@ -115,7 +115,7 @@ export class EditorTabBody extends PureComponent<Props, State> {
             <div className="toolbar__heading">{heading}</div>
             {renderToolbar && renderToolbar()}
           </div>
-          {toolbarItems.map(item => this.renderButton(item))}
+          {toolbarItems?.map(item => this.renderButton(item))}
         </div>
         <div className="panel-editor__scroll">
           <CustomScrollbar autoHide={false} scrollTop={scrollTop} setScrollTop={setScrollTop} updateAfterMountMs={300}>

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -226,3 +226,38 @@ export function preProcessPanelData(data: PanelData, lastResult: PanelData): Pan
     timings: { dataProcessingTime: STOPTIME - STARTTIME },
   };
 }
+
+/**
+ * This function combines multiple series with the same refId.
+ * Mainly used when running append queries.
+ */
+function combineSeries(series: DataFrame[]): DataFrame[] {
+  // TODO: combine multiple series into one
+  // right now returns unchanged series
+  return series;
+}
+
+export function preProcessAppendPanelData(data: PanelData, lastResult: PanelData): PanelData {
+  const { series } = data;
+
+  //  for loading states with no data, use last result
+  if (data.state === LoadingState.Loading && series.length === 0) {
+    if (!lastResult) {
+      lastResult = data;
+    }
+
+    return { ...lastResult, state: LoadingState.Loading };
+  }
+
+  // Make sure the data frames are properly formatted
+  const STARTTIME = performance.now();
+  const processedDataFrames = combineSeries(getProcessedDataFrames([...lastResult.series, ...series]));
+  const STOPTIME = performance.now();
+
+  return {
+    ...lastResult,
+    ...data,
+    series: processedDataFrames,
+    timings: { dataProcessingTime: STOPTIME - STARTTIME },
+  };
+}

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -20,6 +20,7 @@ import {
 } from '@grafana/data';
 import { emitDataRequestEvent } from './analyticsProcessor';
 import { ExpressionDatasourceID, expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
+import { QueryDirection } from 'app/types';
 
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
 
@@ -237,7 +238,11 @@ function combineSeries(series: DataFrame[]): DataFrame[] {
   return series;
 }
 
-export function preProcessAppendPanelData(data: PanelData, lastResult: PanelData): PanelData {
+export function preProcessAppendPanelData(
+  data: PanelData,
+  lastResult: PanelData,
+  direction: QueryDirection
+): PanelData {
   const { series } = data;
 
   //  for loading states with no data, use last result
@@ -251,7 +256,9 @@ export function preProcessAppendPanelData(data: PanelData, lastResult: PanelData
 
   // Make sure the data frames are properly formatted
   const STARTTIME = performance.now();
-  const processedDataFrames = combineSeries(getProcessedDataFrames([...lastResult.series, ...series]));
+  const dataFrames =
+    direction === QueryDirection.backward ? [...lastResult.series, ...series] : [...series, ...lastResult.series];
+  const processedDataFrames = combineSeries(getProcessedDataFrames(dataFrames));
   const STOPTIME = performance.now();
 
   return {

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -228,16 +228,6 @@ export function preProcessPanelData(data: PanelData, lastResult: PanelData): Pan
   };
 }
 
-/**
- * This function combines multiple series with the same refId.
- * Mainly used when running append queries.
- */
-function combineSeries(series: DataFrame[]): DataFrame[] {
-  // TODO: combine multiple series into one
-  // right now returns unchanged series
-  return series;
-}
-
 export function preProcessAppendPanelData(
   data: PanelData,
   lastResult: PanelData,
@@ -258,7 +248,7 @@ export function preProcessAppendPanelData(
   const STARTTIME = performance.now();
   const dataFrames =
     direction === QueryDirection.backward ? [...lastResult.series, ...series] : [...series, ...lastResult.series];
-  const processedDataFrames = combineSeries(getProcessedDataFrames(dataFrames));
+  const processedDataFrames = getProcessedDataFrames(dataFrames);
   const STOPTIME = performance.now();
 
   return {

--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -11,7 +11,7 @@ import DataSourcesList from './DataSourcesList';
 import { DataSourceSettings, NavModel } from '@grafana/data';
 import { IconName } from '@grafana/ui';
 import { StoreState } from 'app/types';
-import { LayoutMode } from 'app/core/components/LayoutSelector/LayoutSelector';
+import { LayoutMode, LayoutModes } from 'app/core/components/LayoutSelector/LayoutSelector';
 // Actions
 import { loadDataSources } from './state/actions';
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -81,7 +81,7 @@ export class DataSourcesListPage extends PureComponent<Props> {
             {hasFetched &&
               dataSourcesCount > 0 && [
                 <OrgActionBar
-                  layoutMode={layoutMode}
+                  layoutMode={layoutMode ?? LayoutModes.List}
                   searchQuery={searchQuery}
                   onSetLayoutMode={mode => setDataSourcesLayoutMode(mode)}
                   setSearchQuery={query => setDataSourcesSearchQuery(query)}

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -119,6 +119,7 @@ const dummyProps: ExploreProps = {
   originPanelId: 1,
   addQueryRow: jest.fn(),
   theme: getTheme(),
+  runAppendQueries: jest.fn(),
 };
 
 const setupErrors = (hasRefId?: boolean) => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -43,7 +43,14 @@ import {
   GrafanaTheme,
 } from '@grafana/data';
 
-import { ExploreId, ExploreItemState, ExploreUIState, ExploreUpdateState, ExploreUrlState } from 'app/types/explore';
+import {
+  ExploreId,
+  ExploreItemState,
+  ExploreUIState,
+  ExploreUpdateState,
+  ExploreUrlState,
+  QueryDirection,
+} from 'app/types/explore';
 import { StoreState } from 'app/types';
 import {
   DEFAULT_RANGE,
@@ -286,9 +293,14 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     );
   };
 
-  showMoreLogs = () => {
+  showMoreNewerLogs = () => {
     const { exploreId } = this.props;
-    this.props.runAppendQueries(exploreId);
+    this.props.runAppendQueries(exploreId, QueryDirection.forward);
+  };
+
+  showMoreOlderLogs = () => {
+    const { exploreId } = this.props;
+    this.props.runAppendQueries(exploreId, QueryDirection.backward);
   };
 
   render() {
@@ -387,7 +399,8 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                               onClickFilterOutLabel={this.onClickFilterOutLabel}
                               onStartScanning={this.onStartScanning}
                               onStopScanning={this.onStopScanning}
-                              showMoreLogs={this.showMoreLogs}
+                              showMoreNewerLogs={this.showMoreNewerLogs}
+                              showMoreOlderLogs={this.showMoreOlderLogs}
                             />
                           )}
                           {mode === ExploreMode.Tracing &&

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -26,6 +26,7 @@ import {
   toggleGraph,
   addQueryRow,
   updateTimeRange,
+  runAppendQueries,
 } from './state/actions';
 // Types
 import {
@@ -122,6 +123,7 @@ export interface ExploreProps {
   originPanelId: number;
   addQueryRow: typeof addQueryRow;
   theme: GrafanaTheme;
+  runAppendQueries: typeof runAppendQueries;
 }
 
 interface ExploreState {
@@ -284,6 +286,11 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     );
   };
 
+  showMoreLogs = () => {
+    const { exploreId } = this.props;
+    this.props.runAppendQueries(exploreId);
+  };
+
   render() {
     const {
       datasourceInstance,
@@ -380,6 +387,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                               onClickFilterOutLabel={this.onClickFilterOutLabel}
                               onStartScanning={this.onStartScanning}
                               onStopScanning={this.onStopScanning}
+                              showMoreLogs={this.showMoreLogs}
                             />
                           )}
                           {mode === ExploreMode.Tracing &&
@@ -498,6 +506,7 @@ const mapDispatchToProps: Partial<ExploreProps> = {
   updateTimeRange,
   toggleGraph,
   addQueryRow,
+  runAppendQueries,
 };
 
 export default compose(

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -62,6 +62,9 @@ interface Props {
   onToggleLogLevel: (hiddenLogLevels: LogLevel[]) => void;
   getRowContext?: (row: LogRowModel, options?: any) => Promise<any>;
   getFieldLinks: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  displayMoreLogsBtn: boolean;
+  showMoreNewerLogs: () => void;
+  showMoreOlderLogs: () => void;
 }
 
 interface State {
@@ -154,6 +157,9 @@ export class Logs extends PureComponent<Props, State> {
       absoluteRange,
       onChangeTime,
       getFieldLinks,
+      displayMoreLogsBtn,
+      showMoreNewerLogs,
+      showMoreOlderLogs,
     } = this.props;
 
     if (!logRows) {
@@ -230,7 +236,11 @@ export class Logs extends PureComponent<Props, State> {
             })}
           />
         )}
-
+        {!loading && hasData && !scanning && displayMoreLogsBtn && (
+          <button className="gf-form-label gf-form-label--btn" onClick={showMoreNewerLogs}>
+            Show more logs
+          </button>
+        )}
         <LogRows
           logRows={logRows}
           deduplicatedRows={dedupedRows}
@@ -246,6 +256,11 @@ export class Logs extends PureComponent<Props, State> {
           timeZone={timeZone}
           getFieldLinks={getFieldLinks}
         />
+        {!loading && hasData && !scanning && displayMoreLogsBtn && (
+          <button className="gf-form-label gf-form-label--btn" onClick={showMoreOlderLogs}>
+            Show more logs
+          </button>
+        )}
 
         {!loading && !hasData && !scanning && (
           <div className="logs-panel-nodata">

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -59,7 +59,9 @@ interface LogsContainerProps {
   absoluteRange: AbsoluteTimeRange;
   isPaused: boolean;
   splitOpen: typeof splitOpen;
-  showMoreLogs: () => void;
+  showMoreNewerLogs: () => void;
+  showMoreOlderLogs: () => void;
+  displayMoreLogsBtn: boolean;
 }
 
 export class LogsContainer extends PureComponent<LogsContainerProps> {
@@ -133,7 +135,9 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
       width,
       isLive,
       exploreId,
-      showMoreLogs,
+      showMoreNewerLogs,
+      showMoreOlderLogs,
+      displayMoreLogsBtn,
     } = this.props;
 
     return (
@@ -156,6 +160,10 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
         </LogsCrossFadeTransition>
         <LogsCrossFadeTransition visible={!isLive}>
           <Collapse label="Logs" loading={loading} isOpen>
+            {dedupedRows?.length > 0 &&
+              `Showing logs between ${dedupedRows[dedupedRows.length - 1]?.timeLocal} and ${
+                dedupedRows[0]?.timeLocal
+              } (${dedupedRows[dedupedRows.length - 1]?.timeFromNow} to ${dedupedRows[0]?.timeFromNow})`}
             <Logs
               dedupStrategy={this.props.dedupStrategy || LogsDedupStrategy.none}
               logRows={logRows}
@@ -178,10 +186,10 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
               width={width}
               getRowContext={this.getLogRowContext}
               getFieldLinks={this.getFieldLinks}
+              displayMoreLogsBtn={displayMoreLogsBtn}
+              showMoreNewerLogs={showMoreNewerLogs}
+              showMoreOlderLogs={showMoreOlderLogs}
             />
-            <button className="gf-form-label gf-form-label--btn" onClick={showMoreLogs}>
-              Show more logs
-            </button>
           </Collapse>
         </LogsCrossFadeTransition>
       </>
@@ -204,6 +212,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     range,
     absoluteRange,
     dedupStrategy,
+    queries,
   } = item;
   const dedupedRows = deduplicatedRowsSelector(item);
   const timeZone = getTimeZone(state.user);
@@ -223,6 +232,9 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     isPaused,
     range,
     absoluteRange,
+    displayMoreLogsBtn: queries.filter(elem => !elem.hide).length === 1,
+    // currently we allow to display more logs when only one query is active
+    // due to timestamp selection issues that are going to be addressed later
   };
 }
 

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -59,6 +59,7 @@ interface LogsContainerProps {
   absoluteRange: AbsoluteTimeRange;
   isPaused: boolean;
   splitOpen: typeof splitOpen;
+  showMoreLogs: () => void;
 }
 
 export class LogsContainer extends PureComponent<LogsContainerProps> {
@@ -132,6 +133,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
       width,
       isLive,
       exploreId,
+      showMoreLogs,
     } = this.props;
 
     return (
@@ -177,6 +179,9 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
               getRowContext={this.getLogRowContext}
               getFieldLinks={this.getFieldLinks}
             />
+            <button className="gf-form-label gf-form-label--btn" onClick={showMoreLogs}>
+              Show more logs
+            </button>
           </Collapse>
         </LogsCrossFadeTransition>
       </>

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -18,6 +18,7 @@ import {
   TimeRange,
   ExploreMode,
   dateMath,
+  dateTime,
 } from '@grafana/data';
 // Services & Utils
 import store from 'app/core/store';
@@ -451,14 +452,14 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
 
     // Some datasource's query builders allow per-query interval limits,
     // but we're using the datasource interval limit for now
-    const minInterval = datasourceInstance.interval;
+    const minInterval = datasourceInstance?.interval;
 
     stopQueryState(querySubscription);
 
-    const datasourceId = datasourceInstance.meta.id;
+    const datasourceId = datasourceInstance?.meta?.id;
 
     const queryOptions: QueryOptions = {
-      minInterval,
+      minInterval: minInterval ?? '1s',
       // maxDataPoints is used in:
       // Loki - used for logs streaming for buffer size, with undefined it falls back to datasource config if it supports that.
       // Elastic - limits the number of datapoints for the counts query and for logs it has hardcoded limit.
@@ -472,7 +473,7 @@ export const runQueries = (exploreId: ExploreId): ThunkResult<void> => {
 
     const datasourceName = exploreItemState.requestedDatasourceName;
 
-    const transaction = buildQueryTransaction(queries, queryOptions, range, scanning);
+    const transaction = buildQueryTransaction(queries, queryOptions, range, !!scanning);
 
     let firstResponse = true;
     dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
@@ -574,8 +575,8 @@ export const runAppendQueries = (exploreId: ExploreId, direction: QueryDirection
     };
 
     const newTimeRange: TimeRange = {
-      from: dateMath.parse(newRaw.from, false, undefined),
-      to: dateMath.parse(newRaw.to, true, undefined),
+      from: dateMath.parse(newRaw.from, false, undefined) ?? dateTime(),
+      to: dateMath.parse(newRaw.to, true, undefined) ?? dateTime(),
       raw: newRaw,
     };
 
@@ -587,14 +588,14 @@ export const runAppendQueries = (exploreId: ExploreId, direction: QueryDirection
 
     // Some datasource's query builders allow per-query interval limits,
     // but we're using the datasource interval limit for now
-    const minInterval = datasourceInstance.interval;
+    const minInterval = datasourceInstance?.interval;
 
     stopQueryState(querySubscription);
 
-    const datasourceId = datasourceInstance.meta.id;
+    const datasourceId = datasourceInstance?.meta?.id;
 
     const queryOptions: QueryOptions = {
-      minInterval,
+      minInterval: minInterval ?? '1s',
       // maxDataPoints is used in:
       // Loki - used for logs streaming for buffer size, with undefined it falls back to datasource config if it supports that.
       // Elastic - limits the number of datapoints for the counts query and for logs it has hardcoded limit.
@@ -606,7 +607,7 @@ export const runAppendQueries = (exploreId: ExploreId, direction: QueryDirection
       mode,
     };
 
-    const transaction = buildQueryTransaction(queries, queryOptions, newTimeRange, scanning);
+    const transaction = buildQueryTransaction(queries, queryOptions, newTimeRange, !!scanning);
 
     let firstResponse = true;
     dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
@@ -702,7 +703,7 @@ export const stateSave = (): ThunkResult<void> => {
     const replace = left && left.urlReplaced === false;
     const urlStates: { [index: string]: string } = { orgId };
     const leftUrlState: ExploreUrlState = {
-      datasource: left.datasourceInstance.name,
+      datasource: left?.datasourceInstance?.name ?? '',
       queries: left.queries.map(clearQueryKeys),
       range: toRawTimeRange(left.range),
       mode: left.mode,
@@ -716,7 +717,7 @@ export const stateSave = (): ThunkResult<void> => {
     urlStates.left = serializeStateToUrlParam(leftUrlState, true);
     if (split) {
       const rightUrlState: ExploreUrlState = {
-        datasource: right.datasourceInstance.name,
+        datasource: right?.datasourceInstance?.name ?? '',
         queries: right.queries.map(clearQueryKeys),
         range: toRawTimeRange(right.range),
         mode: right.mode,

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -537,7 +537,7 @@ export const processQueryResponse = (
   const logsResult = processor.getLogsResult();
 
   // Send legacy data to Angular editors
-  if (state.datasourceInstance.components.QueryCtrl) {
+  if (state?.datasourceInstance?.components?.QueryCtrl) {
     const legacy = series.map(v => toLegacyResponseData(v));
 
     state.eventBridge.emit(PanelEvents.dataReceived, legacy);
@@ -669,7 +669,7 @@ export const exploreReducer = (state = initialExploreState, action: AnyAction): 
     stopQueryState(leftState.querySubscription);
     stopQueryState(rightState.querySubscription);
 
-    if (payload.force || !Number.isInteger(state.left.originPanelId)) {
+    if (payload.force || !Number.isInteger(state?.left?.originPanelId ?? -1)) {
       return initialExploreState;
     }
 

--- a/public/app/features/explore/utils/dateTimeProcessor.ts
+++ b/public/app/features/explore/utils/dateTimeProcessor.ts
@@ -1,0 +1,5 @@
+import { dateTime, DateTime, isDateTime } from '@grafana/data';
+
+export const processDateTime = (dt: DateTime | string) => {
+  return isDateTime(dt) ? dateTime(dt) : dt;
+};

--- a/public/app/features/plugins/PluginListPage.tsx
+++ b/public/app/features/plugins/PluginListPage.tsx
@@ -7,7 +7,7 @@ import PluginList from './PluginList';
 import { loadPlugins } from './state/actions';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { getLayoutMode, getPlugins, getPluginsSearchQuery } from './state/selectors';
-import { LayoutMode } from 'app/core/components/LayoutSelector/LayoutSelector';
+import { LayoutMode, LayoutModes } from 'app/core/components/LayoutSelector/LayoutSelector';
 import { NavModel, PluginMeta } from '@grafana/data';
 import { StoreState } from 'app/types';
 import { setPluginsLayoutMode, setPluginsSearchQuery } from './state/reducers';
@@ -54,7 +54,7 @@ export class PluginListPage extends PureComponent<Props> {
           <>
             <OrgActionBar
               searchQuery={searchQuery}
-              layoutMode={layoutMode}
+              layoutMode={layoutMode ?? LayoutModes.Grid}
               onSetLayoutMode={mode => setPluginsLayoutMode(mode)}
               setSearchQuery={query => setPluginsSearchQuery(query)}
               linkButton={linkButton}

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -86,7 +86,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
     this.languageProvider = new LanguageProvider(this);
     const settingsData = instanceSettings.jsonData || {};
-    this.maxLines = parseInt(settingsData.maxLines, 10) || DEFAULT_MAX_LINES;
+    this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || DEFAULT_MAX_LINES;
   }
 
   getVersion() {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -114,7 +114,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
   };
 
   getLabelKeys(): string[] {
-    return this.labelKeys;
+    return this.labelKeys ?? [];
   }
 
   /**
@@ -129,7 +129,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const { wrapperClasses, value, prefix, text } = input;
 
     // Local text properties
-    const empty = value.document.text.length === 0;
+    const empty = value?.document?.text?.length === 0;
     const selectedLines = value.document.getTextsAtRange(value.selection);
     const currentLine = selectedLines.size === 1 ? selectedLines.first().getText() : null;
 
@@ -235,8 +235,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
   ): Promise<TypeaheadOutput> {
     let context = 'context-labels';
     const suggestions: CompletionItemGroup[] = [];
-    const line = value.anchorBlock.getText();
-    const cursorOffset = value.selection.anchor.offset;
+    const line = value?.anchorBlock.getText();
+    const cursorOffset = value?.selection.anchor.offset;
     const isValueStart = text.match(/^(=|=~|!=|!~)/);
 
     // Get normalized selector
@@ -387,7 +387,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       const rangeParams = absoluteRange ? rangeToParams(absoluteRange) : {};
       const res = await this.request(url, rangeParams);
       this.labelKeys = res.slice().sort();
-      this.logLabelOptions = this.labelKeys.map((key: string) => ({ label: key, value: key, isLeaf: false }));
+      this.logLabelOptions = this.labelKeys?.map((key: string) => ({ label: key, value: key, isLeaf: false }));
     } catch (e) {
       console.error(e);
     }
@@ -473,6 +473,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
         console.error(e);
       }
     }
-    return value;
+    return value ?? [];
   }
 }

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -245,3 +245,8 @@ export type RichHistoryQuery = {
   sessionName: string;
   timeRange?: string;
 };
+
+export enum QueryDirection {
+  backward = 'backward',
+  forward = 'forward',
+}

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -4,7 +4,7 @@ echo -e "Collecting code stats (typescript errors & more)"
 
 
 
-ERROR_COUNT_LIMIT=795
+ERROR_COUNT_LIMIT=760
 DIRECTIVES_LIMIT=172
 CONTROLLERS_LIMIT=139
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `show more logs` functionality in Explore, fixes a couple of strict-null errors.

Known issues:
- [ ] Time range edges (beginning, end) handling (we want to prevent the visible set from shrinking, even though technically it's not a bug)
- [ ] Line limit equal to 1 case where we don't request new lines
- [ ] Time range resets on `show newer logs` call (that's because all the queries we do now are `backward` - I look for a Loki's query direction equivalent at other log sources, like elastic logs)

UI issues:
- [ ] Show more logs buttons vertical margins

**Which issue(s) this PR fixes**:

Fixes #19354 