### PR TITLE
CloudWatch Logs: Adds template variable support to log groups

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
@@ -12,7 +12,7 @@ import { CloudWatchLanguageProvider } from '../language_provider';
 import CloudWatchLink from './CloudWatchLink';
 import { css } from 'emotion';
 
-type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery>;
+type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery> & { allowCustomValue?: boolean };
 
 const labelClass = css`
   margin-left: 3px;
@@ -20,7 +20,7 @@ const labelClass = css`
 `;
 
 export const CloudWatchLogsQueryEditor = memo(function CloudWatchLogsQueryEditor(props: Props) {
-  const { query, data, datasource, onRunQuery, onChange, exploreId, exploreMode } = props;
+  const { query, data, datasource, onRunQuery, onChange, exploreId, exploreMode, allowCustomValue } = props;
 
   let absolute: AbsoluteTimeRange;
   if (data?.request?.range?.from) {
@@ -55,6 +55,7 @@ export const CloudWatchLogsQueryEditor = memo(function CloudWatchLogsQueryEditor
       absoluteRange={absolute}
       syntaxLoaded={isSyntaxReady}
       syntax={syntax}
+      allowCustomValue={allowCustomValue}
       ExtraFieldElement={
         <FormLabel className={`gf-form-label--btn ${labelClass}`} width="auto" tooltip="Link to Graph in AWS">
           <CloudWatchLink query={query as CloudWatchLogsQuery} panelData={data} datasource={datasource} />

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
@@ -20,7 +20,7 @@ const labelClass = css`
 `;
 
 export const CloudWatchLogsQueryEditor = memo(function CloudWatchLogsQueryEditor(props: Props) {
-  const { query, data, datasource, onRunQuery, onChange, exploreId, exploreMode, allowCustomValue } = props;
+  const { query, data, datasource, onRunQuery, onChange, exploreId, exploreMode, allowCustomValue = false } = props;
 
   let absolute: AbsoluteTimeRange;
   if (data?.request?.range?.from) {

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -133,7 +133,9 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
 
     // No need to fetch matching log groups if the search term isn't valid
     // This is also useful for preventing searches when a user is typing out a log group with template vars
-    if (!/^[\.\-_/#A-Za-z0-9]+$/.test(searchTerm)) {
+    // See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_LogGroup.html for the source of the pattern below
+    const logGroupNamePattern = /^[\.\-_/#A-Za-z0-9]+$/;
+    if (!logGroupNamePattern.test(searchTerm)) {
       return Promise.resolve();
     }
 

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -207,28 +207,22 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
     }
   };
 
-  setSelectedLogGroups = (v: Array<SelectableValue<string>>) => {
+  setSelectedLogGroups = (selectedLogGroups: Array<SelectableValue<string>>) => {
     this.setState({
-      selectedLogGroups: v,
+      selectedLogGroups,
     });
 
     const { onChange, query } = this.props;
-
-    if (onChange) {
-      const nextQuery = {
-        ...query,
-        logGroupNames: v.map(logGroupName => logGroupName.value!) ?? [],
-      };
-
-      onChange(nextQuery);
-    }
+    onChange?.({
+      ...(query as CloudWatchLogsQuery),
+      logGroupNames: selectedLogGroups.map(logGroupName => logGroupName.value!) ?? [],
+    });
   };
 
   setCustomLogGroups = (v: string) => {
     const customLogGroup: SelectableValue<string> = { value: v, label: v };
-    this.setState({
-      selectedLogGroups: [...this.state.selectedLogGroups, customLogGroup],
-    });
+    const selectedLogGroups = [...this.state.selectedLogGroups, customLogGroup];
+    this.setSelectedLogGroups(selectedLogGroups);
   };
 
   setSelectedRegion = async (v: SelectableValue<string>) => {

--- a/public/app/plugins/datasource/cloudwatch/components/PanelQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/PanelQueryEditor.tsx
@@ -30,7 +30,11 @@ export class PanelQueryEditor extends PureComponent<Props> {
             }
           />
         </QueryInlineField>
-        {apiMode === ExploreMode.Logs ? <LogsQueryEditor {...this.props} /> : <MetricsQueryEditor {...this.props} />}
+        {apiMode === ExploreMode.Logs ? (
+          <LogsQueryEditor {...this.props} allowCustomValue />
+        ) : (
+          <MetricsQueryEditor {...this.props} />
+        )}
       </>
     );
   }

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -580,6 +580,13 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
         }
         query.region = this.replace(query.region, scopedVars, true, 'region');
         query.region = this.getActualRegion(query.region);
+
+        // interpolate log groups
+        if (query.logGroupNames) {
+          query.logGroupNames = query.logGroupNames.map((logGroup: string) =>
+            this.replace(logGroup, scopedVars, true, 'log groups')
+          );
+        }
       });
     }
 

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -163,6 +163,7 @@ describe('CloudWatchDatasource', () => {
         ],
       });
     });
+
     it('should stop querying when no more data retrieved past max attempts', async () => {
       const fakeFrames = genMockFrames(10);
       for (let i = 7; i < fakeFrames.length; i++) {
@@ -242,6 +243,21 @@ describe('CloudWatchDatasource', () => {
         state: 'Done',
       });
       expect(i).toBe(3);
+    });
+
+    it('should call the replace method on provided log groups', () => {
+      const replaceSpy = jest.spyOn(ctx.ds, 'replace').mockImplementation((target: string) => target);
+      ctx.ds.makeLogActionRequest('StartQuery', [
+        {
+          queryString: 'test query string',
+          region: 'default',
+          logGroupNames: ['log-group', '${my_var}Variable', 'Cool${other_var}'],
+        },
+      ]);
+
+      expect(replaceSpy).toBeCalledWith('log-group', undefined, true, 'log groups');
+      expect(replaceSpy).toBeCalledWith('${my_var}Variable', undefined, true, 'log groups');
+      expect(replaceSpy).toBeCalledWith('Cool${other_var}', undefined, true, 'log groups');
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Lets a user enter custom values into the log groups selector, which are then interpolated with any template variable values.

**Which issue(s) this PR fixes**:
Closes #25099 
Closes https://github.com/grafana/grafana/issues/25185