### PR TITLE
Chore: Fix strict null errors 

### DIFF
--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -346,7 +346,7 @@ export function filterQueriesBySearchFilter(queries: RichHistoryQuery[], searchF
 
     const listOfMatchingQueries = query.queries.filter(query =>
       // Remove fields in which we don't want to be searching
-      Object.values(_.omit(query, ['datasource', 'key', 'refId', 'hide', 'queryType'])).some(value =>
+      Object.values(_.omit(query, ['datasource', 'key', 'refId', 'hide', 'queryType'])).some((value: any) =>
         value.toString().includes(searchFilter)
       )
     );
@@ -356,7 +356,7 @@ export function filterQueriesBySearchFilter(queries: RichHistoryQuery[], searchF
 }
 
 export function filterQueriesByDataSource(queries: RichHistoryQuery[], listOfDatasourceFilters: string[] | null) {
-  return listOfDatasourceFilters?.length > 0
+  return listOfDatasourceFilters && listOfDatasourceFilters.length > 0
     ? queries.filter(q => listOfDatasourceFilters.includes(q.datasourceName))
     : queries;
 }

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -138,7 +138,7 @@ export function RichHistoryQueriesTab(props: Props) {
   } = props;
 
   const [timeFilter, setTimeFilter] = useState<[number, number]>([0, retentionPeriod]);
-  const [filteredQueries, setFilteredQueries] = useState([]);
+  const [filteredQueries, setFilteredQueries] = useState<RichHistoryQuery[]>([]);
   const [searchInput, setSearchInput] = useState('');
 
   const theme = useTheme();
@@ -153,7 +153,7 @@ export function RichHistoryQueriesTab(props: Props) {
         filterAndSortQueries(
           queries,
           sortOrder,
-          datasourceFilters?.map(d => d.value),
+          datasourceFilters?.map(d => d.value) as string[] | null,
           searchValue,
           timeFilter
         )
@@ -167,7 +167,7 @@ export function RichHistoryQueriesTab(props: Props) {
       filterAndSortQueries(
         queries,
         sortOrder,
-        datasourceFilters?.map(d => d.value),
+        datasourceFilters?.map(d => d.value) as string[] | null,
         searchInput,
         timeFilter
       )

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -83,7 +83,7 @@ export function RichHistoryStarredTab(props: Props) {
     exploreId,
   } = props;
 
-  const [filteredQueries, setFilteredQueries] = useState([]);
+  const [filteredQueries, setFilteredQueries] = useState<RichHistoryQuery[]>([]);
   const [searchInput, setSearchInput] = useState('');
 
   const theme = useTheme();
@@ -99,7 +99,7 @@ export function RichHistoryStarredTab(props: Props) {
         filterAndSortQueries(
           starredQueries,
           sortOrder,
-          datasourceFilters?.map(d => d.value),
+          datasourceFilters?.map(d => d.value) as string[] | null,
           searchValue
         )
       );
@@ -112,7 +112,7 @@ export function RichHistoryStarredTab(props: Props) {
       filterAndSortQueries(
         starredQueries,
         sortOrder,
-        datasourceFilters?.map(d => d.value),
+        datasourceFilters?.map(d => d.value) as string[] | null,
         searchInput
       )
     );


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix strict null check errors that resulted from adding Query history search.  
