### PR TITLE
Explore: Don't run queries on datasource change

### DIFF
--- a/public/app/features/explore/state/actions.test.ts
+++ b/public/app/features/explore/state/actions.test.ts
@@ -259,7 +259,7 @@ describe('changing datasource', () => {
 
     jest.spyOn(Actions, 'importQueries').mockImplementationOnce(() => jest.fn);
     jest.spyOn(Actions, 'loadDatasource').mockImplementationOnce(() => jest.fn);
-    jest.spyOn(Actions, 'runQueries').mockImplementationOnce(() => jest.fn);
+    const runQueriesAction = jest.spyOn(Actions, 'runQueries').mockImplementationOnce(() => jest.fn);
     const dispatchedActions = await thunkTester(initialState)
       .givenThunk(changeDatasource)
       .whenThunkIsDispatched(exploreId, name);
@@ -272,6 +272,8 @@ describe('changing datasource', () => {
         mode: ExploreMode.Logs,
       }),
     ]);
+    // Don't run queries just on datasource change
+    expect(runQueriesAction).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -157,7 +157,6 @@ export function changeDatasource(exploreId: ExploreId, datasourceName: string): 
     }
 
     await dispatch(loadDatasource(exploreId, newDataSourceInstance, orgId));
-    dispatch(runQueries(exploreId));
   };
 }
 
@@ -265,11 +264,12 @@ export function loadExploreDatasourcesAndSetDatasource(
   exploreId: ExploreId,
   datasourceName: string
 ): ThunkResult<void> {
-  return dispatch => {
+  return async dispatch => {
     const exploreDatasources = getExploreDatasources();
 
     if (exploreDatasources.length >= 1) {
-      dispatch(changeDatasource(exploreId, datasourceName));
+      await dispatch(changeDatasource(exploreId, datasourceName));
+      dispatch(runQueries(exploreId));
     } else {
       dispatch(loadDatasourceMissingAction({ exploreId }));
     }


### PR DESCRIPTION
- more and more datasources are having long-running queries,
automatically triggering is becoming more of a burden than a help.
- some datasource queries might actually cost money, so running queries
should be explicit.
- make sure to keep running them on page load though