### PR TITLE
GraphPanel: Make legend values clickable series toggles

### DIFF
--- a/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
+++ b/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
@@ -71,7 +71,13 @@ export class LegendItem extends PureComponent<LegendItemProps, LegendItemState> 
       if (this.props[valueName]) {
         const valueFormatted = series.formatValue(series.stats[valueName]);
         legendValueItems.push(
-          <LegendValue key={valueName} valueName={valueName} value={valueFormatted} asTable={asTable} />
+          <LegendValue
+            key={valueName}
+            valueName={valueName}
+            value={valueFormatted}
+            asTable={asTable}
+            onValueClick={this.onLabelClick}
+          />
         );
       }
     }
@@ -196,13 +202,20 @@ interface LegendValueProps {
   value: string;
   valueName: string;
   asTable?: boolean;
+  onValueClick?: (event: any) => void;
 }
 
-function LegendValue(props: LegendValueProps) {
-  const value = props.value;
-  const valueName = props.valueName;
-  if (props.asTable) {
-    return <td className={`graph-legend-value ${valueName}`}>{value}</td>;
+function LegendValue({ value, valueName, asTable, onValueClick }: LegendValueProps) {
+  if (asTable) {
+    return (
+      <td className={`graph-legend-value ${valueName}`} onClick={onValueClick}>
+        {value}
+      </td>
+    );
   }
-  return <div className={`graph-legend-value ${valueName}`}>{value}</div>;
+  return (
+    <div className={`graph-legend-value ${valueName}`} onClick={onValueClick}>
+      {value}
+    </div>
+  );
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes clicking on legend for "min/avg/max/total" does not select the metric (#25402)
- makes legend values clickable series toggles by reusing `onLabelClick()` handler by passing it to the LegendValue. applies to both table and non-table legends.

before
![before_legend-label-value](https://user-images.githubusercontent.com/339208/84596797-c465f900-ae2d-11ea-98de-2a8d951ea52d.gif)

after
![after_legend-label-value](https://user-images.githubusercontent.com/339208/84596756-8bc61f80-ae2d-11ea-8ad3-7a138e13221a.gif)

**Which issue(s) this PR fixes**:

Fixes #25402 

**Special notes for your reviewer**:

This patch does have an effect on text selection for legend values (double-click, drag-to-select).  These compound events start as clicks so the series toggles during the operation. This matches the behavior of the legend labels on click, so no change to this behavior was made. 
![after_text-selection](https://user-images.githubusercontent.com/339208/84597053-37bc3a80-ae2f-11ea-8242-fdadfaaf55cd.gif)

