### PR TITLE
Docs: Fix documentation about dashboards.default_home_dashboard_path

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -536,6 +536,10 @@ Number dashboard versions to keep (per dashboard). Default: `20`, Minimum: `1`.
 This prevents users from setting the dashboard refresh interval of a lower than given interval. Per default this is 5 seconds.
 The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. `30s` or `1m`.
 
+### default_home_dashboard_path
+
+Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
+
 <hr />
 
 ## [users]
@@ -648,10 +652,6 @@ Administrators can increase this if they experience OAuth login state mismatch e
 ### api_key_max_seconds_to_live
 
 Limit of API key seconds to live before expiration. Default is -1 (unlimited).
-
-### default_home_dashboard_path
-
-Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
 
 <hr />
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix documentation about setting dashboards.default_home_dashboard_path, since it was placed under the _auth_ section.

**Which issue(s) this PR fixes**:
Fixes #26441.

