### PR TITLE
Tracing: Add errorIconColor prop to TraceSpanData

### DIFF
--- a/packages/grafana-data/src/types/trace.ts
+++ b/packages/grafana-data/src/types/trace.ts
@@ -58,6 +58,7 @@ export type TraceSpanData = {
   references?: TraceSpanReference[];
   warnings?: string[] | null;
   flags: number;
+  errorIconColor?: string;
 };
 
 export type TraceSpan = TraceSpanData & {

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
@@ -252,7 +252,6 @@ const getStyles = createStyle((theme: Theme) => {
     `,
     errorIcon: css`
       label: errorIcon;
-      background: ${autoColor(theme, '#db2828')};
       border-radius: 6.5px;
       color: ${autoColor(theme, '#fff')};
       font-size: 0.85em;
@@ -418,7 +417,16 @@ export class UnthemedSpanBarRow extends React.PureComponent<SpanBarRowProps> {
                   [styles.svcNameChildrenCollapsed]: isParent && !isChildrenExpanded,
                 })}
               >
-                {showErrorIcon && <IoAlert className={styles.errorIcon} />}
+                {showErrorIcon && (
+                  <IoAlert
+                    style={{
+                      backgroundColor: span.errorIconColor
+                        ? autoColor(theme, span.errorIconColor)
+                        : autoColor(theme, '#db2828'),
+                    }}
+                    className={styles.errorIcon}
+                  />
+                )}
                 {serviceName}{' '}
                 {rpc && (
                   <span>


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds errorIconColor prop to TraceSpanData so one can change the color of the warning icon in the Jaeger ui.
