### PR TITLE
scripts/tag_release.sh: Push only tag, not branch

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -34,7 +34,7 @@ echo "press [y] to push the tags"
 read -n 1 confirm
 
 if [ "${confirm}" == "y" ]; then
-    git push origin "${_branch}" --tags
+    git push origin "${_tag}"
 else
     git tag -d "${_tag}"
     echo "Abort! "


### PR DESCRIPTION
**What this PR does / why we need it**:
When making the last release, I noticed that there was a bug in the tagging script, i.e., it tried to push both the tag and the branch (v7.0.x). It should only push the tag, and not the branch I'm fairly certain. Pushing the branch actually fails (unless it doesn't already exist on GitHub), since it's protected.
