### PR TITLE
DataSourceSettings: Hide custom HTTP header options when access mode is browser

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -210,7 +210,9 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = props => {
           <TLSAuthSettings dataSourceConfig={dataSourceConfig} onChange={onChange} />
         )}
 
-        <CustomHeadersSettings dataSourceConfig={dataSourceConfig} onChange={onChange} />
+        {dataSourceConfig.access === 'proxy' && (
+          <CustomHeadersSettings dataSourceConfig={dataSourceConfig} onChange={onChange} />
+        )}
       </>
     </div>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
Since custom HTTP headers are only added when the access mode is set to server, the option to change them should only be available when the access mode is set to browser, which is what this PR does.

**Which issue(s) this PR fixes**:
Closes #26422 
