### PR TITLE
NewPanelEdit: Copy raw untransformed result from source panel

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -18,11 +18,8 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import { EDIT_PANEL_ID } from 'app/core/constants';
-
 import config from 'app/core/config';
-
 import { PanelQueryRunner } from './PanelQueryRunner';
-import { take } from 'rxjs/operators';
 
 export const panelAdded = eventFactory<PanelModel | undefined>('panel-added');
 export const panelRemoved = eventFactory<PanelModel | undefined>('panel-removed');
@@ -426,10 +423,10 @@ export class PanelModel implements DataConfigSource {
     const sourceQueryRunner = this.getQueryRunner();
 
     // pipe last result to new clone query runner
-    sourceQueryRunner
-      .getData()
-      .pipe(take(1))
-      .subscribe(val => clone.getQueryRunner().pipeDataToSubject(val));
+    const lastResult = sourceQueryRunner.getLastResult();
+    if (lastResult) {
+      clone.getQueryRunner().pipeDataToSubject(lastResult);
+    }
 
     return clone;
   }


### PR DESCRIPTION
When creating the edit clone we just called getData() as a way to pipe data from source panel, this has already transformed data. So if data was filtered out via a transform then we sent that already transformed data to the transform tab. 

This simplifies this logic greatly by just copying the last result if there is any. 

Fixes #24208

Fixes part of #24207