### PR TITLE
Panel Inspect: Hide minimap in json view

### DIFF
--- a/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
@@ -142,7 +142,7 @@ export class InspectJSONTab extends PureComponent<Props, State> {
                 height={height}
                 language="json"
                 showLineNumbers={true}
-                showMiniMap={text && text.length > 100}
+                showMiniMap={false}
                 value={text || ''}
                 readOnly={!isPanelJSON}
                 onBlur={this.onTextChanged}


### PR DESCRIPTION
I have personally never find vscode's minimap useful, and find it more distracting than good. And in the inspect drawer it's blocking content that I rather see.  

thoughts? 

![Screenshot from 2020-07-04 12-25-25](https://user-images.githubusercontent.com/10999/86510646-debe4180-bdf1-11ea-81c1-bb64f3a319f1.png)


