### PR TITLE
Elastic: Internal data links

### DIFF
--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -91,6 +91,15 @@ For example, if you're using a default setup of Filebeat for shipping logs to El
 - **Message field name:**  message
 - **Level field name:** fields.level
 
+### Data links
+
+Data links create a link from specified field that can be accessed in logs view in Explore.
+
+Each data link configuration consists of: 
+- **Field**: Name of the field used by the data link
+- **Url/Query**: If link is external, you fill in full url for the link. In case of internal link this input serves as query for the target data source. In both cases you can interpolate the value from the field with `${__value.raw }` macro.
+- **Internal link**: Switch to select if link is internal or external. In case of internal link, data source selector will be shown where you can select the target data source. At this moment only tracing data sources are supported.
+
 ## Metric Query editor
 
 ![Elasticsearch Query Editor](/img/docs/elasticsearch/query_editor.png)

--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -93,7 +93,7 @@ For example, if you're using a default setup of Filebeat for shipping logs to El
 
 ### Data links
 
-Data links create a link from specified field that can be accessed in logs view in Explore.
+Data links create a link from a specified field that can be accessed in logs view in Explore.
 
 Each data link configuration consists of: 
 - **Field**: Name of the field used by the data link

--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -96,9 +96,9 @@ For example, if you're using a default setup of Filebeat for shipping logs to El
 Data links create a link from a specified field that can be accessed in logs view in Explore.
 
 Each data link configuration consists of: 
-- **Field**: Name of the field used by the data link
-- **Url/Query**: If link is external, you fill in full url for the link. In case of internal link this input serves as query for the target data source. In both cases you can interpolate the value from the field with `${__value.raw }` macro.
-- **Internal link**: Switch to select if link is internal or external. In case of internal link, data source selector will be shown where you can select the target data source. At this moment only tracing data sources are supported.
+- **Field -** Name of the field used by the data link.
+- **URL/query -** If the link is external, then enter the full link URL. If the link is internal link, then this input serves as query for the target data source. In both cases, you can interpolate the value from the field with `${__value.raw }` macro.
+- **Internal link -** Select if the link is internal or external. In case of internal link, a data source selectorallows you to select the target data source. Only tracing data sources are supported.
 
 ## Metric Query editor
 

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -29,4 +29,5 @@ export interface ElasticsearchQuery extends DataQuery {
 export type DataLinkConfig = {
   field: string;
   url: string;
+  datasourceUid?: string;
 };


### PR DESCRIPTION
Add internal data links, similar to what we have in Loki to elastic config.

Right now only tracing data sources are supported as target data source.
![Screenshot from 2020-06-30 16-42-18](https://user-images.githubusercontent.com/1014802/86140014-af0cf200-baf0-11ea-9753-d479d7aa8e07.png)
![Screenshot from 2020-06-30 16-42-37](https://user-images.githubusercontent.com/1014802/86140041-b9c78700-baf0-11ea-9f6e-ac545261d171.png)

We do not have good testing data for this case. In general though for manual testing the point is that the field value is correctly interpolated into the query of target data source and it is open when clicking on it so the actual value does not matter for the test.