### PR TITLE
dsproxy: Allow Cortex DELETE/PUT/POST requests

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -235,18 +235,6 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		return errors.New("Target url is not a valid target")
 	}
 
-	if proxy.ds.Type == models.DS_PROMETHEUS {
-		if proxy.ctx.Req.Request.Method == "DELETE" {
-			return errors.New("Deletes not allowed on proxied Prometheus datasource")
-		}
-		if proxy.ctx.Req.Request.Method == "PUT" {
-			return errors.New("Puts not allowed on proxied Prometheus datasource")
-		}
-		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range") {
-			return errors.New("Posts not allowed on proxied Prometheus datasource except on /query and /query_range")
-		}
-	}
-
 	if proxy.ds.Type == models.DS_ES {
 		if proxy.ctx.Req.Request.Method == "DELETE" {
 			return errors.New("Deletes not allowed on proxied Elasticsearch datasource")


### PR DESCRIPTION
**What this PR does / why we need it**:

We need this in order to use Cortex' Ruler API.
To allow for that, @gotjosh recommended to simply remove this check and ask whether one of the original authors would object to this change.
