### PR TITLE
Image rendering: Fix missing icon on plugins list

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -121,6 +121,10 @@ func (pm *PluginManager) Init() error {
 		app.initApp()
 	}
 
+	if Renderer != nil {
+		Renderer.initFrontendPlugin()
+	}
+
 	for _, p := range Plugins {
 		if p.IsCorePlugin {
 			p.Signature = PluginSignatureInternal

--- a/pkg/plugins/renderer_plugin.go
+++ b/pkg/plugins/renderer_plugin.go
@@ -13,7 +13,7 @@ import (
 )
 
 type RendererPlugin struct {
-	PluginBase
+	FrontendPluginBase
 
 	Executable           string `json:"executable,omitempty"`
 	GrpcPluginV1         pluginModel.RendererPlugin


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix missing image renderer icon on plugins page.

**Which issue(s) this PR fixes**:
Fixes #23189

**Special notes for your reviewer**:
Not sure it makes sense to call `initFrontendPlugin` on a non-frontend plugin, but it resolves the problem :)
