### PR TITLE
Datasource: Make sure data proxy timeout applies to HTTP client

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -126,7 +126,8 @@ connstr =
 # This enables data proxy logging, default is false
 logging = false
 
-# How long the data proxy should wait before timing out default is 30 (seconds)
+# How long the data proxy should wait before timing out default is 30 (seconds).
+# Note: This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
 timeout = 30
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
@@ -235,7 +236,7 @@ versions_to_keep = 20
 min_refresh_interval = 5s
 
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
-default_home_dashboard_path = 
+default_home_dashboard_path =
 
 #################################### Users ###############################
 [users]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -126,8 +126,8 @@ connstr =
 # This enables data proxy logging, default is false
 logging = false
 
-# How long the data proxy should wait before timing out default is 30 (seconds).
-# Note: This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
+# How long the data proxy waits before timing out, default is 30 seconds.
+# This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -128,6 +128,7 @@
 ;logging = false
 
 # How long the data proxy should wait before timing out default is 30 (seconds)
+# Note: This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
 ;timeout = 30
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
@@ -234,7 +235,7 @@
 ;min_refresh_interval = 5s
 
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
-;default_home_dashboard_path = 
+;default_home_dashboard_path =
 
 #################################### Users ###############################
 [users]
@@ -460,7 +461,7 @@
 ;from_name = Grafana
 # EHLO identity in SMTP dialog (defaults to instance_name)
 ;ehlo_identity = dashboard.example.com
-# SMTP startTLS policy (defaults to 'OpportunisticStartTLS') 
+# SMTP startTLS policy (defaults to 'OpportunisticStartTLS')
 ;startTLS_policy = NoStartTLS
 
 [emails]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -127,8 +127,8 @@
 # This enables data proxy logging, default is false
 ;logging = false
 
-# How long the data proxy should wait before timing out default is 30 (seconds)
-# Note: This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
+# How long the data proxy waits before timing out, default is 30 seconds.
+# This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 ;timeout = 30
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -339,9 +339,9 @@ This enables data proxy logging, default is `false`.
 
 ### timeout
 
-How long the data proxy should wait before timing out. Default is `30` (seconds).
+How long the data proxy should wait before timing out. Default is 30 seconds.
 
-> **Note:** This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
+This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 
 ### send_user_header
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -339,7 +339,9 @@ This enables data proxy logging, default is `false`.
 
 ### timeout
 
-How long the data proxy should wait before timing out. Default is `30` (seconds)
+How long the data proxy should wait before timing out. Default is `30` (seconds).
+
+> **Note:** This setting also applies to core backend HTTP data sources where queries are requested using an HTTP client with timeout set.
 
 ### send_user_header
 
@@ -537,7 +539,7 @@ Set the default UI theme: `dark` or `light`. Default is `dark`.
 
 ### External user management
 
-If you manage users externally you can replace the user invite button for organizations with a link to an external site together with a description. 
+If you manage users externally you can replace the user invite button for organizations with a link to an external site together with a description.
 
 ### viewers_can_edit
 
@@ -733,7 +735,7 @@ Either "OpportunisticStartTLS", "MandatoryStartTLS", "NoStartTLS". Default is `e
 
 Default is `false`.
 
-### templates_pattern 
+### templates_pattern
 
 Default is `emails/*.html`.
 
@@ -1224,7 +1226,7 @@ Instruct headless browser instance whether to ignore HTTPS errors during navigat
 
 ### rendering_verbose_logging
 
-Instruct headless browser instance whether to capture and log verbose information when rendering an image. Default is `false` and will only capture and log error messages. 
+Instruct headless browser instance whether to capture and log verbose information when rendering an image. Default is `false` and will only capture and log error messages.
 
 When enabled, debug messages are captured and logged as well.
 

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -51,7 +51,7 @@ func (ds *DataSource) GetHttpClient() (*http.Client, error) {
 	}
 
 	return &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
 		Transport: transport,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**
For backend data sources executing in the backend (not through data proxy) make sure that the timeout applies to cached HTTP client.

**Which issue(s) this PR fixes**:
Fixes #25863 

**Special notes for your reviewer**:
Don't think the timeout setting really works for data proxy, but that's another problem/issue.