### PR TITLE
Dataframe/Alerting: to tsdb.TimeSeriesSlice - accept "empty" time series

### DIFF
--- a/pkg/tsdb/frame_util.go
+++ b/pkg/tsdb/frame_util.go
@@ -44,6 +44,14 @@ func convertTSDBTimePoint(point TimePoint) (t *time.Time, f *float64) {
 func FrameToSeriesSlice(frame *data.Frame) (TimeSeriesSlice, error) {
 	tsSchema := frame.TimeSeriesSchema()
 	if tsSchema.Type == data.TimeSeriesTypeNot {
+		// If not fields, or only a time field, create an empty TimeSeriesSlice with a single
+		// time series in order to trigger "no data" in alerting.
+		if len(frame.Fields) == 0 || (len(frame.Fields) == 1 && frame.Fields[0].Type().Time()) {
+			return TimeSeriesSlice{{
+				Name:   frame.Name,
+				Points: make(TimeSeriesPoints, 0),
+			}}, nil
+		}
 		return nil, fmt.Errorf("input frame is not recognized as a time series")
 	}
 	// If Long, make wide

--- a/pkg/tsdb/frame_util.go
+++ b/pkg/tsdb/frame_util.go
@@ -44,7 +44,7 @@ func convertTSDBTimePoint(point TimePoint) (t *time.Time, f *float64) {
 func FrameToSeriesSlice(frame *data.Frame) (TimeSeriesSlice, error) {
 	tsSchema := frame.TimeSeriesSchema()
 	if tsSchema.Type == data.TimeSeriesTypeNot {
-		// If not fields, or only a time field, create an empty TimeSeriesSlice with a single
+		// If no fields, or only a time field, create an empty TimeSeriesSlice with a single
 		// time series in order to trigger "no data" in alerting.
 		if len(frame.Fields) == 0 || (len(frame.Fields) == 1 && frame.Fields[0].Type().Time()) {
 			return TimeSeriesSlice{{


### PR DESCRIPTION
**What this PR does / why we need it**:
Make it so at least azure insights "empty response" will become no data in alerting, instead of getting an error.

**Which issue(s) this PR fixes**:
I currently assume this is cause of issue #26897.

**Special notes for your reviewer**:
This is perhaps better solved in the SDK but that needs more thought and is tracked in grafana/grafana-plugin-sdk-go#214