### PR TITLE
Chore: fixes PermissionListItem strict-null-error

### DIFF
--- a/public/app/core/components/PermissionList/PermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/PermissionListItem.tsx
@@ -42,7 +42,7 @@ interface Props {
 
 export default class PermissionsListItem extends PureComponent<Props> {
   onPermissionChanged = (option: SelectableValue<PermissionLevel>) => {
-    this.props.onPermissionChanged(this.props.item, option!.value);
+    this.props.onPermissionChanged(this.props.item, option.value!);
   };
 
   onRemoveItem = () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in PermissionListItem causing tests to fail.