### PR TITLE
CloudWatch: Prefer webIdentity over EC2 role also when assuming a role

### DIFF
--- a/pkg/tsdb/cloudwatch/credentials.go
+++ b/pkg/tsdb/cloudwatch/credentials.go
@@ -60,8 +60,8 @@ func GetCredentials(dsInfo *DatasourceInfo) (*credentials.Credentials, error) {
 			[]credentials.Provider{
 				&credentials.EnvProvider{},
 				&credentials.SharedCredentialsProvider{Filename: "", Profile: dsInfo.Profile},
-				remoteCredProvider(stsSess),
 				webIdentityProvider(stsSess),
+				remoteCredProvider(stsSess),
 			})
 		stsConfig := &aws.Config{
 			Region:      aws.String(dsInfo.Region),


### PR DESCRIPTION

**What this PR does / why we need it**:

Same as https://github.com/grafana/grafana/pull/23452 but for assumed roles. The problem is exactly as described in the linked issue of the other PR.

**Which issue(s) this PR fixes**:

With this PR the webIdentity role is preferred over the EC2 role when getting the credentials required to assume the role.
