### PR TITLE
s390x: Binary and docker image support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -592,7 +592,7 @@ jobs:
           version: 18.09.3
       - install-grabpl
       # XXX: Is this necessary?
-      - run: docker run --privileged linuxkit/binfmt:v0.6
+      - run: docker run --privileged linuxkit/binfmt:v0.7
       - run:
           name: Copy Grafana archives
           command: |
@@ -1012,6 +1012,22 @@ workflows:
             - test-backend
             - test-frontend
       - build-backend:
+          filters: *filter-master-or-release
+          edition: oss
+          variant: s390x
+          name: build-oss-backend-s390x
+          requires:
+            - test-backend
+            - test-frontend
+      - build-backend:
+          filters: *filter-master-or-release
+          edition: oss
+          variant: s390x-musl
+          name: build-oss-backend-s390x-musl
+          requires:
+            - test-backend
+            - test-frontend
+      - build-backend:
           filters: *filter-all
           edition: oss
           variant: osx64
@@ -1098,6 +1114,22 @@ workflows:
             - test-backend
             - test-frontend
       - build-backend:
+          filters: *filter-master-or-release
+          name: build-enterprise-backend-s390x
+          edition: enterprise
+          variant: s390x
+          requires:
+            - test-backend
+            - test-frontend
+      - build-backend:
+          filters: *filter-master-or-release
+          name: build-enterprise-backend-s390x-musl
+          edition: enterprise
+          variant: s390x-musl
+          requires:
+            - test-backend
+            - test-frontend
+      - build-backend:
           filters: *filter-all
           name: build-enterprise-backend-osx64
           edition: enterprise
@@ -1177,6 +1209,8 @@ workflows:
             - build-oss-backend-armv7-musl
             - build-oss-backend-arm64
             - build-oss-backend-arm64-musl
+            - build-oss-backend-s390x
+            - build-oss-backend-s390x-musl
             - build-oss-backend-osx64
             - build-oss-backend-win64
             - build-oss-backend-linux-x64
@@ -1195,6 +1229,8 @@ workflows:
             - build-enterprise-backend-armv7-musl
             - build-enterprise-backend-arm64
             - build-enterprise-backend-arm64-musl
+            - build-enterprise-backend-s390x
+            - build-enterprise-backend-s390x-musl
             - build-enterprise-backend-osx64
             - build-enterprise-backend-win64
             - build-enterprise-backend-linux-x64

--- a/build.go
+++ b/build.go
@@ -179,6 +179,8 @@ func makeLatestDistCopies() {
 		".linux-armv6.tar.gz":      "dist/grafana-latest.linux-armv6.tar.gz",
 		".linux-arm64.tar.gz":      "dist/grafana-latest.linux-arm64.tar.gz",
 		".linux-arm64-musl.tar.gz": "dist/grafana-latest.linux-arm64-musl.tar.gz",
+		".linux-s390x.tar.gz":      "dist/grafana-latest.linux-s390x.tar.gz",
+		".linux-s390x-musl.tar.gz": "dist/grafana-latest.linux-s390x-musl.tar.gz",
 	}
 
 	for _, file := range files {
@@ -256,6 +258,9 @@ func createDebPackages() {
 	if pkgArch == "armv7" || pkgArch == "armv6" {
 		debPkgArch = "armhf"
 	}
+	if pkgArch == "s390x" {
+		debPkgArch = "s390x"
+	}
 
 	createPackage(linuxPackageOptions{
 		packageType:            "deb",
@@ -286,6 +291,8 @@ func createRpmPackages() {
 		rpmPkgArch = "armhfp"
 	case pkgArch == "arm64":
 		rpmPkgArch = "aarch64"
+	case pkgArch == "s390x":
+		rpmPkgArch = "s390x"
 	}
 	createPackage(linuxPackageOptions{
 		packageType:            "rpm",

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -56,6 +56,10 @@ docker_build () {
       base_arch="arm64v8/"
       repo_arch="-arm64v8-linux"
       ;;
+    "s390x")
+      base_arch="s390x/"
+      repo_arch="-s390x-linux"
+      ;;
   esac
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
@@ -91,6 +95,7 @@ docker_tag_all () {
   if [ $BUILD_FAST = "0" ]; then
     docker tag "${_docker_repo}-arm32v7-linux:${_grafana_version}${TAG_SUFFIX}" "${_docker_repo}-arm32v7-linux:${tag}${TAG_SUFFIX}"
     docker tag "${_docker_repo}-arm64v8-linux:${_grafana_version}${TAG_SUFFIX}" "${_docker_repo}-arm64v8-linux:${tag}${TAG_SUFFIX}"
+    docker tag "${_docker_repo}-s390x-linux:${_grafana_version}${TAG_SUFFIX}" "${_docker_repo}-s390x-linux:${tag}${TAG_SUFFIX}"
   fi
 }
 
@@ -98,6 +103,7 @@ docker_build "x64"
 if [ $BUILD_FAST = "0" ]; then
   docker_build "armv7"
   docker_build "arm64"
+  docker_build "s390x"
 fi
 
 # Tag as 'latest' for official release; otherwise tag as grafana/grafana:master

--- a/packaging/docker/push_to_docker_hub.sh
+++ b/packaging/docker/push_to_docker_hub.sh
@@ -41,12 +41,14 @@ docker_push_all () {
   docker push "${repo}:${tag}${TAG_SUFFIX}"
   docker push "${repo}-arm32v7-linux:${tag}${TAG_SUFFIX}"
   docker push "${repo}-arm64v8-linux:${tag}${TAG_SUFFIX}"
+  docker push "${repo}-s390x-linux:${tag}${TAG_SUFFIX}"
 
   # Create and push a multi-arch manifest
   docker manifest create "${repo}:${tag}${TAG_SUFFIX}" \
     "${repo}:${tag}${TAG_SUFFIX}" \
     "${repo}-arm32v7-linux:${tag}${TAG_SUFFIX}" \
-    "${repo}-arm64v8-linux:${tag}${TAG_SUFFIX}"
+    "${repo}-arm64v8-linux:${tag}${TAG_SUFFIX}" \
+    "${repo}-s390x-linux:${tag}${TAG_SUFFIX}"
 
   docker manifest push "${repo}:${tag}${TAG_SUFFIX}"
 }

--- a/scripts/build/build-all.sh
+++ b/scripts/build/build-all.sh
@@ -18,6 +18,8 @@ CCARMV7=arm-linux-gnueabihf-gcc
 CCARMV7_MUSL=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
 CCARM64=aarch64-linux-gnu-gcc
 CCARM64_MUSL=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+CCS390x=s390x-linux-gnu-gcc
+CCS390x_MUSL=/tmp/s390x-linux-musl-cross/bin/s390x-linux-musl-gcc
 CCOSX64=/tmp/osxcross/target/bin/o64-clang
 CCWIN64=x86_64-w64-mingw32-gcc
 CCX64=/tmp/x86_64-centos6-linux-gnu/bin/x86_64-centos6-linux-gnu-gcc
@@ -50,8 +52,10 @@ echo "current dir: $(pwd)"
 go run build.go -goarch armv6 -cc ${CCARMV6} ${OPT} build
 go run build.go -goarch armv7 -cc ${CCARMV7} ${OPT} build
 go run build.go -goarch arm64 -cc ${CCARM64} ${OPT} build
+go run build.go -goarch s390x -cc ${CCS390x} ${OPT} build
 go run build.go -goarch armv7 -libc musl -cc ${CCARMV7_MUSL} ${OPT} build
 go run build.go -goarch arm64 -libc musl -cc ${CCARM64_MUSL} ${OPT} build
+go run build.go -goarch s390x -libc musl -cc ${CCS390x_MUSL} ${OPT} build
 go run build.go -goos darwin -cc ${CCOSX64} ${OPT} build
 
 
@@ -94,8 +98,10 @@ go run build.go -goos linux -pkg-arch amd64 -libc musl ${OPT} -skipRpm -skipDeb 
 go run build.go -goos linux -pkg-arch armv6 ${OPT} -skipRpm package-only
 go run build.go -goos linux -pkg-arch armv7 ${OPT} package-only
 go run build.go -goos linux -pkg-arch arm64 ${OPT} package-only
+go run build.go -goos linux -pkg-arch s390x ${OPT} package-only
 go run build.go -goos linux -pkg-arch armv7 -libc musl ${OPT} -skipRpm -skipDeb package-only
 go run build.go -goos linux -pkg-arch arm64 -libc musl ${OPT} -skipRpm -skipDeb package-only
+go run build.go -goos linux -pkg-arch s390x -libc musl ${OPT} -skipRpm -skipDeb package-only
 
 go run build.go -goos darwin -pkg-arch amd64 ${OPT} package-only
 

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -13,6 +13,8 @@ CCARMV7=arm-linux-gnueabihf-gcc
 CCARMV7_MUSL=/tmp/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
 CCARM64=aarch64-linux-gnu-gcc
 CCARM64_MUSL=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+CCS390x=s390x-linux-gnu-gcc
+CCS390x_MUSL=/tmp/s390x-linux-musl-cross/bin/s390x-linux-musl-gcc
 CCX64=/tmp/x86_64-centos6-linux-gnu/bin/x86_64-centos6-linux-gnu-gcc
 CCX64_MUSL=/tmp/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
 
@@ -87,8 +89,10 @@ function build_backend() {
   go run build.go -goarch armv6 -cc ${CCARMV6} ${OPT} build
   go run build.go -goarch armv7 -cc ${CCARMV7} ${OPT} build
   go run build.go -goarch arm64 -cc ${CCARM64} ${OPT} build
+  go run build.go -goarch s390x -cc ${CCS390x} ${OPT} build
   go run build.go -goarch armv7 -libc musl -cc ${CCARMV7_MUSL} ${OPT} build
   go run build.go -goarch arm64 -libc musl -cc ${CCARM64_MUSL} ${OPT} build
+  go run build.go -goarch s390x -libc musl -cc ${CCS390x_MUSL} ${OPT} build
   build_backend_linux_amd64
 }
 
@@ -119,8 +123,10 @@ function package_all() {
   go run build.go -goos linux -pkg-arch armv6 ${OPT} -skipRpm package-only
   go run build.go -goos linux -pkg-arch armv7 ${OPT} package-only
   go run build.go -goos linux -pkg-arch arm64 ${OPT} package-only
+  go run build.go -goos linux -pkg-arch s390x ${OPT} package-only
   go run build.go -goos linux -pkg-arch armv7 -libc musl -skipRpm -skipDeb ${OPT} package-only
   go run build.go -goos linux -pkg-arch arm64 -libc musl -skipRpm -skipDeb ${OPT} package-only
+  go run build.go -goos linux -pkg-arch s390x -libc musl -skipRpm -skipDeb ${OPT} package-only
   package_linux_amd64
   echo "PACKAGE ALL: finished"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add binary and docker image support for `s390x`

**Special notes for your reviewer**:
I could create binary and docker image for `s390x` using these changes. It would be great if you update `grafana/build-container` image with s390x support as I have verified these changes by downloading musl libraries explicitly.