### PR TITLE
Users: Changed hardcoded limit from 10 to 50 when getting users to add them into a team

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -64,7 +64,12 @@ func GetOrgUsersForCurrentOrgLookup(c *models.ReqContext) Response {
 		return Error(403, "Permission denied", nil)
 	}
 
-	orgUsers, err := getOrgUsersHelper(c.OrgId, c.Query("query"), c.QueryInt("limit"))
+	limit := c.QueryInt("limit")
+	if limit > 50 {
+		limit = 50
+	}
+
+	orgUsers, err := getOrgUsersHelper(c.OrgId, c.Query("query"), limit)
 	if err != nil {
 		return Error(500, "Failed to get users for current organization", err)
 	}

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -65,8 +65,8 @@ func GetOrgUsersForCurrentOrgLookup(c *models.ReqContext) Response {
 	}
 
 	limit := c.QueryInt("limit")
-	if limit > 50 {
-		limit = 50
+	if limit == 0 || limit > 100 {
+		limit = 100
 	}
 
 	orgUsers, err := getOrgUsersHelper(c.OrgId, c.Query("query"), limit)

--- a/public/app/core/components/Select/UserPicker.tsx
+++ b/public/app/core/components/Select/UserPicker.tsx
@@ -44,7 +44,7 @@ export class UserPicker extends Component<Props, State> {
     }
 
     return getBackendSrv()
-      .get(`/api/org/users/lookup?query=${query}&limit=10`)
+      .get(`/api/org/users/lookup?query=${query}&limit=50`)
       .then((result: any) => {
         return result.map((user: any) => ({
           id: user.userId,

--- a/public/app/core/components/Select/UserPicker.tsx
+++ b/public/app/core/components/Select/UserPicker.tsx
@@ -44,7 +44,7 @@ export class UserPicker extends Component<Props, State> {
     }
 
     return getBackendSrv()
-      .get(`/api/org/users/lookup?query=${query}&limit=50`)
+      .get(`/api/org/users/lookup?query=${query}`)
       .then((result: any) => {
         return result.map((user: any) => ({
           id: user.userId,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there is a bug which limits the returned user list to 10 when calling endpoint `/api/org/users/lookup`, this value is set in the frontend side and it is harcoded.

This limit is considered very low so this PR removes that value from the frontend and fixed it with a max value of 100 in the backend. Also as the limit parameter was removed from frontend site, the parsed limit value will be 0 which in this case the query would be without limits, so I decided to fixed it to 100 when there is no limit parameter or when it is higher that 100.

I know 100 is a subjetive value but it seems more appropiated for this case. Also this is kind of a workaround because a better solution would be to have pagination or selectable limits values, though I don't have much knowledge about the average value of users so perhaps this fine for this case.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/25552

**Special notes for your reviewer**:

I'm new here and I was looking at the code looking for tests with sample data, users for this case for example, but I couldn't find them so any suggestiong about what I can take a look into would be appreciated.
