### PR TITLE
Prometheus: Fix metrics button when selected option has no children

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -199,8 +199,9 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
   onChangeMetrics = (values: string[], selectedOptions: CascaderOption[]) => {
     let query;
     if (selectedOptions.length === 1) {
-      if (selectedOptions[0].children.length === 0) {
-        query = selectedOptions[0].value;
+      const selectedOption = selectedOptions[0];
+      if (!selectedOption.children || selectedOption.children.length === 0) {
+        query = selectedOption.value;
       } else {
         // Ignore click on group
         return;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes metrics button by checking if selectedOption has any children (not just by checking selectedOption's children length). If selectedOption has no children or if it has children, but children's length is 0, run query (which is selectedOption.value).

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/23298
