### PR TITLE
API: Return ID of the deleted resource for dashboard, datasource and folder DELETE endpoints

### DIFF
--- a/docs/sources/http_api/dashboard.md
+++ b/docs/sources/http_api/dashboard.md
@@ -332,7 +332,11 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 
-{"title": "Production Overview"}
+{
+  "title": "Production Overview",
+  "message": "Dashboard Production Overview deleted",
+  "id": 2
+}
 ```
 
 Status Codes:
@@ -506,7 +510,11 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 
-{"title": "Production Overview"}
+{
+  "title": "Production Overview",
+  "message": "Dashboard Production Overview deleted",
+  "id": 2
+}
 ```
 
 Status Codes:

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -419,7 +419,10 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 
-{"message":"Data source deleted"}
+{
+  "message":"Data source deleted",
+  "id": 1
+}
 ```
 
 ## Data source proxy calls

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -264,7 +264,8 @@ HTTP/1.1 200
 Content-Type: application/json
 
 {
-  "message":"Folder deleted"
+  "message":"Folder deleted",
+  "id": 2
 }
 ```
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -210,6 +210,7 @@ func deleteDashboard(c *models.ReqContext) Response {
 	return JSON(200, util.DynMap{
 		"title":   dash.Title,
 		"message": fmt.Sprintf("Dashboard %s deleted", dash.Title),
+		"id":      dash.Id,
 	})
 }
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -127,7 +127,10 @@ func DeleteDataSourceByName(c *models.ReqContext) Response {
 		return Error(500, "Failed to delete datasource", err)
 	}
 
-	return Success("Data source deleted")
+	return JSON(200, util.DynMap{
+		"message": "Data source deleted",
+		"id":      getCmd.Result.Id,
+	})
 }
 
 func validateURL(tp string, u string) Response {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -93,6 +93,7 @@ func DeleteFolder(c *models.ReqContext) Response {
 	return JSON(200, util.DynMap{
 		"title":   f.Title,
 		"message": fmt.Sprintf("Folder %s deleted", f.Title),
+		"id":      f.Id,
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enrich following endpoints to return the ID of the deleted resource:
- `DELETE /api/datasources/name/:datasourceName`
- `DELETE /api/dashboards/uid/:uid`
- `DELETE /api/dashboards/db/:slug`
- `DELETE /api/folders/:uid`

**Special notes for your reviewer**:
It makes it easier to have access to the resource ID for auditing without any breaking change or important information leakage. 

