### PR TITLE
Inspector: hide invalid stats

### DIFF
--- a/public/app/features/dashboard/components/Inspector/InspectStatsTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectStatsTab.tsx
@@ -23,8 +23,12 @@ export const InspectStatsTab: React.FC<InspectStatsTabProps> = ({ data, dashboar
     dataRows += frame.length;
   }
 
-  stats.push({ displayName: 'Total request time', value: requestTime, unit: 'ms' });
-  stats.push({ displayName: 'Data processing time', value: processingTime, unit: 'ms' });
+  if (requestTime > 0) {
+    stats.push({ displayName: 'Total request time', value: requestTime, unit: 'ms' });
+  }
+  if (processingTime > 0) {
+    stats.push({ displayName: 'Data processing time', value: processingTime, unit: 'ms' });
+  }
   stats.push({ displayName: 'Number of queries', value: data.request.targets.length });
   stats.push({ displayName: 'Total number rows', value: dataRows });
 


### PR DESCRIPTION
The query inspector will currently show invalid stats when it has not processed any data:

![image](https://user-images.githubusercontent.com/705951/89088897-8b3b0700-d34f-11ea-9b20-934283fa7581.png)

rather than confuse people trying to interpret this, lets just hide it