### PR TITLE
Docs: Add variable examples

### DIFF
--- a/docs/sources/linking/dashboard-links.md
+++ b/docs/sources/linking/dashboard-links.md
@@ -14,7 +14,9 @@ When you create a dashboard link, you can include the time range and current tem
 
 Dashboard links can also be used as shortcuts to external systems, such as submitting [a GitHub issue with the current dashboard name](https://github.com/grafana/grafana/issues/new?title=Dashboard%3A%20HTTP%20Requests).
 
-To see an example of dashboard links in action, check out [this demo](https://play.grafana.org/d/rUpVRdamz/dashboard-links-with-variables?orgId=1).
+To see an example of dashboard links in action, check out: 
+- [Dashboard links with variables](https://play.grafana.org/d/rUpVRdamz/dashboard-links-with-variables?orgId=1)
+- [Prometheus repeat](https://play.grafana.org/d/000000036/prometheus-repeat?orgId=1)
 
 Once you've added a dashboard link, it appears in the upper right corner of your dashboard.
 

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -253,6 +253,8 @@
   children:
     - link: /variables/templates-and-variables/
       name: Overview
+    - link: /variables/variable-examples/
+      name: Variable examples
     - link: /variables/add-query-variable/
       name: Add query variable
     - link: /variables/add-custom-variable/

--- a/docs/sources/variables/repeat-panels-or-rows.md
+++ b/docs/sources/variables/repeat-panels-or-rows.md
@@ -15,6 +15,13 @@ Grafana lets you create dynamic dashboards using _template variables_. All varia
 Template variables can be very useful to dynamically change your queries across a whole dashboard. If you want
 Grafana to dynamically create new panels or rows based on what values you have selected, you can use the *Repeat* feature.
 
+## Grafana Play examples
+
+You can see examples in the following dashboards:
+
+- [Prometheus repeat](https://play.grafana.org/d/000000036/prometheus-repeat)
+- [Repeated Rows Dashboard](https://play.grafana.org/dashboard/db/repeated-rows)
+
 ## Repeating panels
 
 If you have a variable with `Multi-value` or `Include all value` options enabled you can choose one panel and have Grafana repeat that panel
@@ -45,5 +52,3 @@ clicking on the cog button, you will access the `Row Options` configuration pane
 you want to repeat the row for.
 
 It may be a good idea to use a variable in the row title as well.
-
-Example: [Repeated Rows Dashboard](https://play.grafana.org/dashboard/db/repeated-rows)

--- a/docs/sources/variables/variable-examples.md
+++ b/docs/sources/variables/variable-examples.md
@@ -11,9 +11,12 @@ weight = 200
 This page contains links to dashboards in Grafana Play with examples of template variables.
 
 - [Elasticsearch Metrics](https://play.grafana.org/d/000000014/elasticsearch-metrics?orgId=1) - Uses ad hoc filters, global variables, and a custom variable.
-- [Graphite Templated Nested](https://play.grafana.org/d/000000056/graphite-templated-nested?orgId=1) - Uses chained query variables, an interval variable, and a repeated panel.
+- [Graphite Templated Nested](https://play.grafana.org/d/000000056/graphite-templated-nested?orgId=1) - Uses query variables, chained query variables, an interval variable, and a repeated panel.
 - [Influx DB Group By Variable](https://play.grafana.org/d/000000137/influxdb-group-by-variable?orgId=1) - Query variable, panel uses the variable results to group the metric data.
-- [InfluxDB Raw Query Template Var](https://play.grafana.org/d/000000083/influxdb-raw-query-template-var?orgId=1) - Uses chained query variables and an interval variable.
+- [InfluxDB Raw Query Template Var](https://play.grafana.org/d/000000083/influxdb-raw-query-template-var?orgId=1) - Uses query variables, chained query variables, and an interval variable.
+- [InfluxDB Server Monitoring](https://play.grafana.org/d/AAy9r_bmk/influxdb-server-monitoring?orgId=1) - Uses query variables, chained query variables, an interval variable, and an ad hoc filter.
 - [Prometheus templating](https://play.grafana.org/d/000000063/prometheus-templating?orgId=1) - Uses chained query variables.
+- [Template Redux](https://play.grafana.org/d/p-k6QtkGz/template-redux?orgId=1) - Uses query variables, chained query variables, ad hoc filters, an interval variable, a text box variable, a custom variable, and a data source variable.
 - [Templating, repeated panels](https://play.grafana.org/d/000000025/templating-repeated-panels?orgId=1) - Two sets of repeated panels use query variables.
-- [Templating value groups](https://play.grafana.org/d/000000024/templating-value-groups?orgId=1) - InfluxDB data source, query variable with value groups.
+- [Templating showcase](https://play.grafana.org/d/000000091/templating-showcase?orgId=1) - Uses custom, query, chained query, and data source variables.
+- [Templating value groups](https://play.grafana.org/d/000000024/templating-value-groups?orgId=1) - Uses query variable with value groups.

--- a/docs/sources/variables/variable-examples.md
+++ b/docs/sources/variables/variable-examples.md
@@ -9,3 +9,11 @@ weight = 200
 # Variable examples
 
 This page contains links to dashboards in Grafana Play with examples of template variables.
+
+- [Elasticsearch Metrics](https://play.grafana.org/d/000000014/elasticsearch-metrics?orgId=1) - Uses ad hoc filters, global variables, and a custom variable.
+- [Graphite Templated Nested](https://play.grafana.org/d/000000056/graphite-templated-nested?orgId=1) - Uses chained query variables, an interval variable, and a repeated panel.
+- [Influx DB Group By Variable](https://play.grafana.org/d/000000137/influxdb-group-by-variable?orgId=1) - Query variable, panel uses the variable results to group the metric data.
+- [InfluxDB Raw Query Template Var](https://play.grafana.org/d/000000083/influxdb-raw-query-template-var?orgId=1) - Uses chained query variables and an interval variable.
+- [Prometheus templating](https://play.grafana.org/d/000000063/prometheus-templating?orgId=1) - Uses chained query variables.
+- [Templating, repeated panels](https://play.grafana.org/d/000000025/templating-repeated-panels?orgId=1) - Two sets of repeated panels use query variables.
+- [Templating value groups](https://play.grafana.org/d/000000024/templating-value-groups?orgId=1) - InfluxDB data source, query variable with value groups.

--- a/docs/sources/variables/variable-examples.md
+++ b/docs/sources/variables/variable-examples.md
@@ -1,0 +1,11 @@
++++
+title = "Variable examples"
+keywords = ["grafana", "templating", "documentation", "guide", "template", "variable"]
+type = "docs"
+[menu.docs]
+weight = 200
++++
+
+# Variable examples
+
+This page contains links to dashboards in Grafana Play with examples of template variables.

--- a/docs/sources/variables/variable-value-tags.md
+++ b/docs/sources/variables/variable-value-tags.md
@@ -7,7 +7,7 @@ weight = 800
 
 # Enter variable value groups/tags (experimental feature)
 
-Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags. 
+Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags.
 
 {{< docs-imagebox img="/img/docs/v50/variable_dropdown_tags.png" max-width="300px" >}}
 

--- a/docs/sources/variables/variable-value-tags.md
+++ b/docs/sources/variables/variable-value-tags.md
@@ -7,11 +7,13 @@ weight = 800
 
 # Enter variable value groups/tags (experimental feature)
 
-Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags.
+Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags. 
 
 {{< docs-imagebox img="/img/docs/v50/variable_dropdown_tags.png" max-width="300px" >}}
 
 This feature is off by default. Click **Enabled** to turn the feature on.
+
+To see an example, check out [Templating value groups](https://play.grafana.org/d/000000024/templating-value-groups?orgId=1).
 
 ## Tags query
 


### PR DESCRIPTION
Adds links to example dashboards for template variables.

This is a starting point. I also want to add deeper dives into individual variable types.