### PR TITLE
Explore/Loki: Fix field type in table for instant queries

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -201,7 +201,7 @@ export function lokiResultsToTableModel(
   table.columns = [
     { text: 'Time', type: FieldType.time },
     ...sortedLabels.map(label => ({ text: label, filterable: true })),
-    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value' },
+    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.number },
   ];
 
   // Populate rows, set value to empty string when label not present.

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -201,7 +201,7 @@ export function lokiResultsToTableModel(
   table.columns = [
     { text: 'Time', type: FieldType.time },
     ...sortedLabels.map(label => ({ text: label, filterable: true })),
-    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.number },
+    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value' },
   ];
 
   // Populate rows, set value to empty string when label not present.

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -201,7 +201,7 @@ export function lokiResultsToTableModel(
   table.columns = [
     { text: 'Time', type: FieldType.time },
     ...sortedLabels.map(label => ({ text: label, filterable: true })),
-    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.time },
+    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.number },
   ];
 
   // Populate rows, set value to empty string when label not present.


### PR DESCRIPTION
**What this PR does / why we need it**:
FieldType for instant queries is currently set to **time**. This PR fixes it by changing FieldType to number in **lokiResultsToTableModel**. 

I have also considered to not add a FieldType, but the results of instant queries should be always a number, right @davkal? Is there a case when i would be text - such as Inf+ / Inf-? 
Before: 
![image](https://user-images.githubusercontent.com/30407135/86032324-7230f480-ba37-11ea-87c5-50e88a001b76.png)

After: 
![image](https://user-images.githubusercontent.com/30407135/86032253-4f9edb80-ba37-11ea-92e3-6543a22feea9.png)


**How to recreate the issue*:
Run query such as `rate({job="grafana"}[5m])` in Explore, look at table results. 

**Special notes for your reviewer**:
This PR is partly connected to https://github.com/grafana/grafana/pull/25845. After merging #25845, there will be only results of instant queries in the table.

