### PR TITLE
Update plugin metadata schema

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -47,10 +47,11 @@ Plugin dependencies.
 
 ### Properties
 
-| Property         | Type     | Required | Description                                                                                                      |
-|------------------|----------|----------|------------------------------------------------------------------------------------------------------------------|
-| `grafanaVersion` | string   | **Yes**  | Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x. |
-| `plugins`        | string[] | No       | An array of required plugins on which this plugin depends.                                                       |
+| Property            | Type     | Required | Description                                                                                                                   |
+|---------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------|
+| `grafanaDependency` | string   | **Yes**  | Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later                     |
+| `grafanaVersion`    | string   | No       | (Deprecated) Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x. |
+| `plugins`           | string[] | No       | An array of required plugins on which this plugin depends.                                                                    |
 
 ## includes
 

--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -49,7 +49,7 @@ Plugin dependencies.
 
 | Property            | Type     | Required | Description                                                                                                                   |
 |---------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------|
-| `grafanaDependency` | string   | **Yes**  | Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later                     |
+| `grafanaDependency` | string   | **Yes**  | Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later.                     |
 | `grafanaVersion`    | string   | No       | (Deprecated) Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x. |
 | `plugins`           | string[] | No       | An array of required plugins on which this plugin depends.                                                                    |
 
@@ -183,5 +183,4 @@ For data source plugins. Parameters for the token authentication request.
 | `client_secret` | string | No       | For data source plugins. OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob. |
 | `grant_type`    | string | No       | For data source plugins. OAuth grant type.                                                                         |
 | `resource`      | string | No       | For data source plugins. OAuth resource.                                                                           |
-
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -10,7 +10,7 @@
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin id has to follow the naming conventions.",
-      "pattern": "^[0-9a-z\\-]+$"
+      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)?(app|panel|datasource)$"
     },
     "type": {
       "type": "string",
@@ -117,13 +117,18 @@
     "dependencies": {
       "type": "object",
       "description": "Plugin dependencies.",
-      "required": ["grafanaVersion"],
+      "required": ["grafanaDependency"],
       "additionalProperties": false,
       "properties": {
         "grafanaVersion": {
           "type": "string",
-          "description": "Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x.",
-          "pattern": "^([0-9x]+\\.[0-9x]+\\.*[0-9x]*\\s*)+$"
+          "description": "(Deprecated) Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x.",
+          "pattern": "^([0-9]+)(\\.[0-9x]+)?(\\.[0-9x])?$"
+        },
+        "grafanaDependency": {
+          "type": "string",
+          "description": "Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later",
+          "pattern": "^(>=|<|>|<=)?([0-9]+)(\\.[0-9]+)?(\\.[0-9])?$"
         },
         "plugins": {
           "type": "array",
@@ -270,8 +275,7 @@
           },
           "url": {
             "type": "string",
-            "description": "For data source plugins. Route URL is where the request is proxied to.",
-            "format": "uri"
+            "description": "For data source plugins. Route URL is where the request is proxied to."
           },
           "reqSignedIn": {
             "type": "boolean"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds the `grafanaDependency` property to the plugin metadata schema. 
- Deprecates `grafanaVersion`.
- Relaxes the constraint for the route URL from a `uri` to any string value to account for variable interpolation in url.