### PR TITLE
Alerts: set zindex above the panel inspector

### DIFF
--- a/packages/grafana-ui/src/components/Alert/_Alert.scss
+++ b/packages/grafana-ui/src/components/Alert/_Alert.scss
@@ -40,7 +40,7 @@
 }
 
 .alert-container {
-  z-index: 8000;
+  z-index: $zindex-tooltip;
 }
 
 .page-alert-list {

--- a/packages/grafana-ui/src/components/Alert/_Alert.scss
+++ b/packages/grafana-ui/src/components/Alert/_Alert.scss
@@ -39,6 +39,10 @@
   background: $alert-warning-bg;
 }
 
+.alert-container {
+  z-index: 8000;
+}
+
 .page-alert-list {
   z-index: 8000;
   min-width: 400px;

--- a/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
@@ -104,7 +104,6 @@ export class InspectJSONTab extends PureComponent<Props, State> {
 
   onClipboardCopied = () => {
     appEvents.emit(AppEvents.alertSuccess, ['Content copied to clipboard']);
-    alert('TODO... the notice is behind the inspector!');
   };
 
   onApplyPanelModel = () => {


### PR DESCRIPTION
The "copy to clipboard" button opens an alert that shows up under the panel inspector.

I'm not sure if the angular styles: `page-alert-list` is still used, since that had the proper zindex