### PR TITLE
Alerting: updating the victorops alerter to handle the no_data alert type

### DIFF
--- a/pkg/services/alerting/notifiers/victorops.go
+++ b/pkg/services/alerting/notifiers/victorops.go
@@ -13,7 +13,7 @@ import (
 
 // AlertStateCritical - Victorops uses "CRITICAL" string to indicate "Alerting" state
 const AlertStateCritical = "CRITICAL"
-
+const AlertStateWarning = "WARNING"
 const alertStateRecovery = "RECOVERY"
 
 func init() {
@@ -86,6 +86,9 @@ func (vn *VictoropsNotifier) Notify(evalContext *alerting.EvalContext) error {
 	messageType := evalContext.Rule.State
 	if evalContext.Rule.State == models.AlertStateAlerting { // translate 'Alerting' to 'CRITICAL' (Victorops analog)
 		messageType = AlertStateCritical
+	}
+	if evalContext.Rule.State == models.AlertStateNoData { // translate 'NODATA' to 'WARNING'
+		messageType = AlertStateWarning
 	}
 
 	if evalContext.Rule.State == models.AlertStateOK {

--- a/pkg/services/alerting/notifiers/victorops.go
+++ b/pkg/services/alerting/notifiers/victorops.go
@@ -13,6 +13,8 @@ import (
 
 // AlertStateCritical - Victorops uses "CRITICAL" string to indicate "Alerting" state
 const AlertStateCritical = "CRITICAL"
+
+// AlertStateWarning - Using "WARNING" to indicate no_data state in VictorOps
 const AlertStateWarning = "WARNING"
 const alertStateRecovery = "RECOVERY"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Alerts sent to Victorops with the messageType of 'no_data' are invalid.  This changes the messageType sent to a 'WARNING'.  That is an alert type recognized by VictorOps.


