### PR TITLE
Azure: Handle real type nan/inf values in Log/Insights Analytics

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -270,8 +270,6 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (Azu
 		return AzureLogAnalyticsResponse{}, err
 	}
 
-	azlog.Debug(string(body))
-
 	if res.StatusCode/100 != 2 {
 		azlog.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, fmt.Errorf("Request failed status: %v: %w", res.Status, fmt.Errorf(string(body)))

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -270,6 +270,8 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(res *http.Response) (Azu
 		return AzureLogAnalyticsResponse{}, err
 	}
 
+	azlog.Debug(string(body))
+
 	if res.StatusCode/100 != 2 {
 		azlog.Debug("Request failed", "status", res.Status, "body", string(body))
 		return AzureLogAnalyticsResponse{}, fmt.Errorf("Request failed status: %v: %w", res.Status, fmt.Errorf(string(body)))

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame.go
@@ -3,6 +3,7 @@ package azuremonitor
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -115,7 +116,21 @@ var realConverter = data.FieldConverter{
 		}
 		jN, ok := v.(json.Number)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type, expected json.Number but got %T", v)
+			s, sOk := v.(string)
+			if sOk {
+				switch s {
+				case "Infinity":
+					f := math.Inf(0)
+					return &f, nil
+				case "-Infinity":
+					f := math.Inf(-1)
+					return &f, nil
+				case "NaN":
+					f := math.NaN()
+					return &f, nil
+				}
+			}
+			return nil, fmt.Errorf("unexpected type, expected json.Number but got type %T for value %v", v, v)
 		}
 		f, err := jN.Float64()
 		if err != nil {

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-table-frame_test.go
@@ -2,6 +2,7 @@ package azuremonitor
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,6 +116,21 @@ func TestLogTableToFrame(t *testing.T) {
 				frame.Meta = &data.FrameMeta{
 					Custom: &LogAnalyticsMeta{ColumnTypes: []string{"bool", "string", "datetime",
 						"dynamic", "guid", "int", "long", "real", "timespan"}},
+				}
+				return frame
+			},
+		},
+		{
+			name:     "nan and infinity in real response",
+			testFile: "loganalytics/8-log-analytics-response-nan-inf.json",
+			expectedFrame: func() *data.Frame {
+				frame := data.NewFrame("",
+					data.NewField("XInf", nil, []*float64{pointer.Float64(math.Inf(0))}),
+					data.NewField("XInfNeg", nil, []*float64{pointer.Float64(math.Inf(-2))}),
+					data.NewField("XNan", nil, []*float64{pointer.Float64(math.NaN())}),
+				)
+				frame.Meta = &data.FrameMeta{
+					Custom: &LogAnalyticsMeta{ColumnTypes: []string{"real", "real", "real"}},
 				}
 				return frame
 			},

--- a/pkg/tsdb/azuremonitor/testdata/loganalytics/8-log-analytics-response-nan-inf.json
+++ b/pkg/tsdb/azuremonitor/testdata/loganalytics/8-log-analytics-response-nan-inf.json
@@ -1,0 +1,29 @@
+{
+    "tables": [
+      {
+        "name": "PrimaryResult",
+        "columns": [
+          {
+            "name": "XInf",
+            "type": "real"
+          },
+          {
+            "name": "XInfNeg",
+            "type": "real"
+          },
+          {
+            "name": "XNan",
+            "type": "real"
+          }
+        ],
+        "rows": [
+          [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ]
+        ]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This handle NaN/-Inf/Inf real values when converting to a dataframe.  Before this, if the user were to divide by 0.0, "Infinity would be returned in the result and the user would get an error: "unexpected type, expected json.Number but got string".

Now those values are properly set as NaN/Inf values.

cc @wardbekker 


