### PR TITLE
Plugins: Provide license token directly via plugin environment

### DIFF
--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -16,4 +16,6 @@ type Licensing interface {
 	LicenseURL(user *SignedInUser) string
 
 	StateInfo() string
+
+	TokenRaw() string
 }

--- a/pkg/plugins/backendplugin/manager.go
+++ b/pkg/plugins/backendplugin/manager.go
@@ -100,7 +100,11 @@ func (m *manager) Register(pluginID string, factory PluginFactoryFunc) error {
 	}
 
 	if m.License.HasLicense() {
-		hostEnv = append(hostEnv, fmt.Sprintf("GF_ENTERPRISE_LICENSE_PATH=%s", m.Cfg.EnterpriseLicensePath))
+		hostEnv = append(
+			hostEnv,
+			fmt.Sprintf("GF_ENTERPRISE_LICENSE_PATH=%s", m.Cfg.EnterpriseLicensePath),
+			fmt.Sprintf("GF_ENTERPRISE_LICENSE_TEXT=%s", m.License.TokenRaw()),
+		)
 	}
 
 	env := pluginSettings.ToEnv("GF_PLUGIN", hostEnv)

--- a/pkg/plugins/backendplugin/manager_test.go
+++ b/pkg/plugins/backendplugin/manager_test.go
@@ -251,6 +251,7 @@ func TestManager(t *testing.T) {
 		t.Run("Plugin registration scenario when Grafana is licensed", func(t *testing.T) {
 			ctx.license.edition = "Enterprise"
 			ctx.license.hasLicense = true
+			ctx.license.tokenRaw = "testtoken"
 			ctx.cfg.BuildVersion = "7.0.0"
 			ctx.cfg.EnterpriseLicensePath = "/license.txt"
 
@@ -258,8 +259,8 @@ func TestManager(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("Should provide expected host environment variables", func(t *testing.T) {
-				require.Len(t, ctx.env, 3)
-				require.EqualValues(t, []string{"GF_VERSION=7.0.0", "GF_EDITION=Enterprise", "GF_ENTERPRISE_LICENSE_PATH=/license.txt"}, ctx.env)
+				require.Len(t, ctx.env, 4)
+				require.EqualValues(t, []string{"GF_VERSION=7.0.0", "GF_EDITION=Enterprise", "GF_ENTERPRISE_LICENSE_PATH=/license.txt", "GF_ENTERPRISE_LICENSE_TEXT=testtoken"}, ctx.env)
 			})
 		})
 	})
@@ -383,6 +384,7 @@ func (tp *testPlugin) CallResource(ctx context.Context, req *backend.CallResourc
 type testLicensingService struct {
 	edition    string
 	hasLicense bool
+	tokenRaw   string
 }
 
 func (t *testLicensingService) HasLicense() bool {
@@ -407,4 +409,8 @@ func (t *testLicensingService) LicenseURL(user *models.SignedInUser) string {
 
 func (t *testLicensingService) HasValidLicense() bool {
 	return false
+}
+
+func (t *testLicensingService) TokenRaw() string {
+	return t.tokenRaw
 }

--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -56,3 +56,7 @@ func (l *OSSLicensingService) Init() error {
 func (*OSSLicensingService) HasValidLicense() bool {
 	return false
 }
+
+func (*OSSLicensingService) TokenRaw() string {
+	return ""
+}


### PR DESCRIPTION
This PR updates the way we provide license tokens to backend plugins, providing the content of the token directly via the `GF_ENTERPRISE_LICENSE_TEXT` environment variable.