### PR TITLE
Prometheus: Fix performance issue in processing of histogram labels 

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -4,17 +4,16 @@ import { addLabelToQuery } from './add_label_to_query';
 export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
 
 export const processHistogramLabels = (labels: string[]) => {
-  const result = [];
+  const resultSet: Set<string> = new Set();
   const regexp = new RegExp('_bucket($|:)');
   for (let index = 0; index < labels.length; index++) {
     const label = labels[index];
     const isHistogramValue = regexp.test(label);
     if (isHistogramValue) {
-      if (result.indexOf(label) === -1) {
-        result.push(label);
-      }
+      resultSet.add(label);
     }
   }
+  const result = [...resultSet];
 
   return { values: { __name__: result } };
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

The `processHistogramLabels()` function uses a quadratic time check for duplicates.   This is very slow when there are a large number of labels.   For example, with our prometheus instance with 78k labels, this function takes 71 seconds to run - and it blocks the UI during that time.

Replacing this with a `Set` instead of linear search through a list for each element reduces the runtime to 12ms.


