### PR TITLE
Docker: Upgrade to base on Alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.3-alpine3.11 as js-builder
+FROM node:12.18.1-alpine3.12 as js-builder
 
 WORKDIR /usr/src/app/
 
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM golang:1.14.2-alpine3.11 as go-builder
+FROM golang:1.14.4-alpine3.12 as go-builder
 
 RUN apk add --no-cache gcc g++
 
@@ -32,7 +32,7 @@ COPY build.go package.json ./
 RUN go run build.go build
 
 # Final stage
-FROM alpine:3.11
+FROM alpine:3.12
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.11
+ARG BASE_IMAGE=alpine:3.12
 FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -60,7 +60,7 @@ docker_build () {
   if [ $UBUNTU_BASE = "0" ]; then
     libc="-musl"
     dockerfile="Dockerfile"
-    base_image="${base_arch}alpine:3.11"
+    base_image="${base_arch}alpine:3.12"
   else
     libc=""
     dockerfile="ubuntu.Dockerfile"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade our Dockerfile to base itself on Alpine 3.12, Node 12.18.1 and Go 1.14.4.
