### PR TITLE
DataSourceWithBackend: add internal comment for new method

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -129,6 +129,11 @@ export class DataSourceWithBackend<
 
   /**
    * Optionally augment the response before returning the results to the
+   *
+   * NOTE: this was added in 7.1 for azure, and will be removed in 7.2
+   * when the entire response pipeline is Observable
+   *
+   * @internal
    */
   processResponse?(res: DataQueryResponse): Promise<DataQueryResponse>;
 


### PR DESCRIPTION
To support azure link construction, we added an async callback to manipulate the results.  In #26043, the entire request change can be observable so we can simply map super.

Since this is not yet released, lets mark it internal and remove it in 7.2