### PR TITLE
Docker: Adds tzdata package to Ubuntu image

### DIFF
--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -28,7 +28,7 @@ WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
 # We need curl in the image
-RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl && \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl tzdata && \
     apt-get autoremove -y && rm -rf /var/lib/apt/lists/*;
 
 COPY --from=grafana-builder /tmp/grafana "$GF_PATHS_HOME"


### PR DESCRIPTION
**What this PR does / why we need it**:

Reporting needs tzdata in the ubuntu image for it to work.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.


-->


**Special notes for your reviewer**:

