### PR TITLE
PanelEditor Fix missing labels and description if there is only single option in category

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -171,14 +171,11 @@ export const DefaultFieldConfigEditor: React.FC<Props> = ({ data, onChange, conf
           : undefined
         : (defaults as any)[item.path];
 
-      const label =
-        categoryItemCount > 1 ? (
-          <Label description={item.description} category={item.category?.slice(1)}>
-            {item.name}
-          </Label>
-        ) : (
-          undefined
-        );
+      const label = (
+        <Label description={item.description} category={item.category?.slice(1)}>
+          {item.name}
+        </Label>
+      );
 
       return (
         <Field label={label} key={`${item.id}/${item.isCustom}`}>


### PR DESCRIPTION
Found this when recording my webinar :D

Before:
![image](https://user-images.githubusercontent.com/2376619/82411998-160ba580-9a73-11ea-9886-8880212ac259.png)

After:
![image](https://user-images.githubusercontent.com/2376619/82412011-1e63e080-9a73-11ea-9b88-dc8151c57daf.png)
