### PR TITLE
SQL: Run tests as integration tests

### DIFF
--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_acl_test.go
+++ b/pkg/services/sqlstore/dashboard_acl_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_service_integration_test.go
+++ b/pkg/services/sqlstore/dashboard_service_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/preferences_test.go
+++ b/pkg/services/sqlstore/preferences_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/searchstore/search_test.go
+++ b/pkg/services/sqlstore/searchstore/search_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 // package search_test contains integration tests for search
 package searchstore_test
 

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/tags_test.go
+++ b/pkg/services/sqlstore/tags_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/user_auth_test.go
+++ b/pkg/services/sqlstore/user_auth_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures we're running the SQL store test suite as integration tests since we're excluding non-integration tagged tests from running.

