### PR TITLE
Reporting: Document layouts

### DIFF
--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -79,9 +79,9 @@ Reports which are scheduled to never be sent have no parameter and will not be s
 
 ### Layout
 
-> The layout renderers are early versions undergoing heavy development. Customizations and variable sized panel layouts are on the roadmap. [Reach out to us](https://grafana.com/contact?about=grafana-enterprise) if you are interested in the future of reporting.
+> We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise) if you would like to get involved in the design process.
 
-Name | Since version | Description | Preview
+Name | Introduced | Description | Preview
 ---- | ------------- | ----------- | -------
 Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
 Landscape | 6.7 | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -82,7 +82,7 @@ Reports which are scheduled to never be sent have no parameter and will not be s
 > We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise) if you would like to get involved in the design process.
 
 Name | Introduced | Description | Preview
----- | ------------- | ----------- | -------
+---- | ---------- | ----------- | -------
 Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
 Landscape | 6.7 | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
 

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -77,6 +77,15 @@ Weekly reports are generated once per week. All fields are required.
 
 Reports which are scheduled to never be sent have no parameter and will not be sent to the scheduler. They may be manually generated from the **Send test email** prompt or via the API.
 
+### Layout
+
+> The layout renderers are early versions undergoing heavy development. Customizations and variable sized panel layouts are on the roadmap. [Reach out to us](https://grafana.com/contact?about=grafana-enterprise) if you are interested in  the future of reporting.
+
+Name | Description | Preview
+---- | ----------- | -------
+Portrait | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
+Landscape | (Available from 6.7+) Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
+
 ### Send test mail
 
 > Only available in Grafana Enterprise v7.0+.

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -79,7 +79,7 @@ Reports which are scheduled to never be sent have no parameter and will not be s
 
 ### Layout
 
-> The layout renderers are early versions undergoing heavy development. Customizations and variable sized panel layouts are on the roadmap. [Reach out to us](https://grafana.com/contact?about=grafana-enterprise) if you are interested in  the future of reporting.
+> The layout renderers are early versions undergoing heavy development. Customizations and variable sized panel layouts are on the roadmap. [Reach out to us](https://grafana.com/contact?about=grafana-enterprise) if you are interested in the future of reporting.
 
 Name | Description | Preview
 ---- | ----------- | -------

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -81,10 +81,10 @@ Reports which are scheduled to never be sent have no parameter and will not be s
 
 > The layout renderers are early versions undergoing heavy development. Customizations and variable sized panel layouts are on the roadmap. [Reach out to us](https://grafana.com/contact?about=grafana-enterprise) if you are interested in the future of reporting.
 
-Name | Description | Preview
----- | ----------- | -------
-Portrait | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
-Landscape | (Available from 6.7+) Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
+Name | Since version | Description | Preview
+---- | ------------- | ----------- | -------
+Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
+Landscape | 6.7 | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
 
 ### Send test mail
 

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -83,7 +83,7 @@ Reports which are scheduled to never be sent have no parameter and will not be s
 
 Name | Introduced | Description | Preview
 ---- | ---------- | ----------- | -------
-Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels rendered per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
+Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
 Landscape | 6.7 | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
 
 ### Send test mail

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -45,7 +45,7 @@ Currently only Organization Admins can create reports.
 
 ### Layout
 
-> We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise&topic=the+reporting+layout+options+design+process) if you would like to get involved in the design process.
+> We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise&topic=design-process&value=reporting) if you would like to get involved in the design process.
 
 Name | Support | Description | Preview
 ---- | ------- | ----------- | -------

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -43,6 +43,15 @@ Currently only Organization Admins can create reports.
 
 {{< docs-imagebox img="/img/docs/enterprise/reports_create_new.png" max-width="500px" class="docs-image--no-shadow" >}}
 
+### Layout
+
+> We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise&topic=the+reporting+layout+options+design+process) if you would like to get involved in the design process.
+
+Name | Support | Description | Preview
+---- | ------- | ----------- | -------
+Portrait | v6.4+ | Portrait generates an A4 page in portrait mode with three panels per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
+Landscape | v6.7+ | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
+
 ### Scheduling
 
 Scheduled reports can be sent on a weekly, daily, or hourly basis. You may also disable scheduling for when you either want to pause a report or send it via the API.
@@ -76,15 +85,6 @@ Weekly reports are generated once per week. All fields are required.
 > Only available in Grafana Enterprise v7.0+.
 
 Reports which are scheduled to never be sent have no parameter and will not be sent to the scheduler. They may be manually generated from the **Send test email** prompt or via the API.
-
-### Layout
-
-> We're actively working on developing new report layout options. [Contact us](https://grafana.com/contact?about=grafana-enterprise) if you would like to get involved in the design process.
-
-Name | Introduced | Description | Preview
----- | ---------- | ----------- | -------
-Portrait | 6.4 | Portrait generates an A4 page in portrait mode with three panels per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_portrait_preview.png" max-width="500px" max-height="500px" class="docs-image--no-shadow" >}}
-Landscape | 6.7 | Landscape generates an A4 page in landscape mode with a single panel per page. | {{< docs-imagebox img="/img/docs/enterprise/reports_landscape_preview.png" max-width="500px" class="docs-image--no-shadow" >}}
 
 ### Send test mail
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We should provide sample pictures of what to export from a rendered report, this PR adds that to the reporting documentation (pictures are already in the website repo).
