### PR TITLE
CloudWatch/Logs: Add error message when log groups are not selected

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -1,24 +1,39 @@
 import { CloudWatchDatasource } from './datasource';
 import { TemplateSrv } from '../../../features/templating/template_srv';
 import { setBackendSrv } from '@grafana/runtime';
-import { DefaultTimeRange } from '@grafana/data';
+import { DataQueryResponse, DefaultTimeRange } from '@grafana/data';
 
 describe('datasource', () => {
+  describe('query', () => {
+    it('should return error if log query and log groups is not specified', async () => {
+      const { datasource } = setup();
+      const response: DataQueryResponse = (await datasource.query({
+        targets: [
+          {
+            queryMode: 'Logs' as 'Logs',
+          },
+        ],
+      } as any)) as any;
+      expect(response.error.message).toBe('Log group is required');
+    });
+
+    it('should return empty response if queries are hidden', async () => {
+      const { datasource } = setup();
+      const response: DataQueryResponse = (await datasource.query({
+        targets: [
+          {
+            queryMode: 'Logs' as 'Logs',
+            hide: true,
+          },
+        ],
+      } as any)) as any;
+      expect(response.data).toEqual([]);
+    });
+  });
+
   describe('describeLogGroup', () => {
     it('replaces region correctly in the query', async () => {
-      const datasource = new CloudWatchDatasource(
-        { jsonData: { defaultRegion: 'us-west-1' } } as any,
-        new TemplateSrv(),
-        {
-          timeRange() {
-            return DefaultTimeRange;
-          },
-        } as any
-      );
-      const datasourceRequestMock = jest.fn();
-      datasourceRequestMock.mockResolvedValue({ data: [] });
-      setBackendSrv({ datasourceRequest: datasourceRequestMock } as any);
-
+      const { datasource, datasourceRequestMock } = setup();
       await datasource.describeLogGroups({ region: 'default' });
       expect(datasourceRequestMock.mock.calls[0][0].data.queries[0].region).toBe('us-west-1');
 
@@ -27,3 +42,16 @@ describe('datasource', () => {
     });
   });
 });
+
+function setup() {
+  const datasource = new CloudWatchDatasource({ jsonData: { defaultRegion: 'us-west-1' } } as any, new TemplateSrv(), {
+    timeRange() {
+      return DefaultTimeRange;
+    },
+  } as any);
+  const datasourceRequestMock = jest.fn();
+  datasourceRequestMock.mockResolvedValue({ data: [] });
+  setBackendSrv({ datasourceRequest: datasourceRequestMock } as any);
+
+  return { datasource, datasourceRequestMock };
+}

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -181,7 +181,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
       );
 
     // No valid targets, return the empty result to save a round trip.
-    if (_.isEmpty(queries)) {
+    if (_.isEmpty(metricQueries)) {
       return Promise.resolve({ data: [] });
     }
 

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -297,7 +297,7 @@ export interface MetricRequest {
   debug?: boolean;
 }
 
-interface MetricQuery {
+export interface MetricQuery {
   [key: string]: any;
   datasourceId: number;
   refId?: string;


### PR DESCRIPTION
As we do not have a good mechanism to prevent running a query, this checks query validity in datasource and returns meaningful error if the issue is missing log groups.

![Screenshot from 2020-05-06 23-32-32](https://user-images.githubusercontent.com/1014802/81233668-69074680-8ff7-11ea-8f01-aeb8456e5e8b.png)
