### PR TITLE
LDAP: fix active sync (don't sync OAuth users)

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -468,13 +468,7 @@ func SearchUsers(query *models.SearchUsersQuery) error {
 	}
 
 	if query.AuthModule != "" {
-		whereConditions = append(
-			whereConditions,
-			`u.id IN (SELECT user_id
-			FROM user_auth
-			WHERE auth_module=?)`,
-		)
-
+		whereConditions = append(whereConditions, `auth_module=?`)
 		whereParams = append(whereParams, query.AuthModule)
 	}
 
@@ -493,6 +487,11 @@ func SearchUsers(query *models.SearchUsersQuery) error {
 	// get total
 	user := models.User{}
 	countSess := x.Table("user").Alias("u")
+
+	// Join with user_auth table if users filtered by auth_module
+	if query.AuthModule != "" {
+		countSess.Join("LEFT", "user_auth", joinCondition)
+	}
 
 	if len(whereConditions) > 0 {
 		countSess.Where(strings.Join(whereConditions, " AND "), whereParams...)

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -454,7 +454,7 @@ func TestUserDataAccess(t *testing.T) {
 				// Calling GetUserByAuthInfoQuery on an existing user will populate an entry in the user_auth table
 				// Make the first log-in during the past
 				getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-				query := &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "test1", AuthId: "test1"}
+				query := &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "ldap", AuthId: "ldap0"}
 				err := GetUserByAuthInfo(query)
 				getTime = time.Now
 
@@ -464,7 +464,7 @@ func TestUserDataAccess(t *testing.T) {
 				// Add a second auth module for this user
 				// Have this module's last log-in be more recent
 				getTime = func() time.Time { return time.Now().AddDate(0, 0, -1) }
-				query = &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "test2", AuthId: "test2"}
+				query = &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "oauth", AuthId: "oauth0"}
 				err = GetUserByAuthInfo(query)
 				getTime = time.Now
 
@@ -480,12 +480,12 @@ func TestUserDataAccess(t *testing.T) {
 					for _, user := range searchUserQuery.Result.Users {
 						if user.Login == login {
 							So(user.AuthModule, ShouldHaveLength, 1)
-							So(user.AuthModule[0], ShouldEqual, "test2")
+							So(user.AuthModule[0], ShouldEqual, "oauth")
 						}
 					}
 
 					// "log in" again with the first auth module
-					updateAuthCmd := &models.UpdateAuthInfoCommand{UserId: query.Result.Id, AuthModule: "test1", AuthId: "test1"}
+					updateAuthCmd := &models.UpdateAuthInfoCommand{UserId: query.Result.Id, AuthModule: "ldap", AuthId: "ldap1"}
 					err = UpdateAuthInfo(updateAuthCmd)
 					So(err, ShouldBeNil)
 
@@ -496,7 +496,48 @@ func TestUserDataAccess(t *testing.T) {
 					for _, user := range searchUserQuery.Result.Users {
 						if user.Login == login {
 							So(user.AuthModule, ShouldHaveLength, 1)
-							So(user.AuthModule[0], ShouldEqual, "test1")
+							So(user.AuthModule[0], ShouldEqual, "ldap")
+						}
+					}
+				})
+			})
+
+			Convey("When searching LDAP users", func() {
+				for i := 0; i < 5; i++ {
+					// Find a user to set tokens on
+					login := fmt.Sprint("loginuser", i)
+
+					// Calling GetUserByAuthInfoQuery on an existing user will populate an entry in the user_auth table
+					// Make the first log-in during the past
+					getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
+					query := &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "ldap", AuthId: fmt.Sprint("ldap", i)}
+					err := GetUserByAuthInfo(query)
+					getTime = time.Now
+
+					So(err, ShouldBeNil)
+					So(query.Result.Login, ShouldEqual, login)
+				}
+
+				// Log in first user with oauth
+				login := "loginuser0"
+				getTime = func() time.Time { return time.Now().AddDate(0, 0, -1) }
+				query := &models.GetUserByAuthInfoQuery{Login: login, AuthModule: "oauth", AuthId: "oauth0"}
+				err := GetUserByAuthInfo(query)
+				getTime = time.Now
+
+				So(err, ShouldBeNil)
+				So(query.Result.Login, ShouldEqual, login)
+
+				Convey("Should only return users recently logged in with ldap when filtered by ldap auth module", func() {
+					searchUserQuery := &models.SearchUsersQuery{AuthModule: "ldap"}
+					err = SearchUsers(searchUserQuery)
+
+					So(err, ShouldBeNil)
+					So(searchUserQuery.Result.Users, ShouldHaveLength, 4)
+					for _, user := range searchUserQuery.Result.Users {
+						if user.Login == login {
+							So(user.AuthModule, ShouldHaveLength, 1)
+							So(user.AuthModule[0], ShouldEqual, "ldap")
 						}
 					}
 				})


### PR DESCRIPTION
This PR fixes bug in LDAP active sync (Enterprise). With this fix user search returns only users that last time logged in with LDAP.