### PR TITLE
Metrics: Add image rendering metrics

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -98,6 +98,12 @@ var (
 
 	// LDAPUsersSyncExecutionTime is a metric summary for LDAP users sync execution duration
 	LDAPUsersSyncExecutionTime prometheus.Summary
+
+	// MRenderingRequestCompleted is a metric counter for how many panels have been successfully rendered
+	MRenderingRequestCompleted prometheus.Counter
+
+	// MRenderingRequestCompleted is a metric counter for how many panels have been rendered with error
+	MRenderingRequestFailed prometheus.Counter
 )
 
 // Timers
@@ -107,6 +113,9 @@ var (
 
 	// MAlertingExecutionTime is a metric summary of alert exeuction duration
 	MAlertingExecutionTime prometheus.Summary
+
+	// MRenderingExecutionTime is a metric summary for panel rendering duration
+	MRenderingExecutionTime prometheus.Summary
 )
 
 // StatTotals
@@ -343,6 +352,25 @@ func init() {
 		Namespace:  ExporterName,
 	})
 
+	MRenderingRequestCompleted = newCounterStartingAtZero(prometheus.CounterOpts{
+		Name:      "rendering_request_completed_total",
+		Help:      "counter for successfully rendered panels",
+		Namespace: ExporterName,
+	})
+
+	MRenderingRequestFailed = newCounterStartingAtZero(prometheus.CounterOpts{
+		Name:      "rendering_request_failed_total",
+		Help:      "counter for panels rendered with error",
+		Namespace: ExporterName,
+	})
+
+	MRenderingExecutionTime = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "rendering_execution_time_milliseconds",
+		Help:       "summary of panel rendering exeuction duration",
+		Objectives: objectiveMap,
+		Namespace:  ExporterName,
+	})
+
 	MDataSourceProxyReqTimer = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "api_dataproxy_request_all_milliseconds",
 		Help:       "summary for dataproxy request duration",
@@ -489,6 +517,9 @@ func initMetricVars() {
 		MAwsCloudWatchGetMetricData,
 		MDBDataSourceQueryByID,
 		LDAPUsersSyncExecutionTime,
+		MRenderingRequestCompleted,
+		MRenderingRequestFailed,
+		MRenderingExecutionTime,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,
 		MStatTotalUsers,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -102,8 +102,11 @@ var (
 	// MRenderingRequestCompleted is a metric counter for how many panels have been successfully rendered
 	MRenderingRequestCompleted prometheus.Counter
 
-	// MRenderingRequestCompleted is a metric counter for how many panels have been rendered with error
+	// MRenderingRequestFailed is a metric counter for how many panels have been rendered with error
 	MRenderingRequestFailed prometheus.Counter
+
+	// MRenderingQueue is a metric gauge for panel rendering queue size
+	MRenderingQueue prometheus.Gauge
 )
 
 // Timers
@@ -371,6 +374,12 @@ func init() {
 		Namespace:  ExporterName,
 	})
 
+	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "rendering_queue_size",
+		Help:      "size of rendering queue",
+		Namespace: ExporterName,
+	})
+
 	MDataSourceProxyReqTimer = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "api_dataproxy_request_all_milliseconds",
 		Help:       "summary for dataproxy request duration",
@@ -520,6 +529,7 @@ func initMetricVars() {
 		MRenderingRequestCompleted,
 		MRenderingRequestFailed,
 		MRenderingExecutionTime,
+		MRenderingQueue,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,
 		MStatTotalUsers,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -99,10 +99,10 @@ var (
 	// LDAPUsersSyncExecutionTime is a metric summary for LDAP users sync execution duration
 	LDAPUsersSyncExecutionTime prometheus.Summary
 
-	// MRenderingRequestCompleted is a metric counter for how many panels have been rendered
+	// MRenderingRequestTotal is a metric counter for image rendering requests
 	MRenderingRequestTotal *prometheus.CounterVec
 
-	// MRenderingQueue is a metric gauge for panel rendering queue size
+	// MRenderingQueue is a metric gauge for image rendering queue size
 	MRenderingQueue prometheus.Gauge
 )
 
@@ -114,7 +114,7 @@ var (
 	// MAlertingExecutionTime is a metric summary of alert exeuction duration
 	MAlertingExecutionTime prometheus.Summary
 
-	// MRenderingSummary is a metric summary for panel rendering duration
+	// MRenderingSummary is a metric summary for image rendering request duration
 	MRenderingSummary *prometheus.SummaryVec
 )
 
@@ -355,7 +355,7 @@ func init() {
 	MRenderingRequestTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name:      "rendering_request_total",
-			Help:      "counter for rendered panels",
+			Help:      "counter for image rendering requests",
 			Namespace: ExporterName,
 		},
 		[]string{"status"},
@@ -364,7 +364,7 @@ func init() {
 	MRenderingSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "rendering_request_duration_milliseconds",
-			Help:       "summary of panel rendering execution duration",
+			Help:       "summary of image rendering request duration",
 			Objectives: objectiveMap,
 			Namespace:  ExporterName,
 		},
@@ -373,7 +373,7 @@ func init() {
 
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
-		Help:      "size of rendering queue",
+		Help:      "size of image rendering queue",
 		Namespace: ExporterName,
 	})
 

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -99,11 +99,8 @@ var (
 	// LDAPUsersSyncExecutionTime is a metric summary for LDAP users sync execution duration
 	LDAPUsersSyncExecutionTime prometheus.Summary
 
-	// MRenderingRequestCompleted is a metric counter for how many panels have been successfully rendered
-	MRenderingRequestCompleted prometheus.Counter
-
-	// MRenderingRequestFailed is a metric counter for how many panels have been rendered with error
-	MRenderingRequestFailed prometheus.Counter
+	// MRenderingRequestCompleted is a metric counter for how many panels have been rendered
+	MRenderingRequestTotal *prometheus.CounterVec
 
 	// MRenderingQueue is a metric gauge for panel rendering queue size
 	MRenderingQueue prometheus.Gauge
@@ -117,8 +114,8 @@ var (
 	// MAlertingExecutionTime is a metric summary of alert exeuction duration
 	MAlertingExecutionTime prometheus.Summary
 
-	// MRenderingExecutionTime is a metric summary for panel rendering duration
-	MRenderingExecutionTime prometheus.Summary
+	// MRenderingSummary is a metric summary for panel rendering duration
+	MRenderingSummary *prometheus.SummaryVec
 )
 
 // StatTotals
@@ -355,24 +352,24 @@ func init() {
 		Namespace:  ExporterName,
 	})
 
