### PR TITLE
Build: fixed failing test

### DIFF
--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -91,7 +91,7 @@ describe('GraphCtrl', () => {
     });
 
     it('should set datapointsOutside', () => {
-      expect(ctx.ctrl.dataWarning).toBe(null);
+      expect(ctx.ctrl.dataWarning).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I introduced a failing test when fixing strict null errors.