### PR TITLE
Toolkit : Fix Windows 10 error when pwd is undefined

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -10,7 +10,7 @@ const isLinkedMode = () => {
   // rather than the present working directory.
   const pwd = process.env.CIRCLE_WORKING_DIRECTORY || process.env.PWD;
 
-  if (path.basename(pwd) === 'grafana-toolkit') {
+  if (pwd!== undefined && path.basename(pwd) === 'grafana-toolkit') {
     return true;
   }
 


### PR DESCRIPTION
In complement to PR #23582, otherwise there's still an error generated by [`path.basename(pwd)`](https://github.com/AgnesToulet/grafana/blob/master/packages/grafana-toolkit/bin/grafana-toolkit.js#L13) :

```shell
internal/validators.js:117
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```