### PR TITLE
Provisioning: Remove provisioned dashboards without parental reader

### DIFF
--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -384,6 +384,10 @@ type ValidateDashboardBeforeSaveCommand struct {
 	Result    *ValidateDashboardBeforeSaveResult
 }
 
+type DeleteOrphanedProvisionedDashboardsCommand struct {
+	ReaderNames []string
+}
+
 //
 // QUERIES
 //

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -74,7 +74,7 @@ func (provider *Provisioner) Provision() error {
 	return nil
 }
 
-// CleanUpOrphanedDashboards delete provisioned dashboards, which have no linked reader
+// CleanUpOrphanedDashboards deletes provisioned dashboards missing a linked reader.
 func (provider *Provisioner) CleanUpOrphanedDashboards() {
 	currentReaders := make([]string, len(provider.fileReaders))
 

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
@@ -16,6 +18,7 @@ type DashboardProvisioner interface {
 	PollChanges(ctx context.Context)
 	GetProvisionerResolvedPath(name string) string
 	GetAllowUIUpdatesFromConfig(name string) bool
+	CleanUpOrphanedDashboards()
 }
 
 // DashboardProvisionerFactory creates DashboardProvisioners based on input
@@ -69,6 +72,19 @@ func (provider *Provisioner) Provision() error {
 	}
 
 	return nil
+}
+
+// CleanUpOrphanedDashboards delete provisioned dashboards, which have no linked reader
+func (provider *Provisioner) CleanUpOrphanedDashboards() {
+	currentReaders := make([]string, len(provider.fileReaders))
+
+	for index, reader := range provider.fileReaders {
+		currentReaders[index] = reader.Cfg.Name
+	}
+
+	if err := bus.Dispatch(&models.DeleteOrphanedProvisionedDashboardsCommand{ReaderNames: currentReaders}); err != nil {
+		provider.log.Warn("Failed to delete orphaned provisioned dashboards", "err", err)
+	}
 }
 
 // PollChanges starts polling for changes in dashboard definition files. It creates goroutine for each provider

--- a/pkg/services/provisioning/dashboards/dashboard_mock.go
+++ b/pkg/services/provisioning/dashboards/dashboard_mock.go
@@ -60,3 +60,6 @@ func (dpm *ProvisionerMock) GetAllowUIUpdatesFromConfig(name string) bool {
 	}
 	return false
 }
+
+// CleanUpOrphanedDashboards not implemented for mocks
+func (dpm *ProvisionerMock) CleanUpOrphanedDashboards() {}

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -139,14 +139,16 @@ func (ps *provisioningServiceImpl) ProvisionDashboards() error {
 		return errutil.Wrap("Failed to create provisioner", err)
 	}
 
+	// If we fail to provision with the new provisioner, mutex will unlock and the polling we restart with the
+	// old provisioner as we did not switch them yet.
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 
 	ps.cancelPolling()
+	dashProvisioner.CleanUpOrphanedDashboards()
 
