### PR TITLE
Elasticsearch: Changes terms min_doc_count default from 1 to 0

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
@@ -79,7 +79,7 @@ export class ElasticBucketAggCtrl {
         case 'terms': {
           settings.order = settings.order || 'desc';
           settings.size = settings.size || '10';
-          settings.min_doc_count = settings.min_doc_count || 1;
+          settings.min_doc_count = settings.min_doc_count || 0;
           settings.orderBy = settings.orderBy || '_term';
 
           if (settings.size !== '0') {


### PR DESCRIPTION
**What this PR does / why we need it**:

Nano-change: changes default value of `min_doc_count` in Elastic terms aggregations from 1 to 0, allowing to visualize missing data as well.

**Which issue(s) this PR fixes**:

Fixes #23636 