### PR TITLE
Gauge: respect orientation setting

### DIFF
--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -62,7 +62,8 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
   };
 
   render() {
-    const { height, width, data, renderCounter } = this.props;
+    const { height, width, data, renderCounter, options } = this.props;
+
     return (
       <VizRepeater
         getValues={this.getValues}
@@ -72,8 +73,18 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
         source={data}
         autoGrid={true}
         renderCounter={renderCounter}
-        orientation={VizOrientation.Auto}
+        orientation={swapHorizontalVertical(options.orientation)}
       />
     );
   }
+}
+
+export function swapHorizontalVertical(orientation: VizOrientation): VizOrientation {
+  if (orientation === VizOrientation.Horizontal) {
+    return VizOrientation.Vertical;
+  }
+  if (orientation === VizOrientation.Vertical) {
+    return VizOrientation.Horizontal;
+  }
+  return orientation;
 }

--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -79,6 +79,12 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
   }
 }
 
+/**
+ * The names vertical/horizontal work well with the bar gauge
+ * but should be the oposite with gauge and stats.
+ *
+ * This function swaps the setting before sending it to the repeater
+ */
 export function swapHorizontalVertical(orientation: VizOrientation): VizOrientation {
   if (orientation === VizOrientation.Horizontal) {
     return VizOrientation.Vertical;

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { config } from 'app/core/config';
 import { StatPanelOptions } from './types';
 import { DataLinksContextMenuApi } from '@grafana/ui/src/components/DataLinks/DataLinksContextMenu';
+import { swapHorizontalVertical } from '../gauge/GaugePanel';
 
 export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
   renderComponent = (
@@ -107,7 +108,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
         itemSpacing={3}
         renderCounter={renderCounter}
         autoGrid={true}
-        orientation={options.orientation}
+        orientation={swapHorizontalVertical(options.orientation)}
       />
     );
   }


### PR DESCRIPTION
Somehow at 7.0, the gauge orientation setting got hardcoded to Auto -- this puts things back to respect the setting.

It also makes the names horizontal/vertical make sense for gauge/stat.  They currently only make sense for the bargauge