### PR TITLE
Docs: Adds deprecation notice to changelog and docs for scripted dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **Interval calculation**: There is now a new option `Max data points` that controls the auto interval `$__interval` calculation. Interval was previously calculated by dividing the panel width by the time range. With the new max data points option it is now easy to set `$__interval` to a dynamic value that is time range agnostic. For example if you set `Max data points` to 10 Grafana will dyanmically set `$__interval` by dividing the current time range by 10.
 - **Datasource/Loki**: Support for [deprecated Loki endpoints](https://github.com/grafana/loki/blob/master/docs/api.md#lokis-http-api) has been removed.
 
+**Deprecation warnings**
+
+- Scripted dashboards is now deprecated. The feature is not removed but will be in a future release. We hope to address the underlying requirement of dynamic dashboards in a different way. [#24059](https://github.com/grafana/grafana/issues/24059)
+
 ## 7.0 Feature highlights
 
 ### Data transformations

--- a/docs/sources/features/dashboard/links.md
+++ b/docs/sources/features/dashboard/links.md
@@ -3,12 +3,14 @@ title = "Navigation links"
 description = ""
 keywords = ["grafana", "linking", "create links", "link panels", "link dashboards", "navigate"]
 type = "docs"
+aliases = ["/docs/grafana/latest/features/navigation-links/"]
 [menu.docs]
+identifier = "dashboards"
 parent = "features"
-weight = 9
+weight = 1
 +++
 
-# Navigation links 
+# Navigation links
 
 You can use links to navigate between commonly used dashboards. Links let you create shortcuts to other dashboards, panels, and even external websites.
 
@@ -18,13 +20,13 @@ Grafana supports three types of links: Dashboard Links, Panel Links, and Data Li
 
 ## Which link should you use?
 
-Start by figuring out how you're currently navigating between dashboards. If you're often jumping between a set of dashboards and struggling to find the same context in each, links can help optimize your workflow. 
+Start by figuring out how you're currently navigating between dashboards. If you're often jumping between a set of dashboards and struggling to find the same context in each, links can help optimize your workflow.
 
 The next step is to figure out which link type is right for your workflow. Even though all the link types in Grafana are used to create shortcuts to other dashboards or external websites, they work in different contexts.
 
-- If the link relates to most if not all of the panels in the dashboard, use a *dashboard link*.
-- If you want to drill down into specific panels, use a *panel link*.
-- If you want to drill down into a specific series, or even a single measurement, use a *data link*.
+- If the link relates to most if not all of the panels in the dashboard, use a _dashboard link_.
+- If you want to drill down into specific panels, use a _panel link_.
+- If you want to drill down into a specific series, or even a single measurement, use a _data link_.
 
 ## Dashboard links
 
@@ -66,7 +68,7 @@ Add a link to a URL at the top of your current dashboard. You can link to any av
    - **Time range** – Select this option to include the dashboard time range in the link. When the user clicks the link, the linked dashboard opens with the indicated time range already set. **Example:** https://play.grafana.org/d/000000010/annotations?orgId=1&from=now-3h&to=now
    - **Variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. **Example:** https://play.grafana.org/d/000000074/alerting?var-app=backend&var-server=backend_01&var-server=backend_03&var-interval=1h
    - **Open in new tab** – Select this option if you want the dashboard link to open in a new tab or window.
-1. Click **Add**. 
+1. Click **Add**.
 
 ### Update a dashboard link
 

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -138,12 +138,12 @@
           name: Export and import
         - link: /reference/datalinks/
           name: Data links
+        - name: Navigation links
+          link: /features/dashboard/links
         - link: /reference/dashboard_history/
-          name: Dashboard version history
+          name: Version history
         - link: /reference/dashboard/
           name: JSON Model
-        - link: /reference/scripting/
-          name: Scripted dashboards
     - name: Data sources
       link: /features/datasources/
       children:
@@ -194,8 +194,6 @@
       link: /features/shortcuts/
     - name: Reporting
       link: /features/reporting/
-    - name: Navigation links
-      link: /features/navigation-links/
 - name: What's new in Grafana
   link: /whatsnew/
   children:

--- a/docs/sources/reference/scripting.md
+++ b/docs/sources/reference/scripting.md
@@ -7,6 +7,7 @@ parent = "dashboard_features"
 weight = 9
 +++
 
+> This feature is deprecated and will be removed in a future release
 
 # Scripted Dashboards
 
@@ -23,7 +24,7 @@ If you open scripted.js you can see how it reads URL parameters from ARGS variab
 ```javascript
 var seriesName = 'argName';
 
-if(!_.isUndefined(ARGS.name)) {
+if (!_.isUndefined(ARGS.name)) {
   seriesName = ARGS.name;
 }
 
@@ -40,12 +41,12 @@ dashboard.panels.push({
   },
   targets: [
     {
-      'target': "randomWalk('" + seriesName + "')"
+      target: "randomWalk('" + seriesName + "')",
     },
     {
-      'target': "randomWalk('random walk2')"
-    }
-  ]
+      target: "randomWalk('random walk2')",
+    },
+  ],
 });
 
 return dashboard;


### PR DESCRIPTION
Closes #24059

Also moves navigation links to be under `Dashboard` in the docs menu as it should not be under root features root
Fixes #23919