### PR TITLE
Units: Match 'length' case with other categories

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -259,7 +259,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     ],
   },
   {
-    name: 'length',
+    name: 'Length',
     formats: [
       { name: 'millimeter (mm)', id: 'lengthmm', fn: decimalSIPrefix('m', -1) },
       { name: 'feet (ft)', id: 'lengthft', fn: toFixedUnit('ft') },


### PR DESCRIPTION
**What this PR does / why we need it**: This PR is changing the `length` category to `Length`, because it was the only unit category starting with a lowercase letter.

Just a tiny PR, but this really bugged me.
