### PR TITLE
GraphPanel: Add Ordinal option for X-Axis Mode

### DIFF
--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -125,6 +125,7 @@ Options are identical for both Y-axes.
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.
+  - **Ordinal -** The data is represented sequentially on the X-axis and the X values are only labelled as timestamps rather than being on a time scale.
 	
 ## Legend
 

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -125,7 +125,7 @@ Options are identical for both Y-axes.
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.
-  - **Ordinal -** The data is represented sequentially on the X-axis and the X values are only labelled as timestamps rather than being on a time scale.
+  - **Ordinal -** Data is represented sequentially on the X-axis, and the X values are only labelled as timestamps rather than being on a time scale.
 	
 ## Legend
 

--- a/public/app/plugins/panel/graph/axes_editor.ts
+++ b/public/app/plugins/panel/graph/axes_editor.ts
@@ -28,6 +28,7 @@ export class AxesEditorCtrl {
       Time: 'time',
       Series: 'series',
       Histogram: 'histogram',
+      Ordinal: 'ordinal',
       // 'Data field': 'field',
     };
 

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -514,6 +514,30 @@ class GraphElement {
         this.addXTableAxis(options);
         break;
       }
+      case 'ordinal': {
+        options.series.bars.barWidth = this.getMinTimeStepOfSeries(this.data) / 1.5;
+        options.series.bars.align = 'center';
+        let ticksMap: any = {};
+        for (const d of this.data) {
+          for (const point of d.data) {
+            ticksMap[point[0]] = true;
+          }
+        }
+
+        const ticks: number[] = Object.keys(ticksMap)
+          .map(Number)
+          .sort();
+
+        this.data = this.data.map((series: any) => {
+          for (const i in series.data) {
+            series.data[i][0] = ticks.indexOf(series.data[i][0]);
+          }
+          return series;
+        });
+
+        this.addOrdinalAxis(options, ticks);
+        break;
+      }
       default: {
         options.series.bars.barWidth = this.getMinTimeStepOfSeries(this.data) / 1.5;
         this.addTimeAxis(options);
@@ -656,6 +680,27 @@ class GraphElement {
       ticks: ticks,
       timeformat: graphTimeFormat(ticks, min, max),
       tickFormatter: graphTickFormatter,
+    };
+  }
+
+  addOrdinalAxis(options: any, ticks: number[]): void {
+    const min = _.isUndefined(this.ctrl.range.from) ? null : this.ctrl.range.from.valueOf();
+    const max = _.isUndefined(this.ctrl.range.to) ? null : this.ctrl.range.to.valueOf();
+
+    const formatter = (epoch: number, axis: any): string => {
+      return graphTickFormatter(ticks[epoch], axis);
+    };
+
+    options.xaxis = {
+      timezone: this.dashboard.getTimezone(),
+      show: this.panel.xaxis.show,
+      mode: null,
+      min: 0,
+      max: ticks.length + 1,
+      label: 'Datetime',
+      ticks: ticks.map((value, index) => index),
+      timeformat: graphTimeFormat(ticks.length, min, max),
+      tickFormatter: formatter,
     };
   }
 

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -515,7 +515,7 @@ class GraphElement {
         break;
       }
       case 'ordinal': {
-        options.series.bars.barWidth = this.getMinTimeStepOfSeries(this.data) / 1.5;
+        options.series.bars.barWidth = 1 / 1.5;
         options.series.bars.align = 'center';
         let ticksMap: any = {};
         for (const d of this.data) {
@@ -691,6 +691,13 @@ class GraphElement {
       return graphTickFormatter(ticks[epoch], axis);
     };
 
+    const tickCount = this.panelWidth / 100;
+    const ratio = Math.floor(ticks.length / tickCount);
+    let showTicks: number[] = [];
+    for (let i = 0; i < ticks.length; i = i + ratio) {
+      showTicks.push(i);
+    }
+
     options.xaxis = {
       timezone: this.dashboard.getTimezone(),
       show: this.panel.xaxis.show,
@@ -698,8 +705,8 @@ class GraphElement {
       min: 0,
       max: ticks.length + 1,
       label: 'Datetime',
-      ticks: ticks.map((value, index) => index),
-      timeformat: graphTimeFormat(ticks.length, min, max),
+      ticks: showTicks,
+      timeformat: graphTimeFormat(showTicks.length, min, max),
       tickFormatter: formatter,
     };
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

This X-Axis Mode will represent data sequentially on the X-axis and the X values will only be labelled as timestamps rather than being on a time scale. This allows you to do things like exclude weekends from the X-axis rather than having lines that span across them.

**Which issue(s) this PR fixes**:

Fixes #2418
