### PR TITLE
Docs: Align naming with Grafana.com

### DIFF
--- a/docs/sources/administration/cli.md
+++ b/docs/sources/administration/cli.md
@@ -23,7 +23,7 @@ grafana-cli -h
 Some commands, such as installing or removing plugins, require `sudo` in order to run.
 
 **Windows users**
-Some commands, such as installing or removing plugins, require you to run Windows PowerShell as Administrator. 
+Some commands, such as installing or removing plugins, require you to run Windows PowerShell as Administrator.
 
 Before you enter commands, `cd` into the Grafana bin directory. The default path is:
 ```
@@ -101,34 +101,34 @@ grafana-cli --insecure --pluginUrl https://company.com/grafana/plugins/<plugin-i
 
 ### Enable debug logging
 
-`--debug` or `-d` enables debug logging. Debug output is returned and shown in the terminal.  
+`--debug` or `-d` enables debug logging. Debug output is returned and shown in the terminal.
 
 **Example:**
 ```bash
 grafana-cli --debug plugins install <plugin-id>
 ```
 
-### Override a configuration setting  
+### Override a configuration setting
 
 `--configOverrides` is a command line argument that acts like an environmental variable override.
 
-For example, you can use it to redirect logging to another file (maybe to log plugin installations in a service like Hosted Grafana) or when resetting the admin password and you have non-default values for some important config value (like where the database is located).
+For example, you can use it to redirect logging to another file (maybe to log plugin installations in Grafana Cloud) or when resetting the admin password and you have non-default values for some important config value (like where the database is located).
 
 **Example:**
 ```bash
 grafana-cli --configOverrides cfg:default.paths.log=/dev/null plugins install <plugin-id>
 ```
 
-### Override homepath value  
+### Override homepath value
 
 Sets the path for the Grafana install/home path, defaults to working directory. You do not need to use this if you are in the Grafana installation directory when using the CLI.
- 
+
 **Example:**
 ```bash
 grafana-cli --homepath "c:\Program Files\grafana" admin reset-admin-password mynewpassword
 ```
 
-### Override config file         
+### Override config file
 
 `--config value` overrides the default location where Grafana expects the configuration file. Refer to [Configuration]({{< relref "../installation/configuration.md" >}}) for more information about configuring Grafana and default configuration file locations.
 
@@ -200,7 +200,7 @@ grafana-cli admin
 
 If there are two flags being used to set the homepath and the config file path, then running the command returns this error:
 
-> Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath 
+> Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath
 
 To correct this, use the `--homepath` global option to specify the Grafana default homepath for this command:
 

--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -74,7 +74,7 @@ To purchase or obtain a trial license contact the Grafana Labs [Sales Team](http
 
 ### License file management
 
-To download your Grafana Enterprise license log in to your [Grafana.com](https://grafana.com) account and go to your **Org Profile**. In the side menu there is a section for Grafana Enterprise licenses. At the bottom of the license details page there is **Download Token** link that will download the *license.jwt* file containing your license.
+To download your Grafana Enterprise license log in to your [Grafana Cloud Account](https://grafana.com) and go to your **Org Profile**. In the side menu there is a section for Grafana Enterprise licenses. At the bottom of the license details page there is **Download Token** link that will download the *license.jwt* file containing your license.
 
 Place the *license.jwt* file in Grafana's data folder. This is usually located at `/var/lib/grafana/data` on Linux systems.
 

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -8,7 +8,7 @@ parent = "enterprise"
 weight = 8
 +++
 
-# License expiration 
+# License expiration
 
 If your license has expired most of Grafana keeps working as normal. Some enterprise functionality stops or runs with reduced functionality and Grafana displays a banner informing the users that Grafana is running on an expired license. Your Grafana admin needs to upload a new license file to restore full functionality.
 
@@ -23,7 +23,7 @@ If your license has expired most of Grafana keeps working as normal. Some enterp
     ```
     The configuration file's location may also be overridden by the `GF_ENTERPRISE_LICENSE_PATH` environment variable.
 
-2. Log in to your [Grafana.com](https://grafana.com/login) user and make sure you're in the correct organization in the dropdown at the top of the page.
+2. Log in to your [Grafana Cloud Account](https://grafana.com/login) and make sure you're in the correct organization in the dropdown at the top of the page.
 3. Under the **Grafana Enterprise** section in the menu bar to the left, choose licenses and download the currently valid license with which you want to run Grafana. If you cannot see a valid license on Grafana.com, please contact your account manager at Grafana Labs to renew your subscription.
 4. Replace the current `license.jwt`-file with the one you've just downloaded.
 5. Restart Grafana.

--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -13,11 +13,11 @@ Grafana supports data source, panel, and app plugins. Having panels as plugins m
 1. In a web browser, navigate to the official [Grafana Plugins page](https://grafana.com/plugins) and find a plugin that you want to install.
 2. Click the plugin, and then click the **Installation** tab.
 
-## Install plugin on Hosted Grafana
+## Install plugin on Grafana Cloud
 
-On the Installation tab, in the **For** field, click the name of the Hosted Grafana instance that you want to install the plugin on.
+On the Installation tab, in the **For** field, click the name of the Grafana instance that you want to install the plugin on.
 
-Grafana handles the plugin installation automatically.
+Grafana Cloud handles the plugin installation automatically.
 
 ## Install plugin on local Grafana
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Align naming conventions with Grafana.com.

**Which issue(s) this PR fixes**:
Here are the related PRs for grafana-com: grafana/grafana-com#1561, grafana/grafana-com#1553.

