### PR TITLE
Fix dense y-axis labels in heatmap using tsbuckets

### DIFF
--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -340,6 +340,8 @@ export class HeatmapRenderer {
 
   addYAxisFromBuckets() {
     const tsBuckets = this.data.tsBuckets;
+    let ticks = Math.ceil(this.chartHeight / DEFAULT_Y_TICK_SIZE_PX);
+    let skip = Math.max(Math.floor(tsBuckets.length / ticks), 1);
 
     this.scope.yScale = this.yScale = d3
       .scaleLinear()
@@ -352,22 +354,28 @@ export class HeatmapRenderer {
     this.ctrl.decimals = decimals;
 
     const tickValueFormatter = this.tickValueFormatter.bind(this);
-    function tickFormatter(valIndex: string) {
+    function tickFormatter(valIndex: string, sparse: boolean) {
       let valueFormatted = tsBuckets[valIndex];
+      if (sparse && parseInt(valIndex, 10) % skip !== 0) {
+        valueFormatted = '';
+      }
       if (!_.isNaN(_.toNumber(valueFormatted)) && valueFormatted !== '') {
         // Try to format numeric tick labels
         valueFormatted = tickValueFormatter(decimals)(_.toNumber(valueFormatted));
       }
       return valueFormatted;
     }
+    function sparseTickFormatter(valIndex: string) {
+      return tickFormatter(valIndex, true);
+    }
 
-    const tsBucketsFormatted = _.map(tsBuckets, (v, i) => tickFormatter(i));
+    const tsBucketsFormatted = _.map(tsBuckets, (v, i) => tickFormatter(i, false));
     this.data.tsBucketsFormatted = tsBucketsFormatted;
 
     const yAxis = d3
       .axisLeft(this.yScale)
       .tickValues(tickValues)
-      .tickFormat(tickFormatter)
+      .tickFormat(sparseTickFormatter)
       .tickSizeInner(0 - this.width)
       .tickSizeOuter(0)
       .tickPadding(Y_AXIS_TICK_PADDING);

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -371,10 +371,7 @@ export class HeatmapRenderer {
       .tickSizeInner(0 - this.width)
       .tickSizeOuter(0)
       .tickPadding(Y_AXIS_TICK_PADDING);
-    if (
-      (tickValues && tickValues.length <= ticks) ||
-      (this.panel.yBucketBound === 'middle' && tickValues && tickValues.length)
-    ) {
+    if (tickValues && tickValues.length <= ticks) {
       yAxis.tickValues(tickValues);
     } else {
       yAxis.ticks(ticks);


### PR DESCRIPTION
This change emulates the non-tsbuckets Y-axis tick count by making
the y-axis label formatter treat a dense set as a sparse set.

fixes #11342

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

