### PR TITLE
Explore/SQL data sources: Show correctly interpolated queries

### DIFF
--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -55,6 +55,7 @@ export class MssqlDatasource {
           ...query,
           datasource: this.name,
           rawSql: this.templateSrv.replace(query.rawSql, scopedVars, this.interpolateVariable),
+          rawQuery: true,
         };
         return expandedQuery;
       });

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -56,6 +56,7 @@ export class MysqlDatasource {
           ...query,
           datasource: this.name,
           rawSql: this.templateSrv.replace(query.rawSql, scopedVars, this.interpolateVariable),
+          rawQuery: true,
         };
         return expandedQuery;
       });

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -61,6 +61,7 @@ export class PostgresDatasource {
           ...query,
           datasource: this.name,
           rawSql: this.templateSrv.replace(query.rawSql, scopedVars, this.interpolateVariable),
+          rawQuery: true,
         };
         return expandedQuery;
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in issue https://github.com/grafana/grafana/issues/21691, when user wants to get to Explore from dashboard panel, interpolateVariablesInQueries is used and it correctly interpolates variables in RawSql query. However, we weren't showing Raw Editor Query with RawSql query, but Query Builder with not interpolated query. Because of the way how Raw Editor Query and Query Builder are implemented, they behave like 2 separate editors and can be de-synchronized. We don't have single source of truth. But for **all of the interpolation in SQL data sources**, we always interpolate and use RawSql query,  so this is consistent behaviour.

There are some issues with SQL query editors that I've noticed, but they are not part of this PR. I have created an [issue](https://github.com/grafana/grafana/issues/25111) for that.

![Kapture 2020-05-26 at 14 42 57](https://user-images.githubusercontent.com/30407135/82902295-888ef080-9f5f-11ea-8fe5-7db5f566b090.gif)


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/21691
