### PR TITLE
Prometheus: Refresh query field metrics on data source change

### DIFF
--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -20,8 +20,8 @@ export default class QueryRows extends PureComponent<QueryRowsProps> {
     const { className = '', exploreEvents, exploreId, queryKeys } = this.props;
     return (
       <div className={className}>
-        {queryKeys.map((key, index) => {
-          return <QueryRow key={key} exploreEvents={exploreEvents} exploreId={exploreId} index={index} />;
+        {queryKeys.map((_, index) => {
+          return <QueryRow key={index} exploreEvents={exploreEvents} exploreId={exploreId} index={index} />;
         })}
       </div>
     );

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -302,7 +302,6 @@ export const itemReducer = (state: ExploreItemState = makeExploreItemState(), ac
       latency: 0,
       queryResponse: createEmptyQueryResponse(),
       loading: false,
-      queryKeys: [],
       supportedModes,
       mode: mode ?? newMode,
       originPanelId: state.urlState && state.urlState.originPanelId,

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -1,4 +1,67 @@
-import { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
+import { mount } from 'enzyme';
+// @ts-ignore
+import RCCascader from 'rc-cascader';
+import React from 'react';
+import PromQlLanguageProvider, { DEFAULT_LOOKUP_METRICS_THRESHOLD } from '../language_provider';
+import PromQueryField, { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
+
+describe('PromQueryField', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    window.getSelection = () => {};
+  });
+
+  it('refreshes metrics when the data source changes', async () => {
+    const metrics = ['foo', 'bar'];
+    const languageProvider = ({
+      histogramMetrics: [] as any,
+      metrics,
+      metricsMetadata: {},
+      lookupsDisabled: false,
+      lookupMetricsThreshold: DEFAULT_LOOKUP_METRICS_THRESHOLD,
+      start: () => {
+        return Promise.resolve([]);
+      },
+    } as unknown) as PromQlLanguageProvider;
+
+    const queryField = mount(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{
+          languageProvider,
+        }}
+        query={{ expr: '', refId: '' }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+        history={[]}
+      />
+    );
+    await Promise.resolve();
+
+    const cascader = queryField.find<RCCascader>(RCCascader);
+    cascader.simulate('click');
+    const cascaderNode: HTMLElement = cascader.instance().getPopupDOMNode();
+
+    for (const item of Array.from(cascaderNode.getElementsByTagName('li'))) {
+      expect(metrics.includes(item.innerHTML)).toBe(true);
+    }
+
+    const changedMetrics = ['baz', 'moo'];
+    queryField.setProps({
+      datasource: {
+        languageProvider: {
+          ...languageProvider,
+          metrics: changedMetrics,
+        },
+      },
+    });
+    await Promise.resolve();
+
+    for (const item of Array.from(cascaderNode.getElementsByTagName('li'))) {
+      expect(changedMetrics.includes(item.innerHTML)).toBe(true);
+    }
+  });
+});
 
 describe('groupMetricsByPrefix()', () => {
   it('returns an empty group for no metrics', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses metrics chooser not refreshing when switching from one Prometheus data source to another (dashboard only).

**Which issue(s) this PR fixes**:
Fixes #23162

**Special notes for your reviewer**:
Funnily enough, the reason why this problem didn't occur in Explore was that the query fields got unmounted and "remounted" seemingly unnecessarily. While in Dashboard, they stay mounted.

And so the ideal way to resolve this seemed to me to have `PromQueryField` refresh the metrics if it sees that `languageProvider` changed in `componentDidUpdate` **and** fix the unnecessary unmounting in Explore, so that the behavior of Dashboard and Explore become consistent in this respect.

As an aside, since storing of props in class fields is generally inadvisable and I didn't see a reason for why it would be necessary here, I refactored this and restructured things a bit so `componentDidMount` and `componentDidUpdate` can be more succinct. Of course please let me know if you would rather not have me include this in this PR.