### PR TITLE
Table: Support date unit formats on string values 

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -118,6 +118,17 @@ describe('toDataFrame', () => {
     expect(guessFieldTypeFromValue('xxxx')).toBe(FieldType.string);
   });
 
+  it('Guess Column Types from strings', () => {
+    expect(guessFieldTypeFromValue('1')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('1.234')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('NaN')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('3.125e7')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('True')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('FALSE')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('true')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('xxxx')).toBe(FieldType.string);
+  });
+
   it('Guess Column Types from series', () => {
     const series = new MutableDataFrame({
       fields: [

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -292,4 +292,15 @@ describe('Date display options', () => {
     });
     expect(processor(0).text).toEqual('1970');
   });
+
+  it('should handle ISO string dates', () => {
+    const processor = getDisplayProcessor({
+      timeZone: 'utc',
+      field: {
+        type: FieldType.time,
+      },
+    });
+
+    expect(processor('2020-08-01T08:48:43.783337Z').text).toEqual('2020-08-01 08:48:43');
+  });
 });

--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -280,6 +280,7 @@ describe('ResultProcessor', () => {
               timeField: {
                 name: 'Time',
                 type: 'time',
+                config: {},
                 values: new ArrayVector([0]),
                 index: 0,
                 display: expect.anything(),

--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -280,7 +280,6 @@ describe('ResultProcessor', () => {
               timeField: {
                 name: 'Time',
                 type: 'time',
-                config: { unit: 'time:YYYY-MM-DD HH:mm:ss' },
                 values: new ArrayVector([0]),
                 index: 0,
                 display: expect.anything(),


### PR DESCRIPTION
Fixes #25884 

So many ways to address this. 

I think the display processor should be smarter here and identify that a date unit has been selected and try to parse strings to dates. 