### PR TITLE
Dashboard: Add AutoMinMaxPerField transformer

### DIFF
--- a/packages/grafana-data/src/transformations/transformers.ts
+++ b/packages/grafana-data/src/transformations/transformers.ts
@@ -13,6 +13,7 @@ import { renameFieldsTransformer } from './transformers/rename';
 import { labelsToFieldsTransformer } from './transformers/labelsToFields';
 import { ensureColumnsTransformer } from './transformers/ensureColumns';
 import { mergeTransformer } from './transformers/merge';
+import { autoMinMaxPerFieldTransformer } from './transformers/autoMinMaxPerField';
 
 export const standardTransformers = {
   noopTransformer,
@@ -31,4 +32,5 @@ export const standardTransformers = {
   labelsToFieldsTransformer,
   ensureColumnsTransformer,
   mergeTransformer,
+  autoMinMaxPerFieldTransformer,
 };

--- a/packages/grafana-data/src/transformations/transformers/autoMinMaxPerField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/autoMinMaxPerField.test.ts
@@ -1,0 +1,55 @@
+import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
+import { DataTransformerConfig, FieldType, FieldConfig } from '../../types';
+import { DataTransformerID } from './ids';
+import { toDataFrame } from '../../dataframe';
+import { transformDataFrame } from '../transformDataFrame';
+import { autoMinMaxPerFieldTransformer, AutoMinMaxPerFieldTransformerOptions } from './autoMinMaxPerField';
+
+describe('Set min/max configs per field', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([autoMinMaxPerFieldTransformer]);
+  });
+
+  it('sets min/max values for fields independently', () => {
+    const cfg: DataTransformerConfig<AutoMinMaxPerFieldTransformerOptions> = {
+      id: DataTransformerID.autoMinMaxPerField,
+      options: {},
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'smallField', type: FieldType.number, values: [0.1, 0.2, 0.3] },
+        { name: 'largeFields', type: FieldType.number, values: [101, 102, 103] },
+      ],
+    });
+
+    const result = transformDataFrame([cfg], [seriesA]);
+    const expectedConfigs: FieldConfig[] = [
+      { min: 0.1, max: 0.3 },
+      { min: 101, max: 103 },
+    ];
+
+    expect(result[0].fields.map(field => field.config)).toEqual(expectedConfigs);
+  });
+
+  it('ignores fields that are not numbers', () => {
+    const cfg: DataTransformerConfig<AutoMinMaxPerFieldTransformerOptions> = {
+      id: DataTransformerID.autoMinMaxPerField,
+      options: {},
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'fieldsA', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'fieldsX', type: FieldType.string, values: ['x', 'y', 'z'] },
+      ],
+    });
+
+    const result = transformDataFrame([cfg], [seriesA]);
+    const expectedConfigs: FieldConfig[] = [{}, {}];
+
+    expect(result[0].fields.map(field => field.config)).toEqual(expectedConfigs);
+  });
+});

--- a/packages/grafana-data/src/transformations/transformers/autoMinMaxPerField.ts
+++ b/packages/grafana-data/src/transformations/transformers/autoMinMaxPerField.ts
@@ -1,0 +1,46 @@
+import { DataTransformerID } from './ids';
+import { DataTransformerInfo } from '../../types/transformations';
+import { DataFrame, Field, FieldType, FieldConfig } from '../../types/dataFrame';
+import { ReducerID, reduceField } from '../../transformations';
+import isNumber from 'lodash/isNumber';
+
+export interface AutoMinMaxPerFieldTransformerOptions {}
+
+export const autoMinMaxPerFieldTransformer: DataTransformerInfo<AutoMinMaxPerFieldTransformerOptions> = {
+  id: DataTransformerID.autoMinMaxPerField,
+  name: 'Calculate min/max per field',
+  description: `Calculate min/max for each field rather than for the complete set of data.
+                Useful for cells in bar gauges.`,
+  defaultOptions: {},
+  transformer: (options: AutoMinMaxPerFieldTransformerOptions) => {
+    const reducers = [ReducerID.min, ReducerID.max];
+    return (data: DataFrame[]) => {
+      console.log(data);
+      return data.map((frame, _) => {
+        const fields: Field[] = frame.fields.map(field => {
+          if (field.type === FieldType.number && field.values) {
+            console.log(field);
+            console.log(field.config);
+            const config: FieldConfig = { ...field.config };
+            console.log(config);
+            if (!isNumber(config.min) || !isNumber(config.max)) {
+              const stats = reduceField({ field, reducers });
+              config.min = stats[ReducerID.min];
+              config.max = stats[ReducerID.max];
+            }
+            return {
+              ...field,
+              config,
+            };
+          } else {
+            return field;
+          }
+        });
+        return {
+          ...frame,
+          fields,
+        };
+      });
+    };
+  },
+};

