### PR TITLE
Enhance custom variable options

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Switch/Switch.tsx
@@ -12,6 +12,7 @@ export interface Props {
   tooltip?: string;
   tooltipPlacement?: PopperJS.Placement;
   transparent?: boolean;
+  disabled?: boolean;
   onChange: (event: React.SyntheticEvent<HTMLInputElement>) => void;
 }
 
@@ -36,6 +37,7 @@ export class Switch extends PureComponent<Props, State> {
       label,
       checked,
       transparent,
+      disabled,
       className,
       tooltip,
       tooltipPlacement,
@@ -44,10 +46,14 @@ export class Switch extends PureComponent<Props, State> {
     const labelId = this.state.id;
     const labelClassName = `gf-form-label ${labelClass} ${transparent ? 'gf-form-label--transparent' : ''} pointer`;
     const switchClassName = `gf-form-switch ${switchClass} ${transparent ? 'gf-form-switch--transparent' : ''}`;
+    const containerClassName = `
+      gf-form gf-form-switch-container ${className || ''}
+      ${disabled ? 'gf-form-switch-container--disabled' : ''}
+    `;
 
     return (
       <div className="gf-form-switch-container-react">
-        <label htmlFor={labelId} className={`gf-form gf-form-switch-container ${className || ''}`}>
+        <label htmlFor={labelId} className={containerClassName}>
           {label && (
             <div className={labelClassName}>
               {label}

--- a/public/app/core/utils/text_width.ts
+++ b/public/app/core/utils/text_width.ts
@@ -1,0 +1,91 @@
+export function getTextWidth(text: string, elem: HTMLElement, padding = true): number {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  const style = window.getComputedStyle(elem);
+  context.font = getFontFromComputedStyle(style);
+  let width = context.measureText(text).width;
+  if (padding) {
+    width = accountPadding(width, style);
+  }
+  return Math.ceil(width);
+}
+
+export function getFontFromComputedStyle(style: CSSStyleDeclaration): string {
+  let font = style.font;
+  // Firefox returns the empty string for .font, so create the .font property manually
+  if (font === '') {
+    const fontStretch = convFontStretch(style.fontStretch);
+    font =
+      style.fontStyle +
+      ' ' +
+      style.fontVariant +
+      ' ' +
+      style.fontWeight +
+      ' ' +
+      fontStretch +
+      ' ' +
+      style.fontSize +
+      '/' +
+      style.lineHeight +
+      ' ' +
+      style.fontFamily;
+  }
+  return font;
+}
+
+function convFontStretch(key: string): string {
+  const last = key.charAt(key.length - 1);
+  if (last !== '%') {
+    return key;
+  }
+
+  // Firefox uses percentages for font-stretch,
+  // but Canvas does not accept percentages
+  // so convert to keywords, as listed at:
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch
+  switch (key) {
+    case '50%':
+      return 'ultra-condensed';
+    case '62.5%':
+      return 'extra-condensed';
+    case '75%':
+      return 'condensed';
+    case '87.5%':
+      return 'semi-condensed';
+    case '100%':
+      return 'normal';
+    case '112.5%':
+      return 'semi-expanded';
+    case '125%':
+      return 'expanded';
+    case '150%':
+      return 'extra-expanded';
+    case '200%':
+      return 'ultra-expanded';
+  }
+  // If the retrieved font-stretch percentage isn't found in the lookup table,
+  // use 'normal' as a last resort.
+  return 'normal';
+}
+
+function accountPadding(width: number, style: CSSStyleDeclaration): number {
+  const l = padToNum(style.paddingLeft);
+  const r = padToNum(style.paddingRight);
+  width /= 1 - (l.pc + r.pc);
+  width += l.px + r.px;
+  return width;
+}
+
+function padToNum(pad: string): { px: number; pc: number } {
+  let px = 0;
+  let pc = 0; // percent
+  if (pad) {
+    if (pad.endsWith('%')) {
+      pc = Number(pad.slice(0, -1)) || 0;
+      pc /= 100;
+    } else if (pad.endsWith('px')) {
+      px = Number(pad.slice(0, -2)) || 0;
+    }
+  }
+  return { px, pc };
+}

--- a/public/app/features/templating/custom_variable.ts
+++ b/public/app/features/templating/custom_variable.ts
@@ -22,6 +22,8 @@ export class CustomVariable implements CustomVariableModel, VariableActions {
   multi: boolean;
   current: VariableOption;
   allValue: string;
+  noclear: boolean;
+  editable: boolean;
 
   defaults: CustomVariableModel = {
     type: 'custom',
@@ -35,6 +37,8 @@ export class CustomVariable implements CustomVariableModel, VariableActions {
     multi: false,
     current: {} as VariableOption,
     allValue: null,
+    noclear: false,
+    editable: false,
   };
 
   /** @ngInject */

--- a/public/app/features/templating/types.ts
+++ b/public/app/features/templating/types.ts
@@ -36,6 +36,7 @@ export interface VariableOption {
   text: string | string[];
   value: string | string[];
   isNone?: boolean;
+  custom?: boolean;
   tags?: VariableTag[];
 }
 
@@ -58,7 +59,10 @@ export interface IntervalVariableModel extends VariableWithOptions {
   refresh: VariableRefresh;
 }
 
-export interface CustomVariableModel extends VariableWithMultiSupport {}
+export interface CustomVariableModel extends VariableWithMultiSupport {
+  noclear: boolean;
+  editable: boolean;
+}
 
 export interface DataSourceVariableModel extends VariableWithMultiSupport {
   regex: string;

--- a/public/app/features/variables/custom/CustomVariableEditor.tsx
+++ b/public/app/features/variables/custom/CustomVariableEditor.tsx
@@ -82,24 +82,24 @@ class CustomVariableEditorUnconnected extends PureComponent<Props> {
               aria-label="Variable editor Form Custom Query field"
             />
           </div>
-          {!this.props.variable.multi && (
-            <div className="section">
-              <Switch
-                label="Do not clear"
-                labelClass="width-10"
-                checked={this.props.variable.noclear}
-                onChange={this.onNoClearChange}
-                tooltip={'Keep text of current option in textbox to simplify copy-paste'}
-              />
-              <Switch
-                label="Make editable"
-                labelClass="width-10"
-                checked={this.props.variable.editable}
-                onChange={this.onEditableChange}
-                tooltip={'Add current option to dropdown list'}
-              />
-            </div>
-          )}
+          <div className="section">
+            <Switch
+              label="Do not clear"
+              labelClass="width-10"
+              checked={this.props.variable.noclear}
+              disabled={this.props.variable.multi}
+              onChange={this.onNoClearChange}
+              tooltip={'Keep text of current option in textbox to simplify copy-paste'}
+            />
+            <Switch
+              label="Make editable"
+              labelClass="width-10"
+              checked={this.props.variable.editable}
+              disabled={this.props.variable.multi}
+              onChange={this.onEditableChange}
+              tooltip={'Add current option to dropdown list'}
+            />
+          </div>
         </div>
         <SelectionOptionsEditor
           variable={this.props.variable}

--- a/public/app/features/variables/custom/CustomVariableEditor.tsx
+++ b/public/app/features/variables/custom/CustomVariableEditor.tsx
@@ -6,6 +6,11 @@ import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { StoreState } from 'app/types';
 import { changeVariableMultiValue } from '../state/actions';
+import { VariableIdentifier } from '../state/types';
+import { ThunkResult } from '../../../types';
+import { LegacyForms } from '@grafana/ui';
+
+const { Switch } = LegacyForms;
 
 interface OwnProps extends VariableEditorProps<CustomVariableModel> {}
 
@@ -25,8 +30,30 @@ class CustomVariableEditorUnconnected extends PureComponent<Props> {
     });
   };
 
+  onNoClearChange = (event: ChangeEvent<HTMLInputElement>) => {
+    this.props.onPropChange({
+      propName: 'noclear',
+      propValue: event.target.checked,
+    });
+  };
+
+  onEditableChange = (event: ChangeEvent<HTMLInputElement>) => {
+    this.props.onPropChange({
+      propName: 'editable',
+      propValue: event.target.checked,
+    });
+  };
+
   onSelectionOptionsChange = async ({ propName, propValue }: OnPropChangeArguments<VariableWithMultiSupport>) => {
     this.props.onPropChange({ propName, propValue, updateOptions: true });
+  };
+
+  onMultiChange = (identifier: VariableIdentifier, multi: boolean): ThunkResult<void> => {
+    if (multi) {
+      this.props.onPropChange({ propName: 'noclear', propValue: false });
+      this.props.onPropChange({ propName: 'editable', propValue: false });
+    }
+    return this.props.changeVariableMultiValue(identifier, multi);
   };
 
   onBlur = (event: FocusEvent<HTMLInputElement>) => {
@@ -55,11 +82,29 @@ class CustomVariableEditorUnconnected extends PureComponent<Props> {
               aria-label="Variable editor Form Custom Query field"
             />
           </div>
+          {!this.props.variable.multi && (
+            <div className="section">
+              <Switch
+                label="Do not clear"
+                labelClass="width-10"
+                checked={this.props.variable.noclear}
+                onChange={this.onNoClearChange}
+                tooltip={'Keep text of current option in textbox to simplify copy-paste'}
+              />
+              <Switch
+                label="Make editable"
+                labelClass="width-10"
+                checked={this.props.variable.editable}
+                onChange={this.onEditableChange}
+                tooltip={'Add current option to dropdown list'}
+              />
+            </div>
+          )}
         </div>
         <SelectionOptionsEditor
           variable={this.props.variable}
           onPropChange={this.onSelectionOptionsChange}
-          onMultiChanged={this.props.changeVariableMultiValue}
+          onMultiChanged={this.onMultiChange}
         />
       </>
     );

--- a/public/app/features/variables/custom/actions.test.ts
+++ b/public/app/features/variables/custom/actions.test.ts
@@ -49,6 +49,8 @@ describe('custom actions', () => {
         index: 0,
         multi: true,
         includeAll: false,
+        noclear: false,
+        editable: false,
       };
 
       const tester = await reduxTester<{ templating: TemplatingState }>()

--- a/public/app/features/variables/custom/reducer.ts
+++ b/public/app/features/variables/custom/reducer.ts
@@ -16,6 +16,8 @@ export const initialCustomVariableModelState: CustomVariableModel = {
   multi: false,
   includeAll: false,
   allValue: null,
+  noclear: false,
+  editable: false,
   query: '',
   options: [],
   current: {} as VariableOption,

--- a/public/app/features/variables/guard.ts
+++ b/public/app/features/variables/guard.ts
@@ -1,4 +1,10 @@
-import { QueryVariableModel, VariableModel, AdHocVariableModel, VariableWithMultiSupport } from '../templating/types';
+import {
+  QueryVariableModel,
+  VariableModel,
+  AdHocVariableModel,
+  CustomVariableModel,
+  VariableWithMultiSupport,
+} from '../templating/types';
 
 export const isQuery = (model: VariableModel): model is QueryVariableModel => {
   return model.type === 'query';
@@ -6,6 +12,10 @@ export const isQuery = (model: VariableModel): model is QueryVariableModel => {
 
 export const isAdHoc = (model: VariableModel): model is AdHocVariableModel => {
   return model.type === 'adhoc';
+};
+
+export const isCustom = (model: VariableModel): model is CustomVariableModel => {
+  return model.type === 'custom';
 };
 
 export const isMulti = (model: VariableModel): model is VariableWithMultiSupport => {

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -104,7 +104,7 @@ const getSelectedTags = (variable: VariableWithOptions): VariableTag[] => {
   return variable.tags.filter(t => t.selected);
 };
 
-const getLinkText = (variable: VariableWithOptions) => {
+export const getLinkText = (variable: VariableWithOptions) => {
   const { current, options } = variable;
 
   if (!current.tags || current.tags.length === 0) {

--- a/public/app/features/variables/pickers/shared/VariableInput.tsx
+++ b/public/app/features/variables/pickers/shared/VariableInput.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { trim } from 'lodash';
 import { NavigationKey } from '../types';
+import { getTextWidth } from 'app/core/utils/text_width';
 
 export interface Props {
   onChange: (value: string) => void;
@@ -27,17 +28,38 @@ export class VariableInput extends PureComponent<Props> {
   }
 
   render() {
+    const value = this.props.value ?? '';
     return (
       <input
         ref={instance => {
           if (instance) {
             instance.focus();
-            instance.setAttribute('style', `width:${Math.max(instance.width, 80)}px`);
+            /* Old code computed width at max(instance.width, 80), but
+             * instance.width is usually incorrectly reported as 0 =>
+             * in fact it was constant width == 80px, which could be
+             * too small for some cases.
+             *
+             * 'instance.scrollWidth' is a bad estimation when there is no text
+             * and when characters are being deleted - in both cases reported
+             * value is a way too high. It provides good estimation only when
+             * text is starting to overfill textbox.
+             *
+             * There is also a way to use 'ch' measurement instead of 'px', but
+             * it is good only for monospace fonts, and with other fonts there are
+             * characters that have 2x width compared to '0' char, and, at the
+             * same time, characters, that have much smaller width.
+             *
+             * As a result, it is better to extract font info from element and
+             * compute actual text width using canvas, add a small margin of 4px
+             * for cursor and selection, and then set sensible min and max limits.
+             */
+            const width = getTextWidth(value, instance) + 4;
+            instance.setAttribute('style', `width:${Math.min(Math.max(width, 80), 300)}px`);
           }
         }}
         type="text"
         className="gf-form-input"
-        value={this.props.value ?? ''}
+        value={value}
         onChange={this.onChange}
         onKeyDown={this.onKeyDown}
       />

--- a/public/sass/components/_switch.scss
+++ b/public/sass/components/_switch.scss
@@ -22,6 +22,13 @@ gf-form-switch[disabled] {
   display: flex;
   cursor: pointer;
   margin-right: $space-xs;
+
+  &--disabled {
+    pointer-events: none;
+    .gf-form-label {
+      color: $text-color-faint;
+    }
+  }
 }
 
 .gf-form-switch {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently custom variable is used mainly to select some value from predefined options. However, it has some serious limitations:
- If user wants to copy content of this variable, for example, he selected UUID of device to debug, and then wants to copy it somewhere else, say, into another dashboard open on another page, he can't do it, as when you click on the custom variable, the text is getting cleared from the input field. The only option then is to find UUID in page URL and copy it from there.
- Custom variable allows to provide some non-predefined values, but there are 2 usability problems:
    - If user provided some custom value and wants to slightly edit it, he needs to retype everything, as this value is cleared when he clicks on variable to edit it.
    - If there is a predefined value, and custom value that user wants to type is a prefix of this predefined value, then user won't be able to set this value, as predefined option will always be selected on Enter. Say, if I have a custom variable for syslog filter and have predefined options with most commonly-used filters, say, 'iwevent', to show all wireless driver events, then I can't filter logs just by 'iw'.

This PR provides a way to have best of both worlds of 'Text box' and 'Custom' variables combined - have a predefined list of most commonly used options in drop-down menu, but at the same time have an ability to provide a custom value and easily edit it.

**Which issue(s) this PR fixes**:

This PR also fixes issue with insufficient size of input field of custom variable. Currently input width is not computed correctly and, moreover, is capped at 80px, which is not enough for a lot of cases. And it makes no sense, as when variable value is entered, input field disappears and current variable value is shown in full length. This PR changes a way of input field width computation and sets sensible min/max limits. For example, max limit is enough to show UUID in a custom variable field.

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

Issue: https://github.com/grafana/grafana/issues/24717

PR has been tested with master branch as of May 14 (commit 6a0abf895e9d9f37eb08c66ab90a1049f03420df) by using `make build-docker-full`.