### PR TITLE
Stackdriver: Use default project name if project name isn't set on the query

### DIFF
--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -322,7 +322,16 @@ func calculateAlignmentPeriod(alignmentPeriod string, intervalMs int64, duration
 
 func (e *StackdriverExecutor) executeQuery(ctx context.Context, query *stackdriverQuery, tsdbQuery *tsdb.TsdbQuery) (*tsdb.QueryResult, stackdriverResponse, error) {
 	queryResult := &tsdb.QueryResult{Meta: simplejson.New(), RefId: query.RefID}
-	req, err := e.createRequest(ctx, e.dsInfo, query, fmt.Sprintf("stackdriver%s", "v3/projects/"+query.ProjectName+"/timeSeries"))
+	projectName := query.ProjectName
+	if projectName == "" {
+		defaultProject, err := e.getDefaultProject(ctx)
+		if err != nil {
+			return queryResult, stackdriverResponse{}, nil
+		}
+		projectName = defaultProject
+	}
+
+	req, err := e.createRequest(ctx, e.dsInfo, query, fmt.Sprintf("stackdriver%s", "v3/projects/"+projectName+"/timeSeries"))
 	if err != nil {
 		queryResult.Error = err
 		return queryResult, stackdriverResponse{}, nil

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -326,6 +326,7 @@ func (e *StackdriverExecutor) executeQuery(ctx context.Context, query *stackdriv
 	if projectName == "" {
 		defaultProject, err := e.getDefaultProject(ctx)
 		if err != nil {
+			queryResult.Error = err
 			return queryResult, stackdriverResponse{}, nil
 		}
 		projectName = defaultProject

--- a/pkg/tsdb/stackdriver/stackdriver.go
+++ b/pkg/tsdb/stackdriver/stackdriver.go
@@ -329,6 +329,7 @@ func (e *StackdriverExecutor) executeQuery(ctx context.Context, query *stackdriv
 			return queryResult, stackdriverResponse{}, nil
 		}
 		projectName = defaultProject
+		slog.Info("No project name set on query, using project name from datasource", "projectName", projectName)
 	}
 
 	req, err := e.createRequest(ctx, e.dsInfo, query, fmt.Sprintf("stackdriver%s", "v3/projects/"+projectName+"/timeSeries"))


### PR DESCRIPTION
**What this PR does / why we need it**:

This relates to #25373. When upgrading to 7.0.3 from 6.6.1, we noticed that alerts driven by Stackdriver queries began failing:

```
 logger=alerting.evalContext ruleId=72 name=$ALERT_NAME error="tsdb.HandleRequest() response error &{{\n \"error\": {\n \"code\": 400,\n \"message\": \"Name must begin with '{resource_container_type}/{resource_container_id}', got: projects/\",\n \"status\": \"INVALID_ARGUMENT\"\n }\n}\n A 0xc0007fc020 [] [] []}" changing state to=alerting
```

This is because the queries didn't have project name set, so requests to the Stackdriver API looked like this:

```
t=2020-06-03T16:28:01+0000 lvl=info msg=Requesting logger=data-proxy-log url=https://content-monitoring.googleapis.com/v3/projects//timeSeries
```

This PR changes the request to fallback to the default project configured on the datasource if there's no project name set on the query. 

I tested by creating a Stackdriver alert in Grafana 6.6.1, upgrading to 7.0.3, and then running master with this patch

![Screen Shot 2020-06-05 at 16 47 52](https://user-images.githubusercontent.com/9082799/83925902-f3091300-a74d-11ea-9331-c28bda5a591f.png)

Logs:

```
t=2020-06-05T21:46:01+0000 lvl=info msg="No project name set on query, using project name from datasource" logger=tsdb.stackdriver projectName=$PROJECT_NAME
t=2020-06-05T21:46:02+0000 lvl=info msg="Got new access token" logger=data-proxy-log ExpiresOn=2020-06-05T22:46:01+0000
t=2020-06-05T21:46:02+0000 lvl=info msg=Requesting logger=data-proxy-log url=https://content-monitoring.googleapis.com/v3/projects/$PROJECT_NAME/timeSeries
t=2020-06-05T21:46:02+0000 lvl=info msg="New state change" logger=alerting.resultHandler ruleId=1 newState=ok prev state=alerting
```


**Which issue(s) this PR fixes**:

Fixes #25373

**Special notes for your reviewer**:

Definitely open to adding tests, but I didn't see any existing tests covering `Query/executeTimeSeriesQuery/executeQuery`. 