### PR TITLE
Datasource/CloudWatch: Makes CloudWatch Logs query history more readable

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -900,6 +900,14 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
     return this.templateSrv.replace(target, scopedVars);
   }
+
+  getQueryDisplayText(query: CloudWatchQuery) {
+    if (query.queryMode === 'Logs') {
+      return query.expression;
+    } else {
+      return JSON.stringify(query);
+    }
+  }
 }
 
 function withTeardown<T = any>(observable: Observable<T>, onUnsubscribe: () => void): Observable<T> {


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes CloudWatch Logs queries as represented in the rich history display more readable by just displaying the query expression and not the`DataQuery` JSON object.
See (https://github.com/grafana/grafana/issues/24333#issuecomment-628718138)

