### PR TITLE
Explore: parse queryType from explore url

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -65,7 +65,9 @@ describe('state functions', () => {
     });
 
     it('returns a valid Explore state from a compact URL parameter', () => {
-      const paramValue = '%5B"now-1h","now","Local","5m",%7B"expr":"metric"%7D,"ui"%5D';
+      // ["now-1h","now","Local",{"expr":"metric"},{"ui":[true,true,true,"none"]}]
+      const paramValue =
+        '%5B"now-1h","now","Local",%7B"expr":"metric"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'Local',
         queries: [{ expr: 'metric' }],
@@ -77,7 +79,9 @@ describe('state functions', () => {
     });
 
     it('should return queries if queryType is present in the url', () => {
-      const paramValue = '%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,"ui"%5D';
+      // ["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"ui":[true,true,true,"none"]}]
+      const paramValue =
+        '%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'x-ray-datasource',
         queries: [{ queryType: 'getTraceSummaries' }],

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -75,6 +75,18 @@ describe('state functions', () => {
         },
       });
     });
+
+    it('should return queries if queryType is present in the url', () => {
+      const paramValue = '%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,"ui"%5D';
+      expect(parseUrlState(paramValue)).toMatchObject({
+        datasource: 'x-ray-datasource',
+        queries: [{ queryType: 'getTraceSummaries' }],
+        range: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      });
+    });
   });
 
   describe('serializeStateToUrlParam', () => {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -246,8 +246,7 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   };
   const datasource = parsed[ParseUrlStateIndex.Datasource];
   const parsedSegments = parsed.slice(ParseUrlStateIndex.SegmentsStart);
-  const metricProperties = ['expr', 'expression', 'target', 'datasource', 'query', 'queryType'];
-  const queries = parsedSegments.filter(segment => isSegment(segment, ...metricProperties));
+  const queries = parsedSegments.filter(segment => !isSegment(segment, 'ui', 'originPanelId'));
 
   const uiState = parsedSegments.filter(segment => isSegment(segment, 'ui'))[0];
   const ui = uiState

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -246,7 +246,7 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   };
   const datasource = parsed[ParseUrlStateIndex.Datasource];
   const parsedSegments = parsed.slice(ParseUrlStateIndex.SegmentsStart);
-  const metricProperties = ['expr', 'expression', 'target', 'datasource', 'query'];
+  const metricProperties = ['expr', 'expression', 'target', 'datasource', 'query', 'queryType'];
   const queries = parsedSegments.filter(segment => isSegment(segment, ...metricProperties));
 
   const uiState = parsedSegments.filter(segment => isSegment(segment, 'ui'))[0];


### PR DESCRIPTION
**What this PR does / why we need it**:

In explore view with x-ray data source we persist the query type in the url. For it to work properly we need to parse it from the url. This way when we reload the page we will get back the right query type.

