### PR TITLE
Table: JSON Cell should try to convert strings to JSON

### DIFF
--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -3,6 +3,7 @@ import { css, cx } from 'emotion';
 import { TableCellProps } from './types';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { JSONFormatter } from '../JSONFormatter/JSONFormatter';
+import { isString } from 'lodash';
 
 export const JSONViewCell: FC<TableCellProps> = props => {
   const { field, cell, tableStyles } = props;
@@ -16,8 +17,16 @@ export const JSONViewCell: FC<TableCellProps> = props => {
     font-family: monospace;
   `;
 
-  const displayValue = JSON.stringify(cell.value);
-  const content = <JSONTooltip value={cell.value} />;
+  let value = cell.value;
+  let displayValue = value;
+  if (isString(value)) {
+    try {
+      value = JSON.parse(value);
+    } catch {} // ignore errors
+  } else {
+    displayValue = JSON.stringify(value);
+  }
+  const content = <JSONTooltip value={value} />;
   return (
     <div className={cx(txt, tableStyles.tableCell)}>
       <Tooltip placement="auto" content={content} theme={'info'}>


### PR DESCRIPTION
When showing JSON strings in the table, we should try to parse them.

Before:
![image](https://user-images.githubusercontent.com/705951/86381464-39b13680-bc42-11ea-890d-fa3dafe19600.png)

After:
![image](https://user-images.githubusercontent.com/705951/86381313-0b335b80-bc42-11ea-97a4-b8b15eecfb0e.png)
