### PR TITLE
Chore: Disable scopelint for tests

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -42,7 +42,6 @@ func TestGetHomeDashboard(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dash := dtos.DashboardFullWithMeta{}
 			dash.Meta.IsHome = true
@@ -802,7 +801,6 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				tc := tc
 				mock := &dashboards.FakeDashboardService{
 					SaveDashboardError: tc.SaveError,
 				}

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -62,7 +62,6 @@ func TestFoldersApiEndpoint(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				tc := tc
 				mock := &fakeFolderService{
 					CreateFolderError: tc.Error,
 				}
@@ -120,7 +119,6 @@ func TestFoldersApiEndpoint(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				tc := tc
 				mock := &fakeFolderService{
 					UpdateFolderError: tc.Error,
 				}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -252,7 +252,6 @@ func TestLoginViewRedirect(t *testing.T) {
 	}
 
 	for _, c := range redirectCases {
-		c := c
 		hs.Cfg.AppUrl = c.appURL
 		hs.Cfg.AppSubUrl = c.appSubURL
 		t.Run(c.desc, func(t *testing.T) {
@@ -421,7 +420,6 @@ func TestLoginPostRedirect(t *testing.T) {
 	}
 
 	for _, c := range redirectCases {
-		c := c
 		hs.Cfg.AppUrl = c.appURL
 		hs.Cfg.AppSubUrl = c.appSubURL
 		t.Run(c.desc, func(t *testing.T) {

--- a/pkg/api/pluginproxy/access_token_provider_test.go
+++ b/pkg/api/pluginproxy/access_token_provider_test.go
@@ -189,7 +189,6 @@ func TestAccessToken(t *testing.T) {
 				},
 			}
 			for _, testCase := range testCases {
-				testCase := testCase
 				Convey(testCase.desc, func() {
 					clearTokenCache()
 					// reset the httphandler counter

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -617,7 +617,6 @@ func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cfg := setting.Cfg{}
 			plugin := plugins.DataSourcePlugin{}

--- a/pkg/cmd/grafana-cli/commands/upgrade_all_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_all_command_test.go
@@ -21,10 +21,9 @@ func TestVersionComparison(t *testing.T) {
 		}
 
 		for k, v := range upgradeablePlugins {
-			key := k
 			val := v
 			t.Run(fmt.Sprintf("for %s should be true", k), func(t *testing.T) {
-				assert.True(t, shouldUpgrade(key, &val))
+				assert.True(t, shouldUpgrade(k, &val))
 			})
 		}
 	})
@@ -41,10 +40,9 @@ func TestVersionComparison(t *testing.T) {
 		}
 
 		for k, v := range shouldNotUpgrade {
-			key := k
 			val := v
 			t.Run(fmt.Sprintf("for %s should be false", k), func(t *testing.T) {
-				assert.False(t, shouldUpgrade(key, &val))
+				assert.False(t, shouldUpgrade(k, &val))
 			})
 		}
 	})

--- a/pkg/cmd/grafana-server/diagnostics_test.go
+++ b/pkg/cmd/grafana-server/diagnostics_test.go
@@ -23,7 +23,6 @@ func TestProfilingDiagnostics(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			os.Clearenv()
 			if tc.enabledEnv != "" {
@@ -56,7 +55,6 @@ func TestTracingDiagnostics(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			os.Clearenv()
 			if tc.enabledEnv != "" {

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -26,7 +26,6 @@ func TestParseInterval(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			res, err := ParseInterval(tc.interval)
 			if tc.err == "" {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -221,7 +221,6 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			s := &SocialAzureAD{
 				SocialBase:    tt.fields.SocialBase,

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -89,7 +89,6 @@ func TestSearchJSONForEmail(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			test := test
 			provider.emailAttributePath = test.EmailAttributePath
 			t.Run(test.Name, func(t *testing.T) {
 				actualResult, err := provider.searchJSONForAttr(test.EmailAttributePath, test.UserInfoJSONResponse)
@@ -153,7 +152,6 @@ func TestSearchJSONForRole(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			test := test
 			provider.roleAttributePath = test.RoleAttributePath
 			t.Run(test.Name, func(t *testing.T) {
 				actualResult, err := provider.searchJSONForAttr(test.RoleAttributePath, test.UserInfoJSONResponse)
@@ -306,7 +304,6 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			test := test
 			provider.roleAttributePath = test.RoleAttributePath
 			t.Run(test.Name, func(t *testing.T) {
 				response, err := json.Marshal(test.APIURLResponse)

--- a/pkg/plugins/backendplugin/grpcplugin/log_wrapper_test.go
+++ b/pkg/plugins/backendplugin/grpcplugin/log_wrapper_test.go
@@ -21,7 +21,6 @@ func TestLogWrapper(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		tc := tc
 		t.Run(fmt.Sprintf("formatArgs testcase %d", i), func(t *testing.T) {
 			res := formatArgs(tc.args...)
 			assert.Exactly(t, tc.expectedResult, res)

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -177,7 +177,6 @@ func TestPluginManager_IsBackendOnlyPlugin(t *testing.T) {
 		{name: "renderer", isBackendOnly: true},
 		{name: "app", isBackendOnly: false},
 	} {
-		c := c
 		t.Run(fmt.Sprintf("Plugin %s", c.name), func(t *testing.T) {
 			result := pluginScanner.IsBackendOnlyPlugin(c.name)
 

--- a/pkg/services/alerting/alerting_usage_test.go
+++ b/pkg/services/alerting/alerting_usage_test.go
@@ -107,7 +107,6 @@ func TestParsingAlertRuleSettings(t *testing.T) {
 	require.NoError(t, err, "Init should not return an error")
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			content, err := ioutil.ReadFile(tc.file)
 			require.NoError(t, err, "expected to be able to read file")

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -372,7 +372,6 @@ func (sc *scenarioContext) verifyUpdateDashboardPermissionsShouldBeAllowed(pt pe
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		tc := fmt.Sprintf("When updating dashboard permissions with %s permissions should be allowed", p.String())
 
 		Convey(tc, func() {
@@ -421,7 +420,6 @@ func (sc *scenarioContext) verifyUpdateDashboardPermissionsShouldNotBeAllowed(pt
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		tc := fmt.Sprintf("When updating dashboard permissions with %s permissions should NOT be allowed", p.String())
 
 		Convey(tc, func() {
@@ -462,7 +460,6 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldBeAllowed(
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		tc := fmt.Sprintf("When updating child dashboard permissions with %s permissions should be allowed", p.String())
 
 		Convey(tc, func() {
@@ -526,7 +523,6 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldNotBeAllow
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		tc := fmt.Sprintf("When updating child dashboard permissions with %s permissions should NOT be allowed", p.String())
 
 		Convey(tc, func() {
@@ -590,7 +586,6 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsWithOverrideShou
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		// permission to update is higher than parent folder permission
 		if p > parentFolderPermission {
 			continue
@@ -636,7 +631,6 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsWithOverrideShou
 	}
 
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
-		p := p
 		// permission to update is lower than or equal to parent folder permission
 		if p <= parentFolderPermission {
 			continue

--- a/pkg/services/sqlstore/migrations/migrations_test.go
+++ b/pkg/services/sqlstore/migrations/migrations_test.go
@@ -16,7 +16,6 @@ func TestMigrations(t *testing.T) {
 	}
 
 	for _, testDB := range testDBs {
-		testDB := testDB
 		sql := `select count(*) as count from migration_log`
 		r := struct {
 			Count int64

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -71,7 +71,6 @@ func TestSqlConnectionString(t *testing.T) {
 		t.Helper()
 
 		for _, testCase := range sqlStoreTestCases {
-			testCase := testCase
 			Convey(testCase.name, func() {
 				sqlstore := &SqlStore{}
 				sqlstore.Cfg = makeSqlStoreTestConfig(testCase.dbType, testCase.dbHost)

--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
@@ -195,7 +195,6 @@ func TestAppInsightsPluginRoutes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			route, routeName, err := datasource.getPluginRoute(plugin, tt.cloudName)
 			tt.Err(t, err)

--- a/pkg/tsdb/azuremonitor/applicationinsights-metrics_test.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-metrics_test.go
@@ -104,7 +104,6 @@ func TestInsightsMetricsResultToFrame(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := loadInsightsMetricsResponse(tt.testFile)
 			require.NoError(t, err)

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -69,7 +69,6 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			queries, err := datasource.buildQueries(tt.queryModel, tt.timeRange)
 			tt.Err(t, err)
@@ -142,7 +141,6 @@ func TestPluginRoutes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			route, proxypass, err := datasource.getPluginRoute(plugin, tt.cloudName)
 			tt.Err(t, err)

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame_test.go
@@ -122,7 +122,6 @@ func TestLogTableToFrame(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := loadLogAnalyticsTestFileWithNumber(tt.testFile)
 			require.NoError(t, err)

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -98,7 +98,6 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range commonAzureModelProps {
 				tt.azureMonitorVariedProperties[k] = v
@@ -364,7 +363,6 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 	datasource := &AzureMonitorDatasource{}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			azData, err := loadTestFile("azuremonitor/" + tt.responseFile)
 			require.NoError(t, err)
@@ -422,7 +420,6 @@ func TestFindClosestAllowIntervalMS(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			interval := findClosestAllowedIntervalMS(tt.inputInterval, tt.allowedTimeGrains)
 			require.Equal(t, tt.expectedInterval, interval)

--- a/pkg/tsdb/azuremonitor/macros_test.go
+++ b/pkg/tsdb/azuremonitor/macros_test.go
@@ -139,7 +139,6 @@ func TestAzureLogAnalyticsMacros(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			defaultTimeField := "TimeGenerated"
 			rawQuery, err := KqlInterpolate(tt.query, timeRange, tt.kql, defaultTimeField)

--- a/pkg/tsdb/frame_util_test.go
+++ b/pkg/tsdb/frame_util_test.go
@@ -128,7 +128,6 @@ func TestFrameToSeriesSlice(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			seriesSlice, err := FrameToSeriesSlice(tt.frame)
 			tt.Err(t, err)

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -35,7 +35,6 @@ func TestInterpolate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
 			query := QueryModel{

--- a/scripts/go/configs/.golangci.toml
+++ b/scripts/go/configs/.golangci.toml
@@ -45,6 +45,10 @@ enable = [
 # "unparam"
 
 [[issues.exclude-rules]]
+path = "_test\\.go"
+linters = ["scopelint"]
+
+[[issues.exclude-rules]]
 linters = ["gosec"]
 text = "G108"
 

--- a/scripts/go/configs/ci/.golangci.toml
+++ b/scripts/go/configs/ci/.golangci.toml
@@ -12,6 +12,10 @@ min-occurrences = 5
 disable-all = true
 
 [[issues.exclude-rules]]
+path = "_test\\.go"
+linters = ["scopelint"]
+
+[[issues.exclude-rules]]
 linters = ["gosec"]
 text = "G108"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As @bergquist [suggested](https://github.com/grafana/grafana/pull/25896#issuecomment-651329377), disable the scopelint Go linter for tests since it makes writing table driven tests a bit hairier. In the future, we should see if it's possible to tweak the linter so it doesn't flag such cases.