### PR TITLE
Search: support URL query params

### DIFF
--- a/public/app/core/components/Select/SortPicker.tsx
+++ b/public/app/core/components/Select/SortPicker.tsx
@@ -21,9 +21,7 @@ const getSortOptions = () => {
 
 export const SortPicker: FC<Props> = ({ onChange, value, placeholder }) => {
   // Using sync Select and manual options fetching here since we need to find the selected option by value
-  const { loading, value: options } = useAsync<SelectableValue[]>(() => {
-    return getSortOptions();
-  }, []);
+  const { loading, value: options } = useAsync<SelectableValue[]>(getSortOptions, []);
 
   return (
     !loading && (

--- a/public/app/core/components/Select/SortPicker.tsx
+++ b/public/app/core/components/Select/SortPicker.tsx
@@ -20,7 +20,7 @@ const getSortOptions = () => {
 };
 
 export const SortPicker: FC<Props> = ({ onChange, value, placeholder }) => {
-  // USing sync Select and manual options fetching here since we need to find the selected option by value
+  // Using sync Select and manual options fetching here since we need to find the selected option by value
   const { loading, value: options } = useAsync<SelectableValue[]>(() => {
     return getSortOptions();
   }, []);

--- a/public/app/core/components/Select/SortPicker.tsx
+++ b/public/app/core/components/Select/SortPicker.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { AsyncSelect, Icon } from '@grafana/ui';
+import { useAsync } from 'react-use';
+import { Select, Icon } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { DEFAULT_SORT } from 'app/features/search/constants';
 import { SearchSrv } from '../../services/search_srv';
@@ -19,15 +20,21 @@ const getSortOptions = () => {
 };
 
 export const SortPicker: FC<Props> = ({ onChange, value, placeholder }) => {
+  // USing sync Select and manual options fetching here since we need to find the selected option by value
+  const { loading, value: options } = useAsync<SelectableValue[]>(() => {
+    return getSortOptions();
+  }, []);
+
   return (
-    <AsyncSelect
-      width={25}
-      onChange={onChange}
-      value={[value]}
-      loadOptions={getSortOptions}
-      defaultOptions
-      placeholder={placeholder ?? `Sort (Default ${DEFAULT_SORT.label})`}
-      prefix={<Icon name="sort-amount-down" />}
-    />
+    !loading && (
+      <Select
+        width={25}
+        onChange={onChange}
+        value={options.filter(opt => opt.value === value)}
+        options={options}
+        placeholder={placeholder ?? `Sort (Default ${DEFAULT_SORT.label})`}
+        prefix={<Icon name="sort-amount-down" />}
+      />
+    )
   );
 };

--- a/public/app/core/components/Select/SortPicker.tsx
+++ b/public/app/core/components/Select/SortPicker.tsx
@@ -23,16 +23,14 @@ export const SortPicker: FC<Props> = ({ onChange, value, placeholder }) => {
   // Using sync Select and manual options fetching here since we need to find the selected option by value
   const { loading, value: options } = useAsync<SelectableValue[]>(getSortOptions, []);
 
-  return (
-    !loading && (
-      <Select
-        width={25}
-        onChange={onChange}
-        value={options?.filter(opt => opt.value === value)}
-        options={options}
-        placeholder={placeholder ?? `Sort (Default ${DEFAULT_SORT.label})`}
-        prefix={<Icon name="sort-amount-down" />}
-      />
-    )
-  );
+  return !loading ? (
+    <Select
+      width={25}
+      onChange={onChange}
+      value={options?.filter(opt => opt.value === value)}
+      options={options}
+      placeholder={placeholder ?? `Sort (Default ${DEFAULT_SORT.label})`}
+      prefix={<Icon name="sort-amount-down" />}
+    />
+  ) : null;
 };

--- a/public/app/core/components/Select/SortPicker.tsx
+++ b/public/app/core/components/Select/SortPicker.tsx
@@ -30,7 +30,7 @@ export const SortPicker: FC<Props> = ({ onChange, value, placeholder }) => {
       <Select
         width={25}
         onChange={onChange}
-        value={options.filter(opt => opt.value === value)}
+        value={options?.filter(opt => opt.value === value)}
         options={options}
         placeholder={placeholder ?? `Sort (Default ${DEFAULT_SORT.label})`}
         prefix={<Icon name="sort-amount-down" />}

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,20 +1,20 @@
 import _ from 'lodash';
+import Mousetrap from 'mousetrap';
+import 'mousetrap-global-bind';
+import { ILocationService, IRootScopeService, ITimeoutService } from 'angular';
+import { locationUtil } from '@grafana/data';
 
 import coreModule from 'app/core/core_module';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { store } from 'app/store/store';
 import { AppEventEmitter, CoreEvents } from 'app/types';
-
-import Mousetrap from 'mousetrap';
-import 'mousetrap-global-bind';
-import { ContextSrv } from './context_srv';
-import { ILocationService, IRootScopeService, ITimeoutService } from 'angular';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
-import { DashboardModel } from '../../features/dashboard/state';
+import { DashboardModel } from 'app/features/dashboard/state';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal';
-import { SaveDashboardModalProxy } from '../../features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
-import { locationUtil } from '@grafana/data';
+import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
+import { defaultQueryParams } from 'app/features/search/reducers/searchQueryReducer';
+import { ContextSrv } from './context_srv';
 
 export class KeybindingSrv {
   helpModal: boolean;
@@ -88,7 +88,7 @@ export class KeybindingSrv {
   }
 
   closeSearch() {
-    const search = _.extend(this.$location.search(), { search: null });
+    const search = _.extend(this.$location.search(), { search: null, ...defaultQueryParams });
     this.$location.search(search);
   }
 

--- a/public/app/features/search/components/ActionRow.tsx
+++ b/public/app/features/search/components/ActionRow.tsx
@@ -50,7 +50,7 @@ export const ActionRow: FC<Props> = ({
       <HorizontalGroup spacing="md" width="auto">
         {showStarredFilter && (
           <div className={styles.checkboxWrapper}>
-            <Checkbox label="Filter by starred" onChange={onStarredFilterChange} />
+            <Checkbox label="Filter by starred" onChange={onStarredFilterChange} value={query.starred} />
           </div>
         )}
         <TagFilter isClearable tags={query.tag} tagOptions={searchSrv.getDashboardTags} onChange={onTagFilterChange} />

--- a/public/app/features/search/components/ActionRow.tsx
+++ b/public/app/features/search/components/ActionRow.tsx
@@ -44,7 +44,7 @@ export const ActionRow: FC<Props> = ({
           {!hideLayout ? (
             <RadioButtonGroup options={layoutOptions} onChange={onLayoutChange} value={query.layout} />
           ) : null}
-          <SortPicker onChange={onSortChange} value={query.sort} />
+          <SortPicker onChange={onSortChange} value={query.sort?.value} />
         </HorizontalGroup>
       </div>
       <HorizontalGroup spacing="md" width="auto">

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -8,7 +8,7 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import { getRouteParams, getUrl } from 'app/core/selectors/location';
 import Page from 'app/core/components/Page/Page';
 import { loadFolderPage } from '../loaders';
-import { ManageDashboards } from './ManageDashboards';
+import ManageDashboards from './ManageDashboards';
 
 interface Props {
   navModel: NavModel;

--- a/public/app/features/search/components/DashboardSearch.test.tsx
+++ b/public/app/features/search/components/DashboardSearch.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { mockSearch } from './mocks';
-import { DashboardSearch } from './DashboardSearch';
+import { DashboardSearch, Props } from './DashboardSearch';
 import { searchResults } from '../testData';
 import { SearchLayout } from '../types';
 
@@ -15,9 +15,10 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-const setup = async (): Promise<any> => {
+const setup = async (testProps?: Partial<Props>): Promise<any> => {
   const props: any = {
     onCloseSearch: () => {},
+    ...testProps,
   };
   let wrapper;
   //@ts-ignore
@@ -116,5 +117,19 @@ describe('DashboardSearch', () => {
       layout: SearchLayout.Folders,
       sort: undefined,
     });
+  });
+
+  it('should call search api with provided search params', async () => {
+    const params = { query: 'test query', tag: ['tag1'], sort: { value: 'asc' } };
+    await setup({ params });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'test query',
+        tag: ['tag1'],
+        sort: 'asc',
+      })
+    );
   });
 });

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -9,59 +9,59 @@ import { SearchResults } from './SearchResults';
 import { ActionRow } from './ActionRow';
 import { connectWithRouteParams, ConnectProps, DispatchProps } from '../connect';
 
-export interface Props {
+export interface OwnProps {
   onCloseSearch: () => void;
   folder?: string;
 }
 
-export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
-  ({ onCloseSearch, folder, params, updateLocation }) => {
-    const payload = folder ? { query: `folder:${folder} ` } : {};
-    const { query, onQueryChange, onTagFilterChange, onTagAdd, onSortChange, onLayoutChange } = useSearchQuery(
-      {
-        ...payload,
-        ...params,
-      },
-      updateLocation
-    );
-    const { results, loading, onToggleSection, onKeyDown } = useDashboardSearch(query, onCloseSearch);
-    const theme = useTheme();
-    const styles = getStyles(theme);
+export type Props = OwnProps & ConnectProps & DispatchProps;
 
-    return (
-      <div tabIndex={0} className={styles.overlay}>
-        <div className={styles.container}>
-          <div className={styles.searchField}>
-            <SearchField query={query} onChange={onQueryChange} onKeyDown={onKeyDown} autoFocus clearable />
-            <div className={styles.closeBtn}>
-              <IconButton name="times" surface="panel" onClick={onCloseSearch} size="xxl" tooltip="Close search" />
-            </div>
-          </div>
-          <div className={styles.search}>
-            <ActionRow
-              {...{
-                onLayoutChange,
-                onSortChange,
-                onTagFilterChange,
-                query,
-              }}
-            />
-            <CustomScrollbar>
-              <SearchResults
-                results={results}
-                loading={loading}
-                onTagSelected={onTagAdd}
-                editable={false}
-                onToggleSection={onToggleSection}
-                layout={query.layout}
-              />
-            </CustomScrollbar>
+export const DashboardSearch: FC<Props> = memo(({ onCloseSearch, folder, params, updateLocation }) => {
+  const payload = folder ? { query: `folder:${folder} ` } : {};
+  const { query, onQueryChange, onTagFilterChange, onTagAdd, onSortChange, onLayoutChange } = useSearchQuery(
+    {
+      ...payload,
+      ...params,
+    },
+    updateLocation
+  );
+  const { results, loading, onToggleSection, onKeyDown } = useDashboardSearch(query, onCloseSearch);
+  const theme = useTheme();
+  const styles = getStyles(theme);
+
+  return (
+    <div tabIndex={0} className={styles.overlay}>
+      <div className={styles.container}>
+        <div className={styles.searchField}>
+          <SearchField query={query} onChange={onQueryChange} onKeyDown={onKeyDown} autoFocus clearable />
+          <div className={styles.closeBtn}>
+            <IconButton name="times" surface="panel" onClick={onCloseSearch} size="xxl" tooltip="Close search" />
           </div>
         </div>
+        <div className={styles.search}>
+          <ActionRow
+            {...{
+              onLayoutChange,
+              onSortChange,
+              onTagFilterChange,
+              query,
+            }}
+          />
+          <CustomScrollbar>
+            <SearchResults
+              results={results}
+              loading={loading}
+              onTagSelected={onTagAdd}
+              editable={false}
+              onToggleSection={onToggleSection}
+              layout={query.layout}
+            />
+          </CustomScrollbar>
+        </div>
       </div>
-    );
-  }
-);
+    </div>
+  );
+});
 
 export default connectWithRouteParams(DashboardSearch);
 

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -19,8 +19,8 @@ export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
     const payload = folder ? { query: `folder:${folder} ` } : {};
     const { query, onQueryChange, onTagFilterChange, onTagAdd, onSortChange, onLayoutChange } = useSearchQuery(
       {
-        ...params,
         ...payload,
+        ...params,
       },
       updateLocation
     );

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -11,18 +11,13 @@ import { connectWithRouteParams, ConnectProps, DispatchProps } from '../connect'
 
 export interface OwnProps {
   onCloseSearch: () => void;
-  folder?: string;
 }
 
 export type Props = OwnProps & ConnectProps & DispatchProps;
 
-export const DashboardSearch: FC<Props> = memo(({ onCloseSearch, folder, params, updateLocation }) => {
-  const payload = folder ? { query: `folder:${folder} ` } : {};
+export const DashboardSearch: FC<Props> = memo(({ onCloseSearch, params, updateLocation }) => {
   const { query, onQueryChange, onTagFilterChange, onTagAdd, onSortChange, onLayoutChange } = useSearchQuery(
-    {
-      ...payload,
-      ...params,
-    },
+    params,
     updateLocation
   );
   const { results, loading, onToggleSection, onKeyDown } = useDashboardSearch(query, onCloseSearch);

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -78,7 +78,7 @@ export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
 );
 
 const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, starred, sort, tag } = getLocationQuery(state.location) as RouteParams;
+  const { query, starred, sort, tag } = getLocationQuery(state.location);
   return parseRouteParams({
     query,
     tag,

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -3,16 +3,17 @@ import { css } from 'emotion';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { useTheme, CustomScrollbar, stylesFactory, IconButton } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
+import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
+import { updateLocation } from 'app/core/reducers/location';
+import { getRouteParams } from 'app/core/selectors/location';
+import { StoreState } from 'app/types';
 import { useSearchQuery } from '../hooks/useSearchQuery';
 import { useDashboardSearch } from '../hooks/useDashboardSearch';
 import { SearchField } from './SearchField';
 import { SearchResults } from './SearchResults';
 import { ActionRow } from './ActionRow';
-import { StoreState } from 'app/types';
-import { getRouteParams } from 'app/core/selectors/location';
 import { RouteParams } from '../types';
-import { connectWithStore } from '../../../core/utils/connectWithReduxStore';
-import { updateLocation } from '../../../core/reducers/location';
+import { handleRouteParams } from '../utils';
 
 export interface Props {
   onCloseSearch: () => void;
@@ -26,15 +27,6 @@ export interface ConnectProps {
 export interface DispatchProps {
   updateLocation: typeof updateLocation;
 }
-
-const handleRouteParams = (params: RouteParams) => {
-  const cleanedParams = Object.entries(params).reduce(
-    (obj, [key, val]) => (val ? { ...obj, [key]: val } : obj),
-    {} as Partial<RouteParams>
-  );
-
-  return { params: cleanedParams };
-};
 
 export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
   ({ onCloseSearch, folder, params, updateLocation }) => {
@@ -86,13 +78,13 @@ export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
 );
 
 const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, tag, starred, sort } = getRouteParams(state.location);
+  const { query, tag, starred, sort } = getRouteParams(state.location) as RouteParams;
   return handleRouteParams({
     query,
     tag,
     starred,
     sort,
-  } as RouteParams);
+  });
 };
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = {

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -5,7 +5,7 @@ import { useTheme, CustomScrollbar, stylesFactory, IconButton } from '@grafana/u
 import { GrafanaTheme } from '@grafana/data';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
 import { updateLocation } from 'app/core/reducers/location';
-import { getRouteParams } from 'app/core/selectors/location';
+import { getLocationQuery } from 'app/core/selectors/location';
 import { StoreState } from 'app/types';
 import { useSearchQuery } from '../hooks/useSearchQuery';
 import { useDashboardSearch } from '../hooks/useDashboardSearch';
@@ -13,7 +13,7 @@ import { SearchField } from './SearchField';
 import { SearchResults } from './SearchResults';
 import { ActionRow } from './ActionRow';
 import { RouteParams } from '../types';
-import { handleRouteParams } from '../utils';
+import { parseRouteParams } from '../utils';
 
 export interface Props {
   onCloseSearch: () => void;
@@ -78,8 +78,8 @@ export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
 );
 
 const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, tag, starred, sort } = getRouteParams(state.location) as RouteParams;
-  return handleRouteParams({
+  const { query, starred, sort, tag } = getLocationQuery(state.location) as RouteParams;
+  return parseRouteParams({
     query,
     tag,
     starred,

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -1,31 +1,17 @@
 import React, { FC, memo } from 'react';
 import { css } from 'emotion';
-import { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { useTheme, CustomScrollbar, stylesFactory, IconButton } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
-import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
-import { updateLocation } from 'app/core/reducers/location';
-import { getLocationQuery } from 'app/core/selectors/location';
-import { StoreState } from 'app/types';
 import { useSearchQuery } from '../hooks/useSearchQuery';
 import { useDashboardSearch } from '../hooks/useDashboardSearch';
 import { SearchField } from './SearchField';
 import { SearchResults } from './SearchResults';
 import { ActionRow } from './ActionRow';
-import { RouteParams } from '../types';
-import { parseRouteParams } from '../utils';
+import { connectWithRouteParams, ConnectProps, DispatchProps } from '../connect';
 
 export interface Props {
   onCloseSearch: () => void;
   folder?: string;
-}
-
-export interface ConnectProps {
-  params: RouteParams;
-}
-
-export interface DispatchProps {
-  updateLocation: typeof updateLocation;
 }
 
 export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
@@ -77,21 +63,7 @@ export const DashboardSearch: FC<Props & ConnectProps & DispatchProps> = memo(
   }
 );
 
-const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, starred, sort, tag } = getLocationQuery(state.location);
-  return parseRouteParams({
-    query,
-    tag,
-    starred,
-    sort,
-  });
-};
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = {
-  updateLocation,
-};
-
-export default connectWithStore(DashboardSearch, mapStateToProps, mapDispatchToProps);
+export default connectWithRouteParams(DashboardSearch);
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {

--- a/public/app/features/search/components/ManageDashboards.tsx
+++ b/public/app/features/search/components/ManageDashboards.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme } from '@grafana/data';
 import { contextSrv } from 'app/core/services/context_srv';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { FilterInput } from 'app/core/components/FilterInput/FilterInput';
-import { FolderDTO, StoreState } from 'app/types';
+import { FolderDTO } from 'app/types';
 import { useManageDashboards } from '../hooks/useManageDashboards';
 import { SearchLayout } from '../types';
 import { ConfirmDeleteModal } from './ConfirmDeleteModal';
@@ -14,12 +14,7 @@ import { useSearchQuery } from '../hooks/useSearchQuery';
 import { SearchResultsFilter } from './SearchResultsFilter';
 import { SearchResults } from './SearchResults';
 import { DashboardActions } from './DashboardActions';
-import { MapDispatchToProps, MapStateToProps } from 'react-redux';
-import { getLocationQuery } from 'app/core/selectors/location';
-import { parseRouteParams } from '../utils';
-import { updateLocation } from 'app/core/reducers/location';
-import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
-import { ConnectProps, DispatchProps } from './DashboardSearch';
+import { connectWithRouteParams, ConnectProps, DispatchProps } from '../connect';
 
 export interface Props {
   folder?: FolderDTO;
@@ -154,21 +149,7 @@ export const ManageDashboards: FC<Props & ConnectProps & DispatchProps> = memo((
   );
 });
 
-const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, starred, sort, tag } = getLocationQuery(state.location);
-  return parseRouteParams({
-    query,
-    tag,
-    starred,
-    sort,
-  });
-};
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = {
-  updateLocation,
-};
-
-export default connectWithStore(ManageDashboards, mapStateToProps, mapDispatchToProps);
+export default connectWithRouteParams(ManageDashboards);
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {

--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -4,7 +4,8 @@ import { getLocationQuery } from 'app/core/selectors/location';
 import { updateLocation } from 'app/core/reducers/location';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
 import { StoreState } from 'app/types';
-import { DashboardSearch } from './DashboardSearch';
+import DashboardSearch from './DashboardSearch';
+import { defaultQueryParams } from '../reducers/searchQueryReducer';
 
 interface OwnProps {
   search?: string | null;
@@ -23,11 +24,12 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }
   const isOpen = search === 'open';
 
   const closeSearch = () => {
-    if (search === 'open') {
+    if (isOpen) {
       updateLocation({
         query: {
           search: null,
           folder: null,
+          ...defaultQueryParams,
         },
         partial: true,
       });

--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { FC, memo } from 'react';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { UrlQueryMap } from '@grafana/data';
 import { getLocationQuery } from 'app/core/selectors/location';
 import { updateLocation } from 'app/core/reducers/location';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
@@ -30,7 +31,7 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }
           search: null,
           folder: null,
           ...defaultQueryParams,
-        },
+        } as UrlQueryMap,
         partial: true,
       });
     }

--- a/public/app/features/search/connect.ts
+++ b/public/app/features/search/connect.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
+import { StoreState } from 'app/types';
+import { getLocationQuery } from 'app/core/selectors/location';
+import { updateLocation } from 'app/core/reducers/location';
+import { parseRouteParams } from './utils';
+import { RouteParams } from './types';
+import { Props as DashboardSearchProps } from './components/DashboardSearch';
+import { Props as ManageDashboardsProps } from './components/ManageDashboards';
+
+export interface ConnectProps {
+  params: RouteParams;
+}
+
+export interface DispatchProps {
+  updateLocation: typeof updateLocation;
+}
+
+type Props = DashboardSearchProps | ManageDashboardsProps;
+
+const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
+  const { query, starred, sort, tag } = getLocationQuery(state.location);
+  return parseRouteParams({
+    query,
+    tag,
+    starred,
+    sort,
+  });
+};
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = {
+  updateLocation,
+};
+
+export const connectWithRouteParams = (Component: React.FC) =>
+  connectWithStore(Component, mapStateToProps, mapDispatchToProps);

--- a/public/app/features/search/connect.ts
+++ b/public/app/features/search/connect.ts
@@ -20,12 +20,13 @@ export interface DispatchProps {
 type Props = DashboardSearchProps | ManageDashboardsProps;
 
 const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, starred, sort, tag } = getLocationQuery(state.location);
+  const { query, starred, sort, tag, layout } = getLocationQuery(state.location);
   return parseRouteParams({
     query,
     tag,
     starred,
     sort,
+    layout,
   });
 };
 

--- a/public/app/features/search/connect.ts
+++ b/public/app/features/search/connect.ts
@@ -20,14 +20,17 @@ export interface DispatchProps {
 type Props = DashboardSearchProps | ManageDashboardsProps;
 
 const mapStateToProps: MapStateToProps<ConnectProps, Props, StoreState> = state => {
-  const { query, starred, sort, tag, layout } = getLocationQuery(state.location);
-  return parseRouteParams({
-    query,
-    tag,
-    starred,
-    sort,
-    layout,
-  });
+  const { query, starred, sort, tag, layout, folder } = getLocationQuery(state.location);
+  return parseRouteParams(
+    {
+      query,
+      tag,
+      starred,
+      sort,
+      layout,
+    },
+    folder
+  );
 };
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = {

--- a/public/app/features/search/connect.ts
+++ b/public/app/features/search/connect.ts
@@ -5,12 +5,12 @@ import { StoreState } from 'app/types';
 import { getLocationQuery } from 'app/core/selectors/location';
 import { updateLocation } from 'app/core/reducers/location';
 import { parseRouteParams } from './utils';
-import { RouteParams } from './types';
+import { DashboardQuery } from './types';
 import { Props as DashboardSearchProps } from './components/DashboardSearch';
 import { Props as ManageDashboardsProps } from './components/ManageDashboards';
 
 export interface ConnectProps {
-  params: RouteParams;
+  params: Partial<DashboardQuery>;
 }
 
 export interface DispatchProps {

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -13,7 +13,7 @@ import {
 import { DashboardQuery, SearchLayout } from '../types';
 import { hasFilters } from '../utils';
 
-export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocation?: (args: any) => {}) => {
+export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocation = (args: any) => {}) => {
   const updateLocationQuery = (query: any) => updateLocation({ query, partial: true });
   const initialState = { ...defaultQuery, ...queryParams };
   const [query, dispatch] = useReducer(queryReducer, initialState);

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -30,11 +30,12 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocat
 
   const onTagAdd = (tag: string) => {
     dispatch({ type: ADD_TAG, payload: tag });
+    updateLocationQuery({ tag: [...query.tag, tag] });
   };
 
   const onClearFilters = () => {
     dispatch({ type: CLEAR_FILTERS });
-    updateLocationQuery(null);
+    updateLocationQuery(defaultQuery);
   };
 
   const onStarredFilterChange = (e: FormEvent<HTMLInputElement>) => {

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -46,7 +46,7 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocat
 
   const onSortChange = (sort: SelectableValue | null) => {
     dispatch({ type: TOGGLE_SORT, payload: sort });
-    updateLocationQuery({ sort: sort.value, layout: SearchLayout.List });
+    updateLocationQuery({ sort: sort?.value, layout: SearchLayout.List });
   };
 
   const onLayoutChange = (layout: SearchLayout) => {

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -46,11 +46,12 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocat
 
   const onSortChange = (sort: SelectableValue | null) => {
     dispatch({ type: TOGGLE_SORT, payload: sort });
-    updateLocationQuery({ sort: sort.value });
+    updateLocationQuery({ sort: sort.value, layout: SearchLayout.List });
   };
 
   const onLayoutChange = (layout: SearchLayout) => {
     dispatch({ type: LAYOUT_CHANGE, payload: layout });
+    updateLocationQuery({ layout });
   };
 
   return {

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -13,16 +13,19 @@ import {
 import { DashboardQuery, SearchLayout } from '../types';
 import { hasFilters } from '../utils';
 
-export const useSearchQuery = (queryParams: Partial<DashboardQuery>) => {
+export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocation?: (args: any) => {}) => {
+  const updateLocationQuery = (query: any) => updateLocation({ query, partial: true });
   const initialState = { ...defaultQuery, ...queryParams };
   const [query, dispatch] = useReducer(queryReducer, initialState);
 
   const onQueryChange = (query: string) => {
     dispatch({ type: QUERY_CHANGE, payload: query });
+    updateLocationQuery({ query });
   };
 
   const onTagFilterChange = (tags: string[]) => {
     dispatch({ type: SET_TAGS, payload: tags });
+    updateLocationQuery({ tag: tags });
   };
 
   const onTagAdd = (tag: string) => {
@@ -31,6 +34,7 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>) => {
 
   const onClearFilters = () => {
     dispatch({ type: CLEAR_FILTERS });
+    updateLocationQuery(null);
   };
 
   const onStarredFilterChange = (e: FormEvent<HTMLInputElement>) => {
@@ -39,6 +43,7 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>) => {
 
   const onSortChange = (sort: SelectableValue | null) => {
     dispatch({ type: TOGGLE_SORT, payload: sort });
+    updateLocationQuery({ sort: sort.value });
   };
 
   const onLayoutChange = (layout: SearchLayout) => {

--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -1,6 +1,6 @@
 import { FormEvent, useReducer } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { defaultQuery, queryReducer } from '../reducers/searchQueryReducer';
+import { defaultQuery, defaultQueryParams, queryReducer } from '../reducers/searchQueryReducer';
 import {
   ADD_TAG,
   CLEAR_FILTERS,
@@ -10,11 +10,11 @@ import {
   TOGGLE_SORT,
   TOGGLE_STARRED,
 } from '../reducers/actionTypes';
-import { DashboardQuery, SearchLayout } from '../types';
+import { DashboardQuery, RouteParams, SearchLayout } from '../types';
 import { hasFilters } from '../utils';
 
 export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocation = (args: any) => {}) => {
-  const updateLocationQuery = (query: any) => updateLocation({ query, partial: true });
+  const updateLocationQuery = (query: RouteParams) => updateLocation({ query, partial: true });
   const initialState = { ...defaultQuery, ...queryParams };
   const [query, dispatch] = useReducer(queryReducer, initialState);
 
@@ -35,11 +35,13 @@ export const useSearchQuery = (queryParams: Partial<DashboardQuery>, updateLocat
 
   const onClearFilters = () => {
     dispatch({ type: CLEAR_FILTERS });
-    updateLocationQuery(defaultQuery);
+    updateLocationQuery(defaultQueryParams);
   };
 
   const onStarredFilterChange = (e: FormEvent<HTMLInputElement>) => {
-    dispatch({ type: TOGGLE_STARRED, payload: (e.target as HTMLInputElement).checked });
+    const starred = (e.target as HTMLInputElement).checked;
+    dispatch({ type: TOGGLE_STARRED, payload: starred });
+    updateLocationQuery({ starred: starred || null });
   };
 
   const onSortChange = (sort: SelectableValue | null) => {

--- a/public/app/features/search/reducers/manageDashboards.test.ts
+++ b/public/app/features/search/reducers/manageDashboards.test.ts
@@ -87,7 +87,7 @@ describe('Manage dashboards reducer', () => {
 
   it('should not display dashboards in a non-expanded folder', () => {
     const general = results.find(res => res.id === 0);
-    const toMove = { dashboards: general.items, folder: { id: 4074 } };
+    const toMove = { dashboards: general?.items, folder: { id: 4074 } };
     const newState = reducer({ ...state, results }, { type: MOVE_ITEMS, payload: toMove });
     expect(newState.results.find((res: DashboardSection) => res.id === 4074).items).toHaveLength(0);
     expect(newState.results.find((res: DashboardSection) => res.id === 0).items).toHaveLength(0);

--- a/public/app/features/search/reducers/searchQueryReducer.ts
+++ b/public/app/features/search/reducers/searchQueryReducer.ts
@@ -27,6 +27,7 @@ export const defaultQueryParams: RouteParams = {
   starred: null,
   query: null,
   tag: null,
+  layout: null,
 };
 
 export const queryReducer = (state: DashboardQuery, action: SearchAction) => {

--- a/public/app/features/search/reducers/searchQueryReducer.ts
+++ b/public/app/features/search/reducers/searchQueryReducer.ts
@@ -1,4 +1,4 @@
-import { DashboardQuery, SearchAction, SearchLayout } from '../types';
+import { DashboardQuery, RouteParams, SearchAction, SearchLayout } from '../types';
 import {
   ADD_TAG,
   CLEAR_FILTERS,
@@ -20,6 +20,13 @@ export const defaultQuery: DashboardQuery = {
   folderIds: [],
   sort: null,
   layout: SearchLayout.Folders,
+};
+
+export const defaultQueryParams: RouteParams = {
+  sort: null,
+  starred: null,
+  query: null,
+  tag: null,
 };
 
 export const queryReducer = (state: DashboardQuery, action: SearchAction) => {

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -96,4 +96,6 @@ export enum SearchLayout {
   Folders = 'folders',
 }
 
-export type RouteParams = Partial<Pick<DashboardQuery, 'query' | 'sort' | 'tag' | 'starred'>>;
+export type RouteParams = Partial<
+  Pick<DashboardQuery, 'query' | 'sort' | 'tag' | 'starred'> & { layout: SearchLayout }
+>;

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -96,6 +96,10 @@ export enum SearchLayout {
   Folders = 'folders',
 }
 
-export type RouteParams = Partial<
-  Pick<DashboardQuery, 'query' | 'sort' | 'tag' | 'starred'> & { layout: SearchLayout }
->;
+export interface RouteParams {
+  query?: string | null;
+  sort?: string | null;
+  starred?: boolean | null;
+  tag?: string[] | null;
+  layout?: SearchLayout | null;
+}

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -95,3 +95,5 @@ export enum SearchLayout {
   List = 'list',
   Folders = 'folders',
 }
+
+export type RouteParams = Partial<Pick<DashboardQuery, 'query' | 'sort' | 'tag' | 'starred'>>;

--- a/public/app/features/search/utils.test.ts
+++ b/public/app/features/search/utils.test.ts
@@ -5,8 +5,10 @@ import {
   getFlattenedSections,
   markSelected,
   mergeReducers,
+  parseRouteParams,
 } from './utils';
 import { sections, searchResults } from './testData';
+import { RouteParams } from './types';
 
 describe('Search utils', () => {
   describe('getFlattenedSections', () => {
@@ -144,6 +146,62 @@ describe('Search utils', () => {
   describe('getCheckedDashboardsUids', () => {
     it('should get uids of all checked dashboards', () => {
       expect(getCheckedDashboardsUids(searchResults as any[])).toEqual(['lBdLINUWk', '8DY63kQZk']);
+    });
+  });
+
+  describe('parseRouteParams', () => {
+    it('should remove all undefined keys', () => {
+      const params: Partial<RouteParams> = { sort: undefined, tag: undefined, query: 'test' };
+
+      expect(parseRouteParams(params)).toEqual({
+        params: {
+          query: 'test',
+        },
+      });
+    });
+
+    it('should return tag as array, if present', () => {
+      //@ts-ignore
+      const params = { sort: undefined, tag: 'test', query: 'test' };
+      expect(parseRouteParams(params)).toEqual({
+        params: {
+          query: 'test',
+          tag: ['test'],
+        },
+      });
+
+      const params2: Partial<RouteParams> = { sort: undefined, tag: ['test'], query: 'test' };
+      expect(parseRouteParams(params2)).toEqual({
+        params: {
+          query: 'test',
+          tag: ['test'],
+        },
+      });
+    });
+
+    it('should return sort as a SelectableValue', () => {
+      const params: Partial<RouteParams> = { sort: 'test' };
+
+      expect(parseRouteParams(params)).toEqual({
+        params: {
+          sort: { value: 'test' },
+        },
+      });
+    });
+
+    it('should prepend folder:{folder} to the query if folder is present', () => {
+      expect(parseRouteParams({}, 'current')).toEqual({
+        params: {
+          query: 'folder:current ',
+        },
+      });
+      // Prepend to exiting query
+      const params: Partial<RouteParams> = { query: 'test' };
+      expect(parseRouteParams(params, 'current')).toEqual({
+        params: {
+          query: 'folder:current test',
+        },
+      });
     });
   });
 });

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -1,6 +1,6 @@
 import { parse, SearchParserResult } from 'search-query-parser';
 import { IconName } from '@grafana/ui';
-import { UrlQueryMap } from '@grafana/data';
+import { UrlQueryMap, UrlQueryValue } from '@grafana/data';
 import { DashboardQuery, DashboardSection, DashboardSectionItem, SearchAction, UidsToDelete } from './types';
 import { NO_ID_SECTIONS, SECTION_STORAGE_KEY } from './constants';
 import { getDashboardSrv } from '../dashboard/services/DashboardSrv';
@@ -188,9 +188,13 @@ export const getParsedQuery = (query: DashboardQuery, queryParsing = false) => {
   let folderIds: number[] = [];
 
   if (parseQuery(query.query).folder === 'current') {
-    const { folderId } = getDashboardSrv().getCurrent().meta;
-    if (folderId) {
-      folderIds = [folderId];
+    try {
+      const { folderId } = getDashboardSrv().getCurrent()?.meta;
+      if (folderId) {
+        folderIds = [folderId];
+      }
+    } catch (e) {
+      console.error(e);
     }
   }
   return { ...parsedQuery, query: parseQuery(query.query).text as string, folderIds };
@@ -233,8 +237,9 @@ export const getSectionStorageKey = (title: string) => {
 /**
  * Remove undefined keys from url params object and format non-primitive values
  * @param params
+ * @param folder
  */
-export const parseRouteParams = (params: UrlQueryMap) => {
+export const parseRouteParams = (params: UrlQueryMap, folder?: UrlQueryValue) => {
   const cleanedParams = Object.entries(params).reduce((obj, [key, val]) => {
     if (!val) {
       return obj;
@@ -246,5 +251,11 @@ export const parseRouteParams = (params: UrlQueryMap) => {
     return { ...obj, [key]: val };
   }, {} as Partial<DashboardQuery>);
 
+  if (folder) {
+    const folderStr = `folder:${folder}`;
+    return {
+      params: { ...cleanedParams, query: `${folderStr} ${(cleanedParams.query ?? '').replace(folderStr, '')}` },
+    };
+  }
   return { params: cleanedParams };
 };

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -1,6 +1,13 @@
 import { parse, SearchParserResult } from 'search-query-parser';
 import { IconName } from '@grafana/ui';
-import { DashboardQuery, DashboardSection, DashboardSectionItem, SearchAction, UidsToDelete } from './types';
+import {
+  DashboardQuery,
+  DashboardSection,
+  DashboardSectionItem,
+  RouteParams,
+  SearchAction,
+  UidsToDelete,
+} from './types';
 import { NO_ID_SECTIONS, SECTION_STORAGE_KEY } from './constants';
 import { getDashboardSrv } from '../dashboard/services/DashboardSrv';
 
@@ -227,4 +234,21 @@ export const getSectionStorageKey = (title: string) => {
     return '';
   }
   return `${SECTION_STORAGE_KEY}.${title.toLowerCase()}`;
+};
+
+/**
+ * Remove undefined keys from url params object and force tag to be array
+ * @param params
+ */
+export const handleRouteParams = (params: RouteParams) => {
+  const cleanedParams = Object.entries(params).reduce((obj, [key, val]) => {
+    if (!val) {
+      return obj;
+    } else if (key === 'tag' && !Array.isArray(val)) {
+      return { ...obj, tag: [val] };
+    }
+    return { ...obj, [key]: val };
+  }, {} as Partial<RouteParams>);
+
+  return { params: cleanedParams };
 };

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -237,7 +237,7 @@ export const getSectionStorageKey = (title: string) => {
 };
 
 /**
- * Remove undefined keys from url params object and force tag to be array
+ * Remove undefined keys from url params object and format non-primitive values
  * @param params
  */
 export const handleRouteParams = (params: RouteParams) => {
@@ -246,6 +246,8 @@ export const handleRouteParams = (params: RouteParams) => {
       return obj;
     } else if (key === 'tag' && !Array.isArray(val)) {
       return { ...obj, tag: [val] };
+    } else if (key === 'sort') {
+      return { ...obj, sort: { value: val } };
     }
     return { ...obj, [key]: val };
   }, {} as Partial<RouteParams>);

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -240,7 +240,7 @@ export const getSectionStorageKey = (title: string) => {
  * Remove undefined keys from url params object and format non-primitive values
  * @param params
  */
-export const handleRouteParams = (params: RouteParams) => {
+export const parseRouteParams = (params: RouteParams) => {
   const cleanedParams = Object.entries(params).reduce((obj, [key, val]) => {
     if (!val) {
       return obj;

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -1,5 +1,6 @@
 import { parse, SearchParserResult } from 'search-query-parser';
 import { IconName } from '@grafana/ui';
+import { UrlQueryMap } from '@grafana/data';
 import {
   DashboardQuery,
   DashboardSection,
@@ -240,17 +241,17 @@ export const getSectionStorageKey = (title: string) => {
  * Remove undefined keys from url params object and format non-primitive values
  * @param params
  */
-export const parseRouteParams = (params: RouteParams) => {
+export const parseRouteParams = (params: UrlQueryMap) => {
   const cleanedParams = Object.entries(params).reduce((obj, [key, val]) => {
     if (!val) {
       return obj;
     } else if (key === 'tag' && !Array.isArray(val)) {
-      return { ...obj, tag: [val] };
+      return { ...obj, tag: [val] as string[] };
     } else if (key === 'sort') {
       return { ...obj, sort: { value: val } };
     }
     return { ...obj, [key]: val };
-  }, {} as Partial<RouteParams>);
+  }, {} as RouteParams);
 
   return { params: cleanedParams };
 };

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -1,14 +1,7 @@
 import { parse, SearchParserResult } from 'search-query-parser';
 import { IconName } from '@grafana/ui';
 import { UrlQueryMap } from '@grafana/data';
-import {
-  DashboardQuery,
-  DashboardSection,
-  DashboardSectionItem,
-  RouteParams,
-  SearchAction,
-  UidsToDelete,
-} from './types';
+import { DashboardQuery, DashboardSection, DashboardSectionItem, SearchAction, UidsToDelete } from './types';
 import { NO_ID_SECTIONS, SECTION_STORAGE_KEY } from './constants';
 import { getDashboardSrv } from '../dashboard/services/DashboardSrv';
 
@@ -251,7 +244,7 @@ export const parseRouteParams = (params: UrlQueryMap) => {
       return { ...obj, sort: { value: val } };
     }
     return { ...obj, [key]: val };
-  }, {} as RouteParams);
+  }, {} as Partial<DashboardQuery>);
 
   return { params: cleanedParams };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Save search filters i.e. tags, sort, starred and search query to URL params. This would enable sharing the URLs for filtered search results. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #24379

**Special notes for your reviewer**:
- The URL params are also enabled for Manage Dashboards view. Not sure if this is necessary and if the main search is opened from manage dashboards view (not sure if this happens often) the main search params will overwrite the ones from manage dashboards. 
- The main search's URL params are cleared when the search is closed. Maybe there'd be some action for manage dashboards view to clear all the filters (now only clearing tags is possible).
