### PR TITLE
Alerting: Store sensitive settings encrypted for alertmanager notifier

### DIFF
--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -29,14 +29,36 @@ func init() {
               As specified in Alertmanager documentation, do not specify a load balancer here. Enter all your Alertmanager URLs comma-separated.
             </info-popover>
 		</div>
-		<div class="gf-form max-width-30">
-        	<span class="gf-form-label width-10">Basic Auth User</span>
-            <input type="text" class="gf-form-input max-width-30" ng-model="ctrl.model.settings.basicAuthUser" placeholder=""></input>
-		</div>
-		<div class="gf-form max-width-30">
-        	<span class="gf-form-label width-10">Basic Auth Password</span>
-            <input type="text" class="gf-form-input max-width-30" ng-model="ctrl.model.settings.basicAuthPassword" placeholder=""></input>
-		</div>
+        <div class="gf-form max-width-30">
+            <span class="gf-form-label width-10">Basic Auth User</span>
+            <div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.basicAuthUser">
+                <input type="text"
+                    class="gf-form-input max-width-30"
+                    ng-init="ctrl.model.secureSettings.basicAuthUser = ctrl.model.settings.basicAuthUser || null; ctrl.model.settings.basicAuthUser = null;"
+                    ng-model="ctrl.model.secureSettings.basicAuthUser"
+                    data-placement="right">
+                </input>
+            </div>
+            <div class="gf-form" ng-if="ctrl.model.secureFields.basicAuthUser">
+                <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+                <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.basicAuthUser = false">reset</a>
+            </div>
+        </div>
+        <div class="gf-form max-width-30">
+            <span class="gf-form-label width-10">Basic Auth Password</span>
+            <div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.basicAuthPassword">
+                <input type="text"
+                    class="gf-form-input max-width-30"
+                    ng-init="ctrl.model.secureSettings.basicAuthPassword = ctrl.model.settings.basicAuthPassword || null; ctrl.model.settings.basicAuthPassword = null;"
+                    ng-model="ctrl.model.secureSettings.basicAuthPassword"
+                    data-placement="right">
+                </input>
+            </div>
+            <div class="gf-form" ng-if="ctrl.model.secureFields.basicAuthPassword">
+                <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+                <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.basicAuthPassword = false">reset</a>
+            </div>
+        </div>
       </div>
     `,
 		Options: []alerting.NotifierOption{
@@ -79,8 +101,8 @@ func NewAlertmanagerNotifier(model *models.AlertNotification) (alerting.Notifier
 			url = append(url, u)
 		}
 	}
-	basicAuthUser := model.Settings.Get("basicAuthUser").MustString()
-	basicAuthPassword := model.Settings.Get("basicAuthPassword").MustString()
+	basicAuthUser := model.DecryptedValue("basicAuthUser", model.Settings.Get("basicAuthUser").MustString())
+	basicAuthPassword := model.DecryptedValue("basicAuthPassword", model.Settings.Get("basicAuthPassword").MustString())
 
 	return &AlertmanagerNotifier{
 		NotifierBase:      NewNotifierBase(model),

--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -29,21 +29,10 @@ func init() {
               As specified in Alertmanager documentation, do not specify a load balancer here. Enter all your Alertmanager URLs comma-separated.
             </info-popover>
 		</div>
-        <div class="gf-form max-width-30">
-            <span class="gf-form-label width-10">Basic Auth User</span>
-            <div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.basicAuthUser">
-                <input type="text"
-                    class="gf-form-input max-width-30"
-                    ng-init="ctrl.model.secureSettings.basicAuthUser = ctrl.model.settings.basicAuthUser || null; ctrl.model.settings.basicAuthUser = null;"
-                    ng-model="ctrl.model.secureSettings.basicAuthUser"
-                    data-placement="right">
-                </input>
-            </div>
-            <div class="gf-form" ng-if="ctrl.model.secureFields.basicAuthUser">
-                <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
-                <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.basicAuthUser = false">reset</a>
-            </div>
-        </div>
+		<div class="gf-form max-width-30">
+        	<span class="gf-form-label width-10">Basic Auth User</span>
+            <input type="text" class="gf-form-input max-width-30" ng-model="ctrl.model.settings.basicAuthUser" placeholder=""></input>
+		</div>
         <div class="gf-form max-width-30">
             <span class="gf-form-label width-10">Basic Auth Password</span>
             <div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.basicAuthPassword">
@@ -101,7 +90,7 @@ func NewAlertmanagerNotifier(model *models.AlertNotification) (alerting.Notifier
 			url = append(url, u)
 		}
 	}
-	basicAuthUser := model.DecryptedValue("basicAuthUser", model.Settings.Get("basicAuthUser").MustString())
+	basicAuthUser := model.Settings.Get("basicAuthUser").MustString()
 	basicAuthPassword := model.DecryptedValue("basicAuthPassword", model.Settings.Get("basicAuthPassword").MustString())
 
 	return &AlertmanagerNotifier{


### PR DESCRIPTION
**What this PR does / why we need it**:
Store basic auth user/password in secure setting.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/25967

