### PR TITLE
InfluxDB: adds policy interpolation in InfluxDB queries

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -179,6 +179,7 @@ export default class InfluxDatasource extends DataSourceApi<InfluxQuery, InfluxO
           ...query,
           datasource: this.name,
           measurement: this.templateSrv.replace(query.measurement, scopedVars, 'regex'),
+          policy: this.templateSrv.replace(query.policy, scopedVars, 'regex'),
         };
 
         if (query.rawQuery) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds policy interpolation in InfluxDB queries, so queries using template variables work properly after going from dashboard panel to Explore.

**Which issue(s) this PR fixes**:

Fixes #25183 

**Special notes for your reviewer**:

How to reproduce it: follow the steps mentioned in #25183.

@aocenas I'm not sure how to mock template variables within datasource tests to test it. Any ideas/examples?