### PR TITLE
NewPanelEditor: increase sidebar min width, value mappings radio no longer full width

### DIFF
--- a/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { HorizontalGroup } from '../Layout/Layout';
-import { FullWidthButtonContainer, IconButton, Label, RadioButtonGroup } from '../index';
+import { IconButton, Label, RadioButtonGroup } from '../index';
 import { Field } from '../Forms/Field';
 import { Input } from '../Input/Input';
 import { MappingType, RangeMap, SelectableValue, ValueMap, ValueMapping } from '@grafana/data';
@@ -81,15 +81,13 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
   return (
     <div>
       <Field label={label}>
-        <FullWidthButtonContainer>
-          <RadioButtonGroup
-            options={MAPPING_OPTIONS}
-            value={type}
-            onChange={type => {
-              onMappingTypeChange(type!);
-            }}
-          />
-        </FullWidthButtonContainer>
+        <RadioButtonGroup
+          options={MAPPING_OPTIONS}
+          value={type}
+          onChange={type => {
+            onMappingTypeChange(type!);
+          }}
+        />
       </Field>
       {renderRow()}
     </div>

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -309,7 +309,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     return (
       <SplitPane
         split="vertical"
-        minSize={100}
+        minSize={300}
         primary="second"
         /* Use persisted state for default size */
         defaultSize={uiState.rightPaneSize}


### PR DESCRIPTION
Super minor details. Increase sidebar min width to 300px as 100px does not make any sense. Also, Value mappings use non full width radio buttons