### PR TITLE
Loki: Improve error message for unescaped \ and add LogQL link to docs

### DIFF
--- a/docs/sources/features/datasources/loki.md
+++ b/docs/sources/features/datasources/loki.md
@@ -59,7 +59,7 @@ The new field with the link shown in log details:
 
 ## Querying Logs
 
-Querying and displaying log data from Loki is available via [Explore]({{< relref "../explore" >}}), and with the [logs panel]({{< relref "../../panels/visualizations/logs-panel.md" >}}) in dashboards. Select the Loki data source, and then enter a log query to display your logs.
+Querying and displaying log data from Loki is available via [Explore]({{< relref "../explore" >}}), and with the [logs panel]({{< relref "../../panels/visualizations/logs-panel.md" >}}) in dashboards. Select the Loki data source, and then enter a [LogQL](https://github.com/grafana/loki/blob/master/docs/logql.md) query to display your logs.
 
 ### Log Queries
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -212,7 +212,7 @@ describe('LokiDatasource', () => {
         await ds.query(options).toPromise();
       } catch (err) {
         expect(err.message).toBe(
-          'Error: parse error at line 1, col 6: invalid char escape. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md'
+          'Error: parse error at line 1, col 6: invalid char escape. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md.'
         );
       }
     });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -189,6 +189,33 @@ describe('LokiDatasource', () => {
       expect(dataFrame.meta?.limit).toBe(20);
       expect(dataFrame.meta?.searchWords).toEqual(['foo']);
     });
+
+    test('should return custom error message when Loki returns escaping error', async () => {
+      const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+      const customSettings = { ...instanceSettings, jsonData: customData };
+      const ds = new LokiDatasource(customSettings, templateSrvMock);
+
+      datasourceRequestMock.mockImplementation(
+        jest.fn().mockReturnValueOnce(
+          Promise.reject({
+            data: 'parse error at line 1, col 6: invalid char escape',
+            status: 400,
+            statusText: 'Bad Request',
+          })
+        )
+      );
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{job="gra\\fana"}', refId: 'B' }],
+      });
+
+      try {
+        await ds.query(options).toPromise();
+      } catch (err) {
+        expect(err.message).toBe(
+          'Error: parse error at line 1, col 6: invalid char escape. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md'
+        );
+      }
+    });
   });
 
   describe('When interpolating variables', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -538,10 +538,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
     if (err.data) {
       if (typeof err.data === 'string') {
-        const escapeErrMessages = ['parse error at', 'error parsing regexp: invalid escape sequence: `\\'];
-        const isEscapeError = escapeErrMessages.some(errMes => err.data.indexOf(errMes) >= 0);
-
-        if (isEscapeError && target.expr.includes('\\')) {
+        if (err.data.includes('escape') && target.expr.includes('\\')) {
           error.message = `Error: ${err.data}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md.`;
         } else {
           error.message = err.data;

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -538,7 +538,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
     if (err.data) {
       if (typeof err.data === 'string') {
-        const escapeErrMessages = ['parse error at line', 'error parsing regexp: invalid escape sequence: `\\'];
+        const escapeErrMessages = ['parse error at', 'error parsing regexp: invalid escape sequence: `\\'];
         const isEscapeError = escapeErrMessages.some(errMes => err.data.indexOf(errMes) >= 0);
 
         if (isEscapeError && target.expr.includes('\\')) {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -538,7 +538,11 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
     if (err.data) {
       if (typeof err.data === 'string') {
-        error.message = err.data;
+        if (err.data.includes('parse error at line') && target.expr.includes('\\')) {
+          error.message = `Error: ${err.data}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md`;
+        } else {
+          error.message = err.data;
+        }
       } else if (err.data.error) {
         error.message = safeStringifyValue(err.data.error);
       }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -538,8 +538,11 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
     if (err.data) {
       if (typeof err.data === 'string') {
-        if (err.data.includes('parse error at line') && target.expr.includes('\\')) {
-          error.message = `Error: ${err.data}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md`;
+        const escapeErrMessages = ['parse error at line', 'error parsing regexp: invalid escape sequence: `\\'];
+        const isEscapeError = escapeErrMessages.some(errMes => err.data.indexOf(errMes) >= 0);
+
+        if (isEscapeError && target.expr.includes('\\')) {
+          error.message = `Error: ${err.data}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md.`;
         } else {
           error.message = err.data;
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in https://github.com/grafana/grafana/issues/20869, the escaping behaviour works for LogQL queries works as designed and as described in [LogQL docs](https://github.com/grafana/loki/blob/master/docs/logql.md).  

This PR improves:
 - documentation by adding link to LogQL to [Loki datasource documentation](https://grafana.com/docs/grafana/latest/features/datasources/loki/)
- error message by adding advice to check if all special characters are escaped and by linking LogQL docs 

For error messages, we are checking if error message includes the work "escape" based on the [error messages in Loki](https://github.com/grafana/loki/blob/master/vendor/rsc.io/binaryregexp/syntax/parse.go#L35) and my testing, where I got following error messages that all included word **escape**: 
- _parse error at line 1, col 8: invalid char escape_
 - _error parsing regexp: invalid escape sequence_

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/20869

