### PR TITLE
Loki: Fix error handling

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -176,7 +176,9 @@ describe('LokiDatasource', () => {
       datasourceRequestMock.mockImplementation(
         jest.fn().mockReturnValueOnce(
           Promise.reject({
-            data: 'parse error at line 1, col 6: invalid char escape',
+            data: {
+              message: 'parse error at line 1, col 6: invalid char escape',
+            },
             status: 400,
             statusText: 'Bad Request',
           })
@@ -189,7 +191,7 @@ describe('LokiDatasource', () => {
       try {
         await ds.query(options).toPromise();
       } catch (err) {
-        expect(err.message).toBe(
+        expect(err.data.message).toBe(
           'Error: parse error at line 1, col 6: invalid char escape. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md.'
         );
       }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -1,14 +1,14 @@
 // Libraries
 import { isEmpty, map as lodashMap } from 'lodash';
 import { Observable, from, merge, of } from 'rxjs';
-import { map, filter, catchError, switchMap } from 'rxjs/operators';
+import { map, catchError, switchMap } from 'rxjs/operators';
 
 // Services & Utils
 import { DataFrame, dateMath, FieldCache, QueryResultMeta } from '@grafana/data';
-import { getBackendSrv, BackendSrvRequest } from '@grafana/runtime';
+import { getBackendSrv, BackendSrvRequest, FetchError } from '@grafana/runtime';
 import { addLabelToQuery } from 'app/plugins/datasource/prometheus/add_label_to_query';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { safeStringifyValue, convertToWebSocketUrl } from 'app/core/utils/explore';
+import { convertToWebSocketUrl } from 'app/core/utils/explore';
 import { lokiResultsToTableModel, processRangeQueryResponse, lokiStreamResultToDataFrame } from './result_transformer';
 import { getHighlighterExpressionsFromQuery } from './query_utils';
 
@@ -120,8 +120,6 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     };
 
     return this._request(INSTANT_QUERY_ENDPOINT, query).pipe(
-      catchError((err: any) => this.throwUnless(err, err.cancelled, target)),
-      filter((response: any) => (response.cancelled ? false : true)),
       map((response: { data: LokiResponse }) => {
         if (response.data.data.resultType === LokiResultType.Stream) {
           return {
@@ -200,8 +198,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     }
     const query = this.createRangeQuery(target, queryOptions);
     return this._request(RANGE_QUERY_ENDPOINT, query).pipe(
-      catchError((err: any) => this.throwUnless(err, err.cancelled || err.status === 404, target)),
-      filter((response: any) => (response.cancelled ? false : true)),
+      catchError((err: any) => this.throwUnless(err, err.status === 404, target)),
       switchMap((response: { data: LokiResponse; status: number }) =>
         processRangeQueryResponse(
           response.data,
@@ -498,42 +495,13 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     return (row && row.searchWords && row.searchWords.length > 0) === true;
   }
 
-  throwUnless = (err: any, condition: boolean, target: LokiQuery) => {
+  throwUnless(err: FetchError, condition: boolean, target: LokiQuery) {
     if (condition) {
       return of(err);
     }
 
-    const error: DataQueryError = this.processError(err, target);
-    throw error;
-  };
-
-  processError = (err: any, target: LokiQuery): DataQueryError => {
-    const error: DataQueryError = {
-      message: (err && err.statusText) || 'Unknown error during query transaction. Please check JS console logs.',
-      refId: target.refId,
-    };
-
-    if (err.data) {
-      if (typeof err.data === 'string') {
-        if (err.data.includes('escape') && target.expr.includes('\\')) {
-          error.message = `Error: ${err.data}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://github.com/grafana/loki/blob/master/docs/logql.md.`;
-        } else {
-          error.message = err.data;
-        }
-      } else if (err.data.error) {
-        error.message = safeStringifyValue(err.data.error);
-      }
-    } else if (err.message) {
-      error.message = err.message;
-    } else if (typeof err === 'string') {
-      error.message = err;
-    }
-
-    error.status = err.status;
-    error.statusText = err.statusText;
-
-    return error;
-  };
+    throw err;
+  }
 
   adjustInterval(interval: number, range: number) {
     // Loki will drop queries that might return more than 11000 data points.


### PR DESCRIPTION
Noticed that loki error handling is broken in 7.0 & 7.1 (and master), unrelated to backend_srv observable rewrite. 

* Removed the error handling in loki data source, seems to be old and not relevant anymore as backendSrv has done that data string => obj translation for a long time 
* There is still some logic of capturing 404 error in some cases and not letting this be seen as an error, so kept that logic
* Removed cancelled filtering as the backendSrv rewrite now makes cancelled requests result in errors so no need to filter these out (So this PR cannot be cherry picked to 7.1) 

Before: (7.0.6)
![Screenshot from 2020-07-13 15-15-36](https://user-images.githubusercontent.com/10999/87309476-f47fe500-c51c-11ea-8ec6-386ea5c40d0e.png)

After:
![Screenshot from 2020-07-13 15-14-33](https://user-images.githubusercontent.com/10999/87309494-f9dd2f80-c51c-11ea-95dc-1c5349dab958.png)

This problem could exist for Prometheus instead.

There are some strange safeStringifyValue that I do not really understand the origin for. 

To fix this for 7.1 we need a slightly modified PR that does not rely on the backendSrv changes in master/7.2   (specifically the changes to cancellation that are now seen as errors) 