### PR TITLE
Docs: Sort log result documentation

### DIFF
--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -110,7 +110,7 @@ You can customize the query history in the Settings tab. Options are described i
 | ------------------------------------------------------------- | --------------------------------------- |
 | Period of time for which Grafana will save your query history | 1 week                                  |
 | Change the default active tab                                 | Query history tab                       |
-| Only show queries for data source currently active in Explore  | True                                    |
+| Only show queries for data source currently active in Explore | True                                    |
 | Clear query history                                           | Permanently deletes all stored queries. |
 
 > Note: Query history settings are global, and applied to both panels in split mode.
@@ -153,14 +153,6 @@ Along with metrics, Explore allows you to investigate your logs with the followi
 
 You can customize how logs are displayed and select which columns are shown.
 
-#### Deduping
-
-Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
-
-- `exact` Exact matches are done on the whole line, except for date fields.
-- `numbers` Matches on the line after stripping out numbers (durations, IP addresses etc.).
-- `signature` The most aggressive deduping - strips all letters and numbers, and matches on the remaining whitespace and punctuation.
-
 #### Time
 
 Shows or hides the time column. This is the timestamp associated with the log line as reported from the data source.
@@ -172,6 +164,18 @@ Shows or hides the unique labels column that includes only non-common labels. Al
 #### Wrap lines
 
 Set this to True if you want the display to use line wrapping. If set to False, it will result in horizontal scrolling.
+
+#### Deduping
+
+Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
+
+- `exact` Exact matches are done on the whole line, except for date fields.
+- `numbers` Matches on the line after stripping out numbers (durations, IP addresses etc.).
+- `signature` The most aggressive deduping - strips all letters and numbers, and matches on the remaining whitespace and punctuation.
+
+#### Flip results order
+
+You can change the order of received logs from the default descending order (newest first) to ascending order (oldest first).
 
 ### Labels and parsed fields
 

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -170,7 +170,7 @@ Set this to True if you want the display to use line wrapping. If set to False, 
 Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
 
 - **exact -** Exact matches are done on the whole line except for date fields.
-- `numbers` Matches on the line after stripping out numbers (durations, IP addresses etc.).
+- **numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
 - `signature` The most aggressive deduping - strips all letters and numbers, and matches on the remaining whitespace and punctuation.
 
 #### Flip results order

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -169,7 +169,7 @@ Set this to True if you want the display to use line wrapping. If set to False, 
 
 Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
 
-- `exact` Exact matches are done on the whole line, except for date fields.
+- **exact -** Exact matches are done on the whole line except for date fields.
 - `numbers` Matches on the line after stripping out numbers (durations, IP addresses etc.).
 - `signature` The most aggressive deduping - strips all letters and numbers, and matches on the remaining whitespace and punctuation.
 

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -169,9 +169,9 @@ Set this to True if you want the display to use line wrapping. If set to False, 
 
 Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
 
-- **exact -** Exact matches are done on the whole line except for date fields.
-- **numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
-- **signature -** The most aggressive deduping, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
+- **Exact -** Exact matches are done on the whole line except for date fields.
+- **Numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
+- **Signature -** The most aggressive deduping, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
 
 #### Flip results order
 

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -171,7 +171,7 @@ Log data can be very repetitive and Explore can help by hiding duplicate log lin
 
 - **exact -** Exact matches are done on the whole line except for date fields.
 - **numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
-- `signature` The most aggressive deduping - strips all letters and numbers, and matches on the remaining whitespace and punctuation.
+- **signature -** The most aggressive deduping, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
 
 #### Flip results order
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR adds documentation to the new [Sort logs order function](https://github.com/grafana/grafana/pull/26669) (part of a future 7.2 release)
- Re-oders the **visualisation options** part based on how it is in UI (below)
![image](https://user-images.githubusercontent.com/30407135/89790775-b6c5aa80-db22-11ea-99c4-b6ae7b099ea5.png)

Also, should we merge this just before 7.2 release, or can we merge it sooner @oddlittlebird?