### PR TITLE
TemplateSrv: fixes global template variables display after refreshing query

### DIFF
--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -447,6 +447,28 @@ describe('templateSrv', () => {
       const target = _templateSrv.replace('this.[[test]].filters');
       expect(target).toBe('this.muuuu.filters');
     });
+
+    it('should not clear index object after updateIndex() when variables array is empty', async () => {
+      const expectedVariablesMock = [
+        {
+          type: 'query',
+          name: 'test',
+          current: {
+            value: 'muuuu',
+          },
+        },
+      ];
+      expect(_templateSrv._variables).toMatchObject(expectedVariablesMock);
+      expect(_templateSrv.index).toMatchObject({
+        test: { ...expectedVariablesMock[0] },
+      });
+      _templateSrv._variables = [];
+      _templateSrv.updateIndex();
+      expect(_templateSrv._variables).toMatchObject([]);
+      expect(_templateSrv.index).toMatchObject({
+        test: { ...expectedVariablesMock[0] },
+      });
+    });
   });
 
   describe('fillVariableValuesForUrl with multi value', () => {

--- a/public/app/features/templating/specs/template_srv.test.ts
+++ b/public/app/features/templating/specs/template_srv.test.ts
@@ -448,7 +448,7 @@ describe('templateSrv', () => {
       expect(target).toBe('this.muuuu.filters');
     });
 
-    it('should not clear index object after updateIndex() when variables array is empty', async () => {
+    it('should not clear index object after updateIndex() when variables array is empty', () => {
       const expectedVariablesMock = [
         {
           type: 'query',

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -75,12 +75,15 @@ export class TemplateSrv implements BaseTemplateSrv {
   updateIndex() {
     const existsOrEmpty = (value: any) => value || value === '';
 
-    this.index = this._variables.reduce((acc, currentValue) => {
-      if (currentValue.current && (currentValue.current.isNone || existsOrEmpty(currentValue.current.value))) {
-        acc[currentValue.name] = currentValue;
-      }
-      return acc;
-    }, {});
+    this.index = this._variables.reduce(
+      (acc, currentValue) => {
+        if (currentValue.current && (currentValue.current.isNone || existsOrEmpty(currentValue.current.value))) {
+          acc[currentValue.name] = currentValue;
+        }
+        return acc;
+      },
+      { ...this.index }
+    );
 
     if (this.timeRange) {
       const from = this.timeRange.from.valueOf().toString();


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `template_srv` method `updateIndex()` with index object spread to prevent it from clearing index when variables array is empty. That fixes the display of global template variables after refreshing query.

**Which issue(s) this PR fixes**:

Fixes #23841
Fixes #25359