### PR TITLE
Prettier: Add prettier config that imports prettier from toolkit

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('@grafana/toolkit/src/config/prettier.plugin.config.json'),
+};

--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
       "git add"
     ]
   },
-  "prettier": {
-    "trailingComma": "es5"
-  },
   "devDependencies": {
     "@babel/core": "7.8.4",
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.8.3",


### PR DESCRIPTION
We had an issue with prettier config for plugins was different from grafana repo code, This should safeguard against that happening in the future 