### PR TITLE
Elastic: Display correct log message based on selected log field

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -319,10 +319,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
   // Find the fields we care about and collect all labels
   const allSeries: LogFields[] = logSeries.map(series => {
     const fieldCache = new FieldCache(series);
-
-    const stringField = fieldCache.hasFieldNamed('line')
-      ? fieldCache.getFieldByName('line')
-      : fieldCache.getFirstFieldOfType(FieldType.string);
+    const stringField = fieldCache.getFirstFieldOfType(FieldType.string);
     if (stringField?.labels) {
       allLabels.push(stringField.labels);
     }

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -79,8 +79,8 @@ function constructDataFrame(
     fields: [
       { name: 'ts', type: FieldType.time, config: { displayName: 'Time' }, values: times }, // Time
       { name: 'line', type: FieldType.string, config: {}, values: lines, labels }, // Line
-      { name: 'id', type: FieldType.string, config: {}, values: uids },
       { name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' }, values: timesNs }, // Time
+      { name: 'id', type: FieldType.string, config: {}, values: uids },
     ],
     length: times.length,
   };

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -78,9 +78,9 @@ function constructDataFrame(
     refId,
     fields: [
       { name: 'ts', type: FieldType.time, config: { displayName: 'Time' }, values: times }, // Time
-      { name: 'line', type: FieldType.string, config: {}, values: lines, labels }, // Line
-      { name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' }, values: timesNs }, // Time
+      { name: 'line', type: FieldType.string, config: {}, values: lines, labels }, // Line - needs to be the first field with string type
       { name: 'id', type: FieldType.string, config: {}, values: uids },
+      { name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' }, values: timesNs }, // Time
     ],
     length: times.length,
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the redundant check/condition in `logSeriesToLogsModel`. We were checking if DataFrame has field with the name **line**, because for Loki we use the name **line** for the log line/entry field. However, this can cause problem, if other data source (e.g. Elastic), have field with the name **line**, but the log line/entry is different field (such as message, source). 

This way, we remove datasource-specific check and make code more universal. We are always going to make the first field with the type of string log line/entry. This was already the case for Elastic and Influx. 

We didn't have to change anything for Loki, I just added the comment to make it super clear. 

Tested locally on Loki, Elastic and Influx. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/25370

