### PR TITLE
Graph: Support setting field unit & override data source (automatic) unit

### DIFF
--- a/public/app/plugins/panel/graph/axes_editor.html
+++ b/public/app/plugins/panel/graph/axes_editor.html
@@ -13,7 +13,10 @@
 
     <div ng-if="yaxis.show">
       <div class="gf-form gf-form--grow">
-        <label class="gf-form-label width-6">Unit</label>
+        <label class="gf-form-label width-6">
+          Unit
+				  <info-popover mode="right-normal">This defines the unit when one is not defined on the field</info-popover>
+        </label>
         <unit-picker onChange="ctrl.setUnitFormat(yaxis)" value="yaxis.format" class="flex-grow-1" />
       </div>
     </div>

--- a/public/app/plugins/panel/graph/axes_editor.html
+++ b/public/app/plugins/panel/graph/axes_editor.html
@@ -15,7 +15,7 @@
       <div class="gf-form gf-form--grow">
         <label class="gf-form-label width-6">
           Unit
-				  <info-popover mode="right-normal">This defines the unit when one is not defined on the field</info-popover>
+				  <info-popover mode="right-normal">The default unit used when not defined by the datasource or in the Fields or Overrides configuration.</info-popover>
         </label>
         <unit-picker onChange="ctrl.setUnitFormat(yaxis)" value="yaxis.format" class="flex-grow-1" />
       </div>

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -305,6 +305,7 @@ export class GraphCtrl extends MetricsPanelCtrl {
     for (const series of this.seriesList) {
       series.applySeriesOverrides(this.panel.seriesOverrides);
 
+      // Always use the configured field unit
       if (series.unit) {
         this.panel.yaxes[series.yaxis - 1].format = series.unit;
       }
@@ -378,6 +379,7 @@ export const plugin = new PanelPlugin<GraphPanelOptions, GraphFieldConfig>(null)
   .useFieldConfig({
     standardOptions: [
       FieldConfigProperty.DisplayName,
+      FieldConfigProperty.Unit,
       FieldConfigProperty.Links, // previously saved as dataLinks on options
     ],
   })


### PR DESCRIPTION
Fixes #26497

Still awkward though.  The main issue is that the the graph panel defines at most two Y axis units, and depending on structure, each field can have different units.  The code (for the last 4 years!) has always used the server defined unit regardless of panel settings:  https://github.com/grafana/grafana/blob/master/public/app/plugins/panel/graph/module.ts#L309

This PR adds Unit to the set of fields you can configure/override and adds info text trying to explain that this is the lowest priority setting.


