### PR TITLE
Table: Do not include angular options in options when switching from angular panel

### DIFF
--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -24,9 +24,10 @@ export const tablePanelChangedHandler = (
   prevPluginId: string,
   prevOptions: any
 ) => {
-  // Changing from angular singlestat
+  // Changing from angular table panel
   if (prevPluginId === 'table-old' && prevOptions.angular) {
-    console.log('Migrating from angular table', panel);
+    // Todo write migration logic
   }
-  return prevOptions;
+
+  return {};
 };


### PR DESCRIPTION
Noticed that when I switched from graph to table panel the json model included all the graph options as well :) 
