### PR TITLE
TimePicker: some fixes and polish after testing feedback

### DIFF
--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -1,5 +1,18 @@
-// List taken from https://stackoverflow.com/questions/38399465/how-to-get-list-of-all-timezones-in-javascript
+import { TimeZone } from '../types';
+import { getTimeZone } from './common';
 
+export const timeZoneFormatUserFriendly = (timeZone: TimeZone | undefined) => {
+  switch (getTimeZone({ timeZone })) {
+    case 'browser':
+      return 'Local browser time';
+    case 'utc':
+      return 'UTC';
+    default:
+      return timeZone;
+  }
+};
+
+// List taken from https://stackoverflow.com/questions/38399465/how-to-get-list-of-all-timezones-in-javascript
 export const getTimeZoneGroups = () => {
   const europeZones = [
     'Europe/Amsterdam',

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangePicker.tsx
@@ -13,7 +13,7 @@ import { stylesFactory } from '../../themes/stylesFactory';
 import { withTheme, useTheme } from '../../themes/ThemeContext';
 
 // Types
-import { isDateTime, rangeUtil, GrafanaTheme, dateTimeFormatWithAbbrevation } from '@grafana/data';
+import { isDateTime, rangeUtil, GrafanaTheme, dateTimeFormat, timeZoneFormatUserFriendly } from '@grafana/data';
 import { TimeRange, TimeOption, TimeZone, dateMath } from '@grafana/data';
 import { Themeable } from '../../types';
 
@@ -206,13 +206,21 @@ const ZoomOutTooltip = () => (
   </>
 );
 
-const TimePickerTooltip = ({ timeRange, timeZone }: { timeRange: TimeRange; timeZone?: TimeZone }) => (
-  <>
-    {dateTimeFormatWithAbbrevation(timeRange.from, { timeZone })}
-    <div className="text-center">to</div>
-    {dateTimeFormatWithAbbrevation(timeRange.to, { timeZone })}
-  </>
-);
+const TimePickerTooltip = ({ timeRange, timeZone }: { timeRange: TimeRange; timeZone?: TimeZone }) => {
+  const theme = useTheme();
+  const styles = getLabelStyles(theme);
+
+  return (
+    <>
+      {dateTimeFormat(timeRange.from, { timeZone })}
+      <div className="text-center">to</div>
+      {dateTimeFormat(timeRange.to, { timeZone })}
+      <div className="text-center">
+        <span className={styles.utc}>{timeZoneFormatUserFriendly(timeZone)}</span>
+      </div>
+    </>
+  );
+};
 
 const TimePickerButtonLabel = memo<Props>(({ hideText, value, timeZone }) => {
   const theme = useTheme();

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -133,6 +133,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
                 invalid={!this.state.isNowDelayValid}
                 placeholder="0m"
                 onChange={this.onNowDelayChange}
+                defaultValue={dashboard.timepicker.nowDelay}
               />
             </Tooltip>
           </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] TimeZones support: `Now delay now` doesn't seem to apply. Adding for example `1m` and going back to dashboard it doesn't apply. Going back to dashboard settings, the `Now delay now` field is empty again. @mckn 
  ![image](https://user-images.githubusercontent.com/1668778/81620286-d0ecd100-93eb-11ea-8e6c-f2cbb2dcff2c.png)
- [x] TimeZones support: Minor/feedback.Would be helpful/nice if timepicker tooltip showed the timezone selected and not the abbreviation since the abbreviation already is displayed in "timepicker selection" @mckn 
  ![image](https://user-images.githubusercontent.com/1668778/81620465-39d44900-93ec-11ea-979d-68a348ec7079.png)
- [x] TimeZones support: Minor/feedback. "timepicker selection" and tooltip maybe should show that local browser time is in use since all other timezones shows this? @mckn 
  ![image](https://user-images.githubusercontent.com/1668778/81620534-68eaba80-93ec-11ea-8ca3-082addf9ef7e.png)

From the following issue: #23551

