### PR TITLE
Logs: Clicking "Load more" from context overlay doesn't expand log row

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -102,6 +102,11 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
   const theme = useContext(ThemeContext);
   const { header } = getLogRowContextStyles(theme);
 
+  const onClickLoadMore = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+    onLoadMoreContext();
+  };
+
   return (
     <div className={header}>
       <span
@@ -120,7 +125,7 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
               cursor: pointer;
             }
           `}
-          onClick={() => onLoadMoreContext()}
+          onClick={onClickLoadMore}
         >
           Load 10 more
         </span>


### PR DESCRIPTION
**What this PR does / why we need it**:
 Clicking "Load more" from the log context overlay doesn't expand the log row itself anymore.

**Which issue(s) this PR fixes**:
Closes #24184

