### PR TITLE
Logs: Add log level Fatal

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -8,6 +8,7 @@ import { DataFrame } from './dataFrame';
  */
 export enum LogLevel {
   emerg = 'critical',
+  fatal = 'critical',
   alert = 'critical',
   crit = 'critical',
   critical = 'critical',
@@ -17,6 +18,7 @@ export enum LogLevel {
   eror = 'error',
   error = 'error',
   info = 'info',
+  information = 'info',
   notice = 'info',
   dbug = 'debug',
   debug = 'debug',

--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -15,7 +15,7 @@ describe('getLoglevel()', () => {
   });
 
   it('returns no log level on when level is part of a word', () => {
-    expect(getLogLevel('this is information')).toBe(LogLevel.unknown);
+    expect(getLogLevel('who warns us')).toBe(LogLevel.unknown);
   });
 
   it('returns same log level for long and short version', () => {


### PR DESCRIPTION
- recognizes log level "fatal"
- renders it with same color as other levels similar to "critical"

Fixes #22258