### PR TITLE
Panel: shows correct panel menu items in view mode

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -1,5 +1,6 @@
-import { PanelModel, DashboardModel } from '../state';
+import { DashboardModel, PanelModel } from '../state';
 import { getPanelMenu } from './getPanelMenu';
+import { describe } from '../../../../test/lib/common';
 
 describe('getPanelMenu', () => {
   it('should return the correct panel menu items', () => {
@@ -68,5 +69,76 @@ describe('getPanelMenu', () => {
         },
       ]
     `);
+  });
+
+  describe('when panel is in view mode', () => {
+    it('should return the correct panel menu items', () => {
+      const getExtendedMenu = () => [{ text: 'Toggle legend', shortcut: 'p l', click: jest.fn() }];
+      const ctrl: any = { getExtendedMenu };
+      const scope: any = { $$childHead: { ctrl } };
+      const angularComponent: any = { getScope: () => scope };
+      const panel = new PanelModel({ isViewing: true });
+      const dashboard = new DashboardModel({});
+
+      const menuItems = getPanelMenu(dashboard, panel, angularComponent);
+      expect(menuItems).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "iconClassName": "eye",
+          "onClick": [Function],
+          "shortcut": "v",
+          "text": "View",
+        },
+        Object {
+          "iconClassName": "edit",
+          "onClick": [Function],
+          "shortcut": "e",
+          "text": "Edit",
+        },
+        Object {
+          "iconClassName": "share-alt",
+          "onClick": [Function],
+          "shortcut": "p s",
+          "text": "Share",
+        },
+        Object {
+          "iconClassName": "info-circle",
+          "onClick": [Function],
+          "shortcut": "i",
+          "subMenu": Array [
+            Object {
+              "onClick": [Function],
+              "text": "Panel JSON",
+            },
+          ],
+          "text": "Inspect",
+          "type": "submenu",
+        },
+        Object {
+          "iconClassName": "cube",
+          "onClick": [Function],
+          "subMenu": Array [
+            Object {
+              "href": undefined,
+              "onClick": [Function],
+              "shortcut": "p l",
+              "text": "Toggle legend",
+            },
+          ],
+          "text": "More...",
+          "type": "submenu",
+        },
+        Object {
+          "type": "divider",
+        },
+        Object {
+          "iconClassName": "trash-alt",
+          "onClick": [Function],
+          "shortcut": "p r",
+          "text": "Remove",
+        },
+      ]
+    `);
+    });
   });
 });

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,6 +1,6 @@
 import { updateLocation } from 'app/core/actions';
 import { store } from 'app/store/store';
-import { getDataSourceSrv, getLocationSrv, AngularComponent } from '@grafana/runtime';
+import { AngularComponent, getDataSourceSrv, getLocationSrv } from '@grafana/runtime';
 import { PanelMenuItem } from '@grafana/data';
 import { copyPanel, duplicatePanel, removePanel, sharePanel } from 'app/features/dashboard/utils/panel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -187,12 +187,12 @@ export function getPanelMenu(
     }
   }
 
-  if (!panel.isEditing) {
+  if (!panel.isEditing && subMenu.length) {
     menu.push({
       type: 'submenu',
       text: 'More...',
       iconClassName: 'cube',
-      subMenu: subMenu,
+      subMenu,
       onClick: onMore,
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
As the original issue states the submenu for `More...` was empty. The problem only occurred for React Panels so this PR tries to remedy this.

**Which issue(s) this PR fixes**:
Fixes #24834

**Special notes for your reviewer**:

