### PR TITLE
grafana/toolkit: Do not suggest Angular panel anymore, add note about grafana tutorials

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.create.ts
@@ -6,6 +6,7 @@ import {
   formatPluginDetails,
   getPluginIdFromName,
   prepareJsonFiles,
+  printGrafanaTutorialsDetails,
   promptPluginDetails,
   promptPluginType,
   removeGitFiles,
@@ -41,6 +42,9 @@ const pluginCreateRunner: TaskRunner<PluginCreateOptions> = async ({ name }) => 
 
   // 6. Remove cloned repository .git dir
   await removeGitFiles(destPath);
+
+  // 7. Promote Grafana Tutorials :)
+  printGrafanaTutorialsDetails(type);
 };
 
 export const pluginCreateTask = new Task<PluginCreateOptions>('plugin:create task', pluginCreateRunner);

--- a/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
@@ -20,13 +20,22 @@ interface PluginDetails {
   keywords: string;
 }
 
-type PluginType = 'angular-panel' | 'react-panel' | 'datasource-plugin' | 'backend-datasource-plugin';
+type PluginType = 'panel-plugin' | 'datasource-plugin' | 'backend-datasource-plugin';
 
-const RepositoriesPaths = {
-  'angular-panel': 'https://github.com/grafana/simple-angular-panel.git',
-  'react-panel': 'https://github.com/grafana/simple-react-panel.git',
+const PluginNames: Record<PluginType, string> = {
+  'panel-plugin': 'Grafana Panel Plugin',
+  'datasource-plugin': 'Grafana Data Source Plugin',
+  'backend-datasource-plugin': 'Grafana Backend Datasource Plugin',
+};
+const RepositoriesPaths: Record<PluginType, string> = {
+  'panel-plugin': 'https://github.com/grafana/simple-react-panel.git',
   'datasource-plugin': 'https://github.com/grafana/simple-datasource.git',
   'backend-datasource-plugin': 'https://github.com/grafana/simple-datasource-backend.git',
+};
+const TutorialPaths: Record<PluginType, string> = {
+  'panel-plugin': 'https://grafana.com/tutorials/build-a-panel-plugin',
+  'datasource-plugin': 'https://grafana.com/tutorials/build-a-data-source-plugin',
+  'backend-datasource-plugin': 'TODO',
 };
 
 export const getGitUsername = async () => {
@@ -61,10 +70,9 @@ export const promptPluginType = async () =>
       message: 'Select plugin type',
       name: 'type',
       choices: [
-        { name: 'Angular panel', value: 'angular-panel' },
-        { name: 'React panel', value: 'react-panel' },
-        { name: 'Datasource plugin', value: 'datasource-plugin' },
-        { name: 'Backend datasource plugin', value: 'backend-datasource-plugin' },
+        { name: 'Panel Plugin', value: 'panel-plugin' },
+        { name: 'Datasource Plugin', value: 'datasource-plugin' },
+        { name: 'Backend Datasource Plugin', value: 'backend-datasource-plugin' },
       ],
     },
   ]);
@@ -156,6 +164,21 @@ export const formatPluginDetails = (details: PluginDetails) => {
   console.log(chalk.bold('Author: '), details.author);
   console.log(chalk.bold('Organisation: '), details.org);
   console.log(chalk.bold('Website: '), details.url);
+  console.log();
+  console.groupEnd();
+};
+
+export const printGrafanaTutorialsDetails = (type: PluginType) => {
+  console.group();
+  console.log();
+  console.log(chalk.bold.yellow(`Congrats! You have just created ${PluginNames[type]}.`));
+  console.log();
+  if (type !== 'backend-datasource-plugin') {
+    console.log(`${PluginNames[type]} tutorial: ${TutorialPaths[type]}`);
+  }
+  console.log(
+    'Learn more about Grafana Plugins at https://grafana.com/docs/grafana/latest/plugins/developing/development/'
+  );
   console.log();
   console.groupEnd();
 };


### PR DESCRIPTION
I think with 7.0 it's time to stop suggesting Angular Panel when scaffolding plugin with grafana-toolkit. 

@marcusolsson I've also added not about Grafana Tutorials to the plugin:create task output.

Plugin templates are also updated now to the latest versions, I've added some more information to readmes too (what are particular plugin types, links to docs and tutorials):
- https://github.com/grafana/simple-react-panel
- https://github.com/grafana/simple-datasource