### PR TITLE
Search: Fix title search null pointer

### DIFF
--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -247,7 +247,7 @@ func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSear
 
 	if len(query.Title) > 0 {
 		sb.WithTitle(query.Title)
-		sb2filters = append(sb2filters, searchstore.TitleFilter{Title: query.Title})
+		sb2filters = append(sb2filters, searchstore.TitleFilter{Dialect: dialect, Title: query.Title})
 	}
 
 	if len(query.Type) > 0 {


### PR DESCRIPTION
Fixes a null-pointer that appeared when searching for a title with `search2` flag.