### PR TITLE
CircleCI: Fix GitHub API rate limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.9
+            VERSION=0.4.10
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp
@@ -88,15 +88,15 @@ jobs:
           command: |
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/grabpl build-backend --edition << parameters.edition >> \
+              /tmp/grabpl build-backend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> \
                 --variants << parameters.variant >> $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/grabpl build-backend --edition << parameters.edition >> \
+              /tmp/grabpl build-backend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> \
                 --variants << parameters.variant >> v7.0.0-test
             else
               # A master or PR build
-              /tmp/grabpl build-backend --edition << parameters.edition >> \
+              /tmp/grabpl build-backend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> \
                 --variants << parameters.variant >> --build-id $CIRCLE_WORKFLOW_ID
             fi
       - run:
@@ -158,13 +158,13 @@ jobs:
           command: |
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/grabpl build-frontend --edition << parameters.edition >> $CIRCLE_TAG
+              /tmp/grabpl build-frontend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/grabpl build-frontend --edition << parameters.edition >> 7.0.0-test
+              /tmp/grabpl build-frontend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> 7.0.0-test
             else
               # A master or PR build
-              /tmp/grabpl build-frontend --edition << parameters.edition >> --build-id $CIRCLE_WORKFLOW_ID
+              /tmp/grabpl build-frontend --github-token $GITHUB_GRAFANABOT_TOKEN --edition << parameters.edition >> --build-id $CIRCLE_WORKFLOW_ID
             fi
       - run:
           name: Move artifacts
@@ -414,20 +414,20 @@ jobs:
             export GRAFANA_API_KEY=$GRAFANA_COM_API_KEY
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/grabpl package --jobs 2 --edition oss --sign $CIRCLE_TAG
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition oss --sign $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/grabpl package --jobs 2 --edition oss --sign v7.0.0-test
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition oss --sign v7.0.0-test
             elif [[ $CIRCLE_BRANCH == "master" ]]; then
               # A master build
-              /tmp/grabpl package --jobs 2 --edition oss --sign --build-id $CIRCLE_WORKFLOW_ID
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition oss --sign --build-id $CIRCLE_WORKFLOW_ID
             elif [[ -n "$CIRCLE_PR_NUMBER" ]]; then
               # A forked PR build, don't sign as it requires an API secret
-              /tmp/grabpl package --jobs 2 --edition oss --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition oss --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             else
               # A non-forked PR build
-              /tmp/grabpl package --jobs 2 --edition oss --sign --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition oss --sign --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             fi
       - run:
@@ -476,20 +476,20 @@ jobs:
 
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/grabpl package --jobs 2 --edition enterprise --sign $CIRCLE_TAG
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition enterprise --sign $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/grabpl package --jobs 2 --edition enterprise --sign v7.0.0-test
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition enterprise --sign v7.0.0-test
             elif [[ $CIRCLE_BRANCH == "master" ]]; then
               # A master build
-              /tmp/grabpl package --jobs 2 --edition enterprise --sign --build-id $CIRCLE_WORKFLOW_ID
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition enterprise --sign --build-id $CIRCLE_WORKFLOW_ID
             elif [[ -n "$CIRCLE_PR_NUMBER" ]]; then
               # A forked PR build, don't sign as it requires an API secret
-              /tmp/grabpl package --jobs 2 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition enterprise --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             else
               # A PR build
-              /tmp/grabpl package --jobs 2 --edition enterprise --sign --build-id $CIRCLE_WORKFLOW_ID --variants \
+              /tmp/grabpl package --github-token $GITHUB_GRAFANABOT_TOKEN --jobs 2 --edition enterprise --sign --build-id $CIRCLE_WORKFLOW_ID --variants \
                 linux-x64,linux-x64-musl,osx64,win64
             fi
       - run:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix GitHub API rate limiting, in CircleCI, by making the build pipeline tool authenticate its (GH API) queries.

Fixes #25181.
