### PR TITLE
CloudWatch Logs: Fixes grouping of results by numeric field

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -174,7 +174,6 @@ func numericFieldToStringField(field *data.Field) (*data.Field, error) {
 	strings := make([]*string, field.Len())
 	for i := 0; i < field.Len(); i++ {
 		floatVal, err := field.FloatAt(i)
-
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -1,10 +1,12 @@
 package cloudwatch
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
@@ -108,9 +110,19 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 func groupResults(results *data.Frame, groupingFieldNames []string) ([]*data.Frame, error) {
 	groupingFields := make([]*data.Field, 0)
 
-	for _, field := range results.Fields {
+	for i, field := range results.Fields {
 		for _, groupingField := range groupingFieldNames {
 			if field.Name == groupingField {
+				// convert numeric grouping field to string field
+				if field.Type().Numeric() {
+					newField, err := numericFieldToStringField(field)
+					if err != nil {
+						return nil, err
+					}
+					results.Fields[i] = newField
+					field = newField
+				}
+
 				groupingFields = append(groupingFields, field)
 			}
 		}
@@ -152,4 +164,27 @@ func generateGroupKey(fields []*data.Field, row int) string {
 	}
 
 	return groupKey
+}
+
+func numericFieldToStringField(field *data.Field) (*data.Field, error) {
+	if !field.Type().Numeric() {
+		return nil, fmt.Errorf("field is not numeric")
+	}
+
+	strings := make([]*string, field.Len())
+	for i := 0; i < field.Len(); i++ {
+		floatVal, err := field.FloatAt(i)
+
+		if err != nil {
+			return nil, err
+		}
+
+		strVal := fmt.Sprintf("%g", floatVal)
+		strings[i] = aws.String(strVal)
+	}
+
+	newField := data.NewField(field.Name, field.Labels, strings)
+	newField.Config = field.Config
+
+	return newField, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where fields weren't grouped correctly when trying to do so with a numeric field.

**Which issue(s) this PR fixes**:
Closes #25721
