### PR TITLE
Loki: Show loki datasource stats in panel inspector

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -32,6 +32,7 @@ import { getThemeColor } from 'app/core/utils/colors';
 
 import { sortInAscendingOrder, deduplicateLogRowsById } from 'app/core/utils/explore';
 import { getGraphSeriesModel } from 'app/plugins/panel/graph2/getGraphSeriesModel';
+import { decimalSIPrefix } from '@grafana/data/src/valueFormats/symbolFormatters';
 
 export const LogLevelColor = {
   [LogLevel.critical]: colors[7],
@@ -371,6 +372,26 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
     meta.push({
       label: 'Limit',
       value: `${limitValue} (${deduplicatedLogRows.length} returned)`,
+      kind: LogsMetaKind.String,
+    });
+  }
+
+  // Hack to print loki stats in Explore. Should be using proper stats display via drawer in Explore (rework in 7.1)
+  let totalBytes = 0;
+  for (const series of logSeries) {
+    const totalBytesKey = series.meta.custom?.lokiQueryStatKey;
+    if (totalBytesKey && series.meta.stats) {
+      const byteStat = series.meta.stats.find(stat => stat.title === totalBytesKey);
+      if (byteStat) {
+        totalBytes += byteStat.value;
+      }
+    }
+  }
+  if (totalBytes > 0) {
+    const { text, suffix } = decimalSIPrefix('B')(totalBytes);
+    meta.push({
+      label: 'Total bytes processed',
+      value: `${text} ${suffix}`,
       kind: LogsMetaKind.String,
     });
   }

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -379,7 +379,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
   // Hack to print loki stats in Explore. Should be using proper stats display via drawer in Explore (rework in 7.1)
   let totalBytes = 0;
   for (const series of logSeries) {
-    const totalBytesKey = series.meta.custom?.lokiQueryStatKey;
+    const totalBytesKey = series.meta?.custom?.lokiQueryStatKey;
     if (totalBytesKey && series.meta.stats) {
       const byteStat = series.meta.stats.find(stat => stat.title === totalBytesKey);
       if (byteStat) {

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -1,5 +1,5 @@
 import { CircularDataFrame, FieldCache, FieldType, MutableDataFrame } from '@grafana/data';
-import { LokiStreamResult, LokiTailResponse } from './types';
+import { LokiStreamResult, LokiTailResponse, LokiStreamResponse, LokiResultType } from './types';
 import * as ResultTransformer from './result_transformer';
 import { enhanceDataFrame } from './result_transformer';
 
@@ -17,6 +17,19 @@ const streamResult: LokiStreamResult[] = [
     values: [['1579857562031616000', "bar: 'foo'"]],
   },
 ];
+
+const lokiResponse: LokiStreamResponse = {
+  status: 'success',
+  data: {
+    result: streamResult,
+    resultType: LokiResultType.Stream,
+    stats: {
+      summary: {
+        bytesTotal: 900,
+      },
+    },
+  },
+};
 
 describe('loki result transformer', () => {
   afterAll(() => {
@@ -45,7 +58,7 @@ describe('loki result transformer', () => {
   describe('lokiStreamsToDataframes', () => {
     it('should enhance data frames', () => {
       jest.spyOn(ResultTransformer, 'enhanceDataFrame');
-      const dataFrames = ResultTransformer.lokiStreamsToDataframes(streamResult, { refId: 'B' }, 500, {
+      const dataFrames = ResultTransformer.lokiStreamsToDataframes(lokiResponse, { refId: 'B' }, 500, {
         derivedFields: [
           {
             matcherRegex: 'trace=(w+)',

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -39,6 +39,12 @@ export interface LokiOptions extends DataSourceJsonData {
   derivedFields?: DerivedFieldConfig[];
 }
 
+export interface LokiStats {
+  [component: string]: {
+    [label: string]: number;
+  };
+}
+
 export interface LokiVectorResult {
   metric: { [label: string]: string };
   value: [number, string];
@@ -49,6 +55,7 @@ export interface LokiVectorResponse {
   data: {
     resultType: LokiResultType.Vector;
     result: LokiVectorResult[];
+    stats?: LokiStats;
   };
 }
 
@@ -62,6 +69,7 @@ export interface LokiMatrixResponse {
   data: {
     resultType: LokiResultType.Matrix;
     result: LokiMatrixResult[];
+    stats?: LokiStats;
   };
 }
 
@@ -75,6 +83,7 @@ export interface LokiStreamResponse {
   data: {
     resultType: LokiResultType.Stream;
     result: LokiStreamResult[];
+    stats?: LokiStats;
   };
 }
 


### PR DESCRIPTION
Adds support for displaying query timings for Loki, combining the new Loki stats API with Grafana's new query stats in the panel inspector.

- puts the loki query result stats into the query results meta stat API
of Grafana, this allows the display of all backend loki stats in the
panel inspector in the dashboards (not making use of units yet)

![Screenshot 2020-05-02 at 22 51 59](https://user-images.githubusercontent.com/859729/80891932-94242a00-8cc7-11ea-993c-4f32308516f9.png)

- added a hack to also display one of those values in Explore as a meta
label using the dataframe meta `custom` mechanims to point to a single
stat entry for each series which is then added together to show total
bytes processed across all query row results (this should be changed for
7.1 to make full use of the panel inspector in Explore)

![Screenshot 2020-05-02 at 22 51 26](https://user-images.githubusercontent.com/859729/80891940-a56d3680-8cc7-11ea-91b1-d4f06e62529b.png)

CC @cyriltovena @slim-bean 