### PR TITLE
Chore: Remove git add for lint-staged to resolve warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,12 +53,10 @@
   },
   "lint-staged": {
     "*.{ts,tsx,json,scss}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*pkg/**/*.go": [
-      "gofmt -w -s",
-      "git add"
+      "gofmt -w -s"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
**What this PR does / why we need it**:
Got this warning from precommit (lint-staged): 
```bash
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```

This fix removes that warning.