### PR TITLE
Dashboard: Get panels in collapsed rows

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -154,6 +154,7 @@ export class DashboardPage extends PureComponent<Props, State> {
     const { dashboard } = this.props;
 
     const panelId = parseInt(urlPanelId!, 10);
+    dashboard!.expandParentRowFor(panelId);
     const panel = dashboard!.getPanelById(panelId);
 
     if (!panel) {
@@ -170,7 +171,6 @@ export class DashboardPage extends PureComponent<Props, State> {
       return;
     }
 
-    dashboard!.expandParentRowFor(panelId);
     callback(panel);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the alert rule edit would not open if trying to navigate to an alert rule in a panel in a collapsed row.

**Which issue(s) this PR fixes**:
Fixes #24972

**Special notes for your reviewer**:

