### PR TITLE
Influx: move token to 'enable flux' section within config editor

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -68,6 +68,19 @@ export class ConfigEditor extends PureComponent<Props> {
             <>
               <div className="gf-form-inline">
                 <div className="gf-form">
+                  <SecretFormField
+                    isConfigured={(secureJsonFields && secureJsonFields.token) as boolean}
+                    value={secureJsonData.token || ''}
+                    label="Token"
+                    labelWidth={10}
+                    inputWidth={20}
+                    onReset={this.onResetPassword}
+                    onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'token')}
+                  />
+                </div>
+              </div>
+              <div className="gf-form-inline">
+                <div className="gf-form">
                   <InlineFormLabel className="width-10">Organization</InlineFormLabel>
                   <div className="width-10">
                     <Input
@@ -132,19 +145,6 @@ export class ConfigEditor extends PureComponent<Props> {
                 inputWidth={20}
                 onReset={this.onResetPassword}
                 onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'password')}
-              />
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <SecretFormField
-                isConfigured={(secureJsonFields && secureJsonFields.token) as boolean}
-                value={secureJsonData.token || ''}
-                label="Token"
-                labelWidth={10}
-                inputWidth={20}
-                onReset={this.onResetPassword}
-                onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'token')}
               />
             </div>
           </div>

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -60,7 +60,7 @@ export class ConfigEditor extends PureComponent<Props> {
               labelClass="width-10"
               checked={options.jsonData.enableFlux || false}
               onChange={this.onToggleFlux}
-              tooltip="Suport flux query endpoint"
+              tooltip="Support flux query endpoint"
             />
           </div>
 

--- a/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -118,22 +118,6 @@ exports[`Render should disable basic auth password input 1`] = `
       <div
         className="gf-form"
       >
-        <SecretFormField
-          inputWidth={20}
-          label="Token"
-          labelWidth={10}
-          onChange={[Function]}
-          onReset={[Function]}
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
         <Component
           className="width-10"
           tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
@@ -349,22 +333,6 @@ exports[`Render should hide basic auth fields when switch off 1`] = `
         <SecretFormField
           inputWidth={20}
           label="Password"
-          labelWidth={10}
-          onChange={[Function]}
-          onReset={[Function]}
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <SecretFormField
-          inputWidth={20}
-          label="Token"
           labelWidth={10}
           onChange={[Function]}
           onReset={[Function]}
@@ -606,22 +574,6 @@ exports[`Render should hide white listed cookies input when browser access chose
       <div
         className="gf-form"
       >
-        <SecretFormField
-          inputWidth={20}
-          label="Token"
-          labelWidth={10}
-          onChange={[Function]}
-          onReset={[Function]}
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
         <Component
           className="width-10"
           tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
@@ -837,22 +789,6 @@ exports[`Render should render component 1`] = `
         <SecretFormField
           inputWidth={20}
           label="Password"
-          labelWidth={10}
-          onChange={[Function]}
-          onReset={[Function]}
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <SecretFormField
-          inputWidth={20}
-          label="Token"
           labelWidth={10}
           onChange={[Function]}
           onReset={[Function]}

--- a/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Render should disable basic auth password input 1`] = `
         label="Enable flux"
         labelClass="width-10"
         onChange={[Function]}
-        tooltip="Suport flux query endpoint"
+        tooltip="Support flux query endpoint"
       />
     </div>
     <div
@@ -277,7 +277,7 @@ exports[`Render should hide basic auth fields when switch off 1`] = `
         label="Enable flux"
         labelClass="width-10"
         onChange={[Function]}
-        tooltip="Suport flux query endpoint"
+        tooltip="Support flux query endpoint"
       />
     </div>
     <div
@@ -505,7 +505,7 @@ exports[`Render should hide white listed cookies input when browser access chose
         label="Enable flux"
         labelClass="width-10"
         onChange={[Function]}
-        tooltip="Suport flux query endpoint"
+        tooltip="Support flux query endpoint"
       />
     </div>
     <div
@@ -733,7 +733,7 @@ exports[`Render should render component 1`] = `
         label="Enable flux"
         labelClass="width-10"
         onChange={[Function]}
-        tooltip="Suport flux query endpoint"
+        tooltip="Support flux query endpoint"
       />
     </div>
     <div


### PR DESCRIPTION
The token is only used for Flux as I understand it, so this move that config item.

Part of collection of misc flux items in #25547
