### PR TITLE
Provisioning: Use proxy as default access mode in provisioning

### DIFF
--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -94,6 +94,10 @@ func validateDefaultUniqueness(datasources []*configs) error {
 				ds.OrgID = 1
 			}
 
+			if ds.Access == "" {
+				ds.Access = "proxy"
+			}
+
 			if ds.IsDefault {
 				defaultCount[ds.OrgID] = defaultCount[ds.OrgID] + 1
 				if defaultCount[ds.OrgID] > 1 {

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -21,6 +21,7 @@ var (
 	versionZero                     = "testdata/version-0"
 	brokenYaml                      = "testdata/broken-yaml"
 	multipleOrgsWithDefault         = "testdata/multiple-org-default"
+	withoutDefaults                 = "testdata/appliedDefaults"
 
 	fakeRepo *fakeRepository
 )
@@ -34,6 +35,18 @@ func TestDatasourceAsConfig(t *testing.T) {
 		bus.AddHandler("test", mockUpdate)
 		bus.AddHandler("test", mockGet)
 		bus.AddHandler("test", mockGetAll)
+
+		Convey("apply default values when missing", func() {
+			dc := newDatasourceProvisioner(logger)
+			err := dc.applyChanges(withoutDefaults)
+			if err != nil {
+				t.Fatalf("applyChanges return an error %v", err)
+			}
+
+			So(len(fakeRepo.inserted), ShouldEqual, 1)
+			So(fakeRepo.inserted[0].OrgId, ShouldEqual, 1)
+			So(fakeRepo.inserted[0].Access, ShouldEqual, "proxy")
+		})
 
 		Convey("One configured datasource", func() {
 			Convey("no datasource in database", func() {

--- a/pkg/services/provisioning/datasources/testdata/appliedDefaults/without-defaults.yaml
+++ b/pkg/services/provisioning/datasources/testdata/appliedDefaults/without-defaults.yaml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+datasources:
+  - name: $TEST_VAR
+    type: type


### PR DESCRIPTION
`Save & Test` is broken if the data source is provisioned without `access` configured. Since we require `access` to be configured in the API I suspect that something changes on the datasource edit page so that access mode is not sent unless configured. While this might not be a common problem it's very frustrating to debug. 

Setting proxy as default value in provisioning should work around this. 

fixes #24591
fixes #19501

