### PR TITLE
Chore: Enable misspell Go linter

### DIFF
--- a/scripts/go/configs/.golangci.toml
+++ b/scripts/go/configs/.golangci.toml
@@ -27,7 +27,7 @@ enable = [
   "govet",
   "ineffassign",
   # "interfacer",
-  # "misspell",
+  "misspell",
   "rowserrcheck",
   "exportloopref",
   "staticcheck",
@@ -75,3 +75,7 @@ text = "402"
 [[issues.exclude-rules]]
 linters = ["gosec"]
 text = "501"
+
+[[issues.exclude-rules]]
+linters = ["misspell"]
+text = "Unknwon` is a misspelling of `Unknown"


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of ongoing effort to harmonize linting with plugin SDK, enable the [misspell](https://github.com/client9/misspell) linter.
