### PR TITLE
CloudWatch/Logs: Fix field autocomplete suggestions inside function

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language_provider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.ts
@@ -153,11 +153,6 @@ export class CloudWatchLanguageProvider extends LanguageProvider {
 
       const commandToken = this.findCommandToken(curToken);
 
-      console.log({
-        commandToken,
-        curToken,
-      });
-
       if (commandToken !== null) {
         const typeaheadOutput = await this.handleCommand(commandToken, curToken, context);
         return typeaheadOutput;

--- a/public/app/plugins/datasource/cloudwatch/language_provider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.ts
@@ -416,7 +416,11 @@ const funcsWithFieldArgs = [
   'isIpv6InSubnet',
 ].map(funcName => funcName.toLowerCase());
 
-function isInsideFunctionParenthesis(curToken: Token) {
+/**
+ * Returns true if cursor is currently inside a function parenthesis for example `count(|)` or `count(@mess|)` should
+ * return true.
+ */
+function isInsideFunctionParenthesis(curToken: Token): boolean {
   const prevToken = prevNonWhitespaceToken(curToken);
 
   if (!prevToken) {


### PR DESCRIPTION
Autocomplete for fields inside a function worked only until first character was inserted so for example `stats count(@|` would not suggest fields starting with `@`.