### PR TITLE
Drawer: update z-index to show tooltips

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -36,6 +36,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, scollableContent: boolean)
         flex-direction: column;
         overflow: hidden;
       }
+      z-index: ${theme.zIndex.dropdown};
     `,
     header: css`
       background-color: ${theme.colors.bg2};


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Drawer component z-index so tooltips can be displayed.


