### PR TITLE
CircleCI: Bump grafana/build-container revision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ executors:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.15
+      - image: grafana/build-container:1.2.16
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.15"
+_version="1.2.16"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump our grafana/build-container revision in CircleCI, in order to get the new image based on Ubuntu 20.04 LTS.

The grafana/build-container image also gets updated with Ruby 2.7, since the build would fail with the old version (2.2). Ruby is needed by the FPM tool.

Fixes #23947.