### PR TITLE
Docs: Time regions add info about UTC timezone

### DIFF
--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -15,7 +15,6 @@ This visualization is the most-used in the Grafana ecosystem. It can render as a
 ## Data and field options
 
 Graph visualizations allow you to apply:
-
 - [Data transformations]({{< relref "../transformations.md" >}})
 - [Alerts](../../alerting/alerts-overview.md) - This is the only type of visualization that allows you to set alerts.
 - [Thresholds]({{< relref "../thresholds.md" >}})
@@ -40,7 +39,7 @@ Use these settings to refine your visualization.
 - **Null value -** How null values are displayed. _This is a very important setting._ See note below.
   - **connected -** If there is a gap in the series, meaning a null value or values, then the line will skip the gap and connect to the next non-null value.
   - **null -** (default) If there is a gap in the series, meaning a null value, then the line in the graph will be broken and show the gap.
-  - **null as zero -** If there is a gap in the series, meaning a null value, then it will be displayed as a zero value in the graph panel.
+  - **null as zero -** If there is a gap in the series, meaning  a null value, then it will be displayed as a zero value in the graph panel.
 
 > **Note:** If you are monitoring a server's CPU load and the load reaches 100%, then the server will lock up and the agent sending statistics will not be able to collect the load statistic. This leads to a gap in the metrics and having the default as _null_ means Grafana will show the gaps and indicate that something is wrong. If this is set to _connected_, then it would be easy to miss this signal.
 
@@ -51,7 +50,7 @@ Use these settings to change the appearance of the tooltip that appears when you
 - **Mode**
   - **All series -** The hover tooltip shows all series in the graph. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
   - **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the graph.
-- **Sort order -** Sorts the order of series in the hover tooltip if you have selected _All series_ mode.
+- **Sort order -** Sorts the order of series in the hover tooltip if you have selected *All series* mode.
   - **None -** The order of the series in the tooltip is determined by the sort order in your query. For example, they could be alphabetically sorted by series name.
   - **Increasing -** The series in the hover tooltip are sorted by value and in increasing order, with the lowest value at the top of the list.
   - **Decreasing -** The series in the hover tooltip are sorted by value and in decreasing order, with the highest value at the top of the list.
@@ -66,32 +65,31 @@ You can add multiple series overrides.
 
 1. Click **Add series override**.
 1. In **Alias or regex** Type or select a series. Click in the field to see a list of available series.
-
-   **Example:** `/Network.*/` would match two series named `Network out` and `Network in`.
+   
+   **Example:**  `/Network.*/` would match two series named `Network out` and `Network in`.
 
 1. Click **+** and then select a style to apply to the series. You can add multiple styles to each entry.
-
-- **Bars -** Show series as a bar graph.
-- **Lines -** Show series as line graph.
-- **Line fill -** Show line graph with area fill.
-- **Fill gradient -** Area fill gradient amount.
-- **Line width -** Set line width.
-- **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
-- **Fill below to -** Fill area between two series.
-- **Staircase line -** Show series as a staircase line.
-- **Dashes -** Show line with dashes.
-- **Hidden Series -** Hide the series.
-- **Dash Length -** Dashed line length.
-- **Dash Space -** Dashed line spacing.
-- **Points -** Show series as separate points.
-- **Point Radius -** Radius for point rendering.
-- **Stack -** Set stack group for series.
-- **Color -** Set series color.
-- **Y-axis -** Set series y-axis.
-- **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
-- **Transform -** Transform value to negative to render below the y-axis.
-- **Legend -** Control if a series is shown in legend.
-- **Hide in tooltip -** Control if a series is shown in graph tooltip.
+  - **Bars -** Show series as a bar graph.
+  - **Lines -** Show series as line graph.
+  - **Line fill -** Show line graph with area fill.
+  - **Fill gradient -** Area fill gradient amount.
+  - **Line width -** Set line width.
+  - **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
+  - **Fill below to -** Fill area between two series.
+  - **Staircase line -** Show series as a staircase line.
+  - **Dashes -** Show line with dashes.
+  - **Hidden Series -** Hide the series.
+  - **Dash Length -** Dashed line length.
+  - **Dash Space -** Dashed line spacing.
+  - **Points -** Show series as separate points.
+  - **Point Radius -** Radius for point rendering.
+  - **Stack -** Set stack group for series.
+  - **Color -** Set series color.
+  - **Y-axis -** Set series y-axis.
+  - **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
+  - **Transform -** Transform value to negative to render below the y-axis.
+  - **Legend -** Control if a series is shown in legend.
+  - **Hide in tooltip -** Control if a series is shown in graph tooltip.
 
 ## Axes
 
