### PR TITLE
Alerting: Change settings column type to mediumtext

### DIFF
--- a/pkg/services/sqlstore/migrations/alert_mig.go
+++ b/pkg/services/sqlstore/migrations/alert_mig.go
@@ -171,4 +171,9 @@ func addAlertMigrations(mg *Migrator) {
 	mg.AddMigration("Add column secure_settings in alert_notification", NewAddColumnMigration(alert_notification, &Column{
 		Name: "secure_settings", Type: DB_Text, Nullable: true,
 	}))
+
+	// change column type of alert.settings
+	mg.AddMigration("alter alert.settings to mediumtext", NewRawSqlMigration("").
+		Mysql("ALTER TABLE alert MODIFY settings MEDIUMTEXT;"))
+
 }

--- a/pkg/services/sqlstore/migrations/alert_mig.go
+++ b/pkg/services/sqlstore/migrations/alert_mig.go
@@ -175,5 +175,4 @@ func addAlertMigrations(mg *Migrator) {
 	// change column type of alert.settings
 	mg.AddMigration("alter alert.settings to mediumtext", NewRawSqlMigration("").
 		Mysql("ALTER TABLE alert MODIFY settings MEDIUMTEXT;"))
-
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes `Error 1406: Data too long for column 'settings'` error (reported from HG customer) when trying to save a dashboard that contains an alert that exceeds the settings column size.

This fix introduces a database migration for MySQL  (similar to the [modification](https://github.com/grafana/grafana/blob/41d432b5ae68c0fc2261e607289206b79410fcfa/pkg/services/sqlstore/migrations/dashboard_mig.go#L93) made for the `data_source.data` column) that changes the settings column type from `text` to `mediumtext`.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
If have tested with `mysql`, `sqlite`, `postgres`. (This migration applies only to `mysql` database; other databases should not be affected)
