### PR TITLE
Tracing: Fix view bounds after trace change

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -202,8 +202,7 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
     if (trace !== nextTrace || childrenHiddenIDs !== nextHiddenIDs || detailStates !== nextDetailStates) {
       this.rowStates = nextTrace ? generateRowStates(nextTrace.spans, nextHiddenIDs, nextDetailStates) : [];
     }
-    if (currentViewRangeTime !== nextViewRangeTime || trace !== nextTrace) {
-      console.log('update createViewedBoundsFunc');
+    if (currentViewRangeTime !== nextViewRangeTime || (trace !== nextTrace && nextTrace)) {
       this.clipping = getClipping(nextViewRangeTime);
       const [zoomStart, zoomEnd] = nextViewRangeTime;
       this.getViewedBounds = createViewedBoundsFunc({

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -202,12 +202,13 @@ export class UnthemedVirtualizedTraceView extends React.Component<VirtualizedTra
     if (trace !== nextTrace || childrenHiddenIDs !== nextHiddenIDs || detailStates !== nextDetailStates) {
       this.rowStates = nextTrace ? generateRowStates(nextTrace.spans, nextHiddenIDs, nextDetailStates) : [];
     }
-    if (currentViewRangeTime !== nextViewRangeTime) {
+    if (currentViewRangeTime !== nextViewRangeTime || trace !== nextTrace) {
+      console.log('update createViewedBoundsFunc');
       this.clipping = getClipping(nextViewRangeTime);
       const [zoomStart, zoomEnd] = nextViewRangeTime;
       this.getViewedBounds = createViewedBoundsFunc({
-        min: trace.startTime,
-        max: trace.endTime,
+        min: nextTrace.startTime,
+        max: nextTrace.endTime,
         viewStart: zoomStart,
         viewEnd: zoomEnd,
       });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/23988

After trace was changed the view bounds were kept the same so each span was positioned outside of the current view.