### PR TITLE
Signing: allow unsigned plugin in dev mode

### DIFF
--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -18,15 +18,18 @@ import (
 func TestPluginManager_Init(t *testing.T) {
 	origRootPath := setting.StaticRootPath
 	origRaw := setting.Raw
+	origEnv := setting.Env
 	t.Cleanup(func() {
 		setting.StaticRootPath = origRootPath
 		setting.Raw = origRaw
+		setting.Env = origEnv
 	})
 
 	var err error
 	setting.StaticRootPath, err = filepath.Abs("../../public/")
 	require.NoError(t, err)
 	setting.Raw = ini.Empty()
+	setting.Env = setting.PROD
 
 	t.Run("Base case", func(t *testing.T) {
 		pm := &PluginManager{


### PR DESCRIPTION
This PR changes the signing validation slightly:

1. Allows unsigned plugins when in `app_mode = development`
2. regardless of settings, any invalid plugin signatures should give an error and not load
