### PR TITLE
CI: Upgrade Go and Node versions in CI build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ executors:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.20
+      - image: grafana/build-container:1.2.22
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -30,7 +30,7 @@ steps:
     GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - make lint-go
   environment:
@@ -39,7 +39,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -47,7 +47,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -62,7 +62,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
@@ -72,7 +72,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
@@ -81,7 +81,7 @@ steps:
   - test-frontend
 
 - name: test-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -91,7 +91,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn run prettier:check
@@ -104,7 +104,7 @@ steps:
   - initialize
 
 - name: build-plugins
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
@@ -113,7 +113,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
@@ -126,7 +126,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   detach: true
   commands:
   - ./e2e/start-server
@@ -146,7 +146,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn storybook:build
@@ -163,7 +163,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -179,7 +179,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -197,7 +197,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -249,7 +249,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -265,7 +265,7 @@ steps:
     GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - make lint-go
   environment:
@@ -274,7 +274,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -282,7 +282,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -297,7 +297,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER
@@ -307,7 +307,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
@@ -316,7 +316,7 @@ steps:
   - test-frontend
 
 - name: test-backend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -326,7 +326,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn run prettier:check
@@ -339,7 +339,7 @@ steps:
   - initialize
 
 - name: build-plugins
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
@@ -348,7 +348,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -361,7 +361,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   detach: true
   commands:
   - ./e2e/start-server
@@ -381,7 +381,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn storybook:build
@@ -410,7 +410,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -434,7 +434,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -452,7 +452,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -476,7 +476,7 @@ steps:
   - package
 
 - name: release-next-npm-packages
-  image: grafana/build-container:1.2.21
+  image: grafana/build-container:1.2.22
   commands:
   - npx lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.1-alpine3.12 as js-builder
+FROM node:12.18.3-alpine3.12 as js-builder
 
 WORKDIR /usr/src/app/
 
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM golang:1.14.4-alpine3.12 as go-builder
+FROM golang:1.14.7-alpine3.12 as go-builder
 
 RUN apk add --no-cache gcc g++
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM node:12.16.3-slim AS js-builder
+FROM node:12.18.3-slim AS js-builder
 
 WORKDIR /usr/src/app/
 
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM golang:1.14.2 AS go-builder
+FROM golang:1.14.7 AS go-builder
 
 WORKDIR /src/grafana
 
@@ -65,7 +65,6 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
     cp conf/ldap.toml /etc/grafana/ldap.toml && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
-
 
 COPY --from=go-builder /src/grafana/bin/linux-amd64/grafana-server /src/grafana/bin/linux-amd64/grafana-cli bin/
 COPY --from=js-builder /usr/src/app/public public

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -85,10 +85,10 @@ RUN mv golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint /tmp/
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20200607
 
-ENV GOVERSION=1.14.4 \
+ENV GOVERSION=1.14.7 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=12.18.0-1nodesource1 \
+    NODEVERSION=12.18.3-1nodesource1 \
     YARNVERSION=1.22.4-1
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.21"
+_version="1.2.22"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,4 +1,4 @@
-build_image = 'grafana/build-container:1.2.21'
+build_image = 'grafana/build-container:1.2.22'
 publish_image = 'grafana/grafana-ci-deploy:1.2.5'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.2.0'
 alpine_image = 'alpine:3.12'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade our CI build image to use latest Go, which has some security fixes, and latest Node v12.
