### PR TITLE
Cherry-pick fix for #16090 to v6.7.x

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -114,7 +114,9 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
+        url: `proxied/api/v1/series?match${encodeURIComponent(
+          '[]'
+        )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
         headers: {},
       });
@@ -137,9 +139,8 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/series?match[]=${encodeURIComponent(
-          'metric{label1="foo", label2="bar", label3="baz"}'
-        )}&start=${raw.from.unix()}&end=${raw.to.unix()}`,
+        url:
+          'proxied/api/v1/series?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C+label2%3D%22bar%22%2C+label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
         silent: true,
         headers: {},
       });
@@ -164,7 +165,9 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/series?match[]=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
+        url: `proxied/api/v1/series?match${encodeURIComponent(
+          '[]'
+        )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,
         headers: {},
       });
@@ -237,7 +240,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledTimes(1);
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/series?match[]=${encodeURIComponent(
+        url: `proxied/api/v1/series?match${encodeURIComponent('[]')}=${encodeURIComponent(
           'up{job="job1"}'
         )}&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         silent: true,

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -70,7 +70,12 @@ export default class PrometheusMetricFindQuery {
     } else {
       const start = this.datasource.getPrometheusTime(this.range.from, false);
       const end = this.datasource.getPrometheusTime(this.range.to, true);
-      url = '/api/v1/series?match[]=' + encodeURIComponent(metric) + '&start=' + start + '&end=' + end;
+      const params = new URLSearchParams({
+        'match[]': metric,
+        start: start.toString(),
+        end: end.toString(),
+      });
+      url = `/api/v1/series?${params.toString()}`;
 
       return this.datasource.metadataRequest(url).then((result: any) => {
         const _labels = _.map(result.data.data, metric => {
@@ -134,7 +139,12 @@ export default class PrometheusMetricFindQuery {
   metricNameAndLabelsQuery(query: string) {
     const start = this.datasource.getPrometheusTime(this.range.from, false);
     const end = this.datasource.getPrometheusTime(this.range.to, true);
-    const url = '/api/v1/series?match[]=' + encodeURIComponent(query) + '&start=' + start + '&end=' + end;
+    const params = new URLSearchParams({
+      'match[]': query,
+      start: start.toString(),
+      end: end.toString(),
+    });
+    const url = `/api/v1/series?${params.toString()}`;
 
     const self = this;
     return this.datasource.metadataRequest(url).then((result: PromDataQueryResponse) => {


### PR DESCRIPTION
Cherry-picking the fix for #16090 (ce8df91 from #21447) into the 6.7.x maintenance branch to help ensure that Grafana plays nice with Prometheus when behind certain proxies that do strict verification of URIs. Applies cleanly.

**Special notes for your reviewer**: Note sure what the usual cycle looks like, but a release for this would be a big help!