### PR TITLE
Image Rendering: New setting to control render request concurrency

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -684,7 +684,7 @@ server_url =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 callback_url =
 #Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
-#and this setting can help protect against that by only allowing certain amount of concurrent request.
+#and this setting can help protect against that by only allowing certain amount of concurrent requests.
 concurrent_render_request_limit = 30
 
 [panels]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -683,6 +683,9 @@ container_name =
 server_url =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 callback_url =
+#Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
+#and this setting can help protect against that by only allowing certain amount of concurrent request.
+concurrent_render_request_limit = 30
 
 [panels]
 # here for to support old env variables, can remove after a few months

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -683,8 +683,8 @@ container_name =
 server_url =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 callback_url =
-#Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
-#and this setting can help protect against that by only allowing certain amount of concurrent requests.
+# Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server,
+# which this setting can help protect against by only allowing a certain amount of concurrent requests.
 concurrent_render_request_limit = 30
 
 [panels]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -673,6 +673,9 @@
 ;server_url =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 ;callback_url =
+#Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
+#and this setting can help protect against that by only allowing certain amount of concurrent request.
+;concurrent_render_request_limit = 30
 
 [panels]
 # If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -673,8 +673,8 @@
 ;server_url =
 # If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 ;callback_url =
-#Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
-#and this setting can help protect against that by only allowing certain amount of concurrent request.
+# Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server,
+# which this setting can help protect against by only allowing a certain amount of concurrent requests.
 ;concurrent_render_request_limit = 30
 
 [panels]

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -824,8 +824,8 @@ If the remote HTTP image renderer service runs on a different server than the Gr
 
 ### concurrent_render_request_limit
 
-Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
-and this setting can help protect against that by only allowing certain amount of concurrent request.
+Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server,
+which this setting can help protect against by only allowing a certain amount of concurrent requests.
 
 ## [panels]
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -822,6 +822,11 @@ URL to a remote HTTP image renderer service, e.g. http://localhost:8081/render, 
 
 If the remote HTTP image renderer service runs on a different server than the Grafana server you may have to configure this to a URL where Grafana is reachable, e.g. http://grafana.domain/.
 
+### concurrent_render_request_limit
+
+Concurrent render request limit affects when the /render HTTP endpoint is used. Rendering many images at the same time can overload the server
+and this setting can help protect against that by only allowing certain amount of concurrent request.
+
 ## [panels]
 
 ### disable_sanitize_html

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -52,7 +52,6 @@ func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
 		headers["Accept-Language"] = acceptLanguageHeader
 	}
 
-	maxConcurrentLimitForApiCalls := 30
 	result, err := hs.RenderService.Render(c.Req.Context(), rendering.Opts{
 		Width:             width,
 		Height:            height,
@@ -63,7 +62,7 @@ func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
 		Path:              c.Params("*") + queryParams,
 		Timezone:          queryReader.Get("tz", ""),
 		Encoding:          queryReader.Get("encoding", ""),
-		ConcurrentLimit:   maxConcurrentLimitForApiCalls,
+		ConcurrentLimit:   hs.Cfg.RendererConcurrentRequestLimit,
 		DeviceScaleFactor: scale,
 		Headers:           headers,
 	})

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -238,11 +238,10 @@ type Cfg struct {
 	Smtp SmtpSettings
 
 	// Rendering
-	ImagesDir             string
-	RendererUrl           string
-	RendererCallbackUrl   string
-	RendererLimit         int
-	RendererLimitAlerting int
+	ImagesDir                      string
+	RendererUrl                    string
+	RendererCallbackUrl            string
+	RendererConcurrentRequestLimit int
 
 	// Security
 	DisableInitAdminCreation         bool
@@ -938,6 +937,8 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 			log.Fatal(4, "Invalid callback_url(%s): %s", cfg.RendererCallbackUrl, err)
 		}
 	}
+	cfg.RendererConcurrentRequestLimit = renderSec.Key("concurrent_render_request_limit").MustInt(30)
+
 	cfg.ImagesDir = filepath.Join(cfg.DataPath, "png")
 	cfg.TempDataLifetime = iniFile.Section("paths").Key("temp_data_lifetime").MustDuration(time.Second * 3600 * 24)
 	cfg.MetricsEndpointEnabled = iniFile.Section("metrics").Key("enabled").MustBool(true)


### PR DESCRIPTION
**What this PR does / why we need it**:
New setting to control render request concurrency. Takes the default from the currently hard-coded value.

**Which issue(s) this PR fixes**:
Fixes #23806

