### PR TITLE
Chore: remove isTimezoneUtc from tests

### DIFF
--- a/public/app/plugins/panel/graph/specs/time_region_manager.test.ts
+++ b/public/app/plugins/panel/graph/specs/time_region_manager.test.ts
@@ -13,9 +13,7 @@ describe('TimeRegionManager', () => {
         },
         panelCtrl: {
           range: {},
-          dashboard: {
-            isTimezoneUtc: () => false,
-          },
+          dashboard: {},
         },
       };
 

--- a/public/test/specs/helpers.ts
+++ b/public/test/specs/helpers.ts
@@ -57,9 +57,6 @@ export function ControllerTestContext(this: any) {
       self.dashboard.getTimezone = () => {
         return self.isUtc ? 'utc' : 'browser';
       };
-      self.dashboard.isTimezoneUtc = () => {
-        return self.isUtc;
-      };
 
       $rootScope.appEvent = sinon.spy();
       $rootScope.onAppEvent = sinon.spy();


### PR DESCRIPTION
With the timezone refactoring the dashbaord funciton `isTimezoneUtc` was also removed.  This breaks the [discrete panel.](https://grafana.com/grafana/plugins/natel-discrete-panel)..  We should either put it back or just remove it from our tests.

Having plugins use `getTimezone() === 'utc'` seems fine