### PR TITLE
Drone: Use base64 encoded GCP key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -379,7 +379,7 @@ steps:
 - name: publish-storybook
   image: grafana/grafana-ci-deploy:1.2.5
   commands:
-  - echo "$${GCP_KEY}" > /tmp/gcpkey.json
+  - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
   - echo gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/canary
   environment:

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -251,7 +251,7 @@ def publish_storybook_step(edition):
             },
         },
         'commands': [
-            'echo "$${GCP_KEY}" > /tmp/gcpkey.json',
+            'printenv GCP_KEY | base64 -d > /tmp/gcpkey.json',
             'gcloud auth activate-service-account --key-file=/tmp/gcpkey.json',
             'echo gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/canary',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:
Use base64 encoded GCP key, to fix issue loading it.