### PR TITLE
Variables: Fixes maximum call stack bug for empty value

### DIFF
--- a/public/app/core/services/bridge_srv.test.ts
+++ b/public/app/core/services/bridge_srv.test.ts
@@ -12,4 +12,32 @@ describe('when checking template variables', () => {
     expect(findTemplateVarChanges(b, a)).toEqual({ 'var-xyz': 'hello' });
     expect(findTemplateVarChanges(a, b)).toEqual({ 'var-xyz': '' });
   });
+
+  it('then should ignore equal values', () => {
+    const a: UrlQueryMap = {
+      'var-xyz': 'hello',
+      bbb: 'ignore me',
+    };
+    const b: UrlQueryMap = {
+      'var-xyz': 'hello',
+      aaa: 'ignore me',
+    };
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
+
+  it('then should ignore equal values with empty values', () => {
+    const a: UrlQueryMap = {
+      'var-xyz': '',
+      bbb: 'ignore me',
+    };
+    const b: UrlQueryMap = {
+      'var-xyz': '',
+      aaa: 'ignore me',
+    };
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
 });

--- a/public/app/core/services/bridge_srv.ts
+++ b/public/app/core/services/bridge_srv.ts
@@ -124,7 +124,7 @@ export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): Ur
     if (!key.startsWith('var-')) {
       continue;
     }
-    if (!query[key]) {
+    if (!query.hasOwnProperty(key)) {
       changes[key] = ''; // removed
       count++;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using an empty value for a Text variable the logic that checked for variable changes in URL got into an endless loop. This PR tries to remedy this.

**Which issue(s) this PR fixes**:
Fixes #25485

**Special notes for your reviewer**:

