### PR TITLE
CloudWatch/Logs: Correctly interpolate variables in logs queries

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -577,6 +577,9 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
     if (makeReplacements) {
       requestParams.queries.forEach(query => {
+        if (query.hasOwnProperty('queryString')) {
+          query.queryString = this.replace(query.queryString, scopedVars, true);
+        }
         query.region = this.replace(query.region, scopedVars, true, 'region');
         query.region = this.getActualRegion(query.region);
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
Interpolation of template variables in CloudWatch logs queries wasn't being done. This PR fixes that issue.

**Which issue(s) this PR fixes**:
Closes #24603