### PR TITLE
Chore: Add IAM to list of ignored terms for codespell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,7 +793,7 @@ jobs:
       - run:
           # Important: all words have to be in lowercase, and separated by "\n".
           name: exclude known exceptions
-          command: 'echo -e "unknwon\nreferer\nerrorstring\neror" > words_to_ignore.txt'
+          command: 'echo -e "unknwon\nreferer\nerrorstring\neror\niam" > words_to_ignore.txt'
       - run:
           name: check documentation spelling errors
           command: "codespell -I ./words_to_ignore.txt docs/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Codespell was causing CI failures due to use of the term "IAM" (Amazon Identity and Access Management) mistakenly being identified as a typo. This PR adds "iam" to the list of codespell exclusions.
