### PR TITLE
Show the add new channel button when a user has no notifications

### DIFF
--- a/public/app/features/alerting/NotificationsListPage.tsx
+++ b/public/app/features/alerting/NotificationsListPage.tsx
@@ -49,14 +49,14 @@ const NotificationsListPage: FC = () => {
     <Page navModel={navModel}>
       <Page.Contents>
         {state.error && <p>{state.error}</p>}
+        <div className="page-action-bar">
+          <div className="page-action-bar__spacer" />
+          <LinkButton icon="channel-add" href="alerting/notification/new">
+            New channel
+          </LinkButton>
+        </div>
         {!!notifications.length && (
           <>
-            <div className="page-action-bar">
-              <div className="page-action-bar__spacer" />
-              <LinkButton icon="channel-add" href="alerting/notification/new">
-                New channel
-              </LinkButton>
-            </div>
             <table className="filter-table filter-table--hover">
               <thead>
                 <tr>


### PR DESCRIPTION
**What this PR does / why we need it**:
Show the add notification channel button also when there are no notification channels

**Which issue(s) this PR fixes**:
Users without notifications don't see the add notification button

