### PR TITLE
AppPlugin: Show exceptions in dev

### DIFF
--- a/public/app/core/nav_model_srv.ts
+++ b/public/app/core/nav_model_srv.ts
@@ -53,6 +53,11 @@ export class NavModelSrv {
   }
 }
 
+export function getExceptionNav(error: any): NavModel {
+  console.error(error);
+  return getWarningNav('Exception thrown', 'See console for details');
+}
+
 export function getNotFoundNav(): NavModel {
   return getWarningNav('Page not found', '404 Error');
 }

--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -9,7 +9,7 @@ import { AppEvents, AppPlugin, AppPluginMeta, NavModel, PluginType, UrlQueryMap 
 import Page from 'app/core/components/Page/Page';
 import { getPluginSettings } from './PluginSettingsCache';
 import { importAppPlugin } from './plugin_loader';
-import { getNotFoundNav, getWarningNav } from 'app/core/nav_model_srv';
+import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/nav_model_srv';
 import { appEvents } from 'app/core/core';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 
@@ -62,7 +62,11 @@ class AppRootPage extends Component<Props, State> {
       });
       this.setState({ plugin: app, loading: false });
     } catch (err) {
-      this.setState({ plugin: null, loading: false, nav: getNotFoundNav() });
+      this.setState({
+        plugin: null,
+        loading: false,
+        nav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
+      });
     }
   }
 


### PR DESCRIPTION
Minor improvement to app plugin DX:
When `NODE_ENV` is dev, print exceptions that bubble up from an app plugin to the console and make developer aware of this instead of only showing "404 Error".
