### PR TITLE
Explore: No longer changes run button red with "cancel" text when live tailing

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -324,6 +324,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                 refreshInterval={refreshInterval}
                 onChangeRefreshInterval={this.onChangeRefreshInterval}
                 splitted={splitted}
+                isLive={isLive}
                 loading={loading || (isLive && !isPaused)}
                 onRun={this.onRunQuery}
                 showDropdown={!isLive}

--- a/public/app/features/explore/RunButton.tsx
+++ b/public/app/features/explore/RunButton.tsx
@@ -21,6 +21,7 @@ const getStyles = memoizeOne(() => {
 type Props = {
   splitted: boolean;
   loading: boolean;
+  isLive: boolean;
   onRun: (loading: boolean) => void;
   refreshInterval?: string;
   onChangeRefreshInterval: (interval: string) => void;
@@ -28,17 +29,17 @@ type Props = {
 };
 
 export function RunButton(props: Props) {
-  const { splitted, loading, onRun, onChangeRefreshInterval, refreshInterval, showDropdown } = props;
+  const { splitted, loading, onRun, onChangeRefreshInterval, refreshInterval, showDropdown, isLive } = props;
   const styles = getStyles();
 
   const runButton = (
     <ResponsiveButton
       splitted={splitted}
-      title={loading ? 'Cancel' : 'Run Query'}
+      title={loading && !isLive ? 'Cancel' : 'Run Query'}
       onClick={() => onRun(loading)}
       buttonClassName={classNames({
-        'navbar-button--primary': !loading,
-        'navbar-button--danger': loading,
+        'navbar-button--primary': isLive || !loading,
+        'navbar-button--danger': loading && !isLive,
         'btn--radius-right-0': showDropdown,
       })}
       icon={loading ? 'fa fa-spinner' : 'sync'}


### PR DESCRIPTION
**What this PR does / why we need it**:
The run button in the Explore toolbar no longer turns red with text that reads "Cancel" when live tailing.

**Which issue(s) this PR fixes**:
Closes #24079


