### PR TITLE
Azure Logs: use executedQueryString in metadata

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -44,7 +44,6 @@ export interface QueryResultMeta {
    * */
   gmdMeta?: any[]; // used by cloudwatch
   alignmentPeriod?: string; // used by stackdriver
-  query?: string; // used by azure log
   searchWords?: string[]; // used by log models and loki
   limit?: number; // used by log models and loki
   json?: boolean; // used to keep track of old json doc values

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
@@ -65,7 +65,7 @@ export default class ResponseParser {
       bucket.datapoints.push([row[valueIndex], epoch]);
       bucket.refId = query.refId;
       bucket.meta = {
-        query: query.query,
+        executedQueryString: query.query,
       };
     });
 
@@ -81,7 +81,7 @@ export default class ResponseParser {
       rows: rows,
       refId: query.refId,
       meta: {
-        query: query.query,
+        executedQueryString: query.query,
       },
     };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData, DataSourceSettings } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, DataSourceSettings, TableData } from '@grafana/data';
 
 export type AzureDataSourceSettings = DataSourceSettings<AzureDataSourceJsonData, AzureDataSourceSecureJsonData>;
 
@@ -124,14 +124,10 @@ export interface AzureLogsVariable {
   value: string;
 }
 
-export interface AzureLogsTableData {
+export interface AzureLogsTableData extends TableData {
   columns: AzureLogsTableColumn[];
   rows: any[];
   type: string;
-  refId: string;
-  meta: {
-    query: string;
-  };
 }
 
 export interface AzureLogsTableColumn {


### PR DESCRIPTION
In the slow quest to remove the one-off metadata keys: #21429