### PR TITLE
Chore: Bump rxjs to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "regenerator-runtime": "0.13.3",
     "reselect": "4.0.0",
     "rst2html": "github:thoward/rst2html#990cb89",
-    "rxjs": "6.5.5",
+    "rxjs": "6.6.0",
     "search-query-parser": "1.5.4",
     "slate": "0.47.8",
     "slate-plain-serializer": "0.7.10",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -26,7 +26,7 @@
     "@braintree/sanitize-url": "4.0.0",
     "apache-arrow": "0.16.0",
     "lodash": "4.17.15",
-    "rxjs": "6.5.5",
+    "rxjs": "6.6.0",
     "xss": "1.0.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23347,6 +23347,13 @@ rxjs@6.5.5, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"


### PR DESCRIPTION
Fixes issue with plugins not being built with grafana-toolkit, described here: https://github.com/grafana/grafana/pull/26039

`concurrently`, one package that we are using, has rxjs dependency set to ^6.3.3. our dependency on rxjs is currently 6.5.5. Few days ago 6.6.0 was released causing grafana-data being dependant on 6.5.5 while concurrently on 6.6.0. Hence, two versions was installed when using grafana-data and grafana-toolkit, causing some weird type mismatch.

Changes in this PR ar verified against local NPM repository set up with https://verdaccio.org/