### PR TITLE
Explore: Add join transform for timeseries shown in table

### DIFF
--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -155,6 +155,38 @@ describe('ResultProcessor', () => {
         expect(theResult.fields[1].display).not.toBeNull();
         expect(theResult.length).toBe(3);
       });
+
+      it('should do join transform if all series are timeseries', () => {
+        const { resultProcessor } = testContext({
+          dataFrames: [
+            toDataFrame({
+              name: 'A-series',
+              refId: 'A',
+              fields: [
+                { name: 'Time', type: FieldType.time, values: [100, 200, 300] },
+                { name: 'A-series', type: FieldType.number, values: [4, 5, 6] },
+              ],
+            }),
+            toDataFrame({
+              name: 'B-series',
+              refId: 'B',
+              fields: [
+                { name: 'Time', type: FieldType.time, values: [100, 200, 300] },
+                { name: 'B-series', type: FieldType.number, values: [4, 5, 6] },
+              ],
+            }),
+          ],
+        });
+
+        let result = resultProcessor.getTableResult()!;
+
+        expect(result.fields[0].name).toBe('Time');
+        expect(result.fields[1].name).toBe('A-series');
+        expect(result.fields[2].name).toBe('B-series');
+        expect(result.fields[0].values.toArray()).toEqual([100, 200, 300]);
+        expect(result.fields[1].values.toArray()).toEqual([4, 5, 6]);
+        expect(result.fields[2].values.toArray()).toEqual([4, 5, 6]);
+      });
     });
 
     describe('when calling getLogsResult', () => {

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -68,8 +68,16 @@ export class ResultProcessor {
       return null;
     }
 
-    const mergeTransformer = standardTransformers.mergeTransformer.transformer({});
-    const data = mergeTransformer(onlyTables)[0];
+    const hasOnlyTimeseries = onlyTables.every(df => isTimeSeries(df));
+
+    // If we have only timeseries we do join on default time column which makes more sense. If we are showing
+    // non timeseries or some mix od data we are not trying to join on anything and just try to merge them in
+    // single table, which may not make sense in most cases, but it's up to the user to query something sensible.
+    const transformer = hasOnlyTimeseries
+      ? standardTransformers.seriesToColumnsTransformer.transformer({})
+      : standardTransformers.mergeTransformer.transformer({});
+
+    const data = transformer(onlyTables)[0];
 
     // set display processor
     for (const field of data.fields) {

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -71,7 +71,7 @@ export class ResultProcessor {
     const hasOnlyTimeseries = onlyTables.every(df => isTimeSeries(df));
 
     // If we have only timeseries we do join on default time column which makes more sense. If we are showing
-    // non timeseries or some mix od data we are not trying to join on anything and just try to merge them in
+    // non timeseries or some mix of data we are not trying to join on anything and just try to merge them in
     // single table, which may not make sense in most cases, but it's up to the user to query something sensible.
     const transformer = hasOnlyTimeseries
       ? standardTransformers.seriesToColumnsTransformer.transformer({})


### PR DESCRIPTION
In case we show timeseries in the table we were doing automatic join transform on Time column. This was changed in https://github.com/grafana/grafana/pull/25694 where we simplified the transform code. This reintroduces the behavior back to the data processing.