### PR TITLE
InfluxDB: add executedQueryString metadata for InfluxQL

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -309,16 +309,20 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return super
         .query(request)
         .toPromise()
-        .then((res: any) => {
-          const data: DataQueryResponse = res.data;
-          if (data && data.state === LoadingState.Done) {
-            const buckets = data.data[0].length;
-            return { status: 'success', message: `Data source is working (${buckets} buckets)` };
+        .then((res: DataQueryResponse) => {
+          if (!res || !res.data || res.state !== LoadingState.Done) {
+            console.log('InfluxDB Error', res);
+            return { status: 'error', message: 'Error reading InfluxDB' };
           }
-          console.log('InfluxDB Error', data);
+          const first = res.data[0];
+          if (first && first.length) {
+            return { status: 'success', message: `${first.length} buckets found` };
+          }
+          console.log('InfluxDB Error', res);
           return { status: 'error', message: 'Error reading buckets' };
         })
         .catch((err: any) => {
+          console.log('InfluxDB Error', err);
           return { status: 'error', message: err.message };
         });
     }

--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -1,20 +1,24 @@
 import _ from 'lodash';
 import TableModel from 'app/core/table_model';
-import { FieldType } from '@grafana/data';
+import { FieldType, QueryResultMeta, TimeSeries, TableData } from '@grafana/data';
 
 export default class InfluxSeries {
+  refId: string;
   series: any;
   alias: any;
   annotation: any;
+  meta?: QueryResultMeta;
 
-  constructor(options: { series: any; alias?: any; annotation?: any }) {
+  constructor(options: { series: any; alias?: any; annotation?: any; meta?: QueryResultMeta; refId?: string }) {
     this.series = options.series;
     this.alias = options.alias;
     this.annotation = options.annotation;
+    this.meta = options.meta;
+    this.refId = options.refId;
   }
 
-  getTimeSeries() {
-    const output: any[] = [];
+  getTimeSeries(): TimeSeries[] {
+    const output: TimeSeries[] = [];
     let i, j;
 
     if (this.series.length === 0) {
@@ -47,7 +51,7 @@ export default class InfluxSeries {
           }
         }
 
-        output.push({ target: seriesName, datapoints: datapoints });
+        output.push({ target: seriesName, datapoints: datapoints, meta: this.meta, refId: this.refId });
       }
     });
 
@@ -143,9 +147,12 @@ export default class InfluxSeries {
     return list;
   }
 
-  getTable() {
+  getTable(): TableData {
     const table = new TableModel();
     let i, j;
+
+    table.refId = this.refId;
+    table.meta = this.meta;
 
     if (this.series.length === 0) {
       return table;


### PR DESCRIPTION
This is not totally necessary since the HTTP request shows the value -- however, I think it is nice to have it in the same place:

![image](https://user-images.githubusercontent.com/705951/85477486-444b3c00-b56f-11ea-8f5e-90380495ba50.png)

This also adds some more strict types for InfluxSeries