### PR TITLE
implicit import symbol-observable to avoid inconsistent symbol

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -1,3 +1,4 @@
+import 'symbol-observable';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid inconsistent observable symbol issue.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/26264

**Special notes for your reviewer**:
This could be blocker to migrate datasource plugin to Grafana 7.x.
Because, grafana-runtime use Observable in datasource base class.
https://github.com/grafana/grafana/blob/v7.0.6/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L105
