### PR TITLE
Query: do not require datasource name and id

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -32,10 +32,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricReq
 	expr := false
 	var ds *models.DataSource
 	for i, query := range reqDto.Queries {
-		name, err := query.Get("datasource").String()
-		if err != nil {
-			return Error(500, "datasource missing name", err)
-		}
+		name, _ := query.Get("datasource").String()
 		if name == "__expr__" {
 			expr = true
 		}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -32,7 +32,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricReq
 	expr := false
 	var ds *models.DataSource
 	for i, query := range reqDto.Queries {
-		name, _ := query.Get("datasource").String()
+		name := query.Get("datasource").MustString("")
 		if name == "__expr__" {
 			expr = true
 		}


### PR DESCRIPTION
The new backend plugins send requsts to:
```
/api/ds/query
```
and each target includes the datasourceId and name -- somehow in explore, the name is not sent, so every new backend plugin returns with: 
```
 Error(500, "datasource missing name"
```

Since the name is only used to see if it is an expresion, can we just skip the check?  Without this fix, none of the new backend plugins work in explore, including:
* new-relic
* splunk
* service now
* google sheets