### PR TITLE
e2e: disables variables tests

### DIFF
--- a/e2e/suite1/specs/queryVariableCrud.spec.ts
+++ b/e2e/suite1/specs/queryVariableCrud.spec.ts
@@ -4,7 +4,7 @@ import { e2e } from '@grafana/e2e';
 // several it functions. Very important to keep the order of these it functions because they have dependency in the order
 // https://github.com/cypress-io/cypress/issues/5987
 // https://github.com/cypress-io/cypress/issues/6023#issuecomment-574031655
-describe('Variables', () => {
+describe.skip('Variables', () => {
   let lastUid = '';
   let lastData = '';
   let variables: VariablesData[] = [


### PR DESCRIPTION
**What this PR does / why we need it**:
Skips e2e test for template variables until we can stabilize them more.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

