### PR TITLE
Elasticsearch: Support using a variable for histogram and terms min doc count

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/bucket_agg.html
@@ -116,7 +116,7 @@
     <div class="gf-form offset-width-7">
       <label class="gf-form-label width-10">Min Doc Count</label>
       <input
-        type="number"
+        type="text"
         class="gf-form-input max-width-12"
         ng-model="agg.settings.min_doc_count"
         ng-blur="onChangeInternal()"
@@ -153,7 +153,7 @@
     <div class="gf-form offset-width-7">
       <label class="gf-form-label width-10">Min Doc Count</label>
       <input
-        type="number"
+        type="text"
         class="gf-form-input max-width-12"
         ng-model="agg.settings.min_doc_count"
         ng-blur="onChangeInternal()"

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -55,6 +55,10 @@ export class ElasticQueryBuilder {
 
     if (aggDef.settings.min_doc_count !== void 0) {
       queryNode.terms.min_doc_count = parseInt(aggDef.settings.min_doc_count, 10);
+
+      if (isNaN(queryNode.terms.min_doc_count)) {
+        queryNode.terms.min_doc_count = aggDef.settings.min_doc_count;
+      }
     }
 
     if (aggDef.settings.missing) {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -103,6 +103,50 @@ describe('ElasticQueryBuilder', () => {
         expect(secondLevel.aggs['5'].avg.field).toBe('@value');
       });
 
+      it('with term agg and valid min_doc_count', () => {
+        const query = builder.build(
+          {
+            metrics: [{ type: 'count', id: '1' }],
+            bucketAggs: [
+              {
+                type: 'terms',
+                field: '@host',
+                settings: { min_doc_count: 1 },
+                id: '2',
+              },
+              { type: 'date_histogram', field: '@timestamp', id: '3' },
+            ],
+          },
+          100,
+          '1000'
+        );
+
+        const firstLevel = query.aggs['2'];
+        expect(firstLevel.terms.min_doc_count).toBe(1);
+      });
+
+      it('with term agg and variable as min_doc_count', () => {
+        const query = builder.build(
+          {
+            metrics: [{ type: 'count', id: '1' }],
+            bucketAggs: [
+              {
+                type: 'terms',
+                field: '@host',
+                settings: { min_doc_count: '$min_doc_count' },
+                id: '2',
+              },
+              { type: 'date_histogram', field: '@timestamp', id: '3' },
+            ],
+          },
+          100,
+          '1000'
+        );
+
+        const firstLevel = query.aggs['2'];
+        expect(firstLevel.terms.min_doc_count).toBe('$min_doc_count');
+      });
+
       it('with metric percentiles', () => {
         const query = builder.build(
           {


### PR DESCRIPTION
**What this PR does / why we need it**:
Support using a variable for histogram and terms min doc count. An addition to #21064 which was just merged.

**Which issue(s) this PR fixes**:
Ref #21052
Ref #21064

**Special notes for your reviewer**:

