### PR TITLE
Settings: Add setting for hiding version number for anonymous users

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -315,6 +315,9 @@ org_name = Main Org.
 # specify role for unauthenticated users
 org_role = Viewer
 
+# mask the Grafana version number for unauthenticated users
+hide_version = false
+
 #################################### Github Auth #########################
 [auth.github]
 enabled = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -314,6 +314,9 @@
 # specify role for unauthenticated users
 ;org_role = Viewer
 
+# mask the Grafana version number for unauthenticated users
+;hide_version = false
+
 #################################### Github Auth ##########################
 [auth.github]
 ;enabled = false

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -20,6 +20,7 @@ export interface BuildInfo {
   edition: string;
   latestVersion: string;
   hasUpdate: boolean;
+  hideVersion: boolean;
 }
 
 /**

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -167,6 +167,16 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		}
 	}
 
+	version := setting.BuildVersion
+	commit := setting.BuildCommit
+	buildstamp := setting.BuildStamp
+
+	if setting.AnonymousHideVersion && !c.IsSignedIn {
+		version = "0.0.0-hidden"
+		commit = "0000000000"
+		buildstamp = 0
+	}
+
 	jsonObj := map[string]interface{}{
 		"defaultDatasource":          defaultDatasource,
 		"datasources":                datasources,
@@ -196,9 +206,9 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"disableSanitizeHtml":        hs.Cfg.DisableSanitizeHtml,
 		"pluginsToPreload":           pluginsToPreload,
 		"buildInfo": map[string]interface{}{
-			"version":       setting.BuildVersion,
-			"commit":        setting.BuildCommit,
-			"buildstamp":    setting.BuildStamp,
+			"version":       version,
+			"commit":        commit,
+			"buildstamp":    buildstamp,
 			"edition":       hs.License.Edition(),
 			"latestVersion": plugins.GrafanaLatestVersion,
 			"hasUpdate":     plugins.GrafanaHasUpdate,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -167,11 +167,12 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		}
 	}
 
+	hideVersion := setting.AnonymousHideVersion && !c.IsSignedIn
 	version := setting.BuildVersion
 	commit := setting.BuildCommit
 	buildstamp := setting.BuildStamp
 
-	if setting.AnonymousHideVersion && !c.IsSignedIn {
+	if hideVersion {
 		version = ""
 		commit = ""
 		buildstamp = 0
@@ -206,6 +207,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"disableSanitizeHtml":        hs.Cfg.DisableSanitizeHtml,
 		"pluginsToPreload":           pluginsToPreload,
 		"buildInfo": map[string]interface{}{
+			"hideVersion":   hideVersion,
 			"version":       version,
 			"commit":        commit,
 			"buildstamp":    buildstamp,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -167,7 +167,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		}
 	}
 
-	hideVersion := setting.AnonymousHideVersion && !c.IsSignedIn
+	hideVersion := hs.Cfg.AnonymousHideVersion && !c.IsSignedIn
 	version := setting.BuildVersion
 	commit := setting.BuildCommit
 	buildstamp := setting.BuildStamp

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -172,8 +172,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 	buildstamp := setting.BuildStamp
 
 	if setting.AnonymousHideVersion && !c.IsSignedIn {
-		version = "0.0.0-hidden"
-		commit = "0000000000"
+		version = ""
+		commit = ""
 		buildstamp = 0
 	}
 

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) *macaron.Macaron {
+func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) (*macaron.Macaron, *HTTPServer) {
 	t.Helper()
 	sqlstore.InitTestDB(t)
 
@@ -46,7 +46,7 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) *macaron.Macaron {
 	}))
 	m.Get("/api/frontend/settings/", hs.GetFrontendSettings)
 
-	return m
+	return m, hs
 }
 
 func TestHTTPServer_GetFrontendSettings_hideVersionAnonyomus(t *testing.T) {
@@ -60,7 +60,7 @@ func TestHTTPServer_GetFrontendSettings_hideVersionAnonyomus(t *testing.T) {
 	}
 
 	cfg := setting.NewCfg()
-	m := setupTestEnvironment(t, cfg)
+	m, hs := setupTestEnvironment(t, cfg)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/frontend/settings", nil)
 
@@ -95,7 +95,7 @@ func TestHTTPServer_GetFrontendSettings_hideVersionAnonyomus(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		setting.AnonymousHideVersion = test.hideVersion
+		hs.Cfg.AnonymousHideVersion = test.hideVersion
 		expected := test.expected
 
 		recorder := httptest.NewRecorder()

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/rendering"
+
+	"github.com/grafana/grafana/pkg/services/licensing"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+
+	"github.com/grafana/grafana/pkg/middleware"
+	"gopkg.in/macaron.v1"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) *macaron.Macaron {
+	t.Helper()
+	sqlstore.InitTestDB(t)
+
+	r := &rendering.RenderingService{Cfg: cfg}
+
+	hs := &HTTPServer{
+		Cfg:           cfg,
+		Bus:           bus.New(),
+		License:       &licensing.OSSLicensingService{},
+		RenderService: r,
+	}
+
+	m := macaron.New()
+	m.Use(middleware.GetContextHandler(nil, nil, nil))
+	m.Use(macaron.Renderer(macaron.RenderOptions{
+		Directory:  path.Join(setting.StaticRootPath, "views"),
+		IndentJSON: true,
+		Delims:     macaron.Delims{Left: "[[", Right: "]]"},
+	}))
+	m.Get("/api/frontend/settings/", hs.GetFrontendSettings)
+
+	return m
+}
+
+func TestHTTPServer_GetFrontendSettings_hideVersionAnonyomus(t *testing.T) {
+	type buildInfo struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Env     string `json:"env"`
+	}
+	type settings struct {
+		BuildInfo buildInfo `json:"buildInfo"`
+	}
+
+	cfg := setting.NewCfg()
+	m := setupTestEnvironment(t, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/frontend/settings", nil)
+
+	setting.BuildVersion = "7.8.9"
+	setting.BuildCommit = "01234567"
+	setting.Env = "testing"
+
+	tests := []struct {
+		hideVersion bool
+		expected    settings
+	}{
+		{
+			hideVersion: false,
+			expected: settings{
+				BuildInfo: buildInfo{
+					Version: setting.BuildVersion,
+					Commit:  setting.BuildCommit,
+					Env:     setting.Env,
+				},
+			},
+		},
+		{
+			hideVersion: true,
+			expected: settings{
+				BuildInfo: buildInfo{
+					Version: "",
+					Commit:  "",
+					Env:     setting.Env,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		setting.AnonymousHideVersion = test.hideVersion
+		expected := test.expected
+
+		recorder := httptest.NewRecorder()
+		m.ServeHTTP(recorder, req)
+		got := settings{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &got)
+		require.NoError(t, err)
+
+		assert.EqualValues(t, expected, got, "unauthenticated showing version")
+	}
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -352,7 +352,7 @@ func (hs *HTTPServer) healthHandler(ctx *macaron.Context) {
 
 	data := simplejson.New()
 	data.Set("database", "ok")
-	if !setting.AnonymousHideVersion {
+	if !hs.Cfg.AnonymousHideVersion {
 		data.Set("version", setting.BuildVersion)
 		data.Set("commit", setting.BuildCommit)
 	}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/grafana/grafana/pkg/services/search"
 	"net"
 	"net/http"
 	"os"
 	"path"
 	"sync"
+
+	"github.com/grafana/grafana/pkg/services/search"
 
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 
@@ -351,8 +352,10 @@ func (hs *HTTPServer) healthHandler(ctx *macaron.Context) {
 
 	data := simplejson.New()
 	data.Set("database", "ok")
-	data.Set("version", setting.BuildVersion)
-	data.Set("commit", setting.BuildCommit)
+	if !setting.AnonymousHideVersion {
+		data.Set("version", setting.BuildVersion)
+		data.Set("commit", setting.BuildCommit)
+	}
 
 	if err := bus.Dispatch(&models.GetDBHealthQuery{}); err != nil {
 		data.Set("database", "failing")

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -361,7 +361,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 	}
 
 	helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
-	if setting.AnonymousHideVersion && !c.IsSignedIn {
+	if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
 		helpVersion = setting.ApplicationName
 	}
 

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -360,9 +360,14 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		})
 	}
 
+	helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
+	if setting.AnonymousHideVersion && !c.IsSignedIn {
+		helpVersion = setting.ApplicationName
+	}
+
 	data.NavTree = append(data.NavTree, &dtos.NavLink{
 		Text:         "Help",
-		SubTitle:     fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit),
+		SubTitle:     helpVersion,
 		Id:           "help",
 		Url:          "#",
 		Icon:         "question-circle",

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -145,9 +145,10 @@ var (
 	LoginCookieName      string
 	LoginMaxLifetimeDays int
 
-	AnonymousEnabled bool
-	AnonymousOrgName string
-	AnonymousOrgRole string
+	AnonymousEnabled     bool
+	AnonymousOrgName     string
+	AnonymousOrgRole     string
+	AnonymousHideVersion bool
 
 	// Auth proxy settings
 	AuthProxyEnabled          bool
@@ -873,6 +874,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	if err != nil {
 		return err
 	}
+	AnonymousHideVersion = iniFile.Section("auth.anonymous").Key("hide_version").MustBool(false)
 
 	// auth proxy
 	authProxy := iniFile.Section("auth.proxy")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -145,10 +145,9 @@ var (
 	LoginCookieName      string
 	LoginMaxLifetimeDays int
 
-	AnonymousEnabled     bool
-	AnonymousOrgName     string
-	AnonymousOrgRole     string
-	AnonymousHideVersion bool
+	AnonymousEnabled bool
+	AnonymousOrgName string
+	AnonymousOrgRole string
 
 	// Auth proxy settings
 	AuthProxyEnabled          bool
@@ -297,6 +296,8 @@ type Cfg struct {
 
 	// Use to enable new features which may still be in alpha/beta stage.
 	FeatureToggles map[string]bool
+
+	AnonymousHideVersion bool
 }
 
 // IsExpressionsEnabled returns whether the expressions feature is enabled.
@@ -874,7 +875,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	if err != nil {
 		return err
 	}
-	AnonymousHideVersion = iniFile.Section("auth.anonymous").Key("hide_version").MustBool(false)
+	cfg.AnonymousHideVersion = iniFile.Section("auth.anonymous").Key("hide_version").MustBool(false)
 
 	// auth proxy
 	authProxy := iniFile.Section("auth.proxy")

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -38,6 +38,11 @@ export let getVersionLinks = (): FooterLink[] => {
   const stateInfo = licenseInfo.stateInfo ? ` (${licenseInfo.stateInfo})` : '';
 
   links.push({ text: `${buildInfo.edition}${stateInfo}`, url: licenseInfo.licenseUrl });
+
+  if (buildInfo.version === '') {
+    return links;
+  }
+
   links.push({ text: `v${buildInfo.version} (${buildInfo.commit})` });
 
   if (buildInfo.hasUpdate) {

--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -39,7 +39,7 @@ export let getVersionLinks = (): FooterLink[] => {
 
   links.push({ text: `${buildInfo.edition}${stateInfo}`, url: licenseInfo.licenseUrl });
 
-  if (buildInfo.version === '') {
+  if (buildInfo.hideVersion) {
     return links;
   }
 

--- a/public/app/plugins/panel/homelinks/module.tsx
+++ b/public/app/plugins/panel/homelinks/module.tsx
@@ -71,12 +71,9 @@ export const HomeLink: FC<HomeLinkProps> = ({ title, url, target, icon }) => {
 export const VersionFooter: FC = () => {
   const styles = getStyles();
   const { version, commit } = config.buildInfo;
+  const versionString = version !== '' ? `Version ${version} (${commit})` : '';
 
-  return (
-    <div className={styles.footer}>
-      Version {version} ({commit})
-    </div>
-  );
+  return <div className={styles.footer}>{versionString}</div>;
 };
 
 export const getStyles = stylesFactory(() => {

--- a/public/app/plugins/panel/homelinks/module.tsx
+++ b/public/app/plugins/panel/homelinks/module.tsx
@@ -70,8 +70,8 @@ export const HomeLink: FC<HomeLinkProps> = ({ title, url, target, icon }) => {
 
 export const VersionFooter: FC = () => {
   const styles = getStyles();
-  const { version, commit } = config.buildInfo;
-  const versionString = version !== '' ? `Version ${version} (${commit})` : '';
+  const { hideVersion, version, commit } = config.buildInfo;
+  const versionString = hideVersion ? '' : `Version ${version} (${commit})`;
 
   return <div className={styles.footer}>{versionString}</div>;
 };


### PR DESCRIPTION
To enable compliance, a lot of users have reported being required by their auditors to hide the version number for unauthenticated users.

Fixes #12925