-	MRenderingRequestCompleted = newCounterStartingAtZero(prometheus.CounterOpts{
-		Name:      "rendering_request_completed_total",
-		Help:      "counter for successfully rendered panels",
-		Namespace: ExporterName,
-	})
+	MRenderingRequestTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:      "rendering_request_total",
+			Help:      "counter for rendered panels",
+			Namespace: ExporterName,
+		},
+		[]string{"status"},
+	)
 
-	MRenderingRequestFailed = newCounterStartingAtZero(prometheus.CounterOpts{
-		Name:      "rendering_request_failed_total",
-		Help:      "counter for panels rendered with error",
-		Namespace: ExporterName,
-	})
-
-	MRenderingExecutionTime = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "rendering_execution_time_milliseconds",
-		Help:       "summary of panel rendering exeuction duration",
-		Objectives: objectiveMap,
-		Namespace:  ExporterName,
-	})
+	MRenderingSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "rendering_request_duration_milliseconds",
+			Help:       "summary of panel rendering execution duration",
+			Objectives: objectiveMap,
+			Namespace:  ExporterName,
+		},
+		[]string{"status"},
+	)
 
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
@@ -526,9 +523,8 @@ func initMetricVars() {
 		MAwsCloudWatchGetMetricData,
 		MDBDataSourceQueryByID,
 		LDAPUsersSyncExecutionTime,
-		MRenderingRequestCompleted,
-		MRenderingRequestFailed,
-		MRenderingExecutionTime,
+		MRenderingRequestTotal,
+		MRenderingSummary,
 		MRenderingQueue,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,

--- a/pkg/services/rendering/plugin_mode.go
+++ b/pkg/services/rendering/plugin_mode.go
@@ -45,6 +45,10 @@ func (rs *RenderingService) renderViaPluginV1(ctx context.Context, renderKey str
 	rs.log.Debug("calling renderer plugin", "req", req)
 
 	rsp, err := rs.pluginInfo.GrpcPluginV1.Render(ctx, req)
+	if ctx.Err() == context.DeadlineExceeded {
+		rs.log.Info("Rendering timed out")
+		return nil, ErrTimeout
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +88,10 @@ func (rs *RenderingService) renderViaPluginV2(ctx context.Context, renderKey str
 	rs.log.Debug("Calling renderer plugin", "req", req)
 
 	rsp, err := rs.pluginInfo.GrpcPluginV2.Render(ctx, req)
+	if ctx.Err() == context.DeadlineExceeded {
+		rs.log.Info("Rendering timed out")
+		return nil, ErrTimeout
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -118,6 +118,7 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	elapsedTime := time.Since(startTime).Milliseconds()
 	if status.Code(err) == codes.DeadlineExceeded {
 		metrics.MRenderingRequestTotal.WithLabelValues("canceled").Inc()
+		metrics.MRenderingSummary.WithLabelValues("canceled").Observe(float64(elapsedTime))
 	} else if err != nil {
 		metrics.MRenderingRequestTotal.WithLabelValues("failure").Inc()
 		metrics.MRenderingSummary.WithLabelValues("failure").Observe(float64(elapsedTime))

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -113,13 +113,14 @@ func (rs *RenderingService) RenderErrorImage(err error) (*RenderResult, error) {
 func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResult, error) {
 	startTime := time.Now()
 	result, err := rs.render(ctx, opts)
+	elapsedTime := time.Since(startTime).Milliseconds()
 	if err != nil {
-		metrics.MRenderingRequestFailed.Inc()
+		metrics.MRenderingRequestTotal.WithLabelValues("error").Inc()
+		metrics.MRenderingSummary.WithLabelValues("error").Observe(float64(elapsedTime))
 	} else {
-		metrics.MRenderingRequestCompleted.Inc()
+		metrics.MRenderingRequestTotal.WithLabelValues("success").Inc()
+		metrics.MRenderingSummary.WithLabelValues("success").Observe(float64(elapsedTime))
 	}
-	elapsedTime := time.Since(startTime).Nanoseconds() / int64(time.Millisecond)
-	metrics.MRenderingExecutionTime.Observe(float64(elapsedTime))
 	return result, err
 }
 

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -118,7 +118,7 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	} else {
 		metrics.MRenderingRequestCompleted.Inc()
 	}
-	elapsedTime := time.Now().Sub(startTime).Nanoseconds() / int64(time.Millisecond)
+	elapsedTime := time.Since(startTime).Nanoseconds() / int64(time.Millisecond)
 	metrics.MRenderingExecutionTime.Observe(float64(elapsedTime))
 	return result, err
 }

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -117,8 +117,7 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	result, err := rs.render(ctx, opts)
 	elapsedTime := time.Since(startTime).Milliseconds()
 	if status.Code(err) == codes.DeadlineExceeded {
-		metrics.MRenderingRequestTotal.WithLabelValues("cancelled").Inc()
-		metrics.MRenderingSummary.WithLabelValues("cancelled").Observe(float64(elapsedTime))
+		metrics.MRenderingRequestTotal.WithLabelValues("canceled").Inc()
 	} else if err != nil {
 		metrics.MRenderingRequestTotal.WithLabelValues("failure").Inc()
 		metrics.MRenderingSummary.WithLabelValues("failure").Observe(float64(elapsedTime))

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -115,8 +115,8 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	result, err := rs.render(ctx, opts)
 	elapsedTime := time.Since(startTime).Milliseconds()
 	if err != nil {
-		metrics.MRenderingRequestTotal.WithLabelValues("error").Inc()
-		metrics.MRenderingSummary.WithLabelValues("error").Observe(float64(elapsedTime))
+		metrics.MRenderingRequestTotal.WithLabelValues("failure").Inc()
+		metrics.MRenderingSummary.WithLabelValues("failure").Observe(float64(elapsedTime))
 	} else {
 		metrics.MRenderingRequestTotal.WithLabelValues("success").Inc()
 		metrics.MRenderingSummary.WithLabelValues("success").Observe(float64(elapsedTime))

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -147,9 +147,11 @@ func (rs *RenderingService) render(ctx context.Context, opts Opts) (*RenderResul
 
 	defer func() {
 		rs.inProgressCount--
+		metrics.MRenderingQueue.Set(float64(rs.inProgressCount))
 	}()
 
 	rs.inProgressCount++
+	metrics.MRenderingQueue.Set(float64(rs.inProgressCount))
 	return rs.renderAction(ctx, renderKey, opts)
 }
 

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -116,7 +114,7 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	startTime := time.Now()
 	result, err := rs.render(ctx, opts)
 	elapsedTime := time.Since(startTime).Milliseconds()
-	if status.Code(err) == codes.DeadlineExceeded {
+	if err == ErrTimeout {
 		metrics.MRenderingRequestTotal.WithLabelValues("timeout").Inc()
 		metrics.MRenderingSummary.WithLabelValues("timeout").Observe(float64(elapsedTime))
 	} else if err != nil {

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -117,8 +117,8 @@ func (rs *RenderingService) Render(ctx context.Context, opts Opts) (*RenderResul
 	result, err := rs.render(ctx, opts)
 	elapsedTime := time.Since(startTime).Milliseconds()
 	if status.Code(err) == codes.DeadlineExceeded {
-		metrics.MRenderingRequestTotal.WithLabelValues("canceled").Inc()
-		metrics.MRenderingSummary.WithLabelValues("canceled").Observe(float64(elapsedTime))
+		metrics.MRenderingRequestTotal.WithLabelValues("timeout").Inc()
+		metrics.MRenderingSummary.WithLabelValues("timeout").Observe(float64(elapsedTime))
 	} else if err != nil {
 		metrics.MRenderingRequestTotal.WithLabelValues("failure").Inc()
 		metrics.MRenderingSummary.WithLabelValues("failure").Observe(float64(elapsedTime))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds metrics for image rendering service in Grafana. Metrics added:
- `rendering_request_total` (Counter Vector)
- `rendering_request_duration_milliseconds` (Summary Vector)
- `rendering_queue_size` (Gauge)

![Screenshot from 2020-04-23 17-07-51](https://user-images.githubusercontent.com/4932851/80108476-00df4c00-8585-11ea-93ce-4f416416892f.png)


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #22782

**Special notes for your reviewer**:

