### PR TITLE
Data source: Fixes async mount errors

### DIFF
--- a/public/app/features/datasources/NewDataSourcePage.tsx
+++ b/public/app/features/datasources/NewDataSourcePage.tsx
@@ -152,7 +152,7 @@ const DataSourceTypeCard: FC<DataSourceTypeCardProps> = props => {
           </div>
         )
       }
-      className={isPhantom && 'add-data-source-item--phantom'}
+      className={isPhantom ? 'add-data-source-item--phantom' : ''}
       onClick={onClick}
       aria-label={selectors.pages.AddDataSource.dataSourcePlugins(plugin.name)}
     />

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
@@ -32,7 +32,7 @@ describe('DataLinks', () => {
       wrapper = await mount(<DataLinks value={testValue} onChange={() => {}} />);
     });
 
-    expect(wrapper.find(Button).filterWhere(button => button.contains('Add')).length).toBe(1);
+    expect(wrapper.find(Button).filterWhere((button: any) => button.contains('Add')).length).toBe(1);
     expect(wrapper.find(DataLink).length).toBe(2);
   });
 
@@ -42,7 +42,7 @@ describe('DataLinks', () => {
     await act(async () => {
       wrapper = await mount(<DataLinks onChange={onChangeMock} />);
     });
-    const addButton = wrapper.find(Button).filterWhere(button => button.contains('Add'));
+    const addButton = wrapper.find(Button).filterWhere((button: any) => button.contains('Add'));
     addButton.simulate('click');
     expect(onChangeMock.mock.calls[0][0].length).toBe(1);
   });

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.test.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { DataLinks } from './DataLinks';
 import { Button } from '@grafana/ui';
 import { DataLink } from './DataLink';
+import { act } from 'react-dom/test-utils';
 
 describe('DataLinks', () => {
   let originalGetSelection: typeof window.getSelection;
@@ -15,31 +16,43 @@ describe('DataLinks', () => {
     window.getSelection = originalGetSelection;
   });
 
-  it('renders correctly when no fields', () => {
-    const wrapper = mount(<DataLinks onChange={() => {}} />);
+  it('renders correctly when no fields', async () => {
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DataLinks onChange={() => {}} />);
+    });
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).contains('Add')).toBeTruthy();
     expect(wrapper.find(DataLink).length).toBe(0);
   });
 
-  it('renders correctly when there are fields', () => {
-    const wrapper = mount(<DataLinks value={testValue} onChange={() => {}} />);
+  it('renders correctly when there are fields', async () => {
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DataLinks value={testValue} onChange={() => {}} />);
+    });
 
     expect(wrapper.find(Button).filterWhere(button => button.contains('Add')).length).toBe(1);
     expect(wrapper.find(DataLink).length).toBe(2);
   });
 
-  it('adds new field', () => {
+  it('adds new field', async () => {
     const onChangeMock = jest.fn();
-    const wrapper = mount(<DataLinks onChange={onChangeMock} />);
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DataLinks onChange={onChangeMock} />);
+    });
     const addButton = wrapper.find(Button).filterWhere(button => button.contains('Add'));
     addButton.simulate('click');
     expect(onChangeMock.mock.calls[0][0].length).toBe(1);
   });
 
-  it('removes field', () => {
+  it('removes field', async () => {
     const onChangeMock = jest.fn();
-    const wrapper = mount(<DataLinks value={testValue} onChange={onChangeMock} />);
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DataLinks value={testValue} onChange={onChangeMock} />);
+    });
     const removeButton = wrapper
       .find(DataLink)
       .at(0)

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -32,8 +32,10 @@ describe('DerivedFields', () => {
       wrapper = await mount(<DerivedFields value={testValue} onChange={() => {}} />);
     });
 
-    expect(wrapper.find(Button).filterWhere(button => button.contains('Add')).length).toBe(1);
-    expect(wrapper.find(Button).filterWhere(button => button.contains('Show example log message')).length).toBe(1);
+    expect(wrapper.find(Button).filterWhere((button: any) => button.contains('Add')).length).toBe(1);
+    expect(wrapper.find(Button).filterWhere((button: any) => button.contains('Show example log message')).length).toBe(
+      1
+    );
     expect(wrapper.find(DerivedField).length).toBe(2);
   });
 
