### PR TITLE
Transformations: Organise fields transformer fixes & detailing

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -181,7 +181,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, field?: Field) 
   return (
     <div className={tableStyles.headerCell} {...headerProps}>
       {column.canSort && (
-        <div {...column.getSortByToggleProps()}>
+        <div {...column.getSortByToggleProps()} className={tableStyles.headerCellLabel} title={column.render('Header')}>
           {column.render('Header')}
           {column.isSorted && (column.isSortedDesc ? <Icon name="angle-down" /> : <Icon name="angle-up" />)}
         </div>

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -10,6 +10,7 @@ export interface TableStyles {
   table: string;
   thead: string;
   headerCell: string;
+  headerCellLabel: string;
   tableCell: string;
   tableCellWrapper: string;
   row: string;
@@ -52,13 +53,17 @@ export const getTableStyles = stylesFactory(
       headerCell: css`
         padding: ${padding}px 10px;
         cursor: pointer;
-        white-space: nowrap;
         color: ${colors.textBlue};
         border-right: 1px solid ${theme.colors.panelBg};
 
         &:last-child {
           border-right: none;
         }
+      `,
+      headerCellLabel: css`
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       `,
       row: css`
         label: row;

--- a/packages/grafana-ui/src/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
+++ b/packages/grafana-ui/src/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
@@ -80,6 +80,7 @@ const OrganizeFieldsTransformerEditor: React.FC<OrganizeFieldsTransformerEditorP
               return (
                 <DraggableFieldName
                   fieldName={fieldName}
+                  renamedFieldName={renameByName[fieldName]}
                   index={index}
                   onToggleVisibility={onToggleVisibility}
                   onRenameField={onRenameField}
@@ -96,8 +97,11 @@ const OrganizeFieldsTransformerEditor: React.FC<OrganizeFieldsTransformerEditorP
   );
 };
 
+OrganizeFieldsTransformerEditor.displayName = 'OrganizeFieldsTransformerEditor';
+
 interface DraggableFieldProps {
   fieldName: string;
+  renamedFieldName?: string;
   index: number;
   visible: boolean;
   onToggleVisibility: (fieldName: string, isVisible: boolean) => void;
@@ -106,6 +110,7 @@ interface DraggableFieldProps {
 
 const DraggableFieldName: React.FC<DraggableFieldProps> = ({
   fieldName,
+  renamedFieldName,
   index,
   visible,
   onToggleVisibility,
@@ -133,12 +138,15 @@ const DraggableFieldName: React.FC<DraggableFieldProps> = ({
                 surface="header"
                 onClick={() => onToggleVisibility(fieldName, visible)}
               />
-              <span className={styles.name}>{fieldName}</span>
+              <span className={styles.name} title={fieldName}>
+                {fieldName}
+              </span>
             </div>
             <Input
               className="flex-grow-1"
+              defaultValue={renamedFieldName || ''}
               placeholder={`Rename ${fieldName}`}
-              onChange={event => onRenameField(fieldName, event.currentTarget.value)}
+              onBlur={event => onRenameField(fieldName, event.currentTarget.value)}
             />
           </div>
         </div>
@@ -146,6 +154,8 @@ const DraggableFieldName: React.FC<DraggableFieldProps> = ({
     </Draggable>
   );
 };
+
+DraggableFieldName.displayName = 'DraggableFieldName';
 
 const getFieldNameStyles = stylesFactory((theme: GrafanaTheme) => ({
   toggle: css`
@@ -161,6 +171,9 @@ const getFieldNameStyles = stylesFactory((theme: GrafanaTheme) => ({
     }
   `,
   name: css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: ${theme.typography.size.sm};
     font-weight: ${theme.typography.weight.semibold};
   `,

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -132,9 +132,10 @@ export class TransformationsEditor extends React.PureComponent<Props> {
                 being visualized. Choose one of the transformations below to start with:
               </p>
               <VerticalGroup>
-                {standardTransformersRegistry.list().map(t => {
+                {standardTransformersRegistry.list().map((t, i) => {
                   return (
                     <TransformationCard
+                      key={`${t.name}/${i}`}
                       title={t.name}
                       description={t.description}
                       actions={<Button>Select</Button>}


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/issues/23551

Fixes:
- Organise fields transformer persisted options(name) is not reflected in the organise transformer editor
- Organise transformer UI - long field names are not wrapped, we need to either wrap or add ellipsis+tooltip
- Table- header cell text overflows container - add ellipsis 
- Missing key prop on transformation cards