### PR TITLE
POC: Only run certain build steps for PR's if certain files have changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
             fi
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -163,7 +163,7 @@ jobs:
             fi
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - restore_cache:
           keys:
             # Use own cache for front-end builds, since for some reason it can't be unpacked for parts of the
@@ -330,9 +330,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -373,9 +373,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -441,9 +441,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -511,9 +511,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -611,7 +611,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(packages/grafana-ui/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|packages/grafana-ui/)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -671,9 +671,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -744,9 +744,9 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)+
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - restore_cache:
           keys:
             - v2-yarn-{{ checksum "yarn.lock" }}
@@ -798,7 +798,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -829,7 +829,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -855,7 +855,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^docs/.*
+          regex: ^docs/
       - run:
           name: Install codespell
           command: "pip install codespell"
@@ -877,7 +877,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^.*\.go$
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: Install Go linters
           command: |
@@ -911,7 +911,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -947,7 +947,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go)
+          regex: ^(go\.mod|go\.sum|.*\.go)+
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -968,7 +968,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^docs/.*
+          regex: ^docs/
       - setup_remote_docker
       - run:
           name: CI job started

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -744,9 +744,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
-      - halt-if-not-matching-files:
-          regex: ^(go\.mod|go\.sum|.*\.go)+
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/.*\.go)+
       - restore_cache:
           keys:
             - v2-yarn-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,7 +671,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/.*\.go)+
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -742,7 +742,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/.*\.go)+
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/|.*\.go)+
       - restore_cache:
           keys:
             - v2-yarn-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,12 @@ commands:
       - run:
           name: "Halt if not matching changed files << parameters.regex >>, inverse: << parameters.inverse >>"
           command: |
-            echo "Revision: << pipeline.git.revision >>"
-            echo "Base revision: << pipeline.git.base_revision >>"
+            if [[ $CIRCLE_BRANCH == "master" || -n $CIRCLE_TAG ]]; then
+              echo "Master branch or release tag. Skipping..."
+              exit 0
+            fi
+
+            echo "Changed files:"
             git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u
 
             if [ << parameters.inverse >> = true ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+          regex: ^(packages/grafana-ui/|package.json|yarn.lock)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
             fi
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|plugins-bundled/|public/.*\.go)+
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|plugins-bundled/|public/|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
             fi
       - checkout
       - halt-if-not-matching-files:
-          regex: ^plugins-bundled/
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|plugins-bundled/|public/.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -671,9 +671,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(package\.json|yarn\.lock|e2e/|emails/|packages/|public/)+
-      - halt-if-not-matching-files:
-          regex: ^(go\.mod|go\.sum|.*\.go)+
+          regex: ^(package\.json|yarn\.lock|go\.mod|go\.sum|e2e/|emails/|packages/|public/.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,28 @@ commands:
             chmod +x grabpl
             mv grabpl /tmp
 
+  halt-if-not-matching-files:
+    description: "Requires files of last commit to match provided glob pattern. If no matches are found, the step will halt and be marked as successful."
+    parameters:
+      regex:
+        type: string
+      inverse:
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: "Halt if not matching changed files << parameters.regex >>, inverse: << parameters.inverse >>"
+          command: |
+            echo "Revision: << pipeline.git.revision >>"
+            echo "Base revision: << pipeline.git.base_revision >>"
+            git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u
+
+            if [ << parameters.inverse >> = true ]; then
+              git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u | egrep -q '<< parameters.regex >>' && circleci step halt
+            else
+              git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u | egrep -q '<< parameters.regex >>' || circleci step halt
+            fi
+
 jobs:
   build-backend:
     description: "Build a certain variant of Grafana back-end binaries"
@@ -79,6 +101,8 @@ jobs:
               circleci step halt
             fi
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go$
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -131,6 +155,8 @@ jobs:
               circleci step halt
             fi
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
       - restore_cache:
           keys:
             # Use own cache for front-end builds, since for some reason it can't be unpacked for parts of the
@@ -197,6 +223,8 @@ jobs:
               circleci step halt
             fi
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^plugins-bundled/
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -260,6 +288,8 @@ jobs:
     executor: base
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: \.sh$
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -292,6 +322,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -331,6 +365,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -395,6 +433,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -461,6 +503,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -557,6 +603,8 @@ jobs:
     executor: grafana-publish
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -615,6 +663,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -684,6 +736,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go)+
       - restore_cache:
           keys:
             - v2-yarn-{{ checksum "yarn.lock" }}
