### PR TITLE
Datasource/CloudWatch: Field suggestions no longer limited to prefix-only

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language_provider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.ts
@@ -309,7 +309,6 @@ export class CloudWatchLanguageProvider extends LanguageProvider {
     return {
       suggestions: [
         {
-          prefixMatch: true,
           label: 'Fields',
           items: fields.map(field => ({
             label: field,


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously field suggestions were limited to being prefix-only. This PR fixes that.
(https://github.com/grafana/grafana/issues/24333)
