### PR TITLE
CloudWatch/Logs: Usability improvements

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -10,6 +10,11 @@ import (
 func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*data.Frame, error) {
 	rowCount := len(response.Results)
 	fieldValues := make(map[string]interface{})
+
+	// Maintaining a list of field names in the order returned from CloudWatch
+	// as just iterating over fieldValues would not give a consistent order
+	fieldNames := make([]*string, 0)
+
 	for i, row := range response.Results {
 		for _, resultField := range row {
 			// Strip @ptr field from results as it's not needed
@@ -17,48 +22,37 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 				continue
 			}
 
-			if *resultField.Field == "@timestamp" {
-				if _, exists := fieldValues[*resultField.Field]; !exists {
-					fieldValues[*resultField.Field] = make([]*time.Time, rowCount)
-				}
+			if _, exists := fieldValues[*resultField.Field]; !exists {
+				fieldNames = append(fieldNames, resultField.Field)
 
+				// Check if field is time field
+				if _, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value); err == nil {
+					fieldValues[*resultField.Field] = make([]*time.Time, rowCount)
+				} else {
+					fieldValues[*resultField.Field] = make([]*string, rowCount)
+				}
+			}
+
+			if timeField, ok := fieldValues[*resultField.Field].([]*time.Time); ok {
 				parsedTime, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value)
 				if err != nil {
 					return nil, err
 				}
 
-				fieldValues[*resultField.Field].([]*time.Time)[i] = &parsedTime
+				timeField[i] = &parsedTime
 			} else {
-				if _, exists := fieldValues[*resultField.Field]; !exists {
-					// Check if field is time field
-					if _, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value); err == nil {
-						fieldValues[*resultField.Field] = make([]*time.Time, rowCount)
-					} else {
-						fieldValues[*resultField.Field] = make([]*string, rowCount)
-					}
-				}
-
-				if timeField, ok := fieldValues[*resultField.Field].([]*time.Time); ok {
-					parsedTime, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value)
-					if err != nil {
-						return nil, err
-					}
-
-					timeField[i] = &parsedTime
-				} else {
-					fieldValues[*resultField.Field].([]*string)[i] = resultField.Value
-				}
+				fieldValues[*resultField.Field].([]*string)[i] = resultField.Value
 			}
 		}
 	}
 
 	newFields := make([]*data.Field, 0)
-	for fieldName, vals := range fieldValues {
-		newFields = append(newFields, data.NewField(fieldName, nil, vals))
+	for _, fieldName := range fieldNames {
+		newFields = append(newFields, data.NewField(*fieldName, nil, fieldValues[*fieldName]))
 
-		if fieldName == "@timestamp" {
+		if *fieldName == "@timestamp" {
 			newFields[len(newFields)-1].SetConfig(&data.FieldConfig{Title: "Time"})
-		} else if fieldName == "@logStream" || fieldName == "@log" {
+		} else if *fieldName == "@logStream" || *fieldName == "@log" {
 			newFields[len(newFields)-1].SetConfig(
 				&data.FieldConfig{
 					Custom: map[string]interface{}{

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -214,15 +214,15 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
                   let moreRecordsMatched = false;
                   for (const frame of frames) {
                     const recordsMatched = frame.meta?.custom?.['Statistics']['RecordsMatched'];
-                    if (recordsMatched > (prevRecordsMatched[frame.refId] ?? 0)) {
+                    if (recordsMatched > (prevRecordsMatched[frame.refId!] ?? 0)) {
                       moreRecordsMatched = true;
                     }
-                    prevRecordsMatched[frame.refId] = recordsMatched;
+                    prevRecordsMatched[frame.refId!] = recordsMatched;
                   }
                   const noProgressMade = i >= MAX_ATTEMPTS - 2 && !moreRecordsMatched;
                   if (noProgressMade) {
                     for (const frame of frames) {
-                      frame.meta.custom['Status'] = CloudWatchLogsQueryStatus.Complete;
+                      _.set(frame, 'meta.custom.Status', CloudWatchLogsQueryStatus.Complete);
                     }
                   }
 

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -172,8 +172,9 @@ describe('CloudWatchDatasource', () => {
     it('should stop querying when no more data retrieved past max attempts', async () => {
       const fakeFrames = genMockFrames(10);
       for (let i = 7; i < fakeFrames.length; i++) {
-        fakeFrames[i].meta.custom['Statistics']['RecordsMatched'] =
-          fakeFrames[6].meta.custom['Statistics']['RecordsMatched'];
+        fakeFrames[i].meta!.custom!['Statistics']['RecordsMatched'] = fakeFrames[6].meta!.custom!['Statistics'][
+          'RecordsMatched'
+        ];
       }
 
       let i = 0;
@@ -192,7 +193,7 @@ describe('CloudWatchDatasource', () => {
       const expectedData = [
         {
           ...fakeFrames[MAX_ATTEMPTS - 1],
-          meta: { custom: { ...fakeFrames[MAX_ATTEMPTS - 1].meta.custom, Status: 'Complete' } },
+          meta: { custom: { ...fakeFrames[MAX_ATTEMPTS - 1].meta!.custom, Status: 'Complete' } },
         },
       ];
       expect(myResponse).toEqual({


### PR DESCRIPTION
**What this PR does / why we need it**:
- Improves handling of long-running queries: Queries that exceed the maximum number of attempts have the correct `Status` set, meaning the query doesn't seem to go on indefinitely anymore. Furthermore, queries won't be stopped in this way unless they exceed the maximum number of attempts _and_ no new results have been returned since the last time.

- Dataframe field order was inconsistent as a result of adding them to the dataframe in the order the map containing them was iterated over. This has been fixed such that the frame's fields will now be in the order they are in the CloudWatch response.

See https://github.com/grafana/grafana/issues/24333
