### PR TITLE
BarGauge: Fix space bug in single series mode

### DIFF
--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -44,7 +44,7 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
         displayMode={options.displayMode}
         onClick={openMenu}
         className={targetClassName}
-        alignmentFactors={alignmentFactors}
+        alignmentFactors={count > 1 ? alignmentFactors : undefined}
         showUnfilled={options.showUnfilled}
       />
     );


### PR DESCRIPTION
Fixes bug introduced by the stat text mode option PR. 

In single series mode the Bar Gauge still made space for title 