### PR TITLE
Prometheus: Add metadata for summary metrics

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -5,7 +5,7 @@ import { Value } from 'slate';
 import { dateTime, LanguageProvider, HistoryItem } from '@grafana/data';
 import { CompletionItem, TypeaheadInput, TypeaheadOutput, CompletionItemGroup } from '@grafana/ui';
 
-import { parseSelector, processLabels, processHistogramLabels } from './language_utils';
+import { parseSelector, processLabels, processHistogramLabels, fixSummariesMetadata } from './language_utils';
 import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
 import { PrometheusDatasource } from './datasource';
@@ -114,7 +114,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   start = async (): Promise<any[]> => {
     this.metrics = await this.request('/api/v1/label/__name__/values', []);
     this.lookupsDisabled = this.metrics.length > this.lookupMetricsThreshold;
-    this.metricsMetadata = await this.request('/api/v1/metadata', {});
+    this.metricsMetadata = fixSummariesMetadata(await this.request('/api/v1/metadata', {}));
     this.processHistogramMetrics(this.metrics);
     return [];
   };

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -115,7 +115,7 @@ export function expandRecordingRules(query: string, mapping: { [name: string]: s
 }
 
 /**
- * Adds metadata for synthetic summary metrics for which the API does not provide metadata.
+ * Adds metadata for synthetic metrics for which the API does not provide metadata.
  * See https://github.com/grafana/grafana/issues/22337 for details.
  *
  * @param metadata HELP and TYPE metadata from /api/v1/metadata

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -1,3 +1,5 @@
+import { PromMetricsMetadata } from './types';
+
 export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
 
 export const processHistogramLabels = (labels: string[]) => {
@@ -110,4 +112,35 @@ export function expandRecordingRules(query: string, mapping: { [name: string]: s
   const ruleNames = Object.keys(mapping);
   const rulesRegex = new RegExp(`(\\s|^)(${ruleNames.join('|')})(\\s|$|\\(|\\[|\\{)`, 'ig');
   return query.replace(rulesRegex, (match, pre, name, post) => `${pre}${mapping[name]}${post}`);
+}
+
+/**
+ * Adds metadata for synthetic summary metrics for which the API does not provide metadata.
+ * See https://github.com/grafana/grafana/issues/22337 for details.
+ *
+ * @param metadata HELP and TYPE metadata from /api/v1/metadata
+ */
+export function fixSummariesMetadata(metadata: PromMetricsMetadata): PromMetricsMetadata {
+  if (!metadata) {
+    return metadata;
+  }
+  const summaryMetadata: PromMetricsMetadata = {};
+  for (const metric in metadata) {
+    const item = metadata[metric][0];
+    if (item.type === 'summary') {
+      summaryMetadata[`${metric}_count`] = [
+        {
+          type: 'counter',
+          help: `Count of events that have been observed for the base metric (${item.help})`,
+        },
+      ];
+      summaryMetadata[`${metric}_sum`] = [
+        {
+          type: 'counter',
+          help: `Total sum of all observed values for the base metric (${item.help})`,
+        },
+      ];
+    }
+  }
+  return { ...metadata, ...summaryMetadata };
 }


### PR DESCRIPTION
- summary metrics don't have metadata available from the metadata API,
so Grafana can help and just add it
- given a summary metric `foo`, we add metadata info for `foo_sum` and
`foo_count`
- with tests

Example using the prometheus instance at http://demo.robustperception.io:9090/

<img width="635" alt="Screenshot 2020-05-03 at 22 16 30" src="https://user-images.githubusercontent.com/859729/80924988-9dc39580-8d8c-11ea-9a3e-e6d3fd05f43a.png">


Fixes #22337

CC @gotjosh 