### PR TITLE
Branding: Use AppTitle as document title

### DIFF
--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -13,6 +13,7 @@ import { useStyles } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
 
 export const LoginPage: FC = () => {
+  document.title = Branding.AppTitle;
   const loginStyles = useStyles(getLoginStyles);
   return (
     <Branding.LoginBackground className={loginStyles.container}>


### PR DESCRIPTION
Hi,

This PR follows the quick discussion in #25235.
It tries to make the login page title inherit from the `AppTitle` variable, as in every other page.

Thank you for your help & support 👍