### PR TITLE
CircleCI: Upgrade Grafana build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,13 @@ executors:
       - image: cimg/base:stable
   node:
     docker:
-      - image: cimg/node:12.16
+      - image: cimg/node:12.18
   go:
     docker:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.19
+      - image: grafana/build-container:1.2.20
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.19"
+_version="1.2.20"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the Grafana build image in CircleCI config to 1.2.20. Also upgrade Node image to 12.18.