### PR TITLE
CloudWatch/Logs: Fix suggestion for already inserted field

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language_provider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.ts
@@ -317,7 +317,7 @@ export class CloudWatchLanguageProvider extends LanguageProvider {
           label: 'Fields',
           items: fields.map(field => ({
             label: field,
-            insertText: field.match(/@?[_a-zA-Z]+[_.0-9a-zA-Z]*/) ? field : `\`${field}\``,
+            insertText: field.match(/@?[_a-zA-Z]+[_.0-9a-zA-Z]*/) ? undefined : `\`${field}\``,
           })),
         },
       ],


### PR DESCRIPTION
Fixes
> CloudWatch Logs: Clicking on auto-completed stream doesn't do anything just keep suggesting streams over and over again.

from: https://github.com/grafana/grafana/issues/24504

If item has insertText then it is not filtered out in the Suggestion plugin even if it already matches the full prefix.