### PR TITLE
TextPanel: Remove semicolon in markup

### DIFF
--- a/public/app/plugins/panel/text/TextPanel.tsx
+++ b/public/app/plugins/panel/text/TextPanel.tsx
@@ -82,7 +82,7 @@ export class TextPanel extends PureComponent<Props, State> {
     const styles = getStyles();
     return (
       <CustomScrollbar autoHeightMin="100%">
-        <DangerouslySetHtmlContent html={html} className={cx('markdown-html', styles.content)} />;
+        <DangerouslySetHtmlContent html={html} className={cx('markdown-html', styles.content)} />
       </CustomScrollbar>
     );
   }


### PR DESCRIPTION
Accidentally added in https://github.com/grafana/grafana/pull/26612 (which is marked for 7.1.2 so this needs to also be)