### PR TITLE
BackendSrv: Improves logic for hiding requests from query inspector

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -49,7 +49,7 @@ export type BackendSrvRequest = {
   /**
    * Set to to true to not include call in query inspector
    */
-  silent?: boolean;
+  hideFromInspector?: boolean;
 
   /**
    * The data to send

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -118,6 +118,11 @@ export class BackendSrv implements BackendService {
       }
     }
 
+    if (options.hideFromInspector === undefined) {
+      // Hide all local non data query calls
+      options.hideFromInspector = isLocalUrl(options.url) && !isDataQuery(options.url);
+    }
+
     return options;
   }
 

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -83,21 +83,22 @@ describe('backendSrv', () => {
   describe('parseRequestOptions', () => {
     it.each`
       retry        | url                                      | headers                           | orgId        | noBackendCache | expected
-      ${undefined} | ${'http://localhost:3000/api/dashboard'} | ${undefined}                      | ${undefined} | ${undefined}   | ${{ retry: 0, url: 'http://localhost:3000/api/dashboard' }}
-      ${1}         | ${'http://localhost:3000/api/dashboard'} | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ retry: 1, url: 'http://localhost:3000/api/dashboard', headers: { Authorization: 'Some Auth' } }}
-      ${undefined} | ${'api/dashboard'}                       | ${undefined}                      | ${undefined} | ${undefined}   | ${{ retry: 0, url: 'api/dashboard' }}
-      ${undefined} | ${'/api/dashboard'}                      | ${undefined}                      | ${undefined} | ${undefined}   | ${{ retry: 0, url: 'api/dashboard' }}
-      ${undefined} | ${'/api/dashboard/'}                     | ${undefined}                      | ${undefined} | ${undefined}   | ${{ retry: 0, url: 'api/dashboard/' }}
-      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${undefined} | ${undefined}   | ${{ retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth' } }}
-      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${undefined}   | ${{ retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1 } }}
-      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1, 'X-Grafana-NoCache': 'true' } }}
-      ${1}         | ${'/api/dashboard/'}                     | ${undefined}                      | ${undefined} | ${undefined}   | ${{ retry: 1, url: 'api/dashboard/' }}
-      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${undefined} | ${undefined}   | ${{ retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth' } }}
-      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${undefined}   | ${{ retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1 } }}
-      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1, 'X-Grafana-NoCache': 'true' } }}
+      ${undefined} | ${'http://localhost:3000/api/dashboard'} | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: false, retry: 0, url: 'http://localhost:3000/api/dashboard' }}
+      ${1}         | ${'http://localhost:3000/api/dashboard'} | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ hideFromInspector: false, retry: 1, url: 'http://localhost:3000/api/dashboard', headers: { Authorization: 'Some Auth' } }}
+      ${undefined} | ${'api/dashboard'}                       | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard' }}
+      ${undefined} | ${'/api/dashboard'}                      | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard' }}
+      ${undefined} | ${'/api/dashboard/'}                     | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard/' }}
+      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth' } }}
+      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${undefined}   | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1 } }}
+      ${undefined} | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ hideFromInspector: true, retry: 0, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1, 'X-Grafana-NoCache': 'true' } }}
+      ${1}         | ${'/api/dashboard/'}                     | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 1, url: 'api/dashboard/' }}
+      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${undefined} | ${undefined}   | ${{ hideFromInspector: true, retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth' } }}
+      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${undefined}   | ${{ hideFromInspector: true, retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1 } }}
+      ${1}         | ${'/api/dashboard/'}                     | ${{ Authorization: 'Some Auth' }} | ${1}         | ${true}        | ${{ hideFromInspector: true, retry: 1, url: 'api/dashboard/', headers: { 'X-DS-Authorization': 'Some Auth', 'X-Grafana-Org-Id': 1, 'X-Grafana-NoCache': 'true' } }}
+      ${undefined} | ${'api/datasources/proxy'}               | ${undefined}                      | ${undefined} | ${undefined}   | ${{ hideFromInspector: false, retry: 0, url: 'api/datasources/proxy' }}
     `(
       "when called with retry: '$retry', url: '$url' and orgId: '$orgId' then result should be '$expected'",
-      ({ retry, url, headers, orgId, noBackendCache, expected }) => {
+      async ({ retry, url, headers, orgId, noBackendCache, expected }) => {
         const srv = new BackendSrv({
           contextSrv: {
             user: {
@@ -107,7 +108,7 @@ describe('backendSrv', () => {
         } as any);
 
         if (noBackendCache) {
-          srv.withNoBackendCache(async () => {
+          await srv.withNoBackendCache(async () => {
             expect(srv['parseRequestOptions']({ retry, url, headers })).toEqual(expected);
           });
         } else {
@@ -298,58 +299,6 @@ describe('backendSrv', () => {
   });
 
   describe('datasourceRequest', () => {
-    describe('when making a successful call and silent is true', () => {
-      it('then it should not emit message', async () => {
-        const url = 'http://localhost:3000/api/some-mock';
-        const { backendSrv, appEventsMock, expectRequestCallChain } = getTestContext({ url });
-        const options = { url, method: 'GET', silent: true };
-        const result = await backendSrv.datasourceRequest(options);
-
-        expect(result).toEqual({
-          data: { test: 'hello world' },
-          ok: true,
-          redirected: false,
-          status: 200,
-          statusText: 'Ok',
-          type: 'basic',
-          url,
-          config: options,
-        });
-
-        expect(appEventsMock.emit).not.toHaveBeenCalled();
-        expectRequestCallChain({ url, method: 'GET', silent: true });
-      });
-    });
-
-    describe('when making a successful call and silent is not defined', () => {
-      it('then it should not emit message', async () => {
-        const url = 'http://localhost:3000/api/some-mock';
-        const { backendSrv, expectRequestCallChain } = getTestContext({ url });
-        const options = { url, method: 'GET' };
-
-        let inspectorPacket: any = null;
-        backendSrv.getInspectorStream().subscribe({
-          next: rsp => (inspectorPacket = rsp),
-        });
-
-        const result = await backendSrv.datasourceRequest(options);
-        const expectedResult = {
-          data: { test: 'hello world' },
-          ok: true,
-          redirected: false,
-          status: 200,
-          statusText: 'Ok',
-          type: 'basic',
-          url,
-          config: options,
-        };
-
-        expect(result).toEqual(expectedResult);
-        expect(inspectorPacket).toEqual(expectedResult);
-        expectRequestCallChain({ url, method: 'GET' });
-      });
-    });
-
     describe('when called with the same requestId twice', () => {
       it('then it should cancel the first call and the first call should be unsubscribed', async () => {
         const url = '/api/dashboard/';

--- a/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
@@ -133,7 +133,7 @@ export class QueryInspector extends PureComponent<Props, State> {
 
   onDataSourceResponse(response: any) {
     // ignore silent requests
-    if (response.config?.silent) {
+    if (response.config?.hideFromInspector) {
       return;
     }
 

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -15,7 +15,7 @@ import { getPanelInspectorStyles } from '../dashboard/components/Inspector/style
 
 function stripPropsFromResponse(response: any) {
   // ignore silent requests
-  if (response.config?.silent) {
+  if (response.config?.hideFromInspector) {
     return {};
   }
 

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -26,7 +26,7 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery> {
   }
 
   async metadataRequest(url: string, params?: Record<string, any>): Promise<any> {
-    const res = await this._request(url, params, { silent: true }).toPromise();
+    const res = await this._request(url, params, { hideFromInspector: true }).toPromise();
     return res.data.data;
   }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -268,7 +268,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   }
 
   async metadataRequest(url: string, params?: Record<string, string>) {
-    const res = await this._request(url, params, { silent: true }).toPromise();
+    const res = await this._request(url, params, { hideFromInspector: true }).toPromise();
     return res.data.data || res.data.values || [];
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -145,7 +145,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
   // Use this for tab completion features, wont publish response to other components
   metadataRequest(url: string) {
-    return this._request(url, null, { method: 'GET', silent: true });
+    return this._request(url, null, { method: 'GET', hideFromInspector: true });
   }
 
   interpolateQueryExpr(value: string | string[] = [], variable: any) {

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -73,7 +73,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/labels',
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -92,7 +92,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/label/resource/values',
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -117,7 +117,7 @@ describe('PrometheusMetricFindQuery', () => {
         url: `proxied/api/v1/series?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -141,7 +141,7 @@ describe('PrometheusMetricFindQuery', () => {
         method: 'GET',
         url:
           'proxied/api/v1/series?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C+label2%3D%22bar%22%2C+label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -168,7 +168,7 @@ describe('PrometheusMetricFindQuery', () => {
         url: `proxied/api/v1/series?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -187,7 +187,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(datasourceRequestMock).toHaveBeenCalledWith({
         method: 'GET',
         url: 'proxied/api/v1/label/__name__/values',
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });
@@ -243,7 +243,7 @@ describe('PrometheusMetricFindQuery', () => {
         url: `proxied/api/v1/series?match${encodeURIComponent('[]')}=${encodeURIComponent(
           'up{job="job1"}'
         )}&start=${raw.from.unix()}&end=${raw.to.unix()}`,
-        silent: true,
+        hideFromInspector: true,
         headers: {},
       });
     });

--- a/public/app/plugins/datasource/zipkin/datasource.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.ts
@@ -36,7 +36,7 @@ export class ZipkinDatasource extends DataSourceApi<ZipkinQuery> {
   }
 
   async metadataRequest(url: string, params?: Record<string, any>): Promise<any> {
-    const res = await this.request(url, params, { silent: true }).toPromise();
+    const res = await this.request(url, params, { hideFromInspector: true }).toPromise();
     return res.data;
   }
 


### PR DESCRIPTION
After the backendSrv refactoring where I unified the requests paths for all http api calls it created this issue where meta analytics events would show up after a few seconds in the QueryInspector. 

This PR 
* Changes name of the silent bool to hideFromInspector to be more descriptive 
* When unset the auto logic will set this to true for all local non-data query calls  