### PR TITLE
CloudWatch: Fix variable naming

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -38,11 +38,11 @@ type DatasourceInfo struct {
 	SecretKey string
 }
 
-const CLOUDWATCH_TS_FORMAT = "2006-01-02 15:04:05.000"
+const cloudWatchTSFormat = "2006-01-02 15:04:05.000"
 
 // Constants also defined in datasource/cloudwatch/datasource.ts
-const LOG_IDENTIFIER_INTERNAL = "__log__grafana_internal__"
-const LOGSTREAM_IDENTIFIER_INTERNAL = "__logstream__grafana_internal__"
+const logIdentifierInternal = "__log__grafana_internal__"
+const logStreamIdentifierInternal = "__logstream__grafana_internal__"
 
 func (e *CloudWatchExecutor) getLogsClient(region string) (*cloudwatchlogs.CloudWatchLogs, error) {
 	e.mux.Lock()
@@ -226,7 +226,7 @@ func queryResultsToDataframe(results *cloudwatchlogs.GetQueryResultsOutput) (*da
 			}
 
 			if _, exists := fieldValues[*resultField.Field]; !exists {
-				if _, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value); err == nil {
+				if _, err := time.Parse(cloudWatchTSFormat, *resultField.Value); err == nil {
 					fieldValues[*resultField.Field] = make([]*time.Time, rowCount)
 				} else if _, err := strconv.ParseFloat(*resultField.Value, 64); err == nil {
 					fieldValues[*resultField.Field] = make([]*float64, rowCount)
@@ -236,7 +236,7 @@ func queryResultsToDataframe(results *cloudwatchlogs.GetQueryResultsOutput) (*da
 			}
 
 			if timeField, ok := fieldValues[*resultField.Field].([]*time.Time); ok {
-				parsedTime, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value)
+				parsedTime, err := time.Parse(cloudWatchTSFormat, *resultField.Value)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -242,7 +242,7 @@ func (e *CloudWatchExecutor) executeStartQuery(ctx context.Context, logsClient c
 		EndTime:       aws.Int64(endTime.Unix()),
 		Limit:         aws.Int64(parameters.Get("limit").MustInt64(1000)),
 		LogGroupNames: aws.StringSlice(parameters.Get("logGroupNames").MustStringArray()),
-		QueryString:   aws.String("fields @timestamp,ltrim(@log) as " + LOG_IDENTIFIER_INTERNAL + ",ltrim(@logStream) as " + LOGSTREAM_IDENTIFIER_INTERNAL + "|" + parameters.Get("queryString").MustString("")),
+		QueryString:   aws.String("fields @timestamp,ltrim(@log) as " + logIdentifierInternal + ",ltrim(@logStream) as " + logStreamIdentifierInternal + "|" + parameters.Get("queryString").MustString("")),
 	}
 	return logsClient.StartQueryWithContext(ctx, startQueryInput)
 }

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -52,7 +52,7 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 
 		if *fieldName == "@timestamp" {
 			newFields[len(newFields)-1].SetConfig(&data.FieldConfig{Title: "Time"})
-		} else if *fieldName == LOGSTREAM_IDENTIFIER_INTERNAL || *fieldName == LOG_IDENTIFIER_INTERNAL {
+		} else if *fieldName == logStreamIdentifierInternal || *fieldName == logIdentifierInternal {
 			newFields[len(newFields)-1].SetConfig(
 				&data.FieldConfig{
 					Custom: map[string]interface{}{

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -26,7 +26,7 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 				fieldNames = append(fieldNames, resultField.Field)
 
 				// Check if field is time field
-				if _, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value); err == nil {
+				if _, err := time.Parse(cloudWatchTSFormat, *resultField.Value); err == nil {
 					fieldValues[*resultField.Field] = make([]*time.Time, rowCount)
 				} else {
 					fieldValues[*resultField.Field] = make([]*string, rowCount)
@@ -34,7 +34,7 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 			}
 
 			if timeField, ok := fieldValues[*resultField.Field].([]*time.Time); ok {
-				parsedTime, err := time.Parse(CLOUDWATCH_TS_FORMAT, *resultField.Value)
+				parsedTime, err := time.Parse(cloudWatchTSFormat, *resultField.Value)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -40,11 +40,11 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Value: aws.String("fakelog"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Field: aws.String(logStreamIdentifierInternal),
 					Value: aws.String("fakelogstream"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
+					Field: aws.String(logIdentifierInternal),
 					Value: aws.String("fakelog"),
 				},
 			},
@@ -70,11 +70,11 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Value: aws.String("fakelog"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Field: aws.String(logStreamIdentifierInternal),
 					Value: aws.String("fakelogstream"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
+					Field: aws.String(logIdentifierInternal),
 					Value: aws.String("fakelog"),
 				},
 			},
@@ -100,11 +100,11 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Value: aws.String("fakelog"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOGSTREAM_IDENTIFIER_INTERNAL),
+					Field: aws.String(logStreamIdentifierInternal),
 					Value: aws.String("fakelogstream"),
 				},
 				&cloudwatchlogs.ResultField{
-					Field: aws.String(LOG_IDENTIFIER_INTERNAL),
+					Field: aws.String(logIdentifierInternal),
 					Value: aws.String("fakelog"),
 				},
 			},
@@ -145,7 +145,7 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		aws.String("fakelog"),
 	})
 
-	hiddenLogStreamField := data.NewField(LOGSTREAM_IDENTIFIER_INTERNAL, nil, []*string{
+	hiddenLogStreamField := data.NewField(logStreamIdentifierInternal, nil, []*string{
 		aws.String("fakelogstream"),
 		aws.String("fakelogstream"),
 		aws.String("fakelogstream"),
@@ -156,7 +156,7 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		},
 	})
 
-	hiddenLogField := data.NewField(LOG_IDENTIFIER_INTERNAL, nil, []*string{
+	hiddenLogField := data.NewField(logIdentifierInternal, nil, []*string{
 		aws.String("fakelog"),
 		aws.String("fakelog"),
 		aws.String("fakelog"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix some variable naming in CloudWatch code; non-idiomatic variable naming will be caught once we enable stricter linting in Grafana.
