### PR TITLE
DRAFT: Prometheus: Improve handling of large amounts of metric names

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/marked": "0.6.5",
     "@types/mousetrap": "1.6.3",
     "@types/node": "13.7.0",
+    "@types/oboe": "^2.0.28",
     "@types/papaparse": "4.5.9",
     "@types/pixelmatch": "4.0.0",
     "@types/pngjs": "3.4.1",
@@ -201,6 +202,7 @@
     "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.10.3",
     "webpack-merge": "4.2.2",
+    "worker-loader": "^2.0.0",
     "zone.js": "0.7.8"
   },
   "dependencies": {
@@ -243,6 +245,7 @@
     "mousetrap": "1.6.5",
     "mousetrap-global-bind": "1.1.0",
     "nodemon": "2.0.2",
+    "oboe": "2.1.4",
     "papaparse": "4.6.3",
     "prismjs": "1.19.0",
     "prop-types": "15.7.2",

--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -39,6 +39,13 @@ export interface BackendSrv {
 
   // DataSource requests add hooks into the query inspector
   datasourceRequest(options: BackendSrvRequest): Promise<any>;
+
+  // Can be used to augment the request headers just like the backend service
+  // would anywhere else in the code base. (Obviously, there should be good
+  // reasons not to use the request API that this service provides.)
+  augmentRequestHeaders(headers: BackendSrvRequest['headers']): any;
+
+  augmentDataSourceRequestHeaders(headers: BackendSrvRequest['headers']): any;
 }
 
 let singletonInstance: BackendSrv;

--- a/packages/grafana-ui/src/utils/typeahead.ts
+++ b/packages/grafana-ui/src/utils/typeahead.ts
@@ -8,8 +8,8 @@ export const flattenGroupItems = (groupedItems: CompletionItemGroup[]): Completi
       label,
       kind: CompletionItemKind.GroupTitle,
     };
-    all.push(titleItem, ...items);
-    return all;
+
+    return all.concat(titleItem, items);
   }, []);
 };
 

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -19,7 +19,7 @@ import templateSrv from 'app/features/templating/template_srv';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { CustomVariable } from 'app/features/templating/custom_variable';
 
-const datasourceRequestMock = jest.fn().mockResolvedValue(createDefaultPromResponse());
+export const datasourceRequestMock = jest.fn().mockResolvedValue(createDefaultPromResponse());
 
 jest.mock('./metric_find_query');
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -6,8 +6,16 @@ import { HistoryItem } from '@grafana/data';
 import { PromQuery } from './types';
 import StreamJSONResponse from './workers/StreamJSONResponse.worker';
 import { MockWorker } from './workers/mocks/StreamJSONResponse.worker';
+import { BackendSrv } from '@grafana/runtime';
 
 import Mock = jest.Mock;
