### PR TITLE
CloudWatch Logs: Move query response stats to appropriate FrameMeta property

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -489,10 +489,19 @@ func TestQuery_GetQueryResults(t *testing.T) {
 	expFrame.Meta = &data.FrameMeta{
 		Custom: map[string]interface{}{
 			"Status": "Complete",
-			"Statistics": cloudwatchlogs.QueryStatistics{
-				BytesScanned:   aws.Float64(512),
-				RecordsMatched: aws.Float64(256),
-				RecordsScanned: aws.Float64(1024),
+		},
+		Stats: []data.QueryStat{
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Bytes scanned"},
+				Value:       512,
+			},
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Records scanned"},
+				Value:       1024,
+			},
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Records matched"},
+				Value:       256,
 			},
 		},
 		PreferredVisualization: "logs",

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -95,24 +95,45 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 	}
 
 	frame := data.NewFrame("CloudWatchLogsResponse", newFields...)
+
+	bytesScanned := -1.0
+	recordsScanned := -1.0
+	recordsMatched := -1.0
+	if response != nil && response.Statistics != nil {
+		if response.Statistics.BytesScanned != nil {
+			bytesScanned = *response.Statistics.BytesScanned
+		}
+
+		if response.Statistics.RecordsScanned != nil {
+			recordsScanned = *response.Statistics.RecordsScanned
+		}
+
+		if response.Statistics.RecordsMatched != nil {
+			recordsMatched = *response.Statistics.RecordsMatched
+		}
+	}
+
 	frame.Meta = &data.FrameMeta{
 		Stats: []data.QueryStat{
 			{
 				FieldConfig: data.FieldConfig{DisplayName: "Bytes scanned"},
-				Value:       *response.Statistics.BytesScanned,
+				Value:       bytesScanned,
 			},
 			{
 				FieldConfig: data.FieldConfig{DisplayName: "Records scanned"},
-				Value:       *response.Statistics.RecordsScanned,
+				Value:       recordsScanned,
 			},
 			{
 				FieldConfig: data.FieldConfig{DisplayName: "Records matched"},
-				Value:       *response.Statistics.RecordsMatched,
+				Value:       recordsMatched,
 			},
 		},
-		Custom: map[string]interface{}{
+	}
+
+	if response != nil && response.Status != nil {
+		frame.Meta.Custom = map[string]interface{}{
 			"Status": *response.Status,
-		},
+		}
 	}
 
 	// Results aren't guaranteed to come ordered by time (ascending), so we need to sort

--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -96,9 +96,22 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput) (*d
 
 	frame := data.NewFrame("CloudWatchLogsResponse", newFields...)
 	frame.Meta = &data.FrameMeta{
+		Stats: []data.QueryStat{
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Bytes scanned"},
+				Value:       *response.Statistics.BytesScanned,
+			},
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Records scanned"},
+				Value:       *response.Statistics.RecordsScanned,
+			},
+			{
+				FieldConfig: data.FieldConfig{DisplayName: "Records matched"},
+				Value:       *response.Statistics.RecordsMatched,
+			},
+		},
 		Custom: map[string]interface{}{
-			"Status":     *response.Status,
-			"Statistics": *response.Statistics,
+			"Status": *response.Status,
 		},
 	}
 

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -195,10 +195,19 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		Meta: &data.FrameMeta{
 			Custom: map[string]interface{}{
 				"Status": "ok",
-				"Statistics": cloudwatchlogs.QueryStatistics{
-					BytesScanned:   aws.Float64(2000),
-					RecordsMatched: aws.Float64(3),
-					RecordsScanned: aws.Float64(5000),
+			},
+			Stats: []data.QueryStat{
+				{
+					FieldConfig: data.FieldConfig{DisplayName: "Bytes scanned"},
+					Value:       2000,
+				},
+				{
+					FieldConfig: data.FieldConfig{DisplayName: "Records scanned"},
+					Value:       5000,
+				},
+				{
+					FieldConfig: data.FieldConfig{DisplayName: "Records matched"},
+					Value:       3,
 				},
 			},
 		},

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -248,7 +248,8 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
                 map(frames => {
                   let moreRecordsMatched = false;
                   for (const frame of frames) {
-                    const recordsMatched = frame.meta?.custom?.['Statistics']['RecordsMatched'];
+                    const recordsMatched = frame.meta?.stats?.find(stat => stat.displayName === 'Records matched')
+                      ?.value!;
                     if (recordsMatched > (prevRecordsMatched[frame.refId!] ?? 0)) {
                       moreRecordsMatched = true;
                     }

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -167,8 +167,11 @@ describe('CloudWatchDatasource', () => {
     it('should stop querying when no more data retrieved past max attempts', async () => {
       const fakeFrames = genMockFrames(10);
       for (let i = 7; i < fakeFrames.length; i++) {
-        fakeFrames[i].meta!.custom!['Statistics']['RecordsMatched'] = fakeFrames[6].meta!.custom!['Statistics'][
-          'RecordsMatched'
+        fakeFrames[i].meta!.stats = [
+          {
+            displayName: 'Records matched',
+            value: fakeFrames[6].meta!.stats?.find(stat => stat.displayName === 'Records matched')?.value!,
+          },
         ];
       }
 
@@ -193,6 +196,7 @@ describe('CloudWatchDatasource', () => {
               ...fakeFrames[MAX_ATTEMPTS - 1].meta!.custom,
               Status: 'Complete',
             },
+            stats: fakeFrames[MAX_ATTEMPTS - 1].meta!.stats,
           },
         },
       ];
@@ -1101,10 +1105,13 @@ function genMockFrames(numResponses: number): DataFrame[] {
       meta: {
         custom: {
           Status: i === numResponses - 1 ? CloudWatchLogsQueryStatus.Complete : CloudWatchLogsQueryStatus.Running,
-          Statistics: {
-            RecordsMatched: (i + 1) * recordIncrement,
-          },
         },
+        stats: [
+          {
+            displayName: 'Records matched',
+            value: (i + 1) * recordIncrement,
+          },
+        ],
       },
       length: 0,
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves query stats out of `meta.custom` into `meta.stats` so that they show up in the query inspector.
