### PR TITLE
InfluxDB: Fixed new group by dropdown now showing after first use 

### DIFF
--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -90,6 +90,12 @@ export class InfluxQueryBuilder {
           if (tag.key === withKey) {
             return memo;
           }
+
+          // value operators not supported in these types of queries
+          if (tag.operator === '>' || tag.operator === '<') {
+            return memo;
+          }
+
           memo.push(renderTagCondition(tag, memo.length));
           return memo;
         },

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -167,6 +167,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
     const plusButton = this.uiSegmentSrv.newPlusButton();
     this.groupBySegment.value = plusButton.value;
     this.groupBySegment.html = plusButton.html;
+    this.groupBySegment.fake = true;
     this.panelCtrl.refresh();
   }
 
@@ -308,6 +309,7 @@ export class InfluxQueryCtrl extends QueryCtrl {
     if (segment.type === 'condition') {
       return Promise.resolve([this.uiSegmentSrv.newSegment('AND'), this.uiSegmentSrv.newSegment('OR')]);
     }
+
     if (segment.type === 'operator') {
       const nextValue = this.tagSegments[index + 1].value;
       if (/^\/.*\/$/.test(nextValue)) {

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -32,6 +32,15 @@ describe('InfluxQueryBuilder', () => {
       expect(query).toBe('SHOW TAG KEYS WHERE "host" = \'se1\'');
     });
 
+    it('should ignore condition if operator is a value operator', () => {
+      const builder = new InfluxQueryBuilder({
+        measurement: '',
+        tags: [{ key: 'value', value: '10', operator: '>' }],
+      });
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe('SHOW TAG KEYS');
+    });
+
     it('should have no conditions in measurement query for query with no tags', () => {
       const builder = new InfluxQueryBuilder({ measurement: '', tags: [] });
       const query = builder.buildExploreQuery('MEASUREMENTS');


### PR DESCRIPTION
Fixed issue with group by + dropdown being empty after first use (so you cannot add more than one option from the list). 

Also fixes #26027  issue with removing value where condition 