### PR TITLE
Explore/Tooltip: Fix label value in tooltip

### DIFF
--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
@@ -4,6 +4,7 @@ import {
   getColumnFromDimension,
   formattedValueToString,
   getDisplayProcessor,
+  getFieldDisplayName,
 } from '@grafana/data';
 import { SeriesTable } from './SeriesTable';
 import { GraphTooltipContentProps } from './types';
@@ -30,14 +31,13 @@ export const SingleModeGraphTooltip: React.FC<GraphTooltipContentProps> = ({
   const value = getValueFromDimension(dimensions.yAxis, activeDimensions.yAxis[0], activeDimensions.yAxis[1]);
   const display = valueField.display ?? getDisplayProcessor({ field: valueField, timeZone });
   const disp = display(value);
-  const labelName = valueField.config?.displayName || valueField.state?.displayName || valueField.name;
 
   return (
     <SeriesTable
       series={[
         {
           color: disp.color,
-          label: labelName,
+          label: getFieldDisplayName(valueField),
           value: formattedValueToString(disp),
         },
       ]}

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
@@ -30,13 +30,14 @@ export const SingleModeGraphTooltip: React.FC<GraphTooltipContentProps> = ({
   const value = getValueFromDimension(dimensions.yAxis, activeDimensions.yAxis[0], activeDimensions.yAxis[1]);
   const display = valueField.display ?? getDisplayProcessor({ field: valueField, timeZone });
   const disp = display(value);
+  const labelName = valueField.config?.displayName || valueField.state?.displayName || valueField.name;
 
   return (
     <SeriesTable
       series={[
         {
           color: disp.color,
-          label: valueField.config.displayName,
+          label: labelName,
           value: formattedValueToString(disp),
         },
       ]}

--- a/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphTooltip/SingleModeGraphTooltip.tsx
@@ -36,7 +36,7 @@ export const SingleModeGraphTooltip: React.FC<GraphTooltipContentProps> = ({
       series={[
         {
           color: disp.color,
-          label: valueField.name,
+          label: valueField.config.displayName,
           value: formattedValueToString(disp),
         },
       ]}

--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -91,7 +91,7 @@ export const getMultiSeriesGraphHoverInfo = (
       datapointIndex: hoverIndex,
       seriesIndex: i,
       color: disp.color,
-      label: field.name,
+      label: field.config.displayName,
       time: time.display ? formattedValueToString(time.display(pointTime)) : pointTime,
     });
   }

--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -3,6 +3,7 @@ import {
   Field,
   formattedValueToString,
   getDisplayProcessor,
+  getFieldDisplayName,
   TimeZone,
   dateTimeFormat,
 } from '@grafana/data';
@@ -85,14 +86,13 @@ export const getMultiSeriesGraphHoverInfo = (
 
     const display = field.display ?? getDisplayProcessor({ field, timeZone });
     const disp = display(field.values.get(hoverIndex));
-    const labelName = field.config?.displayName || field.state?.displayName || field.name;
 
     results.push({
       value: formattedValueToString(disp),
       datapointIndex: hoverIndex,
       seriesIndex: i,
       color: disp.color,
-      label: labelName,
+      label: getFieldDisplayName(field),
       time: time.display ? formattedValueToString(time.display(pointTime)) : pointTime,
     });
   }

--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -85,13 +85,14 @@ export const getMultiSeriesGraphHoverInfo = (
 
     const display = field.display ?? getDisplayProcessor({ field, timeZone });
     const disp = display(field.values.get(hoverIndex));
+    const labelName = field.config?.displayName || field.state?.displayName || field.name;
 
     results.push({
       value: formattedValueToString(disp),
       datapointIndex: hoverIndex,
       seriesIndex: i,
       color: disp.color,
-      label: field.config.displayName,
+      label: labelName,
       time: time.display ? formattedValueToString(time.display(pointTime)) : pointTime,
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Brought up by @marcusolsson on slack: 
>In the dashboard, the tooltip shows the name of the time series, whereas in Explore more, it says “Value” for any time series, which makes it difficult to know which time series you’re looking at.


**React graph:**
![image](https://user-images.githubusercontent.com/30407135/86130935-3c4a4980-bae5-11ea-95d1-5ec5d18164ca.png)
**Angular graph:** 
![image](https://user-images.githubusercontent.com/30407135/86130955-42d8c100-bae5-11ea-89ea-8317c303c86b.png)

This PR fixes this by preferring `field.config?.displayName` or `field.state?.displayName` and fallbacks to `field.name` which is in many cases **Value**.

**What should the reviewer know:**

In Loki, the series name was under `field.state.displayName`  and not the `field.config.displayName`. Is this correct? 