### PR TITLE
Postgres: Fix add button

### DIFF
--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -208,10 +208,12 @@ export class PostgresQueryCtrl extends QueryCtrl {
     }
   }
 
-  resetPlusButton(button: { html: any; value: any }) {
+  resetPlusButton(button: { html: any; value: any; type: any; fake: any }) {
     const plusButton = this.uiSegmentSrv.newPlusButton();
     button.html = plusButton.html;
     button.value = plusButton.value;
+    button.type = plusButton.type;
+    button.fake = plusButton.fake;
   }
 
   getTableSegments() {


### PR DESCRIPTION
Previously the add button on the postgres UI would break after the first usage. This was due to the button not being fully reset after use.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the UI so that the plus button can be used more than once.
Before: 
https://stormcloud9-misc.s3.amazonaws.com/vokoscreenNG-2020-05-25_13-45-50.webm
After:
https://stormcloud9-misc.s3.amazonaws.com/vokoscreenNG-2020-05-25_13-44-28.webm


**Which issue(s) this PR fixes**:
Fixes #24904. That issue reports multiple problems, but this is the largest of them. I'll separate the issues so they can be tracked independently.

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

