### PR TITLE
WIP: Part one of fixing dashboard state init/clean up problems

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -77,7 +77,7 @@ export class DashboardPage extends PureComponent<Props, State> {
     rememberScrollTop: 0,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     this.props.initDashboard({
       $injector: this.props.$injector,
       $scope: this.props.$scope,
@@ -91,7 +91,7 @@ export class DashboardPage extends PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
-    if (this.props.dashboard) {
+    if (this.props.initPhase === DashboardInitPhase.Completed) {
       this.props.cleanUpDashboard();
       this.setPanelFullscreenClass(false);
     }

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -18,7 +18,14 @@ import {
   dashboardInitSlow,
 } from './reducers';
 // Types
-import { DashboardDTO, DashboardRouteInfo, StoreState, ThunkDispatch, ThunkResult } from 'app/types';
+import {
+  DashboardDTO,
+  DashboardRouteInfo,
+  StoreState,
+  ThunkDispatch,
+  ThunkResult,
+  DashboardInitPhase,
+} from 'app/types';
 import { DashboardModel } from './DashboardModel';
 import { DataQuery, locationUtil } from '@grafana/data';
 import { getConfig } from '../../../core/config';
@@ -123,6 +130,12 @@ async function fetchDashboard(
  */
 export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
   return async (dispatch, getState) => {
+    const dashboardState = getState().dashboard;
+
+    if (dashboardState.initPhase !== DashboardInitPhase.NotStarted) {
+      return;
+    }
+
     // set fetching state
     dispatch(dashboardInitFetching());
 


### PR DESCRIPTION
Tries to fix #24026 

This solves problems of navigating away from Home Dashboard to explore before dashboard init has completed. You can now navigate back. 

Todo 
- [ ] For this to work when navigating between dashboards we need to index dashboard state by uid.  

