### PR TITLE
Docs: Add info about logs/metrics unification to What's New docs

### DIFF
--- a/docs/sources/guides/whats-new-in-v7-1.md
+++ b/docs/sources/guides/whats-new-in-v7-1.md
@@ -23,6 +23,7 @@ The main highlights are:
 - [**Deep linking for Google Cloud Monitoring (formerly named Google Stackdriver) datasource**]({{< relref "#deep-linking-for-google-cloud-monitoring-formerly-named-google-stackdriver-datasource" >}})
 - [**Transforms**]({{< relref "#transforms" >}})
 - [**Stat panel text mode**]({{< relref "#stat-panel-text-mode" >}})
+- [**Unification of Explore modes**]({{< relref "#explore-mode-unification" >}})
 - [**Grafana Enterprise features**]({{< relref "#grafana-enterprise-features" >}})
   - [**Support for HashiCorp Vault**]({{< relref "#support-for-hashicorp-vault" >}})
   - [**Internal links for Elastic**]({{< relref "#internal-links-for-elastic" >}})
@@ -72,6 +73,11 @@ By default, the Stat panel displays:
 You can use the Text mode option to control what text the panel renders. If the value is not important, only name and color is, then change the `Text mode` to **Name**. The value will still be used to determine color and is displayed in a tooltip.
 
 {{< docs-imagebox img="/img/docs/v71/stat-panel-text-modes.png" max-width="1025px" caption="Stat panel" >}}
+
+## Unification of Explore modes
+
+New to Grafana is 7.1 is a fairly major change to Explore that does away with the query mode selector altogether.
+Many data sources are in a position where they can tell us whether a response contains time series data or logs data, and using this information, Explore now chooses which visualization to use for that data. This means there’s no need to switch back and forth between Logs and Metrics modes depending on the type of query you want to make, leading to more productive exploration of your data. 
 
 ## Grafana Enterprise features
 

--- a/docs/sources/guides/whats-new-in-v7-1.md
+++ b/docs/sources/guides/whats-new-in-v7-1.md
@@ -23,7 +23,7 @@ The main highlights are:
 - [**Deep linking for Google Cloud Monitoring (formerly named Google Stackdriver) datasource**]({{< relref "#deep-linking-for-google-cloud-monitoring-formerly-named-google-stackdriver-datasource" >}})
 - [**Transforms**]({{< relref "#transforms" >}})
 - [**Stat panel text mode**]({{< relref "#stat-panel-text-mode" >}})
-- [**Unification of Explore modes**]({{< relref "#explore-mode-unification" >}})
+- [**Unification of Explore modes**]({{< relref "#explore-modes-unified" >}})
 - [**Grafana Enterprise features**]({{< relref "#grafana-enterprise-features" >}})
   - [**Support for HashiCorp Vault**]({{< relref "#support-for-hashicorp-vault" >}})
   - [**Internal links for Elastic**]({{< relref "#internal-links-for-elastic" >}})
@@ -74,10 +74,11 @@ You can use the Text mode option to control what text the panel renders. If the 
 
 {{< docs-imagebox img="/img/docs/v71/stat-panel-text-modes.png" max-width="1025px" caption="Stat panel" >}}
 
-## Unification of Explore modes
+## Explore modes unified
 
-New to Grafana is 7.1 is a fairly major change to Explore that does away with the query mode selector altogether.
-Many data sources are in a position where they can tell us whether a response contains time series data or logs data, and using this information, Explore now chooses which visualization to use for that data. This means there’s no need to switch back and forth between Logs and Metrics modes depending on the type of query you want to make, leading to more productive exploration of your data. 
+Grafana 7.1 includes a major change to Explore: it removes the query mode selector.
+
+Many data sources tell Grafana whether a response contains time series data or logs data. Using this information, Explore chooses which visualization to use for that data. This means that you don't need to switch back and forth between Logs and Metrics modes depending on the type of query that you want to make. 
 
 ## Grafana Enterprise features
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds information to the docs about the explore mode unification introduced to Grafana 7.1

