### PR TITLE
Fix: Icon and Tooltip on Variables editor

### DIFF
--- a/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
+++ b/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
@@ -34,7 +34,7 @@ export const FormLabel: FunctionComponent<Props> = ({
       {tooltip && (
         <Tooltip placement="top" content={tooltip} theme={'info'}>
           <div className="gf-form-help-icon gf-form-help-icon--right-normal">
-            <Icon name="info-circle" size="xs" style={{ marginLeft: '10px' }} />
+            <Icon name="info-circle" size="sm" style={{ marginLeft: '10px' }} />
           </div>
         </Tooltip>
       )}

--- a/packages/grafana-ui/src/components/Forms/Legacy/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Switch/Switch.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import uniqueId from 'lodash/uniqueId';
 import { Tooltip } from '../../../Tooltip/Tooltip';
 import * as PopperJS from 'popper.js';
+import { Icon } from '../../..';
 
 export interface Props {
   label: string;
@@ -54,7 +55,7 @@ export class Switch extends PureComponent<Props, State> {
               {tooltip && (
                 <Tooltip placement={tooltipPlacement ? tooltipPlacement : 'auto'} content={tooltip} theme={'info'}>
                   <div className="gf-form-help-icon gf-form-help-icon--right-normal">
-                    <i className="fa fa-info-circle" />
+                    <Icon name="info-circle" size="sm" style={{ marginLeft: '10px' }} />
                   </div>
                 </Tooltip>
               )}

--- a/public/app/features/variables/editor/SelectionOptionsEditor.tsx
+++ b/public/app/features/variables/editor/SelectionOptionsEditor.tsx
@@ -53,7 +53,7 @@ export const SelectionOptionsEditor: FunctionComponent<SelectionOptionsEditorPro
             labelClass="width-10"
             checked={props.variable.includeAll}
             onChange={onIncludeAllChanged}
-            tooltip={'Enables multiple values to be selected at the same time'}
+            tooltip={'Enables an option to include all variables'}
           />
         </div>
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the Icon component in Switch to have uniform :information_source: icons. Fix tooltip text.

**Which issue(s) this PR fixes**:
Fixes #25137

**Special notes for your reviewer**:
### Before:
![Screenshot from 2020-07-06 15-33-24](https://user-images.githubusercontent.com/946275/86598865-0eaa4800-bf9e-11ea-8e96-fc384b195f3b.png)

### After: 
![Screenshot from 2020-07-06 15-32-28](https://user-images.githubusercontent.com/946275/86598879-1833b000-bf9e-11ea-8ea5-09d8987a6acb.png)

