### PR TITLE
AppPlugin: give full control to page layout when navigation is missing

### DIFF
--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -42,6 +42,10 @@ export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
   /**
    * Set the component displayed under:
    *   /a/${plugin-id}/*
+   *
+   * If the NavModel is configured, the page will have a managed frame, otheriwse it has full control.
+   *
+   * NOTE: this structure will change in 7.2+ so that it is managed with a normal react router
    */
   setRootPage(root: ComponentClass<AppRootProps<T>>, rootNav?: NavModel) {
     this.root = root;

--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -9,9 +9,9 @@ import { AppEvents, AppPlugin, AppPluginMeta, NavModel, PluginType, UrlQueryMap 
 import Page from 'app/core/components/Page/Page';
 import { getPluginSettings } from './PluginSettingsCache';
 import { importAppPlugin } from './plugin_loader';
-import { getLoadingNav } from './PluginPage';
 import { getNotFoundNav, getWarningNav } from 'app/core/nav_model_srv';
 import { appEvents } from 'app/core/core';
+import PageLoader from 'app/core/components/PageLoader/PageLoader';
 
 interface Props {
   pluginId: string; // From the angular router
@@ -23,7 +23,7 @@ interface Props {
 interface State {
   loading: boolean;
   plugin?: AppPlugin | null;
-  nav: NavModel;
+  nav?: NavModel;
 }
 
 export function getAppPluginPageError(meta: AppPluginMeta) {
@@ -44,7 +44,6 @@ class AppRootPage extends Component<Props, State> {
     super(props);
     this.state = {
       loading: true,
-      nav: getLoadingNav(),
     };
   }
 
@@ -78,6 +77,14 @@ class AppRootPage extends Component<Props, State> {
     if (plugin && !plugin.root) {
       // TODO? redirect to plugin page?
       return <div>No Root App</div>;
+    }
+
+    // When no naviagion is set, give full control to the app plugin
+    if (!nav) {
+      if (plugin && plugin.root) {
+        return <plugin.root meta={plugin.meta} query={query} path={path} onNavChanged={this.onNavChanged} />;
+      }
+      return <PageLoader />;
     }
 
     return (


### PR DESCRIPTION
This is an altenative to https://github.com/grafana/grafana/pull/26245 and https://github.com/grafana/grafana/pull/26216

In 7.2, we should fix this so that we pass a react-router to apps and give them the ability to structure however they need.  However, we need something simpler to get in 7.1

This PR changes the behavior without changing any methods.  

If a navModel is defined, the container will include it, otherwise the page has full control of the layout
