### PR TITLE
docs: customMetricsNamespaces for Cloudwatch provisioning

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: 1
 
 datasources:
@@ -226,6 +225,7 @@ datasources:
     jsonData:
       authType: credentials
       defaultRegion: eu-west-2
+      customMetricsNamespaces: "CWAgent"
 
   # Keep to test old /api/prom API
   - name: gdev-loki-0.3
@@ -270,5 +270,3 @@ datasources:
     access: proxy
     url: http://localhost:9411
     editable: false
-
-

--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -25,15 +25,15 @@ build dashboards or use Explore with CloudWatch metrics and CloudWatch Logs.
 > NOTE: If at any moment you have issues with getting this data source to work and Grafana is giving you undescriptive errors then don't
 > forget to check your log file (try looking in /var/log/grafana/grafana.log).
 
-| Name                       | Description                                                                                             |
-| -------------------------- | ------------------------------------------------------------------------------------------------------- |
-| _Name_                     | The data source name. This is how you refer to the data source in panels and queries.                   |
-| _Default_                  | Default data source means that it will be pre-selected for new panels.                                  |
-| _Default Region_           | Used in query editor to set region (can be changed on per query basis)                                  |
-| _Custom Metrics namespace_ | Specify the CloudWatch namespace of Custom metrics                                                      |
-| _Auth Provider_            | Specify the provider to get credentials.                                                                |
-| _Credentials_ profile name | Specify the name of the profile to use (if you use `~/.aws/credentials` file), leave blank for default. |
-| _Assume Role Arn_          | Specify the ARN of the role to assume                                                                   |
+| Name                       | Description                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| _Name_                     | The data source name. This is how you refer to the data source in panels and queries.                                    |
+| _Default_                  | Default data source means that it will be pre-selected for new panels.                                                   |
+| _Default Region_           | Used in query editor to set region (can be changed on per query basis)                                                   |
+| _Custom Metrics namespace_ | Specify the CloudWatch namespace of Custom metrics                                                                       |
+| _Auth Provider_            | Specify the provider to get credentials.                                                                                 |
+| _Credentials_ profile name | Specify the name of the profile to use (if you use `~/.aws/credentials` file), leave blank for default.                  |
+| _Assume Role Arn_          | Specify the ARN of the role to assume                                                                                    |
 | _External ID_              | If you are assuming a role in another account, that has been created with an external ID, specify the exterrnal ID here. |
 
 ## Authentication
@@ -385,6 +385,7 @@ datasources:
     jsonData:
       authType: credentials
       defaultRegion: eu-west-2
+      customMetricsNamespaces: 'CWAgent,CustomNameSpace'
 ```
 
 ### Using `accessKey` and `secretKey`


### PR DESCRIPTION
Documents an undocumented feature - it is possible to provision custom namespaces for the Cloudwatch data source.

Fixes #17468