### PR TITLE
NewPanelEditor: bring back queries not being run on editmode navigation

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -315,14 +315,18 @@ export class DashboardModel {
   panelInitialized(panel: PanelModel) {
     panel.initialized();
 
-    // refresh new panels unless we are in fullscreen / edit mode
-    if (!this.otherPanelInFullscreen(panel)) {
-      panel.refresh();
-    }
-
-    // refresh if panel is in edit mode and there is no last result
-    if (this.panelInEdit === panel && !this.panelInEdit.getQueryRunner().getLastResult()) {
-      panel.refresh();
+    if (this.panelInEdit === panel) {
+      if (this.panelInEdit.getQueryRunner().getLastResult()) {
+        return;
+      } else {
+        // refresh if panel is in edit mode and there is no last result
+        panel.refresh();
+      }
+    } else {
+      // refresh new panels unless we are in fullscreen / edit mode
+      if (!this.otherPanelInFullscreen(panel)) {
+        panel.refresh();
+      }
     }
   }
 


### PR DESCRIPTION
Ref #21111

@torkelo pls have a look. I couldn't find what caused this regression, guess something is/was removed that maybe is used in the otherPanelInFullscreen method? Do you recall anything when making the new edit mode the default?