### PR TITLE
CircleCI: Unpin grafana/docs-base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -858,7 +858,8 @@ jobs:
       - run:
           name: Build Grafana docs website
           command: |
-            IMAGE=grafana/docs-base@sha256:63758b74e3990ab61e274f5e98da092d5c38378829dad0488aa97c59f0144f34
+            # Use latest revision here, since we want to catch if it breaks
+            IMAGE=grafana/docs-base:latest
 
             # In order to copy sources into the remote container, we need to employ a trick of creating a container
             # with a volume, that we copy the sources into. Then, we launch the build container, with the volume


### PR DESCRIPTION
**What this PR does / why we need it**:
CircleCI: Change back to using _latest_ revision of grafana/docs-base, since we want to catch if it breaks.
