### PR TITLE
PanelEditor: adds annotations and alertState to Redux

### DIFF
--- a/public/app/core/reducers/root.ts
+++ b/public/app/core/reducers/root.ts
@@ -15,6 +15,7 @@ import organizationReducers from 'app/features/org/state/reducers';
 import ldapReducers from 'app/features/admin/state/reducers';
 import templatingReducers from 'app/features/variables/state/reducers';
 import importDashboardReducers from 'app/features/manage-dashboards/state/reducers';
+import annotationsReducers from 'app/features/annotations/state/reducers';
 
 const rootReducers = {
   ...sharedReducers,
@@ -32,6 +33,7 @@ const rootReducers = {
   ...ldapReducers,
   ...templatingReducers,
   ...importDashboardReducers,
+  ...annotationsReducers,
 };
 
 const addedReducers = {};

--- a/public/app/features/alerting/AlertTab.tsx
+++ b/public/app/features/alerting/AlertTab.tsx
@@ -19,6 +19,7 @@ import { TestRuleResult } from './TestRuleResult';
 import { AppNotificationSeverity, CoreEvents, StoreState } from 'app/types';
 import { updateLocation } from 'app/core/actions';
 import { PanelEditorTabId } from '../dashboard/components/PanelEditor/types';
+import { clearAlertState } from '../annotations/state/reducers';
 
 interface OwnProps {
   dashboard: DashboardModel;
@@ -31,6 +32,7 @@ interface ConnectedProps {
 
 interface DispatchProps {
   updateLocation: typeof updateLocation;
+  clearAlertState: typeof clearAlertState;
 }
 
 export type Props = OwnProps & ConnectedProps & DispatchProps;
@@ -134,6 +136,7 @@ class UnConnectedAlertTab extends PureComponent<Props, State> {
           yesText: 'Delete',
           onConfirm: () => {
             delete panel.alert;
+            this.props.clearAlertState({ panelId: panel.id });
             panel.thresholds = [];
             this.panelCtrl.alertState = null;
             this.panelCtrl.render();
@@ -228,6 +231,6 @@ const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = (
   };
 };
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = { updateLocation };
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = { updateLocation, clearAlertState };
 
 export const AlertTab = connect(mapStateToProps, mapDispatchToProps)(UnConnectedAlertTab);

--- a/public/app/features/annotations/state/reducers.ts
+++ b/public/app/features/annotations/state/reducers.ts
@@ -1,0 +1,86 @@
+import cloneDeep from 'lodash/cloneDeep';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AnnotationEvent } from '@grafana/data';
+
+import { cleanUpDashboard, cleanUpEditPanel } from 'app/features/dashboard/state/reducers';
+import { updateEditorInitState } from '../../dashboard/components/PanelEditor/state/reducers';
+import { EDIT_PANEL_ID } from '../../../core/constants';
+import { StoreState } from '../../../types';
+
+export type AnnotationsIdentifier = { panelId: number };
+
+export interface AlertState {
+  id: number;
+  dashboardId: number;
+  panelId: number;
+  state: string;
+  newDateState: string;
+}
+
+export interface AnnotationsAndAlertState {
+  annotations: AnnotationEvent[];
+  alertState: AlertState;
+}
+
+export interface AnnotationsState extends Record<string, AnnotationsAndAlertState> {}
+
+export const initialAnnotationsState: AnnotationsState = {};
+
+const UNKNOWN_PANEL_ID = 'UNKNOWN_PANEL_ID';
+
+const annotationsSlice = createSlice({
+  name: 'annotations',
+  initialState: initialAnnotationsState,
+  reducers: {
+    setAnnotationsAndAlert: (
+      state,
+      action: PayloadAction<{
+        identifier: AnnotationsIdentifier;
+        annotations: AnnotationEvent[];
+        alertState: AlertState;
+      }>
+    ) => {
+      const { annotations, alertState, identifier } = action.payload;
+      const panelId = identifier.panelId ?? UNKNOWN_PANEL_ID;
+
+      if (!state[panelId]) {
+        state[panelId] = { annotations, alertState };
+        return;
+      }
+
+      state[panelId] = { annotations, alertState };
+    },
+  },
+  extraReducers: builder =>
+    builder
+      .addCase(cleanUpDashboard, (state, action) => initialAnnotationsState)
+      .addCase(updateEditorInitState, (state, action) => {
+        const { sourcePanel } = action.payload;
+        const sourcePanelId = sourcePanel.id ?? UNKNOWN_PANEL_ID;
+
+        if (!state[sourcePanelId]) {
+          return;
+        }
+
+        state[EDIT_PANEL_ID] = cloneDeep(state[sourcePanelId]);
+      })
+      .addCase(cleanUpEditPanel, (state, action) => {
+        delete state[EDIT_PANEL_ID];
+      }),
+});
+
+export const getAnnotationsAndAlertState = (state: StoreState, panelId: number): AnnotationsAndAlertState => {
+  const defaultAlertState = ({ state: undefined } as unknown) as AlertState;
+  const annotations = state.annotations[panelId] ? state.annotations[panelId].annotations : [];
+  const alertState = state.annotations[panelId] ? state.annotations[panelId].alertState : defaultAlertState;
+
+  return { annotations, alertState: alertState ?? defaultAlertState };
+};
+
+export const { setAnnotationsAndAlert } = annotationsSlice.actions;
+
+export const annotationsReducer = annotationsSlice.reducer;
+
+export default {
+  annotations: annotationsReducer,
+};

--- a/public/app/features/annotations/state/reducers.ts
+++ b/public/app/features/annotations/state/reducers.ts
@@ -16,6 +16,7 @@ export interface AlertState {
   state: string;
   newDateState: string;
 }
+const initialAlertState = ({ state: undefined } as unknown) as AlertState;
 
 export interface AnnotationsAndAlertState {
   annotations: AnnotationEvent[];
@@ -50,6 +51,15 @@ const annotationsSlice = createSlice({
 
       state[panelId] = { annotations, alertState };
     },
+    clearAlertState: (state, action: PayloadAction<AnnotationsIdentifier>) => {
+      const { panelId } = action.payload;
+
+      if (!state[panelId]) {
+        return;
+      }
+
+      state[panelId].alertState = initialAlertState;
+    },
   },
   extraReducers: builder =>
     builder
@@ -70,14 +80,13 @@ const annotationsSlice = createSlice({
 });
 
 export const getAnnotationsAndAlertState = (state: StoreState, panelId: number): AnnotationsAndAlertState => {
-  const defaultAlertState = ({ state: undefined } as unknown) as AlertState;
   const annotations = state.annotations[panelId] ? state.annotations[panelId].annotations : [];
-  const alertState = state.annotations[panelId] ? state.annotations[panelId].alertState : defaultAlertState;
+  const alertState = state.annotations[panelId] ? state.annotations[panelId].alertState : initialAlertState;
 
-  return { annotations, alertState: alertState ?? defaultAlertState };
+  return { annotations, alertState: alertState ?? initialAlertState };
 };
 
-export const { setAnnotationsAndAlert } = annotationsSlice.actions;
+export const { setAnnotationsAndAlert, clearAlertState } = annotationsSlice.actions;
 
 export const annotationsReducer = annotationsSlice.reducer;
 

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -11,6 +11,8 @@ import {
 } from './reducers';
 import { cleanUpEditPanel, panelModelAndPluginReady } from '../../../state/reducers';
 import store from '../../../../../core/store';
+import { EDIT_PANEL_ID } from '../../../../../core/constants';
+import { clearAlertState } from 'app/features/annotations/state/reducers';
 
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return dispatch => {
@@ -46,6 +48,12 @@ export function panelEditorCleanUp(): ThunkResult<void> {
       modifiedSaveModel.id = sourcePanel.id;
 
       sourcePanel.restoreModel(modifiedSaveModel);
+
+      const modifiedAlertState = getStore().annotations[EDIT_PANEL_ID].alertState;
+      const sourceAlertState = getStore().annotations[sourcePanel.id].alertState;
+      if (!modifiedAlertState.state && sourceAlertState.state) {
+        dispatch(clearAlertState({ panelId: sourcePanel.id }));
+      }
 
       if (panelTypeChanged) {
         dispatch(panelModelAndPluginReady({ panelId: sourcePanel.id, plugin: panel.plugin! }));

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -12,7 +12,7 @@ import { axesEditorComponent } from './axes_editor';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 import { getProcessedDataFrames } from 'app/features/dashboard/state/runRequest';
-import { getColorFromHexRgbOrName, PanelEvents, DataFrame, DataLink, VariableSuggestion } from '@grafana/data';
+import { DataFrame, DataLink, getColorFromHexRgbOrName, PanelEvents, VariableSuggestion } from '@grafana/data';
 
 import { GraphContextMenuCtrl } from './GraphContextMenuCtrl';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
@@ -157,7 +157,7 @@ class GraphCtrl extends MetricsPanelCtrl {
     this.events.on(PanelEvents.initPanelActions, this.onInitPanelActions.bind(this));
 
     this.onDataLinksChange = this.onDataLinksChange.bind(this);
-    this.annotationsPromise = Promise.resolve({ annotations: [] });
+    this.annotationsPromise = annotationsSrv.getLastAnnotationsResult(this.panel.id);
   }
 
   onInitEditMode() {

--- a/public/app/types/store.ts
+++ b/public/app/types/store.ts
@@ -19,6 +19,7 @@ import { PanelEditorState } from '../features/dashboard/components/PanelEditor/s
 import { ApiKeysState } from './apiKeys';
 import { TemplatingState } from '../features/variables/state/reducers';
 import { ImportDashboardState } from '../features/manage-dashboards/state/reducers';
+import { AnnotationsState } from '../features/annotations/state/reducers';
 
 export interface StoreState {
   navIndex: NavIndex;
@@ -44,6 +45,7 @@ export interface StoreState {
   userListAdmin: UserListAdminState;
   templating: TemplatingState;
   importDashboard: ImportDashboardState;
+  annotations: AnnotationsState;
 }
 
 /*


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to address: `When entering edit mode for a panel with annotations or alert the annotations or alert state will not load in editor until you refresh (trigger query). A bit tricky to fix.` from #21111.
**Which issue(s) this PR fixes**:
Relates #21111

**Special notes for your reviewer**:
If this is feels like an ok solution, then I'll add tests and such.
