### PR TITLE
LDAP: fix LDAP test with special chars in username

### DIFF
--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -211,7 +211,7 @@ export function loadLdapState(): ThunkResult<void> {
 export function loadUserMapping(username: string): ThunkResult<void> {
   return async dispatch => {
     try {
-      const response = await getBackendSrv().get(`/api/admin/ldap/${username}`);
+      const response = await getBackendSrv().get(`/api/admin/ldap/${encodeURIComponent(username)}`);
       const { name, surname, email, login, isGrafanaAdmin, isDisabled, roles, teams } = response;
       const userInfo: LdapUser = {
         info: { name, surname, email, login },


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix LDAP "Test user mapping" by encoding the username before sending it. Else, the application crashes if the username contains chars like `\` or doesn't find the user if the username contains chars like `?`

**Which issue(s) this PR fixes**:
Fixes #26197



