### PR TITLE
Cloudwatch: Add af-south-1 region

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -23,7 +23,7 @@ import (
 
 // Known AWS regions.
 var knownRegions = []string{
-	"ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1",
+	"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1",
 	"ap-southeast-2", "ca-central-1", "cn-north-1", "cn-northwest-1", "eu-central-1", "eu-north-1", "eu-west-1",
 	"eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-gov-east-1", "us-gov-west-1",
 	"us-iso-east-1", "us-isob-east-1", "us-west-1", "us-west-2",

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -123,9 +123,10 @@ func TestCloudWatchMetrics(t *testing.T) {
 		result, err := executor.handleGetRegions(context.Background(), simplejson.New(), &tsdb.TsdbQuery{})
 		require.NoError(t, err)
 
-		assert.Equal(t, "ap-east-1", result[0].Text)
-		assert.Equal(t, "ap-northeast-1", result[1].Text)
-		assert.Equal(t, "ap-northeast-2", result[2].Text)
+		assert.Equal(t, "af-south-1", result[0].Text)
+		assert.Equal(t, "ap-east-1", result[1].Text)
+		assert.Equal(t, "ap-northeast-1", result[2].Text)
+		assert.Equal(t, "ap-northeast-2", result[3].Text)
 	})
 
 	t.Run("When calling handleGetEc2InstanceAttribute", func(t *testing.T) {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -70,6 +70,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
         },
         (err: any) => {
           const regions = [
+            'af-south-1',
             'ap-east-1',
             'ap-northeast-1',
             'ap-northeast-2',


### PR DESCRIPTION

**What this PR does / why we need it**:

This allows you to select the `af-south-1` region using the AWS CloudWatch datasource in Grafana

**Which issue(s) this PR fixes**:

Fixes #26477 

**Special notes for your reviewer**:

Describing the AWS Region:

```
$ aws --profile prod ec2 describe-regions --filters "Name=region-name,Values=af-south-1"
{
    "Regions": [
        {
            "Endpoint": "ec2.af-south-1.amazonaws.com",
            "RegionName": "af-south-1",
            "OptInStatus": "opted-in"
        }
    ]
}
```

Listing AWS CloudWatch Metrics from that region:

```
$ aws --profile prod --region af-south-1 cloudwatch list-metrics --namespace 'AWS/EC2' --max-items 1
{
    "Metrics": [
        {
            "Namespace": "AWS/EC2",
            "MetricName": "CPUUtilization",
            "Dimensions": [
                {
                    "Name": "InstanceId",
                    "Value": "i-00000000000000000"
                }
            ]
        }
    ],
    "NextToken": "x"
}
```