### PR TITLE
postgres: use time_bucket_gapfill for TimescaleDB

### DIFF
--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -109,7 +109,7 @@ func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string,
 		}
 
 		if m.timescaledb {
-			return fmt.Sprintf("time_bucket('%vs',%s)", interval.Seconds(), args[0]), nil
+			return fmt.Sprintf("time_bucket_gapfill('%vs',%s)", interval.Seconds(), args[0]), nil
 		}
 
 		return fmt.Sprintf(

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -98,7 +98,7 @@ func TestMacroEngine(t *testing.T) {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column,'5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
+				So(sql, ShouldEqual, "GROUP BY time_bucket_gapfill('300s',time_column)")
 			})
 
 			Convey("interpolate __timeGroup function with spaces between args and TimescaleDB enabled", func() {
@@ -106,7 +106,7 @@ func TestMacroEngine(t *testing.T) {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
+				So(sql, ShouldEqual, "GROUP BY time_bucket_gapfill('300s',time_column)")
 			})
 
 			Convey("interpolate __unixEpochFilter function", func() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This changes grafana to use the `time_bucket_gapfill()` function, allowing empty time periods to be visualized, and fixes the "Null value" option so it actually works as intended.

**Old behavior:**
![image](https://user-images.githubusercontent.com/1826947/82773404-f4fada00-9e0f-11ea-8b63-ac15e6edac4d.png)

**New behavior:**
![image](https://user-images.githubusercontent.com/1826947/82773534-46a36480-9e10-11ea-8746-40e51491fb6a.png)
![image](https://user-images.githubusercontent.com/1826947/82773515-3be8cf80-9e10-11ea-8116-c5db45e502ef.png)



**Which issue(s) this PR fixes**:
Fixes  #15145.

**Special notes for your reviewer**:

