### PR TITLE
Gauge: Fix display name showing for only single series

### DIFF
--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -21,7 +21,7 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
     valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>,
     menuProps: DataLinksContextMenuApi
   ): JSX.Element => {
-    const { options } = this.props;
+    const { options, fieldConfig } = this.props;
     const { value, alignmentFactors, orientation, width, height, count } = valueProps;
     const { field, display, view, colIndex } = value;
     const { openMenu, targetClassName } = menuProps;
@@ -33,7 +33,7 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
 
     return (
       <BarGauge
-        value={clearNameForSingleSeries(count, field, display)}
+        value={clearNameForSingleSeries(count, fieldConfig.defaults, display)}
         width={width}
         height={height}
         orientation={orientation}

--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -12,14 +12,14 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
     valueProps: VizRepeaterRenderValueProps<FieldDisplay>,
     menuProps: DataLinksContextMenuApi
   ): JSX.Element => {
-    const { options } = this.props;
+    const { options, fieldConfig } = this.props;
     const { width, height, count, value } = valueProps;
     const { field, display } = value;
     const { openMenu, targetClassName } = menuProps;
 
     return (
       <Gauge
-        value={clearNameForSingleSeries(count, field, display)}
+        value={clearNameForSingleSeries(count, fieldConfig.defaults, display)}
         width={width}
         height={height}
         field={field}


### PR DESCRIPTION
Fixes #26525 

But now need to fix #25212 as well impacting Prometheus as well. Basically changing defaults display name has no impact on any panels as it's set by data source. Only override has impact. 

But then how to check if specific display name has been set? I check here if it exists in defaults (Field tab) to see if a user has set custom display name, but setting custom display name has no impact for Graphite & Prometheus as it's overriden by data source. hmm.. 