### PR TITLE
Dashboard: fix promql query editor resolution field's position to prevent overflow

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -155,7 +155,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
             <div className="gf-form-label">Resolution</div>
             <Select
               isSearchable={false}
-              maxMenuHeight={150}
+              menuPlacement="bottom"
               options={INTERVAL_FACTOR_OPTIONS}
               onChange={this.onIntervalFactorChange}
               value={intervalFactorOption}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -155,6 +155,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
             <div className="gf-form-label">Resolution</div>
             <Select
               isSearchable={false}
+              maxMenuHeight={150}
               options={INTERVAL_FACTOR_OPTIONS}
               onChange={this.onIntervalFactorChange}
               value={intervalFactorOption}

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
       </div>
       <Select
         isSearchable={false}
+        maxMenuHeight={150}
         onChange={[Function]}
         options={
           Array [

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
       </div>
       <Select
         isSearchable={false}
-        maxMenuHeight={150}
+        menuPlacement="bottom"
         onChange={[Function]}
         options={
           Array [


### PR DESCRIPTION
**What this PR does / why we need it**:
currently the resolution select overflows its container and makes certain options inaccessible without the keyboard:
![2020-06-12 at 09 28](https://user-images.githubusercontent.com/5599894/84507648-2a684a00-ac8f-11ea-9e81-e12b235557e8.gif)

this moves the menu below the select so that the panel can be scrolled to accommodate:
![2020-06-16 at 08 33](https://user-images.githubusercontent.com/5599894/84774669-28aec700-afac-11ea-8ef2-ded4ccfc352a.gif)


**Special notes for your reviewer**:
suggestion for the [developer guide](https://github.com/grafana/grafana/blob/master/contribute/developer-guide.md) -- in addition to the `ulimit` thing i also had to set a `GOPATH` env var to run the backend. this manifested as a bunch of `go: writing go.mod cache: mkdir /pkg: read-only file system` errors when running `make run`, which was relatively easy to troubleshoot but would potentially still be nice to call out in that doc
