### PR TITLE
Datasource/CloudWatch: Fix some react errors

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -256,13 +256,13 @@ export default class LogsCheatSheet extends PureComponent<ExploreStartPageProps,
     return (
       <div>
         <h2>CloudWatch Logs Cheat Sheet</h2>
-        {CLIQ_EXAMPLES.map(cat => (
-          <div>
+        {CLIQ_EXAMPLES.map((cat, i) => (
+          <div key={`cat-${i}`}>
             <div className={`cheat-sheet-item__title ${cx(exampleCategory)}`}>{cat.category}</div>
-            {cat.examples.map((item, i) => (
-              <div className="cheat-sheet-item" key={`item-${i}`}>
+            {cat.examples.map((item, j) => (
+              <div className="cheat-sheet-item" key={`item-${j}`}>
                 <h4>{item.title}</h4>
-                {this.renderExpression(item.expr, `item-${i}`)}
+                {this.renderExpression(item.expr, `item-${j}`)}
               </div>
             ))}
           </div>

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -155,7 +155,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
 
   onLogGroupSearchDebounced = debounce(this.onLogGroupSearch, 300);
 
-  componentWillMount = () => {
+  componentDidMount = () => {
     const { datasource, query, onChange } = this.props;
 
     this.setState({


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a warning caused by a `key` prop not being set, and changes the deprecated `componentWillMount` to `componentDidMount` in `LogsQueryField.tsx`