### PR TITLE
Gauge: Hide orientation option in panel options

### DIFF
--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -7,7 +7,7 @@ import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMig
 export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .useFieldConfig()
   .setPanelOptions(builder => {
-    addStandardDataReduceOptions(builder);
+    addStandardDataReduceOptions(builder, false);
     builder
       .addBooleanSwitch({
         path: 'showThresholdLabels',


### PR DESCRIPTION
Gauge should not show orientation option, this setting was added to Guage by mistake during 7.0 