### PR TITLE
Explore: Fix split functionality

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -282,7 +282,8 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                   splitted={splitted}
                   title="Split"
                   /* This way ResponsiveButton doesn't add event as a parameter when invoking split function
-                   * which breaks splitting functionality */
+                   * which breaks splitting functionality
+                   */
                   onClick={() => split()}
                   icon="columns"
                   iconClassName="icon-margin-right"

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -281,7 +281,9 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                 <ResponsiveButton
                   splitted={splitted}
                   title="Split"
-                  onClick={split}
+                  /* This way ResponsiveButton doesn't add event as a parameter when invoking split function
+                   * which breaks splitting functionality */
+                  onClick={() => split()}
                   icon="columns"
                   iconClassName="icon-margin-right"
                   disabled={isLive}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes splitting functionality. Responsive button was passing event parameter to splitOpen function and therefore [this part of the code was being run](https://github.com/grafana/grafana/blob/master/public/app/features/explore/state/actions.ts#L720) which resulted in error as it didn't have correct parameters. By passing `() => split()` to onClick, we are making sure that event parameters are not passed. 

![image](https://user-images.githubusercontent.com/30407135/80031094-81506f00-84e9-11ea-92ca-b3dc09a99269.png)

Fixes  https://github.com/grafana/grafana/issues/23734