--- a/packages/grafana-data/src/transformations/transformers/ids.ts
+++ b/packages/grafana-data/src/transformations/transformers/ids.ts
@@ -17,4 +17,5 @@ export enum DataTransformerID {
   filterByRefId = 'filterByRefId',
   noop = 'noop',
   ensureColumns = 'ensureColumns',
+  autoMinMaxPerField = 'autoMinMaxPerField',
 }

--- a/public/app/core/components/TransformersUI/AutoMinMaxPerFieldTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/AutoMinMaxPerFieldTransformerEditor.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
+import { AutoMinMaxPerFieldTransformerOptions } from '@grafana/data/src/transformations/transformers/autoMinMaxPerField';
+
+export const AutoMinMaxPerFieldTransformerEditor: React.FC<TransformerUIProps<
+  AutoMinMaxPerFieldTransformerOptions
+>> = ({ input, options, onChange }) => {
+  return null;
+};
+
+export const autoMinMaxPerFieldTransformerRegistryItem: TransformerRegistyItem<AutoMinMaxPerFieldTransformerOptions> = {
+  id: DataTransformerID.autoMinMaxPerField,
+  editor: AutoMinMaxPerFieldTransformerEditor,
+  transformation: standardTransformers.autoMinMaxPerFieldTransformer,
+  name: 'Calculate min/max per field',
+  description: `Calculate min/max per field instead of globally.
+                Useful for bar gauge table cells.`,
+};

--- a/public/app/core/utils/standardTransformers.ts
+++ b/public/app/core/utils/standardTransformers.ts
@@ -7,6 +7,7 @@ import { seriesToFieldsTransformerRegistryItem } from '../components/Transformer
 import { calculateFieldTransformRegistryItem } from '../components/TransformersUI/CalculateFieldTransformerEditor';
 import { labelsToFieldsTransformerRegistryItem } from '../components/TransformersUI/LabelsToFieldsTransformerEditor';
 import { mergeTransformerRegistryItem } from '../components/TransformersUI/MergeTransformerEditor';
+import { autoMinMaxPerFieldTransformerRegistryItem } from '../components/TransformersUI/AutoMinMaxPerFieldTransformerEditor';
 import { seriesToRowsTransformerRegistryItem } from '../components/TransformersUI/SeriesToRowsTransformerEditor';
 
 export const getStandardTransformers = (): Array<TransformerRegistyItem<any>> => {
@@ -20,5 +21,6 @@ export const getStandardTransformers = (): Array<TransformerRegistyItem<any>> =>
     calculateFieldTransformRegistryItem,
     labelsToFieldsTransformerRegistryItem,
     mergeTransformerRegistryItem,
+    autoMinMaxPerFieldTransformerRegistryItem,
   ];
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR introduces a new transformer called `AutoMinMaxPerField` which configures each fields min/max configs based on just its own values. My motivation for this is explained in #26383. Basically, table cell bar gauges all share the same min/max when calculated automatically, but this is often not desirable.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26383

**Special notes for your reviewer**:

Keeping this as a draft because I'm not sure whether this is the best way to implement this functionality. This approach means that min/max can be set from the transformations panel, the field panel, and the overrides panel. I see a couple issues with this:

1) Having this configuration in a third location makes it hard to discover.
2) It is not obvious how configurations in these three locations will interact. From observation, it appears that adding this transformation makes the configuration under "Field" useless, though the "Overrides" configuration will still be applied (with auto min/max using the whole DataFrame for calculations).

 It may be better to create a new standard configuration called `AutoMinMaxMode` that can be set to either `Global` or `Field`. This keeps the configuration in the same spot, and avoids any new confusion about how the configs will interact.


