### PR TITLE
Dashboard: Fixed disable draggable panels on correct breakpoint

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -64,8 +64,9 @@ function GridWrapper({
   /*
     Disable draggable if mobile device, solving an issue with unintentionally
      moving panels. https://github.com/grafana/grafana/issues/18497
+     theme.breakpoints.md = 769
   */
-  const draggable = width <= 420 ? false : isDraggable;
+  const draggable = width <= 769 ? false : isDraggable;
 
   return (
     <ReactGridLayout


### PR DESCRIPTION
Dashboard switches to responsive single column layout at medium breakpoint (769px) so DasbboardGrid needs to disable dragging at same point, noticed this as if you click on panel headers in responsive mode the panels get dragged to the bottom by just that click  