### PR TITLE
Add DescribeAlarms to minimal IAM policy

### DIFF
--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -63,6 +63,7 @@ Here is a minimal policy example:
       "Action": [
         "cloudwatch:DescribeAlarmsForMetric",
         "cloudwatch:DescribeAlarmHistory",
+        "cloudwatch:DescribeAlarms",
         "cloudwatch:ListMetrics",
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:GetMetricData"


### PR DESCRIPTION
DescribeAlarms is used in the prefix matching of the annotations query.

**What this PR does / why we need it:**
Documentation improvement