### PR TITLE
DataSourceWithBackend: remove unused function

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -134,11 +134,6 @@ export class DataSourceWithBackend<
   processResponse?(res: DataQueryResponse): Promise<DataQueryResponse>;
 
   /**
-   * Optionally process the results for display
-   */
-  processDataFrameResult?(frame: DataFrame, idx: number): Promise<DataFrame>;
-
-  /**
    * Override to skip executing a query
    *
    * @virtual
@@ -146,7 +141,11 @@ export class DataSourceWithBackend<
   filterQuery?(query: TQuery): boolean;
 
   /**
-   * Override to apply template variables
+   * Override to apply template variables.  The result is usually also `TQuery`, but sometimes this can
+   * be used to modify the query structure before sending to the backend.
+   *
+   * NOTE: if you do modify the structure or use template variables, alerting queries may not work
+   * as expected
    *
    * @virtual
    */

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -6,7 +6,6 @@ import {
   DataQuery,
   DataSourceJsonData,
   ScopedVars,
-  DataFrame,
 } from '@grafana/data';
 import { Observable, from, of } from 'rxjs';
 import { config } from '..';


### PR DESCRIPTION
An early version of #25297 used this function to process individual items, but it got replaced with:
```
processResponse?(res: DataQueryResponse): Promise<DataQueryResponse>
```