### PR TITLE
Azure: query builder cleanup

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -931,11 +931,22 @@ describe('AzureMonitorDatasource', () => {
           'Transactions'
         )
         .then((results: any) => {
-          expect(results.dimensions.length).toEqual(4);
-          expect(results.dimensions[0].text).toEqual('None');
-          expect(results.dimensions[0].value).toEqual('None');
-          expect(results.dimensions[1].text).toEqual('Response type');
-          expect(results.dimensions[1].value).toEqual('ResponseType');
+          expect(results.dimensions).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "text": "Response type",
+                "value": "ResponseType",
+              },
+              Object {
+                "text": "Geo type",
+                "value": "GeoType",
+              },
+              Object {
+                "text": "API name",
+                "value": "ApiName",
+              },
+            ]
+          `);
         });
     });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -74,13 +74,16 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
     const aggregation = templateSrv.replace(item.aggregation, scopedVars);
     const top = templateSrv.replace(item.top || '', scopedVars);
 
-    const dimensionsFilters = item.dimensionFilters.map(f => {
-      return {
-        dimension: templateSrv.replace(f.dimension, scopedVars),
-        operator: f.operator || 'eq',
-        filter: templateSrv.replace(f.filter, scopedVars),
-      };
-    });
+    const dimensionsFilters = item.dimensionFilters
+      .filter(f => f.dimension && f.dimension !== 'None')
+      .map(f => {
+        const filter = templateSrv.replace(f.filter, scopedVars);
+        return {
+          dimension: templateSrv.replace(f.dimension, scopedVars),
+          operator: f.operator || 'eq',
+          filter: filter || '*', // send * when empty
+        };
+      });
 
     return {
       refId: target.refId,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/response_parser.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/response_parser.ts
@@ -92,10 +92,6 @@ export default class ResponseParser {
       return dimensions;
     }
 
-    if (!metricData.isDimensionRequired) {
-      dimensions.push({ text: 'None', value: 'None' });
-    }
-
     for (let i = 0; i < metricData.dimensions.length; i++) {
       const text = metricData.dimensions[i].localizedValue;
       const value = metricData.dimensions[i].value;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -100,7 +100,7 @@
         >
         </gf-form-dropdown>
       </div>
-      <div class="gf-form gf-form--grow aggregation-dropdown-wrapper">
+      <div class="gf-form">
         <label class="gf-form-label query-keyword width-9">Aggregation</label>
         <div class="gf-form-select-wrapper gf-form-select-wrapper--caret-indent">
           <select
@@ -110,6 +110,9 @@
             ng-change="ctrl.refresh()"
           ></select>
         </div>
+      </div>
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
       </div>
     </div>
     <div class="gf-form-inline">

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -533,7 +533,6 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
       operator: 'eq',
       filter: '',
     });
-    this.refresh();
   }
 
   azureMonitorRemoveDimensionFilter(index: number) {


### PR DESCRIPTION
This avoids sending `None` filter queries, and does not refresh right after add