### PR TITLE
CircleCI: Upgrade grabpl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.14
+            VERSION=0.4.16
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
In CircleCI, upgrade the build pipeline tool to v0.4.16, which upgrades to Alpine 3.12 as base image.

I've tested building 7.0.4 images with grabpl v0.4.16, and they work.

**Which issue(s) this PR fixes**:

Fixes #25380.
