### PR TITLE
Add displayname to TextArea component

### DIFF
--- a/packages/grafana-ui/src/components/TextArea/TextArea.tsx
+++ b/packages/grafana-ui/src/components/TextArea/TextArea.tsx
@@ -30,3 +30,5 @@ const getTextAreaStyle = stylesFactory((theme: GrafanaTheme, invalid = false) =>
     ),
   };
 });
+
+TextArea.displayName = 'TextArea';


### PR DESCRIPTION
**What this PR does / why we need it**:
Very tiny PR. I discovered during writing my tests for Query history that TextArea doesn't have displayName and therefore it is named ForwardRef. Also, I couldn't use `wrapper.find(TextArea)`. 
I didn't end up using `wrapper.find(TextArea)` in my tests, but at least I'll fix it here. 🙂
