### PR TITLE
Fix list of sample providers

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -13,7 +13,7 @@ weight = 3
 # Generic OAuth Authentication
 
 You can configure many different OAuth2 authentication services with Grafana using the generic OAuth2 feature. Below you
-can find examples using BitBucket, OneLogin, Auth0 and Centrify. [Octa]({{< relref "octa.md" >}}) and [Azure AD]({{< relref "azuread.md" >}}) have moved to separate pages.
+can find examples using BitBucket, OneLogin, Auth0 and Centrify. [Okta]({{< relref "okta.md" >}}) and [Azure AD]({{< relref "azuread.md" >}}) have moved to separate pages.
 
 This callback URL must match the full HTTP address that you use in your browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -12,8 +12,13 @@ weight = 3
 
 # Generic OAuth Authentication
 
-You can configure many different OAuth2 authentication services with Grafana using the generic OAuth2 feature. Below you
-can find examples using BitBucket, OneLogin, Auth0 and Centrify. [Okta]({{< relref "okta.md" >}}) and [Azure AD]({{< relref "azuread.md" >}}) have moved to separate pages.
+You can configure many different OAuth2 authentication services with Grafana using the generic OAuth2 feature. Examples:
+- [BitBucket](#set-up-oauth2-with-bitbucket) 
+- [OneLogin](#set-up-oauth2-with-onelogin)
+- [Auth0](#set-up-oauth2-with-auth0)
+- [Centrify](#set-up-oauth2-with-centrify)
+- [Okta]({{< relref "okta.md" >}}) 
+- [Azure AD]({{< relref "azuread.md" >}})
 
 This callback URL must match the full HTTP address that you use in your browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -13,7 +13,7 @@ weight = 3
 # Generic OAuth Authentication
 
 You can configure many different OAuth2 authentication services with Grafana using the generic OAuth2 feature. Below you
-can find examples using Okta, BitBucket, OneLogin and Azure.
+can find examples using BitBucket, OneLogin, Auth0 and Centrify. [Octa]({{< relref "octa.md" >}}) and [Azure AD]({{< relref "azuread.md" >}}) have moved to separate pages.
 
 This callback URL must match the full HTTP address that you use in your browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
 

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -13,12 +13,12 @@ weight = 3
 # Generic OAuth Authentication
 
 You can configure many different OAuth2 authentication services with Grafana using the generic OAuth2 feature. Examples:
-- [BitBucket](#set-up-oauth2-with-bitbucket) 
-- [OneLogin](#set-up-oauth2-with-onelogin)
 - [Auth0](#set-up-oauth2-with-auth0)
+- [Azure AD]({{< relref "azuread.md" >}})
+- [BitBucket](#set-up-oauth2-with-bitbucket) 
 - [Centrify](#set-up-oauth2-with-centrify)
 - [Okta]({{< relref "okta.md" >}}) 
-- [Azure AD]({{< relref "azuread.md" >}})
+- [OneLogin](#set-up-oauth2-with-onelogin)
 
 This callback URL must match the full HTTP address that you use in your browser to access Grafana, but with the prefix path of `/login/generic_oauth`.
 
@@ -59,6 +59,32 @@ Check for the presence of a role using the [JMESPath](http://jmespath.org/exampl
 
 See [JMESPath examples](#jmespath-examples) for more information.
 
+## Set up OAuth2 with Auth0
+
+1.  Create a new Client in Auth0
+    - Name: Grafana
+    - Type: Regular Web Application
+
+2.  Go to the Settings tab and set:
+    - Allowed Callback URLs: `https://<grafana domain>/login/generic_oauth`
+
+3. Click Save Changes, then use the values at the top of the page to configure Grafana:
+
+    ```bash
+    [auth.generic_oauth]
+    enabled = true
+    allow_sign_up = true
+    team_ids =
+    allowed_organizations =
+    name = Auth0
+    client_id = <client id>
+    client_secret = <client secret>
+    scopes = openid profile email
+    auth_url = https://<domain>/authorize
+    token_url = https://<domain>/oauth/token
+    api_url = https://<domain>/userinfo
+    ```
+
 ## Set up OAuth2 with Bitbucket
 
 ```bash
@@ -75,6 +101,37 @@ api_url = https://api.bitbucket.org/2.0/user
 team_ids =
 allowed_organizations =
 ```
+
+## Set up OAuth2 with Centrify
+
+1.  Create a new Custom OpenID Connect application configuration in the Centrify dashboard.
+
+2.  Create a memorable unique Application ID, e.g. "grafana", "grafana_aws", etc.
+
+3.  Put in other basic configuration (name, description, logo, category)
+
+4.  On the Trust tab, generate a long password and put it into the OpenID Connect Client Secret field.
+
+5.  Put the URL to the front page of your Grafana instance into the "Resource Application URL" field.
+
+6.  Add an authorized Redirect URI like https://your-grafana-server/login/generic_oauth
+
+7.  Set up permissions, policies, etc. just like any other Centrify app
+
+8.  Configure Grafana as follows:
+
+    ```bash
+    [auth.generic_oauth]
+    name = Centrify
+    enabled = true
+    allow_sign_up = true
+    client_id = <OpenID Connect Client ID from Centrify>
+    client_secret = <your generated OpenID Connect Client Secret"
+    scopes = openid profile email
+    auth_url = https://<your domain>.my.centrify.com/OAuth2/Authorize/<Application ID>
+    token_url = https://<your domain>.my.centrify.com/OAuth2/Token/<Application ID>
+    api_url = https://<your domain>.my.centrify.com/OAuth2/UserInfo/<Application ID>
+    ```
 
 ## Set up OAuth2 with OneLogin
 
@@ -109,63 +166,6 @@ allowed_organizations =
     api_url = https://<onelogin domain>.onelogin.com/oidc/2/me
     team_ids =
     allowed_organizations =
-    ```
-
-## Set up OAuth2 with Auth0
-
-1.  Create a new Client in Auth0
-    - Name: Grafana
-    - Type: Regular Web Application
-
-2.  Go to the Settings tab and set:
-    - Allowed Callback URLs: `https://<grafana domain>/login/generic_oauth`
-
-3. Click Save Changes, then use the values at the top of the page to configure Grafana:
-
-    ```bash
-    [auth.generic_oauth]
-    enabled = true
-    allow_sign_up = true
-    team_ids =
-    allowed_organizations =
-    name = Auth0
-    client_id = <client id>
-    client_secret = <client secret>
-    scopes = openid profile email
-    auth_url = https://<domain>/authorize
-    token_url = https://<domain>/oauth/token
-    api_url = https://<domain>/userinfo
-    ```
-
-## Set up OAuth2 with Centrify
-
-1.  Create a new Custom OpenID Connect application configuration in the Centrify dashboard.
-
-2.  Create a memorable unique Application ID, e.g. "grafana", "grafana_aws", etc.
-
-3.  Put in other basic configuration (name, description, logo, category)
-
-4.  On the Trust tab, generate a long password and put it into the OpenID Connect Client Secret field.
-
-5.  Put the URL to the front page of your Grafana instance into the "Resource Application URL" field.
-
-6.  Add an authorized Redirect URI like https://your-grafana-server/login/generic_oauth
-
-7.  Set up permissions, policies, etc. just like any other Centrify app
-
-8.  Configure Grafana as follows:
-
-    ```bash
-    [auth.generic_oauth]
-    name = Centrify
-    enabled = true
-    allow_sign_up = true
-    client_id = <OpenID Connect Client ID from Centrify>
-    client_secret = <your generated OpenID Connect Client Secret"
-    scopes = openid profile email
-    auth_url = https://<your domain>.my.centrify.com/OAuth2/Authorize/<Application ID>
-    token_url = https://<your domain>.my.centrify.com/OAuth2/Token/<Application ID>
-    api_url = https://<your domain>.my.centrify.com/OAuth2/UserInfo/<Application ID>
     ```
 
 ## JMESPath examples


### PR DESCRIPTION
The sample providers on this page has changed, so the list at the top of the page is no longer correct. Also link to Octo and Azure AD pages from here, since they are also OAuth2 providers.

**What this PR does / why we need it**:
-Its a change to the documentation.

**Which issue(s) this PR fixes**:
-There is no issue for this.
