### PR TITLE
CircleCI: Upgrade build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.8
+            VERSION=0.4.9
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp
@@ -155,7 +155,17 @@ jobs:
             - node_modules
       - run:
           name: Build Grafana frontend
-          command: /tmp/grabpl build-frontend --edition << parameters.edition >>
+          command: |
+            if [[ -n $CIRCLE_TAG ]]; then
+              # A release build
+              /tmp/grabpl build-frontend --edition << parameters.edition >> $CIRCLE_TAG
+            elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
+              # We're testing the release pipeline
+              /tmp/grabpl build-frontend --edition << parameters.edition >> 7.0.0-test
+            else
+              # A master or PR build
+              /tmp/grabpl build-frontend --edition << parameters.edition >> --build-id $CIRCLE_WORKFLOW_ID
+            fi
       - run:
           name: Move artifacts
           command: mkdir << parameters.edition >> && cp -r public << parameters.edition >>/


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade CircleCI to use v0.4.9 of the build pipeline tool.