### PR TITLE
Docs: Images in alerts require an external image storage provider

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -213,10 +213,7 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 Grafana can render the panel associated with the alert rule as a PNG image and include that in the notification. Read more about the requirements and how to configure
 [image rendering]({{< relref "../administration/image_rendering/" >}}).
 
-Most Notification Channels require that this image be publicly accessible (Slack and PagerDuty for example). In order to include images in alert notifications, Grafana can upload the image to an image store. It currently supports
-Amazon S3, Webdav, Google Cloud Storage and Azure Blob Storage. So to set that up you need to configure the [external image uploader]({{< relref "../installation/configuration/#external-image-storage" >}}) in your grafana-server ini config file.
-
-Be aware that some notifiers require public access to the image to be able to include it in the notification. So make sure to enable public access to the images. If you're using local image uploader, your Grafana instance need to be accessible by the internet.
+You must configure an [external image storage provider]({{< relref "../installation/configuration/#external-image-storage" >}}) in order to receive images in alert notifications. If your notification channel requires that the image be publicly accessible (e.g. Slack, PagerDuty), configure a provider which uploads the image to a remote image store like Amazon S3, Webdav, Google Cloud Storage, or Azure Blob Storage. Otherwise, the local provider can be used to serve the image directly from Grafana.
 
 Notification services which need public image access are marked as 'external only'.
 


### PR DESCRIPTION
Be more explicit about the fact that providing images in alert notifications requires an external image storage provider. Previously this read as if it was only necessary for publicly accessible images, but even if they are served from Grafana, the administrator must set up the "local" image provider in the configuration.

By default, Grafana doesn't have an external image storage provider configured, so images are never uploaded after they are rendered. As a result, the images are not available in alert notifications.

I'm not sure if this is a given, but I spent a good amount of time troubleshooting this in order to get images working in my alert notifications so I figured I'd add it to the docs.