### PR TITLE
Zipkin: Add method to data source to display query text

### DIFF
--- a/public/app/plugins/datasource/zipkin/datasource.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.ts
@@ -45,6 +45,10 @@ export class ZipkinDatasource extends DataSourceApi<ZipkinQuery> {
     return true;
   }
 
+  getQueryDisplayText(query: ZipkinQuery) {
+    return query.query;
+  }
+
   private request<T = any>(apiUrl: string, data?: any, options?: DatasourceRequestOptions): Observable<{ data: T }> {
     // Hack for proxying metadata requests
     const baseUrl = `/api/datasources/proxy/${this.instanceSettings.id}`;


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds getQueryDisplayText method to display query text in rich history.