### PR TITLE
StatPanel: Add migration for singlestat tableColumn to to fields property 

### DIFF
--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -198,6 +198,18 @@ describe('sharedSingleStatMigrationHandler', () => {
     expect(panel.fieldConfig.defaults.max).toBe(undefined);
   });
 
+  it('change from angular singlestat with tableColumn set', () => {
+    const old: any = {
+      angular: {
+        tableColumn: 'info',
+      },
+    };
+    const panel = {} as PanelModel;
+    const newOptions = sharedSingleStatPanelChangedHandler(panel, 'singlestat', old);
+    expect(newOptions.reduceOptions.calcs).toEqual(['mean']);
+    expect(newOptions.reduceOptions.fields).toBe('/^info$/');
+  });
+
   it('change from angular singlestat with no enabled gauge', () => {
     const old: any = {
       angular: {

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -55,7 +55,7 @@ function migrateFromAngularSinglestat(panel: PanelModel<Partial<SingleStatBaseOp
   const prevPanel = prevOptions.angular;
   const reducer = fieldReducers.getIfExists(prevPanel.valueName);
   const options = {
-    fieldOptions: {
+    reduceOptions: {
       calcs: [reducer ? reducer.id : ReducerID.mean],
     },
     orientation: VizOrientation.Horizontal,
@@ -65,6 +65,10 @@ function migrateFromAngularSinglestat(panel: PanelModel<Partial<SingleStatBaseOp
 
   if (prevPanel.format) {
     defaults.unit = prevPanel.format;
+  }
+
+  if (prevPanel.tableColumn) {
+    options.reduceOptions.fields = `/^${prevPanel.tableColumn}$/`;
   }
 
   if (prevPanel.nullPointMode) {


### PR DESCRIPTION
with the new fields option introduced in https://github.com/grafana/grafana/pull/24829 we can now migrate the tableColumn option in the old singlestat 