### PR TITLE
POC: monaco language workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ awsconfig
 /.awcache
 /dist
 /public/build
+/public/lib
 /public/views/index.html
 /public/views/error.html
 /emails/dist

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -8,6 +8,34 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 type Props = CodeEditorProps & Themeable;
 
+// @ts-ignore
+const originalEnvironment = self.MonacoEnvironment;
+console.log('MonacoEnvironment (original)', originalEnvironment);
+
+// @ts-ignore
+self.MonacoEnvironment = {
+  getWorkerUrl: (moduleId: string, label: string) => {
+    const orig = originalEnvironment.getWorkerUrl(moduleId, label);
+    console.log('MONACO getWorkerUrl', moduleId, label, orig);
+    if (label === 'json') {
+      //      return 'public/lib/monaco/min/vs/language/json/jsonWorker.js'; // standard distriution
+      return 'public/build/monaco-json.worker.js'; // Built by webpack
+    }
+    if (label === 'css') {
+      return 'CSS'; //'./css.worker.bundle.js';
+    }
+    if (label === 'html') {
+      const v = 'public/lib/monaco/min/vs/language/html/htmlWorker.js';
+      console.log('HTML', v);
+      return v;
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return 'TYPESCRIPT'; //./ts.worker.bundle.js';
+    }
+    return orig;
+  },
+};
+
 class UnthemedCodeEditor extends React.PureComponent<Props> {
   completionCancel?: monaco.IDisposable;
 

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -33,6 +33,13 @@ module.exports = {
   target: 'web',
   entry: {
     app: './public/app/index.ts',
+
+    // When specified... these are loaded on starup? not asyn
+    'monaco.editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
+    'monaco.json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
+    // 'monaco.html.worker': 'monaco-editor/esm/vs/language/html/html.worker',
+    // 'monaco.css.worker': 'monaco-editor/esm/vs/language/css/css.worker',
+    // 'monaco.ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker',
   },
   output: {
     path: path.resolve(__dirname, '../../public/build'),

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 // https://github.com/visionmedia/debug/issues/701#issuecomment-505487361
 function shouldExclude(filename) {
@@ -62,10 +63,52 @@ module.exports = {
     fs: 'empty',
   },
   plugins: [
+    new CopyWebpackPlugin([
+      {
+        context: path.resolve(__dirname, '../../node_modules/monaco-editor/'),
+        from: 'min/vs/**',
+        to: '../lib/monaco/', // inside the public/build folder
+        globOptions: {
+          ignore: [
+            // Skip unnecessary languages
+            '**/basic-languages/abap/**',
+            '**/basic-languages/cameligo/**',
+            '**/basic-languages/apex/**',
+            '**/basic-languages/azcli/**',
+            '**/basic-languages/bat/**',
+            '**/basic-languages/solidity/**',
+            '**/basic-languages/fsharp/**',
+            '**/basic-languages/clojure/**',
+            '**/basic-languages/coffee/**',
+            '**/basic-languages/cpp/**',
+            '**/basic-languages/csharp/**',
+            '**/basic-languages/csp/**',
+            '**/basic-languages/java/**',
+            '**/basic-languages/kotlin/**',
+            '**/basic-languages/lua/**',
+            '**/basic-languages/objective-c/**',
+            '**/basic-languages/php/**',
+            '**/basic-languages/python/**',
+            '**/basic-languages/perl/**',
+            '**/basic-languages/r/**',
+            '**/basic-languages/razor/**',
+            '**/basic-languages/ruby/**',
+            '**/basic-languages/rust/**',
+            '**/basic-languages/vb/**',
+            '**/basic-languages/st/**',
+            '**/basic-languages/sb/**',
+            '**/basic-languages/scheme/**',
+            '**/basic-languages/sophia/**',
+            '**/basic-languages/swift/**',
+            '**/basic-languages/twig/**',
+          ],
+        },
+      },
+    ]),
     new MonacoWebpackPlugin({
       // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
-      filename: 'monaco-[name].worker.js',
-      languages: ['json', 'markdown', 'html', 'sql', 'mysql', 'pgsql'],
+      filename: 'monaco-[name].worker.js', // only json
+      languages: ['json', 'markdown', 'sql', 'mysql', 'pgsql'],
       features: [
         '!accessibilityHelp',
         'bracketMatching',


### PR DESCRIPTION
This PR expolores ways to load languages more dynamically with runtime workers.

Unclear how/if this can work with the monaco-editor-webpack-plugin since it already mucks with `getWorkerUrl` 
https://github.com/microsoft/monaco-editor-webpack-plugin/blob/master/src/index.ts#L201