@@ -43,7 +45,7 @@ describe('DerivedFields', () => {
     await act(async () => {
       wrapper = await mount(<DerivedFields onChange={onChangeMock} />);
     });
-    const addButton = wrapper.find(Button).filterWhere(button => button.contains('Add'));
+    const addButton = wrapper.find(Button).filterWhere((button: any) => button.contains('Add'));
     addButton.simulate('click');
     expect(onChangeMock.mock.calls[0][0].length).toBe(1);
   });

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { DerivedFields } from './DerivedFields';
 import { Button } from '@grafana/ui';
 import { DerivedField } from './DerivedField';
+import { act } from 'react-dom/test-utils';
 
 describe('DerivedFields', () => {
   let originalGetSelection: typeof window.getSelection;
@@ -15,32 +16,44 @@ describe('DerivedFields', () => {
     window.getSelection = originalGetSelection;
   });
 
-  it('renders correctly when no fields', () => {
-    const wrapper = mount(<DerivedFields onChange={() => {}} />);
+  it('renders correctly when no fields', async () => {
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DerivedFields onChange={() => {}} />);
+    });
     expect(wrapper.find(Button).length).toBe(1);
     expect(wrapper.find(Button).contains('Add')).toBeTruthy();
     expect(wrapper.find(DerivedField).length).toBe(0);
   });
 
-  it('renders correctly when there are fields', () => {
-    const wrapper = mount(<DerivedFields value={testValue} onChange={() => {}} />);
+  it('renders correctly when there are fields', async () => {
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DerivedFields value={testValue} onChange={() => {}} />);
+    });
 
     expect(wrapper.find(Button).filterWhere(button => button.contains('Add')).length).toBe(1);
     expect(wrapper.find(Button).filterWhere(button => button.contains('Show example log message')).length).toBe(1);
     expect(wrapper.find(DerivedField).length).toBe(2);
   });
 
-  it('adds new field', () => {
+  it('adds new field', async () => {
     const onChangeMock = jest.fn();
-    const wrapper = mount(<DerivedFields onChange={onChangeMock} />);
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DerivedFields onChange={onChangeMock} />);
+    });
     const addButton = wrapper.find(Button).filterWhere(button => button.contains('Add'));
     addButton.simulate('click');
     expect(onChangeMock.mock.calls[0][0].length).toBe(1);
   });
 
-  it('removes field', () => {
+  it('removes field', async () => {
     const onChangeMock = jest.fn();
-    const wrapper = mount(<DerivedFields value={testValue} onChange={onChangeMock} />);
+    let wrapper: any;
+    await act(async () => {
+      wrapper = await mount(<DerivedFields value={testValue} onChange={onChangeMock} />);
+    });
     const removeButton = wrapper
       .find(DerivedField)
       .at(0)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes async mounting of Elasticsearch DataLinks and Loki DerivedFields by wrapping them in `act()` to prevent them from throwing the following errors:

```
>> ● Console
>> 
>>     console.error node_modules/react-dom/cjs/react-dom.development.js:530
>>       Warning: An update to null inside a test was not wrapped in act(...).
>>       
>>       When testing, code that causes React state updates should be wrapped into act(...):
>>       
>>       act(() => {
>>         /* fire events that update state /
>>       });
>>       / assert on the output /
>>       
>>       This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
>>           in Unknown
>>           in div (created by FormField)
>>           in FormField
>>           in div
>>           in div
>>           in Unknown
>>           in div
>>           in Unknown (created by WrapperComponent)
>>           in WrapperComponent
```