### PR TITLE
PanelEdit: Remove field label for single item categories

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -178,7 +178,7 @@ export const DefaultFieldConfigEditor: React.FC<Props> = ({ data, onChange, conf
       );
 
       // hide label if there is only one item and category name is same as item, name
-      if (categoryItemCount === 1 && item.category?.length && item.category[0] === item.name) {
+      if (categoryItemCount === 1 && item.category?.[0] === item.name) {
         label = undefined;
       }
 

--- a/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/FieldConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, ReactNode } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import {
   DataFrame,
@@ -171,11 +171,16 @@ export const DefaultFieldConfigEditor: React.FC<Props> = ({ data, onChange, conf
           : undefined
         : (defaults as any)[item.path];
 
-      const label = (
+      let label: ReactNode | undefined = (
         <Label description={item.description} category={item.category?.slice(1)}>
           {item.name}
         </Label>
       );
+
+      // hide label if there is only one item and category name is same as item, name
+      if (categoryItemCount === 1 && item.category?.length && item.category[0] === item.name) {
+        label = undefined;
+      }
 
       return (
         <Field label={label} key={`${item.id}/${item.isCustom}`}>


### PR DESCRIPTION
Fixes this double section & item name we have for value mapppings and data links and thresholds 

Problem:
![Screenshot from 2020-07-01 20-32-48](https://user-images.githubusercontent.com/10999/86279293-10f55680-bbda-11ea-812b-b4e9e6c0fa63.png)

With fix: 

![Screenshot from 2020-07-01 20-32-55](https://user-images.githubusercontent.com/10999/86279298-1357b080-bbda-11ea-93a5-46b5ab1c34f9.png)
