### PR TITLE
@grafana/ui: Revert rc-slider dependency update

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -50,7 +50,7 @@
     "papaparse": "4.6.3",
     "rc-cascader": "1.0.1",
     "rc-drawer": "3.1.3",
-    "rc-slider": "9.2.3",
+    "rc-slider": "8.7.1",
     "rc-time-picker": "^3.7.3",
     "react": "16.12.0",
     "react-beautiful-dnd": "13.0.0",

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -75,6 +75,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, isHorizontal: boolean) => 
       .rc-slider-tooltip {
         cursor: grab;
         user-select: none;
+        z-index: ${theme.zIndex.tooltip};
       }
 
       .rc-slider-tooltip-inner {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts rc-slider dependency update. Adds z-index to tooltip.
More info: https://github.com/grafana/grafana/pull/22977#issuecomment-619216018