### PR TITLE
Fix: preventing the click outside wrapper from throwing errors due to listening to unmounted nodes.

### DIFF
--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -35,7 +35,7 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
   componentWillUnmount() {
     window.removeEventListener('click', this.onOutsideClick, false);
     if (this.props.includeButtonPress) {
-      window.addEventListener('keyup', this.onOutsideClick, false);
+      window.removeEventListener('keyup', this.onOutsideClick, false);
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like we have a bug where we adds another event listener instead of removing it on unmount. This causes a lot of errors to appear in the console when triggering key events inside a ClickOutsideWrapper component.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/25749

**Special notes for your reviewer**:
I will also have a look if I can prevent the other error that @torkelo managed to trigger in a separate PR.
