### PR TITLE
Datasource/Loki: Fixes issue where cached log values weren't merged when labels were refreshed

### DIFF
--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
   datasource={
     Object {
       "languageProvider": LokiLanguageProvider {
+        "addLabelValuesToOptions": [Function],
         "cleanText": [Function],
         "datasource": [Circular],
         "fetchSeriesLabels": [Function],

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -144,6 +144,40 @@ describe('Language completion provider', () => {
       ]);
     });
   });
+
+  describe('label values', () => {
+    it('should fetch label values if not cached', async () => {
+      const absoluteRange: AbsoluteTimeRange = {
+        from: 0,
+        to: 5000,
+      };
+
+      const datasource = makeMockLokiDatasource({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      const provider = await getLanguageProvider(datasource);
+      const requestSpy = jest.spyOn(provider, 'request');
+      const labelValues = await provider.fetchLabelValues('testkey', absoluteRange);
+      expect(requestSpy).toHaveBeenCalled();
+      expect(labelValues).toEqual(['label1_val1', 'label1_val2']);
+    });
+
+    it('should return cached values', async () => {
+      const absoluteRange: AbsoluteTimeRange = {
+        from: 0,
+        to: 5000,
+      };
+
+      const datasource = makeMockLokiDatasource({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      const provider = await getLanguageProvider(datasource);
+      const requestSpy = jest.spyOn(provider, 'request');
+      const labelValues = await provider.fetchLabelValues('testkey', absoluteRange);
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(labelValues).toEqual(['label1_val1', 'label1_val2']);
+
+      const nextLabelValues = await provider.fetchLabelValues('testkey', absoluteRange);
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(nextLabelValues).toEqual(['label1_val1', 'label1_val2']);
+    });
+  });
 });
 
 describe('Request URL', () => {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -450,18 +450,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const cacheKey = this.generateCacheKey(url, start, end, key);
     const params = { start, end };
 
-    const addLabelValuesToOptions = (values: string[]) => {
-      return this.logLabelOptions.map(keyOption => {
-        if (keyOption.value === key) {
-          return {
-            ...keyOption,
-            children: values.map(value => ({ label: value, value })),
-          };
-        }
-        return keyOption;
-      });
-    };
-
     let value = this.labelsCache.get(cacheKey);
     if (!value) {
       try {
@@ -472,15 +460,24 @@ export default class LokiLanguageProvider extends LanguageProvider {
         value = values;
         this.labelsCache.set(cacheKey, value);
 
-        // Add to label options
-        this.logLabelOptions = addLabelValuesToOptions(values);
+        this.logLabelOptions = this.addLabelValuesToOptions(key, values);
       } catch (e) {
         console.error(e);
       }
     } else {
-      // Add to label options
-      this.logLabelOptions = addLabelValuesToOptions(value);
+      this.logLabelOptions = this.addLabelValuesToOptions(key, value);
     }
     return value;
   }
+
+  private addLabelValuesToOptions = (labelKey: string, values: string[]) => {
+    return this.logLabelOptions.map(keyOption =>
+      keyOption.value === labelKey
+        ? {
+            ...keyOption,
+            children: values.map(value => ({ label: value, value })),
+          }
+        : keyOption
+    );
+  };
 }

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -449,6 +449,19 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     const cacheKey = this.generateCacheKey(url, start, end, key);
     const params = { start, end };
+
+    const addLabelValuesToOptions = (values: string[]) => {
+      return this.logLabelOptions.map(keyOption => {
+        if (keyOption.value === key) {
+          return {
+            ...keyOption,
+            children: values.map(value => ({ label: value, value })),
+          };
+        }
+        return keyOption;
+      });
+    };
+
     let value = this.labelsCache.get(cacheKey);
     if (!value) {
       try {
@@ -460,18 +473,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
         this.labelsCache.set(cacheKey, value);
 
         // Add to label options
-        this.logLabelOptions = this.logLabelOptions.map(keyOption => {
-          if (keyOption.value === key) {
-            return {
-              ...keyOption,
-              children: values.map(value => ({ label: value, value })),
-            };
-          }
-          return keyOption;
-        });
+        this.logLabelOptions = addLabelValuesToOptions(values);
       } catch (e) {
         console.error(e);
       }
+    } else {
+      // Add to label options
+      this.logLabelOptions = addLabelValuesToOptions(value);
     }
     return value;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where cached log values weren't merged with log labels upon being refreshed.

**Which issue(s) this PR fixes**:
Closes #24087