+
+type MockBackendSrv = { augmentDataSourceRequestHeaders: BackendSrv['augmentDataSourceRequestHeaders'] };
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: (): MockBackendSrv => ({
+    augmentDataSourceRequestHeaders: headers => headers,
+  }),
+}));
 
 jest.mock('./workers/StreamJSONResponse.worker');
 function mockStreamJSONResponse(metrics: string[] = [], metadata: any = {}) {

--- a/public/app/plugins/datasource/prometheus/workers/GroupMetricsByPrefix.worker.test.tsx
+++ b/public/app/plugins/datasource/prometheus/workers/GroupMetricsByPrefix.worker.test.tsx
@@ -1,4 +1,4 @@
-import { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
+import { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './GroupMetricsByPrefix.worker';
 
 describe('groupMetricsByPrefix()', () => {
   it('returns an empty group for no metrics', () => {

--- a/public/app/plugins/datasource/prometheus/workers/GroupMetricsByPrefix.worker.ts
+++ b/public/app/plugins/datasource/prometheus/workers/GroupMetricsByPrefix.worker.ts
@@ -1,0 +1,70 @@
+import { chain } from 'lodash';
+import { CascaderOption } from '@grafana/ui';
+import { PromMetricsMetadata } from '../types';
+
+export const RECORDING_RULES_GROUP = '__recording_rules__';
+
+// See: https://github.com/microsoft/TypeScript/issues/20595#issuecomment-587297818
+const postMessage = ((self as unknown) as Worker).postMessage;
+
+export type GroupMetricsByPrefixPayload = {
+  data: {
+    metrics: string[];
+    metadata?: PromMetricsMetadata;
+  };
+};
+
+export interface GroupMetricsByPrefixWorker extends Worker {
+  postMessage(message: GroupMetricsByPrefixPayload['data'], transfer: Transferable[]): void;
+  postMessage(message: GroupMetricsByPrefixPayload['data'], options?: PostMessageOptions): void;
+}
+
+self.onmessage = function({ data }: GroupMetricsByPrefixPayload) {
+  const { metrics, metadata } = data;
+  postMessage(groupMetricsByPrefix(metrics, metadata));
+};
+
+function addMetricsMetadata(metric: string, metadata?: PromMetricsMetadata): CascaderOption {
+  const option: CascaderOption = { label: metric, value: metric };
+  if (metadata && metadata[metric]) {
+    const { type = '', help } = metadata[metric][0];
+    option.title = [metric, type.toUpperCase(), help].join('\n');
+  }
+  return option;
+}
+
+export function groupMetricsByPrefix(metrics: string[], metadata?: PromMetricsMetadata): CascaderOption[] {
+  // Filter out recording rules and insert as first option
+  const ruleRegex = /:\w+:/;
+  const ruleNames = metrics.filter(metric => ruleRegex.test(metric));
+  const rulesOption = {
+    label: 'Recording rules',
+    value: RECORDING_RULES_GROUP,
+    children: ruleNames
+      .slice()
+      .sort()
+      .map(name => ({ label: name, value: name })),
+  };
+
+  const options = ruleNames.length > 0 ? [rulesOption] : [];
+
+  const delimiter = '_';
+  const metricsOptions = chain(metrics)
+    .filter((metric: string) => !ruleRegex.test(metric))
+    .groupBy((metric: string) => metric.split(delimiter)[0])
+    .map(
+      (metricsForPrefix: string[], prefix: string): CascaderOption => {
+        const prefixIsMetric = metricsForPrefix.length === 1 && metricsForPrefix[0] === prefix;
+        const children = prefixIsMetric ? [] : metricsForPrefix.sort().map(m => addMetricsMetadata(m, metadata));
+        return {
+          children,
+          label: prefix,
+          value: prefix,
+        };
+      }
+    )
+    .sortBy('label')
+    .value();
+
+  return [...options, ...metricsOptions];
+}

--- a/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.test.ts
+++ b/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.test.ts
@@ -34,7 +34,7 @@ const createAwaitableMock = () => {
   return mock;
 };
 
-function streamMockData(mockData: any[] | {}, workerOptions: Parameters<typeof streamJSONResponse>[0]): AwaitableMock {
+function streamMockData(mockData: any[] | {}, workerOptions: Parameters<typeof streamJSONResponse>[0]) {
   oboe.mockImplementationOnce(() => {
     return new MockOboe(mockData);
   });

--- a/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.test.ts
+++ b/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.test.ts
@@ -1,0 +1,132 @@
+import { streamJSONResponse } from './StreamJSONResponse.worker';
+import { JSON_STREAM_DONE } from './consts';
+import { MockOboe } from './mocks/oboe';
+import oboeOriginal from 'oboe';
+import Mock = jest.Mock;
+
+jest.mock('oboe');
+const oboe = (oboeOriginal as unknown) as jest.Mock;
+
+interface AwaitableMock extends Mock {
+  waitToHaveBeenCalledTimes: (t: number) => Promise<void>;
+}
+
+// See: https://github.com/facebook/jest/issues/7432#issuecomment-443536177
+const createAwaitableMock = () => {
+  let resolve: (value?: unknown) => void;
+  let times: number;
+  let calledCount = 0;
+  const mock = jest.fn() as AwaitableMock;
+
+  mock.mockImplementation(() => {
+    calledCount += 1;
+    if (resolve && calledCount >= times) {
+      resolve();
+    }
+  });
+  mock.waitToHaveBeenCalledTimes = (t: number) => {
+    times = t;
+    return new Promise(r => {
+      resolve = r;
+    });
+  };
+
+  return mock;
+};
+
+function streamMockData(mockData: any[] | {}, workerOptions: Parameters<typeof streamJSONResponse>[0]): AwaitableMock {
+  oboe.mockImplementationOnce(() => {
+    return new MockOboe(mockData);
+  });
+
+  const cb = createAwaitableMock();
+  streamJSONResponse(workerOptions, cb);
+  return cb;
+}
+
+describe('StreamJSONResponse Web Worker', () => {
+  it('can handle an empty response', async () => {
+    let cb = streamMockData([], {
+      url: '',
+    });
+
+    await cb.waitToHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenNthCalledWith(1, JSON_STREAM_DONE);
+
+    cb = streamMockData(
+      {},
+      {
+        url: '',
+      }
+    );
+
+    await cb.waitToHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenNthCalledWith(1, JSON_STREAM_DONE);
+  });
+
+  it('chunks arrays correctly (and returns all nodes if below limit)', async () => {
+    const cb = streamMockData([0, 1, 2, 3, 4], {
+      url: '',
+      chunkSize: 2,
+    });
+
+    await cb.waitToHaveBeenCalledTimes(4);
+    expect(cb).toHaveBeenNthCalledWith(1, [0, 1]);
+    expect(cb).toHaveBeenNthCalledWith(2, [2, 3]);
+    expect(cb).toHaveBeenNthCalledWith(3, [4]);
+    expect(cb).toHaveBeenNthCalledWith(4, JSON_STREAM_DONE);
+  });
+
+  it('chunks objects correctly (and returns all nodes if below limit)', async () => {
+    const cb = streamMockData(
+      {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+      },
+      {
+        url: '',
+        chunkSize: 2,
+        hasObjectResponse: true,
+      }
+    );
+
+    await cb.waitToHaveBeenCalledTimes(4);
+    expect(cb).toHaveBeenNthCalledWith(1, { a: 1, b: 2 });
+    expect(cb).toHaveBeenNthCalledWith(2, { c: 3, d: 4 });
+    expect(cb).toHaveBeenNthCalledWith(3, { e: 5 });
+    expect(cb).toHaveBeenNthCalledWith(4, JSON_STREAM_DONE);
+  });
+
+  it('truncates array responses at the specified limit', async () => {
+    const cb = streamMockData(['foo', 'bar', 'moo'], {
+      url: '',
+      limit: 2,
+    });
+
+    await cb.waitToHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenNthCalledWith(1, ['foo', 'bar']);
+    expect(cb).toHaveBeenNthCalledWith(2, JSON_STREAM_DONE);
+  });
+
+  it('truncates object responses at the specified limit', async () => {
+    const cb = streamMockData(
+      {
+        foo: 1,
+        bar: 2,
+        moo: 3,
+      },
+      {
+        hasObjectResponse: true,
+        limit: 2,
+        url: '',
+      }
+    );
+
+    await cb.waitToHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenNthCalledWith(1, { foo: 1, bar: 2 });
+    expect(cb).toHaveBeenNthCalledWith(2, JSON_STREAM_DONE);
+  });
+});

--- a/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.ts
+++ b/public/app/plugins/datasource/prometheus/workers/StreamJSONResponse.worker.ts
@@ -1,0 +1,95 @@
+import oboe from 'oboe';
+import { JSON_STREAM_DONE } from './consts';
+
+// See: https://github.com/microsoft/TypeScript/issues/20595#issuecomment-587297818
+const postMessage = ((self as unknown) as Worker).postMessage;
+let isFetching = false;
+
+export type StreamJSONResponsePayload = {
+  data: {
+    url: string;
+    chunkSize?: number;
+    hasObjectResponse?: boolean;
+    headers?: any;
+    limit?: number;
+    path?: string;
+    withCredentials?: boolean;
+  };
+};
+
+export interface StreamJSONResponseWorker extends Worker {
+  postMessage(message: StreamJSONResponsePayload['data'], transfer: Transferable[]): void;
+  postMessage(message: StreamJSONResponsePayload['data'], options?: PostMessageOptions): void;
+}
+
+export function streamJSONResponse(data: StreamJSONResponsePayload['data'], callback: (arg: any) => void) {
+  // Node.js doesn't support instantiation via web worker, so checking for whether this
+  // instance is already fetching wouldn't work during tests.
+  if (isFetching && !(process.env.NODE_ENV === 'test')) {
+    throw new Error('Worker is already fetching data!');
+  }
+  isFetching = true;
+
+  const {
+    url,
+    hasObjectResponse = false,
+    headers = {},
+    chunkSize = Number.MAX_SAFE_INTEGER,
+    limit = Number.MAX_SAFE_INTEGER,
+    path = 'data.*',
+    withCredentials = false,
+  } = data;
+  let nodes: any = hasObjectResponse ? {} : [];
+  let totalNodeCount = 0;
+
+  // Important to use oboe 2.1.4!! 2.1.5 can't be used in web workers!
+  oboe({ url, headers, withCredentials })
+    .node(path, function(this: oboe.Oboe, node, _path) {
+      totalNodeCount++;
+
+      if (hasObjectResponse) {
+        nodes[_path[_path.length - 1]] = node;
+      } else {
+        nodes.push(node);
+      }
+
+      const chunkNodeCount = hasObjectResponse ? Object.keys(nodes).length : nodes.length;
+      if (chunkNodeCount % chunkSize === 0) {
+        callback(nodes);
+        nodes = hasObjectResponse ? {} : [];
+      }
+
+      if (totalNodeCount >= limit) {
+        if (chunkNodeCount > 0) {
+          callback(nodes);
+        }
+        this.abort();
+        callback(JSON_STREAM_DONE);
+        return oboe.drop;
+      }
+
+      // Since we stream chunks, we don't need oboe to build an object.
+      // Reduces RAM use dramatically!
+      return oboe.drop;
+    })
+    .fail(error => {
+      // If e.g. 405 happens, oboe will trigger this twice. Once with
+      // the request failure error and once with its own error about not
+      // being able to parse the response.
+      if (error.statusCode) {
+        throw error;
+      }
+    })
+    .done(() => {
+      if (nodes.length > 0 || Object.keys(nodes).length > 0) {
+        callback(nodes);
+      }
+      callback(JSON_STREAM_DONE);
+    });
+}
+
+self.onmessage = function({ data }: StreamJSONResponsePayload) {
+  streamJSONResponse(data, postMessage);
+};
+
+export default function dummyRequiredForJestMockImplementationToWork() {}

--- a/public/app/plugins/datasource/prometheus/workers/consts.ts
+++ b/public/app/plugins/datasource/prometheus/workers/consts.ts
@@ -1,0 +1,5 @@
+// Constants that both app and workers need, since workers can import from
+// the app but the app can't import from a worker.
+
+// Symbols can't be used with web workers.
+export const JSON_STREAM_DONE = 'JSON_STREAM_DONE';

--- a/public/app/plugins/datasource/prometheus/workers/mocks/StreamJSONResponse.worker.ts
+++ b/public/app/plugins/datasource/prometheus/workers/mocks/StreamJSONResponse.worker.ts
@@ -1,0 +1,17 @@
+import { JSON_STREAM_DONE } from '../consts';
+
+export class MockWorker {
+  mockData: any;
+  onmessage: (arg: any) => void;
+
+  constructor(mockData: any) {
+    this.mockData = mockData;
+  }
+
+  postMessage = jest.fn(function(this: any) {
+    this.onmessage({ data: this.mockData });
+    this.onmessage({ data: JSON_STREAM_DONE });
+  });
+
+  terminate() {}
+}

--- a/public/app/plugins/datasource/prometheus/workers/mocks/oboe.ts
+++ b/public/app/plugins/datasource/prometheus/workers/mocks/oboe.ts
@@ -1,0 +1,68 @@
+import { Oboe, FailReason, PatternMap, CallbackSignature } from 'oboe';
+
+export class MockOboe implements Oboe {
+  doAbort: boolean;
+  doneCallback: (result: any) => void;
+  mockData: any[] | { [key: string]: any };
+
+  constructor(mockData: any[] | {}) {
+    this.mockData = mockData;
+  }
+
+  done(callback: (result: any) => void): Oboe {
+    this.doneCallback = callback;
+    return this;
+  }
+
+  fail(callback: (result: FailReason) => void): Oboe {
+    return this;
+  }
+
+  node(pattern: string | PatternMap, callback?: CallbackSignature): Oboe {
+    if (callback) {
+      const cb = callback.bind(this);
+
+      setTimeout(() => {
+        if (Array.isArray(this.mockData)) {
+          for (const item of this.mockData) {
+            if (!this.doAbort) {
+              cb(item, null, []);
+            }
+          }
+        } else {
+          for (const key of Object.keys(this.mockData)) {
+            if (!this.doAbort) {
+              cb(this.mockData[key], [key]);
+            }
+          }
+        }
+
+        this.doneCallback(null);
+      }, 10);
+    }
+    return this;
+  }
+
+  on(event: string, pattern: string | CallbackSignature, callback?: CallbackSignature): Oboe {
+    return this;
+  }
+
+  path(pattern: string | any, callback?: CallbackSignature): Oboe {
+    return this;
+  }
+
+  removeListener(event: string, pattern: string | CallbackSignature, callback?: CallbackSignature): Oboe {
+    return this;
+  }
+
+  // eslint-disable-next-line
+  start(callback: (status: number, headers: Object) => void): Oboe {
+    return this;
+  }
+
+  abort(): void {
+    this.doAbort = true;
+  }
+
+  source: string;
+}

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -10,6 +10,44 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
+const babelLoaderOptions = {
+  cacheDirectory: true,
+  babelrc: false,
+  // Note: order is top-to-bottom and/or left-to-right
+  plugins: [
+    [
+      require('@rtsao/plugin-proposal-class-properties'),
+      {
+        loose: true,
+      },
+    ],
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+    '@babel/plugin-proposal-optional-chaining',
+    'angularjs-annotate',
+  ],
+  // Note: order is bottom-to-top and/or right-to-left
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: 'last 3 versions',
+        },
+        useBuiltIns: 'entry',
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    [
+      '@babel/preset-typescript',
+      {
+        allowNamespaces: true,
+      },
+    ],
+    '@babel/preset-react',
+  ],
+};
+
 module.exports = (env = {}) =>
   merge(common, {
     devtool: 'cheap-module-source-map',
@@ -30,48 +68,23 @@ module.exports = (env = {}) =>
       // Note: order is bottom-to-top and/or right-to-left
       rules: [
         {
+          test: /\.worker\.ts$/,
+          exclude: /node_modules/,
+          use: [
+            { loader: 'worker-loader' },
+            {
+              loader: 'babel-loader',
+              options: babelLoaderOptions,
+            },
+          ],
+        },
+        {
           test: /\.tsx?$/,
           exclude: /node_modules/,
           use: [
             {
               loader: 'babel-loader',
-              options: {
-                cacheDirectory: true,
-                babelrc: false,
-                // Note: order is top-to-bottom and/or left-to-right
-                plugins: [
-                  [
-                    require('@rtsao/plugin-proposal-class-properties'),
-                    {
-                      loose: true,
-                    },
-                  ],
-                  '@babel/plugin-proposal-nullish-coalescing-operator',
-                  '@babel/plugin-proposal-optional-chaining',
-                  'angularjs-annotate',
-                ],
-                // Note: order is bottom-to-top and/or right-to-left
-                presets: [
-                  [
-                    '@babel/preset-env',
-                    {
-                      targets: {
-                        browsers: 'last 3 versions',
-                      },
-                      useBuiltIns: 'entry',
-                      corejs: 3,
-                      modules: false,
-                    },
-                  ],
-                  [
-                    '@babel/preset-typescript',
-                    {
-                      allowNamespaces: true,
-                    },
-                  ],
-                  '@babel/preset-react',
-                ],
-              },
+              options: babelLoaderOptions,
             },
             {
               loader: 'eslint-loader',

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -9,6 +9,45 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
+const babelLoaderOptions = {
+  cacheDirectory: true,
+  babelrc: false,
+  // Note: order is top-to-bottom and/or left-to-right
+  plugins: [
+    [
+      require('@rtsao/plugin-proposal-class-properties'),
+      {
+        loose: true,
+      },
+    ],
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+    '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-syntax-dynamic-import', // needed for `() => import()` in routes.ts
+    'angularjs-annotate',
+  ],
+  // Note: order is bottom-to-top and/or right-to-left
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: 'last 3 versions',
+        },
+        useBuiltIns: 'entry',
+        corejs: 3,
+        modules: false,
+      },
+    ],
+    [
+      '@babel/preset-typescript',
+      {
+        allowNamespaces: true,
+      },
+    ],
+    '@babel/preset-react',
+  ],
+};
+
 module.exports = merge(common, {
   mode: 'production',
   devtool: 'source-map',
@@ -22,49 +61,23 @@ module.exports = merge(common, {
     // Note: order is bottom-to-top and/or right-to-left
     rules: [
       {
+        test: /\.worker\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          { loader: 'worker-loader' },
+          {
+            loader: 'babel-loader',
+            options: babelLoaderOptions,
+          },
+        ],
+      },
+      {
         test: /\.tsx?$/,
         exclude: /node_modules/,
         use: [
           {
             loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-              babelrc: false,
-              // Note: order is top-to-bottom and/or left-to-right
-              plugins: [
-                [
-                  require('@rtsao/plugin-proposal-class-properties'),
-                  {
-                    loose: true,
-                  },
-                ],
-                '@babel/plugin-proposal-nullish-coalescing-operator',
-                '@babel/plugin-proposal-optional-chaining',
-                '@babel/plugin-syntax-dynamic-import', // needed for `() => import()` in routes.ts
-                'angularjs-annotate',
-              ],
-              // Note: order is bottom-to-top and/or right-to-left
-              presets: [
-                [
-                  '@babel/preset-env',
-                  {
-                    targets: {
-                      browsers: 'last 3 versions',
-                    },
-                    useBuiltIns: 'entry',
-                    corejs: 3,
-                    modules: false,
-                  },
-                ],
-                [
-                  '@babel/preset-typescript',
-                  {
-                    allowNamespaces: true,
-                  },
-                ],
-                '@babel/preset-react',
-              ],
-            },
+            options: babelLoaderOptions,
           },
           {
             loader: 'eslint-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5704,6 +5704,13 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==
 
+"@types/oboe@^2.0.28":
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/@types/oboe/-/oboe-2.0.28.tgz#3afcb0cc949fcdf777861d96e8571f3b486f0fa7"
+  integrity sha1-OvywzJSfzfd3hh2W6FcfO0hvD6c=
+  dependencies:
+    "@types/node" "*"
+
 "@types/papaparse@4.5.9":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-4.5.9.tgz#ff887bd362f57cd0c87320d2de38ac232bb55e81"
@@ -13911,6 +13918,11 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
+  integrity sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=
+
 "http-parser-js@>=0.4.0 <0.4.11":
   version "0.4.10"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
@@ -16156,7 +16168,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.4.0:
+loader-utils@^1.0.0, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -17947,6 +17959,13 @@ object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+oboe@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.4.tgz#20c88cdb0c15371bb04119257d4fdd34b0aa49f6"
+  integrity sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=
+  dependencies:
+    http-https "^1.0.0"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -22194,6 +22213,14 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+schema-utils@^0.4.0:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
@@ -25401,6 +25428,14 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"
 
 worker-rpc@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Metric names will now be fetched via web worker, not blocking the UI thread. Also, the connection will be dropped once we have received 100K metric names.

**Which issue(s) this PR fixes**:
Fixes #21893

**Special notes for your reviewer**:
- You can use [this mock server](https://github.com/s-h-a-d-o-w/prometheus-mock) if you want to see the effects of this in action.
- I also tried out `worker-plugin` but ended up not using it because it threw warnings when it tried to process a library that we use that already uses web workers ([a known issue](https://github.com/GoogleChromeLabs/worker-plugin/issues/12)): `[Webpack] WARNING in new Worker() will only be bundled if passed a String.`
It also makes [eslint process already compiled code](https://github.com/webpack-contrib/eslint-loader/issues/261#issuecomment-587236828), obviously resulting in lots of errors.
- Raised the metric name threshold to 100K because we can easily handle that in terms of metric names.

**Minor additional improvements**
- Used to be that metadata was mapped to metrics on every key stroke, even though they are only fetched in `start()`. Now, they are mapped right there, in `start()`. This uses more RAM but obviously improves performance. Theoretically, metrics and metadata could be removed if it wasn't for the fact that they're used in dependencies - where that on-the-fly mapping happens as well. So... it seems like things could be improved further by only having the "premapped" metrics data. But - significant refactoring task.
- Using a worker for `GroupMetricsByPrefix` addresses a minor hitch once all data actually arrived. (With a large data set, UI would freeze for a second or so.)

**Minor downsides**
- Requests take longer to execute because of the overhead from streaming. It's negligible with just hundreds or thousands of metric names though. And beyond that, obviously not blocking the main thread becomes more important.
- `eslint-loader` currently doesn't appear to work with workers. But since we lint on CI, I think that this is also negligible.
- No solution for TS import yet (note the `@ts-ignore` for the import) - official docs [only explain loader syntax](https://github.com/webpack-contrib/worker-loader#integrating-with-typescript) and when I tried the same thing without it, TS simply wouldn't find the type for the module. Hence the @ts-ignore.
