### PR TITLE
Add DescribeAlarmHistory to minimal IAM policy

### DIFF
--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -62,6 +62,7 @@ Here is a minimal policy example:
       "Effect": "Allow",
       "Action": [
         "cloudwatch:DescribeAlarmsForMetric",
+        "cloudwatch:DescribeAlarmHistory",
         "cloudwatch:ListMetrics",
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:GetMetricData"


### PR DESCRIPTION
DescribeAlarmHistory is used in the annotations query

**What this PR does / why we need it**:
Documentation improvement