### PR TITLE
Org/user/team preferences: Fixes so UI Theme can be set back to Default

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -100,7 +100,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
   };
 
   onThemeChanged = (theme: SelectableValue<string>) => {
-    if (!theme || !theme.value) {
+    if (!theme || typeof theme.value !== 'string') {
       return;
     }
     this.setState({ theme: theme.value });


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the Theme dropdown in the SharedPreferences component so the user is able to set it back to  the `Default` value. 

**Which issue(s) this PR fixes**:
Fixes #24510