### PR TITLE
Query history: Add keyboard shortcut support for commenting

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
@@ -120,6 +120,13 @@ describe('RichHistoryCard', () => {
       wrapper.simulate('keydown', { key: 'Enter', shiftKey: true });
       expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(0);
     });
+    it('should close update comment form when enter and ctrl keys pressed', () => {
+      const wrapper = setup({ query: starredQueryWithComment });
+      const editCommentButton = wrapper.find({ title: 'Edit comment' });
+      editCommentButton.simulate('click');
+      wrapper.simulate('keydown', { key: 'Enter', ctrlKey: true });
+      expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(0);
+    });
     it('should not close update comment form when enter key pressed', () => {
       const wrapper = setup({ query: starredQueryWithComment });
       const editCommentButton = wrapper.find({ title: 'Edit comment' });

--- a/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
@@ -104,7 +104,7 @@ describe('RichHistoryCard', () => {
       const wrapper = setup({ query: starredQueryWithComment });
       const editCommentButton = wrapper.find({ title: 'Edit comment' });
       editCommentButton.simulate('click');
-      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(1);
+      expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(1);
     });
     it('should close update comment form when escape key pressed', () => {
       const wrapper = setup({ query: starredQueryWithComment });
@@ -118,14 +118,14 @@ describe('RichHistoryCard', () => {
       const editCommentButton = wrapper.find({ title: 'Edit comment' });
       editCommentButton.simulate('click');
       wrapper.simulate('keydown', { key: 'Enter', shiftKey: true });
-      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(0);
+      expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(0);
     });
     it('should not close update comment form when enter key pressed', () => {
       const wrapper = setup({ query: starredQueryWithComment });
       const editCommentButton = wrapper.find({ title: 'Edit comment' });
       editCommentButton.simulate('click');
       wrapper.simulate('keydown', { key: 'Enter', shiftKey: false });
-      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(1);
+      expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(1);
     });
   });
 

--- a/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
@@ -100,6 +100,33 @@ describe('RichHistoryCard', () => {
       expect(wrapper.find({ title: 'Add comment' })).toHaveLength(1);
       expect(wrapper.find({ title: 'Edit comment' })).toHaveLength(0);
     });
+    it('should open update comment form when edit comment button clicked', () => {
+      const wrapper = setup({ query: starredQueryWithComment });
+      const editCommentButton = wrapper.find({ title: 'Edit comment' });
+      editCommentButton.simulate('click');
+      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(1);
+    });
+    it('should close update comment form when escape key pressed', () => {
+      const wrapper = setup({ query: starredQueryWithComment });
+      const editCommentButton = wrapper.find({ title: 'Edit comment' });
+      editCommentButton.simulate('click');
+      wrapper.simulate('keydown', { key: 'Escape' });
+      expect(wrapper.find({ 'aria-label': 'Update comment form' })).toHaveLength(0);
+    });
+    it('should close update comment form when enter and shift keys pressed', () => {
+      const wrapper = setup({ query: starredQueryWithComment });
+      const editCommentButton = wrapper.find({ title: 'Edit comment' });
+      editCommentButton.simulate('click');
+      wrapper.simulate('keydown', { key: 'Enter', shiftKey: true });
+      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(0);
+    });
+    it('should not close update comment form when enter key pressed', () => {
+      const wrapper = setup({ query: starredQueryWithComment });
+      const editCommentButton = wrapper.find({ title: 'Edit comment' });
+      editCommentButton.simulate('click');
+      wrapper.simulate('keydown', { key: 'Enter', shiftKey: false });
+      expect(wrapper.find({ 'aria-label': 'Form to update comment' })).toHaveLength(1);
+    });
   });
 
   describe('starring', () => {

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -195,16 +195,26 @@ export function RichHistoryCard(props: Props) {
 
   const onUpdateComment = () => {
     updateRichHistory(query.ts, 'comment', comment);
-    toggleActiveUpdateComment();
+    setActiveUpdateComment(false);
   };
 
   const onCancelUpdateComment = () => {
-    toggleActiveUpdateComment();
+    setActiveUpdateComment(false);
     setComment(query.comment);
   };
 
+  const onKeyDown = (keyEvent: React.KeyboardEvent) => {
+    if (keyEvent.key === 'Enter' && (keyEvent.shiftKey || keyEvent.ctrlKey)) {
+      onUpdateComment();
+    }
+
+    if (keyEvent.key === 'Escape') {
+      onCancelUpdateComment();
+    }
+  };
+
   const updateComment = (
-    <div className={styles.updateCommentContainer}>
+    <div className={styles.updateCommentContainer} aria-label={comment ? 'Update comment form' : 'Add comment form'}>
       <TextArea
         value={comment}
         placeholder={comment ? undefined : 'An optional description of what the query does.'}
@@ -212,7 +222,9 @@ export function RichHistoryCard(props: Props) {
         className={styles.textArea}
       />
       <div className={styles.commentButtonRow}>
-        <Button onClick={onUpdateComment}>Save comment</Button>
+        <Button onClick={onUpdateComment} aria-label="Submit button">
+          Save comment
+        </Button>
         <Button variant="secondary" onClick={onCancelUpdateComment}>
           Cancel
         </Button>
@@ -240,7 +252,7 @@ export function RichHistoryCard(props: Props) {
   );
 
   return (
-    <div className={styles.queryCard}>
+    <div className={styles.queryCard} onKeyDown={onKeyDown}>
       <div className={styles.cardRow}>
         <div className={styles.datasourceContainer}>
           <img src={dsImg} aria-label="Data source icon" />

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -40,7 +40,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, height: number) => {
 
   /* 134px is based on the width of the Query history tabs bar, so the content is aligned to right side of the tab */
   const cardWidth = '100% - 134px';
-  const sliderHeight = `${height - 200}px`;
+  const sliderHeight = `${height - 180}px`;
   return {
     container: css`
       display: flex;
@@ -161,10 +161,7 @@ export function RichHistoryQueriesTab(props: Props) {
     <div className={styles.container}>
       <div className={styles.containerSlider}>
         <div className={styles.slider}>
-          <div className="label-slider">
-            Filter history <br />
-            between
-          </div>
+          <div className="label-slider">Filter history</div>
           <div className="label-slider">{mapNumbertoTimeInSlider(sliderRetentionFilter[0])}</div>
           <div className="slider">
             <Slider


### PR DESCRIPTION
This PR fixes points 3 and 7 in https://github.com/grafana/grafana/issues/24630: 
- Point 3 - Adds support for keyboard shortcuts when adding/editing comments. For consistency (following https://github.com/grafana/grafana/pull/24654), enter is used for a newline and ctr + enter or shift + enter is used to save the changes. Escape button is used to close edit/add comment mode. 

- Adds test coverage for this new keyboard shortcuts
- Point 7 - Shortens Filter history between to Filter history