### PR TITLE
Docs: Panel inspector

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Dashboards"
+type = "docs"
+[menu.docs]
+identifier = "dashboards"
+weight = 4
++++

--- a/docs/sources/guides/whats-new-in-v7-0.md
+++ b/docs/sources/guides/whats-new-in-v7-0.md
@@ -76,11 +76,13 @@ Up until now the overrides were available only for Graph and Table panel(via Col
 
 This feature enables even more powerful visualizations and fine grained control over how the data is displayed.
 
-## Panel inspect and export to CSV
+## Inspect panels and export data to CSV
 
 {{< docs-imagebox img="/img/docs/v70/panel_edit_export_raw_data.png" max-width="800px" class="docs-image--right" caption="Panel Edit - Export raw data to CSV" >}}
 
-Another new feature of Grafana 7.0 is Panel inspect. Inspect allows you to view the raw data for any Grafana panel as well as export that data to a CSV file. With Panel inspect you will also be able to perform simple raw data transformations like join, view query stats or detailed execution data.
+Another new feature of Grafana 7.0 is the panel inspector. Inspect allows you to view the raw data for any Grafana panel as well as export that data to a CSV file. With Panel inspect you will also be able to perform simple raw data transformations like join, view query stats or detailed execution data.
+
+Learn more about this feature in [Inspect a panel]({{< relref "../panels/inspect-panel.md" >}})
 
 <div class="clearfix"></div>
 

--- a/docs/sources/panels/_index.md
+++ b/docs/sources/panels/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Panels"
+type = "docs"
+[menu.docs]
+identifier = "panels"
+weight = 4
++++

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -11,7 +11,7 @@ weight = 400
 
 > **Note:** This documentation refers to a feature only available in Grafana 7.0 beta.
 
-The panel inspector helps you understand and troubleshoot your panels. You can inspect the raw data for any Grafana panel, export that data to a comma-separated variable (CSV) file, view query requests, and export panel and data JSON.
+The panel inspector helps you understand and troubleshoot your panels. You can inspect the raw data for any Grafana panel, export that data to a comma-separated values (CSV) file, view query requests, and export panel and data JSON.
 
 ## Panel inspector UI
 

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -9,6 +9,8 @@ weight = 400
 
 # Inspect a panel
 
+> **Note:** This documentation refers to a feature only available in Grafana 7.0 beta.
+
 The panel inspector helps you understand and troubleshoot your panels. You can inspect the raw data for any Grafana panel, export that data to a comma-separated variable (CSV) file, view query requests, and export panel and data JSON.
 
 ## Panel inspector UI

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -61,7 +61,7 @@ Grafana generates a CSV file in your default browser download location. You can 
  
 ### Inspect query performance
 
-The Stats tab displays statistics that tell you how long your query takes, how many queries you send, and the number of rows return. This information can help you troubleshoot your queries, especially if any of the numbers is unexpectedly high or low.
+The Stats tab displays statistics that tell you how long your query takes, how many queries you send, and the number of rows returned. This information can help you troubleshoot your queries, especially if any of the numbers is unexpectedly high or low.
 
 1. Open the panel inspector.
 1. Navigate to the Stats tab. 

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -1,0 +1,85 @@
++++
+title = "Inspect a panel"
+type = "docs"
+[menu.docs]
+identifier = "inspect-a-panel"
+parent = "panels"
+weight = 400
++++
+
+# Inspect a panel
+
+The panel inspector helps you understand and troubleshoot your panels. You can inspect the raw data for any Grafana panel, export that data to a comma-separated variable (CSV) file, view query requests, and export panel and data JSON.
+
+## Panel inspector UI
+
+The panel inspector displays Inspect: <NameOfPanelBeingInspected> at the top of the pane. Click the arrow in the upper right corner to expand or reduce the pane.
+
+The panel inspector consists of four tabs:
+
+* **Data tab -** Shows the raw data returned by the query with transformations applied. Field options such as overrides and value mappings are not applied.
+* **Stats tab -** Shows how long your query takes and how much it returns.
+* **JSON tab -** Allows you to view and copy the panel JSON, panel data JSON, and data frame structure JSON. This is useful if you are provisioning or administering Grafana. 
+* **Query tab -** Shows you the requests to the server sent when Grafana queries the data source. 
+
+> **Note:** Not all panel types include all four tabs. For example, dashboard list panels do not have raw data to inspect, so they do not display the Stats, Data, or Query tabs.
+
+## Panel inspector tasks
+Tasks you can perform in the panel inspector are described below. 
+
+### Open the panel inspector
+
+You can inspect any panel that you can view.
+
+1. In Grafana, navigate to the dashboard that contains the panel you want to inspect.
+1. Click the title of the panel you want to inspect and then click **Inspect**.
+   Or
+   Hover your cursor over the panel title and then press **i**.
+
+The panel inspector pane opens on the right side of the screen.
+
+### Inspect raw query results
+
+View raw query results in a table. This is the data returned by the query with transformations applied and before the panel applies field configurations or overrides.
+
+1. Open the panel inspector and then click the **Data** tab or in the panel menu click **Inspect > Data**.
+
+2. If your panel contains multiple queries or queries multiple nodes, then you have additional options.
+* **Select result -** Choose which result set data you want to view.
+* **Transform data**
+  * **Join by time -** View raw data from all your queries at once, one result set per column. Click a column heading to reorder the data.
+
+### Download raw query results as CSV
+
+Grafana generates a CSV file in your default browser download location. You can open it in the viewer of your choice.
+
+1. Open the panel inspector.
+1. Inspect the raw query results as described above. Adjust settings until you see the raw data that you want to export.
+1. Click **Download CSV**.
+ 
+### Inspect query performance
+
+The Stats tab displays statistics that tell you how long your query takes, how many queries you send, and the number of rows return. This information can help you troubleshoot your queries, especially if any of the numbers is unexpectedly high or low.
+
+1. Open the panel inspector.
+1. Navigate to the Stats tab. 
+
+Statistics are displayed in read-only format.
+
+### View panel JSON model
+
+Explore and export panel, panel data, and data frame JSON models.
+
+1. Open the panel inspector and then click the **JSON** tab or in the panel menu click **Inspect > Panel JSON**.
+1. In Select source, choose one of the following options:
+   * **Panel JSON -** Displays a JSON object representing the panel.
+   * **Panel data -** Displays a JSON object representing the data that was passed to the panel.
+   * **DataFrame structure -** Displays the raw result set with transformations, field configuration, and overrides configuration applied.
+1. You can expand or collapse portions of the JSON to explore it, or you can click **Copy to clipboard** and paste the JSON in another application. 
+
+### View raw request and response to data source
+
+1. Open the panel inspector and then click the **Query** tab or in the panel menu click **Inspect > Query**.
+1. Click **Refresh**.
+
+Grafana sends a query to the server to collect information and then displays the result. You can now drill down on specific portions of the query, expand or collapse all of it, or copy the data to the clipboard to use in other applications.


### PR DESCRIPTION
Adds Inspect a panel topic and links from What's new in 7.0.

Also adds a couple folders that will be needed to hold doc architecture that is coming. 

**What this PR does / why we need it**: Features need docs.

**Special notes for your reviewer**: If this is ready to go or requires only minor edits, my feelings will not be hurt if this is merged for me. I would like to get this out.

