### PR TITLE
Datasources: add new tab and feature toggle

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -38,6 +38,7 @@ export interface FeatureToggles {
    * Available only in Grafana Enterprise
    */
   meta: boolean;
+  datasourceInsights: boolean;
 }
 
 /**

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -52,6 +52,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     expressions: false,
     newEdit: false,
     meta: false,
+    datasourceInsights: false,
   };
   licenseInfo: LicenseInfo = {} as LicenseInfo;
   rendererAvailable = false;

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -54,7 +54,7 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
       url: `datasources/edit/${dataSource.id}/permissions`,
     });
 
-    if (config.featureToggles.dataSourceInsights) {
+    if (config.featureToggles.datasourceInsights) {
       navModel.children.push({
         active: false,
         icon: 'info-circle',

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -53,6 +53,16 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
       text: 'Permissions',
       url: `datasources/edit/${dataSource.id}/permissions`,
     });
+
+    if (config.featureToggles.dataSourceInsights) {
+      navModel.children.push({
+        active: false,
+        icon: 'info-circle',
+        id: `datasource-insights-${dataSource.id}`,
+        text: 'Insights',
+        url: `datasources/edit/${dataSource.id}/insights`,
+      });
+    }
   }
 
   return navModel;


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new tab and a feature toggle to enable a new Enterprise feature (Datasource Insights)
