### PR TITLE
Dashboard: Add failsafe for slug generation

### DIFF
--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -189,7 +190,18 @@ func (dash *Dashboard) UpdateSlug() {
 }
 
 func SlugifyTitle(title string) string {
-	return slug.Make(strings.ToLower(title))
+	s := slug.Make(strings.ToLower(title))
+	if s == "" {
+		// If the dashboard name is only characters outside of the
+		// sluggable characters, the slug creation will return an
+		// empty string which will mess up URLs. This failsafe picks
+		// that up and creates the slug as a base64 identifier instead.
+		s = base64.RawURLEncoding.EncodeToString([]byte(title))
+		if slug.MaxLength != 0 && len(s) > slug.MaxLength {
+			s = s[:slug.MaxLength]
+		}
+	}
+	return s
 }
 
 // GetUrl return the html url for a folder if it's folder, otherwise for a dashboard


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When a dashboard title contains only characters which cannot be converted by the slug library into a URL friendly name we store an empty slug. This is a problem because when trying to open a dashboard with an empty slug the router will throw the client into an infinite loop. This PR adds a failsafe which sets the slug to a base64 variant of the title meaning than any non-empty title will be valid as a dashboard name.

This allows dashboard titles to be part of less-commonly used alphabets (I tried it with cuneiform) or emojis.

Another way to do this would be to escape the unicode to the URL escaped version. I chose not to do that because 1. it triggers a funny bug in search 2. the rendering in the browsers URL bar can be a little bit funny when having zero-width spaces and things like that. Let me know if there's a reason why we'd want to do that instead.

**Which issue(s) this PR fixes**:

Fixes #22618 (general solution, not only for the 🐴 emoji)

**Special notes for your reviewer**:
I used 𒆠 and 🙃 to test the functionality. I also tried with the first Kanji characters appearing on Google when googling Kanji: 漢字, but that seems to already work.
