### PR TITLE
CircleCI: Update grabpl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.2.12
+            VERSION=0.3.0
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Update build pipeline tool to v0.3.0 in v7.0.x branch, since it contains hardcoded v7 what's new and release notes URLs (will de-hardcode these soon).
