### PR TITLE
Explore: Revert QueryRows refactor

### DIFF
--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -20,8 +20,8 @@ export default class QueryRows extends PureComponent<QueryRowsProps> {
     const { className = '', exploreEvents, exploreId, queryKeys } = this.props;
     return (
       <div className={className}>
-        {queryKeys.map((_, index) => {
-          return <QueryRow key={index} exploreEvents={exploreEvents} exploreId={exploreId} index={index} />;
+        {queryKeys.map((key, index) => {
+          return <QueryRow key={key} exploreEvents={exploreEvents} exploreId={exploreId} index={index} />;
         })}
       </div>
     );

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -302,6 +302,7 @@ export const itemReducer = (state: ExploreItemState = makeExploreItemState(), ac
       latency: 0,
       queryResponse: createEmptyQueryResponse(),
       loading: false,
+      queryKeys: [],
       supportedModes,
       mode: mode ?? newMode,
       originPanelId: state.urlState && state.urlState.originPanelId,


### PR DESCRIPTION
**What this PR does / why we need it**:
While query fields should not rely on getting unmounted when the data source changes (and instead react to that change in e.g. `componentDidUpdate()` by refreshing metrics and potentially other things that need resetting), query fields other than `PromQueryField` still do (rely on this).

(Originally refactor: https://github.com/grafana/grafana/pull/24116/files#diff-7627636e74306bf9d3edac75038407b4)

**Which issue(s) this PR fixes**:
Metrics information not getting updated when changing between multiple sources for the same data source type.