@@ -734,6 +790,8 @@ jobs:
           MYSQL_PASSWORD: password
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go$
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -763,6 +821,8 @@ jobs:
           POSTGRES_DB: grafanatest
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go$
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -787,6 +847,8 @@ jobs:
       - image: cimg/python:3.8
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^docs/.*
       - run:
           name: Install codespell
           command: "pip install codespell"
@@ -807,6 +869,8 @@ jobs:
       GOGC: 20
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^.*\.go$
       - run:
           name: Install Go linters
           command: |
@@ -839,6 +903,8 @@ jobs:
     executor: node
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(e2e/|emails/|packages/|public/|package.json|yarn.lock)+
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -873,6 +939,8 @@ jobs:
     executor: go
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^(go.mod|go.sum|.*\.go$
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"
@@ -892,6 +960,8 @@ jobs:
     executor: base
     steps:
       - checkout
+      - halt-if-not-matching-files:
+          regex: ^docs/.*
       - setup_remote_docker
       - run:
           name: CI job started
@@ -1157,8 +1227,6 @@ workflows:
             - lint-go
       - build-release-publisher:
           filters: *filter-master-or-release
-      - codespell:
-          filters: *filter-all
       - lint-go:
           filters: *filter-all
       - shellcheck:
@@ -1196,7 +1264,6 @@ workflows:
             - build-oss-frontend
             - test-backend
             - test-frontend
-            - codespell
             - shellcheck
             - build-oss-plugins
       - package-enterprise:
@@ -1214,7 +1281,6 @@ workflows:
             - build-enterprise-frontend
             - test-backend
             - test-frontend
-            - codespell
             - shellcheck
             - build-enterprise-plugins
       - build-oss-windows-installer:
@@ -1310,11 +1376,12 @@ workflows:
           filters: *filter-all
           requires:
             - package-oss
+      - codespell:
+          filters: *filter-all
       - build-docs-website:
           filters: *filter-not-release-or-master
           requires:
-            - mysql-integration-test
-            - postgres-integration-test
+            - codespell
       - deploy-to-kubernetes:
           filters: *filter-only-master
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,9 @@ commands:
             echo "Changed files:"
             git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u
 
+            echo "Exit if circleci configuration changed"
+            git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u | egrep -q '^\.circleci/config\.yml$' && exit 0
+
             if [ << parameters.inverse >> = true ]; then
               git log --oneline --pretty="format:" --name-only origin/master.. | awk 'NF' | sort -u | egrep -q '<< parameters.regex >>' && circleci step halt
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
             fi
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go$
+          regex: ^(go.mod|go.sum|.*\.go)
       - run:
           name: CI job started
           command: ./scripts/ci-job-started.sh
@@ -798,7 +798,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go$
+          regex: ^(go.mod|go.sum|.*\.go)
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -829,7 +829,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go$
+          regex: ^(go.mod|go.sum|.*\.go)
       - run:
           name: ci job started
           command: "./scripts/ci-job-started.sh"
@@ -947,7 +947,7 @@ jobs:
     steps:
       - checkout
       - halt-if-not-matching-files:
-          regex: ^(go.mod|go.sum|.*\.go$
+          regex: ^(go.mod|go.sum|.*\.go)
       - run:
           name: CI job started
           command: "./scripts/ci-job-started.sh"


### PR DESCRIPTION
Proof of concepts for skipping certain build steps for PR's if certain files haven't been changed. Attempt of quick win to reduce build times.

**Notes:**
- Not sure comparing against origin/master will work in all cases (forks etc).
- CircleCI provides parameters for revision (current commit) and base revision (commit before) so using that will only allow to compare changed files since the last commit - maybe that's what we want?  

**Examples:**
- Build of this PR before adding condition to build everything if circleci config changed: https://app.circleci.com/pipelines/github/grafana/grafana/10538/workflows/b8ed1aa8-b0a9-48ba-adae-c25879acd244 (Duration 7m 1s)
- Build with changes in `docs/` folder: https://app.circleci.com/pipelines/github/grafana/grafana/10561/workflows/0dac3312-3ef2-44bf-bd3e-7d2122da8e5b
- Build with changes in backend files: https://app.circleci.com/pipelines/github/grafana/grafana/10563/workflows/3d2b71c7-32e2-4f9b-811f-e6a338fd0557
- Build with changes in frontend files: https://app.circleci.com/pipelines/github/grafana/grafana/10564/workflows/a896f62b-6343-4ece-ba51-b4704b533baf
- Build with changes in backend and frontend files:  https://app.circleci.com/pipelines/github/grafana/grafana/10565/workflows/9ea0dd07-3f6f-44dc-aee4-f623cb90b264