### PR TITLE
AdminUsers: reset page to zero on query change

### DIFF
--- a/public/app/features/admin/state/reducers.test.ts
+++ b/public/app/features/admin/state/reducers.test.ts
@@ -10,8 +10,10 @@ import {
   userMappingInfoLoadedAction,
   userProfileLoadedAction,
   userSessionsLoadedAction,
+  userListAdminReducer,
+  queryChanged,
 } from './reducers';
-import { LdapState, LdapUser, UserAdminState, UserDTO } from 'app/types';
+import { LdapState, LdapUser, UserAdminState, UserDTO, UserListAdminState } from 'app/types';
 
 const makeInitialLdapState = (): LdapState => ({
   connectionInfo: [],
@@ -27,6 +29,15 @@ const makeInitialUserAdminState = (): UserAdminState => ({
   sessions: [],
   orgs: [],
   isLoading: true,
+});
+
+const makeInitialUserListAdminState = (): UserListAdminState => ({
+  users: [],
+  query: '',
+  page: 0,
+  perPage: 50,
+  totalPages: 1,
+  showPaging: false,
 });
 
 const getTestUserMapping = (): LdapUser => ({
@@ -257,6 +268,26 @@ describe('Edit Admin user page reducer', () => {
               seenAt: '2020-01-01 00:00:00',
             },
           ],
+        });
+    });
+  });
+});
+
+describe('User List Admin reducer', () => {
+  describe('When query changed', () => {
+    it('should reset page to 0', () => {
+      const initialState = {
+        ...makeInitialUserListAdminState(),
+        page: 3,
+      };
+
+      reducerTester<UserListAdminState>()
+        .givenReducer(userListAdminReducer, initialState)
+        .whenActionIsDispatched(queryChanged('test'))
+        .thenStateShouldEqual({
+          ...makeInitialUserListAdminState(),
+          query: 'test',
+          page: 0,
         });
     });
   });

--- a/public/app/features/admin/state/reducers.ts
+++ b/public/app/features/admin/state/reducers.ts
@@ -156,6 +156,7 @@ export const userListAdminSlice = createSlice({
     queryChanged: (state, action: PayloadAction<string>) => ({
       ...state,
       query: action.payload,
+      page: 0,
     }),
     pageChanged: (state, action: PayloadAction<number>) => ({
       ...state,


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes user search on `/admin/users` to work no matter what page you are on (https://github.com/grafana/grafana/issues/26209)

Before if you searched for a user while on page 2 you would see empty results. This happens because page state does not get reset when query changes. The fix is to reset page to `0` whenever the query changes.

before
![search-page-before](https://user-images.githubusercontent.com/339208/87313220-912b8e00-c4ef-11ea-8817-4551255906f7.gif)

after
![search-page-fixed](https://user-images.githubusercontent.com/339208/87313234-94bf1500-c4ef-11ea-90b6-5a3ecf3f5dc9.gif)

**Which issue(s) this PR fixes**:

Fixes #26209