### PR TITLE
Variables: change VariableEditorList row action Icon to IconButton

### DIFF
--- a/public/app/features/variables/editor/VariableEditorList.tsx
+++ b/public/app/features/variables/editor/VariableEditorList.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent, PureComponent } from 'react';
-import { Icon } from '@grafana/ui';
+import { IconButton } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 
 import EmptyListCTA from '../../../core/components/EmptyListCTA/EmptyListCTA';
@@ -111,9 +111,10 @@ export class VariableEditorList extends PureComponent<Props> {
 
                         <td style={{ width: '1%' }}>
                           {index > 0 && (
-                            <Icon
+                            <IconButton
                               onClick={event => this.onChangeVariableOrder(event, variable, MoveType.up)}
                               name="arrow-up"
+                              title="Move variable up"
                               aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowArrowUpButtons(
                                 variable.name
                               )}
@@ -122,9 +123,10 @@ export class VariableEditorList extends PureComponent<Props> {
                         </td>
                         <td style={{ width: '1%' }}>
                           {index < this.props.variables.length - 1 && (
-                            <Icon
+                            <IconButton
                               onClick={event => this.onChangeVariableOrder(event, variable, MoveType.down)}
                               name="arrow-down"
+                              title="Move variable down"
                               aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowArrowDownButtons(
                                 variable.name
                               )}
@@ -132,26 +134,24 @@ export class VariableEditorList extends PureComponent<Props> {
                           )}
                         </td>
                         <td style={{ width: '1%' }}>
-                          <a
+                          <IconButton
                             onClick={event => this.onDuplicateVariable(event, toVariableIdentifier(variable))}
-                            className="btn btn-inverse btn-small"
+                            name="copy"
+                            title="Duplicate variable"
                             aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowDuplicateButtons(
                               variable.name
                             )}
-                          >
-                            Duplicate
-                          </a>
+                          />
                         </td>
                         <td style={{ width: '1%' }}>
-                          <a
+                          <IconButton
                             onClick={event => this.onRemoveVariable(event, toVariableIdentifier(variable))}
-                            className="btn btn-danger btn-small"
+                            name="trash-alt"
+                            title="Remove variable"
                             aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowRemoveButtons(
                               variable.name
                             )}
-                          >
-                            <Icon name="times" style={{ marginBottom: 0 }} />
-                          </a>
+                          />
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes duplicate button looking like a tag (#21807)
- changes VariableEditorList row action buttons to match the QueryEditorRow action buttons

before
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/339208/83272714-82845400-a199-11ea-9fc7-0a5a312bfba8.png">

after
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/339208/83272592-523cb580-a199-11ea-91e7-b7768215aa91.png">
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/339208/83538622-0ef98400-a4c4-11ea-945e-52c564dd7549.png">

QueryEditorRow actions
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/339208/83273016-f6bef780-a199-11ea-895c-e675d2779340.png">

**Which issue(s) this PR fixes**:

Fixes #21807

