### PR TITLE
Chore: Upgrade build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.24
+            VERSION=0.4.25
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
   - cp -r $(yarn cache dir) yarn-cache
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.4.24
+    GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
   image: grafana/build-container:1.2.21
@@ -78,7 +78,7 @@ steps:
 - name: test-backend
   image: grafana/build-container:1.2.21
   commands:
-  - go test -covermode=atomic ./pkg/...
+  - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
   - cp -r $(go env GOCACHE) go-cache
   depends_on:
@@ -250,7 +250,7 @@ steps:
   - cp -r $(yarn cache dir) yarn-cache
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.4.24
+    GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
   image: grafana/build-container:1.2.21
@@ -306,7 +306,7 @@ steps:
 - name: test-backend
   image: grafana/build-container:1.2.21
   commands:
-  - go test -covermode=atomic ./pkg/...
+  - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
   - cp -r $(go env GOCACHE) go-cache
   depends_on:

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -129,7 +129,7 @@ def pipeline(name, edition, trigger, steps, services=[]):
     return pipeline
 
 def init_steps(edition):
-    grabpl_version = '0.4.24'
+    grabpl_version = '0.4.25'
     common_cmds = [
         'curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
         'tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
@@ -307,7 +307,7 @@ def test_backend_step():
         ],
         'commands': [
             # First execute non-integration tests in parallel, since it should be safe
-            'go test -covermode=atomic ./pkg/...',
+            './bin/grabpl test-backend',
             # Then execute integration tests in serial
             './bin/grabpl integration-tests',
             # Keep the test cache


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the build pipeline tool, to run back-end tests with a number of retries since these have been flaky under Drone.
