### PR TITLE
Security: Use Header.Set and Header.Del for X-Grafana-User header

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -187,8 +187,12 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 			req.Header.Add("Authorization", dsAuth)
 		}
 
-		if proxy.cfg.SendUserHeader && !proxy.ctx.SignedInUser.IsAnonymous {
-			req.Header.Add("X-Grafana-User", proxy.ctx.SignedInUser.Login)
+		if proxy.cfg.SendUserHeader {
+			if proxy.ctx.SignedInUser.IsAnonymous {
+				req.Header.Del("X-Grafana-User")
+			} else {
+				req.Header.Set("X-Grafana-User", proxy.ctx.SignedInUser.Login)
+			}
 		}
 
 		keepCookieNames := []string{}

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -187,13 +187,7 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 			req.Header.Add("Authorization", dsAuth)
 		}
 
-		if proxy.cfg.SendUserHeader {
-			if proxy.ctx.SignedInUser.IsAnonymous {
-				req.Header.Del("X-Grafana-User")
-			} else {
-				req.Header.Set("X-Grafana-User", proxy.ctx.SignedInUser.Login)
-			}
-		}
+		applyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
 
 		keepCookieNames := []string{}
 		if proxy.ds.JsonData != nil {

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -79,10 +79,14 @@ func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.
 			return
 		}
 
-		req.Header.Add("X-Grafana-Context", string(ctxJSON))
+		req.Header.Set("X-Grafana-Context", string(ctxJSON))
 
-		if cfg.SendUserHeader && !ctx.SignedInUser.IsAnonymous {
-			req.Header.Add("X-Grafana-User", ctx.SignedInUser.Login)
+		if cfg.SendUserHeader {
+			if ctx.SignedInUser.IsAnonymous {
+				req.Header.Del("X-Grafana-User")
+			} else {
+				req.Header.Set("X-Grafana-User", ctx.SignedInUser.Login)
+			}
 		}
 
 		if len(route.Headers) > 0 {

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -81,13 +81,7 @@ func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.
 
 		req.Header.Set("X-Grafana-Context", string(ctxJSON))
 
-		if cfg.SendUserHeader {
-			if ctx.SignedInUser.IsAnonymous {
-				req.Header.Del("X-Grafana-User")
-			} else {
-				req.Header.Set("X-Grafana-User", ctx.SignedInUser.Login)
-			}
-		}
+		applyUserHeader(cfg.SendUserHeader, req, ctx.SignedInUser)
 
 		if len(route.Headers) > 0 {
 			headers, err := getHeaders(route, ctx.OrgId, appID)

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -3,6 +3,7 @@ package pluginproxy
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"net/url"
 	"text/template"
 
@@ -46,4 +47,15 @@ func InterpolateURL(anURL *url.URL, route *plugins.AppPluginRoute, orgID int64, 
 	}
 
 	return result, err
+}
+
+// Set the X-Grafana-User header if needed
+func applyUserHeader(sendUserHeader bool, req *http.Request, user *models.SignedInUser) {
+	if sendUserHeader {
+		if user.IsAnonymous {
+			req.Header.Del("X-Grafana-User")
+		} else {
+			req.Header.Set("X-Grafana-User", user.Login)
+		}
+	}
 }

--- a/pkg/api/pluginproxy/utils.go
+++ b/pkg/api/pluginproxy/utils.go
@@ -49,13 +49,10 @@ func InterpolateURL(anURL *url.URL, route *plugins.AppPluginRoute, orgID int64, 
 	return result, err
 }
 
-// Set the X-Grafana-User header if needed
+// Set the X-Grafana-User header if needed (and remove if not)
 func applyUserHeader(sendUserHeader bool, req *http.Request, user *models.SignedInUser) {
-	if sendUserHeader {
-		if user.IsAnonymous {
-			req.Header.Del("X-Grafana-User")
-		} else {
-			req.Header.Set("X-Grafana-User", user.Login)
-		}
+	req.Header.Del("X-Grafana-User")
+	if sendUserHeader && !user.IsAnonymous {
+		req.Header.Set("X-Grafana-User", user.Login)
 	}
 }


### PR DESCRIPTION
This ensures that the X-Grafana-User header can be trusted.

If the configuration enabled the setting of this header, the
server can now trust that X-Grafana-User is set/unset by Grafana.

Before this, an anonymous user could simply set the X-Grafana-User
header themselves (using the developer tool for example)


---


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: 

This edit is needed to ensure that the X-Grafana-User can be trusted.

**Which issue(s) this PR fixes**:

- The one I was going to create for this issue which I came across while attempting to ensure only logged-in users could access all metrics. Non logged in users can simply spoof the header using eg. the DevTools to add the header themselves.

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:

Thanks for reviewing this. There is some code duplication here, maybe this could be fixed more cleanly but I'm not familiar enough with the codebase to know where this would go.
