### PR TITLE
Bring back scripts evaluation in TextPanel

### DIFF
--- a/public/app/plugins/panel/text/TextPanel.test.tsx
+++ b/public/app/plugins/panel/text/TextPanel.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { TextPanel } from './TextPanel';
+import { dateMath, dateTime, LoadingState, FieldConfigSource } from '@grafana/data';
+import { TextOptions } from './types';
+import { updateConfig } from 'app/core/config';
+
+describe('TextPanel', () => {
+  describe('when html sanitization disabled', () => {
+    it('should evaluate provided scripts', done => {
+      jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      updateConfig({
+        disableSanitizeHtml: true,
+      });
+
+      expect(window.alert).not.toBeCalled();
+
+      createTextPanel({
+        series: [],
+        timeRange: {
+          from: dateMath.parse('now-6h') || dateTime(),
+          to: dateMath.parse('now') || dateTime(),
+          raw: { from: 'now-6h', to: 'now' },
+        },
+        state: LoadingState.Done,
+      });
+
+      expect(window.alert).toBeCalled();
+    });
+  });
+});
+
+const createTextPanel = (data: PanelData) => {
+  const timeRange = {
+    from: dateMath.parse('now-6h') || dateTime(),
+    to: dateMath.parse('now') || dateTime(),
+    raw: { from: 'now-6h', to: 'now' },
+  };
+
+  const options: TextOptions = {
+    content: '<script>alert("evaluated!");</script>',
+    mode: 'html',
+  };
+
+  const fieldConfig: FieldConfigSource = {
+    defaults: {},
+    overrides: [],
+  };
+
+  return mount<TextPanel>(
+    <TextPanel
+      id={1}
+      data={data}
+      timeRange={timeRange}
+      timeZone={'utc'}
+      options={options}
+      fieldConfig={fieldConfig}
+      onFieldConfigChange={() => {}}
+      onOptionsChange={() => {}}
+      onChangeTimeRange={() => {}}
+      replaceVariables={s => s}
+      renderCounter={0}
+      width={532}
+      transparent={false}
+      height={250}
+    />
+  );
+};


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/26406

When html sanitization is disabled we need to process html against any inline script tag occurrences and eval those scripts to have an effect. React's `dangerouslySetInnerHTML` uses `innerHTML` which does not evaluate scripts: https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML

@ryantxu I couldn't get the test for new logic to pass, any ideas? Seems like the parsed text is undefined in the test env, no idea why. Maybe some jsdom issue?