### PR TITLE
CloudWatch/Logs: Prevents hidden data frame fields from displaying in tables

### DIFF
--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -59,7 +59,7 @@ export class FieldCache {
 
   getFirstFieldOfType(type: FieldType, includeHidden = false): FieldWithIndex | undefined {
     const fields = this.fieldByType[type];
-    const firstField = fields.find(field => includeHidden || !field.config.custom?.['hidden']);
+    const firstField = fields.find(field => includeHidden || !field.config.custom?.hidden);
     return firstField;
   }
 

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -57,9 +57,9 @@ export class FieldCache {
     return types && types.length > 0;
   }
 
-  getFirstFieldOfType(type: FieldType): FieldWithIndex | undefined {
+  getFirstFieldOfType(type: FieldType, includeHidden = false): FieldWithIndex | undefined {
     const fields = this.fieldByType[type];
-    const firstField = fields.find(field => !(field.config.custom && field.config.custom['Hidden']));
+    const firstField = fields.find(field => includeHidden || !field.config.custom?.['hidden']);
     return firstField;
   }
 

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -96,6 +96,7 @@ export interface Column {
   text: string; // For a Column, the 'text' is the field name
   filterable?: boolean;
   unit?: string;
+  custom?: Record<string, any>;
 }
 
 export interface TableData extends QueryResultBase {

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -83,8 +83,10 @@ class UnThemedLogDetails extends PureComponent<Props> {
     return (
       row.dataFrame.fields
         .map((field, index) => ({ ...field, index }))
-        // Remove Id which we use for react key and entry field which we are showing as the log message.
-        .filter((field, index) => 'id' !== field.name && row.entryFieldIndex !== index)
+        // Remove Id which we use for react key and entry field which we are showing as the log message. Also remove hidden fields.
+        .filter(
+          (field, index) => !('id' === field.name || row.entryFieldIndex === index || field.config.custom?.hidden)
+        )
         // Filter out fields without values. For example in elastic the fields are parsed from the document which can
         // have different structure per row and so the dataframe is pretty sparse.
         .filter(field => {

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -7,6 +7,7 @@ export interface TableFieldOptions {
   width: number;
   align: FieldTextAlignment;
   displayMode: TableCellDisplayMode;
+  hidden?: boolean;
 }
 
 export enum TableCellDisplayMode {

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -38,9 +38,12 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
   const columns: Column[] = [];
   let fieldCountWithoutWidth = data.fields.length;
 
-  for (let fieldIndex = 0; fieldIndex < data.fields.length; fieldIndex++) {
-    const field = data.fields[fieldIndex];
+  for (const [fieldIndex, field] of data.fields.entries()) {
     const fieldTableOptions = (field.config.custom || {}) as TableFieldOptions;
+
+    if (fieldTableOptions.hidden) {
+      continue;
+    }
 
     if (fieldTableOptions.width) {
       availableWidth -= fieldTableOptions.width;

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -39,6 +39,8 @@ type DatasourceInfo struct {
 }
 
 const CLOUDWATCH_TS_FORMAT = "2006-01-02 15:04:05.000"
+const LOG_IDENTIFIER_INTERNAL = "__log_grafana_internal__"
+const LOGSTREAM_IDENTIFIER_INTERNAL = "__logstream__grafana_internal__"
 
 func (e *CloudWatchExecutor) getLogsClient(region string) (*cloudwatchlogs.CloudWatchLogs, error) {
 	e.mux.Lock()

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -39,7 +39,9 @@ type DatasourceInfo struct {
 }
 
 const CLOUDWATCH_TS_FORMAT = "2006-01-02 15:04:05.000"
-const LOG_IDENTIFIER_INTERNAL = "__log_grafana_internal__"
+
+// Constants also defined in datasource/cloudwatch/datasource.ts
+const LOG_IDENTIFIER_INTERNAL = "__log__grafana_internal__"
 const LOGSTREAM_IDENTIFIER_INTERNAL = "__logstream__grafana_internal__"
 
 func (e *CloudWatchExecutor) getLogsClient(region string) (*cloudwatchlogs.CloudWatchLogs, error) {

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -52,11 +52,11 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 
 		if *fieldName == "@timestamp" {
 			newFields[len(newFields)-1].SetConfig(&data.FieldConfig{Title: "Time"})
-		} else if *fieldName == "@logStream" || *fieldName == "@log" {
+		} else if *fieldName == LOGSTREAM_IDENTIFIER_INTERNAL || *fieldName == LOG_IDENTIFIER_INTERNAL {
 			newFields[len(newFields)-1].SetConfig(
 				&data.FieldConfig{
 					Custom: map[string]interface{}{
-						"Hidden": true,
+						"hidden": true,
 					},
 				},
 			)

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -39,6 +39,14 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Field: aws.String("@log"),
 					Value: aws.String("fakelog"),
 				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Value: aws.String("fakelogstream"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
+					Value: aws.String("fakelog"),
+				},
 			},
 			{
 				&cloudwatchlogs.ResultField{
@@ -61,6 +69,14 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Field: aws.String("@log"),
 					Value: aws.String("fakelog"),
 				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Value: aws.String("fakelogstream"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
+					Value: aws.String("fakelog"),
+				},
 			},
 			{
 				&cloudwatchlogs.ResultField{
@@ -81,6 +97,14 @@ func TestLogsResultsToDataframes(t *testing.T) {
 				},
 				&cloudwatchlogs.ResultField{
 					Field: aws.String("@log"),
+					Value: aws.String("fakelog"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Value: aws.String("fakelogstream"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
 					Value: aws.String("fakelog"),
 				},
 			},
@@ -114,20 +138,32 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		aws.String("fakelogstream"),
 		aws.String("fakelogstream"),
 	})
-	logStreamField.SetConfig(&data.FieldConfig{
-		Custom: map[string]interface{}{
-			"Hidden": true,
-		},
-	})
 
 	logField := data.NewField("@log", nil, []*string{
 		aws.String("fakelog"),
 		aws.String("fakelog"),
 		aws.String("fakelog"),
 	})
-	logField.SetConfig(&data.FieldConfig{
+
+	hiddenLogStreamField := data.NewField(LOGSTREAM_IDENTIFIER_INTERNAL, nil, []*string{
+		aws.String("fakelogstream"),
+		aws.String("fakelogstream"),
+		aws.String("fakelogstream"),
+	})
+	hiddenLogStreamField.SetConfig(&data.FieldConfig{
 		Custom: map[string]interface{}{
-			"Hidden": true,
+			"hidden": true,
+		},
+	})
+
+	hiddenLogField := data.NewField(LOG_IDENTIFIER_INTERNAL, nil, []*string{
+		aws.String("fakelog"),
+		aws.String("fakelog"),
+		aws.String("fakelog"),
+	})
+	hiddenLogField.SetConfig(&data.FieldConfig{
+		Custom: map[string]interface{}{
+			"hidden": true,
 		},
 	})
 
@@ -138,6 +174,8 @@ func TestLogsResultsToDataframes(t *testing.T) {
 			lineField,
 			logStreamField,
 			logField,
+			hiddenLogStreamField,
+			hiddenLogField,
 		},
 		RefID: "",
 		Meta: &data.FrameMeta{

--- a/public/app/core/table_model.ts
+++ b/public/app/core/table_model.ts
@@ -5,7 +5,7 @@ import { Column, TableData, QueryResultMeta } from '@grafana/data';
  * Extends the standard Column class with variables that get
  * mutated in the angular table panel.
  */
-interface MutableColumn extends Column {
+export interface MutableColumn extends Column {
   title?: string;
   sort?: boolean;
   desc?: boolean;

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -10,7 +10,7 @@ import {
   PreferredVisualisationType,
 } from '@grafana/data';
 import { ExploreItemState } from 'app/types/explore';
-import TableModel, { mergeTablesIntoModel } from 'app/core/table_model';
+import TableModel, { mergeTablesIntoModel, MutableColumn } from 'app/core/table_model';
 import { sortLogsResult, refreshIntervalToSortOrder } from 'app/core/utils/explore';
 import { dataFrameToLogsModel } from 'app/core/logs_model';
 import { getGraphSeriesModel } from 'app/plugins/panel/graph2/getGraphSeriesModel';
@@ -61,10 +61,11 @@ export class ResultProcessor {
       const fieldCount = fields.length;
       const rowCount = frame.length;
 
-      const columns = fields.map(field => ({
+      const columns: MutableColumn[] = fields.map(field => ({
         text: field.name,
         type: field.type,
         filterable: field.config.filterable,
+        custom: field.config.custom,
       }));
 
       const rows: any[][] = [];

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -50,7 +50,9 @@ import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContext
 import { AwsUrl, encodeUrl } from './aws_url';
 
 const TSDB_QUERY_ENDPOINT = '/api/tsdb/query';
-const LOG_IDENTIFIER_INTERNAL = '__log_grafana_internal__';
+
+// Constants also defined in tsdb/cloudwatch/cloudwatch.go
+const LOG_IDENTIFIER_INTERNAL = '__log__grafana_internal__';
 const LOGSTREAM_IDENTIFIER_INTERNAL = '__logstream__grafana_internal__';
 
 const displayAlert = (datasourceName: string, region: string) =>

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -45,10 +45,13 @@ import { from, empty, Observable } from 'rxjs';
 import { delay, expand, map, mergeMap, tap, finalize, catchError } from 'rxjs/operators';
 import { CloudWatchLanguageProvider } from './language_provider';
 
-const TSDB_QUERY_ENDPOINT = '/api/tsdb/query';
 import { VariableWithMultiSupport } from 'app/features/templating/types';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 import { AwsUrl, encodeUrl } from './aws_url';
+
+const TSDB_QUERY_ENDPOINT = '/api/tsdb/query';
+const LOG_IDENTIFIER_INTERNAL = '__log_grafana_internal__';
+const LOGSTREAM_IDENTIFIER_INTERNAL = '__logstream__grafana_internal__';
 
 const displayAlert = (datasourceName: string, region: string) =>
   store.dispatch(
@@ -348,12 +351,12 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
     let logField = null;
 
     for (const field of row.dataFrame.fields) {
-      if (field.name === '@logStream') {
+      if (field.name === LOGSTREAM_IDENTIFIER_INTERNAL) {
         logStreamField = field;
         if (logField !== null) {
           break;
         }
-      } else if (field.name === '@log') {
+      } else if (field.name === LOG_IDENTIFIER_INTERNAL) {
         logField = field;
         if (logStreamField !== null) {
           break;


### PR DESCRIPTION
**What this PR does / why we need it**:
In order for CloudWatch logs users to be able to see the surrounding context of log rows returned in Explore, we need to explicitly return the `@log` and `@logStream` fields associated with each row as the CloudWatch logs API requires this information for retrieving log row context. In most cases however this information shouldn't be visible to users as it can distract from the fields that they are actually interested in. This PR hides fields that are specified as "hidden", so that they are not displayed in tables.

See https://github.com/grafana/grafana/issues/24333

**Special notes for your reviewer**:
One issue this might cause is that in some situations a user might actually want to see the `@log` or `@logStream` fields, for example if they were grouping the results of a stats query by log group. Solving this issue might involve some complex logic involving parsing of a user's query and extracting the arguments of `field` and `display` commands, but I imagine there might be many edge-cases involved in this kind of solution.

EDIT: Resolved by aliasing `@log` and `@logStream` to "\_\_log_grafana_internal__" and " "\_\_logstream__grafana_internal__" respectively. A workaround was needed as currently it seems CloudWatch does not allow for a query to refer to a field both by an alias and its non-aliased name, but by performing a redundant transformation on the `@log` and `@logStream` fields (such as `ltrim` or `concat(@log, "")`), I imagine CloudWatch no longer considers the fields the same, and an error isn't thrown.