### PR TITLE
CircleCI: Upgrade shellcheck to v0.7.1 and pin version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,12 @@ jobs:
       - run:
           name: Install ShellCheck
           command: |
-            sudo apt-get update && sudo apt-get install -y shellcheck
+            VERSION=0.7.1
+            CHKSUM=beca3d7819a6bdcfbd044576df4fc284053b48f468b2f03428fe66f4ceb2c05d9b5411357fa15003cb0311406c255084cf7283a3b8fce644c340c2f6aa910b9f
+            curl -fLO http://storage.googleapis.com/grafana-build-pipeline/dependencies/shellcheck-v${VERSION}.linux.x86_64.tar.xz
+            echo $CHKSUM shellcheck-v${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
+            tar xf shellcheck-v${VERSION}.linux.x86_64.tar.xz
+            sudo mv shellcheck-v${VERSION}/shellcheck /usr/local/bin/
       - run:
           name: ShellCheck
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
           command: |
             VERSION=0.7.1
             CHKSUM=beca3d7819a6bdcfbd044576df4fc284053b48f468b2f03428fe66f4ceb2c05d9b5411357fa15003cb0311406c255084cf7283a3b8fce644c340c2f6aa910b9f
-            curl -fLO http://storage.googleapis.com/grafana-build-pipeline/dependencies/shellcheck-v${VERSION}.linux.x86_64.tar.xz
+            curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v${VERSION}.linux.x86_64.tar.xz
             echo $CHKSUM shellcheck-v${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
             tar xf shellcheck-v${VERSION}.linux.x86_64.tar.xz
             sudo mv shellcheck-v${VERSION}/shellcheck /usr/local/bin/

--- a/scripts/ci-metrics-publisher.sh
+++ b/scripts/ci-metrics-publisher.sh
@@ -8,7 +8,7 @@ for ((i = 1; i <= $#; i++ )); do
   remainder="${!i}"
   # Find everything until last = character (= is included in the result)
   # This allows to add tags to metric names
-  metricName=$(grep -o "\(.*\)=" <<< $remainder)
+  metricName=$(grep -o "\(.*\)=" <<< "$remainder")
   # Get the metric value
   value=${remainder#"$metricName"}
   # Remove remaining = character from metric name


### PR DESCRIPTION
**What this PR does / why we need it**:
In CircleCI I've made the following changes in order to ensure reproducible builds, since I discovered that shellcheck would fail in our v6.7.x branch due to the version not being pinned:

* Upgrade shellcheck to v0.7.1
* Download shellcheck from our Cloud Storage
* Pin shellcheck version