### PR TITLE
Jaeger: fixes cascader option label duration value

### DIFF
--- a/public/app/plugins/datasource/jaeger/QueryField.test.tsx
+++ b/public/app/plugins/datasource/jaeger/QueryField.test.tsx
@@ -67,7 +67,7 @@ describe('JaegerQueryField', function() {
 
     wrapper.update();
     expect(wrapper.find(ButtonCascader).props().options[0].children[1].children[0]).toEqual({
-      label: 'rootOp [99 ms]',
+      label: 'rootOp [0.099 ms]',
       value: '12345',
     });
   });

--- a/public/app/plugins/datasource/jaeger/QueryField.tsx
+++ b/public/app/plugins/datasource/jaeger/QueryField.tsx
@@ -21,7 +21,7 @@ function findRootSpan(spans: Span[]): Span | undefined {
 function getLabelFromTrace(trace: TraceData & { spans: Span[] }): string {
   const rootSpan = findRootSpan(trace.spans);
   if (rootSpan) {
-    return `${rootSpan.operationName} [${rootSpan.duration} ms]`;
+    return `${rootSpan.operationName} [${rootSpan.duration / 1000} ms]`;
   }
   return trace.traceID;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes cascader option label value to display duration in milliseconds instead of microseconds. Jaeger provides traces in a microsecond-level precision, but we use milliseconds pretty much everywhere else (even in the Jaeger traces response), so the cascader label gets adjusted accordingly.

**Which issue(s) this PR fixes**:

Fixes #24965 