### PR TITLE
Datasources list: Search now respects datasource type

### DIFF
--- a/public/app/features/datasources/state/selectors.ts
+++ b/public/app/features/datasources/state/selectors.ts
@@ -5,7 +5,7 @@ export const getDataSources = (state: DataSourcesState) => {
   const regex = new RegExp(state.searchQuery, 'i');
 
   return state.dataSources.filter((dataSource: DataSourceSettings) => {
-    return regex.test(dataSource.name) || regex.test(dataSource.database);
+    return regex.test(dataSource.name) || regex.test(dataSource.database) || regex.test(dataSource.type);
   });
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where datasource types weren't being included when searching the datasources list.

**Which issue(s) this PR fixes**:
Closes #26399 