### PR TITLE
CircleCI: Upgrade to Go 1.14.3 and Node 12.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.18
+      - image: grafana/build-container:1.2.19
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -76,10 +76,10 @@ RUN cd /tmp && \
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20200514
 
-ENV GOVERSION=1.14.1 \
+ENV GOVERSION=1.14.3 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=12.13.0
+    NODEVERSION=12.17.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.18"
+_version="1.2.19"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the build image we use in CircleCI to have Go 1.14.3 and Node 12.17.0. We get intermittent segfaults now while building our Go code for ARMv7 (I could also find a corresponding issue for Go 1.14.x), and hopefully upgrading Go will help.
