### PR TITLE
Notifications: use reply-to option for emails

### DIFF
--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -183,6 +183,7 @@ func (ns *NotificationService) buildEmailMessage(cmd *models.SendEmailCommand) (
 		Body:          buffer.String(),
 		EmbeddedFiles: cmd.EmbeddedFiles,
 		AttachedFiles: buildAttachedFiles(cmd.AttachedFiles),
+		ReplyTo:       cmd.ReplyTo,
 	}, nil
 }
 

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -126,6 +126,7 @@ func (ns *NotificationService) sendEmailCommandHandlerSync(ctx context.Context, 
 		SingleEmail:   cmd.SingleEmail,
 		EmbeddedFiles: cmd.EmbeddedFiles,
 		Subject:       cmd.Subject,
+		ReplyTo:       cmd.ReplyTo,
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the `ReplyTo` field from the `SendEmailCommand` when sending emails from Grafana.

*Notes for reviewers:*
This is a parameter that can be set for the Reporting feature but we cannot use it without this fix.

