### PR TITLE
Chore: Rename plugin CI image as grafana/grafana-plugin-ci:latest-alpine

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/README.md
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/README.md
@@ -1,6 +1,6 @@
 # Using this docker image
 
-Currently tagged and uploaded to dockerhub as srclosson/integrations-ci-build 
+Uploaded to dockerhub as grafana/grafana-plugin-ci:latest-alpine
 
 Based off of `circleci/node:12-browsers` 
 

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
@@ -4,4 +4,4 @@
 ## Common variable declarations
 ##
 
-DOCKER_IMAGE_NAME="srclosson/grafana-plugin-ci-alpine"
+DOCKER_IMAGE_NAME="grafana/grafana-plugin-ci:latest-alpine"

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/test/docker-compose.yml
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/test/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ${HOME}/.ssh:/root/.ssh
       - ../../..:/home/circleci/grafana-toolkit
   cibuilt:
-    image: "srclosson/grafana-plugin-ci-alpine"
+    image: "grafana/grafana-plugin-ci:latest-alpine"
     user: root
     volumes:
       - ../scripts:/home/circleci/scripts


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename Alpine based plugin CI image to be an official Grafana image, i.e. be under the grafana org on DockerHub. This way anyone of us can build and upload new images.

I just made a new version of the image myself, so had to rename it for the grafana org in order to upload it.