### PR TITLE
@grafana/ui: avoid imports to @grafana/data/src/...

### DIFF
--- a/packages/grafana-data/src/transformations/index.ts
+++ b/packages/grafana-data/src/transformations/index.ts
@@ -7,7 +7,11 @@ export { FilterFieldsByNameTransformerOptions } from './transformers/filterByNam
 export { FilterFramesByRefIdTransformerOptions } from './transformers/filterByRefId';
 export { SeriesToColumnsOptions } from './transformers/seriesToColumns';
 export { ReduceTransformerOptions } from './transformers/reduce';
-export { CalculateFieldTransformerOptions } from './transformers/calculateField';
+export {
+  CalculateFieldTransformerOptions,
+  CalculateFieldMode,
+  getResultFieldNameForCalculateFieldTransformerOptions,
+} from './transformers/calculateField';
 export { OrganizeFieldsTransformerOptions } from './transformers/organize';
 export { createOrderFieldsComparer } from './transformers/order';
 export { transformDataFrame } from './transformDataFrame';

--- a/packages/grafana-data/src/transformations/index.ts
+++ b/packages/grafana-data/src/transformations/index.ts
@@ -7,6 +7,7 @@ export { FilterFieldsByNameTransformerOptions } from './transformers/filterByNam
 export { FilterFramesByRefIdTransformerOptions } from './transformers/filterByRefId';
 export { SeriesToColumnsOptions } from './transformers/seriesToColumns';
 export { ReduceTransformerOptions } from './transformers/reduce';
+export { LabelsToFieldsOptions } from './transformers/labelsToFields';
 export {
   CalculateFieldTransformerOptions,
   CalculateFieldMode,

--- a/packages/grafana-ui/src/components/TransformersUI/CalculateFieldTransformerEditor.tsx
+++ b/packages/grafana-ui/src/components/TransformersUI/CalculateFieldTransformerEditor.tsx
@@ -12,16 +12,14 @@ import {
   BinaryOperationID,
   SelectableValue,
   binaryOperators,
+  CalculateFieldMode,
+  getResultFieldNameForCalculateFieldTransformerOptions,
 } from '@grafana/data';
 import { StatsPicker } from '../StatsPicker/StatsPicker';
 import { Switch } from '../Forms/Legacy/Switch/Switch';
 import { Input } from '../Input/Input';
 import { FilterPill } from '../FilterPill/FilterPill';
 import { HorizontalGroup } from '../Layout/Layout';
-import {
-  CalculateFieldMode,
-  getResultFieldNameForCalculateFieldTransformerOptions,
-} from '@grafana/data/src/transformations/transformers/calculateField';
 import { Select } from '../Select/Select';
 import defaults from 'lodash/defaults';
 

--- a/packages/grafana-ui/src/components/TransformersUI/LabelsToFieldsTransformerEditor.tsx
+++ b/packages/grafana-ui/src/components/TransformersUI/LabelsToFieldsTransformerEditor.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
-import { LabelsToFieldsOptions } from '@grafana/data/src/transformations/transformers/labelsToFields';
+import {
+  DataTransformerID,
+  standardTransformers,
+  TransformerRegistyItem,
+  TransformerUIProps,
+  LabelsToFieldsOptions,
+} from '@grafana/data';
 
 export const LabelsAsFieldsTransformerEditor: React.FC<TransformerUIProps<LabelsToFieldsOptions>> = ({
   input,


### PR DESCRIPTION
A few things have been added recently that reference:
```
} from '@grafana/data/src/transfor...
```

This makes plugins fail with messages like:

![image](https://user-images.githubusercontent.com/705951/81221729-0e8acd80-8f98-11ea-9343-50caebe4e499.png)
