### PR TITLE
Azure Monitor: Fix failure when using table join in Log Analytics queries

### DIFF
--- a/pkg/tsdb/azuremonitor/macros_test.go
+++ b/pkg/tsdb/azuremonitor/macros_test.go
@@ -29,11 +29,18 @@ func TestAzureLogAnalyticsMacros(t *testing.T) {
 		Err       require.ErrorAssertionFunc
 	}{
 		{
-			name:     "invalid macro should throw error",
+			name:     "invalid macro should be ignored",
 			query:    &tsdb.Query{},
 			kql:      "$__invalid()",
-			expected: "",
-			Err:      require.Error,
+			expected: "$__invalid()",
+			Err:      require.NoError,
+		},
+		{
+			name:     "Kusto variables should be ignored",
+			query:    &tsdb.Query{},
+			kql:      ") on $left.b == $right.y",
+			expected: ") on $left.b == $right.y",
+			Err:      require.NoError,
 		},
 		{
 			name:     "$__contains macro with a multi template variable that has multiple selected values as a parameter should build in clause",


### PR DESCRIPTION
When adding alerting for Azure Log Analytics, I used the existing macro class that was written for App Insights Analytics. The regex was a bit too greedy and tries to match anything starting with a $ sign. This limits the regex with a whitelist for known macros and ignores text that looks like a macro  (like $left and $right)

## Test Setup

1. Credentials can be found in the private plugin-provisioning repo
1. Provision the YAML by placing it in the conf/provisioning/datasources and restarting your Grafana instance
1. Test with this query that uses Kusto variables when joining two queries. I used the `danieltest` workspace on our Azure, selected the `Table` format and the Table panel as display type.

```
let allocatable = Perf
| where ObjectName == "LogicalDisk" or  // the object name used in Windows records
  ObjectName == "Logical Disk"          // the object name used in Linux records
| where CounterName == "Free Megabytes"
| where TimeGenerated >= $__timeFrom() and TimeGenerated <= $__timeTo() 
| summarize a=toreal(sum(CounterValue)) by Computer
| project a, b="abc";

allocatable
| join kind=inner (
Perf 
| where ObjectName == "LogicalDisk" or  // the object name used in Windows records
  ObjectName == "Logical Disk"          // the object name used in Linux records
| where CounterName == "% Used Space"
| where $__timeFilter(TimeGenerated)
| summarize arg_max(TimeGenerated, * ) by Computer
| summarize x=toreal(sum(CounterValue))
| project x,y="abc"
) on $left.b == $right.y
```
Fixes #24488 


**Special notes for your reviewer**:

It should return something like this if it works:

![image](https://user-images.githubusercontent.com/434655/81575032-d7a52500-93a6-11ea-89a2-267950711b58.png)

If it doesn't work then you will either get no data or an error.

