### PR TITLE
Dashboard: Fix so default data source is selected when data source can't be found in panel editor

### DIFF
--- a/public/app/core/components/Select/DataSourcePicker.tsx
+++ b/public/app/core/components/Select/DataSourcePicker.tsx
@@ -15,6 +15,7 @@ export interface Props {
   openMenuOnFocus?: boolean;
   showLoading?: boolean;
   placeholder?: string;
+  invalid?: boolean;
 }
 
 export class DataSourcePicker extends PureComponent<Props> {
@@ -48,6 +49,7 @@ export class DataSourcePicker extends PureComponent<Props> {
       openMenuOnFocus,
       showLoading,
       placeholder,
+      invalid,
     } = this.props;
 
     const options = datasources.map(ds => ({
@@ -80,6 +82,7 @@ export class DataSourcePicker extends PureComponent<Props> {
         placeholder={placeholder}
         noOptionsMessage="No datasources found"
         value={value}
+        invalid={invalid}
       />
     );
   }

--- a/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRow.tsx
@@ -89,7 +89,13 @@ export class QueryEditorRow extends PureComponent<Props, State> {
   async loadDatasource() {
     const { query, panel } = this.props;
     const dataSourceSrv = getDatasourceSrv();
-    const datasource = await dataSourceSrv.get(query.datasource || panel.datasource);
+    let datasource;
+
+    try {
+      datasource = await dataSourceSrv.get(query.datasource || panel.datasource);
+    } catch (error) {
+      datasource = await dataSourceSrv.get();
+    }
 
     this.setState({
       datasource,


### PR DESCRIPTION
**What this PR does / why we need it**:
If you, for example is importing or inserting a dashboard and the datasource in the target dashboard doesn't exist locally. You can now change this one in the panel edit mode.

**Which issue(s) this PR fixes**:
Fixes #24336

**Special notes for your reviewer**:
Not super happy that we are doing the fallback handling in both the QueryRow and the QueryTab. Would be nice to do some refactorings to prevent this.
