### PR TITLE
Dashboard: Fix for folder picker menu not being visible outside modal when saving dashboard

### DIFF
--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -88,7 +88,7 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       position: relative;
       flex-grow: 1;
       /* we want input to be above addons, especially for focused state */
-      z-index: 0;
+      z-index: 1;
 
       /* when input rendered with addon before only*/
       &:not(:first-child):last-child {

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -88,7 +88,7 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
       position: relative;
       flex-grow: 1;
       /* we want input to be above addons, especially for focused state */
-      z-index: 1;
+      z-index: 0;
 
       /* when input rendered with addon before only*/
       &:not(:first-child):last-child {

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -312,6 +312,11 @@ export function SelectBase<T>({
         }}
         styles={{
           ...resetSelectStyles(),
+          menuPortal: ({ position, width }: any) => ({
+            position,
+            width,
+            zIndex: theme.zIndex.dropdown,
+          }),
           //These are required for the menu positioning to function
           menu: ({ top, bottom, position }: any) => ({
             top,

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -312,9 +312,6 @@ export function SelectBase<T>({
         }}
         styles={{
           ...resetSelectStyles(),
-          menuPortal: () => ({
-            zIndex: theme.zIndex.dropdown,
-          }),
           //These are required for the menu positioning to function
           menu: ({ top, bottom, position }: any) => ({
             top,


### PR DESCRIPTION
Fixes #24228

Tested with
- Dashboard import
- Save as modal

Please test this in places where this has been a known problem before.

![Screenshot from 2020-05-05 17-29-41](https://user-images.githubusercontent.com/1438972/81084767-9c15e100-8ef6-11ea-9ff2-3146dc7b158f.png)
![Screenshot from 2020-05-05 17-29-54](https://user-images.githubusercontent.com/1438972/81084770-9d470e00-8ef6-11ea-9d6f-abbfd29b3c90.png)
