### PR TITLE
RadioButtons: Updates design and no longer full width in panel edit

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -28,13 +28,13 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme, size: RadioButt
   const c = theme.palette;
   const textColor = theme.colors.textSemiWeak;
   const textColorHover = theme.colors.text;
-  const textColorActive = theme.isLight ? c.blue77 : c.blue95;
+  const textColorActive = theme.colors.textBlue;
   const borderColor = theme.colors.border2;
   const borderColorHover = theme.colors.border3;
-  const borderColorActive = theme.isLight ? c.blue77 : c.blue95;
+  const borderColorActive = theme.colors.border2;
   const bg = theme.colors.bodyBg;
   const bgDisabled = theme.isLight ? c.gray95 : c.gray15;
-  const bgActive = theme.isLight ? c.white : c.gray05;
+  const bgActive = theme.colors.bg2;
 
   const border = `1px solid ${borderColor}`;
   const borderActive = `1px solid ${borderColorActive}`;

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -247,7 +247,7 @@ export const getStandardOptionEditors = () => {
     id: 'radio',
     name: 'Radio',
     description: 'Allows option selection',
-    editor: props => <RadioButtonGroup {...props} options={props.item.settings?.options} fullWidth />,
+    editor: props => <RadioButtonGroup {...props} options={props.item.settings?.options} />,
   };
 
   const unit: StandardEditorsRegistryItem<string> = {


### PR DESCRIPTION
I have never fully felt the new radio buttons fit in with the rest of the design. Just something that felt off with the blue-bordered active state. Both in terms of grabbing a bit too much focus and just looked a bit too different from other inputs & buttons. 

This PR is one alternative design that I think both fits in better and is less attention-grabbing. 

<img width="886" alt="Screen Shot 2020-04-25 at 11 36 33" src="https://user-images.githubusercontent.com/10999/80276474-651b2080-86e9-11ea-8630-3d979f56152f.png">

<img width="887" alt="Screen Shot 2020-04-25 at 11 37 35" src="https://user-images.githubusercontent.com/10999/80276531-c5aa5d80-86e9-11ea-8b6e-591a211bc724.png">
