### PR TITLE
TemplateSrv: Formatting options for ${__from} and ${__to}, unix seconds epoch, ISO 8601/RFC 3339 

### DIFF
--- a/docs/sources/features/datasources/graphite.md
+++ b/docs/sources/features/datasources/graphite.md
@@ -140,10 +140,10 @@ You can use a variable in a metric node path or as a parameter to a function.
 There are two syntaxes:
 
 - `$<varname>`  Example: apps.frontend.$server.requests.count
-- `[[varname]]` Example: apps.frontend.[[server]].requests.count
+- `${varname}` Example: apps.frontend.${server}.requests.count
 
 Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. Use
-the second syntax in expressions like  `my.server[[serverNumber]].count`.
+the second syntax in expressions like  `my.server${serverNumber}.count`.
 
 Example:
 [Graphite Templated Dashboard](https://play.grafana.org/dashboard/db/graphite-templated-nested)

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -77,7 +77,7 @@ The `$timeFilter` variable returns the currently selected time range as an expre
 
 This is used in several places, including:
 
-- The WHERE clause for the InfluxDB data source. Grafana adds it automatically to InfluxDB queries when in Query Editor Mode. It has to be added manually in Text Editor Mode: `WHERE $timeFilter`.
+- The WHERE clause for the InfluxDB data source. Grafana adds it automatically to InfluxDB queries when in Query Editor mode. You can add it manually in Text Editor mode: `WHERE $timeFilter`.
 - Log Analytics queries in the Azure Monitor data source.
 - SQL queries in MySQL, Postgres, and MSSQL
 - The `$__timeFilter` variable is used in the MySQL data source.

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -13,20 +13,23 @@ weight = 200
 Grafana has global built-in variables that can be used in expressions in the query editor. This topic lists them in alphabetical order and defines them.
 
 ## $__dashboard
-> Only available in Grafana v6.7+
 
-This variable is the UID of the current dashboard.
-`${__dashboard.name}` is the name of the current dashboard.
+- `${__dashboard.name}` is the name of the current dashboard
+- `${__dashboard.uid}` is the UID of the current dashboard (used in url)
 
 ## $__from and $__to
 
-> Only available in Grafana v6.0+
+Grafana has two built in time range variables: `$__from` and `$__to`. They are currently always interpolated as epoch milliseconds by default but you can control formatting using a special formating syntax.
 
-Grafana has two built in time range variables: `$__from` and `$__to`. They are currently always interpolated as epoch milliseconds. 
+> This special formatting syntax is only available in Grafan a 7.1.2+
+
+| Syntax              | Example result | Description |
+| ------------------- | ------------- | ----------- |
+| `${__from:date}` | 2020-07-13T20:19:09.254Z | Defaults to ISO 8601/RFC 3339 |
 
 ## $__interval
 
-The `$__interval` variable can be used as a parameter to group by time (for InfluxDB, MySQL, Postgres, MSSQL), Date histogram interval (for Elasticsearch) or as a *summarize* function parameter (for Graphite).
+The `$__interval` variable can be used as a parameter to group by time (for InfluxDB, MySQL, Postgres, MSSQL), Date histogram interval (for Elasticsearch) or as a _summarize_ function parameter (for Graphite).
 
 Grafana automatically calculates an interval that can be used to group by time in queries. When there are more data points than can be shown on a graph then queries can be made more efficient by grouping by a larger interval. It is more efficient to group by 1 day than by 10s when looking at 3 months of data and the graph will look the same and the query will be faster. The `$__interval` is calculated using the time range and the width of the graph (the number of pixels).
 
@@ -48,8 +51,6 @@ This variable is only available in the Singlestat panel and can be used in the p
 
 ## $__org
 
-> Only available in Grafana v6.7+
-
 This variable is the ID of the current organization.
 `${__org.name}` is the name of the current organization.
 
@@ -62,8 +63,6 @@ This variable is the ID of the current organization.
 
 ## $__range
 
-> Only available in Grafana v5.3+
-
 Currently only supported for Prometheus data sources. This variable represents the range for the current dashboard. It is calculated by `to - from`. It has a millisecond and a second representation called `$__range_ms` and `$__range_s`.
 
 ## $timeFilter or $__timeFilter
@@ -71,7 +70,8 @@ Currently only supported for Prometheus data sources. This variable represents t
 The `$timeFilter` variable returns the currently selected time range as an expression. For example, the time range interval `Last 7 days` expression is `time > now() - 7d`.
 
 This is used in several places, including:
-* The WHERE clause for the InfluxDB data source. Grafana adds it automatically to InfluxDB queries when in Query Editor Mode. It has to be added manually in Text Editor Mode: `WHERE $timeFilter`.
-* Log Analytics queries in the Azure Monitor data source.
-* SQL queries in MySQL, Postgres, and MSSQL
-* The `$__timeFilter` variable is used in the MySQL data source.
+
+- The WHERE clause for the InfluxDB data source. Grafana adds it automatically to InfluxDB queries when in Query Editor Mode. It has to be added manually in Text Editor Mode: `WHERE $timeFilter`.
+- Log Analytics queries in the Azure Monitor data source.
+- SQL queries in MySQL, Postgres, and MSSQL
+- The `$__timeFilter` variable is used in the MySQL data source.

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -31,7 +31,7 @@ Grafana has two built in time range variables: `$__from` and `$__to`. They are c
 | `${__from:date:seconds}` | 1594671549               | Unix seconds epoch |
 | `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) |
 
-The above syntax of course works with `${__to}` as well.  
+The above syntax works with `${__to}` as well.  
 
 ## $__interval
 

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -19,7 +19,7 @@ Grafana has global built-in variables that can be used in expressions in the que
 
 ## $__from and $__to
 
-Grafana has two built in time range variables: `$__from` and `$__to`. They are currently always interpolated as epoch milliseconds by default but you can control formatting using a special formating syntax.
+Grafana has two built in time range variables: `$__from` and `$__to`. They are currently always interpolated as epoch milliseconds by default but you can control date formatting.
 
 > This special formatting syntax is only available in Grafan a 7.1.2+
 
@@ -31,7 +31,7 @@ Grafana has two built in time range variables: `$__from` and `$__to`. They are c
 | `${__from:date:seconds}` | 1594671549               | Unix seconds epoch |
 | `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) |
 
