### PR TITLE
Add `raw` format to formatRegistry

### DIFF
--- a/public/app/features/templating/formatRegistry.ts
+++ b/public/app/features/templating/formatRegistry.ts
@@ -29,6 +29,12 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
+      id: 'raw',
+      name: 'raw',
+      description: 'Keep value as is',
+      formatter: value => value,
+    },
+    {
       id: 'regex',
       name: 'Regex',
       description: 'Values are regex escaped and multi-valued variables generate a (<value>|<value>) expression',


### PR DESCRIPTION
Fixes `:raw` format broken by https://github.com/grafana/grafana/pull/26607