### PR TITLE
Docs: fixing links

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -7,137 +7,51 @@ parent = "features"
 weight = 6
 +++
 
-# User Authentication Overview
+# Alerts overview
 
-Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user
-permissions and org memberships.
+Alerts allow you to identify problems in your system moments after they occur. By quickly identifying unintended changes in your system, you can minimize disruptions to your services.
 
-Here is a table showing all supported authentication providers and the features available for them. [Team sync]({{< relref "../enterprise/team-sync.md" >}}) and [active sync]({{< relref "../enterprise/enhanced_ldap.md#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
+Alerts consists of two parts:
 
-Provider | Support | Role mapping | Team sync<br> *(Enterprise only)* | Active sync<br> *(Enterprise only)*
--------- | :-----: | :----------: | :-------: | :---------: 
-[Auth Proxy]({{< relref "auth-proxy.md" >}})       | v2.1+ | - | v6.3+ | - 
-[Azure AD OAuth]({{< relref "azuread.md" >}})      | v6.7+ | v6.7+ | v6.7+ | - 
-[Generic OAuth]({{< relref "generic-oauth.md" >}}) | v4.0+ | v6.5+ | - | - 
-[GitHub OAuth]({{< relref "github.md" >}})         | v2.0+ | - | v6.3+ | -
-[GitLab OAuth]({{< relref "gitlab.md" >}})         | v5.3+ | - | v6.4+ | -
-[Google OAuth]({{< relref "google.md" >}})         | v2.0+ | - | - | - 
-[LDAP]({{< relref "ldap.md" >}})                   | v2.1+ | v2.1+ | v5.3+ | v6.3+
-[Okta OAuth]({{< relref "okta.md" >}})             | v7.0+ | v7.0+ | v7.0+ | - 
-[SAML]({{< relref "../enterprise/saml.md" >}}) (Enterprise only)    | v6.3+ | v7.0+ | v7.0+ | - 
+- Alert rules - When the alert is triggered. Alert rules are defined by one or more conditions that are regularly evaluated by Grafana.
+- Notification channel - How the alert is delivered. When the conditions of an alert rule are met, the Grafana notifies the channels configured for that alert.
 
+Currently only the graph panel visualization supports alerts.
 
-## Grafana Auth
+## Alert tasks
 
-Grafana of course has a built in user authentication system with password authentication enabled by default. You can
-disable authentication by enabling anonymous access. You can also hide login form and only allow login through an auth
-provider (listed above). There is also options for allowing self sign up.
+You can perform the following tasks for alerts:
 
-### Login and short-lived tokens
+- [Add or edit an alert notification channel]({{< relref "notifications.md" >}})
+- [Create an alert rule]({{< relref "create-alerts.md" >}})
+- [View existing alert rules and their current state]({{< relref "view-alerts.md" >}})
+- [Test alert rules and troubleshoot]({{< relref "troubleshoot-alerts.md" >}})
 
-> The following applies when using Grafana's built in user authentication, LDAP (without Auth proxy) or OAuth integration.
+## Clustering
 
-Grafana are using short-lived tokens as a mechanism for verifying authenticated users.
-These short-lived tokens are rotated each `token_rotation_interval_minutes` for an active authenticated user.
+Currently alerting supports a limited form of high availability. Since v4.2.0 of Grafana, alert notifications are deduped when running multiple servers. This means all alerts are executed on every server but no duplicate alert notifications are sent due to the deduping logic. Proper load balancing of alerts will be introduced in the future.
 
-An active authenticated user that gets it token rotated will extend the `login_maximum_inactive_lifetime_days` time from "now" that Grafana will remember the user.
-This means that a user can close its browser and come back before `now + login_maximum_inactive_lifetime_days` and still being authenticated.
- This is true as long as the time since user login is less than `login_maximum_lifetime_days`.
+## Notifications
 
-#### Remote logout
+You can also set alert rule notifications along with a detailed message about the alert rule. The message can contain anything: information about how you might solve the issue, link to runbook, and so on.
 
-You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
-a Grafana admin user you can also do the same for any user from the Server Admin / Edit User view.
+The actual notifications are configured and shared between multiple alerts.
 
-## Settings
+## Alert execution
 
-Example:
+Alert rules are evaluated in the Grafana backend in a scheduler and query execution engine that is part
+of core Grafana. Only some data sources are supported right now. They include `Graphite`, `Prometheus`, `InfluxDB`, `Elasticsearch`,
+`Stackdriver`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`.
 
-```bash
-[auth]
+## Metrics from the alert engine
 
-# Login cookie name
-login_cookie_name = grafana_session
+The alert engine publishes some internal metrics about itself. You can read more about how Grafana publishes [internal metrics]({{< relref "../administration/metrics/" >}}).
 
-# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
-login_maximum_inactive_lifetime_days = 7
+Description | Type | Metric name
+---------- | ----------- | ----------
+Total number of alerts | counter | `alerting.active_alerts`
+Alert execution result | counter | `alerting.result`
+Notifications sent counter | counter | `alerting.notifications_sent`
+Alert execution timer | timer | `alerting.execution_time`
 
-# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
-login_maximum_lifetime_days = 30
-
-# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
-token_rotation_interval_minutes = 10
-
-# The maximum lifetime (seconds) an api key can be used. If it is set all the api keys should have limited lifetime that is lower than this value.
-api_key_max_seconds_to_live = -1
-```
-
-### Anonymous authentication
-
-You can make Grafana accessible without any login required by enabling anonymous access in the configuration file.
-
-Example:
-
-```bash
-[auth.anonymous]
-enabled = true
-
-# Organization name that should be used for unauthenticated users
-org_name = Main Org.
-
-# Role for unauthenticated users, other valid values are `Editor` and `Admin`
-org_role = Viewer
-```
-
-If you change your organization name in the Grafana UI this setting needs to be updated to match the new name.
-
-### Basic authentication
-
-Basic auth is enabled by default and works with the built in Grafana user password authentication system and LDAP
-authentication integration.
-
-To disable basic auth:
-
-```bash
-[auth.basic]
-enabled = false
-```
-
-### Disable login form
-
-You can hide the Grafana login form using the below configuration settings.
-
-```bash
-[auth]
-disable_login_form = true
-```
-
-### Automatic OAuth login
-
-Set to true to attempt login with OAuth automatically, skipping the login screen.
-This setting is ignored if multiple OAuth providers are configured.
-Defaults to `false`.
-
-```bash
-[auth]
-oauth_auto_login = true
-```
-
-### Hide sign-out menu
-
-Set the option detailed below to true to hide sign-out menu link. Useful if you use an auth proxy.
-
-```bash
-[auth]
-disable_signout_menu = true
-```
-
-### URL redirect after signing out
-
-URL to redirect the user to after signing out from Grafana. This can for example be used to enable signout from oauth provider.
-
-```bash
-[auth]
-signout_redirect_url =
-```
 

--- a/docs/sources/auth/_index.md
+++ b/docs/sources/auth/_index.md
@@ -9,4 +9,135 @@ parent = "admin"
 weight = 3
 +++
 
+# User Authentication Overview
+
+Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user permissions and org memberships.
+
+Here is a table showing all supported authentication providers and the features available for them. [Team sync]({{< relref "../enterprise/team-sync.md" >}}) and [active sync]({{< relref "../enterprise/enhanced_ldap.md#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
+
+Provider | Support | Role mapping | Team sync<br> *(Enterprise only)* | Active sync<br> *(Enterprise only)*
+-------- | :-----: | :----------: | :-------: | :---------: 
+[Auth Proxy]({{< relref "auth-proxy.md" >}})       | v2.1+ | - | v6.3+ | - 
+[Azure AD OAuth]({{< relref "azuread.md" >}})      | v6.7+ | v6.7+ | v6.7+ | - 
+[Generic OAuth]({{< relref "generic-oauth.md" >}}) | v4.0+ | v6.5+ | - | - 
+[GitHub OAuth]({{< relref "github.md" >}})         | v2.0+ | - | v6.3+ | -
+[GitLab OAuth]({{< relref "gitlab.md" >}})         | v5.3+ | - | v6.4+ | -
+[Google OAuth]({{< relref "google.md" >}})         | v2.0+ | - | - | - 
+[LDAP]({{< relref "ldap.md" >}})                   | v2.1+ | v2.1+ | v5.3+ | v6.3+
+[Okta OAuth]({{< relref "okta.md" >}})             | v7.0+ | v7.0+ | v7.0+ | - 
+[SAML]({{< relref "../enterprise/saml.md" >}}) (Enterprise only)    | v6.3+ | v7.0+ | v7.0+ | - 
+
+## Grafana Auth
+
+Grafana of course has a built in user authentication system with password authentication enabled by default. You can
+disable authentication by enabling anonymous access. You can also hide login form and only allow login through an auth
+provider (listed above). There is also options for allowing self sign up.
+
+### Login and short-lived tokens
+
+> The following applies when using Grafana's built in user authentication, LDAP (without Auth proxy) or OAuth integration.
+
+Grafana are using short-lived tokens as a mechanism for verifying authenticated users.
+These short-lived tokens are rotated each `token_rotation_interval_minutes` for an active authenticated user.
+
+An active authenticated user that gets it token rotated will extend the `login_maximum_inactive_lifetime_days` time from "now" that Grafana will remember the user.
+This means that a user can close its browser and come back before `now + login_maximum_inactive_lifetime_days` and still being authenticated.
+ This is true as long as the time since user login is less than `login_maximum_lifetime_days`.
+
+#### Remote logout
+
+You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
+a Grafana admin user you can also do the same for any user from the Server Admin / Edit User view.
+
+## Settings
+
+Example:
+
+```bash
+[auth]
+
+# Login cookie name
+login_cookie_name = grafana_session
+
+# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
+login_maximum_inactive_lifetime_days = 7
+
+# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+login_maximum_lifetime_days = 30
+
+# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+token_rotation_interval_minutes = 10
+
+# The maximum lifetime (seconds) an api key can be used. If it is set all the api keys should have limited lifetime that is lower than this value.
+api_key_max_seconds_to_live = -1
+```
+
+### Anonymous authentication
+
+You can make Grafana accessible without any login required by enabling anonymous access in the configuration file.
+
+Example:
+
+```bash
+[auth.anonymous]
+enabled = true
+
+# Organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+# Role for unauthenticated users, other valid values are `Editor` and `Admin`
+org_role = Viewer
+```
+
+If you change your organization name in the Grafana UI this setting needs to be updated to match the new name.
+
+### Basic authentication
+
+Basic auth is enabled by default and works with the built in Grafana user password authentication system and LDAP
+authentication integration.
+
+To disable basic auth:
+
+```bash
+[auth.basic]
+enabled = false
+```
+
+### Disable login form
+
+You can hide the Grafana login form using the below configuration settings.
+
+```bash
+[auth]
+disable_login_form = true
+```
+
+### Automatic OAuth login
+
+Set to true to attempt login with OAuth automatically, skipping the login screen.
+This setting is ignored if multiple OAuth providers are configured.
+Defaults to `false`.
+
+```bash
+[auth]
+oauth_auto_login = true
+```
+
+### Hide sign-out menu
+
+Set the option detailed below to true to hide sign-out menu link. Useful if you use an auth proxy.
+
+```bash
+[auth]
+disable_signout_menu = true
+```
+
+### URL redirect after signing out
+
+URL to redirect the user to after signing out from Grafana. This can for example be used to enable signout from oauth provider.
+
+```bash
+[auth]
+signout_redirect_url =
+```
 

--- a/docs/sources/auth/overview.md
+++ b/docs/sources/auth/overview.md
@@ -11,8 +11,7 @@ weight = 1
 
 # User Authentication Overview
 
-Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user
-permissions and org memberships.
+Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user permissions and org memberships.
 
 Here is a table showing all supported authentication providers and the features available for them. [Team sync]({{< relref "../enterprise/team-sync.md" >}}) and [active sync]({{< relref "../enterprise/enhanced_ldap.md#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
@@ -27,7 +26,6 @@ Provider | Support | Role mapping | Team sync<br> *(Enterprise only)* | Active s
 [LDAP]({{< relref "ldap.md" >}})                   | v2.1+ | v2.1+ | v5.3+ | v6.3+
 [Okta OAuth]({{< relref "okta.md" >}})             | v7.0+ | v7.0+ | v7.0+ | - 
 [SAML]({{< relref "../enterprise/saml.md" >}}) (Enterprise only)    | v6.3+ | v7.0+ | v7.0+ | - 
-
 
 ## Grafana Auth
 


### PR DESCRIPTION
This corrects some incorrect content copy/pasting that resulted in broken links