### PR TITLE
Search: add query param to prepopulate search text

### DIFF
--- a/e2e/suite1/specs/query-editor.spec.ts
+++ b/e2e/suite1/specs/query-editor.spec.ts
@@ -29,7 +29,7 @@ e2e.scenario({
 
     cy.contains(queryText.slice(0, -1)).should('be.visible');
 
-    e2e.components.QueryField.container().type('{ctrl}z');
+    e2e.components.QueryField.container().type('{cmd}z');
 
     cy.contains(queryText).should('be.visible');
   },

--- a/e2e/suite1/specs/query-editor.spec.ts
+++ b/e2e/suite1/specs/query-editor.spec.ts
@@ -29,7 +29,7 @@ e2e.scenario({
 
     cy.contains(queryText.slice(0, -1)).should('be.visible');
 
-    e2e.components.QueryField.container().type('{cmd}z');
+    e2e.components.QueryField.container().type('{ctrl}z');
 
     cy.contains(queryText).should('be.visible');
   },

--- a/public/app/features/search/components/DashboardSearch.test.tsx
+++ b/public/app/features/search/components/DashboardSearch.test.tsx
@@ -76,7 +76,7 @@ describe('DashboardSearch', () => {
 
     expect(mockSearch).toHaveBeenCalledTimes(1);
     expect(mockSearch).toHaveBeenCalledWith({
-      query: 'folder:testFolder',
+      query: undefined,
       tag: [],
       skipRecent: false,
       skipStarred: false,
@@ -92,7 +92,7 @@ describe('DashboardSearch', () => {
 
     expect(mockSearch).toHaveBeenCalledTimes(1);
     expect(mockSearch).toHaveBeenCalledWith({
-      query: 'folder:testFolder test query',
+      query: 'test query',
       tag: [],
       skipRecent: false,
       skipStarred: false,

--- a/public/app/features/search/components/DashboardSearch.test.tsx
+++ b/public/app/features/search/components/DashboardSearch.test.tsx
@@ -15,9 +15,15 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-const setup = async (): Promise<any> => {
+interface TestProps {
+  folder?: string;
+  queryText?: string;
+}
+
+const setup = async (testProps?: TestProps): Promise<any> => {
   const props: any = {
     onCloseSearch: () => {},
+    ...testProps,
   };
   let wrapper;
   //@ts-ignore
@@ -39,6 +45,54 @@ describe('DashboardSearch', () => {
     expect(mockSearch).toHaveBeenCalledTimes(1);
     expect(mockSearch).toHaveBeenCalledWith({
       query: '',
+      tag: [],
+      skipRecent: false,
+      skipStarred: false,
+      starred: false,
+      folderIds: [],
+      layout: SearchLayout.Folders,
+      sort: undefined,
+    });
+  });
+
+  it('should call search api with passed in query when initialised with query param', async () => {
+    await setup({ queryText: 'test query' });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith({
+      query: 'test query',
+      tag: [],
+      skipRecent: false,
+      skipStarred: false,
+      starred: false,
+      folderIds: [],
+      layout: SearchLayout.Folders,
+      sort: undefined,
+    });
+  });
+
+  it('should call search api with passed in folder when initialised with folder param', async () => {
+    await setup({ folder: 'testFolder' });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith({
+      query: 'folder:testFolder',
+      tag: [],
+      skipRecent: false,
+      skipStarred: false,
+      starred: false,
+      folderIds: [],
+      layout: SearchLayout.Folders,
+      sort: undefined,
+    });
+  });
+
+  it('should call search api with passed in folder and query when initialised with folder and query params', async () => {
+    await setup({ queryText: 'test query', folder: 'testFolder' });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith({
+      query: 'folder:testFolder test query',
       tag: [],
       skipRecent: false,
       skipStarred: false,

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -11,10 +11,13 @@ import { ActionRow } from './ActionRow';
 export interface Props {
   onCloseSearch: () => void;
   folder?: string;
+  queryText?: string;
 }
 
-export const DashboardSearch: FC<Props> = memo(({ onCloseSearch, folder }) => {
-  const payload = folder ? { query: `folder:${folder} ` } : {};
+export const DashboardSearch: FC<Props> = memo(({ onCloseSearch, folder, queryText = '' }) => {
+  const folderFilter = folder ? 'folder:' + folder + ' ' : '';
+  const initialQuery = folderFilter + queryText;
+  const payload = initialQuery ? { query: initialQuery } : {};
   const { query, onQueryChange, onTagFilterChange, onTagAdd, onSortChange, onLayoutChange } = useSearchQuery(payload);
   const { results, loading, onToggleSection, onKeyDown } = useDashboardSearch(query, onCloseSearch);
   const theme = useTheme();

--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -19,7 +19,7 @@ interface DispatchProps {
 
 export type Props = OwnProps & DispatchProps;
 
-export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }) => {
+export const SearchWrapper: FC<Props> = memo(({ search, folder, queryText, updateLocation }) => {
   const isOpen = search === 'open';
 
   const closeSearch = () => {
@@ -34,12 +34,12 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }
     }
   };
 
-  return isOpen ? <DashboardSearch onCloseSearch={closeSearch} folder={folder} /> : null;
+  return isOpen ? <DashboardSearch onCloseSearch={closeSearch} folder={folder} queryText={queryText} /> : null;
 });
 
 const mapStateToProps: MapStateToProps<{}, OwnProps, StoreState> = (state: StoreState) => {
-  const { search, folder } = getLocationQuery(state.location);
-  return { search, folder };
+  const { search, folder, query } = getLocationQuery(state.location);
+  return { search, folder, queryText: query };
 };
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = {

--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -28,6 +28,7 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, queryText, updat
         query: {
           search: null,
           folder: null,
+          query: null,
         },
         partial: true,
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
adds a query parameter to prepopulate  dashboard search text when using the `seach=open` param. this enables folks to make a [custom search engine](https://www.techrepublic.com/article/pro-tip-add-custom-search-engines-in-chrome-for-more-efficient-searching/) to make searching for dashboards super easy

no filter:
![image](https://user-images.githubusercontent.com/5599894/84521098-8a1c2080-aca2-11ea-8de6-26f41d4d55d0.png)

just folder (side note -- folders with spaces dont seem to behave super nicely here; i.e. you cant actually search within them. seems like that behavior exists on master so calling that out of scope for this PR):
![image](https://user-images.githubusercontent.com/5599894/84521219-af109380-aca2-11ea-9492-89c0d0595f2d.png)

just query:
![image](https://user-images.githubusercontent.com/5599894/84521319-cfd8e900-aca2-11ea-9390-a8a141497866.png)

folder + query:
![image](https://user-images.githubusercontent.com/5599894/84521474-0f9fd080-aca3-11ea-974e-17aad7c95cc1.png)

closing cleans up the url:
![2020-06-12 at 11 56](https://user-images.githubusercontent.com/5599894/84522022-e469b100-aca3-11ea-9132-fe953973ce5c.gif)
