### PR TITLE
Chore: set author to grafana labs

### DIFF
--- a/plugins-bundled/internal/input-datasource/src/plugin.json
+++ b/plugins-bundled/internal/input-datasource/src/plugin.json
@@ -9,7 +9,7 @@
   "info": {
     "description": "Data source that supports manual table & CSV input",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -22,7 +22,7 @@
   "info": {
     "description": "Data source for Amazon AWS monitoring service",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/elasticsearch/plugin.json
+++ b/public/app/plugins/datasource/elasticsearch/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Open source logging & analytics database",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "keywords": ["elasticsearch"],

--- a/public/app/plugins/datasource/graphite/plugin.json
+++ b/public/app/plugins/datasource/graphite/plugin.json
@@ -21,7 +21,7 @@
   "info": {
     "description": "Open source time series database",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/influxdb/plugin.json
+++ b/public/app/plugins/datasource/influxdb/plugin.json
@@ -17,7 +17,7 @@
   "info": {
     "description": "Open source time series database",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/jaeger/plugin.json
+++ b/public/app/plugins/datasource/jaeger/plugin.json
@@ -14,7 +14,7 @@
   "info": {
     "description": "Open source, end-to-end distributed tracing",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -17,7 +17,7 @@
   "info": {
     "description": "Like Prometheus but for logs. OSS logging solution from Grafana Labs",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/mssql/plugin.json
+++ b/public/app/plugins/datasource/mssql/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Data source for Microsoft SQL Server compatible databases",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/mysql/plugin.json
+++ b/public/app/plugins/datasource/mysql/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Data source for MySQL databases",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/opentsdb/plugin.json
+++ b/public/app/plugins/datasource/opentsdb/plugin.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "Open source time series database",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/postgres/plugin.json
+++ b/public/app/plugins/datasource/postgres/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Data source for PostgreSQL and compatible databases",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -30,7 +30,7 @@
   "info": {
     "description": "Open source time series database & alerting",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/stackdriver/plugin.json
+++ b/public/app/plugins/datasource/stackdriver/plugin.json
@@ -20,7 +20,7 @@
       "large": "img/stackdriver_logo.svg"
     },
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     }
   },

--- a/public/app/plugins/datasource/testdata/plugin.json
+++ b/public/app/plugins/datasource/testdata/plugin.json
@@ -16,7 +16,7 @@
   "info": {
     "description": "Generates test data in different forms",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/datasource/zipkin/plugin.json
+++ b/public/app/plugins/datasource/zipkin/plugin.json
@@ -14,7 +14,7 @@
   "info": {
     "description": "Placeholder for the distributed tracing system.",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/alertlist/plugin.json
+++ b/public/app/plugins/panel/alertlist/plugin.json
@@ -8,7 +8,7 @@
   "info": {
     "description": "Shows list of alerts and their current status",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/annolist/plugin.json
+++ b/public/app/plugins/panel/annolist/plugin.json
@@ -9,7 +9,7 @@
   "info": {
     "description": "List annotations",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -6,7 +6,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/dashlist/plugin.json
+++ b/public/app/plugins/panel/dashlist/plugin.json
@@ -8,7 +8,7 @@
   "info": {
     "description": "List of dynamic links to other dashboards",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/gauge/plugin.json
+++ b/public/app/plugins/panel/gauge/plugin.json
@@ -5,7 +5,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/gettingstarted/plugin.json
+++ b/public/app/plugins/panel/gettingstarted/plugin.json
@@ -8,7 +8,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/graph/plugin.json
+++ b/public/app/plugins/panel/graph/plugin.json
@@ -6,7 +6,7 @@
   "info": {
     "description": "Graph Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/graph2/plugin.json
+++ b/public/app/plugins/panel/graph2/plugin.json
@@ -6,7 +6,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -6,7 +6,7 @@
   "info": {
     "description": "Heatmap Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/homelinks/plugin.json
+++ b/public/app/plugins/panel/homelinks/plugin.json
@@ -8,7 +8,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/logs/plugin.json
+++ b/public/app/plugins/panel/logs/plugin.json
@@ -5,7 +5,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/news/plugin.json
+++ b/public/app/plugins/panel/news/plugin.json
@@ -9,7 +9,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -6,7 +6,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/pluginlist/plugin.json
+++ b/public/app/plugins/panel/pluginlist/plugin.json
@@ -8,7 +8,7 @@
   "info": {
     "description": "Plugin List for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/singlestat/plugin.json
+++ b/public/app/plugins/panel/singlestat/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Singlestat Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/stat/plugin.json
+++ b/public/app/plugins/panel/stat/plugin.json
@@ -7,7 +7,7 @@
   "info": {
     "description": "Singlestat Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/table-old/plugin.json
+++ b/public/app/plugins/panel/table-old/plugin.json
@@ -8,7 +8,7 @@
   "info": {
     "description": "Table Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -6,7 +6,7 @@
   "info": {
     "description": "Table Panel for Grafana",
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -7,7 +7,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {

--- a/public/app/plugins/panel/text2/plugin.json
+++ b/public/app/plugins/panel/text2/plugin.json
@@ -8,7 +8,7 @@
 
   "info": {
     "author": {
-      "name": "Grafana Project",
+      "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
     "logos": {


### PR DESCRIPTION
The mix of "Grafana Labs" and "Grafana Project" is odd... lets use "by Grafana Labs" everywhere

![image](https://user-images.githubusercontent.com/705951/80319484-4a1dde80-87c5-11ea-8442-b221f1584603.png)
