### PR TITLE
Operation: Implement socket-activatability for HTTP endpoints

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -127,6 +127,8 @@ Configure the Grafana server to start at boot:
 sudo systemctl enable grafana-server.service
 ```
 
+Grafana also supports the systemd socket activation mechanism.
+
 ### Start the server with init.d
 
 To start the service and verify that the service has started:

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -164,6 +164,8 @@ Configure the Grafana server to start at boot:
 sudo systemctl enable grafana-server
 ```
 
+Grafana also supports the systemd socket activation mechanism.
+
 > **SUSE or OpenSUSE users:** You might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
 
 ### Start the server with init.d


### PR DESCRIPTION
This commit implement the ability to socket-activate Grafana. This way,
one can use either xinetd's or systemd's socket activation mechanism while
maintaining the current behavior if it is not used.
This has a multitude of advantages, among these:
  * allowing to transparently restart Grafana without breaking
  connections (including transparent upgrades and crash recovery, should it ever
  happen) as the socket is not managed by the Grafana binary
  * allowing to parallelize the start of Grafana and components depending on it,
  as connectivity is already established, allowing for faster boot-times of
  system and/or service complexes
  * allowing on-demand starting of Grafana upon the first connection