### PR TITLE
Dashboard: Fix loading custom home dashboard

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -201,7 +201,6 @@ describeInitScenario('Initializing home dashboard', ctx => {
   ctx.setup(() => {
     ctx.args.routeInfo = DashboardRouteInfo.Home;
     ctx.backendSrv.get.mockResolvedValue({
-      meta: {},
       redirectUri: '/u/123/my-home',
     });
   });
@@ -209,6 +208,17 @@ describeInitScenario('Initializing home dashboard', ctx => {
   it('Should redirect to custom home dashboard', () => {
     expect(ctx.actions[1].type).toBe(updateLocation.type);
     expect(ctx.actions[1].payload.path).toBe('/u/123/my-home');
+  });
+});
+
+describeInitScenario('Initializing home dashboard cancelled', ctx => {
+  ctx.setup(() => {
+    ctx.args.routeInfo = DashboardRouteInfo.Home;
+    ctx.backendSrv.get.mockResolvedValue([]);
+  });
+
+  it('Should abort init process', () => {
+    expect(ctx.actions.length).toBe(1);
   });
 });
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -69,7 +69,7 @@ async function fetchDashboard(
         const dashDTO: DashboardDTO = await backendSrv.get('/api/dashboards/home');
 
         // if above all is cancelled it will return an array
-        if (!dashDTO.meta) {
+        if (Array.isArray(dashDTO)) {
           return null;
         }
 


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/24430  I added a check so the loading dashboard did not crash when loading home dashboard call was cancelled. But the check was wrong as it did not account for the scenario when you have a custom home dashboard 