### PR TITLE
TablePanel: Fix JSON tooltip positioning

### DIFF
--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -21,14 +21,7 @@ export const JSONViewCell: FC<TableCellProps> = props => {
   return (
     <div className={cx(txt, tableStyles.tableCell)}>
       <Tooltip placement="auto" content={content} theme={'info'}>
-        <div
-          className={css`
-            overflow: hidden;
-            text-overflow: ellipsis;
-          `}
-        >
-          {displayValue}
-        </div>
+        <div className={tableStyles.overflow}>{displayValue}</div>
       </Tooltip>
     </div>
   );

--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -21,7 +21,15 @@ export const JSONViewCell: FC<TableCellProps> = props => {
   return (
     <div className={cx(txt, tableStyles.tableCell)}>
       <Tooltip placement="auto" content={content} theme={'info'}>
-        <span>{displayValue}</span>
+        <div
+          className={css`
+            width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          `}
+        >
+          {displayValue}
+        </div>
       </Tooltip>
     </div>
   );

--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -23,7 +23,6 @@ export const JSONViewCell: FC<TableCellProps> = props => {
       <Tooltip placement="auto" content={content} theme={'info'}>
         <div
           className={css`
-            width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;
           `}

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -17,6 +17,7 @@ export interface TableStyles {
   row: string;
   theme: GrafanaTheme;
   resizeHandle: string;
+  overflow: string;
 }
 
 export const getTableStyles = stylesFactory(
@@ -91,6 +92,10 @@ export const getTableStyles = stylesFactory(
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
+      `,
+      overflow: css`
+        overflow: hidden;
+        text-overflow: ellipsis;
       `,
       resizeHandle: css`
         label: resizeHandle;


### PR DESCRIPTION
It needed a positioned block element, that's why it didn't work properly
Closes #24322
Check by using Elastic data source in logs mode and cell display mode JSON view.