### PR TITLE
Docker: Fix nightly vulnerability scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,7 +972,13 @@ jobs:
           command: "./scripts/ci-job-succeeded.sh"
           when: on_success
 
-  scan-docker-images:
+  scan-docker-image:
+    description: "Scans a docker image for vulnerabilities using trivy"
+    parameters:
+      image:
+        type: string
+      tag:
+        type: string
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -995,29 +1001,8 @@ jobs:
           name: Clear trivy cache
           command: trivy --clear-cache
       - run:
-          name: Scan grafana/grafana:master
-          command: trivy --exit-code 1 grafana/grafana:master
-      - run:
-          name: Scan grafana/grafana:master-ubuntu
-          command: trivy --exit-code 1 grafana/grafana:master-ubuntu
-      - run:
-          name: Scan grafana/grafana-enterprise:master
-          command: trivy --exit-code 1 grafana/grafana-enterprise:master
-      - run:
-          name: Scan grafana/grafana-enterprise:master-ubuntu
-          command: trivy --exit-code 1 grafana/grafana-enterprise:master-ubuntu
-      - run:
-          name: Scan grafana/grafana:latest
-          command: trivy --exit-code 1 grafana/grafana:latest
-      - run:
-          name: Scan grafana/grafana:latest-ubuntu
-          command: trivy --exit-code 1 grafana/grafana:latest-ubuntu
-      - run:
-          name: Scan grafana/grafana-enterprise:latest
-          command: trivy --exit-code 1 grafana/grafana-enterprise:latest
-      - run:
-          name: Scan grafana/grafana-enterprise:latest-ubuntu
-          command: trivy --exit-code 1 grafana/grafana-enterprise:latest-ubuntu
+          name: Scan Docker image
+          command: trivy --exit-code 1 << parameters.image >>:<< parameters.tag >>
       - save_cache:
           key: vulnerability-db
           paths:
@@ -1336,6 +1321,12 @@ workflows:
           filters: *filter-only-master
           requires:
             - build-enterprise-docker-images
+      - scan-docker-image:
+          filters: *filter-all
+          matrix:
+            parameters:
+              image: [grafana/grafana, grafana/grafana-enterprise]
+              tag: [latest, master, latest-ubuntu, master-ubuntu]
 
   nightly:
     triggers:
@@ -1343,4 +1334,8 @@ workflows:
           cron: "0 0 * * *"
           filters: *filter-only-master
     jobs:
-      - scan-docker-images
+      - scan-docker-image:
+          matrix:
+            parameters:
+              image: [grafana/grafana, grafana/grafana-enterprise]
+              tag: [latest, master, latest-ubuntu, master-ubuntu]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1001,8 +1001,11 @@ jobs:
           name: Clear trivy cache
           command: trivy --clear-cache
       - run:
-          name: Scan Docker image
-          command: trivy --exit-code 1 << parameters.image >>:<< parameters.tag >>
+          name: Scan Docker image for unkown/low/medium vulnerabilities
+          command: trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM << parameters.image >>:<< parameters.tag >>
+      - run:
+          name: Scan Docker image for high/critical vulnerabilities
+          command: trivy --exit-code 1 --severity HIGH,CRITICAL << parameters.image >>:<< parameters.tag >>
       - save_cache:
           key: vulnerability-db
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1324,12 +1324,6 @@ workflows:
           filters: *filter-only-master
           requires:
             - build-enterprise-docker-images
-      - scan-docker-image:
-          filters: *filter-all
-          matrix:
-            parameters:
-              image: [grafana/grafana, grafana/grafana-enterprise]
-              tag: [latest, master, latest-ubuntu, master-ubuntu]
 
   nightly:
     triggers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Runs each Docker image vulnerability scan as separate jobs so that each one can run to completeness.
- Only fails now if a high or critical vulnerability is found.

Think matrix builds should work with schedule as well, but unsure. Lets merge and see what's happen.

You can see how it works [here](https://app.circleci.com/pipelines/github/grafana/grafana/9743/workflows/4f902e27-6164-4122-a887-f6959b00cff1) when I had it temporary enabled for the build of this PR.