### PR TITLE
Postgres plugin: User-defined aggregates in query builder

### DIFF
--- a/docs/sources/features/datasources/postgres.md
+++ b/docs/sources/features/datasources/postgres.md
@@ -116,6 +116,9 @@ avg(tx_bytes) OVER (ORDER BY "time" ROWS 5 PRECEDING) AS "tx_bytes"
 
 You may add further value columns by clicking the plus button and selecting `Column` from the menu. Multiple value columns will be plotted as separate series in the graph panel.
 
+Additional columns may be autocompleted in the column field, provided that you add data types (with CREATE TYPE) and define aggregates (with CREATE AGGREGATE) for it named min, max, sum, count, avg or count.
+These aggregates should take a single parameter, your custom type, and return a numeric data type.
+
 ### Filter data (WHERE)
 To add a filter click the plus icon to the right of the `WHERE` condition. You can remove filters by clicking on
 the filter and selecting `Remove`. A filter for the current selected timerange is automatically added to new queries.

--- a/public/app/plugins/datasource/postgres/meta_query.ts
+++ b/public/app/plugins/datasource/postgres/meta_query.ts
@@ -129,7 +129,7 @@ table_schema IN (
       case 'value': {
         query += ' AND column_name <> ' + this.quoteIdentAsLiteral(this.target.timeColumn);
         // Check for either known data_type names or user-defined types with user-defined
-        //   aggregations that look like things we could graph.
+        // aggregations that look like things we could graph.
         query += `
         AND (
           data_type IN ('bigint','integer','double precision','real')


### PR DESCRIPTION
This adds additional entries in the **Postgres query builder** under
 the value or "Column" selection in the case of a user-defined
 data type where the user has also defined min, max, sum, count,
 avg aggregates for that data type.

There is no additional Grafana configuration for this; a database administrator can define types and aggregate functions, and Grafana will discover them in the Postgres query builder's autocomplete list on tables that use them.

While a user can type in the column name today, the discoverability is poor.  By including additional trivially graphed types in the autocomplete list, dashboard editors can have an easier time finding the right columns.


Resolves:  https://github.com/grafana/grafana-postgresql-datasource/issues/130
(but without any new configuration section)

```
>> Test Suites: 482 passed, 482 total
>> Tests:       6 skipped, 3867 passed, 3873 total
>> Snapshots:   180 passed, 180 total
>> Time:        174.204 s
>> Ran all test suites.
```