### PR TITLE
Datasource/CloudWatch: Switch to metrics mode, logs API, when choosing stats query from cheatsheet

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -340,6 +340,7 @@ export interface ExploreStartPageProps {
   datasource?: DataSourceApi;
   exploreMode: ExploreMode;
   onClickExample: (query: DataQuery) => void;
+  exploreId?: any;
 }
 
 /**

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -342,6 +342,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                             onClickExample={this.onClickExample}
                             datasource={datasourceInstance}
                             exploreMode={mode}
+                            exploreId={exploreId}
                           />
                         </div>
                       )}

--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -270,8 +270,21 @@ export default class LogsCheatSheet extends PureComponent<ExploreStartPageProps,
   }
 
   render() {
-    const { exploreMode } = this.props;
-
-    return exploreMode === ExploreMode.Logs && this.renderLogsCheatSheet();
+    return (
+      <div>
+        <h2>CloudWatch Logs Cheat Sheet</h2>
+        {CLIQ_EXAMPLES.map(cat => (
+          <div>
+            <div className={`cheat-sheet-item__title ${cx(exampleCategory)}`}>{cat.category}</div>
+            {cat.examples.map((item, i) => (
+              <div className="cheat-sheet-item" key={`item-${i}`}>
+                <h4>{item.title}</h4>
+                {this.renderExpression(item.expr, `item-${i}`)}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user chooses a `stats` query from the list of example queries in the CloudWatch Logs cheatsheet, the mode is switched to Metrics mode, with the `Logs API` selected.  (See https://github.com/grafana/grafana/issues/24333)
