### PR TITLE
Provisioning: setting configuration files path per type

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -26,6 +26,17 @@ plugins = data/plugins
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = conf/provisioning
 
+#################################### Provisioning ###############################
+[provisioning]
+# folder that contains datasource provisioning config files, default is paths.provisioning/datasources
+datasources_path =
+# folder that contains dashboards provisioning config files, default is paths.provisioning/dashboards
+dashboards_path =
+# folder that contains alert notifications channels provisioning config files, default is paths.provisioning/notifiers
+notifiers_path =
+# folder that contains plugins provisioning config files, default is paths.provisioning/plugins
+plugins_path =
+
 #################################### Server ##############################
 [server]
 # Protocol (http, https, h2, socket)

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -28,13 +28,13 @@ provisioning = conf/provisioning
 
 #################################### Provisioning ###############################
 [provisioning]
-# folder that contains datasource provisioning config files, default is paths.provisioning/datasources
+# folder that contains data source provisioning config files, the default is paths.provisioning/datasources
 datasources_path =
-# folder that contains dashboards provisioning config files, default is paths.provisioning/dashboards
+# folder that contains dashboard provisioning config files, the default is paths.provisioning/dashboards
 dashboards_path =
-# folder that contains alert notifications channels provisioning config files, default is paths.provisioning/notifiers
+# folder that contains alert notification channel provisioning config files, the default is paths.provisioning/notifiers
 notifiers_path =
-# folder that contains plugins provisioning config files, default is paths.provisioning/plugins
+# folder that contains plugin provisioning config files, the default is paths.provisioning/plugins
 plugins_path =
 
 #################################### Server ##############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -28,13 +28,13 @@
 
 #################################### Provisioning ###############################
 [provisioning]
-# folder that contains datasource provisioning config files, default is paths.provisioning/datasources
+# folder that contains data source provisioning config files, the default is paths.provisioning/datasources
 ;datasources_path =
-# folder that contains dashboards provisioning config files, default is paths.provisioning/dashboards
+# folder that contains dashboard provisioning config files, the default is paths.provisioning/dashboards
 ;dashboards_path =
-# folder that contains alert notifications channels provisioning config files, default is paths.provisioning/notifiers
+# folder that contains alert notification channel provisioning config files, the default is paths.provisioning/notifiers
 ;notifiers_path =
-# folder that contains plugins provisioning config files, default is paths.provisioning/plugins
+# folder that contains plugin provisioning config files, the default is paths.provisioning/plugins
 ;plugins_path =
 
 #################################### Server ####################################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -26,6 +26,17 @@
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 ;provisioning = conf/provisioning
 
