### PR TITLE
Prometheus: Show "Loading metrics..." when switching sources

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -187,6 +187,10 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
       datasource: { languageProvider },
     } = this.props;
 
+    this.setState({
+      syntaxLoaded: false,
+    });
+
     Prism.languages[PRISM_SYNTAX] = languageProvider.syntax;
     this.languageProviderInitializationPromise = makePromiseCancelable(languageProvider.start());
     this.languageProviderInitializationPromise.promise


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to display the correct loading state in the metrics chooser when switching between different prometheus sources.

**Which issue(s) this PR fixes**:
Fixes #24291

