### PR TITLE
CloudWatch/Logs: Fix suggestions of fields after comma

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language_provider.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.test.ts
@@ -40,6 +40,10 @@ describe('CloudWatchLanguageProvider', () => {
     await runSuggestionTest('fields field1, \\', [fields, FUNCTIONS.map(v => v.label)]);
   });
 
+  it('should suggest fields and functions after comma with prefix', async () => {
+    await runSuggestionTest('fields field1, @mess\\', [fields, FUNCTIONS.map(v => v.label)]);
+  });
+
   it('should suggest fields and functions after display command', async () => {
     await runSuggestionTest('display \\', [fields, FUNCTIONS.map(v => v.label)]);
   });

--- a/public/app/plugins/datasource/cloudwatch/language_provider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.ts
@@ -165,7 +165,7 @@ export class CloudWatchLanguageProvider extends LanguageProvider {
 
     const currentTokenIsComma = curToken.content === ',' && curToken.types.includes('punctuation');
     const currentTokenIsCommaOrAfterComma =
-      currentTokenIsComma || (curToken.prev?.content === ',' && curToken.prev.types.includes('punctuation'));
+      currentTokenIsComma || (prevToken?.content === ',' && prevToken?.types.includes('punctuation'));
 
     // We only show suggestions if we are after a command or after a comma which is a field separator
     if (!(currentTokenIsAfterCommand || currentTokenIsCommaOrAfterComma)) {


### PR DESCRIPTION
In cases of query like `fields @message, hos|` the second field was not suggested once there was a name prefix due checking directly previous token (which was whitespace) instead of previous non whitespace token.