### PR TITLE
Field/Overrides: Allow title override for 'time' fields

### DIFF
--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -45,7 +45,7 @@ export const getStandardFieldConfigs = () => {
       placeholder: 'none',
       expandTemplateVars: true,
     },
-    shouldApply: field => field.type !== FieldType.time,
+    shouldApply: () => true,
     category,
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows fields with type 'time' to have their titles overridden.

**Which issue(s) this PR fixes**:
Closes #24245