### PR TITLE
grafana-cli: Add ability to read password from stdin to reset admin password

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -113,7 +113,7 @@ var adminCommands = []*cli.Command{
 		Action: runDbCommand(resetPasswordCommand),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:  "passwordFromStdin",
+				Name:  "password-from-stdin",
 				Usage: "Read the password from stdin",
 				Value: false,
 			},

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -111,6 +111,13 @@ var adminCommands = []*cli.Command{
 		Name:   "reset-admin-password",
 		Usage:  "reset-admin-password <new password>",
 		Action: runDbCommand(resetPasswordCommand),
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "passwordFromStdin",
+				Usage: "Read the password from stdin",
+				Value: false,
+			},
+		},
 	},
 	{
 		Name:  "data-migration",

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -25,10 +25,10 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 
 		scanner := bufio.NewScanner(os.Stdin)
 		if ok := scanner.Scan(); !ok {
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("can't read password from stdin: %w", err)
+			}
 			return fmt.Errorf("can't read password from stdin")
-		}
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("can't read password from stdin: %w", err)
 		}
 		newPassword = scanner.Text()
 	} else {

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -27,7 +27,7 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 		reader := bufio.NewReader(os.Stdin)
 		line, err := reader.ReadString('\n')
 		if err != nil {
-			return fmt.Errorf("can't read password from stdin: %v", err)
+			return fmt.Errorf("can't read password from stdin: %w", err)
 		}
 		newPassword = strings.TrimSuffix(line, "\n")
 	} else {

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -21,7 +21,7 @@ const AdminUserId = 1
 func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) error {
 	newPassword := ""
 
-	if c.Bool("passwordFromStdin") {
+	if c.Bool("password-from-stdin") {
 		logger.Infof("\nNew Password: ")
 
 		reader := bufio.NewReader(os.Stdin)

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -22,7 +22,7 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 	newPassword := ""
 
 	if c.Bool("password-from-stdin") {
-		logger.Infof("\nNew Password: ")
+		logger.Infof("New Password: ")
 
 		reader := bufio.NewReader(os.Stdin)
 		line, err := reader.ReadString('\n')

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/bus"
@@ -16,7 +19,20 @@ import (
 const AdminUserId = 1
 
 func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) error {
-	newPassword := c.Args().First()
+	newPassword := ""
+
+	if c.Bool("passwordFromStdin") {
+		logger.Infof("\nNew Password: ")
+
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("can't read password from stdin: %v", err)
+		}
+		newPassword = strings.TrimSuffix(line, "\n")
+	} else {
+		newPassword = c.Args().First()
+	}
 
 	password := models.Password(newPassword)
 	if password.IsWeak() {

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/bus"
@@ -24,12 +23,14 @@ func resetPasswordCommand(c utils.CommandLine, sqlStore *sqlstore.SqlStore) erro
 	if c.Bool("password-from-stdin") {
 		logger.Infof("New Password: ")
 
-		reader := bufio.NewReader(os.Stdin)
-		line, err := reader.ReadString('\n')
-		if err != nil {
+		scanner := bufio.NewScanner(os.Stdin)
+		if ok := scanner.Scan(); !ok {
+			return fmt.Errorf("can't read password from stdin")
+		}
+		if err := scanner.Err(); err != nil {
 			return fmt.Errorf("can't read password from stdin: %w", err)
 		}
-		newPassword = strings.TrimSuffix(line, "\n")
+		newPassword = scanner.Text()
 	} else {
 		newPassword = c.Args().First()
 	}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

**What this PR does / why we need it**:
This PR adds the ability to securely read the password from stdin, either typing or sending it via the pipe. It helps to use the reset-admin-password command in scripts.

**Which issue(s) this PR fixes**:
Fixes #14076

**Special notes for your reviewer**:
I understand that the issue is 2 years old, but in my opinion, it deserves to be fixed. 

This PR also covers cases to read the password from a file or from an env variable:
```bash
echo $MY_PASSWORD | grafana-cli admin reset-admin-password --passwordFromStdin
cat ./passwords.txt | grafana-cli admin reset-admin-password --passwordFromStdin
``` 
