### PR TITLE
Prometheus: Add off switch for metric/label name lookup

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -14,7 +14,7 @@ describe('PromQueryField', () => {
     window.getSelection = () => {};
   });
 
-  it('renders a metrics chooser if lookups are not disabled in the datasource settings', () => {
+  it('renders metrics chooser regularly if lookups are not disabled in the datasource settings', () => {
     const datasource = ({
       languageProvider: {
         start: () => Promise.resolve([]),
@@ -35,7 +35,7 @@ describe('PromQueryField', () => {
     expect(queryField.find(ButtonCascader).length).toBe(1);
   });
 
-  it('does not render metrics chooser if lookups are disabled in datasource settings', () => {
+  it('renders a disabled metrics chooser if lookups are disabled in datasource settings', () => {
     const queryField = mount(
       <PromQueryField
         // @ts-ignore
@@ -47,7 +47,12 @@ describe('PromQueryField', () => {
       />
     );
 
-    expect(queryField.find(ButtonCascader).length).toBe(0);
+    expect(
+      queryField
+        .find(ButtonCascader)
+        .find('button')
+        .props().disabled
+    ).toBe(true);
   });
 
   it('refreshes metrics when the data source changes', async () => {

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -4,11 +4,50 @@ import RCCascader from 'rc-cascader';
 import React from 'react';
 import PromQlLanguageProvider, { DEFAULT_LOOKUP_METRICS_THRESHOLD } from '../language_provider';
 import PromQueryField, { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
+import { ButtonCascader } from '@grafana/ui';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { PromOptions } from '../types';
 
 describe('PromQueryField', () => {
   beforeAll(() => {
     // @ts-ignore
     window.getSelection = () => {};
+  });
+
+  it('renders a metrics chooser if lookups are not disabled in the datasource settings', () => {
+    const datasource = ({
+      languageProvider: {
+        start: () => Promise.resolve([]),
+      },
+    } as unknown) as DataSourceInstanceSettings<PromOptions>;
+
+    const queryField = mount(
+      <PromQueryField
+        // @ts-ignore
+        datasource={datasource}
+        query={{ expr: '', refId: '' }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+        history={[]}
+      />
+    );
+
+    expect(queryField.find(ButtonCascader).length).toBe(1);
+  });
+
+  it('does not render metrics chooser if lookups are disabled in datasource settings', () => {
+    const queryField = mount(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{ lookupsDisabled: true }}
+        query={{ expr: '', refId: '' }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+        history={[]}
+      />
+    );
+
+    expect(queryField.find(ButtonCascader).length).toBe(0);
   });
 
   it('refreshes metrics when the data source changes', async () => {

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -268,9 +268,11 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
     // Hint for big disabled lookups
     let hint: QueryHint;
-    if (!datasource.lookupsDisabled && languageProvider.lookupsDisabled) {
+    if (datasource.lookupsDisabled || languageProvider.lookupsDisabled) {
       hint = {
-        label: `Dynamic label lookup is disabled for datasources with more than ${lookupMetricsThreshold} metrics.`,
+        label: datasource.lookupsDisabled
+          ? 'Retrieval of metric/label names for autocomplete and metrics chooser is disabled in the data source configuration.'
+          : `Dynamic label lookup is disabled for datasources with more than ${lookupMetricsThreshold} metrics.`,
         type: 'INFO',
       };
     }

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -316,11 +316,13 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     return (
       <>
         <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">
-          <div className="gf-form flex-shrink-0">
-            <ButtonCascader options={metricsOptions} disabled={buttonDisabled} onChange={this.onChangeMetrics}>
-              {chooserText}
-            </ButtonCascader>
-          </div>
+          {this.languageProvider && (
+            <div className="gf-form flex-shrink-0">
+              <ButtonCascader options={metricsOptions} disabled={buttonDisabled} onChange={this.onChangeMetrics}>
+                {chooserText}
+              </ButtonCascader>
+            </div>
+          )}
           <div className="gf-form gf-form--grow flex-shrink-1">
             <QueryField
               additionalPlugins={this.plugins}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -246,12 +246,10 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
   onUpdateLanguage = () => {
     const {
-      histogramMetrics,
-      metrics,
-      metricsMetadata,
-      lookupsDisabled,
-      lookupMetricsThreshold,
-    } = this.props.datasource.languageProvider;
+      datasource,
+      datasource: { languageProvider },
+    } = this.props;
+    const { histogramMetrics, metrics, metricsMetadata, lookupMetricsThreshold } = languageProvider;
 
     if (!metrics) {
       return;
@@ -270,7 +268,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
     // Hint for big disabled lookups
     let hint: QueryHint;
-    if (lookupsDisabled) {
+    if (!datasource.lookupsDisabled && languageProvider.lookupsDisabled) {
       hint = {
         label: `Dynamic label lookup is disabled for datasources with more than ${lookupMetricsThreshold} metrics.`,
         type: 'INFO',
@@ -304,6 +302,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
   render() {
     const {
+      datasource,
       datasource: { languageProvider },
       query,
       ExtraFieldElement,
@@ -316,7 +315,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     return (
       <>
         <div className="gf-form-inline gf-form-inline--nowrap flex-grow-1">
-          {this.languageProvider && (
+          {!datasource.lookupsDisabled && (
             <div className="gf-form flex-shrink-0">
               <ButtonCascader options={metricsOptions} disabled={buttonDisabled} onChange={this.onChangeMetrics}>
                 {chooserText}

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -16,7 +16,7 @@ export const ConfigEditor = (props: Props) => {
         onChange={onOptionsChange}
       />
 
-      <PromSettings value={options} onChange={onOptionsChange} />
+      <PromSettings options={options} onOptionsChange={onOptionsChange} />
     </>
   );
 };

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -1,6 +1,6 @@
 import React, { SyntheticEvent } from 'react';
 import { EventsWithValidation, InlineFormLabel, regexValidation, LegacyForms } from '@grafana/ui';
-const { Select, Input, FormField } = LegacyForms;
+const { Select, Input, FormField, Switch } = LegacyForms;
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
 import { PromOptions } from '../types';
 
@@ -75,11 +75,19 @@ export const PromSettings = (props: Props) => {
       </div>
       <h3 className="page-heading">Misc</h3>
       <div className="gf-form-group">
+        <div className="gf-form">
+          <Switch
+            label="Disable query editor metric/label name lookup"
+            labelClass="width-18"
+            checked={value.jsonData.disableLanguageProvider}
+            onChange={onChangeHandlerSwitch('disableLanguageProvider', value, onChange)}
+          />
+        </div>
         <div className="gf-form-inline">
           <div className="gf-form max-width-30">
             <FormField
               label="Custom query parameters"
-              labelWidth={14}
+              labelWidth={18}
               tooltip="Add Custom parameters to Prometheus or Thanos queries."
               inputEl={
                 <Input
@@ -127,6 +135,18 @@ const onChangeHandler = (key: keyof PromOptions, value: Props['value'], onChange
     jsonData: {
       ...value.jsonData,
       [key]: getValueFromEventItem(eventItem),
+    },
+  });
+};
+
+const onChangeHandlerSwitch = (key: keyof PromOptions, value: Props['value'], onChange: Props['onChange']) => (
+  eventItem: SyntheticEvent<HTMLInputElement>
+) => {
+  onChange({
+    ...value,
+    jsonData: {
+      ...value.jsonData,
+      [key]: eventItem.currentTarget.checked,
     },
   });
 };

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -78,10 +78,10 @@ export const PromSettings = (props: Props) => {
       <div className="gf-form-group">
         <div className="gf-form">
           <Switch
-            checked={options.jsonData.disableLanguageProvider}
+            checked={options.jsonData.disableMetricsLookup}
             label="Disable metrics lookup"
             labelClass="width-14"
-            onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableLanguageProvider')}
+            onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
             tooltip="Checking this option will disable the metrics chooser and metric/label support in the query field's autocomplete. This helps if you have performance issues with bigger Prometheus instances."
           />
         </div>

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -79,10 +79,10 @@ export const PromSettings = (props: Props) => {
         <div className="gf-form">
           <Switch
             checked={options.jsonData.disableLanguageProvider}
-            label="Disable metric lookup"
+            label="Disable metrics lookup"
             labelClass="width-14"
             onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableLanguageProvider')}
-            tooltip="Switch on if you experience performance issues in the query editor. This will disable autocomplete and the metrics chooser."
+            tooltip="Checking this option will disable the metrics chooser and metric/label support in the query field's autocomplete. This helps if you have performance issues with bigger Prometheus instances."
           />
         </div>
         <div className="gf-form-inline">

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -100,8 +100,11 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.directUrl = instanceSettings.jsonData.directUrl;
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
-    this.languageProvider = new PrometheusLanguageProvider(this);
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
+
+    if (!instanceSettings.jsonData.disableLanguageProvider) {
+      this.languageProvider = new PrometheusLanguageProvider(this);
+    }
   }
 
   init = () => {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -102,7 +102,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
     this.languageProvider = new PrometheusLanguageProvider(this);
-    this.lookupsDisabled = instanceSettings.jsonData.disableLanguageProvider;
+    this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup;
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -83,6 +83,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   queryTimeout: string;
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
+  lookupsDisabled: boolean;
   resultTransformer: ResultTransformer;
   customQueryParameters: any;
 
@@ -100,11 +101,9 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.directUrl = instanceSettings.jsonData.directUrl;
     this.resultTransformer = new ResultTransformer(templateSrv);
     this.ruleMappings = {};
+    this.languageProvider = new PrometheusLanguageProvider(this);
+    this.lookupsDisabled = instanceSettings.jsonData.disableLanguageProvider;
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
-
-    if (!instanceSettings.jsonData.disableLanguageProvider) {
-      this.languageProvider = new PrometheusLanguageProvider(this);
-    }
   }
 
   init = () => {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -112,10 +112,15 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   };
 
   start = async (): Promise<any[]> => {
+    if (this.datasource.lookupsDisabled) {
+      return [];
+    }
+
     this.metrics = await this.request('/api/v1/label/__name__/values', []);
     this.lookupsDisabled = this.metrics.length > this.lookupMetricsThreshold;
     this.metricsMetadata = await this.request('/api/v1/metadata', {});
     this.processHistogramMetrics(this.metrics);
+
     return [];
   };
 

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -20,7 +20,7 @@ export interface PromOptions extends DataSourceJsonData {
   httpMethod: string;
   directUrl: string;
   customQueryParameters?: string;
-  disableLanguageProvider?: boolean;
+  disableMetricsLookup?: boolean;
 }
 
 export interface PromQueryRequest extends PromQuery {

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -20,6 +20,7 @@ export interface PromOptions extends DataSourceJsonData {
   httpMethod: string;
   directUrl: string;
   customQueryParameters?: string;
+  disableLanguageProvider?: boolean;
 }
 
 export interface PromQueryRequest extends PromQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:
This will help users with amounts of metric name data that is too much for a browser to handle.
Query editor autocomplete will be disabled and metrics chooser hidden, since obviously both rely on this data.

**Which issue(s) this PR fixes**:
Fixes #22702

**Special notes for your reviewer**:
~~Tests will still be added.~~ DONE