### PR TITLE
Don't require HTTPS for HSTS headers to be emmitted

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -475,7 +475,7 @@ mitigate the risk of [Clickjacking](https://www.owasp.org/index.php/Clickjacking
 
 ### strict_transport_security
 
-Set to `true` if you want to enable HTTP `Strict-Transport-Security` (HSTS) response header. This is only sent when HTTPS is enabled in this configuration. HSTS tells browsers that the site should only be accessed using HTTPS.
+Set to `true` if you want to enable HTTP `Strict-Transport-Security` (HSTS) response header. Only use this when HTTPS is enabled in your configuration, or when there is another upstream system that ensures your application does HTTPS (like a frontend load balancer). HSTS tells browsers that the site should only be accessed using HTTPS.
 
 ### strict_transport_security_max_age_seconds
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -300,7 +300,7 @@ func AddDefaultResponseHeaders() macaron.Handler {
 
 // AddSecurityHeaders adds various HTTP(S) response headers that enable various security protections behaviors in the client's browser.
 func AddSecurityHeaders(w macaron.ResponseWriter) {
-	if (setting.Protocol == setting.HTTPS || setting.Protocol == setting.HTTP2) && setting.StrictTransportSecurity {
+	if setting.Protocol == setting.HTTP2 && setting.StrictTransportSecurity {
 		strictHeaderValues := []string{fmt.Sprintf("max-age=%v", setting.StrictTransportSecurityMaxAge)}
 		if setting.StrictTransportSecurityPreload {
 			strictHeaderValues = append(strictHeaderValues, "preload")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -60,7 +60,6 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 
 		middlewareScenario(t, "middleware should add correct Strict-Transport-Security header", func(sc *scenarioContext) {
 			setting.StrictTransportSecurity = true
-			setting.Protocol = setting.HTTPS
 			setting.StrictTransportSecurityMaxAge = 64000
 			sc.fakeReq("GET", "/api/").exec()
 			So(sc.resp.Header().Get("Strict-Transport-Security"), ShouldEqual, "max-age=64000")


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/26770