### PR TITLE
Fix: Redirect to correct url after creating a folder

### DIFF
--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -1,13 +1,12 @@
-import { AppEvents } from '@grafana/data';
+import { AppEvents, locationUtil } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { FolderState, ThunkResult } from 'app/types';
 import { DashboardAcl, DashboardAclUpdateDTO, NewDashboardAclItem, PermissionLevel } from 'app/types/acl';
-
 import { updateLocation, updateNavIndex } from 'app/core/actions';
 import { buildNavModel } from './navModel';
 import appEvents from 'app/core/app_events';
 import { loadFolder, loadFolderPermissions } from './reducers';
-import { getBackendSrv } from '@grafana/runtime';
 
 export function getFolderByUid(uid: string): ThunkResult<void> {
   return async dispatch => {
@@ -122,9 +121,8 @@ export function addFolderPermission(newItem: NewDashboardAclItem): ThunkResult<v
 
 export function createNewFolder(folderName: string): ThunkResult<void> {
   return async dispatch => {
-    // @ts-ignore
-    const newFolder = await getBackendSrv().createFolder({ title: folderName });
+    const newFolder = await getBackendSrv().post('/api/folders', { title: folderName });
     appEvents.emit(AppEvents.alertSuccess, ['Folder Created', 'OK']);
-    dispatch(updateLocation({ path: newFolder.url }));
+    dispatch(updateLocation({ path: locationUtil.stripBaseFromUrl(newFolder.url) }));
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the redirect after creating a new folder would end up on a 404 page.


**Which issue(s) this PR fixes**:
Fixes #26108

**Special notes for your reviewer**:

