### PR TITLE
OAuth: Refactor user syncing

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -187,7 +187,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 
 	metrics.MApiLoginOAuth.Inc()
 
-	if redirectTo, _ := url.QueryUnescape(ctx.GetCookie("redirect_to")); len(redirectTo) > 0 {
+	if redirectTo, err := url.QueryUnescape(ctx.GetCookie("redirect_to")); err == nil && len(redirectTo) > 0 {
 		if err := hs.ValidateRedirectTo(redirectTo); err == nil {
 			middleware.DeleteCookie(ctx.Resp, "redirect_to", hs.CookieOptionsFromCfg)
 			ctx.Redirect(redirectTo)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -96,7 +96,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 		return
 	}
 
-	// handle call back
+	// handle callback
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
@@ -125,6 +125,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 			ctx.Handle(500, "login.OAuthLogin(Failed to setup TlsClientCa)", nil)
 			return
 		}
+
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 
@@ -172,55 +173,14 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 		return
 	}
 
-	extUser := &models.ExternalUserInfo{
-		AuthModule: "oauth_" + name,
-		OAuthToken: token,
-		AuthId:     userInfo.Id,
-		Name:       userInfo.Name,
-		Login:      userInfo.Login,
-		Email:      userInfo.Email,
-		OrgRoles:   map[int64]models.RoleType{},
-		Groups:     userInfo.Groups,
-	}
-
-	if userInfo.Role != "" {
-		rt := models.RoleType(userInfo.Role)
-		if rt.IsValid() {
-			// The user will be assigned a role in either the auto-assigned organization or in the default one
-			var orgID int64
-			if setting.AutoAssignOrg && setting.AutoAssignOrgId > 0 {
-				orgID = int64(setting.AutoAssignOrgId)
-			} else {
-				orgID = int64(1)
-			}
-			extUser.OrgRoles[orgID] = rt
-		}
-	}
-
-	// add/update user in grafana
-	cmd := &models.UpsertUserCommand{
-		ReqContext:    ctx,
-		ExternalUser:  extUser,
-		SignupAllowed: connect.IsSignupAllowed(),
-	}
-
-	err = bus.Dispatch(cmd)
+	user, err := syncUser(ctx, token, userInfo, name, connect)
 	if err != nil {
 		hs.redirectWithError(ctx, err)
 		return
 	}
 
-	// Do not expose disabled status,
-	// just show incorrect user credentials error (see #17947)
-	if cmd.Result.IsDisabled {
-		oauthLogger.Warn("User is disabled", "user", cmd.Result.Login)
-		hs.redirectWithError(ctx, login.ErrInvalidCredentials)
-		return
-	}
-
 	// login
-	err = hs.loginUserWithUser(cmd.Result, ctx)
-	if err != nil {
+	if err := hs.loginUserWithUser(user, ctx); err != nil {
 		hs.redirectWithError(ctx, err)
 		return
 	}
@@ -237,6 +197,59 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	}
 
 	ctx.Redirect(setting.AppSubUrl + "/")
+}
+
+// syncUser syncs a Grafana user profile with the corresponding OAuth profile.
+func syncUser(ctx *models.ReqContext, token *oauth2.Token, userInfo *social.BasicUserInfo, name string,
+	connect social.SocialConnector) (*models.User, error) {
+	oauthLogger.Debug("Syncing Grafana user with corresponding OAuth profile")
+	extUser := &models.ExternalUserInfo{
+		AuthModule: fmt.Sprintf("oauth_%s", name),
+		OAuthToken: token,
+		AuthId:     userInfo.Id,
+		Name:       userInfo.Name,
+		Login:      userInfo.Login,
+		Email:      userInfo.Email,
+		OrgRoles:   map[int64]models.RoleType{},
+		Groups:     userInfo.Groups,
+	}
+
+	if userInfo.Role != "" {
+		rt := models.RoleType(userInfo.Role)
+		if rt.IsValid() {
+			// The user will be assigned a role in either the auto-assigned organization or in the default one
+			var orgID int64
+			if setting.AutoAssignOrg && setting.AutoAssignOrgId > 0 {
+				orgID = int64(setting.AutoAssignOrgId)
+				logger.Debug("The user has a role assignment and organization membership is auto-assigned",
+					"role", userInfo.Role, "orgId", orgID)
+			} else {
+				orgID = int64(1)
+				logger.Debug("The user has a role assignment and organization membership is not auto-assigned",
+					"role", userInfo.Role, "orgId", orgID)
+			}
+			extUser.OrgRoles[orgID] = rt
+		}
+	}
+
+	// add/update user in Grafana
+	cmd := &models.UpsertUserCommand{
+		ReqContext:    ctx,
+		ExternalUser:  extUser,
+		SignupAllowed: connect.IsSignupAllowed(),
+	}
+	if err := bus.Dispatch(cmd); err != nil {
+		return nil, err
+	}
+
+	// Do not expose disabled status,
+	// just show incorrect user credentials error (see #17947)
+	if cmd.Result.IsDisabled {
+		oauthLogger.Warn("User is disabled", "user", cmd.Result.Login)
+		return nil, login.ErrInvalidCredentials
+	}
+
+	return cmd.Result, nil
 }
 
 func hashStatecode(code, seed string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor user syncing in OAuth logic, just in order to make the logic less complex and easier to follow/verify. Realized this would be useful when reviewing a PR that augments this logic.

Also adding some debug logs, to help in diagnosing issues.