### PR TITLE
Provisioning: Add support for provisioning users

### DIFF
--- a/conf/provisioning/users/sample.yaml
+++ b/conf/provisioning/users/sample.yaml
@@ -1,0 +1,9 @@
+# # config file version
+apiVersion: 1
+
+users:
+  - name: Fake
+    login: fake-user
+    email: example@example.com
+    password: "hello"
+    orgID: 1

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -125,9 +125,7 @@ func (ps *provisioningServiceImpl) ProvisionNotifications() error {
 }
 
 func (ps *provisioningServiceImpl) ProvisionUsers() error {
-	ps.log.Info("Provisioning2 users")
 	usersPath := path.Join(ps.Cfg.ProvisioningPath, "users")
-	ps.log.Info(usersPath)
 	err := ps.provisionUsers(usersPath)
 	return errutil.Wrap("Alert notification provisioning error", err)
 }

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -4,6 +4,7 @@ type Calls struct {
 	ProvisionDatasources                []interface{}
 	ProvisionNotifications              []interface{}
 	ProvisionDashboards                 []interface{}
+	ProvisionUsers                      []interface{}
 	GetDashboardProvisionerResolvedPath []interface{}
 	GetAllowUIUpdatesFromConfig         []interface{}
 }
@@ -13,6 +14,7 @@ type ProvisioningServiceMock struct {
 	ProvisionDatasourcesFunc                func() error
 	ProvisionNotificationsFunc              func() error
 	ProvisionDashboardsFunc                 func() error
+	ProvisionUsersFunc                      func() error
 	GetDashboardProvisionerResolvedPathFunc func(name string) string
 	GetAllowUIUpdatesFromConfigFunc         func(name string) bool
 }
@@ -43,6 +45,14 @@ func (mock *ProvisioningServiceMock) ProvisionDashboards() error {
 	mock.Calls.ProvisionDashboards = append(mock.Calls.ProvisionDashboards, nil)
 	if mock.ProvisionDashboardsFunc != nil {
 		return mock.ProvisionDashboardsFunc()
+	}
+	return nil
+}
+
+func (mock *ProvisioningServiceMock) ProvisionUsers() error {
+	mock.Calls.ProvisionUsers = append(mock.Calls.ProvisionUsers, nil)
+	if mock.ProvisionUsersFunc != nil {
+		return mock.ProvisionUsersFunc()
 	}
 	return nil
 }

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -97,6 +97,7 @@ func setup() *serviceTestStruct {
 		},
 		nil,
 		nil,
+		nil,
 	)
 	serviceTest.service.Cfg = setting.NewCfg()
 

--- a/pkg/services/provisioning/users/config_reader.go
+++ b/pkg/services/provisioning/users/config_reader.go
@@ -1,0 +1,59 @@
+package users
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"gopkg.in/yaml.v2"
+)
+
+type configReader struct {
+	log log.Logger
+}
+
+// Find YAML files in the config path and parse them
+func (cr *configReader) readConfig(path string) ([]*usersAsConfig, error) {
+	var users []*usersAsConfig
+	cr.log.Debug("Looking for user notification provisioning files", "path", path)
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		cr.log.Error("Can't read user provisioning files from directory", "path", path, "error", err)
+		return users, nil
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
+			newUsers, err := cr.parseUserConfig(path, file)
+			if err != nil {
+				return nil, err
+			}
+
+			if newUsers != nil {
+				users = append(users, newUsers)
+			}
+		}
+	}
+
+	return users, nil
+}
+
+func (cr *configReader) parseUserConfig(path string, file os.FileInfo) (*usersAsConfig, error) {
+	filename, _ := filepath.Abs(filepath.Join(path, file.Name()))
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg *usersAsConfig
+	err = yaml.Unmarshal(yamlFile, &cfg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg.mapToUserFromConfig(cr), nil
+}

--- a/pkg/services/provisioning/users/config_reader_test.go
+++ b/pkg/services/provisioning/users/config_reader_test.go
@@ -1,0 +1,15 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNotificationAsConfig(t *testing.T) {
+	logger := log.New("fake.log")
+
+	// TODO: Add some tests if the rest of the code looks fine
+	logger.Crit("No tests!")
+}

--- a/pkg/services/provisioning/users/config_reader_test.go
+++ b/pkg/services/provisioning/users/config_reader_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNotificationAsConfig(t *testing.T) {

--- a/pkg/services/provisioning/users/types.go
+++ b/pkg/services/provisioning/users/types.go
@@ -1,0 +1,33 @@
+package users
+
+type usersAsConfig struct {
+	Users []*userFromConfig
+}
+
+type userFromConfig struct {
+	Name     string
+	Login    string
+	Email    string
+	Password string
+	OrgID    int64
+}
+
+func (cfg *usersAsConfig) mapToUserFromConfig(cr *configReader) *usersAsConfig {
+	r := &usersAsConfig{}
+	if cfg == nil {
+		return r
+	}
+
+	for _, user := range cfg.Users {
+
+		r.Users = append(r.Users, &userFromConfig{
+			Name:     user.Name,
+			Login:    user.Login,
+			Email:    user.Email,
+			Password: user.Password,
+			OrgID:    user.OrgID,
+		})
+	}
+
+	return r
+}

--- a/pkg/services/provisioning/users/users.go
+++ b/pkg/services/provisioning/users/users.go
@@ -1,0 +1,80 @@
+package users
+
+import (
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+func Provision(configDirectory string) error {
+	dc := newUsersProvisioner(log.New("provisioning.users"))
+	return dc.applyChanges(configDirectory)
+}
+
+type UsersProvisioner struct {
+	log         log.Logger
+	cfgProvider *configReader
+}
+
+func newUsersProvisioner(log log.Logger) UsersProvisioner {
+	return UsersProvisioner{
+		log:         log,
+		cfgProvider: &configReader{log: log},
+	}
+}
+
+// For each of the users in the config, create them if they do not already
+// exist. If they do exist, update their email, login, and password fields.
+func (dc *UsersProvisioner) apply(cfg *usersAsConfig) error {
+	for _, user := range cfg.Users {
+		// First check if the user already exists
+		// TODO: Is user.Email the right thing to check here?
+		query := models.GetUserByLoginQuery{LoginOrEmail: user.Email}
+		if err := bus.Dispatch(&query); err != nil {
+			if err == models.ErrUserNotFound {
+				// The user doesn't exist, so create it
+				cmd := models.CreateUserCommand{
+					Login:    user.Login,
+					Email:    user.Email,
+					Password: user.Password,
+					Name:     user.Name,
+					OrgId:    user.OrgID,
+				}
+				if err := bus.Dispatch(&cmd); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		} else {
+			// The user already exists, update it from the config
+			cmd := models.UpdateUserCommand{
+				Login: user.Login,
+				Email: user.Email,
+				Name:  user.Name,
+			}
+			if err := bus.Dispatch(&cmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Find and read all the configs in the config path, then for each config
+// create/update the users as necessary.
+func (dc *UsersProvisioner) applyChanges(configPath string) error {
+	configs, err := dc.cfgProvider.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range configs {
+		if err := dc.apply(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for configuring users from `.yml` files in `provisioning/users`. The `Name`, `Login`, `Email`, `Password`, and `GroupID` fields can be set from the config (there is an example in `conf/provisioning/users/sample.yml`).

**Which issue(s) this PR fixes**:

Fixes #19848

**Special notes for your reviewer**:

The structure was copied from the notifications provisioning code and there aren't any tests/doc changes yet, so I'm mostly looking to see if this is something that could be land-able and if the approach is generally correct.

@marefr 

