### PR TITLE
Add Chris Trott to the Grafana team

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -95,6 +95,7 @@ The current team members are:
 * Tobias Skarhed ([Grafana Labs](https://grafana.com/))
 * Torkel Ödegaard ([Grafana Labs](https://grafana.com/))
 * Utkarsh Bhatnagar ([Tinder](https://www.tinder.com/))
+* Chris Trott ([Grafana Labs](https://grafana.com/))
 
 ### Maintainers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -69,6 +69,7 @@ The current team members are:
 * Arve Knudsen ([Grafana Labs](https://grafana.com/))
 * Brian Gann ([Grafana Labs](https://grafana.com/))
 * Carl Bergquist ([Grafana Labs](https://grafana.com/))
+* Chris Trott ([Grafana Labs](https://grafana.com/))
 * Daniel Lee ([Grafana Labs](https://grafana.com/))
 * David Kaltschmidt ([Grafana Labs](https://grafana.com/))
 * Diana Payton ([Grafana Labs](https://grafana.com/))
@@ -95,7 +96,6 @@ The current team members are:
 * Tobias Skarhed ([Grafana Labs](https://grafana.com/))
 * Torkel Ödegaard ([Grafana Labs](https://grafana.com/))
 * Utkarsh Bhatnagar ([Tinder](https://www.tinder.com/))
-* Chris Trott ([Grafana Labs](https://grafana.com/))
 
 ### Maintainers
 


### PR DESCRIPTION
Chris Trott has been proposed as a new team member and the vote achieved the super majority required.

@trotttrotttrott can you approve the PR to confirm that you accept, please. Welcome to the team!