### PR TITLE
Field options: show field name when title option config is empty

### DIFF
--- a/packages/grafana-ui/src/components/OptionsUI/string.tsx
+++ b/packages/grafana-ui/src/components/OptionsUI/string.tsx
@@ -14,7 +14,9 @@ export const StringValueEditor: React.FC<FieldConfigEditorProps<string, StringFi
       placeholder={item.settings?.placeholder}
       value={value || ''}
       rows={item.settings?.useTextarea && item.settings.rows}
-      onChange={(e: React.FormEvent<any>) => onChange(e.currentTarget.value)}
+      onChange={(e: React.FormEvent<any>) =>
+        onChange(e.currentTarget.value.trim() === '' ? undefined : e.currentTarget.value)
+      }
     />
   );
 };


### PR DESCRIPTION
Fixes #24022 
Closes https://github.com/grafana/grafana/pull/24083