### PR TITLE
StatPanel: Fix stat panel display name not showing when explicitly set

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -69,6 +69,8 @@ export interface PanelProps<T = any> {
   onChangeTimeRange: (timeRange: AbsoluteTimeRange) => void;
   /** @internal */
   renderCounter: number;
+  /** Panel title */
+  title: string;
 }
 
 export interface PanelEditorProps<T = any> {

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -273,6 +273,7 @@ export class PanelChrome extends PureComponent<Props, State> {
           <PanelComponent
             id={panel.id}
             data={data}
+            title={panel.title}
             timeRange={timeRange}
             timeZone={this.props.dashboard.getTimezone()}
             options={panelOptions}

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.test.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.test.tsx
@@ -84,6 +84,7 @@ function createBarGaugePanelWithData(data: PanelData): ReactWrapper<PanelProps<B
       timeRange={timeRange}
       timeZone={'utc'}
       options={options}
+      title="hello"
       fieldConfig={fieldConfig}
       onFieldConfigChange={() => {}}
       onOptionsChange={() => {}}

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -26,7 +26,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
     valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
     menuProps: DataLinksContextMenuApi
   ): JSX.Element => {
-    const { timeRange, options, fieldConfig } = this.props;
+    const { timeRange, options } = this.props;
     const { value, alignmentFactors, width, height, count } = valueProps;
     const { openMenu, targetClassName } = menuProps;
     let sparkline: BigValueSparkline | undefined;
@@ -46,11 +46,6 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
       }
     }
 
-    let textMode = options.textMode;
-    if (options.textMode === BigValueTextMode.Auto && fieldConfig.defaults.displayName) {
-      textMode = BigValueTextMode.ValueAndName;
-    }
-
     return (
       <BigValue
         value={value.display}
@@ -59,7 +54,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
         colorMode={options.colorMode}
         graphMode={options.graphMode}
         justifyMode={options.justifyMode}
-        textMode={textMode}
+        textMode={this.getTextMode()}
         alignmentFactors={alignmentFactors}
         width={width}
         height={height}
@@ -69,6 +64,18 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
       />
     );
   };
+
+  getTextMode() {
+    const { options, fieldConfig, title } = this.props;
+
+    // If we have manually set displayName or panel title switch text mode to value and name
+    if (options.textMode === BigValueTextMode.Auto && (fieldConfig.defaults.displayName || !title)) {
+      return BigValueTextMode.ValueAndName;
+    }
+
+    return options.textMode;
+  }
+
   renderValue = (valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>): JSX.Element => {
     const { value } = valueProps;
     const { getLinks, hasLinks } = value;

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -6,6 +6,7 @@ import {
   DataLinksContextMenu,
   VizRepeater,
   VizRepeaterRenderValueProps,
+  BigValueTextMode,
 } from '@grafana/ui';
 import {
   DisplayValueAlignmentFactors,
@@ -25,7 +26,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
     valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
     menuProps: DataLinksContextMenuApi
   ): JSX.Element => {
-    const { timeRange, options } = this.props;
+    const { timeRange, options, fieldConfig } = this.props;
     const { value, alignmentFactors, width, height, count } = valueProps;
     const { openMenu, targetClassName } = menuProps;
     let sparkline: BigValueSparkline | undefined;
@@ -45,6 +46,11 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
       }
     }
 
+    let textMode = options.textMode;
+    if (options.textMode === BigValueTextMode.Auto && fieldConfig.defaults.displayName) {
+      textMode = BigValueTextMode.ValueAndName;
+    }
+
     return (
       <BigValue
         value={value.display}
@@ -53,7 +59,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
         colorMode={options.colorMode}
         graphMode={options.graphMode}
         justifyMode={options.justifyMode}
-        textMode={options.textMode}
+        textMode={textMode}
         alignmentFactors={alignmentFactors}
         width={width}
         height={height}


### PR DESCRIPTION
Fixes #26583

A bit conflicted on how to solve this or if it should be solved. with Text mode set to Auto should stat panel show display name if set via Field tab default? what about via override? I started on a fix like that, to check in StatPanel.tsx if fieldConfig.defaults.displayName was set and then switch text mode to value and name (passed to BigValue). But not sure, maybe Auto should just be if count === 1 then do not show name, if you want to show name if count === 1 you have to change display name. and to fix broken old dashboards instead of adding logic in StatPanel.tsx we can do a migration that for panels with default displayName set we change textMode. Only downside with that users will try to change Display name and it won't have any effect when text mode set to Auto.

