### PR TITLE
FieldType: hack... set field type from custom config

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
@@ -72,11 +72,17 @@ export function arrowTableToDataFrame(table: Table): ArrowDataFrame {
           console.log('UNKNOWN Type:', schema);
       }
 
+      const config = parseOptionalMeta(col.metadata.get('config')) || {};
+      if (config.custom?.fieldType) {
+        // HACK until we sort out something like: https://github.com/grafana/grafana/pull/22083
+        type = config.custom?.fieldType;
+      }
+
       fields.push({
         name: stripFieldNamePrefix(col.name),
         type,
         values,
-        config: parseOptionalMeta(col.metadata.get('config')) || {},
+        config,
         labels: parseOptionalMeta(col.metadata.get('labels')),
       });
     }


### PR DESCRIPTION
Currently there is no way for arrow data (backend plugins) to set the field type.  I started a more robust solution in https://github.com/grafana/grafana/pull/22083, but that has a bunch of details to sort out.

This PR is just a quick hack to set the field using `config.custom.fieldType` 