### PR TITLE
Types: add reportGrid to the feature toggles

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -40,6 +40,7 @@ export interface FeatureToggles {
    */
   meta: boolean;
   datasourceInsights: boolean;
+  reportGrid: boolean;
 }
 
 /**

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -54,6 +54,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     newEdit: false,
     meta: false,
     datasourceInsights: false,
+    reportGrid: false,
   };
   licenseInfo: LicenseInfo = {} as LicenseInfo;
   rendererAvailable = false;


### PR DESCRIPTION
This PR adds `reportGrid` feature toggle to the types. This feature recently introduced in Enterprise, and we need this for further work on the frontend part.