### PR TITLE
API: Recognize dashboard errors when saving a folder

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -127,6 +128,11 @@ func toFolderDto(g guardian.DashboardGuardian, folder *models.Folder) dtos.Folde
 }
 
 func toFolderError(err error) Response {
+	var dashboardErr models.DashboardErr
+	if ok := errors.As(err, &dashboardErr); ok {
+		return Error(dashboardErr.StatusCode, err.Error(), err)
+	}
+
 	if err == models.ErrFolderTitleEmpty ||
 		err == models.ErrFolderSameNameExists ||
 		err == models.ErrFolderWithSameUIDExists ||


### PR DESCRIPTION
**What this PR does / why we need it**:
Recognize dashboard errors when saving a folder via the API, for example that a dashboard by the same name already exists.

**Which issue(s) this PR fixes**:
Fixes #26478.

