### PR TITLE
Data source: Fix query/annotation help content formatting

### DIFF
--- a/public/sass/components/_gf-form.scss
+++ b/public/sass/components/_gf-form.scss
@@ -164,7 +164,7 @@ $input-border: 1px solid $input-border-color;
 }
 
 .gf-form-pre {
-  display: block;
+  display: block !important;
   flex-grow: 1;
   margin: 0;
   margin-right: $space-xs;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `gf-form-pre` style that impacts annotations help box, query help box, last query error and last generated query for the following datasources:
- Azure Monitor
- StackDriver
- MySQL
- MSSQL
- PostgreSQL

**Which issue(s) this PR fixes**:
Fixes #24519

**Special notes for your reviewer**:
I could only test MySQL and PostgreSQL.

This style change was introduced when this file (https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/Alert/_Alert.scss) has been created, setting the `.alert` `display: flex` property more important than the `gf-form-pre` one.
