### PR TITLE
Provisioning: Validate that datasource access field equals to direct or proxy

### DIFF
--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,7 +37,7 @@ func (cr *configReader) readConfig(path string) ([]*configs, error) {
 		}
 	}
 
-	err = validateDefaultUniqueness(datasources)
+	err = cr.validateDefaultUniqueness(datasources)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +83,7 @@ func (cr *configReader) parseDatasourceConfig(path string, file os.FileInfo) (*c
 	return v0.mapToDatasourceFromConfig(apiVersion.APIVersion), nil
 }
 
-func validateDefaultUniqueness(datasources []*configs) error {
+func (cr *configReader) validateDefaultUniqueness(datasources []*configs) error {
 	defaultCount := map[int64]int{}
 	for i := range datasources {
 		if datasources[i].Datasources == nil {
@@ -95,7 +96,12 @@ func validateDefaultUniqueness(datasources []*configs) error {
 			}
 
 			if ds.Access == "" {
-				ds.Access = "proxy"
+				ds.Access = models.DS_ACCESS_PROXY
+			}
+
+			if ds.Access != models.DS_ACCESS_DIRECT && ds.Access != models.DS_ACCESS_PROXY {
+				cr.log.Warn("invalid access value, will use 'proxy' instead", "value", ds.Access)
+				ds.Access = models.DS_ACCESS_PROXY
 			}
 
 			if ds.IsDefault {

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -22,6 +22,7 @@ var (
 	brokenYaml                      = "testdata/broken-yaml"
 	multipleOrgsWithDefault         = "testdata/multiple-org-default"
 	withoutDefaults                 = "testdata/appliedDefaults"
+	invalidAccess                   = "testdata/invalid-access"
 
 	fakeRepo *fakeRepository
 )
@@ -147,6 +148,12 @@ func TestDatasourceAsConfig(t *testing.T) {
 			reader := &configReader{}
 			_, err := reader.readConfig(brokenYaml)
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("invalid access should warn about invalid value and return 'proxy'", func() {
+			reader := &configReader{log: logger}
+			configs, _ := reader.readConfig(invalidAccess)
+			So(configs[0].Datasources[0].Access, ShouldEqual, models.DS_ACCESS_PROXY)
 		})
 
 		Convey("skip invalid directory", func() {

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -152,7 +152,8 @@ func TestDatasourceAsConfig(t *testing.T) {
 
 		Convey("invalid access should warn about invalid value and return 'proxy'", func() {
 			reader := &configReader{log: logger}
-			configs, _ := reader.readConfig(invalidAccess)
+			configs, err := reader.readConfig(invalidAccess)
+			So(err, ShouldBeNil)
 			So(configs[0].Datasources[0].Access, ShouldEqual, models.DS_ACCESS_PROXY)
 		})
 

--- a/pkg/services/provisioning/datasources/testdata/invalid-access/invalid-access.yaml
+++ b/pkg/services/provisioning/datasources/testdata/invalid-access/invalid-access.yaml
@@ -1,0 +1,6 @@
+apiVersion: 1
+
+datasources:
+  - name: invalid-access
+    type: prometheus
+    access: INVALID_ACCESS


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation of datasource configuration that `access` field should equal to proxy or direct. If it's not, we will change the value to 'proxy' (default value) and will warn about it into the console log. 

**Which issue(s) this PR fixes**:
Fixes #25866

**Special notes for your reviewer**:
Nothing special. There was a difficult choice between error and warning. I chose the second because returning an error will break Grafana startup for users with invalid value in access filed (which makes this change a breaking change).
