### PR TITLE
Docs: Update index page with link to What's new in v7.0

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -65,8 +65,8 @@ aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", 
         <h4>Provisioning</h4>
         <p>Learn how to automate your Grafana configuration.</p>
     </a>
-    <a href="{{< relref "guides/whats-new-in-v6-6.md" >}}" class="nav-cards__item nav-cards__item--guide">
-        <h4>What's new in v6.6</h4>
+    <a href="{{< relref "guides/whats-new-in-v7-0.md" >}}" class="nav-cards__item nav-cards__item--guide">
+        <h4>What's new in v7.0</h4>
         <p>Explore the features and enhancements in the latest release.</p>
     </a>
 


### PR DESCRIPTION
Update docs index page with link to What's new in v7.0