### PR TITLE
Tests: Fix back-end tests on Windows

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -1002,7 +1003,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 			dash := GetDashboardShouldReturn200WithConfig(sc, mock)
 
 			Convey("Should return relative path to provisioning file", func() {
-				So(dash.Meta.ProvisionedExternalId, ShouldEqual, "test/dashboard1.json")
+				So(dash.Meta.ProvisionedExternalId, ShouldEqual, filepath.Join("test", "dashboard1.json"))
 			})
 		})
 

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -85,7 +85,7 @@ func readPluginManifest(body []byte) (*pluginManifest, error) {
 // getPluginSignatureState returns the signature state for a plugin.
 func getPluginSignatureState(log log.Logger, plugin *PluginBase) PluginSignature {
 	log.Debug("Getting signature state of plugin", "plugin", plugin.Id)
-	manifestPath := path.Join(plugin.PluginDir, "MANIFEST.txt")
+	manifestPath := filepath.Join(plugin.PluginDir, "MANIFEST.txt")
 
 	byteValue, err := ioutil.ReadFile(manifestPath)
 	if err != nil || len(byteValue) < 10 {
@@ -106,7 +106,7 @@ func getPluginSignatureState(log log.Logger, plugin *PluginBase) PluginSignature
 	log.Debug("Verifying contents of plugin manifest", "plugin", plugin.Id)
 	for p, hash := range manifest.Files {
 		// Open the file
-		fp := path.Join(plugin.PluginDir, p)
+		fp := filepath.Join(plugin.PluginDir, p)
 		f, err := os.Open(fp)
 		if err != nil {
 			return PluginSignatureModified

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -160,7 +160,7 @@ func TestPluginManager_Init(t *testing.T) {
 		err := pm.Init()
 		require.NoError(t, err)
 
-		assert.Empty(t, pm.scanningErrors)
+		require.Empty(t, pm.scanningErrors)
 		assert.Equal(t, []string{"gel"}, fm.registeredPlugins)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a couple of back-end tests on Windows.

**Which issue(s) this PR fixes**:

Fixes #19062.

**Special notes for your reviewer**:
filepath.Join is the right function to use to compose filesystem paths, since it will use `\` on Windows.