### PR TITLE
SQL: Fix missing org error messages

### DIFF
--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -245,9 +245,9 @@ func getOrCreateOrg(sess *DBSession, orgName string) (int64, error) {
 			org.Name = mainOrgName
 			org.Id = int64(setting.AutoAssignOrgId)
 		} else {
-			sqlog.Info("Could not create user: organization id %v does not exist",
+			sqlog.Error("Could not create user: organization ID does not exist", "orgID",
 				setting.AutoAssignOrgId)
-			return 0, fmt.Errorf("Could not create user: organization id %v does not exist",
+			return 0, fmt.Errorf("could not create user: organization ID %d does not exist",
 				setting.AutoAssignOrgId)
 		}
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix error messages (a log message and an actual error) when an org can't be created.