### PR TITLE
Transformations: Sort order should be preserved as entered by user when using the reduce transformation

### DIFF
--- a/packages/grafana-data/src/utils/Registry.test.ts
+++ b/packages/grafana-data/src/utils/Registry.test.ts
@@ -1,0 +1,31 @@
+import { Registry } from './Registry';
+import { FieldReducerInfo, fieldReducers, ReducerID } from '../transformations';
+
+describe('Registry', () => {
+  describe('selectOptions', () => {
+    describe('when called with current', () => {
+      it('then order in select.current should be same as current', () => {
+        const list = fieldReducers.list();
+        const registry = new Registry<FieldReducerInfo>(() => list);
+        const current = [ReducerID.step, ReducerID.mean, ReducerID.allIsZero, ReducerID.first, ReducerID.delta];
+        const select = registry.selectOptions(current);
+        expect(select.current).toEqual([
+          { description: 'Minimum interval between values', label: 'Step', value: 'step' },
+          { description: 'Average Value', label: 'Mean', value: 'mean' },
+          { description: 'All values are zero', label: 'All Zeros', value: 'allIsZero' },
+          { description: 'First Value', label: 'First', value: 'first' },
+          { description: 'Cumulative change in value', label: 'Delta', value: 'delta' },
+        ]);
+      });
+
+      describe('when called without current', () => {
+        it('then it should return an empty array', () => {
+          const list = fieldReducers.list();
+          const registry = new Registry<FieldReducerInfo>(() => list);
+          const select = registry.selectOptions();
+          expect(select.current).toEqual([]);
+        });
+      });
+    });
+  });
+});

--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -84,10 +84,10 @@ export class Registry<T extends RegistryItem> {
       current: [],
     } as RegistrySelectInfo;
 
-    const currentIds: any = {};
+    const currentOptions: Record<string, SelectableValue<string>> = {};
     if (current) {
       for (const id of current) {
-        currentIds[id] = true;
+        currentOptions[id] = {};
       }
     }
 
@@ -106,10 +106,16 @@ export class Registry<T extends RegistryItem> {
       };
 
       select.options.push(option);
-      if (currentIds[ext.id]) {
-        select.current.push(option);
+      if (currentOptions[ext.id]) {
+        currentOptions[ext.id] = option;
       }
     }
+
+    if (current) {
+      // this makes sure we preserve the order of ids
+      select.current = Object.values(currentOptions);
+    }
+
     return select;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the reduce transformer, the order of the reducers where not the same as the user entered but in an internal order. This PR attempts to remedy this.

**Which issue(s) this PR fixes**:
Fixes #24207

**Special notes for your reviewer**:

