### PR TITLE
Plugin CI Dockerfile: Upgrade golangci-lint, pin Alpine version, don't use apk cache

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/Dockerfile
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine 
-USER root 
+FROM alpine:3.12
+USER root
 ADD scripts scripts
 ADD install /usr/local
 WORKDIR scripts

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/README.md
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/README.md
@@ -15,7 +15,7 @@ The home directory will be `/home/circleci`
 
 ## Go
 - Go 1.14 is installed in `/usr/local/bin/go`
-- golangci-lint 1.23.7 is installed in `/usr/local/bin/golangci-lint`
+- golangci-lint is installed in `/usr/local/bin/golangci-lint`
 - mage is installed in `/home/circleci/go/bin/mage`
 
 All of the above directories are in the path, so there is no need to specify fully qualified paths.

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -10,12 +10,12 @@ rm /bin/cp
 mv /usr/local/bin/cp /bin/cp
 
 sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories
-apk add nodejs npm yarn build-base openssh git-lfs perl-utils
+apk add --no-cache nodejs npm yarn build-base openssh git-lfs perl-utils
 
 #
 # Only relevant for testing, but cypress does not work with musl/alpine.
 #
-# apk add xvfb glib nss nspr gdk-pixbuf "gtk+3.0" pango atk cairo dbus-libs libxcomposite libxrender libxi libxtst libxrandr libxscrnsaver alsa-lib at-spi2-atk at-spi2-core cups-libs gcompat libc6-compat
+# apk add --no-cache xvfb glib nss nspr gdk-pixbuf "gtk+3.0" pango atk cairo dbus-libs libxcomposite libxrender libxi libxtst libxrandr libxscrnsaver alsa-lib at-spi2-atk at-spi2-core cups-libs gcompat libc6-compat
 
 # Install Go
 filename="go1.14.linux-amd64.tar.gz"
@@ -23,10 +23,11 @@ get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "08df79b46b0adf49
 untar_file "/tmp/$filename"
 
 # Install golangci-lint
-filename="golangci-lint-1.26.0-linux-amd64"
-get_file "https://github.com/golangci/golangci-lint/releases/download/v1.26.0/$filename.tar.gz" \
+GOLANGCILINT_VERSION=1.28.0
+filename="golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64"
+get_file "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/$filename.tar.gz" \
     "/tmp/$filename.tar.gz" \
-    "59b0e49a4578fea574648a2fd5174ed61644c667ea1a1b54b8082fde15ef94fd"
+    "179d34edf4baf6454a7081fbaaf74dc99397a3be8e1a535dee04d835a977bf76"
 untar_file "/tmp/$filename.tar.gz"
 ln -s /usr/local/${filename}/golangci-lint /usr/local/bin/golangci-lint
 ln -s /usr/local/go/bin/go /usr/local/bin/go
@@ -34,7 +35,7 @@ ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 chmod 755 /usr/local/bin/golangci-lint
 
 # Install dependencies
-apk add fontconfig zip jq
+apk add --no-cache fontconfig zip jq
 
 # Install code climate
 get_file "https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64" \
@@ -45,7 +46,7 @@ chmod +x /usr/local/bin/cc-test-reporter
 wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.4.4/grabpl"
 chmod +x /usr/local/bin/grabpl
 
-apk add git
+apk add --no-cache git
 # Install Mage
 mkdir -pv /tmp/mage $HOME/go/bin
 git clone https://github.com/magefile/mage.git /tmp/mage
@@ -66,6 +67,5 @@ cd /usr/local/grafana-toolkit && yarn install && cd $current_dir
 ln -s /usr/local/grafana-toolkit/bin/grafana-toolkit.js /usr/local/bin/grafana-toolkit
 
 # Cleanup after yourself
-/bin/rm -rf /tmp/mage 
+/bin/rm -rf /tmp/mage
 /bin/rm -rf $HOME/go
-/bin/rm -rf /var/cache/apk/*


### PR DESCRIPTION
**What this PR does / why we need it**:
In the plugin Alpine based CI Dockerfile:

* Upgrade golangci-lint
* Pin Alpine version, so we know which one we get
* Don't use apk cache, as is the best practice in Dockerfiles

If needed, I can split the PR up, but I noticed the other issues simply when looking to upgrade golangci-lint.