+#################################### Provisioning ###############################
+[provisioning]
+# folder that contains datasource provisioning config files, default is paths.provisioning/datasources
+;datasources_path =
+# folder that contains dashboards provisioning config files, default is paths.provisioning/dashboards
+;dashboards_path =
+# folder that contains alert notifications channels provisioning config files, default is paths.provisioning/notifiers
+;notifiers_path =
+# folder that contains plugins provisioning config files, default is paths.provisioning/plugins
+;plugins_path =
+
 #################################### Server ####################################
 [server]
 # Protocol (http, https, h2, socket)

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -2,7 +2,6 @@ package provisioning
 
 import (
 	"context"
-	"path"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -115,26 +114,22 @@ func (ps *provisioningServiceImpl) Run(ctx context.Context) error {
 }
 
 func (ps *provisioningServiceImpl) ProvisionDatasources() error {
-	datasourcePath := path.Join(ps.Cfg.ProvisioningPath, "datasources")
-	err := ps.provisionDatasources(datasourcePath)
+	err := ps.provisionDatasources(ps.Cfg.ProvisioningDatasourcesPath)
 	return errutil.Wrap("Datasource provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionPlugins() error {
-	appPath := path.Join(ps.Cfg.ProvisioningPath, "plugins")
-	err := ps.provisionPlugins(appPath)
+	err := ps.provisionPlugins(ps.Cfg.ProvisioningPluginsPath)
 	return errutil.Wrap("app provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionNotifications() error {
-	alertNotificationsPath := path.Join(ps.Cfg.ProvisioningPath, "notifiers")
-	err := ps.provisionNotifiers(alertNotificationsPath)
+	err := ps.provisionNotifiers(ps.Cfg.ProvisioningNotifiersPath)
 	return errutil.Wrap("Alert notification provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionDashboards() error {
-	dashboardPath := path.Join(ps.Cfg.ProvisioningPath, "dashboards")
-	dashProvisioner, err := ps.newDashboardProvisioner(dashboardPath)
+	dashProvisioner, err := ps.newDashboardProvisioner(ps.Cfg.ProvisioningDashboardsPath)
 	if err != nil {
 		return errutil.Wrap("Failed to create provisioner", err)
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -666,22 +666,22 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 		return err
 	}
 	provisioningConfig := iniFile.Section("provisioning")
-	provisioningDatasourcesPath, err := valueAsString(provisioningConfig, "datasources_path", path.Join(provisioning, "datasources"))
+	provisioningDatasourcesPath, err := valueAsString(provisioningConfig, "datasources_path", filepath.Join(provisioning, "datasources"))
 	if err != nil {
 		return err
 	}
 	cfg.ProvisioningDatasourcesPath = makeAbsolute(provisioningDatasourcesPath, HomePath)
-	provisioningDashboardsPath, err := valueAsString(provisioningConfig, "dashboards_path", path.Join(provisioning, "dashboards"))
+	provisioningDashboardsPath, err := valueAsString(provisioningConfig, "dashboards_path", filepath.Join(provisioning, "dashboards"))
 	if err != nil {
 		return err
 	}
 	cfg.ProvisioningDashboardsPath = makeAbsolute(provisioningDashboardsPath, HomePath)
-	provisioningNotifiersPath, err := valueAsString(provisioningConfig, "notifiers_path", path.Join(provisioning, "notifiers"))
+	provisioningNotifiersPath, err := valueAsString(provisioningConfig, "notifiers_path", filepath.Join(provisioning, "notifiers"))
 	if err != nil {
 		return err
 	}
 	cfg.ProvisioningNotifiersPath = makeAbsolute(provisioningNotifiersPath, HomePath)
-	provisioningPluginsPath, err := valueAsString(provisioningConfig, "plugins_path", path.Join(provisioning, "plugins"))
+	provisioningPluginsPath, err := valueAsString(provisioningConfig, "plugins_path", filepath.Join(provisioning, "plugins"))
 	if err != nil {
 		return err
 	}
@@ -1187,7 +1187,7 @@ func (cfg *Cfg) LogConfigSources() {
 	cfg.Logger.Info("Path Data", "path", cfg.DataPath)
 	cfg.Logger.Info("Path Logs", "path", cfg.LogsPath)
 	cfg.Logger.Info("Path Plugins", "path", PluginsPath)
-	cfg.Logger.Info("Path Datasources Provisioning", "path", cfg.ProvisioningDatasourcesPath)
+	cfg.Logger.Info("Path Data Sources Provisioning", "path", cfg.ProvisioningDatasourcesPath)
 	cfg.Logger.Info("Path Dashboards Provisioning", "path", cfg.ProvisioningDashboardsPath)
 	cfg.Logger.Info("Path Notifiers Provisioning", "path", cfg.ProvisioningNotifiersPath)
 	cfg.Logger.Info("Path Plugins Provisioning", "path", cfg.ProvisioningPluginsPath)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -239,10 +239,15 @@ type Cfg struct {
 	Packaging string
 
 	// Paths
-	ProvisioningPath   string
 	DataPath           string
 	LogsPath           string
 	BundledPluginsPath string
+
+	// Provisioning
+	ProvisioningDatasourcesPath string
+	ProvisioningDashboardsPath  string
+	ProvisioningNotifiersPath   string
+	ProvisioningPluginsPath     string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -655,11 +660,33 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	}
 	PluginsPath = makeAbsolute(plugins, HomePath)
 	cfg.BundledPluginsPath = makeAbsolute("plugins-bundled", HomePath)
+
 	provisioning, err := valueAsString(iniFile.Section("paths"), "provisioning", "")
 	if err != nil {
 		return err
 	}
-	cfg.ProvisioningPath = makeAbsolute(provisioning, HomePath)
+	provisioningConfig := iniFile.Section("provisioning")
+	provisioningDatasourcesPath, err := valueAsString(provisioningConfig, "datasources_path", path.Join(provisioning, "datasources"))
+	if err != nil {
+		return err
+	}
+	cfg.ProvisioningDatasourcesPath = makeAbsolute(provisioningDatasourcesPath, HomePath)
+	provisioningDashboardsPath, err := valueAsString(provisioningConfig, "dashboards_path", path.Join(provisioning, "dashboards"))
+	if err != nil {
+		return err
+	}
+	cfg.ProvisioningDashboardsPath = makeAbsolute(provisioningDashboardsPath, HomePath)
+	provisioningNotifiersPath, err := valueAsString(provisioningConfig, "notifiers_path", path.Join(provisioning, "notifiers"))
+	if err != nil {
+		return err
+	}
+	cfg.ProvisioningNotifiersPath = makeAbsolute(provisioningNotifiersPath, HomePath)
+	provisioningPluginsPath, err := valueAsString(provisioningConfig, "plugins_path", path.Join(provisioning, "plugins"))
+	if err != nil {
+		return err
+	}
+	cfg.ProvisioningPluginsPath = makeAbsolute(provisioningPluginsPath, HomePath)
+
 	server := iniFile.Section("server")
 	AppUrl, AppSubUrl, err = parseAppUrlAndSubUrl(server)
 	if err != nil {
@@ -1160,7 +1187,11 @@ func (cfg *Cfg) LogConfigSources() {
 	cfg.Logger.Info("Path Data", "path", cfg.DataPath)
 	cfg.Logger.Info("Path Logs", "path", cfg.LogsPath)
 	cfg.Logger.Info("Path Plugins", "path", PluginsPath)
-	cfg.Logger.Info("Path Provisioning", "path", cfg.ProvisioningPath)
+	cfg.Logger.Info("Path Datasources Provisioning", "path", cfg.ProvisioningDatasourcesPath)
+	cfg.Logger.Info("Path Dashboards Provisioning", "path", cfg.ProvisioningDashboardsPath)
+	cfg.Logger.Info("Path Notifiers Provisioning", "path", cfg.ProvisioningNotifiersPath)
+	cfg.Logger.Info("Path Plugins Provisioning", "path", cfg.ProvisioningPluginsPath)
+
 	cfg.Logger.Info("App mode " + Env)
 }
 

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -319,7 +319,8 @@ func TestLoadingSettings(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "/etc/absolute/path")
 			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../not/absolute/path")
-			// There are no entries in mock provisioning config for plugins and notifiers. They should be default values
+			// There are no entries in mock provisioning config for plugins and notifiers
+			// They should equal default values
 			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "../../conf/provisioning/notifiers")
 			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
 		})

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -298,7 +298,7 @@ func TestLoadingSettings(t *testing.T) {
 	})
 
 	Convey("Test reading provisioning config", t, func() {
-		Convey("By default it should use provisioning folder setting", func() {
+		Convey("By default it should use the provisioning folder setting", func() {
 			cfg := NewCfg()
 			err := cfg.Load(&CommandLineArgs{
 				HomePath: "../../",
@@ -310,7 +310,7 @@ func TestLoadingSettings(t *testing.T) {
 			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
 		})
 
-		Convey("With settings in provisioning section it should override defaults", func() {
+		Convey("With settings in the provisioning section it should override defaults", func() {
 			cfg := NewCfg()
 			err := cfg.Load(&CommandLineArgs{
 				HomePath: "../../",

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -298,27 +298,30 @@ func TestLoadingSettings(t *testing.T) {
 	})
 
 	Convey("Test reading provisioning config", t, func() {
+		homePath, err := filepath.Abs("../..")
+		So(err, ShouldBeNil)
+
 		Convey("By default it should use the provisioning folder setting", func() {
 			cfg := NewCfg()
 			err := cfg.Load(&CommandLineArgs{
-				HomePath: "../../",
+				HomePath: homePath,
 			})
 			So(err, ShouldBeNil)
-			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "../../conf/provisioning/dashboards")
-			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../conf/provisioning/datasources")
-			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "../../conf/provisioning/notifiers")
-			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
+			So(cfg.ProvisioningDashboardsPath, ShouldEqual, filepath.Join(homePath, "conf/provisioning/dashboards"))
+			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, filepath.Join(homePath, "conf/provisioning/datasources"))
+			So(cfg.ProvisioningNotifiersPath, ShouldEqual, filepath.Join(homePath, "conf/provisioning/notifiers"))
+			So(cfg.ProvisioningPluginsPath, ShouldEqual, filepath.Join(homePath, "conf/provisioning/plugins"))
 		})
 
 		Convey("With settings in the provisioning section it should override defaults", func() {
 			cfg := NewCfg()
 			err := cfg.Load(&CommandLineArgs{
-				HomePath: "../../",
+				HomePath: homePath,
 				Config:   filepath.Join(HomePath, "pkg/setting/testdata/provisioning.ini"),
 			})
 			So(err, ShouldBeNil)
 			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "/etc/absolute/path")
-			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../not/absolute/path")
+			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, filepath.Join(homePath, "not/absolute/path"))
 			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "/another/path")
 			So(cfg.ProvisioningPluginsPath, ShouldEqual, "/yet/another/path")
 		})

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -296,6 +296,34 @@ func TestLoadingSettings(t *testing.T) {
 			So(value, ShouldEqual, "")
 		})
 	})
+
+	Convey("Test reading provisioning config", t, func() {
+		Convey("By default it should use provisioning folder setting", func() {
+			cfg := NewCfg()
+			err := cfg.Load(&CommandLineArgs{
+				HomePath: "../../",
+			})
+			So(err, ShouldBeNil)
+			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "../../conf/provisioning/dashboards")
+			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../conf/provisioning/datasources")
+			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "../../conf/provisioning/notifiers")
+			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
+		})
+
+		Convey("With settings in provisioning section it should override defaults", func() {
+			cfg := NewCfg()
+			err := cfg.Load(&CommandLineArgs{
+				HomePath: "../../",
+				Config:   filepath.Join(HomePath, "pkg/setting/testdata/provisioning.ini"),
+			})
+			So(err, ShouldBeNil)
+			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "/etc/absolute/path")
+			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../not/absolute/path")
+			// There are no entries in mock provisioning config for plugins and notifiers. They should be default values
+			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "../../conf/provisioning/notifiers")
+			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
+		})
+	})
 }
 
 func TestParseAppUrlAndSubUrl(t *testing.T) {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -319,10 +319,8 @@ func TestLoadingSettings(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(cfg.ProvisioningDashboardsPath, ShouldEqual, "/etc/absolute/path")
 			So(cfg.ProvisioningDatasourcesPath, ShouldEqual, "../../not/absolute/path")
-			// There are no entries in mock provisioning config for plugins and notifiers
-			// They should equal default values
-			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "../../conf/provisioning/notifiers")
-			So(cfg.ProvisioningPluginsPath, ShouldEqual, "../../conf/provisioning/plugins")
+			So(cfg.ProvisioningNotifiersPath, ShouldEqual, "/another/path")
+			So(cfg.ProvisioningPluginsPath, ShouldEqual, "/yet/another/path")
 		})
 	})
 }

--- a/pkg/setting/testdata/provisioning.ini
+++ b/pkg/setting/testdata/provisioning.ini
@@ -1,0 +1,3 @@
+[provisioning]
+datasources_path = not/absolute/path
+dashboards_path = /etc/absolute/path

--- a/pkg/setting/testdata/provisioning.ini
+++ b/pkg/setting/testdata/provisioning.ini
@@ -1,3 +1,5 @@
 [provisioning]
 datasources_path = not/absolute/path
 dashboards_path = /etc/absolute/path
+notifiers_path = /another/path
+plugins_path = /yet/another/path


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to specify different paths for different types of provisioning configuration files (datasources, dashboards, etc.) via grafana config.

**Which issue(s) this PR fixes**:
Fixes #24631
