### PR TITLE
Default configuration is defaults.ini

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -125,7 +125,7 @@ yarn e2e:dev
 
 ## Configure Grafana for development
 
-The default configuration, `grafana.ini`, is located in the `conf` directory.
+The default configuration, `defaults.ini`, is located in the `conf` directory.
 
 To override the default configuration, create a `custom.ini` file in the `conf` directory. You only need to add the options you wish to override.
 


### PR DESCRIPTION
The `conf ` directory doesn't have any `grafana.ini`, but a `defaults.ini`, which contains the default configuration.

**What this PR does / why we need it**:
Fix misleading documentation.

**Which issue(s) this PR fixes**:
Fixes #26068 

