### PR TITLE
Orgs: Remove org deprecation notice as we have decided to preserve multi-org support 

### DIFF
--- a/public/app/features/admin/AdminListOrgsPage.tsx
+++ b/public/app/features/admin/AdminListOrgsPage.tsx
@@ -3,7 +3,7 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import Page from 'app/core/components/Page/Page';
 import { useSelector } from 'react-redux';
 import { StoreState } from 'app/types/store';
-import { LinkButton, InfoBox, VerticalGroup } from '@grafana/ui';
+import { LinkButton } from '@grafana/ui';
 import { getBackendSrv } from '@grafana/runtime';
 import { AdminOrgsTable } from './AdminOrgsTable';
 import useAsyncFn from 'react-use/lib/useAsyncFn';

--- a/public/app/features/admin/AdminListOrgsPage.tsx
+++ b/public/app/features/admin/AdminListOrgsPage.tsx
@@ -30,21 +30,6 @@ export const AdminListOrgsPages: FC = () => {
       <Page.Contents>
         <>
           <div className="page-action-bar">
-            <InfoBox branded>
-              <VerticalGroup spacing="xs">
-                <p>
-                  Fewer than 1% of Grafana installations use organizations, and we think that most of those would have a
-                  better experience with Teams instead. As such, we are considering de-emphasizing and eventually
-                  deprecating Organizations in a future Grafana release. If you would like to provide feedback or
-                  describe your need, please do so{' '}
-                  <a className="external-link" href="https://github.com/grafana/grafana/issues/24588">
-                    here
-                  </a>
-                  .{' '}
-                </p>
-              </VerticalGroup>
-            </InfoBox>
-
             <div className="page-action-bar__spacer" />
             <LinkButton icon="plus" href="org/new">
               New org


### PR DESCRIPTION
After an overwhelmingly negative reaction to our proposal to remove orgs and streamline user management (#24588) we have decided to keep support for multiple orgs. 

 