### PR TITLE
Update getting started link

### DIFF
--- a/emails/templates/welcome_on_signup.html
+++ b/emails/templates/welcome_on_signup.html
@@ -29,7 +29,7 @@
 				<tr>
 					<td class="center">
 						<p>
-							If you are new to Grafana please read the <a href="https://docs.grafana.com/guides/gettingstarted/">Getting Started</a> guide.
+							If you are new to Grafana please read the <a href="https://grafana.com/docs/grafana/latest/getting-started/getting-started/">Getting Started</a> guide.
 						</p>
 					</td>
 					<td class="expander"></td>


### PR DESCRIPTION
The "Getting Started" link in the welcome email goes to an old URL, this PR updates it to point to the correct URL and avoid redirects.

