### PR TITLE
CircleCI: Upgrade build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.11
+            VERSION=0.4.14
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the build pipeline tool in CircleCI to the latest version, in order to remove `es-check es5` check.