### PR TITLE
Graph: Revert bar centering to fix tooltip issue

### DIFF
--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -516,7 +516,6 @@ class GraphElement {
       }
       default: {
         options.series.bars.barWidth = this.getMinTimeStepOfSeries(this.data) / 1.5;
-        options.series.bars.align = 'center';
         this.addTimeAxis(options);
         break;
       }


### PR DESCRIPTION
Reverts https://github.com/grafana/grafana/pull/19723 as it's causing to many issues with the All series tooltip (Default tooltip mode). Mostly because this tooltip mode is really crap at detecting data points your hovering over. The code is messy and soon to be replaced so opting to revert this instead.

Fixes #22611  (And many duplicates as this has been reported many times) 
