### PR TITLE
Build: adding support to rollup *.json files to include moment-timezone data.

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -23,26 +23,27 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@braintree/sanitize-url": "4.0.0",
     "apache-arrow": "0.16.0",
     "lodash": "4.17.15",
     "rxjs": "6.5.5",
-    "xss": "1.0.6",
-    "@braintree/sanitize-url": "4.0.0"
+    "xss": "1.0.6"
   },
   "devDependencies": {
     "@grafana/eslint-config": "^1.0.0-rc1",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "@rollup/plugin-commonjs": "11.0.2",
+    "@rollup/plugin-json": "4.0.3",
     "@rollup/plugin-node-resolve": "7.1.1",
+    "@types/braintree__sanitize-url": "4.0.0",
     "@types/jest": "23.3.14",
     "@types/jquery": "1.10.35",
     "@types/lodash": "4.14.123",
     "@types/node": "10.14.1",
     "@types/papaparse": "4.5.9",
     "@types/react": "16.8.16",
-    "@types/sinon": "^7.5.2",
     "@types/rollup-plugin-visualizer": "2.6.0",
-    "@types/braintree__sanitize-url": "4.0.0",
+    "@types/sinon": "^7.5.2",
     "pretty-format": "25.1.0",
     "rollup": "2.0.6",
     "rollup-plugin-sourcemaps": "0.5.0",

--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -1,6 +1,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import sourceMaps from 'rollup-plugin-sourcemaps';
+import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
 const pkg = require('./package.json');
@@ -22,6 +23,9 @@ const buildCjsPackage = ({ env }) => {
     ],
     external: ['lodash', 'apache-arrow'], // Use Lodash & arrow from grafana
     plugins: [
+      json({
+        include: ['../../node_modules/moment-timezone/data/packed/latest.json'],
+      }),
       commonjs({
         include: /node_modules/,
         namedExports: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,6 +4328,13 @@
     magic-string "^0.25.2"
     resolve "^1.11.0"
 
+"@rollup/plugin-json@4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.0.3.tgz#747e2c2884c5a0fa00b66c9c0f3f1012cddca534"
+  integrity sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.1.tgz#8c6e59c4b28baf9d223028d0e450e06a485bb2b7"
@@ -4345,6 +4352,15 @@
   integrity sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
   dependencies:
     estree-walker "^1.0.1"
+
+"@rollup/pluginutils@^3.0.8":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.0.9.tgz#aa6adca2c45e5a1b950103a999e3cddfe49fd775"
+  integrity sha512-TLZavlfPAZYI7v33wQh4mTP6zojne14yok3DNSLcjoG/Hirxfkonn6icP5rrNWRn8nZsirJBFFpijVOJzkUHDg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    micromatch "^4.0.2"
 
 "@rtsao/plugin-proposal-class-properties@7.0.1-patch.1":
   version "7.0.1-patch.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the master build is failing due to rollup not supporting *.json files. When adding moment-timezone we need to support that so we can include all the time zone data.
