### PR TITLE
DatasourcePlugin: Adds per-mode StartPage components

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -87,6 +87,16 @@ export class DataSourcePlugin<
     return this;
   }
 
+  setExploreMetricsStartPage(ExploreStartPage: ComponentType<ExploreStartPageProps>) {
+    this.components.ExploreMetricsStartPage = ExploreStartPage;
+    return this;
+  }
+
+  setExploreLogsStartPage(ExploreStartPage: ComponentType<ExploreStartPageProps>) {
+    this.components.ExploreLogsStartPage = ExploreStartPage;
+    return this;
+  }
+
   setVariableQueryEditor(VariableQueryEditor: any) {
     this.components.VariableQueryEditor = VariableQueryEditor;
     return this;
@@ -144,6 +154,8 @@ export interface DataSourcePluginComponents<
   ExploreMetricsQueryField?: ComponentType<ExploreQueryFieldProps<DSType, TQuery, TOptions>>;
   ExploreLogsQueryField?: ComponentType<ExploreQueryFieldProps<DSType, TQuery, TOptions>>;
   ExploreStartPage?: ComponentType<ExploreStartPageProps>;
+  ExploreMetricsStartPage?: ComponentType<ExploreStartPageProps>;
+  ExploreLogsStartPage?: ComponentType<ExploreStartPageProps>;
   ConfigEditor?: ComponentType<DataSourcePluginOptionsEditorProps<TOptions, TSecureOptions>>;
   MetadataInspector?: ComponentType<MetadataInspectorProps<DSType, TQuery, TOptions>>;
 }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -19,6 +19,7 @@ import {
   RawTimeRange,
   TimeRange,
   TimeZone,
+  ExploreStartPageProps,
 } from '@grafana/data';
 
 import store from 'app/core/store';
@@ -302,7 +303,16 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const { showRichHistory } = this.state;
     const exploreClass = split ? 'explore explore-split' : 'explore';
     const styles = getStyles(theme);
-    const StartPage = datasourceInstance?.components?.ExploreStartPage;
+
+    let StartPage: React.ComponentType<ExploreStartPageProps>;
+    if (mode === ExploreMode.Metrics && datasourceInstance.components?.ExploreMetricsStartPage) {
+      StartPage = datasourceInstance.components.ExploreMetricsStartPage;
+    } else if (mode === ExploreMode.Logs && datasourceInstance.components?.ExploreLogsStartPage) {
+      StartPage = datasourceInstance.components.ExploreLogsStartPage;
+    } else {
+      StartPage = datasourceInstance?.components?.ExploreStartPage;
+    }
+
     const showStartPage = !queryResponse || queryResponse.state === LoadingState.NotStarted;
 
     // TEMP: Remove for 7.0

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -304,7 +304,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const exploreClass = split ? 'explore explore-split' : 'explore';
     const styles = getStyles(theme);
 
-    let StartPage: React.ComponentType<ExploreStartPageProps>;
+    let StartPage: React.ComponentType<ExploreStartPageProps> | null;
     if (mode === ExploreMode.Metrics && datasourceInstance.components?.ExploreMetricsStartPage) {
       StartPage = datasourceInstance.components.ExploreMetricsStartPage;
     } else if (mode === ExploreMode.Logs && datasourceInstance.components?.ExploreLogsStartPage) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds per-mode StartPage components, `ExploreLogsStartPage` and `ExploreMetricsStartPage`, and corresponding setters `setExploreLogsStartPage` and `setExploreMetricsStartPage`, for data sources that might require different "Cheat sheets" depending on the query mode (e.g. CloudWatch).

