### PR TITLE
NewPanelEdit: Fixes issue with angular panel clean up, and cleanup after leaving edit mode

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -33,7 +33,7 @@ describe('panelEditor actions', () => {
         panels: [{ id: 12, type: 'graph' }],
       });
 
-      const panel = sourcePanel.getEditClone();
+      const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
 
       const state: PanelEditorState = {
@@ -65,7 +65,7 @@ describe('panelEditor actions', () => {
         panels: [{ id: 12, type: 'graph' }],
       });
 
-      const panel = sourcePanel.getEditClone();
+      const panel = dashboard.initEditPanel(sourcePanel);
       panel.type = 'table';
       panel.plugin = getPanelPlugin({ id: 'table' });
       panel.updateOptions({ prop: true });
@@ -76,6 +76,8 @@ describe('panelEditor actions', () => {
         getSourcePanel: () => sourcePanel,
         querySubscription: { unsubscribe: jest.fn() },
       };
+
+      const panelDestroy = (panel.destroy = jest.fn());
 
       const dispatchedActions = await thunkTester({
         panelEditor: state,
@@ -89,6 +91,7 @@ describe('panelEditor actions', () => {
       expect(dispatchedActions.length).toBe(3);
       expect(dispatchedActions[0].type).toBe(panelModelAndPluginReady.type);
       expect(sourcePanel.plugin).toEqual(panel.plugin);
+      expect(panelDestroy.mock.calls.length).toEqual(1);
     });
 
     it('should discard changes when shouldDiscardChanges is true', async () => {
@@ -101,7 +104,7 @@ describe('panelEditor actions', () => {
         panels: [{ id: 12, type: 'graph' }],
       });
 
-      const panel = sourcePanel.getEditClone();
+      const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
 
       const state: PanelEditorState = {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -341,6 +341,7 @@ export class DashboardModel {
   }
 
   exitPanelEditor() {
+    this.panelInEdit.destroy();
     this.panelInEdit = undefined;
   }
 

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -82,6 +82,9 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
       scope.$on('$destroy', () => {
         elem.off();
 
+        panel.events.emit(PanelEvents.panelTeardown);
+        panel.events.removeAllListeners();
+
         if (panelScrollbar) {
           panelScrollbar.dispose();
         }


### PR DESCRIPTION
Fixes some issue that I think where introduced after beta1 where angular panels where not properly destroyed & clean-up when leaving edit mode or when switching from angular panel to react. 

You could see this bug in switching from Graph to stat panel, nothing really worked as angular panel was not clean-ed up (event listeneres where still there). 

And you could see this when leaving edit mode with ESC, the graph tooltip is still there 