### PR TITLE
Dashboard/Links: Fixes open in new window for dashboard link

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -25,7 +25,11 @@ export const DashboardLinks: FC<Props> = ({ dashboard }) => {
           }
 
           const linkElement = (
-            <a className="gf-form-label" href={sanitizeUrl(linkInfo.href)} target={link.target}>
+            <a
+              className="gf-form-label"
+              href={sanitizeUrl(linkInfo.href)}
+              target={link.targetBlank ? '_blank' : '_self'}
+            >
               <Icon name={iconMap[link.icon] as IconName} />
               <span>{sanitize(linkInfo.title)}</span>
             </a>

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -25,11 +25,7 @@ export const DashboardLinks: FC<Props> = ({ dashboard }) => {
           }
 
           const linkElement = (
-            <a
-              className="gf-form-label"
-              href={sanitizeUrl(linkInfo.href)}
-              target={link.targetBlank ? '_blank' : '_self'}
-            >
+            <a className="gf-form-label" href={sanitizeUrl(linkInfo.href)} target={link.target}>
               <Icon name={iconMap[link.icon] as IconName} />
               <span>{sanitize(linkInfo.title)}</span>
             </a>

--- a/public/app/features/dashboard/components/SubMenu/DashboardsDropdown.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardsDropdown.tsx
@@ -45,7 +45,7 @@ export class DashboardsDropdown extends PureComponent<Props, State> {
       <div className="gf-form">
         <a
           className="gf-form-label pointer"
-          target={link.target}
+          target={link.targetBlank ? '_blank' : '_self'}
           onClick={this.onDropDownClick}
           data-placement="bottom"
           data-toggle="dropdown"

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -44,7 +44,7 @@ export interface DashboardLink {
   asDropdown: boolean;
   tags: [];
   searchHits?: [];
-  target: string;
+  targetBlank: boolean;
 }
 
 export class DashboardModel {


### PR DESCRIPTION
**What this PR does / why we need it**:
replaces link.target with link.targetBlank

**Which issue(s) this PR fixes**:
fixes #24771 
