### PR TITLE
Queries: Move explore state out of query targets

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -433,6 +433,11 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   // Request Timing
   startTime: number;
   endTime?: number;
+
+  // Explore state used by various datasources
+  liveStreaming?: boolean;
+  showingGraph?: boolean;
+  showingTable?: boolean;
 }
 
 export interface DataQueryTimings {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -124,7 +124,6 @@ export function buildQueryTransaction(
   scanning: boolean,
   timeZone?: TimeZone
 ): QueryTransaction {
-  const configuredQueries = queries.map(query => ({ ...query, ...queryOptions }));
   const key = queries.reduce((combinedKey, query) => {
     combinedKey += query.key;
     return combinedKey;
@@ -149,7 +148,7 @@ export function buildQueryTransaction(
     // TODO: the query request expects number and we are using string here. Seems like it works so far but can create
     // issues down the road.
     panelId: panelId as any,
-    targets: configuredQueries, // Datasources rely on DataQueries being passed under the targets key.
+    targets: queries, // Datasources rely on DataQueries being passed under the targets key.
     range,
     requestId: 'explore',
     rangeRaw: range.raw,
@@ -159,6 +158,9 @@ export function buildQueryTransaction(
     },
     maxDataPoints: queryOptions.maxDataPoints,
     exploreMode: queryOptions.mode,
+    liveStreaming: queryOptions.liveStreaming,
+    showingGraph: queryOptions.showingGraph,
+    showingTable: queryOptions.showingTable,
   };
 
   return {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -71,6 +71,25 @@ const displayCustomError = (title: string, message: string) =>
 export const MAX_ATTEMPTS = 8;
 const POLLING_TIMES = [100, 200, 500, 1000];
 
+const metricsParams = [
+  'queryMode',
+  'id',
+  'region',
+  'namespace',
+  'expression',
+  'metricName',
+  'dimensions',
+  'statistics',
+  'period',
+  'alias',
+  'matchExact',
+  'datasource',
+  'queryType',
+  'key',
+  'hide',
+  'refId',
+];
+
 export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWatchJsonData> {
   type: any;
   proxyUrl: any;
@@ -199,12 +218,14 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
             throw { message: 'Invalid extended statistics' };
           }
 
+          const reducedItem = _.pick(item, metricsParams);
+
           return {
             intervalMs: options.intervalMs,
             maxDataPoints: options.maxDataPoints,
             datasourceId: this.id,
             type: 'timeSeriesQuery',
-            ...item,
+            ...reducedItem,
           };
         }
       );

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -71,25 +71,6 @@ const displayCustomError = (title: string, message: string) =>
 export const MAX_ATTEMPTS = 8;
 const POLLING_TIMES = [100, 200, 500, 1000];
 
-const metricsParams = [
-  'queryMode',
-  'id',
-  'region',
-  'namespace',
-  'expression',
-  'metricName',
-  'dimensions',
-  'statistics',
-  'period',
-  'alias',
-  'matchExact',
-  'datasource',
-  'queryType',
-  'key',
-  'hide',
-  'refId',
-];
-
 export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWatchJsonData> {
   type: any;
   proxyUrl: any;
@@ -218,14 +199,12 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
             throw { message: 'Invalid extended statistics' };
           }
 
-          const reducedItem = _.pick(item, metricsParams);
-
           return {
             intervalMs: options.intervalMs,
             maxDataPoints: options.maxDataPoints,
             datasourceId: this.id,
             type: 'timeSeriesQuery',
-            ...reducedItem,
+            ...item,
           };
         }
       );

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1,4 +1,4 @@
-import LokiDatasource, { RangeQueryOptions } from './datasource';
+import LokiDatasource from './datasource';
 import { LokiQuery, LokiResponse, LokiResultType } from './types';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { AnnotationQueryRequest, DataFrame, DataSourceApi, dateTime, FieldCache, TimeRange } from '@grafana/data';
@@ -81,7 +81,7 @@ describe('LokiDatasource', () => {
         intervalMs: 2000,
       };
 
-      const req = ds.createRangeQuery(target, options);
+      const req = ds.createRangeQuery(target, options as any);
       expect(req.start).toBeDefined();
       expect(req.end).toBeDefined();
       expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
@@ -345,8 +345,8 @@ describe('LokiDatasource', () => {
         raw: { from: '0', to: '1000000001' },
       };
       // Odd timerange/interval combination that would lead to a float step
-      const options: RangeQueryOptions = { range, intervalMs: 2000 };
-      expect(Number.isInteger(ds.createRangeQuery(query, options).step!)).toBeTruthy();
+      const options = { range, intervalMs: 2000 };
+      expect(Number.isInteger(ds.createRangeQuery(query, options as any).step!)).toBeTruthy();
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -42,10 +42,7 @@ import LanguageProvider from './language_provider';
 import { serializeParams } from '../../../core/utils/fetch';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 
-export type RangeQueryOptions = Pick<
-  DataQueryRequest<LokiQuery>,
-  'range' | 'intervalMs' | 'maxDataPoints' | 'reverse' | 'liveStreaming' | 'showingGraph' | 'showingTable'
->;
+export type RangeQueryOptions = DataQueryRequest<LokiQuery> | AnnotationQueryRequest<LokiQuery>;
 export const DEFAULT_MAX_LINES = 1000;
 export const LOKI_ENDPOINT = '/loki/api/v1';
 
@@ -146,7 +143,9 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const startNs = this.getTime(options.range.from, false);
       const endNs = this.getTime(options.range.to, true);
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
-      const step = Math.ceil(this.adjustInterval(options.intervalMs || 1000, rangeMs) / 1000);
+      const step = Math.ceil(
+        this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000
+      );
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),
@@ -163,7 +162,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       ...DEFAULT_QUERY_PARAMS,
       ...range,
       query,
-      limit: Math.min(options.maxDataPoints || Infinity, this.maxLines),
+      limit: Math.min((options as DataQueryRequest<LokiQuery>).maxDataPoints || Infinity, this.maxLines),
     };
   }
 
