### PR TITLE
DashboardManager: Disable editing if there are no folder permissions

### DIFF
--- a/public/app/features/search/components/ManageDashboards.tsx
+++ b/public/app/features/search/components/ManageDashboards.tsx
@@ -58,7 +58,7 @@ export const ManageDashboards: FC<Props> = memo(({ folderId, folderUid }) => {
     onDeleteItems,
     onMoveItems,
   } = useManageDashboards(query, { hasEditPermissionInFolders: contextSrv.hasEditPermissionInFolders }, folderUid);
-  console.log(canMove);
+
   const onMoveTo = () => {
     setIsMoveModalOpen(true);
   };

--- a/public/app/features/search/components/ManageDashboards.tsx
+++ b/public/app/features/search/components/ManageDashboards.tsx
@@ -58,7 +58,7 @@ export const ManageDashboards: FC<Props> = memo(({ folderId, folderUid }) => {
     onDeleteItems,
     onMoveItems,
   } = useManageDashboards(query, { hasEditPermissionInFolders: contextSrv.hasEditPermissionInFolders }, folderUid);
-
+  console.log(canMove);
   const onMoveTo = () => {
     setIsMoveModalOpen(true);
   };
@@ -100,8 +100,8 @@ export const ManageDashboards: FC<Props> = memo(({ folderId, folderUid }) => {
       <div className={styles.results}>
         <SearchResultsFilter
           allChecked={allChecked}
-          canDelete={canDelete}
-          canMove={canMove}
+          canDelete={hasEditPermissionInFolders && canDelete}
+          canMove={hasEditPermissionInFolders && canMove}
           deleteItem={onItemDelete}
           moveTo={onMoveTo}
           onToggleAllChecked={onToggleAllChecked}
@@ -115,7 +115,7 @@ export const ManageDashboards: FC<Props> = memo(({ folderId, folderUid }) => {
         <SearchResults
           loading={loading}
           results={results}
-          editable
+          editable={hasEditPermissionInFolders}
           onTagSelected={onTagAdd}
           onToggleSection={onToggleSection}
           onToggleChecked={onToggleChecked}


### PR DESCRIPTION
Fixes #22530
Hides these when there are no editing permissions:
- Delete button
- Move button
- Checkboxes for selecting dashboards