### PR TITLE
Azure Monitor: Deep linking from Log Analytic queries to the Azure Portal

### DIFF
--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -319,7 +319,7 @@ Perf
 
 {{< docs-imagebox img="/img/docs/v70/azure-log-analytics-deep-linking.png" max-width="500px" class="docs-image--right" caption="Azure Log Analytics deep linking" >}}
 
-Left clicking a time series in the panel shows a context menu with a link to `View in Azure Portal`. Clicking that link will open a new tab that will take you to the Azure Log Analytics query editor in the Azure Portal and runs the query from the Grafana panel there. If you're not currently logged in to the Azure Portal, the link will forward you to the login page. The provided link is valid for any account but will only display the query if your account has rights for the Azure Log Analytics workspace specified in the query.
+Click on a time series in the panel to see a context menu with a link to `View in Azure Portal`. Clicking that link opens the Azure Log Analytics query editor in the Azure Portal and runs the query from the Grafana panel there. If you're not currently logged in to the Azure Portal, then the link opens the login page. The provided link is valid for any account, but it only displays the query if your account has access to the Azure Log Analytics workspace specified in the query.
 
 <div class="clearfix"></div>
 
@@ -327,7 +327,7 @@ Left clicking a time series in the panel shows a context menu with a link to `Vi
 
 > Only available in Grafana v7.0+.
 
-Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works [here]({{< relref "../../alerting/rules.md" >}}).
+Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works in [Alerting rules]({{< relref "../../alerting/rules.md" >}}).
 
 ### Writing Analytics Queries For the Application Insights Service
 

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -79,7 +79,7 @@ In the query editor for a panel, after choosing your Azure Monitor data source, 
 
 The query editor will change depending on which one you pick. Azure Monitor is the default.
 
-## Querying the Azure Monitor Service
+## Querying the Azure Monitor service
 
 The Azure Monitor service provides metrics for all the Azure services that you have running. It helps you understand how your applications on Azure are performing and to proactively find issues affecting your applications.
 
@@ -93,7 +93,7 @@ Examples of metrics that you can get from the service are:
 
 {{< docs-imagebox img="/img/docs/v60/azuremonitor-service-query-editor.png" class="docs-image--no-shadow" caption="Azure Monitor Query Editor" >}}
 
-### Formatting Legend Keys with Aliases for the Azure Monitor Service
+### Formatting legend keys with aliases for Azure Monitor
 
 The default legend formatting for the Azure Monitor API is:
 
@@ -106,7 +106,7 @@ Azure Monitor Examples:
 - `dimension: {{dimensionvalue}}`
 - `{{resourcegroup}} - {{resourcename}}`
 
-### Alias Patterns for Azure Monitor
+### Alias patterns for Azure Monitor
 
 - `{{resourcegroup}}` = replaced with the value of the Resource Group
 - `{{namespace}}` = replaced with the value of the Namespace (e.g. Microsoft.Compute/virtualMachines)
@@ -115,7 +115,7 @@ Azure Monitor Examples:
 - `{{dimensionname}}` = replaced with dimension key/label (e.g. blobtype)
 - `{{dimensionvalue}}` = replaced with dimension value (e.g. BlockBlob)
 
-### Templating with Variables for the Azure Monitor Service
+### Templating with variables for Azure Monitor
 
 Instead of hard-coding things like server, application and sensor name in your metric queries you can use variables in their place. Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data being displayed in your dashboard.
 
@@ -149,11 +149,11 @@ Examples:
 Check out the [Templating]({{< relref "../../variables/templates-and-variables.md" >}}) documentation for an introduction to the templating feature and the different
 types of template variables.
 
-### Azure Monitor Metrics Whitelist
+### Azure Monitor metrics whitelist
 
 Not all metrics returned by the Azure Monitor API have values. The Grafana data source has a whitelist to only return metric names if it is possible they might have values. This whitelist is updated regularly as new services and metrics are added to the Azure cloud. You can find the current whitelist [here](https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/supported_namespaces.ts).
 
-### Azure Monitor Alerting
+### Azure Monitor alerting
 
 Grafana alerting is supported for the Azure Monitor service. This is not Azure Alerts support. Read more about how alerting in Grafana works [here]({{< relref "../../alerting/rules.md" >}}).
 
@@ -163,7 +163,7 @@ Grafana alerting is supported for the Azure Monitor service. This is not Azure A
 
 {{< docs-imagebox img="/img/docs/v60/appinsights-service-query-editor.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
 
-### Formatting Legend Keys with Aliases for the Application Insights Service
+### Formatting legend keys with aliases for Application Insights
 
 The default legend formatting is:
 
@@ -177,13 +177,13 @@ Application Insights Examples:
 - `city: {{groupbyvalue}}`
 - `{{groupbyname}}: {{groupbyvalue}}`
 
-### Alias Patterns for Application Insights
+### Alias patterns for Application Insights
 
 - `{{groupbyvalue}}` = replaced with the value of the group by
 - `{{groupbyname}}` = replaced with the name/label of the group by
 - `{{metric}}` = replaced with metric name (e.g. requests/count)
 
-### Filter Expressions for Application Insights
+### Filter expressions for Application Insights
 
 The filter field takes an OData filter expression.
 
@@ -194,7 +194,7 @@ Examples:
 - `client/city ne 'Boydton' and client/city ne 'Dublin'`
 - `client/city eq 'Boydton' or client/city eq 'Dublin'`
 
-### Templating with Variables for Application Insights
+### Templating with variables for Application Insights
 
 Use the one of the following queries in the `Query` field in the Variable edit view.
 
@@ -214,13 +214,13 @@ Examples:
 
 {{< docs-imagebox img="/img/docs/v60/appinsights-service-variables.png" class="docs-image--no-shadow" caption="Nested Application Insights Template Variables" >}}
 
-### Application Insights Alerting
+### Application Insights alerting
 
 Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works [here]({{< relref "../../alerting/rules.md" >}}).
 
 {{< docs-imagebox img="/img/docs/v60/azuremonitor-alerting.png" class="docs-image--no-shadow" caption="Azure Monitor Alerting" >}}
 
-## Querying the Azure Log Analytics Service
+## Querying the Azure Log Analytics service
 
 Queries are written in the new [Azure Log Analytics (or KustoDB) Query Language](https://docs.loganalytics.io/index). A Log Analytics Query can be formatted as Time Series data or as Table data.
 
@@ -246,7 +246,7 @@ If your credentials give you access to multiple subscriptions then choose the ap
 
 {{< docs-imagebox img="/img/docs/v60/azureloganalytics-service-query-editor.png" class="docs-image--no-shadow" caption="Azure Log Analytics Query Editor" >}}
 
-### Azure Log Analytics Macros
+### Azure Log Analytics macros
 
 To make writing queries easier there are several Grafana macros that can be used in the where clause of a query:
 
@@ -268,13 +268,13 @@ To make writing queries easier there are several Grafana macros that can be used
 
   If using the `All` option, then check the `Include All Option` checkbox and in the `Custom all value` field type in the following value: `all`. If `$myVar` has value `all` then the macro will instead expand to `1 == 1`. For template variables with a lot of options, this will increase the query performance by not building a large where..in clause.
 
-### Azure Log Analytics Builtin Variables
+### Azure Log Analytics builtin variables
 
 There are also some Grafana variables that can be used in Azure Log Analytics queries:
 
 - `$__interval` - Grafana calculates the minimum time grain that can be used to group by time in queries. More details on how it works [here]({{< relref "../../variables/templates-and-variables.md#interval-variables" >}}). It returns a time grain like `5m` or `1h` that can be used in the bin function. E.g. `summarize count() by bin(TimeGenerated, $__interval)`
 
-### Templating with Variables for Azure Log Analytics
+### Templating with variables for Azure Log Analytics
 
 Any Log Analytics query that returns a list of values can be used in the `Query` field in the Variable edit view. There is also one Grafana function for Log Analytics that returns a list of workspaces.
 
@@ -319,17 +319,19 @@ Perf
 
 {{< docs-imagebox img="/img/docs/v70/azure-log-analytics-deep-linking.png" max-width="500px" class="docs-image--right" caption="Azure Log Analytics deep linking" >}}
 
-Click on a time series in the panel to see a context menu with a link to `View in Azure Portal`. Clicking that link opens the Azure Log Analytics query editor in the Azure Portal and runs the query from the Grafana panel there. If you're not currently logged in to the Azure Portal, then the link opens the login page. The provided link is valid for any account, but it only displays the query if your account has access to the Azure Log Analytics workspace specified in the query.
+Click on a time series in the panel to see a context menu with a link to `View in Azure Portal`. Clicking that link opens the Azure Log Analytics query editor in the Azure Portal and runs the query from the Grafana panel there.
+
+If you're not currently logged in to the Azure Portal, then the link opens the login page. The provided link is valid for any account, but it only displays the query if your account has access to the Azure Log Analytics workspace specified in the query.
 
 <div class="clearfix"></div>
 
-### Azure Log Analytics Alerting
+### Azure Log Analytics alerting
 
 > Only available in Grafana v7.0+.
 
 Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works in [Alerting rules]({{< relref "../../alerting/rules.md" >}}).
 
-### Writing Analytics Queries For the Application Insights Service
+### Writing analytics queries For the Application Insights service
 
 If you change the service type to "Application Insights", the menu icon to the right adds another option, "Toggle Edit Mode". Once clicked, the query edit mode changes to give you a full text area in which to write log analytics queries. (This is identical to how the InfluxDB data source lets you write raw queries.)
 

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -313,9 +313,21 @@ Perf
 | order by TimeGenerated asc
 ```
 
