### PR TITLE
Dashboard: Variable without a current value in json model causes crash on load

### DIFF
--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -196,7 +196,7 @@ describe('shared actions', () => {
         ${['A', 'B', 'C']} | ${'B'}       | ${'C'}       | ${'B'}
         ${['A', 'B', 'C']} | ${'X'}       | ${undefined} | ${'A'}
         ${['A', 'B', 'C']} | ${'X'}       | ${'C'}       | ${'C'}
-        ${undefined}       | ${'B'}       | ${undefined} | ${'A'}
+        ${undefined}       | ${'B'}       | ${undefined} | ${'should not dispatch setCurrentVariableValue'}
       `('then correct actions are dispatched', async ({ withOptions, withCurrent, defaultValue, expected }) => {
         let custom;
 

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -308,7 +308,9 @@ export const validateVariableSelectionState = (
     // 3. use the first value
     if (variableInState.options) {
       const option = variableInState.options[0];
-      return setValue(variableInState, option);
+      if (option) {
+        return setValue(variableInState, option);
+      }
     }
 
     // 4... give up

--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
+import { default as lodashDefaults } from 'lodash/defaults';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import {
@@ -29,15 +30,20 @@ variableAdapters.setInit(() => [createQueryVariableAdapter()]);
 describe('sharedReducer', () => {
   describe('when addVariable is dispatched', () => {
     it('then state should be correct', () => {
-      const model = ({ name: 'name from model', type: 'type from model' } as unknown) as QueryVariableModel;
+      const model = ({
+        name: 'name from model',
+        type: 'type from model',
+        current: undefined,
+      } as unknown) as QueryVariableModel;
+
       const payload = toVariablePayload({ id: '0', type: 'query' }, { global: true, index: 0, model });
+
       reducerTester<VariablesState>()
         .givenReducer(sharedReducer, { ...initialVariablesState })
         .whenActionIsDispatched(addVariable(payload))
         .thenStateShouldEqual({
           [0]: {
-            ...initialQueryVariableModelState,
-            ...model,
+            ...lodashDefaults({}, model, initialQueryVariableModelState),
             id: '0',
             global: true,
             index: 0,

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -18,9 +18,10 @@ const sharedReducerSlice = createSlice({
     addVariable: (state: VariablesState, action: PayloadAction<VariablePayload<AddVariable>>) => {
       const id = action.payload.id ?? action.payload.data.model.name; // for testing purposes we can call this with an id
       const initialState = cloneDeep(variableAdapters.get(action.payload.type).initialState);
+      const model = cloneDeep(action.payload.data.model);
 
       const variable = {
-        ...lodashDefaults(action.payload.data.model, initialState),
+        ...lodashDefaults({}, model, initialState),
         id: id,
         index: action.payload.data.index,
         global: action.payload.data.global,

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash/cloneDeep';
+import { default as lodashDefaults } from 'lodash/defaults';
 
 import { VariableType } from '@grafana/data';
 import { VariableModel, VariableOption, VariableWithOptions } from '../../templating/types';
@@ -16,13 +17,15 @@ const sharedReducerSlice = createSlice({
   reducers: {
     addVariable: (state: VariablesState, action: PayloadAction<VariablePayload<AddVariable>>) => {
       const id = action.payload.id ?? action.payload.data.model.name; // for testing purposes we can call this with an id
+      const initialState = cloneDeep(variableAdapters.get(action.payload.type).initialState);
+
       const variable = {
-        ...cloneDeep(variableAdapters.get(action.payload.type).initialState),
-        ...action.payload.data.model,
+        ...lodashDefaults(action.payload.data.model, initialState),
         id: id,
         index: action.payload.data.index,
         global: action.payload.data.global,
       };
+
       state[id] = variable;
     },
     addInitLock: (state: VariablesState, action: PayloadAction<VariablePayload>) => {


### PR DESCRIPTION
The way default state (initial state) for a variable was built was not working properly. 

```ts
   const variable = {
        ...cloneDeep(variableAdapters.get(action.payload.type).initialState),
        ...action.payload.data.model,
        id: id,
        index: action.payload.data.index,
        global: action.payload.data.global,
      };
```

Using spread operator here actually overwrites default values with undefined values if the model contains undefined properties (which they can, for example in this case the current property was set to undefined during dashboard migration). https://github.com/grafana/grafana/blob/master/public/app/features/dashboard/state/DashboardMigrator.ts#L505 

I choose to fix it here instead so that it does come back again if some other property happens to be set to undefined. 

Fixes #24241