### PR TITLE
Zipkin: Fix error when span contains remoteEndpoint

### DIFF
--- a/public/app/plugins/datasource/zipkin/types.ts
+++ b/public/app/plugins/datasource/zipkin/types.ts
@@ -5,14 +5,18 @@ export type ZipkinSpan = {
   id: string;
   timestamp: number;
   duration: number;
-  localEndpoint: {
-    serviceName: string;
-    ipv4: string;
-    port?: number;
-  };
+  localEndpoint?: ZipkinEndpoint;
+  remoteEndpoint?: ZipkinEndpoint;
   annotations?: ZipkinAnnotation[];
   tags?: { [key: string]: string };
   kind?: 'CLIENT' | 'SERVER' | 'PRODUCER' | 'CONSUMER';
+};
+
+export type ZipkinEndpoint = {
+  serviceName: string;
+  ipv4?: string;
+  ipv6?: string;
+  port?: number;
 };
 
 export type ZipkinAnnotation = {

--- a/public/app/plugins/datasource/zipkin/utils/testData.ts
+++ b/public/app/plugins/datasource/zipkin/utils/testData.ts
@@ -45,6 +45,18 @@ export const zipkinResponse: ZipkinSpan[] = [
       error: '404',
     },
   },
+  {
+    traceId: 'trace_id',
+    parentId: 'span 1 id',
+    name: 'span 3',
+    id: 'span 3 id',
+    timestamp: 6,
+    duration: 7,
+    remoteEndpoint: {
+      serviceName: 'spanstore-jdbc',
+      ipv6: '127.0.0.1',
+    },
+  },
 ];
 
 export const jaegerTrace: TraceData & { spans: SpanData[] } = {
@@ -71,6 +83,16 @@ export const jaegerTrace: TraceData & { spans: SpanData[] } = {
           key: 'ipv4',
           type: 'string',
           value: '1.0.0.1',
+        },
+      ],
+    },
+    'spanstore-jdbc': {
+      serviceName: 'spanstore-jdbc',
+      tags: [
+        {
+          key: 'ipv6',
+          type: 'string',
+          value: '127.0.0.1',
         },
       ],
     },
@@ -133,6 +155,25 @@ export const jaegerTrace: TraceData & { spans: SpanData[] } = {
           value: true,
         },
       ],
+      references: [
+        {
+          refType: 'CHILD_OF',
+          spanID: 'span 1 id',
+          traceID: 'trace_id',
+        },
+      ],
+    },
+    {
+      duration: 7,
+      flags: 1,
+      logs: [],
+      operationName: 'span 3',
+      processID: 'spanstore-jdbc',
+      startTime: 6,
+      tags: [],
+      spanID: 'span 3 id',
+      traceID: 'trace_id',
+      warnings: null as any,
       references: [
         {
           refType: 'CHILD_OF',


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/24218

Zipkin span can contain remote or local endpoints or both which wasn't really handled in the transform.

Had hard time to replicate this as I do not have any app that would generate such trace right now and wasn't able to run react-native example from the zipkin so mainly count on span model api and tests here.