### PR TITLE
Drone: Reduce parallelism of certain steps to conserve memory

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -98,6 +98,8 @@ steps:
   - yarn run packages:typecheck
   - yarn run typecheck
   - yarn run test
+  environment:
+    TEST_MAX_WORKERS: 50%
   depends_on:
   - initialize
 
@@ -331,6 +333,8 @@ steps:
   - yarn run packages:typecheck
   - yarn run typecheck
   - yarn run test
+  environment:
+    TEST_MAX_WORKERS: 50%
   depends_on:
   - initialize
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
-  - ./bin/grabpl build-backend --edition oss --build-id $DRONE_BUILD_NUMBER --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
+  - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
   depends_on:
   - initialize
   - lint-backend
@@ -75,7 +75,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
-  - ./bin/grabpl build-frontend --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
+  - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
   - initialize
   - test-frontend
@@ -107,7 +107,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
-  - ./bin/grabpl build-plugins --edition oss --no-install-deps
+  - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
   - initialize
   - lint-backend
@@ -115,7 +115,7 @@ steps:
 - name: package
   image: grafana/build-container:1.2.21
   commands:
-  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
+  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
   - build-backend
   - build-frontend
@@ -300,7 +300,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
-  - ./bin/grabpl build-backend --edition oss --build-id $DRONE_BUILD_NUMBER
+  - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER
   depends_on:
   - initialize
   - lint-backend
@@ -310,7 +310,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
-  - ./bin/grabpl build-frontend --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
+  - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
   - initialize
   - test-frontend
@@ -342,7 +342,7 @@ steps:
   image: grafana/build-container:1.2.21
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
-  - ./bin/grabpl build-plugins --edition oss --no-install-deps
+  - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
   - initialize
   - lint-backend
@@ -350,7 +350,7 @@ steps:
 - name: package
   image: grafana/build-container:1.2.21
   commands:
-  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
+  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
   - build-backend
   - build-frontend

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -272,7 +272,10 @@ def build_backend_step(edition, variants=None):
         ],
         'commands': [
             'rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)',
-            './bin/grabpl build-backend --edition {} --build-id $DRONE_BUILD_NUMBER{}'.format(edition, variants_str),
+            # TODO: Convert number of jobs to percentage
+            './bin/grabpl build-backend --jobs 8 --edition {} --build-id $DRONE_BUILD_NUMBER{}'.format(
+                edition, variants_str
+            ),
         ],
     }
 
@@ -286,7 +289,8 @@ def build_frontend_step(edition):
         ],
         'commands': [
             restore_yarn_cache,
-            './bin/grabpl build-frontend --no-install-deps --edition {} '.format(edition) +
+            # TODO: Use percentage for num jobs
+            './bin/grabpl build-frontend --jobs 8 --no-install-deps --edition {} '.format(edition) +
                 '--build-id $DRONE_BUILD_NUMBER --no-pull-enterprise',
         ],
     }
@@ -301,7 +305,8 @@ def build_plugins_step(edition):
         ],
         'commands': [
             restore_yarn_cache,
-            './bin/grabpl build-plugins --edition {} --no-install-deps'.format(edition),
+            # TODO: Use percentage for num jobs
+            './bin/grabpl build-plugins --jobs 8 --edition {} --no-install-deps'.format(edition),
         ],
     }
 
@@ -397,7 +402,8 @@ def package_step(edition, variants=None):
             'shellcheck',
         ],
         'commands': [
-            '. scripts/build/gpg-test-vars.sh && ./bin/grabpl package --edition {} '.format(edition) +
+            # TODO: Use percentage for jobs
+            '. scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition {} '.format(edition) +
                 '--build-id $DRONE_BUILD_NUMBER --no-pull-enterprise' + variants_str,
         ],
     }

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -330,6 +330,9 @@ def test_frontend_step():
         'depends_on': [
             'initialize',
         ],
+        'environment': {
+            'TEST_MAX_WORKERS': '50%',
+        },
         'commands': [
             restore_yarn_cache,
             'yarn run prettier:check',


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce parallelism of some Drone steps in order to avoid running out of memory. @captncraig suspects some builds are killed due to OOM, let's see if we can avoid it.