### PR TITLE
Templating: Fixed access to system variables like __dashboard, __user & __org during dashboard load & variable queries

### DIFF
--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -568,18 +568,19 @@ describe('shared actions', () => {
 
         tester.thenDispatchedActionsPredicateShouldEqual(dispatchedActions => {
           expect(dispatchedActions[0]).toEqual(variablesInitTransaction({ uid }));
-          expect(dispatchedActions[1]).toEqual(
+          expect(dispatchedActions[1].type).toEqual(addVariable.type);
+          expect(dispatchedActions[1].payload.id).toEqual('__dashboard');
+          expect(dispatchedActions[2].type).toEqual(addVariable.type);
+          expect(dispatchedActions[2].payload.id).toEqual('__org');
+          expect(dispatchedActions[3].type).toEqual(addVariable.type);
+          expect(dispatchedActions[3].payload.id).toEqual('__user');
+          expect(dispatchedActions[4]).toEqual(
             addVariable(toVariablePayload(constant, { global: false, index: 0, model: constant }))
           );
-          expect(dispatchedActions[2]).toEqual(addInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[3]).toEqual(resolveInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[4]).toEqual(removeInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[5].type).toEqual(addVariable.type);
-          expect(dispatchedActions[5].payload.id).toEqual('__dashboard');
-          expect(dispatchedActions[6].type).toEqual(addVariable.type);
-          expect(dispatchedActions[6].payload.id).toEqual('__org');
-          expect(dispatchedActions[7].type).toEqual(addVariable.type);
-          expect(dispatchedActions[7].payload.id).toEqual('__user');
+          expect(dispatchedActions[5]).toEqual(addInitLock(toVariablePayload(constant)));
+          expect(dispatchedActions[6]).toEqual(resolveInitLock(toVariablePayload(constant)));
+          expect(dispatchedActions[7]).toEqual(removeInitLock(toVariablePayload(constant)));
+
           expect(dispatchedActions[8]).toEqual(variablesCompleteTransaction({ uid }));
           return dispatchedActions.length === 9;
         });
@@ -607,18 +608,18 @@ describe('shared actions', () => {
           expect(dispatchedActions[0]).toEqual(cleanVariables());
           expect(dispatchedActions[1]).toEqual(variablesClearTransaction());
           expect(dispatchedActions[2]).toEqual(variablesInitTransaction({ uid }));
-          expect(dispatchedActions[3]).toEqual(
+          expect(dispatchedActions[3].type).toEqual(addVariable.type);
+          expect(dispatchedActions[3].payload.id).toEqual('__dashboard');
+          expect(dispatchedActions[4].type).toEqual(addVariable.type);
+          expect(dispatchedActions[4].payload.id).toEqual('__org');
+          expect(dispatchedActions[5].type).toEqual(addVariable.type);
+          expect(dispatchedActions[5].payload.id).toEqual('__user');
+          expect(dispatchedActions[6]).toEqual(
             addVariable(toVariablePayload(constant, { global: false, index: 0, model: constant }))
           );
-          expect(dispatchedActions[4]).toEqual(addInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[5]).toEqual(resolveInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[6]).toEqual(removeInitLock(toVariablePayload(constant)));
-          expect(dispatchedActions[7].type).toEqual(addVariable.type);
-          expect(dispatchedActions[7].payload.id).toEqual('__dashboard');
-          expect(dispatchedActions[8].type).toEqual(addVariable.type);
-          expect(dispatchedActions[8].payload.id).toEqual('__org');
-          expect(dispatchedActions[9].type).toEqual(addVariable.type);
-          expect(dispatchedActions[9].payload.id).toEqual('__user');
+          expect(dispatchedActions[7]).toEqual(addInitLock(toVariablePayload(constant)));
+          expect(dispatchedActions[8]).toEqual(resolveInitLock(toVariablePayload(constant)));
+          expect(dispatchedActions[9]).toEqual(removeInitLock(toVariablePayload(constant)));
           expect(dispatchedActions[10]).toEqual(variablesCompleteTransaction({ uid }));
           return dispatchedActions.length === 11;
         });

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -552,10 +552,10 @@ export const initVariablesTransaction = (dashboardUid: string, dashboard: Dashbo
       dispatch(cancelVariables());
     }
 
-    // Add system variables like __dashboard and __user
-    dispatch(addSystemTemplateVariables(dashboard));
     // Start init transaction
     dispatch(variablesInitTransaction({ uid: dashboardUid }));
+    // Add system variables like __dashboard and __user
+    dispatch(addSystemTemplateVariables(dashboard));
     // Load all variables into redux store
     dispatch(initDashboardTemplating(dashboard.templating.list));
     // Process all variable updates

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -96,7 +96,7 @@ export const initDashboardTemplating = (list: VariableModel[]): ThunkResult<void
   };
 };
 
-export const completeDashboardTemplating = (dashboard: DashboardModel): ThunkResult<void> => {
+export const addSystemTemplateVariables = (dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
     const dashboardModel: DashboardVariableModel = {
       id: '__dashboard',
@@ -552,12 +552,15 @@ export const initVariablesTransaction = (dashboardUid: string, dashboard: Dashbo
       dispatch(cancelVariables());
     }
 
+    // Add system variables like __dashboard and __user
+    dispatch(addSystemTemplateVariables(dashboard));
+    // Start init transaction
     dispatch(variablesInitTransaction({ uid: dashboardUid }));
-
+    // Load all variables into redux store
     dispatch(initDashboardTemplating(dashboard.templating.list));
+    // Process all variable updates
     await dispatch(processVariables());
-    dispatch(completeDashboardTemplating(dashboard));
-
+    // Mark update as complete
     dispatch(variablesCompleteTransaction({ uid: dashboardUid }));
   } catch (err) {
     dispatch(notifyApp(createErrorNotification('Templating init failed', err)));


### PR DESCRIPTION
Fixes #25757 

System variables should be added before query variables are processed 