### PR TITLE
N/A: Update @iconscout/react-unicons dependency and remove ES module workaround

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,9 @@
-const esModule = '@iconscout/react-unicons';
 
 module.exports = {
   verbose: false,
   transform: {
     '^.+\\.(ts|tsx|js|jsx)$': 'ts-jest',
-    [`(${esModule}).+\\.js$`]: 'babel-jest',
   },
-  transformIgnorePatterns: [`/node_modules/(?!${esModule})`],
   moduleDirectories: ['node_modules', 'public'],
   roots: ['<rootDir>/public/app', '<rootDir>/public/test', '<rootDir>/packages', '<rootDir>/scripts'],
   testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -32,7 +32,7 @@
     "@grafana/e2e-selectors": "7.1.0-pre.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@grafana/tsconfig": "^1.0.0-rc1",
-    "@iconscout/react-unicons": "^1.0.0",
+    "@iconscout/react-unicons": "^1.1.1",
     "@torkelo/react-select": "3.0.8",
     "@types/react-beautiful-dnd": "12.1.2",
     "@types/react-color": "3.0.1",

--- a/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/TimeSyncButton.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`TimeSyncButton should render component 1`] = `
           <div
             className="css-1cvxpvr"
           >
-            <UilLink
+            <bM
               className="icon-brand-gradient css-1q2xpj8-topPadding"
               color="currentColor"
               size={18}
@@ -45,7 +45,7 @@ exports[`TimeSyncButton should render component 1`] = `
                   d="M10,17.55,8.23,19.27a2.47,2.47,0,0,1-3.5-3.5l4.54-4.55a2.46,2.46,0,0,1,3.39-.09l.12.1a1,1,0,0,0,1.4-1.43A2.75,2.75,0,0,0,14,9.59a4.46,4.46,0,0,0-6.09.22L3.31,14.36a4.48,4.48,0,0,0,6.33,6.33L11.37,19A1,1,0,0,0,10,17.55ZM20.69,3.31a4.49,4.49,0,0,0-6.33,0L12.63,5A1,1,0,0,0,14,6.45l1.73-1.72a2.47,2.47,0,0,1,3.5,3.5l-4.54,4.55a2.46,2.46,0,0,1-3.39.09l-.12-.1a1,1,0,0,0-1.4,1.43,2.75,2.75,0,0,0,.23.21,4.47,4.47,0,0,0,6.09-.22l4.55-4.55A4.49,4.49,0,0,0,20.69,3.31Z"
                 />
               </svg>
-            </UilLink>
+            </bM>
           </div>
         </Icon>
       </button>

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -14,7 +14,6 @@ function shouldExclude(filename) {
     'apache-arrow',
     'react-hook-form',
     'rc-trigger',
-    '@iconscout/react-unicons',
   ];
   for (const package of packagesToProcessbyBabel) {
     if (filename.indexOf(`node_modules/${package}`) > 0) {


### PR DESCRIPTION
**What this PR does / why we need it:**
@iconscout/react-unicons v1.1.1 ships with [commonJS]( https://github.com/Iconscout/react-unicons/blob/master/package.json). This PRs updates the dependency and removes ES module workaround. 