@@ -185,7 +184,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     let linesLimit = 0;
     if (target.maxLines === undefined) {
       // no target.maxLines, using options.maxDataPoints
-      linesLimit = Math.min(options.maxDataPoints || Infinity, this.maxLines);
+      linesLimit = Math.min((options as DataQueryRequest<LokiQuery>).maxDataPoints || Infinity, this.maxLines);
     } else {
       // using target.maxLines
       if (isNaN(target.maxLines)) {
@@ -196,7 +195,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     }
 
     const queryOptions = { ...options, maxDataPoints: linesLimit };
-    if (options.liveStreaming) {
+    if ((options as DataQueryRequest<LokiQuery>).liveStreaming) {
       return this.runLiveQuery(target, queryOptions);
     }
     const query = this.createRangeQuery(target, queryOptions);
@@ -210,7 +209,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
           responseListLength,
           linesLimit,
           this.instanceSettings.jsonData,
-          options.reverse
+          (options as DataQueryRequest<LokiQuery>).reverse
         )
       )
     );

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -42,7 +42,10 @@ import LanguageProvider from './language_provider';
 import { serializeParams } from '../../../core/utils/fetch';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 
-export type RangeQueryOptions = Pick<DataQueryRequest<LokiQuery>, 'range' | 'intervalMs' | 'maxDataPoints' | 'reverse'>;
+export type RangeQueryOptions = Pick<
+  DataQueryRequest<LokiQuery>,
+  'range' | 'intervalMs' | 'maxDataPoints' | 'reverse' | 'liveStreaming' | 'showingGraph' | 'showingTable'
+>;
 export const DEFAULT_MAX_LINES = 1000;
 export const LOKI_ENDPOINT = '/loki/api/v1';
 
@@ -193,7 +196,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     }
 
     const queryOptions = { ...options, maxDataPoints: linesLimit };
