### PR TITLE
Explore/Logs: Fix tooltip display for log graph

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -153,6 +153,9 @@ export function makeSeriesForLogs(sortedRows: LogRowModel[], bucketSize: number,
       ...valueField.config,
       color: series.color,
     };
+    valueField.name = series.alias;
+    const fieldDisplayProcessor = getDisplayProcessor({ field: valueField, timeZone });
+    valueField.display = (value: any) => ({ ...fieldDisplayProcessor(value), color: series.color });
 
     const points = getFlotPairs({
       xField: timeField,


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously hovering over the Explore graph in Logs mode would display multiple values, but all with the label 'Value' and omitting the corresponding graph color.
<img width="274" alt="image" src="https://user-images.githubusercontent.com/45561153/84385561-b4f56e80-abe7-11ea-860e-f4b2da9d67aa.png">

This PR ensures the series' name and color is displayed along with the value(s).
<img width="386" alt="image" src="https://user-images.githubusercontent.com/45561153/84385487-8ecfce80-abe7-11ea-9992-fd6d8440babf.png">
