### PR TITLE
Toolkit/Plugin: throw an Error instead of a string

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -116,7 +116,7 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
 
   fs.exists(jobsDir, jobsDirExists => {
     if (!jobsDirExists) {
-      throw 'You must run plugin:ci-build prior to running plugin:ci-package';
+      throw new Error('You must run plugin:ci-build prior to running plugin:ci-package');
     }
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Throwing an `Error` instead of just a string when calling the `grafana-toolkit plugin:ci-package` command so we can see the error message and the stack trace.

I was experiencing this while I was developing an app plugin and didn't run `grafana-toolkit plugin:ci-build` before packaging, however only got `undefined` instead of the error message on the console. 
