### PR TITLE
Chore: Update Grafana version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
-  "version": "7.0.0-pre.0"
+  "version": "7.1.0-pre.0"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "private": true,
   "name": "grafana",
-  "version": "7.0.0-pre",
+  "version": "7.1.0-pre",
   "repository": "github:grafana/grafana",
   "scripts": {
     "api-tests": "jest --notify --watch --config=devenv/e2e-api-tests/jest.js",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/data",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana Data Library",
   "keywords": [
     "typescript"

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e-selectors",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana End-to-End Test Selectors Library",
   "keywords": [
     "cli",
@@ -25,9 +25,9 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@types/node": "13.7.7",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-node-resolve": "7.1.1",
+    "@types/node": "13.7.7",
     "@types/rollup-plugin-visualizer": "2.6.0",
     "@types/systemjs": "^0.20.6",
     "pretty-format": "25.1.0",

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana End-to-End Test Library",
   "keywords": [
     "cli",
@@ -46,8 +46,8 @@
   },
   "types": "src/index.ts",
   "dependencies": {
+    "@grafana/e2e-selectors": "7.1.0-pre.0",
     "@grafana/tsconfig": "^1.0.0-rc1",
-    "@grafana/e2e-selectors": "7.0.0-pre.0",
     "blink-diff": "1.0.13",
     "commander": "5.0.0",
     "cypress": "3.7.0",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/runtime",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana Runtime Library",
   "keywords": [
     "grafana",
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@grafana/data": "7.0.0-pre.0",
-    "@grafana/ui": "7.0.0-pre.0",
+    "@grafana/data": "7.1.0-pre.0",
+    "@grafana/ui": "7.1.0-pre.0",
     "systemjs": "0.20.19",
     "systemjs-plugin-css": "0.1.37"
   },

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/toolkit",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana Toolkit",
   "keywords": [
     "grafana",
@@ -29,10 +29,10 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.0",
-    "@grafana/data": "7.0.0-pre.0",
+    "@grafana/data": "7.1.0-pre.0",
     "@grafana/eslint-config": "^1.0.0-rc1",
     "@grafana/tsconfig": "^1.0.0-rc1",
-    "@grafana/ui": "7.0.0-pre.0",
+    "@grafana/ui": "7.1.0-pre.0",
     "@types/command-exists": "^1.2.0",
     "@types/execa": "^0.9.0",
     "@types/expect-puppeteer": "3.3.1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/ui",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Grafana Components Library",
   "keywords": [
     "grafana",
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@grafana/data": "7.0.0-pre.0",
-    "@grafana/e2e-selectors": "7.0.0-pre.0",
+    "@grafana/data": "7.1.0-pre.0",
+    "@grafana/e2e-selectors": "7.1.0-pre.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "@iconscout/react-unicons": "^1.0.0",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaegertracing/jaeger-ui-components",
-  "version": "0.0.1",
+  "version": "7.1.0-pre.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana-plugins/input-datasource",
-  "version": "7.0.0-pre.0",
+  "version": "7.1.0-pre.0",
   "description": "Input Datasource",
   "private": true,
   "repository": {
@@ -16,9 +16,9 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/data": "^7.0.0-pre",
-    "@grafana/ui": "^7.0.0-pre",
-    "@grafana/toolkit": "^7.0.0-pre"
+    "@grafana/data": "7.1.0-pre.0",
+    "@grafana/toolkit": "7.1.0-pre.0",
+    "@grafana/ui": "7.1.0-pre.0"
   },
   "volta": {
     "node": "12.16.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Grafana version to v7.1.0-pre. Question: Should I also run `yarn packages:prepare`, in order to update NPM package versions? The release guide doesn't say.

