### PR TITLE
Monaco: check suggestions against current word

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/suggestions.test.ts
+++ b/packages/grafana-ui/src/components/Monaco/suggestions.test.ts
@@ -15,6 +15,13 @@ describe('Check suggestion index', () => {
     expect(prefix).toEqual('');
   });
 
+  it('insert new word', () => {
+    const line = 'this is a new ';
+    const { index, prefix } = findInsertIndex(line);
+    expect(index).toEqual(line.length);
+    expect(prefix).toEqual('');
+  });
+
   it('complte a simple word', () => {
     const line = 'SELECT * FROM tab';
     const { index, prefix } = findInsertIndex(line);
@@ -25,7 +32,7 @@ describe('Check suggestion index', () => {
   it('complete a quoted word', () => {
     const line = 'SELECT "hello", "wo';
     const { index, prefix } = findInsertIndex(line);
-    expect(index).toEqual(line.lastIndexOf('#') + 1);
+    expect(index).toEqual(line.lastIndexOf('"') + 1);
     expect(prefix).toEqual('wo');
   });
 });

--- a/packages/grafana-ui/src/components/Monaco/suggestions.test.ts
+++ b/packages/grafana-ui/src/components/Monaco/suggestions.test.ts
@@ -1,0 +1,31 @@
+import { findInsertIndex } from './suggestions';
+
+describe('Check suggestion index', () => {
+  it('find last $ sign', () => {
+    const line = ' hello $123';
+    const { index, prefix } = findInsertIndex(line);
+    expect(index).toEqual(line.indexOf('$'));
+    expect(prefix).toEqual('$123');
+  });
+
+  it('insert into empty line', () => {
+    const line = '';
+    const { index, prefix } = findInsertIndex(line);
+    expect(index).toEqual(0);
+    expect(prefix).toEqual('');
+  });
+
+  it('complte a simple word', () => {
+    const line = 'SELECT * FROM tab';
+    const { index, prefix } = findInsertIndex(line);
+    expect(index).toEqual(line.lastIndexOf(' ') + 1);
+    expect(prefix).toEqual('tab');
+  });
+
+  it('complete a quoted word', () => {
+    const line = 'SELECT "hello", "wo';
+    const { index, prefix } = findInsertIndex(line);
+    expect(index).toEqual(line.lastIndexOf('#') + 1);
+    expect(prefix).toEqual('wo');
+  });
+});

--- a/packages/grafana-ui/src/components/Monaco/suggestions.ts
+++ b/packages/grafana-ui/src/components/Monaco/suggestions.ts
@@ -80,7 +80,7 @@ export function registerSuggestions(
       const lastVar = currentLine.lastIndexOf('$');
       const wordStart = Math.max(lastSep, lastVar);
       const currentWord = currentLine.substring(wordStart);
-      range.startColumn = wordStart;
+      range.startColumn = wordStart + 1;
 
       const suggestions = getCompletionItems(currentWord, getSuggestions(), range);
       if (suggestions.length) {


### PR DESCRIPTION
The current monaco suggestions work when they start with a `$` or it is an empty line.  This changes the prefix check to look at the current word on the current line.

![image](https://user-images.githubusercontent.com/705951/86284750-4e38f480-bb98-11ea-9a3a-1c3483577b83.png)

The downside of returning any suggestions off '' is that it will replace any out-of-the-box language suggestions for that same input
