### PR TITLE
CircleCI: Temporarily ignore failure to publish master Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,8 +622,12 @@ jobs:
             if [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
               /tmp/grabpl publish-docker --jobs 4 --edition << parameters.edition >> --ubuntu=<< parameters.ubuntu >> --dry-run
-            else
+            elif [[ -n $CIRCLE_TAG ]]; then
+              # This is a release
               /tmp/grabpl publish-docker --jobs 4 --edition << parameters.edition >> --ubuntu=<< parameters.ubuntu >>
+            else
+              # TODO: Don't ignore errors, temporary workaround until we fix #22955
+              /tmp/grabpl publish-docker --jobs 4 --edition << parameters.edition >> --ubuntu=<< parameters.ubuntu >> || echo Publishing failed!
             fi
       - run:
           name: CI job failed


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to #22955, master builds will sometimes fail due to failure to publish Docker images. This PR makes it so that we ignore the error, as a band-aid until #22955 is fixed.