@@ -110,7 +108,6 @@ Options are identical for both Y-axes.
 - **Label -** The Y axis label. (default “")
 
 ### Y-Axes
-
 - **Align -** Select to align left and right Y-axes by value. (default unchecked/false)
 - **Level -** Available when **Align** is selected. Value to use for alignment of left and right Y-axes, starting from Y=0. (default 0)
 
@@ -120,15 +117,14 @@ Options are identical for both Y-axes.
 - **Mode -** The display mode completely changes the visualization of the graph panel. It's like three panels in one. The main mode is the time series mode with time on the X-axis. The other two modes are a basic bar chart mode with series on the X-axis instead of time and a histogram mode.
   - **Time -** (default) The X-axis represents time and that the data is grouped by time (for example, by hour, or by minute).
   - **Series -** The data is grouped by series and not by time. The Y-axis still represents the value.
-    - **Value -** The aggregation type to use for the values. The default is total (summing the values together).
-  - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range.
-
+    - **Value -**  The aggregation type to use for the values. The default is total (summing the values together).
+  - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range. 
+   
     For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../getting-started/intro-histograms.md" >}}).
-
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.
-
+	
 ## Legend
 
 Use these settings to refine how the legend appears in your visualization.
@@ -151,7 +147,7 @@ Additional values can be shown along-side the legend names:
 - **Total -** Sum of all values returned from the metric query.
 - **Decimals -** Controls how many decimals are displayed for legend values and graph hover tooltips.
 
-The legend values are calculated on the client side by Grafana and depend on what type of aggregation or point consolidation your metric query is using. All the above legend values cannot be correct at the same time.
+The legend values are calculated on the client side by Grafana and depend on what type of aggregation or point consolidation your metric query is using. All the above legend values cannot be correct at the same time. 
 
 For example, if you plot a rate like requests/second, this is probably using average as an aggregator, then the Total in the legend will not represent the total number of requests. It is just the sum of all data points received by Grafana.
 
@@ -160,7 +156,7 @@ For example, if you plot a rate like requests/second, this is probably using ave
 Hide series when all values of a series from a metric query are of a specific value.
 
 - **With only nulls -** Value=null (default unchecked)
-- **With only zeroes -** Value=zero (default unchecked)
+- **With only zeroes -** Value=zero (default unchecked) 
 
 ### Time regions
 

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -15,6 +15,7 @@ This visualization is the most-used in the Grafana ecosystem. It can render as a
 ## Data and field options
 
 Graph visualizations allow you to apply:
+
 - [Data transformations]({{< relref "../transformations.md" >}})
 - [Alerts](../../alerting/alerts-overview.md) - This is the only type of visualization that allows you to set alerts.
 - [Thresholds]({{< relref "../thresholds.md" >}})
@@ -39,7 +40,7 @@ Use these settings to refine your visualization.
 - **Null value -** How null values are displayed. _This is a very important setting._ See note below.
   - **connected -** If there is a gap in the series, meaning a null value or values, then the line will skip the gap and connect to the next non-null value.
   - **null -** (default) If there is a gap in the series, meaning a null value, then the line in the graph will be broken and show the gap.
-  - **null as zero -** If there is a gap in the series, meaning  a null value, then it will be displayed as a zero value in the graph panel.
+  - **null as zero -** If there is a gap in the series, meaning a null value, then it will be displayed as a zero value in the graph panel.
 
 > **Note:** If you are monitoring a server's CPU load and the load reaches 100%, then the server will lock up and the agent sending statistics will not be able to collect the load statistic. This leads to a gap in the metrics and having the default as _null_ means Grafana will show the gaps and indicate that something is wrong. If this is set to _connected_, then it would be easy to miss this signal.
 
@@ -50,7 +51,7 @@ Use these settings to change the appearance of the tooltip that appears when you
 - **Mode**
   - **All series -** The hover tooltip shows all series in the graph. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
   - **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the graph.
-- **Sort order -** Sorts the order of series in the hover tooltip if you have selected *All series* mode.
+- **Sort order -** Sorts the order of series in the hover tooltip if you have selected _All series_ mode.
   - **None -** The order of the series in the tooltip is determined by the sort order in your query. For example, they could be alphabetically sorted by series name.
   - **Increasing -** The series in the hover tooltip are sorted by value and in increasing order, with the lowest value at the top of the list.
   - **Decreasing -** The series in the hover tooltip are sorted by value and in decreasing order, with the highest value at the top of the list.
@@ -65,31 +66,32 @@ You can add multiple series overrides.
 
 1. Click **Add series override**.
 1. In **Alias or regex** Type or select a series. Click in the field to see a list of available series.
-   
-   **Example:**  `/Network.*/` would match two series named `Network out` and `Network in`.
+
+   **Example:** `/Network.*/` would match two series named `Network out` and `Network in`.
 
 1. Click **+** and then select a style to apply to the series. You can add multiple styles to each entry.
-  - **Bars -** Show series as a bar graph.
-  - **Lines -** Show series as line graph.
-  - **Line fill -** Show line graph with area fill.
-  - **Fill gradient -** Area fill gradient amount.
-  - **Line width -** Set line width.
-  - **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
-  - **Fill below to -** Fill area between two series.
-  - **Staircase line -** Show series as a staircase line.
-  - **Dashes -** Show line with dashes.
-  - **Hidden Series -** Hide the series.
-  - **Dash Length -** Dashed line length.
-  - **Dash Space -** Dashed line spacing.
-  - **Points -** Show series as separate points.
-  - **Point Radius -** Radius for point rendering.
-  - **Stack -** Set stack group for series.
-  - **Color -** Set series color.
-  - **Y-axis -** Set series y-axis.
-  - **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
-  - **Transform -** Transform value to negative to render below the y-axis.
-  - **Legend -** Control if a series is shown in legend.
-  - **Hide in tooltip -** Control if a series is shown in graph tooltip.
+
+- **Bars -** Show series as a bar graph.
+- **Lines -** Show series as line graph.
+- **Line fill -** Show line graph with area fill.
+- **Fill gradient -** Area fill gradient amount.
+- **Line width -** Set line width.
+- **Null point mode -** Option to ignore null values or replace with zero. Important if you want to ignore gaps in your data.
+- **Fill below to -** Fill area between two series.
+- **Staircase line -** Show series as a staircase line.
+- **Dashes -** Show line with dashes.
+- **Hidden Series -** Hide the series.
+- **Dash Length -** Dashed line length.
+- **Dash Space -** Dashed line spacing.
+- **Points -** Show series as separate points.
+- **Point Radius -** Radius for point rendering.
+- **Stack -** Set stack group for series.
+- **Color -** Set series color.
+- **Y-axis -** Set series y-axis.
+- **Z-index -** Set series z-index (rendering order). Important when overlaying different styles (bar charts, area charts).
+- **Transform -** Transform value to negative to render below the y-axis.
+- **Legend -** Control if a series is shown in legend.
+- **Hide in tooltip -** Control if a series is shown in graph tooltip.
 
 ## Axes
 
@@ -108,6 +110,7 @@ Options are identical for both Y-axes.
 - **Label -** The Y axis label. (default “")
 
 ### Y-Axes
+
 - **Align -** Select to align left and right Y-axes by value. (default unchecked/false)
 - **Level -** Available when **Align** is selected. Value to use for alignment of left and right Y-axes, starting from Y=0. (default 0)
 
@@ -117,14 +120,15 @@ Options are identical for both Y-axes.
 - **Mode -** The display mode completely changes the visualization of the graph panel. It's like three panels in one. The main mode is the time series mode with time on the X-axis. The other two modes are a basic bar chart mode with series on the X-axis instead of time and a histogram mode.
   - **Time -** (default) The X-axis represents time and that the data is grouped by time (for example, by hour, or by minute).
   - **Series -** The data is grouped by series and not by time. The Y-axis still represents the value.
-    - **Value -**  The aggregation type to use for the values. The default is total (summing the values together).
-  - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range. 
-   
+    - **Value -** The aggregation type to use for the values. The default is total (summing the values together).
+  - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range.
+
     For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../getting-started/intro-histograms.md" >}}).
+
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.
-	
+
 ## Legend
 
 Use these settings to refine how the legend appears in your visualization.
@@ -147,7 +151,7 @@ Additional values can be shown along-side the legend names:
 - **Total -** Sum of all values returned from the metric query.
 - **Decimals -** Controls how many decimals are displayed for legend values and graph hover tooltips.
 
-The legend values are calculated on the client side by Grafana and depend on what type of aggregation or point consolidation your metric query is using. All the above legend values cannot be correct at the same time. 
+The legend values are calculated on the client side by Grafana and depend on what type of aggregation or point consolidation your metric query is using. All the above legend values cannot be correct at the same time.
 
 For example, if you plot a rate like requests/second, this is probably using average as an aggregator, then the Total in the legend will not represent the total number of requests. It is just the sum of all data points received by Grafana.
 
@@ -156,8 +160,8 @@ For example, if you plot a rate like requests/second, this is probably using ave
 Hide series when all values of a series from a metric query are of a specific value.
 
 - **With only nulls -** Value=null (default unchecked)
-- **With only zeroes -** Value=zero (default unchecked) 
+- **With only zeroes -** Value=zero (default unchecked)
 
 ### Time regions
 
-Time regions allow you to highlight certain time regions of the graph to make it easier to see for example weekends, business hours and/or off work hours.
+Time regions allow you to highlight certain time regions of the graph to make it easier to see for example weekends, business hours and/or off work hours. All configured time regions refer to UTC time.

--- a/public/app/plugins/panel/graph/time_regions_form.html
+++ b/public/app/plugins/panel/graph/time_regions_form.html
@@ -83,7 +83,7 @@
 
   <div class="gf-form-button-row">
     <button class="btn btn-inverse" ng-click="ctrl.addTimeRegion()">
-      <icon name="'plus'"></icon>&nbsp;Add time region<tip>All configured time regions refers to UTC time</tip>
+      <icon name="'plus'"></icon>&nbsp;Add time region<tip>All configured time regions refer to UTC time</tip>
     </button>
   </div>
 </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
From docs, it is not clear that configured time regions refer to UTC time zone. 
Related to: https://github.com/grafana/grafana/issues/26402


