### PR TITLE
TextPanel: Removes text mode

### DIFF
--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -14,7 +14,6 @@ export const plugin = new PanelPlugin<TextOptions>(TextPanel)
         settings: {
           options: [
             { value: 'markdown', label: 'Markdown' },
-            { value: 'text', label: 'Text' },
             { value: 'html', label: 'HTML' },
           ],
         },

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -6,6 +6,7 @@
   "skipDataQuery": true,
 
   "info": {
+    "version": "7.1.0",
     "author": {
       "name": "Grafana Labs",
       "url": "https://grafana.com"

--- a/public/app/plugins/panel/text/textPanelMigrationHandler.test.ts
+++ b/public/app/plugins/panel/text/textPanelMigrationHandler.test.ts
@@ -40,4 +40,28 @@ describe('textPanelMigrationHandler', () => {
       expect(result.mode).toEqual('markdown');
     });
   });
+
+  describe('when invoked and previous version was using text mode', () => {
+    it('then should switch to markdown', () => {
+      const panel: PanelModel<TextOptions> = {
+        id: 1,
+        fieldConfig: ({} as unknown) as FieldConfigSource,
+        options: {
+          content: `# Title
+
+        For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)
+      `,
+          mode: 'text',
+        },
+      };
+
+      const result = textPanelMigrationHandler(panel);
+
+      expect(result.content).toEqual(`# Title
+
+        For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)
+      `);
+      expect(result.mode).toEqual('markdown');
+    });
+  });
 });

--- a/public/app/plugins/panel/text/textPanelMigrationHandler.ts
+++ b/public/app/plugins/panel/text/textPanelMigrationHandler.ts
@@ -11,5 +11,9 @@ export const textPanelMigrationHandler = (panel: PanelModel<TextOptions>): Parti
     return { content, mode };
   }
 
-  return panel.options as TextOptions;
+  if (panel.options.mode === 'text') {
+    return { content: panel.options.content, mode: 'markdown' };
+  }
+
+  return panel.options;
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the mode `text` on Text Panel and migrates any usages to `markdown` mode instead.

**Which issue(s) this PR fixes**:
Relates #25004

**Special notes for your reviewer**:

