### PR TITLE
Drone: Tighten grafana-enterprise access to token

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -160,6 +160,8 @@ steps:
   - mkdir -p /hugo/content/docs/grafana
   - cp -r docs/sources /hugo/content/docs/grafana/latest
   - cd /hugo && make prod
+  depends_on:
+  - initialize
 
 - name: copy-packages-for-docker
   image: grafana/build-container:1.2.21


### PR DESCRIPTION
**What this PR does / why we need it**:
In Drone shared module, tighten access to GitHub token for enterprise builds as much as possible (only `git` basically). No practical effects for this repository's builds, except I make the build-docs-website step depend on the initialize step (necessary for enterprise builds).

**NB:** .drone.yml is auto-generated from .drone.star, and is what is actually used to configure our Drone CI. You may read it to see how the actual configuration changes (very little for this PR).
