### PR TITLE
Fix build-container

### DIFF
--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -29,6 +29,8 @@ ENV OSX_SDK_URL=https://s3.dockerproject.org/darwin/v2 \
 # might wanna make sure osx cross and the other tarball as well as the packages ends up somewhere other than tmp
 # might also wanna put them as their own layer to not have to unpack them every time?
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update   && \
     apt-get upgrade -yq && \
     apt-get install -yq \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
After updating in ubuntu 20.04 [build-container](https://github.com/grafana/grafana/blob/master/scripts/build/ci-build/Dockerfile) build (`make build`) hangs when trying to install `tzdata` package:
```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 
```
This PR fixes it following [this](https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image#answer-949998) suggestion.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
The default timezone for the image is set to `Etc/UTC`.

Probably this can be an issue with other containers using `ubuntu` base image [which were recently updated](https://github.com/grafana/grafana/commit/51c19da98d6cc6b8772ba4e2e88566470f075696).
