### PR TITLE
Dashboard: Fix empty panels after scrolling on Safari/iOS

### DIFF
--- a/public/sass/components/_navbar.scss
+++ b/public/sass/components/_navbar.scss
@@ -5,6 +5,7 @@
   padding: 0 16px 0 60px;
   display: flex;
   flex-grow: 0;
+  flex-shrink: 0;
   border-bottom: 1px solid transparent;
   transition-duration: 350ms;
   transition-timing-function: ease-in-out;

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -13,6 +13,7 @@
   width: 100%;
   flex-grow: 1;
   min-height: 0;
+  display: flex;
 }
 
 .dashboard-content {


### PR DESCRIPTION
Fixes #26442 

This one was tricky as we have made no change to scrollbar / lazy loading, nor any lib upgrade. 

This was caused by a css change for class dashboard-scroll (change to flex box, so we do not need absolute css height calc math). https://github.com/grafana/grafana/pull/24009 

Somehow this change broke firefox, scrolling still worked but we got no scroll events. 

Fixed it by subtle css changes. 

 