### PR TITLE
Plugins: Allow files missing versus manifest

### DIFF
--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -109,6 +109,12 @@ func getPluginSignatureState(log log.Logger, plugin *PluginBase) PluginSignature
 		fp := path.Join(plugin.PluginDir, p)
 		f, err := os.Open(fp)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// We are tolerant with files missing from the plug-in
+				log.Debug("Plug-in is missing file from manifest, ignoring this", "plugin", plugin.Id, "filename", p)
+				continue
+			}
+
 			return PluginSignatureModified
 		}
 		defer f.Close()

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -119,7 +119,8 @@ func TestPluginManager_Init(t *testing.T) {
 		err := pm.Init()
 		require.NoError(t, err)
 
-		assert.Equal(t, []error{fmt.Errorf(`plugin "test"'s signature has been modified`)}, pm.scanningErrors)
+		assert.Empty(t, pm.scanningErrors)
+		assert.Equal(t, []string{"test"}, fm.registeredPlugins)
 	})
 
 	t.Run("Transform plugins should be ignored when expressions feature is off", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify plugin loading to allow files missing that are listed in the manifest.

Please see https://github.com/grafana/grafana/pull/24573 first, since it's the foundation of this PR and fixes a bug.

**Which issue(s) this PR fixes**:

Fixes #24492.

**Special notes for your reviewer**:
Draft since I'm not 100% sure if #24492 is how we should solve this.
