### PR TITLE
LDAP: Get all groups for all group base search DNs

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -538,7 +538,6 @@ func (server *Server) requestMemberOf(entry *ldap.Entry) ([]string, error) {
 					getAttribute(groupIDAttribute, group),
 				)
 			}
-			break
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Annegies van 't Zand <ace.vtzand@gmail.com>

**What this PR does / why we need it**:

The LDAP configurations allows to search through multiple base DNs for groups, however currently once a base DN returns any group(s) it won't search the other base DN's specified.
This PR makes sure all groups in all the group base DNs specified are returned.

**Which issue(s) this PR fixes**:

Fixes #17137

**Special notes for your reviewer**:

