### PR TITLE
Graphite: Fix tag value dropdowns not showing in query editor 

### DIFF
--- a/public/app/plugins/datasource/graphite/partials/query.editor.html
+++ b/public/app/plugins/datasource/graphite/partials/query.editor.html
@@ -20,7 +20,8 @@
           css-class="query-segment-key"
           get-options="ctrl.getTags($index, $query)"
           on-change="ctrl.tagChanged(tag, $index)"
-        />
+        ></gf-form-dropdown>
+        
         <gf-form-dropdown
           model="tag.operator"
           label-mode="true"
@@ -28,7 +29,7 @@
           get-options="ctrl.getTagOperators()"
           on-change="ctrl.tagChanged(tag, $index)"
           min-input-width="30"
-        />
+        ></gf-form-dropdown>
         <gf-form-dropdown
           model="tag.value"
           allow-custom="true"


### PR DESCRIPTION
Fixes #25880

This was caused by the jQuery Upgrade that breaks (changes) how jquery parses html templates, it no longer replaces self-closing tags with closing tags. 

The bug only happens if you have two self-closing tag angular directives after each other (as siblings). 

I searched code base and could not find any other case 