### PR TITLE
Chore: do not bundle rxjs with @grafana/data

### DIFF
--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -21,7 +21,7 @@ const buildCjsPackage = ({ env }) => {
         globals: {},
       },
     ],
-    external: ['lodash', 'apache-arrow'], // Use Lodash & arrow from grafana
+    external: ['lodash', 'rxjs', 'apache-arrow'], // Use Lodash, rxjs & arrow from grafana
     plugins: [
       json({
         include: ['../../node_modules/moment-timezone/data/packed/latest.json'],


### PR DESCRIPTION
Using `7.1.0 beta2`, building plugins was failing with cryptic error:

```
import("/home/ryan/workspace/grafana/plugins/drone-app/node_modules/                           rxjs/internal/Observable").Observable<import("/home/ryan/workspace/grafana/plugins/drone-app/node_modules/@grafana/data/types/datasource").DataQueryResponse>' is not assignable to type '
import("/home/ryan/workspace/grafana/plugins/drone-app/node_modules/@grafana/data/node_modules/rxjs/internal/Observable").Observable<import("/home/ryan/workspace/grafana/plugins/drone-app/node_modules/@grafana/data/types/datasource").DataQueryResponse>'.
```

If I manually remove the embedded rxjs, the build is fine:
![image](https://user-images.githubusercontent.com/705951/86418052-d21bdb00-bc83-11ea-9231-bed3f5636dd2.png)

maybe this will help?