### PR TITLE
Azure: Restore Insights Metrics alias feature

### DIFF
--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
@@ -259,16 +259,10 @@ func (e *ApplicationInsightsDatasource) getPluginRoute(plugin *plugins.DataSourc
 // Alias patterns like {{metric}} are replaced with the appropriate data values.
 func formatApplicationInsightsLegendKey(alias string, metricName string, labels data.Labels) string {
 
-	// backwards support for "ToLower" (eww). Could be a problem if there were
-	// two keys that varied only in case, but I don't think that would
-	// happen with azure.
-	lowerLabels := labels.Copy()
-	for k, v := range lowerLabels {
-		if strings.ToLower(k) == k {
-			continue
-		}
+	// Could be a collision problem if there were two keys that varied only in case, but I don't think that would happen in azure.
+	lowerLabels := data.Labels{}
+	for k, v := range labels {
 		lowerLabels[strings.ToLower(k)] = v
-		delete(lowerLabels, k)
 	}
 	keys := make([]string, 0, len(labels))
 	for k := range lowerLabels {

--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
@@ -318,6 +318,4 @@ func applyInsightsMetricAlias(frame *data.Frame, alias string) {
 
 		field.Config.DisplayName = displayName
 	}
-	return
-
 }

--- a/pkg/tsdb/azuremonitor/applicationinsights-metrics_test.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-metrics_test.go
@@ -18,6 +18,7 @@ func TestInsightsMetricsResultToFrame(t *testing.T) {
 		name          string
 		testFile      string
 		metric        string
+		alias         string
 		agg           string
 		dimensions    []string
 		expectedFrame func() *data.Frame
@@ -102,6 +103,49 @@ func TestInsightsMetricsResultToFrame(t *testing.T) {
 				return frame
 			},
 		},
+		{
+			name:       "segmented series with alias",
+			testFile:   "applicationinsights/4-application-insights-response-metrics-multi-segmented.json",
+			metric:     "traces/count",
+			alias:      "{{ metric }}: Country,City: {{ client/countryOrRegion }},{{ client/city }}",
+			agg:        "sum",
+			dimensions: []string{"client/countryOrRegion", "client/city"},
+			expectedFrame: func() *data.Frame {
+				frame := data.NewFrame("",
+					data.NewField("StartTime", nil, []time.Time{
+						time.Date(2020, 6, 25, 16, 15, 32, 14e7, time.UTC),
+						time.Date(2020, 6, 25, 16, 16, 0, 0, time.UTC),
+					}),
+
+					data.NewField("traces/count", data.Labels{"client/city": "Washington", "client/countryOrRegion": "United States"}, []*float64{
+						pointer.Float64(2),
+						nil,
+					}).SetConfig(&data.FieldConfig{DisplayName: "traces/count: Country,City: United States,Washington"}),
+
+					data.NewField("traces/count", data.Labels{"client/city": "Des Moines", "client/countryOrRegion": "United States"}, []*float64{
+						pointer.Float64(2),
+						pointer.Float64(1),
+					}).SetConfig(&data.FieldConfig{DisplayName: "traces/count: Country,City: United States,Des Moines"}),
+
+					data.NewField("traces/count", data.Labels{"client/city": "", "client/countryOrRegion": "United States"}, []*float64{
+						nil,
+						pointer.Float64(11),
+					}).SetConfig(&data.FieldConfig{DisplayName: "traces/count: Country,City: United States,"}),
+
+					data.NewField("traces/count", data.Labels{"client/city": "Chicago", "client/countryOrRegion": "United States"}, []*float64{
+						nil,
+						pointer.Float64(3),
+					}).SetConfig(&data.FieldConfig{DisplayName: "traces/count: Country,City: United States,Chicago"}),
+
+					data.NewField("traces/count", data.Labels{"client/city": "Tokyo", "client/countryOrRegion": "Japan"}, []*float64{
+						nil,
+						pointer.Float64(1),
+					}).SetConfig(&data.FieldConfig{DisplayName: "traces/count: Country,City: Japan,Tokyo"}),
+				)
+
+				return frame
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -110,6 +154,9 @@ func TestInsightsMetricsResultToFrame(t *testing.T) {
 
 			frame, err := InsightsMetricsResultToFrame(res, tt.metric, tt.agg, tt.dimensions)
 			require.NoError(t, err)
+
+			applyInsightsMetricAlias(frame, tt.alias)
+
 			if diff := cmp.Diff(tt.expectedFrame(), frame, data.FrameTestCompareOptions()...); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -338,6 +338,23 @@ func formatAzureMonitorLegendKey(alias string, resourceName string, metricName s
 	endIndex := strings.Index(seriesID, "/providers")
 	resourceGroup := seriesID[startIndex:endIndex]
 
+	// backwards support for "ToLower" (eww). Could be a problem if there were
+	// two keys that varied only in case, but I don't think that would
+	// happen with azure.
+	lowerLabels := labels.Copy()
+	for k, v := range lowerLabels {
+		if strings.ToLower(k) == k {
+			continue
+		}
+		lowerLabels[strings.ToLower(k)] = v
+		delete(lowerLabels, k)
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range lowerLabels {
+		keys = append(keys, k)
+	}
+	keys = sort.StringSlice(keys)
+
 	result := legendKeyFormat.ReplaceAllFunc([]byte(alias), func(in []byte) []byte {
 		metaPartName := strings.Replace(string(in), "{{", "", 1)
 		metaPartName = strings.Replace(metaPartName, "}}", "", 1)
@@ -359,23 +376,15 @@ func formatAzureMonitorLegendKey(alias string, resourceName string, metricName s
 			return []byte(metricName)
 		}
 
-		keys := make([]string, 0, len(labels))
-		if metaPartName == "dimensionname" || metaPartName == "dimensionvalue" {
-			for k := range labels {
-				keys = append(keys, k)
-			}
-			keys = sort.StringSlice(keys)
-		}
-
 		if metaPartName == "dimensionname" {
 			return []byte(keys[0])
 		}
 
 		if metaPartName == "dimensionvalue" {
-			return []byte(labels[keys[0]])
+			return []byte(lowerLabels[keys[0]])
 		}
 
-		if v, ok := labels[metaPartName]; ok {
+		if v, ok := lowerLabels[metaPartName]; ok {
 			return []byte(v)
 		}
 		return in

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -338,16 +338,10 @@ func formatAzureMonitorLegendKey(alias string, resourceName string, metricName s
 	endIndex := strings.Index(seriesID, "/providers")
 	resourceGroup := seriesID[startIndex:endIndex]
 
-	// backwards support for "ToLower" (eww). Could be a problem if there were
-	// two keys that varied only in case, but I don't think that would
-	// happen with azure.
-	lowerLabels := labels.Copy()
-	for k, v := range lowerLabels {
-		if strings.ToLower(k) == k {
-			continue
-		}
+	// Could be a collision problem if there were two keys that varied only in case, but I don't think that would happen in azure.
+	lowerLabels := data.Labels{}
+	for k, v := range labels {
 		lowerLabels[strings.ToLower(k)] = v
-		delete(lowerLabels, k)
 	}
 	keys := make([]string, 0, len(labels))
 	for k := range lowerLabels {

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -374,7 +374,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			name:         "multiple dimension time series response with label alias",
 			responseFile: "7-azure-monitor-response-multi-dimension.json",
 			mockQuery: &AzureMonitorQuery{
-				Alias: "{{resourcegroup}} {Blob Type={{blobtype}}, Tier={{tier}}}",
+				Alias: "{{resourcegroup}} {Blob Type={{blobtype}}, Tier={{Tier}}}",
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
 				},


### PR DESCRIPTION
fix feature removed by earlier work - the Alias ability in application insights.

This also fixes a case sensitivity issue in related the azure monitor metrics alias feature.
