### PR TITLE
Docs: Update debian.md

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -55,7 +55,7 @@ After you add the repository:
 
 ```
 sudo apt-get update
-sudo apt-get install grafana
+sudo apt-get install grafana-enterprise
 ```
 
 #### To install the latest OSS release:

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -39,6 +39,13 @@ If you install from the APT repository, then Grafana is automatically updated ev
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+
+
+# Alternatively you can add the beta repository, see in the table above
+sudo add-apt-repository "deb https://packages.grafana.com/enterprise/deb stable main"
+
+sudo apt-get update
+sudo apt-get install grafana-enterprise
 ```
 
 #### To install the latest OSS release:
@@ -47,6 +54,12 @@ wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+
+# Alternatively you can add the beta repository, see in the table above
+sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
+
+sudo apt-get update
+sudo apt-get install grafana
 ```
 
 ### Set up repository for ARM

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -39,13 +39,6 @@ If you install from the APT repository, then Grafana is automatically updated ev
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-
-
-# Alternatively you can add the beta repository, see in the table above
-sudo add-apt-repository "deb https://packages.grafana.com/enterprise/deb stable main"
-
-sudo apt-get update
-sudo apt-get install grafana-enterprise
 ```
 
 #### To install the latest OSS release:
@@ -54,12 +47,6 @@ sudo apt-get install grafana-enterprise
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-
-# Alternatively you can add the beta repository, see in the table above
-sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
-
-sudo apt-get update
-sudo apt-get install grafana
 ```
 
 ### Set up repository for ARM

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -40,12 +40,22 @@ sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 
+Add this repository for stable releases:
 
-# Alternatively you can add the beta repository, see in the table above
-sudo add-apt-repository "deb https://packages.grafana.com/enterprise/deb stable main"
+```bash
+echo "deb https://packages.grafana.com/enterprise/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list 
+```
 
+Add this repository if you want beta releases:
+```bash
+echo "deb https://packages.grafana.com/enterprise/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list 
+```
+
+After you add the repository:
+
+```
 sudo apt-get update
-sudo apt-get install grafana-enterprise
+sudo apt-get install grafana
 ```
 
 #### To install the latest OSS release:

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -54,17 +54,7 @@ sudo apt-get install grafana-enterprise
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-
-# Alternatively you can add the beta repository, refer to the table above for links
-echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-
-sudo apt-get update
-sudo apt-get install grafana
 ```
-
-### Set up repository for ARM
-
-If you have problems using `add-apt-repository`, you can set up the repository without it.
 
 Add this repository for stable releases:
 
@@ -75,6 +65,13 @@ echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/a
 Add this repository if you want beta releases:
 ```bash
 echo "deb https://packages.grafana.com/oss/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list 
+```
+
+After you add the repository:
+
+```
+sudo apt-get update
+sudo apt-get install grafana
 ```
 
 ### Install .deb package

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -55,8 +55,8 @@ sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 
-# Alternatively you can add the beta repository, see in the table above
-sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
+# Alternatively you can add the beta repository, refer to the table above for links
+echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 
 sudo apt-get update
 sudo apt-get install grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Debian/Ubuntu installation instructions to not use add-apt-repository, since it doesn't work uniformly across all distributions (e.g. Ubuntu 16.04).

**Which issue(s) this PR fixes**:

Fixes #22527

**Special notes for your reviewer**:

