### PR TITLE
Provisioning: describe which folder caused an error while provisioning from files structure

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -275,6 +275,8 @@ providers:
 
 When Grafana starts, it will update/insert all dashboards available in the configured path. Then later on poll that path every **updateIntervalSeconds** and look for updated json files and update/insert those into the database.
 
+> **Note.** Dashboards will be provisioned to the `General` folder if the `folder` option is missing or empty.
+
 #### Making changes to a provisioned dashboard
 
 It's possible to make changes to a provisioned dashboard in the Grafana UI. However, it is not possible to automatically save the changes back to the provisioning source.
@@ -332,6 +334,8 @@ providers:
 `server` and `application` will become new folders in Grafana menu.
 
 > **Note.** `folder` and `folderUid` options should be empty or missing to make `foldersFromFilesStructure` work.
+
+> **Note.** To provision dashboards to the `General` folder, you should store them in the root of your `path`.
 
 ## Alert Notification Channels
 

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -275,7 +275,7 @@ providers:
 
 When Grafana starts, it will update/insert all dashboards available in the configured path. Then later on poll that path every **updateIntervalSeconds** and look for updated json files and update/insert those into the database.
 
-> **Note.** Dashboards will be provisioned to the `General` folder if the `folder` option is missing or empty.
+> **Note:** Dashboards are provisioned to the General folder if the `folder` option is missing or empty.
 
 #### Making changes to a provisioned dashboard
 
@@ -335,7 +335,7 @@ providers:
 
 > **Note.** `folder` and `folderUid` options should be empty or missing to make `foldersFromFilesStructure` work.
 
-> **Note.** To provision dashboards to the `General` folder, you should store them in the root of your `path`.
+> **Note:** To provision dashboards to the General folder, store them in the root of your `path`.
 
 ## Alert Notification Channels
 

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+const RootFolderName = "General"
+
 // Typed errors
 var (
 	ErrDashboardNotFound = DashboardErr{
@@ -101,7 +103,6 @@ var (
 		Reason:     "Unique identifier needed to be able to get a dashboard",
 		StatusCode: 400,
 	}
-	RootFolderName = "General"
 )
 
 // DashboardErr represents a dashboard error.
@@ -141,7 +142,7 @@ func (d UpdatePluginDashboardError) Error() string {
 	return "Dashboard belong to plugin"
 }
 
-var (
+const (
 	DashTypeJson     = "file"
 	DashTypeDB       = "db"
 	DashTypeScript   = "script"
@@ -218,8 +219,8 @@ func NewDashboardFolder(title string) *Dashboard {
 }
 
 // GetTags turns the tags in data json into go string array
-func (dash *Dashboard) GetTags() []string {
-	return dash.Data.Get("tags").MustStringArray()
+func (d *Dashboard) GetTags() []string {
+	return d.Data.Get("tags").MustStringArray()
 }
 
 func NewDashboardFromJson(data *simplejson.Json) *Dashboard {
@@ -274,14 +275,14 @@ func (cmd *SaveDashboardCommand) GetDashboardModel() *Dashboard {
 }
 
 // GetString a
-func (dash *Dashboard) GetString(prop string, defaultValue string) string {
-	return dash.Data.Get(prop).MustString(defaultValue)
+func (d *Dashboard) GetString(prop string, defaultValue string) string {
+	return d.Data.Get(prop).MustString(defaultValue)
 }
 
 // UpdateSlug updates the slug
-func (dash *Dashboard) UpdateSlug() {
-	title := dash.Data.Get("title").MustString()
-	dash.Slug = SlugifyTitle(title)
+func (d *Dashboard) UpdateSlug() {
+	title := d.Data.Get("title").MustString()
+	d.Slug = SlugifyTitle(title)
 }
 
 func SlugifyTitle(title string) string {
@@ -300,13 +301,13 @@ func SlugifyTitle(title string) string {
 }
 
 // GetUrl return the html url for a folder if it's folder, otherwise for a dashboard
-func (dash *Dashboard) GetUrl() string {
-	return GetDashboardFolderUrl(dash.IsFolder, dash.Uid, dash.Slug)
+func (d *Dashboard) GetUrl() string {
+	return GetDashboardFolderUrl(d.IsFolder, d.Uid, d.Slug)
 }
 
 // Return the html url for a dashboard
-func (dash *Dashboard) GenerateUrl() string {
-	return GetDashboardUrl(dash.Uid, dash.Slug)
+func (d *Dashboard) GenerateUrl() string {
+	return GetDashboardUrl(d.Uid, d.Slug)
 }
 
 // GetDashboardFolderUrl return the html url for a folder if it's folder, otherwise for a dashboard

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -143,9 +143,7 @@ func (d UpdatePluginDashboardError) Error() string {
 }
 
 const (
-	DashTypeJson     = "file"
 	DashTypeDB       = "db"
-	DashTypeScript   = "script"
 	DashTypeSnapshot = "snapshot"
 )
 
@@ -301,8 +299,8 @@ func SlugifyTitle(title string) string {
 }
 
 // GetUrl return the html url for a folder if it's folder, otherwise for a dashboard
-func (d *Dashboard) GetUrl() string {
-	return GetDashboardFolderUrl(d.IsFolder, d.Uid, d.Slug)
+func (dash *Dashboard) GetUrl() string {
+	return GetDashboardFolderUrl(dash.IsFolder, dash.Uid, dash.Slug)
 }
 
 // Return the html url for a dashboard

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -10,14 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/util"
-
 	"github.com/grafana/grafana/pkg/bus"
-
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -148,7 +146,7 @@ func (fr *FileReader) storeDashboardsInFoldersFromFileStructure(filesFoundOnDisk
 
 		folderID, err := getOrCreateFolderID(fr.Cfg, fr.dashboardProvisioningService, folderName)
 		if err != nil && err != ErrFolderNameMissing {
-			return err
+			return fmt.Errorf("can't provision %s folder from files structure: %w", folderName, err)
 		}
 
 		provisioningMetadata, err := fr.saveDashboard(path, folderID, fileInfo, dashboardRefs)

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -146,7 +146,7 @@ func (fr *FileReader) storeDashboardsInFoldersFromFileStructure(filesFoundOnDisk
 
 		folderID, err := getOrCreateFolderID(fr.Cfg, fr.dashboardProvisioningService, folderName)
 		if err != nil && err != ErrFolderNameMissing {
-			return fmt.Errorf("can't provision %s folder from files structure: %w", folderName, err)
+			return fmt.Errorf("can't provision folder %q from file system structure: %w", folderName, err)
 		}
 
 		provisioningMetadata, err := fr.saveDashboard(path, folderID, fileInfo, dashboardRefs)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a description about which folder caused an error while provisioning folders from files structure.

**Which issue(s) this PR fixes**:
If we receive an error about folder while provisioning, it will look like this:
```
EROR[08-03|23:57:48] Failed to provision dashboard            logger=provisioning error="Failed to provision dashboards: Failed to provision config default: A folder with that name already exists"
```
This is ok for an ordinary dashboard provisioning. We can easily find a folder by the provisioning config name. But, using the `foldersFromFilesStructure` option makes it harder to determine a problematic folder.
We know which folder caused the problem, and, in my opinion, we need to share it with users.

Besides, I noticed that it's not clear from the documentation how to provision dashboards to the General folder. So I have added some notes about it.

**Special notes for your reviewer**:
Also, this PR:
* makes some variables constant because, as was mentioned before, we want to avoid globals in Grafana
* fixes an issue with receiver names for the dashboard struct
(it's just because I touched them while researching)