### PR TITLE
Variables: Fix hide option labels on Safari

### DIFF
--- a/public/app/features/variables/editor/VariableEditorEditor.tsx
+++ b/public/app/features/variables/editor/VariableEditorEditor.tsx
@@ -184,10 +184,10 @@ export class VariableEditorEditorUnConnected extends PureComponent<Props> {
                     <option label="" value={VariableHide.dontHide}>
                       {''}
                     </option>
-                    <option label="" value={VariableHide.hideLabel}>
+                    <option label="Label" value={VariableHide.hideLabel}>
                       Label
                     </option>
-                    <option label="" value={VariableHide.hideVariable}>
+                    <option label="Variable" value={VariableHide.hideVariable}>
                       Variable
                     </option>
                   </select>


### PR DESCRIPTION
**What this PR does / why we need it**: This PR sets the label attribute of the Variable hide option selector so that they are visible in Safari. 

![labels](https://user-images.githubusercontent.com/814226/89735386-2dce4680-da30-11ea-93da-475e8b05e327.png)

**Which issue(s) this PR fixes**: Fixes #25879

**Special notes for your reviewer**: According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option, "If the label attribute isn't defined, its value is that of the element text content." Safari interprets an empty label attribute as "defined" whereas Chrome does not. An alternative fix could be to remove the `label` attribute altogether, but this seemed less consistent with other usages in the file.

It looks like an assertion could be added [here](https://github.com/grafana/grafana/blob/master/e2e/suite1/specs/queryVariableCrud.spec.ts#L606), but it didn't seem like this was a ton of value.
