### PR TITLE
PanelEditor: Fixed issue with PanelModel change plugin type

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -214,8 +214,13 @@ describe('PanelModel', () => {
           });
         });
 
+        model.editSourceId = 1001;
         model.changePlugin(newPlugin);
         model.alert = { id: 2 };
+      });
+
+      it('should keep editSourceId', () => {
+        expect(model.editSourceId).toBe(1001);
       });
 
       it('should apply next panel option defaults', () => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -84,6 +84,7 @@ const mustKeepProps: { [str: string]: boolean } = {
   queryRunner: true,
   transformations: true,
   fieldConfig: true,
+  editSourceId: true,
 };
 
 const defaults: any = {


### PR DESCRIPTION
* editSourceId was lost after switching panel type and so panel type change was not saved when saving from within the edit mode 

Fixes #23910