### PR TITLE
Logging: Adding debug line to search ldap.

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -373,13 +373,19 @@ func (server *Server) getSearchRequest(
 
 	filter := fmt.Sprintf("(|%s)", search)
 
-	return &ldap.SearchRequest{
+	searchRequest := &ldap.SearchRequest{
 		BaseDN:       base,
 		Scope:        ldap.ScopeWholeSubtree,
 		DerefAliases: ldap.NeverDerefAliases,
 		Attributes:   attributes,
 		Filter:       filter,
 	}
+
+	server.log.Debug(
+		"LDAP SearchRequest", "searchRequest", fmt.Sprintf("%+v\n", searchRequest),
+	)
+
+	return searchRequest
 }
 
 // buildGrafanaUser extracts info from UserInfo model to ExternalUserInfo


### PR DESCRIPTION
Debugging LDAP configuration is very difficult, especially whenever the user is not found in the first place due to a major misconfiguration.

Cases like [this](https://community.grafana.com/t/ldap-logging-and-configuration/421) still are common. 

Adding this line for debugging will add the possibility to pick up problems like wrong basedn or wrong filter query.

The output will show like this:
![ldap-search](https://user-images.githubusercontent.com/551844/80095665-345baf80-8560-11ea-83be-807eb919b123.png)

