### PR TITLE
PanelEditor: Fixes issue changing panel type from graph to stat and thresholds not taking affect after going back to dashboard

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -1,8 +1,6 @@
 import { FieldConfig } from './dataFrame';
 import { DataTransformerConfig } from './transformations';
 import { ApplyFieldOverrideOptions } from './fieldOverrides';
-import { InterpolateFunction } from './panel';
-import { FieldConfigOptionsRegistry } from '../field';
 
 export type KeyValue<T = any> = { [s: string]: T };
 

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -1,6 +1,8 @@
 import { FieldConfig } from './dataFrame';
 import { DataTransformerConfig } from './transformations';
 import { ApplyFieldOverrideOptions } from './fieldOverrides';
+import { InterpolateFunction } from './panel';
+import { FieldConfigOptionsRegistry } from '../field';
 
 export type KeyValue<T = any> = { [s: string]: T };
 

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -88,6 +88,7 @@ describe('panelEditor actions', () => {
 
       expect(dispatchedActions.length).toBe(3);
       expect(dispatchedActions[0].type).toBe(panelModelAndPluginReady.type);
+      expect(sourcePanel.plugin).toEqual(panel.plugin);
     });
 
     it('should discard changes when shouldDiscardChanges is true', async () => {

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -11,7 +11,6 @@ import {
 } from './reducers';
 import { cleanUpEditPanel, panelModelAndPluginReady } from '../../../state/reducers';
 import store from '../../../../../core/store';
-import { source } from 'common-tags';
 
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return dispatch => {

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -11,6 +11,7 @@ import {
 } from './reducers';
 import { cleanUpEditPanel, panelModelAndPluginReady } from '../../../state/reducers';
 import store from '../../../../../core/store';
+import { source } from 'common-tags';
 
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return dispatch => {
@@ -46,6 +47,10 @@ export function panelEditorCleanUp(): ThunkResult<void> {
       modifiedSaveModel.id = sourcePanel.id;
 
       sourcePanel.restoreModel(modifiedSaveModel);
+
+      // Loaded plugin is not included in the persisted properties
+      // So is not handled by restoreModel
+      sourcePanel.plugin = panel.plugin;
 
       if (panelTypeChanged) {
         dispatch(panelModelAndPluginReady({ panelId: sourcePanel.id, plugin: panel.plugin! }));

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -73,6 +73,7 @@ export class PanelChrome extends PureComponent<Props, State> {
 
     panel.events.on(PanelEvents.refresh, this.onRefresh);
     panel.events.on(PanelEvents.render, this.onRender);
+
     dashboard.panelInitialized(this.props.panel);
 
     // Move snapshot data into the query response
@@ -98,6 +99,15 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (!this.wantsQueryExecution) {
         this.setState({ isFirstLoad: false });
       }
+    }
+
+    if (!this.querySubscription) {
+      this.querySubscription = panel
+        .getQueryRunner()
+        .getData()
+        .subscribe({
+          next: data => this.onDataUpdate(data),
+        });
     }
   }
 
@@ -184,15 +194,7 @@ export class PanelChrome extends PureComponent<Props, State> {
         return;
       }
 
-      const queryRunner = panel.getQueryRunner();
-
-      if (!this.querySubscription) {
-        this.querySubscription = queryRunner.getData().subscribe({
-          next: data => this.onDataUpdate(data),
-        });
-      }
-
-      queryRunner.run({
+      panel.getQueryRunner().run({
         datasource: panel.datasource,
         queries: panel.targets,
         panelId: panel.id,

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -314,18 +314,10 @@ export class DashboardModel {
   panelInitialized(panel: PanelModel) {
     panel.initialized();
 
-    if (this.panelInEdit === panel) {
-      if (this.panelInEdit.getQueryRunner().getLastResult()) {
-        return;
-      } else {
-        // refresh if panel is in edit mode and there is no last result
-        panel.refresh();
-      }
-    } else {
-      // refresh new panels unless we are in fullscreen / edit mode
-      if (!this.otherPanelInFullscreen(panel)) {
-        panel.refresh();
-      }
+    const lastResult = panel.getQueryRunner().getLastResult();
+
+    if (!this.otherPanelInFullscreen(panel) && !lastResult) {
+      panel.refresh();
     }
   }
 


### PR DESCRIPTION
The PanelModel.plugin was not updated when switching panel plugin in new edit mode, leading to field config registry not updating to new plugin type etc. 

Also fixes issues of not reusing query result when switching from angular to react and going back to dashboard. 

* Fixes #24140