### PR TITLE
Influx/flux: include interpolated query with error for query inspector

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -25,6 +25,11 @@ func ExecuteQuery(ctx context.Context, query QueryModel, runner queryRunner, max
 	tables, err := runner.runQuery(ctx, flux)
 	if err != nil {
 		dr.Error = err
+		metaFrame := data.NewFrame("meta for error")
+		metaFrame.Meta = &data.FrameMeta{
+			ExecutedQueryString: flux,
+		}
+		dr.Frames = append(dr.Frames, metaFrame)
 		return
 	}
 

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -90,10 +90,7 @@ func RunnerFromDataSource(dsInfo *models.DataSource) (*Runner, error) {
 func backendDataResponseToTSDBResponse(dr *backend.DataResponse, refID string) *tsdb.QueryResult {
 	qr := &tsdb.QueryResult{RefId: refID}
 
-	if dr.Error != nil {
-		qr.Error = dr.Error
-		return qr
-	}
+	qr.Error = dr.Error
 
 	if dr.Frames != nil {
 		qr.Dataframes = tsdb.NewDecodedDataFrames(dr.Frames)

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -66,7 +66,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       }
     }
 
-    // Proces flux queries (data frame request)
+    // Process flux queries (data frame request)
     if (hasFlux) {
       if (!this.enableFlux) {
         throw 'Flux not enabled for this datasource';


### PR DESCRIPTION
that includes a Frame with meta and the ExecutedQueryString.
part of #25547

**Special notes for your reviewer**:

This is a bit icky. I think we may say somewhere in error handling either return an error or a Frame (need to look into this), which doesn't work out well here. This is general area of some inconsistency we ended up with between the frontend and backend for data queries.

That being said it works. With this change you can now see the interpolated query even when there is an error executing that interpolated string.