### PR TITLE
Transformations: Make sidebar subscribe to panel's query runner

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -332,8 +332,6 @@ export function SelectBase<T>({
           }),
           container: () => ({
             position: 'relative',
-            // This puts the menu above Inputs (z-index: 1)
-            zIndex: theme.zIndex.dropdown,
             width: width ? `${8 * width}px` : '100%',
           }),
         }}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, CSSProperties } from 'react';
 import Transition from 'react-transition-group/Transition';
-import { FieldConfigSource, GrafanaTheme, PanelData, PanelPlugin, SelectableValue } from '@grafana/data';
+import { FieldConfigSource, GrafanaTheme, PanelPlugin, SelectableValue } from '@grafana/data';
 import { DashboardModel, PanelModel } from '../../state';
 import { CustomScrollbar, stylesFactory, Tab, TabContent, TabsBar, Select, useTheme, Icon, Input } from '@grafana/ui';
 import { DefaultFieldConfigEditor, OverrideFieldConfigEditor } from './FieldConfigEditor';
@@ -12,7 +12,6 @@ import { usePanelLatestData } from './usePanelLatestData';
 interface Props {
   plugin: PanelPlugin;
   panel: PanelModel;
-  data: PanelData;
   width: number;
   dashboard: DashboardModel;
   onClose: () => void;
@@ -24,7 +23,6 @@ interface Props {
 export const OptionsPaneContent: React.FC<Props> = ({
   plugin,
   panel,
-  data,
   width,
   onFieldConfigsChange,
   onPanelOptionsChanged,
@@ -36,13 +34,13 @@ export const OptionsPaneContent: React.FC<Props> = ({
   const styles = getStyles(theme);
   const [activeTab, setActiveTab] = useState('options');
   const [isSearching, setSearchMode] = useState(false);
-  const currentData = usePanelLatestData(panel);
+  const [currentData, hasSeries] = usePanelLatestData(panel);
 
   const renderFieldOptions = useCallback(
     (plugin: PanelPlugin) => {
       const fieldConfig = panel.getFieldConfig();
 
-      if (!fieldConfig || !currentData) {
+      if (!fieldConfig || !hasSeries) {
         return null;
       }
 
@@ -51,7 +49,7 @@ export const OptionsPaneContent: React.FC<Props> = ({
           config={fieldConfig}
           plugin={plugin}
           onChange={onFieldConfigsChange}
-          data={currentData}
+          data={currentData.series}
         />
       );
     },
@@ -62,7 +60,7 @@ export const OptionsPaneContent: React.FC<Props> = ({
     (plugin: PanelPlugin) => {
       const fieldConfig = panel.getFieldConfig();
 
-      if (!fieldConfig || !currentData) {
+      if (!fieldConfig || !hasSeries) {
         return null;
       }
 
@@ -71,7 +69,7 @@ export const OptionsPaneContent: React.FC<Props> = ({
           config={fieldConfig}
           plugin={plugin}
           onChange={onFieldConfigsChange}
-          data={currentData}
+          data={currentData.series}
         />
       );
     },
@@ -105,7 +103,7 @@ export const OptionsPaneContent: React.FC<Props> = ({
                   panel={panel}
                   plugin={plugin}
                   dashboard={dashboard}
-                  data={data}
+                  data={currentData}
                   onPanelConfigChange={onPanelConfigChange}
                   onFieldConfigsChange={onFieldConfigsChange}
                   onPanelOptionsChanged={onPanelOptionsChanged}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -7,6 +7,7 @@ import { DefaultFieldConfigEditor, OverrideFieldConfigEditor } from './FieldConf
 import { css } from 'emotion';
 import { PanelOptionsTab } from './PanelOptionsTab';
 import { DashNavButton } from 'app/features/dashboard/components/DashNav/DashNavButton';
+import { usePanelLatestData } from './usePanelLatestData';
 
 interface Props {
   plugin: PanelPlugin;
@@ -35,12 +36,13 @@ export const OptionsPaneContent: React.FC<Props> = ({
   const styles = getStyles(theme);
   const [activeTab, setActiveTab] = useState('options');
   const [isSearching, setSearchMode] = useState(false);
+  const currentData = usePanelLatestData(panel);
 
   const renderFieldOptions = useCallback(
     (plugin: PanelPlugin) => {
       const fieldConfig = panel.getFieldConfig();
 
-      if (!fieldConfig) {
+      if (!fieldConfig || !currentData) {
         return null;
       }
 
@@ -49,18 +51,18 @@ export const OptionsPaneContent: React.FC<Props> = ({
           config={fieldConfig}
           plugin={plugin}
           onChange={onFieldConfigsChange}
-          data={data.series}
+          data={currentData}
         />
       );
     },
-    [data, plugin, panel, onFieldConfigsChange]
+    [currentData, plugin, panel, onFieldConfigsChange]
   );
 
   const renderFieldOverrideOptions = useCallback(
     (plugin: PanelPlugin) => {
       const fieldConfig = panel.getFieldConfig();
 
-      if (!fieldConfig) {
+      if (!fieldConfig || !currentData) {
         return null;
       }
 
@@ -69,11 +71,11 @@ export const OptionsPaneContent: React.FC<Props> = ({
           config={fieldConfig}
           plugin={plugin}
           onChange={onFieldConfigsChange}
-          data={data.series}
+          data={currentData}
         />
       );
     },
-    [data, plugin, panel, onFieldConfigsChange]
+    [currentData, plugin, panel, onFieldConfigsChange]
   );
 
   // When the panel has no query only show the main tab

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -275,7 +275,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   }
 
   renderOptionsPane() {
-    const { plugin, dashboard, data, panel, uiState } = this.props;
+    const { plugin, dashboard, panel, uiState } = this.props;
 
     if (!plugin) {
       return <div />;
@@ -285,7 +285,6 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
       <OptionsPaneContent
         plugin={plugin}
         dashboard={dashboard}
-        data={data}
         panel={panel}
         width={uiState.rightPaneSize as number}
         onClose={this.onTogglePanelOptions}

--- a/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
+++ b/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { PanelModel } from '../../state';
 import { Unsubscribable } from 'rxjs';
 
-export const usePanelLatestData = (panel: PanelModel) => {
+export const usePanelLatestData = (panel: PanelModel): [PanelData | null, boolean] => {
   const querySubscription = useRef<Unsubscribable>(null);
   const [latestData, setLatestData] = useState<PanelData>(null);
 
@@ -23,5 +23,9 @@ export const usePanelLatestData = (panel: PanelModel) => {
     };
   }, [panel]);
 
-  return latestData?.series;
+  return [
+    latestData,
+    // TODO: make this more clever, use PanelData.state
+    !!(latestData && latestData.series),
+  ];
 };

--- a/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
+++ b/public/app/features/dashboard/components/PanelEditor/usePanelLatestData.ts
@@ -1,0 +1,27 @@
+import { PanelData } from '@grafana/data';
+import { useEffect, useRef, useState } from 'react';
+import { PanelModel } from '../../state';
+import { Unsubscribable } from 'rxjs';
+
+export const usePanelLatestData = (panel: PanelModel) => {
+  const querySubscription = useRef<Unsubscribable>(null);
+  const [latestData, setLatestData] = useState<PanelData>(null);
+
+  useEffect(() => {
+    querySubscription.current = panel
+      .getQueryRunner()
+      .getData()
+      .subscribe({
+        next: data => setLatestData(data),
+      });
+
+    return () => {
+      if (querySubscription.current) {
+        console.log('unsubscribing');
+        querySubscription.current.unsubscribe();
+      }
+    };
+  }, [panel]);
+
+  return latestData?.series;
+};


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/issues/22269

This makes sure panel editor sidebar is subscribed to panel query runner to reflect changes after transformations are applied. This is required for matchers to have correct data as well as data links to suggest correct variables.