### PR TITLE
Loki: Fix label matcher for log metrics queries

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -101,10 +101,10 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
         {isLabel && (
           <>
             <td className={style.logsDetailsIcon}>
-              <IconButton name="search-minus" title="Filter for value" onClick={this.filterLabel} />
+              <IconButton name="search-plus" title="Filter for value" onClick={this.filterLabel} />
             </td>
             <td className={style.logsDetailsIcon}>
-              <IconButton name="search-plus" title="Filter out value" onClick={this.filterOutLabel} />
+              <IconButton name="search-minus" title="Filter out value" onClick={this.filterOutLabel} />
             </td>
           </>
         )}

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
@@ -1,4 +1,4 @@
-import { addLabelToQuery, addLabelToSelector, keepSelectorFilters } from './add_label_to_query';
+import { addLabelToQuery, addLabelToSelector } from './add_label_to_query';
 
 describe('addLabelToQuery()', () => {
   it('should add label to simple query', () => {
@@ -58,6 +58,11 @@ describe('addLabelToQuery()', () => {
       'avg(foo{bar="baz"}) + sum(xx_yy{bar="baz"})'
     );
   });
+
+  it('should not remove filters', () => {
+    expect(addLabelToQuery('{x="y"} |="yy"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy"');
+    expect(addLabelToQuery('{x="y"} |="yy" !~"xx"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy" !~"xx"');
+  });
 });
 
 describe('addLabelToSelector()', () => {
@@ -70,17 +75,5 @@ describe('addLabelToSelector()', () => {
   });
   test('should add a label to a selector with custom operator', () => {
     expect(addLabelToSelector('{}', 'baz', '42', '!=')).toBe('{baz!="42"}');
-  });
-});
-
-describe('keepSelectorFilters()', () => {
-  test('should return empty string if no filter is in selector', () => {
-    expect(keepSelectorFilters('{foo="bar"}')).toBe('');
-  });
-  test('should return a filter if filter is in selector', () => {
-    expect(keepSelectorFilters('{foo="bar"} |="baz"')).toBe('|="baz"');
-  });
-  test('should return multiple filters if multiple filters are in selector', () => {
-    expect(keepSelectorFilters('{foo!="bar"} |="baz" |~"yy" !~"xx"')).toBe('|="baz" |~"yy" !~"xx"');
   });
 });

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -91,12 +91,6 @@ export function addLabelToSelector(selector: string, labelKey: string, labelValu
   return `{${formatted}}`;
 }
 
-export function keepSelectorFilters(selector: string) {
-  // Remove all label-key between {} and return filters. If first character is space, remove it.
-  const filters = selector.replace(/\{(.*?)\}/g, '').replace(/^ /, '');
-  return filters;
-}
-
 function isPositionInsideChars(text: string, position: number, openChar: string, closeChar: string) {
   const nextSelectorStart = text.slice(position).indexOf(openChar);
   const nextSelectorEnd = text.slice(position).indexOf(closeChar);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does following:

- implements the same logic for adding labels, [as used in prometheus](https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/prometheus/datasource.ts#L687-L716)
- adds test coverage for loki filters - to make sure that they are not removed
- fixes switched order of filter for and filter out labels

![c8d98fe89255b2e7053d04714da10c1d](https://user-images.githubusercontent.com/30407135/80982613-dc5c5d00-8e2b-11ea-9d75-2f002f933ab7.gif)

**Which issue(s) this PR fixes**:

Fixes #21589 


