### PR TITLE
Explore: Run queries on Metrics to Logs transition

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -156,6 +156,11 @@ export function changeDatasource(
     }
 
     await dispatch(loadDatasource(exploreId, newDataSourceInstance, orgId));
+
+    // Exception - we only want to run queries on data source change, if the queries were imported
+    if (options?.importQueries) {
+      dispatch(runQueries(exploreId));
+    }
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have removed running of [queries on data source change](https://github.com/grafana/grafana/pull/26033/files). However, this means that when using import queries, these are not run. This PR adds exception - to run query if we are importing queries.

One of the other solution that I was considering was to add  `shouldRunQuery` props to `loadDatasource` function, but I feel that that solution would be more confusing - we would be adding a new functionality to `loadDatasource` that I don't think belongs there. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/26674
