### PR TITLE
Query history: Fix search filtering if null value

### DIFF
--- a/public/app/core/utils/richHistory.test.ts
+++ b/public/app/core/utils/richHistory.test.ts
@@ -20,7 +20,7 @@ const mock: any = {
       datasourceId: 'datasource historyId',
       datasourceName: 'datasource history name',
       queries: [
-        { expr: 'query1', refId: '1' },
+        { expr: 'query1', maxLines: null, refId: '1' },
         { expr: 'query2', refId: '2' },
       ],
       sessionName: '',
@@ -96,7 +96,7 @@ describe('addToRichHistory', () => {
       mock.storedHistory,
       mock.storedHistory[0].datasourceId,
       mock.storedHistory[0].datasourceName,
-      [{ expr: 'query1', refId: 'A' } as DataQuery, { expr: 'query2', refId: 'B' } as DataQuery],
+      [{ expr: 'query1', maxLines: null, refId: 'A' } as DataQuery, { expr: 'query2', refId: 'B' } as DataQuery],
       mock.testStarred,
       mock.testComment,
       mock.testSessionName
@@ -110,7 +110,7 @@ describe('addToRichHistory', () => {
       mock.storedHistory,
       mock.storedHistory[0].datasourceId,
       mock.storedHistory[0].datasourceName,
-      [{ expr: 'query1', refId: 'A' } as DataQuery, { expr: 'query2', refId: 'B' } as DataQuery],
+      [{ expr: 'query1', maxLines: null, refId: 'A' } as DataQuery, { expr: 'query2', refId: 'B' } as DataQuery],
       mock.testStarred,
       mock.testComment,
       mock.testSessionName

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -330,7 +330,7 @@ export function filterQueriesBySearchFilter(queries: RichHistoryQuery[], searchF
     const listOfMatchingQueries = query.queries.filter(query =>
       // Remove fields in which we don't want to be searching
       Object.values(_.omit(query, ['datasource', 'key', 'refId', 'hide', 'queryType'])).some((value: any) =>
-        value.toString().includes(searchFilter)
+        value?.toString().includes(searchFilter)
       )
     );
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If some of the DataQuery object has property with null value (e.g. `{ expr: "{app="cainjector"}", key: "Q-1596103673004-0.6974408372251228-0", maxLines: null, refId: "A"}`, when using search, error was thrown. This PR fixes this by checking if value is non-null before using `toString` method.

![image](https://user-images.githubusercontent.com/30407135/89208804-58964600-d5bd-11ea-8090-9e115c4dae30.png)