### PR TITLE
Devenv: Fix trace id pattern for Loki

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -249,11 +249,11 @@ datasources:
     jsonData:
       derivedFields:
         - name: "traceID"
-          matcherRegex: "trace_id=(\\w+)"
+          matcherRegex: "traceID=(\\w+)"
           url: "$${__value.raw}"
           datasourceUid: gdev-jaeger
         - name: "traceID"
-          matcherRegex: "trace_id=(\\w+)"
+          matcherRegex: "traceID=(\\w+)"
           url: "$${__value.raw}"
           datasourceUid: gdev-zipkin
 


### PR DESCRIPTION
Seems like the field name with trace id changed in grafana and so the ones before did not match it anymore.

Other issue is that right now only the zipkin link will show, that needs to be fixed in separate PR.