### PR TITLE
Upgrade build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,6 +922,9 @@ jobs:
 
   deploy-to-kubernetes:
     description: "Deploy Grafana master Docker image to Kubernetes"
+    parameters:
+      edition:
+        type: string
     executor: base
     steps:
       - attach_workspace:
@@ -1323,6 +1326,7 @@ workflows:
             - postgres-integration-test
       - deploy-to-kubernetes:
           filters: *filter-only-master
+          edition: enterprise
           requires:
             - build-enterprise-docker-images
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.19
+            VERSION=0.4.20
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp
@@ -924,11 +924,14 @@ jobs:
     description: "Deploy Grafana master Docker image to Kubernetes"
     executor: base
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - install-grabpl
       - run:
           name: Deploy to Kubernetes
           command: |
-            /tmp/grabpl deploy-to-k8s $CIRCLE_WORKFLOW_ID
+            cp -r /tmp/workspace/<< parameters.edition >>/dist .
+            /tmp/grabpl deploy-to-k8s
 
   release-packages:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,9 +922,6 @@ jobs:
 
   deploy-to-kubernetes:
     description: "Deploy Grafana master Docker image to Kubernetes"
-    parameters:
-      edition:
-        type: string
     executor: base
     steps:
       - attach_workspace:
@@ -933,7 +930,7 @@ jobs:
       - run:
           name: Deploy to Kubernetes
           command: |
-            cp -r /tmp/workspace/<< parameters.edition >>/dist .
+            cp -r /tmp/workspace/enterprise/dist .
             /tmp/grabpl deploy-to-k8s
 
   release-packages:
@@ -1326,7 +1323,6 @@ workflows:
             - postgres-integration-test
       - deploy-to-kubernetes:
           filters: *filter-only-master
-          edition: enterprise
           requires:
             - build-enterprise-docker-images
 


### PR DESCRIPTION
Upgrade build pipeline tool in order to [publish docker image manifests with build ID tag](https://github.com/grafana/build-pipeline/pull/107) and change [tag for enterprise docker image deployed to Kubernetes](https://github.com/grafana/build-pipeline/pull/108).