### PR TITLE
Dashboard import: enable creating new folders in import

### DIFF
--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -63,7 +63,14 @@ export const ImportDashboardForm: FC<Props> = ({
         />
       </Field>
       <Field label="Folder">
-        <InputControl as={FolderPicker} name="folder" useNewForms initialFolderId={initialFolderId} control={control} />
+        <InputControl
+          as={FolderPicker}
+          name="folder"
+          useNewForms
+          enableCreateNew
+          initialFolderId={initialFolderId}
+          control={control}
+        />
       </Field>
       <Field
         label="Unique identifier (uid)"


### PR DESCRIPTION
Fixes #24316 

Adds missing `enableCreateNew` property to the FolderPicker component.