### PR TITLE
Rich history: Updates for default settings and starred queries deletion

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistory.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.tsx
@@ -88,7 +88,7 @@ class UnThemedRichHistory extends PureComponent<RichHistoryProps, RichHistorySta
       datasourceFilters: store.getObject(RICH_HISTORY_SETTING_KEYS.datasourceFilters, null),
       retentionPeriod: store.getObject(RICH_HISTORY_SETTING_KEYS.retentionPeriod, 7),
       starredTabAsFirstTab: store.getBool(RICH_HISTORY_SETTING_KEYS.starredTabAsFirstTab, false),
-      activeDatasourceOnly: store.getBool(RICH_HISTORY_SETTING_KEYS.activeDatasourceOnly, false),
+      activeDatasourceOnly: store.getBool(RICH_HISTORY_SETTING_KEYS.activeDatasourceOnly, true),
     };
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the feedback and discussion with UX (@jessover9000), we have decided to update:

- Change default setting of “show only queries for current data source” to true
- Double confirm for starred query deletion

![image](https://user-images.githubusercontent.com/30407135/85257545-4fff0b80-b466-11ea-9369-ad1c4908347d.png)

**Which issue(s) this PR fixes**:
Partly https://github.com/grafana/grafana/issues/24630
