### PR TITLE
Chore: use Wrap for all admin API

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func AdminGetSettings(c *models.ReqContext) {
+func AdminGetSettings(c *models.ReqContext) Response {
 	settings := make(map[string]interface{})
 
 	for _, section := range setting.Raw.Sections() {
@@ -35,16 +35,15 @@ func AdminGetSettings(c *models.ReqContext) {
 		}
 	}
 
-	c.JSON(200, settings)
+	return JSON(200, settings)
 }
 
-func AdminGetStats(c *models.ReqContext) {
+func AdminGetStats(c *models.ReqContext) Response {
 	statsQuery := models.GetAdminStatsQuery{}
 
 	if err := bus.Dispatch(&statsQuery); err != nil {
-		c.JsonApiErr(500, "Failed to get admin stats from database", err)
-		return
+		return Error(500, "Failed to get admin stats from database", err)
 	}
 
-	c.JSON(200, statsQuery.Result)
+	return JSON(200, statsQuery.Result)
 }

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) {
+func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) Response {
 	cmd := models.CreateUserCommand{
 		Login:    form.Login,
 		Email:    form.Email,
@@ -20,24 +20,20 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) {
 	if len(cmd.Login) == 0 {
 		cmd.Login = cmd.Email
 		if len(cmd.Login) == 0 {
-			c.JsonApiErr(400, "Validation error, need specify either username or email", nil)
-			return
+			return Error(400, "Validation error, need specify either username or email", nil)
 		}
 	}
 
 	if len(cmd.Password) < 4 {
-		c.JsonApiErr(400, "Password is missing or too short", nil)
-		return
+		return Error(400, "Password is missing or too short", nil)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == models.ErrOrgNotFound {
-			c.JsonApiErr(400, models.ErrOrgNotFound.Error(), nil)
-			return
+			return Error(400, models.ErrOrgNotFound.Error(), nil)
 		}
 
-		c.JsonApiErr(500, "failed to create user", err)
-		return
+		return Error(500, "failed to create user", err)
 	}
 
 	metrics.MApiAdminUserCreate.Inc()
@@ -49,28 +45,25 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) {
 		Id:      user.Id,
 	}
 
-	c.JSON(200, result)
+	return JSON(200, result)
 }
 
-func AdminUpdateUserPassword(c *models.ReqContext, form dtos.AdminUpdateUserPasswordForm) {
+func AdminUpdateUserPassword(c *models.ReqContext, form dtos.AdminUpdateUserPasswordForm) Response {
 	userID := c.ParamsInt64(":id")
 
 	if len(form.Password) < 4 {
-		c.JsonApiErr(400, "New password too short", nil)
-		return
+		return Error(400, "New password too short", nil)
 	}
 
 	userQuery := models.GetUserByIdQuery{Id: userID}
 
 	if err := bus.Dispatch(&userQuery); err != nil {
-		c.JsonApiErr(500, "Could not read user from database", err)
-		return
+		return Error(500, "Could not read user from database", err)
 	}
 
 	passwordHashed, err := util.EncodePassword(form.Password, userQuery.Result.Salt)
 	if err != nil {
-		c.JsonApiErr(500, "Could not encode password", err)
-		return
+		return Error(500, "Could not encode password", err)
 	}
 
 	cmd := models.ChangeUserPasswordCommand{
@@ -79,15 +72,14 @@ func AdminUpdateUserPassword(c *models.ReqContext, form dtos.AdminUpdateUserPass
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		c.JsonApiErr(500, "Failed to update user password", err)
-		return
+		return Error(500, "Failed to update user password", err)
 	}
 
-	c.JsonOK("User password updated")
+	return Success("User password updated")
 }
 
 // PUT /api/admin/users/:id/permissions
-func AdminUpdateUserPermissions(c *models.ReqContext, form dtos.AdminUpdateUserPermissionsForm) {
+func AdminUpdateUserPermissions(c *models.ReqContext, form dtos.AdminUpdateUserPermissionsForm) Response {
 	userID := c.ParamsInt64(":id")
 
 	cmd := models.UpdateUserPermissionsCommand{
@@ -97,32 +89,28 @@ func AdminUpdateUserPermissions(c *models.ReqContext, form dtos.AdminUpdateUserP
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == models.ErrLastGrafanaAdmin {
-			c.JsonApiErr(400, models.ErrLastGrafanaAdmin.Error(), nil)
-			return
+			return Error(400, models.ErrLastGrafanaAdmin.Error(), nil)
 		}
 
-		c.JsonApiErr(500, "Failed to update user permissions", err)
-		return
+		return Error(500, "Failed to update user permissions", err)
 	}
 
-	c.JsonOK("User permissions updated")
+	return Success("User permissions updated")
 }
 
-func AdminDeleteUser(c *models.ReqContext) {
+func AdminDeleteUser(c *models.ReqContext) Response {
 	userID := c.ParamsInt64(":id")
 
 	cmd := models.DeleteUserCommand{UserId: userID}
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == models.ErrUserNotFound {
-			c.JsonApiErr(404, models.ErrUserNotFound.Error(), nil)
-			return
+			return Error(404, models.ErrUserNotFound.Error(), nil)
 		}
-		c.JsonApiErr(500, "Failed to delete user", err)
-		return
+		return Error(500, "Failed to delete user", err)
 	}
 
-	c.JsonOK("User deleted")
+	return Success("User deleted")
 }
 
 // POST /api/admin/users/:id/disable

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -266,13 +266,13 @@ func putAdminScenario(desc string, url string, routePattern string, role models.
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = Wrap(func(c *models.ReqContext) {
+		sc.defaultHandler = Wrap(func(c *models.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 			sc.context.OrgId = TestOrgID
 			sc.context.OrgRole = role
 
-			AdminUpdateUserPermissions(c, cmd)
+			return AdminUpdateUserPermissions(c, cmd)
 		})
 
 		sc.m.Put(routePattern, sc.defaultHandler)
@@ -396,11 +396,11 @@ func adminDeleteUserScenario(desc string, url string, routePattern string, fn sc
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = Wrap(func(c *models.ReqContext) {
+		sc.defaultHandler = Wrap(func(c *models.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 
-			AdminDeleteUser(c)
+			return AdminDeleteUser(c)
 		})
 
 		sc.m.Delete(routePattern, sc.defaultHandler)
@@ -414,11 +414,11 @@ func adminCreateUserScenario(desc string, url string, routePattern string, cmd d
 		defer bus.ClearBusHandlers()
 
 		sc := setupScenarioContext(url)
-		sc.defaultHandler = Wrap(func(c *models.ReqContext) {
+		sc.defaultHandler = Wrap(func(c *models.ReqContext) Response {
 			sc.context = c
 			sc.context.UserId = TestUserID
 
-			AdminCreateUser(c, cmd)
+			return AdminCreateUser(c, cmd)
 		})
 
 		sc.m.Post(routePattern, sc.defaultHandler)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -387,16 +387,16 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// admin api
 	r.Group("/api/admin", func(adminRoute routing.RouteRegister) {
-		adminRoute.Get("/settings", AdminGetSettings)
-		adminRoute.Post("/users", bind(dtos.AdminCreateUserForm{}), AdminCreateUser)
-		adminRoute.Put("/users/:id/password", bind(dtos.AdminUpdateUserPasswordForm{}), AdminUpdateUserPassword)
-		adminRoute.Put("/users/:id/permissions", bind(dtos.AdminUpdateUserPermissionsForm{}), AdminUpdateUserPermissions)
-		adminRoute.Delete("/users/:id", AdminDeleteUser)
+		adminRoute.Get("/settings", Wrap(AdminGetSettings))
+		adminRoute.Post("/users", bind(dtos.AdminCreateUserForm{}), Wrap(AdminCreateUser))
+		adminRoute.Put("/users/:id/password", bind(dtos.AdminUpdateUserPasswordForm{}), Wrap(AdminUpdateUserPassword))
+		adminRoute.Put("/users/:id/permissions", bind(dtos.AdminUpdateUserPermissionsForm{}), Wrap(AdminUpdateUserPermissions))
+		adminRoute.Delete("/users/:id", Wrap(AdminDeleteUser))
 		adminRoute.Post("/users/:id/disable", Wrap(hs.AdminDisableUser))
 		adminRoute.Post("/users/:id/enable", Wrap(AdminEnableUser))
 		adminRoute.Get("/users/:id/quotas", Wrap(GetUserQuotas))
 		adminRoute.Put("/users/:id/quotas/:target", bind(models.UpdateUserQuotaCmd{}), Wrap(UpdateUserQuota))
-		adminRoute.Get("/stats", AdminGetStats)
+		adminRoute.Get("/stats", Wrap(AdminGetStats))
 		adminRoute.Post("/pause-all-alerts", bind(dtos.PauseAllAlertsCommand{}), Wrap(PauseAllAlerts))
 
 		adminRoute.Post("/users/:id/logout", Wrap(hs.AdminLogoutUser))


### PR DESCRIPTION
**What this PR does / why we need it**:
Standardize the API to use the `Wrap` function for all `/api/admin` endpoints.

**Special notes for your reviewer**:
Having a standardized API makes it easier to add feature across the whole API like auditing.
