### PR TITLE
Fix: Value mappings match against string values

### DIFF
--- a/packages/grafana-data/src/utils/valueMappings.test.ts
+++ b/packages/grafana-data/src/utils/valueMappings.test.ts
@@ -78,4 +78,15 @@ describe('Format value with value mappings', () => {
 
     expect(getMappedValue(valueMappings, value).text).toEqual('1-20');
   });
+
+  it('should map value text to mapping', () => {
+    const valueMappings: ValueMapping[] = [
+      { id: 0, operator: '', text: '1-20', type: MappingType.RangeToText, from: '1', to: '20' },
+      { id: 1, operator: '', text: 'ELVA', type: MappingType.ValueToText, value: 'elva' },
+    ];
+
+    const value = 'elva';
+
+    expect(getMappedValue(valueMappings, value).text).toEqual('ELVA');
+  });
 });

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -19,7 +19,9 @@ const addValueToTextMappingText = (
   const valueToTextMappingAsNumber = parseFloat(valueToTextMapping.value as string);
 
   if (isNaN(valueAsNumber) || isNaN(valueToTextMappingAsNumber)) {
-    return allValueMappings;
+    if (value === valueToTextMapping.value) {
+      return allValueMappings.concat(valueToTextMapping);
+    }
   }
 
   if (valueAsNumber !== valueToTextMappingAsNumber) {

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
@@ -52,7 +52,6 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
           <HorizontalGroup>
             <Field label="From">
               <Input
-                type="number"
                 defaultValue={(valueMapping as RangeMap).from!}
                 onBlur={e => onMappingFromChange(e.currentTarget.value)}
                 onKeyDown={onKeyDown(onMappingFromChange)}
@@ -60,7 +59,6 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
             </Field>
             <Field label="To">
               <Input
-                type="number"
                 defaultValue={(valueMapping as RangeMap).to}
                 onBlur={e => onMappingToChange(e.currentTarget.value)}
                 onKeyDown={onKeyDown(onMappingToChange)}
@@ -83,7 +81,6 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
       <>
         <Field label="Value">
           <Input
-            type="number"
             defaultValue={(valueMapping as ValueMap).value}
             onBlur={e => onMappingValueChange(e.currentTarget.value)}
             onKeyDown={onKeyDown(onMappingValueChange)}

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/MappingRow.tsx
@@ -52,6 +52,7 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
           <HorizontalGroup>
             <Field label="From">
               <Input
+                type="number"
                 defaultValue={(valueMapping as RangeMap).from!}
                 onBlur={e => onMappingFromChange(e.currentTarget.value)}
                 onKeyDown={onKeyDown(onMappingFromChange)}
@@ -59,6 +60,7 @@ export const MappingRow: React.FC<Props> = ({ valueMapping, updateValueMapping, 
             </Field>
             <Field label="To">
               <Input
+                type="number"
                 defaultValue={(valueMapping as RangeMap).to}
                 onBlur={e => onMappingToChange(e.currentTarget.value)}
                 onKeyDown={onKeyDown(onMappingToChange)}

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -159,7 +159,7 @@ export const getStandardFieldConfigs = () => {
     process: valueMappingsOverrideProcessor,
     settings: {},
     defaultValue: [],
-    shouldApply: field => field.type === FieldType.number,
+    shouldApply: () => true,
     category: ['Value mappings'],
     getItemsCount: (value?) => (value ? value.length : 0),
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a regression on the new Table introduced in 7.0 that removed the ability to match string values to valuemappings. 

**Which issue(s) this PR fixes**:

Fixes #25351

**Special notes for your reviewer**:

