### PR TITLE
Dashboard: Go to explore now works even after discarding dashboard changes

### DIFF
--- a/public/app/features/dashboard/services/ChangeTracker.ts
+++ b/public/app/features/dashboard/services/ChangeTracker.ts
@@ -59,7 +59,6 @@ export class ChangeTracker {
         return true;
       }
 
-      console.log('location change start', event);
       if (this.hasChanges()) {
         event.preventDefault();
         this.next = next;

--- a/public/app/features/dashboard/services/ChangeTracker.ts
+++ b/public/app/features/dashboard/services/ChangeTracker.ts
@@ -6,7 +6,6 @@ import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { AppEventConsumer, CoreEvents } from 'app/types';
 import { appEvents } from 'app/core/app_events';
 import { UnsavedChangesModal } from '../components/SaveDashboard/UnsavedChangesModal';
-import { getLocationSrv } from '@grafana/runtime';
 
 export class ChangeTracker {
   current: any;
@@ -60,6 +59,7 @@ export class ChangeTracker {
         return true;
       }
 
+      console.log('location change start', event);
       if (this.hasChanges()) {
         event.preventDefault();
         this.next = next;
@@ -188,8 +188,9 @@ export class ChangeTracker {
   gotoNext = () => {
     const baseLen = this.$location.absUrl().length - this.$location.url().length;
     const nextUrl = this.next.substring(baseLen);
-    getLocationSrv().update({
-      path: nextUrl,
+
+    this.$timeout(() => {
+      this.$location.url(nextUrl);
     });
   };
 }


### PR DESCRIPTION
Fixes #24118 

Revert change to change tracker so that it uses angular location change like before. 

We still have a problem with navigate to explore from panel menu because it is done using redux updateLocation, this should be done using angular location change. The reason is that redux location change cannot be canceled and rolled back (angular location change can, which unsaved changes tracking rely on). 

So there is still issues if you try to go explore and hit cancel, then try to do things in the dashboard. redux url state has changed but angular url change was canceled (rightfully) so the state has diverged (redux url state wrong, thinks it's in explore)

https://github.com/grafana/grafana/blob/905e644c226e4e40f49bda1d9ef072b8b74d7218/public/app/features/explore/state/actions.ts#L896