### PR TITLE
Annotations: adds Loki annotation tags deduplication

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -355,6 +355,7 @@ describe('LokiDatasource', () => {
                   {
                     stream: {
                       label: 'value',
+                      label2: 'value ',
                     },
                     values: [['1549016857498000000', 'hello']],
                   },

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -497,7 +497,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const tags: string[] = [];
       for (const field of frame.fields) {
         if (field.labels) {
-          tags.push.apply(tags, Object.values(field.labels));
+          tags.push.apply(tags, [...new Set(Object.values(field.labels).map((label: string) => label.trim()))]);
         }
       }
       const view = new DataFrameView<{ ts: string; line: string }>(frame);


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds deduplication of loki labels to prevent annotation tags from throwing a duplicate entry error.

**Which issue(s) this PR fixes**:

Fixes #21041 

**Special notes for your reviewer**:

Example dashboard: https://github.com/grafana/loki/blob/master/production/loki-mixin/dashboard-loki-operational.json