### PR TITLE
Docs: Fixed location of items in docs

### DIFF
--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -110,7 +110,7 @@
     name: Dashboard list
   - link: /features/panels/text/
     name: Text
-- name: Dashboard features
+- name: Dashboards
   link: /features/dashboard/
   children:
   - link: /features/dashboard/dashboards/
@@ -131,6 +131,8 @@
     name: Time range
   - link: /reference/export_import/
     name: Export and import
+  - link: /features/dashboard/links/
+    name: Navigation links
   - link: /reference/datalinks/
     name: Data links
   - link: /reference/dashboard_history/
@@ -189,8 +191,6 @@
     name: Notifications
 - name: Image rendering
   link: /administration/image_rendering/
-- name: Navigation links
-  link: /features/navigation-links/
 - name: Templates and variables
   link: /variables/
   children:


### PR DESCRIPTION
Due to a merge  conflict with another PR this docs fix that moved Navigations links under dashboard got overwritten  