### PR TITLE
DataSourceWithBackend: use datasource id when datasource property is not set

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -1,0 +1,35 @@
+import { BackendSrv } from 'src/services';
+import { DataSourceWithBackend } from './DataSourceWithBackend';
+import { DataSourceJsonData, DataQuery, DataSourceInstanceSettings, DataQueryRequest } from '@grafana/data';
+
+class MyDataSource extends DataSourceWithBackend<DataQuery, DataSourceJsonData> {
+  constructor(instanceSettings: DataSourceInstanceSettings<DataSourceJsonData>) {
+    super(instanceSettings);
+  }
+}
+
+const backendSrv = ({
+  datasourceRequest: jest.fn(),
+} as unknown) as BackendSrv;
+
+jest.mock('../services', () => ({
+  getBackendSrv: () => backendSrv,
+}));
+
+describe('DataSourceWithBackend', () => {
+  test('check the executed queries', () => {
+    const settings = {
+      name: 'test',
+      id: 1234,
+      jsonData: {},
+    } as DataSourceInstanceSettings<DataSourceJsonData>;
+
+    const ds = new MyDataSource(settings);
+    ds.query({
+      targets: [{ refId: 'A' }, { refId: 'B' }],
+    } as DataQueryRequest);
+
+    const mock = (backendSrv.datasourceRequest as any).mock;
+    expect(mock.calls.length).toBe(1);
+  });
+});

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -8,12 +8,28 @@ class MyDataSource extends DataSourceWithBackend<DataQuery, DataSourceJsonData> 
   }
 }
 
+const mockDatasourceRequest = jest.fn();
+
 const backendSrv = ({
-  datasourceRequest: jest.fn(),
+  datasourceRequest: mockDatasourceRequest,
 } as unknown) as BackendSrv;
 
 jest.mock('../services', () => ({
   getBackendSrv: () => backendSrv,
+}));
+jest.mock('..', () => ({
+  config: {
+    bootData: {
+      user: {
+        orgId: 77,
+      },
+    },
+    datasources: {
+      sample: {
+        id: 8674,
+      },
+    },
+  },
 }));
 
 describe('DataSourceWithBackend', () => {
@@ -24,12 +40,44 @@ describe('DataSourceWithBackend', () => {
       jsonData: {},
     } as DataSourceInstanceSettings<DataSourceJsonData>;
 
+    mockDatasourceRequest.mockReset();
+    mockDatasourceRequest.mockReturnValue(Promise.resolve({}));
     const ds = new MyDataSource(settings);
     ds.query({
-      targets: [{ refId: 'A' }, { refId: 'B' }],
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A' }, { refId: 'B', datasource: 'sample' }],
     } as DataQueryRequest);
 
-    const mock = (backendSrv.datasourceRequest as any).mock;
+    const mock = mockDatasourceRequest.mock;
     expect(mock.calls.length).toBe(1);
+
+    const args = mock.calls[0][0];
+    expect(args).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "queries": Array [
+            Object {
+              "datasourceId": 1234,
+              "intervalMs": 5000,
+              "maxDataPoints": 10,
+              "orgId": 77,
+              "refId": "A",
+            },
+            Object {
+              "datasource": "sample",
+              "datasourceId": 8674,
+              "intervalMs": 5000,
+              "maxDataPoints": 10,
+              "orgId": 77,
+              "refId": "B",
+            },
+          ],
+        },
+        "method": "POST",
+        "requestId": undefined,
+        "url": "/api/ds/query",
+      }
+    `);
   });
 });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -62,21 +62,25 @@ export class DataSourceWithBackend<
       targets = targets.filter(q => this.filterQuery!(q));
     }
     const queries = targets.map(q => {
+      let datasourceId = this.id;
       if (q.datasource === ExpressionDatasourceID) {
         return {
           ...q,
-          datasourceId: this.id,
+          datasourceId,
           orgId,
         };
       }
-      const dsName = q.datasource && q.datasource !== 'default' ? q.datasource : config.defaultDatasource;
-      const ds = config.datasources[dsName];
-      if (!ds) {
-        throw new Error('Unknown Datasource: ' + q.datasource);
+      if (q.datasource) {
+        const dsName = q.datasource === 'default' ? config.defaultDatasource : q.datasource;
+        const ds = config.datasources[dsName];
+        if (!ds) {
+          throw new Error('Unknown Datasource: ' + q.datasource);
+        }
+        datasourceId = ds.id;
       }
       return {
         ...this.applyTemplateVariables(q, request.scopedVars),
-        datasourceId: ds.id,
+        datasourceId,
         intervalMs,
         maxDataPoints,
         orgId,


### PR DESCRIPTION
In the panel query runner path, every target gets the panel.target added -- the current DataSourceWithBackend looks up the datasource and sets the ID base on this.  This should not be required, and currently breaks support in explore.

