### PR TITLE
Grafana-UI: Enable empty time range

### DIFF
--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -5,7 +5,7 @@ export interface DateTimeBuiltinFormat {
   __momentBuiltinFormatBrand: any;
 }
 export const ISO_8601: DateTimeBuiltinFormat = moment.ISO_8601;
-export type DateTimeInput = Date | string | number | Array<string | number> | DateTime; // null | undefined
+export type DateTimeInput = Date | string | number | Array<string | number> | DateTime | null; // | undefined;
 export type FormatInput = string | DateTimeBuiltinFormat | undefined;
 export type DurationInput = string | number | DateTimeDuration;
 export type DurationUnit =

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.mdx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.mdx
@@ -5,6 +5,22 @@ import { TimeRangeInput } from './TimeRangeInput';
 
 A variant of `TimeRangePicker` for use in forms.
 
+`dateTime(null)` can be used to provide empty time range value. The shape of the return value on input clear is:
+
+```javascript
+{
+  from: dateTime(null),
+  to: dateTime(null),
+  raw: {
+    from: dateTime(null),
+    to: dateTime(null),
+  },
+};
+```
+
+`dateMath.isValid()` from `@grafana/data` can be used to check for a valid time range value.
+
+
 ### Usage
 
 ```jsx

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
@@ -29,8 +29,31 @@ export const basic = () => {
       {(value, updateValue) => {
         return (
           <TimeRangeInput
-            onChangeTimeZone={tz => action('onTimeZoneChange fired')(tz)}
-            timeZone="browser"
+            value={value}
+            onChange={timeRange => {
+              action('onChange fired')(timeRange);
+              updateValue(timeRange);
+            }}
+          />
+        );
+      }}
+    </UseState>
+  );
+};
+
+export const clearable = () => {
+  return (
+    <UseState
+      initialState={{
+        from: dateTime(),
+        to: dateTime(),
+        raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
+      }}
+    >
+      {(value, updateValue) => {
+        return (
+          <TimeRangeInput
+            clearable
             value={value}
             onChange={timeRange => {
               action('onChange fired')(timeRange);

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { dateTime, TimeFragment } from '@grafana/data';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { UseState } from '../../utils/storybook/UseState';
-import { TimeRangeInput } from './TimeRangeInput';
+import { InputTimeRange, TimeRangeInput } from './TimeRangeInput';
 import mdx from './TimeRangeInput.mdx';
 
 export default {
@@ -20,11 +20,13 @@ export default {
 export const basic = () => {
   return (
     <UseState
-      initialState={{
-        from: dateTime(),
-        to: dateTime(),
-        raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
-      }}
+      initialState={
+        {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
+        } as InputTimeRange
+      }
     >
       {(value, updateValue) => {
         return (
@@ -44,11 +46,13 @@ export const basic = () => {
 export const clearable = () => {
   return (
     <UseState
-      initialState={{
-        from: dateTime(),
-        to: dateTime(),
-        raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
-      }}
+      initialState={
+        {
+          from: dateTime(),
+          to: dateTime(),
+          raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
+        } as InputTimeRange
+      }
     >
       {(value, updateValue) => {
         return (

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.story.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { dateTime, TimeFragment } from '@grafana/data';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { UseState } from '../../utils/storybook/UseState';
-import { InputTimeRange, TimeRangeInput } from './TimeRangeInput';
+import { TimeRangeInput } from './TimeRangeInput';
 import mdx from './TimeRangeInput.mdx';
 
 export default {
@@ -20,13 +20,11 @@ export default {
 export const basic = () => {
   return (
     <UseState
-      initialState={
-        {
-          from: dateTime(),
-          to: dateTime(),
-          raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
-        } as InputTimeRange
-      }
+      initialState={{
+        from: dateTime(),
+        to: dateTime(),
+        raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
+      }}
     >
       {(value, updateValue) => {
         return (
@@ -46,13 +44,11 @@ export const basic = () => {
 export const clearable = () => {
   return (
     <UseState
-      initialState={
-        {
-          from: dateTime(),
-          to: dateTime(),
-          raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
-        } as InputTimeRange
-      }
+      initialState={{
+        from: dateTime(),
+        to: dateTime(),
+        raw: { from: 'now-6h' as TimeFragment, to: 'now' as TimeFragment },
+      }}
     >
       {(value, updateValue) => {
         return (

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -17,7 +17,7 @@ export const defaultTimeRange: TimeRange = {
   raw: { from: 'now-6h', to: 'now' },
 };
 
-interface InputTimeRange {
+export interface InputTimeRange {
   from: DateTime | string;
   to: DateTime | string;
   raw: RawTimeRange;

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -132,7 +132,7 @@ const getStyles = (theme: GrafanaTheme) => {
     clearIcon: css`
       margin-right: ${theme.spacing.xs};
       &:hover {
-        color: ${theme.palette.white};
+        color: ${theme.colors.linkHover};
       }
     `,
     placeholder: css`

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -1,6 +1,6 @@
-import React, { FC, FormEvent, useState } from 'react';
+import React, { FC, FormEvent, MouseEvent, useState } from 'react';
 import { css, cx } from 'emotion';
