### PR TITLE
CircleCI: Disable for PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,11 @@ version: 2.1
 
 aliases:
   # Workflow filters
-  # filter-all triggers for all branches and version tags
-  - &filter-all
-    tags:
-      only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
   - &filter-only-release
     branches:
       only: chore/test-release-pipeline
     tags:
       only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-  - &filter-not-release-or-master
-    tags:
-      ignore: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-    branches:
-      ignore:
-        - master
-        - chore/test-release-pipeline
   - &filter-only-master
     branches:
       only: master
@@ -1051,39 +1040,39 @@ workflows:
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           edition: oss
           variant: osx64
           name: build-oss-backend-osx64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           edition: oss
           variant: win64
           name: build-oss-backend-win64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           edition: oss
           variant: linux-x64
           name: build-oss-backend-linux-x64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           edition: oss
           variant: linux-x64-musl
           name: build-oss-backend-linux-x64-musl
           requires:
             - lint-go
       - build-frontend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-oss-frontend
           edition: oss
       - build-plugins:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-oss-plugins
           edition: oss
           requires:
@@ -1124,39 +1113,39 @@ workflows:
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-backend-osx64
           edition: enterprise
           variant: osx64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-backend-win64
           edition: enterprise
           variant: win64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-backend-linux-x64
           edition: enterprise
           variant: linux-x64
           requires:
             - lint-go
       - build-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-backend-linux-x64-musl
           edition: enterprise
           variant: linux-x64-musl
           requires:
             - lint-go
       - build-frontend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-frontend
           edition: enterprise
       - build-plugins:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-plugins
           edition: enterprise
           requires:
@@ -1164,31 +1153,31 @@ workflows:
       - build-release-publisher:
           filters: *filter-master-or-release
       - codespell:
-          filters: *filter-all
+          filters: *filter-master-or-release
       - lint-go:
-          filters: *filter-all
+          filters: *filter-master-or-release
       - shellcheck:
-          filters: *filter-all
+          filters: *filter-master-or-release
       - test-backend:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - lint-go
       - test-frontend:
-          filters: *filter-all
+          filters: *filter-master-or-release
       - mysql-integration-test:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - lint-go
             - test-backend
             - test-frontend
       - postgres-integration-test:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - lint-go
             - test-backend
             - test-frontend
       - package-oss:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - build-oss-backend-armv6
             - build-oss-backend-armv7
@@ -1206,7 +1195,7 @@ workflows:
             - shellcheck
             - build-oss-plugins
       - package-enterprise:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - build-enterprise-backend-armv6
             - build-enterprise-backend-armv7
@@ -1224,11 +1213,11 @@ workflows:
             - shellcheck
             - build-enterprise-plugins
       - build-oss-windows-installer:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - package-oss
       - build-enterprise-windows-installer:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - package-enterprise
       - release-next-packages:
@@ -1264,12 +1253,12 @@ workflows:
             - postgres-integration-test
             - build-release-publisher
       - publish-storybook:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - test-backend
             - test-frontend
       - build-docker-images:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-oss-docker-images
           edition: oss
           ubuntu: false
@@ -1280,7 +1269,7 @@ workflows:
             - package-oss
             - build-oss-windows-installer
       - build-docker-images:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-oss-ubuntu-docker-images
           edition: oss
           ubuntu: true
@@ -1291,7 +1280,7 @@ workflows:
             - package-oss
             - build-oss-windows-installer
       - build-docker-images:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-docker-images
           edition: enterprise
           ubuntu: false
@@ -1302,7 +1291,7 @@ workflows:
             - package-enterprise
             - build-enterprise-windows-installer
       - build-docker-images:
-          filters: *filter-all
+          filters: *filter-master-or-release
           name: build-enterprise-ubuntu-docker-images
           edition: enterprise
           ubuntu: true
@@ -1313,14 +1302,9 @@ workflows:
             - package-enterprise
             - build-enterprise-windows-installer
       - end-to-end-tests:
-          filters: *filter-all
+          filters: *filter-master-or-release
           requires:
             - package-oss
-      - build-docs-website:
-          filters: *filter-not-release-or-master
-          requires:
-            - mysql-integration-test
-            - postgres-integration-test
       - deploy-to-kubernetes:
           filters: *filter-only-master
           requires:


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable CircleCI for PR testing, since Drone is now the preferred method. Simply done by converting job triggers reacting to branch pushes (corresponding to PRs), into triggers on master/release.