### PR TITLE
Elastic: Fix error "e.buckets[Symbol.iterator] is not a function" when using filter

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -135,8 +135,8 @@ export class ElasticResponse {
       table.addColumn({ text: metricName });
       values.push(value);
     };
-
-    for (const bucket of esAgg.buckets) {
+    const buckets = _.isArray(esAgg.buckets) ? esAgg.buckets : [esAgg.buckets];
+    for (const bucket of buckets) {
       const values = [];
 
       for (const propValues of _.values(props)) {
@@ -230,8 +230,7 @@ export class ElasticResponse {
           if (bucket.key_as_string) {
             props[aggDef.field] = bucket.key_as_string;
           }
-          const aggs = _.isArray(bucket) ? bucket : [bucket];
-          this.processBuckets(aggs, target, seriesList, table, props, depth + 1);
+          this.processBuckets(bucket, target, seriesList, table, props, depth + 1);
         }
       }
     }

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -136,8 +136,7 @@ export class ElasticResponse {
       values.push(value);
     };
 
-    const buckets = _.isArray(esAgg.buckets) ? esAgg.buckets : [esAgg.buckets];
-    for (const bucket of buckets) {
+    for (const bucket of esAgg.buckets) {
       const values = [];
 
       for (const propValues of _.values(props)) {
@@ -195,8 +194,6 @@ export class ElasticResponse {
         }
       }
 
-      console.log('values', values);
-
       table.rows.push(values);
     }
   }
@@ -233,7 +230,8 @@ export class ElasticResponse {
           if (bucket.key_as_string) {
             props[aggDef.field] = bucket.key_as_string;
           }
-          this.processBuckets(bucket, target, seriesList, table, props, depth + 1);
+          const bucketInArray = _.isArray(bucket) ? bucket : [bucket];
+          this.processBuckets(bucketInArray, target, seriesList, table, props, depth + 1);
         }
       }
     }

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -230,8 +230,8 @@ export class ElasticResponse {
           if (bucket.key_as_string) {
             props[aggDef.field] = bucket.key_as_string;
           }
-          const bucketInArray = _.isArray(bucket) ? bucket : [bucket];
-          this.processBuckets(bucketInArray, target, seriesList, table, props, depth + 1);
+          const aggs = _.isArray(bucket) ? bucket : [bucket];
+          this.processBuckets(aggs, target, seriesList, table, props, depth + 1);
         }
       }
     }

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -136,7 +136,8 @@ export class ElasticResponse {
       values.push(value);
     };
 
-    for (const bucket of esAgg.buckets) {
+    const buckets = _.isArray(esAgg.buckets) ? esAgg.buckets : [esAgg.buckets];
+    for (const bucket of buckets) {
       const values = [];
 
       for (const propValues of _.values(props)) {
@@ -193,6 +194,8 @@ export class ElasticResponse {
           }
         }
       }
+
+      console.log('values', values);
 
       table.rows.push(values);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

In Elastic, adding a filter triggers `e.buckets[Symbol.iterator] is not a function`. I have looked into it and found out that when we are using filter, buckets at the bottom that we receive are not an arrays, but objects such as `{ *: { doc_count: 1174 }}`. However, in `processAggregationDocs` we count on buckets are in array. This PR fixes this issue by making sure that bucket is array, even if it is just 1 bucket. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/25574
Fixes https://github.com/grafana/grafana/issues/25680
