### PR TITLE
InfluxDB: Fix invalid memory address or nil pointer dereference when schema is missing in URL

### DIFF
--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -141,7 +141,10 @@ func (e *InfluxDBExecutor) getQuery(dsInfo *models.DataSource, queries []*tsdb.Q
 
 func (e *InfluxDBExecutor) createRequest(dsInfo *models.DataSource, query string) (*http.Request, error) {
 
-	u, _ := url.Parse(dsInfo.Url)
+	u, err := url.Parse(dsInfo.Url)
+	if err != nil {
+		return nil, err
+	}
 	u.Path = path.Join(u.Path, "query")
 	httpMode := dsInfo.JsonData.Get("httpMode").MustString("GET")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add guard if parsing url fails in influxdb backend data source.

**Which issue(s) this PR fixes**:
Fixes #25242 

**Special notes for your reviewer**:

