### PR TITLE
Fix pagination of issues/PR's in changelog generator

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/changelog.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/changelog.ts
@@ -57,7 +57,7 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = useSpinner<ChangelogOp
       return;
     }
 
-    const res = await client.get('/issues', {
+    let res = await client.get('/issues', {
       params: {
         state: 'closed',
         per_page: 100,
@@ -66,8 +66,20 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = useSpinner<ChangelogOp
       },
     });
 
+    const data: any[] = res.data;
+
+    while (res.headers.link) {
+      const links = parseLink(res.headers.link);
+      if (links.next) {
+        res = await client.get(links.next);
+        data.push(...res.data);
+      } else {
+        break;
+      }
+    }
+
     const mergedIssues = [];
-    for (const item of res.data) {
+    for (const item of data) {
       if (!item.pull_request) {
         // it's an issue, not pull request
         mergedIssues.push(item);
@@ -100,17 +112,40 @@ const changelogTaskRunner: TaskRunner<ChangelogOptions> = useSpinner<ChangelogOp
 function getMarkdownLineForIssue(item: any) {
   const githubGrafanaUrl = 'https://github.com/grafana/grafana';
   let markdown = '';
-  const title = item.title.replace(/^([^:]*)/, (_match: any, g1: any) => {
+  let title: string = item.title.replace(/^([^:]*)/, (_match: any, g1: any) => {
     return `**${g1}**`;
   });
+  title = title.trim();
+  if (title[title.length - 1] === '.') {
+    title = title.slice(0, -1);
+  }
 
-  markdown += '* ' + title + '.';
-  markdown += ` [#${item.number}](${githubGrafanaUrl}/pull/${item.number})`;
-  markdown += `, [@${item.user.login}](${item.user.html_url})`;
+  if (!item.pull_request) {
+    console.log(item);
+    markdown += '* ' + title + '.';
+    markdown += ` [#${item.number}](${githubGrafanaUrl}/issues/${item.number})`;
+  } else {
+    markdown += '* ' + title + '.';
+    markdown += ` [#${item.number}](${githubGrafanaUrl}/pull/${item.number})`;
+    markdown += `, [@${item.user.login}](${item.user.html_url})`;
+  }
 
   markdown += '\n';
 
   return markdown;
+}
+
+function parseLink(s) {
+  const output: any = {};
+  const regex = /<([^>]+)>; rel="([^"]+)"/g;
+
+  let m;
+  while ((m = regex.exec(s))) {
+    const [_, v, k] = m;
+    output[k] = v;
+  }
+
+  return output;
 }
 
 export const changelogTask = new Task<ChangelogOptions>('Changelog generator task', changelogTaskRunner);

--- a/packages/grafana-toolkit/src/cli/tasks/changelog.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/changelog.ts
@@ -140,7 +140,7 @@ function parseLink(s: any) {
 
   let m;
   while ((m = regex.exec(s))) {
-    const [_, v, k] = m;
+    const [, v, k] = m;
     output[k] = v;
   }
 

--- a/packages/grafana-toolkit/src/cli/tasks/changelog.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/changelog.ts
@@ -134,7 +134,7 @@ function getMarkdownLineForIssue(item: any) {
   return markdown;
 }
 
-function parseLink(s) {
+function parseLink(s: any) {
   const output: any = {};
   const regex = /<([^>]+)>; rel="([^"]+)"/g;
 

--- a/packages/grafana-toolkit/src/cli/tasks/changelog.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/changelog.ts
@@ -121,7 +121,6 @@ function getMarkdownLineForIssue(item: any) {
   }
 
   if (!item.pull_request) {
-    console.log(item);
     markdown += '* ' + title + '.';
     markdown += ` [#${item.number}](${githubGrafanaUrl}/issues/${item.number})`;
   } else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix pagination of issues/PR's in changelog generator when there are more than 100 issues/PR's with add to changelog label in milestone.

Also fix link for issues and some formatting of title.