### PR TITLE
Search: Only move dashboards into expanded folders UI-wise

### DIFF
--- a/public/app/features/search/reducers/manageDashboards.test.ts
+++ b/public/app/features/search/reducers/manageDashboards.test.ts
@@ -1,7 +1,7 @@
 import { TOGGLE_ALL_CHECKED, TOGGLE_CHECKED, DELETE_ITEMS, MOVE_ITEMS } from './actionTypes';
 import { manageDashboardsReducer as reducer, manageDashboardsState as state } from './manageDashboards';
 import { sections } from '../testData';
-import { UidsToDelete } from '../types';
+import { DashboardSection, UidsToDelete } from '../types';
 
 // Remove Recent and Starred sections as they're not used in manage dashboards
 const results = sections.slice(2);
@@ -83,5 +83,13 @@ describe('Manage dashboards reducer', () => {
     expect(newState.results[0].items[1].uid).toEqual('lBdLINUWk');
     expect(newState.results[3].items).toHaveLength(1);
     expect(newState.results[3].items[0].uid).toEqual('LCFWfl9Zz');
+  });
+
+  it('should not display dashboards in a non-expanded folder', () => {
+    const general = results.find(res => res.id === 0);
+    const toMove = { dashboards: general.items, folder: { id: 4074 } };
+    const newState = reducer({ ...state, results }, { type: MOVE_ITEMS, payload: toMove });
+    expect(newState.results.find((res: DashboardSection) => res.id === 4074).items).toHaveLength(0);
+    expect(newState.results.find((res: DashboardSection) => res.id === 0).items).toHaveLength(0);
   });
 });

--- a/public/app/features/search/reducers/manageDashboards.ts
+++ b/public/app/features/search/reducers/manageDashboards.ts
@@ -53,11 +53,13 @@ const reducer = (state: ManageDashboardsState, action: SearchAction) => {
         ...state,
         results: state.results.map(result => {
           if (folder.id === result.id) {
-            return {
-              ...result,
-              items: [...result.items, ...dashboards.map(db => ({ ...db, checked: false }))],
-              checked: false,
-            };
+            return result.expanded
+              ? {
+                  ...result,
+                  items: [...result.items, ...dashboards.map(db => ({ ...db, checked: false }))],
+                  checked: false,
+                }
+              : result;
           } else {
             return { ...result, items: result.items.filter(item => !uids.includes(item.uid)) };
           }

--- a/public/app/features/search/testData.ts
+++ b/public/app/features/search/testData.ts
@@ -107,7 +107,7 @@ export const sections = [
     id: 2,
     uid: 'JB_zdOUWk',
     title: 'gdev dashboards',
-    expanded: false,
+    expanded: true,
     url: '/dashboards/f/JB_zdOUWk/gdev-dashboards',
     icon: 'folder',
     score: 2,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Do not add moved dashboards to a folder in UI if the folder isn't expanded, as it prevents fetching the folder's dashboards from api. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #25358

**Special notes for your reviewer**:

