### PR TITLE
Explore/InfluxDB: Remove limit on number of measurements listed in log explore

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -60,7 +60,7 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     const { datasource } = this.props;
     try {
       const queryBuilder = new InfluxQueryBuilder({ measurement: '', tags: [] }, datasource.database);
-      const measureMentsQuery = queryBuilder.buildExploreQuery('MEASUREMENTS');
+      const measureMentsQuery = queryBuilder.buildExploreQuery('MEASUREMENTS', { withLimit: 100 });
       const influxMeasurements = await datasource.metricFindQuery(measureMentsQuery);
 
       const measurements = [];

--- a/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
+++ b/public/app/plugins/datasource/influxdb/components/InfluxLogsQueryField.tsx
@@ -60,7 +60,7 @@ export class InfluxLogsQueryField extends React.PureComponent<Props, State> {
     const { datasource } = this.props;
     try {
       const queryBuilder = new InfluxQueryBuilder({ measurement: '', tags: [] }, datasource.database);
-      const measureMentsQuery = queryBuilder.buildExploreQuery('MEASUREMENTS', { withLimit: 100 });
+      const measureMentsQuery = queryBuilder.buildExploreQuery('MEASUREMENTS');
       const influxMeasurements = await datasource.metricFindQuery(measureMentsQuery);
 
       const measurements = [];

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -261,7 +261,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
   getTagValues(options: any = {}) {
     const queryBuilder = new InfluxQueryBuilder({ measurement: options.measurement || '', tags: [] }, this.database);
-    const query = queryBuilder.buildExploreQuery('TAG_VALUES', options.key);
+    const query = queryBuilder.buildExploreQuery('TAG_VALUES', { withKey: options.key });
     return this.metricFindQuery(query, options);
   }
 

--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -28,7 +28,11 @@ function renderTagCondition(tag: { operator: any; value: string; condition: any;
 export class InfluxQueryBuilder {
   constructor(private target: { measurement: any; tags: any; policy?: any }, private database?: string) {}
 
-  buildExploreQuery(type: string, withKey?: string, withMeasurementFilter?: string) {
+  buildExploreQuery(
+    type: string,
+    options: { withKey?: string; withMeasurementFilter?: string; withLimit?: number } = {}
+  ): string {
+    const { withKey, withMeasurementFilter, withLimit } = options;
     let query;
     let measurement;
     let policy;
@@ -106,11 +110,8 @@ export class InfluxQueryBuilder {
         query += ' WHERE ' + whereConditions.join(' ');
       }
     }
-    if (type === 'MEASUREMENTS') {
-      query += ' LIMIT 100';
-      //Solve issue #2524 by limiting the number of measurements returned
-      //LIMIT must be after WITH MEASUREMENT and WHERE clauses
-      //This also could be used for TAG KEYS and TAG VALUES, if desired
+    if (withLimit) {
+      query += ' LIMIT ' + withLimit;
     }
     return query;
   }

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -268,7 +268,10 @@ export class InfluxQueryCtrl extends QueryCtrl {
   }
 
   getMeasurements(measurementFilter: any) {
-    const query = this.queryBuilder.buildExploreQuery('MEASUREMENTS', undefined, measurementFilter);
+    const query = this.queryBuilder.buildExploreQuery('MEASUREMENTS', {
+      withMeasurementFilter: measurementFilter,
+      withLimit: 100,
+    });
     return this.datasource
       .metricFindQuery(query)
       .then(this.transformToSegments(true))
@@ -324,7 +327,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
       query = this.queryBuilder.buildExploreQuery('TAG_KEYS');
       addTemplateVars = false;
     } else if (segment.type === 'value') {
-      query = this.queryBuilder.buildExploreQuery('TAG_VALUES', this.tagSegments[index - 2].value);
+      query = this.queryBuilder.buildExploreQuery('TAG_VALUES', { withKey: this.tagSegments[index - 2].value });
       addTemplateVars = true;
     }
 

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -41,27 +41,33 @@ describe('InfluxQueryBuilder', () => {
       expect(query).toBe('SHOW TAG KEYS');
     });
 
-    it('should have no conditions in measurement query for query with no tags', () => {
+    it('should have no conditions in measurement query for query with no tags and no limit set', () => {
       const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
       const query = builder.buildExploreQuery('MEASUREMENTS');
+      expect(query).toBe('SHOW MEASUREMENTS');
+    });
+
+    it('should have no conditions in measurement query for query with no tags', () => {
+      const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS LIMIT 100');
     });
 
     it('should have no conditions in measurement query for query with no tags and empty query', () => {
       const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
-      const query = builder.buildExploreQuery('MEASUREMENTS', undefined, '');
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withMeasurementFilter: '', withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS LIMIT 100');
     });
 
     it('should have WITH MEASUREMENT in measurement query for non-empty query with no tags', () => {
       const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
-      const query = builder.buildExploreQuery('MEASUREMENTS', undefined, 'something');
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withMeasurementFilter: 'something', withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS WITH MEASUREMENT =~ /something/ LIMIT 100');
     });
 
     it('should escape the regex value in measurement query', () => {
       const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
-      const query = builder.buildExploreQuery('MEASUREMENTS', undefined, 'abc/edf/');
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withMeasurementFilter: 'abc/edf/', withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS WITH MEASUREMENT =~ /abc\\/edf\\// LIMIT 100');
     });
 
@@ -70,7 +76,7 @@ describe('InfluxQueryBuilder', () => {
         measurement: '',
         tags: [{ key: 'app', value: 'email' }],
       });
-      const query = builder.buildExploreQuery('MEASUREMENTS', undefined, 'something');
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withMeasurementFilter: 'something', withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS WITH MEASUREMENT =~ /something/ WHERE "app" = \'email\' LIMIT 100');
     });
 
@@ -79,7 +85,7 @@ describe('InfluxQueryBuilder', () => {
         measurement: '',
         tags: [{ key: 'app', value: 'email' }],
       });
-      const query = builder.buildExploreQuery('MEASUREMENTS');
+      const query = builder.buildExploreQuery('MEASUREMENTS', { withLimit: 100 });
       expect(query).toBe('SHOW MEASUREMENTS WHERE "app" = \'email\' LIMIT 100');
     });
 
@@ -88,7 +94,7 @@ describe('InfluxQueryBuilder', () => {
         measurement: '',
         tags: [{ key: 'app', value: 'asdsadsad' }],
       });
-      const query = builder.buildExploreQuery('TAG_VALUES', 'app');
+      const query = builder.buildExploreQuery('TAG_VALUES', { withKey: 'app' });
       expect(query).toBe('SHOW TAG VALUES WITH KEY = "app"');
     });
 
@@ -100,7 +106,7 @@ describe('InfluxQueryBuilder', () => {
           { key: 'host', value: 'server1' },
         ],
       });
-      const query = builder.buildExploreQuery('TAG_VALUES', 'app');
+      const query = builder.buildExploreQuery('TAG_VALUES', { withKey: 'app' });
       expect(query).toBe('SHOW TAG VALUES FROM "cpu" WITH KEY = "app" WHERE "host" = \'server1\'');
     });
 
@@ -113,7 +119,7 @@ describe('InfluxQueryBuilder', () => {
           { key: 'host', value: 'server1' },
         ],
       });
-      const query = builder.buildExploreQuery('TAG_VALUES', 'app');
+      const query = builder.buildExploreQuery('TAG_VALUES', { withKey: 'app' });
       expect(query).toBe('SHOW TAG VALUES FROM "one_week"."cpu" WITH KEY = "app" WHERE "host" = \'server1\'');
     });
 
@@ -123,7 +129,7 @@ describe('InfluxQueryBuilder', () => {
         policy: 'default',
         tags: [],
       });
-      const query = builder.buildExploreQuery('TAG_VALUES', 'app');
+      const query = builder.buildExploreQuery('TAG_VALUES', { withKey: 'app' });
       expect(query).toBe('SHOW TAG VALUES FROM "cpu" WITH KEY = "app"');
     });
 
@@ -132,7 +138,7 @@ describe('InfluxQueryBuilder', () => {
         measurement: 'cpu',
         tags: [{ key: 'host', value: '/server.*/' }],
       });
-      const query = builder.buildExploreQuery('TAG_VALUES', 'app');
+      const query = builder.buildExploreQuery('TAG_VALUES', { withKey: 'app' });
       expect(query).toBe('SHOW TAG VALUES FROM "cpu" WITH KEY = "app" WHERE "host" =~ /server.*/');
     });
 


### PR DESCRIPTION
## What

* make callers of the influxdb query builder sets query limits explicitly
* removes the limit on the number of measurements loaded into the list in the influxdb logs explore pane.

## Why

in #8092 (a resolution to #2524) a hard-coded `LIMIT 100` was added to mitigate issues of slow running queries on databases with large numbers of measurements. This hard-coded limit is generally not noticed as the queries are mostly combined with a filter (such as the autocomplete query) so it is only "100 of the search query".

However because the value is hard-coded internally, when the query builder is been used elsewhere in contexts without such
a query filter, the limit of 100 is unexpected.

This behaviour can be seen on the "logs" explore view for influxdb, where if your influxdb database contained more than 100 measurements, and your "logs" measurement wasn't in the
first 100 returned, then there was no way to select your "logs" field, which was confusing (is my log shipping broken?)
and annoying (why can't I play with the handy explore!).

I believe the limit of 100 behaviour was not intentional on the logs explore view, as the component appears to have been
designed with the expectation that all measurements are returned.

Without the limit this page **is going to be slow for people with large numbers of metrics** (it performs N+1 requests!), so
I hope this change will:

1. make the page at least usable (even if slow for some)
2. highlight the larger problem with this component that we should not be making "show measurements" queries without filters or N+1 requests