-	if err := dashProvisioner.Provision(); err != nil {
-		// If we fail to provision with the new provisioner, mutex will unlock and the polling we restart with the
-		// old provisioner as we did not switch them yet.
+	err = dashProvisioner.Provision()
+	if err != nil {
 		return errutil.Wrap("Failed to provision dashboards", err)
 	}
 	ps.dashboardProvisioner = dashProvisioner

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -139,8 +139,6 @@ func (ps *provisioningServiceImpl) ProvisionDashboards() error {
 		return errutil.Wrap("Failed to create provisioner", err)
 	}
 
-	// If we fail to provision with the new provisioner, the mutex will unlock and the polling will restart with the
-	// old provisioner as we did not switch them yet.
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 
@@ -149,6 +147,8 @@ func (ps *provisioningServiceImpl) ProvisionDashboards() error {
 
 	err = dashProvisioner.Provision()
 	if err != nil {
+		// If we fail to provision with the new provisioner, the mutex will unlock and the polling will restart with the
+		// old provisioner as we did not switch them yet.
 		return errutil.Wrap("Failed to provision dashboards", err)
 	}
 	ps.dashboardProvisioner = dashProvisioner

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -139,7 +139,7 @@ func (ps *provisioningServiceImpl) ProvisionDashboards() error {
 		return errutil.Wrap("Failed to create provisioner", err)
 	}
 
-	// If we fail to provision with the new provisioner, mutex will unlock and the polling we restart with the
+	// If we fail to provision with the new provisioner, the mutex will unlock and the polling will restart with the
 	// old provisioner as we did not switch them yet.
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()

--- a/pkg/services/sqlstore/dashboard_provisioning.go
+++ b/pkg/services/sqlstore/dashboard_provisioning.go
@@ -10,7 +10,7 @@ func init() {
 	bus.AddHandler("sql", SaveProvisionedDashboard)
 	bus.AddHandler("sql", GetProvisionedDataByDashboardId)
 	bus.AddHandler("sql", UnprovisionDashboard)
-	bus.AddHandler("sql", DeleteOrphanedProvisionedDashboard)
+	bus.AddHandler("sql", DeleteOrphanedProvisionedDashboards)
 }
 
 type DashboardExtras struct {
@@ -90,7 +90,7 @@ func UnprovisionDashboard(cmd *models.UnprovisionDashboardCommand) error {
 	return nil
 }
 
-func DeleteOrphanedProvisionedDashboard(cmd *models.DeleteOrphanedProvisionedDashboardsCommand) error {
+func DeleteOrphanedProvisionedDashboards(cmd *models.DeleteOrphanedProvisionedDashboardsCommand) error {
 	return inTransaction(func(sess *DBSession) error {
 		var result []*models.DashboardProvisioning
 
@@ -106,7 +106,7 @@ func DeleteOrphanedProvisionedDashboard(cmd *models.DeleteOrphanedProvisionedDas
 
 		for _, deleteDashCommand := range result {
 			err := deleteDashboard(&models.DeleteDashboardCommand{Id: deleteDashCommand.DashboardId}, sess)
-			if err != nil && err != models.ErrDashboardNotFound {
+			if err != nil && !errors.Is(err, models.ErrDashboardNotFound) {
 				return err
 			}
 		}

--- a/pkg/services/sqlstore/dashboard_provisioning.go
+++ b/pkg/services/sqlstore/dashboard_provisioning.go
@@ -1,6 +1,8 @@
 package sqlstore
 
 import (
+	"errors"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 )

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -81,7 +81,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 				So(query.Result, ShouldNotBeNil)
 
 				deleteCmd := &models.DeleteOrphanedProvisionedDashboardsCommand{ReaderNames: []string{"default"}}
-				So(DeleteOrphanedProvisionedDashboard(deleteCmd), ShouldBeNil)
+				So(DeleteOrphanedProvisionedDashboards(deleteCmd), ShouldBeNil)
 
 				query = &models.GetDashboardsQuery{DashboardIds: []int64{cmd.Result.Id, anotherCmd.Result.Id}}
 				err = GetDashboards(query)

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -54,6 +54,43 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			So(cmd.Result.Id, ShouldNotEqual, 0)
 			dashId := cmd.Result.Id
 
+			Convey("Deleting orphaned provisioned dashboards", func() {
+				anotherCmd := &models.SaveProvisionedDashboardCommand{
+					DashboardCmd: &models.SaveDashboardCommand{
+						OrgId:    1,
+						IsFolder: false,
+						FolderId: folderCmd.Result.Id,
+						Dashboard: simplejson.NewFromAny(map[string]interface{}{
+							"id":    nil,
+							"title": "another_dashboard",
+						}),
+					},
+					DashboardProvisioning: &models.DashboardProvisioning{
+						Name:       "another_reader",
+						ExternalId: "/var/grafana.json",
+						Updated:    now.Unix(),
+					},
+				}
+
+				err := SaveProvisionedDashboard(anotherCmd)
+				So(err, ShouldBeNil)
+
+				query := &models.GetDashboardsQuery{DashboardIds: []int64{anotherCmd.Result.Id}}
+				err = GetDashboards(query)
+				So(err, ShouldBeNil)
+				So(query.Result, ShouldNotBeNil)
+
+				deleteCmd := &models.DeleteOrphanedProvisionedDashboardsCommand{ReaderNames: []string{"default"}}
+				So(DeleteOrphanedProvisionedDashboard(deleteCmd), ShouldBeNil)
+
+				query = &models.GetDashboardsQuery{DashboardIds: []int64{cmd.Result.Id, anotherCmd.Result.Id}}
+				err = GetDashboards(query)
+				So(err, ShouldBeNil)
+
+				So(len(query.Result), ShouldEqual, 1)
+				So(query.Result[0].Id, ShouldEqual, dashId)
+			})
+
 			Convey("Can query for provisioned dashboards", func() {
 				query := &models.GetProvisionedDashboardDataQuery{Name: "default"}
 				err := GetProvisionedDashboardDataQuery(query)


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

**What this PR does / why we need it**:
This PR adds deletion of provisioned dashboards, which have no link with provision reader configuration (or you can say, that they are orphan).

The deletion process starts on the Grafana load and occurs on every dashboard provision configuration reloading (requesting `/api/admin/provisioning/dashboards/reload` endpoint).

**Which issue(s) this PR fixes**:
Fixes #15716

**Special notes for your reviewer**:
There are two problems:
* This realization ignores `providers[].disableDeletion` flag, because there is no information about previous file readers' settings in the database. In my opinion, to solve this problem we need to add a column to the `dashboard_provisioning` table and store the information about dashboards deletion possibility in it.
* We don't delete folders, because there is no information either folder provisioned or not.

I also wanted to mention that I tried to reuse existed code as much as possible.
