### PR TITLE
Quick fix on default license_path in docs

### DIFF
--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -76,7 +76,7 @@ To purchase or obtain a trial license contact the Grafana Labs [Sales Team](http
 
 To download your Grafana Enterprise license log in to your [Grafana Cloud Account](https://grafana.com) and go to your **Org Profile**. In the side menu there is a section for Grafana Enterprise licenses. At the bottom of the license details page there is **Download Token** link that will download the *license.jwt* file containing your license.
 
-Place the *license.jwt* file in Grafana's data folder. This is usually located at `/var/lib/grafana/data` on Linux systems.
+Place the *license.jwt* file in Grafana's data folder. This is usually located at `/var/lib/grafana` on Linux systems.
 
 You can also configure a custom location for the license file via the ini setting:
 


### PR DESCRIPTION
Current text:

Place the *license.jwt* file in Grafana's data folder. This is usually located at `/var/lib/grafana/data` on Linux systems.

Fix:

`/var/lib/grafana/data` → `/var/lib/grafana`