### PR TITLE
CircleCI: Upgrade build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.16
+      - image: grafana/build-container:1.2.17
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -889,18 +889,13 @@ jobs:
           when: on_success
 
   build-docs-website:
-    executor: grafana-build
+    executor: base
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
-      - run:
-          name: Install docker
-          command: |
-            apt-get update
-            apt-get install -y docker.io
       - run:
           name: Build Grafana docs website
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.10
+            VERSION=0.4.11
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.16"
+_version="1.2.17"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade grafana/build-container in CircleCI to the latest version, which is based on Debian Stretch. This version of the build image should produce more portable binaries, that also work on Ubuntu 18.04 ARM64.

**Which issue(s) this PR fixes**:
Fixes #24844.

**Special notes for your reviewer**:

