### PR TITLE
Grafana UI: Apply disabled styles to LinkButton

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.story.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { select, text } from '@storybook/addon-knobs';
+import { select, text, boolean } from '@storybook/addon-knobs';
 import { Button, ButtonVariant } from './Button';
 import { withCenteredStory, withHorizontallyCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { getIconKnob } from '../../utils/storybook/knobs';
@@ -24,11 +24,11 @@ const sizes = ['sm', 'md', 'lg'];
 export const simple = () => {
   const variant = select('Variant', variants, 'primary');
   const size = select('Size', sizes, 'md');
-  const buttonText = text('text', 'Button');
+  const buttonText = text('Text', 'Button');
+  const disabled = boolean('Disabled', false);
   const icon = getIconKnob();
-
   return (
-    <Button variant={variant as ButtonVariant} size={size as ComponentSize} icon={icon}>
+    <Button variant={variant as ButtonVariant} size={size as ComponentSize} icon={icon} disabled={disabled}>
       {buttonText}
     </Button>
   );

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -182,7 +182,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 
     return (
       <a
-        className={cx(styles.button, className, linkButtonStyles)}
+        className={cx(styles.button, linkButtonStyles, className)}
         {...otherProps}
         ref={ref}
         tabIndex={disabled ? -1 : 0}

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -72,6 +72,12 @@ export interface StyleProps {
   hasText: boolean;
 }
 
+const disabledStyles = css`
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+`;
+
 export const getButtonStyles = stylesFactory((props: StyleProps) => {
   const { theme, variant } = props;
   const { padding, fontSize, height } = getPropertiesForButtonSize(props);
@@ -98,9 +104,7 @@ export const getButtonStyles = stylesFactory((props: StyleProps) => {
 
         &[disabled],
         &:disabled {
-          cursor: not-allowed;
-          opacity: 0.65;
-          box-shadow: none;
+          ${disabledStyles};
         }
       `,
       getFocusStyle(theme),
@@ -157,7 +161,7 @@ Button.displayName = 'Button';
 
 type ButtonLinkProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement>;
 export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
-  ({ variant, icon, children, className, ...otherProps }, ref) => {
+  ({ variant, icon, children, className, disabled, ...otherProps }, ref) => {
     const theme = useContext(ThemeContext);
     const styles = getButtonStyles({
       theme,
@@ -167,8 +171,22 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       hasIcon: icon !== undefined,
     });
 
+    const linkButtonStyles =
+      disabled &&
+      cx(
+        disabledStyles,
+        css`
+          pointer-events: none;
+        `
+      );
+
     return (
-      <a className={cx(styles.button, className)} {...otherProps} ref={ref}>
+      <a
+        className={cx(styles.button, className, linkButtonStyles)}
+        {...otherProps}
+        ref={ref}
+        tabIndex={disabled ? -1 : 0}
+      >
         <ButtonContent icon={icon} size={otherProps.size}>
           {children}
         </ButtonContent>

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -138,7 +138,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       white-space: pre-wrap;
       word-break: break-all;
     `,
-    //Log details sepcific CSS
+    //Log details specific CSS
     logDetailsContainer: css`
       label: logs-row-details-table;
       border: 1px solid ${borderColor};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently there is no way to disable `LinkButton` since it's using `a` tag, for which `disabled` attribute doesn't work. In order to actually disable `LinkButton` we need to manually apply disabled styles and remove pointer events + tabindex to make it un-clickable. 
