### PR TITLE
ThemeContext: Fix useStyles return type

### DIFF
--- a/packages/grafana-ui/src/themes/ThemeContext.tsx
+++ b/packages/grafana-ui/src/themes/ThemeContext.tsx
@@ -51,7 +51,7 @@ export function useTheme(): GrafanaTheme {
 export function useStyles<T>(getStyles: (theme: GrafanaTheme) => T) {
   const theme = useTheme();
 
-  let memoizedStyleCreator = memoizedStyleCreators.get(getStyles);
+  let memoizedStyleCreator = memoizedStyleCreators.get(getStyles) as typeof getStyles;
   if (!memoizedStyleCreator) {
     memoizedStyleCreator = stylesFactory(getStyles);
     memoizedStyleCreators.set(getStyles, memoizedStyleCreator);


### PR DESCRIPTION
Used a type override in my project, so I didn't notice this. :facepalm: 

Autocomplete still didn't work correctly as originally intended [here](https://github.com/grafana/grafana/pull/26056) because `useStyles` still returned `any`.
