### PR TITLE
Search: raise service init prio

### DIFF
--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -11,7 +11,11 @@ import (
 )
 
 func init() {
-	registry.RegisterService(&SearchService{})
+	registry.Register(&registry.Descriptor{
+		Name:         "SearchService",
+		Instance:     &SearchService{},
+		InitPriority: 20,
+	})
 }
 
 type Query struct {


### PR DESCRIPTION
Search service needs to be initialised before service that depend on it.