### PR TITLE
Flux: Ensure connections to InfluxDB are closed

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -41,6 +41,7 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)
 	}
+	defer runner.client.Close()
 	return tRes, nil
 }
 

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -30,7 +30,7 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 		return nil, err
 	}
 	defer runner.client.Close()
-	
+
 	for _, query := range tsdbQuery.Queries {
 		qm, err := GetQueryModelTSDB(query, tsdbQuery.TimeRange, dsInfo)
 		if err != nil {

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -29,7 +29,8 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 	if err != nil {
 		return nil, err
 	}
-
+	defer runner.client.Close()
+	
 	for _, query := range tsdbQuery.Queries {
 		qm, err := GetQueryModelTSDB(query, tsdbQuery.TimeRange, dsInfo)
 		if err != nil {
@@ -41,7 +42,6 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)
 	}
-	defer runner.client.Close()
 	return tRes, nil
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
Ensures TCP connections created between the Grafana Flux datasource and InFluxDB are closed after they have been used.

Which issue(s) this PR fixes:
Fixes grafana#26731

Special notes for your reviewer: