### PR TITLE
Docs: Remove beta text from What is new in Grafana 7

### DIFF
--- a/docs/sources/guides/whats-new-in-v7-0.md
+++ b/docs/sources/guides/whats-new-in-v7-0.md
@@ -12,7 +12,7 @@ weight = -17
 
 # What's new in Grafana v7.0
 
-This topic includes the release notes for the Grafana v7.0, which is currently in beta. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
+This topic includes the release notes for the Grafana v7.0. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 This major release of Grafana is the next step in our Observability story. It includes powerful new features for manipulating, transforming, and doing math on data. Grafana Enterprise has the first version of Usage analytics, which will help Grafana Admins better manage large, corporate Grafana ecosystems.
 

--- a/docs/sources/guides/whats-new-in-v7-0.md
+++ b/docs/sources/guides/whats-new-in-v7-0.md
@@ -12,7 +12,7 @@ weight = -17
 
 # What's new in Grafana v7.0
 
-This topic includes the release notes for the Grafana v7.0. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
+This topic includes the release notes for Grafana v7.0. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 This major release of Grafana is the next step in our Observability story. It includes powerful new features for manipulating, transforming, and doing math on data. Grafana Enterprise has the first version of Usage analytics, which will help Grafana Admins better manage large, corporate Grafana ecosystems.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed beta text from What is new in Grafana 7. The same as https://github.com/grafana/grafana/pull/24787#event-3350552722