### PR TITLE
Explore/Loki: Fix context menu log line highlighting

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -217,7 +217,10 @@ export const LogRowContext: React.FunctionComponent<LogRowContextProps> = ({
 
   return (
     <ClickOutsideWrapper onClick={onOutsideClick}>
-      <div>
+      {/* e.stopPropagation is necessary so the log details doesn't open when clicked on log line in context
+       * and/or when context log line is being highlighted
+       */}
+      <div onClick={e => e.stopPropagation()}>
         {context.after && (
           <LogRowContextGroup
             rows={context.after}

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -102,11 +102,6 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
   const theme = useContext(ThemeContext);
   const { header } = getLogRowContextStyles(theme);
 
-  const onClickLoadMore = (event: React.SyntheticEvent) => {
-    event.stopPropagation();
-    onLoadMoreContext();
-  };
-
   return (
     <div className={header}>
       <span
@@ -125,7 +120,7 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
               cursor: pointer;
             }
           `}
-          onClick={onClickLoadMore}
+          onClick={onLoadMoreContext}
         >
           Load 10 more
         </span>

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -213,8 +213,7 @@ export const LogRowContext: React.FunctionComponent<LogRowContextProps> = ({
   return (
     <ClickOutsideWrapper onClick={onOutsideClick}>
       {/* e.stopPropagation is necessary so the log details doesn't open when clicked on log line in context
-       * and/or when context log line is being highlighted
-       */}
+       * and/or when context log line is being highlighted */}
       <div onClick={e => e.stopPropagation()}>
         {context.after && (
           <LogRowContextGroup


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `e.stopPropagation` on the whole context menu, not just its header. This prevents log details to be opened and prevents reseting of the cursor position when log line in context is being highlighted. 

![Kapture 2020-06-21 at 16 15 05](https://user-images.githubusercontent.com/30407135/85226956-770ffb80-b3da-11ea-9058-0c20761a7815.gif)

**Which issue(s) this PR fixes**:

Fixes #25582 

