### PR TITLE
Provide correct field scoped vars for data links interpolation

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -118,8 +118,8 @@ describe('applyFieldOverrides', () => {
           "__field": Object {
             "text": "Field",
             "value": Object {
-              "label": undefined,
-              "labels": "",
+              "formattedLabels": "",
+              "labels": undefined,
               "name": "A message",
             },
           },
@@ -137,8 +137,8 @@ describe('applyFieldOverrides', () => {
           "__field": Object {
             "text": "Field",
             "value": Object {
-              "label": undefined,
-              "labels": "",
+              "formattedLabels": "",
+              "labels": undefined,
               "name": "B info",
             },
           },

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -112,8 +112,8 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         text: 'Field',
         value: {
           name: displayName, // Generally appropriate (may include the series name if useful)
-          labels: formatLabels(field.labels!),
-          label: field.labels,
+          formattedLabels: formatLabels(field.labels!),
+          labels: field.labels,
         },
       };
 


### PR DESCRIPTION
Fixes #25106

In https://github.com/grafana/grafana/pull/24024 (https://github.com/grafana/grafana/commit/5dca59f72048f3928d699254763d3dfbe586f12d#diff-d94589eab80f69c7edf5759634cd6aeeR111) `labels` field scoped var was renamed to `label`, while `labels` started to represent formatted labels. I don't know if this was intentional or just by accident, but it broke labels interpolation in data links. But it was definitely a breaking change.

In this PR I'm bringing back the `labels` scoped var to contain a dictionary with field labels. The formated labels scoped var is now named `formattedLabels`. I couldn't find the formatted labels to be used anywhere. @torkelo @ryantxu maybe you recall if this scoped var is used anywhere?

Another approach I have considered was to implement migration for the data links to update `__field.labels` to `__field.label`, but I found this as an unnecessarily complex solution. 

I also feel like the `formattedLabels` scoped var is more verbose than `labels`.