### PR TITLE
Select: fixed broken layout in safari when select have description

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -43,13 +43,14 @@ export const SelectMenuOptions = React.forwardRef<HTMLDivElement, React.PropsWit
     const styles = getSelectStyles(theme);
     const { children, innerProps, data, renderOptionLabel, isSelected, isFocused } = props;
 
+    const containerStyles = cx(
+      styles.option,
+      isFocused && styles.optionFocused,
+      data.description && styles.optionWithDescription
+    );
+
     return (
-      <div
-        ref={ref}
-        className={cx(styles.option, isFocused && styles.optionFocused)}
-        {...innerProps}
-        aria-label="Select option"
-      >
+      <div ref={ref} className={containerStyles} {...innerProps} aria-label="Select option">
         {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} />}
         <div className={styles.optionBody}>
           <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -29,6 +29,9 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme) => {
         background: ${optionBgHover};
       }
     `,
+    optionWithDescription: css`
+      min-height: 55px;
+    `,
     optionImage: css`
       width: 16px;
       margin-right: 10px;

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -25,6 +25,7 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme) => {
       white-space: nowrap;
       cursor: pointer;
       border-left: 2px solid transparent;
+      min-height: 36px;
       &:hover {
         background: ${optionBgHover};
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
When the select options have a description the line got the wrong height in Safari. Forcing the min line height to be 55px when a description is rendered for a select option.

**Which issue(s) this PR fixes**:
Fixes #24513 

