### PR TITLE
dockerfile: updated images in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Golang build container
-FROM golang:1.13.1-alpine
+FROM golang:1.13.10-alpine
 
 RUN apk add --no-cache gcc g++
 
@@ -16,7 +16,7 @@ COPY build.go package.json ./
 RUN go run build.go build
 
 # Node build container
-FROM node:10.14.2-alpine
+FROM node:10.20.1-alpine
 
 # PhantomJS
 RUN apk add --no-cache curl &&\
@@ -44,7 +44,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM alpine:3.10
+FROM alpine:3.11
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.13.1 AS go-builder
+FROM golang:1.13.10 AS go-builder
 
 WORKDIR /src/grafana
 
@@ -12,7 +12,7 @@ COPY pkg pkg/
 
 RUN go run build.go build
 
-FROM node:10.17 AS js-builder
+FROM node:10.20.1 AS js-builder
 
 # PhantomJS
 RUN apt-get update && apt-get install -y curl &&\
@@ -34,7 +34,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM ubuntu:18.10
+FROM ubuntu:20.04
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 EXPOSE 3000

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.10
+ARG BASE_IMAGE=alpine:3.11
 FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"

--- a/packaging/docker/Dockerfile.ubuntu
+++ b/packaging/docker/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:18.10
+ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE} AS grafana-builder
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -60,11 +60,11 @@ docker_build () {
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
     dockerfile="Dockerfile"
-    base_image="${base_arch}alpine:3.10"
+    base_image="${base_arch}alpine:3.11"
   else
     libc=""
     dockerfile="Dockerfile.ubuntu"
-    base_image="${base_arch}ubuntu:18.10"
+    base_image="${base_arch}ubuntu:20.10"
   fi
 
   grafana_tgz="grafana-latest.linux-${arch}${libc}.tar.gz"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -64,7 +64,7 @@ docker_build () {
   else
     libc=""
     dockerfile="Dockerfile.ubuntu"
-    base_image="${base_arch}ubuntu:20.10"
+    base_image="${base_arch}ubuntu:20.04"
   fi
 
   grafana_tgz="grafana-latest.linux-${arch}${libc}.tar.gz"

--- a/scripts/ci-metrics-publisher.sh
+++ b/scripts/ci-metrics-publisher.sh
@@ -8,7 +8,7 @@ for ((i = 1; i <= $#; i++ )); do
   remainder="${!i}"
   # Find everything until last = character (= is included in the result)
   # This allows to add tags to metric names
-  metricName=$(grep -o "\(.*\)=" <<< $remainder)
+  metricName=$(grep -o "\(.*\)=" <<< "$remainder")
   # Get the metric value
   value=${remainder#"$metricName"}
   # Remove remaining = character from metric name


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated dockerfile to use latest versions of each image and to be consistent between alpine and Ubuntu.
Golang 1.13.1 to 1.13.10
Node 10.14.2 to 10.20.1

Updated Alpine in final image to 3.11 as this is the version already being used for the Golang and node images.
Updated Ubuntu image to 20.04 as 18.10 in the Ubuntu image is out of support since 18th July 2019. 20.04 is new as only released 23rd April so could alternative go down to 18.04 (EOL April 2023) or go to 19.10 (EOL July 2020)

