### PR TITLE
Docs: Enterprise Vault feature

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -86,7 +86,7 @@ export GF_PLUGIN_GRAFANA_IMAGE_RENDERER_RENDERING_IGNORE_HTTPS_ERRORS=true
 
 > Only available in Grafana 7.1+.
 
-> For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect, you must restart Grafana for the changes to take effect.
+> For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect, you must restart Grafana.
 
 If any of your options contains the expression `$__<provider>{<argument>}`
 or `${<environment variable>}`, then they will be processed by Grafana's

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -93,7 +93,7 @@ or `${<environment variable>}`, then they will be processed by Grafana's
 variable expander. The expander runs the provider with the provided argument
 to get the final value of the option.
 
-There are three providers: `env`, `file` and `vault`.
+There are three providers: `env`, `file`, and `vault`.
 
 ### Env provider
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -86,12 +86,14 @@ export GF_PLUGIN_GRAFANA_IMAGE_RENDERER_RENDERING_IGNORE_HTTPS_ERRORS=true
 
 > Only available in Grafana 7.1+.
 
+> For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect, you must restart Grafana for the changes to take effect.
+
 If any of your options contains the expression `$__<provider>{<argument>}`
 or `${<environment variable>}`, then they will be processed by Grafana's
 variable expander. The expander runs the provider with the provided argument
 to get the final value of the option.
 
-There are two providers: `env` and `file`.
+There are three providers: `env`, `file` and `vault`.
 
 ### Env provider
 
@@ -103,7 +105,7 @@ Grafana's log directory would be set to the `grafana` directory in the
 directory behind the `LOGDIR` environment variable in the following
 example.
 
-```
+```ini
 [paths]
 logs = $__env{LOGDIR}/grafana
 ```
@@ -115,12 +117,16 @@ beginning and the end of files.
 The database password in the following example would be replaced by
 the content of the `/etc/secrets/gf_sql_password` file:
 
-```
+```ini
 [database]
 password = $__file{/etc/secrets/gf_sql_password}
 ```
 
-> For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect, you must restart Grafana for the changes to take effect.
+### Vault provider
+
+The `vault` provider allows you to manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault).
+
+> Vault provider is only available in Grafana Enterprise v7.1+. For more information, refer to [Vault integration]({{< relref "../enterprise/vault.md" >}}) in [Grafana Enterprise]({{< relref "../enterprise" >}}).
 
 <hr />
 

--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -54,6 +54,7 @@ With Grafana Enterprise, you get access to new features, including:
 * [Export dashboard as PDF]({{< relref "export-pdf.md" >}})
 * [White labeling]({{< relref "white-labeling.md" >}}) to customize Grafana from the brand and logo to the footer links.
 * [Usage insights]({{< relref "usage-insights.md" >}}) to understand how your Grafana instance is used.
+* [Vault integration]({{< relref "vault.md" >}}) to manage your configuration or provisionning secrets with Vault.
 
 ## Enterprise plugins
 

--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -54,7 +54,7 @@ With Grafana Enterprise, you get access to new features, including:
 * [Export dashboard as PDF]({{< relref "export-pdf.md" >}})
 * [White labeling]({{< relref "white-labeling.md" >}}) to customize Grafana from the brand and logo to the footer links.
 * [Usage insights]({{< relref "usage-insights.md" >}}) to understand how your Grafana instance is used.
-* [Vault integration]({{< relref "vault.md" >}}) to manage your configuration or provisionning secrets with Vault.
+* [Vault integration]({{< relref "vault.md" >}}) to manage your configuration or provisioning secrets with Vault.
 
 ## Enterprise plugins
 

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -186,3 +186,33 @@ List of comma- or space-separated roles that will be mapped to the Admin role.
 ### role_values_grafana_admin
 
 List of comma- or space-separated roles that will be mapped to the Grafana Admin (Super Admin) role.
+
+## [keystore.vault]
+
+### url
+
+Location of the Vault server.
+
+### namespace
+
+Vault's namespace if using Vault with multi-tenancy.
+
+### auth_method
+
+Method for authenticating towards Vault. Vault is inactive if this option is not set. Current possible values: `token`.
+
+### token
+
+ Secret token to connect to Vault when auth_method is `token`.
+
+ ### lease_renewal_interval
+
+ Time between checking if there are any secrets which needs to be renewed.
+
+ ### lease_renewal_expires_within
+
+ Time until expiration for tokens which are renewed. Should have a value higher than lease_renewal_interval.
+
+ ### lease_renewal_increment
+
+ New duration for renewed tokens. Vault may be configured to ignore this value and impose a stricter limit.

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -195,7 +195,7 @@ Location of the Vault server.
 
 ### namespace
 
-Vault's namespace if using Vault with multi-tenancy.
+Vault namespace if using Vault with multi-tenancy.
 
 ### auth_method
 
@@ -203,16 +203,16 @@ Method for authenticating towards Vault. Vault is inactive if this option is not
 
 ### token
 
- Secret token to connect to Vault when auth_method is `token`.
+Secret token to connect to Vault when auth_method is `token`.
 
- ### lease_renewal_interval
+### lease_renewal_interval
 
- Time between checking if there are any secrets which needs to be renewed.
+Time between checking if there are any secrets which needs to be renewed.
 
- ### lease_renewal_expires_within
+### lease_renewal_expires_within
 
- Time until expiration for tokens which are renewed. Should have a value higher than lease_renewal_interval.
+Time until expiration for tokens which are renewed. Should have a value higher than lease_renewal_interval.
 
- ### lease_renewal_increment
+### lease_renewal_increment
 
- New duration for renewed tokens. Vault may be configured to ignore this value and impose a stricter limit.
+New duration for renewed tokens. Vault may be configured to ignore this value and impose a stricter limit.

--- a/docs/sources/enterprise/vault.md
+++ b/docs/sources/enterprise/vault.md
@@ -1,0 +1,136 @@
++++
+title = "Vault"
+description = ""
+keywords = ["grafana", "vault", "configuration"]
+type = "docs"
+[menu.docs]
+parent = "enterprise"
+weight = 700
++++
+
+# Vault integration
+
+> Only available in Grafana Enterprise v7.1+.
+
+For organizations managing their secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault)
+Grafana integrates with Vault for [Configuration]({{< relref "../administration/configuration.md" >}})
+and [Provisioning]({{< relref "../administration/provisioning.md" >}}).
+
+> Note: If you have Grafana set up for [high availability]{{< relref "../tutorials/ha_setup.md" >}} we advise not to use dynamic secrets for provisioning files.
+> Each Grafana instance is responsible for renewing its own leases. Your data sources' leases might expire when one of your Grafana servers shuts down.
+
+## Configuration
+
+Before using Vault you need to activate it by providing a URL, authentication method (currently only token),
+and a token for your Vault service. Grafana will automatically renew the service token if it is renewable and
+set up with a limited lifetime.
+
+If you're using short-lived leases, you can also configure how often Grafana should renew the lease and for
+how long. We recommend keeping the defaults here unless you run into problems.
+
+```
+[keystore.vault]
+# Location of the Vault server
+;url =
+# Vault's namespace if using Vault with multi-tenancy
+;namespace =
+# Method for authenticating towards Vault. Vault is inactive if this option is not set
+# Possible values: token
+;auth_method =
+# Secret token to connect to Vault when auth_method is token
+;token =
+# Time between checking if there are any secrets which needs to be renewed.
+;lease_renewal_interval = 5m
+# Time until expiration for tokens which are renewed. Should have a value higher the lease_renewal_interval
+;lease_renewal_expires_within = 15m
+# New duration for renewed tokens. Vault may be configured to ignore this value and impose a stricter limit.
+;lease_renewal_increment = 1h
+```
+
+Example for `vault server -dev`:
+
+```
+[keystore.vault]
+url = http://127.0.0.1:8200 # HTTP should only be used for local testing
+auth_method = token
+token = s.sAZLyI0r7sFLMPq6MWtoOhAN # replace with your key
+```
+
+## Using the Vault expander
+
+When you've configured Vault you'll need to set the configuration or provisioning files you wish to
+use Vault. Vault configuration is an extension of [Configuration]({{< relref "../administration/configuration.md" >}})'s
+[variable expansion]({{< relref "../administration/configuration.md#variable-expansion" >}}) and follows the
+`$__vault{<argument>}` syntax.
+
+The argument to Vault consists of three parts separated by a colon, the first part specifies which secrets engine
+should be used, the second part which secret should be accessed, and the third part which field of that secret
+should be used. For example, if you place a Key/Value secret for the Grafana admin user in _secret/grafana/admin_defaults_
+the syntax for accessing it's _password_ field would be `$__vault{kv:secret/grafana/admin_defaults:password}`.
+
+### Secrets engines
+
+Vault supports many secrets engines which represents different methods for storing or generating secrets when requested by an
+authorized user. Grafana supports a subset of these which are most likely to be relevant for a Grafana installation.
+
+#### Key/Value
+
+Grafana supports Vault's [K/V version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) storage engine which
+is used to store and retrieve arbitrary secrets as `kv`. 
+
+```
+$__vault{kv:secret/grafana/smtp:username}
+```
+
+#### Databases
+
+Vault's [Databases secrets engines](https://www.vaultproject.io/docs/secrets/databases) is a family of
+secret engines which shares a similar syntax and grants the user dynamic access to a database.
+You can use this both for setting up Grafana's own database access and for provisioning data sources.
+
+```
+$__vault{database:database/creds/grafana:username}
+```
+
+### Examples
+
+#### Configuration
+
+The following is a partial example for using Vault to set up a Grafana configuration file's email and database credentials.
+Refer to the [Configuration]({{< relref "../administration/configuration.md" >}}) section for more information.
+
+```
+[smtp]
+enabled = true
+host = $__vault{kv:secret/grafana/smtp:hostname}:587
+user = $__vault{kv:secret/grafana/smtp:username}
+password = $__vault{kv:secret/grafana/smtp:password}
+
+[database]
+type = mysql
+host = mysqlhost:3306
+name = grafana
+user = $__vault{database:database/creds/grafana:username}
+password = $__vault{database:database/creds/grafana:password}
+```
+
+#### Provisioning
+
+The following is a full examples of a provisioning YAML file setting up a MySQL data source using Vault's
+database secrets engine.
+Refer to the [Provisioning]({{< relref "../administration/provisioning.md" >}}) section for more information.
+
+**provisioning/custom.yaml**
+
+```
+apiVersion: 1
+
+datasources:
+  - name: statistics
+    type: mysql
+    url: localhost:3306
+    database: stats
+    user: $__vault{database:database/creds/ro/stats:username}
+    secureJsonData:
+      password: $__vault{database:database/creds/ro/stats:password}
+```

--- a/docs/sources/enterprise/vault.md
+++ b/docs/sources/enterprise/vault.md
@@ -16,7 +16,7 @@ If you manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/prod
 and [Provisioning]({{< relref "../administration/provisioning.md" >}}).
 
 > **Note:** If you have Grafana set up for [high availability]({{< relref "../tutorials/ha_setup.md" >}}), then we advise not to use dynamic secrets for provisioning files.
-> Each Grafana instance is responsible for renewing its own leases. Your data sources' leases might expire when one of your Grafana servers shuts down.
+> Each Grafana instance is responsible for renewing its own leases. Your data source leases might expire when one of your Grafana servers shuts down.
 
 ## Configuration
 

--- a/docs/sources/enterprise/vault.md
+++ b/docs/sources/enterprise/vault.md
@@ -12,11 +12,11 @@ weight = 700
 
 > Only available in Grafana Enterprise v7.1+.
 
-For organizations managing their secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault)
+For organizations managing their secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault),
 Grafana integrates with Vault for [Configuration]({{< relref "../administration/configuration.md" >}})
 and [Provisioning]({{< relref "../administration/provisioning.md" >}}).
 
-> Note: If you have Grafana set up for [high availability]{{< relref "../tutorials/ha_setup.md" >}} we advise not to use dynamic secrets for provisioning files.
+> Note: If you have Grafana set up for [high availability]({{< relref "../tutorials/ha_setup.md" >}}) we advise not to use dynamic secrets for provisioning files.
 > Each Grafana instance is responsible for renewing its own leases. Your data sources' leases might expire when one of your Grafana servers shuts down.
 
 ## Configuration
@@ -28,7 +28,7 @@ set up with a limited lifetime.
 If you're using short-lived leases, you can also configure how often Grafana should renew the lease and for
 how long. We recommend keeping the defaults here unless you run into problems.
 
-```
+```ini
 [keystore.vault]
 # Location of the Vault server
 ;url =
@@ -41,7 +41,7 @@ how long. We recommend keeping the defaults here unless you run into problems.
 ;token =
 # Time between checking if there are any secrets which needs to be renewed.
 ;lease_renewal_interval = 5m
-# Time until expiration for tokens which are renewed. Should have a value higher the lease_renewal_interval
+# Time until expiration for tokens which are renewed. Should have a value higher than lease_renewal_interval
 ;lease_renewal_expires_within = 15m
 # New duration for renewed tokens. Vault may be configured to ignore this value and impose a stricter limit.
 ;lease_renewal_increment = 1h
@@ -49,21 +49,21 @@ how long. We recommend keeping the defaults here unless you run into problems.
 
 Example for `vault server -dev`:
 
-```
+```ini
 [keystore.vault]
 url = http://127.0.0.1:8200 # HTTP should only be used for local testing
 auth_method = token
 token = s.sAZLyI0r7sFLMPq6MWtoOhAN # replace with your key
 ```
 
+
 ## Using the Vault expander
 
 When you've configured Vault you'll need to set the configuration or provisioning files you wish to
-use Vault. Vault configuration is an extension of [Configuration]({{< relref "../administration/configuration.md" >}})'s
-[variable expansion]({{< relref "../administration/configuration.md#variable-expansion" >}}) and follows the
+use Vault. Vault configuration is an extension of configuration's [variable expansion]({{< relref "../administration/configuration.md#variable-expansion" >}}) and follows the
 `$__vault{<argument>}` syntax.
 
-The argument to Vault consists of three parts separated by a colon, the first part specifies which secrets engine
+The argument to Vault consists of three parts separated by a colon: the first part specifies which secrets engine
 should be used, the second part which secret should be accessed, and the third part which field of that secret
 should be used. For example, if you place a Key/Value secret for the Grafana admin user in _secret/grafana/admin_defaults_
 the syntax for accessing it's _password_ field would be `$__vault{kv:secret/grafana/admin_defaults:password}`.
@@ -78,7 +78,7 @@ authorized user. Grafana supports a subset of these which are most likely to be 
 Grafana supports Vault's [K/V version 2](https://www.vaultproject.io/docs/secrets/kv/kv-v2) storage engine which
 is used to store and retrieve arbitrary secrets as `kv`. 
 
-```
+```ini
 $__vault{kv:secret/grafana/smtp:username}
 ```
 
@@ -88,7 +88,7 @@ Vault's [Databases secrets engines](https://www.vaultproject.io/docs/secrets/dat
 secret engines which shares a similar syntax and grants the user dynamic access to a database.
 You can use this both for setting up Grafana's own database access and for provisioning data sources.
 
-```
+```ini
 $__vault{database:database/creds/grafana:username}
 ```
 
@@ -99,7 +99,7 @@ $__vault{database:database/creds/grafana:username}
 The following is a partial example for using Vault to set up a Grafana configuration file's email and database credentials.
 Refer to the [Configuration]({{< relref "../administration/configuration.md" >}}) section for more information.
 
-```
+```ini
 [smtp]
 enabled = true
 host = $__vault{kv:secret/grafana/smtp:hostname}:587
@@ -122,7 +122,7 @@ Refer to the [Provisioning]({{< relref "../administration/provisioning.md" >}}) 
 
 **provisioning/custom.yaml**
 
-```
+```ini
 apiVersion: 1
 
 datasources:

--- a/docs/sources/enterprise/vault.md
+++ b/docs/sources/enterprise/vault.md
@@ -12,7 +12,7 @@ weight = 700
 
 > Only available in Grafana Enterprise v7.1+.
 
-If you are managing your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration]({{< relref "../administration/configuration.md" >}})
+If you manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration]({{< relref "../administration/configuration.md" >}})
 and [Provisioning]({{< relref "../administration/provisioning.md" >}}).
 
 > **Note:** If you have Grafana set up for [high availability]({{< relref "../tutorials/ha_setup.md" >}}), then we advise not to use dynamic secrets for provisioning files.

--- a/docs/sources/enterprise/vault.md
+++ b/docs/sources/enterprise/vault.md
@@ -12,27 +12,26 @@ weight = 700
 
 > Only available in Grafana Enterprise v7.1+.
 
-For organizations managing their secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault),
-Grafana integrates with Vault for [Configuration]({{< relref "../administration/configuration.md" >}})
+If you are managing your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration]({{< relref "../administration/configuration.md" >}})
 and [Provisioning]({{< relref "../administration/provisioning.md" >}}).
 
-> Note: If you have Grafana set up for [high availability]({{< relref "../tutorials/ha_setup.md" >}}) we advise not to use dynamic secrets for provisioning files.
+> **Note:** If you have Grafana set up for [high availability]({{< relref "../tutorials/ha_setup.md" >}}), then we advise not to use dynamic secrets for provisioning files.
 > Each Grafana instance is responsible for renewing its own leases. Your data sources' leases might expire when one of your Grafana servers shuts down.
 
 ## Configuration
 
-Before using Vault you need to activate it by providing a URL, authentication method (currently only token),
-and a token for your Vault service. Grafana will automatically renew the service token if it is renewable and
+Before using Vault, you need to activate it by providing a URL, authentication method (currently only token),
+and a token for your Vault service. Grafana automatically renews the service token if it is renewable and
 set up with a limited lifetime.
 
-If you're using short-lived leases, you can also configure how often Grafana should renew the lease and for
-how long. We recommend keeping the defaults here unless you run into problems.
+If you're using short-lived leases, then you can also configure how often Grafana should renew the lease and for
+how long. We recommend keeping the defaults unless you run into problems.
 
 ```ini
 [keystore.vault]
 # Location of the Vault server
 ;url =
-# Vault's namespace if using Vault with multi-tenancy
+# Vault namespace if using Vault with multi-tenancy
 ;namespace =
 # Method for authenticating towards Vault. Vault is inactive if this option is not set
 # Possible values: token
@@ -56,16 +55,18 @@ auth_method = token
 token = s.sAZLyI0r7sFLMPq6MWtoOhAN # replace with your key
 ```
 
-
 ## Using the Vault expander
 
-When you've configured Vault you'll need to set the configuration or provisioning files you wish to
+After you configure Vault, you must set the configuration or provisioning files you wish to
 use Vault. Vault configuration is an extension of configuration's [variable expansion]({{< relref "../administration/configuration.md#variable-expansion" >}}) and follows the
 `$__vault{<argument>}` syntax.
 
-The argument to Vault consists of three parts separated by a colon: the first part specifies which secrets engine
-should be used, the second part which secret should be accessed, and the third part which field of that secret
-should be used. For example, if you place a Key/Value secret for the Grafana admin user in _secret/grafana/admin_defaults_
+The argument to Vault consists of three parts separated by a colon:
+* The first part specifies which secrets engine should be used.
+* The second part specifies which secret should be accessed.
+* The third part specifies which field of that secret should be used.
+
+For example, if you place a Key/Value secret for the Grafana admin user in _secret/grafana/admin_defaults_
 the syntax for accessing it's _password_ field would be `$__vault{kv:secret/grafana/admin_defaults:password}`.
 
 ### Secrets engines
@@ -84,7 +85,7 @@ $__vault{kv:secret/grafana/smtp:username}
 
 #### Databases
 
-Vault's [Databases secrets engines](https://www.vaultproject.io/docs/secrets/databases) is a family of
+The Vault [databases secrets engines](https://www.vaultproject.io/docs/secrets/databases) is a family of
 secret engines which shares a similar syntax and grants the user dynamic access to a database.
 You can use this both for setting up Grafana's own database access and for provisioning data sources.
 
@@ -94,10 +95,12 @@ $__vault{database:database/creds/grafana:username}
 
 ### Examples
 
+The following examples show you how to set your [configuration]({{< relref "../administration/configuration.md" >}}) or [provisioning]({{< relref "../administration/provisioning.md" >}}) files to use Vault to retrieve configuration values.
+
 #### Configuration
 
 The following is a partial example for using Vault to set up a Grafana configuration file's email and database credentials.
-Refer to the [Configuration]({{< relref "../administration/configuration.md" >}}) section for more information.
+Refer to [Configuration]({{< relref "../administration/configuration.md" >}}) for more information.
 
 ```ini
 [smtp]
@@ -118,7 +121,7 @@ password = $__vault{database:database/creds/grafana:password}
 
 The following is a full examples of a provisioning YAML file setting up a MySQL data source using Vault's
 database secrets engine.
-Refer to the [Provisioning]({{< relref "../administration/provisioning.md" >}}) section for more information.
+Refer to [Provisioning]({{< relref "../administration/provisioning.md" >}}) for more information.
 
 **provisioning/custom.yaml**
 

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -328,6 +328,8 @@
       link: /enterprise/white-labeling/
     - name: Usage insights
       link: /enterprise/usage-insights/
+    - name: Vault integration
+      link: /enterprise/vault/
     - name: License expiration
       link: /enterprise/license-expiration/
 - name: Plugins


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation for the Grafana Enterprise 7.1 Vault integration.

**Special notes for your reviewer**:
Replaces #25861 as Emil is away and I don't have write access to his fork.
