### PR TITLE
Explore: refactors LogRowContextProvider to get rid of unnecessary dimensions

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
@@ -138,7 +138,6 @@ describe('LogRowContextProvider', () => {
         }
         return Promise.resolve({ data: [secondResult] });
       };
-      let wrapper: any;
       let updateLimitCalled = false;
 
       const mockedChildren = jest.fn((mockState: any) => {
@@ -165,9 +164,7 @@ describe('LogRowContextProvider', () => {
         return <></>;
       });
       await act(async () => {
-        wrapper = await mount(
-          <LogRowContextProvider row={row} getRowContext={getRowContextMock} children={mockedChildren} />
-        );
+        await mount(<LogRowContextProvider row={row} getRowContext={getRowContextMock} children={mockedChildren} />);
       });
     });
   });

--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
@@ -159,9 +159,8 @@ describe('LogRowContextProvider', () => {
           updateLimitCalled = true;
           return <></>;
         }
-        if (updateLimitCalled && result.before.length > 0) {
+        if (updateLimitCalled && result.before.length > 0 && limit > 10) {
           expect(limit).toBe(20);
-          expect(hasMoreContextRows).toEqual({ before: true, after: false });
         }
         return <></>;
       });

--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.test.tsx
@@ -34,7 +34,13 @@ describe('getRowContexts', () => {
 
       const result = await getRowContexts(getRowContextMock, row, 10);
 
-      expect(result).toEqual({ data: [[['3', '2']], [['6', '5', '4']]], errors: ['', ''] });
+      expect(result).toEqual({
+        data: [
+          ['3', '2'],
+          ['6', '5', '4'],
+        ],
+        errors: ['', ''],
+      });
     });
 
     it('then the result should be in correct format and filtered without uid', async () => {
@@ -63,7 +69,13 @@ describe('getRowContexts', () => {
 
       const result = await getRowContexts(getRowContextMock, row, 10);
 
-      expect(result).toEqual({ data: [[['3', '2', '1']], [['6', '5']]], errors: ['', ''] });
+      expect(result).toEqual({
+        data: [
+          ['3', '2', '1'],
+          ['6', '5'],
+        ],
+        errors: ['', ''],
+      });
     });
   });
 

--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
@@ -1,6 +1,5 @@
 import { LogRowModel, toDataFrame, Field, FieldCache } from '@grafana/data';
 import React, { useState, useEffect } from 'react';
-import flatten from 'lodash/flatten';
 import useAsync from 'react-use/lib/useAsync';
 
 import { DataQueryResponse, DataQueryError } from '@grafana/data';
@@ -101,11 +100,7 @@ export const getRowContexts = async (
           const lineField: Field<string> = dataFrame.fields.filter(field => field.name === 'line')[0];
           const line = lineField.values.get(fieldIndex); // assuming that both fields have same length
 
-          if (data.length === 0) {
-            data[0] = [line];
-          } else {
-            data[0].push(line);
-          }
+          data.push(line);
         }
       }
 
@@ -161,10 +156,10 @@ export const LogRowContextProvider: React.FunctionComponent<LogRowContextProvide
         let hasMoreLogsBefore = true,
           hasMoreLogsAfter = true;
 
-        const currentResultBefore = currentResult?.data[0][0];
-        const currentResultAfter = currentResult?.data[1][0];
-        const valueBefore = value.data[0][0];
-        const valueAfter = value.data[1][0];
+        const currentResultBefore = currentResult?.data[0];
+        const currentResultAfter = currentResult?.data[1];
+        const valueBefore = value.data[0];
+        const valueAfter = value.data[1];
 
         // checks if there are more log rows in a given direction
         // if after fetching additional rows the length of result is the same,
@@ -189,8 +184,8 @@ export const LogRowContextProvider: React.FunctionComponent<LogRowContextProvide
 
   return children({
     result: {
-      before: result ? flatten(result.data[0]) : [],
-      after: result ? flatten(result.data[1]) : [],
+      before: result ? result.data[0] : [],
+      after: result ? result.data[1] : [],
     },
     errors: {
       before: result ? result.errors[0] : undefined,


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors LogRowContextProvider to remove unnecessary dimensions. Adjusts tests.

**Which issue(s) this PR fixes**:

ref #24135