### PR TITLE
Alerting: Store sensitive settings encrypted for pagerduty notifier

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -24,7 +24,19 @@ func init() {
       <h3 class="page-heading">PagerDuty settings</h3>
       <div class="gf-form">
         <span class="gf-form-label width-14">Integration Key</span>
-        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.integrationKey" placeholder="Pagerduty Integration Key"></input>
+		<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.integrationKey">
+			<input type="text"
+				class="gf-form-input max-width-22"
+				ng-init="ctrl.model.secureSettings.integrationKey = ctrl.model.settings.integrationKey || null; ctrl.model.settings.integrationKey = null;"
+				ng-model="ctrl.model.secureSettings.integrationKey"
+				placeholder="Pagerduty Integration Key"
+				data-placement="right">
+			</input>
+		</div>
+		<div class="gf-form" ng-if="ctrl.model.secureFields.integrationKey">
+			<input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+			<a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.integrationKey = false">reset</a>
+		</div>
       </div>
       <div class="gf-form">
         <span class="gf-form-label width-14">Severity</span>
@@ -105,7 +117,7 @@ var (
 func NewPagerdutyNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
 	severity := model.Settings.Get("severity").MustString("critical")
 	autoResolve := model.Settings.Get("autoResolve").MustBool(false)
-	key := model.Settings.Get("integrationKey").MustString()
+	key := model.DecryptedValue("integrationKey", model.Settings.Get("integrationKey").MustString())
 	messageInDetails := model.Settings.Get("messageInDetails").MustBool(false)
 	if key == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find integration key property in settings"}


### PR DESCRIPTION
**What this PR does / why we need it**:
Store pagerduty integration key in secure setting.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/25967