### PR TITLE
Explore: Replace link with button component

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -15,7 +15,7 @@ import {
   LinkModel,
   Field,
 } from '@grafana/data';
-import { LegacyForms, LogLabels, ToggleButtonGroup, ToggleButton, LogRows } from '@grafana/ui';
+import { LegacyForms, LogLabels, ToggleButtonGroup, ToggleButton, LogRows, Button } from '@grafana/ui';
 const { Switch } = LegacyForms;
 import store from 'app/core/store';
 
@@ -256,18 +256,18 @@ export class Logs extends PureComponent<Props, State> {
         {!loading && !hasData && !scanning && (
           <div className="logs-panel-nodata">
             No logs found.
-            <a className="link" onClick={this.onClickScan}>
+            <Button size="xs" variant="link" onClick={this.onClickScan}>
               Scan for older logs
-            </a>
+            </Button>
           </div>
         )}
 
         {scanning && (
           <div className="logs-panel-nodata">
             <span>{scanText}</span>
-            <a className="link" onClick={this.onClickStopScan}>
+            <Button size="xs" variant="link" onClick={this.onClickStopScan}>
               Stop scan
-            </a>
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
Replaces non-detectable `Scan for older logs` and `Stop Scan` link with the Button component so it is visible right away that it's a clickable link.

Fixes #20528
