### PR TITLE
v7.0.6 backports & version bump

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
-  "version": "7.0.5"
+  "version": "7.0.6"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "private": true,
   "name": "grafana",
-  "version": "7.0.4",
+  "version": "7.0.6",
   "repository": "github:grafana/grafana",
   "scripts": {
     "api-tests": "jest --notify --watch --config=devenv/e2e-api-tests/jest.js",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/data",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana Data Library",
   "keywords": [
     "typescript"

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e-selectors",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana End-to-End Test Selectors Library",
   "keywords": [
     "cli",

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana End-to-End Test Library",
   "keywords": [
     "cli",
@@ -44,7 +44,7 @@
   "types": "src/index.ts",
   "dependencies": {
     "@cypress/webpack-preprocessor": "4.1.3",
-    "@grafana/e2e-selectors": "7.0.5",
+    "@grafana/e2e-selectors": "7.0.6",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "blink-diff": "1.0.13",
     "commander": "5.0.0",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/runtime",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana Runtime Library",
   "keywords": [
     "grafana",
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@grafana/data": "7.0.5",
-    "@grafana/ui": "7.0.5",
+    "@grafana/data": "7.0.6",
+    "@grafana/ui": "7.0.6",
     "systemjs": "0.20.19",
     "systemjs-plugin-css": "0.1.37"
   },

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -15,6 +15,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   datasources: { [str: string]: DataSourceInstanceSettings } = {};
   panels: { [key: string]: PanelPluginMeta } = {};
   minRefreshInterval = '';
+  appUrl = '';
   appSubUrl = '';
   windowTitlePrefix = '';
   buildInfo: BuildInfo = {} as BuildInfo;
@@ -67,6 +68,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
       newPanelTitle: 'Panel Title',
       playlist_timespan: '1m',
       unsaved_changes_warning: true,
+      appUrl: '',
       appSubUrl: '',
       buildInfo: {
         version: 'v1.0',

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/toolkit",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana Toolkit",
   "keywords": [
     "grafana",
@@ -29,10 +29,10 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.0",
-    "@grafana/data": "7.0.5",
+    "@grafana/data": "7.0.6",
     "@grafana/eslint-config": "^1.0.0-rc1",
     "@grafana/tsconfig": "^1.0.0-rc1",
-    "@grafana/ui": "7.0.5",
+    "@grafana/ui": "7.0.6",
     "@types/command-exists": "^1.2.0",
     "@types/execa": "^0.9.0",
     "@types/expect-puppeteer": "3.3.1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/ui",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Grafana Components Library",
   "keywords": [
     "grafana",
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@grafana/data": "7.0.5",
-    "@grafana/e2e-selectors": "7.0.5",
+    "@grafana/data": "7.0.6",
+    "@grafana/e2e-selectors": "7.0.6",
     "@grafana/slate-react": "0.22.9-grafana",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "@iconscout/react-unicons": "^1.0.0",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaegertracing/jaeger-ui-components",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -172,6 +172,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"datasources":                datasources,
 		"minRefreshInterval":         setting.MinRefreshInterval,
 		"panels":                     panels,
+		"appUrl":                     setting.AppUrl,
 		"appSubUrl":                  setting.AppSubUrl,
 		"allowOrgCreate":             (setting.AllowUserOrgCreate && c.IsSignedIn) || c.IsGrafanaAdmin,
 		"authProxyEnabled":           setting.AuthProxyEnabled,

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -37,11 +37,25 @@ func (hs *HTTPServer) ValidateRedirectTo(redirectTo string) error {
 	if to.IsAbs() {
 		return login.ErrAbsoluteRedirectTo
 	}
+
+	if to.Host != "" {
+		return login.ErrForbiddenRedirectTo
+	}
+
+	// path should have exactly one leading slash
+	if !strings.HasPrefix(to.Path, "/") {
+		return login.ErrForbiddenRedirectTo
+	}
+	if strings.HasPrefix(to.Path, "//") {
+		return login.ErrForbiddenRedirectTo
+	}
+
 	// when using a subUrl, the redirect_to should start with the subUrl (which contains the leading slash), otherwise the redirect
 	// will send the user to the wrong location
 	if hs.Cfg.AppSubUrl != "" && !strings.HasPrefix(to.Path, hs.Cfg.AppSubUrl+"/") {
 		return login.ErrInvalidRedirectTo
 	}
+
 	return nil
 }
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -207,6 +207,48 @@ func TestLoginViewRedirect(t *testing.T) {
 			appURL:      "http://localhost:3000/",
 			status:      302,
 		},
+		{
+			desc:        "non-Grafana URL without scheme",
+			url:         "example.com",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
+		{
+			desc:        "non-Grafana URL without scheme",
+			url:         "www.example.com",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
+		{
+			desc:        "URL path is a host with two leading slashes",
+			url:         "//example.com",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
+		{
+			desc:        "URL path is a host with three leading slashes",
+			url:         "///example.com",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
+		{
+			desc:        "URL path is an IP address with two leading slashes",
+			url:         "//0.0.0.0",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
+		{
+			desc:        "URL path is an IP address with three leading slashes",
+			url:         "///0.0.0.0",
+			redirectURL: "/",
+			appURL:      "http://localhost:3000/",
+			status:      302,
+		},
 	}
 
 	for _, c := range redirectCases {
@@ -232,7 +274,7 @@ func TestLoginViewRedirect(t *testing.T) {
 			if c.status == 302 {
 				location, ok := sc.resp.Header()["Location"]
 				assert.True(t, ok)
-				assert.Equal(t, location[0], c.redirectURL)
+				assert.Equal(t, c.redirectURL, location[0])
 
 				setCookie, ok := sc.resp.Header()["Set-Cookie"]
 				assert.True(t, ok, "Set-Cookie exists")
@@ -332,6 +374,48 @@ func TestLoginPostRedirect(t *testing.T) {
 			url:    "http://example.com",
 			appURL: "https://localhost:3000/",
 			err:    login.ErrAbsoluteRedirectTo,
+		},
+		{
+			desc:   "invalid URL",
+			url:    ":foo",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrInvalidRedirectTo,
+		},
+		{
+			desc:   "non-Grafana URL without scheme",
+			url:    "example.com",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
+		},
+		{
+			desc:   "non-Grafana URL without scheme",
+			url:    "www.example.com",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
+		},
+		{
+			desc:   "URL path is a host with two leading slashes",
+			url:    "//example.com",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
+		},
+		{
+			desc:   "URL path is a host with three leading slashes",
+			url:    "///example.com",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
+		},
+		{
+			desc:   "URL path is an IP address with two leading slashes",
+			url:    "//0.0.0.0",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
+		},
+		{
+			desc:   "URL path is an IP address with three leading slashes",
+			url:    "///0.0.0.0",
+			appURL: "http://localhost:3000/",
+			err:    login.ErrForbiddenRedirectTo,
 		},
 	}
 

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -20,6 +20,7 @@ var (
 	ErrUserDisabled          = errors.New("User is disabled")
 	ErrAbsoluteRedirectTo    = errors.New("Absolute urls are not allowed for redirect_to cookie value")
 	ErrInvalidRedirectTo     = errors.New("Invalid redirect_to cookie value")
+	ErrForbiddenRedirectTo   = errors.New("Forbidden redirect_to cookie value")
 )
 
 var loginLogger = log.New("login")

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -51,8 +51,16 @@ func notAuthorized(c *models.ReqContext) {
 	if setting.AppSubUrl != "" && !strings.HasPrefix(redirectTo, setting.AppSubUrl) {
 		redirectTo = setting.AppSubUrl + c.Req.RequestURI
 	}
-	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, newCookieOptions)
 
+	// remove forceLogin query param if it exists
+	if parsed, err := url.ParseRequestURI(redirectTo); err == nil {
+		params := parsed.Query()
+		params.Del("forceLogin")
+		parsed.RawQuery = params.Encode()
+		WriteCookie(c.Resp, "redirect_to", url.QueryEscape(parsed.String()), 0, newCookieOptions)
+	} else {
+		c.Logger.Debug("Failed parsing request URI; redirect cookie will not be set", "redirectTo", redirectTo, "error", err)
+	}
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 
@@ -79,7 +87,9 @@ func RoleAuth(roles ...models.RoleType) macaron.Handler {
 
 func Auth(options *AuthOptions) macaron.Handler {
 	return func(c *models.ReqContext) {
-		if !c.IsSignedIn && options.ReqSignedIn && !c.AllowAnonymous {
+		forceLogin := c.AllowAnonymous && c.QueryBool("forceLogin")
+		requireLogin := !c.AllowAnonymous || forceLogin
+		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
 			notAuthorized(c)
 			return
 		}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/url"
+	"strconv"
 	"strings"
 
 	macaron "gopkg.in/macaron.v1"
@@ -87,7 +88,13 @@ func RoleAuth(roles ...models.RoleType) macaron.Handler {
 
 func Auth(options *AuthOptions) macaron.Handler {
 	return func(c *models.ReqContext) {
-		forceLogin := c.AllowAnonymous && c.QueryBool("forceLogin")
+		forceLogin := false
+		if c.AllowAnonymous {
+			forceLoginParam, err := strconv.ParseBool(c.Req.URL.Query().Get("forceLogin"))
+			if err == nil {
+				forceLogin = forceLoginParam
+			}
+		}
 		requireLogin := !c.AllowAnonymous || forceLogin
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
 			notAuthorized(c)

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana-plugins/input-datasource",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Input Datasource",
   "private": true,
   "repository": {
@@ -16,9 +16,9 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/data": "7.0.5",
+    "@grafana/data": "7.0.6",
     "@grafana/toolkit": "7.0.4",
-    "@grafana/ui": "7.0.5"
+    "@grafana/ui": "7.0.6"
   },
   "volta": {
     "node": "12.16.2"

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -101,15 +101,8 @@ export class LoginCtrl extends PureComponent<Props, State> {
   };
 
   toGrafana = () => {
-    const params = this.props.routeParams;
     // Use window.location.href to force page reload
-    if (params.redirect && params.redirect[0] === '/') {
-      if (config.appSubUrl !== '' && !params.redirect.startsWith(config.appSubUrl)) {
-        window.location.href = config.appSubUrl + params.redirect;
-      } else {
-        window.location.href = params.redirect;
-      }
-    } else if (this.result.redirectUrl) {
+    if (this.result.redirectUrl) {
       if (config.appSubUrl !== '' && !this.result.redirectUrl.startsWith(config.appSubUrl)) {
         window.location.href = config.appSubUrl + this.result.redirectUrl;
       } else {

--- a/public/app/core/components/sidemenu/SignIn.test.tsx
+++ b/public/app/core/components/sidemenu/SignIn.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { SignIn } from './SignIn';
 
+jest.mock('../../config', () => ({
+  appUrl: 'http://localhost:3000/',
+}));
+
 describe('Render', () => {
   it('should render component', () => {
     const wrapper = shallow(<SignIn url="/" />);

--- a/public/app/core/components/sidemenu/SignIn.tsx
+++ b/public/app/core/components/sidemenu/SignIn.tsx
@@ -1,18 +1,26 @@
 import React, { FC } from 'react';
+import config from 'app/core/config';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
 import { StoreState } from 'app/types';
 import { Icon } from '@grafana/ui';
 
+const getForcedLoginUrl = (url: string) => {
+  const urlObj = new URL(url, config.appUrl);
+  let params = urlObj.searchParams;
+  params.set('forceLogin', 'true');
+  return urlObj.toString();
+};
+
 export const SignIn: FC<any> = ({ url }) => {
-  const loginUrl = `login?redirect=${encodeURIComponent(url)}`;
+  const forcedLoginUrl = getForcedLoginUrl(url);
   return (
     <div className="sidemenu-item">
-      <a href={loginUrl} className="sidemenu-link" target="_self">
+      <a href={forcedLoginUrl} className="sidemenu-link" target="_self">
         <span className="icon-circle sidemenu-icon">
           <Icon name="sign-in-alt" size="xl" />
         </span>
       </a>
-      <a href={loginUrl} target="_self">
+      <a href={forcedLoginUrl} target="_self">
         <ul className="dropdown-menu dropdown-menu--sidemenu" role="menu">
           <li className="side-menu-header">
             <span className="sidemenu-item-text">Sign In</span>

--- a/public/app/core/components/sidemenu/__snapshots__/SignIn.test.tsx.snap
+++ b/public/app/core/components/sidemenu/__snapshots__/SignIn.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Render should render component 1`] = `
 >
   <a
     className="sidemenu-link"
-    href="login?redirect=%2F"
+    href="http://localhost:3000/?forceLogin=true"
     target="_self"
   >
     <span
@@ -19,7 +19,7 @@ exports[`Render should render component 1`] = `
     </span>
   </a>
   <a
-    href="login?redirect=%2F"
+    href="http://localhost:3000/?forceLogin=true"
     target="_self"
   >
     <ul

--- a/public/app/core/services/bridge_srv.test.ts
+++ b/public/app/core/services/bridge_srv.test.ts
@@ -12,4 +12,42 @@ describe('when checking template variables', () => {
     expect(findTemplateVarChanges(b, a)).toEqual({ 'var-xyz': 'hello' });
     expect(findTemplateVarChanges(a, b)).toEqual({ 'var-xyz': '' });
   });
+
+  it('then should ignore equal values', () => {
+    const a: UrlQueryMap = {
+      'var-xyz': 'hello',
+      bbb: 'ignore me',
+    };
+    const b: UrlQueryMap = {
+      'var-xyz': 'hello',
+      aaa: 'ignore me',
+    };
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
+
+  it('then should ignore equal values with empty values', () => {
+    const a: UrlQueryMap = {
+      'var-xyz': '',
+      bbb: 'ignore me',
+    };
+    const b: UrlQueryMap = {
+      'var-xyz': '',
+      aaa: 'ignore me',
+    };
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
+
+  it('then should ignore empty array values', () => {
+    const a: UrlQueryMap = {
+      'var-adhoc': [],
+    };
+    const b: UrlQueryMap = {};
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
 });

--- a/public/app/core/services/bridge_srv.test.ts
+++ b/public/app/core/services/bridge_srv.test.ts
@@ -50,4 +50,27 @@ describe('when checking template variables', () => {
     expect(findTemplateVarChanges(b, a)).toBeUndefined();
     expect(findTemplateVarChanges(a, b)).toBeUndefined();
   });
+
+  it('Should handle array values with one value same as just value', () => {
+    const a: UrlQueryMap = {
+      'var-test': ['test'],
+    };
+    const b: UrlQueryMap = {
+      'var-test': 'test',
+    };
+
+    expect(findTemplateVarChanges(b, a)).toBeUndefined();
+    expect(findTemplateVarChanges(a, b)).toBeUndefined();
+  });
+
+  it('Should detect change in array value and return array with single value', () => {
+    const a: UrlQueryMap = {
+      'var-test': ['test'],
+    };
+    const b: UrlQueryMap = {
+      'var-test': 'asd',
+    };
+
+    expect(findTemplateVarChanges(a, b)['var-test']).toEqual(['test']);
+  });
 });

--- a/public/app/core/services/bridge_srv.ts
+++ b/public/app/core/services/bridge_srv.ts
@@ -93,11 +93,9 @@ export class BridgeSrv {
             dispatch(templateVarsChangedInUrl(changes));
           }
         }
-        this.lastQuery = state.location.query;
-      } else {
-        this.lastQuery = {};
       }
 
+      this.lastQuery = state.location.query;
       this.lastPath = state.location.path;
       this.lastUrl = state.location.url;
     });
@@ -117,6 +115,18 @@ export class BridgeSrv {
   }
 }
 
+function getUrlValueForComparison(value: any): any {
+  if (isArray(value)) {
+    if (value.length === 0) {
+      value = undefined;
+    } else if (value.length === 1) {
+      value = value[0];
+    }
+  }
+
+  return value;
+}
+
 export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): UrlQueryMap | undefined {
   let count = 0;
   const changes: UrlQueryMap = {};
@@ -130,21 +140,9 @@ export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): Ur
     let newValue = getUrlValueForComparison(query[key]);
 
     if (!isEqual(newValue, oldValue)) {
-      changes[key] = newValue;
+      changes[key] = query[key];
       count++;
     }
-  }
-
-  function getUrlValueForComparison(value: any): any {
-    if (isArray(value)) {
-      if (value.length === 0) {
-        value = undefined;
-      } else if (value.length === 1) {
-        value = value[0];
-      }
-    }
-
-    return value;
   }
 
   for (const key in old) {

--- a/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
+++ b/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import _ from 'lodash';
 import angular, { ILocationService, IScope } from 'angular';
 import { selectors } from '@grafana/e2e-selectors';
@@ -10,7 +9,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { DashboardSrv } from '../../services/DashboardSrv';
 import { CoreEvents } from 'app/types';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
-import { AppEvents, locationUtil, TimeZone } from '@grafana/data';
+import { AppEvents, locationUtil, TimeZone, urlUtil } from '@grafana/data';
 import { promiseToDigest } from '../../../../core/utils/promiseToDigest';
 
 export class SettingsCtrl {
@@ -123,8 +122,7 @@ export class SettingsCtrl {
     const url = this.$location.path();
 
     for (const section of this.sections) {
-      const sectionParams = _.defaults({ editview: section.id }, params);
-      section.url = getConfig().appSubUrl + url + '?' + $.param(sectionParams);
+      section.url = locationUtil.assureBaseUrl(urlUtil.renderUrl(url, { ...params, editview: section.id }));
     }
   }
 


### PR DESCRIPTION
Prepping for a 7.0.6 release 

* Templating: Fixed recursive queries triggered when switching dashboard settings view #26137
* Templating: Fix recursive loop of template variable queries when changing ad-hoc-variable #26191
* Auth: Add support for forcing authentication in anonymous mode and modify SignIn to use it instead of redirect #25567
* Auth: Fix POST request failures with anonymous access #26049

* [x] Bumped version to 7.0.6
