### PR TITLE
cloudwatch: avoid sorting the result

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -66,7 +66,6 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 	for k := range metricDataResults {
 		metricDataResultLabels = append(metricDataResultLabels, k)
 	}
-	sort.Strings(metricDataResultLabels)
 
 	partialData := false
 	result := tsdb.TimeSeriesSlice{}


### PR DESCRIPTION
Grafana should respect the returned sort order
by default. If the users wants another order
we should use transformations to change it.

fixes #25494