### PR TITLE
Annotations: Ignore cancelled annotation query errors

### DIFF
--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -59,9 +59,14 @@ export class AnnotationsSrv {
         };
       })
       .catch(err => {
+        if (err.cancelled) {
+          return [];
+        }
+
         if (!err.message && err.data && err.data.message) {
           err.message = err.data.message;
         }
+
         console.error('AnnotationSrv.query error', err);
         appEvents.emit(AppEvents.alertError, ['Annotation Query Failed', err.message || err]);
         return [];


### PR DESCRIPTION
Fixes #26667 

After the backendSrv refactoring and fetch / observable PR https://github.com/grafana/grafana/pull/25746 I changed so cancellations are errors so that the caller can now a cancellation from normal response