### PR TITLE
PanelEdit: Fixed re-using query result after leaving panel edit

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -58,10 +58,7 @@ export function panelEditorCleanUp(): ThunkResult<void> {
       // Resend last query result on source panel query runner
       // But do this after the panel edit editor exit process has completed
       setTimeout(() => {
-        const lastResult = panel.getQueryRunner().getLastResult();
-        if (lastResult) {
-          sourcePanel.getQueryRunner().pipeDataToSubject(lastResult);
-        }
+        sourcePanel.getQueryRunner().useLastResultFrom(panel.getQueryRunner());
       }, 20);
     }
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -235,10 +235,6 @@ export class PanelChrome extends PureComponent<Props, State> {
     return panel.snapshotData && panel.snapshotData.length;
   }
 
-  panelHasLastResult = () => {
-    return !!this.props.panel.getQueryRunner().getLastResult();
-  };
-
   get wantsQueryExecution() {
     return !(this.props.plugin.meta.skipDataQuery || this.hasPanelSnapshot);
   }

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -6,8 +6,10 @@ import {
   PanelProps,
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
+  PanelData,
 } from '@grafana/data';
 import { ComponentClass } from 'react';
+import { PanelQueryRunner } from './PanelQueryRunner';
 
 class TablePanelCtrl {}
 
@@ -334,6 +336,17 @@ describe('PanelModel', () => {
 
         expect(model.axes).toBeUndefined();
         expect(model.thresholds).toBeUndefined();
+      });
+    });
+
+    describe('destroy', () => {
+      it('Should still preserve last query result', () => {
+        model.getQueryRunner().useLastResultFrom({
+          getLastResult: () => ({} as PanelData),
+        } as PanelQueryRunner);
+
+        model.destroy();
+        expect(model.getQueryRunner().getLastResult()).toBeDefined();
       });
     });
   });

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -422,11 +422,8 @@ export class PanelModel implements DataConfigSource {
     clone.isEditing = true;
     const sourceQueryRunner = this.getQueryRunner();
 
-    // pipe last result to new clone query runner
-    const lastResult = sourceQueryRunner.getLastResult();
-    if (lastResult) {
-      clone.getQueryRunner().pipeDataToSubject(lastResult);
-    }
+    // Copy last query result
+    clone.getQueryRunner().useLastResultFrom(sourceQueryRunner);
 
     return clone;
   }
@@ -469,7 +466,6 @@ export class PanelModel implements DataConfigSource {
 
     if (this.queryRunner) {
       this.queryRunner.destroy();
-      this.queryRunner = null;
     }
   }
 

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -190,11 +190,6 @@ export class PanelQueryRunner {
     });
   }
 
-  pipeDataToSubject = (data: PanelData) => {
-    this.subject.next(data);
-    this.lastResult = data;
-  };
-
   resendLastResult = () => {
     if (this.lastResult) {
       this.subject.next(this.lastResult);
@@ -212,6 +207,15 @@ export class PanelQueryRunner {
 
     if (this.subscription) {
       this.subscription.unsubscribe();
+    }
+  }
+
+  useLastResultFrom(runner: PanelQueryRunner) {
+    this.lastResult = runner.getLastResult();
+
+    if (this.lastResult) {
+      // The subject is a replay subject so anyone subscribing will get this last result
+      this.subject.next(this.lastResult);
     }
   }
 


### PR DESCRIPTION
There was a timing issue with leaving panel edit, destroying the PanelModel & nulling out the PanelQueryRunner. So when the PanelEditor cleanup redux thunk that copies the edit panel query runner last result to the source panel it was gone (because this happens in a timeout to make sure the edit mode is fully exited).

We have a remaining problem of leaving edit mode when the query is still loading, we just copy the loading state to the source panel, so it just keeps spinning :) But leaving that for another RP 