### PR TITLE
Overrides: support an append mode

### DIFF
--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -2,6 +2,11 @@ import { ComponentType } from 'react';
 import { RegistryItem, Registry } from '../utils/Registry';
 import { NumberFieldConfigSettings, SelectFieldConfigSettings, StringFieldConfigSettings } from '../field';
 
+export enum OptionsEditorOverrideBehavior {
+  Replace = 'replace',
+  Append = 'append',
+}
+
 /**
  * Option editor registry item
  */
@@ -34,6 +39,9 @@ export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue> ex
    * Array of strings representing category of the options property.
    */
   category?: string[];
+  /**
+   * Use this value when nothing is configured
+   */
   defaultValue?: TValue;
   /**
    * Function that enables configuration of when option editor should be shown based on current options properties.
@@ -46,6 +54,11 @@ export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue> ex
    * @param value
    */
   getItemsCount?: (value?: TValue) => number;
+  /**
+   * Some values may need special treatment when trying to override the existing value.  For example
+   * An array of links may want to *append* to the list of values rather than replace them
+   */
+  overrideBehavior?: OptionsEditorOverrideBehavior;
 }
 
 /**

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -35,6 +35,7 @@ import { UnitValueEditor } from '../components/OptionsUI/units';
 import { DataLinksValueEditor } from '../components/OptionsUI/links';
 import { ColorValueEditor } from '../components/OptionsUI/color';
 import { StatsPickerEditor } from '../components/OptionsUI/stats';
+import { OptionsEditorOverrideBehavior } from '@grafana/data/src/types/OptionsUIRegistryBuilder';
 
 /**
  * Returns collection of common field config properties definitions
@@ -198,6 +199,7 @@ export const getStandardFieldConfigs = () => {
     shouldApply: () => true,
     category: ['Data links'],
     getItemsCount: value => (value ? value.length : 0),
+    overrideBehavior: OptionsEditorOverrideBehavior.Append,
   };
 
   // const color: FieldConfigPropertyItem<any, string, StringFieldConfigSettings> = {


### PR DESCRIPTION
when applying field overrides to links, we really want to keep both values.

This PR explores how we can have an append mode.  In this iteration it is configured globally for the field, but it would be better if this were part of the UI

See https://github.com/grafana/grafana/issues/26762
![image](https://user-images.githubusercontent.com/705951/89345907-145a8280-d65d-11ea-8aa4-bcf8fefd6307.png)

