### PR TITLE
Update share_panel.md

### DIFF
--- a/docs/sources/reference/share_panel.md
+++ b/docs/sources/reference/share_panel.md
@@ -21,7 +21,7 @@ Example of a link to a server-side rendered PNG:
 https://play.grafana.org/d/000000012/grafana-play-home?orgId=1&from=1568719680173&to=1568726880174&panelId=4&fullscreen
 ```
 
-#### Query String Parameters For Server-Side Rendered Images
+## Query String Parameters For Server-Side Rendered Images
 
 - **width**: width in pixels. Default is 800.
 - **height**: height in pixels. Default is 400.

--- a/docs/sources/reference/share_panel.md
+++ b/docs/sources/reference/share_panel.md
@@ -45,7 +45,7 @@ Below there should be an interactive Grafana graph embedded in an iframe:
 
 <iframe src="https://snapshot.raintank.io/dashboard-solo/snapshot/y7zwi2bZ7FcoTlB93WN7yWO4aMiz3pZb?from=1493369923321&to=1493377123321&panelId=4" width="650" height="300" frameborder="0"></iframe>
 
-#### Export Panel Data
+## Export Panel Data
 
 {{< docs-imagebox img="/img/docs/v50/export_panel_data.png" max-width="500px" >}}
 


### PR DESCRIPTION
I wanted to direct link to the Export Panel Data section to answer a question and noticed that I couldn't because the heading used made it a subsection of the Embed Panel section. Export Panel Data doesn't directly relate to embedding so it shouldn't be a subsection of that. This also makes this section linkable with the heading change.
