### PR TITLE
Graph panel: Move Stacking and null values before Hover tooltip options (#26035)

### DIFF
--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -32,6 +32,17 @@ Use these settings to refine your visualization.
 - **Points -** Display points for values.
 - **Point radius -** Controls how large the points are.
 
+### Stacking and null value
+
+- **Stack -** Each series is stacked on top of another.
+- **Percent -** Available when **Stack** is selected. Each series is drawn as a percentage of the total of all series.
+- **Null value -** How null values are displayed. _This is a very important setting._ See note below.
+  - **connected -** If there is a gap in the series, meaning a null value or values, then the line will skip the gap and connect to the next non-null value.
+  - **null -** (default) If there is a gap in the series, meaning a null value, then the line in the graph will be broken and show the gap.
+  - **null as zero -** If there is a gap in the series, meaning  a null value, then it will be displayed as a zero value in the graph panel.
+
+> **Note:** If you are monitoring a server's CPU load and the load reaches 100%, then the server will lock up and the agent sending statistics will not be able to collect the load statistic. This leads to a gap in the metrics and having the default as _null_ means Grafana will show the gaps and indicate that something is wrong. If this is set to _connected_, then it would be easy to miss this signal.
+
 ### Hover tooltip
 
 Use these settings to change the appearance of the tooltip that appears when you hover your cursor over the graph visualization.
@@ -43,17 +54,6 @@ Use these settings to change the appearance of the tooltip that appears when you
   - **None -** The order of the series in the tooltip is determined by the sort order in your query. For example, they could be alphabetically sorted by series name.
   - **Increasing -** The series in the hover tooltip are sorted by value and in increasing order, with the lowest value at the top of the list.
   - **Decreasing -** The series in the hover tooltip are sorted by value and in decreasing order, with the highest value at the top of the list.
-
-### Stacking and null value
-
-- **Stack -** Each series is stacked on top of another.
-- **Percent -** Available when **Stack** is selected. Each series is drawn as a percentage of the total of all series.
-- **Null value -** How null values are displayed. _This is a very important setting._ See note below.
-  - **connected -** If there is a gap in the series, meaning a null value or values, then the line will skip the gap and connect to the next non-null value.
-  - **null -** (default) If there is a gap in the series, meaning a null value, then the line in the graph will be broken and show the gap.
-  - **null as zero -** If there is a gap in the series, meaning  a null value, then it will be displayed as a zero value in the graph panel.
-
-> **Note:** If you are monitoring a server's CPU load and the load reaches 100%, then the server will lock up and the agent sending statistics will not be able to collect the load statistic. This leads to a gap in the metrics and having the default as _null_ means Grafana will show the gaps and indicate that something is wrong. If this is set to _connected_, then it would be easy to miss this signal.
 
 ## Series overrides
 

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -82,6 +82,38 @@
 </div>
 
 <div class="gf-form-group">
+  <h5 class="section-heading">Stacking and null value</h5>
+  <gf-form-switch
+    class="gf-form"
+    label="Stack"
+    label-class="width-7"
+    checked="ctrl.panel.stack"
+    on-change="ctrl.render()"
+  >
+  </gf-form-switch>
+  <gf-form-switch
+    class="gf-form"
+    ng-show="ctrl.panel.stack"
+    label="Percent"
+    label-class="width-7"
+    checked="ctrl.panel.percentage"
+    on-change="ctrl.render()"
+  >
+  </gf-form-switch>
+  <div class="gf-form">
+    <label class="gf-form-label width-7">Null value</label>
+    <div class="gf-form-select-wrapper">
+      <select
+        class="gf-form-input max-width-9"
+        ng-model="ctrl.panel.nullPointMode"
+        ng-options="f for f in ['connected', 'null', 'null as zero']"
+        ng-change="ctrl.render()"
+      ></select>
+    </div>
+  </div>
+</div>
+
+<div class="gf-form-group">
   <h5 class="section-heading">Hover tooltip</h5>
   <div class="gf-form">
     <label class="gf-form-label width-9">Mode</label>
@@ -112,38 +144,6 @@
         class="gf-form-input"
         ng-model="ctrl.panel.tooltip.value_type"
         ng-options="f for f in ['cumulative','individual']"
-        ng-change="ctrl.render()"
-      ></select>
-    </div>
-  </div>
-</div>
-
-<div class="gf-form-group">
-  <h5 class="section-heading">Stacking and null value</h5>
-  <gf-form-switch
-    class="gf-form"
-    label="Stack"
-    label-class="width-7"
-    checked="ctrl.panel.stack"
-    on-change="ctrl.render()"
-  >
-  </gf-form-switch>
-  <gf-form-switch
-    class="gf-form"
-    ng-show="ctrl.panel.stack"
-    label="Percent"
-    label-class="width-7"
-    checked="ctrl.panel.percentage"
-    on-change="ctrl.render()"
-  >
-  </gf-form-switch>
-  <div class="gf-form">
-    <label class="gf-form-label width-7">Null value</label>
-    <div class="gf-form-select-wrapper">
-      <select
-        class="gf-form-input max-width-9"
-        ng-model="ctrl.panel.nullPointMode"
-        ng-options="f for f in ['connected', 'null', 'null as zero']"
         ng-change="ctrl.render()"
       ></select>
     </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Moves the `Stacking and null value` section before the `Hover tooltip` to fix UI behavior of `Stack` in `Stacking and null value`.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26035

**Special notes for your reviewer**: