### PR TITLE
Loki: Fix query stats display in Explore

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -300,7 +300,7 @@ export function lokiStreamsToDataframes(
   const stats: QueryResultMetaStat[] = lokiStatsToMetaStat(response.data.stats);
   // Use custom mechanism to identify which stat we want to promote to label
   const custom = {
-    lokiQueryStatKey: 'Summary: totalBytesProcessed',
+    lokiQueryStatKey: 'Summary: total bytes processed',
   };
   const series: DataFrame[] = data.map(stream => {
     const dataFrame = lokiStreamResultToDataFrame(stream, reverse);


### PR DESCRIPTION
- the stats label changed in the original PR, so the custom key did no
longer work, this change fixes it and the total bytes processed show up
in the explore logs meta data

Fix on top of #24190