### PR TITLE
Elasticsearch: Fix building of raw document queries resulting in error Unknown BaseAggregationBuilder error 

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -205,14 +205,20 @@ export class ElasticQueryBuilder {
 
     this.addAdhocFilters(query, adhocFilters);
 
-    // handle document query
+    // Handle document query:
+    // 1. If target doesn't have bucketAggs and type is not raw_document, it is invalid query.
     if (target.bucketAggs.length === 0) {
       metric = target.metrics[0];
       if (!metric || metric.type !== 'raw_document') {
         throw { message: 'Invalid query' };
       }
+    }
 
-      const size = (metric.settings && metric.settings.size) || 500;
+    // 2. Check if metric type is raw_document. If metric doesn't have size (or size is 0), update size to 500.
+    // Otherwise it will not be a valid query and error will be thrown.
+    if (target.metrics[0].type === 'raw_document') {
+      metric = target.metrics[0];
+      const size = (metric.settings && metric.settings.size !== 0 && metric.settings.size) || 500;
       return this.documentQuery(query, size);
     }
 

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -205,8 +205,7 @@ export class ElasticQueryBuilder {
 
     this.addAdhocFilters(query, adhocFilters);
 
-    // Handle document query:
-    // 1. If target doesn't have bucketAggs and type is not raw_document, it is invalid query.
+    // If target doesn't have bucketAggs and type is not raw_document, it is invalid query.
     if (target.bucketAggs.length === 0) {
       metric = target.metrics[0];
       if (!metric || metric.type !== 'raw_document') {
@@ -214,8 +213,10 @@ export class ElasticQueryBuilder {
       }
     }
 
-    // 2. Check if metric type is raw_document. If metric doesn't have size (or size is 0), update size to 500.
-    // Otherwise it will not be a valid query and error will be thrown.
+    /* Handle document query:
+     * Check if metric type is raw_document. If metric doesn't have size (or size is 0), update size to 500.
+     * Otherwise it will not be a valid query and error will be thrown.
+     */
     if (target.metrics[0].type === 'raw_document') {
       metric = target.metrics[0];
       const size = (metric.settings && metric.settings.size !== 0 && metric.settings.size) || 500;


### PR DESCRIPTION
**What this PR does / why we need it**:
Using Elastic datasource, when switching from any non-raw-document queries to raw-document queries, **Unknown BaseAggregationBuilder error** was thrown, which is user-unfriendly name for [Unknown aggregation error](https://github.com/elastic/elasticsearch/issues/28950). And it was thrown because we didn't process query as document query. This PR fixes it and checks in a first place, if _metric type === raw_document_. If the type of the query is raw_document, we process query as documentQuery. 

When we run raw-document queries, we shouldn't have any aggregation. 
**Current master - throwing error:** 
![broken](https://user-images.githubusercontent.com/30407135/81324187-dcac6080-9096-11ea-8807-2fde4c5167fd.gif)

**Fixed version:**
![fixed](https://user-images.githubusercontent.com/30407135/81324191-dfa75100-9096-11ea-9d47-5027722f83b4.gif)

**Which issue(s) this PR fixes**:

Fixes #24161


