### PR TITLE
Plugins-Bundled: Set GEL/Expressions to version v0.4.0

### DIFF
--- a/plugins-bundled/external.json
+++ b/plugins-bundled/external.json
@@ -2,8 +2,8 @@
   "plugins": [
     {
       "name": "gel",
-      "version": "0.2.0",
-      "checksum": "059e06b927ab5ff0d75a1719a0a669ca3502b9a130f54261b196f4b23b775a61"
+      "version": "0.4.0",
+      "checksum": "7602e53fa5d828b3a7c42f819e7c527ec6d7b8e5c8342901b438d589a531a0a0"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates pointer to external bundled GEL version.

**fixes**:

Current version of GEL in the betas is too old and was made before breaking changes to the protobuf.

**Special notes for your reviewer**:

Ran `mage zip`, uploaded it to gcloud:

```
# kbrandt @ kbrandt-ws in ~/go/github.com/grafana/gel-app on git:master o [10:38:14] 
$ gsutil cp gel-0.4.0.zip gs://plugins-ci/plugins/gel/gel-0.4.0.zip
Copying file://gel-0.4.0.zip [Content-Type=application/zip]...
- [1 files][ 48.2 MiB/ 48.2 MiB]    2.0 MiB/s                                   
Operation completed over 1 objects/48.2 MiB.                                     

# kbrandt @ kbrandt-ws in ~/go/github.com/grafana/gel-app on git:master o [10:38:52] 
$ sha256sum gel-0.4.0.zip 
7602e53fa5d828b3a7c42f819e7c527ec6d7b8e5c8342901b438d589a531a0a0  gel-0.4.0.zip
```

Not sure if there are additional steps or if everything else is automated, or if there is a way to test the bundling workflow.

cc @ryantxu 