### PR TITLE
UX: replace dashboard settings icon

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -258,7 +258,7 @@ class DashNav extends PureComponent<Props> {
         <DashNavButton
           tooltip="Dashboard settings"
           classSuffix="settings"
-          icon="cog"
+          icon="sliders-v-alt"
           onClick={this.onOpenSettings}
           key="button-settings"
         />

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -261,10 +261,10 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
           <HorizontalGroup>
             <HorizontalGroup spacing="sm" align="center">
               <Button
-                icon="cog"
+                icon="sliders-v-alt"
                 onClick={this.onOpenDashboardSettings}
                 variant="secondary"
-                title="Open dashboad settings"
+                title="Open dashboard settings"
               />
               <Button onClick={this.onDiscard} variant="secondary" title="Undo all changes">
                 Discard


### PR DESCRIPTION
The dashboard settings icon (top right) is the same as the general
settings icon in the main navigation bar (left middle). I think UX can
be improved by not having the same icon with different functionality
twice on the same page.

Thanks to Apurva Bhide for noticing.


**What this PR does / why we need it**:

replaces the dashboard settings icon

**Which issue(s) this PR fixes**:

it improves user experience by not having the same icon with different functionality
twice on the same page