### PR TITLE
ThemeContext: Make useStyles type-aware

### DIFF
--- a/packages/grafana-ui/src/themes/ThemeContext.test.tsx
+++ b/packages/grafana-ui/src/themes/ThemeContext.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { config } from '@grafana/runtime';
+import { css } from 'emotion';
+import { mount } from 'enzyme';
+import { useStyles } from './ThemeContext';
+
+describe('useStyles', () => {
+  it('passes in theme and returns style object', () => {
+    const Dummy: React.FC = function() {
+      const styles = useStyles(theme => {
+        expect(theme).toEqual(config.theme);
+
+        return {
+          someStyle: css`
+            color: ${theme?.palette.critical};
+          `,
+        };
+      });
+
+      expect(typeof styles.someStyle).toBe('string');
+
+      return <div>dummy</div>;
+    };
+
+    mount(<Dummy />);
+  });
+});

--- a/packages/grafana-ui/src/themes/ThemeContext.tsx
+++ b/packages/grafana-ui/src/themes/ThemeContext.tsx
@@ -38,12 +38,11 @@ export const withTheme = <P extends Themeable, S extends {} = {}>(Component: Rea
 export function useTheme(): GrafanaTheme {
   return useContext(ThemeContextMock || ThemeContext);
 }
+
 /** Hook for using memoized styles with access to the theme. */
-export const useStyles = (getStyles: (theme?: GrafanaTheme) => any) => {
-  const currentTheme = useTheme();
-  const callback = stylesFactory(stylesTheme => getStyles(stylesTheme));
-  return callback(currentTheme);
-};
+export function useStyles<T>(getStyles: (theme: GrafanaTheme) => T) {
+  return stylesFactory(getStyles)(useTheme());
+}
 
 /**
  * Enables theme context  mocking


### PR DESCRIPTION
Simply a minor improvement to `useStyles` that occurred to me as I wanted to use it.
The returned styles object won't be `any` any more but instead has the type of the styles one creates. => Autocomplete :tada: 
