### PR TITLE
Azure Monitor: Fix for application insights Azure China plugin route

### DIFF
--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/tsdb"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -313,4 +317,69 @@ func TestApplicationInsightsDatasource(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestPluginRoutes(t *testing.T) {
+	datasource := &ApplicationInsightsDatasource{}
+	plugin := &plugins.DataSourcePlugin{
+		Routes: []*plugins.AppPluginRoute{
+			{
+				Path:   "appinsights",
+				Method: "GET",
+				URL:    "https://api.applicationinsights.io",
+				Headers: []plugins.AppPluginRouteHeader{
+					{Name: "X-API-Key", Content: "{{.SecureJsonData.appInsightsApiKey}}"},
+					{Name: "x-ms-app", Content: "Grafana"},
+				},
+			},
+			{
+				Path:   "chinaappinsights",
+				Method: "GET",
+				URL:    "https://api.applicationinsights.azure.cn",
+				Headers: []plugins.AppPluginRouteHeader{
+					{Name: "X-API-Key", Content: "{{.SecureJsonData.appInsightsApiKey}}"},
+					{Name: "x-ms-app", Content: "Grafana"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		cloudName         string
+		expectedRouteName string
+		expectedRouteURL  string
+		Err               require.ErrorAssertionFunc
+	}{
+		{
+			name:              "plugin proxy route for the Azure public cloud",
+			cloudName:         "azuremonitor",
+			expectedRouteName: "appinsights",
+			expectedRouteURL:  "https://api.applicationinsights.io",
+			Err:               require.NoError,
+		},
+		{
+			name:              "plugin proxy route for the Azure China cloud",
+			cloudName:         "chinaazuremonitor",
+			expectedRouteName: "chinaappinsights",
+			expectedRouteURL:  "https://api.applicationinsights.azure.cn",
+			Err:               require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route, routeName, err := datasource.getPluginRoute(plugin, tt.cloudName)
+			tt.Err(t, err)
+
+			if diff := cmp.Diff(tt.expectedRouteURL, route.URL, cmpopts.EquateNaNs()); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.expectedRouteName, routeName, cmpopts.EquateNaNs()); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
When alerting was introduced in 20faef8de5fbdaa2395d5097e6d3f862b143f5d1 and query code was ported from the frontend to the backend, it missed adding logic for switching to the correct plugin route for Azure China Application Insights query.

Fixes #23613

**Special notes for your reviewer**:
- We can't test this directly as we don't have access to an Azure China account. In debug mode, you can see the api calls made to Azure China:

`https://api.applicationinsights.azure.cn/v1/apps/metrics/requests/duration?aggregation=avg&interval=PT1H&segment=client%2Fcity&timespan=2020-04-24T21%3A50%3A52Z%2F2020-04-24T22%3A50%3A52Z`
