### PR TITLE
Docs: Fix alias for time-range-controls.md

### DIFF
--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -1,9 +1,9 @@
 +++
 title = "Time range controls"
 keywords = ["grafana", "dashboard", "documentation", "time range"]
+aliases = ["/docs/grafana/latest/reference/timerange/"]
 type = "docs"
 [menu.docs]
-aliases = ["/docs/grafana/latest/reference/timerange/"]
 name = "Time range controls"
 parent = "dashboards"
 weight = 7


### PR DESCRIPTION
Moved the alias metadata up in the metadata list to fix a 404 link error in Google search results.