### PR TITLE
Panel: Cancel panel query via loading spinner

### DIFF
--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -73,6 +73,7 @@ export type IconName =
   | 'calendar-alt'
   | 'play'
   | 'pause'
+  | 'stop-circle'
   | 'calculator-alt'
   | 'compass'
   | 'sliders-v-alt'
@@ -187,6 +188,7 @@ export const getAvailableIcons = (): IconName[] => [
   'calendar-alt',
   'play',
   'pause',
+  'stop-circle',
   'calculator-alt',
   'compass',
   'sliders-v-alt',

--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -73,7 +73,6 @@ export type IconName =
   | 'calendar-alt'
   | 'play'
   | 'pause'
-  | 'stop-circle'
   | 'calculator-alt'
   | 'compass'
   | 'sliders-v-alt'
@@ -188,7 +187,6 @@ export const getAvailableIcons = (): IconName[] => [
   'calendar-alt',
   'play',
   'pause',
-  'stop-circle',
   'calculator-alt',
   'compass',
   'sliders-v-alt',

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -87,10 +87,16 @@ export class PanelHeader extends Component<Props, State> {
     });
   };
 
+  onCancelQuery = () => {
+    this.props.panel.getQueryRunner().cancelQuery();
+  };
+
   private renderLoadingState(): JSX.Element {
     return (
-      <div className="panel-loading">
-        <Icon className="fa-spin" name="fa fa-spinner" />
+      <div className="panel-loading" onClick={this.onCancelQuery}>
+        <Tooltip content="Cancel query">
+          <Icon className="panel-loading__spinner spin-counter-clock" name="sync" />
+        </Tooltip>
       </div>
     );
   }

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -25,6 +25,7 @@ import {
   applyFieldOverrides,
   DataConfigSource,
   TimeZone,
+  LoadingState,
 } from '@grafana/data';
 
 export interface QueryRunnerOptions<
@@ -196,6 +197,22 @@ export class PanelQueryRunner {
         this.subject.next(this.lastResult);
       },
     });
+  }
+
+  cancelQuery() {
+    if (!this.subscription) {
+      return;
+    }
+
+    this.subscription.unsubscribe();
+
+    // If we have an old result with loading state, send it with done state
+    if (this.lastResult && this.lastResult.state === LoadingState.Loading) {
+      this.subject.next({
+        ...this.lastResult,
+        state: LoadingState.Done,
+      });
+    }
   }
 
   resendLastResult = () => {

--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -78,6 +78,10 @@ $panel-header-no-title-zindex: 1;
   z-index: $panel-header-z-index + 1;
   font-size: $font-size-lg;
   color: $text-color-weak;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .panel-empty {

--- a/public/sass/mixins/_animations.scss
+++ b/public/sass/mixins/_animations.scss
@@ -34,3 +34,16 @@
     transition: max-height 250ms ease-in-out;
   }
 }
+
+@keyframes spin-counter-clock {
+  0% {
+    transform: rotate(359deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+.spin-counter-clock {
+  animation: spin-counter-clock 3s infinite linear;
+}


### PR DESCRIPTION
Closes #25783 

This 
* Updates the loading spinner to use the same refresh icon we use in refresh picker and run query button in explore. Had to add a new counter clock wise rotation for the spinner to work with this icon as the refresh icon arrows point in the counter clockwise direction. 
* Adds a tooltip and pointer cursor for the loading icon 
* Clicking on loading spinner will cancel the query 

<img width="535" alt="Screen Shot 2020-06-30 at 21 58 16" src="https://user-images.githubusercontent.com/10999/86171326-d5e11d80-bb1c-11ea-83ae-3a270d254223.png">

This will cancel the http request where data source set requestId correctly in the backendSrv.datasourceRequest call. Many do not set requestId in a way where this works. For that we need https://github.com/grafana/grafana/pull/25746 