### PR TITLE
Templating: Fixes renaming a variable using special characters or same name

### DIFF
--- a/public/app/features/variables/editor/actions.ts
+++ b/public/app/features/variables/editor/actions.ts
@@ -95,6 +95,10 @@ export const completeChangeVariableName = (identifier: VariableIdentifier, newNa
   getState
 ) => {
   const originalVariable = getVariable(identifier.id, getState());
+  if (originalVariable.name === newName) {
+    dispatch(changeVariableNameSucceeded(toVariablePayload(identifier, { newName })));
+    return;
+  }
   const model = { ...cloneDeep(originalVariable), name: newName, id: newName };
   const global = originalVariable.global;
   const index = originalVariable.index;

--- a/public/app/features/variables/editor/actions.ts
+++ b/public/app/features/variables/editor/actions.ts
@@ -57,11 +57,6 @@ export const onEditorAdd = (identifier: VariableIdentifier): ThunkResult<void> =
 
 export const changeVariableName = (identifier: VariableIdentifier, newName: string): ThunkResult<void> => {
   return (dispatch, getState) => {
-    const variableInState = getVariable(identifier.id, getState());
-    if (newName === variableInState.name) {
-      return;
-    }
-
     let errorText = null;
     if (!newName.match(/^(?!__).*$/)) {
       errorText = "Template names cannot begin with '__', that's reserved for Grafana's global variables";

--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -315,6 +315,29 @@ describe('shared actions', () => {
   });
 
   describe('changeVariableName', () => {
+    describe('when changeVariableName is dispatched with the same name', () => {
+      it('then the correct actions are dispatched', () => {
+        const textbox = textboxBuilder()
+          .withId('textbox')
+          .withName('textbox')
+          .build();
+        const constant = constantBuilder()
+          .withId('constant')
+          .withName('constant')
+          .build();
+
+        reduxTester<{ templating: TemplatingState }>()
+          .givenRootReducer(getTemplatingRootReducer())
+          .whenActionIsDispatched(addVariable(toVariablePayload(textbox, { global: false, index: 0, model: textbox })))
+          .whenActionIsDispatched(
+            addVariable(toVariablePayload(constant, { global: false, index: 1, model: constant }))
+          )
+          .whenActionIsDispatched(changeVariableName(toVariableIdentifier(constant), constant.name), true)
+          .thenDispatchedActionsShouldEqual(
+            changeVariableNameSucceeded({ type: 'constant', id: 'constant', data: { newName: 'constant' } })
+          );
+      });
+    });
     describe('when changeVariableName is dispatched with an unique name', () => {
       it('then the correct actions are dispatched', () => {
         const textbox = textboxBuilder()

--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -315,28 +315,6 @@ describe('shared actions', () => {
   });
 
   describe('changeVariableName', () => {
-    describe('when changeVariableName is dispatched with the same name', () => {
-      it('then no actions are dispatched', () => {
-        const textbox = textboxBuilder()
-          .withId('textbox')
-          .withName('textbox')
-          .build();
-        const constant = constantBuilder()
-          .withId('constant')
-          .withName('constant')
-          .build();
-
-        reduxTester<{ templating: TemplatingState }>()
-          .givenRootReducer(getTemplatingRootReducer())
-          .whenActionIsDispatched(addVariable(toVariablePayload(textbox, { global: false, index: 0, model: textbox })))
-          .whenActionIsDispatched(
-            addVariable(toVariablePayload(constant, { global: false, index: 1, model: constant }))
-          )
-          .whenActionIsDispatched(changeVariableName(toVariableIdentifier(constant), constant.name), true)
-          .thenNoActionsWhereDispatched();
-      });
-    });
-
     describe('when changeVariableName is dispatched with an unique name', () => {
       it('then the correct actions are dispatched', () => {
         const textbox = textboxBuilder()


### PR DESCRIPTION
**What this PR does / why we need it**:
You couldn't delete an invalid character after typing it into the name-input field.
While investigating, the issue turned out to be bigger, as there was a problem with
valid characters too. (See test scenarios below)

The fix seems to be, to remove an unnecessary check in the `changeVariableName`
action. There is theoretically now the possibility, that the `changeVariableName`
action is called with the same name, as the variable is already, but practically
there seems no possibility, that this could happen. A test, which checks that, had
to be removed too.

Test scenarios:
* 1st Scenario
    1. Type "@"
    2. Try deleting it
* 2nd Scenario
    1. Type "w"
    2. delete "w"
    3. Try typing "w" again

**Which issue(s) this PR fixes:**
Fixes #26562 

**Special notes for your reviewer**:
@hugohaggmark I removed a check and a test, that you created. This check seemed unnecessary to me, so I removed it to fix the bug. Please correct me if I am wrong. Maybe you had your reasons to implement it that way.
