### PR TITLE
Docker: Upgrade to Alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Golang build container
-FROM golang:1.14.1-alpine
+FROM golang:1.14.2-alpine3.11 as go-builder
 
 RUN apk add --no-cache gcc g++
 
@@ -15,7 +15,7 @@ COPY build.go package.json ./
 RUN go run build.go build
 
 # Node build container
-FROM node:12.13.0-alpine
+FROM node:12.16.3-alpine3.11 as js-builder
 
 WORKDIR /usr/src/app/
 
@@ -34,7 +34,7 @@ ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
 # Final container
-FROM alpine:3.10
+FROM alpine:3.11
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 
@@ -52,7 +52,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
+    apk add --no-cache --upgrade openssl musl-utils
 
 COPY conf ./conf
 
@@ -70,9 +70,9 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
-COPY --from=0 /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-cli ./bin/
-COPY --from=1 /usr/src/app/public ./public
-COPY --from=1 /usr/src/app/tools ./tools
+COPY --from=go-builder /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-cli ./bin/
+COPY --from=js-builder /usr/src/app/public ./public
+COPY --from=js-builder /usr/src/app/tools ./tools
 
 EXPOSE 3000
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.14.1 AS go-builder
+FROM golang:1.14.2 AS go-builder
 
 WORKDIR /src/grafana
 
@@ -11,7 +11,7 @@ COPY pkg pkg/
 
 RUN go run build.go build
 
-FROM node:12.13 AS js-builder
+FROM node:12.16.3-slim AS js-builder
 
 WORKDIR /usr/src/app/
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.10
+ARG BASE_IMAGE=alpine:3.11
 FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache --upgrade --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssl musl-utils
+    apk add --no-cache --upgrade openssl musl-utils
 
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -60,7 +60,7 @@ docker_build () {
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
     dockerfile="Dockerfile"
-    base_image="${base_arch}alpine:3.10"
+    base_image="${base_arch}alpine:3.11"
   else
     libc=""
     dockerfile="ubuntu.Dockerfile"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade our Docker images to base themselves on Alpine 3.11.

**Which issue(s) this PR fixes**:

Fixes #21920.

**Special notes for your reviewer**:
I also make sure to upgrade our base images to latest Go and Node v12.

I've scanned the image built from /Dockerfile, finding no vulnerabilities:

```
✗ trivy grafana/grafana:dev                                                
2020-04-30T09:25:20.048+0200	INFO	Detecting Alpine vulnerabilities...

grafana/grafana:dev (alpine 3.11.6)
===================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```