### PR TITLE
Variables: Always Make timeRange Available in MetricFindQuery

### DIFF
--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -27,10 +27,7 @@ export const updateQueryVariableOptions = (
         dispatch(removeVariableEditorError({ errorProp: 'update' }));
       }
       const dataSource = await getDatasourceSrv().get(variableInState.datasource ?? '');
-      const queryOptions: any = { range: undefined, variable: variableInState, searchFilter };
-      if (variableInState.refresh === VariableRefresh.onTimeRangeChanged) {
-        queryOptions.range = getTimeSrv().timeRange();
-      }
+      const queryOptions: any = { range: getTimeSrv().timeRange(), variable: variableInState, searchFilter };
 
       if (!dataSource.metricFindQuery) {
         return;

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,6 +1,6 @@
 import { AppEvents, DataSourcePluginMeta, DataSourceSelectItem } from '@grafana/data';
 import { validateVariableSelectionState } from '../state/actions';
-import { QueryVariableModel, VariableRefresh } from '../types';
+import { QueryVariableModel } from '../types';
 import { ThunkResult } from '../../../types';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import templateSrv from '../../templating/template_srv';


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As a plugin developer it makes things more difficult when the `metricFindQuery` method on my datasource only gets access to the current dashboard timeRange through the queryOptions object, when the variable is refreshed on timeRange change. If the refresh mode is set to `never` or `on dashboard load` I get an undefined object  instead of a timeRange, even when I still need access to the current timeRange in my case.

This PR removes what I understand to be the conditional that prevents the timeRange from being returned when using any other refresh mode than `on time range change`.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #25715

**Special notes for your reviewer**:
I admit that I haven't run this locally as it is a rather small fix that I expect doesn't have a big impact on other pieces of code. If this has any bigger impact, please let me know and I'll look a bit deeper into this.

