### PR TITLE
Document the front-end proxy path for live log tailing with Loki

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -129,8 +129,10 @@ The following filter types are currently supported:
 
 Loki supports Live tailing which displays logs in real-time. This feature is supported in [Explore]({{< relref "../explore/#loki-specific-features" >}}).
 
-Note that Live Tailing relies on two Websocket connections: one between the browser and the Grafana server, and another between the Grafana server and the Loki server. If you run any reverse proxies, please configure them accordingly.
-
+Note that Live Tailing relies on two Websocket connections: one between the browser and the Grafana server, and another between the Grafana server and the Loki server. If you run any reverse proxies, please configure them accordingly. The following example for Apache2 can be used for proxying between the browser and the Grafana server:
+```
+ProxyPassMatch "^/(api/datasources/proxy/\d+/loki/api/v1/tail)" "ws://127.0.0.1:3000/$1"
+```
 
 > Note: This feature is only available in Grafana v6.3+
 


### PR DESCRIPTION
**What this PR does / why we need it**:

So that anyone who puts a reverse proxy in front of Grafana knows what path pattern needs to be proxied as a websocket request for live tailing to work.

**Which issue(s) this PR fixes**:

Relates to #19555 