### PR TITLE
Settings: Remove global variable

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
@@ -77,7 +76,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricReq
 			return Error(500, "Metric request error", err)
 		}
 	} else {
-		if !setting.IsExpressionsEnabled() {
+		if !hs.Cfg.IsExpressionsEnabled() {
 			return Error(404, "Expressions feature toggle is not enabled", nil)
 		}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -215,7 +215,6 @@ var (
 	S3TempImageStoreSecretKey string
 
 	ImageUploadProvider string
-	FeatureToggles      map[string]bool
 )
 
 // TODO move all global vars to this struct
@@ -1023,7 +1022,6 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	for _, feature := range util.SplitString(featuresTogglesStr) {
 		cfg.FeatureToggles[feature] = true
 	}
-	FeatureToggles = cfg.FeatureToggles
 
 	// check old location for this option
 	if panelsSection.Key("enable_alpha").MustBool(false) {
@@ -1190,12 +1188,4 @@ func (s *DynamicSection) Key(k string) *ini.Key {
 // As a side effect, the value of the setting key will be updated if an environment variable is present.
 func (cfg *Cfg) SectionWithEnvOverrides(s string) *DynamicSection {
 	return &DynamicSection{cfg.Raw.Section(s), cfg.Logger}
-}
-
-func IsExpressionsEnabled() bool {
-	v, ok := FeatureToggles["expressions"]
-	if !ok {
-		return false
-	}
-	return v
 }


### PR DESCRIPTION
Somehow we have added more global setting variables (everything should move to Cfg struct). 
