### PR TITLE
Feature: Dashboard Usage Tracking

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -306,6 +306,7 @@ func (hs *HTTPServer) registerRoutes() {
 				dashIdRoute.Get("/versions", Wrap(GetDashboardVersions))
 				dashIdRoute.Get("/versions/:id", Wrap(GetDashboardVersion))
 				dashIdRoute.Post("/restore", bind(dtos.RestoreDashboardVersionCommand{}), Wrap(hs.RestoreDashboardVersion))
+				dashIdRoute.Post("/visit", Wrap(hs.VisitDashboard))
 
 				dashIdRoute.Group("/permissions", func(dashboardPermissionRoute routing.RouteRegister) {
 					dashboardPermissionRoute.Get("/", Wrap(GetDashboardPermissionList))

--- a/pkg/api/dashboard_visit.go
+++ b/pkg/api/dashboard_visit.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+func (hs *HTTPServer) VisitDashboard(c *models.ReqContext) Response {
+	dashboardId := c.ParamsInt64(":dashboardId")
+	visitDashboardCommand := &models.VisitDashboardCommand{
+		UserId:      c.UserId,
+		OrgId:       c.OrgId,
+		DashboardId: dashboardId,
+	}
+
+	if err := bus.Dispatch(visitDashboardCommand); err != nil {
+		hs.log.Warn("Failed to mark dashboard as visited", "userId", c.UserId, "orgId", c.OrgId, "dashboardId", dashboardId, "err", err)
+	}
+
+	return Success("")
+}

--- a/pkg/cmd/grafana-server/server.go
+++ b/pkg/cmd/grafana-server/server.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/rendering"
 	_ "github.com/grafana/grafana/pkg/services/search"
 	_ "github.com/grafana/grafana/pkg/services/sqlstore"
+	_ "github.com/grafana/grafana/pkg/services/usage"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 	"golang.org/x/xerrors"

--- a/pkg/models/dashboard_visit.go
+++ b/pkg/models/dashboard_visit.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+type VisitDashboardCommand struct {
+	UserId      int64
+	DashboardId int64
+	OrgId       int64
+}
+
+// VisitDashboardCommand is the command to add an entry in the DB that
+// the user `UserId` visited the dashboard `DashboardId` in `OrgId`
+type DashboardVisit struct {
+	UserId      int64
+	DashboardId int64
+	OrgId       int64
+	VisitedAt   time.Time
+}

--- a/pkg/services/sqlstore/migrations/dashboard_visit_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_visit_mig.go
@@ -1,0 +1,22 @@
+package migrations
+
+import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func addDashboardVisitMigration(mg *Migrator) {
+	dashboardVisitV1 := Table{
+		Name: "dashboard_visit",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "user_id", Type: DB_BigInt, Nullable: false},
+			{Name: "dashboard_id", Type: DB_BigInt, Nullable: false},
+			{Name: "org_id", Type: DB_BigInt, Nullable: false},
+			{Name: "visited_at", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"user_id"}},
+			{Cols: []string{"dashboard_id"}},
+		},
+	}
+
+	mg.AddMigration("create dashboard_visit table", NewAddTableMigration(dashboardVisitV1))
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -34,6 +34,7 @@ func AddMigrations(mg *Migrator) {
 	addServerlockMigrations(mg)
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
+	addDashboardVisitMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/usage/dashboard_visit_service.go
+++ b/pkg/services/usage/dashboard_visit_service.go
@@ -1,0 +1,43 @@
+package usage
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func init() {
+	registry.Register(&registry.Descriptor{
+		Name:         "VisitDashboardService",
+		Instance:     &VisitDashboardService{},
+		InitPriority: registry.Low,
+	})
+}
+
+type VisitDashboardService struct {
+	Bus      bus.Bus            `inject:""`
+	SQLStore *sqlstore.SqlStore `inject:""`
+}
+
+func (vds *VisitDashboardService) Init() error {
+	vds.Bus.AddHandler(vds.VisitDashboard)
+	return nil
+}
+
+func (vds *VisitDashboardService) VisitDashboard(cmd *models.VisitDashboardCommand) error {
+	entry := models.DashboardVisit{
+		UserId:      cmd.UserId,
+		DashboardId: cmd.DashboardId,
+		OrgId:       cmd.OrgId,
+		VisitedAt:   time.Now(),
+	}
+
+	return vds.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		_, err := sess.Insert(&entry)
+		return err
+	})
+}

--- a/public/app/core/services/__mocks__/backend_srv.ts
+++ b/public/app/core/services/__mocks__/backend_srv.ts
@@ -25,6 +25,7 @@ export const backendSrv = {
   getDashboard: jest.fn(),
   getDashboardByUid: jest.fn(),
   getFolderByUid: jest.fn(),
+  visitDashboard: jest.fn(),
   post: jest.fn(),
   resolveCancelerIfExists: jest.fn(),
   datasourceRequest: jest.fn(() => Promise.resolve(makePromResponse())),

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -276,6 +276,10 @@ export class BackendSrv implements BackendService {
     });
   }
 
+  visitDashboard(dashboardId: number) {
+    return this.request({ method: 'POST', url: `/api/dashboards/id/${dashboardId}/visit` });
+  }
+
   createFolder(payload: any) {
     return this.post('/api/folders', payload);
   }

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -269,6 +269,10 @@ describeInitScenario('Initializing existing dashboard', ctx => {
     expect(ctx.dashboardSrv.setCurrent).toBeCalled();
   });
 
+  it('Should mark dashboard as visited', () => {
+    expect(ctx.backendSrv.visitDashboard).toBeCalled();
+  });
+
   it('Should initialize redux variables if newVariables is enabled', () => {
     expect(ctx.actions[3].type).toBe(variablesInitTransaction.type);
   });

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -165,6 +165,8 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       return;
     }
 
+    backendSrv.visitDashboard(dashboard.id);
+
     // add missing orgId query param
     const storeState = getState();
     if (!storeState.location.query.orgId) {

--- a/public/test/mocks/common.ts
+++ b/public/test/mocks/common.ts
@@ -5,6 +5,7 @@ export const backendSrv = {
   getDashboard: jest.fn(),
   getDashboardByUid: jest.fn(),
   getFolderByUid: jest.fn(),
+  visitDashboard: jest.fn(),
   post: jest.fn(),
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In large grafana deployments, admins are often overwhelmed with
dashboards, harming discoverability and usability in general of Grafana.

In this commit we add in a "visited" column to the dashboard meta, along
side the similar "Created" and "Updated" timestamps. "Visited" gets
updated every time the "GetDashboard" api call is made (But does not
block this call, so as not to break read only deployments). This allows
us to track dashboards that have been abandoned or are no longer in use
and attempt to keep the cruft under control more easily

**Which issue(s) this PR fixes**:
Fixes grafana#16700

**Notes**:

I've added this to the model interface - not sure whether this is the right place for this - perhaps it might be worthwhile adding a new "VisitDashboardCommand" to the Bus or similar? This was the path of least resistance, but happy to change this up if necessary
