### PR TITLE
CloudWatch: Fix error with expression only query

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
@@ -70,6 +70,37 @@ describe('QueryEditor', () => {
     });
   });
 
+  it('normalizes query on mount', async () => {
+    const { act } = renderer;
+    const props = setup();
+    // This does not actually even conform to the prop type but this happens on initialisation somehow
+    props.query = {
+      queryMode: 'Metrics',
+      apiMode: 'Metrics',
+      refId: '',
+      expression: '',
+      matchExact: true,
+    } as any;
+    await act(async () => {
+      renderer.create(<MetricsQueryEditor {...props} />);
+    });
+    expect((props.onChange as jest.Mock).mock.calls[0][0]).toEqual({
+      namespace: '',
+      metricName: '',
+      expression: '',
+      dimensions: {},
+      region: 'default',
+      id: '',
+      alias: '',
+      statistics: ['Average'],
+      period: '',
+      queryMode: 'Metrics',
+      apiMode: 'Metrics',
+      refId: '',
+      matchExact: true,
+    });
+  });
+
   describe('should use correct default values', () => {
     it('when region is null is display default in the label', async () => {
       // @ts-ignore strict null error TS2345: Argument of type '() => Promise<void>' is not assignable to parameter of type '() => void | undefined'.

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -53,6 +53,12 @@ export const normalizeQuery = ({
 export class MetricsQueryEditor extends PureComponent<Props, State> {
   state: State = { showMeta: false };
 
+  componentDidMount(): void {
+    const metricsQuery = this.props.query as CloudWatchMetricsQuery;
+    const query = normalizeQuery(metricsQuery);
+    this.props.onChange(query);
+  }
+
   onChange(query: CloudWatchMetricsQuery) {
     const { onChange, onRunQuery } = this.props;
     onChange(query);


### PR DESCRIPTION
There was some unfortunate [initialisation code](https://github.com/grafana/grafana/pull/21163/files#diff-3d15a6bca92bf6d3cab962e101acb86eL26) that normalized the query which was partly removed in https://github.com/grafana/grafana/pull/21163. This created problem when running the query as some properties were undefined and it failed inside data source query function.

The way this happens is:
- go to explore -> cloud watch metrics datasource
![Screenshot from 2020-05-07 11-32-43](https://user-images.githubusercontent.com/1014802/81278900-9f27e300-9056-11ea-844f-465ef5bd0abf.png)

- fill anything into the expression
- run
- if expression is filled other inputs are hidden, if not initialized properly to some empty values there would be an error in the console.