### PR TITLE
release_publisher: Fix Debian/RPM naming

### DIFF
--- a/scripts/build/release_publisher/externalrelease.go
+++ b/scripts/build/release_publisher/externalrelease.go
@@ -28,11 +28,12 @@ func (re releaseFromExternalContent) prepareRelease(baseArchiveURL, whatsNewURL 
 
 	builds := []build{}
 	for _, ba := range re.artifactConfigurations {
-		sha256, err := re.getter.getContents(fmt.Sprintf("%s.sha256", ba.getURL(baseArchiveURL, version, rt)))
+		url := ba.getURL(baseArchiveURL, version, rt)
+		sha256, err := re.getter.getContents(fmt.Sprintf("%s.sha256", url))
 		if err != nil {
 			return nil, err
 		}
-		builds = append(builds, newBuild(baseArchiveURL, ba, version, rt, sha256))
+		builds = append(builds, newBuild(url, ba, sha256))
 	}
 
 	r := release{

--- a/scripts/build/release_publisher/main.go
+++ b/scripts/build/release_publisher/main.go
@@ -44,7 +44,6 @@ func main() {
 	if enterprise {
 		product = "grafana-enterprise"
 		baseURL = createBaseURL(archiveProviderRoot, "enterprise", product, nightly)
-
 	} else {
 		product = "grafana"
 		baseURL = createBaseURL(archiveProviderRoot, "oss", product, nightly)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the scripts/build/release_publisher tool so naming of Debian and RPM packages is correct on publishing to grafana.com.

The reason the fix is needed is that the build pipeline tool fixed naming of pre-release Debian/RPM packages, so the pre-release component gets prefixed with `~` instead of `-`, f.ex. _grafana_7.1.0~aed17029pre_amd64.deb_. The scripts/build/release_publisher tool was out of sync with this.

**Which issue(s) this PR fixes**:
Fixes #25236.