### PR TITLE
Plugins: PluginPageRouter POC

### DIFF
--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,7 +1,8 @@
-import { ComponentClass } from 'react';
+import { ComponentClass, ComponentType } from 'react';
 import { KeyValue } from './data';
 import { NavModel } from './navModel';
 import { PluginMeta, GrafanaPlugin, PluginIncludeType } from './plugin';
+import { UrlQueryMap } from '../utils';
 
 export enum CoreApp {
   Dashboard = 'dashboard',
@@ -13,11 +14,6 @@ export interface AppRootProps<T = KeyValue> {
 
   path: string; // The URL path to this page
   query: KeyValue; // The URL query parameters
-
-  /**
-   * Pass the nav model to the container... is there a better way?
-   */
-  onNavChanged: (nav: NavModel) => void;
 }
 
 export interface AppPluginMeta<T = KeyValue> extends PluginMeta<T> {
@@ -26,8 +22,7 @@ export interface AppPluginMeta<T = KeyValue> extends PluginMeta<T> {
 
 export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
   // Content under: /a/${plugin-id}/*
-  root?: ComponentClass<AppRootProps<T>>;
-  rootNav?: NavModel; // Initial navigation model
+  root?: ComponentType<AppRootProps<T>>;
 
   // Old style pages
   angularPages?: { [component: string]: any };
@@ -43,9 +38,8 @@ export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
    * Set the component displayed under:
    *   /a/${plugin-id}/*
    */
-  setRootPage(root: ComponentClass<AppRootProps<T>>, rootNav?: NavModel) {
+  setRootPage(root: ComponentClass<AppRootProps<T>>) {
     this.root = root;
-    this.rootNav = rootNav;
     return this;
   }
 
@@ -73,6 +67,23 @@ export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
       }
     }
   }
+}
+
+export interface PluginPageRouteProps {
+  path: string;
+  component: ComponentType;
+  /*
+   * If nav model then the component get's rendered inside a page & page contents
+   * If not then the component can control full page style
+   */
+  navModel?: NavModel;
+}
+
+export interface PluginPageRouterProps {}
+
+export class PluginPageRouter {
+  static Router: ComponentType<PluginPageRouterProps> = (props: PluginPageRouterProps) => null;
+  static Route: ComponentType<PluginPageRouteProps> = (props: PluginPageRouteProps) => null;
 }
 
 /**

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -45,6 +45,7 @@ class Page extends Component<Props> {
 
   render() {
     const { navModel } = this.props;
+
     return (
       <div className="page-scrollbar-wrapper">
         <CustomScrollbar autoHeightMin={'100%'} className="custom-scrollbar--page">

--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -6,12 +6,14 @@ import { connect } from 'react-redux';
 import { StoreState } from 'app/types';
 import { AppEvents, AppPlugin, AppPluginMeta, NavModel, PluginType, UrlQueryMap } from '@grafana/data';
 
-import Page from 'app/core/components/Page/Page';
 import { getPluginSettings } from './PluginSettingsCache';
 import { importAppPlugin } from './plugin_loader';
 import { getLoadingNav } from './PluginPage';
 import { getNotFoundNav, getWarningNav } from 'app/core/nav_model_srv';
 import { appEvents } from 'app/core/core';
+
+// has no exports only sets components exported in grafana/data
+import './PluginPageRouter';
 
 interface Props {
   pluginId: string; // From the angular router
@@ -73,22 +75,18 @@ class AppRootPage extends Component<Props, State> {
 
   render() {
     const { path, query } = this.props;
-    const { loading, plugin, nav } = this.state;
+    const { plugin } = this.state;
 
-    if (plugin && !plugin.root) {
-      // TODO? redirect to plugin page?
-      return <div>No Root App</div>;
+    if (!plugin) {
+      return <div>Loading</div>;
     }
 
-    return (
-      <Page navModel={nav}>
-        <Page.Contents isLoading={loading}>
-          {plugin && plugin.root && (
-            <plugin.root meta={plugin.meta} query={query} path={path} onNavChanged={this.onNavChanged} />
-          )}
-        </Page.Contents>
-      </Page>
-    );
+    const AppRootPage = plugin.root;
+    if (!AppRootPage) {
+      return <div>No react root app page</div>;
+    }
+
+    return <AppRootPage meta={plugin.meta} query={query} path={path} />;
   }
 }
 

--- a/public/app/features/plugins/PluginPageRouter.tsx
+++ b/public/app/features/plugins/PluginPageRouter.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+import { connect, MapStateToProps, MapDispatchToProps } from 'react-redux';
+import { PluginPageRouter, PluginPageRouteProps, PluginPageRouterProps, UrlQueryMap } from '@grafana/data';
+import Page from 'app/core/components/Page/Page';
+import { StoreState } from 'app/types';
+
+export const NotFound: FC<PluginPageRouteProps> = () => {
+  return <h2>Not route matched and no default route found</h2>;
+};
+
+export interface ConnectedProps {
+  path: string;
+  page?: string | null;
+  query: UrlQueryMap;
+}
+
+export type RouterProps = PluginPageRouterProps & ConnectedProps;
+
+export const Router: FC<RouterProps> = ({ children, page }) => {
+  let defaultRoute: React.ReactNode = NotFound;
+
+  const fullPagePath = `/${page}`;
+
+  for (const child of React.Children.toArray(children) as any) {
+    console.log('child', child);
+    if (!child) {
+      continue;
+    }
+
+    if (child.props.path === fullPagePath) {
+      return child;
+    }
+
+    if (child.props.path === '/') {
+      defaultRoute = child;
+    }
+  }
+
+  return defaultRoute;
+};
+
+const Route: FC<PluginPageRouteProps> = ({ component }) => {
+  return React.createElement(component);
+};
+
+const mapStateToProps: MapStateToProps<ConnectedProps, PluginPageRouterProps, StoreState> = (state, props) => ({
+  query: state.location.query,
+  path: state.location.path,
+  page: state.location.routeParams.page as string,
+});
+
+PluginPageRouter.Router = connect(mapStateToProps)(Router);
+PluginPageRouter.Route = Route;

--- a/public/app/routes/routes.ts
+++ b/public/app/routes/routes.ts
@@ -235,7 +235,7 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
         component: () => SafeDynamicImport(import(/* webpackChunkName: "explore" */ 'app/features/explore/Wrapper')),
       },
     })
-    .when('/a/:pluginId/', {
+    .when('/a/:pluginId/:page?', {
       // Someday * and will get a ReactRouter under that path!
       template: '<react-container />',
       reloadOnSearch: false,


### PR DESCRIPTION
I really do not like the current react app RootPage props (onNavChanged) and the proposals in https://github.com/grafana/grafana/pull/26216 

This needs to be more declarative in the render path. 

Very quick and dirty POC to test this. A bit tricky as Page & PageContents & PageHeader are not in grafana-ui (easy to move, but Footer is not so easy). 

So tested this with a static components from core method to see if this approach is workable. 

Can be played with using: https://github.com/grafana/simple-app-plugin/compare/plugin-route-poc 

```typescript

  render() {
    const { Router, Route } = PluginPageRouter;

    return (
      <Router>
        <Route path="/" component={this.renderHome} />
        <Route path="/page1" component={this.renderPage1} />
        <Route path="/page2" component={this.renderPage2} />
      </Router>
    );
  }

  renderPage1() {
    return (
      <div style={{ padding: '50px' }}>
        <h1>Page1</h1>
        <a href="a/yourorg-simple-app/">Go to home</a>
      </div>
    );
  }

  renderPage2() {
    return (
      <div style={{ padding: '50px' }}>
        <h1>Page2</h1>
        <a href="a/yourorg-simple-app/">Go to home</a>
      </div>
    );
  }

  renderHome() {
    return (
      <div style={{ padding: '50px' }}>
        <h1>home</h1>
        <a href="a/yourorg-simple-app/page1">Go to page1</a>
        <br />
        <a href="a/yourorg-simple-app/page1">Go to page2</a>
      </div>
    );
  }
```

I never got the part of some routes having page header. But my thinking there is to add navModel to Route component / props. And then Route component can wrap the component in Page & and PageContents (And add PageHeader). 
