### PR TITLE
Elasticsearch: Fix displaying of bucket script input

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -47,7 +47,7 @@
 </div>
 
 <div class="gf-form-group" ng-if="showVariables">
-	<elastic-pipeline-variables variables="agg.pipelineVariables" options="pipelineAggOptions" on-change="onChangeInternal()" />
+	<elastic-pipeline-variables variables="agg.pipelineVariables" options="pipelineAggOptions" on-change="onChangeInternal()"></elastic-pipeline-variables>
   <div class="gf-form offset-width-7">
     <label class="gf-form-label width-10">
       Script


### PR DESCRIPTION
**What this PR does / why we need it**:
We have done a jQuery Upgrade that breaks (changes) how jquery parses html templates, it no longer replaces self-closing tags with closing tags. Script input was missing closing tag and therefore wasn't correctly displayed. Similar to https://github.com/grafana/grafana/pull/25889

**Before:**
![image](https://user-images.githubusercontent.com/30407135/88294988-24896e00-ccfd-11ea-8199-bf61078d9cd2.png)

**After:** 
![image](https://user-images.githubusercontent.com/30407135/88294896-0ae82680-ccfd-11ea-802a-8597ee5293a3.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/26532

