### PR TITLE
Fix typo in GitHub Auth Doc page

### DIFF
--- a/docs/sources/auth/github.md
+++ b/docs/sources/auth/github.md
@@ -25,7 +25,7 @@ http://<my_grafana_server_name_or_ip>:<grafana_server_port>/login/github
 ```
 
 This callback URL must match the full HTTP address that you use in your
-browser to access Grafana, but with the prefix path of `/login/github`.
+browser to access Grafana, but with the suffix path of `/login/github`.
 When the GitHub OAuth application is created you will get a Client ID and a
 Client Secret. Specify these in the Grafana configuration file. For
 example:


### PR DESCRIPTION
https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana

<!-- removing the template because I think it's irrelevant for this PR -->