### PR TITLE
WIP-POC: Field class 

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -14,6 +14,7 @@ import {
   TimeSeriesValue,
   FieldDTO,
   DataFrameDTO,
+  FieldImpl,
 } from '../types/index';
 import { isDateTime } from '../datetime/moment_wrapper';
 import { ArrayVector } from '../vector/ArrayVector';
@@ -24,12 +25,12 @@ import { ArrayDataFrame } from './ArrayDataFrame';
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map(c => {
     const { text, ...disp } = c;
-    return {
+    return new FieldImpl({
       name: text, // rename 'text' to the 'name' field
       config: (disp || {}) as FieldConfig,
       values: new ArrayVector(),
       type: FieldType.other,
-    };
+    });
   });
 
   if (!isArray(table.rows)) {
@@ -67,13 +68,13 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   }
 
   const fields = [
-    {
+    new FieldImpl({
       name: 'Time',
       type: FieldType.time,
       config: {},
       values: new ArrayVector<number>(times),
-    },
-    {
+    }),
+    new FieldImpl({
       name: timeSeries.target || 'Value',
       type: FieldType.number,
       config: {
@@ -81,7 +82,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
       },
       values: new ArrayVector<TimeSeriesValue>(values),
       labels: timeSeries.tags,
-    },
+    }),
   ];
 
   return {
@@ -110,20 +111,20 @@ function convertGraphSeriesToDataFrame(graphSeries: GraphSeriesXY): DataFrame {
   return {
     name: graphSeries.label,
     fields: [
-      {
+      new FieldImpl({
         name: graphSeries.label || 'Value',
         type: FieldType.number,
         config: {},
         values: x,
-      },
-      {
+      }),
+      new FieldImpl({
         name: 'Time',
         type: FieldType.time,
         config: {
           unit: 'dateTimeAsIso',
         },
         values: y,
-      },
+      }),
     ],
     length: x.buffer.length,
   };

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -16,6 +16,7 @@ import {
   ValueLinkConfig,
   GrafanaTheme,
   TimeZone,
+  FieldImpl,
 } from '../types';
 import { fieldMatchers, ReducerID, reduceField } from '../transformations';
 import { FieldMatcher } from '../types/transformations';
@@ -178,11 +179,13 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
       }
 
       // Overwrite the configs
-      const f: Field = {
+      const f: Field = new FieldImpl({
         ...field,
         config,
         type,
-      };
+      });
+
+      // Here is where it gets' tricky, since these take in field as argument
 
       // and set the display processor using it
       f.display = getDisplayProcessor({

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -2,7 +2,7 @@ import { DataTransformerID } from './ids';
 import { DataTransformerInfo, MatcherConfig } from '../../types/transformations';
 import { fieldReducers, reduceField, ReducerID } from '../fieldReducer';
 import { alwaysFieldMatcher } from '../matchers/predicates';
-import { DataFrame, Field, FieldType } from '../../types/dataFrame';
+import { DataFrame, Field, FieldType, FieldImpl } from '../../types/dataFrame';
 import { ArrayVector } from '../../vector/ArrayVector';
 import { KeyValue } from '../../types/data';
 import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
@@ -42,27 +42,31 @@ export const reduceTransformer: DataTransformerInfo<ReduceTransformerOptions> = 
         const byId: KeyValue<ArrayVector> = {};
 
         values.push(new ArrayVector()); // The name
-        fields.push({
-          name: 'Field',
-          type: FieldType.string,
-          values: values[0],
-          config: {},
-        });
+        fields.push(
+          new FieldImpl({
+            name: 'Field',
+            type: FieldType.string,
+            values: values[0],
+            config: {},
+          })
+        );
 
         for (const info of calculators) {
           const vals = new ArrayVector();
           byId[info.id] = vals;
           values.push(vals);
 
-          fields.push({
-            name: info.id,
-            type: FieldType.other, // UNKNOWN until after we call the functions
-            values: values[values.length - 1],
-            config: {
-              title: info.name,
-              // UNIT from original field?
-            },
-          });
+          fields.push(
+            new FieldImpl({
+              name: info.id,
+              type: FieldType.other, // UNKNOWN until after we call the functions
+              values: values[values.length - 1],
+              config: {
+                title: info.name,
+                // UNIT from original field?
+              },
+            })
+          );
         }
 
         for (let i = 0; i < series.fields.length; i++) {

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -13,7 +13,7 @@ import {
   FieldConfig,
   DataFrameView,
   DataLink,
-  Field,
+  FieldImpl,
 } from '@grafana/data';
 
 import templateSrv from 'app/features/templating/template_srv';
@@ -74,10 +74,10 @@ function constructDataFrame(
   const dataFrame = {
     refId,
     fields: [
-      { name: 'ts', type: FieldType.time, config: { title: 'Time' }, values: times }, // Time
-      { name: 'line', type: FieldType.string, config: {}, values: lines, labels }, // Line
-      { name: 'id', type: FieldType.string, config: {}, values: uids },
-      { name: 'tsNs', type: FieldType.time, config: { title: 'Time ns' }, values: timesNs }, // Time
+      new FieldImpl({ name: 'ts', type: FieldType.time, config: { title: 'Time' }, values: times }), // Time
+      new FieldImpl({ name: 'line', type: FieldType.string, config: {}, values: lines, labels }), // Line
+      new FieldImpl({ name: 'id', type: FieldType.string, config: {}, values: uids }),
+      new FieldImpl({ name: 'tsNs', type: FieldType.time, config: { title: 'Time ns' }, values: timesNs }), // Time
     ],
     length: times.length,
   };


### PR DESCRIPTION
I wish we had a DataFrame class and Field class, think it could help with all these optional functions on these two objects. And make things have good defaults and have DataFrame & field utility functions be more discoverable and used.

But it might not add that much value, or to late & big a change.

But just wanted to try it for Field, would prefer to name the implementation Field and the interface IField so we can just new Field everywhere. 

To keep the spread operations still working my idea is to have a FieldContent interface that contains all the data. so we can new Field({...field.content, config: newConfig}. 

Surprised how few type error this got for field, will probably get more type errors if we tried it on DataFrame as well. 

But got a little bit stuck on exactly how to approach the display & getLink functions. They both take in a field as an argument so cannot be sent in via the constructor. 

```ts
// Overwrite the configs
      const f: Field = new FieldImpl({
        ...field,
        config,
        type,
      });

      // Here is where it gets' tricky, since these take in field as argument

      // and set the display processor using it
      f.display = getDisplayProcessor({
        field: f,
        theme: options.theme,
        timeZone: options.timeZone,
      });

      // Attach data links supplier
      f.getLinks = getLinksSupplier(frame, f, fieldScopedVars, context.replaceVariables, {
        theme: options.theme,
        timeZone: options.timeZone,
      });
```