### PR TITLE
Dashboard Links: Keep links in sync with dashboard time range

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useReducer } from 'react';
 import { Icon, IconName, Tooltip } from '@grafana/ui';
 import { sanitize, sanitizeUrl } from '@grafana/data/src/text/sanitize';
 import { DashboardLinksDashboard } from './DashboardLinksDashboard';
@@ -7,6 +7,8 @@ import { getLinkSrv } from '../../../panel/panellinks/link_srv';
 import { DashboardModel } from '../../state';
 import { DashboardLink } from '../../state/DashboardModel';
 import { iconMap } from '../DashLinks/DashLinksEditorCtrl';
+import { useEffectOnce } from 'react-use';
+import { CoreEvents } from 'app/types';
 
 export interface Props {
   dashboard: DashboardModel;
@@ -17,6 +19,17 @@ export const DashboardLinks: FC<Props> = ({ dashboard, links }) => {
   if (!links.length) {
     return null;
   }
+
+  // Emulate forceUpdate (https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate)
+  const [, forceUpdate] = useReducer(x => x + 1, 0);
+
+  useEffectOnce(() => {
+    dashboard.on(CoreEvents.timeRangeUpdated, forceUpdate);
+
+    return () => {
+      dashboard.off(CoreEvents.timeRangeUpdated, forceUpdate);
+    };
+  });
 
   return (
     <>


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates dashboard links that make use of the current time range when that time range is updated.

**Which issue(s) this PR fixes**:
Closes #26694 
