### PR TITLE
Explore: Unified Logs/Metrics interface

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -48,6 +48,8 @@ export interface QueryResultMeta {
   searchWords?: string[]; // used by log models and loki
   limit?: number; // used by log models and loki
   json?: boolean; // used to keep track of old json doc values
+  instant?: boolean;
+  responseType?: 'Metrics' | 'Logs';
 }
 
 export interface QueryResultMetaStat extends FieldConfig {

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -113,6 +113,7 @@ export interface DataSourcePluginMeta<T extends KeyValue = {}> extends PluginMet
   builtIn?: boolean; // Is this for all
   metrics?: boolean;
   logs?: boolean;
+  unified?: boolean;
   annotations?: boolean;
   alerting?: boolean;
   tracing?: boolean;

--- a/packages/grafana-data/src/types/flot.ts
+++ b/packages/grafana-data/src/types/flot.ts
@@ -6,3 +6,260 @@ export interface FlotDataPoint {
   series: any;
   seriesIndex: number;
 }
+
+export interface FlotFont {
+  size: number; // in pixels
+  lineHeight: number; // in pixels
+  style: string;
+  weight: string;
+  family: string;
+  variant: string;
+  color: string;
+}
+
+export interface FlotCrosshairOptions {
+  mode?: null | 'x' | 'y' | 'xy';
+  color?: string;
+  lineWidth?: number;
+}
+
+export interface FlotSelectionOptions {
+  mode?: null | 'x' | 'y' | 'xy';
+  color?: string;
+  shape?: 'round' | 'miter' | 'bevel';
+  minSize?: number;
+}
+
+export interface FlotPlotOptions {
+  colors?: string[];
+  legend?: FlotLegend;
+  xaxis?: FlotAxis;
+  yaxis?: FlotAxis;
+  xaxes?: FlotAxis[];
+  yaxes?: FlotAxis[];
+  series?: Partial<FlotSeries>;
+  grid?: GridOptions;
+  interaction?: {
+    redrawOverlayInterval?: number;
+  };
+  hooks?: FlotHooks;
+
+  crosshair?: FlotCrosshairOptions;
+
+  selection?: FlotSelectionOptions;
+}
+
+export interface FlotPlot {
+  // public functions
+  setData: (data: Array<Array<[number, number]> | FlotSeries>) => void;
+  setupGrid: () => void;
+  draw: () => void;
+  getPlaceHolder: () => HTMLElement;
+  getCanvas: () => HTMLCanvasElement;
+  getPlotOffset: () => { left: number; right: number; top: number; bottom: number };
+  width: () => number;
+  height: () => number;
+  offset: () => { left: number; top: number };
+  getData: () => FlotSeries[];
+  getAxes: () => {
+    [key: string]: FlotAxis;
+    xaxis: FlotAxis;
+    yaxis: FlotAxis;
+  };
+  getXAxes: () => FlotAxis[];
+  getYAxes: () => FlotAxis[];
+  c2p: (pos: { left: number; top: number }) => { x: number; y: number };
+  p2c: any;
+  getOptions: () => FlotPlotOptions;
+  highlight: any;
+  unhighlight: any;
+  triggerRedrawOverlay: any;
+  pointOffset: any;
+  shutdown: any;
+  destroy: any;
+  resize: any;
+
+  // public attributes
+  hooks: FlotHooks;
+}
+
+export interface FlotDatapoints {
+  points: number[];
+  format?: {
+    number: boolean;
+    required: boolean;
+    x?: boolean;
+    y?: boolean;
+    defaultValue?: number;
+    autoscale?: boolean;
+  };
+  pointsize?: number;
+}
+
+export interface FlotHooks {
+  processOptions?: (plot: FlotPlot, options: FlotPlotOptions) => void;
+  processRawData?: (
+    plot: FlotPlot,
+    series: FlotSeries,
+    data: Array<[number, number]>,
+    datapoints: FlotDatapoints
+  ) => void;
+  processDatapoints?: (plot: FlotPlot, series: FlotSeries, datapoints: Required<FlotDatapoints>) => void;
+  processOffset?: (plot: FlotPlot, offset: { left: number; right: number; top: number; bottom: number }) => void;
+  drawBackground?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  drawSeries?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D, series: FlotSeries) => void;
+  draw?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  bindEvents?: (plot: FlotPlot, eventHolder: JQuery) => void;
+  drawOverlay?: (plot: FlotPlot, canvascontext: CanvasRenderingContext2D) => void;
+  shutdown?: (plot: FlotPlot, eventHolder: JQuery) => void;
+}
+
+export interface FlotAxisCommon {
+  show?: null | boolean;
+  position?: 'bottom' | 'top' | 'left' | 'right';
+
+  color?: null | string;
+  tickColor?: null | string;
+  font?: null | FlotFont;
+
+  min?: null | number;
+  max?: null | number;
+  autoscaleMargin?: null | number;
+
+  transform?: null | ((v: number) => number);
+  inverseTransform?: null | ((v: number) => number);
+
+  ticks?:
+    | null
+    | number
+    | number[]
+    | Array<[number, string]>
+    | ((axis: { min: number; max: number }) => number[] | Array<[number, string]>);
+  tickSize?: number | [number, string];
+  minTickSize?: number | [number, string];
+  tickFormatter?: ((val: number, b: Pick<FlotAxis, 'min' | 'max' | 'tickDecimals' | 'tickSize'>) => string) | string;
+  tickDecimals?: null | number;
+
+  labelWidth?: null | number;
+  labelHeight?: null | number;
+  reserveSpace?: null | true;
+
+  tickLength?: null | number; // in pixels
+
+  alignTicksWithAxis?: null | number;
+}
+
+export interface FlotAxisDefaultMode extends FlotAxisCommon {
+  mode?: null; // null means data are interpreted as decimal numbers
+}
+
+export interface FlotAxisTS extends FlotAxisCommon {
+  mode?: 'time';
+  timezone?: null | 'browser' | string; // only makes sense for mode 'time'
+
+  minTickSize?: [number, 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'];
+  timeformat?: null | string;
+  monthNames?: null | [string, string, string, string, string, string, string, string, string, string, string, string];
+  dayNames?: null | [string, string, string, string, string, string, string];
+  twelveHourClock?: boolean;
+}
+
+export type FlotAxis = FlotAxisDefaultMode | FlotAxisTS;
+
+export interface FlotGradient {
+  colors: Array<
+    | {
+        opacity?: number;
+        brightness?: number;
+      }
+    | string
+  >;
+}
+export interface FlotGridMarking {
+  xaxis?: { from: number; to: number };
+  yaxis?: { from: number; to: number };
+  x2axis?: { from: number; to: number };
+  y2axis?: { from: number; to: number };
+  color?: string;
+}
+
+export interface GridOptions {
+  show?: boolean;
+  aboveData?: boolean;
+  color?: string;
+  backgroundColor?: FlotGradient | string | null;
+  margin?: number | { top?: number; right?: number; bottom?: number; left?: number };
+  labelMargin?: number;
+  axisMargin?: number;
+  markings?: FlotGridMarking[] | ((axes: Record<'xaxis' | 'yaxis', FlotAxis>) => FlotGridMarking[]);
+  borderWidth?: number | { top?: number; right?: number; bottom?: number; left?: number };
+  borderColor?: string | null | { top?: string; right?: string; bottom?: string; left?: string };
+  minBorderMargin?: number | null;
+  clickable?: boolean;
+  hoverable?: boolean;
+  autoHighlight?: boolean;
+  mouseActiveRadius?: number;
+}
+
+export interface DisplayOptions {
+  show?: boolean;
+  lineWidth?: number;
+  fill?: boolean | number;
+}
+
+export interface FlotLineOptions extends DisplayOptions {
+  zero?: boolean;
+  steps?: boolean;
+  fillColor?: null | false | string;
+}
+
+export interface FlotBarOptions extends DisplayOptions {
+  zero?: boolean;
+  barWidth?: number; // in units of x-axis
+  align?: 'left' | 'right' | 'center';
+  horizontal?: boolean;
+  fillColor?: null | false | string | FlotGradient;
+}
+
+export interface FlotPointOptions extends DisplayOptions {
+  radius?: number;
+  symbol?: 'circle' | ((ctx: any, x: number, y: number, radius: number, shadow: boolean) => void);
+  fillColor?: null | false | string;
+}
+
+export interface FlotSeries {
+  data: Array<[number, number]>;
+
+  color?: string | number;
+  label?: string;
+  lines?: FlotLineOptions;
+  bars?: FlotBarOptions;
+  points?: FlotPointOptions;
+  xaxis?: number; // ID of x-axis to plot series against
+  yaxis?: number; // ID of y-axis to plot series against
+  clickable?: boolean;
+  hoverable?: boolean;
+  shadowSize?: number;
+  highlightColor?: string | number;
+
+  // Stack options
+  stack?: null | boolean | number | string;
+}
+
+export interface FlotLegend {
+  show?: boolean;
+  labelFormatter?: (label: string, series: FlotSeries) => string;
+  labelBoxBorderColor?: string;
+  noColumns?: number;
+  position?: 'ne' | 'nw' | 'se' | 'sw';
+  margin?: number | [number, number];
+  backgroundColor?: string;
+  backgroundOpacity?: number; // [0,1]
+  container?: Element;
+  sorted?:
+    | boolean
+    | 'ascending'
+    | 'descending'
+    | 'reverse'
+    | ((a: { label: string; color: string }, b: { label: string; color: string }) => number);
+}

--- a/packages/grafana-data/src/types/graph.ts
+++ b/packages/grafana-data/src/types/graph.ts
@@ -1,5 +1,6 @@
 import { DisplayValue } from './displayValue';
 import { Field } from './dataFrame';
+import { FlotSeries } from './flot';
 
 export interface YAxis {
   index: number;
@@ -12,6 +13,7 @@ export type GraphSeriesValue = number | null;
 /** View model projection of a series */
 export interface GraphSeriesXY {
   color?: string;
+  highlightColor?: string;
   data: GraphSeriesValue[][]; // [x,y][]
   isVisible: boolean;
   label: string;
@@ -24,6 +26,31 @@ export interface GraphSeriesXY {
   timeStep: number;
 
   info?: DisplayValue[]; // Legend info
+
+  showBars?: boolean;
+  showLines?: boolean;
+  showPoints?: boolean;
+}
+
+export function graphSeriesToFlotSeries(graphSeries: GraphSeriesXY): FlotSeries {
+  return {
+    data: graphSeries.data as Array<[number, number]>,
+    color: graphSeries.color,
+    highlightColor: graphSeries.highlightColor,
+    label: graphSeries.label,
+    lines: {
+      show: graphSeries.showLines,
+    },
+    bars: {
+      show: graphSeries.showBars,
+    },
+    points: {
+      show: graphSeries.showPoints,
+    },
+    stack: graphSeries.showBars,
+
+    yaxis: graphSeries.yAxis.index,
+  };
 }
 
 export interface CreatePlotOverlay {

--- a/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { css } from 'emotion';
 import { GraphSeriesValue } from '@grafana/data';
 
-import { Graph, GraphProps } from './Graph';
+import Graph, { GraphProps } from './Graph';
 import { LegendRenderOptions, LegendItem, LegendDisplayMode } from '../Legend/Legend';
 import { GraphLegend } from './GraphLegend';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
@@ -76,6 +76,7 @@ export const GraphWithLegend: React.FunctionComponent<GraphWithLegendProps> = (p
   } = props;
   const { graphContainer, wrapper, legendContainer } = getGraphWithLegendStyles(props);
 
+  const logsYAxis = series.find(s => s.yAxis.index === 1);
   const legendItems = series.reduce<LegendItem[]>((acc, s) => {
     return shouldHideLegendItem(s.data, hideEmpty, hideZero)
       ? acc
@@ -84,7 +85,7 @@ export const GraphWithLegend: React.FunctionComponent<GraphWithLegendProps> = (p
             label: s.label,
             color: s.color || '',
             isVisible: s.isVisible,
-            yAxis: s.yAxis.index,
+            yAxis: logsYAxis ? s.yAxis.index! : 1,
             displayValues: s.info || [],
           },
         ]);

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -111,6 +111,11 @@ function getInitialState(props: Props, columns: Column[]): Partial<ReactTableInt
 
 export const Table: FC<Props> = memo((props: Props) => {
   const { data, height, onCellClick, width, columnMinWidth = COLUMN_MIN_WIDTH, noHeader, resizable = true } = props;
+
+  if (!data) {
+    return <></>;
+  }
+
   const theme = useTheme();
   const tableStyles = getTableStyles(theme);
 

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -19,6 +19,7 @@ type DataSourcePlugin struct {
 	FrontendPluginBase
 	Annotations  bool              `json:"annotations"`
 	Metrics      bool              `json:"metrics"`
+	Unified      bool              `json:"unified"`
 	Alerting     bool              `json:"alerting"`
 	Explore      bool              `json:"explore"`
 	Table        bool              `json:"tables"`

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -471,7 +471,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
     // Stats are per query, keeping track by refId
     const { refId } = series;
     if (refId && !queriesVisited[refId]) {
-      if (totalBytesKey && series.meta.stats) {
+      if (totalBytesKey && series.meta?.stats) {
         const byteStat = series.meta.stats.find(stat => stat.displayName === totalBytesKey);
         if (byteStat) {
           totalBytes += byteStat.value;

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -14,7 +14,7 @@ import { ExploreId } from 'app/types/explore';
 import { shallow } from 'enzyme';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { Explore, ExploreProps } from './Explore';
-import { scanStopAction } from './state/actionTypes';
+import { scanStopAction, toggleLogLevelAction } from './state/actionTypes';
 import { toggleGraph } from './state/actions';
 import { SecondaryActions } from './SecondaryActions';
 import { TraceView } from './TraceView/TraceView';
@@ -51,6 +51,7 @@ const dummyProps: ExploreProps = {
   },
   scanStart: jest.fn(),
   scanStopAction: scanStopAction,
+  toggleLogLevelAction: toggleLogLevelAction,
   setQueries: jest.fn(),
   split: false,
   queryKeys: [],

--- a/public/app/features/explore/ExploreGraphPanel.tsx
+++ b/public/app/features/explore/ExploreGraphPanel.tsx
@@ -45,8 +45,8 @@ interface Props extends Themeable {
   absoluteRange: AbsoluteTimeRange;
   loading?: boolean;
   showPanel: boolean;
-  showBars: boolean;
-  showLines: boolean;
+  showBars?: boolean;
+  showLines?: boolean;
   isStacked: boolean;
   showingGraph?: boolean;
   showingTable?: boolean;
@@ -115,7 +115,7 @@ class UnThemedExploreGraphPanel extends PureComponent<Props, State> {
     };
 
     const height = showPanel === false ? 100 : showingGraph && showingTable ? 200 : 400;
-    const lineWidth = showLines ? 1 : 5;
+    const lineWidth = 1;
     const seriesToShow = showAllTimeSeries ? series : series.slice(0, MAX_NUMBER_OF_TIME_SERIES);
 
     return (
@@ -140,7 +140,7 @@ class UnThemedExploreGraphPanel extends PureComponent<Props, State> {
               onSeriesToggle={onSeriesToggle}
               onHorizontalRegionSelected={this.onChangeTime}
             >
-              {/* For logs we are using mulit mode until we refactor logs histogram to use barWidth instead of lineWidth to render bars */}
+              {/* For logs we are using multi mode until we refactor logs histogram to use barWidth instead of lineWidth to render bars */}
               <Chart.Tooltip mode={showBars ? 'multi' : 'single'} />
             </GraphWithLegend>
           );

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -378,7 +378,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     containerWidth,
   } = exploreItem;
 
-  const isUnified = datasourceInstance?.meta?.unified;
+  const isUnified = datasourceInstance?.meta?.unified ?? false;
   const hasLiveOption = datasourceInstance?.meta?.streaming && (mode === ExploreMode.Logs || isUnified) ? true : false;
 
   return {

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -63,6 +63,7 @@ interface StateProps {
   hasLiveOption: boolean;
   isLive: boolean;
   isPaused: boolean;
+  isUnified: boolean;
   originPanelId?: number;
   queries: DataQuery[];
   datasourceLoading?: boolean;
@@ -176,6 +177,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
       hasLiveOption,
       isLive,
       isPaused,
+      isUnified,
       originPanelId,
       datasourceLoading,
       containerWidth,
@@ -235,7 +237,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                     hideTextValue={showSmallDataSourcePicker}
                   />
                 </div>
-                {showModeToggle ? (
+                {showModeToggle && !isUnified ? (
                   <div className="query-type-toggle">
                     <ToggleButtonGroup label="" transparent={true}>
                       <ToggleButton
@@ -376,7 +378,8 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     containerWidth,
   } = exploreItem;
 
-  const hasLiveOption = !!(datasourceInstance?.meta?.streaming && mode === ExploreMode.Logs);
+  const isUnified = datasourceInstance?.meta?.unified;
+  const hasLiveOption = datasourceInstance?.meta?.streaming && (mode === ExploreMode.Logs || isUnified) ? true : false;
 
   return {
     datasourceMissing,
@@ -391,6 +394,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     hasLiveOption,
     isLive,
     isPaused,
+    isUnified,
     originPanelId,
     queries,
     syncedTimes,

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -3,31 +3,19 @@ import React, { PureComponent } from 'react';
 import {
   rangeUtil,
   RawTimeRange,
-  LogLevel,
   TimeZone,
   AbsoluteTimeRange,
   LogsMetaKind,
   LogsDedupStrategy,
   LogRowModel,
-  LogsDedupDescription,
   LogsMetaItem,
   GraphSeriesXY,
   LinkModel,
   Field,
 } from '@grafana/data';
-import { LegacyForms, LogLabels, ToggleButtonGroup, ToggleButton, LogRows } from '@grafana/ui';
-const { Switch } = LegacyForms;
-import store from 'app/core/store';
 
-import { ExploreGraphPanel } from './ExploreGraphPanel';
+import { LogLabels, LogRows } from '@grafana/ui';
 import { MetaInfoText } from './MetaInfoText';
-import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
-
-const SETTINGS_KEYS = {
-  showLabels: 'grafana.explore.logs.showLabels',
-  showTime: 'grafana.explore.logs.showTime',
-  wrapLogMessage: 'grafana.explore.logs.wrapLogMessage',
-};
 
 function renderMetaItem(value: any, kind: LogsMetaKind) {
   if (kind === LogsMetaKind.LabelsMap) {
@@ -55,77 +43,21 @@ interface Props {
   scanning?: boolean;
   scanRange?: RawTimeRange;
   dedupStrategy: LogsDedupStrategy;
+
+  showLabels: boolean;
+  showTime: boolean;
+  wrapLogMessage: boolean;
+
   showContextToggle?: (row?: LogRowModel) => boolean;
-  onChangeTime: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
-  onDedupStrategyChange: (dedupStrategy: LogsDedupStrategy) => void;
-  onToggleLogLevel: (hiddenLogLevels: LogLevel[]) => void;
-  getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
+  getRowContext?: (row: LogRowModel, options?: any) => Promise<any>;
   getFieldLinks: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
 }
 
-interface State {
-  showLabels: boolean;
-  showTime: boolean;
-  wrapLogMessage: boolean;
-}
-
-export class Logs extends PureComponent<Props, State> {
-  state = {
-    showLabels: store.getBool(SETTINGS_KEYS.showLabels, false),
-    showTime: store.getBool(SETTINGS_KEYS.showTime, true),
-    wrapLogMessage: store.getBool(SETTINGS_KEYS.wrapLogMessage, true),
-  };
-
-  onChangeDedup = (dedup: LogsDedupStrategy) => {
-    const { onDedupStrategyChange } = this.props;
-    if (this.props.dedupStrategy === dedup) {
-      return onDedupStrategyChange(LogsDedupStrategy.none);
-    }
-    return onDedupStrategyChange(dedup);
-  };
-
-  onChangeLabels = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    if (target) {
-      const showLabels = target.checked;
-      this.setState({
-        showLabels,
-      });
-      store.set(SETTINGS_KEYS.showLabels, showLabels);
-    }
-  };
-
-  onChangeTime = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    if (target) {
-      const showTime = target.checked;
-      this.setState({
-        showTime,
-      });
-      store.set(SETTINGS_KEYS.showTime, showTime);
-    }
-  };
-
-  onChangewrapLogMessage = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    if (target) {
-      const wrapLogMessage = target.checked;
-      this.setState({
-        wrapLogMessage,
-      });
-      store.set(SETTINGS_KEYS.wrapLogMessage, wrapLogMessage);
-    }
-  };
-
-  onToggleLogLevel = (hiddenRawLevels: string[]) => {
-    const hiddenLogLevels: LogLevel[] = hiddenRawLevels.map(level => LogLevel[level as LogLevel]);
-    this.props.onToggleLogLevel(hiddenLogLevels);
-  };
-
+export class Logs extends PureComponent<Props> {
   onClickScan = (event: React.SyntheticEvent) => {
     event.preventDefault();
     if (this.props.onStartScanning) {
@@ -144,8 +76,6 @@ export class Logs extends PureComponent<Props, State> {
     const {
       logRows,
       logsMeta,
-      logsSeries,
-      visibleRange,
       highlighterExpressions,
       loading = false,
       onClickFilterLabel,
@@ -154,19 +84,18 @@ export class Logs extends PureComponent<Props, State> {
       scanning,
       scanRange,
       showContextToggle,
-      width,
       dedupedRows,
-      absoluteRange,
-      onChangeTime,
+      dedupStrategy,
       getFieldLinks,
+      showLabels,
+      showTime,
+      wrapLogMessage,
     } = this.props;
 
     if (!logRows) {
       return null;
     }
 
-    const { showLabels, showTime, wrapLogMessage } = this.state;
-    const { dedupStrategy } = this.props;
     const hasData = logRows && logRows.length > 0;
     const dedupCount = dedupedRows
       ? dedupedRows.reduce((sum, row) => (row.duplicates ? sum + row.duplicates : sum), 0)
@@ -182,49 +111,9 @@ export class Logs extends PureComponent<Props, State> {
     }
 
     const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
-    const series = logsSeries ? logsSeries : [];
 
     return (
-      <div className="logs-panel">
-        <div className="logs-panel-graph">
-          <ExploreGraphPanel
-            series={series}
-            width={width}
-            onHiddenSeriesChanged={this.onToggleLogLevel}
-            loading={loading}
-            absoluteRange={visibleRange || absoluteRange}
-            isStacked={true}
-            showPanel={false}
-            showingGraph={true}
-            showingTable={true}
-            timeZone={timeZone}
-            showBars={true}
-            showLines={false}
-            onUpdateTimeRange={onChangeTime}
-          />
-        </div>
-        <div className="logs-panel-options">
-          <div className="logs-panel-controls">
-            <Switch label="Time" checked={showTime} onChange={this.onChangeTime} transparent />
-            <Switch label="Unique labels" checked={showLabels} onChange={this.onChangeLabels} transparent />
-            <Switch label="Wrap lines" checked={wrapLogMessage} onChange={this.onChangewrapLogMessage} transparent />
-            <ToggleButtonGroup label="Dedup" transparent={true}>
-              {Object.keys(LogsDedupStrategy).map((dedupType: string, i) => (
-                <ToggleButton
-                  key={i}
-                  value={dedupType}
-                  onChange={this.onChangeDedup}
-                  selected={dedupStrategy === dedupType}
-                  // @ts-ignore
-                  tooltip={LogsDedupDescription[dedupType]}
-                >
-                  {dedupType}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
-          </div>
-        </div>
-
+      <>
         {hasData && meta && (
           <MetaInfoText
             metaItems={meta.map(item => {
@@ -270,7 +159,7 @@ export class Logs extends PureComponent<Props, State> {
             </a>
           </div>
         )}
-      </div>
+      </>
     );
   }
 }

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -268,7 +268,9 @@ export class LogsContainer extends PureComponent<LogsContainerProps, LogsContain
                   getFieldLinks={this.getFieldLinks}
                 />
               ) : (
-                <Table data={tableResult} width={width} height={this.getTableHeight()} onCellClick={onClickCell} />
+                tableResult && (
+                  <Table data={tableResult} width={width} height={this.getTableHeight()} onCellClick={onClickCell} />
+                )
               )}
             </div>
           </Collapse>

--- a/public/app/features/explore/LogsControls.tsx
+++ b/public/app/features/explore/LogsControls.tsx
@@ -31,18 +31,24 @@ export class LogsControls extends PureComponent<Props> {
   };
 
   onChangeLabels = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    return this.props.onLabelsChange(target.checked);
+    if (event) {
+      const target = event.target as HTMLInputElement;
+      return this.props.onLabelsChange(target.checked);
+    }
   };
 
   onChangeTime = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    return this.props.onTimeChange(target.checked);
+    if (event) {
+      const target = event.target as HTMLInputElement;
+      return this.props.onTimeChange(target.checked);
+    }
   };
 
   onChangewrapLogMessage = (event?: React.SyntheticEvent) => {
-    const target = event && (event.target as HTMLInputElement);
-    return this.props.onWrapLogMessageChange(target.checked);
+    if (event) {
+      const target = event.target as HTMLInputElement;
+      return this.props.onWrapLogMessageChange(target.checked);
+    }
   };
 
   render() {

--- a/public/app/features/explore/LogsControls.tsx
+++ b/public/app/features/explore/LogsControls.tsx
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react';
+
+import { LogsDedupStrategy, LogRowModel } from '@grafana/data';
+import { Field, RadioButtonGroup, Switch } from '@grafana/ui';
+import { css, cx } from 'emotion';
+
+export const fieldClass = css`
+  gap: 12px;
+  align-items: center;
+`;
+
+export const pushRight = css`
+  margin-right: auto;
+`;
+
+interface Props {
+  logRows?: LogRowModel[];
+  showLabels: boolean;
+  showTime: boolean;
+  wrapLogMessage: boolean;
+  dedupStrategy: LogsDedupStrategy;
+  onDedupStrategyChange: (dedupStrategy: LogsDedupStrategy) => void;
+  onLabelsChange: (showLabels: boolean) => void;
+  onTimeChange: (showTime: boolean) => void;
+  onWrapLogMessageChange: (wrapLogMessage: boolean) => void;
+}
+
+export class LogsControls extends PureComponent<Props> {
+  onChangeDedup = (dedup: LogsDedupStrategy) => {
+    return this.props.onDedupStrategyChange(dedup);
+  };
+
+  onChangeLabels = (event?: React.SyntheticEvent) => {
+    const target = event && (event.target as HTMLInputElement);
+    return this.props.onLabelsChange(target.checked);
+  };
+
+  onChangeTime = (event?: React.SyntheticEvent) => {
+    const target = event && (event.target as HTMLInputElement);
+    return this.props.onTimeChange(target.checked);
+  };
+
+  onChangewrapLogMessage = (event?: React.SyntheticEvent) => {
+    const target = event && (event.target as HTMLInputElement);
+    return this.props.onWrapLogMessageChange(target.checked);
+  };
+
+  render() {
+    const { logRows, showTime, showLabels, dedupStrategy, wrapLogMessage } = this.props;
+
+    if (!logRows) {
+      return null;
+    }
+
+    return (
+      <>
+        <Field label="Time" horizontal className={cx(fieldClass)}>
+          <Switch value={showTime} onChange={this.onChangeTime} />
+        </Field>
+        <Field label="Unique labels" horizontal className={cx(fieldClass)}>
+          <Switch value={showLabels} onChange={this.onChangeLabels} />
+        </Field>
+        <Field label="Wrap lines" horizontal className={cx(fieldClass)}>
+          <Switch value={wrapLogMessage} onChange={this.onChangewrapLogMessage} />
+        </Field>
+        <Field label="Dedup" horizontal className={cx(fieldClass, pushRight)}>
+          <RadioButtonGroup
+            options={Object.keys(LogsDedupStrategy).map((dedupType: string) => ({
+              label: dedupType,
+              value: dedupType,
+            }))}
+            value={dedupStrategy}
+            onChange={this.onChangeDedup}
+          />
+        </Field>
+      </>
+    );
+  }
+}

--- a/public/app/features/explore/state/reducers.ts
+++ b/public/app/features/explore/state/reducers.ts
@@ -533,9 +533,17 @@ export const processQueryResponse = (
 
   const latency = request.endTime ? request.endTime - request.startTime : 0;
   const processor = new ResultProcessor(state, series, request.intervalMs, request.timezone as TimeZone);
-  const graphResult = processor.getGraphResult();
+
+  let graphResult = processor.getGraphResult();
+
   const tableResult = processor.getTableResult();
   const logsResult = processor.getLogsResult();
+
+  if (graphResult && logsResult) {
+    graphResult.unshift(...logsResult.series);
+  } else if (!graphResult && logsResult) {
+    graphResult = logsResult.series;
+  }
 
   // Send legacy data to Angular editors
   if (state.datasourceInstance.components.QueryCtrl) {

--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -6,7 +6,7 @@ jest.mock('@grafana/data/src/datetime/formatter', () => ({
 import { ResultProcessor } from './ResultProcessor';
 import { ExploreItemState } from 'app/types/explore';
 import TableModel from 'app/core/table_model';
-import { ExploreMode, FieldType, LogRowModel, TimeSeries, toDataFrame } from '@grafana/data';
+import { FieldType, LogRowModel, TimeSeries, toDataFrame, ExploreMode } from '@grafana/data';
 
 const testContext = (options: any = {}) => {
   const timeSeries = toDataFrame({
@@ -108,8 +108,11 @@ describe('ResultProcessor', () => {
           ],
           info: [],
           isVisible: true,
+          showBars: false,
+          showLines: true,
+          showPoints: false,
           yAxis: {
-            index: 1,
+            index: 2,
           },
           seriesIndex: 0,
           timeField,
@@ -124,11 +127,11 @@ describe('ResultProcessor', () => {
         const { resultProcessor } = testContext();
         let theResult = resultProcessor.getTableResult();
 
-        expect(theResult?.fields[0].name).toEqual('value');
-        expect(theResult?.fields[1].name).toEqual('time');
+        expect(theResult?.fields[0].name).toEqual('time');
+        expect(theResult?.fields[1].name).toEqual('value');
         expect(theResult?.fields[2].name).toEqual('tsNs');
         expect(theResult?.fields[3].name).toEqual('message');
-        expect(theResult?.fields[1].display).not.toBeNull();
+        expect(theResult?.fields[0].display).not.toBeNull();
         expect(theResult?.length).toBe(3);
 
         // Same data though a DataFrame
@@ -242,6 +245,9 @@ describe('ResultProcessor', () => {
               timeField,
               valueField,
               timeStep: 100,
+              showBars: true,
+              showLines: false,
+              showPoints: false,
             },
           ],
         });

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { shuffle } from 'lodash';
-import { ExploreStartPageProps, DataQuery, ExploreMode } from '@grafana/data';
+import { ExploreStartPageProps, DataQuery } from '@grafana/data';
 import LokiLanguageProvider from '../language_provider';
 
 const DEFAULT_EXAMPLES = ['{job="default/prometheus"}'];
@@ -76,11 +76,11 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
     );
   }
 
-  renderLogsCheatSheet() {
+  render() {
     const { userExamples } = this.state;
 
     return (
-      <>
+      <div>
         <h2>Loki Cheat Sheet</h2>
         <div className="cheat-sheet-item">
           <div className="cheat-sheet-item__title">See your logs</div>
@@ -114,14 +114,6 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
             supports exact and regular expression filters.
           </div>
         </div>
-      </>
-    );
-  }
-
-  renderMetricsCheatSheet() {
-    return (
-      <div>
-        <h2>LogQL Cheat Sheet</h2>
         {LOGQL_EXAMPLES.map(item => (
           <div className="cheat-sheet-item" key={item.expression}>
             <div className="cheat-sheet-item__title">{item.title}</div>
@@ -131,11 +123,5 @@ export default class LokiCheatSheet extends PureComponent<ExploreStartPageProps,
         ))}
       </div>
     );
-  }
-
-  render() {
-    const { exploreMode } = this.props;
-
-    return exploreMode === ExploreMode.Logs ? this.renderLogsCheatSheet() : this.renderMetricsCheatSheet();
   }
 }

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1,15 +1,7 @@
 import LokiDatasource, { RangeQueryOptions } from './datasource';
 import { LokiQuery, LokiResponse, LokiResultType } from './types';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
-import {
-  AnnotationQueryRequest,
-  DataFrame,
-  DataSourceApi,
-  dateTime,
-  ExploreMode,
-  FieldCache,
-  TimeRange,
-} from '@grafana/data';
+import { AnnotationQueryRequest, DataFrame, DataSourceApi, dateTime, FieldCache, TimeRange } from '@grafana/data';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { CustomVariable } from 'app/features/templating/custom_variable';
 import { makeMockLokiDatasource } from './mocks';
@@ -109,24 +101,9 @@ describe('LokiDatasource', () => {
       datasourceRequestMock.mockImplementation(() => Promise.resolve(testResp));
     });
 
-    test('should run instant query and range query when in metrics mode', async () => {
-      const options = getQueryOptions<LokiQuery>({
-        targets: [{ expr: 'rate({job="grafana"}[5m])', refId: 'A' }],
-        exploreMode: ExploreMode.Metrics,
-      });
-
-      ds.runInstantQuery = jest.fn(() => of({ data: [] }));
-      ds.runRangeQuery = jest.fn(() => of({ data: [] }));
-      await ds.query(options).toPromise();
-
-      expect(ds.runInstantQuery).toBeCalled();
-      expect(ds.runRangeQuery).toBeCalled();
-    });
-
     test('should just run range query when in logs mode', async () => {
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: '{job="grafana"}', refId: 'B' }],
-        exploreMode: ExploreMode.Logs,
       });
 
       ds.runInstantQuery = jest.fn(() => of({ data: [] }));

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -20,7 +20,6 @@ import {
   LoadingState,
   AnnotationEvent,
   DataFrameView,
-  TimeSeries,
   PluginMeta,
   DataSourceApi,
   DataSourceInstanceSettings,
@@ -28,7 +27,6 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   AnnotationQueryRequest,
-  ExploreMode,
   ScopedVars,
 } from '@grafana/data';
 
@@ -93,30 +91,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
         expr: this.templateSrv.replace(target.expr, options.scopedVars, this.interpolateQueryExpr),
       }));
 
-    if (options.exploreMode === ExploreMode.Metrics) {
-      filteredTargets.forEach(target =>
-        subQueries.push(
-          this.runInstantQuery(target, options, filteredTargets.length),
-          this.runRangeQuery(target, options, filteredTargets.length)
-        )
-      );
-    } else {
-      filteredTargets.forEach(target =>
-        subQueries.push(
-          this.runRangeQuery(target, options, filteredTargets.length).pipe(
-            map(dataQueryResponse => {
-              if (options.exploreMode === ExploreMode.Logs && dataQueryResponse.data.find(d => isTimeSeries(d))) {
-                throw new Error(
-                  'Logs mode does not support queries that return time series data. Please perform a logs query or switch to Metrics mode.'
-                );
-              } else {
-                return dataQueryResponse;
-              }
-            })
-          )
-        )
-      );
-    }
+    filteredTargets.forEach(target => subQueries.push(this.runRangeQuery(target, options, filteredTargets.length)));
 
     // No valid targets, return the empty result to save a round trip.
     if (isEmpty(subQueries)) {
@@ -146,7 +121,10 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       filter((response: any) => (response.cancelled ? false : true)),
       map((response: { data: LokiResponse }) => {
         if (response.data.data.resultType === LokiResultType.Stream) {
-          throw new Error('Metrics mode does not support logs. Use an aggregation or switch to Logs mode.');
+          return {
+            data: [],
+            key: `${target.refId}_instant`,
+          };
         }
 
         return {
@@ -575,7 +553,3 @@ export function lokiSpecialRegexEscape(value: any) {
 }
 
 export default LokiDatasource;
-
-function isTimeSeries(data: any): data is TimeSeries {
-  return data.hasOwnProperty('datapoints');
-}

--- a/public/app/plugins/datasource/loki/plugin.json
+++ b/public/app/plugins/datasource/loki/plugin.json
@@ -6,6 +6,7 @@
 
   "logs": true,
   "metrics": true,
+  "unified": true,
   "alerting": false,
   "annotations": true,
   "streaming": true,

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -146,6 +146,9 @@ function lokiMatrixToTimeSeries(matrixResult: LokiMatrixResult, options: Transfo
     target: createMetricLabel(matrixResult.metric, options),
     datapoints: lokiPointsToTimeseriesPoints(matrixResult.values, options),
     tags: matrixResult.metric,
+    meta: {
+      responseType: 'Metrics',
+    },
   };
 }
 
@@ -312,6 +315,7 @@ export function lokiStreamsToDataframes(
         limit,
         stats,
         custom,
+        responseType: 'Logs',
       },
     };
   });

--- a/public/app/plugins/panel/graph2/getGraphSeriesModel.ts
+++ b/public/app/plugins/panel/graph2/getGraphSeriesModel.ts
@@ -80,13 +80,13 @@ export const getGraphSeriesModel = (
         }
 
         let color: FieldColor;
-        if (seriesOptions[field.name] && seriesOptions[field.name].color) {
+        if (seriesOptions[field.name]?.color) {
           // Case when panel has settings provided via SeriesOptions, i.e. graph panel
           color = {
             mode: FieldColorMode.Fixed,
             fixedColor: seriesOptions[field.name].color,
           };
-        } else if (field.config && field.config.color) {
+        } else if (field.config?.color) {
           // Case when color settings are set on field, i.e. Explore logs histogram (see makeSeriesForLogs)
           color = field.config.color;
         } else {
@@ -129,13 +129,16 @@ export const getGraphSeriesModel = (
           info: statsDisplayValues,
           isVisible: true,
           yAxis: {
-            index: (seriesOptions[field.name] && seriesOptions[field.name].yAxis) || 1,
+            index: (seriesOptions[field.name] && seriesOptions[field.name].yAxis) || graphOptions.yaxis || 1,
           },
           // This index is used later on to retrieve appropriate series/time for X and Y axes
           seriesIndex: fieldColumnIndex,
           timeField: { ...timeField },
           valueField: { ...field },
           timeStep,
+          showBars: graphOptions.showBars,
+          showPoints: graphOptions.showPoints,
+          showLines: graphOptions.showLines,
         });
       }
     }

--- a/public/app/plugins/panel/graph2/types.ts
+++ b/public/app/plugins/panel/graph2/types.ts
@@ -10,6 +10,8 @@ export interface GraphOptions {
   showBars: boolean;
   showLines: boolean;
   showPoints: boolean;
+
+  yaxis?: number;
 }
 
 export interface Options {

--- a/public/sass/components/_panel_logs.scss
+++ b/public/sass/components/_panel_logs.scss
@@ -10,6 +10,16 @@ $column-horizontal-spacing: 10px;
   flex-direction: column;
 }
 
+.results-panel-options {
+  display: flex;
+  background-color: $page-bg;
+  padding: $space-sm $space-md $space-sm $space-md;
+  border-radius: $border-radius;
+  margin: 0 0 $space-sm;
+  border: $panel-border;
+  flex-direction: column;
+}
+
 .logs-panel-controls {
   display: flex;
   justify-items: flex-start;
@@ -18,6 +28,27 @@ $column-horizontal-spacing: 10px;
 
   > * {
     margin-right: $spacer * 2;
+  }
+
+  > .align-right {
+    margin-left: auto;
+    margin-right: 0px;
+  }
+}
+
+.results-panel-controls {
+  display: flex;
+  justify-items: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+
+  > * {
+    margin-right: $spacer * 2;
+  }
+
+  > .align-right {
+    margin-left: auto;
+    margin-right: 0px;
   }
 }
 


### PR DESCRIPTION
Initial PR for logs/metrics unification, allowing for datasources marked as "unified" to have a joined interface for querying and investigating logs and metrics data.

Key changes:
- Adds `responseType` parameter to `QueryResultMeta`.
- Adds `unified` parameter to datasource plugin interface.
- Explore Logs view controls updated to use newer UI components and moved out into separate component.
- Adds option for unified datasources to have results displayed using logs view or table view.
- Adds per-series graph vis params, so metrics results are displayed as line graphs, and logs results as bar charts. Also allows for different graph types to be displayed on the same graph.
- Loki changed to unified datasource.

To-do:
- [ ] Make sure loki live tailing isn't broken
- [ ] Merging of table results should be fixed so that they join on time column

Currently a draft PR as I'd like to test if this breaks any existing behavior for other datasources or for dashboard graphs.

The work involved in making Influx and Elasticsearch unified datasources is largely complete, with separate PRs for each datasource planned once this PR is merged.