### PR TITLE
CloudWatch/Logs: Allows a user to search for log groups that aren't there initially

### DIFF
--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -2,6 +2,9 @@ import { SelectableValue } from '@grafana/data';
 import React from 'react';
 
 export type SelectValue<T> = T | SelectableValue<T> | T[] | Array<SelectableValue<T>>;
+export type InputActionMeta = {
+  action: 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
+};
 
 export interface SelectCommonProps<T> {
   allowCustomValue?: boolean;
@@ -39,7 +42,7 @@ export interface SelectCommonProps<T> {
   onCloseMenu?: () => void;
   /** allowCustomValue must be enabled. Function decides what to do with that custom value. */
   onCreateOption?: (value: string) => void;
-  onInputChange?: (label: string) => void;
+  onInputChange?: (value: string, actionMeta: InputActionMeta) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   onOpenMenu?: () => void;
   openMenuOnFocus?: boolean;

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { CloudWatchLogsQueryField } from './LogsQueryField';
 import { ExploreId } from '../../../../types';
+import { DescribeLogGroupsRequest } from '../types';
+import { SelectableValue } from '@grafana/data';
+
+jest.mock('lodash/debounce', () => {
+  const fakeDebounce = (func: () => any, period: number) => func;
+  return fakeDebounce;
+});
 
 describe('CloudWatchLogsQueryField', () => {
   it('updates upstream query log groups on region change', async () => {
@@ -57,5 +64,152 @@ describe('CloudWatchLogsQueryField', () => {
     expect(getLogGroupSelect().props.value.length).toBe(0);
     // Make sure we correctly updated the upstream state
     expect(onChange.mock.calls[onChange.mock.calls.length - 1][0]).toEqual({ region: 'region2', logGroupNames: [] });
+  });
+
+  it('should merge results of remote log groups search with existing results', async () => {
+    const allLogGroups = [
+      'AmazingGroup',
+      'AmazingGroup2',
+      'AmazingGroup3',
+      'BeautifulGroup',
+      'BeautifulGroup2',
+      'BeautifulGroup3',
+      'CrazyGroup',
+      'CrazyGroup2',
+      'CrazyGroup3',
+      'DeliciousGroup',
+      'DeliciousGroup2',
+      'DeliciousGroup3',
+      'EnjoyableGroup',
+      'EnjoyableGroup2',
+      'EnjoyableGroup3',
+      'FavouriteGroup',
+      'FavouriteGroup2',
+      'FavouriteGroup3',
+      'GorgeousGroup',
+      'GorgeousGroup2',
+      'GorgeousGroup3',
+      'HappyGroup',
+      'HappyGroup2',
+      'HappyGroup3',
+      'IncredibleGroup',
+      'IncredibleGroup2',
+      'IncredibleGroup3',
+      'JollyGroup',
+      'JollyGroup2',
+      'JollyGroup3',
+      'KoolGroup',
+      'KoolGroup2',
+      'KoolGroup3',
+      'LovelyGroup',
+      'LovelyGroup2',
+      'LovelyGroup3',
+      'MagnificentGroup',
+      'MagnificentGroup2',
+      'MagnificentGroup3',
+      'NiceGroup',
+      'NiceGroup2',
+      'NiceGroup3',
+      'OddGroup',
+      'OddGroup2',
+      'OddGroup3',
+      'PerfectGroup',
+      'PerfectGroup2',
+      'PerfectGroup3',
+      'QuietGroup',
+      'QuietGroup2',
+      'QuietGroup3',
+      'RestlessGroup',
+      'RestlessGroup2',
+      'RestlessGroup3',
+      'SurpriseGroup',
+      'SurpriseGroup2',
+      'SurpriseGroup3',
+      'TestingGroup',
+      'TestingGroup2',
+      'TestingGroup3',
+      'UmbrellaGroup',
+      'UmbrellaGroup2',
+      'UmbrellaGroup3',
+      'VelvetGroup',
+      'VelvetGroup2',
+      'VelvetGroup3',
+      'WaterGroup',
+      'WaterGroup2',
+      'WaterGroup3',
+      'XylophoneGroup',
+      'XylophoneGroup2',
+      'XylophoneGroup3',
+      'YellowGroup',
+      'YellowGroup2',
+      'YellowGroup3',
+      'ZebraGroup',
+      'ZebraGroup2',
+      'ZebraGroup3',
+    ];
+
+    const onChange = jest.fn();
+    const wrapper = shallow<CloudWatchLogsQueryField>(
+      <CloudWatchLogsQueryField
+        history={[]}
+        absoluteRange={{ from: 1, to: 10 }}
+        syntaxLoaded={false}
+        syntax={{} as any}
+        exploreId={ExploreId.left}
+        datasource={
+          {
+            getRegions() {
+              return Promise.resolve([
+                {
+                  label: 'region1',
+                  value: 'region1',
+                  text: 'region1',
+                },
+                {
+                  label: 'region2',
+                  value: 'region2',
+                  text: 'region2',
+                },
+              ]);
+            },
+            describeLogGroups(params: DescribeLogGroupsRequest) {
+              const theLogGroups = allLogGroups
+                .filter(logGroupName => logGroupName.startsWith(params.logGroupNamePrefix ?? ''))
+                .slice(0, Math.max(params.limit ?? 50, 50));
+              return Promise.resolve(theLogGroups);
+            },
+          } as any
+        }
+        query={{} as any}
+        onRunQuery={() => {}}
+        onChange={onChange}
+      />
+    );
+
+    const initialAvailableGroups = allLogGroups
+      .slice(0, 50)
+      .map(logGroupName => ({ value: logGroupName, label: logGroupName }));
+    wrapper.setState({
+      availableLogGroups: initialAvailableGroups,
+    });
+
+    await wrapper.instance().onLogGroupSearch('Water', 'default', { action: 'input-change' });
+
+    let nextAvailableGroups = (wrapper.state('availableLogGroups') as Array<SelectableValue<string>>).map(
+      logGroup => logGroup.value
+    );
+    expect(nextAvailableGroups).toEqual(
+      initialAvailableGroups.map(logGroup => logGroup.value).concat(['WaterGroup', 'WaterGroup2', 'WaterGroup3'])
+    );
+
+    await wrapper.instance().onLogGroupSearch('Velv', 'default', { action: 'input-change' });
+    nextAvailableGroups = (wrapper.state('availableLogGroups') as Array<SelectableValue<string>>).map(
+      logGroup => logGroup.value
+    );
+    expect(nextAvailableGroups).toEqual(
+      initialAvailableGroups
+        .map(logGroup => logGroup.value)
+        .concat(['WaterGroup', 'WaterGroup2', 'WaterGroup3', 'VelvetGroup', 'VelvetGroup2', 'VelvetGroup3'])
+    );
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Initially, only the first page of log groups is used to populate the log groups selector, meaning that for users with many log groups, they can't select those on pages 2 and beyond. To get around this, when a user types into the log groups selector, a `DescribeLogGroups` request is made with the user's input as search prefix, the response of which can include log group names from any page.

**Which issue(s) this PR fixes**:
Closes #24554

**Special notes for your reviewer**:
Ideally some kind of virtualization or pagination should be implemented at some point so that a user can simply scroll through the list of all options, or click a "Load 50 next log groups" button to retrieve the next, though I imagine this would involve some changes to the `Select` component itself.
