### PR TITLE
Cloud monitoring: do not create deep link if there are no timeseries

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -221,7 +221,11 @@ func (e *CloudMonitoringExecutor) executeTimeSeriesQuery(ctx context.Context, ts
 			break
 		}
 		query.Params.Set("resourceType", resourceType)
-		queryRes.Meta.Set("deepLink", query.buildDeepLink())
+		dl := ""
+		if len(resp.TimeSeries) > 0 {
+			dl = query.buildDeepLink()
+		}
+		queryRes.Meta.Set("deepLink", dl)
 	}
 
 	return result, nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The deep link should not be constructed if no timeseries are found; In order to overcome the issue described [here](https://github.com/grafana/grafana/pull/25858#pullrequestreview-438929086) the deep linking builder, if no resource type is included in the query filter, tries to get that information from the cloud monitoring API timeseries response and if it's not found then it logs an error and returns an empty link.
This fix is useful for not polluting the logs with unnecessary errors if no timeseries are found.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

