### PR TITLE
Do not rename export for InlineFormLabel

### DIFF
--- a/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
+++ b/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
@@ -41,3 +41,5 @@ export const FormLabel: FunctionComponent<Props> = ({
     </label>
   );
 };
+
+export const InlineFormLabel = FormLabel;

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -163,7 +163,7 @@ export { FileUpload } from './FileUpload/FileUpload';
 // Legacy forms
 
 // Export this until we've figured out a good approach to inline form styles.
-export { FormLabel as InlineFormLabel } from './FormLabel/FormLabel';
+export { InlineFormLabel } from './FormLabel/FormLabel';
 
 // Select
 import { Select, AsyncSelect } from './Forms/Legacy/Select/Select';


### PR DESCRIPTION
Currently `InlineFormLabel` is exposed from grafana/ui using renamed re-export `export { FormLabel as InlineFormLabel } from './FormLabel/FormLabel';`

For some reason that I haven't found rollup-based solution for yet, `InlineFormLabels` does not end up in the package bundle.

This PR uses classic named export to expose `InlineFormLabel`