### PR TITLE
Auth: Fix POST request failures with anonymous access

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 
 	macaron "gopkg.in/macaron.v1"
@@ -87,7 +88,13 @@ func RoleAuth(roles ...models.RoleType) macaron.Handler {
 
 func Auth(options *AuthOptions) macaron.Handler {
 	return func(c *models.ReqContext) {
-		forceLogin := c.AllowAnonymous && c.QueryBool("forceLogin")
+		forceLogin := false
+		if c.AllowAnonymous {
+			forceLoginParam, err := strconv.ParseBool(c.Req.URL.Query().Get("forceLogin"))
+			if err == nil {
+				forceLogin = forceLoginParam
+			}
+		}
 		requireLogin := !c.AllowAnonymous || forceLogin
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
 			notAuthorized(c)


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This fix does not use `context.QueryBool()` for getting `forceLogin` url parameter.

**Which issue(s) this PR fixes**:
Macaron `context.QueryBool()` seems to modify the request context that causes the POST (and PUT) requests to fail with:
`http: proxy error: net/http: HTTP/1.x transport connection broken: http: ContentLength=333 with Body length 0`

This modification is introduced [here](https://github.com/grafana/grafana/pull/25567) and affects anonymous requests.

How to reproduce the issue:
- enable anonymous access by setting `GF_AUTH_ANONYMOUS_ENABLED=true` and `GF_AUTH_ANONYMOUS_ORG_ROLE="Viewer"`
- start graphite:
`make devenv sources=graphite11`
- import [this](https://gist.github.com/papagian/3d6fe23a7a46f0a4e58fcebd2b365c6d) dashboard
- signout
- access the dashboard anonymously
- you should see a number of failures like:
`Request URL:http://localhost:3000/api/datasources/proxy/1/render
EROR[07-03|11:37:54] Data proxy error                         logger=data-proxy-log userId=0 orgId=1 uname= path=/api/datasources/proxy/1/render remote_addr=[::1] referer="http://localhost:3000/d/000000012/grafana-play-home?orgId=1" error="http: proxy error: net/http: HTTP/1.x transport connection broken: http: ContentLength=333 with Body length 0"`


<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
An alternatively would be to allow `forceLogin` only for GETs.
