### PR TITLE
TablePanel: Add support for basic gauge as a cell display mode

### DIFF
--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -37,6 +37,8 @@ export const BarGaugeCell: FC<TableCellProps> = props => {
 
   if (field.config.custom && field.config.custom.displayMode === TableCellDisplayMode.LcdGauge) {
     barGaugeMode = BarGaugeDisplayMode.Lcd;
+  } else if (field.config.custom && field.config.custom.displayMode === TableCellDisplayMode.BasicGauge) {
+    barGaugeMode = BarGaugeDisplayMode.Basic;
   }
 
   let width;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -17,6 +17,7 @@ export enum TableCellDisplayMode {
   GradientGauge = 'gradient-gauge',
   LcdGauge = 'lcd-gauge',
   JSONView = 'json-view',
+  BasicGauge = 'basic',
 }
 
 export type FieldTextAlignment = 'auto' | 'left' | 'right' | 'center';

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -91,6 +91,7 @@ function getCellComponent(displayMode: TableCellDisplayMode, field: Field) {
     case TableCellDisplayMode.ColorBackground:
       return withTableStyles(DefaultCell, getBackgroundColorStyle);
     case TableCellDisplayMode.LcdGauge:
+    case TableCellDisplayMode.BasicGauge:
     case TableCellDisplayMode.GradientGauge:
       return BarGaugeCell;
     case TableCellDisplayMode.JSONView:

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -45,6 +45,7 @@ export const plugin = new PanelPlugin<Options, CustomFieldConfig>(TablePanel)
               { value: TableCellDisplayMode.ColorBackground, label: 'Color background' },
               { value: TableCellDisplayMode.GradientGauge, label: 'Gradient gauge' },
               { value: TableCellDisplayMode.LcdGauge, label: 'LCD gauge' },
+              { value: TableCellDisplayMode.BasicGauge, label: 'Basic gauge' },
               { value: TableCellDisplayMode.JSONView, label: 'JSON View' },
             ],
           },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for the Basic Gauge type as a table cell display mode. 

**Which issue(s) this PR fixes**:

Fixes #25704

