### PR TITLE
Graphite: Makes query annotations work again

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -225,8 +225,8 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
           const target = result.data[i];
 
           for (let y = 0; y < target.length; y++) {
-            const time = target.fields[1].values.get(y);
-            const value = target.fields[0].values.get(y);
+            const time = target.fields[0].values.get(y);
+            const value = target.fields[1].values.get(y);
 
             if (!value) {
               continue;


### PR DESCRIPTION
**What this PR does / why we need it**:
When we changed the order of fields from [value,time] to [time,value] we forgot to change Graphite annotations query. This PR tries to remedy this.

**Which issue(s) this PR fixes**:
Fixes #24405

**Special notes for your reviewer**:

