### PR TITLE
UI/Switch: Makes Switch ID generation more stable

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, useRef } from 'react';
 import { css, cx } from 'emotion';
 import uniqueId from 'lodash/uniqueId';
 import { GrafanaTheme } from '@grafana/data';
@@ -79,7 +79,7 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
   ({ value, checked, disabled = false, onChange, ...inputProps }, ref) => {
     const theme = useTheme();
     const styles = getSwitchStyles(theme);
-    const switchId = uniqueId('switch-');
+    const switchIdRef = useRef(uniqueId('switch-'));
 
     return (
       <div className={cx(styles.switch)}>
@@ -90,11 +90,11 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
           onChange={event => {
             onChange?.(event);
           }}
-          id={switchId}
+          id={switchIdRef.current}
           {...inputProps}
           ref={ref}
         />
-        <label htmlFor={switchId} />
+        <label htmlFor={switchIdRef.current} />
       </div>
     );
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously a new ID was being generated for a switch every time it was rendered. This PR ensures each switch's ID is only generated once.