### PR TITLE
Panel Inspect: improve structure display

### DIFF
--- a/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectJSONTab.tsx
@@ -74,16 +74,16 @@ export class InspectJSONTab extends PureComponent<Props, State> {
         return { note: 'Missing Response Data' };
       }
       return this.props.data.series.map(frame => {
-        const fields = frame.fields.map(field => {
-          return chain(field)
-            .omit('values')
-            .omit('calcs')
-            .omit('display')
-            .value();
-        });
+        const { table, fields, ...rest } = frame as any; // remove 'table' from arrow response
         return {
-          ...frame,
-          fields,
+          ...rest,
+          fields: frame.fields.map(field => {
+            return chain(field)
+              .omit('values')
+              .omit('state')
+              .omit('display')
+              .value();
+          }),
         };
       });
     }


### PR DESCRIPTION
The inspector "DataFrame structure" tab includes a bunch of info that makes it hard to quickly understand the structure:

After:
![image](https://user-images.githubusercontent.com/705951/86516463-9b55da00-bdd5-11ea-9419-a14ff581a96a.png)

Before:
![image](https://user-images.githubusercontent.com/705951/86516493-df48df00-bdd5-11ea-8d9b-bd840af67c2c.png)
and scrolling down more, it includes the raw arrow table
![image](https://user-images.githubusercontent.com/705951/86516517-0ef7e700-bdd6-11ea-9c46-4b3edc1a9a8a.png)

