### PR TITLE
Runtime: expose angular injector

### DIFF
--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -4,3 +4,4 @@ export * from './dataSourceSrv';
 export * from './LocationSrv';
 export * from './EchoSrv';
 export * from './templateSrv';
+export * from './legacyAngularInjector';

--- a/packages/grafana-runtime/src/services/legacyAngularInjector.ts
+++ b/packages/grafana-runtime/src/services/legacyAngularInjector.ts
@@ -1,0 +1,23 @@
+import { auto } from 'angular';
+
+let singleton: auto.IInjectorService;
+
+/**
+ * Used during startup by Grafana to temporarily expose the angular injector to
+ * pure javascript plugins using {@link getLegacyAngularInjector}.
+ *
+ * @internal
+ */
+export const setLegacyAngularInjector = (instance: auto.IInjectorService) => {
+  singleton = instance;
+};
+
+/**
+ * WARNING: this function provides a temporary way for plugins to access anything in the
+ * angular injector.  While the migration from angular to react continues, there are a few
+ * options that do not yet have good alternatives.  Note that use of this function will
+ * be removed in the future.
+ *
+ * @beta
+ */
+export const getLegacyAngularInjector = (): auto.IInjectorService => singleton;

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -6,7 +6,7 @@ import Drop from 'tether-drop';
 
 // Utils and servies
 import { colors } from '@grafana/ui';
-import { getTemplateSrv, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
+import { getTemplateSrv, setBackendSrv, setDataSourceSrv, setLegacyAngularInjector } from '@grafana/runtime';
 import config from 'app/core/config';
 import coreModule from 'app/core/core_module';
 import { profiler } from 'app/core/profiler';
@@ -31,6 +31,7 @@ import { DashboardSrv, setDashboardSrv } from 'app/features/dashboard/services/D
 import { ILocationService, ITimeoutService, IRootScopeService, IAngularEvent } from 'angular';
 import { AppEvent, AppEvents, locationUtil } from '@grafana/data';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { auto } from 'angular';
 
 export type GrafanaRootScope = IRootScopeService & AppEventEmitter & AppEventConsumer & { colors: string[] };
 
@@ -47,7 +48,8 @@ export class GrafanaCtrl {
     datasourceSrv: DatasourceSrv,
     keybindingSrv: KeybindingSrv,
     dashboardSrv: DashboardSrv,
-    angularLoader: AngularLoader
+    angularLoader: AngularLoader,
+    $injector: auto.IInjectorService
   ) {
     // make angular loader service available to react components
     setAngularLoader(angularLoader);
@@ -57,6 +59,7 @@ export class GrafanaCtrl {
     setLinkSrv(linkSrv);
     setKeybindingSrv(keybindingSrv);
     setDashboardSrv(dashboardSrv);
+    setLegacyAngularInjector($injector);
 
     locationUtil.initialize({
       getConfig: () => config,


### PR DESCRIPTION
In our angular migration.... there are still many features that do not yet have a solid react/javascript alternative.  This leads to a few hacks like:
* inject variables into a datasource and then expose them as variables off the datasource
* stick with angular... since many features only exist there.

As a stop-gap, can we just expose the injector?  this would let plugin developers use react, but still have access to some of the more esoteric parts of grafana.  In particular [appEvents](https://github.com/grafana/grafana/pull/23334)

This will give 7.0 plugin developers a way to at least start using react if they require more advanced features
