### PR TITLE
Elasticsearch: adds words highlight on logs query

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -6,7 +6,7 @@ import { toUtc, dateTime } from '@grafana/data';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, DataFrame } from '@grafana/data';
 import { ElasticsearchOptions, ElasticsearchQuery } from './types';
 
 jest.mock('@grafana/runtime', () => ({
@@ -228,6 +228,13 @@ describe('ElasticDatasource', function(this: any) {
       const links = response.data[0].fields.find((field: Field) => field.name === 'host').config.links;
       expect(links.length).toBe(1);
       expect(links[0].url).toBe('http://localhost:3000/${__value.raw}');
+    });
+
+    it('should add search words to DataFrame metadata', async () => {
+      const { response } = await setupDataSource();
+      response.data.forEach((dataFrame: DataFrame) => {
+        expect(dataFrame.meta.searchWords).toEqual(['escape\\:test']);
+      });
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -404,8 +404,9 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       const er = new ElasticResponse(sentTargets, res);
       if (sentTargets.some(target => target.isLogsQuery)) {
         const response = er.getLogs(this.logMessageField, this.logLevelField);
+        const searchWords = targets.map(target => target.query);
         for (const dataFrame of response.data) {
-          this.enhanceDataFrame(dataFrame);
+          this.enhanceDataFrame(dataFrame, searchWords);
         }
         return response;
       }
@@ -585,7 +586,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     return false;
   }
 
-  enhanceDataFrame(dataFrame: DataFrame) {
+  enhanceDataFrame(dataFrame: DataFrame, searchWords?: string[]) {
     if (this.dataLinks.length) {
       for (const field of dataFrame.fields) {
         const dataLink = this.dataLinks.find(dataLink => field.name && field.name.match(dataLink.field));
@@ -601,6 +602,10 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
         }
       }
     }
+    dataFrame.meta = {
+      ...dataFrame.meta,
+      searchWords: searchWords ?? [],
+    };
   }
 
   private isPrimitive(obj: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds words highlight on logs query with Elasticsearch datasource.

**Which issue(s) this PR fixes**:

Fixes #20098

**Special notes for your reviewer**:

How to test it:
1. Open Explore
2. Select Elasticsearch Logs datasource
3. Type something in the logs query field.
4. Run query. The expression you entered is going to be highlighted in logs result.