### PR TITLE
Fix: changing so we are using date/time values  in UTC during test

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -35,7 +35,7 @@ describe('CloudWatchDatasource', () => {
   const defaultTimeRange = { from: new Date(start), to: new Date(start + 3600 * 1000) };
 
   const timeSrv = {
-    time: { from: '2016-12-31 15:00:00', to: '2016-12-31 16:00:00' },
+    time: { from: '2016-12-31 15:00:00Z', to: '2016-12-31 16:00:00Z' },
     timeRange: () => {
       return {
         from: dateMath.parse(timeSrv.time.from, false),


### PR DESCRIPTION
**What this PR does / why we need it**:
There are one test that handles the test time data in local time format making it act differently depending on the time zone of the computer running it. This will make the test date time values specified in UTC.
