### PR TITLE
Docs: Fix broken link to Slack documentation

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -94,8 +94,8 @@ Addresses | Email addresses to recipients. You can enter multiple email addresse
 To set up Slack, you need to configure an incoming Slack webhook URL. You can follow
 [Sending messages using Incoming Webhooks](https://api.slack.com/incoming-webhooks) on how to do that. If you want to include screenshots of the
 firing alerts in the Slack messages you have to configure either the [external image destination](#external-image-store)
-in Grafana or a bot integration via Slack Apps. Follow Slack's guide to set up a bot integration and use the token
-provided (https://api.slack.com/bot-users), which starts with "xoxb".
+in Grafana or a bot integration via Slack Apps. [Follow Slack's guide to set up a bot integration](https://api.slack.com/bot-users) and use the token
+provided, which starts with "xoxb".
 
 Setting | Description
 ---------- | -----------


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This change fixes a link broken due to link formatting on the docs.

The issue is present here, in the last sentence of the paragraph: https://grafana.com/docs/grafana/latest/alerting/notifications/#slack


**Special notes for your reviewer**:

This seems to be a larger issue with the way the documentation generator handles characters around links. In this example, a link like this: `(https://api.slack.com/bot-users)` is hyperlinked to `https://api.slack.com/bot-users),`

I'd like to defer to the maintainers on whether it's worthwhile to dig into this issue further with Hugo, or to just fix this currently broken link and move on.

Thanks!