### PR TITLE
Do not break dashboard settings UI when time intervals end with trailing comma

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
+++ b/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
@@ -255,7 +255,7 @@ export class SettingsCtrl {
   };
 
   onRefreshIntervalChange = (intervals: string[]) => {
-    this.dashboard.timepicker.refresh_intervals = intervals;
+    this.dashboard.timepicker.refresh_intervals = intervals.filter(i => i.trim() !== '');
   };
 
   onNowDelayChange = (nowDelay: string) => {

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -112,7 +112,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
 
           <div className="gf-form">
             <span className="gf-form-label width-7">Auto-refresh</span>
-            <Input width={60} value={this.getRefreshIntervals()} onChange={this.onRefreshIntervalChange} />
+            <Input width={60} defaultValue={this.getRefreshIntervals()} onBlur={this.onRefreshIntervalChange} />
           </div>
           <div className="gf-form">
             <span className="gf-form-label width-7">Now delay now-</span>


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/26097

Done:
1. Time intervals input is controlled now and change is propagated on blur
2. SettingsCtrl makes sure saved refresh intervals do not contain empty values