### PR TITLE
Docs: Put curl examples into separate topic

### DIFF
--- a/docs/sources/http_api/curl-examples.md
+++ b/docs/sources/http_api/curl-examples.md
@@ -1,0 +1,23 @@
++++
+title = "cURL examples"
+description = "cURL examples"
+keywords = ["grafana", "http", "documentation", "api", "curl"]
+type = "docs"
+[menu.docs]
++++
+
+# cURL examples
+
+This page provides examples of calls to the Grafana API using cURL.
+
+The most basic example for a dashboard for which there is no authentication. You can test the following on your local machine, assuming a default installation and anonymous access enabled, required:
+
+```
+curl http://localhost:3000/api/search
+```
+
+Here’s a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "../auth/#basic-auth" >}}) enabled using the default admin credentials:
+
+```
+curl http://admin:admin@localhost:3000/api/search
+```

--- a/docs/sources/http_api/folder_dashboard_search.md
+++ b/docs/sources/http_api/folder_dashboard_search.md
@@ -97,16 +97,3 @@ Content-Type: application/json
   }
 ]
 ```
-## cURL examples
-
-The most basic example for a dashboard for which there is no authentication. You can test the following on your local machine, assuming a default installation and anonymous access enabled, required:
-
-```
-curl http://localhost:3000/api/search
-```
-
-Here’s a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "../auth/#basic-auth" >}}) enabled using the default admin credentials:
-
-```
-curl http://admin:admin@localhost:3000/api/dashboards/home
-```

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -382,6 +382,8 @@
       link: /http_api/auth/
     - name: Create API Tokens and Dashboards for a Specific Organization
       link: /tutorials/api_org_token_howto/
+    - name: cURL examples
+      link: /http_api/curl-examples/  
     - name: Admin API
       link: /http_api/admin/
     - name: Alerting API


### PR DESCRIPTION
Applied @sakjur's suggested edit and moved content into a separate topic