### PR TITLE
Download CSV: format the dates

### DIFF
--- a/packages/grafana-data/src/vector/FormattedVector.ts
+++ b/packages/grafana-data/src/vector/FormattedVector.ts
@@ -1,0 +1,25 @@
+import { Vector } from '../types/vector';
+import { DisplayProcessor } from '../types';
+import { formattedValueToString } from '../valueFormats';
+import { vectorToArray } from './vectorToArray';
+
+export class FormattedVector<T = any> implements Vector<string> {
+  constructor(private source: Vector<T>, private formatter: DisplayProcessor) {}
+
+  get length() {
+    return this.source.length;
+  }
+
+  get(index: number): string {
+    const v = this.source.get(index);
+    return formattedValueToString(this.formatter(v));
+  }
+
+  toArray(): string[] {
+    return vectorToArray(this);
+  }
+
+  toJSON(): string[] {
+    return this.toArray();
+  }
+}

--- a/packages/grafana-data/src/vector/index.ts
+++ b/packages/grafana-data/src/vector/index.ts
@@ -4,5 +4,6 @@ export * from './CircularVector';
 export * from './ConstantVector';
 export * from './BinaryOperationVector';
 export * from './SortedVector';
+export * from './FormattedVector';
 
 export { vectorator } from './FunctionalVector';

--- a/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
@@ -12,7 +12,7 @@ import {
   FieldType,
   FormattedVector,
   DisplayProcessor,
-  dateTimeAsIso,
+  getDisplayProcessor,
 } from '@grafana/data';
 import { Button, Field, Icon, LegacyForms, Select, Table } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -61,8 +61,13 @@ export class InspectDataTab extends PureComponent<Props, State> {
     // Replace the time field with a formatted time
     const { timeIndex, timeField } = getTimeField(dataFrame);
     if (timeField) {
-      // Use the configurd date or dateTimeIso
-      const processor: DisplayProcessor = timeField.display ? timeField.display : v => dateTimeAsIso(v);
+      // Use the configurd date or standandard time display
+      let processor: DisplayProcessor = timeField.display;
+      if (!processor) {
+        processor = getDisplayProcessor({
+          field: timeField,
+        });
+      }
 
       const formattedDateField = {
         ...timeField,

--- a/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
@@ -59,25 +59,23 @@ export class InspectDataTab extends PureComponent<Props, State> {
     const { transformId } = this.state;
 
     // Replace the time field with a formatted time
-    if (true) {
-      const { timeIndex, timeField } = getTimeField(dataFrame);
-      if (timeField) {
-        // Use the configurd date or dateTimeIso
-        const processor: DisplayProcessor = timeField.display ? timeField.display : v => dateTimeAsIso(v);
+    const { timeIndex, timeField } = getTimeField(dataFrame);
+    if (timeField) {
+      // Use the configurd date or dateTimeIso
+      const processor: DisplayProcessor = timeField.display ? timeField.display : v => dateTimeAsIso(v);
 
-        const formattedDateField = {
-          ...timeField,
-          type: FieldType.string,
-          values: new FormattedVector(timeField.values, processor),
-        };
+      const formattedDateField = {
+        ...timeField,
+        type: FieldType.string,
+        values: new FormattedVector(timeField.values, processor),
+      };
 
-        const fields = [...dataFrame.fields];
-        fields[timeIndex] = formattedDateField;
-        dataFrame = {
-          ...dataFrame,
-          fields,
-        };
-      }
+      const fields = [...dataFrame.fields];
+      fields[timeIndex] = formattedDateField;
+      dataFrame = {
+        ...dataFrame,
+        fields,
+      };
     }
 
     const dataFrameCsv = toCSV([dataFrame]);

--- a/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
@@ -8,6 +8,11 @@ import {
   SelectableValue,
   toCSV,
   transformDataFrame,
+  getTimeField,
+  FieldType,
+  FormattedVector,
+  DisplayProcessor,
+  dateTimeAsIso,
 } from '@grafana/data';
 import { Button, Field, Icon, LegacyForms, Select, Table } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -52,6 +57,29 @@ export class InspectDataTab extends PureComponent<Props, State> {
   exportCsv = (dataFrame: DataFrame) => {
     const { panel } = this.props;
     const { transformId } = this.state;
+
+    // Replace the time field with a formatted time
+    if (true) {
+      const { timeIndex, timeField } = getTimeField(dataFrame);
+      if (timeField) {
+        // Use the configurd date or dateTimeIso
+        const processor: DisplayProcessor = timeField.display ? timeField.display : v => dateTimeAsIso(v);
+
+        const formattedDateField = {
+          ...timeField,
+          type: FieldType.string,
+          values: new FormattedVector(timeField.values, processor),
+        };
+
+        const fields = [...dataFrame.fields];
+        fields[timeIndex] = formattedDateField;
+        dataFrame = {
+          ...dataFrame,
+          fields,
+        };
+      }
+    }
+
     const dataFrameCsv = toCSV([dataFrame]);
 
     const blob = new Blob([dataFrameCsv], {


### PR DESCRIPTION
Fixes #24973

This is a simple fix to replace the field with a formattedvalue.  I suspect longer term we will need to have download open a set of options like it did before
