### PR TITLE
Docs: add disable_brute_force_login_protection to configuration document

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -355,6 +355,11 @@ Define a whitelist of allowed IP addresses or domains, with ports, to be used in
 
 Set to `true` if you host Grafana behind HTTPS. Default is `false`.
 
+
+### disable_brute_force_login_protection
+
+Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`.
+
 ### cookie_samesite
 
 Sets the `SameSite` cookie attribute and prevents the browser from sending this cookie along with cross-site requests. The main goal is to mitigate the risk of cross-origin information leakage. This setting also provides some protection against cross-site request forgery attacks (CSRF),  [read more about SameSite here](https://www.owasp.org/index.php/SameSite). Valid values are `lax`, `strict`, `none`, and `disabled`. Default is `lax`. Using value `disabled` does not add any `SameSite` attribute to cookies.

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -355,7 +355,6 @@ Define a whitelist of allowed IP addresses or domains, with ports, to be used in
 
 Set to `true` if you host Grafana behind HTTPS. Default is `false`.
 
-
 ### disable_brute_force_login_protection
 
 Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`.


### PR DESCRIPTION
Fixes: #20287
I was wondering if there is a way to prevent a brute force attack so I first looked at the documentation and found nothing. After searching more I found this feature in one PR. For more clarification, I add this to documentation.