### PR TITLE
Chore: adds core datasources to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,19 @@ lerna.json @grafana/grafana-frontend-platform
 
 /public/app/features/explore/ @grafana/observability-squad
 /packages/jaeger-ui-components/ @grafana/observability-squad
+
+# Core datasources
+/public/app/plugins/datasource/cloudwatch @grafana/backend-platform @grafana/observability-squad
+/public/app/plugins/datasource/elasticsearch @grafana/observability-squad
+/public/app/plugins/datasource/grafana-azure-monitor-datasource @grafana/backend-platform
+/public/app/plugins/datasource/graphite @grafana/observability-squad
+/public/app/plugins/datasource/influxdb @grafana/observability-squad
+/public/app/plugins/datasource/jaeger @grafana/observability-squad
+/public/app/plugins/datasource/loki @grafana/observability-squad
+/public/app/plugins/datasource/mssql @grafana/backend-platform
+/public/app/plugins/datasource/mysql @grafana/backend-platform
+/public/app/plugins/datasource/opentsdb @grafana/observability-squad
+/public/app/plugins/datasource/postgres @grafana/backend-platform
+/public/app/plugins/datasource/prometheus @grafana/observability-squad
+/public/app/plugins/datasource/stackdriver @grafana/backend-platform
+/public/app/plugins/datasource/zipkin @grafana/observability-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@ lerna.json @grafana/grafana-frontend-platform
 /public/app/plugins/datasource/loki @grafana/observability-squad
 /public/app/plugins/datasource/mssql @grafana/backend-platform
 /public/app/plugins/datasource/mysql @grafana/backend-platform
-/public/app/plugins/datasource/opentsdb @grafana/observability-squad
+/public/app/plugins/datasource/opentsdb @grafana/backend-platform
 /public/app/plugins/datasource/postgres @grafana/backend-platform
 /public/app/plugins/datasource/prometheus @grafana/observability-squad
 /public/app/plugins/datasource/stackdriver @grafana/backend-platform


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds core datasources to codeowners file, so when working on a certain core datasource plugin the review assignments are automatically pointing to the correct team, instead of frontend platform.