### PR TITLE
Drone/CircleCI: Upgrade build pipeline tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
       - run:
           name: "Install Grafana build pipeline tool"
           command: |
-            VERSION=0.4.25
+            VERSION=0.5.0
             curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v${VERSION}/grabpl
             chmod +x grabpl
             mv grabpl /tmp

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ steps:
   - cp -r $(yarn cache dir) yarn-cache
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.4.25
+    GRABPL_VERSION: 0.5.0
 
 - name: lint-backend
   image: grafana/build-container:1.2.24
@@ -264,7 +264,7 @@ steps:
   - cp -r $(yarn cache dir) yarn-cache
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.4.25
+    GRABPL_VERSION: 0.5.0
 
 - name: lint-backend
   image: grafana/build-container:1.2.24

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -43,7 +43,7 @@ get_file "https://codeclimate.com/downloads/test-reporter/test-reporter-latest-l
     "b4138199aa755ebfe171b57cc46910b13258ace5fbc4eaa099c42607cd0bff32"
 chmod +x /usr/local/bin/cc-test-reporter
 
-wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.4.4/grabpl"
+wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.0/grabpl"
 chmod +x /usr/local/bin/grabpl
 
 apk add --no-cache git

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
@@ -43,7 +43,7 @@ get_file "https://codeclimate.com/downloads/test-reporter/test-reporter-latest-l
     "b4138199aa755ebfe171b57cc46910b13258ace5fbc4eaa099c42607cd0bff32"
 chmod 755 /usr/local/bin/cc-test-reporter
 
-wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.4.4/grabpl"
+wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.0/grabpl"
 chmod +x /usr/local/bin/grabpl
 
 # Install Mage
@@ -52,7 +52,7 @@ git clone https://github.com/magefile/mage.git /tmp/mage
 pushd /tmp/mage && go run bootstrap.go && popd
 mv $HOME/go/bin/mage /usr/local/bin
 # Cleanup after yourself
-/bin/rm -rf /tmp/mage 
+/bin/rm -rf /tmp/mage
 /bin/rm -rf $HOME/go
 
 # Install grafana-toolkit deps

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
@@ -27,7 +27,7 @@ get_file "https://codeclimate.com/downloads/test-reporter/test-reporter-latest-l
     "b4138199aa755ebfe171b57cc46910b13258ace5fbc4eaa099c42607cd0bff32"
 chmod +x /usr/local/bin/cc-test-reporter
 
-wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.4.4/grabpl"
+wget -O /usr/local/bin/grabpl "https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.0/grabpl"
 chmod +x /usr/local/bin/grabpl
 
 # Install Mage
@@ -36,7 +36,7 @@ git clone https://github.com/magefile/mage.git /tmp/mage
 pushd /tmp/mage && go run bootstrap.go && popd
 mv $HOME/go/bin/mage /usr/local/bin
 # Cleanup after yourself
-/bin/rm -rf /tmp/mage 
+/bin/rm -rf /tmp/mage
 /bin/rm -rf $HOME/go
 
 # Perform user specific initialization

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -137,7 +137,7 @@ def pipeline(name, edition, trigger, steps, services=[]):
     return pipeline
 
 def init_steps(edition):
-    grabpl_version = '0.4.25'
+    grabpl_version = '0.5.0'
     common_cmds = [
         'curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
         'tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade to new version of the build pipeline tool, with static musl libc linking. Should make our musl (Alpine Linux compatible) binaries more portable, since they become independent of the system's version of musl (1.2 breaks compatibility with 1.1 on 32-bit archs).
 
**Which issue(s) this PR fixes**:
Fixes #23567.
