### PR TITLE
Explore: Run query on splitOpen action

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -91,7 +91,7 @@ type Props = StateProps & DispatchProps & OwnProps;
 
 export class UnConnectedExploreToolbar extends PureComponent<Props> {
   onChangeDatasource = async (option: { value: any }) => {
-    this.props.changeDatasource(this.props.exploreId, option.value);
+    this.props.changeDatasource(this.props.exploreId, option.value, { importQueries: true });
   };
 
   onClearAll = () => {

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -163,7 +163,7 @@ export function RichHistoryCard(props: Props) {
   const onRunQuery = async () => {
     const queriesToRun = query.queries;
     if (query.datasourceName !== datasourceInstance?.name) {
-      await changeDatasource(exploreId, query.datasourceName);
+      await changeDatasource(exploreId, query.datasourceName, { importQueries: true });
       setQueries(exploreId, queriesToRun);
     } else {
       setQueries(exploreId, queriesToRun);

--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -122,7 +122,11 @@ export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<vo
 /**
  * Loads a new datasource identified by the given name.
  */
-export function changeDatasource(exploreId: ExploreId, datasourceName: string): ThunkResult<void> {
+export function changeDatasource(
+  exploreId: ExploreId,
+  datasourceName: string,
+  options?: { importQueries: boolean }
+): ThunkResult<void> {
   return async (dispatch, getState) => {
     let newDataSourceInstance: DataSourceApi;
 
@@ -150,7 +154,9 @@ export function changeDatasource(exploreId: ExploreId, datasourceName: string): 
       })
     );
 
-    await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, newDataSourceInstance));
+    if (options?.importQueries) {
+      await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, newDataSourceInstance));
+    }
 
     if (getState().explore[exploreId].isLive) {
       dispatch(changeRefreshInterval(exploreId, RefreshPicker.offOption.value));
@@ -268,7 +274,7 @@ export function loadExploreDatasourcesAndSetDatasource(
     const exploreDatasources = getExploreDatasources();
 
     if (exploreDatasources.length >= 1) {
-      await dispatch(changeDatasource(exploreId, datasourceName));
+      await dispatch(changeDatasource(exploreId, datasourceName, { importQueries: true }));
       dispatch(runQueries(exploreId));
     } else {
       dispatch(loadDatasourceMissingAction({ exploreId }));
@@ -729,6 +735,7 @@ export function splitOpen<T extends DataQuery = any>(options?: { datasourceUid: 
       const dataSourceSettings = getDatasourceSrv().getDataSourceSettingsByUid(options.datasourceUid);
       await dispatch(changeDatasource(ExploreId.right, dataSourceSettings.name));
       await dispatch(setQueriesAction({ exploreId: ExploreId.right, queries }));
+      await dispatch(runQueries(ExploreId.right));
     } else {
       rightState.queries = leftState.queries.slice();
       rightState.urlState = urlState;


### PR DESCRIPTION
When opening a split with some existing query, rung that query so that when clicking on internal link you already see what you want instead of having to run the query manually.

ie state before when clicking on link
![Screenshot from 2020-07-08 15-34-26](https://user-images.githubusercontent.com/1014802/86925625-65945680-c131-11ea-8970-db33fa1d9541.png)

This seems to be a side effect of https://github.com/grafana/grafana/pull/26033.