### PR TITLE
Plugins: Require backend plugins to be signed when using plugin path

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -174,7 +174,7 @@ func (pm *PluginManager) checkPluginPaths() error {
 			continue
 		}
 
-		if err := pm.scan(path, false); err != nil {
+		if err := pm.scan(path, true); err != nil {
 			return errutil.Wrapf(err, "failed to scan directory configured for plugin '%s': '%s'", pluginID, path)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When you use 
```
[plugin.<plugin id>]
path = /some/path
```

which I usually do in development signing is not required. This PR changes this to require signed.