### PR TITLE
postgres: Add custom select expression support

### DIFF
--- a/public/app/plugins/datasource/postgres/postgres_query.ts
+++ b/public/app/plugins/datasource/postgres/postgres_query.ts
@@ -220,6 +220,11 @@ export default class PostgresQuery {
       }
     }
 
+    const expression: any = _.find(column, (g: any) => g.type === 'select_expression');
+    if (expression) {
+      query = expression.params[0].replace(/\$expr\b/g, query);
+    }
+
     const alias: any = _.find(column, (g: any) => g.type === 'alias');
     if (alias) {
       query += ' AS ' + this.quoteIdentifier(alias.params[0]);

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -188,6 +188,8 @@ export class PostgresQueryCtrl extends QueryCtrl {
     };
     this.selectMenu.push(windows);
 
+    this.selectMenu.push({ text: 'Expression', value: 'select_expression' });
+
     this.selectMenu.push({ text: 'Alias', value: 'alias' });
     this.selectMenu.push({ text: 'Column', value: 'column' });
   }
@@ -367,6 +369,10 @@ export class PostgresQueryCtrl extends QueryCtrl {
     return _.findIndex(selectParts, (p: any) => p.def.type === 'window' || p.def.type === 'moving_window');
   }
 
+  findExpressionIndex(selectParts: any) {
+    return _.findIndex(selectParts, (p: any) => p.def.type === 'select_expression');
+  }
+
   addSelectPart(selectParts: any[], item: { value: any }, subItem: { type: any; value: any }) {
     let partType = item.value;
     if (subItem && subItem.type) {
@@ -419,6 +425,26 @@ export class PostgresQueryCtrl extends QueryCtrl {
         if (!_.find(selectParts, (p: any) => p.def.type === 'alias')) {
           addAlias = true;
         }
+        break;
+      case 'select_expression':
+        const exprIndex = this.findExpressionIndex(selectParts);
+        if (exprIndex !== -1) {
+          // replace current expression
+          selectParts[exprIndex] = partModel;
+        } else {
+          const windowIndex = this.findWindowIndex(selectParts);
+          if (windowIndex !== -1) {
+            selectParts.splice(windowIndex + 1, 0, partModel);
+          } else {
+            const aggIndex = this.findAggregateIndex(selectParts);
+            if (aggIndex !== -1) {
+              selectParts.splice(aggIndex + 1, 0, partModel);
+            } else {
+              selectParts.splice(1, 0, partModel);
+            }
+          }
+        }
+
         break;
       case 'alias':
         addAlias = true;

--- a/public/app/plugins/datasource/postgres/sql_part.ts
+++ b/public/app/plugins/datasource/postgres/sql_part.ts
@@ -75,6 +75,14 @@ register({
 });
 
 register({
+  type: 'select_expression',
+  style: 'label',
+  label: 'Expr:',
+  params: [{ name: 'expression', type: 'string' }],
+  defaultParams: ['($expr)'],
+});
+
+register({
   type: 'alias',
   style: 'label',
   params: [{ name: 'name', type: 'string', quote: 'double' }],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This adds support for creating custom parent expressions which wrap an individual SELECT expression generated by the query builder.
This allows the user to perform simple operations the query build doesn't natively express. For example taking a field, and performing addition, multiplication, etc.
Prior to this change, the only way to perform such operations was to switch to the raw SQL editor. This is a very heavy handed approach to the problem, as you lose all the functionality of the query builder.

![image](https://user-images.githubusercontent.com/1826947/82497343-154b3180-9abc-11ea-845b-c26bd183c496.png)

**Which issue(s) this PR fixes**:
Closes grafana/grafana#24948 
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:
Note, I didn't adjust any documentation, as the existing documentation doesn't talk about the features at this level of detail, and the functionality seems intuitive (to me anyway).
