### PR TITLE
Fix typo; systemd service consistency

### DIFF
--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -161,10 +161,10 @@ sudo systemctl status grafana-server
 Configure the Grafana server to start at boot:
 
 ```bash
-sudo systemctl enable grafana-server.service
+sudo systemctl enable grafana-server
 ```
 
-> **SUSE or OpenSUSE users:** You might need to start the server with the systemd method, then then use the init.d method to configure Grafana to start at boot.
+> **SUSE or OpenSUSE users:** You might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
 
 ### Start the server with init.d
 


### PR DESCRIPTION
Fix double "then".
As previous systemd commands do not include ".service" postfix, remove it also for the "enable" command.