-    if (target.liveStreaming) {
+    if (options.liveStreaming) {
       return this.runLiveQuery(target, queryOptions);
     }
     const query = this.createRangeQuery(target, queryOptions);

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -24,7 +24,6 @@ export enum LokiResultType {
 
 export interface LokiQuery extends DataQuery {
   expr: string;
-  liveStreaming?: boolean;
   query?: string;
   format?: string;
   reverse?: boolean;

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -21,6 +21,7 @@ import templateSrv from 'app/features/templating/template_srv';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { VariableHide } from '../../../features/variables/types';
 import { describe } from '../../../../test/lib/common';
+import { QueryOptions } from 'app/types';
 
 const datasourceRequestMock = jest.fn().mockResolvedValue(createDefaultPromResponse());
 
@@ -1683,7 +1684,7 @@ describe('PrometheusDatasource for POST', () => {
   });
 });
 
-const getPrepareTargetsContext = (target: PromQuery, app?: CoreApp) => {
+const getPrepareTargetsContext = (target: PromQuery, app?: CoreApp, queryOptions?: Partial<QueryOptions>) => {
   const instanceSettings = ({
     url: 'proxied',
     directUrl: 'direct',
@@ -1694,7 +1695,9 @@ const getPrepareTargetsContext = (target: PromQuery, app?: CoreApp) => {
   const start = 0;
   const end = 1;
   const panelId = '2';
-  const options = ({ targets: [target], interval: '1s', panelId, app } as any) as DataQueryRequest<PromQuery>;
+  const options = ({ targets: [target], interval: '1s', panelId, app, ...queryOptions } as any) as DataQueryRequest<
+    PromQuery
+  >;
 
   const ds = new PrometheusDatasource(instanceSettings);
   const { queries, activeTargets } = ds.prepareTargets(options, start, end);
@@ -1744,11 +1747,12 @@ describe('prepareTargets', () => {
         const target: PromQuery = {
           refId: 'A',
           expr: 'up',
-          showingGraph: true,
-          showingTable: true,
         };
 
-        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore);
+        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore, {
+          showingGraph: true,
+          showingTable: true,
+        });
 
         expect(queries.length).toBe(2);
         expect(activeTargets.length).toBe(2);
@@ -1817,11 +1821,12 @@ describe('prepareTargets', () => {
         const target: PromQuery = {
           refId: 'A',
           expr: 'up',
-          showingGraph: false,
-          showingTable: true,
         };
 
-        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore);
+        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore, {
+          showingGraph: false,
+          showingTable: true,
+        });
 
         expect(queries.length).toBe(1);
         expect(activeTargets.length).toBe(1);
@@ -1854,11 +1859,12 @@ describe('prepareTargets', () => {
         const target: PromQuery = {
           refId: 'A',
           expr: 'up',
-          showingGraph: true,
-          showingTable: false,
         };
 
-        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore);
+        const { queries, activeTargets, panelId, end, start } = getPrepareTargetsContext(target, CoreApp.Explore, {
+          showingGraph: true,
+          showingTable: false,
+        });
 
         expect(queries.length).toBe(1);
         expect(activeTargets.length).toBe(1);
@@ -1958,7 +1964,6 @@ function createDataRequest(targets: any[], overrides?: Partial<DataQueryRequest>
         start: dateTime().subtract(5, 'minutes'),
         end: dateTime(),
         expr: 'test',
-        showingGraph: true,
         ...t,
       };
     }),
@@ -1967,6 +1972,7 @@ function createDataRequest(targets: any[], overrides?: Partial<DataQueryRequest>
       to: dateTime(),
     },
     interval: '15s',
+    showingGraph: true,
   };
 
   return Object.assign(defaults, overrides || {}) as DataQueryRequest<PromQuery>;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -205,7 +205,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
         continue;
       }
 
-      if (target.showingTable) {
+      if (options.showingTable) {
         // create instant target only if Table is showed in Explore
         const instantTarget: any = cloneDeep(target);
         instantTarget.format = 'table';
@@ -218,7 +218,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
         queries.push(this.createQuery(instantTarget, options, start, end));
       }
 
-      if (target.showingGraph) {
+      if (options.showingGraph) {
         // create time series target only if Graph is showed in Explore
         target.format = 'time_series';
         target.instant = false;


### PR DESCRIPTION
**What this PR does / why we need it**:
Before being provided to a data source's query method, query targets are populated with various pieces of explore state
in `buildQueryTransaction`. Since this data isn't query-specific, it makes more sense to move it out of the targets and up a level as part of the `DataQueryRequest` object

**Which issue(s) this PR fixes**:
Closes #26202
