### PR TITLE
Azure Monitor: fixes undefined is not iterable

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
@@ -26,7 +26,7 @@ describe('createSchemaFunctions', () => {
   });
 
   describe('when called and results have no functions', () => {
-    it('then is should return an empty object', () => {
+    it('then it should return an empty object', () => {
       const parser = new ResponseParser({});
 
       const results = parser.createSchemaFunctions();

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
@@ -1,0 +1,37 @@
+import ResponseParser from './response_parser';
+import { expect } from '../../../../../test/lib/common';
+
+describe('createSchemaFunctions', () => {
+  describe('when called and results have functions', () => {
+    it('then is should return correct result', () => {
+      const functions = [
+        { name: 'some name', body: 'some body', displayName: 'some displayName', category: 'some category' },
+      ];
+      const parser = new ResponseParser({ functions });
+
+      const results = parser.createSchemaFunctions();
+
+      expect(results).toEqual({
+        ['some name']: {
+          Body: 'some body',
+          DocString: 'some displayName',
+          Folder: 'some category',
+          FunctionKind: 'Unknown',
+          InputParameters: [],
+          Name: 'some name',
+          OutputColumns: [],
+        },
+      });
+    });
+  });
+
+  describe('when called and results have no functions', () => {
+    it('then is should return an empty object', () => {
+      const parser = new ResponseParser({});
+
+      const results = parser.createSchemaFunctions();
+
+      expect(results).toEqual({});
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.test.ts
@@ -3,7 +3,7 @@ import { expect } from '../../../../../test/lib/common';
 
 describe('createSchemaFunctions', () => {
   describe('when called and results have functions', () => {
-    it('then is should return correct result', () => {
+    it('then it should return correct result', () => {
       const functions = [
         { name: 'some name', body: 'some body', displayName: 'some displayName', category: 'some category' },
       ];

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
@@ -1,15 +1,14 @@
 import _ from 'lodash';
-import { dateTime } from '@grafana/data';
+import { AnnotationEvent, dateTime, TimeSeries } from '@grafana/data';
 import {
-  AzureLogsVariable,
   AzureLogsTableData,
+  AzureLogsVariable,
+  KustoColumn,
   KustoDatabase,
   KustoFunction,
-  KustoTable,
   KustoSchema,
-  KustoColumn,
+  KustoTable,
 } from '../types';
-import { TimeSeries, AnnotationEvent } from '@grafana/data';
 
 export default class ResponseParser {
   columns: string[];
@@ -190,6 +189,9 @@ export default class ResponseParser {
 
   createSchemaFunctions(): { [key: string]: KustoFunction } {
     const functions: { [key: string]: KustoFunction } = {};
+    if (!this.results.functions) {
+      return functions;
+    }
 
     for (const func of this.results.functions) {
       functions[func.name] = {


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason the `functions` part of Azure results can be undefined. This PR remedy the error message that is a result of this api behaviour.

**Which issue(s) this PR fixes**:
Fixes #19944

**Special notes for your reviewer**:

