### PR TITLE
@grafana/toolkit: Use process.cwd() instead of PWD to get directory

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -8,7 +8,7 @@ let includeInternalScripts = false;
 const isLinkedMode = () => {
   // In circleci we are in linked mode. Detect by using the circle working directory,
   // rather than the present working directory.
-  const pwd = process.env.CIRCLE_WORKING_DIRECTORY || process.env.PWD;
+  const pwd = process.env.CIRCLE_WORKING_DIRECTORY || process.env.PWD || process.cwd();
 
   if (path.basename(pwd) === 'grafana-toolkit') {
     return true;


### PR DESCRIPTION
**What this PR does / why we need it**:

In windows system env.PWD is not present but we can get the current dictionary with the cwd method.

**Which issue(s) this PR fixes**:

Fixes #24582 - Error running yarn dev command

