### PR TITLE
grafana/toolkit: Modify close milestone task to remove label from more than 100 pull requests and add dry run option

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -104,6 +104,7 @@ export const run = (includeInternalScripts = false) => {
     program
       .command('close-milestone')
       .option('-m, --milestone <milestone>', 'Specify milestone')
+      .option('--dryRun', 'Only simulate actions')
       .description('Helps ends a milestone by removing the cherry-pick label and closing it')
       .action(async cmd => {
         if (!cmd.milestone) {
@@ -113,6 +114,7 @@ export const run = (includeInternalScripts = false) => {
 
         await execTask(closeMilestoneTask)({
           milestone: cmd.milestone,
+          dryRun: !!cmd.dryRun,
         });
       });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Fixes close-milestone task to remove `cherry-pick needed` label from all the required pull requests (it used to remove it from the first 100)
- Adds a dry run option for only simulating actions (useful for development)

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #
-->

**Special notes for your reviewer**:
disclaimer: I have tested that the `dryOption` is set properly but I haven't tried to close an existing milestone (for the obvious reasons) 
