### PR TITLE
Explore/Loki: POC for toggling parsed fields in the list view

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
@@ -28,7 +28,6 @@ const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowMode
     getRows: () => [],
     onClickFilterLabel: () => {},
     onClickFilterOutLabel: () => {},
-    showParsedFields: [],
     ...(propOverrides || {}),
   };
 

--- a/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
@@ -28,6 +28,7 @@ const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowMode
     getRows: () => [],
     onClickFilterLabel: () => {},
     onClickFilterOutLabel: () => {},
+    showParsedFields: [],
     ...(propOverrides || {}),
   };
 

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -38,7 +38,10 @@ export interface Props extends Themeable {
   onMouseLeave?: () => void;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  showParsedFields: Array<string>;
 }
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
@@ -154,6 +157,9 @@ class UnThemedLogDetails extends PureComponent<Props> {
       className,
       onMouseEnter,
       onMouseLeave,
+      onClickShowParsedField,
+      onClickHideParsedField,
+      showParsedFields,
     } = this.props;
     const style = getLogRowStyles(theme, row.logLevel);
     const styles = getStyles(theme);
@@ -211,11 +217,14 @@ class UnThemedLogDetails extends PureComponent<Props> {
                       parsedKey={key}
                       parsedValue={value}
                       links={links}
+                      onClickShowParsedField={onClickShowParsedField}
+                      onClickHideParsedField={onClickHideParsedField}
                       getStats={() =>
                         fieldIndex === undefined
                           ? this.getStatsForParsedField(key)
                           : calculateStats(row.dataFrame.fields[fieldIndex].values.toArray())
                       }
+                      showParsedFields={showParsedFields}
                     />
                   );
                 })}

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -41,7 +41,7 @@ export interface Props extends Themeable {
   onClickShowParsedField?: (key: string) => void;
   onClickHideParsedField?: (key: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
-  showParsedFields: Array<string>;
+  showParsedFields: string[];
 }
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -32,10 +32,10 @@ export interface Props extends Themeable {
   onMouseLeave?: () => void;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  showParsedFields?: string[];
   onClickShowParsedField?: (key: string) => void;
   onClickHideParsedField?: (key: string) => void;
-  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
-  showParsedFields: string[];
 }
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -18,11 +18,11 @@ export interface Props extends Themeable {
   isLabel?: boolean;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
-  onClickShowParsedField?: (key: string) => void;
-  onClickHideParsedField?: (key: string) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
   showParsedFields?: string[];
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
 }
 
 interface State {

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -20,6 +20,7 @@ export interface Props extends Themeable {
   onClickFilterOutLabel?: (key: string, value: string) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
+  showParsedFields: Array<string>;
 }
 
 interface State {
@@ -52,6 +53,20 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     showFieldsStats: false,
     fieldCount: 0,
     fieldStats: null,
+  };
+
+  showField = () => {
+    const { onClickShowParsedField, parsedKey } = this.props;
+    if (onClickShowParsedField) {
+      onClickShowParsedField(parsedKey);
+    }
+  };
+
+  hideField = () => {
+    const { onClickHideParsedField, parsedKey } = this.props;
+    if (onClickHideParsedField) {
+      onClickHideParsedField(parsedKey);
+    }
   };
 
   filterLabel = () => {
@@ -87,14 +102,21 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   }
 
   render() {
-    const { theme, parsedKey, parsedValue, isLabel, links } = this.props;
+    const { theme, parsedKey, parsedValue, isLabel, links, showParsedFields } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
     const styles = getStyles(theme);
     const style = getLogRowStyles(theme);
+    const toggleFieldButton =
+      !isLabel && showParsedFields.includes(parsedKey) ? (
+        <IconButton name="eye-slash" title="Hide field" onClick={this.hideField} />
+      ) : (
+        <IconButton name="eye" title="Show field" onClick={this.showField} />
+      );
+
     return (
       <tr className={cx(style.logDetailsValue, { [styles.noHoverBackground]: showFieldsStats })}>
         {/* Action buttons - show stats/filter results */}
-        <td className={style.logsDetailsIcon} colSpan={isLabel ? undefined : 3}>
+        <td className={style.logsDetailsIcon} colSpan={isLabel ? undefined : 2}>
           <IconButton name="signal" title={'Ad-hoc statistics'} onClick={this.showStats} />
         </td>
 
@@ -106,6 +128,12 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
             <td className={style.logsDetailsIcon}>
               <IconButton name="search-minus" title="Filter out value" onClick={this.filterOutLabel} />
             </td>
+          </>
+        )}
+
+        {!isLabel && (
+          <>
+            <td className={style.logsDetailsIcon}>{toggleFieldButton}</td>
           </>
         )}
 

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -18,8 +18,8 @@ export interface Props extends Themeable {
   isLabel?: boolean;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
-  onClickShowParsedField?: (key: String) => void;
-  onClickHideParsedField?: (key: String) => void;
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
   showParsedFields?: string[];

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -18,9 +18,11 @@ export interface Props extends Themeable {
   isLabel?: boolean;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickShowParsedField?: (key: String) => void;
+  onClickHideParsedField?: (key: String) => void;
   links?: Array<LinkModel<Field>>;
   getStats: () => LogLabelStatsModel[] | null;
-  showParsedFields: Array<string>;
+  showParsedFields?: string[];
 }
 
 interface State {
@@ -107,7 +109,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const styles = getStyles(theme);
     const style = getLogRowStyles(theme);
     const toggleFieldButton =
-      !isLabel && showParsedFields.includes(parsedKey) ? (
+      !isLabel && showParsedFields && showParsedFields.includes(parsedKey) ? (
         <IconButton name="eye-slash" title="Hide field" onClick={this.hideField} />
       ) : (
         <IconButton name="eye" title="Show field" onClick={this.showField} />

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -47,6 +47,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: wordBreakAll;
       word-break: break-all;
     `,
+    showingField: css`
+      color: ${theme.palette.blue95};
+    `,
   };
 });
 
@@ -110,9 +113,9 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const style = getLogRowStyles(theme);
     const toggleFieldButton =
       !isLabel && showParsedFields && showParsedFields.includes(parsedKey) ? (
-        <IconButton name="eye-slash" title="Hide field" onClick={this.hideField} />
+        <IconButton name="eye" className={styles.showingField} title="Hide this field" onClick={this.hideField} />
       ) : (
-        <IconButton name="eye" title="Show field" onClick={this.showField} />
+        <IconButton name="eye" title="Show this field instead of the message" onClick={this.showField} />
       );
 
     return (

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -27,12 +27,14 @@ import { selectThemeVariant } from '../../themes/selectThemeVariant';
 
 //Components
 import { LogDetails } from './LogDetails';
+import { LogRowMessageParsed } from './LogRowMessageParsed';
 import { LogRowMessage } from './LogRowMessage';
 import { LogLabels } from './LogLabels';
 
 interface Props extends Themeable {
   highlighterExpressions?: string[];
   row: LogRowModel;
+  showParsedFields: Array<string>;
   showDuplicates: boolean;
   showLabels: boolean;
   showTime: boolean;
@@ -43,6 +45,8 @@ interface Props extends Themeable {
   getRows: () => LogRowModel[];
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
   onContextClick?: () => void;
   getRowContext: (row: LogRowModel, options?: RowContextOptions) => Promise<DataQueryResponse>;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
@@ -133,6 +137,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       getRows,
       onClickFilterLabel,
       onClickFilterOutLabel,
+      onClickShowParsedField,
+      onClickHideParsedField,
       highlighterExpressions,
       allowDetails,
       row,
@@ -141,6 +147,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       showContextToggle,
       showLabels,
       showTime,
+      showParsedFields,
       wrapLogMessage,
       theme,
       getFieldLinks,
@@ -175,19 +182,23 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               <LogLabels labels={row.uniqueLabels} />
             </td>
           )}
-          <LogRowMessage
-            highlighterExpressions={highlighterExpressions}
-            row={row}
-            getRows={getRows}
-            errors={errors}
-            hasMoreContextRows={hasMoreContextRows}
-            updateLimit={updateLimit}
-            context={context}
-            contextIsOpen={showContext}
-            showContextToggle={showContextToggle}
-            wrapLogMessage={wrapLogMessage}
-            onToggleContext={this.toggleContext}
-          />
+          {showParsedFields.length > 0 ? (
+            <LogRowMessageParsed className={hoverBackground} row={row} showParsedFields={showParsedFields} />
+          ) : (
+            <LogRowMessage
+              highlighterExpressions={highlighterExpressions}
+              row={row}
+              getRows={getRows}
+              errors={errors}
+              hasMoreContextRows={hasMoreContextRows}
+              updateLimit={updateLimit}
+              context={context}
+              contextIsOpen={showContext}
+              showContextToggle={showContextToggle}
+              wrapLogMessage={wrapLogMessage}
+              onToggleContext={this.toggleContext}
+            />
+          )}
         </tr>
         {this.state.showDetails && (
           <LogDetails
@@ -198,8 +209,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             getFieldLinks={getFieldLinks}
             onClickFilterLabel={onClickFilterLabel}
             onClickFilterOutLabel={onClickFilterOutLabel}
+            onClickShowParsedField={onClickShowParsedField}
+            onClickHideParsedField={onClickHideParsedField}
             getRows={getRows}
             row={row}
+            showParsedFields={showParsedFields}
           />
         )}
       </>

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -34,7 +34,7 @@ import { LogLabels } from './LogLabels';
 interface Props extends Themeable {
   highlighterExpressions?: string[];
   row: LogRowModel;
-  showParsedFields: Array<string>;
+  showParsedFields: string[];
   showDuplicates: boolean;
   showLabels: boolean;
   showTime: boolean;
@@ -183,7 +183,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             </td>
           )}
           {showParsedFields.length > 0 ? (
-            <LogRowMessageParsed className={hoverBackground} row={row} showParsedFields={showParsedFields} />
+            <LogRowMessageParsed row={row} showParsedFields={showParsedFields} />
           ) : (
             <LogRowMessage
               highlighterExpressions={highlighterExpressions}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -34,7 +34,6 @@ import { LogLabels } from './LogLabels';
 interface Props extends Themeable {
   highlighterExpressions?: string[];
   row: LogRowModel;
-  showParsedFields: string[];
   showDuplicates: boolean;
   showLabels: boolean;
   showTime: boolean;
@@ -45,12 +44,13 @@ interface Props extends Themeable {
   getRows: () => LogRowModel[];
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
-  onClickShowParsedField?: (key: string) => void;
-  onClickHideParsedField?: (key: string) => void;
   onContextClick?: () => void;
   getRowContext: (row: LogRowModel, options?: RowContextOptions) => Promise<DataQueryResponse>;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
   showContextToggle?: (row?: LogRowModel) => boolean;
+  showParsedFields?: string[];
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
 }
 
 interface State {
@@ -182,8 +182,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               <LogLabels labels={row.uniqueLabels} />
             </td>
           )}
-          {showParsedFields.length > 0 ? (
-            <LogRowMessageParsed row={row} showParsedFields={showParsedFields} />
+          {showParsedFields && showParsedFields.length > 0 ? (
+            <LogRowMessageParsed row={row} showParsedFields={showParsedFields!} />
           ) : (
             <LogRowMessage
               highlighterExpressions={highlighterExpressions}

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
@@ -1,13 +1,9 @@
 import React, { PureComponent } from 'react';
 import memoizeOne from 'memoize-one';
-import { css, cx } from 'emotion';
 import { Field, getParser, LinkModel, LogRowModel } from '@grafana/data';
 
 import { Themeable } from '../../types/theme';
 import { withTheme } from '../../themes/index';
-
-//Components
-import { LogDetailsRow } from './LogDetailsRow';
 
 type FieldDef = {
   key: string;
@@ -18,7 +14,7 @@ type FieldDef = {
 
 export interface Props extends Themeable {
   row: LogRowModel;
-  showParsedFields: Array<string>;
+  showParsedFields: string[];
 }
 
 class UnThemedLogRowMessageParsed extends PureComponent<Props> {
@@ -41,20 +37,21 @@ class UnThemedLogRowMessageParsed extends PureComponent<Props> {
   });
 
   render() {
-    const { row, theme, showParsedFields } = this.props;
+    const { row, showParsedFields } = this.props;
     const fields = this.parseMessage(row.entry);
 
     return (
       <td>
         {showParsedFields.map(parsedKey => {
           const field = fields.find(field => {
-            const { key, value, links, fieldIndex } = field;
+            const { key } = field;
             return key === parsedKey;
           });
 
           if (field) {
             return `${parsedKey}=${field.value} `;
           }
+          return '';
         })}
       </td>
     );

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
@@ -1,0 +1,65 @@
+import React, { PureComponent } from 'react';
+import memoizeOne from 'memoize-one';
+import { css, cx } from 'emotion';
+import { Field, getParser, LinkModel, LogRowModel } from '@grafana/data';
+
+import { Themeable } from '../../types/theme';
+import { withTheme } from '../../themes/index';
+
+//Components
+import { LogDetailsRow } from './LogDetailsRow';
+
+type FieldDef = {
+  key: string;
+  value: string;
+  links?: Array<LinkModel<Field>>;
+  fieldIndex?: number;
+};
+
+export interface Props extends Themeable {
+  row: LogRowModel;
+  showParsedFields: Array<string>;
+}
+
+class UnThemedLogRowMessageParsed extends PureComponent<Props> {
+  getParser = memoizeOne(getParser);
+
+  parseMessage = memoizeOne((rowEntry): FieldDef[] => {
+    const parser = this.getParser(rowEntry);
+    if (!parser) {
+      return [];
+    }
+    // Use parser to highlight detected fields
+    const parsedFields = parser.getFields(rowEntry);
+    const fields = parsedFields.map(field => {
+      const key = parser.getLabelFromField(field);
+      const value = parser.getValueFromField(field);
+      return { key, value };
+    });
+
+    return fields;
+  });
+
+  render() {
+    const { row, theme, showParsedFields } = this.props;
+    const fields = this.parseMessage(row.entry);
+
+    return (
+      <td>
+        {showParsedFields.map(parsedKey => {
+          const field = fields.find(field => {
+            const { key, value, links, fieldIndex } = field;
+            return key === parsedKey;
+          });
+
+          if (field) {
+            return `${parsedKey}=${field.value} `;
+          }
+        })}
+      </td>
+    );
+  }
+}
+
+export const LogRowMessageParsed = withTheme(UnThemedLogRowMessageParsed);
+LogRowMessageParsed.displayName = 'LogRowMessageParsed';

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
@@ -1,16 +1,10 @@
 import React, { PureComponent } from 'react';
-import memoizeOne from 'memoize-one';
-import { Field, getParser, LinkModel, LogRowModel } from '@grafana/data';
+import { LogRowModel } from '@grafana/data';
 
 import { Themeable } from '../../types/theme';
 import { withTheme } from '../../themes/index';
 
-type FieldDef = {
-  key: string;
-  value: string;
-  links?: Array<LinkModel<Field>>;
-  fieldIndex?: number;
-};
+import { parseMessage } from './logParser';
 
 export interface Props extends Themeable {
   row: LogRowModel;
@@ -18,27 +12,9 @@ export interface Props extends Themeable {
 }
 
 class UnThemedLogRowMessageParsed extends PureComponent<Props> {
-  getParser = memoizeOne(getParser);
-
-  parseMessage = memoizeOne((rowEntry): FieldDef[] => {
-    const parser = this.getParser(rowEntry);
-    if (!parser) {
-      return [];
-    }
-    // Use parser to highlight detected fields
-    const parsedFields = parser.getFields(rowEntry);
-    const fields = parsedFields.map(field => {
-      const key = parser.getLabelFromField(field);
-      const value = parser.getValueFromField(field);
-      return { key, value };
-    });
-
-    return fields;
-  });
-
   render() {
     const { row, showParsedFields } = this.props;
-    const fields = this.parseMessage(row.entry);
+    const fields = parseMessage(row.entry);
 
     return (
       <td>

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageParsed.tsx
@@ -16,21 +16,23 @@ class UnThemedLogRowMessageParsed extends PureComponent<Props> {
     const { row, showParsedFields } = this.props;
     const fields = parseMessage(row.entry);
 
-    return (
-      <td>
-        {showParsedFields.map(parsedKey => {
-          const field = fields.find(field => {
-            const { key } = field;
-            return key === parsedKey;
-          });
+    const line = showParsedFields
+      .map(parsedKey => {
+        const field = fields.find(field => {
+          const { key } = field;
+          return key === parsedKey;
+        });
 
-          if (field) {
-            return `${parsedKey}=${field.value} `;
-          }
-          return '';
-        })}
-      </td>
-    );
+        if (field) {
+          return `${parsedKey}=${field.value}`;
+        }
+
+        return null;
+      })
+      .filter(s => s !== null)
+      .join(' ');
+
+    return <td>{line}</td>;
   }
 }
 

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -1,14 +1,37 @@
 import React, { PureComponent } from 'react';
 import memoizeOne from 'memoize-one';
-import { TimeZone, LogsDedupStrategy, LogRowModel, Field, LinkModel, LogsSortOrder, sortLogRows } from '@grafana/data';
+import {
+  TimeZone,
+  LogsDedupStrategy,
+  LogRowModel,
+  Field,
+  LinkModel,
+  LogsSortOrder,
+  sortLogRows,
+  GrafanaTheme,
+} from '@grafana/data';
 
+import { Button } from '../Button';
 import { Themeable } from '../../types/theme';
+import { stylesFactory } from '../../themes';
 import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
+
+import { css } from 'emotion';
 
 //Components
 import { LogRow } from './LogRow';
 import { RowContextOptions } from './LogRowContextProvider';
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+  parsedFieldsInfo: css`
+    color: ${theme.colors.textWeak};
+    font-size: ${theme.typography.size.sm};
+    font-weight: ${theme.typography.weight.semibold};
+    margin-bottom: ${theme.spacing.d};
+    display: flex;
+  `,
+}));
 
 export const PREVIEW_LIMIT = 100;
 export const RENDER_LIMIT = 500;
@@ -103,6 +126,14 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     }
   };
 
+  clearParsedFields = () => {
+    this.setState(state => {
+      return {
+        showParsedFields: [],
+      };
+    });
+  };
+
   render() {
     const {
       dedupStrategy,
@@ -148,8 +179,19 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     const getRows = this.makeGetRows(orderedRows);
     const getRowContext = this.props.getRowContext ? this.props.getRowContext : () => Promise.resolve([]);
 
+    const style = getStyles(theme);
+
     return (
       <div className={horizontalScrollWindow}>
+        {showParsedFields.length > 0 && (
+          <div className={style.parsedFieldsInfo}>
+            You have hidden some parsed fields in your logs output.{' '}
+            <Button variant="secondary" size="sm" onClick={this.clearParsedFields}>
+              Show all parsed fields
+            </Button>
+          </div>
+        )}
+
         <table className={logsRowsTable}>
           <tbody>
             {hasData &&

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -1,37 +1,14 @@
 import React, { PureComponent } from 'react';
 import memoizeOne from 'memoize-one';
-import {
-  TimeZone,
-  LogsDedupStrategy,
-  LogRowModel,
-  Field,
-  LinkModel,
-  LogsSortOrder,
-  sortLogRows,
-  GrafanaTheme,
-} from '@grafana/data';
+import { TimeZone, LogsDedupStrategy, LogRowModel, Field, LinkModel, LogsSortOrder, sortLogRows } from '@grafana/data';
 
-import { Button } from '../Button';
 import { Themeable } from '../../types/theme';
-import { stylesFactory } from '../../themes';
 import { withTheme } from '../../themes/index';
 import { getLogRowStyles } from './getLogRowStyles';
-
-import { css } from 'emotion';
 
 //Components
 import { LogRow } from './LogRow';
 import { RowContextOptions } from './LogRowContextProvider';
-
-const getStyles = stylesFactory((theme: GrafanaTheme) => ({
-  parsedFieldsInfo: css`
-    color: ${theme.colors.textWeak};
-    font-size: ${theme.typography.size.sm};
-    font-weight: ${theme.typography.weight.semibold};
-    margin-bottom: ${theme.spacing.d};
-    display: flex;
-  `,
-}));
 
 export const PREVIEW_LIMIT = 100;
 export const RENDER_LIMIT = 500;
@@ -57,11 +34,13 @@ export interface Props extends Themeable {
   onClickFilterOutLabel?: (key: string, value: string) => void;
   getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  showParsedFields?: string[];
+  onClickShowParsedField?: (key: string) => void;
+  onClickHideParsedField?: (key: string) => void;
 }
 
 interface State {
   renderAll: boolean;
-  showParsedFields: string[];
 }
 
 class UnThemedLogRows extends PureComponent<Props, State> {
@@ -74,7 +53,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
   state: State = {
     renderAll: false,
-    showParsedFields: [],
   };
 
   componentDidMount() {
@@ -104,36 +82,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     sortLogRows(logRows, logsSortOrder)
   );
 
-  showParsedField = (key: string) => {
-    const index = this.state.showParsedFields.indexOf(key);
-    if (index === -1) {
-      this.setState(state => {
-        return {
-          showParsedFields: state.showParsedFields.concat(key),
-        };
-      });
-    }
-  };
-
-  hideParsedField = (key: string) => {
-    const index = this.state.showParsedFields.indexOf(key);
-    if (index > -1) {
-      this.setState(state => {
-        return {
-          showParsedFields: state.showParsedFields.filter(k => key !== k),
-        };
-      });
-    }
-  };
-
-  clearParsedFields = () => {
-    this.setState(state => {
-      return {
-        showParsedFields: [],
-      };
-    });
-  };
-
   render() {
     const {
       dedupStrategy,
@@ -154,8 +102,11 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       getFieldLinks,
       disableCustomHorizontalScroll,
       logsSortOrder,
+      showParsedFields,
+      onClickShowParsedField,
+      onClickHideParsedField,
     } = this.props;
-    const { renderAll, showParsedFields } = this.state;
+    const { renderAll } = this.state;
     const { logsRowsTable, logsRowsHorizontalScroll } = getLogRowStyles(theme);
     const dedupedRows = deduplicatedRows ? deduplicatedRows : logRows;
     const hasData = logRows && logRows.length > 0;
@@ -179,19 +130,8 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     const getRows = this.makeGetRows(orderedRows);
     const getRowContext = this.props.getRowContext ? this.props.getRowContext : () => Promise.resolve([]);
 
-    const style = getStyles(theme);
-
     return (
       <div className={horizontalScrollWindow}>
-        {showParsedFields.length > 0 && (
-          <div className={style.parsedFieldsInfo}>
-            You have hidden some parsed fields in your logs output.{' '}
-            <Button variant="secondary" size="sm" onClick={this.clearParsedFields}>
-              Show all parsed fields
-            </Button>
-          </div>
-        )}
-
         <table className={logsRowsTable}>
           <tbody>
             {hasData &&
@@ -212,8 +152,8 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   allowDetails={allowDetails}
                   onClickFilterLabel={onClickFilterLabel}
                   onClickFilterOutLabel={onClickFilterOutLabel}
-                  onClickShowParsedField={this.showParsedField}
-                  onClickHideParsedField={this.hideParsedField}
+                  onClickShowParsedField={onClickShowParsedField}
+                  onClickHideParsedField={onClickHideParsedField}
                   getFieldLinks={getFieldLinks}
                   logsSortOrder={logsSortOrder}
                 />
@@ -236,8 +176,8 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   allowDetails={allowDetails}
                   onClickFilterLabel={onClickFilterLabel}
                   onClickFilterOutLabel={onClickFilterOutLabel}
-                  onClickShowParsedField={this.showParsedField}
-                  onClickHideParsedField={this.hideParsedField}
+                  onClickShowParsedField={onClickShowParsedField}
+                  onClickHideParsedField={onClickHideParsedField}
                   getFieldLinks={getFieldLinks}
                   logsSortOrder={logsSortOrder}
                 />

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -38,6 +38,7 @@ export interface Props extends Themeable {
 
 interface State {
   renderAll: boolean;
+  showParsedFields: Array<string>;
 }
 
 class UnThemedLogRows extends PureComponent<Props, State> {
@@ -50,6 +51,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
   state: State = {
     renderAll: false,
+    showParsedFields: [],
   };
 
   componentDidMount() {
@@ -79,6 +81,28 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     sortLogRows(logRows, logsSortOrder)
   );
 
+  showParsedField = (key: string) => {
+    const index = this.state.showParsedFields.indexOf(key);
+    if (index === -1) {
+      this.setState(state => {
+        return {
+          showParsedFields: state.showParsedFields.concat(key),
+        };
+      });
+    }
+  };
+
+  hideParsedField = (key: string) => {
+    const index = this.state.showParsedFields.indexOf(key);
+    if (index > -1) {
+      this.setState(state => {
+        return {
+          showParsedFields: state.showParsedFields.filter(k => key !== k),
+        };
+      });
+    }
+  };
+
   render() {
     const {
       dedupStrategy,
@@ -100,7 +124,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       disableCustomHorizontalScroll,
       logsSortOrder,
     } = this.props;
-    const { renderAll } = this.state;
+    const { renderAll, showParsedFields } = this.state;
     const { logsRowsTable, logsRowsHorizontalScroll } = getLogRowStyles(theme);
     const dedupedRows = deduplicatedRows ? deduplicatedRows : logRows;
     const hasData = logRows && logRows.length > 0;
@@ -140,11 +164,14 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   showDuplicates={showDuplicates}
                   showLabels={showLabels}
                   showTime={showTime}
+                  showParsedFields={showParsedFields}
                   wrapLogMessage={wrapLogMessage}
                   timeZone={timeZone}
                   allowDetails={allowDetails}
                   onClickFilterLabel={onClickFilterLabel}
                   onClickFilterOutLabel={onClickFilterOutLabel}
+                  onClickShowParsedField={this.showParsedField}
+                  onClickHideParsedField={this.hideParsedField}
                   getFieldLinks={getFieldLinks}
                   logsSortOrder={logsSortOrder}
                 />
@@ -161,11 +188,14 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   showDuplicates={showDuplicates}
                   showLabels={showLabels}
                   showTime={showTime}
+                  showParsedFields={showParsedFields}
                   wrapLogMessage={wrapLogMessage}
                   timeZone={timeZone}
                   allowDetails={allowDetails}
                   onClickFilterLabel={onClickFilterLabel}
                   onClickFilterOutLabel={onClickFilterOutLabel}
+                  onClickShowParsedField={this.showParsedField}
+                  onClickHideParsedField={this.hideParsedField}
                   getFieldLinks={getFieldLinks}
                   logsSortOrder={logsSortOrder}
                 />

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -38,7 +38,7 @@ export interface Props extends Themeable {
 
 interface State {
   renderAll: boolean;
-  showParsedFields: Array<string>;
+  showParsedFields: string[];
 }
 
 class UnThemedLogRows extends PureComponent<Props, State> {

--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -1,0 +1,32 @@
+import { Field, getParser, LinkModel } from '@grafana/data';
+import memoizeOne from 'memoize-one';
+
+import { MAX_CHARACTERS } from './LogRowMessage';
+
+const memoizedGetParser = memoizeOne(getParser);
+
+export type FieldDef = {
+  key: string;
+  value: string;
+  links?: Array<LinkModel<Field>>;
+  fieldIndex?: number;
+};
+
+export const parseMessage = memoizeOne((rowEntry): FieldDef[] => {
+  if (rowEntry.length > MAX_CHARACTERS) {
+    return [];
+  }
+  const parser = memoizedGetParser(rowEntry);
+  if (!parser) {
+    return [];
+  }
+  // Use parser to highlight detected fields
+  const parsedFields = parser.getFields(rowEntry);
+  const fields = parsedFields.map(field => {
+    const key = parser.getLabelFromField(field);
+    const value = parser.getValueFromField(field);
+    return { key, value };
+  });
+
+  return fields;
+});

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -77,18 +77,20 @@ interface State {
   wrapLogMessage: boolean;
   logsSortOrder: LogsSortOrder | null;
   isFlipping: boolean;
+  showParsedFields: string[];
 }
 
 export class Logs extends PureComponent<Props, State> {
   flipOrderTimer: NodeJS.Timeout;
   cancelFlippingTimer: NodeJS.Timeout;
 
-  state = {
+  state: State = {
     showLabels: store.getBool(SETTINGS_KEYS.showLabels, false),
     showTime: store.getBool(SETTINGS_KEYS.showTime, true),
     wrapLogMessage: store.getBool(SETTINGS_KEYS.wrapLogMessage, true),
     logsSortOrder: null,
     isFlipping: false,
+    showParsedFields: [],
   };
 
   componentWillUnmount() {
@@ -170,6 +172,37 @@ export class Logs extends PureComponent<Props, State> {
     }
   };
 
+  showParsedField = (key: string) => {
+    const index = this.state.showParsedFields.indexOf(key);
+
+    if (index === -1) {
+      this.setState(state => {
+        return {
+          showParsedFields: state.showParsedFields.concat(key),
+        };
+      });
+    }
+  };
+
+  hideParsedField = (key: string) => {
+    const index = this.state.showParsedFields.indexOf(key);
+    if (index > -1) {
+      this.setState(state => {
+        return {
+          showParsedFields: state.showParsedFields.filter(k => key !== k),
+        };
+      });
+    }
+  };
+
+  clearParsedFields = () => {
+    this.setState(state => {
+      return {
+        showParsedFields: [],
+      };
+    });
+  };
+
   render() {
     const {
       logRows,
@@ -195,7 +228,7 @@ export class Logs extends PureComponent<Props, State> {
       return null;
     }
 
-    const { showLabels, showTime, wrapLogMessage, logsSortOrder, isFlipping } = this.state;
+    const { showLabels, showTime, wrapLogMessage, logsSortOrder, isFlipping, showParsedFields } = this.state;
     const { dedupStrategy } = this.props;
     const hasData = logRows && logRows.length > 0;
     const dedupCount = dedupedRows
@@ -290,6 +323,25 @@ export class Logs extends PureComponent<Props, State> {
           />
         )}
 
+        {showParsedFields && showParsedFields.length > 0 && (
+          <MetaInfoText
+            metaItems={[
+              {
+                label: 'Showing only parsed labels',
+                value: renderMetaItem(showParsedFields, LogsMetaKind.LabelsMap),
+              },
+              {
+                label: '',
+                value: (
+                  <Button variant="secondary" size="sm" onClick={this.clearParsedFields}>
+                    Show all parsed fields
+                  </Button>
+                ),
+              },
+            ]}
+          />
+        )}
+
         <LogRows
           logRows={logRows}
           deduplicatedRows={dedupedRows}
@@ -306,6 +358,9 @@ export class Logs extends PureComponent<Props, State> {
           timeZone={timeZone}
           getFieldLinks={getFieldLinks}
           logsSortOrder={logsSortOrder}
+          showParsedFields={showParsedFields}
+          onClickShowParsedField={this.showParsedField}
+          onClickHideParsedField={this.hideParsedField}
         />
 
         {!loading && !hasData && !scanning && (

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -327,7 +327,7 @@ export class Logs extends PureComponent<Props, State> {
           <MetaInfoText
             metaItems={[
               {
-                label: 'Showing only parsed labels',
+                label: 'Showing only parsed fields',
                 value: renderMetaItem(showParsedFields, LogsMetaKind.LabelsMap),
               },
               {


### PR DESCRIPTION
This is a working POC and a proposal on toggling what parsed fields to display in the Explore/Loki view. But it is only meant as a discussion starter.

This pr adds a toggle button in the Log details view, where its is possible to toggle one or more parsed fields to be displayed instead of the raw log message.

Our logs are pretty big json blobs (50ish fields), and json log rows are quite hard to read in general, so this would improve the usability a lot.

This was [discussed briefly on slack](https://grafana.slack.com/archives/CSKQV9Y5B/p1594137083079000?thread_ts=1594137083.079000&cid=CSKQV9Y5B) today between @carlpett, @jessover9000 and @aocenas but I'm guessing more people could be interested in this

![toggle-parsed-fields](https://user-images.githubusercontent.com/762956/87432898-f020fe00-c5e8-11ea-8011-d6d2ef5c96b0.gif)

