### PR TITLE
Chore: Remove beta references from Query history

### DIFF
--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -51,8 +51,6 @@ You can close the newly created query by clicking on the Close Split button.
 
 ## Query history
 
-> BETA: Query history is a beta feature.
-
 Query history is a list of queries that you have used in Explore. The history is local to your browser and is not shared with others. To open and interact with your history, click the **Query history** button in Explore.
 
 ### View query history

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -99,7 +99,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, height: number) => {
       font-size: ${theme.typography.heading.h4};
       margin: ${theme.spacing.md} ${theme.spacing.xxs} ${theme.spacing.sm} ${theme.spacing.xxs};
     `,
-    feedback: css`
+    footer: css`
       height: 60px;
       margin-top: ${theme.spacing.lg};
       display: flex;
@@ -225,10 +225,7 @@ export function RichHistoryQueriesTab(props: Props) {
             </div>
           );
         })}
-        <div className={styles.feedback}>
-          Query history is a beta feature. The history is local to your browser and is not shared with others.
-          <a href="https://github.com/grafana/grafana/issues/new/choose">Feedback?</a>
-        </div>
+        <div className={styles.footer}>The history is local to your browser and is not shared with others.</div>
       </div>
     </div>
   );

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -51,7 +51,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     sort: css`
       width: 170px;
     `,
-    feedback: css`
+    footer: css`
       height: 60px;
       margin-top: ${theme.spacing.lg};
       display: flex;
@@ -129,10 +129,7 @@ export function RichHistoryStarredTab(props: Props) {
             />
           );
         })}
-        <div className={styles.feedback}>
-          Query history is a beta feature. The history is local to your browser and is not shared with others.
-          <a href="https://github.com/grafana/grafana/issues/new/choose">Feedback?</a>
-        </div>
+        <div className={styles.footer}>The history is local to your browser and is not shared with others.</div>
       </div>
     </div>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes beta references in Query history
