### PR TITLE
Dashboard: Render PanelChrome on refresh

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -209,6 +209,9 @@ export class PanelChrome extends PureComponent<Props, State> {
         cacheTimeout: panel.cacheTimeout,
         transformations: panel.transformations,
       });
+    } else {
+      // The panel should render on refresh as well if it doesn't have a query, like clock panel
+      this.onRender();
     }
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where one couldn't change the background color of clock panel for the first time.

**Which issue(s) this PR fixes**:

Fixes #23306