+### Deep linking from Grafana panels to the Log Analytics query editor in Azure Portal
+
+> Only available in Grafana v7.0+.
+
+{{< docs-imagebox img="/img/docs/v70/azure-log-analytics-deep-linking.png" max-width="500px" class="docs-image--right" caption="Azure Log Analytics deep linking" >}}
+
+Left clicking a time series in the panel shows a context menu with a link to `View in Azure Portal`. Clicking that link will open a new tab that will take you to the Azure Log Analytics query editor in the Azure Portal and runs the query from the Grafana panel there. If you're not currently logged in to the Azure Portal, the link will forward you to the login page. The provided link is valid for any account but will only display the query if your account has rights for the Azure Log Analytics workspace specified in the query.
+
+<div class="clearfix"></div>
+
 ### Azure Log Analytics Alerting
 
-Not implemented yet.
+> Only available in Grafana v7.0+.
+
+Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works [here]({{< relref "../../alerting/rules.md" >}}).
 
 ### Writing Analytics Queries For the Application Insights Service
 

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -57,8 +57,13 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					RefID:        "A",
 					ResultFormat: "time_series",
 					URL:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/query",
-					Params:       url.Values{"query": {"query=Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer"}},
-					Target:       "query=query%3DPerf+%7C+where+%5B%27TimeGenerated%27%5D+%3E%3D+datetime%28%272018-03-15T13%3A00%3A00Z%27%29+and+%5B%27TimeGenerated%27%5D+%3C%3D+datetime%28%272018-03-15T13%3A34%3A00Z%27%29+%7C+where+%5B%27Computer%27%5D+in+%28%27comp1%27%2C%27comp2%27%29+%7C+summarize+avg%28CounterValue%29+by+bin%28TimeGenerated%2C+34000ms%29%2C+Computer",
+					Model: map[string]interface{}{
+						"query":        "query=Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+						"resultFormat": "time_series",
+						"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					},
+					Params: url.Values{"query": {"query=Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer"}},
+					Target: "query=query%3DPerf+%7C+where+%5B%27TimeGenerated%27%5D+%3E%3D+datetime%28%272018-03-15T13%3A00%3A00Z%27%29+and+%5B%27TimeGenerated%27%5D+%3C%3D+datetime%28%272018-03-15T13%3A34%3A00Z%27%29+%7C+where+%5B%27Computer%27%5D+in+%28%27comp1%27%2C%27comp2%27%29+%7C+summarize+avg%28CounterValue%29+by+bin%28TimeGenerated%2C+34000ms%29%2C+Computer",
 				},
 			},
 			Err: require.NoError,
