### PR TITLE
grafana/toolkit: fix binary path so toolkit is not run in linked mode when installed from npm

### DIFF
--- a/packages/grafana-toolkit/bin/grafana-toolkit.js
+++ b/packages/grafana-toolkit/bin/grafana-toolkit.js
@@ -23,8 +23,9 @@ const isLinkedMode = () => {
 };
 
 const entrypoint = () => {
-  const resolvedJsDir = path.resolve(`${__dirname}/../dist/src/cli/index.js`);
-  const resolvedTsDir = path.resolve(`${__dirname}/../src/cli/index.ts`);
+  const entrypointBase = `${__dirname}/../src/cli/index`;
+  const resolvedJsDir = path.resolve(`${entrypointBase}.js`);
+  const resolvedTsDir = path.resolve(`${entrypointBase}.ts`);
 
   // IF we have a toolkit directory AND linked grafana toolkit AND the toolkit dir is a symbolic lik
   // THEN run everything in linked mode
@@ -46,4 +47,3 @@ const entrypoint = () => {
 };
 
 require(entrypoint()).run(includeInternalScripts);
-


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/25816

Problem was introduced by https://github.com/grafana/grafana/pull/24951. Made toolkit being executed in linked mode (meaning TS etc). The path to the js entry point was wrong, as there is no `dist` directory in the published version of toolkit. It's only used as a temporary directory for building the distribution.

We really need verification script for the canary to make sure the templates are working:0