### PR TITLE
Typeahead: Fix z-index

### DIFF
--- a/public/sass/components/_slate_editor.scss
+++ b/public/sass/components/_slate_editor.scss
@@ -29,7 +29,7 @@
 .slate-typeahead {
   .typeahead {
     position: relative;
-    z-index: auto;
+    z-index: $zindex-typeahead;
     border-radius: $border-radius;
     border: $panel-border;
     max-height: calc(66vh);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes issue with typeahead z-index. 

Before:
![image](https://user-images.githubusercontent.com/30407135/80081337-19367300-8553-11ea-81ad-4ac4d6bbc3c5.png)

After:
![image](https://user-images.githubusercontent.com/30407135/80080854-74b43100-8552-11ea-8e0a-deb6aa9b1167.png)


