### PR TITLE
Table: Fixes Cannot read property subRows of null

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useMemo, useCallback } from 'react';
+import React, { FC, memo, useCallback, useMemo } from 'react';
 import { DataFrame, Field } from '@grafana/data';
 import {
   Cell,
@@ -6,10 +6,10 @@ import {
   HeaderGroup,
   useAbsoluteLayout,
   useResizeColumns,
-  useSortBy,
-  useTable,
   UseResizeColumnsState,
+  useSortBy,
   UseSortByState,
+  useTable,
 } from 'react-table';
 import { FixedSizeList } from 'react-window';
 import { getColumns, getTextAlign } from './utils';
@@ -73,14 +73,9 @@ export const Table: FC<Props> = memo((props: Props) => {
     if (!data.fields.length) {
       return [];
     }
-
-    // Check if an array buffer already exists
-    const buffer = (data.fields[0].values as any).buffer;
-    if (Array.isArray(buffer) && buffer.length === data.length) {
-      return buffer;
-    }
-
-    // For arrow tables, the `toArray` implementation is expensive and akward *especially* for timestamps
+    // as we only use this to fake the length of our data set for react-table we need to make sure we always return an array
+    // filled with values at each index otherwise we'll end up trying to call accessRow for null|undefined value in
+    // https://github.com/tannerlinsley/react-table/blob/7be2fc9d8b5e223fc998af88865ae86a88792fdb/src/hooks/useTable.js#L585
     return Array(data.length).fill(0);
   }, [data]);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After some investigation it seems like react-table expects data to be [objects](https://github.com/tannerlinsley/react-table/blob/master/docs/quickstart.mdx#define-row-shape) and you could add [subRows to this object as showed here.](https://github.com/tannerlinsley/react-table/blob/7be2fc9d8b5e223fc998af88865ae86a88792fdb/examples/basic/src/makeData.js#L34)

We're just using the `data` prop passed to `useTable` to tell react-table the length of our data set and using the real fields to lookup the actual value here:
https://github.com/grafana/grafana/blob/bffa0fa4f6ebe01bef58f0407a89c44a0661b52a/packages/grafana-ui/src/components/Table/utils.ts#L56

So making sure we're passing an array filled with values at every index in the array I just removed the previous check for Array.isArray and buffer lengths. If I understand this correctly, this shouldn't have any other impact than a potential performance impact.

**Which issue(s) this PR fixes**:
Fixes #24274

**Special notes for your reviewer**:

