### PR TITLE
LDAP: users without org mappings are marked as disabled

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -427,7 +427,7 @@ func (server *Server) buildGrafanaUser(user *ldap.Entry) (*models.ExternalUserIn
 		}
 	}
 
-	// If there are groups org mappings configured but no matching mappings
+	// If there are group org mappings configured, but no matching mappings,
 	// the user will not be able to login and will be disabled
 	if len(server.Config.Groups) > 0 && len(extUser.OrgRoles) == 0 {
 		extUser.IsDisabled = true

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -427,6 +427,12 @@ func (server *Server) buildGrafanaUser(user *ldap.Entry) (*models.ExternalUserIn
 		}
 	}
 
+	// If there are groups org mappings configured but no matching mappings
+	// the user will not be able to login and will be disabled
+	if len(server.Config.Groups) > 0 && len(extUser.OrgRoles) == 0 {
+		extUser.IsDisabled = true
+	}
+
 	return extUser, nil
 }
 

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -113,7 +113,36 @@ func TestLDAPPrivateMethods(t *testing.T) {
 			result, err := server.serializeUsers(users)
 
 			So(err, ShouldBeNil)
+			So(result[0].IsDisabled, ShouldBeFalse)
 			So(result[0].Name, ShouldEqual, "Roel")
+		})
+
+		Convey("a user without matching groups should be marked as disabled", func() {
+			server := &Server{
+				Config: &ServerConfig{
+					Groups: []*GroupToOrgRole{{
+						GroupDN: "foo",
+						OrgId:   1,
+						OrgRole: models.ROLE_EDITOR,
+					}},
+				},
+				Connection: &MockConnection{},
+				log:        log.New("test-logger"),
+			}
+
+			entry := ldap.Entry{
+				DN: "dn",
+				Attributes: []*ldap.EntryAttribute{
+					{Name: "memberof", Values: []string{"admins"}},
+				},
+			}
+			users := []*ldap.Entry{&entry}
+
+			result, err := server.serializeUsers(users)
+
+			So(err, ShouldBeNil)
+			So(len(result), ShouldEqual, 1)
+			So(result[0].IsDisabled, ShouldBeTrue)
 		})
 	})
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR corrects the mapping of `extUser` so that it knows that a user that does not have org mappings (where org mappings are expected by the ldap config) is disabled.

This will make it so that LDAP Debug view will correctly show disabled for users that don't have any valid mappings and also make it so that the LDAP background sync disables users that no longer have valid org mappings.


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

