### PR TITLE
Transform: Display correct field name when using reduce transformation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/reduce.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.test.ts
@@ -58,7 +58,7 @@ describe('Reducer Transformer', () => {
       {
         name: 'Field',
         type: FieldType.string,
-        values: new ArrayVector(['temperature {A}', 'humidity {A}', 'temperature {B}', 'humidity {B}']),
+        values: new ArrayVector(['A temperature', 'A humidity', 'B temperature', 'B humidity']),
         config: {},
       },
       {
@@ -104,7 +104,7 @@ describe('Reducer Transformer', () => {
       {
         name: 'Field',
         type: FieldType.string,
-        values: new ArrayVector(['temperature {A}', 'temperature {B}']),
+        values: new ArrayVector(['A temperature', 'B temperature']),
         config: {},
       },
       {
@@ -150,7 +150,7 @@ describe('Reducer Transformer', () => {
       {
         name: 'Field',
         type: FieldType.string,
-        values: new ArrayVector(['temperature', 'humidity']),
+        values: new ArrayVector(['A temperature', 'A humidity']),
         config: {},
       },
       {
@@ -196,7 +196,7 @@ describe('Reducer Transformer', () => {
       {
         name: 'Field',
         type: FieldType.string,
-        values: new ArrayVector(['temperature']),
+        values: new ArrayVector(['A temperature']),
         config: {},
       },
       {

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -9,6 +9,7 @@ import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
 import { getFieldMatcher } from '../matchers';
 import { FieldMatcherID } from '../matchers/ids';
 import { filterFieldsTransformer } from './filter';
+import { getFieldDisplayName } from '../../field';
 
 export interface ReduceTransformerOptions {
   reducers: ReducerID[];
@@ -79,9 +80,7 @@ export const reduceTransformer: DataTransformerInfo<ReduceTransformerOptions> = 
             });
 
             // Update the name list
-            const seriesName = series.name ?? series.refId ?? seriesIndex;
-            const fieldName =
-              field.name === seriesName || data.length === 1 ? field.name : `${field.name} {${seriesName}}`;
+            const fieldName = getFieldDisplayName(field, series);
 
             values[0].buffer.push(fieldName);
 

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -80,7 +80,7 @@ export const reduceTransformer: DataTransformerInfo<ReduceTransformerOptions> = 
             });
 
             // Update the name list
-            const fieldName = getFieldDisplayName(field, series);
+            const fieldName = getFieldDisplayName(field, series, data);
 
             values[0].buffer.push(fieldName);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects the field name using `getFieldDisplayName`. 

**Which issue(s) this PR fixes**:
Fixes #24842

**Special notes for your reviewer**:

