### PR TITLE
Update panel loading icon

### DIFF
--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -74,10 +74,10 @@ $panel-header-no-title-zindex: 1;
 .panel-loading {
   position: absolute;
   top: 4px;
-  right: 4px;
+  right: 8px;
   z-index: $panel-header-z-index + 1;
-  font-size: $font-size-sm;
-  color: $text-color-weak;
+  font-size: $font-size-lg;
+  color: $text-blue;
 }
 
 .panel-empty {


### PR DESCRIPTION
Panel's loading circle is really hard to notice.
I made it a bit bigger and changed the color.

Please let me know what you think.
<img width="252" alt="Screen Shot 2020-06-28 at 17 00 59" src="https://user-images.githubusercontent.com/15690241/86015414-34799f00-ba2a-11ea-9847-58aae14e2564.png">
