### PR TITLE
Loki/Prometheus: updates addLabelToQuery method to prevent it from adding labels outside of selector when using Loki datasource

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -347,17 +347,16 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     let expression = query.expr ?? '';
     switch (action.type) {
       case 'ADD_FILTER': {
-        expression = addLabelToQuery(expression, action.key, action.value);
+        expression = addLabelToQuery(expression, action.key, action.value, undefined, true);
         break;
       }
       case 'ADD_FILTER_OUT': {
-        expression = addLabelToQuery(expression, action.key, action.value, '!=');
+        expression = addLabelToQuery(expression, action.key, action.value, '!=', true);
         break;
       }
       default:
         break;
     }
-
     return { ...query, expr: expression };
   }
 

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
@@ -63,6 +63,15 @@ describe('addLabelToQuery()', () => {
     expect(addLabelToQuery('{x="y"} |="yy"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy"');
     expect(addLabelToQuery('{x="y"} |="yy" !~"xx"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy" !~"xx"');
   });
+
+  it('should add label to query properly with Loki datasource', () => {
+    expect(addLabelToQuery('{job="grafana"} |= "foo-bar"', 'filename', 'test.txt', undefined, true)).toBe(
+      '{filename="test.txt",job="grafana"} |= "foo-bar"'
+    );
+    expect(addLabelToQuery('{job="grafana"} |= "foo-bar"', 'filename', 'test.txt')).toBe(
+      '{filename="test.txt",job="grafana"} |= "foo{filename="test.txt"}-bar"'
+    );
+  });
 });
 
 describe('addLabelToSelector()', () => {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -40,6 +40,10 @@ export function addLabelToQuery(
     const isColonBounded = word.endsWith(':');
 
     previousWord = word;
+
+    // with Prometheus datasource, adds an empty selector to a bare metric name
+    // but doesn't add it with Loki datasource so there are no unnecessary labels
+    // e.g. when the filter contains a dash (-) character inside
     if (
       !isLokiDatasource &&
       !insideSelector &&

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -23,7 +23,7 @@ export function addLabelToQuery(
   key: string,
   value: string,
   operator?: string,
-  isLokiDatasource?: boolean
+  hasNoMetrics?: boolean
 ): string {
   if (!key || !value) {
     throw new Error('Need label to add to query.');
@@ -45,7 +45,7 @@ export function addLabelToQuery(
     // but doesn't add it with Loki datasource so there are no unnecessary labels
     // e.g. when the filter contains a dash (-) character inside
     if (
-      !isLokiDatasource &&
+      !hasNoMetrics &&
       !insideSelector &&
       !isColonBounded &&
       !previousWordIsKeyWord &&

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -18,8 +18,13 @@ const builtInWords = [
 const metricNameRegexp = /([A-Za-z:][\w:]*)\b(?![\(\]{=!",])/g;
 const selectorRegexp = /{([^{]*)}/g;
 
-// addLabelToQuery('foo', 'bar', 'baz') => 'foo{bar="baz"}'
-export function addLabelToQuery(query: string, key: string, value: string, operator?: string): string {
+export function addLabelToQuery(
+  query: string,
+  key: string,
+  value: string,
+  operator?: string,
+  isLokiDatasource?: boolean
+): string {
   if (!key || !value) {
     throw new Error('Need label to add to query.');
   }
@@ -35,7 +40,13 @@ export function addLabelToQuery(query: string, key: string, value: string, opera
     const isColonBounded = word.endsWith(':');
 
     previousWord = word;
-    if (!insideSelector && !isColonBounded && !previousWordIsKeyWord && builtInWords.indexOf(word) === -1) {
+    if (
+      !isLokiDatasource &&
+      !insideSelector &&
+      !isColonBounded &&
+      !previousWordIsKeyWord &&
+      builtInWords.indexOf(word) === -1
+    ) {
       return `${word}{}`;
     }
     return word;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `addLabelToQuery` method to prevent it from adding labels outside of selector when using Loki datasource.

**Which issue(s) this PR fixes**:

Fixes #25010