### PR TITLE
Docs: Move Postgres version warning and remove details

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -11,8 +11,6 @@ weight = 7
 
 # Using PostgreSQL in Grafana
 
-> NOTE: In **9.5.18, 9.4.23, 9.6.14, 10.9, 11.4, 12-beta2** versions of PostgreSQL has a [bug](https://www.postgresql.org/message-id/flat/28827.1561082086%40sss.pgh.pa.us#df2287bd7481153984bef6bab40af0db) which prevents execution of multiple column modifications via `ALTER TABLE` statement. Because Grafana uses it during initial database set up and since PostgreSQL has [fixed](https://github.com/postgres/postgres/commit/f946a409143d01951411382fbc3c91c7eb640094) this issue, Grafana **does not support these versions**
-
 Grafana ships with a built-in PostgreSQL data source plugin that allows you to query and visualize data from a PostgreSQL compatible database.
 
 ## Adding the data source

--- a/docs/sources/installation/requirements.md
+++ b/docs/sources/installation/requirements.md
@@ -54,6 +54,8 @@ Grafana supports the following databases:
 
 By default, Grafana installs with and uses SQLite, which is an embedded database stored in the Grafana installation location.
 
+> NOTE: PostgreSQL versions 9.5.18, 9.4.23, 9.6.14, 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
+
 ## Supported web browsers
 
 Grafana is supported in the current version of the following browsers. Older versions of these browsers might not be supported, so you should always upgrade to the latest version when using Grafana.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current PostgreSQL version warning is for the data source PostgreSQL documentation, but the bug affects Postgres when used as Grafana's relational database, not as a datasource.

I also took the opportunity to reduce the amount of details about the bug and update the link to link to the full thread about the bug in the `pgsql-bugs` mailing list.