### PR TITLE
Loki: Allow aliasing Loki queries in dashboard

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -6,6 +6,17 @@ import { LokiQueryEditor } from './LokiQueryEditor';
 import { LokiDatasource } from '../datasource';
 import { LokiQuery } from '../types';
 
+const createMockRequestRange = (from: string, to: string) => {
+  return {
+    request: {
+      range: {
+        from: toUtc(from, 'YYYY-MM-DD'),
+        to: toUtc(to, 'YYYY-MM-DD'),
+      },
+    },
+  };
+};
+
 const setup = (propOverrides?: object) => {
   const datasourceMock: unknown = {};
   const datasource: LokiDatasource = datasourceMock as LokiDatasource;
@@ -18,14 +29,7 @@ const setup = (propOverrides?: object) => {
     legendFormat: 'My Legend',
   };
 
-  const data: any = {
-    request: {
-      range: {
-        from: toUtc('2020-01-01', 'YYYY-MM-DD'),
-        to: toUtc('2020-01-02', 'YYYY-MM-DD'),
-      },
-    },
-  };
+  const data = createMockRequestRange('2020-01-01', '2020-01-02');
 
   const props: any = {
     datasource,
@@ -49,6 +53,14 @@ const setup = (propOverrides?: object) => {
 describe('Render LokiQueryEditor with legend', () => {
   it('should render', () => {
     const { wrapper } = setup();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should update absolute timerange', () => {
+    const { wrapper } = setup();
+    wrapper.setProps({
+      data: createMockRequestRange('2019-01-01', '2020-01-02'),
+    });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { toUtc } from '@grafana/data';
+
+import { LokiQueryEditor } from './LokiQueryEditor';
+import { LokiDatasource } from '../datasource';
+import { LokiQuery } from '../types';
+
+const setup = (propOverrides?: object) => {
+  const datasourceMock: unknown = {};
+  const datasource: LokiDatasource = datasourceMock as LokiDatasource;
+  const onRunQuery = jest.fn();
+  const onChange = jest.fn();
+
+  const query: LokiQuery = {
+    expr: '',
+    refId: 'A',
+    legendFormat: 'My Legend',
+  };
+
+  const data: any = {
+    request: {
+      range: {
+        from: toUtc('2020-01-01', 'YYYY-MM-DD'),
+        to: toUtc('2020-01-02', 'YYYY-MM-DD'),
+      },
+    },
+  };
+
+  const props: any = {
+    datasource,
+    onChange,
+    onRunQuery,
+    query,
+    data,
+  };
+
+  Object.assign(props, propOverrides);
+
+  const wrapper = shallow(<LokiQueryEditor {...props} />);
+  const instance = wrapper.instance() as LokiQueryEditor;
+
+  return {
+    instance,
+    wrapper,
+  };
+};
+
+describe('Render LokiQueryEditor with legend', () => {
+  it('should render', () => {
+    const { wrapper } = setup();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -1,45 +1,107 @@
 // Libraries
-import React, { memo } from 'react';
+import React, { PureComponent } from 'react';
 
 // Types
 import { AbsoluteTimeRange, QueryEditorProps } from '@grafana/data';
+import { InlineFormLabel } from '@grafana/ui';
 import { LokiDatasource } from '../datasource';
 import { LokiQuery } from '../types';
 import { LokiQueryField } from './LokiQueryField';
 
 type Props = QueryEditorProps<LokiDatasource, LokiQuery>;
 
-export const LokiQueryEditor = memo(function LokiQueryEditor(props: Props) {
-  const { query, data, datasource, onChange, onRunQuery } = props;
+interface State {
+  legendFormat: string;
+}
 
-  let absolute: AbsoluteTimeRange;
+export class LokiQueryEditor extends PureComponent<Props, State> {
+  // Query target to be modified and used for queries
+  query: LokiQuery;
 
-  if (data && data.request) {
-    const { range } = data.request;
-    absolute = {
-      from: range.from.valueOf(),
-      to: range.to.valueOf(),
+  absolute: AbsoluteTimeRange;
+
+  constructor(props: Props) {
+    super(props);
+    // Use default query to prevent undefined input values
+    const defaultQuery: Partial<LokiQuery> = { expr: '', legendFormat: '' };
+    const query = Object.assign({}, defaultQuery, props.query);
+    this.query = query;
+    // Query target properties that are fully controlled inputs
+    this.state = {
+      // Fully controlled text inputs
+      legendFormat: query.legendFormat,
     };
-  } else {
-    absolute = {
-      from: Date.now() - 10000,
-      to: Date.now(),
-    };
+
+    const { data } = this.props;
+
+    if (data && data.request) {
+      const { range } = data.request;
+      this.absolute = {
+        from: range.from.valueOf(),
+        to: range.to.valueOf(),
+      };
+    } else {
+      this.absolute = {
+        from: Date.now() - 10000,
+        to: Date.now(),
+      };
+    }
   }
 
-  return (
-    <div>
-      <LokiQueryField
-        datasource={datasource}
-        query={query}
-        onChange={onChange}
-        onRunQuery={onRunQuery}
-        history={[]}
-        data={data}
-        absoluteRange={absolute}
-      />
-    </div>
-  );
-});
+  onFieldChange = (query: LokiQuery, override?: any) => {
+    this.query.expr = query.expr;
+  };
+
+  onLegendChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const legendFormat = e.currentTarget.value;
+    this.query.legendFormat = legendFormat;
+    this.setState({ legendFormat });
+  };
+
+  onRunQuery = () => {
+    const { query } = this;
+    this.props.onChange(query);
+    this.props.onRunQuery();
+  };
+
+  render() {
+    const { datasource, query, data } = this.props;
+    const { legendFormat } = this.state;
+
+    return (
+      <div>
+        <LokiQueryField
+          datasource={datasource}
+          query={query}
+          onChange={this.onFieldChange}
+          onRunQuery={this.onRunQuery}
+          history={[]}
+          data={data}
+          absoluteRange={this.absolute}
+        />
+
+        <div className="gf-form-inline">
+          <div className="gf-form">
+            <InlineFormLabel
+              width={7}
+              tooltip="Controls the name of the time series, using name or pattern. For example
+        {{hostname}} will be replaced with label value for the label hostname."
+            >
+              Legend
+            </InlineFormLabel>
+            <input
+              type="text"
+              className="gf-form-input"
+              placeholder="legend format"
+              value={legendFormat}
+              onChange={this.onLegendChange}
+              onBlur={this.onRunQuery}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default LokiQueryEditor;

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -85,7 +85,7 @@ export class LokiQueryEditor extends PureComponent<Props, State> {
             <InlineFormLabel
               width={7}
               tooltip="Controls the name of the time series, using name or pattern. For example
-        {{hostname}} will be replaced with label value for the label hostname."
+        {{hostname}} will be replaced with label value for the label hostname. The legend only applies to metric queries."
             >
               Legend
             </InlineFormLabel>

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 
 // Types
-import { AbsoluteTimeRange, QueryEditorProps } from '@grafana/data';
+import { AbsoluteTimeRange, QueryEditorProps, PanelData } from '@grafana/data';
 import { InlineFormLabel } from '@grafana/ui';
 import { LokiDatasource } from '../datasource';
 import { LokiQuery } from '../types';
@@ -18,8 +18,6 @@ export class LokiQueryEditor extends PureComponent<Props, State> {
   // Query target to be modified and used for queries
   query: LokiQuery;
 
-  absolute: AbsoluteTimeRange;
-
   constructor(props: Props) {
     super(props);
     // Use default query to prevent undefined input values
@@ -31,22 +29,22 @@ export class LokiQueryEditor extends PureComponent<Props, State> {
       // Fully controlled text inputs
       legendFormat: query.legendFormat,
     };
+  }
 
-    const { data } = this.props;
-
+  calcAbsoluteRange = (data: PanelData): AbsoluteTimeRange => {
     if (data && data.request) {
       const { range } = data.request;
-      this.absolute = {
+      return {
         from: range.from.valueOf(),
         to: range.to.valueOf(),
       };
-    } else {
-      this.absolute = {
-        from: Date.now() - 10000,
-        to: Date.now(),
-      };
     }
-  }
+
+    return {
+      from: Date.now() - 10000,
+      to: Date.now(),
+    };
+  };
 
   onFieldChange = (query: LokiQuery, override?: any) => {
     this.query.expr = query.expr;
@@ -77,7 +75,7 @@ export class LokiQueryEditor extends PureComponent<Props, State> {
           onRunQuery={this.onRunQuery}
           history={[]}
           data={data}
-          absoluteRange={this.absolute}
+          absoluteRange={this.calcAbsoluteRange(data)}
         />
 
         <div className="gf-form-inline">

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render LokiQueryEditor with legend should render 1`] = `
+<div>
+  <Component
+    absoluteRange={
+      Object {
+        "from": 1577836800000,
+        "to": 1577923200000,
+      }
+    }
+    data={
+      Object {
+        "request": Object {
+          "range": Object {
+            "from": "2020-01-01T00:00:00.000Z",
+            "to": "2020-01-02T00:00:00.000Z",
+          },
+        },
+      }
+    }
+    datasource={Object {}}
+    history={Array []}
+    onChange={[Function]}
+    onRunQuery={[Function]}
+    query={
+      Object {
+        "expr": "",
+        "legendFormat": "My Legend",
+        "refId": "A",
+      }
+    }
+  />
+  <div
+    className="gf-form-inline"
+  >
+    <div
+      className="gf-form"
+    >
+      <Component
+        tooltip="Controls the name of the time series, using name or pattern. For example
+        {{hostname}} will be replaced with label value for the label hostname."
+        width={7}
+      >
+        Legend
+      </Component>
+      <input
+        className="gf-form-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        placeholder="legend format"
+        type="text"
+        value="My Legend"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
     >
       <Component
         tooltip="Controls the name of the time series, using name or pattern. For example
-        {{hostname}} will be replaced with label value for the label hostname."
+        {{hostname}} will be replaced with label value for the label hostname. The legend only applies to metric queries."
         width={7}
       >
         Legend

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -56,3 +56,60 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
   </div>
 </div>
 `;
+
+exports[`Render LokiQueryEditor with legend should update absolute timerange 1`] = `
+<div>
+  <Component
+    absoluteRange={
+      Object {
+        "from": 1546300800000,
+        "to": 1577923200000,
+      }
+    }
+    data={
+      Object {
+        "request": Object {
+          "range": Object {
+            "from": "2019-01-01T00:00:00.000Z",
+            "to": "2020-01-02T00:00:00.000Z",
+          },
+        },
+      }
+    }
+    datasource={Object {}}
+    history={Array []}
+    onChange={[Function]}
+    onRunQuery={[Function]}
+    query={
+      Object {
+        "expr": "",
+        "legendFormat": "My Legend",
+        "refId": "A",
+      }
+    }
+  />
+  <div
+    className="gf-form-inline"
+  >
+    <div
+      className="gf-form"
+    >
+      <Component
+        tooltip="Controls the name of the time series, using name or pattern. For example
+        {{hostname}} will be replaced with label value for the label hostname. The legend only applies to metric queries."
+        width={7}
+      >
+        Legend
+      </Component>
+      <input
+        className="gf-form-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        placeholder="legend format"
+        type="text"
+        value="My Legend"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -143,8 +143,10 @@ function createUid(ts: string, labelsString: string, line: string): string {
 }
 
 function lokiMatrixToTimeSeries(matrixResult: LokiMatrixResult, options: TransformerOptions): TimeSeries {
+  const name = createMetricLabel(matrixResult.metric, options);
   return {
-    target: createMetricLabel(matrixResult.metric, options),
+    target: name,
+    title: name,
     datapoints: lokiPointsToTimeseriesPoints(matrixResult.values, options),
     tags: matrixResult.metric,
     meta: options.meta,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Allows aliasing Loki metric queries like Prometheus time series.

<img width="880" alt="Screenshot 2020-06-18 at 21 02 01" src="https://user-images.githubusercontent.com/1249775/85061487-2b294080-b1a7-11ea-8bfd-4c5df29be2c0.png">

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #25562
Fixes #24679 

**Special notes for your reviewer**:

