### PR TITLE
N/A: Fix table, when field has undefined or null values

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
   UseSortByState,
 } from 'react-table';
 import { FixedSizeList } from 'react-window';
-import { getColumns, getTextAlign } from './utils';
+import { getColumns, getTextAlign, isNullOrUndefined } from './utils';
 import { useTheme } from '../../themes';
 import { TableColumnResizeActionCallback, TableFilterActionCallback, TableSortByActionCallback } from './types';
 import { getTableStyles, TableStyles } from './styles';
@@ -76,8 +76,12 @@ export const Table: FC<Props> = memo((props: Props) => {
 
     // Check if an array buffer already exists
     const buffer = (data.fields[0].values as any).buffer;
-    if (Array.isArray(buffer) && buffer.length === data.length) {
-      return buffer;
+
+    // Check if buffer is array and filter out all null and undefined values as they would throw an error
+    const filteredBuffer = Array.isArray(buffer) && buffer.filter(value => !isNullOrUndefined(value));
+
+    if (filteredBuffer && filteredBuffer.length === data.length) {
+      return filteredBuffer;
     }
 
     // For arrow tables, the `toArray` implementation is expensive and akward *especially* for timestamps

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -72,6 +72,13 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
   return columns;
 }
 
+export function isNullOrUndefined(value: any) {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  return false;
+}
+
 function getCellComponent(displayMode: TableCellDisplayMode, field: Field) {
   switch (displayMode) {
     case TableCellDisplayMode.ColorText:


### PR DESCRIPTION
**What this PR does / why we need it**:
Table component receives data as a prop. One of the thing we do - we [process](https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/Table/Table.tsx#L72-L85) this data to variable **memoizedData** -> React table data array that acts like a dummy array to let react-table know how many rows exist. 

However, if `data.fields[0].values` -  first field's array of values - contains undefined/null value(s), it is going to throw an error inside of react-table `TypeError: Cannot read property 'subRows' of null`. This happens also in the case of linked issue (see gifs and issue below).

Therefore, to fix this issue, we need to filter out undefined and null values and check, if the length of the filtered buffer is the same as data.length. If yes, memoizedData = buffer (the same as filteredBuffer). If not, proceed as when buffer.length !== data.length.

On current master:
![Kapture 2020-05-05 at 16 37 29](https://user-images.githubusercontent.com/30407135/81078627-c4014680-8eee-11ea-9bc0-7e1a55697c65.gif)

Fixed:
![Kapture 2020-05-05 at 16 36 28](https://user-images.githubusercontent.com/30407135/81078607-bd72cf00-8eee-11ea-806e-31f2efcbeb18.gif)

**Which issue(s) this PR fixes**:

Fixes #24077

**What should reviewer know**:

How to trigger error:
1. Choose gdev-elasticsearch-v5-metrics as data source
2. From Logs-Metrics buttons choose Logs
3. Run query
4. Switch to Metrics - error is thrown
