### PR TITLE
Plugins: Store public key for plugin manifests in the database.

### DIFF
--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -49,7 +49,7 @@ func newManifestVerifier(sqlstore *sqlstore.SqlStore) *manifestVerifier {
 }
 
 // getPublicKey loads public keys from the database.
-// Soon we can updated keys from https://grafana.com/api/plugins/ci/keys
+// Soon we can update keys from https://grafana.com/api/plugins/ci/keys
 func (pmv *manifestVerifier) getPublicKey(keyID string) (string, error) {
 	pmv.lock.Lock()
 	defer pmv.lock.Unlock()
@@ -76,7 +76,7 @@ func (pmv *manifestVerifier) getPublicKey(keyID string) (string, error) {
 		return key.PublicKey, nil
 	}
 
-	return "", errors.New("Could not find public Key")
+	return "", errors.New("could not find public key")
 }
 
 // readPluginManifest attempts to read and verify the plugin manifest
@@ -112,7 +112,7 @@ func (pmv *manifestVerifier) readPluginManifest(body []byte) (*pluginManifest, e
 	return manifest, nil
 }
 
-// GetPluginSignatureState returns the signature state for a plugin
+// verifyPluginSignature verifies a plugin's signature.
 func (pmv *manifestVerifier) verifyPluginSignature(plugin *PluginBase) PluginSignature {
 	manifestPath := path.Join(plugin.PluginDir, "MANIFEST.txt")
 

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -19,36 +20,38 @@ import (
 
 // Soon we can fetch keys from:
 //  https://grafana.com/api/plugins/ci/keys
-var defaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: OpenPGP.js v4.10.1
-Comment: https://openpgpjs.org
+// var defaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+// Version: OpenPGP.js v4.10.1
+// Comment: https://openpgpjs.org
 
-xpMEXpTXXxMFK4EEACMEIwQBiOUQhvGbDLvndE0fEXaR0908wXzPGFpf0P0Z
-HJ06tsq+0higIYHp7WTNJVEZtcwoYLcPRGaa9OQqbUU63BEyZdgAkPTz3RFd
-5+TkDWZizDcaVFhzbDd500yTwexrpIrdInwC/jrgs7Zy/15h8KA59XXUkdmT
-YB6TR+OA9RKME+dCJozNGUdyYWZhbmEgPGVuZ0BncmFmYW5hLmNvbT7CvAQQ
-EwoAIAUCXpTXXwYLCQcIAwIEFQgKAgQWAgEAAhkBAhsDAh4BAAoJEH5NDGpw
-iGbnaWoCCQGQ3SQnCkRWrG6XrMkXOKfDTX2ow9fuoErN46BeKmLM4f1EkDZQ
-Tpq3SE8+My8B5BIH3SOcBeKzi3S57JHGBdFA+wIJAYWMrJNIvw8GeXne+oUo
-NzzACdvfqXAZEp/HFMQhCKfEoWGJE8d2YmwY2+3GufVRTI5lQnZOHLE8L/Vc
-1S5MXESjzpcEXpTXXxIFK4EEACMEIwQBtHX/SD5Qm3v4V92qpaIZQgtTX0sT
-cFPjYWAHqsQ1iENrYN/vg1wU3ADlYATvydOQYvkTyT/tbDvx2Fse8PL84MQA
-YKKQ6AJ3gLVvmeouZdU03YoV4MYaT8KbnJUkZQZkqdz2riOlySNI9CG3oYmv
-omjUAtzgAgnCcurfGLZkkMxlmY8DAQoJwqQEGBMKAAkFAl6U118CGwwACgkQ
-fk0ManCIZuc0jAIJAVw2xdLr4ZQqPUhubrUyFcqlWoW8dQoQagwO8s8ubmby
-KuLA9FWJkfuuRQr+O9gHkDVCez3aism7zmJBqIOi38aNAgjJ3bo6leSS2jR/
-x5NqiKVi83tiXDPncDQYPymOnMhW0l7CVA7wj75HrFvvlRI/4MArlbsZ2tBn
-N1c5v9v/4h6qeA==
-=DNbR
------END PGP PUBLIC KEY BLOCK-----
-`
+// xpMEXpTXXxMFK4EEACMEIwQBiOUQhvGbDLvndE0fEXaR0908wXzPGFpf0P0Z
+// HJ06tsq+0higIYHp7WTNJVEZtcwoYLcPRGaa9OQqbUU63BEyZdgAkPTz3RFd
+// 5+TkDWZizDcaVFhzbDd500yTwexrpIrdInwC/jrgs7Zy/15h8KA59XXUkdmT
+// YB6TR+OA9RKME+dCJozNGUdyYWZhbmEgPGVuZ0BncmFmYW5hLmNvbT7CvAQQ
+// EwoAIAUCXpTXXwYLCQcIAwIEFQgKAgQWAgEAAhkBAhsDAh4BAAoJEH5NDGpw
+// iGbnaWoCCQGQ3SQnCkRWrG6XrMkXOKfDTX2ow9fuoErN46BeKmLM4f1EkDZQ
+// Tpq3SE8+My8B5BIH3SOcBeKzi3S57JHGBdFA+wIJAYWMrJNIvw8GeXne+oUo
+// NzzACdvfqXAZEp/HFMQhCKfEoWGJE8d2YmwY2+3GufVRTI5lQnZOHLE8L/Vc
+// 1S5MXESjzpcEXpTXXxIFK4EEACMEIwQBtHX/SD5Qm3v4V92qpaIZQgtTX0sT
+// cFPjYWAHqsQ1iENrYN/vg1wU3ADlYATvydOQYvkTyT/tbDvx2Fse8PL84MQA
+// YKKQ6AJ3gLVvmeouZdU03YoV4MYaT8KbnJUkZQZkqdz2riOlySNI9CG3oYmv
+// omjUAtzgAgnCcurfGLZkkMxlmY8DAQoJwqQEGBMKAAkFAl6U118CGwwACgkQ
+// fk0ManCIZuc0jAIJAVw2xdLr4ZQqPUhubrUyFcqlWoW8dQoQagwO8s8ubmby
+// KuLA9FWJkfuuRQr+O9gHkDVCez3aism7zmJBqIOi38aNAgjJ3bo6leSS2jR/
+// x5NqiKVi83tiXDPncDQYPymOnMhW0l7CVA7wj75HrFvvlRI/4MArlbsZ2tBn
+// N1c5v9v/4h6qeA==
+// =DNbR
+// -----END PGP PUBLIC KEY BLOCK-----
+// `
 
-var publicKeys = []publicKey{
-	{
-		KeyID:     "7e4d0c6a708866e7",
-		PublicKey: defaultPublicKey,
-	},
-}
+// var publicKeys = []ManifestKeys{
+// 	{
+// 		KeyID:     "7e4d0c6a708866e7",
+// 		PublicKey: defaultPublicKey,
+// 		UpdatedAt: time.Now().Unix(),
+// 		Since:     time.Now().Unix(),
+// 	},
+// }
 
 // pluginManifest holds details for the file manifest
 type pluginManifest struct {
@@ -59,29 +62,59 @@ type pluginManifest struct {
 	Files   map[string]string `json:"files"`
 }
 
-type publicKey struct {
+type ManifestKeys struct {
+	ID        int64  `xorm:"id autoincr"`
+	KeyID     string `xorm:"key_id"`
+	PublicKey string
+	Since     int64
+	RevokedAt int64
+	UpdatedAt int64
+}
+
+type manifestKeysJSON struct {
 	KeyID     string `json:"keyId"`
 	Since     int64  `json:"since"`
 	RevokedAt int64  `json:"revoked_at"`
 	PublicKey string `json:"public"`
 }
 
-func (pmv *manifestVerifier) getPublicKey(keyID string) (string, error) {
-	for _, v := range publicKeys {
-		if v.KeyID == keyID {
-			return v.PublicKey, nil
-		}
-	}
-
-	return "", errors.New("Could not find public Key")
-}
-
 type manifestVerifier struct {
-	sqlstore *sqlstore.SqlStore
+	sqlstore   *sqlstore.SqlStore
+	lock       sync.Mutex
+	publicKeys map[string]ManifestKeys
 }
 
 func newManifestVerifier(sqlstore *sqlstore.SqlStore) *manifestVerifier {
 	return &manifestVerifier{sqlstore: sqlstore}
+}
+
+func (pmv *manifestVerifier) getPublicKey(keyID string) (string, error) {
+	pmv.lock.Lock()
+	defer pmv.lock.Unlock()
+
+	// since we don't have any public keys we need to load them first
+	if len(pmv.publicKeys) == 0 {
+		session := pmv.sqlstore.NewSession()
+		defer session.Close()
+
+		var keys []ManifestKeys
+		err := session.Find(&keys)
+		if err != nil {
+			return "", err
+		}
+
+		pmv.publicKeys = make(map[string]ManifestKeys, len(keys))
+		for _, k := range keys {
+			pmv.publicKeys[k.KeyID] = k
+		}
+	}
+
+	key, exist := pmv.publicKeys[keyID]
+	if exist {
+		return key.PublicKey, nil
+	}
+
+	return "", errors.New("Could not find public Key")
 }
 
 // readPluginManifest attempts to read and verify the plugin manifest

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -18,41 +18,6 @@ import (
 	"golang.org/x/crypto/openpgp/clearsign"
 )
 
-// Soon we can fetch keys from:
-//  https://grafana.com/api/plugins/ci/keys
-// var defaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-// Version: OpenPGP.js v4.10.1
-// Comment: https://openpgpjs.org
-
-// xpMEXpTXXxMFK4EEACMEIwQBiOUQhvGbDLvndE0fEXaR0908wXzPGFpf0P0Z
-// HJ06tsq+0higIYHp7WTNJVEZtcwoYLcPRGaa9OQqbUU63BEyZdgAkPTz3RFd
-// 5+TkDWZizDcaVFhzbDd500yTwexrpIrdInwC/jrgs7Zy/15h8KA59XXUkdmT
-// YB6TR+OA9RKME+dCJozNGUdyYWZhbmEgPGVuZ0BncmFmYW5hLmNvbT7CvAQQ
-// EwoAIAUCXpTXXwYLCQcIAwIEFQgKAgQWAgEAAhkBAhsDAh4BAAoJEH5NDGpw
-// iGbnaWoCCQGQ3SQnCkRWrG6XrMkXOKfDTX2ow9fuoErN46BeKmLM4f1EkDZQ
-// Tpq3SE8+My8B5BIH3SOcBeKzi3S57JHGBdFA+wIJAYWMrJNIvw8GeXne+oUo
-// NzzACdvfqXAZEp/HFMQhCKfEoWGJE8d2YmwY2+3GufVRTI5lQnZOHLE8L/Vc
-// 1S5MXESjzpcEXpTXXxIFK4EEACMEIwQBtHX/SD5Qm3v4V92qpaIZQgtTX0sT
-// cFPjYWAHqsQ1iENrYN/vg1wU3ADlYATvydOQYvkTyT/tbDvx2Fse8PL84MQA
-// YKKQ6AJ3gLVvmeouZdU03YoV4MYaT8KbnJUkZQZkqdz2riOlySNI9CG3oYmv
-// omjUAtzgAgnCcurfGLZkkMxlmY8DAQoJwqQEGBMKAAkFAl6U118CGwwACgkQ
-// fk0ManCIZuc0jAIJAVw2xdLr4ZQqPUhubrUyFcqlWoW8dQoQagwO8s8ubmby
-// KuLA9FWJkfuuRQr+O9gHkDVCez3aism7zmJBqIOi38aNAgjJ3bo6leSS2jR/
-// x5NqiKVi83tiXDPncDQYPymOnMhW0l7CVA7wj75HrFvvlRI/4MArlbsZ2tBn
-// N1c5v9v/4h6qeA==
-// =DNbR
-// -----END PGP PUBLIC KEY BLOCK-----
-// `
-
-// var publicKeys = []ManifestKeys{
-// 	{
-// 		KeyID:     "7e4d0c6a708866e7",
-// 		PublicKey: defaultPublicKey,
-// 		UpdatedAt: time.Now().Unix(),
-// 		Since:     time.Now().Unix(),
-// 	},
-// }
-
 // pluginManifest holds details for the file manifest
 type pluginManifest struct {
 	Plugin  string            `json:"plugin"`
@@ -62,6 +27,8 @@ type pluginManifest struct {
 	Files   map[string]string `json:"files"`
 }
 
+// ManifestKeys is the database representation of public keys
+// used to verify plugin manifests.
 type ManifestKeys struct {
 	ID        int64  `xorm:"id autoincr"`
 	KeyID     string `xorm:"key_id"`
@@ -88,6 +55,8 @@ func newManifestVerifier(sqlstore *sqlstore.SqlStore) *manifestVerifier {
 	return &manifestVerifier{sqlstore: sqlstore}
 }
 
+// getPublicKey loads public keys from the database.
+// Soon we can updated keys from https://grafana.com/api/plugins/ci/keys
 func (pmv *manifestVerifier) getPublicKey(keyID string) (string, error) {
 	pmv.lock.Lock()
 	defer pmv.lock.Unlock()

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -38,13 +38,6 @@ type ManifestKeys struct {
 	UpdatedAt int64
 }
 
-type manifestKeysJSON struct {
-	KeyID     string `json:"keyId"`
-	Since     int64  `json:"since"`
-	RevokedAt int64  `json:"revoked_at"`
-	PublicKey string `json:"public"`
-}
-
 type manifestVerifier struct {
 	sqlstore   *sqlstore.SqlStore
 	lock       sync.Mutex

--- a/pkg/plugins/manifest_test.go
+++ b/pkg/plugins/manifest_test.go
@@ -24,19 +24,19 @@ func TestDatabaseAccessForManifestKeys(t *testing.T) {
 		session := mv.sqlstore.NewSession()
 		defer session.Close()
 		affected, err := session.Insert(testKeys)
-		assert.Nil(t, err)
-		assert.Equal(t, affected, int64(len(testKeys)))
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(testKeys)), affected)
 	})
 
 	t.Run("can query keys from database", func(t *testing.T) {
-		keys, err := mv.getPublicKey("keyid1")
-		assert.Nil(t, err)
-		assert.Equal(t, keys, testKeys[0].PublicKey)
+		key, err := mv.getPublicKey("keyid1")
+		require.NoError(t, err)
+		assert.Equal(t, testKeys[0].PublicKey, key)
 	})
 
 	t.Run("should return error if key doesn't exist", func(t *testing.T) {
 		_, err := mv.getPublicKey("missing keyId")
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 	})
 }
 

--- a/pkg/plugins/manifest_test.go
+++ b/pkg/plugins/manifest_test.go
@@ -39,8 +39,10 @@ NR7DnB0CCQHO+4FlSPtXFTzNepoc+CytQyDAeOLMLmf2Tqhk2YShk+G/YlVX
 =hBea
 -----END PGP SIGNATURE-----`
 
+	mv := newManifestVerifier(nil)
+
 	t.Run("valid manifest", func(t *testing.T) {
-		manifest, err := readPluginManifest([]byte(txt))
+		manifest, err := mv.readPluginManifest([]byte(txt))
 
 		assert.Nil(t, err)
 		assert.NotNil(t, manifest)
@@ -49,7 +51,7 @@ NR7DnB0CCQHO+4FlSPtXFTzNepoc+CytQyDAeOLMLmf2Tqhk2YShk+G/YlVX
 
 	t.Run("invalid manifest", func(t *testing.T) {
 		modified := strings.ReplaceAll(txt, "README.md", "xxxxxxxxxx")
-		manifest, err := readPluginManifest([]byte(modified))
+		manifest, err := mv.readPluginManifest([]byte(modified))
 		assert.NotNil(t, err)
 		assert.Nil(t, manifest)
 	})

--- a/pkg/plugins/manifest_test.go
+++ b/pkg/plugins/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatabaseAccessForManifestKeys(t *testing.T) {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -128,7 +128,6 @@ func (pm *PluginManager) Init() error {
 		if p.IsCorePlugin {
 			p.Signature = PluginSignatureInternal
 		} else {
-			//p.Signature = verifyPluginSignature(pm.SQLStore, p)
 			p.Signature = manifestVerifier.verifyPluginSignature(p)
 			metrics.SetPluginBuildInformation(p.Id, p.Type, p.Info.Version)
 		}

--- a/pkg/services/sqlstore/migrations/plugin_setting.go
+++ b/pkg/services/sqlstore/migrations/plugin_setting.go
@@ -87,7 +87,7 @@ N1c5v9v/4h6qeA==
 `
 
 	mg.AddMigration(
-		"insert public key into manifest)keys table",
+		"insert public key into manifest_keys table",
 		NewRawSqlMigration(fmt.Sprintf(`INSERT into manifest_keys (key_id, public_key, since, updated_at) VALUES ('%s', '%s', %d, %d)`,
 			defaultKeyID,
 			defaultPublicKey,

--- a/pkg/services/sqlstore/migrations/plugin_setting.go
+++ b/pkg/services/sqlstore/migrations/plugin_setting.go
@@ -48,7 +48,7 @@ func addAppSettingsMigration(mg *Migrator) {
 		Name: "manifest_keys",
 		Columns: []*Column{
 			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
-			{Name: "key_id", Type: DB_BigInt, Nullable: false},
+			{Name: "key_id", Type: DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "public_key", Type: DB_Text, Nullable: false},
 			{Name: "since", Type: DB_BigInt, Nullable: false},
 			{Name: "revoked_at", Type: DB_BigInt, Nullable: true},
@@ -60,6 +60,8 @@ func addAppSettingsMigration(mg *Migrator) {
 	}
 
 	mg.AddMigration("create manifest_keys table", NewAddTableMigration(manifestKeys))
+
+	addTableIndicesMigrations(mg, "v1", manifestKeys)
 
 	var defaultKeyID = `7e4d0c6a708866e7`
 	var defaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -86,11 +88,11 @@ N1c5v9v/4h6qeA==
 -----END PGP PUBLIC KEY BLOCK-----
 `
 
-	mg.AddMigration(
-		"insert public key into manifest_keys table",
-		NewRawSqlMigration(fmt.Sprintf(`INSERT into manifest_keys (key_id, public_key, since, updated_at) VALUES ('%s', '%s', %d, %d)`,
-			defaultKeyID,
-			defaultPublicKey,
-			time.Now().Unix(),
-			time.Now().Unix())))
+	var insertManifestKey = fmt.Sprintf(`INSERT into manifest_keys (key_id, since, updated_at, public_key) VALUES ('%s', %d, %d, '%s')`,
+		defaultKeyID,
+		time.Now().Unix(),
+		time.Now().Unix(),
+		defaultPublicKey)
+
+	mg.AddMigration("insert public key into manifest_keys table", NewRawSqlMigration(insertManifestKey))
 }

--- a/pkg/services/sqlstore/migrations/plugin_setting.go
+++ b/pkg/services/sqlstore/migrations/plugin_setting.go
@@ -88,10 +88,9 @@ N1c5v9v/4h6qeA==
 
 	mg.AddMigration(
 		"insert public key into manifest)keys table",
-		NewRawSqlMigration(
-			fmt.Sprintf(`INSERT into manifest_keys (key_id, public_key, since, updated_at) VALUES ("%s", "%s", %d, %d)`,
-				defaultKeyID,
-				defaultPublicKey,
-				time.Now().Unix(),
-				time.Now().Unix())))
+		NewRawSqlMigration(fmt.Sprintf(`INSERT into manifest_keys (key_id, public_key, since, updated_at) VALUES ('%s', '%s', %d, %d)`,
+			defaultKeyID,
+			defaultPublicKey,
+			time.Now().Unix(),
+			time.Now().Unix())))
 }

--- a/pkg/services/sqlstore/migrations/plugin_setting.go
+++ b/pkg/services/sqlstore/migrations/plugin_setting.go
@@ -1,6 +1,11 @@
 package migrations
 
-import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+import (
+	"fmt"
+	"time"
+
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
 
 func addAppSettingsMigration(mg *Migrator) {
 
@@ -38,4 +43,55 @@ func addAppSettingsMigration(mg *Migrator) {
 		{Name: "secure_json_data", Type: DB_Text, Nullable: true},
 		{Name: "plugin_version", Type: DB_NVarchar, Nullable: true, Length: 50},
 	}))
+
+	manifestKeys := Table{
+		Name: "manifest_keys",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "key_id", Type: DB_BigInt, Nullable: false},
+			{Name: "public_key", Type: DB_Text, Nullable: false},
+			{Name: "since", Type: DB_BigInt, Nullable: false},
+			{Name: "revoked_at", Type: DB_BigInt, Nullable: true},
+			{Name: "updated_at", Type: DB_BigInt, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"key_id"}, Type: UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create manifest_keys table", NewAddTableMigration(manifestKeys))
+
+	var defaultKeyID = `7e4d0c6a708866e7`
+	var defaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: OpenPGP.js v4.10.1
+Comment: https://openpgpjs.org
+
+xpMEXpTXXxMFK4EEACMEIwQBiOUQhvGbDLvndE0fEXaR0908wXzPGFpf0P0Z
+HJ06tsq+0higIYHp7WTNJVEZtcwoYLcPRGaa9OQqbUU63BEyZdgAkPTz3RFd
+5+TkDWZizDcaVFhzbDd500yTwexrpIrdInwC/jrgs7Zy/15h8KA59XXUkdmT
+YB6TR+OA9RKME+dCJozNGUdyYWZhbmEgPGVuZ0BncmFmYW5hLmNvbT7CvAQQ
+EwoAIAUCXpTXXwYLCQcIAwIEFQgKAgQWAgEAAhkBAhsDAh4BAAoJEH5NDGpw
+iGbnaWoCCQGQ3SQnCkRWrG6XrMkXOKfDTX2ow9fuoErN46BeKmLM4f1EkDZQ
+Tpq3SE8+My8B5BIH3SOcBeKzi3S57JHGBdFA+wIJAYWMrJNIvw8GeXne+oUo
+NzzACdvfqXAZEp/HFMQhCKfEoWGJE8d2YmwY2+3GufVRTI5lQnZOHLE8L/Vc
+1S5MXESjzpcEXpTXXxIFK4EEACMEIwQBtHX/SD5Qm3v4V92qpaIZQgtTX0sT
+cFPjYWAHqsQ1iENrYN/vg1wU3ADlYATvydOQYvkTyT/tbDvx2Fse8PL84MQA
+YKKQ6AJ3gLVvmeouZdU03YoV4MYaT8KbnJUkZQZkqdz2riOlySNI9CG3oYmv
+omjUAtzgAgnCcurfGLZkkMxlmY8DAQoJwqQEGBMKAAkFAl6U118CGwwACgkQ
+fk0ManCIZuc0jAIJAVw2xdLr4ZQqPUhubrUyFcqlWoW8dQoQagwO8s8ubmby
+KuLA9FWJkfuuRQr+O9gHkDVCez3aism7zmJBqIOi38aNAgjJ3bo6leSS2jR/
+x5NqiKVi83tiXDPncDQYPymOnMhW0l7CVA7wj75HrFvvlRI/4MArlbsZ2tBn
+N1c5v9v/4h6qeA==
+=DNbR
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+	mg.AddMigration(
+		"insert public key into manifest)keys table",
+		NewRawSqlMigration(
+			fmt.Sprintf(`INSERT into manifest_keys (key_id, public_key, since, updated_at) VALUES ("%s", "%s", %d, %d)`,
+				defaultKeyID,
+				defaultPublicKey,
+				time.Now().Unix(),
+				time.Now().Unix())))
 }


### PR DESCRIPTION
Storing the public key in the database instead of hardcoded will allow users to add new keys without recompiling/upgrading Grafana. 

Once this is merged we can think about download new keys/revoking keys from grafana.com / filesystem. 

ref https://github.com/grafana/grafana/issues/23619