### PR TITLE
GraphLegend: Only display scrollbar if necessary

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -119,7 +119,6 @@
 }
 
 .graph-legend-table {
-  padding-bottom: 1px;
   padding-right: 5px;
   padding-left: 5px;
 


### PR DESCRIPTION
Fixes #23795
Please try in some other browser too with the provided example. This feels like a flaky fix.