### PR TITLE
grafana/ui: Fix Icon alignment on Safari

### DIFF
--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -117,6 +117,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, surface: SurfaceType, size
     `,
     icon: css`
       margin-bottom: 0;
+      vertical-align: baseline;
       display: flex;
     `,
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The icons used inside the `IconButton` component have wrong alignment causing their bottom parts to be cut out:
![Screenshot 2020-05-13 at 11 14 42](https://user-images.githubusercontent.com/8878045/81788605-7a76b400-950b-11ea-99c2-147bd557cb32.png)

The issue seems to be due to `vertical-align: middle` prop, switching it to `baseline` inside `IconButton` fixes the issue, while also doesn't impact the positioning of the icons on Chrome. 
![Screenshot 2020-05-13 at 11 14 51](https://user-images.githubusercontent.com/8878045/81788795-c32e6d00-950b-11ea-9d1c-37f0effa6304.png)


