### PR TITLE
Security: Tag value sanitization fix in OpenTSDB data source

### DIFF
--- a/public/app/plugins/datasource/opentsdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/opentsdb/query_ctrl.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import kbn from 'app/core/utils/kbn';
 import { QueryCtrl } from 'app/plugins/sdk';
 import { auto } from 'angular';
+import { textUtil } from '@grafana/data';
 
 export class OpenTsQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
@@ -90,7 +91,7 @@ export class OpenTsQueryCtrl extends QueryCtrl {
 
   getTextValues(metricFindResult: any) {
     return _.map(metricFindResult, value => {
-      return value.text;
+      return textUtil.escapeHtml(value.text);
     });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds HTML sanitization to the tag value of the OpenTSDB datasource.

**Side effects**
In case that the tag value starts with a sanitized character, then it won't be searchable with typeahead.
For example:
Tag value - `<b>test</b>`
The suggestion will appear by default, but when typing `<` it won't appear.

**Which issue(s) this PR fixes**:
Fixes #24537 

**Special notes for your reviewer**:
Should also be ported to Grafana 6.7.x