### PR TITLE
Explore: adds table result dataframes sorting to get response columns order based on queries order

### DIFF
--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -51,12 +51,15 @@ export class ResultProcessor {
     }
 
     const onlyTables = this.dataFrames
-      .filter(frame => shouldShowInVisualisationType(frame, 'table'))
-      .sort((frameA, frameB) => {
-        if (frameA.refId > frameB.refId) {
+      .filter((frame: DataFrame) => shouldShowInVisualisationType(frame, 'table'))
+      .sort((frameA: DataFrame, frameB: DataFrame) => {
+        const frameARefId = frameA.refId!;
+        const frameBRefId = frameB.refId!;
+
+        if (frameARefId > frameBRefId) {
           return 1;
         }
-        if (frameA.refId < frameB.refId) {
+        if (frameARefId < frameBRefId) {
           return -1;
         }
         return 0;

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -50,7 +50,17 @@ export class ResultProcessor {
       return null;
     }
 
-    const onlyTables = this.dataFrames.filter(frame => shouldShowInVisualisationType(frame, 'table'));
+    const onlyTables = this.dataFrames
+      .filter(frame => shouldShowInVisualisationType(frame, 'table'))
+      .sort((frameA, frameB) => {
+        if (frameA.refId > frameB.refId) {
+          return 1;
+        }
+        if (frameA.refId < frameB.refId) {
+          return -1;
+        }
+        return 0;
+      });
 
     if (onlyTables.length === 0) {
       return null;


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds sorting of dataframes in Explore table result to make sure the rendered table has a correct order of columns - relevant to the order of queries.

**Which issue(s) this PR fixes**:

Fixes #24731