### PR TITLE
Dockerfile: Move Go stage after JS one, since it's faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,3 @@
-# Golang build container
-FROM golang:1.14.2-alpine3.11 as go-builder
-
-RUN apk add --no-cache gcc g++
-
-WORKDIR $GOPATH/src/github.com/grafana/grafana
-
-COPY go.mod go.sum ./
-
-RUN go mod verify
-
-COPY pkg pkg
-COPY build.go package.json ./
-
-RUN go run build.go build
-
-# Node build container
 FROM node:12.16.3-alpine3.11 as js-builder
 
 WORKDIR /usr/src/app/
@@ -33,7 +16,22 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-# Final container
+FROM golang:1.14.2-alpine3.11 as go-builder
+
+RUN apk add --no-cache gcc g++
+
+WORKDIR $GOPATH/src/github.com/grafana/grafana
+
+COPY go.mod go.sum ./
+
+RUN go mod verify
+
+COPY pkg pkg
+COPY build.go package.json ./
+
+RUN go run build.go build
+
+# Final stage
 FROM alpine:3.11
 
 LABEL maintainer="Grafana team <hello@grafana.com>"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,16 +1,3 @@
-FROM golang:1.14.2 AS go-builder
-
-WORKDIR /src/grafana
-
-COPY go.mod go.sum ./
-
-RUN go mod verify
-
-COPY build.go package.json ./
-COPY pkg pkg/
-
-RUN go run build.go build
-
 FROM node:12.16.3-slim AS js-builder
 
 WORKDIR /usr/src/app/
@@ -28,6 +15,19 @@ COPY emails emails
 
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
+
+FROM golang:1.14.2 AS go-builder
+
+WORKDIR /src/grafana
+
+COPY go.mod go.sum ./
+
+RUN go mod verify
+
+COPY build.go package.json ./
+COPY pkg pkg/
+
+RUN go run build.go build
 
 FROM ubuntu:20.04
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In /Dockerfile*, move Go stage after the JS one, since Go builds much faster than JS. The only reason for this change is to save the time it takes to build JS after making Go changes, when building development Docker images.
