### PR TITLE
PanelEditor: stores option group collapse state

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/types.ts
+++ b/public/app/features/dashboard/components/PanelEditor/types.ts
@@ -23,3 +23,7 @@ export const displayModes = [
   { value: DisplayMode.Fit, label: 'Fit', description: 'Fit in the space keeping ratio' },
   { value: DisplayMode.Exact, label: 'Exact', description: 'Same size as the dashboard' },
 ];
+
+export type OptionGroupStorageItem = { defaultToClosed: boolean };
+export const defaultStorageItem: OptionGroupStorageItem = { defaultToClosed: false };
+export type StoreOptionGroupCallback = (value: OptionGroupStorageItem) => void;

--- a/public/app/features/dashboard/components/PanelEditor/utils.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.ts
@@ -1,7 +1,8 @@
 import { CSSProperties } from 'react';
 import { PanelModel } from '../../state/PanelModel';
-import { DisplayMode } from './types';
+import { DisplayMode, StoreOptionGroupCallback } from './types';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
+import { PANEL_EDITOR_UI_STATE_STORAGE_KEY } from './state/reducers';
 
 export function calculatePanelSize(mode: DisplayMode, width: number, height: number, panel: PanelModel): CSSProperties {
   if (mode === DisplayMode.Fill) {
@@ -22,5 +23,19 @@ export function calculatePanelSize(mode: DisplayMode, width: number, height: num
   return {
     width: pWidth * scale,
     height: pHeight * scale,
+  };
+}
+
+export function getOptionGroupStorageKey(id: string): string {
+  return `${PANEL_EDITOR_UI_STATE_STORAGE_KEY}.optionGroup[${id}]`;
+}
+
+export function storeOptionGroupExpanded(isExpanded: boolean, onSaveToStore: StoreOptionGroupCallback) {
+  onSaveToStore({ defaultToClosed: !isExpanded });
+}
+
+export function onOptionGroupToggle(onSaveToStore: StoreOptionGroupCallback) {
+  return function(isExpanded: boolean): void {
+    storeOptionGroupExpanded(isExpanded, onSaveToStore);
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Initial draft to see what you think about this pattern before I move forward. I think I would rather have a self-contained OptionGroup that stores its value to local storage without wrapper, but again that also has some drawbacks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

