### PR TITLE
Search: Support multiple order filters

### DIFF
--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -3,7 +3,6 @@ package search
 import (
 	"sort"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -49,7 +48,7 @@ type FindPersistedDashboardsQuery struct {
 	Page         int64
 	Permission   models.PermissionType
 
-	SortBy searchstore.FilterOrderBy
+	Filters []interface{}
 
 	Result HitList
 }
@@ -86,7 +85,9 @@ func (s *SearchService) searchHandler(query *Query) error {
 	}
 
 	if sortOpt, exists := s.sortOptions[query.Sort]; exists {
-		dashboardQuery.SortBy = sortOpt.Filter
+		for _, filter := range sortOpt.Filter {
+			dashboardQuery.Filters = append(dashboardQuery.Filters, filter)
+		}
 	}
 
 	if err := bus.Dispatch(&dashboardQuery); err != nil {

--- a/pkg/services/search/sorting.go
+++ b/pkg/services/search/sorting.go
@@ -11,13 +11,17 @@ var (
 		Name:        "alpha-asc",
 		DisplayName: "Alphabetically (A-Z)",
 		Description: "Sort results in an alphabetically ascending order",
-		Filter:      searchstore.TitleSorter{},
+		Filter: []SortOptionFilter{
+			searchstore.TitleSorter{},
+		},
 	}
 	sortAlphaDesc = SortOption{
 		Name:        "alpha-desc",
 		DisplayName: "Alphabetically (Z-A)",
 		Description: "Sort results in an alphabetically descending order",
-		Filter:      searchstore.TitleSorter{Descending: true},
+		Filter: []SortOptionFilter{
+			searchstore.TitleSorter{Descending: true},
+		},
 	}
 )
 
@@ -25,7 +29,11 @@ type SortOption struct {
 	Name        string
 	DisplayName string
 	Description string
-	Filter      searchstore.FilterOrderBy
+	Filter      []SortOptionFilter
+}
+
+type SortOptionFilter interface {
+	searchstore.FilterOrderBy
 }
 
 // RegisterSortOption allows for hooking in more search options from

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -216,12 +216,7 @@ type DashboardSearchProjection struct {
 }
 
 func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error) {
-	if query.SortBy == nil {
-		query.SortBy = searchstore.TitleSorter{}
-	}
-
 	filters := []interface{}{
-		query.SortBy,
 		permissions.DashboardPermissionFilter{
 			OrgRole:         query.SignedInUser.OrgRole,
 			OrgId:           query.SignedInUser.OrgId,
@@ -230,6 +225,8 @@ func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSear
 			PermissionLevel: query.Permission,
 		},
 	}
+
+	filters = append(filters, query.Filters...)
 
 	if query.OrgId != 0 {
 		filters = append(filters, searchstore.OrgFilter{OrgId: query.OrgId})

--- a/pkg/services/sqlstore/searchstore/builder.go
+++ b/pkg/services/sqlstore/searchstore/builder.go
@@ -113,13 +113,14 @@ func (b *Builder) applyFilters() (ordering string) {
 		b.params = append(b.params, groupParams...)
 	}
 
-	if len(orders) > 0 {
-		orderBy := fmt.Sprintf(" ORDER BY %s", strings.Join(orders, ", "))
-		b.sql.WriteString(orderBy)
-
-		order := strings.Join(orderJoins, "")
-		order += orderBy
-		return order
+	if len(orders) < 1 {
+		orders = append(orders, TitleSorter{}.OrderBy())
 	}
-	return " ORDER BY dashboard.id"
+
+	orderBy := fmt.Sprintf(" ORDER BY %s", strings.Join(orders, ", "))
+	b.sql.WriteString(orderBy)
+
+	order := strings.Join(orderJoins, "")
+	order += orderBy
+	return order
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We ran into a problem which could be solved by allowing multiple order by filters to be passed to search. Fixing my original design here.