### PR TITLE
Postgres: Add custom Query Builder value columns to datasource config

### DIFF
--- a/public/app/plugins/datasource/postgres/config_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/config_ctrl.ts
@@ -20,6 +20,7 @@ export class PostgresConfigCtrl {
     this.datasourceSrv = datasourceSrv;
     this.current.jsonData.sslmode = this.current.jsonData.sslmode || 'verify-full';
     this.current.jsonData.postgresVersion = this.current.jsonData.postgresVersion || 903;
+    this.current.jsonData.metaValueColumnsQuery = this.current.jsonData.metaValueColumnsQuery || null;
     this.showTimescaleDBHelp = false;
     this.autoDetectFeatures();
     this.onPasswordReset = createResetHandler(this, PasswordFieldEnum.Password);

--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -155,3 +155,32 @@
 		</p>
 	</div>
 </div>
+
+<div class="gf-form-group">
+		<h3 class="page-heading">Advanced Query Builder Settings</h3>
+		<div class="gf-form">
+			<span class="gf-form-label width-10">
+				Extra Value Columns
+				<info-popover mode="left-normal" position="top center">
+					Add columns to the query builder's built-in selection.<br/>
+					This lets you format non-standard data types for SELECT
+					in the Postgres query builder.<br/>
+					Rows from this query get UNION'd with the basic Postgres data types.<br/><br/>
+					You must select 1 column of type TEXT, no trailing semicolon.<br/><br/>
+					$__table_constraint gets replaced with the currently selected table like: TABLE_NAME = 'current_table'
+				</info-popover>
+			</span>
+			<textarea type="text" class="gf-form-input" ng-model='ctrl.current.jsonData.metaValueColumnsQuery'
+			placeholder="SELECT
+UNNEST( ARRAY[
+	concat('(', column_name, ').min'),
+	concat('(', column_name, ').max'),
+	concat('(', column_name, ').samplesum'),
+	concat('(', column_name, ').samplecount')
+] )
+FROM information_schema.columns
+WHERE
+	udt_name = 'custom_user_datatype'
+	AND $__table_constraint"></textarea>
+		</div>
+</div>

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -54,7 +54,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     super($scope, $injector);
     this.target = this.target;
     this.queryModel = new PostgresQuery(this.target, templateSrv, this.panel.scopedVars);
-    this.metaBuilder = new PostgresMetaQuery(this.target, this.queryModel);
+    this.metaBuilder = new PostgresMetaQuery(this.target, this.queryModel, this.datasource.jsonData);
     this.updateProjection();
 
     this.formats = [


### PR DESCRIPTION
* New Postgres configuration section for custom metadata queries.

* Updated meta_query to add user-defined columns for query builder SELECT Columns.

* Updated query_ctrl to pass in new configuration.

**What this PR does / why we need it**:
This PR adds the ability for users with Postgresql / TimescaleDB to use the grafana query builder with custom data types.  Consider a data type:
```
create type metric as (
  min double precision,
  max double precision,
  samplesum double precision,
  samplecount integer);
```

Currently you'd need to reach for the SQL text box to use that data type at all.  By allowing users to supply additional formatted columns with their data sources the range of graphable data types is greatly expanded.

Note that this is a pretty advanced feature and there are intentionally not a lot of guard rails.  When the datasource query is badly configured the query builder `400`'s.  It is expected that the typical use case for this functionality is a one-off dive per custom data type - which is probably an infrequent occurrence.

**Test results**:
```
>> Test Suites: 459 passed, 459 total
>> Tests:       2 skipped, 3848 passed, 3850 total
>> Snapshots:   171 passed, 171 total
>> Time:        285.422s
>> Ran all test suites.
```

**Special notes for your reviewer**:
This is my first Grafana contribution and I set up my dev environment today.  If I've missed anything basic in this PR, please do let me know.