### PR TITLE
Metrics: expose metrics for the number of configured datasources

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -156,6 +156,9 @@ var (
 	// StatsTotalActiveAdmins is a metric total amount of active admins
 	StatsTotalActiveAdmins prometheus.Gauge
 
+	// StatsTotalDataSources is a metric total number of defined datasources, labeled by pluginId
+	StatsTotalDataSources *prometheus.GaugeVec
+
 	// grafanaBuildVersion is a metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built
 	grafanaBuildVersion *prometheus.GaugeVec
 
@@ -463,6 +466,12 @@ func init() {
 		Namespace: ExporterName,
 	})
 
+	StatsTotalDataSources = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "stat_totals_datasource",
+		Help:      "total number of defined datasources, labeled by pluginId",
+		Namespace: ExporterName,
+	}, []string{"plugin_id"})
+
 	grafanaBuildVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which Grafana was built",
@@ -538,6 +547,7 @@ func initMetricVars() {
 		StatsTotalActiveViewers,
 		StatsTotalActiveEditors,
 		StatsTotalActiveAdmins,
+		StatsTotalDataSources,
 		grafanaBuildVersion,
 		grafanPluginBuildInfoDesc,
 	)

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -209,6 +209,16 @@ func (uss *UsageStatsService) updateTotalStats() {
 	metrics.StatsTotalActiveEditors.Set(float64(statsQuery.Result.ActiveEditors))
 	metrics.StatsTotalAdmins.Set(float64(statsQuery.Result.Admins))
 	metrics.StatsTotalActiveAdmins.Set(float64(statsQuery.Result.ActiveAdmins))
+
+	dsStats := models.GetDataSourceStatsQuery{}
+	if err := uss.Bus.Dispatch(&dsStats); err != nil {
+		metricsLogger.Error("Failed to get datasource stats", "error", err)
+		return
+	}
+
+	for _, dsStat := range dsStats.Result {
+		metrics.StatsTotalDataSources.WithLabelValues(dsStat.Type).Set(float64(dsStat.Count))
+	}
 }
 
 func getEdition() string {


### PR DESCRIPTION
This PR adds a `stat_totals_datasource` metric which exposes a `GaugeVec` with the number of configured data sources of each type.