### PR TITLE
InfluxDB: Less chatty logging

### DIFF
--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 func (e *InfluxDBExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
-	glog.Info("query", "q", tsdbQuery.Queries)
+	glog.Debug("Received a query request", "numQueries", len(tsdbQuery.Queries))
 
 	version := dsInfo.JsonData.Get("version").MustString("")
 	if version == "Flux" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Convert a log message issued on every InfluxDB query to debug level, and also don't log a pointer address.

**Which issue(s) this PR fixes**:
Fixes #26848.

