### PR TITLE
PanelEditor: Fixed right side options pane moved to top when clicking new radio buttons 

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -46,6 +46,7 @@ export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
   let max = Number.MIN_VALUE;
 
   const reducers = [ReducerID.min, ReducerID.max];
+
   for (const frame of data) {
     for (const field of frame.fields) {
       if (field.type === FieldType.number) {

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -44,8 +44,6 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme, size: RadioButt
   return {
     radio: css`
       position: absolute;
-      top: 0;
-      left: -100vw;
       opacity: 0;
       z-index: -1000;
 

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneContent.tsx
@@ -98,7 +98,7 @@ export const OptionsPaneContent: React.FC<Props> = ({
             />
           </TabsBar>
           <TabContent className={styles.tabContent}>
-            <CustomScrollbar>
+            <CustomScrollbar autoHeightMin="100%">
               {showMainTab ? (
                 <PanelOptionsTab
                   panel={panel}


### PR DESCRIPTION
Fixes #24138

Caused by native radio button was absolutely position at the top left of the page, caused native scroll event to move scroll pane to the hidden native radio input 