### PR TITLE
CircleCI: Upgrade grabpl in order to fix package publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.5
+            VERSION=0.4.6
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the package publishing jobs in CircleCI master pipeline, by upgrading the build pipeline tool.
