### PR TITLE
Logs: Use result range instead of timepicker range for log histogram

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -1,6 +1,7 @@
 import { Labels } from './data';
 import { GraphSeriesXY } from './graph';
 import { DataFrame } from './dataFrame';
+import { AbsoluteTimeRange } from './time';
 
 /**
  * Mapping of log level abbreviation to canonical log level.
@@ -74,6 +75,7 @@ export interface LogsModel {
   meta?: LogsMetaItem[];
   rows: LogRowModel[];
   series?: GraphSeriesXY[];
+  visibleRange?: AbsoluteTimeRange;
 }
 
 export interface LogSearchMatch {

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -45,6 +45,7 @@ interface Props {
   logsMeta?: LogsMetaItem[];
   logsSeries?: GraphSeriesXY[];
   dedupedRows?: LogRowModel[];
+  visibleRange?: AbsoluteTimeRange;
 
   width: number;
   highlighterExpressions?: string[];
@@ -144,6 +145,7 @@ export class Logs extends PureComponent<Props, State> {
       logRows,
       logsMeta,
       logsSeries,
+      visibleRange,
       highlighterExpressions,
       loading = false,
       onClickFilterLabel,
@@ -190,7 +192,7 @@ export class Logs extends PureComponent<Props, State> {
             width={width}
             onHiddenSeriesChanged={this.onToggleLogLevel}
             loading={loading}
-            absoluteRange={absoluteRange}
+            absoluteRange={visibleRange || absoluteRange}
             isStacked={true}
             showPanel={false}
             showingGraph={true}

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -40,6 +40,7 @@ interface LogsContainerProps {
   logsMeta?: LogsMetaItem[];
   logsSeries?: GraphSeriesXY[];
   dedupedRows?: LogRowModel[];
+  visibleRange?: AbsoluteTimeRange;
 
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
@@ -107,6 +108,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
       onStopScanning,
       absoluteRange,
       timeZone,
+      visibleRange,
       scanning,
       range,
       width,
@@ -150,6 +152,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
               onDedupStrategyChange={this.handleDedupStrategyChange}
               onToggleLogLevel={this.handleToggleLogLevel}
               absoluteRange={absoluteRange}
+              visibleRange={visibleRange}
               timeZone={timeZone}
               scanning={scanning}
               scanRange={range.raw}
@@ -190,6 +193,7 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: string }
     logRows: logsResult && logsResult.rows,
     logsMeta: logsResult && logsResult.meta,
     logsSeries: logsResult && logsResult.series,
+    visibleRange: logsResult && logsResult.visibleRange,
     scanning,
     timeZone,
     dedupStrategy,

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -104,7 +104,7 @@ export class ResultProcessor {
       return null;
     }
 
-    const newResults = dataFrameToLogsModel(this.dataFrames, this.intervalMs, this.timeZone);
+    const newResults = dataFrameToLogsModel(this.dataFrames, this.intervalMs, this.timeZone, this.state.absoluteRange);
     const sortOrder = refreshIntervalToSortOrder(this.state.refreshInterval);
     const sortedNewResults = sortLogsResult(newResults, sortOrder);
     const rows = sortedNewResults.rows;


### PR DESCRIPTION
If a logs datasource does not send histogram data for the requested
time range, the logs model computes a timeseries based on the log row
counts, bucketed by an automcatically calculated time interval. Even
when this histogram time series did not span the whole requested time
range it was still rendered in the graph across the whole range, leaving
an empty area at its start. Users find this confusing and are lead to
believe their log data is missing.

This change fixes this by anchoring the start of the timeseries on the
first log row's timestamp from the result, and adds this smaller range
as `visibleRange` to the logs model and passes it through to the logs
component that optionally takes it into account to not render the empty
area. The end of the timeseries is still anchored in the timepicker's To-range
to show if recently no logs were seen.

The interval (bucket size) is also adjusted to account for a potentially
finer resolution on the shorter visible time interval.
The bucketsize multiplier was also changed from 10 to 20 to account for
the space between the chart's bars.

The change in behavior is that the histogram chart no longer represents the time picker range, but given the user feedback, that seems less confusing.

Example of a "Last hour" request, which returned 20mins of log lines that now fill the whole chart.
![Screenshot 2020-05-22 at 18 43 17](https://user-images.githubusercontent.com/859729/82690361-5b3efb80-9c5c-11ea-96b1-89ce0f2810b2.png)

Compare to the current behavior which has an empty area prior to 18:20:
![Screenshot 2020-05-22 at 18 45 54](https://user-images.githubusercontent.com/859729/82690445-832e5f00-9c5c-11ea-85d7-81abf589d20c.png)

CC @cyriltovena 

