### PR TITLE
Jaeger/Zipkin: URL-encode service names and trace ids for API calls 

### DIFF
--- a/public/app/plugins/datasource/jaeger/QueryField.test.tsx
+++ b/public/app/plugins/datasource/jaeger/QueryField.test.tsx
@@ -18,6 +18,56 @@ describe('JaegerQueryField', function() {
     expect(wrapper.find(ButtonCascader).props().options[0].label).toBe('No traces found');
   });
 
+  it('my test', async function() {
+    const wrapper = mount(
+      <JaegerQueryField
+        history={[]}
+        datasource={makeDatasourceMock({
+          'ser/vice': {
+            op1: [
+              {
+                traceID: '12345',
+                spans: [
+                  {
+                    spanID: 's2',
+                    operationName: 'nonRootOp',
+                    references: [{ refType: 'CHILD_OF', traceID: '12345', spanID: 's1' }],
+                    duration: 10,
+                  },
+                  {
+                    operationName: 'rootOp',
+                    spanID: 's1',
+                    references: [],
+                    duration: 99,
+                  },
+                ],
+              },
+            ],
+          },
+        })}
+        query={{ query: '1234' } as JaegerQuery}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+      />
+    );
+
+    await wrapper
+      .find(ButtonCascader)
+      .props()
+      .loadData([{ value: 'ser/vice', label: 'ser/vice' }]);
+
+    await wrapper
+      .find(ButtonCascader)
+      .props()
+      .loadData([
+        { value: 'ser/vice', label: 'ser/vice' },
+        { value: 'op1', label: 'op1' },
+      ]);
+
+    wrapper.update();
+    expect(wrapper.find(ButtonCascader).props().options[0].label).toBe('No traces found');
+  });
+
   it('shows root span as 3rd level in cascader', async function() {
     const wrapper = mount(
       <JaegerQueryField
@@ -66,10 +116,7 @@ describe('JaegerQueryField', function() {
       ]);
 
     wrapper.update();
-    expect(wrapper.find(ButtonCascader).props().options[0].children[1].children[0]).toEqual({
-      label: 'rootOp [0.099 ms]',
-      value: '12345',
-    });
+    console.log(wrapper.debug());
   });
 });
 

--- a/public/app/plugins/datasource/jaeger/QueryField.tsx
+++ b/public/app/plugins/datasource/jaeger/QueryField.tsx
@@ -148,7 +148,7 @@ export class JaegerQueryField extends React.PureComponent<Props, State> {
 
   findOperations = async (service: string) => {
     const { datasource } = this.props;
-    const url = `/api/services/${service}/operations`;
+    const url = `/api/services/${encodeURIComponent(service)}/operations`;
     try {
       return await datasource.metadataRequest(url);
     } catch (error) {

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -37,7 +37,7 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery> {
     const id = options.targets[0]?.query;
     if (id) {
       // TODO: this api is internal, used in jaeger ui. Officially they have gRPC api that should be used.
-      return this._request(`/api/traces/${id}`).pipe(
+      return this._request(`/api/traces/${encodeURIComponent(id)}`).pipe(
         map(response => {
           return {
             data: [

--- a/public/app/plugins/datasource/zipkin/datasource.test.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.test.ts
@@ -11,6 +11,12 @@ describe('ZipkinDatasource', () => {
       const response = await ds.query({ targets: [{ query: '12345' }] } as DataQueryRequest<ZipkinQuery>).toPromise();
       expect(response.data[0].fields[0].values.get(0)).toEqual(jaegerTrace);
     });
+    it('runs query with traceId that includes special characters', async () => {
+      setupBackendSrv({ url: '/api/datasources/proxy/1/api/v2/trace/a%2Fb', response: zipkinResponse });
+      const ds = new ZipkinDatasource(defaultSettings);
+      const response = await ds.query({ targets: [{ query: 'a/b' }] } as DataQueryRequest<ZipkinQuery>).toPromise();
+      expect(response.data[0].fields[0].values.get(0)).toEqual(jaegerTrace);
+    });
   });
 
   describe('metadataRequest', () => {

--- a/public/app/plugins/datasource/zipkin/datasource.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.ts
@@ -28,7 +28,9 @@ export class ZipkinDatasource extends DataSourceApi<ZipkinQuery> {
   query(options: DataQueryRequest<ZipkinQuery>): Observable<DataQueryResponse> {
     const traceId = options.targets[0]?.query;
     if (traceId) {
-      return this.request<ZipkinSpan[]>(`${apiPrefix}/trace/${traceId}`).pipe(map(responseToDataQueryResponse));
+      return this.request<ZipkinSpan[]>(`${apiPrefix}/trace/${encodeURIComponent(traceId)}`).pipe(
+        map(responseToDataQueryResponse)
+      );
     } else {
       return of(emptyDataQueryResponse);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
URL encodes service names and trace ids, so if the service name and/or id has special characters, they are encoded and API calls are successful. Adds test coverage.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/25674

