### PR TITLE
DashboardLinks: do not over-query search endpoint

### DIFF
--- a/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
@@ -65,7 +65,7 @@ export class DashLinksEditorCtrl {
   }
 
   saveLink() {
-    this.dashboard.links = [...this.dashboard.links];
+    this.dashboard.links = _.cloneDeep(this.dashboard.links);
     this.backToList();
   }
 

--- a/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
@@ -54,7 +54,7 @@ export class DashLinksEditorCtrl {
   };
 
   addLink() {
-    this.dashboard.links.push(this.link);
+    this.dashboard.links = [...this.dashboard.links, this.link];
     this.mode = 'list';
     this.dashboard.updateSubmenuVisibility();
   }
@@ -65,6 +65,7 @@ export class DashLinksEditorCtrl {
   }
 
   saveLink() {
+    this.dashboard.links = [...this.dashboard.links];
     this.backToList();
   }
 

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -10,16 +10,17 @@ import { iconMap } from '../DashLinks/DashLinksEditorCtrl';
 
 export interface Props {
   dashboard: DashboardModel;
+  links: DashboardLink[];
 }
 
-export const DashboardLinks: FC<Props> = ({ dashboard }) => {
-  if (!dashboard.links.length) {
+export const DashboardLinks: FC<Props> = ({ dashboard, links }) => {
+  if (!links.length) {
     return null;
   }
 
   return (
     <>
-      {dashboard.links.map((link: DashboardLink, index: number) => {
+      {links.map((link: DashboardLink, index: number) => {
         const linkInfo = getLinkSrv().getAnchorInfo(link);
         const key = `${link.title}-$${index}`;
 

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -19,13 +19,17 @@ interface State {
 export class DashboardLinksDashboard extends PureComponent<Props, State> {
   state: State = { resolvedLinks: [] };
 
+  componentDidMount() {
+    this.searchForDashboards();
+  }
+
   componentDidUpdate(prevProps: Readonly<Props>) {
-    if (!this.props.link.asDropdown && prevProps.linkInfo !== this.props.linkInfo) {
-      this.onResolveLinks();
+    if (this.props.link !== prevProps.link) {
+      this.searchForDashboards();
     }
   }
 
-  onResolveLinks = async () => {
+  searchForDashboards = async () => {
     const { dashboardId, link } = this.props;
 
     const searchHits = await searchForTags(link);
@@ -73,7 +77,7 @@ export class DashboardLinksDashboard extends PureComponent<Props, State> {
       <>
         <a
           className="gf-form-label pointer"
-          onClick={this.onResolveLinks}
+          onClick={this.searchForDashboards}
           data-placement="bottom"
           data-toggle="dropdown"
         >

--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -7,6 +7,7 @@ import { DashboardModel } from '../../state';
 import { DashboardLinks } from './DashboardLinks';
 import { Annotations } from './Annotations';
 import { SubMenuItems } from './SubMenuItems';
+import { DashboardLink } from '../../state/DashboardModel';
 
 interface OwnProps {
   dashboard: DashboardModel;
@@ -14,6 +15,7 @@ interface OwnProps {
 
 interface ConnectedProps {
   variables: VariableModel[];
+  links: DashboardLink[];
 }
 
 interface DispatchProps {}
@@ -66,9 +68,17 @@ class SubMenuUnConnected extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = state => ({
-  variables: getSubMenuVariables(state.templating.variables),
-});
+const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = state => {
+  return {
+    variables: getSubMenuVariables(state.templating.variables),
+
+    /** Haven't found any other way to force links being passed to the links menu. Not spreading into new array makes
+     * the DashboardLinks not re-render as it gets reference to the same array in the model.
+     * Ref: https://github.com/grafana/grafana/issues/26289
+     */
+    links: [...state.dashboard.getModel()?.links],
+  };
+};
 
 export const SubMenu = connect(mapStateToProps)(SubMenuUnConnected);
 SubMenu.displayName = 'SubMenu';

--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -11,11 +11,11 @@ import { DashboardLink } from '../../state/DashboardModel';
 
 interface OwnProps {
   dashboard: DashboardModel;
+  links: DashboardLink[];
 }
 
 interface ConnectedProps {
   variables: VariableModel[];
-  links: DashboardLink[];
 }
 
 interface DispatchProps {}
@@ -51,7 +51,8 @@ class SubMenuUnConnected extends PureComponent<Props> {
   };
 
   render() {
-    const { dashboard, variables } = this.props;
+    const { dashboard, variables, links } = this.props;
+
     if (!this.isSubMenuVisible()) {
       return null;
     }
@@ -61,7 +62,7 @@ class SubMenuUnConnected extends PureComponent<Props> {
         <SubMenuItems variables={variables} />
         <Annotations annotations={dashboard.annotations.list} onAnnotationChanged={this.onAnnotationStateChanged} />
         <div className="gf-form gf-form--grow" />
-        {dashboard && <DashboardLinks dashboard={dashboard} />}
+        {dashboard && <DashboardLinks dashboard={dashboard} links={links} />}
         <div className="clearfix" />
       </div>
     );
@@ -71,12 +72,6 @@ class SubMenuUnConnected extends PureComponent<Props> {
 const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = state => {
   return {
     variables: getSubMenuVariables(state.templating.variables),
-
-    /** Haven't found any other way to force links being passed to the links menu. Not spreading into new array makes
-     * the DashboardLinks not re-render as it gets reference to the same array in the model.
-     * Ref: https://github.com/grafana/grafana/issues/26289
-     */
-    links: [...state.dashboard.getModel()?.links],
   };
 };
 

--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -67,7 +67,7 @@ class SubMenuUnConnected extends PureComponent<Props> {
 }
 
 const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = state => ({
-  variables: getSubMenuVariables(state),
+  variables: getSubMenuVariables(state.templating.variables),
 });
 
 export const SubMenu = connect(mapStateToProps)(SubMenuUnConnected);

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -309,7 +309,7 @@ export class DashboardPage extends PureComponent<Props, State> {
           >
             <div className="dashboard-content">
               {initError && this.renderInitFailedState()}
-              {!editPanel && <SubMenu dashboard={dashboard} />}
+              {!editPanel && <SubMenu dashboard={dashboard} links={dashboard.links} />}
 
               <DashboardGrid
                 dashboard={dashboard}

--- a/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
+++ b/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
@@ -211,6 +211,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
               "version": 0,
             }
           }
+          links={Array []}
         />
         <DashboardGrid
           dashboard={
@@ -569,6 +570,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
               "version": 0,
             }
           }
+          links={Array []}
         />
         <DashboardGrid
           dashboard={

--- a/public/app/features/variables/state/selectors.ts
+++ b/public/app/features/variables/state/selectors.ts
@@ -2,6 +2,7 @@ import { StoreState } from '../../../types';
 import { VariableModel } from '../types';
 import { getState } from '../../../store/store';
 import { NEW_VARIABLE_ID } from './types';
+import memoizeOne from 'memoize-one';
 
 export const getVariable = <T extends VariableModel = VariableModel>(
   id: string,
@@ -42,9 +43,9 @@ export const getVariables = (state: StoreState = getState(), includeNewVariable 
   return getFilteredVariables(filter, state);
 };
 
-export const getSubMenuVariables = (state: StoreState): VariableModel[] => {
-  return getVariables(state);
-};
+export const getSubMenuVariables = memoizeOne((variables: Record<string, VariableModel>): VariableModel[] => {
+  return getVariables(getState());
+});
 
 export const getEditorVariables = (state: StoreState): VariableModel[] => {
   return getVariables(state, true);


### PR DESCRIPTION
Tries to fix the dashboard links issue that looks pretty big: 
Fixes #26289 

Dashboard to replicate issue: 
https://gist.github.com/torkelo/34628b4904befe0ba0bac6df9fbee232


Problem
* 1) SubMenu is connected to redux but is using a getSubMenuVariables selector that filters and creates a new array every redux update which causes SubMenu to render on every redux update (and as you scroll down a big dashboard there are redux updates as panels get's loaded)
* 2) DashboardLinks build linkInfo models every render, and DashboardLinksDashboards component will search for new update every time linkInfo model changed  => lots of calls to dashboard search api 

Solution
1) Memoize the call to getSubMenuVariables , was not easy as it takes in state and not the thing we want to memomize on (state variables object), had to do a bit of a hacky soliution without changing all get variable selector functions 
2) Update DashboardLinksDashboards way of detecting changes 

New Problem (why this is WIP):
1) Now DashboardLinksDashboards does not update when the link definition updates (need to make the link definition update mutable so a new link object is created), or switch to lodash deep equals in componentDidUpdate 

