### PR TITLE
CloudWatch/Logs: Add data links to CloudWatch logs for deep linking to AWS

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/aws_url.ts
+++ b/public/app/plugins/datasource/cloudwatch/aws_url.ts
@@ -12,7 +12,7 @@ export interface AwsUrl {
 }
 
 export function encodeUrl(obj: AwsUrl, region: string): string {
-  return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:logs-insights$3FqueryDetail$3D${JSURL.stringify(
+  return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logs-insights:queryDetail=${JSURL.stringify(
     obj
   )}`;
 }

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -120,7 +120,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
             }))
           )
         ),
-        map(response => this.addDataLinksToResponse(response, options))
+        map(response => this.addDataLinksToLogsResponse(response, options))
       );
     }
 
@@ -226,7 +226,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
     );
   }
 
-  private addDataLinksToResponse(response: DataQueryResponse, options: DataQueryRequest<CloudWatchQuery>) {
+  private addDataLinksToLogsResponse(response: DataQueryResponse, options: DataQueryRequest<CloudWatchQuery>) {
     for (const dataFrame of response.data as DataFrame[]) {
       const range = this.timeSrv.timeRange();
       const start = range.from.toISOString();
@@ -245,7 +245,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
       const encodedUrl = encodeUrl(
         urlProps,
-        this.replace(this.getActualRegion(curTarget.region), options.scopedVars, true, 'region')
+        this.getActualRegion(this.replace(curTarget.region, options.scopedVars, true, 'region'))
       );
 
       for (const field of dataFrame.fields) {
@@ -267,7 +267,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
       this.makeLogActionRequest(
         'StopQuery',
         [...this.logQueries.values()].map(logQuery => ({ queryId: logQuery.id, region: logQuery.region })),
-        null,
+        undefined,
         false
       ).pipe(finalize(() => this.logQueries.clear()));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds data links to CloudWatch logs responses for deep linking to AWS CloudWatch logs insights from dashboard panels.
