### PR TITLE
Panel Loading: spin clockwise, not counter clockwise

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -95,7 +95,7 @@ export class PanelHeader extends Component<Props, State> {
     return (
       <div className="panel-loading" onClick={this.onCancelQuery}>
         <Tooltip content="Cancel query">
-          <Icon className="panel-loading__spinner spin-counter-clock" name="sync" />
+          <Icon className="panel-loading__spinner spin-clockwise" name="sync" />
         </Tooltip>
       </div>
     );

--- a/public/sass/mixins/_animations.scss
+++ b/public/sass/mixins/_animations.scss
@@ -37,7 +37,7 @@
 
 @keyframes spin-clockwise {
   0% {
-    transform: rotate(0deg) scaleX(-1); // scaleX flips the icon so arrows point the correct way
+    transform: rotate(0deg) scaleX(-1); // scaleX flips the `sync` icon so arrows point the correct way
   }
   100% {
     transform: rotate(359deg) scaleX(-1);

--- a/public/sass/mixins/_animations.scss
+++ b/public/sass/mixins/_animations.scss
@@ -35,15 +35,15 @@
   }
 }
 
-@keyframes spin-counter-clock {
+@keyframes spin-clockwise {
   0% {
-    transform: rotate(359deg);
+    transform: rotate(0deg) scaleX(-1); // scaleX flips the icon so arrows point the correct way
   }
   100% {
-    transform: rotate(0deg);
+    transform: rotate(359deg) scaleX(-1);
   }
 }
 
-.spin-counter-clock {
-  animation: spin-counter-clock 3s infinite linear;
+.spin-clockwise {
+  animation: spin-clockwise 3s infinite linear;
 }


### PR DESCRIPTION
In #25954, the loading icon changed to match the refresh icon (`sync`) -- the arrows point left, so the spinner goes counter-clockwise.

My brain will totally explode if we have to watch time spinning counter-clockwise... call me old fashioned.

This flips the icon and spins it clockwise:
![image](https://user-images.githubusercontent.com/705951/86303286-3ffece80-bbc0-11ea-90f1-fed30151a216.png)

ideally the refresh icon would also be flipped, but that is not urgent.
