### PR TITLE
DatatLinks: Fix open in new tab state mismatch

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkEditor.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkEditor.tsx
@@ -53,7 +53,7 @@ export const DataLinkEditor: React.FC<DataLinkEditorProps> = React.memo(
         </Field>
 
         <Field label="Open in new tab">
-          <Switch checked={value.targetBlank || false} onChange={onOpenInNewTabChanged} />
+          <Switch value={value.targetBlank || false} onChange={onOpenInNewTabChanged} />
         </Field>
 
         {isLast && (


### PR DESCRIPTION
Fixes #25445 

This was probably caused when moving from the legacy `Switch`.