### PR TITLE
OverrideEditor: Use field config default value when adding a new override 

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OverrideEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OverrideEditor.tsx
@@ -82,14 +82,18 @@ export const OverrideEditor: React.FC<OverrideEditorProps> = ({
 
   const onDynamicConfigValueAdd = useCallback(
     (id: string) => {
+      const registryItem = registry.get(id);
       const propertyConfig: DynamicConfigValue = {
         id,
+        value: registryItem.defaultValue,
       };
+
       if (override.properties) {
         override.properties.push(propertyConfig);
       } else {
         override.properties = [propertyConfig];
       }
+
       onChange(override);
     },
     [override, onChange]


### PR DESCRIPTION
Currently the bar gauge was crashing when adding thresholds override as adding an override always adds it with undefined value, and this actually removes the default value. 

Fixed it in the editor when we add the override, it looks up the item and adds it with the default value. 

But wonder if this line is correct: 
https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/field/fieldOverrides.ts#L231

Should a null / undefined override value remove the value from the the default? not 100% sure