### PR TITLE
Grafana npm packages: Add guide and tooling for local packages registry setup

### DIFF
--- a/devenv/local-npm/conf/nginx/Dockerfile
+++ b/devenv/local-npm/conf/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM tutum/nginx
+RUN rm /etc/nginx/sites-enabled/default
+ADD sites-enabled /etc/nginx/sites-enabled

--- a/devenv/local-npm/conf/nginx/sites-enabled/verdaccio-conf
+++ b/devenv/local-npm/conf/nginx/sites-enabled/verdaccio-conf
@@ -1,0 +1,14 @@
+server {
+  listen 80 default_server;
+	access_log /var/log/nginx/verdaccio.log;
+	charset utf-8;
+  location / {
+    proxy_pass              http://grafana-npm.local:4873/;
+    proxy_set_header        Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+  }
+}

--- a/devenv/local-npm/docker-compose.yaml
+++ b/devenv/local-npm/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '2'
+
+services:
+  verdaccio:
+    image: verdaccio/verdaccio:4
+    container_name: verdaccio_root_path
+    ports:
+      - "4873:4873"
+    volumes:
+      - verdaccio:/verdaccio
+
+  nginx:
+    restart: always
+    build: conf/nginx
+    ports:
+      - "80:80"
+    volumes:
+      - /www/public
+    volumes_from:
+      - verdaccio
+    links:
+      - verdaccio:verdaccio
+
+volumes:
+  verdaccio:
+    driver: local

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "packages:publishCanary": "lerna publish from-package --contents dist --dist-tag canary --yes",
     "packages:publishLatest": "lerna publish from-package --contents dist --yes",
     "packages:publishNext": "lerna publish from-package --contents dist --dist-tag next --yes",
+    "packages:publishDev": "lerna publish from-package --contents dist --dist-tag dev --yes --registry http://grafana-npm.local:4873 --force-publish=*",
     "packages:typecheck": "lerna run typecheck",
     "precommit": "grafana-toolkit precommit",
     "prettier:check": "prettier --list-different \"**/*.{ts,tsx,scss}\"",


### PR DESCRIPTION
This PR adds guide and tooling to setup local npm registry and publish @grafana/* packages to it. Hopefully, this will help us avoid situations when broken packages are pushed to npm. Also, this approach makes it way easier to debug packages locally as you can test the actually published dist without the need to publish to npm.

I'm gonna present this approach during front-end weekly