### PR TITLE
Graph: Fix XSS vulnerability with series overrides

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
@@ -7,7 +7,7 @@
 		</div>
 		<div class="gf-form max-width-15">
 			<label class="gf-form-label query-keyword">Alias</label>
-			<input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="alias patterns" ng-blur="ctrl.refresh()">
+			<input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="alias patterns" ng-blur="ctrl.refresh()" pattern='[^<>&\\"]+'>
 		</div>
 	</div>
 

--- a/public/app/plugins/datasource/testdata/partials/query.editor.html
+++ b/public/app/plugins/datasource/testdata/partials/query.editor.html
@@ -12,7 +12,7 @@
 		</div>
 		<div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Alias</label>
-			<input type="text" class="gf-form-input width-14" placeholder="optional" ng-model="ctrl.target.alias" ng-change="ctrl.refresh()" ng-model-onblur>
+			<input type="text" class="gf-form-input width-14" placeholder="optional" ng-model="ctrl.target.alias" ng-model-onblur pattern='[^<>&\\"]+'>
 		</div>
 		<div ng-if="ctrl.showLabels" class="gf-form gf-form--grow">
 			<label class="gf-form-label query-keyword width-7">
@@ -215,7 +215,7 @@
 		</div>
 	</div>
 
-	
+
 	<div class="gf-form-inline" ng-if="ctrl.scenario.id === 'arrow'">
 		<div class="gf-form" style="width: 100%;">
 			<textarea type="string"

--- a/public/app/plugins/datasource/testdata/partials/query.editor.html
+++ b/public/app/plugins/datasource/testdata/partials/query.editor.html
@@ -12,7 +12,7 @@
 		</div>
 		<div class="gf-form">
 			<label class="gf-form-label query-keyword width-7">Alias</label>
-			<input type="text" class="gf-form-input width-14" placeholder="optional" ng-model="ctrl.target.alias" ng-model-onblur pattern='[^<>&\\"]+'>
+			<input type="text" class="gf-form-input width-14" placeholder="optional" ng-model="ctrl.target.alias" ng-model-onblur ng-change="ctrl.refresh()" pattern='[^<>&\\"]+'>
 		</div>
 		<div ng-if="ctrl.showLabels" class="gf-form gf-form--grow">
 			<label class="gf-form-label query-keyword width-7">

--- a/public/app/plugins/panel/graph/series_overrides_ctrl.ts
+++ b/public/app/plugins/panel/graph/series_overrides_ctrl.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import coreModule from 'app/core/core_module';
+import { textUtil } from '@grafana/data';
 
 /** @ngInject */
 export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: any) {
@@ -79,7 +80,7 @@ export function SeriesOverridesCtrl($scope: any, $element: JQuery, popoverSrv: a
 
   $scope.getSeriesNames = () => {
     return _.map($scope.ctrl.seriesList, series => {
-      return series.alias;
+      return textUtil.escapeHtml(series.alias);
     });
   };
 


### PR DESCRIPTION
This fixes possible XSS vulnerability when specifying series alias (i.e. test data or elastic search).

The problem is caused by the bs-typeahead directive which evals the select options passed to it. We are using an old version of ng-strap which allows only an array of strings to be passed as available options. The alias in Elastic and TestData query editor allows providing special characters, so, for instance, specifying alias as `<img src onerror="alert(document.cookie)">` creates a possible XSS attack vector.

The solution I'm proposing here is:
1. Adding validation to the alias fields in the corresponding query editors. This will prevent users from inputting insecure values. _This will fix core datasources._
2. Escaping aliases when rendering series overrides typeahead. This may break overrides that have `<>&"` special characters in it. But only in a situation, when someone actually selects such override as then the override will contain escaped string, which will not match any series when Graph overrides are applied. _This will fix and possibly break external query editors of external data sources that allow alias confg._ 

I'm afraid of bumping the ng-strap as we have version that is modified.