### PR TITLE
DataLinks: add internal flag in comments

### DIFF
--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -35,6 +35,7 @@ export interface DataLink<T extends DataQuery = any> {
   // If dataLink represents internal link this has to be filled. Internal link is defined as a query in a particular
   // datas ource that we want to show to the user. Usually this results in a link to explore but can also lead to
   // more custom onClick behaviour if needed.
+  // @internal and subject to change in future releases
   internal?: {
     query: T;
     datasourceUid: string;


### PR DESCRIPTION
The `internal` flag on datalinks is a shortcut to make something work while we find a better generic event system/pattern.  Lets make sure to mark this clearly as an unstable API that should be used with caution