### PR TITLE
Dashboard: Add Duplicate dashboard links button to links list

### DIFF
--- a/docs/sources/linking/dashboard-links.md
+++ b/docs/sources/linking/dashboard-links.md
@@ -64,8 +64,8 @@ To change or update an existing dashboard link, follow this procedure.
 
 ## Duplicate a dashboard link
 
-To duplicate an existing dashboard link, click the blue **⇄** next to the existing link that you want to duplicate.
+To duplicate an existing dashboard link, click the duplicate icon next to the existing link that you want to duplicate.
 
 ## Delete a dashboard link
 
-To delete an existing dashboard link, click the red **X** next to the existing link that you want to delete.
+To delete an existing dashboard link, click the trash icon next to the duplicate icon that you want to delete.

--- a/docs/sources/linking/dashboard-links.md
+++ b/docs/sources/linking/dashboard-links.md
@@ -62,6 +62,10 @@ To change or update an existing dashboard link, follow this procedure.
 1. In Dashboard Settings, on the Links tab, click the existing link that you want to edit.
 1. Change the settings and then click **Update**.
 
+## Duplicate a dashboard link
+
+To duplicate an existing dashboard link, click the blue **⇄** next to the existing link that you want to duplicate.
+
 ## Delete a dashboard link
 
 To delete an existing dashboard link, click the red **X** next to the existing link that you want to delete.

--- a/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
+++ b/public/app/features/dashboard/components/DashLinks/DashLinksEditorCtrl.ts
@@ -74,6 +74,11 @@ export class DashLinksEditorCtrl {
     _.move(this.dashboard.links, index, index + dir);
   }
 
+  duplicateLink(link: any, index: number) {
+    this.dashboard.links.splice(index, 0, link);
+    this.dashboard.updateSubmenuVisibility();
+  }
+
   deleteLink(index: number) {
     this.dashboard.links.splice(index, 1);
     this.dashboard.updateSubmenuVisibility();

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -68,13 +68,13 @@
             <icon ng-click="ctrl.moveLink($index, 1)" ng-hide="$last" name="'arrow-down'"></icon>
           </td>
           <td style="width: 1%">
-            <a ng-click="ctrl.duplicateLink(link, $index)" class="btn btn-primary btn-primary">
-              <icon name="'repeat'" style="margin-bottom: 0;"></icon>
+            <a ng-click="ctrl.duplicateLink(link, $index)" class="btn">
+              <icon name="'copy'" style="margin-bottom: 0;"></icon>
             </a>
           </td>
           <td style="width: 1%">
-            <a ng-click="ctrl.deleteLink($index)" class="btn btn-danger btn-small" ng-hide="annotation.builtIn">
-              <icon name="'times'" style="margin-bottom: 0;"></icon>
+            <a ng-click="ctrl.deleteLink($index)" class="btn" ng-hide="annotation.builtIn">
+              <icon name="'trash-alt'" style="margin-bottom: 0;"></icon>
             </a>
           </td>
         </tr>

--- a/public/app/features/dashboard/components/DashLinks/editor.html
+++ b/public/app/features/dashboard/components/DashLinks/editor.html
@@ -39,7 +39,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="link in ctrl.dashboard.links">
+        <tr ng-repeat="link in ctrl.dashboard.links track by $index">
           <td class="pointer" ng-click="ctrl.editLink(link)">
             <icon name="'external-link-alt'"></icon>
             {{ link.type }}
@@ -66,6 +66,11 @@
           </td>
           <td style="width: 1%">
             <icon ng-click="ctrl.moveLink($index, 1)" ng-hide="$last" name="'arrow-down'"></icon>
+          </td>
+          <td style="width: 1%">
+            <a ng-click="ctrl.duplicateLink(link, $index)" class="btn btn-primary btn-primary">
+              <icon name="'repeat'" style="margin-bottom: 0;"></icon>
+            </a>
           </td>
           <td style="width: 1%">
             <a ng-click="ctrl.deleteLink($index)" class="btn btn-danger btn-small" ng-hide="annotation.builtIn">


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: This PR allows users to duplicate individual `Dashboard Links` to work faster. I wish this feature was already implemented when I was creating `Dashboard Links `for all regions that we have deployments in. Pressing `New` button and copy-pasting each textbox was quite a burden. With this feature, users can easily duplicate the links and change only the needed/required areas. For example: region parts of the URL, title...

<img width="1061" alt="Screenshot 2020-07-25 at 17 21 47" src="https://user-images.githubusercontent.com/15844674/88460953-45d68f80-cea0-11ea-8545-4080d50e6581.png">

**Which issue(s) this PR fixes**: _None of the existing ones_

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**: First contribution :) ~I wasn't really sure which button type to use. I've decided `repeat` is the most appropriate, although `copy` also looks appropriate.~ Changed to `copy`.
