### PR TITLE
Grafana Toolkit: add an option for signing plugins as admin

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -194,9 +194,12 @@ export const run = (includeInternalScripts = false) => {
 
   program
     .command('plugin:ci-package')
+    .option('--signing-admin', 'Use the admin API endpoint for signing the manifest.', false)
     .description('Create a zip packages for the plugin')
     .action(async cmd => {
-      await execTask(ciPackagePluginTask)({});
+      await execTask(ciPackagePluginTask)({
+        signingAdmin: cmd.signingAdmin,
+      });
     });
 
   program

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -26,6 +26,7 @@ const rimraf = promisify(rimrafCallback);
 export interface PluginCIOptions {
   finish?: boolean;
   upload?: boolean;
+  signingAdmin?: boolean;
 }
 
 /**
@@ -106,7 +107,7 @@ export const ciBuildPluginDocsTask = new Task<PluginCIOptions>('Build Plugin Doc
  *  2. zip it into packages in `~/ci/packages`
  *  3. prepare grafana environment in: `~/ci/grafana-test-env`
  */
-const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
+const packagePluginRunner: TaskRunner<PluginCIOptions> = async ({ signingAdmin }) => {
   const start = Date.now();
   const ciDir = getCiFolder();
   const packagesDir = path.resolve(ciDir, 'packages');
@@ -163,7 +164,8 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async () => {
 
   // Write a manifest.txt file in the dist folder
   try {
-    await execa('grabpl', ['build-plugin-manifest', distContentDir]);
+    const grabplCommandFlags = signingAdmin ? ['build-plugin-manifest', 'signing-admin'] : ['build-plugin-manifest'];
+    await execa('grabpl', [...grabplCommandFlags, distContentDir]);
   } catch (err) {
     console.warn(`Error signing manifest: ${distContentDir}`, err);
   }

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -162,7 +162,9 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async ({ signingAdmin }
     }
   });
 
-  // Write a manifest.txt file in the dist folder
+  // Write a MANIFEST.txt file in the dist folder
+  // By using the --signing-admin flag the plugin doesn't need to be in the plugins database to be signed,
+  // however it requires an Admin API key.
   try {
     const grabplCommandFlags = signingAdmin ? ['build-plugin-manifest', 'signing-admin'] : ['build-plugin-manifest'];
     await execa('grabpl', [...grabplCommandFlags, distContentDir]);

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -166,7 +166,7 @@ const packagePluginRunner: TaskRunner<PluginCIOptions> = async ({ signingAdmin }
   // By using the --signing-admin flag the plugin doesn't need to be in the plugins database to be signed,
   // however it requires an Admin API key.
   try {
-    const grabplCommandFlags = signingAdmin ? ['build-plugin-manifest', 'signing-admin'] : ['build-plugin-manifest'];
+    const grabplCommandFlags = signingAdmin ? ['build-plugin-manifest', '--signing-admin'] : ['build-plugin-manifest'];
     await execa('grabpl', [...grabplCommandFlags, distContentDir]);
   } catch (err) {
     console.warn(`Error signing manifest: ${distContentDir}`, err);


### PR DESCRIPTION
### The problem
When the `grafana-toolkit plugin:ci-package` command is called it is communicating with the `grabpl` executable under the hood in order to get a signed MANIFEST.txt for the plugin. `grabpl` has an option for exceptional cases - it can sign a plugin without having it in the plugin database by providing an extra flag. Unfortunately this flag is not "proxied" by the toolkit at this point.

### The solution
Add a `--signing-admin` flag to the `grafana-toolkit plugin:ci-package` command.

### The future
As we discussed with @ryantxu the Toolkit is probably not the best place for things that are closely CI related, so we are planning to lift it out in the future.