-The above syntax of course works with `${__to} as well.  
+The above syntax of course works with `${__to}` as well.  
 
 ## $__interval
 

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -10,7 +10,7 @@ weight = 200
 
 # Global variables
 
-Grafana has global built-in variables that can be used in expressions in the query editor. This topic lists them in alphabetical order and defines them.
+Grafana has global built-in variables that can be used in expressions in the query editor. This topic lists them in alphabetical order and defines them. These variables are useful in both queries, dashboard links, panel links & data links.
 
 ## $__dashboard
 
@@ -23,9 +23,15 @@ Grafana has two built in time range variables: `$__from` and `$__to`. They are c
 
 > This special formatting syntax is only available in Grafan a 7.1.2+
 
-| Syntax              | Example result | Description |
-| ------------------- | ------------- | ----------- |
-| `${__from:date}` | 2020-07-13T20:19:09.254Z | Defaults to ISO 8601/RFC 3339 |
+| Syntax                   | Example result           | Description |
+| ------------------------ | ------------------------ | ----------- |
+| `${__from}`              | 1594671549254            | Unix millisecond epoch |
+| `${__from:date}`         | 2020-07-13T20:19:09.254Z | No args, defaults to ISO 8601/RFC 3339 | 
+| `${__from:date:iso}`     | 2020-07-13T20:19:09.254Z | ISO 8601/RFC 3339 |
+| `${__from:date:seconds}` | 1594671549               | Unix seconds epoch |
+| `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) |
+
+The above syntax of course works with `${__to} as well.  
 
 ## $__interval
 

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -10,7 +10,7 @@ weight = 200
 
 # Global variables
 
-Grafana has global built-in variables that can be used in expressions in the query editor. This topic lists them in alphabetical order and defines them. These variables are useful in both queries, dashboard links, panel links & data links.
+Grafana has global built-in variables that can be used in expressions in the query editor. This topic lists them in alphabetical order and defines them. These variables are useful in queries, dashboard links, panel links, and data links.
 
 ## $__dashboard
 

--- a/docs/sources/variables/global-variables.md
+++ b/docs/sources/variables/global-variables.md
@@ -35,7 +35,7 @@ The above syntax of course works with `${__to}` as well.
 
 ## $__interval
 
-The `$__interval` variable can be used as a parameter to group by time (for InfluxDB, MySQL, Postgres, MSSQL), Date histogram interval (for Elasticsearch) or as a _summarize_ function parameter (for Graphite).
+You can use the `$__interval` variable as a parameter to group by time (for InfluxDB, MySQL, Postgres, MSSQL), Date histogram interval (for Elasticsearch), or as a _summarize_ function parameter (for Graphite).
 
 Grafana automatically calculates an interval that can be used to group by time in queries. When there are more data points than can be shown on a graph then queries can be made more efficient by grouping by a larger interval. It is more efficient to group by 1 day than by 10s when looking at 3 months of data and the graph will look the same and the query will be faster. The `$__interval` is calculated using the time range and the width of the graph (the number of pixels).
 

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -3,15 +3,16 @@ import { convertToStoreState } from 'test/helpers/convertToStoreState';
 import { getTemplateSrvDependencies } from '../../../test/helpers/getTemplateSrvDependencies';
 import { variableAdapters } from '../variables/adapters';
 import { createQueryVariableAdapter } from '../variables/query/adapter';
+import { dateTime, TimeRange } from '@grafana/data';
 
 describe('templateSrv', () => {
   let _templateSrv: any;
 
-  function initTemplateSrv(variables: any[]) {
+  function initTemplateSrv(variables: any[], timeRange?: TimeRange) {
     const state = convertToStoreState(variables);
 
     _templateSrv = new TemplateSrv(getTemplateSrvDependencies(state));
-    _templateSrv.init(variables);
+    _templateSrv.init(variables, timeRange);
   }
 
   describe('init', () => {
@@ -604,6 +605,20 @@ describe('templateSrv', () => {
         __interval_ms: { text: '100', value: '100' },
       });
       expect(target).toBe('10 * 100');
+    });
+  });
+
+  describe('date formating', () => {
+    beforeEach(() => {
+      initTemplateSrv([], {
+        from: dateTime(1594671549254),
+        to: dateTime(1595237229747),
+      } as TimeRange);
+    });
+
+    it('should replace ${__from} with epoch from', () => {
+      const target = _templateSrv.replace('${__from}');
+      expect(target).toBe('1594671549254');
     });
   });
 });

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -616,9 +616,29 @@ describe('templateSrv', () => {
       } as TimeRange);
     });
 
-    it('should replace ${__from} with epoch from', () => {
+    it('should replace ${__from} with ms epoch value', () => {
       const target = _templateSrv.replace('${__from}');
       expect(target).toBe('1594671549254');
+    });
+
+    it('should replace ${__from:date:seconds} with epoch in seconds', () => {
+      const target = _templateSrv.replace('${__from:date:seconds}');
+      expect(target).toBe('1594671549');
+    });
+
+    it('should replace ${__from:date} with iso date', () => {
+      const target = _templateSrv.replace('${__from:date}');
+      expect(target).toBe('2020-07-13T20:19:09.254Z');
+    });
+
+    it('should replace ${__from:date:iso} with iso date', () => {
+      const target = _templateSrv.replace('${__from:date:iso}');
+      expect(target).toBe('2020-07-13T20:19:09.254Z');
+    });
+
+    it('should replace ${__from:date:YYYY-MM} using custom format', () => {
+      const target = _templateSrv.replace('${__from:date:YYYY-MM}');
+      expect(target).toBe('2020-07');
     });
   });
 });

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -7,7 +7,7 @@ import { ScopedVars } from '@grafana/data';
  * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
  * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
  */
-export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
+export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
 
 // Helper function since lastIndex is not reset
 export const variableRegexExec = (variableString: string) => {


### PR DESCRIPTION
Closes #15903 

Introduces an extended templating syntax format that can have 1 or more arguments like this `${variable:<formatName>:<optionalArg1>:<optionalArg2>}` 

Adds date format and args
* `${__from:date}`  no args, defaults to iso/rfc (example 2020-07-13T20:19:09.254Z) 
* `${__from:date:iso}` same as above
* `${__from:date:ms}` unix millisecond epoch same as no date format `${__from}`
* `${__from:date:seconds}` unix seconds epoch
* `${__from:date:YYYY-MM}` custom date format

TODO
* [x] Get feedback on naming and syntax 
* [x] Update docs

In the upcoming PR:
* [x] Possibly refactor formats to use a new format registry using Registry class (could be useful for syntax IntelliSense in the future) 