-import { dateTime, GrafanaTheme, TimeRange, TimeZone } from '@grafana/data';
+import { DateTime, dateTime, GrafanaTheme, RawTimeRange, TimeRange, TimeZone } from '@grafana/data';
 import { useStyles } from '../../themes/ThemeContext';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../Icon/Icon';
@@ -17,6 +17,12 @@ export const defaultTimeRange: TimeRange = {
   raw: { from: 'now-6h', to: 'now' },
 };
 
+interface InputTimeRange {
+  from: DateTime | string;
+  to: DateTime | string;
+  raw: RawTimeRange;
+}
+
 const isValidTimeRange = (range: any) => {
   return isValid(range.from) && isValid(range.to);
 };
@@ -24,10 +30,11 @@ const isValidTimeRange = (range: any) => {
 export interface Props {
   value: TimeRange;
   timeZone?: TimeZone;
-  onChange: (timeRange: TimeRange) => void;
+  onChange: (timeRange: InputTimeRange) => void;
   onChangeTimeZone?: (timeZone: TimeZone) => void;
   hideTimeZone?: boolean;
-  placeholder: string;
+  placeholder?: string;
+  clearable?: boolean;
 }
 
 const noop = () => {};
@@ -36,6 +43,7 @@ export const TimeRangeInput: FC<Props> = ({
   value,
   onChange,
   onChangeTimeZone,
+  clearable,
   hideTimeZone = true,
   timeZone = 'browser',
   placeholder = 'Select time range',
@@ -58,6 +66,13 @@ export const TimeRangeInput: FC<Props> = ({
     onChange(timeRange);
   };
 
+  const onRangeClear = (event: MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    const from = '';
+    const to = '';
+    onChange({ from, to, raw: { from, to } });
+  };
+
   return (
     <div className={styles.container}>
       <div tabIndex={0} className={styles.pickerInput} aria-label="TimePicker Open Button" onClick={onOpen}>
@@ -66,7 +81,11 @@ export const TimeRangeInput: FC<Props> = ({
         ) : (
           <span className={styles.placeholder}>{placeholder}</span>
         )}
+
         <span className={styles.caretIcon}>
+          {isValidTimeRange(value) && clearable && (
+            <Icon className={styles.clearIcon} name="times" size="lg" onClick={onRangeClear} />
+          )}
           <Icon name={isOpen ? 'angle-up' : 'angle-down'} size="lg" />
         </span>
       </div>
@@ -117,6 +136,12 @@ const getStyles = (theme: GrafanaTheme) => {
         margin-left: ${theme.spacing.xs};
       `
     ),
+    clearIcon: css`
+      margin-right: ${theme.spacing.xs};
+      &:hover {
+        color: ${theme.palette.white};
+      }
+    `,
     placeholder: css`
       color: ${theme.colors.formInputPlaceholderText};
       opacity: 1;

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -1,6 +1,6 @@
 import React, { FC, FormEvent, MouseEvent, useState } from 'react';
 import { css, cx } from 'emotion';
-import { DateTime, dateTime, GrafanaTheme, RawTimeRange, TimeRange, TimeZone } from '@grafana/data';
+import { dateTime, GrafanaTheme, TimeRange, TimeZone, dateMath } from '@grafana/data';
 import { useStyles } from '../../themes/ThemeContext';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../Icon/Icon';
@@ -9,7 +9,6 @@ import { getFocusStyle } from '../Forms/commonStyles';
 import { TimePickerButtonLabel } from './TimeRangePicker';
 import { TimePickerContent } from './TimeRangePicker/TimePickerContent';
 import { otherOptions, quickOptions } from './rangeOptions';
-import { isValid } from './TimeRangePicker/TimeRangeForm';
 
 export const defaultTimeRange: TimeRange = {
   from: dateTime().subtract(6, 'hour'),
@@ -17,20 +16,14 @@ export const defaultTimeRange: TimeRange = {
   raw: { from: 'now-6h', to: 'now' },
 };
 
-export interface InputTimeRange {
-  from: DateTime | string;
-  to: DateTime | string;
-  raw: RawTimeRange;
-}
-
 const isValidTimeRange = (range: any) => {
-  return isValid(range.from) && isValid(range.to);
+  return dateMath.isValid(range.from) && dateMath.isValid(range.to);
 };
 
 export interface Props {
-  value: InputTimeRange;
+  value: TimeRange;
   timeZone?: TimeZone;
-  onChange: (timeRange: InputTimeRange) => void;
+  onChange: (timeRange: TimeRange) => void;
   onChangeTimeZone?: (timeZone: TimeZone) => void;
   hideTimeZone?: boolean;
   placeholder?: string;
@@ -68,8 +61,8 @@ export const TimeRangeInput: FC<Props> = ({
 
   const onRangeClear = (event: MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
-    const from = '';
-    const to = '';
+    const from = dateTime(null);
+    const to = dateTime(null);
     onChange({ from, to, raw: { from, to } });
   };
 

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -28,7 +28,7 @@ const isValidTimeRange = (range: any) => {
 };
 
 export interface Props {
-  value: TimeRange;
+  value: InputTimeRange;
   timeZone?: TimeZone;
   onChange: (timeRange: InputTimeRange) => void;
   onChangeTimeZone?: (timeZone: TimeZone) => void;
@@ -77,7 +77,7 @@ export const TimeRangeInput: FC<Props> = ({
     <div className={styles.container}>
       <div tabIndex={0} className={styles.pickerInput} aria-label="TimePicker Open Button" onClick={onOpen}>
         {isValidTimeRange(value) ? (
-          <TimePickerButtonLabel value={value} />
+          <TimePickerButtonLabel value={value as TimeRange} />
         ) : (
           <span className={styles.placeholder}>{placeholder}</span>
         )}
@@ -93,7 +93,7 @@ export const TimeRangeInput: FC<Props> = ({
         <ClickOutsideWrapper includeButtonPress={false} onClick={onClose}>
           <TimePickerContent
             timeZone={timeZone}
-            value={isValidTimeRange(value) ? value : defaultTimeRange}
+            value={isValidTimeRange(value) ? (value as TimeRange) : defaultTimeRange}
             onChange={onRangeChange}
             otherOptions={otherOptions}
             quickOptions={quickOptions}

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangeInput.tsx
@@ -1,6 +1,6 @@
 import React, { FC, FormEvent, useState } from 'react';
 import { css, cx } from 'emotion';
-import { GrafanaTheme, TimeRange, TimeZone } from '@grafana/data';
+import { dateTime, GrafanaTheme, TimeRange, TimeZone } from '@grafana/data';
 import { useStyles } from '../../themes/ThemeContext';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../Icon/Icon';
@@ -9,6 +9,17 @@ import { getFocusStyle } from '../Forms/commonStyles';
 import { TimePickerButtonLabel } from './TimeRangePicker';
 import { TimePickerContent } from './TimeRangePicker/TimePickerContent';
 import { otherOptions, quickOptions } from './rangeOptions';
+import { isValid } from './TimeRangePicker/TimeRangeForm';
+
+export const defaultTimeRange: TimeRange = {
+  from: dateTime().subtract(6, 'hour'),
+  to: dateTime(),
+  raw: { from: 'now-6h', to: 'now' },
+};
+
+const isValidTimeRange = (range: any) => {
+  return isValid(range.from) && isValid(range.to);
+};
 
 export interface Props {
   value: TimeRange;
@@ -16,6 +27,7 @@ export interface Props {
   onChange: (timeRange: TimeRange) => void;
   onChangeTimeZone?: (timeZone: TimeZone) => void;
   hideTimeZone?: boolean;
+  placeholder: string;
 }
 
 const noop = () => {};
@@ -26,6 +38,7 @@ export const TimeRangeInput: FC<Props> = ({
   onChangeTimeZone,
   hideTimeZone = true,
   timeZone = 'browser',
+  placeholder = 'Select time range',
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const styles = useStyles(getStyles);
@@ -48,7 +61,11 @@ export const TimeRangeInput: FC<Props> = ({
   return (
     <div className={styles.container}>
       <div tabIndex={0} className={styles.pickerInput} aria-label="TimePicker Open Button" onClick={onOpen}>
-        <TimePickerButtonLabel value={value} />
+        {isValidTimeRange(value) ? (
+          <TimePickerButtonLabel value={value} />
+        ) : (
+          <span className={styles.placeholder}>{placeholder}</span>
+        )}
         <span className={styles.caretIcon}>
           <Icon name={isOpen ? 'angle-up' : 'angle-down'} size="lg" />
         </span>
@@ -57,7 +74,7 @@ export const TimeRangeInput: FC<Props> = ({
         <ClickOutsideWrapper includeButtonPress={false} onClick={onClose}>
           <TimePickerContent
             timeZone={timeZone}
-            value={value}
+            value={isValidTimeRange(value) ? value : defaultTimeRange}
             onChange={onRangeChange}
             otherOptions={otherOptions}
             quickOptions={quickOptions}
@@ -100,5 +117,9 @@ const getStyles = (theme: GrafanaTheme) => {
         margin-left: ${theme.spacing.xs};
       `
     ),
+    placeholder: css`
+      color: ${theme.colors.formInputPlaceholderText};
+      opacity: 1;
+    `,
   };
 };

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangePicker/TimeRangeForm.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangePicker/TimeRangeForm.tsx
@@ -143,7 +143,7 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
   return value;
 }
 
-export function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
+function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
   if (isDateTime(value)) {
     return value.isValid();
   }

--- a/packages/grafana-ui/src/components/TimePicker/TimeRangePicker/TimeRangeForm.tsx
+++ b/packages/grafana-ui/src/components/TimePicker/TimeRangePicker/TimeRangeForm.tsx
@@ -143,7 +143,7 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
   return value;
 }
 
-function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
+export function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
   if (isDateTime(value)) {
     return value.isValid();
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Add a possibility to use `TimeRangeInput` in an empty state, without initial date value as well as enabling clearing the input.

![Screenshot 2020-07-14 at 12 40 10](https://user-images.githubusercontent.com/8878045/87410606-379a9080-c5cf-11ea-991b-229574b1111f.png)

![Screenshot 2020-07-14 at 12 40 18](https://user-images.githubusercontent.com/8878045/87410585-2ea9bf00-c5cf-11ea-92d5-cb255ae8f2a9.png)

