### PR TITLE
Backend Readme: Add section on avoiding simplejson

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -71,6 +71,10 @@ Refactor HTTP handlers so that the handler methods are on the HttpServer instanc
 
 Store newly introduced date columns in the database as epochs if they require date comparison. This permits a unified approach for comparing dates against all the supported databases instead of handling dates differently for each database. Also, by comparing epochs, we no longer need error pruning transformations to and from other time zones.
 
+### Avoid use of the simplejson package
+
+Use of the `simplejson` package (`pkg/components/simplejson`) in place of types (Go structs) results in code that is difficult to maintain. Instead, create types for objects and use the Go standard library's [`encoding/json`](https://golang.org/pkg/encoding/json/) package.
+
 ### Provisionable*
 
 All new features that require state should be possible to configure using config files. For example:

--- a/pkg/components/simplejson/simplejson.go
+++ b/pkg/components/simplejson/simplejson.go
@@ -1,3 +1,5 @@
+// Package simplejson provides a wrapper for arbitrary JSON objects that adds methods to access properties.
+// Use of this package in place of types and the standard library's encoding/json package is strongly discouraged.
 package simplejson
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates `pkg/README.md` with note about avoiding simplejson. Also adds pkg documentation and a similar warning.

Why we need it: simplejson is evil, types are not.

**Special notes for your reviewer**:

I'm not quite sure if this readme is really appropriate for why. "Go is a typed language, use types".

There could also be notes about what to do, for now, with tsdb.Query which has a simplejson object as a property... but seems appropriate to keep this short based on the scope of the doc.

Example of moving queries from simplejson to structs with encoding/json: https://github.com/grafana/grafana/pull/24937 
