### PR TITLE
Explore: Fix showing of results of queries in table

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -15,6 +15,8 @@ export enum LoadingState {
   Error = 'Error',
 }
 
+type PreferredVisualisationType = 'graph' | 'table';
+
 export interface QueryResultMeta {
   /** DatasSource Specific Values */
   custom?: Record<string, any>;
@@ -27,6 +29,9 @@ export interface QueryResultMeta {
 
   /** Used to track transformation ids that where part of the processing */
   transformations?: string[];
+
+  /** Currently used to show results in Explore only in preferred visualisation option */
+  preferredVisualisationType?: PreferredVisualisationType;
 
   /**
    * Legacy data source specific, should be moved to custom

--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -12,6 +12,9 @@ const testContext = (options: any = {}) => {
   const timeSeries = toDataFrame({
     name: 'A-series',
     refId: 'A',
+    meta: {
+      preferredVisualisationType: 'graph',
+    },
     fields: [
       { name: 'time', type: FieldType.time, values: [100, 200, 300] },
       { name: 'A-series', type: FieldType.number, values: [4, 5, 6] },

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -48,9 +48,7 @@ export class ResultProcessor {
       return null;
     }
 
-    const onlyTables = this.dataFrames.filter(frame =>
-      shouldShowInTable(frame, this.state.datasourceInstance?.meta.id)
-    );
+    const onlyTables = this.dataFrames.filter(frame => shouldShowInTable(frame));
 
     if (onlyTables.length === 0) {
       return null;
@@ -127,17 +125,8 @@ function isTimeSeries(frame: DataFrame, datasource?: string): boolean {
   return false;
 }
 
-/* In Explore table, we don't want to show time-series.
- * EXCEPTION: For Prometheus, we want to show time-series when they are result of instant queries.
- */
-function shouldShowInTable(frame: DataFrame, datasource?: string) {
-  // DataFrames with exactly 2 fields, when first field.type === time are time-series.
-  if (frame.fields.length === 2 && frame.fields[0].type === FieldType.time) {
-    // Hack: Prometheus instant vectors's value has always length === 1.
-    // https://prometheus.io/docs/prometheus/latest/querying/api/#instant-vectors
-    if (datasource && datasource === 'prometheus' && frame.length === 1) {
-      return true;
-    }
+function shouldShowInTable(frame: DataFrame) {
+  if (frame.meta?.preferredVisualisationType && frame.meta?.preferredVisualisationType !== 'table') {
     return false;
   }
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -452,7 +452,11 @@ export class ElasticResponse {
         this.nameSeries(tmpSeriesList, target);
 
         for (let y = 0; y < tmpSeriesList.length; y++) {
-          const series = toDataFrame(tmpSeriesList[y]);
+          let series = toDataFrame(tmpSeriesList[y]);
+
+          // When log results, show aggregations only in graph. Log fields are then going to be shown in table.
+          series = addPreferredVisualisationType(series, 'graph');
+
           dataFrame.push(series);
         }
       }
@@ -567,4 +571,15 @@ const createEmptyDataFrame = (
   }
 
   return series;
+};
+
+const addPreferredVisualisationType = (series: any, type: string) => {
+  let s = series;
+  s.meta
+    ? (s.meta.preferredVisualisationType = type)
+    : (s.meta = {
+        preferredVisualisationType: type,
+      });
+
+  return s;
 };

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -189,6 +189,10 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       responseListLength,
       refId: target.refId,
       valueWithRefId: target.valueWithRefId,
+      meta: {
+        /** Fix for showing of Prometheus results in Explore table. We want to show result of instant query in table and the rest of time series in graph */
+        preferredVisualisationType: query.instant ? 'table' : 'graph',
+      },
     };
     const series = this.resultTransformer.transform(response, transformerOptions);
 

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -76,6 +76,7 @@ export class ResultTransformer {
       datapoints: dps,
       query: options.query,
       refId: options.refId,
+      meta: options.meta,
       target: metricLabel,
       tags: metricData.metric,
     };
@@ -144,7 +145,7 @@ export class ResultTransformer {
     let metricLabel = null;
     metricLabel = this.createMetricLabel(md.metric, options);
     dps.push([parseFloat(md.value[1]), md.value[0] * 1000]);
-    return { target: metricLabel, datapoints: dps, tags: md.metric, refId: options.refId };
+    return { target: metricLabel, datapoints: dps, tags: md.metric, refId: options.refId, meta: options.meta };
   }
 
   createMetricLabel(labelData: { [key: string]: string }, options: any) {


### PR DESCRIPTION
*What this PR does / why we need it**:
**Context:**
In [ResultProcessor](https://github.com/grafana/grafana/blob/master/public/app/features/explore/utils/ResultProcessor.ts#L53) when we are creating table results, we filter out all frames that are single-value time series -> we are checking if it the data frame has exactly 2 fields and if the first one is time. So in case of https://github.com/grafana/grafana/issues/23657, if Prometheus instant query doesn't have any metrics (*metric name is erased when you do aggregation in Prometheus*),  its data frame has only 2 fields and the first one is time. Therefore, as single-value time series, it is not shown in the Explore table. 

And checking if data frame has exactly 2 fields and the first one is time, filters out a lot of results of queries of other datasources (elastic, influxdb,...).

**Solution:**
After the discussion, we have agreed that solution should meet following criteria:

- In Explore table we want to show all time series results
- EXCEPTION 1: For Prometheus, we want to show in table results of instant queries
- EXCEPTION 2: For Elastic, if we do logs query, we want to show aggregation only in graph and logs fields in table

I have created a DataFrame meta property _preferredVisualisationType_ (more generic and usable across the whole Grafana than _hideInExploreTable_ ). In ResultProcessor, I have added `shouldShowInTable` function that determines if DataFrame should be shown Explore table. It checks if DataFrame has PreferredVisualisationType meta property, and if it has, it should equal to table - otherwise it shouldn't be shown. If it doesn't have PreferredVisualisationType meta property, then it should be shown in table .

When processing results of EXCEPTION 1 and 2, I have set the meta property PreferredVisualisationType to 'graph', therefore they are not going to be shown in Explore table.  

**hideInExploreTable vs preferredVisualisationType:**
After the discussion, I have decided to use preferredVisualisationType instead of hideInExploreTable as we would like to eliminate Explore-specific-exceptions as much as possible. PreferredVisualisationType meta property is more generic and therefore it can be used in the future across whole Grafana. 
Possible other use-cases - showing users the recommended visualisation types. 

**Tested with following datasources:**
✅Prometheus
✅Loki
✅Graphite
✅Influx
✅Elastic7
✅Elastic6 (found and created an [issue with showing of results in table](https://github.com/grafana/grafana/issues/24077) that is not connected to this PR and reproducible in play)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/23657



