### PR TITLE
Dashboard: Fix for viewer can enter panel edit mode by modifying url (but cannot not save anything) 

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -139,6 +139,20 @@ describe('DashboardPage', () => {
     });
   });
 
+  dashboardPageScenario('When user goes into panel edit but has no edit permissions', ctx => {
+    ctx.setup(() => {
+      ctx.mount();
+      ctx.setDashboardProp({}, { canEdit: false });
+      ctx.wrapper?.setProps({
+        urlEditPanelId: '1',
+      });
+    });
+
+    it('Should update component state to fullscreen and edit', () => {
+      const state = ctx.wrapper?.state();
+      expect(state?.editPanel).toBe(null);
+    });
+  });
   dashboardPageScenario('When user goes back to dashboard from view panel', ctx => {
     ctx.setup(() => {
       ctx.mount();

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -117,6 +117,12 @@ export class DashboardPage extends PureComponent<Props, State> {
     // entering edit mode
     if (!editPanel && urlEditPanelId) {
       this.getPanelByIdFromUrlParam(urlEditPanelId, panel => {
+        // if no edit permission show error
+        if (!dashboard.canEditPanel(panel)) {
+          this.props.notifyApp(createErrorNotification('Permission to edit panel denied'));
+          return;
+        }
+
         this.setState({ editPanel: panel });
       });
     }


### PR DESCRIPTION
Fixes #26555

Regression in 7.0 with the change to edit mode 