@@ -100,7 +105,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -133,7 +138,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"ObjectName","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"ObjectName","type":"string"},{"name":"avg_CounterValue","type":"real"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -150,7 +155,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"avg_CounterValue","type":"int"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"avg_CounterValue","type":"int"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -158,7 +163,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 			testFile: "loganalytics/4-log-analytics-response-metrics-no-time-column.json",
 			query:    "test query",
 			series:   nil,
-			meta:     `{"columns":[{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+			meta:     `{"columns":[{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:      require.NoError,
 		},
 		{
@@ -166,7 +171,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 			testFile: "loganalytics/5-log-analytics-response-metrics-no-value-column.json",
 			query:    "test query",
 			series:   nil,
-			meta:     `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+			meta:     `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:      require.NoError,
 		},
 	}
@@ -175,7 +180,13 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			data, _ := loadLogAnalyticsTestFile(tt.testFile)
 
-			series, meta, err := datasource.parseToTimeSeries(data, tt.query)
+			model := map[string]interface{}{
+				"subscription": "1234",
+				"workspace":    "aworkspace",
+			}
+			params := url.Values{}
+			params.Add("query", tt.query)
+			series, meta, err := datasource.parseToTimeSeries(data, model, params)
 			tt.Err(t, err)
 
 			if diff := cmp.Diff(tt.series, series, cmpopts.EquateNaNs()); diff != "" {
@@ -262,7 +273,7 @@ func TestParsingAzureLogAnalyticsTableResponses(t *testing.T) {
 			},
 			meta: `{"columns":[{"name":"TenantId","type":"string"},{"name":"Computer","type":"string"},{"name":"ObjectName","type":"string"},{"name":"CounterName","type":"string"},` +
 				`{"name":"InstanceName","type":"string"},{"name":"Min","type":"real"},{"name":"Max","type":"real"},{"name":"SampleCount","type":"int"},{"name":"CounterValue","type":"real"},` +
-				`{"name":"TimeGenerated","type":"datetime"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
+				`{"name":"TimeGenerated","type":"datetime"}],"subscription":"1234","workspace":"aworkspace","query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err: require.NoError,
 		},
 	}
@@ -271,7 +282,13 @@ func TestParsingAzureLogAnalyticsTableResponses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			data, _ := loadLogAnalyticsTestFile(tt.testFile)
 
-			tables, meta, err := datasource.parseToTables(data, tt.query)
+			model := map[string]interface{}{
+				"subscription": "1234",
+				"workspace":    "aworkspace",
+			}
+			params := url.Values{}
+			params.Add("query", tt.query)
+			tables, meta, err := datasource.parseToTables(data, model, params)
 			tt.Err(t, err)
 
 			if diff := cmp.Diff(tt.tables, tables, cmpopts.EquateNaNs()); diff != "" {

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -100,7 +100,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query"}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -133,7 +133,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"ObjectName","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query"}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"ObjectName","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -150,7 +150,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 					},
 				},
 			},
-			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"avg_CounterValue","type":"int"}],"query":"test query"}`,
+			meta: `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"avg_CounterValue","type":"int"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:  require.NoError,
 		},
 		{
@@ -158,7 +158,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 			testFile: "loganalytics/4-log-analytics-response-metrics-no-time-column.json",
 			query:    "test query",
 			series:   nil,
-			meta:     `{"columns":[{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query"}`,
+			meta:     `{"columns":[{"name":"Computer","type":"string"},{"name":"avg_CounterValue","type":"real"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:      require.NoError,
 		},
 		{
@@ -166,7 +166,7 @@ func TestParsingAzureLogAnalyticsResponses(t *testing.T) {
 			testFile: "loganalytics/5-log-analytics-response-metrics-no-value-column.json",
 			query:    "test query",
 			series:   nil,
-			meta:     `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"}],"query":"test query"}`,
+			meta:     `{"columns":[{"name":"TimeGenerated","type":"datetime"},{"name":"Computer","type":"string"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err:      require.NoError,
 		},
 	}
@@ -262,7 +262,7 @@ func TestParsingAzureLogAnalyticsTableResponses(t *testing.T) {
 			},
 			meta: `{"columns":[{"name":"TenantId","type":"string"},{"name":"Computer","type":"string"},{"name":"ObjectName","type":"string"},{"name":"CounterName","type":"string"},` +
 				`{"name":"InstanceName","type":"string"},{"name":"Min","type":"real"},{"name":"Max","type":"real"},{"name":"SampleCount","type":"int"},{"name":"CounterValue","type":"real"},` +
-				`{"name":"TimeGenerated","type":"datetime"}],"query":"test query"}`,
+				`{"name":"TimeGenerated","type":"datetime"}],"query":"test query","encodedQuery":"H4sIAAAAAAAA/ypJLS5RKCxNLaoEBAAA///0rBfVCgAAAA=="}`,
 			Err: require.NoError,
 		},
 	}

--- a/pkg/tsdb/azuremonitor/types.go
+++ b/pkg/tsdb/azuremonitor/types.go
@@ -80,6 +80,8 @@ type AzureLogAnalyticsTable struct {
 
 type metadata struct {
 	Columns      []column `json:"columns"`
+	Subscription string   `json:"subscription"`
+	Workspace    string   `json:"workspace"`
 	Query        string   `json:"query"`
 	EncodedQuery string   `json:"encodedQuery"`
 }

--- a/pkg/tsdb/azuremonitor/types.go
+++ b/pkg/tsdb/azuremonitor/types.go
@@ -79,8 +79,9 @@ type AzureLogAnalyticsTable struct {
 }
 
 type metadata struct {
-	Columns []column `json:"columns"`
-	Query   string   `json:"query"`
+	Columns      []column `json:"columns"`
+	Query        string   `json:"query"`
+	EncodedQuery string   `json:"encodedQuery"`
 }
 
 type column struct {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/app_insights/app_insights_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/app_insights/app_insights_datasource.ts
@@ -218,7 +218,7 @@ export default class AppInsightsDatasource {
 
         return {
           status: 'error',
-          message: 'Returned http status code ' + response.status,
+          message: 'Application Insights: Returned http status code ' + response.status,
         };
       })
       .catch((error: any) => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/annotations.editor.html
@@ -39,7 +39,7 @@
         <button class="btn btn-primary width-10" ng-click="ctrl.panelCtrl.refresh()">Run</button>
       </div>
       <div class="gf-form">
-        <label class="gf-form-label">(Run Query: Shift+Enter, Trigger Suggestion: Ctrl+Space)</label>
+        <label class="gf-form-label">(New Line: Shift+Enter, Run Query: Enter, Trigger Suggestion: Ctrl+Space)</label>
       </div>
     </div>
     <kusto-editor

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -210,7 +210,7 @@
           <button class="btn btn-primary width-10" ng-click="ctrl.refresh()">Run</button>
         </div>
         <div class="gf-form">
-          <label class="gf-form-label">(Run Query: Shift+Enter, Trigger Suggestion: Ctrl+Space)</label>
+          <label class="gf-form-label">(New Line: Shift+Enter, Run Query: Enter, Trigger Suggestion: Ctrl+Space)</label>
         </div>
         <div class="gf-form gf-form--grow">
           <div class="gf-form-label gf-form-label--grow"></div>


### PR DESCRIPTION
# How to test

## Setup
1. Credentials can be found in the [private plugin-provisioning repo](https://github.com/grafana/plugin-provisioning/blob/master/plugins/azuremonitor/provisioning/datasources/azmonitor-ds.yaml)
2. Provision the YAML by placing it in the `conf/provisioning/datasources` and restarting your Grafana instance
3. Import this [sample dashboard](https://gist.github.com/daniellee/f6cfcc2b3afff6f2a2f9b31d353d803e) 

## Test

1. Click on a graph panel in the imported dashboard and click on the View in Azure Portal link
    ![image](https://user-images.githubusercontent.com/434655/81385323-7154a400-9113-11ea-9984-b28ec30e42af.png)
2. Verify that the link opens the query editor for Log Analytics in the Azure Portal with the query from the panel:

If you have never logged into the Azure Portal or use the Azure Log Analytics service before, you might not come directly to the query editor and instead see the below welcome screen. Click on `Get Started` and it should take you to the query editor:

![image](https://user-images.githubusercontent.com/434655/81385648-035cac80-9114-11ea-90c3-9b870be3c982.png)

## Notes to reviewer

- To build the url, 4 fields are needed - SubscriptionId, Resource Group, Workspace and the query. Unfortunately, the resource group is never used otherwise for Log Analytics and is therefore not saved in the panel json. I added another api call to fetch the workspace details and parse the resource group out of the id. I couldn't find a better way to do it - this is the only API call that I could find that returns anything to do with a workspace's resource group.
- I added some simple caching on the frontend for this extra call to get the workspace details. Is there a better way to do this? With the current solution, there is a cache per panel. If I have 5 panels on a dashboard, then the first time the dashboard loads, it will make 5 calls to get workspace details - after that they will be cached. 
    - I tried to do some caching with the `Cache-Control` HTTP header but couldn't get it to work reliably.
    - If I move the workspaces query and cache to the backend, then you lose the ability to refresh the page to invalidate the cache (for when you have added a new workspace).
- The query string is gzipped and base64 encoded on the backend but is url-encoded on the frontend. When I tried using the url-encoded version of base64 in Go, the Azure Portal couldn't unzip it.

Fixes #24321 

